### PR TITLE
Fix #180: Remove traling slash from client Host

### DIFF
--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -198,6 +198,7 @@ func (c *KubeConfig) Run() {
 		// TODO: eventually apiserver should start on 443 and be secure by default
 		clientConfig.Host = "http://localhost:8080"
 	}
+	clientConfig.Host = strings.TrimRight(clientConfig.Host, "/")
 
 	if kubeclient.IsConfigTransportSecure(clientConfig) {
 		auth, err := kubecfg.LoadAuthInfo(c.AuthConfig, os.Stdin)


### PR DESCRIPTION
Fixes #180:
- `openshift kube -h "http://127.0.0.1:8080/" list pods`
- `KUBERNETES_MASTER="http://127.0.0.1:8080/" openshift kube list pods`
