### PR TITLE
Typo in help, we create services.

### DIFF
--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -17,7 +17,7 @@ OpenShift for Admins
 OpenShift helps you build, deploy, and manage your applications. To start an all-in-one server, run:
 
     $ openshift start &
-    $ openshift kube create service -c examples/test-service.json
+    $ openshift kube create services -c examples/test-service.json
 
 OpenShift is built around Docker and the Kubernetes container orchestration service.  You must have
 Docker installed on this machine to start your server.


### PR DESCRIPTION
The help output of the openshift command contains a typo, as we create services not service.

```
# output/go/bin/openshift kube create service -c examples/test-service.json
F0814 14:34:02.750933 02417 kubecfg.go:219] usage: kubecfg [OPTIONS] create <builds|minions|pods|replicationControllers|services>
# output/go/bin/openshift kube create services -c examples/test-service.json
Name                Labels              Selector            Port
----------          ----------          ----------          ----------
frontend                                name=frontend       9998

# 
```
