### PR TITLE
[DEVEXP-346] Allow docker type build from a repo with additional directory

### DIFF
--- a/api/examples/build.json
+++ b/api/examples/build.json
@@ -5,7 +5,6 @@
     "input": {
         "imageTag": "test/dockerBuild",
         "sourceURI": "github.com/test/dockerBuild",
-        "type": "docker"
     },
     "kind": "Build",
     "podID": "build-sti-5065bcf2-3d4d-11e4-a95b-0800279696e1",

--- a/api/examples/buildConfig.json
+++ b/api/examples/buildConfig.json
@@ -2,11 +2,12 @@
     "apiVersion": "v1beta1",
     "creationTimestamp": "2014-09-16T19:33:36Z",
     "desiredInput": {
-        "builderImage": "openshift/ruby-19-centos",
         "imageTag": "test-ruby-app",
         "registry": "localhost:5000",
         "sourceURI": "git://github.com/pmorie/simple-ruby",
-        "type": "sti"
+        "stiInput": {
+            "builderImage": "openshift/ruby-19-centos"
+        }
     },
     "id": "5a6a5b9c-3dd8-11e4-9d75-0800279696e1",
     "kind": "BuildConfig",

--- a/api/examples/builds.json
+++ b/api/examples/builds.json
@@ -8,7 +8,6 @@
             "input": {
                 "imageTag": "test/dockerbuild",
                 "sourceURI": "git://github.com/test/dockerbuild",
-                "type": "docker"
             },
             "podID": "build-sti-5065bcf2-3d4d-11e4-a95b-0800279696e1",
             "resourceVersion": 114,

--- a/api/examples/create_build.json
+++ b/api/examples/create_build.json
@@ -2,7 +2,6 @@
 	"kind": "Build",
 	"apiVersion": "v1beta1",
 	"input": {
-		"type": "docker",
 		"sourceURI": "github.com/test/dockerBuild",
 		"imageTag": "test/dockerBuild"
 	}

--- a/api/examples/create_buildConfig.json
+++ b/api/examples/create_buildConfig.json
@@ -1,10 +1,11 @@
 {
-	"kind": "BuildConfig",
-	"apiVersion": "v1beta1",
-	"desiredInput": {
-		"type": "sti",
-		"sourceURI": "git://github.com/pmorie/simple-ruby",
-		"builderImage": "openshift/ruby-19-centos",
-		"imageTag": "test-ruby-app"
-	}
+    "kind": "BuildConfig",
+    "apiVersion": "v1beta1",
+    "desiredInput": {
+        "sourceURI": "git://github.com/pmorie/simple-ruby",
+        "imageTag": "test-ruby-app",
+        "stiInput": {
+            "builderImage": "openshift/ruby-19-centos",
+        }
+    }
 }

--- a/api/openshift3.html
+++ b/api/openshift3.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><html><head><title>OpenShift 3 API documentation</title><meta http-equiv=X-UA-Compatible content="IE=edge"><meta http-equiv=Content-Type content="text/html; charset=utf-8"><meta name=generator content="https://github.com/kevinrenskers/raml2html 1.0.3"><link rel=stylesheet href=http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css><link rel=stylesheet href=http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/default.min.css><script type=text/javascript src=http://code.jquery.com/jquery-1.11.0.min.js></script><script type=text/javascript src=http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js></script><script type=text/javascript src=http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js></script><script type=text/javascript>
+<!DOCTYPE HTML><html><head><title>OpenShift 3 API documentation</title><meta http-equiv=X-UA-Compatible content="IE=edge"><meta http-equiv=Content-Type content="text/html; charset=utf-8"><meta name=generator content="https://github.com/kevinrenskers/raml2html 1.0.4"><link rel=stylesheet href=http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css><link rel=stylesheet href=http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/styles/default.min.css><script type=text/javascript src=http://code.jquery.com/jquery-1.11.0.min.js></script><script type=text/javascript src=http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js></script><script type=text/javascript src=http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.1/highlight.min.js></script><script type=text/javascript>
         $(document).ready(function() {
             $('.page-header pre code, .top-resource-description pre code').each(function(i, block) {
                 hljs.highlightBlock(block);
@@ -176,24 +176,26 @@
     "status": "success"
 }
 </code></pre></div></div></div></div></div></div></div></div></div></div><div class="panel panel-default"><div class=panel-heading><h3 id=_buildConfigHooks__buildID___secret___plugin_ class=panel-title>/buildConfigHooks/{buildID}/{secret}/{plugin}</h3></div><div class=panel-body><div class=panel-group><div class="panel panel-white"><div class=panel-heading><h4 class=panel-title><a class=collapsed data-toggle=collapse href=#panel__buildConfigHooks__buildID___secret___plugin_><span class=parent></span>/buildConfigHooks/{buildID}/{secret}/{plugin}</a> <span class=methods><a href=# data-toggle=modal data-target=#_buildConfigHooks__buildID___secret___plugin__post><span class="badge badge_post">post</span></a></span></h4></div><div id=panel__buildConfigHooks__buildID___secret___plugin_ class="panel-collapse collapse"><div class=panel-body><div class=list-group><div data-toggle=modal data-target=#_buildConfigHooks__buildID___secret___plugin__post class=list-group-item><span class="badge badge_post">post</span><div class=method_description><p>Webhook on push event from external repository.</p><p>buildID specifies which build to trigger, whereas plugin defines source of the request, this might be github, bitbucket or others.</p></div><div class=clearfix></div></div></div></div></div><div class="modal fade" tabindex=0 id=_buildConfigHooks__buildID___secret___plugin__post><div class=modal-dialog><div class=modal-content><div class=modal-header><button type=button class=close data-dismiss=modal aria-hidden=true>&times;</button><h4 class=modal-title id=myModalLabel><span class="badge badge_post">post</span> <span class=parent></span>/buildConfigHooks/{buildID}/{secret}/{plugin}</h4></div><div class=modal-body><div class="alert alert-info"><p>Webhook on push event from external repository.</p><p>buildID specifies which build to trigger, whereas plugin defines source of the request, this might be github, bitbucket or others.</p></div><ul class="nav nav-tabs"><li class=active><a href=#_buildConfigHooks__buildID___secret___plugin__post_request data-toggle=tab>Request</a></li><li><a href=#_buildConfigHooks__buildID___secret___plugin__post_response data-toggle=tab>Response</a></li></ul><div class=tab-content><div class="tab-pane active" id=_buildConfigHooks__buildID___secret___plugin__post_request><h3>URI Parameters</h3><ul><li><strong>buildID</strong>: <em>required (string)</em></li><li><strong>secret</strong>: <em>required (string)</em></li><li><strong>plugin</strong>: <em>required (string)</em></li></ul></div><div class=tab-pane id=_buildConfigHooks__buildID___secret___plugin__post_response><h2>HTTP status code <a href=http://httpstatus.es/204 target=_blank>204</a></h2><p>No content</p></div></div></div></div></div></div></div></div></div></div><div class="panel panel-default"><div class=panel-heading><h3 id=_buildConfigs class=panel-title>/buildConfigs</h3></div><div class=panel-body><div class=panel-group><div class="panel panel-white"><div class=panel-heading><h4 class=panel-title><a class=collapsed data-toggle=collapse href=#panel__buildConfigs><span class=parent></span>/buildConfigs</a> <span class=methods><a href=# data-toggle=modal data-target=#_buildConfigs_get><span class="badge badge_get">get</span></a> <a href=# data-toggle=modal data-target=#_buildConfigs_post><span class="badge badge_post">post</span></a></span></h4></div><div id=panel__buildConfigs class="panel-collapse collapse"><div class=panel-body><div class=list-group><div data-toggle=modal data-target=#_buildConfigs_get class=list-group-item><span class="badge badge_get">get</span><div class=method_description><p>List all BuildConfigs.</p><p>BuildConfig contains the inputs needed to produce a new deployable image.</p></div><div class=clearfix></div></div><div data-toggle=modal data-target=#_buildConfigs_post class=list-group-item><span class="badge badge_post">post</span><div class=method_description><p>Create a new build.</p></div><div class=clearfix></div></div></div></div></div><div class="modal fade" tabindex=0 id=_buildConfigs_get><div class=modal-dialog><div class=modal-content><div class=modal-header><button type=button class=close data-dismiss=modal aria-hidden=true>&times;</button><h4 class=modal-title id=myModalLabel><span class="badge badge_get">get</span> <span class=parent></span>/buildConfigs</h4></div><div class=modal-body><div class="alert alert-info"><p>List all BuildConfigs.</p><p>BuildConfig contains the inputs needed to produce a new deployable image.</p></div><ul class="nav nav-tabs"><li class=active><a href=#_buildConfigs_get_request data-toggle=tab>Request</a></li><li><a href=#_buildConfigs_get_response data-toggle=tab>Response</a></li></ul><div class=tab-content><div class="tab-pane active" id=_buildConfigs_get_request></div><div class=tab-pane id=_buildConfigs_get_response><h2>HTTP status code <a href=http://httpstatus.es/200 target=_blank>200</a></h2><h3>Body</h3><p><strong>Type: application/json</strong></p></div></div></div></div></div></div><div class="modal fade" tabindex=0 id=_buildConfigs_post><div class=modal-dialog><div class=modal-content><div class=modal-header><button type=button class=close data-dismiss=modal aria-hidden=true>&times;</button><h4 class=modal-title id=myModalLabel><span class="badge badge_post">post</span> <span class=parent></span>/buildConfigs</h4></div><div class=modal-body><div class="alert alert-info"><p>Create a new build.</p></div><ul class="nav nav-tabs"><li class=active><a href=#_buildConfigs_post_request data-toggle=tab>Request</a></li></ul><div class=tab-content><div class="tab-pane active" id=_buildConfigs_post_request><h3>Body</h3><p><strong>Type: application/json</strong></p><p><strong>Example</strong>:</p><pre><code>{
-	"kind": "BuildConfig",
-	"apiVersion": "v1beta1",
-	"desiredInput": {
-		"type": "sti",
-		"sourceURI": "git://github.com/pmorie/simple-ruby",
-		"builderImage": "openshift/ruby-19-centos",
-		"imageTag": "test-ruby-app"
-	}
+    "kind": "BuildConfig",
+    "apiVersion": "v1beta1",
+    "desiredInput": {
+        "sourceURI": "git://github.com/pmorie/simple-ruby",
+        "imageTag": "test-ruby-app",
+        "stiInput": {
+            "builderImage": "openshift/ruby-19-centos",
+        }
+    }
 }
 </code></pre></div></div></div></div></div></div></div><div class="panel panel-white"><div class=panel-heading><h4 class=panel-title><a class=collapsed data-toggle=collapse href=#panel__buildConfigs__configID_><span class=parent>/buildConfigs</span>/{configID}</a> <span class=methods><a href=# data-toggle=modal data-target=#_buildConfigs__configID__get><span class="badge badge_get">get</span></a> <a href=# data-toggle=modal data-target=#_buildConfigs__configID__put><span class="badge badge_put">put</span></a> <a href=# data-toggle=modal data-target=#_buildConfigs__configID__delete><span class="badge badge_delete">delete</span></a></span></h4></div><div id=panel__buildConfigs__configID_ class="panel-collapse collapse"><div class=panel-body><div class=list-group><div data-toggle=modal data-target=#_buildConfigs__configID__get class=list-group-item><span class="badge badge_get">get</span><div class=method_description><p>Get a specific build configuration.</p></div><div class=clearfix></div></div><div data-toggle=modal data-target=#_buildConfigs__configID__put class=list-group-item><span class="badge badge_put">put</span><div class=method_description><p>Update a specific build configuration.</p></div><div class=clearfix></div></div><div data-toggle=modal data-target=#_buildConfigs__configID__delete class=list-group-item><span class="badge badge_delete">delete</span><div class=method_description><p>Delete a specific build configuration.</p></div><div class=clearfix></div></div></div></div></div><div class="modal fade" tabindex=0 id=_buildConfigs__configID__get><div class=modal-dialog><div class=modal-content><div class=modal-header><button type=button class=close data-dismiss=modal aria-hidden=true>&times;</button><h4 class=modal-title id=myModalLabel><span class="badge badge_get">get</span> <span class=parent>/buildConfigs</span>/{configID}</h4></div><div class=modal-body><div class="alert alert-info"><p>Get a specific build configuration.</p></div><ul class="nav nav-tabs"><li class=active><a href=#_buildConfigs__configID__get_request data-toggle=tab>Request</a></li><li><a href=#_buildConfigs__configID__get_response data-toggle=tab>Response</a></li></ul><div class=tab-content><div class="tab-pane active" id=_buildConfigs__configID__get_request><h3>URI Parameters</h3><ul><li><strong>configID</strong>: <em>required (string)</em></li></ul></div><div class=tab-pane id=_buildConfigs__configID__get_response><h2>HTTP status code <a href=http://httpstatus.es/200 target=_blank>200</a></h2><h3>Body</h3><p><strong>Type: application/json</strong></p><p><strong>Example</strong>:</p><pre><code>{
     "apiVersion": "v1beta1",
     "creationTimestamp": "2014-09-16T19:33:36Z",
     "desiredInput": {
-        "builderImage": "openshift/ruby-19-centos",
         "imageTag": "test-ruby-app",
         "registry": "localhost:5000",
         "sourceURI": "git://github.com/pmorie/simple-ruby",
-        "type": "sti"
+        "stiInput": {
+            "builderImage": "openshift/ruby-19-centos"
+        }
     },
     "id": "5a6a5b9c-3dd8-11e4-9d75-0800279696e1",
     "kind": "BuildConfig",
@@ -203,11 +205,12 @@
     "apiVersion": "v1beta1",
     "creationTimestamp": "2014-09-16T19:33:36Z",
     "desiredInput": {
-        "builderImage": "openshift/ruby-19-centos",
         "imageTag": "test-ruby-app",
         "registry": "localhost:5000",
         "sourceURI": "git://github.com/pmorie/simple-ruby",
-        "type": "sti"
+        "stiInput": {
+            "builderImage": "openshift/ruby-19-centos"
+        }
     },
     "id": "5a6a5b9c-3dd8-11e4-9d75-0800279696e1",
     "kind": "BuildConfig",
@@ -229,7 +232,6 @@
             "input": {
                 "imageTag": "test/dockerbuild",
                 "sourceURI": "git://github.com/test/dockerbuild",
-                "type": "docker"
             },
             "podID": "build-sti-5065bcf2-3d4d-11e4-a95b-0800279696e1",
             "resourceVersion": 114,
@@ -243,7 +245,6 @@
 	"kind": "Build",
 	"apiVersion": "v1beta1",
 	"input": {
-		"type": "docker",
 		"sourceURI": "github.com/test/dockerBuild",
 		"imageTag": "test/dockerBuild"
 	}
@@ -255,7 +256,6 @@
     "input": {
         "imageTag": "test/dockerBuild",
         "sourceURI": "github.com/test/dockerBuild",
-        "type": "docker"
     },
     "kind": "Build",
     "podID": "build-sti-5065bcf2-3d4d-11e4-a95b-0800279696e1",
@@ -269,7 +269,6 @@
     "input": {
         "imageTag": "test/dockerBuild",
         "sourceURI": "github.com/test/dockerBuild",
-        "type": "docker"
     },
     "kind": "Build",
     "podID": "build-sti-5065bcf2-3d4d-11e4-a95b-0800279696e1",

--- a/examples/sample-app/buildcfg/buildcfg.json
+++ b/examples/sample-app/buildcfg/buildcfg.json
@@ -4,7 +4,6 @@
     "apiVersion": "v1beta1",
     "desiredInput":
     {
-        "type":      "docker",
         "sourceURI": "git://github.com/openshift/ruby-hello-world.git",
         "imageTag":  "openshift/origin-ruby-sample",
         "registry":  "127.0.0.1:5001"

--- a/images/builder/docker/docker-builder/build.sh
+++ b/images/builder/docker/docker-builder/build.sh
@@ -4,30 +4,53 @@ IFS=$'\n\t'
 
 DOCKER_SOCKET=/var/run/docker.sock
 
-if [ ! -e $DOCKER_SOCKET ]; then
-  echo "Docker socket missing at $DOCKER_SOCKET"
+if [ ! -e "${DOCKER_SOCKET}" ]; then
+  echo "Docker socket missing at ${DOCKER_SOCKET}"
   exit 1
 fi
 
-TAG=$BUILD_TAG
-if [ -n "$DOCKER_REGISTRY" ]; then
-  TAG=$DOCKER_REGISTRY/$BUILD_TAG
+TAG="${BUILD_TAG}"
+if [ -n "${REGISTRY}" ]; then
+  TAG="${REGISTRY}/${BUILD_TAG}"
 fi
 
-if [[ $DOCKER_CONTEXT_URL != "git://"* ]] && [[ $DOCKER_CONTEXT_URL != "git@"* ]]; then
-  URL=$DOCKER_CONTEXT_URL
-  if [[ $URL != "http://"* ]] && [[ $URL != "https://"* ]]; then
-    URL="https://"$URL
+if [[ "${SOURCE_URI}" != "git://"* ]] && [[ "${SOURCE_URI}" != "git@"* ]]; then
+  URL="${SOURCE_URI}"
+  if [[ "${URL}" != "http://"* ]] && [[ "${URL}" != "https://"* ]]; then
+    URL="https://${URL}"
   fi
   curl --head --silent --fail --location --max-time 16 $URL > /dev/null
   if [ $? != 0 ]; then
-    echo "Not found: "$DOCKER_CONTEXT_URL
+    echo "Not found: ${SOURCE_URI}"
     exit 1
   fi
 fi
 
-docker build --rm -t $TAG $DOCKER_CONTEXT_URL
+if [ -n "${SOURCE_REF}" ] || [ -n "${CONTEXT_DIR}" ]; then
+  BUILD_DIR=$(mktemp --directory --suffix=docker-build)
+  git clone --recursive "${SOURCE_URI}" "${BUILD_DIR}"
+  if [ $? != 0 ]; then
+    echo "Error trying to fetch git source: ${SOURCE_URI}"
+    exit 1
+  fi
+  if [ -n "${SOURCE_REF}" ]; then
+    pushd "${BUILD_DIR}"
+    git checkout "${SOURCE_REF}"
+    if [ $? != 0 ]; then
+      echo "Error trying to checkout branch: ${SOURCE_REF}"
+      exit 1
+    fi
+    popd
+  fi
+  if [ -n "${CONTEXT_DIR}" ] && [ ! -d "${BUILD_DIR}/${CONTEXT_DIR}" ]; then
+    echo "ContextDir does not exist in the repository: ${CONTEXT_DIR}"
+    exit 1
+  fi
+  docker build --rm -t "${TAG}" "${BUILD_DIR}/${CONTEXT_DIR}"
+else
+  docker build --rm -t "${TAG}" "${SOURCE_URI}"
+fi
 
-if [ -n "$DOCKER_REGISTRY" ] || [ -s "/root/.dockercfg" ]; then
-  docker push $TAG
+if [ -n "${REGISTRY}" ] || [ -s "/root/.dockercfg" ]; then
+  docker push "${TAG}"
 fi

--- a/images/builder/docker/sti-builder/build.sh
+++ b/images/builder/docker/sti-builder/build.sh
@@ -2,24 +2,24 @@
 
 DOCKER_SOCKET=/var/run/docker.sock
 
-if [ ! -e $DOCKER_SOCKET ]; then
+if [ ! -e "${DOCKER_SOCKET}" ]; then
   echo "Docker socket missing at $DOCKER_SOCKET"
   exit 1
 fi
 
-TAG=$BUILD_TAG
-if [ -n "$DOCKER_REGISTRY" ]; then
-  TAG=$DOCKER_REGISTRY/$BUILD_TAG
+TAG="${BUILD_TAG}"
+if [ -n "$REGISTRY" ]; then
+  TAG=$REGISTRY/$BUILD_TAG
 fi
 
 REF_OPTION=""
-if [ -n "$SOURCE_REF" ]; then
-  REF_OPTION="--ref $SOURCE_REF"
+if [ -n "${SOURCE_REF}" ]; then
+  REF_OPTION="--ref ${SOURCE_REF}"
 fi
 
-BUILD_TEMP_DIR=${TEMP_DIR-$TMPDIR}
-TMPDIR=$BUILD_TEMP_DIR sti build $SOURCE_URI $BUILDER_IMAGE $TAG $REF_OPTION
+BUILD_TEMP_DIR="${TEMP_DIR-$TMPDIR}"
+TMPDIR="${BUILD_TEMP_DIR}" sti build "${SOURCE_URI}" "${BUILDER_IMAGE}" "${TAG}" "${REF_OPTION}"
 
-if [ -n "$DOCKER_REGISTRY" ] || [ -s "/root/.dockercfg" ]; then
-  docker push $TAG
+if [ -n "${REGISTRY}" ] || [ -s "/root/.dockercfg" ]; then
+  docker push "${TAG}"
 fi

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -20,11 +20,8 @@ type Build struct {
 	PodID string `json:"podID,omitempty" yaml:"podID,omitempty"`
 }
 
-// BuildInput defines the type of build and input parameters for a given build
+// BuildInput defines input parameters for a given build
 type BuildInput struct {
-	// Type is the type of build to execute
-	Type BuildType `json:"type,omitempty" yaml:"type,omitempty"`
-
 	// SourceURI points to the source that will be built. The structure of the source
 	// will depend on the type of build to run
 	SourceURI string `json:"sourceURI,omitempty" yaml:"sourceURI,omitempty"`
@@ -36,9 +33,25 @@ type BuildInput struct {
 	ImageTag string `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
 
 	// Registry to push the result image to
-	Registry string `json:"registry",omitempty" yaml:"registry,omitempty"`
+	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
 
-	// BuilderImage is the image used to execute the build when running STI builds
+	// DockerBuild represents build parameters specific to docker build
+	DockerInput *DockerBuildInput `json:"dockerInput,omitempty" yaml:"dockerInput,omitempty"`
+
+	// STIBuild represents build parameters specific to STI build
+	STIInput *STIBuildInput `json:"stiInput,omitempty" yaml:"stiInput,omitempty"`
+}
+
+// DockerBuildInput defines input parameters specific to docker build
+type DockerBuildInput struct {
+	// ContextDir is a directory inside the SourceURI structure which should be used as a docker
+	// context when building
+	ContextDir string `json:"contextDir,omitempty" yaml:"contextDir,omitempty"`
+}
+
+// STIBuildInput defines input parameters specific to sti build
+type STIBuildInput struct {
+	// BuilderImage is the image used to execute the build
 	BuilderImage string `json:"builderImage,omitempty" yaml:"builderImage,omitempty"`
 }
 

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -20,11 +20,8 @@ type Build struct {
 	PodID string `json:"podID,omitempty" yaml:"podID,omitempty"`
 }
 
-// BuildInput defines the type of build and input parameters for a given build
+// BuildInput defines input parameters for a given build
 type BuildInput struct {
-	// Type is the type of build to execute
-	Type BuildType `json:"type,omitempty" yaml:"type,omitempty"`
-
 	// SourceURI points to the source that will be built. The structure of the source
 	// will depend on the type of build to run
 	SourceURI string `json:"sourceURI,omitempty" yaml:"sourceURI,omitempty"`
@@ -36,9 +33,25 @@ type BuildInput struct {
 	ImageTag string `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
 
 	// Registry to push the result image to
-	Registry string `json:"registry",omitempty" yaml:"registry,omitempty"`
+	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
 
-	// BuilderImage is the image used to execute the build when running STI builds
+	// DockerBuild represents build parameters specific to docker build
+	DockerInput *DockerBuildInput `json:"dockerInput,omitempty" yaml:"dockerInput,omitempty"`
+
+	// STIBuild represents build parameters specific to STI build
+	STIInput *STIBuildInput `json:"stiInput,omitempty" yaml:"stiInput,omitempty"`
+}
+
+// DockerBuildInput defines input parameters specific to docker build
+type DockerBuildInput struct {
+	// ContextDir is a directory inside the SourceURI structure which should be used as a docker
+	// context when building
+	ContextDir string `json:"contextDir,omitempty" yaml:"contextDir,omitempty"`
+}
+
+// STIBuildInput defines input parameters specific to sti build
+type STIBuildInput struct {
+	// BuilderImage is the image used to execute the build
 	BuilderImage string `json:"builderImage,omitempty" yaml:"builderImage,omitempty"`
 }
 

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -37,14 +37,16 @@ func validateBuildInput(input *api.BuildInput) errs.ErrorList {
 	if len(input.ImageTag) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("imageTag", input.ImageTag))
 	}
-	if input.Type == api.STIBuildType {
-		if len(input.BuilderImage) == 0 {
-			allErrs = append(allErrs, errs.NewFieldRequired("builderImage", input.BuilderImage))
-		}
-	} else {
-		if len(input.BuilderImage) != 0 {
-			allErrs = append(allErrs, errs.NewFieldInvalid("builderImage", input.BuilderImage))
-		}
+	if input.STIInput != nil {
+		allErrs = append(allErrs, validateSTIBuild(input.STIInput).Prefix("stiBuild")...)
+	}
+	return allErrs
+}
+
+func validateSTIBuild(sti *api.STIBuildInput) errs.ErrorList {
+	allErrs := errs.ErrorList{}
+	if len(sti.BuilderImage) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("builderImage", sti.BuilderImage))
 	}
 	return allErrs
 }

--- a/pkg/build/registry/build/rest_test.go
+++ b/pkg/build/registry/build/rest_test.go
@@ -333,7 +333,6 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 		"empty ID": {
 			JSONBase: kubeapi.JSONBase{ID: ""},
 			Input: api.BuildInput{
-				Type:      api.DockerBuildType,
 				SourceURI: "http://my.build.com/the/build/Dockerfile",
 				ImageTag:  "repository/dataBuild",
 			},
@@ -360,7 +359,6 @@ func mockBuild() *api.Build {
 			ID: "dataBuild",
 		},
 		Input: api.BuildInput{
-			Type:      api.DockerBuildType,
 			SourceURI: "http://my.build.com/the/build/Dockerfile",
 			ImageTag:  "repository/dataBuild",
 		},

--- a/pkg/build/registry/buildconfig/rest_test.go
+++ b/pkg/build/registry/buildconfig/rest_test.go
@@ -254,7 +254,6 @@ func mockBuildConfig() *api.BuildConfig {
 			ID: "dataBuild",
 		},
 		DesiredInput: api.BuildInput{
-			Type:      api.DockerBuildType,
 			SourceURI: "http://my.build.com/the/buildConfig/Dockerfile",
 			ImageTag:  "repository/dataBuild",
 		},
@@ -321,10 +320,11 @@ func TestBuildConfigRESTValidatesCreate(t *testing.T) {
 		"blank sourceURI": {
 			JSONBase: kubeapi.JSONBase{ID: "abc"},
 			DesiredInput: api.BuildInput{
-				SourceURI:    "",
-				ImageTag:     "data/image",
-				Type:         api.STIBuildType,
-				BuilderImage: "builder/image",
+				SourceURI: "",
+				ImageTag:  "data/image",
+				STIInput: &api.STIBuildInput{
+					BuilderImage: "builder/image",
+				},
 			},
 		},
 		"blank ImageTag": {
@@ -332,16 +332,16 @@ func TestBuildConfigRESTValidatesCreate(t *testing.T) {
 			DesiredInput: api.BuildInput{
 				SourceURI: "http://github.com/test/source",
 				ImageTag:  "",
-				Type:      api.DockerBuildType,
 			},
 		},
 		"blank BuilderImage": {
 			JSONBase: kubeapi.JSONBase{ID: "abc"},
 			DesiredInput: api.BuildInput{
-				SourceURI:    "http://github.com/test/source",
-				ImageTag:     "data/image",
-				Type:         api.STIBuildType,
-				BuilderImage: "",
+				SourceURI: "http://github.com/test/source",
+				ImageTag:  "data/image",
+				STIInput: &api.STIBuildInput{
+					BuilderImage: "",
+				},
 			},
 		},
 	}
@@ -365,16 +365,16 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 			DesiredInput: api.BuildInput{
 				SourceURI: "http://github.com/test/source",
 				ImageTag:  "data/image",
-				Type:      api.DockerBuildType,
 			},
 		},
 		"blank sourceURI": {
 			JSONBase: kubeapi.JSONBase{ID: "abc"},
 			DesiredInput: api.BuildInput{
-				SourceURI:    "",
-				ImageTag:     "data/image",
-				Type:         api.STIBuildType,
-				BuilderImage: "builder/image",
+				SourceURI: "",
+				ImageTag:  "data/image",
+				STIInput: &api.STIBuildInput{
+					BuilderImage: "builder/image",
+				},
 			},
 		},
 		"blank ImageTag": {
@@ -382,25 +382,16 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 			DesiredInput: api.BuildInput{
 				SourceURI: "http://github.com/test/source",
 				ImageTag:  "",
-				Type:      api.DockerBuildType,
 			},
 		},
 		"blank BuilderImage on STIBuildType": {
 			JSONBase: kubeapi.JSONBase{ID: "abc"},
 			DesiredInput: api.BuildInput{
-				SourceURI:    "http://github.com/test/source",
-				ImageTag:     "data/image",
-				Type:         api.STIBuildType,
-				BuilderImage: "",
-			},
-		},
-		"non-blank BuilderImage on DockerBuildType": {
-			JSONBase: kubeapi.JSONBase{ID: "abc"},
-			DesiredInput: api.BuildInput{
-				SourceURI:    "http://github.com/test/source",
-				ImageTag:     "data/image",
-				Type:         api.DockerBuildType,
-				BuilderImage: "builder/image",
+				SourceURI: "http://github.com/test/source",
+				ImageTag:  "data/image",
+				STIInput: &api.STIBuildInput{
+					BuilderImage: "",
+				},
 			},
 		},
 	}

--- a/pkg/build/registry/etcd/etcd_test.go
+++ b/pkg/build/registry/etcd/etcd_test.go
@@ -61,7 +61,6 @@ func TestEtcdCreateBuild(t *testing.T) {
 			ID: "foo",
 		},
 		Input: api.BuildInput{
-			Type:      api.DockerBuildType,
 			SourceURI: "http://my.build.com/the/build/Dockerfile",
 			ImageTag:  "repository/dataBuild",
 		},
@@ -229,7 +228,6 @@ func TestEtcdCreateBuildConfig(t *testing.T) {
 			ID: "foo",
 		},
 		DesiredInput: api.BuildInput{
-			Type:      api.DockerBuildType,
 			SourceURI: "http://my.build.com/the/build/Dockerfile",
 			ImageTag:  "repository/dataBuild",
 		},

--- a/pkg/build/strategy/docker.go
+++ b/pkg/build/strategy/docker.go
@@ -19,6 +19,11 @@ func NewDockerBuildStrategy(dockerBuilderImage string, useLocalImage bool) *Dock
 // CreateBuildPod creates the pod to be used for the Docker build
 // TODO: Make the Pod definition configurable
 func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*api.Pod, error) {
+	contextDir := ""
+	if build.Input.DockerInput != nil {
+		contextDir = build.Input.DockerInput.ContextDir
+	}
+
 	pod := &api.Pod{
 		JSONBase: api.JSONBase{
 			ID: build.PodID,
@@ -32,8 +37,10 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*api.Pod, 
 						Image: bs.dockerBuilderImage,
 						Env: []api.EnvVar{
 							{Name: "BUILD_TAG", Value: build.Input.ImageTag},
-							{Name: "DOCKER_CONTEXT_URL", Value: build.Input.SourceURI},
-							{Name: "DOCKER_REGISTRY", Value: build.Input.Registry},
+							{Name: "SOURCE_URI", Value: build.Input.SourceURI},
+							{Name: "SOURCE_REF", Value: build.Input.SourceRef},
+							{Name: "REGISTRY", Value: build.Input.Registry},
+							{Name: "CONTEXT_DIR", Value: contextDir},
 						},
 					},
 				},

--- a/pkg/build/strategy/sti.go
+++ b/pkg/build/strategy/sti.go
@@ -48,10 +48,10 @@ func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*api.Pod, err
 						Image: bs.stiBuilderImage,
 						Env: []api.EnvVar{
 							{Name: "BUILD_TAG", Value: build.Input.ImageTag},
-							{Name: "DOCKER_REGISTRY", Value: build.Input.Registry},
 							{Name: "SOURCE_URI", Value: build.Input.SourceURI},
 							{Name: "SOURCE_REF", Value: build.Input.SourceRef},
-							{Name: "BUILDER_IMAGE", Value: build.Input.BuilderImage},
+							{Name: "REGISTRY", Value: build.Input.Registry},
+							{Name: "BUILDER_IMAGE", Value: build.Input.STIInput.BuilderImage},
 						},
 					},
 				},

--- a/pkg/cmd/client/build/printer.go
+++ b/pkg/cmd/client/build/printer.go
@@ -24,6 +24,7 @@ func printBuild(build *api.Build, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", build.ID, build.Status, build.PodID)
 	return err
 }
+
 func printBuildList(buildList *api.BuildList, w io.Writer) error {
 	for _, build := range buildList.Items {
 		if err := printBuild(&build, w); err != nil {
@@ -34,9 +35,15 @@ func printBuildList(buildList *api.BuildList, w io.Writer) error {
 }
 
 func printBuildConfig(bc *api.BuildConfig, w io.Writer) error {
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", bc.ID, bc.DesiredInput.Type, bc.DesiredInput.SourceURI)
+	buildType := api.DockerBuildType
+	if bc.DesiredInput.STIInput != nil {
+		buildType = api.STIBuildType
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%v\t%s\n", bc.ID, buildType, bc.DesiredInput.SourceURI)
 	return err
 }
+
 func printBuildConfigList(buildList *api.BuildConfigList, w io.Writer) error {
 	for _, buildConfig := range buildList.Items {
 		if err := printBuildConfig(&buildConfig, w); err != nil {

--- a/test/integration/buildcfgclient_test.go
+++ b/test/integration/buildcfgclient_test.go
@@ -77,20 +77,13 @@ func TestBuildConfigClient(t *testing.T) {
 			"label2": "value2",
 		},
 		DesiredInput: api.BuildInput{
-			Type:         api.DockerBuildType,
-			SourceURI:    "http://my.docker/build",
-			ImageTag:     "namespace/builtimage",
-			BuilderImage: "anImage",
+			SourceURI: "http://my.docker/build",
+			ImageTag:  "namespace/builtimage",
 		},
-	}
-	got, err := osClient.CreateBuildConfig(ctx, buildConfig)
-	if err == nil {
-		t.Fatalf("unexpected non-error: %v", err)
 	}
 
 	// get a created buildConfig
-	buildConfig.DesiredInput.BuilderImage = ""
-	got, err = osClient.CreateBuildConfig(ctx, buildConfig)
+	got, err := osClient.CreateBuildConfig(ctx, buildConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -77,20 +77,13 @@ func TestBuildClient(t *testing.T) {
 			"label2": "value2",
 		},
 		Input: api.BuildInput{
-			Type:         api.DockerBuildType,
-			SourceURI:    "http://my.docker/build",
-			ImageTag:     "namespace/builtimage",
-			BuilderImage: "anImage",
+			SourceURI: "http://my.docker/build",
+			ImageTag:  "namespace/builtimage",
 		},
-	}
-	got, err := osClient.CreateBuild(ctx, build)
-	if err == nil {
-		t.Fatalf("unexpected non-error: %v", err)
 	}
 
 	// get a created build
-	build.Input.BuilderImage = ""
-	got, err = osClient.CreateBuild(ctx, build)
+	got, err := osClient.CreateBuild(ctx, build)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -44,7 +44,6 @@ func TestWebhookGithubPush(t *testing.T) {
 			ID: "pushbuild",
 		},
 		DesiredInput: buildapi.BuildInput{
-			Type:      buildapi.DockerBuildType,
 			SourceURI: "http://my.docker/build",
 			ImageTag:  "namespace/builtimage",
 		},
@@ -86,7 +85,6 @@ func TestWebhookGithubPing(t *testing.T) {
 			ID: "pingbuild",
 		},
 		DesiredInput: buildapi.BuildInput{
-			Type:      buildapi.DockerBuildType,
 			SourceURI: "http://my.docker/build",
 			ImageTag:  "namespace/builtimage",
 		},


### PR DESCRIPTION
This is the initial part of the work behind adding the additional directory to docker builds, especially this commit covers restructuring the `BuildInput` object splitting the docker related and STI related stuff into sub-objects. 
Still to do: 
- [x] docs
- [x] build image
