### PR TITLE
Make volume directory absolute so that the default value works.

### DIFF
--- a/pkg/cmd/master/master.go
+++ b/pkg/cmd/master/master.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -330,7 +331,11 @@ func (c *config) runAssetServer() {
 }
 
 func (c *config) runKubelet() {
-	rootDirectory := path.Clean(c.VolumeDir)
+	rootDirectory, err := filepath.Abs(c.VolumeDir)
+	if err != nil {
+		glog.Errorf("Error converting volume directory to an absolute path: %v", err)
+		rootDirectory = path.Clean(c.VolumeDir)
+	}
 	minionHost := c.bindAddr
 	minionPort := 10250
 


### PR DESCRIPTION
I've noticed that if I use an EmptyDir volume for a pod:

```
...
"volumes": [{
  "name": "log",
  "source": {
    "emptyDir": {}
  }
}],
...
```

I get an error about the path backing the volume not being absolute:

```
E1010 14:09:28.760682 15073 kubelet.go:559] Error running pod f36577d7-5075-11e4-9a05-08002703df9c.etcd container mux: API error (500): Cannot start container 3d464959418664d758d9518cb5d5c27c9774c2a8f97b6ac070e672c1a888da32: cannot bind mount volume: openshift.local.volumes/f36577d7-5075-11e4-9a05-08002703df9c/volumes/empty/log volume paths must be absolute.
```

I've checked the way the volume path for kubelets is constructed and I believe that the problem is with the way the value of `volumeDir` is used. Correct me if I'm wrong but the backing folder for the volume has to be an absolute path for the kubelet. That being said I'm not sure whether it should be the kubernetes to make the path absolute (because there are no comments on `CreateVolumeBuilder()` in `kubernetes/pkg/volume/volume.go` concerning requirement on the `rootDir` parameter) or the Openshift so...I propose this patch. If however the proper place to put it would be in kubernetes, I'm happy to dig deeper there.

For the error case (when for some reason getcwd fails) I've thought it would be best to fallback to previous behavior. Again I'm not sure about it and please let me know what You think.
