### PR TITLE
Add support for a project resource

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/api/latest"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	configapi "github.com/openshift/origin/pkg/config/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
@@ -20,6 +21,7 @@ func TestExamples(t *testing.T) {
 	expected := map[string]runtime.Object{
 		"guestbook/template.json":                    &templateapi.Template{},
 		"hello-openshift/hello-pod.json":             &kubeapi.Pod{},
+		"hello-openshift/hello-project.json":         &projectapi.Project{},
 		"simple-ruby-app/buildcfg/buildcfg.json":     &buildapi.BuildConfig{},
 		"simple-ruby-app/buildinvoke/pushevent.json": nil, // Skip.
 		"simple-ruby-app/registry-config.json":       &configapi.Config{},

--- a/examples/hello-openshift/hello-project.json
+++ b/examples/hello-openshift/hello-project.json
@@ -1,0 +1,10 @@
+{
+  "id": "hello-openshift-project",
+  "kind": "Project",
+  "apiVersion": "v1beta1",
+  "displayName": "Hello OpenShift",
+  "description": "This is an example project to demonstrate OpenShift v3",
+  "labels": {
+    "name": "hello-openshift-project"
+  }
+}

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -8,8 +8,9 @@ import (
 	_ "github.com/openshift/origin/pkg/config/api"
 	_ "github.com/openshift/origin/pkg/deploy/api"
 	_ "github.com/openshift/origin/pkg/image/api"
-	_ "github.com/openshift/origin/pkg/template/api"
+	_ "github.com/openshift/origin/pkg/project/api"
 	_ "github.com/openshift/origin/pkg/route/api"
+	_ "github.com/openshift/origin/pkg/template/api"
 )
 
 // Codec is the identity codec for this package - it can only convert itself

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -8,8 +8,9 @@ import (
 	_ "github.com/openshift/origin/pkg/config/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/deploy/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/image/api/v1beta1"
-	_ "github.com/openshift/origin/pkg/template/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/project/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/route/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/template/api/v1beta1"
 )
 
 // Codec encodes internal objects to the v1beta1 scheme

--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -29,12 +29,14 @@ import (
 	. "github.com/openshift/origin/pkg/cmd/client/api"
 	"github.com/openshift/origin/pkg/cmd/client/build"
 	"github.com/openshift/origin/pkg/cmd/client/image"
+	"github.com/openshift/origin/pkg/cmd/client/project"
 	"github.com/openshift/origin/pkg/cmd/client/route"
 	"github.com/openshift/origin/pkg/config"
 	configapi "github.com/openshift/origin/pkg/config/api"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployclient "github.com/openshift/origin/pkg/deploy/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
@@ -114,6 +116,7 @@ var parser = kubecfg.NewParser(map[string]runtime.Object{
 	"deployments":             &deployapi.Deployment{},
 	"deploymentConfigs":       &deployapi.DeploymentConfig{},
 	"routes":                  &routeapi.Route{},
+	"projects":                &projectapi.Project{},
 })
 
 func prettyWireStorage() string {
@@ -264,6 +267,7 @@ func (c *KubeConfig) Run() {
 		"deployments":             {"Deployment", client.RESTClient, latest.Codec},
 		"deploymentConfigs":       {"DeploymentConfig", client.RESTClient, latest.Codec},
 		"routes":                  {"Route", client.RESTClient, latest.Codec},
+		"projects":                {"Project", client.RESTClient, latest.Codec},
 	}
 
 	matchFound := c.executeConfigRequest(method, clients) || c.executeTemplateRequest(method, client) || c.executeBuildLogRequest(method, client) || c.executeControllerRequest(method, kubeClient) || c.executeAPIRequest(method, clients)
@@ -546,6 +550,7 @@ func humanReadablePrinter() *kubecfg.HumanReadablePrinter {
 	image.RegisterPrintHandlers(printer)
 	deployclient.RegisterPrintHandlers(printer)
 	route.RegisterPrintHandlers(printer)
+	project.RegisterPrintHandlers(printer)
 
 	return printer
 }

--- a/pkg/cmd/client/project/printer.go
+++ b/pkg/cmd/client/project/printer.go
@@ -1,0 +1,30 @@
+package project
+
+import (
+	"fmt"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubecfg"
+	"github.com/openshift/origin/pkg/project/api"
+	"io"
+)
+
+var projectColumns = []string{"ID", "Namespace", "Display Name", "Description"}
+
+// RegisterPrintHandlers registers HumanReadablePrinter handlers for project resources.
+func RegisterPrintHandlers(printer *kubecfg.HumanReadablePrinter) {
+	printer.Handler(projectColumns, printProject)
+	printer.Handler(projectColumns, printProjectList)
+}
+
+func printProject(project *api.Project, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", project.ID, project.Namespace, project.DisplayName, project.Description)
+	return err
+}
+
+func printProjectList(projects *api.ProjectList, w io.Writer) error {
+	for _, project := range projects.Items {
+		if err := printProject(&project, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -40,6 +40,8 @@ import (
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/image/registry/imagerepository"
 	"github.com/openshift/origin/pkg/image/registry/imagerepositorymapping"
+	projectetcd "github.com/openshift/origin/pkg/project/registry/etcd"
+	projectregistry "github.com/openshift/origin/pkg/project/registry/project"
 	routeetcd "github.com/openshift/origin/pkg/route/registry/etcd"
 	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
 	"github.com/openshift/origin/pkg/template"
@@ -48,6 +50,7 @@ import (
 	// Register versioned api types
 	_ "github.com/openshift/origin/pkg/config/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/image/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/project/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/route/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/template/api/v1beta1"
 )
@@ -113,6 +116,7 @@ func (c *MasterConfig) RunAPI(m APIInstaller) {
 	imageRegistry := imageetcd.New(c.EtcdHelper)
 	deployEtcd := deployetcd.New(c.EtcdHelper)
 	routeEtcd := routeetcd.New(c.EtcdHelper)
+	projectEtcd := projectetcd.New(c.EtcdHelper)
 
 	// initialize OpenShift API
 	storage := map[string]apiserver.RESTStorage{
@@ -129,7 +133,8 @@ func (c *MasterConfig) RunAPI(m APIInstaller) {
 
 		"templateConfigs": template.NewStorage(),
 
-		"routes": routeregistry.NewREST(routeEtcd),
+		"routes":   routeregistry.NewREST(routeEtcd),
+		"projects": projectregistry.NewREST(projectEtcd),
 	}
 
 	osMux := http.NewServeMux()

--- a/pkg/project/api/register.go
+++ b/pkg/project/api/register.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("",
+		&Project{},
+		&ProjectList{},
+	)
+}
+
+func (*Project) IsAnAPIObject()     {}
+func (*ProjectList) IsAnAPIObject() {}

--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// ProjectList is a list of Project objects.
+type ProjectList struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Items            []Project `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// Project is a logical top-level container for a set of origin resources
+type Project struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Labels           map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DisplayName      string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+}

--- a/pkg/project/api/v1beta1/register.go
+++ b/pkg/project/api/v1beta1/register.go
@@ -1,0 +1,15 @@
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("v1beta1",
+		&Project{},
+		&ProjectList{},
+	)
+}
+
+func (*Project) IsAnAPIObject()     {}
+func (*ProjectList) IsAnAPIObject() {}

--- a/pkg/project/api/v1beta1/types.go
+++ b/pkg/project/api/v1beta1/types.go
@@ -1,0 +1,19 @@
+package v1beta1
+
+import (
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// ProjectList is a list of Project objects.
+type ProjectList struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Items            []Project `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+// Project is a logical top-level container for a set of origin resources
+type Project struct {
+	kubeapi.JSONBase `json:",inline" yaml:",inline"`
+	Labels           map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	DisplayName      string            `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+}

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -1,0 +1,33 @@
+package validation
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/openshift/origin/pkg/project/api"
+	"strings"
+)
+
+// ValidateProject tests required fields for a Project.
+func ValidateProject(project *api.Project) errors.ErrorList {
+	result := errors.ErrorList{}
+	if len(project.ID) == 0 {
+		result = append(result, errors.NewFieldRequired("ID", project.ID))
+	} else if !util.IsDNS952Label(project.ID) {
+		result = append(result, errors.NewFieldInvalid("ID", project.ID))
+	}
+	if !util.IsDNSSubdomain(project.Namespace) {
+		result = append(result, errors.NewFieldInvalid("Namespace", project.Namespace))
+	}
+	if !validateNoNewLineOrTab(project.DisplayName) {
+		result = append(result, errors.NewFieldInvalid("DisplayName", project.DisplayName))
+	}
+	if !validateNoNewLineOrTab(project.Description) {
+		result = append(result, errors.NewFieldInvalid("Description", project.Description))
+	}
+	return result
+}
+
+// validateNoNewLineOrTab ensures a string has no new-line or tab
+func validateNoNewLineOrTab(s string) bool {
+	return !(strings.Contains(s, "\n") || strings.Contains(s, "\t"))
+}

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -1,0 +1,94 @@
+package validation
+
+import (
+	"testing"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/openshift/origin/pkg/project/api"
+)
+
+func TestValidateProject(t *testing.T) {
+	testCases := []struct {
+		name    string
+		project api.Project
+		numErrs int
+	}{
+		{
+			name: "missing id",
+			project: api.Project{
+				JSONBase:    kubeapi.JSONBase{Namespace: kubeapi.NamespaceDefault},
+				DisplayName: "hi",
+				Description: "This is a description",
+			},
+			// Should fail because the ID is missing.
+			numErrs: 1,
+		},
+		{
+			name: "invalid id",
+			project: api.Project{
+				JSONBase:    kubeapi.JSONBase{ID: "141-.124.$", Namespace: kubeapi.NamespaceDefault},
+				DisplayName: "hi",
+				Description: "This is a description",
+			},
+			// Should fail because the ID is invalid.
+			numErrs: 1,
+		},
+		{
+			name: "missing namespace",
+			project: api.Project{
+				JSONBase:    kubeapi.JSONBase{ID: "foo", Namespace: ""},
+				DisplayName: "hi",
+				Description: "This is a description",
+			},
+			// Should fail because the namespace is missing.
+			numErrs: 1,
+		},
+		{
+			name: "invalid namespace",
+			project: api.Project{
+				JSONBase:    kubeapi.JSONBase{ID: "foo", Namespace: "141-.124.$"},
+				DisplayName: "hi",
+				Description: "This is a description",
+			},
+			// Should fail because the namespace is missing.
+			numErrs: 1,
+		},
+		{
+			name: "invalid description",
+			project: api.Project{
+				JSONBase:    kubeapi.JSONBase{ID: "foo", Namespace: "foo"},
+				DisplayName: "hi",
+				Description: "This is a \n description",
+			},
+			// Should fail because the description has a \n
+			numErrs: 1,
+		},
+		{
+			name: "invalid display name",
+			project: api.Project{
+				JSONBase:    kubeapi.JSONBase{ID: "foo", Namespace: "foo"},
+				DisplayName: "h\t\ni",
+				Description: "This is a description",
+			},
+			// Should fail because the display name has \t \n
+			numErrs: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		errs := ValidateProject(&tc.project)
+		if len(errs) != tc.numErrs {
+			t.Errorf("Unexpected error list for case %q: %+v", tc.name, errs)
+		}
+	}
+
+	project := api.Project{
+		JSONBase:    kubeapi.JSONBase{ID: "foo", Namespace: kubeapi.NamespaceDefault},
+		DisplayName: "hi",
+		Description: "This is a description",
+	}
+	errs := ValidateProject(&project)
+	if len(errs) != 0 {
+		t.Errorf("Unexpected non-zero error list: %#v", errs)
+	}
+}

--- a/pkg/project/doc.go
+++ b/pkg/project/doc.go
@@ -1,0 +1,2 @@
+// Package project provides support for projects including RESTStorage implementations and registries.
+package project

--- a/pkg/project/registry/etcd/etcd.go
+++ b/pkg/project/registry/etcd/etcd.go
@@ -1,0 +1,82 @@
+package etcd
+
+import (
+	"errors"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	etcderr "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	"github.com/openshift/origin/pkg/project/api"
+)
+
+const (
+	// ProjectPath is the path to project resources in etcd
+	ProjectPath string = "/projects"
+)
+
+// Etcd implements ProjectRegistry and ProjectRepositoryRegistry backed by etcd.
+type Etcd struct {
+	tools.EtcdHelper
+}
+
+// New returns a new etcd registry.
+func New(helper tools.EtcdHelper) *Etcd {
+	return &Etcd{
+		EtcdHelper: helper,
+	}
+}
+
+// makeProjectListKey constructs etcd paths to project directories
+func makeProjectListKey(ctx kubeapi.Context) string {
+	return ProjectPath
+}
+
+// makeProjectKey constructs etcd paths to project items
+func makeProjectKey(ctx kubeapi.Context, id string) string {
+	return makeProjectListKey(ctx) + "/" + id
+}
+
+// ListProjects retrieves a list of projects that match selector.
+func (r *Etcd) ListProjects(ctx kubeapi.Context, selector labels.Selector) (*api.ProjectList, error) {
+	list := api.ProjectList{}
+	err := r.ExtractList(makeProjectListKey(ctx), &list.Items, &list.ResourceVersion)
+	if err != nil {
+		return nil, err
+	}
+	filtered := []api.Project{}
+	for _, item := range list.Items {
+		if selector.Matches(labels.Set(item.Labels)) {
+			filtered = append(filtered, item)
+		}
+	}
+	list.Items = filtered
+	return &list, nil
+}
+
+// GetProject retrieves a specific project
+func (r *Etcd) GetProject(ctx kubeapi.Context, id string) (*api.Project, error) {
+	var project api.Project
+	if err := r.ExtractObj(makeProjectKey(ctx, id), &project, false); err != nil {
+		return nil, etcderr.InterpretGetError(err, "project", id)
+	}
+	return &project, nil
+}
+
+// CreateProject creates a new project
+func (r *Etcd) CreateProject(ctx kubeapi.Context, project *api.Project) error {
+	err := r.CreateObj(makeProjectKey(ctx, project.ID), project, 0)
+	return etcderr.InterpretCreateError(err, "project", project.ID)
+}
+
+// UpdateProject updates an existing project
+func (r *Etcd) UpdateProject(ctx kubeapi.Context, project *api.Project) error {
+	return errors.New("not supported")
+}
+
+// DeleteProject deletes an existing project
+func (r *Etcd) DeleteProject(ctx kubeapi.Context, id string) error {
+	err := r.Delete(makeProjectKey(ctx, id), false)
+	return etcderr.InterpretDeleteError(err, "project", id)
+}

--- a/pkg/project/registry/etcd/etcd_test.go
+++ b/pkg/project/registry/etcd/etcd_test.go
@@ -1,0 +1,275 @@
+package etcd
+
+import (
+	"fmt"
+	"testing"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/coreos/go-etcd/etcd"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/project/api"
+)
+
+func NewTestEtcd(client tools.EtcdClient) *Etcd {
+	return New(tools.EtcdHelper{client, latest.Codec, latest.ResourceVersioner})
+}
+
+func TestEtcdListProjectsEmpty(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := makeProjectListKey(ctx)
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcd(fakeClient)
+	projects, err := registry.ListProjects(ctx, labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(projects.Items) != 0 {
+		t.Errorf("Unexpected projects list: %#v", projects)
+	}
+}
+
+func TestEtcdListProjectsError(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := makeProjectListKey(ctx)
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: fmt.Errorf("some error"),
+	}
+	registry := NewTestEtcd(fakeClient)
+	projects, err := registry.ListProjects(ctx, labels.Everything())
+	if err == nil {
+		t.Error("unexpected nil error")
+	}
+
+	if projects != nil {
+		t.Errorf("Unexpected non-nil projects: %#v", projects)
+	}
+}
+
+func TestEtcdListProjectsEverything(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := makeProjectListKey(ctx)
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Project{JSONBase: kubeapi.JSONBase{ID: "foo"}}),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Project{JSONBase: kubeapi.JSONBase{ID: "bar"}}),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcd(fakeClient)
+	projects, err := registry.ListProjects(ctx, labels.Everything())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(projects.Items) != 2 || projects.Items[0].ID != "foo" || projects.Items[1].ID != "bar" {
+		t.Errorf("Unexpected projects list: %#v", projects)
+	}
+}
+
+func TestEtcdListProjectsFiltered(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	key := makeProjectListKey(ctx)
+	fakeClient.Data[key] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Nodes: []*etcd.Node{
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Project{
+							JSONBase: kubeapi.JSONBase{ID: "foo"},
+							Labels:   map[string]string{"env": "prod"},
+						}),
+					},
+					{
+						Value: runtime.EncodeOrDie(latest.Codec, &api.Project{
+							JSONBase: kubeapi.JSONBase{ID: "bar"},
+							Labels:   map[string]string{"env": "dev"},
+						}),
+					},
+				},
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcd(fakeClient)
+	projects, err := registry.ListProjects(ctx, labels.SelectorFromSet(labels.Set{"env": "dev"}))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(projects.Items) != 1 || projects.Items[0].ID != "bar" {
+		t.Errorf("Unexpected projects list: %#v", projects)
+	}
+}
+
+func TestEtcdGetProject(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Set(makeProjectKey(ctx, "foo"), runtime.EncodeOrDie(latest.Codec, &api.Project{JSONBase: kubeapi.JSONBase{ID: "foo"}}), 0)
+	registry := NewTestEtcd(fakeClient)
+	project, err := registry.GetProject(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if project.ID != "foo" {
+		t.Errorf("Unexpected project: %#v", project)
+	}
+}
+
+func TestEtcdGetProjectNotFound(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Data[makeProjectKey(ctx, "foo")] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	registry := NewTestEtcd(fakeClient)
+	project, err := registry.GetProject(ctx, "foo")
+	if err == nil {
+		t.Errorf("Unexpected non-error.")
+	}
+	if project != nil {
+		t.Errorf("Unexpected project: %#v", project)
+	}
+}
+
+func TestEtcdCreateProject(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.TestIndex = true
+	fakeClient.Data[makeProjectKey(ctx, "foo")] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: nil,
+		},
+		E: tools.EtcdErrorNotFound,
+	}
+	registry := NewTestEtcd(fakeClient)
+	err := registry.CreateProject(ctx, &api.Project{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resp, err := fakeClient.Get(makeProjectKey(ctx, "foo"), false, false)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	var project api.Project
+	err = latest.Codec.DecodeInto([]byte(resp.Node.Value), &project)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if project.ID != "foo" {
+		t.Errorf("Unexpected project: %#v %s", project, resp.Node.Value)
+	}
+}
+
+func TestEtcdCreateProjectAlreadyExists(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Data[makeProjectKey(ctx, "foo")] = tools.EtcdResponseWithError{
+		R: &etcd.Response{
+			Node: &etcd.Node{
+				Value: runtime.EncodeOrDie(latest.Codec, &api.Project{JSONBase: kubeapi.JSONBase{ID: "foo"}}),
+			},
+		},
+		E: nil,
+	}
+	registry := NewTestEtcd(fakeClient)
+	err := registry.CreateProject(ctx, &api.Project{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo",
+		},
+	})
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+	if !errors.IsAlreadyExists(err) {
+		t.Errorf("Expected 'already exists' error, got %#v", err)
+	}
+}
+
+func TestEtcdUpdateProject(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	registry := NewTestEtcd(fakeClient)
+	err := registry.UpdateProject(ctx, &api.Project{})
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+}
+
+func TestEtcdDeleteProjectNotFound(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Err = tools.EtcdErrorNotFound
+	registry := NewTestEtcd(fakeClient)
+	err := registry.DeleteProject(ctx, "foo")
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+	if !errors.IsNotFound(err) {
+		t.Errorf("Expected 'not found' error, got %#v", err)
+	}
+}
+
+func TestEtcdDeleteProjectError(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	fakeClient.Err = fmt.Errorf("Some error")
+	registry := NewTestEtcd(fakeClient)
+	err := registry.DeleteProject(ctx, "foo")
+	if err == nil {
+		t.Error("Unexpected non-error")
+	}
+}
+
+func TestEtcdDeleteProjectOK(t *testing.T) {
+	ctx := kubeapi.NewContext()
+	fakeClient := tools.NewFakeEtcdClient(t)
+	registry := NewTestEtcd(fakeClient)
+	key := makeProjectKey(ctx, "foo")
+	err := registry.DeleteProject(ctx, "foo")
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
+	if len(fakeClient.DeletedKeys) != 1 {
+		t.Errorf("Expected 1 delete, found %#v", fakeClient.DeletedKeys)
+	} else if fakeClient.DeletedKeys[0] != key {
+		t.Errorf("Unexpected key: %s, expected %s", fakeClient.DeletedKeys[0], key)
+	}
+}

--- a/pkg/project/registry/project/registry.go
+++ b/pkg/project/registry/project/registry.go
@@ -1,0 +1,22 @@
+package project
+
+import (
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/openshift/origin/pkg/project/api"
+)
+
+// Registry is an interface for things that know how to store Project objects.
+type Registry interface {
+	// ListProjects obtains a list of Projects that match a selector.
+	ListProjects(ctx kubeapi.Context, selector labels.Selector) (*api.ProjectList, error)
+	// GetProject retrieves a specific Project.
+	GetProject(ctx kubeapi.Context, id string) (*api.Project, error)
+	// CreateProject creates a new Project.
+	CreateProject(ctx kubeapi.Context, Project *api.Project) error
+	// UpdateProject updates an Project.
+	UpdateProject(ctx kubeapi.Context, Project *api.Project) error
+	// DeleteProject deletes an Project.
+	DeleteProject(ctx kubeapi.Context, id string) error
+}

--- a/pkg/project/registry/project/rest.go
+++ b/pkg/project/registry/project/rest.go
@@ -1,0 +1,90 @@
+package project
+
+import (
+	"fmt"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/openshift/origin/pkg/project/api"
+	"github.com/openshift/origin/pkg/project/api/validation"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	registry Registry
+}
+
+// NewStorage returns a new REST.
+func NewREST(registry Registry) apiserver.RESTStorage {
+	return &REST{registry}
+}
+
+// New returns a new Project for use with Create and Update.
+func (s *REST) New() runtime.Object {
+	return &api.Project{}
+}
+
+// List retrieves a list of Projects that match selector.
+func (s *REST) List(ctx kubeapi.Context, selector, fields labels.Selector) (runtime.Object, error) {
+	projects, err := s.registry.ListProjects(ctx, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	return projects, nil
+}
+
+// Get retrieves an Project by id.
+func (s *REST) Get(ctx kubeapi.Context, id string) (runtime.Object, error) {
+	project, err := s.registry.GetProject(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return project, nil
+}
+
+// Create registers the given Project.
+func (s *REST) Create(ctx kubeapi.Context, obj runtime.Object) (<-chan runtime.Object, error) {
+	project, ok := obj.(*api.Project)
+	if !ok {
+		return nil, fmt.Errorf("not a project: %#v", obj)
+	}
+
+	// TODO decide if we should set namespace == name, think longer term we need some type of reservation here
+	// but i want to be able to let existing kubernetes ns grow into a project as well
+	if len(project.Namespace) == 0 {
+		project.Namespace = project.ID
+	}
+
+	// TODO set an id if not provided?, set a Namespace attribute if not provided?
+	project.CreationTimestamp = util.Now()
+
+	if errs := validation.ValidateProject(project); len(errs) > 0 {
+		return nil, errors.NewInvalid("project", project.ID, errs)
+	}
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		if err := s.registry.CreateProject(ctx, project); err != nil {
+			return nil, err
+		}
+		return s.Get(ctx, project.ID)
+	}), nil
+}
+
+// Update is not supported for Projects, as they are immutable.
+func (s *REST) Update(ctx kubeapi.Context, obj runtime.Object) (<-chan runtime.Object, error) {
+	// TODO handle update of display name, labels, etc.
+	return nil, fmt.Errorf("Projects may not be changed.")
+}
+
+// Delete asynchronously deletes a Project specified by its id.
+func (s *REST) Delete(ctx kubeapi.Context, id string) (<-chan runtime.Object, error) {
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		return &kubeapi.Status{Status: kubeapi.StatusSuccess}, s.registry.DeleteProject(ctx, id)
+	}), nil
+}

--- a/pkg/project/registry/project/rest_test.go
+++ b/pkg/project/registry/project/rest_test.go
@@ -1,0 +1,241 @@
+package project
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/openshift/origin/pkg/project/api"
+	"github.com/openshift/origin/pkg/project/registry/test"
+)
+
+func TestListProjectsError(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	mockRegistry.Err = fmt.Errorf("test error")
+
+	storage := REST{
+		registry: mockRegistry,
+	}
+
+	projects, err := storage.List(nil, nil, nil)
+	if err != mockRegistry.Err {
+		t.Errorf("Expected %#v, Got %#v", mockRegistry.Err, err)
+	}
+
+	if projects != nil {
+		t.Errorf("Unexpected non-nil projects list: %#v", projects)
+	}
+}
+
+func TestListProjectsEmptyList(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	mockRegistry.Projects = &api.ProjectList{
+		Items: []api.Project{},
+	}
+
+	storage := REST{
+		registry: mockRegistry,
+	}
+
+	projects, err := storage.List(nil, labels.Everything(), labels.Everything())
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	if len(projects.(*api.ProjectList).Items) != 0 {
+		t.Errorf("Unexpected non-zero projects list: %#v", projects)
+	}
+}
+
+func TestListProjectsPopulatedList(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	mockRegistry.Projects = &api.ProjectList{
+		Items: []api.Project{
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "foo",
+				},
+			},
+			{
+				JSONBase: kubeapi.JSONBase{
+					ID: "bar",
+				},
+			},
+		},
+	}
+
+	storage := REST{
+		registry: mockRegistry,
+	}
+
+	list, err := storage.List(nil, labels.Everything(), labels.Everything())
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	projects := list.(*api.ProjectList)
+
+	if e, a := 2, len(projects.Items); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}
+
+func TestCreateProjectBadObject(t *testing.T) {
+	storage := REST{}
+
+	channel, err := storage.Create(nil, &api.ProjectList{})
+	if channel != nil {
+		t.Errorf("Expected nil, got %v", channel)
+	}
+	if strings.Index(err.Error(), "not a project:") == -1 {
+		t.Errorf("Expected 'not an project' error, got %v", err)
+	}
+}
+
+func TestCreateProjectMissingID(t *testing.T) {
+	storage := REST{}
+
+	channel, err := storage.Create(nil, &api.Project{})
+	if channel != nil {
+		t.Errorf("Expected nil channel, got %v", channel)
+	}
+	if !errors.IsInvalid(err) {
+		t.Errorf("Expected 'invalid' error, got %v", err)
+	}
+}
+
+func TestCreateRegistrySaveError(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	mockRegistry.Err = fmt.Errorf("test error")
+	storage := REST{registry: mockRegistry}
+
+	channel, err := storage.Create(nil, &api.Project{
+		JSONBase: kubeapi.JSONBase{ID: "foo"},
+	})
+	if channel == nil {
+		t.Errorf("Expected nil channel, got %v", channel)
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	select {
+	case result := <-channel:
+		status, ok := result.(*kubeapi.Status)
+		if !ok {
+			t.Errorf("Expected status type, got: %#v", result)
+		}
+		if status.Status != kubeapi.StatusFailure || status.Message != "foo" {
+			t.Errorf("Expected failure status, got %#V", status)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	default:
+	}
+}
+
+func TestCreateProjectOK(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	storage := REST{registry: mockRegistry}
+
+	channel, err := storage.Create(nil, &api.Project{
+		JSONBase: kubeapi.JSONBase{ID: "foo"},
+	})
+	if channel == nil {
+		t.Errorf("Expected nil channel, got %v", channel)
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	select {
+	case result := <-channel:
+		project, ok := result.(*api.Project)
+		if !ok {
+			t.Errorf("Expected project type, got: %#v", result)
+		}
+		if project.ID != "foo" {
+			t.Errorf("Unexpected project: %#v", project)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	default:
+	}
+}
+
+func TestGetProjectError(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	mockRegistry.Err = fmt.Errorf("bad")
+	storage := REST{registry: mockRegistry}
+
+	project, err := storage.Get(nil, "foo")
+	if project != nil {
+		t.Errorf("Unexpected non-nil project: %#v", project)
+	}
+	if err != mockRegistry.Err {
+		t.Errorf("Expected %#v, got %#v", mockRegistry.Err, err)
+	}
+}
+
+func TestGetProjectOK(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	mockRegistry.Project = &api.Project{
+		JSONBase: kubeapi.JSONBase{ID: "foo"},
+	}
+	storage := REST{registry: mockRegistry}
+
+	project, err := storage.Get(nil, "foo")
+	if project == nil {
+		t.Error("Unexpected nil project")
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error", err)
+	}
+	if project.(*api.Project).ID != "foo" {
+		t.Errorf("Unexpected project: %#v", project)
+	}
+}
+
+func TestUpdateProject(t *testing.T) {
+	storage := REST{}
+	channel, err := storage.Update(nil, &api.Project{})
+	if channel != nil {
+		t.Errorf("Unexpected non-nil channel: %#v", channel)
+	}
+	if err == nil {
+		t.Fatal("Unexpected nil err")
+	}
+	if strings.Index(err.Error(), "Projects may not be changed.") == -1 {
+		t.Errorf("Expected 'may not be changed' error, got: %#v", err)
+	}
+}
+
+func TestDeleteProject(t *testing.T) {
+	mockRegistry := test.NewProjectRegistry()
+	storage := REST{registry: mockRegistry}
+	channel, err := storage.Delete(nil, "foo")
+	if channel == nil {
+		t.Error("Unexpected nil channel")
+	}
+	if err != nil {
+		t.Errorf("Unexpected non-nil error: %#v", err)
+	}
+
+	select {
+	case result := <-channel:
+		status, ok := result.(*kubeapi.Status)
+		if !ok {
+			t.Errorf("Expected status type, got: %#v", result)
+		}
+		if status.Status != kubeapi.StatusSuccess {
+			t.Errorf("Expected status=success, got: %#v", status)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	default:
+	}
+}

--- a/pkg/project/registry/test/project.go
+++ b/pkg/project/registry/test/project.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"sync"
+
+	kubeapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/openshift/origin/pkg/project/api"
+)
+
+type ProjectRegistry struct {
+	Err      error
+	Project  *api.Project
+	Projects *api.ProjectList
+	sync.Mutex
+}
+
+func NewProjectRegistry() *ProjectRegistry {
+	return &ProjectRegistry{}
+}
+
+func (r *ProjectRegistry) ListProjects(ctx kubeapi.Context, selector labels.Selector) (*api.ProjectList, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Projects, r.Err
+}
+
+func (r *ProjectRegistry) GetProject(ctx kubeapi.Context, id string) (*api.Project, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Project, r.Err
+}
+
+func (r *ProjectRegistry) CreateProject(ctx kubeapi.Context, project *api.Project) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Project = project
+	return r.Err
+}
+
+func (r *ProjectRegistry) UpdateProject(ctx kubeapi.Context, project *api.Project) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.Project = project
+	return r.Err
+}
+
+func (r *ProjectRegistry) DeleteProject(ctx kubeapi.Context, id string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.Err
+}


### PR DESCRIPTION
This is an initial pull request to add support for a Project resource.  

The Project resource is not scoped by Kubernetes namepace, but it's used to reserve a Kubernetes namespace for origin users.  A project can be created to associate with an existing Kubernetes namespace, or the namespace is taken from the Project id.  This is limited API support to do basic CRUD operations.  There is no Watch support at this time.  Project has limited metadata with more to follow based on UX input.
