### PR TITLE
Add support for images & image repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ The Kubernetes APIs are exposed at `http://localhost:8080/api/v1beta1/*`:
 Several experimental API objects are being prototyped, and should be available soon at:
 
 * `http://localhost:8080/osapi/v1beta1/images`
-* `http://localhost:8080/osapi/v1beta1/imagesByRepository`
 * `http://localhost:8080/osapi/v1beta1/imageRepositories`
 * `http://localhost:8080/osapi/v1beta1/builds`
 * `http://localhost:8080/osapi/v1beta1/buildConfigs`

--- a/examples/image/test-image-repository.json
+++ b/examples/image/test-image-repository.json
@@ -1,0 +1,13 @@
+{
+  "id": "test",
+  "kind": "ImageRepository",
+  "apiVersion": "v1beta1",
+  "dockerImageRepository": "openshift/ruby-19-centos",
+  "tags": {
+    "latest": "foo",
+    "another": "bar",
+  },
+  "labels": {
+    "color": "blue"
+  }
+}

--- a/examples/image/test-image.json
+++ b/examples/image/test-image.json
@@ -1,0 +1,88 @@
+{
+  "id": "test",
+  "kind": "Image",
+  "version": "v1beta1",
+  "dockerImageReference": "openshift/ruby-19-centos:latest",
+  "metadata": {
+    "Architecture": "amd64",
+    "Author": "Michal Fojtik \u003cmfojtik@redhat.com\u003e",
+    "Comment": "",
+    "Config": {
+        "AttachStderr": false,
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "Cmd": [
+            "/opt/ruby/bin/usage"
+        ],
+        "CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+            "HOME=/opt/ruby",
+            "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+            "APP_ROOT=."
+        ],
+        "ExposedPorts": {
+            "9292/tcp": {}
+        },
+        "Hostname": "df1704c4368e",
+        "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": [],
+        "OpenStdin": false,
+        "PortSpecs": null,
+        "StdinOnce": false,
+        "Tty": false,
+        "User": "ruby",
+        "Volumes": null,
+        "WorkingDir": "/opt/ruby/src"
+    },
+    "Container": "72ce367abbc2862232b5e5e3485e51f096983e4e28b8dbefba9a6fd5ce0d6e48",
+    "ContainerConfig": {
+        "AttachStderr": false,
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "#(nop) CMD [/opt/ruby/bin/usage]"
+        ],
+"CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+            "HOME=/opt/ruby",
+            "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+            "APP_ROOT=."
+        ],
+        "ExposedPorts": {
+            "9292/tcp": {}
+        },
+        "Hostname": "df1704c4368e",
+        "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": [],
+        "OpenStdin": false,
+        "PortSpecs": null,
+        "StdinOnce": false,
+        "Tty": false,
+        "User": "ruby",
+        "Volumes": null,
+        "WorkingDir": "/opt/ruby/src"
+    },
+    "Created": "2014-08-08T14:36:01.303084707Z",
+    "DockerVersion": "1.1.2-dev",
+    "Id": "7dbbbc6cb29d5abc29b722c06d5209a499fa97cd655c59793540d00933ab4e45",
+    "Os": "linux",
+    "Parent": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+    "Size": 0
+  }
+}

--- a/examples/image/test-mapping.json
+++ b/examples/image/test-mapping.json
@@ -1,0 +1,94 @@
+{
+  "kind": "ImageRepositoryMapping",
+  "version": "v1beta1",
+  "dockerImageRepository": "openshift/ruby-19-centos",
+  "image": {
+    "kind": "Image",
+    "version": "v1beta1",
+    "id": "abcd1234",
+    "dockerImageReference": "openshift/ruby-19-centos:latest",
+    "metadata": {
+      "Architecture": "amd64",
+      "Author": "Michal Fojtik \u003cmfojtik@redhat.com\u003e",
+      "Comment": "",
+      "Config": {
+          "AttachStderr": false,
+          "AttachStdin": false,
+          "AttachStdout": false,
+          "Cmd": [
+              "/opt/ruby/bin/usage"
+          ],
+          "CpuShares": 0,
+          "Cpuset": "",
+          "Domainname": "",
+          "Entrypoint": null,
+          "Env": [
+              "HOME=/opt/ruby",
+              "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+              "APP_ROOT=."
+          ],
+          "ExposedPorts": {
+              "9292/tcp": {}
+          },
+          "Hostname": "df1704c4368e",
+          "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+          "Memory": 0,
+          "MemorySwap": 0,
+          "NetworkDisabled": false,
+          "OnBuild": [],
+          "OpenStdin": false,
+          "PortSpecs": null,
+          "StdinOnce": false,
+          "Tty": false,
+          "User": "ruby",
+          "Volumes": null,
+          "WorkingDir": "/opt/ruby/src"
+      },
+      "Container": "72ce367abbc2862232b5e5e3485e51f096983e4e28b8dbefba9a6fd5ce0d6e48",
+      "ContainerConfig": {
+          "AttachStderr": false,
+          "AttachStdin": false,
+          "AttachStdout": false,
+          "Cmd": [
+              "/bin/sh",
+              "-c",
+              "#(nop) CMD [/opt/ruby/bin/usage]"
+          ],
+  "CpuShares": 0,
+          "Cpuset": "",
+          "Domainname": "",
+          "Entrypoint": null,
+          "Env": [
+              "HOME=/opt/ruby",
+              "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+              "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+              "APP_ROOT=."
+          ],
+          "ExposedPorts": {
+              "9292/tcp": {}
+          },
+          "Hostname": "df1704c4368e",
+          "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+          "Memory": 0,
+          "MemorySwap": 0,
+          "NetworkDisabled": false,
+          "OnBuild": [],
+          "OpenStdin": false,
+          "PortSpecs": null,
+          "StdinOnce": false,
+          "Tty": false,
+          "User": "ruby",
+          "Volumes": null,
+          "WorkingDir": "/opt/ruby/src"
+      },
+      "Created": "2014-08-08T14:36:01.303084707Z",
+      "DockerVersion": "1.1.2-dev",
+      "Id": "7dbbbc6cb29d5abc29b722c06d5209a499fa97cd655c59793540d00933ab4e45",
+      "Os": "linux",
+      "Parent": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+      "Size": 0
+    }
+  },
+  "tag": "sometag"
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -53,3 +53,19 @@ echo "kube(services): ok"
 ${KUBE_CMD} list minions
 ${KUBE_CMD} get minions/127.0.0.1
 echo "kube(minions): ok"
+
+${KUBE_CMD} list images
+${KUBE_CMD} -c examples/image/test-image.json create images
+${KUBE_CMD} delete images/test
+echo "kube(images): ok"
+
+${KUBE_CMD} list imageRepositories
+${KUBE_CMD} -c examples/image/test-image-repository.json create imageRepositories
+${KUBE_CMD} delete imageRepositories/test
+echo "kube(imageRepositories): ok"
+
+${KUBE_CMD} -c examples/image/test-image-repository.json create imageRepositories
+${KUBE_CMD} -c examples/image/test-mapping.json create imageRepositoryMappings
+${KUBE_CMD} list images
+${KUBE_CMD} list imageRepositories
+echo "kube(imageRepositoryMappings): ok"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,19 +3,46 @@ package client
 import (
 	kubeclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/build/api/v1beta1"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	_ "github.com/openshift/origin/pkg/image/api/v1beta1"
 )
 
 // Interface exposes methods on OpenShift resources.
 type Interface interface {
 	BuildInterface
+	ImageInterface
+	ImageRepositoryInterface
+	ImageRepositoryMappingInterface
 }
 
 // BuildInterface exposes methods on Build resources.
 type BuildInterface interface {
 	ListBuilds(selector labels.Selector) (buildapi.BuildList, error)
 	UpdateBuild(buildapi.Build) (buildapi.Build, error)
+}
+
+// ImageInterface exposes methods on Image resources.
+type ImageInterface interface {
+	ListImages(selector labels.Selector) (imageapi.ImageList, error)
+	GetImage(id string) (imageapi.Image, error)
+	CreateImage(imageapi.Image) (imageapi.Image, error)
+}
+
+// ImageRepositoryInterface exposes methods on ImageRepository resources.
+type ImageRepositoryInterface interface {
+	ListImageRepositories(selector labels.Selector) (imageapi.ImageRepositoryList, error)
+	GetImageRepository(id string) (imageapi.ImageRepository, error)
+	WatchImageRepositories(field, label labels.Selector, resourceVersion uint64) (watch.Interface, error)
+	CreateImageRepository(repo imageapi.ImageRepository) (imageapi.ImageRepository, error)
+	UpdateImageRepository(repo imageapi.ImageRepository) (imageapi.ImageRepository, error)
+}
+
+// ImageRepositoryMappingInterface exposes methods on ImageRepositoryMapping resources.
+type ImageRepositoryMappingInterface interface {
+	CreateImageRepositoryMapping(mapping imageapi.ImageRepositoryMapping) error
 }
 
 // Client is an OpenShift client object
@@ -42,4 +69,53 @@ func (c *Client) ListBuilds(selector labels.Selector) (result buildapi.BuildList
 func (c *Client) UpdateBuild(build buildapi.Build) (result buildapi.Build, err error) {
 	err = c.Put().Path("builds").Path(build.ID).Body(build).Do().Into(&result)
 	return
+}
+
+func (c *Client) ListImages(selector labels.Selector) (result imageapi.ImageList, err error) {
+	err = c.Get().Path("images").SelectorParam("labels", selector).Do().Into(&result)
+	return
+}
+
+func (c *Client) GetImage(id string) (result imageapi.Image, err error) {
+	err = c.Get().Path("images").Path(id).Do().Into(&result)
+	return
+}
+
+func (c *Client) CreateImage(image imageapi.Image) (result imageapi.Image, err error) {
+	err = c.Post().Path("images").Body(image).Do().Into(&result)
+	return
+}
+
+func (c *Client) ListImageRepositories(selector labels.Selector) (result imageapi.ImageRepositoryList, err error) {
+	err = c.Get().Path("imageRepositories").SelectorParam("labels", selector).Do().Into(&result)
+	return
+}
+
+func (c *Client) GetImageRepository(id string) (result imageapi.ImageRepository, err error) {
+	err = c.Get().Path("imageRepositories").Path(id).Do().Into(&result)
+	return
+}
+
+func (c *Client) WatchImageRepositories(field, label labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return c.Get().
+		Path("watch").
+		Path("imageRepositories").
+		UintParam("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}
+
+func (c *Client) CreateImageRepository(repo imageapi.ImageRepository) (result imageapi.ImageRepository, err error) {
+	err = c.Post().Path("imageRepositories").Body(repo).Do().Into(&result)
+	return
+}
+
+func (c *Client) UpdateImageRepository(repo imageapi.ImageRepository) (result imageapi.ImageRepository, err error) {
+	err = c.Put().Path("imageRepositories").Path(repo.ID).Body(repo).Do().Into(&result)
+	return
+}
+
+func (c *Client) CreateImageRepositoryMapping(mapping imageapi.ImageRepositoryMapping) error {
+	return c.Post().Path("imageRepositoryMappings").Body(mapping).Do().Error()
 }

--- a/pkg/cmd/client/image/printer.go
+++ b/pkg/cmd/client/image/printer.go
@@ -1,0 +1,57 @@
+package image
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubecfg"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+var imageColumns = []string{"ID", "Docker Ref"}
+var imageRepositoryColumns = []string{"ID", "Docker Repo", "Tags"}
+
+// RegisterPrintHandlers registers HumanReadablePrinter handlers for image and image repository resources.
+func RegisterPrintHandlers(printer *kubecfg.HumanReadablePrinter) {
+	printer.Handler(imageColumns, printImage)
+	printer.Handler(imageColumns, printImageList)
+	printer.Handler(imageRepositoryColumns, printImageRepository)
+	printer.Handler(imageRepositoryColumns, printImageRepositoryList)
+}
+
+func printImage(image *api.Image, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\n", image.ID, image.DockerImageReference)
+	return err
+}
+
+func printImageList(images *api.ImageList, w io.Writer) error {
+	for _, image := range images.Items {
+		if err := printImage(&image, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printImageRepository(repo *api.ImageRepository, w io.Writer) error {
+	tags := ""
+	if len(repo.Tags) > 0 {
+		var t []string
+		for tag, _ := range repo.Tags {
+			t = append(t, tag)
+		}
+		tags = strings.Join(t, ",")
+	}
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", repo.ID, repo.DockerImageRepository, tags)
+	return err
+}
+
+func printImageRepositoryList(repos *api.ImageRepositoryList, w io.Writer) error {
+	for _, repo := range repos.Items {
+		if err := printImageRepository(&repo, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -39,6 +39,8 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/client/build"
+	"github.com/openshift/origin/pkg/cmd/client/image"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type RESTClient interface {
@@ -86,12 +88,15 @@ func usage(name string) string {
 }
 
 var parser = kubecfg.NewParser(map[string]interface{}{
-	"pods":                   api.Pod{},
-	"services":               api.Service{},
-	"replicationControllers": api.ReplicationController{},
-	"minions":                api.Minion{},
-	"builds":                 buildapi.Build{},
-	"buildConfigs":           buildapi.BuildConfig{},
+	"pods":                    api.Pod{},
+	"services":                api.Service{},
+	"replicationControllers":  api.ReplicationController{},
+	"minions":                 api.Minion{},
+	"builds":                  buildapi.Build{},
+	"buildConfigs":            buildapi.BuildConfig{},
+	"images":                  imageapi.Image{},
+	"imageRepositories":       imageapi.ImageRepository{},
+	"imageRepositoryMappings": imageapi.ImageRepositoryMapping{},
 })
 
 func prettyWireStorage() string {
@@ -209,12 +214,15 @@ func (c *KubeConfig) Run() {
 
 	method := c.Arg(0)
 	clients := map[string]RESTClient{
-		"minions":                kubeClient.RESTClient,
-		"pods":                   kubeClient.RESTClient,
-		"services":               kubeClient.RESTClient,
-		"replicationControllers": kubeClient.RESTClient,
-		"builds":                 client.RESTClient,
-		"buildConfigs":           client.RESTClient,
+		"minions":                 kubeClient.RESTClient,
+		"pods":                    kubeClient.RESTClient,
+		"services":                kubeClient.RESTClient,
+		"replicationControllers":  kubeClient.RESTClient,
+		"builds":                  client.RESTClient,
+		"buildConfigs":            client.RESTClient,
+		"images":                  client.RESTClient,
+		"imageRepositories":       client.RESTClient,
+		"imageRepositoryMappings": client.RESTClient,
 	}
 
 	matchFound := c.executeAPIRequest(method, clients) || c.executeControllerRequest(method, kubeClient)
@@ -415,7 +423,10 @@ func (c *KubeConfig) executeControllerRequest(method string, client *kubeclient.
 
 func humanReadablePrinter() *kubecfg.HumanReadablePrinter {
 	printer := kubecfg.NewHumanReadablePrinter()
-	build.RegisterPrintHandlers(printer)
+
 	// Add Handler calls here to support additional types
+	build.RegisterPrintHandlers(printer)
+	image.RegisterPrintHandlers(printer)
+
 	return printer
 }

--- a/pkg/image/api/register.go
+++ b/pkg/image/api/register.go
@@ -1,0 +1,13 @@
+package api
+
+import "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+func init() {
+	runtime.AddKnownTypes("",
+		Image{},
+		ImageList{},
+		ImageRepository{},
+		ImageRepositoryList{},
+		ImageRepositoryMapping{},
+	)
+}

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/fsouza/go-dockerclient"
+)
+
+// ImageList is a list of Image objects.
+type ImageList struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Items            []Image `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// Image is an immutable representation of a Docker image and metadata at a point in time.
+type Image struct {
+	kubeapi.JSONBase     `json:",inline" yaml:",inline"`
+	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DockerImageReference string            `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
+	Metadata             docker.Image      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+// ImageRepositoryList is a list of ImageRepository objects.
+type ImageRepositoryList struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Items            []ImageRepository `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// ImageRepository stores a mapping of tags to images, metadata overrides that are applied
+// when images are tagged in a repository, and an optional reference to a Docker image
+// repository on a registry.
+type ImageRepository struct {
+	kubeapi.JSONBase      `json:",inline" yaml:",inline"`
+	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DockerImageRepository string            `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	Tags                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// TODO add metadata overrides
+
+// ImageRepositoryMapping represents a mapping from a single tag to a Docker image as
+// well as the reference to the Docker image repository the image came from.
+type ImageRepositoryMapping struct {
+	kubeapi.JSONBase      `json:",inline" yaml:",inline"`
+	DockerImageRepository string `json:"dockerImageRepository" yaml:"dockerImageRepository"`
+	Image                 Image  `json:"image" yaml:"image"`
+	Tag                   string `json:"tag" yaml:"tag"`
+}

--- a/pkg/image/api/v1beta1/register.go
+++ b/pkg/image/api/v1beta1/register.go
@@ -1,0 +1,13 @@
+package v1beta1
+
+import "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+func init() {
+	runtime.AddKnownTypes("v1beta1",
+		Image{},
+		ImageList{},
+		ImageRepository{},
+		ImageRepositoryList{},
+		ImageRepositoryMapping{},
+	)
+}

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -1,0 +1,47 @@
+package v1beta1
+
+import (
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/fsouza/go-dockerclient"
+)
+
+// ImageList is a list of Image objects.
+type ImageList struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Items            []Image `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// Image is an immutable representation of a Docker image and metadata at a point in time.
+type Image struct {
+	kubeapi.JSONBase     `json:",inline" yaml:",inline"`
+	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DockerImageReference string            `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
+	Metadata             docker.Image      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+// ImageRepositoryList is a list of ImageRepository objects.
+type ImageRepositoryList struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Items            []ImageRepository `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// ImageRepository stores a mapping of tags to images, metadata overrides that are applied
+// when images are tagged in a repository, and an optional reference to a Docker image
+// repository on a registry.
+type ImageRepository struct {
+	kubeapi.JSONBase      `json:",inline" yaml:",inline"`
+	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DockerImageRepository string            `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	Tags                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// TODO add metadata overrides
+
+// ImageRepositoryMapping represents a mapping from a single tag to a Docker image as
+// well as the reference to the Docker image repository the image came from.
+type ImageRepositoryMapping struct {
+	kubeapi.JSONBase      `json:",inline" yaml:",inline"`
+	DockerImageRepository string `json:"dockerImageRepository" yaml:"dockerImageRepository"`
+	Image                 Image  `json:"image" yaml:"image"`
+	Tag                   string `json:"tag" yaml:"tag"`
+}

--- a/pkg/image/doc.go
+++ b/pkg/image/doc.go
@@ -1,0 +1,3 @@
+// Package image provides support for images, image repositories, and image repository mappings,
+// including RESTStorage implementations and registries.
+package image

--- a/pkg/image/etcdregistry.go
+++ b/pkg/image/etcdregistry.go
@@ -1,0 +1,152 @@
+package image
+
+import (
+	"errors"
+
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+// EtcdRegistry implements ImageRegistry and ImageRepositoryRegistry backed by etcd.
+type EtcdRegistry struct {
+	tools.EtcdHelper
+}
+
+// NewEtcdRegistry returns a new EtcdRegistry.
+func NewEtcdRegistry(client tools.EtcdClient) *EtcdRegistry {
+	registry := &EtcdRegistry{
+		EtcdHelper: tools.EtcdHelper{
+			client,
+			runtime.Codec,
+			runtime.ResourceVersioner,
+		},
+	}
+
+	return registry
+}
+
+// ListImages retrieves a list of images that match selector.
+func (r *EtcdRegistry) ListImages(selector labels.Selector) (*api.ImageList, error) {
+	list := api.ImageList{}
+	err := r.ExtractList("/images", &list.Items, &list.ResourceVersion)
+	if err != nil {
+		return nil, err
+	}
+	filtered := []api.Image{}
+	for _, item := range list.Items {
+		if selector.Matches(labels.Set(item.Labels)) {
+			filtered = append(filtered, item)
+		}
+	}
+	list.Items = filtered
+	return &list, nil
+}
+
+func makeImageKey(id string) string {
+	return "/images/" + id
+}
+
+// GetImage retrieves a specific image
+func (r *EtcdRegistry) GetImage(id string) (*api.Image, error) {
+	var image api.Image
+	if err := r.ExtractObj(makeImageKey(id), &image, false); err != nil {
+		return nil, err
+	}
+	return &image, nil
+}
+
+// CreateImage creates a new image
+func (r *EtcdRegistry) CreateImage(image api.Image) error {
+	err := r.CreateObj(makeImageKey(image.ID), &image)
+	if tools.IsEtcdNodeExist(err) {
+		return apierrors.NewAlreadyExists("image", image.ID)
+	}
+	return err
+}
+
+// UpdateImage updates an existing image
+func (r *EtcdRegistry) UpdateImage(image api.Image) error {
+	return errors.New("not supported")
+}
+
+// DeleteImage deletes an existing image
+func (r *EtcdRegistry) DeleteImage(id string) error {
+	key := makeImageKey(id)
+	err := r.Delete(key, false)
+	if tools.IsEtcdNotFound(err) {
+		return apierrors.NewNotFound("image", id)
+	}
+	return err
+}
+
+// ListImageRepositories retrieves a list of ImageRepositories that match selector.
+func (r *EtcdRegistry) ListImageRepositories(selector labels.Selector) (*api.ImageRepositoryList, error) {
+	list := api.ImageRepositoryList{}
+	err := r.ExtractList("/imageRepositories", &list.Items, &list.ResourceVersion)
+	if err != nil {
+		return nil, err
+	}
+	filtered := []api.ImageRepository{}
+	for _, item := range list.Items {
+		if selector.Matches(labels.Set(item.Labels)) {
+			filtered = append(filtered, item)
+		}
+	}
+	list.Items = filtered
+	return &list, nil
+}
+
+func makeImageRepositoryKey(id string) string {
+	return "/imageRepositories/" + id
+}
+
+// GetImageRepository retrieves an ImageRepository by id.
+func (r *EtcdRegistry) GetImageRepository(id string) (*api.ImageRepository, error) {
+	var repo api.ImageRepository
+	if err := r.ExtractObj(makeImageRepositoryKey(id), &repo, false); err != nil {
+		return nil, err
+	}
+	return &repo, nil
+}
+
+// WatchImageRepositories begins watching for new, changed, or deleted ImageRepositories.
+func (r *EtcdRegistry) WatchImageRepositories(resourceVersion uint64, filter func(repo *api.ImageRepository) bool) (watch.Interface, error) {
+	return r.WatchList("/imageRepositories", resourceVersion, func(obj interface{}) bool {
+		repo, ok := obj.(*api.ImageRepository)
+		if !ok {
+			glog.Errorf("Unexpected object during image repository watch: %#v", obj)
+			return false
+		}
+		return filter(repo)
+	})
+}
+
+// CreateImageRepository registers the given ImageRepository.
+func (r *EtcdRegistry) CreateImageRepository(repo api.ImageRepository) error {
+	err := r.CreateObj(makeImageRepositoryKey(repo.ID), &repo)
+	if err != nil && tools.IsEtcdNodeExist(err) {
+		return apierrors.NewAlreadyExists("imageRepository", repo.ID)
+	}
+
+	return err
+}
+
+// UpdateImageRepository replaces an existing ImageRepository in the registry with the given ImageRepository.
+func (r *EtcdRegistry) UpdateImageRepository(repo api.ImageRepository) error {
+	return r.SetObj(makeImageRepositoryKey(repo.ID), &repo)
+}
+
+// DeleteImageRepository deletes an ImageRepository by id.
+func (r *EtcdRegistry) DeleteImageRepository(id string) error {
+	imageRepositoryKey := makeImageRepositoryKey(id)
+	err := r.Delete(imageRepositoryKey, false)
+	if err != nil && tools.IsEtcdNotFound(err) {
+		return apierrors.NewNotFound("imageRepository", id)
+	}
+	return err
+}

--- a/pkg/image/etcdregistry_test.go
+++ b/pkg/image/etcdregistry_test.go
@@ -1,0 +1,594 @@
+package image
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubeerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/openshift/origin/pkg/image/api"
+	_ "github.com/openshift/origin/pkg/image/api/v1beta1"
+)
+
+func NewTestEtcdRegistry(client tools.EtcdClient) *EtcdRegistry {
+	return NewEtcdRegistry(client)
+}
+
+func TestEtcdListImagesEmpty(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/images"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	images, err := registry.ListImages(labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(images.Items) != 0 {
+		t.Errorf("Unexpected images list: %#v", images)
+	}
+}
+
+func TestEtcdListImagesError(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/images"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: fmt.Errorf("some error"),
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	images, err := registry.ListImages(labels.Everything())
+	if err == nil {
+		t.Error("unexpected nil error")
+	}
+
+	if images != nil {
+		t.Errorf("Unexpected non-nil images: %#v", images)
+	}
+}
+
+func TestEtcdListImagesEverything(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/images"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(api.Image{JSONBase: kubeapi.JSONBase{ID: "foo"}}),
+					},
+					{
+						Value: runtime.EncodeOrDie(api.Image{JSONBase: kubeapi.JSONBase{ID: "bar"}}),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	images, err := registry.ListImages(labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(images.Items) != 2 || images.Items[0].ID != "foo" || images.Items[1].ID != "bar" {
+		t.Errorf("Unexpected images list: %#v", images)
+	}
+}
+
+func TestEtcdListImagesFiltered(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/images"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(api.Image{
+							JSONBase: kubeapi.JSONBase{ID: "foo"},
+							Labels:   map[string]string{"env": "prod"},
+						}),
+					},
+					{
+						Value: runtime.EncodeOrDie(api.Image{
+							JSONBase: kubeapi.JSONBase{ID: "bar"},
+							Labels:   map[string]string{"env": "dev"},
+						}),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	images, err := registry.ListImages(labels.SelectorFromSet(labels.Set{"env": "dev"}))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(images.Items) != 1 || images.Items[0].ID != "bar" {
+		t.Errorf("Unexpected images list: %#v", images)
+	}
+}
+
+func TestEtcdGetImage(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Set("/images/foo", runtime.EncodeOrDie(api.Image{JSONBase: kubeapi.JSONBase{ID: "foo"}}), 0)
+	registry := NewTestEtcdRegistry(fakeClient)
+	image, err := registry.GetImage("foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if image.ID != "foo" {
+		t.Errorf("Unexpected image: %#v", image)
+	}
+}
+
+func TestEtcdGetImageNotFound(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Data["/images/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	image, err := registry.GetImage("foo")
+	if err == nil {
+		t.Errorf("Unexpected non-error.")
+	}
+	if image != nil {
+		t.Errorf("Unexpected image: %#v", image)
+	}
+}
+
+func TestEtcdCreateImage(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.TestIndex = true
+	fakeClient.Data["/images/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.CreateImage(api.Image{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo",
+		},
+		DockerImageReference: "openshift/ruby-19-centos",
+		Metadata: docker.Image{
+			ID: "abc123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resp, err := fakeClient.Get("/images/foo", false, false)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	var image api.Image
+	err = runtime.DecodeInto([]byte(resp.Node.Value), &image)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if image.ID != "foo" {
+		t.Errorf("Unexpected image: %#v %s", image, resp.Node.Value)
+	}
+
+	if e, a := "openshift/ruby-19-centos", image.DockerImageReference; e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+
+	if e, a := "abc123", image.Metadata.ID; e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}
+
+func TestEtcdCreateImageAlreadyExists(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Data["/images/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value: runtime.EncodeOrDie(api.Image{JSONBase: kubeapi.JSONBase{ID: "foo"}}),
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.CreateImage(api.Image{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo",
+		},
+	})
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+	if !kubeerrors.IsAlreadyExists(err) {
+		t.Errorf("Expected 'already exists' error, got %#v", err)
+	}
+}
+
+func TestEtcdUpdateImage(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.UpdateImage(api.Image{})
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+}
+
+func TestEtcdDeleteImageNotFound(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Err = tools.EtcdErrorNotFound
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.DeleteImage("foo")
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+	if !kubeerrors.IsNotFound(err) {
+		t.Errorf("Expected 'not found' error, got %#v", err)
+	}
+}
+
+func TestEtcdDeleteImageError(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Err = fmt.Errorf("Some error")
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.DeleteImage("foo")
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+}
+
+func TestEtcdDeleteImageOK(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	registry := NewTestEtcdRegistry(fakeClient)
+	key := "/images/foo"
+	err := registry.DeleteImage("foo")
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
+	if len(fakeClient.DeletedKeys) != 1 {
+		t.Errorf("Expected 1 delete, found %#v", fakeClient.DeletedKeys)
+	} else if fakeClient.DeletedKeys[0] != key {
+		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[0], key)
+	}
+}
+
+func TestEtcdListImagesRepositoriesEmpty(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/imageRepositories"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	repos, err := registry.ListImageRepositories(labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(repos.Items) != 0 {
+		t.Errorf("Unexpected image repositories list: %#v", repos)
+	}
+}
+
+func TestEtcdListImageRepositoriesError(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/imageRepositories"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: fmt.Errorf("some error"),
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	repos, err := registry.ListImageRepositories(labels.Everything())
+	if err == nil {
+		t.Error("unexpected nil error")
+	}
+
+	if repos != nil {
+		t.Errorf("Unexpected non-nil repos: %#v", repos)
+	}
+}
+
+func TestEtcdListImageRepositoriesEverything(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/imageRepositories"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(api.ImageRepository{JSONBase: kubeapi.JSONBase{ID: "foo"}}),
+					},
+					{
+						Value: runtime.EncodeOrDie(api.ImageRepository{JSONBase: kubeapi.JSONBase{ID: "bar"}}),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	repos, err := registry.ListImageRepositories(labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(repos.Items) != 2 || repos.Items[0].ID != "foo" || repos.Items[1].ID != "bar" {
+		t.Errorf("Unexpected images list: %#v", repos)
+	}
+}
+
+func TestEtcdListImageRepositoriesFiltered(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := "/imageRepositories"
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(api.ImageRepository{
+							JSONBase: kubeapi.JSONBase{ID: "foo"},
+							Labels:   map[string]string{"env": "prod"},
+						}),
+					},
+					{
+						Value: runtime.EncodeOrDie(api.ImageRepository{
+							JSONBase: kubeapi.JSONBase{ID: "bar"},
+							Labels:   map[string]string{"env": "dev"},
+						}),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	repos, err := registry.ListImageRepositories(labels.SelectorFromSet(labels.Set{"env": "dev"}))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(repos.Items) != 1 || repos.Items[0].ID != "bar" {
+		t.Errorf("Unexpected repos list: %#v", repos)
+	}
+}
+
+func TestEtcdGetImageRepository(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Set("/imageRepositories/foo", runtime.EncodeOrDie(api.ImageRepository{JSONBase: kubeapi.JSONBase{ID: "foo"}}), 0)
+	registry := NewTestEtcdRegistry(fakeClient)
+	repo, err := registry.GetImageRepository("foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if repo.ID != "foo" {
+		t.Errorf("Unexpected repo: %#v", repo)
+	}
+}
+
+func TestEtcdGetImageRepositoryNotFound(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Data["/imageRepositories/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	repo, err := registry.GetImageRepository("foo")
+	if err == nil {
+		t.Errorf("Unexpected non-error.")
+	}
+	if repo != nil {
+		t.Errorf("Unexpected non-nil repo: %#v", repo)
+	}
+}
+
+func TestEtcdCreateImageRepository(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.TestIndex = true
+	fakeClient.Data["/imageRepositories/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.CreateImageRepository(api.ImageRepository{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo",
+		},
+		Labels:                map[string]string{"a": "b"},
+		DockerImageRepository: "c/d",
+		Tags: map[string]string{"t1": "v1"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resp, err := fakeClient.Get("/imageRepositories/foo", false, false)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	var repo api.ImageRepository
+	err = runtime.DecodeInto([]byte(resp.Node.Value), &repo)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if repo.ID != "foo" {
+		t.Errorf("Unexpected repo: %#v %s", repo, resp.Node.Value)
+	}
+
+	if len(repo.Labels) != 1 || repo.Labels["a"] != "b" {
+		t.Errorf("Unexpected labels: %#v", repo.Labels)
+	}
+
+	if repo.DockerImageRepository != "c/d" {
+		t.Errorf("Unexpected docker image repo: %s", repo.DockerImageRepository)
+	}
+
+	if len(repo.Tags) != 1 || repo.Tags["t1"] != "v1" {
+		t.Errorf("Unexpected tags: %#v", repo.Tags)
+	}
+}
+
+func TestEtcdCreateImageRepositoryAlreadyExists(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Data["/imageRepositories/foo"] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value: runtime.EncodeOrDie(api.ImageRepository{JSONBase: kubeapi.JSONBase{ID: "foo"}}),
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.CreateImageRepository(api.ImageRepository{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo",
+		},
+	})
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+	if !kubeerrors.IsAlreadyExists(err) {
+		t.Errorf("Expected 'already exists' error, got %#v", err)
+	}
+}
+
+func TestEtcdUpdateImageRepository(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.TestIndex = true
+
+	resp, _ := fakeClient.Set("/imageRepositories/foo", runtime.EncodeOrDie(api.ImageRepository{JSONBase: kubeapi.JSONBase{ID: "foo"}}), 0)
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.UpdateImageRepository(api.ImageRepository{
+		JSONBase:              kubeapi.JSONBase{ID: "foo", ResourceVersion: resp.Node.ModifiedIndex},
+		DockerImageRepository: "some/repo",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	repo, err := registry.GetImageRepository("foo")
+	if repo.DockerImageRepository != "some/repo" {
+		t.Errorf("Unexpected repo: %#v", repo)
+	}
+}
+
+func TestEtcdDeleteImageRepositoryNotFound(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Err = tools.EtcdErrorNotFound
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.DeleteImageRepository("foo")
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+	if !kubeerrors.IsNotFound(err) {
+		t.Errorf("Expected 'not found' error, got %#v", err)
+	}
+}
+
+func TestEtcdDeleteImageRepositoryError(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Err = fmt.Errorf("Some error")
+	registry := NewTestEtcdRegistry(fakeClient)
+	err := registry.DeleteImageRepository("foo")
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+}
+
+func TestEtcdDeleteImageRepositoryOK(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	registry := NewTestEtcdRegistry(fakeClient)
+	key := "/imageRepositories/foo"
+	err := registry.DeleteImageRepository("foo")
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
+	if len(fakeClient.DeletedKeys) != 1 {
+		t.Errorf("Expected 1 delete, found %#v", fakeClient.DeletedKeys)
+	} else if fakeClient.DeletedKeys[0] != key {
+		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[0], key)
+	}
+}
+
+func TestEtcdWatchImageRepositories(t *testing.T) {
+	fakeClient := tools.NewFakeEtcdClient(t)
+	registry := NewTestEtcdRegistry(fakeClient)
+	filterFields := labels.SelectorFromSet(labels.Set{"ID": "foo"})
+
+	watching, err := registry.WatchImageRepositories(1, func(repo *api.ImageRepository) bool {
+		fields := labels.Set{
+			"ID": repo.ID,
+		}
+		return filterFields.Matches(fields)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeClient.WaitForWatchCompletion()
+
+	repo := &api.ImageRepository{JSONBase: kubeapi.JSONBase{ID: "foo"}}
+	repoBytes, _ := runtime.Codec.Encode(repo)
+	fakeClient.WatchResponse <- &etcd.Response{
+		Action: "set",
+		Node: &etcd.Node{
+			Value: string(repoBytes),
+		},
+	}
+
+	event := <-watching.ResultChan()
+	if e, a := watch.Added, event.Type; e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+	if e, a := repo, event.Object; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+
+	select {
+	case _, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+	default:
+	}
+
+	fakeClient.WatchInjectError <- nil
+	if _, ok := <-watching.ResultChan(); ok {
+		t.Errorf("watching channel should be closed")
+	}
+	watching.Stop()
+}

--- a/pkg/image/imagerepositorymappingstorage.go
+++ b/pkg/image/imagerepositorymappingstorage.go
@@ -1,0 +1,114 @@
+package image
+
+import (
+	"errors"
+	"fmt"
+
+	baseapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubeerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+// ImageRepositoryMappingStorage implements the RESTStorage interface in terms of an ImageRegistry and ImageRepositoryRegistry.
+// It Only supports the Create method and is used to simply adding a new Image and tag to an ImageRepository.
+type ImageRepositoryMappingStorage struct {
+	imageRegistry           ImageRegistry
+	imageRepositoryRegistry ImageRepositoryRegistry
+}
+
+// NewImageRepositoryMappingStorage returns a new ImageRepositoryMappingStorage.
+func NewImageRepositoryMappingStorage(imageRegistry ImageRegistry, imageRepositoryRegistry ImageRepositoryRegistry) apiserver.RESTStorage {
+	return &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+}
+
+// New returns a new ImageRepositoryMapping for use with Create.
+func (s *ImageRepositoryMappingStorage) New() interface{} {
+	return &api.ImageRepositoryMapping{}
+}
+
+// Get is not supported.
+func (s *ImageRepositoryMappingStorage) Get(id string) (interface{}, error) {
+	return nil, errors.New("not supported")
+}
+
+// List is not supported.
+func (s *ImageRepositoryMappingStorage) List(selector labels.Selector) (interface{}, error) {
+	return nil, errors.New("not supported")
+}
+
+// Create registers a new image (if it doesn't exist) and updates the specified ImageRepository's tags.
+func (s *ImageRepositoryMappingStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	mapping, ok := obj.(*api.ImageRepositoryMapping)
+	if !ok {
+		return nil, fmt.Errorf("not an image repository mapping: %#v", obj)
+	}
+
+	repo, err := s.findImageRepository(mapping.DockerImageRepository)
+	if err != nil {
+		return nil, err
+	}
+	if repo == nil {
+		return nil, fmt.Errorf("Unable to locate an image repository for '%s'", mapping.DockerImageRepository)
+	}
+
+	if errs := ValidateImageRepositoryMapping(mapping); len(errs) > 0 {
+		return nil, kubeerrors.NewInvalid("imageRepositoryMapping", mapping.ID, errs)
+	}
+
+	image := mapping.Image
+
+	image.CreationTimestamp = util.Now()
+
+	//TODO apply metadata overrides
+
+	if repo.Tags == nil {
+		repo.Tags = make(map[string]string)
+	}
+	repo.Tags[mapping.Tag] = image.DockerImageReference
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		err = s.imageRegistry.CreateImage(image)
+		if err != nil && !kubeerrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+
+		err = s.imageRepositoryRegistry.UpdateImageRepository(*repo)
+		if err != nil {
+			return nil, err
+		}
+
+		return &baseapi.Status{Status: baseapi.StatusSuccess}, nil
+	}), nil
+}
+
+// findImageRepository retrieves an ImageRepository whose DockerImageRepository matches dockerRepo.
+func (s *ImageRepositoryMappingStorage) findImageRepository(dockerRepo string) (*api.ImageRepository, error) {
+	//TODO make this more efficient
+	list, err := s.imageRepositoryRegistry.ListImageRepositories(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	var repo *api.ImageRepository
+	for _, r := range list.Items {
+		if dockerRepo == r.DockerImageRepository {
+			repo = &r
+			break
+		}
+	}
+
+	return repo, nil
+}
+
+// Update is not supported.
+func (s *ImageRepositoryMappingStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	return nil, errors.New("not supported")
+}
+
+// Delete is not supported.
+func (s *ImageRepositoryMappingStorage) Delete(id string) (<-chan interface{}, error) {
+	return nil, errors.New("not supported")
+}

--- a/pkg/image/imagerepositorymappingstorage_test.go
+++ b/pkg/image/imagerepositorymappingstorage_test.go
@@ -1,0 +1,200 @@
+package image
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/imagetest"
+)
+
+func TestGetImageRepositoryMapping(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	obj, err := storage.Get("foo")
+	if obj != nil {
+		t.Errorf("Unexpected non-nil object %#v", obj)
+	}
+	if err == nil || strings.Index(err.Error(), "not supported") == -1 {
+		t.Errorf("Expected 'not supported' error, got %#v", err)
+	}
+}
+
+func TestListImageRepositoryMappings(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	list, err := storage.List(labels.Everything())
+	if list != nil {
+		t.Errorf("Unexpected non-nil list %#v", list)
+	}
+	if err == nil || strings.Index(err.Error(), "not supported") == -1 {
+		t.Errorf("Expected 'not supported' error, got %#v", err)
+	}
+}
+
+func TestDeleteImageRepositoryMapping(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	channel, err := storage.Delete("repo1")
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel %#v", channel)
+	}
+	if err == nil || strings.Index(err.Error(), "not supported") == -1 {
+		t.Errorf("Expected 'not supported' error, got %#v", err)
+	}
+}
+
+func TestUpdateImageRepositoryMapping(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	channel, err := storage.Update("repo1")
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel %#v", channel)
+	}
+	if err == nil || strings.Index(err.Error(), "not supported") == -1 {
+		t.Errorf("Expected 'not supported' error, got %#v", err)
+	}
+}
+
+func TestCreateImageRepositoryMappingBadObject(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	channel, err := storage.Create("bad object")
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel %#v", channel)
+	}
+	if err == nil || strings.Index(err.Error(), "not an image repository mapping") == -1 {
+		t.Errorf("Expected 'not an image repository mapping' error, got %#v", err)
+	}
+}
+
+func TestCreateImageRepositoryMappingFindError(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	imageRepositoryRegistry.Err = fmt.Errorf("123")
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	mapping := api.ImageRepositoryMapping{
+		DockerImageRepository: "localhost:5000/someproject/somerepo",
+		Image: api.Image{
+			JSONBase: kubeapi.JSONBase{
+				ID: "imageID1",
+			},
+			DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
+		},
+		Tag: "latest",
+	}
+
+	channel, err := storage.Create(&mapping)
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel %#v", channel)
+	}
+	if err == nil || err.Error() != "123" {
+		t.Errorf("Expected 'unable to locate' error, got %#v", err)
+	}
+}
+
+func TestCreateImageRepositoryMappingNotFound(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	imageRepositoryRegistry.ImageRepositories = &api.ImageRepositoryList{
+		Items: []api.ImageRepository{
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "repo1",
+				},
+				DockerImageRepository: "localhost:5000/test/repo",
+			},
+		},
+	}
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	mapping := api.ImageRepositoryMapping{
+		DockerImageRepository: "localhost:5000/someproject/somerepo",
+		Image: api.Image{
+			JSONBase: kubeapi.JSONBase{
+				ID: "imageID1",
+			},
+			DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
+		},
+		Tag: "latest",
+	}
+
+	channel, err := storage.Create(&mapping)
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel %#v", channel)
+	}
+	if err == nil || strings.Index(err.Error(), "Unable to locate an image repository") == -1 {
+		t.Errorf("Expected 'unable to locate' error, got %#v", err)
+	}
+}
+
+func TestCreateImageRepositoryMapping(t *testing.T) {
+	imageRegistry := imagetest.NewImageRegistry()
+	imageRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	imageRepositoryRegistry.ImageRepositories = &api.ImageRepositoryList{
+		Items: []api.ImageRepository{
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "repo1",
+				},
+				DockerImageRepository: "localhost:5000/someproject/somerepo",
+			},
+		},
+	}
+	storage := &ImageRepositoryMappingStorage{imageRegistry, imageRepositoryRegistry}
+
+	mapping := api.ImageRepositoryMapping{
+		DockerImageRepository: "localhost:5000/someproject/somerepo",
+		Image: api.Image{
+			JSONBase: kubeapi.JSONBase{
+				ID: "imageID1",
+			},
+			DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
+			Metadata: docker.Image{
+				Config: &docker.Config{
+					Cmd:          []string{"ls", "/"},
+					Env:          []string{"a=1"},
+					ExposedPorts: map[docker.Port]struct{}{"1234/tcp": {}},
+					Memory:       1234,
+					CpuShares:    99,
+					WorkingDir:   "/workingDir",
+				},
+			},
+		},
+		Tag: "latest",
+	}
+	ch, err := storage.Create(&mapping)
+	if err != nil {
+		t.Errorf("Unexpected error creating mapping: %#v", err)
+	}
+
+	out := <-ch
+	t.Logf("out = '%#v'", out)
+
+	image, err := imageRegistry.GetImage("imageID1")
+	if err != nil {
+		t.Errorf("Unexpected error retrieving image: %#v", err)
+	}
+	if e, a := mapping.Image.DockerImageReference, image.DockerImageReference; e != a {
+		t.Errorf("Expected %s, got %s", e, a)
+	}
+	if !reflect.DeepEqual(mapping.Image.Metadata, image.Metadata) {
+		t.Errorf("Expected %#v, got %#v", mapping.Image, image)
+	}
+}

--- a/pkg/image/imagerepositorystorage.go
+++ b/pkg/image/imagerepositorystorage.go
@@ -1,0 +1,109 @@
+package image
+
+import (
+	"fmt"
+
+	"code.google.com/p/go-uuid/uuid"
+
+	baseapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+// ImageRepositoryStorage implements the RESTStorage interface in terms of an ImageRepositoryRegistry.
+type ImageRepositoryStorage struct {
+	registry ImageRepositoryRegistry
+}
+
+// NewImageRepositoryStorage returns a new ImageRepositoryStorage.
+func NewImageRepositoryStorage(registry ImageRepositoryRegistry) apiserver.RESTStorage {
+	return &ImageRepositoryStorage{registry}
+}
+
+// New returns a new ImageRepository for use with Create and Update.
+func (s *ImageRepositoryStorage) New() interface{} {
+	return &api.ImageRepository{}
+}
+
+// Get retrieves an ImageRepository by id.
+func (s *ImageRepositoryStorage) Get(id string) (interface{}, error) {
+	repo, err := s.registry.GetImageRepository(id)
+	if err != nil {
+		return nil, err
+	}
+	return repo, nil
+}
+
+// List retrieves a list of ImageRepositories that match selector.
+func (s *ImageRepositoryStorage) List(selector labels.Selector) (interface{}, error) {
+	imageRepositories, err := s.registry.ListImageRepositories(selector)
+	if err != nil {
+		return nil, err
+	}
+	return imageRepositories, err
+}
+
+// Watch begins watching for new, changed, or deleted ImageRepositories.
+func (s *ImageRepositoryStorage) Watch(label, field labels.Selector, resourceVersion uint64) (watch.Interface, error) {
+	return s.registry.WatchImageRepositories(resourceVersion, func(repo *api.ImageRepository) bool {
+		fields := labels.Set{
+			"ID": repo.ID,
+			"DockerImageRepository": repo.DockerImageRepository,
+		}
+		return label.Matches(labels.Set(repo.Labels)) && field.Matches(fields)
+	})
+}
+
+// Create registers the given ImageRepository.
+func (s *ImageRepositoryStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	repo, ok := obj.(*api.ImageRepository)
+	if !ok {
+		return nil, fmt.Errorf("not an image repository: %#v", obj)
+	}
+
+	if len(repo.ID) == 0 {
+		repo.ID = uuid.NewUUID().String()
+	}
+
+	if repo.Tags == nil {
+		repo.Tags = make(map[string]string)
+	}
+
+	repo.CreationTimestamp = util.Now()
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		if err := s.registry.CreateImageRepository(*repo); err != nil {
+			return nil, err
+		}
+		return s.Get(repo.ID)
+	}), nil
+}
+
+// Update replaces an existing ImageRepository in the registry with the given ImageRepository.
+func (s *ImageRepositoryStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	repo, ok := obj.(*api.ImageRepository)
+	if !ok {
+		return nil, fmt.Errorf("not an image repository: %#v", obj)
+	}
+	if len(repo.ID) == 0 {
+		return nil, fmt.Errorf("id is unspecified: %#v", repo)
+	}
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		err := s.registry.UpdateImageRepository(*repo)
+		if err != nil {
+			return nil, err
+		}
+		return s.Get(repo.ID)
+	}), nil
+}
+
+// Delete asynchronously deletes an ImageRepository specified by its id.
+func (s *ImageRepositoryStorage) Delete(id string) (<-chan interface{}, error) {
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		return &baseapi.Status{Status: baseapi.StatusSuccess}, s.registry.DeleteImageRepository(id)
+	}), nil
+}

--- a/pkg/image/imagerepositorystorage_test.go
+++ b/pkg/image/imagerepositorystorage_test.go
@@ -1,0 +1,254 @@
+package image
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/imagetest"
+)
+
+func TestGetImageRepositoryError(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.Err = fmt.Errorf("test error")
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	image, err := storage.Get("image1")
+	if image != nil {
+		t.Errorf("Unexpected non-nil image: %#v", image)
+	}
+	if err != mockRepositoryRegistry.Err {
+		t.Errorf("Expected %#v, got %#v", mockRepositoryRegistry.Err, err)
+	}
+}
+
+func TestGetImageRepositoryOK(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.ImageRepository = &api.ImageRepository{
+		JSONBase:              kubeapi.JSONBase{ID: "foo"},
+		DockerImageRepository: "openshift/ruby-19-centos",
+	}
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	repo, err := storage.Get("foo")
+	if repo == nil {
+		t.Errorf("Unexpected nil repo: %#v", repo)
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+	if e, a := mockRepositoryRegistry.ImageRepository, repo; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestListImageRepositoriesError(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.Err = fmt.Errorf("test error")
+
+	storage := ImageRepositoryStorage{
+		registry: mockRepositoryRegistry,
+	}
+
+	imageRepositories, err := storage.List(nil)
+	if err != mockRepositoryRegistry.Err {
+		t.Errorf("Expected %#v, Got %#v", mockRepositoryRegistry.Err, err)
+	}
+
+	if imageRepositories != nil {
+		t.Errorf("Unexpected non-nil imageRepositories list: %#v", imageRepositories)
+	}
+}
+
+func TestListImageRepositoriesEmptyList(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.ImageRepositories = &api.ImageRepositoryList{
+		Items: []api.ImageRepository{},
+	}
+
+	storage := ImageRepositoryStorage{
+		registry: mockRepositoryRegistry,
+	}
+
+	imageRepositories, err := storage.List(labels.Everything())
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	if len(imageRepositories.(*api.ImageRepositoryList).Items) != 0 {
+		t.Errorf("Unexpected non-zero imageRepositories list: %#v", imageRepositories)
+	}
+}
+
+func TestListImageRepositoriesPopulatedList(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.ImageRepositories = &api.ImageRepositoryList{
+		Items: []api.ImageRepository{
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "foo",
+				},
+			},
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "bar",
+				},
+			},
+		},
+	}
+
+	storage := ImageRepositoryStorage{
+		registry: mockRepositoryRegistry,
+	}
+
+	list, err := storage.List(labels.Everything())
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	imageRepositories := list.(*api.ImageRepositoryList)
+
+	if e, a := 2, len(imageRepositories.Items); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}
+
+func TestCreateImageRepositoryBadObject(t *testing.T) {
+	storage := ImageRepositoryStorage{}
+
+	channel, err := storage.Create("hello")
+	if channel != nil {
+		t.Errorf("Expected nil, got %v", channel)
+	}
+	if strings.Index(err.Error(), "not an image repository:") == -1 {
+		t.Errorf("Expected 'not an image repository' error, got %v", err)
+	}
+}
+
+func TestCreateImageRepositoryOK(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	channel, err := storage.Create(&api.ImageRepository{})
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	result := <-channel
+	repo, ok := result.(*api.ImageRepository)
+	if !ok {
+		t.Errorf("Unexpected result: %#v", result)
+	}
+	if len(repo.ID) == 0 {
+		t.Errorf("Expected repo's ID to be set: %#v", repo)
+	}
+	if repo.CreationTimestamp.IsZero() {
+		t.Error("Unexpected zero CreationTimestamp")
+	}
+}
+
+func TestCreateImageRepositoryRegistryErrorSaving(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.Err = fmt.Errorf("foo")
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	channel, err := storage.Create(&api.ImageRepository{})
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+	result := <-channel
+	status, ok := result.(*kubeapi.Status)
+	if !ok {
+		t.Errorf("Expected status, got %#v", result)
+	}
+	if status.Status != "failure" || status.Message != "foo" {
+		t.Errorf("Expected status=failure, message=foo, got %#v", status)
+	}
+}
+
+func TestUpdateImageRepositoryBadObject(t *testing.T) {
+	storage := ImageRepositoryStorage{}
+
+	channel, err := storage.Update("hello")
+	if channel != nil {
+		t.Errorf("Expected nil, got %v", channel)
+	}
+	if strings.Index(err.Error(), "not an image repository:") == -1 {
+		t.Errorf("Expected 'not an image repository' error, got %v", err)
+	}
+}
+
+func TestUpdateImageRepositoryMissingID(t *testing.T) {
+	storage := ImageRepositoryStorage{}
+
+	channel, err := storage.Update(&api.ImageRepository{})
+	if channel != nil {
+		t.Errorf("Expected nil, got %v", channel)
+	}
+	if strings.Index(err.Error(), "id is unspecified:") == -1 {
+		t.Errorf("Expected 'id is unspecified' error, got %v", err)
+	}
+}
+
+func TestUpdateImageRepositoryRegistryErrorSaving(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	mockRepositoryRegistry.Err = fmt.Errorf("foo")
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	channel, err := storage.Update(&api.ImageRepository{
+		JSONBase: kubeapi.JSONBase{ID: "bar"},
+	})
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+	result := <-channel
+	status, ok := result.(*kubeapi.Status)
+	if !ok {
+		t.Errorf("Expected status, got %#v", result)
+	}
+	if status.Status != "failure" || status.Message != "foo" {
+		t.Errorf("Expected status=failure, message=foo, got %#v", status)
+	}
+}
+
+func TestUpdateImageRepositoryOK(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	channel, err := storage.Update(&api.ImageRepository{
+		JSONBase: kubeapi.JSONBase{ID: "bar"},
+	})
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+	result := <-channel
+	repo, ok := result.(*api.ImageRepository)
+	if !ok {
+		t.Errorf("Expected image repository, got %#v", result)
+	}
+	if repo.ID != "bar" {
+		t.Errorf("Unexpected repo returned: %#v", repo)
+	}
+}
+
+func TestDeleteImageRepository(t *testing.T) {
+	mockRepositoryRegistry := imagetest.NewImageRepositoryRegistry()
+	storage := ImageRepositoryStorage{registry: mockRepositoryRegistry}
+
+	channel, err := storage.Delete("foo")
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+	result := <-channel
+	status, ok := result.(*kubeapi.Status)
+	if !ok {
+		t.Errorf("Expected status, got %#v", result)
+	}
+	if status.Status != "success" {
+		t.Errorf("Expected status=success, got %#v", status)
+	}
+}

--- a/pkg/image/imagestorage.go
+++ b/pkg/image/imagestorage.go
@@ -1,0 +1,80 @@
+package image
+
+import (
+	"errors"
+	"fmt"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubeerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+// ImageStorage implements the RESTStorage interface in terms of an ImageRegistry.
+type ImageStorage struct {
+	registry ImageRegistry
+}
+
+// NewStorage returns a new ImageStorage.
+func NewImageStorage(registry ImageRegistry) apiserver.RESTStorage {
+	return &ImageStorage{registry}
+}
+
+// New returns a new Image for use with Create and Update.
+func (s *ImageStorage) New() interface{} {
+	return &api.Image{}
+}
+
+// Get retrieves an Image by id.
+func (s *ImageStorage) Get(id string) (interface{}, error) {
+	image, err := s.registry.GetImage(id)
+	if err != nil {
+		return nil, err
+	}
+	return image, nil
+}
+
+// List retrieves a list of Images that match selector.
+func (s *ImageStorage) List(selector labels.Selector) (interface{}, error) {
+	images, err := s.registry.ListImages(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
+// Create registers the given Image.
+func (s *ImageStorage) Create(obj interface{}) (<-chan interface{}, error) {
+	image, ok := obj.(*api.Image)
+	if !ok {
+		return nil, fmt.Errorf("not an image: %#v", obj)
+	}
+
+	image.CreationTimestamp = util.Now()
+
+	if errs := ValidateImage(image); len(errs) > 0 {
+		return nil, kubeerrors.NewInvalid("image", image.ID, errs)
+	}
+
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		if err := s.registry.CreateImage(*image); err != nil {
+			return nil, err
+		}
+		return s.Get(image.ID)
+	}), nil
+}
+
+// Update is not supported for Images, as they are immutable.
+func (s *ImageStorage) Update(obj interface{}) (<-chan interface{}, error) {
+	return nil, errors.New("not supported")
+}
+
+// Delete asynchronously deletes an Image specified by its id.
+func (s *ImageStorage) Delete(id string) (<-chan interface{}, error) {
+	return apiserver.MakeAsync(func() (interface{}, error) {
+		return &kubeapi.Status{Status: kubeapi.StatusSuccess}, s.registry.DeleteImage(id)
+	}), nil
+}

--- a/pkg/image/imagestorage_test.go
+++ b/pkg/image/imagestorage_test.go
@@ -1,0 +1,241 @@
+package image
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubeerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/imagetest"
+)
+
+func TestListImagesError(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	mockRegistry.Err = fmt.Errorf("test error")
+
+	storage := ImageStorage{
+		registry: mockRegistry,
+	}
+
+	images, err := storage.List(nil)
+	if err != mockRegistry.Err {
+		t.Errorf("Expected %#v, Got %#v", mockRegistry.Err, err)
+	}
+
+	if images != nil {
+		t.Errorf("Unexpected non-nil images list: %#v", images)
+	}
+}
+
+func TestListImagesEmptyList(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	mockRegistry.Images = &api.ImageList{
+		Items: []api.Image{},
+	}
+
+	storage := ImageStorage{
+		registry: mockRegistry,
+	}
+
+	images, err := storage.List(labels.Everything())
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	if len(images.(*api.ImageList).Items) != 0 {
+		t.Errorf("Unexpected non-zero images list: %#v", images)
+	}
+}
+
+func TestListImagesPopulatedList(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	mockRegistry.Images = &api.ImageList{
+		Items: []api.Image{
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "foo",
+				},
+			},
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "bar",
+				},
+			},
+		},
+	}
+
+	storage := ImageStorage{
+		registry: mockRegistry,
+	}
+
+	list, err := storage.List(labels.Everything())
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	images := list.(*api.ImageList)
+
+	if e, a := 2, len(images.Items); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}
+
+func TestCreateImageBadObject(t *testing.T) {
+	storage := ImageStorage{}
+
+	channel, err := storage.Create("hello")
+	if channel != nil {
+		t.Errorf("Expected nil, got %v", channel)
+	}
+	if strings.Index(err.Error(), "not an image:") == -1 {
+		t.Errorf("Expected 'not an image' error, got %v", err)
+	}
+}
+
+func TestCreateImageMissingID(t *testing.T) {
+	storage := ImageStorage{}
+
+	channel, err := storage.Create(&api.Image{})
+	if channel != nil {
+		t.Errorf("Expected nil channel, got %v", channel)
+	}
+	if !kubeerrors.IsInvalid(err) {
+		t.Errorf("Expected 'invalid' error, got %v", err)
+	}
+}
+
+func TestCreateImageRegistrySaveError(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	mockRegistry.Err = fmt.Errorf("test error")
+	storage := ImageStorage{registry: mockRegistry}
+
+	channel, err := storage.Create(&api.Image{
+		JSONBase:             kubeapi.JSONBase{ID: "foo"},
+		DockerImageReference: "openshift/ruby-19-centos",
+	})
+	if channel == nil {
+		t.Errorf("Expected nil channel, got %v", channel)
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	select {
+	case result := <-channel:
+		status, ok := result.(*kubeapi.Status)
+		if !ok {
+			t.Errorf("Expected status type, got: %#v", result)
+		}
+		if status.Status != "failure" || status.Message != "foo" {
+			t.Errorf("Expected failure status, got %#V", status)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	default:
+	}
+}
+
+func TestCreateImageOK(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	storage := ImageStorage{registry: mockRegistry}
+
+	channel, err := storage.Create(&api.Image{
+		JSONBase:             kubeapi.JSONBase{ID: "foo"},
+		DockerImageReference: "openshift/ruby-19-centos",
+	})
+	if channel == nil {
+		t.Errorf("Expected nil channel, got %v", channel)
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	select {
+	case result := <-channel:
+		image, ok := result.(*api.Image)
+		if !ok {
+			t.Errorf("Expected image type, got: %#v", result)
+		}
+		if image.ID != "foo" {
+			t.Errorf("Unexpected image: %#v", image)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	default:
+	}
+}
+
+func TestGetImageError(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	mockRegistry.Err = fmt.Errorf("bad")
+	storage := ImageStorage{registry: mockRegistry}
+
+	image, err := storage.Get("foo")
+	if image != nil {
+		t.Errorf("Unexpected non-nil image: %#v", image)
+	}
+	if err != mockRegistry.Err {
+		t.Errorf("Expected %#v, got %#v", mockRegistry.Err, err)
+	}
+}
+
+func TestGetImageOK(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	mockRegistry.Image = &api.Image{
+		JSONBase:             kubeapi.JSONBase{ID: "foo"},
+		DockerImageReference: "openshift/ruby-19-centos",
+	}
+	storage := ImageStorage{registry: mockRegistry}
+
+	image, err := storage.Get("foo")
+	if image == nil {
+		t.Error("Unexpected nil image")
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error", err)
+	}
+	if image.(*api.Image).ID != "foo" {
+		t.Errorf("Unexpected image: %#v", image)
+	}
+}
+
+func TestUpdateImage(t *testing.T) {
+	storage := ImageStorage{}
+	channel, err := storage.Update(&api.Image{})
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel: %#v", channel)
+	}
+	if err == nil || strings.Index(err.Error(), "not supported") == -1 {
+		t.Errorf("Expected 'not supported' error, got: %#v", err)
+	}
+}
+
+func TestDeleteImage(t *testing.T) {
+	mockRegistry := imagetest.NewImageRegistry()
+	storage := ImageStorage{registry: mockRegistry}
+	channel, err := storage.Delete("foo")
+	if channel == nil {
+		t.Error("Unexpected nil channel")
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	select {
+	case result := <-channel:
+		status, ok := result.(*kubeapi.Status)
+		if !ok {
+			t.Errorf("Expected status type, got: %#v", result)
+		}
+		if status.Status != "success" {
+			t.Errorf("Expected status=success, got: %#v", status)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	default:
+	}
+}

--- a/pkg/image/imagetest/image.go
+++ b/pkg/image/imagetest/image.go
@@ -1,0 +1,56 @@
+package imagetest
+
+import (
+	"sync"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+type ImageRegistry struct {
+	Err    error
+	Image  *api.Image
+	Images *api.ImageList
+	sync.Mutex
+}
+
+func NewImageRegistry() *ImageRegistry {
+	return &ImageRegistry{}
+}
+
+func (r *ImageRegistry) ListImages(selector labels.Selector) (*api.ImageList, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Images, r.Err
+}
+
+func (r *ImageRegistry) GetImage(id string) (*api.Image, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Image, r.Err
+}
+
+func (r *ImageRegistry) CreateImage(image api.Image) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Image = &image
+	return r.Err
+}
+
+func (r *ImageRegistry) UpdateImage(image api.Image) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Image = &image
+	return r.Err
+}
+
+func (r *ImageRegistry) DeleteImage(id string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Err
+}

--- a/pkg/image/imagetest/imagerepository.go
+++ b/pkg/image/imagetest/imagerepository.go
@@ -1,0 +1,61 @@
+package imagetest
+
+import (
+	"sync"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+type ImageRepositoryRegistry struct {
+	Err               error
+	ImageRepository   *api.ImageRepository
+	ImageRepositories *api.ImageRepositoryList
+	sync.Mutex
+}
+
+func NewImageRepositoryRegistry() *ImageRepositoryRegistry {
+	return &ImageRepositoryRegistry{}
+}
+
+func (r *ImageRepositoryRegistry) ListImageRepositories(selector labels.Selector) (*api.ImageRepositoryList, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.ImageRepositories, r.Err
+}
+
+func (r *ImageRepositoryRegistry) GetImageRepository(id string) (*api.ImageRepository, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.ImageRepository, r.Err
+}
+
+func (r *ImageRepositoryRegistry) WatchImageRepositories(resourceVersion uint64, filter func(repo *api.ImageRepository) bool) (watch.Interface, error) {
+	return nil, r.Err
+}
+
+func (r *ImageRepositoryRegistry) CreateImageRepository(repo api.ImageRepository) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.ImageRepository = &repo
+	return r.Err
+}
+
+func (r *ImageRepositoryRegistry) UpdateImageRepository(repo api.ImageRepository) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.ImageRepository = &repo
+	return r.Err
+}
+
+func (r *ImageRepositoryRegistry) DeleteImageRepository(id string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Err
+}

--- a/pkg/image/interfaces.go
+++ b/pkg/image/interfaces.go
@@ -1,0 +1,37 @@
+package image
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+import "github.com/openshift/origin/pkg/image/api"
+
+// ImageRegistry is an interface for things that know how to store Image objects.
+type ImageRegistry interface {
+	// ListImages obtains a list of images that match a selector.
+	ListImages(selector labels.Selector) (*api.ImageList, error)
+	// GetImage retrieves a specific image.
+	GetImage(id string) (*api.Image, error)
+	// CreateImage creates a new image.
+	CreateImage(image api.Image) error
+	// UpdateImage updates an image.
+	UpdateImage(image api.Image) error
+	// DeleteImage deletes an image.
+	DeleteImage(id string) error
+}
+
+// ImageRepositoryRegistry is an interface for things that know how to store ImageRepository objects.
+type ImageRepositoryRegistry interface {
+	// ListImageRepositories obtains a list of image repositories that match a selector.
+	ListImageRepositories(selector labels.Selector) (*api.ImageRepositoryList, error)
+	// GetImageRepository retrieves a specific image repository.
+	GetImageRepository(id string) (*api.ImageRepository, error)
+	// WatchImageRepositories watches for new/changed/deleted image repositories.
+	WatchImageRepositories(resourceVersion uint64, filter func(repo *api.ImageRepository) bool) (watch.Interface, error)
+	// CreateImageRepository creates a new image repository.
+	CreateImageRepository(repo api.ImageRepository) error
+	// UpdateImageRepository updates an image repository.
+	UpdateImageRepository(repo api.ImageRepository) error
+	// DeleteImageRepository deletes an image repository.
+	DeleteImageRepository(id string) error
+}

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -1,0 +1,40 @@
+package image
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+// ValidateImage tests required fields for an Image.
+func ValidateImage(image *api.Image) errors.ErrorList {
+	result := errors.ErrorList{}
+
+	if len(image.ID) == 0 {
+		result = append(result, errors.NewFieldRequired("ID", image.ID))
+	}
+
+	if len(image.DockerImageReference) == 0 {
+		result = append(result, errors.NewFieldRequired("DockerImageReference", image.DockerImageReference))
+	}
+
+	return result
+}
+
+// ValidateImageRepositoryMapping tests required fields for an ImageRepositoryMapping.
+func ValidateImageRepositoryMapping(mapping *api.ImageRepositoryMapping) errors.ErrorList {
+	result := errors.ErrorList{}
+
+	if len(mapping.DockerImageRepository) == 0 {
+		result = append(result, errors.NewFieldRequired("DockerImageRepository", mapping.DockerImageRepository))
+	}
+
+	if len(mapping.Tag) == 0 {
+		result = append(result, errors.NewFieldRequired("Tag", mapping.Tag))
+	}
+
+	for _, err := range ValidateImage(&mapping.Image).Prefix("image") {
+		result = append(result, err)
+	}
+
+	return result
+}

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -1,0 +1,108 @@
+package image
+
+import (
+	"testing"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubeerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+func TestValidateImageOK(t *testing.T) {
+	errs := ValidateImage(&api.Image{
+		JSONBase:             kubeapi.JSONBase{ID: "foo"},
+		DockerImageReference: "openshift/ruby-19-centos",
+	})
+	if len(errs) > 0 {
+		t.Errorf("Unexpected non-empty error list: %#v", errs)
+	}
+}
+
+func TestValidateImageMissingFields(t *testing.T) {
+	errorCases := map[string]struct {
+		I api.Image
+		T kubeerrors.ValidationErrorType
+		F string
+	}{
+		"missing ID":                   {api.Image{DockerImageReference: "ref"}, kubeerrors.ValidationErrorTypeRequired, "ID"},
+		"missing DockerImageReference": {api.Image{JSONBase: kubeapi.JSONBase{ID: "foo"}}, kubeerrors.ValidationErrorTypeRequired, "DockerImageReference"},
+	}
+
+	for k, v := range errorCases {
+		errs := ValidateImage(&v.I)
+		if len(errs) == 0 {
+			t.Errorf("Expected failure for %s", k)
+			continue
+		}
+		for i := range errs {
+			if errs[i].(kubeerrors.ValidationError).Type != v.T {
+				t.Errorf("%s: expected errors to have type %s: %v", k, v.T, errs[i])
+			}
+			if errs[i].(kubeerrors.ValidationError).Field != v.F {
+				t.Errorf("%s: expected errors to have field %s: %v", k, v.F, errs[i])
+			}
+		}
+	}
+}
+
+func TestValidateImageRepositoryMappingNotOK(t *testing.T) {
+	errorCases := map[string]struct {
+		I api.ImageRepositoryMapping
+		T kubeerrors.ValidationErrorType
+		F string
+	}{
+		"missing DockerImageRepository": {
+			api.ImageRepositoryMapping{
+				Tag: "latest",
+				Image: api.Image{
+					JSONBase: kubeapi.JSONBase{
+						ID: "foo",
+					},
+					DockerImageReference: "openshift/ruby-19-centos",
+				},
+			},
+			kubeerrors.ValidationErrorTypeRequired,
+			"DockerImageRepository",
+		},
+		"missing Tag": {
+			api.ImageRepositoryMapping{
+				DockerImageRepository: "openshift/ruby-19-centos",
+				Image: api.Image{
+					JSONBase: kubeapi.JSONBase{
+						ID: "foo",
+					},
+					DockerImageReference: "openshift/ruby-19-centos",
+				},
+			},
+			kubeerrors.ValidationErrorTypeRequired,
+			"Tag",
+		},
+		"missing image attributes": {
+			api.ImageRepositoryMapping{
+				Tag: "latest",
+				DockerImageRepository: "openshift/ruby-19-centos",
+				Image: api.Image{
+					DockerImageReference: "openshift/ruby-19-centos",
+				},
+			},
+			kubeerrors.ValidationErrorTypeRequired,
+			"image.ID",
+		},
+	}
+
+	for k, v := range errorCases {
+		errs := ValidateImageRepositoryMapping(&v.I)
+		if len(errs) == 0 {
+			t.Errorf("Expected failure for %s", k)
+			continue
+		}
+		for i := range errs {
+			if errs[i].(kubeerrors.ValidationError).Type != v.T {
+				t.Errorf("%s: expected errors to have type %s: %v", k, v.T, errs[i])
+			}
+			if errs[i].(kubeerrors.ValidationError).Field != v.F {
+				t.Errorf("%s: expected errors to have field %s: %v", k, v.F, errs[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds support for images and image repositories to origin. It also adds a webhook for the Docker registry that can be invoked whenever a new tag is pushed to a Docker image repository. The webhook receives data from the registry (repository, image id, image metadata, tag) and stores the data in origin. The corresponding Docker registry changes are here: https://github.com/ncdc/docker-registry/compare/openshift_hook

**TODO**
- [x] godoc comments
- [x] tests
- [x] etcd registry implementation
- [x] validation methods
- [x] kubecfg support
