### PR TITLE
Add integration tests for build/buildConfig client

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -42,7 +42,7 @@ type BuildConfig struct {
 	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
 	// DesiredInput is the input used to create builds from this configuration
-	DesiredInput BuildInput
+	DesiredInput BuildInput `json:"desiredInput,omitempty" yaml:"desiredInput,omitempty"`
 }
 
 // BuildType is a type of build (docker, sti, etc)

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -42,7 +42,7 @@ type BuildConfig struct {
 	Labels       map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
 	// DesiredInput is the input used to create builds from this configuration
-	DesiredInput BuildInput
+	DesiredInput BuildInput `json:"desiredInput,omitempty" yaml:"desiredInput,omitempty"`
 }
 
 // BuildType is a type of build (docker, sti, etc)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,8 +20,18 @@ type Interface interface {
 
 // BuildInterface exposes methods on Build resources.
 type BuildInterface interface {
+	CreateBuild(buildapi.Build) (buildapi.Build, error)
 	ListBuilds(selector labels.Selector) (buildapi.BuildList, error)
 	UpdateBuild(buildapi.Build) (buildapi.Build, error)
+	DeleteBuild(string) error
+}
+
+// BuildConfigInterface exposes methods on BuildConfig resources
+type BuildConfigInterface interface {
+	CreateBuildConfig(buildapi.BuildConfig) (buildapi.BuildConfig, error)
+	ListBuildConfigs(selector labels.Selector) (buildapi.BuildConfigList, error)
+	UpdateBuildConfig(buildapi.BuildConfig) (buildapi.BuildConfig, error)
+	DeleteBuildConfig(string) error
 }
 
 // ImageInterface exposes methods on Image resources.
@@ -59,6 +69,12 @@ func New(host string, auth *kubeclient.AuthInfo) (*Client, error) {
 	return &Client{restClient}, nil
 }
 
+// CreateBuild creates a new build
+func (c *Client) CreateBuild(build buildapi.Build) (result buildapi.Build, err error) {
+	err = c.Post().Path("builds").Body(build).Do().Into(&result)
+	return
+}
+
 // ListBuilds returns a list of builds.
 func (c *Client) ListBuilds(selector labels.Selector) (result buildapi.BuildList, err error) {
 	err = c.Get().Path("builds").SelectorParam("labels", selector).Do().Into(&result)
@@ -68,6 +84,36 @@ func (c *Client) ListBuilds(selector labels.Selector) (result buildapi.BuildList
 // UpdateBuild updates an existing build.
 func (c *Client) UpdateBuild(build buildapi.Build) (result buildapi.Build, err error) {
 	err = c.Put().Path("builds").Path(build.ID).Body(build).Do().Into(&result)
+	return
+}
+
+// DeleteBuild deletes a build
+func (c *Client) DeleteBuild(id string) (err error) {
+	err = c.Delete().Path("builds").Path(id).Do().Error()
+	return
+}
+
+// CreateBuildConfig creates a new build config
+func (c *Client) CreateBuildConfig(build buildapi.BuildConfig) (result buildapi.BuildConfig, err error) {
+	err = c.Post().Path("buildConfigs").Body(build).Do().Into(&result)
+	return
+}
+
+// ListBuildConfigs returns a list of builds.
+func (c *Client) ListBuildConfigs(selector labels.Selector) (result buildapi.BuildConfigList, err error) {
+	err = c.Get().Path("buildConfigs").SelectorParam("labels", selector).Do().Into(&result)
+	return
+}
+
+// UpdateBuildConfig updates an existing build.
+func (c *Client) UpdateBuildConfig(build buildapi.BuildConfig) (result buildapi.BuildConfig, err error) {
+	err = c.Put().Path("buildConfigs").Path(build.ID).Body(build).Do().Into(&result)
+	return
+}
+
+// DeleteBuildConfig deletes a build
+func (c *Client) DeleteBuildConfig(id string) (err error) {
+	err = c.Delete().Path("buildConfigs").Path(id).Do().Error()
 	return
 }
 

--- a/test/integration/buildcfgclient_test.go
+++ b/test/integration/buildcfgclient_test.go
@@ -1,0 +1,118 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	// "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+
+	"github.com/openshift/origin/pkg/build"
+	"github.com/openshift/origin/pkg/build/api"
+	buildregistry "github.com/openshift/origin/pkg/build/registry/build"
+	buildconfigregistry "github.com/openshift/origin/pkg/build/registry/buildconfig"
+	osclient "github.com/openshift/origin/pkg/client"
+)
+
+func init() {
+	requireEtcd()
+}
+
+func TestBuildConfigClient(t *testing.T) {
+	etcdClient := newEtcdClient()
+	m := master.New(&master.Config{
+		EtcdServers: etcdClient.GetCluster(),
+	})
+	osMux := http.NewServeMux()
+	storage := map[string]apiserver.RESTStorage{
+		"builds":       buildregistry.NewStorage(build.NewEtcdRegistry(etcdClient)),
+		"buildConfigs": buildconfigregistry.NewStorage(build.NewEtcdRegistry(etcdClient)),
+	}
+	apiserver.NewAPIGroup(m.API_v1beta1()).InstallREST(osMux, "/api/v1beta1")
+	apiserver.NewAPIGroup(storage, runtime.Codec).InstallREST(osMux, "/osapi/v1beta1")
+	apiserver.InstallSupport(osMux)
+
+	s := httptest.NewServer(osMux)
+
+	kubeclient := client.NewOrDie(s.URL, nil)
+	osclient, _ := osclient.New(s.URL, nil)
+
+	info, err := kubeclient.ServerVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e, a := version.Get(), *info; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %#v, got %#v", e, a)
+	}
+
+	buildConfigs, err := osclient.ListBuildConfigs(labels.Everything())
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if len(buildConfigs.Items) != 0 {
+		t.Errorf("expected no buildConfigs, got %#v", buildConfigs)
+	}
+
+	// get a validation error
+	buildConfig := api.BuildConfig{
+		Labels: map[string]string{
+			"label1": "value1",
+			"label2": "value2",
+		},
+		DesiredInput: api.BuildInput{
+			Type:         api.DockerBuildType,
+			SourceURI:    "http://my.docker/build",
+			ImageTag:     "namespace/builtimage",
+			BuilderImage: "anImage",
+		},
+	}
+	got, err := osclient.CreateBuildConfig(buildConfig)
+	if err == nil {
+		t.Fatalf("unexpected non-error: %v", err)
+	}
+
+	// get a created buildConfig
+	buildConfig.DesiredInput.BuilderImage = ""
+	got, err = osclient.CreateBuildConfig(buildConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID == "" {
+		t.Errorf("unexpected empty buildConfig ID %v", got)
+	}
+
+	// get a list of buildConfigs
+	buildConfigs, err = osclient.ListBuildConfigs(labels.Everything())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(buildConfigs.Items) != 1 {
+		t.Errorf("expected one buildConfig, got %#v", buildConfigs)
+	}
+	actual := buildConfigs.Items[0]
+	if actual.ID != got.ID {
+		t.Errorf("expected buildConfig %#v, got %#v", got, actual)
+	}
+
+	// delete a buildConfig
+	err = osclient.DeleteBuildConfig(got.ID)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	buildConfigs, err = osclient.ListBuildConfigs(labels.Everything())
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if len(buildConfigs.Items) != 0 {
+		t.Errorf("expected no buildConfigs, got %#v", buildConfigs)
+	}
+}

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -1,0 +1,121 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	// "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+
+	"github.com/openshift/origin/pkg/build"
+	"github.com/openshift/origin/pkg/build/api"
+	buildregistry "github.com/openshift/origin/pkg/build/registry/build"
+	buildconfigregistry "github.com/openshift/origin/pkg/build/registry/buildconfig"
+	osclient "github.com/openshift/origin/pkg/client"
+)
+
+func init() {
+	requireEtcd()
+}
+
+func TestBuildClient(t *testing.T) {
+	etcdClient := newEtcdClient()
+	m := master.New(&master.Config{
+		EtcdServers: etcdClient.GetCluster(),
+	})
+	osMux := http.NewServeMux()
+	storage := map[string]apiserver.RESTStorage{
+		"builds":       buildregistry.NewStorage(build.NewEtcdRegistry(etcdClient)),
+		"buildConfigs": buildconfigregistry.NewStorage(build.NewEtcdRegistry(etcdClient)),
+	}
+	apiserver.NewAPIGroup(m.API_v1beta1()).InstallREST(osMux, "/api/v1beta1")
+	apiserver.NewAPIGroup(storage, runtime.Codec).InstallREST(osMux, "/osapi/v1beta1")
+	apiserver.InstallSupport(osMux)
+
+	s := httptest.NewServer(osMux)
+
+	kubeclient := client.NewOrDie(s.URL, nil)
+	osclient, _ := osclient.New(s.URL, nil)
+
+	info, err := kubeclient.ServerVersion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e, a := version.Get(), *info; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %#v, got %#v", e, a)
+	}
+
+	builds, err := osclient.ListBuilds(labels.Everything())
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if len(builds.Items) != 0 {
+		t.Errorf("expected no builds, got %#v", builds)
+	}
+
+	// get a validation error
+	build := api.Build{
+		Labels: map[string]string{
+			"label1": "value1",
+			"label2": "value2",
+		},
+		Input: api.BuildInput{
+			Type:         api.DockerBuildType,
+			SourceURI:    "http://my.docker/build",
+			ImageTag:     "namespace/builtimage",
+			BuilderImage: "anImage",
+		},
+	}
+	got, err := osclient.CreateBuild(build)
+	if err == nil {
+		t.Fatalf("unexpected non-error: %v", err)
+	}
+
+	// get a created build
+	build.Input.BuilderImage = ""
+	got, err = osclient.CreateBuild(build)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID == "" {
+		t.Errorf("unexpected empty build ID %v", got)
+	}
+
+	// get a list of builds
+	builds, err = osclient.ListBuilds(labels.Everything())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(builds.Items) != 1 {
+		t.Errorf("expected one build, got %#v", builds)
+	}
+	actual := builds.Items[0]
+	if actual.ID != got.ID {
+		t.Errorf("expected build %#v, got %#v", got, actual)
+	}
+	if actual.Status != api.BuildNew {
+		t.Errorf("expected build status to be BuildNew, got %s", actual.Status)
+	}
+
+	// delete a build
+	err = osclient.DeleteBuild(got.ID)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	builds, err = osclient.ListBuilds(labels.Everything())
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if len(builds.Items) != 0 {
+		t.Errorf("expected no builds, got %#v", builds)
+	}
+}

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -1,0 +1,27 @@
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/golang/glog"
+)
+
+func newEtcdClient() *etcd.Client {
+	return etcd.NewClient([]string{})
+}
+
+func requireEtcd() {
+	if _, err := newEtcdClient().Get("/", false, false); err != nil {
+		glog.Fatalf("unable to connect to etcd for integration testing: %v", err)
+	}
+}
+
+func withEtcdKey(f func(string)) {
+	prefix := fmt.Sprintf("/test-%d", rand.Int63())
+	defer newEtcdClient().Delete(prefix, true)
+	f(prefix)
+}


### PR DESCRIPTION
Fixed tags in BuildConfig API type, added client methods for Builds and BuildConfigs, and added integration tests for BuildConfig and Build client.
