### PR TITLE
Create a Docker buildenv for Origin

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -14,10 +14,6 @@ hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 # Go to the top of the tree.
 cd "${OS_REPO_ROOT}"
 
-# Fetch the version.
-version=$(gitcommit)
-kube_version=$(go run ${hackdir}/version.go ${hackdir}/../Godeps/Godeps.json github.com/GoogleCloudPlatform/kubernetes/pkg/api)
-
 if [[ $# == 0 ]]; then
   # Update $@ with the default list of targets to build.
   set -- cmd/openshift
@@ -33,5 +29,4 @@ if [[ ! -z "$OS_BUILD_TAGS" ]]; then
   build_tags="-tags \"$OS_BUILD_TAGS\""
 fi
 
-
-go install $build_tags -ldflags "-X github.com/GoogleCloudPlatform/kubernetes/pkg/version.gitCommit '${kube_version}' -X github.com/openshift/origin/pkg/version.commitFromGit '${version}'" "${binaries[@]}"
+go install $build_tags -ldflags "$(os::build::ldflags)" "${binaries[@]}"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -15,7 +15,7 @@ hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 cd "${OS_REPO_ROOT}"
 
 # Fetch the version.
-version=$(gitcommit)
+version=$(os::build::gitcommit)
 kube_version=$(go run ${hackdir}/version.go ${hackdir}/../Godeps/Godeps.json github.com/GoogleCloudPlatform/kubernetes/pkg/api)
 
 docker build -t openshift/base-builder images/builder/docker/base

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script generates a release script in _output/releases
+# This script generates release zips into _output/releases
 
 set -o errexit
 set -o nounset
@@ -8,30 +8,30 @@ set -o pipefail
 
 hackdir=$(CDPATH="" cd $(dirname $0); pwd)
 
-
 # Set the environment variables required by the build.
 . "${hackdir}/config-go.sh"
 
 # Go to the top of the tree.
 cd "${OS_REPO_ROOT}"
 
-# Build clean
-make clean
-hack/build-go.sh
+context="${OS_REPO_ROOT}/_output/buildenv-context"
 
-# Fetch the version.
-version=$(gitcommit)
+# clean existing output
+rm -rf "${OS_REPO_ROOT}/_output/releases"
+rm -rf "${context}"
+mkdir -p "${context}"
 
-# Copy built contents to the release directory
-release="_output/release"
-rm -rf "${release}"
-mkdir -p "${release}"
-cp _output/go/bin/openshift "${release}"
+# generate version definitions
+echo "export OS_VERSION=0.1"                            > "${context}/os-version-defs"
+echo "export OS_GITCOMMIT=\"$(os::build::gitcommit)\"" >> "${context}/os-version-defs"
+echo "export OS_LD_FLAGS=\"$(os::build::ldflags)\""    >> "${context}/os-version-defs"
 
-releases="_output/releases"
-mkdir -p "${releases}"
-release_file="${releases}/openshift-origin-linux64-${version}.tar.gz"
+# create the input archive
+git archive --format=tar -o "${context}/archive.tar" HEAD
+tar -rf "${context}/archive.tar" -C "${context}" os-version-defs
+gzip -f "${context}/archive.tar"
 
-tar cvzf "${release_file}" -C "${release}" .
-
-echo "Built to ${release_file}"
+# build in the clean environment
+docker build --tag openshift-origin-buildenv "${OS_REPO_ROOT}/hack/buildenv"
+cat "${context}/archive.tar.gz" | docker run -i --cidfile="${context}/cid" openshift-origin-buildenv
+docker cp $(cat ${context}/cid):/go/src/github.com/openshift/origin/_output/releases "${OS_REPO_ROOT}/_output"

--- a/hack/buildenv/Dockerfile
+++ b/hack/buildenv/Dockerfile
@@ -1,0 +1,27 @@
+# This file creates a standard build environment for building Origin
+
+FROM  fedora:21
+MAINTAINER  Clayton Coleman <ccoleman@redhat.com>
+
+RUN yum install -y git hg golang golang-pkg-darwin golang-pkg-windows && yum clean all
+
+ENV GOPATH /go
+# Get the code coverage tool and godep
+RUN go get code.google.com/p/go.tools/cmd/cover github.com/tools/godep
+
+# Mark this as a os-build container
+RUN touch /os-build-image
+
+WORKDIR /go/src/github.com/openshift/origin
+
+ENV OS_CROSSPLATFORMS \
+  darwin/amd64 \
+  windows/amd64
+# (set an explicit GOARM of 5 for maximum compatibility)
+ENV GOARM 5
+ENV GOOS    linux
+ENV GOARCH  amd64
+ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+
+# Expect a tar with the source of OpenShift (and /os-version-defs in the root)
+CMD tar -xzf - && ./hack/buildenv/build.sh

--- a/hack/buildenv/build.sh
+++ b/hack/buildenv/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/buildenv/common.sh"
+
+platforms=(linux/amd64 $OS_CROSSPLATFORMS)
+targets=("${compile_targets[@]}")
+
+if [[ $# -gt 0 ]]; then
+  targets=("$@")
+fi
+
+for platform in "${platforms[@]}"; do
+  (
+    # Subshell to contain these exports
+    export GOOS=${platform%/*}
+    export GOARCH=${platform##*/}
+
+    os::build::make_binaries "${targets[@]}"
+  )
+done

--- a/hack/buildenv/common.sh
+++ b/hack/buildenv/common.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+cd "${OS_ROOT}"
+
+source "${OS_ROOT}/hack/common.sh"
+
+readonly OS_TARGET="${OS_ROOT}/_output/build"
+readonly OS_GO_PACKAGE=github.com/openshift/origin
+readonly OS_RELEASES="${OS_ROOT}/_output/releases"
+
+compile_targets=(
+  cmd/openshift
+)
+
+mkdir -p "${OS_TARGET}"
+
+if [[ ! -f "/os-build-image" ]]; then
+  echo "WARNING: This script should be run in the os-build container image!" >&2
+fi
+
+if [[ -f "./os-version-defs" ]]; then
+  source "./os-version-defs"
+else
+  echo "WARNING: No version information provided in build image"
+  readonly OS_VERSION="${OS_VERSION:-unknown}"
+  readonly OS_GITCOMMIT="${OS_GITCOMMIT:-unknown}"
+fi
+
+
+function os::build::make_binary() {
+  local -r gopkg=$1
+  local -r bin=${gopkg##*/}
+
+  echo "+++ Building ${bin} for ${GOOS}/${GOARCH}"
+  pushd "${OS_ROOT}" >/dev/null
+  godep go build -ldflags "${OS_LD_FLAGS-}" -o "${ARCH_TARGET}/${bin}" "${gopkg}"
+  popd >/dev/null
+}
+
+function os::build::make_binaries() {
+  [[ $# -gt 0 ]] || {
+    echo "!!! Internal error. os::build::make_binaries called with no targets."
+  }
+
+  local -a targets=("$@")
+  local -a binaries=()
+  local target
+  for target in "${targets[@]}"; do
+    binaries+=("${OS_GO_PACKAGE}/${target}")
+  done
+
+  ARCH_TARGET="${OS_TARGET}/${GOOS}/${GOARCH}"
+  mkdir -p "${ARCH_TARGET}"
+
+  local b
+  for b in "${binaries[@]}"; do
+    os::build::make_binary "$b"
+  done
+
+  mkdir -p "${OS_RELEASES}"
+  readonly ARCHIVE_NAME="openshift-origin-${OS_VERSION}-${OS_GITCOMMIT}-${GOOS}-${GOARCH}.tar.gz"
+  tar -czf "${OS_RELEASES}/${ARCHIVE_NAME}" -C "${ARCH_TARGET}" .
+}

--- a/hack/buildenv/export.sh
+++ b/hack/buildenv/export.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/buildenv/common.sh"
+
+tar -C "${OS_RELEASES}" -cf - .

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This script provides common script functions for the hacks
+
+# os::build::gitcommit prints the current Git commit information
+function os::build::gitcommit() {
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  topdir=$(dirname "$0")/..
+  cd "${topdir}"
+
+  # TODO: when we start making tags, switch to git describe?
+  if git_commit=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null); then
+    # Check if the tree is dirty.
+    if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
+      echo "${git_commit}-dirty"
+    else
+      echo "${git_commit}"
+    fi
+  else
+    echo "(none)"
+  fi
+  return 0
+}
+
+# os::build::kube::gitcommit returns the version of Kubernetes we have
+# vendored.
+function os::build::kube::gitcommit() {
+  (
+    # Run this in a subshell to prevent settings/variables from leaking.
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+
+    topdir=$(dirname "$0")/..
+    cd "${topdir}"
+
+    go run hack/version.go ./Godeps/Godeps.json github.com/GoogleCloudPlatform/kubernetes/pkg/api
+  )
+}
+
+# os::build::ldflags calculates the -ldflags argument for building OpenShift
+function os::build::ldflags() {
+  (
+    # Run this in a subshell to prevent settings/variables from leaking.
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+
+    topdir=$(dirname "$0")/..
+    cd "${topdir}"
+
+    declare -a ldflags=()
+    ldflags+=(-X "${OS_GO_PACKAGE}/pkg/version.commitFromGit" "$(os::build::gitcommit)")
+    ldflags+=(-X "github.com/GoogleCloudPlatform/kubernetes/pkg/version.gitCommit" "$(os::build::kube::gitcommit)")
+
+    # The -ldflags parameter takes a single string, so join the output.
+    echo "${ldflags[*]-}"
+  )
+}

--- a/hack/config-go.sh
+++ b/hack/config-go.sh
@@ -3,28 +3,8 @@
 # This script sets up a go workspace locally and builds all go components.
 # You can 'source' this file if you want to set up GOPATH in your local shell.
 
-# gitcommit prints the current Git commit information
-function gitcommit() {
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  topdir=$(dirname "$0")/..
-  cd "${topdir}"
-
-  # TODO: when we start making tags, switch to git describe?
-  if git_commit=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null); then
-    # Check if the tree is dirty.
-    if ! dirty_tree=$(git status --porcelain) || [[ -n "${dirty_tree}" ]]; then
-      echo "${git_commit}-dirty"
-    else
-      echo "${git_commit}"
-    fi
-  else
-    echo "(none)"
-  fi
-  return 0
-}
+hackdir=$(CDPATH="" cd $(dirname $0); pwd)
+source "${hackdir}/common.sh"
 
 if [[ -z "$(which go)" ]]; then
   echo "Can't find 'go' in PATH, please fix and retry." >&2


### PR DESCRIPTION
Allows cross-compilation for Windows and Darwin in a controlled fashion.

Run `hack/build-release.sh` on a system with Docker
