### PR TITLE
Better startup error handling and configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /_output
 /third_party
-/*.etcd
+/openshift.local.*
 /.project
 /.vagrant
 *.swp

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -24,15 +24,15 @@ API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 GO_OUT=$(dirname $0)/../_output/go/bin
 
+ETCD_DATA_DIR=$(mktemp -d /tmp/openshift.local.etcd.XXXX)
+VOLUME_DIR=$(mktemp -d /tmp/openshift.local.volumes.XXXX)
+
 # Check openshift version
 out=$(${GO_OUT}/openshift version)
 echo openshift: $out
 
-# Remove any local data
-rm -rf $(dirname $0)/../openshift.local.etcd/
-
 # Start openshift
-${GO_OUT}/openshift start 1>&2 &
+${GO_OUT}/openshift start --volumeDir=$VOLUME_DIR --etcdDir=$ETCD_DATA_DIR 1>&2 &
 OS_PID=$!
 
 wait_for_url "http://127.0.0.1:${KUBELET_PORT}/healthz" "kubelet: "


### PR DESCRIPTION
Short circuit kubelet initialization if the root volume directory can't be
created, as volume mounts are non-functional in the absence of the directory.
Without this check, volume mounts (including Docker socket mounts for builds)
fail in non-obvious ways.

Make the etcd and volume directories configurable to better facilitate dev
and test environments. Retain the existing defaults for turnkey prod-like
operation.
