### PR TITLE
Fix missing 'apiVersion' in example templates

### DIFF
--- a/api/examples/template.json
+++ b/api/examples/template.json
@@ -1,6 +1,7 @@
 {
-  "kind": "Template",
   "id": "example1",
+  "kind": "Template",
+  "apiVersion": "v1beta1",
   "name": "My awesome PHP app",
   "description": "Example PHP application with PostgreSQL database",
   "parameters": [

--- a/examples/guestbook/template.json
+++ b/examples/guestbook/template.json
@@ -1,7 +1,7 @@
 {
   "id": "guestbook",
-  "apiVersion": "v1beta1",
   "kind": "Template",
+  "apiVersion": "v1beta1",
   "name": "guestbook-example",
   "description": "Example shows how to build a simple multi-tier application using Kubernetes and Docker",
   "parameters": [

--- a/examples/simple-ruby-app/template/template.json
+++ b/examples/simple-ruby-app/template/template.json
@@ -1,6 +1,7 @@
 {
   "id": "ruby-helloworld-sample-template",
   "kind": "Template",
+  "apiVersion": "v1beta1",
   "name": "ruby-hello-world-template",
   "description": "This example shows how to create a simple ruby application in openshift origin v3",
   "parameters": [


### PR DESCRIPTION
When the template.apiVersion is missing, the runtime.Object parser
can't figure out the Template object properly and thus the
TemplateProcessor produces a Config with null items.

Bug 1146024 - https://bugzilla.redhat.com/show_bug.cgi?id=1146024

All of the below should produce Config with non-null items:

```
openshift kube process -c ./examples/guestbook/template.json
openshift kube process -c ./api/examples/template.json
openshift kube process -c ./examples/simple-ruby-app/template/template.json
```

@mfojtik @bparees review pls

TODO: Fix the k8s `DecodeInto()` to handle unknown/empty "apiVersion" and try to use `latest.Version` instead. /cc @smarterclayton 
