### PR TITLE
Bug 1150921 - Problem with pushing images to public repo caused by missing .dockercfg file in $HOME.

### DIFF
--- a/images/builder/docker/docker-builder/Dockerfile
+++ b/images/builder/docker/docker-builder/Dockerfile
@@ -1,4 +1,5 @@
 FROM fedora:20
 RUN yum -y install docker-io git
+ENV HOME /root
 ADD ./build.sh /tmp/build.sh
 CMD ["/tmp/build.sh"]

--- a/images/builder/docker/docker-builder/build.sh
+++ b/images/builder/docker/docker-builder/build.sh
@@ -28,6 +28,6 @@ fi
 
 docker build --rm -t $TAG $DOCKER_CONTEXT_URL
 
-if [ -n "$DOCKER_REGISTRY" ] || [ -s "/.dockercfg" ]; then
+if [ -n "$DOCKER_REGISTRY" ] || [ -s "/root/.dockercfg" ]; then
   docker push $TAG
 fi

--- a/images/builder/docker/sti-builder/Dockerfile
+++ b/images/builder/docker/sti-builder/Dockerfile
@@ -9,5 +9,6 @@ RUN export GOPATH=/tmp/go && \
     ./contrib/build -n && \
     cp /tmp/go/bin/sti /usr/bin/sti
 
+ENV HOME /root
 ADD ./build.sh /opt/build.sh
 CMD ["/opt/build.sh"]

--- a/images/builder/docker/sti-builder/build.sh
+++ b/images/builder/docker/sti-builder/build.sh
@@ -20,6 +20,6 @@ fi
 BUILD_TEMP_DIR=${TEMP_DIR-$TMPDIR}
 TMPDIR=$BUILD_TEMP_DIR sti build $SOURCE_URI $BUILDER_IMAGE $TAG $REF_OPTION
 
-if [ -n "$DOCKER_REGISTRY" ] || [ -s "/.dockercfg" ]; then
+if [ -n "$DOCKER_REGISTRY" ] || [ -s "/root/.dockercfg" ]; then
   docker push $TAG
 fi

--- a/pkg/build/strategy/util.go
+++ b/pkg/build/strategy/util.go
@@ -48,7 +48,7 @@ func setupDockerConfig(podSpec *api.Pod) {
 	dockerConfigVolumeMount := api.VolumeMount{
 		Name:      "docker-cfg",
 		ReadOnly:  true,
-		MountPath: "/.dockercfg",
+		MountPath: "/root/.dockercfg",
 	}
 
 	podSpec.DesiredState.Manifest.Volumes = append(podSpec.DesiredState.Manifest.Volumes,


### PR DESCRIPTION
It appears that recently `fedora:20` image changed it's `$HOME` setting. Since we plan to move to `centos7` image where also `$HOME` is set to `/root` I've decided to go this way instead of hardcoding the location. This way we'll avoid changing the location on every image/`$HOME` variable change. I'm open to discussion, though. 
This change is another requirement for #143.
