### PR TITLE
Make race flag override match upstream

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -29,12 +29,7 @@ else
 fi
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 30s}
 
-# make race detection configurable to facilitate faster local iteration
-if [ "${KUBE_RACE:-true}" == "false" ] ; then
-  KUBE_RACE=""
-else
-  KUBE_RACE="-race"
-fi
+KUBE_RACE=${KUBE_RACE:--race}
 
 cd "${OS_TARGET}"
 


### PR DESCRIPTION
Use the upstream convention for overriding the -race flag.
