### PR TITLE
Initial implementation of Config creation

### DIFF
--- a/examples/guestbook/config.json
+++ b/examples/guestbook/config.json
@@ -1,0 +1,131 @@
+{
+  "id": "guestbook",
+  "kind": "Config",
+  "name": "guestbook",
+  "description": "A simple guestbook application configuration",
+  "items": [
+    {
+      "id": "frontend",
+      "kind": "Service",
+      "apiVersion": "v1beta1",
+      "port": 5432,
+      "selector": {
+        "name": "frontend"
+      }
+    },
+    {
+      "id": "redismaster",
+      "kind": "Service",
+      "apiVersion": "v1beta1",
+      "port": 10000,
+      "selector": {
+        "name": "redis-master"
+      }
+    },
+    {
+      "id": "redisslave",
+      "kind": "Service",
+      "apiVersion": "v1beta1",
+      "port": 10001,
+      "labels": {
+        "name": "redisslave"
+      },
+      "selector": {
+        "name": "redisslave"
+      }
+    },
+    {
+      "id": "redis-master-2",
+      "kind": "Pod",
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "manifest": {
+          "version": "v1beta1",
+          "id": "redis-master-2",
+          "containers": [{
+            "name": "master",
+            "image": "dockerfile/redis",
+            "env": [
+              {
+                "name": "REDIS_PASSWORD",
+                "value": "secret"
+              }
+            ],
+            "ports": [{
+              "containerPort": 6379
+            }]
+          }]
+        }
+      },
+      "labels": {
+        "name": "redis-master"
+      }
+    },
+    {
+      "id": "frontendController",
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "replicas": 3,
+        "replicaSelector": {"name": "frontend"},
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "version": "v1beta1",
+              "id": "frontendController",
+              "containers": [{
+                "name": "php-redis",
+                "image": "brendanburns/php-redis",
+                "env": [
+                  {
+                    "name": "ADMIN_USERNAME",
+                    "value": "admin"
+                  },
+                  {
+                    "name": "ADMIN_PASSWORD",
+                    "value": "secret"
+                  },
+                  {
+                    "name": "REDIS_PASSWORD",
+                    "value": "secret"
+                  }
+                ],
+                "ports": [{"containerPort": 80, "hostPort": 8000}]
+              }]
+            }
+          },
+          "labels": {"name": "frontend"}
+        }},
+        "labels": {"name": "frontend"}
+    },
+    {
+      "id": "redisSlaveController",
+      "kind": "ReplicationController",
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "replicas": 2,
+        "replicaSelector": {"name": "redisslave"},
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "version": "v1beta1",
+              "id": "redisSlaveController",
+              "containers": [{
+                "name": "slave",
+                "image": "brendanburns/redis-slave",
+                "env": [
+                  {
+                    "name": "REDIS_PASSWORD",
+                    "value": "secret"
+                  }
+                ],
+                "ports": [{"containerPort": 6379, "hostPort": 6380}]
+              }]
+            }
+          },
+          "labels": {"name": "redisslave"}
+        }},
+        "labels": {"name": "redisslave"}
+    }
+  ]
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -69,3 +69,6 @@ ${KUBE_CMD} -c examples/image/test-mapping.json create imageRepositoryMappings
 ${KUBE_CMD} list images
 ${KUBE_CMD} list imageRepositories
 echo "kube(imageRepositoryMappings): ok"
+
+${KUBE_CMD} apply -c examples/guestbook/config.json
+echo "kube(config): ok"

--- a/pkg/cmd/client/api/types.go
+++ b/pkg/cmd/client/api/types.go
@@ -1,0 +1,12 @@
+package api
+
+import "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
+type RESTClient interface {
+	Verb(verb string) *client.Request
+}
+
+type ClientMappings map[string]struct {
+	Kind   string
+	Client RESTClient
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	clientapi "github.com/openshift/origin/pkg/cmd/client/api"
+)
+
+// configJSON stores the raw Config JSON representation
+// TODO: Replace this with configapi.Config when it handles the unregistred types.
+type configJSON struct {
+	Items []interface{} `json:"items" yaml:"items"`
+}
+
+// Apply creates and manages resources defined in the Config. It wont stop on
+// error, but it will finish the job and then return list of errors.
+func Apply(data []byte, storage clientapi.ClientMappings) (errs errors.ErrorList) {
+
+	// Unmarshal the Config JSON using default json package instead of
+	// api.Decode()
+	conf := configJSON{}
+	if err := json.Unmarshal(data, &conf); err != nil {
+		return append(errs, fmt.Errorf("Unable to parse Config: %v", err))
+	}
+
+	for _, item := range conf.Items {
+		kind, itemId, parseErrs := parseKindAndId(item)
+		if len(parseErrs) != 0 {
+			errs = append(errs, parseErrs...)
+			continue
+		}
+
+		client, path := getClientAndPath(kind, storage)
+		if client == nil {
+			errs = append(errs, fmt.Errorf("The resource %s is not a known type - unable to create %s", kind, itemId))
+			continue
+		}
+
+		// Serialize the single Config item back into JSON
+		itemJson, _ := json.Marshal(item)
+
+		request := client.Verb("POST").Path(path).Body(itemJson)
+		_, err := request.Do().Get()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("[%s#%s] Failed to create: %v", kind, itemId, err))
+		}
+	}
+
+	return
+}
+
+// getClientAndPath returns the RESTClient and path defined for given resource
+// kind.
+func getClientAndPath(kind string, mappings clientapi.ClientMappings) (client clientapi.RESTClient, path string) {
+	for k, m := range mappings {
+		if k == kind {
+			return m.Client, k
+		}
+	}
+	return
+}
+
+// parseKindAndId extracts the 'kind' and 'id' fields from the Config item JSON
+// and report errors if these fields are missing.
+func parseKindAndId(item interface{}) (kind, id string, errs errors.ErrorList) {
+	itemMap := item.(map[string]interface{})
+
+	kind, ok := itemMap["kind"].(string)
+	if !ok {
+		errs = append(errs, reportError(item, "Missing 'kind' field for Config item"))
+	}
+
+	id, ok = itemMap["id"].(string)
+	if !ok {
+		errs = append(errs, reportError(item, "Missing 'id' field for Config item"))
+	}
+
+	return
+}
+
+// reportError provides a human-readable error message that include the Config
+// item JSON representation.
+func reportError(item interface{}, message string) error {
+	itemJson, _ := json.Marshal(item)
+	return fmt.Errorf(message+": %s", string(itemJson))
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	kubeclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	clientapi "github.com/openshift/origin/pkg/cmd/client/api"
+)
+
+func TestParseKindAndItem(t *testing.T) {
+	data, _ := ioutil.ReadFile("../../examples/guestbook/config.json")
+	conf := configJSON{}
+	if err := json.Unmarshal(data, &conf); err != nil {
+		t.Errorf("Failed to parse Config: %v", err)
+	}
+
+	kind, itemId, err := parseKindAndId(conf.Items[0])
+	if len(err) != 0 {
+		t.Errorf("Failed to parse kind and id from the Config item: %v", err)
+	}
+
+	if kind != "Service" && itemId != "frontend" {
+		t.Errorf("Invalid kind and id, should be Service and frontend: %s, %s", kind, itemId)
+	}
+}
+
+func TestApply(t *testing.T) {
+	invalidData := []byte(`{"items": [ { "foo": "bar" } ]}`)
+	invalidConf := configJSON{}
+	if err := json.Unmarshal(invalidData, &invalidConf); err != nil {
+		t.Errorf("Failed to parse Config: %v", err)
+	}
+	clients := clientapi.ClientMappings{}
+	errs := Apply(invalidData, clients)
+	if len(errs) == 0 {
+		t.Errorf("Expected missing kind field for Config item, got %v", errs)
+	}
+	uErrs := Apply([]byte(`{ "foo": }`), clients)
+	if len(uErrs) == 0 {
+		t.Errorf("Expected unmarshal error, got nothing")
+	}
+}
+
+func ExampleApply() {
+	kubeClient, _ := kubeclient.New("127.0.0.1", nil)
+	clients := clientapi.ClientMappings{
+		"pods": {
+			Kind:   "Pod",
+			Client: kubeClient.RESTClient,
+		},
+		"services": {
+			Kind:   "Service",
+			Client: kubeClient.RESTClient,
+		},
+	}
+	data, _ := ioutil.ReadFile("../../examples/guestbook/config.json")
+	errs := Apply(data, clients)
+	fmt.Println(errs)
+	// Output:
+	// [The resource Service is not a known type - unable to create frontend The resource Service is not a known type - unable to create redismaster The resource Service is not a known type - unable to create redisslave The resource Pod is not a known type - unable to create redis-master-2 The resource ReplicationController is not a known type - unable to create frontendController The resource ReplicationController is not a known type - unable to create redisSlaveController]
+	//
+}


### PR DESCRIPTION
This PR contains initial support for Config creation for the Origin `kubecfg` client. There is an example Config JSON (same format as you get when you use templateConfig for generation).

To try this out, you can execute this command:

```
$ openshift kube apply -c pkg/config/example/config.json
```

The the client will create the resources in following order: Services, Pods, ReplicationControllers. 

FYI: This PR bundles https://github.com/openshift/origin/pull/41 because I need Config{} object.
