### PR TITLE
Log streaming

### DIFF
--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -9,7 +9,9 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
 	"github.com/openshift/origin/pkg/build/registry/build"
+	"github.com/openshift/origin/pkg/build/api"
 )
 
 // REST is an implementation of RESTStorage for the api server.
@@ -47,6 +49,10 @@ func (r *REST) ResourceLocation(ctx kubeapi.Context, id string) (string, error) 
 	buildContainerName := pod.DesiredState.Manifest.Containers[0].Name
 	location := &url.URL{
 		Path: r.proxyPrefix + "/" + buildHost + "/containerLogs/" + buildPodID + "/" + buildContainerName,
+	}
+	if build.Status == api.BuildRunning {
+		params := url.Values{"follow": []string{"1"}}
+		location.RawQuery = params.Encode()
 	}
 	if err != nil {
 		return "", err

--- a/pkg/build/registry/buildlog/rest_test.go
+++ b/pkg/build/registry/buildlog/rest_test.go
@@ -1,0 +1,85 @@
+package buildlog
+
+import (
+	"testing"
+
+	kubeapi	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	"github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/registry/test"
+)
+
+type podClient struct {
+}
+
+func (p *podClient) ListPods(ctx kubeapi.Context, selector labels.Selector) (*kubeapi.PodList, error) {
+	return nil, nil
+}
+
+func (p *podClient) GetPod(ctx kubeapi.Context, id string) (*kubeapi.Pod, error) {
+	pod := &kubeapi.Pod{
+		JSONBase:     kubeapi.JSONBase{ID: "foo"},
+		DesiredState: kubeapi.PodState{
+			Manifest: kubeapi.ContainerManifest{
+				Version: "v1beta1",
+				Containers: []kubeapi.Container{
+					{
+						Name: "foo-container",
+					},
+				},
+			},
+		},
+		CurrentState: kubeapi.PodState{
+			Host: "foo-host",
+		},
+	}
+	return pod, nil
+}
+
+func (p *podClient) DeletePod(ctx kubeapi.Context, id string) error {
+	return nil
+}
+
+func (p *podClient) CreatePod(ctx kubeapi.Context, pod *kubeapi.Pod) (*kubeapi.Pod, error) {
+	return nil, nil
+}
+
+func (p *podClient) UpdatePod(ctx kubeapi.Context, pod *kubeapi.Pod) (*kubeapi.Pod, error) {
+	return nil, nil
+}
+
+func TestRegistryResourceLocation(t *testing.T) {
+	expectedLocations := map[api.BuildStatus]string{
+		api.BuildComplete: "/proxy/minion/foo-host/containerLogs/foo-pod/foo-container",
+		api.BuildRunning: "/proxy/minion/foo-host/containerLogs/foo-pod/foo-container?follow=1",
+	}
+
+	ctx := kubeapi.NewDefaultContext()
+	proxyPrefix := "/proxy/minion"
+
+	for buildStatus, expectedLocation := range expectedLocations {
+		expectedBuild := mockBuild(buildStatus)
+		buildRegistry := test.BuildRegistry{Build: expectedBuild}
+		storage := REST{&buildRegistry, &podClient{}, proxyPrefix}
+		redirector := apiserver.Redirector(&storage)
+		location, err := redirector.ResourceLocation(ctx, "foo")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if location != expectedLocation {
+			t.Errorf("Expected: %s, Got %s", expectedLocation, location)
+		}
+	}
+}
+
+func mockBuild(buildStatus api.BuildStatus) *api.Build {
+	return &api.Build{
+		JSONBase: kubeapi.JSONBase{
+			ID: "foo-build",
+		},
+		Status: buildStatus,
+		PodID:  "foo-pod",
+	}
+}


### PR DESCRIPTION
Adding possibility to stream logs if the build is running.
If the build is complete/failed the logs will be snapshoted.

There is a pending PR in k8s, which needs to get to our vendored k8s, before this PR can be merged.
`https://github.com/GoogleCloudPlatform/kubernetes/pull/1829`

Also there are two bottle-necks that need to be taken into account:
1.  When the build is running and the image is being downloaded, this state is also classified as 'running', but the container itself is not running so the query for logs will return error, that container
2.  The `WriteTimeout` in our vendored  k8s (.../kubernetes/pkg/kubelet/server.go#L57) needs to be bumped to some reasonable timeout, else the connection between client and kubelet will be shutdown after 10 sec. 
