### PR TITLE
Use openshift/minimal-registry as a Docker registry to speed up the demo

### DIFF
--- a/examples/simple-ruby-app/registry_config/registry_config.json
+++ b/examples/simple-ruby-app/registry_config/registry_config.json
@@ -26,7 +26,7 @@
                         "manifest": {
                             "containers": [
                                 {
-                                    "image": "registry",
+                                    "image": "openshift/minimal-registry",
                                     "name": "registry-container",
                                     "ports": [
                                         {


### PR DESCRIPTION
The `mfojtik/registry` docker file is here:

https://github.com/mfojtik/docker-registry/blob/caf4d6d211ff369521da80f6272ad1f2575a1401/contrib/golang_impl/Dockerfile

However, since it is using the `scratch` image, it needs to be build from the `docker-registry` repo.
