### PR TITLE
Try to wait for DinD to stop before exiting

### DIFF
--- a/images/builder/docker/docker-builder/build.sh
+++ b/images/builder/docker/docker-builder/build.sh
@@ -41,6 +41,22 @@ if [ -n "$DOCKER_REGISTRY" ]; then
   docker push $TAG
 fi
 
-if $NEED_DIND; then
-  kill -15 $(cat /var/run/docker.pid)
+if [ $NEED_DIND == "true" ]; then
+  docker_pid=$(cat /var/run/docker.pid)
+  kill -15 $docker_pid
+
+  # wait up to 10 seconds for the Docker daemon to stop
+  #
+  # if it takes longer than that, something is probably wrong
+  # and we may end up leaking loopback devices
+  ATTEMPTS=0
+  while [ $ATTEMPTS -lt 10 ]; do
+    ps -p $docker_pid &> /dev/null
+    if [ $? -eq 0 ]; then
+      let ATTEMPTS=ATTEMPTS+1
+      sleep 1
+    else
+      break
+    fi
+  done
 fi

--- a/images/builder/docker/sti-builder/build.sh
+++ b/images/builder/docker/sti-builder/build.sh
@@ -48,5 +48,21 @@ if [ -n "$DOCKER_REGISTRY" ]; then
 fi
 
 if [ $NEED_DIND == "true" ]; then
-  kill -15 $(cat /var/run/docker.pid)
+  docker_pid=$(cat /var/run/docker.pid)
+  kill -15 $docker_pid
+
+  # wait up to 10 seconds for the Docker daemon to stop
+  #
+  # if it takes longer than that, something is probably wrong
+  # and we may end up leaking loopback devices
+  ATTEMPTS=0
+  while [ $ATTEMPTS -lt 10 ]; do
+    ps -p $docker_pid &> /dev/null
+    if [ $? -eq 0 ]; then
+      let ATTEMPTS=ATTEMPTS+1
+      sleep 1
+    else
+      break
+    fi
+  done
 fi


### PR DESCRIPTION
Wait up to 10 seconds for the DinD daemon to stop before exiting from
the build script. In my testing, allowing the daemon to stop fixes the
dangling loopback device issue.

Partial fix for #101
