### PR TITLE
[WIP] Make docker-builder and sti-builder use Centos 7 base image

### DIFF
--- a/images/builder/docker/docker-builder/Dockerfile
+++ b/images/builder/docker/docker-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM centos:centos7
 RUN yum -y install docker-io git
 ADD ./build.sh /tmp/build.sh
 CMD ["/tmp/build.sh"]

--- a/images/builder/docker/sti-builder/Dockerfile
+++ b/images/builder/docker/sti-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM centos:centos7
 RUN yum -y install docker-io golang golang-src golang-pkg-bin-linux-amd64 golang-pkg-linux-amd64 git && \
     yum clean all
 


### PR DESCRIPTION
Still testing this.

This is an initial step to use one common base image for all components. 
