### PR TITLE
Don't error out on template items of unknown kind

### DIFF
--- a/pkg/template/api/validation/validation.go
+++ b/pkg/template/api/validation/validation.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"fmt"
 	"regexp"
 
 	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -40,7 +39,7 @@ func ValidateTemplate(template *Template) (errs ErrorList) {
 		case *kubeapi.Service:
 			err = ValidateService(obj)
 		default:
-			err = append(err, NewFieldInvalid("kind", fmt.Sprintf("%T", item)))
+			// Pass-through unknown types.
 		}
 		errs = append(errs, err.PrefixIndex(i).Prefix("items")...)
 	}

--- a/pkg/template/api/validation/validation_test.go
+++ b/pkg/template/api/validation/validation_test.go
@@ -67,7 +67,7 @@ func TestValidateTemplate(t *testing.T) {
 	template.Parameters[0].Name = "VALID_NAME"
 	shouldPass(template)
 
-	// Add invalid Item, should fail on Object.kind
+	// Add Item of unknown Kind, should pass
 	template.Items = []runtime.Object{{}}
-	shouldFail(template)
+	shouldPass(template)
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -78,6 +78,8 @@ func (p *TemplateProcessor) GetParameterByName(t *api.Template, name string) *ap
 //
 // Example of Parameter expression:
 //   - ${PARAMETER_NAME}
+//
+// TODO: Implement substitution for more types and fields.
 func (p *TemplateProcessor) SubstituteParameters(t *api.Template) error {
 	// Make searching for given parameter name/value more effective
 	paramMap := make(map[string]string, len(t.Parameters))
@@ -94,7 +96,7 @@ func (p *TemplateProcessor) SubstituteParameters(t *api.Template) error {
 			p.substituteParametersInManifest(&obj.DesiredState.Manifest, paramMap)
 			t.Items[i] = runtime.Object{Object: *obj}
 		default:
-			glog.V(1).Infof("Unable to process parameters for resource '%T'.", obj)
+			glog.V(1).Infof("Parameter substitution not implemented for resource '%T'.", obj)
 		}
 	}
 


### PR DESCRIPTION
Fixes:

```
[bparees@bparees ~/git/gocode/src/github.com/openshift/origin/examples/simple-ruby-app]$ openshift kube process -c template/template.json > processed/template.processed.json
F0919 17:31:50.027251 29007 kubecfg.go:456] failed to process template: request [&http.Request{Method:"POST", URL:(*url.URL)(0xc21006e4d0), Proto:"HTTP/1.1", ProtoMajor:1, ProtoMinor:1, Header:http.Header{}, Body:ioutil.nopCloser{Reader:(*bytes.Buffer)(0xc21006e3f0)}, ContentLength:2548, TransferEncoding:[]string(nil), Close:false, Host:"localhost:8080", Form:url.Values(nil), PostForm:url.Values(nil), MultipartForm:(*multipart.Form)(nil), Trailer:http.Header(nil), RemoteAddr:"", RequestURI:"", TLS:(*tls.ConnectionState)(nil)}] failed (500) 500 Internal Server Error: {"kind":"Status","creationTimestamp":null,"apiVersion":"v1beta1","status":"failure","message":"Invalid template config: errors.ErrorList{errors.ValidationError{Type:\"fieldValueInvalid\", Field:\"items[1].kind\", BadValue:\"runtime.Object\"}}","code":500}
```
