### PR TITLE
Disable coverage for Travis + go tip

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -19,8 +19,14 @@ find_test_dirs() {
     \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${OS_GO_PACKAGE}/%s\n"
 }
 
-# -covermode=atomic becomes default with -race in Go >=1.3
-KUBE_COVER=${KUBE_COVER:--cover -covermode=atomic}
+# there is currently a race in the coverage code in tip.  Remove this when it is fixed
+# see https://code.google.com/p/go/issues/detail?id=8630 for details.
+if [ "${TRAVIS_GO_VERSION}" == "tip" ]; then
+  KUBE_COVER=""
+else
+  # -covermode=atomic becomes default with -race in Go >=1.3
+  KUBE_COVER=${KUBE_COVER:--cover -covermode=atomic}
+fi
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 30s}
 
 cd "${OS_TARGET}"


### PR DESCRIPTION
There is currently a race in code coverage analysis for go tip. Will reenable when it's fixed.
