### PR TITLE
api/examples: Store env vars as array instead of key/value object

### DIFF
--- a/api/examples/create-image.json
+++ b/api/examples/create-image.json
@@ -2,11 +2,16 @@
   "data":
   {
     "url":"https://registry.hub.docker.com/u/library/nginx",
-    "environment":
-    {
-      "name1": "value1",
-      "name2": "value2"
-    },
+    "env": [
+      {
+        "name": "name1",
+        "value": "value1"
+      },
+      {
+        "name": "name2",
+        "value": "value2"
+      }
+    ],
     "networkPorts": [
       {
         "hostPort": 8080,

--- a/api/examples/image-repositories.json
+++ b/api/examples/image-repositories.json
@@ -5,11 +5,16 @@
       "visibility": "public",
       "domain": "domain",
       "name": "server/domain/nginx",
-      "environment": 
-      {
-        "VAR1": "value1",
-        "VAR2": "value2"
-      },
+      "env": [
+        {
+          "name": "VAR1",
+          "value": "value1"
+        },
+        {
+          "name": "VAR2",
+          "value": "value2"
+        }
+      ],
       "networkPorts": [
         {
           "hostPort": 8080,

--- a/api/examples/image-repository.json
+++ b/api/examples/image-repository.json
@@ -4,11 +4,16 @@
     "visibility": "public",
     "domain": "domain",
     "name": "server/domain/nginx",
-    "environment": 
-    {
-      "name1": "value1",
-      "name2": "value2"
-    },
+    "env": [
+      {
+        "name": "name1",
+        "value": "value1"
+      },
+      {
+        "name": "name2",
+        "value": "value2"
+      }
+    ],
     "networkPorts": [
       {
         "hostPort": 8080,

--- a/api/examples/image.json
+++ b/api/examples/image.json
@@ -4,11 +4,16 @@
     "id": "53c4249f076573c0f4000001",
     "name": "nginx-19273412433342",
     "image-stream": "server/domain/nginx",
-    "environment":
-    {
-      "name1": "value1",
-      "name2": "value2"
-    },
+    "env": [
+      {
+        "name": "name1",
+        "value": "value1"
+      },
+      {
+        "name": "name2",
+        "value": "value2"
+      }
+    ],
     "networkPorts": [
       {
         "hostPort": 8080,

--- a/api/examples/images.json
+++ b/api/examples/images.json
@@ -5,11 +5,16 @@
       "id": "53c4249f076573c0f4000001",
       "name": "nginx-19273412433342",
       "image-stream": "server/domain/nginx",
-      "environment":
-      {
-        "name1": "value1",
-        "name2": "value2"
-      },
+      "env": [
+        {
+          "name": "name1",
+          "value": "value1"
+        },
+        {
+          "name": "name2",
+          "value": "value2"
+        }
+      ],
       "networkPorts": [
         {
           "hostPort": 8080,

--- a/api/examples/template_example_1.json
+++ b/api/examples/template_example_1.json
@@ -83,11 +83,20 @@
                   "name": "postgres",
                   "tag": "9.2"
                 },
-                "env": {
-                  "PGPASSWORD": "${DB_PASSWORD}",
-                  "PGUSER": "${DB_USER}",
-                  "PGDATABASE": "${DB_NAME}"
-                },
+                "env": [
+                  {
+                    "name": "PGPASSWORD",
+                    "value": "${DB_PASSWORD}"
+                  },
+                  {
+                    "name": "PGUSER",
+                    "value": "${DB_USER}"
+                  },
+                  {
+                    "name": "PGDATABASE",
+                    "value": "${DB_NAME}"
+                  }
+                ],
                 "ports": [
                   {
                     "containerPort": 5432,

--- a/api/examples/template_example_2.json
+++ b/api/examples/template_example_2.json
@@ -63,9 +63,12 @@
                   "name": "dockerfile/redis",
                   "tag": "latest"
                 },
-                "env": {
-                  "REDIS_PASSWORD": "${REDIS_PASSWORD}"
-                },
+                "env": [
+                  {
+                    "name": "REDIS_PASSWORD",
+                    "value": "${REDIS_PASSWORD}"
+                  }
+                ],
                 "ports": [
                   {
                     "containerPort": 6379,


### PR DESCRIPTION
For better JSON Schema validation.
