### PR TITLE
Accessible build logs

### DIFF
--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -1,0 +1,79 @@
+package buildlog
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/openshift/origin/pkg/build/registry/build"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// REST is an implementation of RESTStorage for the api server.
+type REST struct {
+	BuildRegistry build.Registry
+	PodClient     client.PodInterface
+	proxyPrefix   string
+}
+
+// NewREST creates a new REST for BuildLog
+// Takes build registry and pod client to get neccessary attibutes to assamble
+// URL to which the request shall be redirected in order to get build logs.
+func NewREST(b build.Registry, c client.PodInterface, p string) apiserver.RESTStorage {
+	return &REST{
+		BuildRegistry: b,
+		PodClient: c,
+		proxyPrefix: p,
+	}
+}
+
+// Redirector implementation
+func (r *REST) ResourceLocation(id string) (string, error) {
+	build, err := r.BuildRegistry.GetBuild(id)
+	if err != nil {
+		return "", fmt.Errorf("No such build")
+	}
+
+	pod, err := r.PodClient.GetPod(kubeapi.NewContext(), build.PodID)
+	if err != nil {
+		return "", fmt.Errorf("No such pod")
+	}
+	buildPodID := build.PodID
+	buildHost  := pod.CurrentState.Host
+	// Build will take place only in one container 
+	buildContainerName := pod.DesiredState.Manifest.Containers[0].Name
+	location := &url.URL{
+		Path: r.proxyPrefix + "/" + buildHost + "/containerLogs/" + buildPodID + "/" + buildContainerName,
+	}
+	if err != nil {
+		return "", err
+	}
+	return location.String(), nil
+}
+
+func (r *REST) Get(ctx kubeapi.Context, id string) (runtime.Object, error) {
+	return nil, fmt.Errorf("BuildLog can't be retrieved")
+}
+
+func (r *REST) New() runtime.Object {
+	return nil
+}
+
+func (r *REST) List(ctx kubeapi.Context, selector, fields labels.Selector) (runtime.Object, error) {
+	return nil, fmt.Errorf("BuildLog can't be listed")
+}
+
+func (r *REST) Delete(ctx kubeapi.Context, id string) (<-chan runtime.Object, error) {
+	return nil, fmt.Errorf("BuildLog can't be deleted")
+}
+
+func (r *REST) Create(ctx kubeapi.Context, obj runtime.Object) (<-chan runtime.Object, error) {
+	return nil, fmt.Errorf("BuildLog can't be created")
+}
+
+func (r *REST) Update(ctx kubeapi.Context, obj runtime.Object) (<-chan runtime.Object, error) {
+	return nil, fmt.Errorf("BuildLog can't be updated")
+}

--- a/pkg/cmd/client/client.go
+++ b/pkg/cmd/client/client.go
@@ -50,6 +50,7 @@ func NewCommandKubecfg(name string) *cobra.Command {
 	flag.StringVar(&cfg.ClientConfig.KeyFile, "client_key", "", "Path to a client key file for TLS.")
 	flag.BoolVar(&cfg.ClientConfig.Insecure, "insecure_skip_tls_verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
 	flag.StringVar(&cfg.ImageName, "image", "", "Image used when updating a replicationController.  Will apply to the first container in the pod template.")
+	flag.StringVar(&cfg.ID, "id", "", "Specifies ID of requested resource.")
 
 	return cmd
 }

--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -71,6 +72,7 @@ type KubeConfig struct {
 	WWW            string
 	TemplateFile   string
 	TemplateStr    string
+	ID             string
 
 	ImageName string
 
@@ -108,6 +110,9 @@ func usage(name string) string {
 
   Process template into config:
   %[1]s [OPTIONS] process -c template.json
+
+  Retrieve build logs:
+  %[1]s [OPTIONS] buildLogs --id="buildID"
 `, name, prettyWireStorage())
 }
 
@@ -276,7 +281,7 @@ func (c *KubeConfig) Run() {
 		"routes":                  {"Route", client.RESTClient, latest.Codec},
 	}
 
-	matchFound := c.executeConfigRequest(method, clients) || c.executeTemplateRequest(method, client) || c.executeControllerRequest(method, kubeClient) || c.executeAPIRequest(method, clients)
+	matchFound := c.executeConfigRequest(method, clients) || c.executeTemplateRequest(method, client) || c.executeBuildLogRequest(method, client) || c.executeControllerRequest(method, kubeClient) || c.executeAPIRequest(method, clients)
 	if matchFound == false {
 		glog.Fatalf("Unknown command %s", method)
 	}
@@ -468,6 +473,26 @@ func (c *KubeConfig) executeControllerRequest(method string, client *kubeclient.
 		return false
 	}
 	if err != nil {
+		glog.Fatalf("Error: %v", err)
+	}
+	return true
+}
+
+// executeBuildLogRequest retrieves the logs from builder container
+func (c *KubeConfig) executeBuildLogRequest(method string, client *osclient.Client) bool {
+	if method != "buildLogs" {
+		return false
+	}
+	if len(c.ID) == 0 {
+		glog.Fatal("Build ID required")
+	}
+	request := client.Verb("GET").Path("redirect").Path("buildLogs").Path(c.ID)
+	readCloser, err := request.Stream()
+	if err != nil {
+		glog.Fatalf("Error: %v", err)
+	}
+	defer readCloser.Close()
+	if _, err := io.Copy(os.Stdout, readCloser); err != nil {
 		glog.Fatalf("Error: %v", err)
 	}
 	return true

--- a/pkg/cmd/master/master.go
+++ b/pkg/cmd/master/master.go
@@ -36,6 +36,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildregistry "github.com/openshift/origin/pkg/build/registry/build"
 	buildconfigregistry "github.com/openshift/origin/pkg/build/registry/buildconfig"
+	buildlogregistry "github.com/openshift/origin/pkg/build/registry/buildlog"
 	buildetcd "github.com/openshift/origin/pkg/build/registry/etcd"
 	"github.com/openshift/origin/pkg/build/strategy"
 	"github.com/openshift/origin/pkg/build/webhook"
@@ -205,6 +206,7 @@ func (c *config) runApiserver() {
 	kubePrefix := "/api/v1beta1"
 	kube2Prefix := "/api/v1beta2"
 	osPrefix := "/osapi/v1beta1"
+	proxyPrefix := "/proxy/minion"
 
 	kubeClient := c.getKubeClient()
 	osClient := c.getOsClient()
@@ -227,6 +229,7 @@ func (c *config) runApiserver() {
 	storage := map[string]apiserver.RESTStorage{
 		"builds":                  buildregistry.NewREST(buildRegistry),
 		"buildConfigs":            buildconfigregistry.NewREST(buildRegistry),
+		"buildLogs":               buildlogregistry.NewREST(buildRegistry, kubeClient, proxyPrefix),
 		"images":                  image.NewREST(imageRegistry),
 		"imageRepositories":       imagerepository.NewREST(imageRegistry),
 		"imageRepositoryMappings": imagerepositorymapping.NewREST(imageRegistry, imageRegistry),


### PR DESCRIPTION
Adding option to retrieve logs form a build.
Usage:
        `kube buildLogs --id="buildID"`
