### PR TITLE
Correct ImageRepository tagging

### DIFF
--- a/pkg/image/imagerepositorymappingstorage.go
+++ b/pkg/image/imagerepositorymappingstorage.go
@@ -67,7 +67,7 @@ func (s *ImageRepositoryMappingStorage) Create(obj interface{}) (<-chan interfac
 	if repo.Tags == nil {
 		repo.Tags = make(map[string]string)
 	}
-	repo.Tags[mapping.Tag] = image.DockerImageReference
+	repo.Tags[mapping.Tag] = image.ID
 
 	return apiserver.MakeAsync(func() (interface{}, error) {
 		err = s.imageRegistry.CreateImage(image)

--- a/pkg/image/imagerepositorymappingstorage_test.go
+++ b/pkg/image/imagerepositorymappingstorage_test.go
@@ -197,4 +197,12 @@ func TestCreateImageRepositoryMapping(t *testing.T) {
 	if !reflect.DeepEqual(mapping.Image.Metadata, image.Metadata) {
 		t.Errorf("Expected %#v, got %#v", mapping.Image, image)
 	}
+
+	repo, err := imageRepositoryRegistry.GetImageRepository("repo1")
+	if err != nil {
+		t.Errorf("Unexpected non-nil err: %#v", err)
+	}
+	if e, a := "imageID1", repo.Tags["latest"]; e != a {
+		t.Errorf("Expected %s, got %s", e, a)
+	}
 }


### PR DESCRIPTION
Correct the ImageRepository's tag value to be the ID of the Image
instead of the Image's DockerImageReference.
