### PR TITLE
Fix problem with replicationController ops in kube command

### DIFF
--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -229,7 +229,7 @@ func (c *KubeConfig) Run() {
 		"imageRepositoryMappings": {"ImageRepositoryMapping", client.RESTClient},
 	}
 
-	matchFound := c.executeConfigRequest(method, clients) || c.executeAPIRequest(method, clients) || c.executeControllerRequest(method, kubeClient)
+	matchFound := c.executeConfigRequest(method, clients) || c.executeControllerRequest(method, kubeClient) || c.executeAPIRequest(method, clients)
 	if matchFound == false {
 		glog.Fatalf("Unknown command %s", method)
 	}
@@ -381,7 +381,7 @@ func (c *KubeConfig) executeAPIRequest(method string, clients ClientMappings) bo
 func (c *KubeConfig) executeControllerRequest(method string, client *kubeclient.Client) bool {
 	parseController := func() string {
 		if len(c.Args) != 2 {
-			glog.Fatal("usage: kubecfg [OPTIONS] stop|rm|rollingupdate <controller>")
+			glog.Fatal("usage: kubecfg [OPTIONS] stop|rm|rollingupdate|run|resize <controller>")
 		}
 		return c.Arg(1)
 	}


### PR DESCRIPTION
Currently if you try to do 'openshift kube resize <controller> 2', the command will fail because the executeAPIRequest method assumes that the first argument is of the form '<resourceType>/<name>'.  The fix is to run the executeControllerRequest method first which will simply return false and fall through to executeAPIRequest.
