### PR TITLE
Fix repository address in example template

### DIFF
--- a/examples/simple-ruby-app/template/template.json
+++ b/examples/simple-ruby-app/template/template.json
@@ -48,7 +48,7 @@
               "id": "frontendController",
               "containers": [{
                 "name": "ruby-helloworld",
-                "image": "localhost:5000/openshift/origin-ruby-sample",
+                "image": "127.0.0.1:5000/openshift/origin-ruby-sample",
                 "env": [
                   {
                     "name": "ADMIN_USERNAME",


### PR DESCRIPTION
The docker registry is bound by default to 127.0.0.1, not localhost
