### PR TITLE
Disable golang travis for tip to fix build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.3
   - 1.2
-  - tip
 
 env:
  - TEST_ASSETS=true


### PR DESCRIPTION
Go tip appears to be broken by symbol substitution for the gitCommit version in our version pkg.  Disable for now until tip is fixed.
