### PR TITLE
Use a bind mount for API docs/raml2html

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,4 @@
 FROM google/nodejs
 RUN npm i -g raml2html
-ADD . /data
 CMD ["-i", "/data/oov3.raml", "-o", "/data/oov3.html"]
 ENTRYPOINT ["raml2html"]

--- a/hack/build-api-docs-image.sh
+++ b/hack/build-api-docs-image.sh
@@ -4,10 +4,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-hackdir=$(CDPATH="" cd $(dirname $0); pwd)
+hack_dir=$(CDPATH="" cd $(dirname $0); pwd)
+api_dir=$hack_dir/../api
 
-cd $hackdir/../api && docker build -t kubernetes/raml2html .
-docker rm oov3docgen &>/dev/null || :
-docker run --name=oov3docgen kubernetes/raml2html
-docker cp oov3docgen:/data/oov3.html $hackdir/../api/
-docker rm oov3docgen &>/dev/null || :
+image_name=kubernetes/raml2html
+image=$(docker images -q $image_name)
+
+if [ -z "$image" ]; then
+  echo "Building raml2html image"
+  (cd $api_dir && docker build -t kubernetes/raml2html .)
+fi
+
+echo "Running raml2html"
+docker run --rm -v $api_dir:/data --name=oov3docgen kubernetes/raml2html


### PR DESCRIPTION
Bind mount the api dir into the docs container instead of always
recreating the docs image.
