### PR TITLE
Lock down raml2html version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 FROM google/nodejs
-RUN npm i -g raml2html
+RUN npm i -g raml2html@1.0.4
 ADD . /data
 CMD ["-i", "/data/openshift3.raml", "-o", "/data/openshift3.html"]
 ENTRYPOINT ["raml2html"]


### PR DESCRIPTION
Lock down raml2html version to 1.0.4

Fixes #104
