### PR TITLE
Fix link in API readme

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,8 @@
 # OpenShift v3 REST API (Alpha) 
 
 ## Viewing the documentation ##
-Clone this repository and open oov3.html locally on your browser
+Use htmlpreview for github with a URL like:
+[https://rawgit.com/openshift/origin/master/api/oov3.html] (https://rawgit.com/openshift/origin/master/api/oov3.html)
 
 ## Generating the API document
 Use [raml2html](https://www.npmjs.org/package/raml2html):


### PR DESCRIPTION
Add link to html version of API documentation in the API readme. The link will only work when the repository is made public.
