### PR TITLE
Fixed path for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ ADD . /gopath/src/github.com/openshift/origin
 RUN go get github.com/openshift/origin && \
     hack/build-go.sh
 
-ENTRYPOINT ["output/go/bin/openshift"]
+ENTRYPOINT ["_output/go/bin/openshift"]


### PR DESCRIPTION
Dear all,

the output path in hack/build-go.sh and in the Dockerfile are different.
Just fixed the incorrect path in the dockerfile
