### PR TITLE
Allow direct URL loads for kubecfg

### DIFF
--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -32,7 +32,7 @@ func NewCommandKubecfg(name string) *cobra.Command {
 	flag.BoolVar(&cfg.ServerVersion, "server_version", false, "Print the server's version number.")
 	flag.BoolVar(&cfg.PreventSkew, "expect_version_match", false, "Fail if server's version doesn't match own version.")
 	flag.StringVarP(&cfg.HttpServer, "host", "h", "", "The host to connect to.")
-	flag.StringVarP(&cfg.Config, "config", "c", "", "Path to the config file.")
+	flag.StringVarP(&cfg.Config, "config", "c", "", "Path or URL to the config file.")
 	flag.StringVarP(&cfg.Selector, "label", "l", "", "Selector (label query) to use for listing")
 	flag.DurationVarP(&cfg.UpdatePeriod, "update", "u", 60*time.Second, "Update interval period")
 	flag.StringVarP(&cfg.PortSpec, "port", "p", "", "The port spec, comma-separated list of <external>:<internal>,...")

--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -19,6 +19,8 @@ package client
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"sort"
@@ -100,11 +102,32 @@ func (c *KubeConfig) readConfig(storage string) []byte {
 	if len(c.Config) == 0 {
 		glog.Fatal("Need config file (-c)")
 	}
-	data, err := ioutil.ReadFile(c.Config)
-	if err != nil {
-		glog.Fatalf("Unable to read %v: %v\n", c.Config, err)
+
+	var data []byte
+	if url, err := url.Parse(c.Config); err == nil && (url.Scheme == "http" || url.Scheme == "https") {
+		resp, err := http.Get(url.String())
+		if err != nil {
+			glog.Fatalf("Unable to access URL %v: %v\n", url, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			glog.Fatalf("Unable to read URL, server reported %d %s", resp.StatusCode, resp.Status)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			glog.Fatalf("Unable to read URL %v: %v\n", url, err)
+		}
+		data = body
+
+	} else {
+		body, err := ioutil.ReadFile(c.Config)
+		if err != nil {
+			glog.Fatalf("Unable to read %v: %v\n", c.Config, err)
+		}
+		data = body
 	}
-	data, err = parser.ToWireFormat(data, storage)
+
+	data, err := parser.ToWireFormat(data, storage)
 	if err != nil {
 		glog.Fatalf("Error parsing %v as an object for %v: %v\n", c.Config, storage, err)
 	}


### PR DESCRIPTION
http:// and https:// URLs will be fetched by the client.

Allows `openshift kube -c "https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/examples/guestbook/redis-master.json" create pods`

Parallel: https://github.com/GoogleCloudPlatform/kubernetes/pull/1211
