### PR TITLE
Allow Docker build from git repo

### DIFF
--- a/images/builder/docker/docker-builder/Dockerfile
+++ b/images/builder/docker/docker-builder/Dockerfile
@@ -1,3 +1,4 @@
 FROM openshift/kubernetes-fedora-dind
+RUN yum -y install git
 ADD ./build.sh /tmp/build.sh
 CMD ["/tmp/build.sh"]


### PR DESCRIPTION
Docker already allows building from a Github repository:
https://docs.docker.com/reference/commandline/cli/#build
The only thing missing in the image we have is the git command. This PR adds the git command to the docker-build image.
