### PR TITLE
Prefer local images for builds, instead of always reaching the hub

### DIFF
--- a/pkg/build/strategy/docker.go
+++ b/pkg/build/strategy/docker.go
@@ -8,11 +8,12 @@ import (
 // DockerBuildStrategy creates Docker build using a docker builder image
 type DockerBuildStrategy struct {
 	dockerBuilderImage string
+	useLocalImage      bool
 }
 
 // NewDockerBuildStrategy creates a new DockerBuildStrategy
-func NewDockerBuildStrategy(dockerBuilderImage string) *DockerBuildStrategy {
-	return &DockerBuildStrategy{dockerBuilderImage}
+func NewDockerBuildStrategy(dockerBuilderImage string, useLocalImage bool) *DockerBuildStrategy {
+	return &DockerBuildStrategy{dockerBuilderImage, useLocalImage}
 }
 
 // CreateBuildPod creates the pod to be used for the Docker build
@@ -41,6 +42,9 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*api.Pod, 
 				},
 			},
 		},
+	}
+	if bs.useLocalImage {
+		pod.DesiredState.Manifest.Containers[0].ImagePullPolicy = api.PullIfNotPresent
 	}
 
 	setupDockerSocket(pod)

--- a/pkg/build/strategy/docker_test.go
+++ b/pkg/build/strategy/docker_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDockerCreateBuildPod(t *testing.T) {
-	strategy := NewDockerBuildStrategy("docker-test-image")
+	strategy := NewDockerBuildStrategy("docker-test-image", true)
 	expected := mockDockerBuild()
 	actual, _ := strategy.CreateBuildPod(expected)
 
@@ -23,8 +23,10 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		t.Errorf("Expected docker-build, but got %s!", container.Name)
 	}
 	if container.Image != strategy.dockerBuilderImage {
-		t.Errorf("Expected %s image, got %s!", container.Image,
-			strategy.dockerBuilderImage)
+		t.Errorf("Expected %s image, got %s!", container.Image, strategy.dockerBuilderImage)
+	}
+	if container.ImagePullPolicy != kubeapi.PullIfNotPresent {
+		t.Errorf("Expected %v, got %v", kubeapi.PullIfNotPresent, container.ImagePullPolicy)
 	}
 	if actual.DesiredState.Manifest.RestartPolicy.Never == nil {
 		t.Errorf("Expected never, got %#v", actual.DesiredState.Manifest.RestartPolicy)

--- a/pkg/build/strategy/sti.go
+++ b/pkg/build/strategy/sti.go
@@ -11,6 +11,7 @@ import (
 type STIBuildStrategy struct {
 	stiBuilderImage      string
 	tempDirectoryCreator TempDirectoryCreator
+	useLocalImage        bool
 }
 
 type TempDirectoryCreator interface {
@@ -27,8 +28,8 @@ var STITempDirectoryCreator = &tempDirectoryCreator{}
 
 // NewSTIBuildStrategy creates a new STIBuildStrategy with the given
 // builder image
-func NewSTIBuildStrategy(stiBuilderImage string, tc TempDirectoryCreator) *STIBuildStrategy {
-	return &STIBuildStrategy{stiBuilderImage, tc}
+func NewSTIBuildStrategy(stiBuilderImage string, tc TempDirectoryCreator, useLocalImage bool) *STIBuildStrategy {
+	return &STIBuildStrategy{stiBuilderImage, tc, useLocalImage}
 }
 
 // CreateBuildPod creates a pod that will execute the STI build
@@ -59,6 +60,9 @@ func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*api.Pod, err
 				},
 			},
 		},
+	}
+	if bs.useLocalImage {
+		pod.DesiredState.Manifest.Containers[0].ImagePullPolicy = api.PullIfNotPresent
 	}
 
 	if err := bs.setupTempVolume(pod); err != nil {

--- a/pkg/build/strategy/sti_test.go
+++ b/pkg/build/strategy/sti_test.go
@@ -14,7 +14,7 @@ func (t *FakeTempDirCreator) CreateTempDirectory() (string, error) {
 }
 
 func TestSTICreateBuildPod(t *testing.T) {
-	strategy := NewSTIBuildStrategy("sti-test-image", &FakeTempDirCreator{})
+	strategy := NewSTIBuildStrategy("sti-test-image", &FakeTempDirCreator{}, true)
 	expected := mockSTIBuild()
 	actual, _ := strategy.CreateBuildPod(expected)
 
@@ -29,8 +29,10 @@ func TestSTICreateBuildPod(t *testing.T) {
 		t.Errorf("Expected sti-build, but got %s!", container.Name)
 	}
 	if container.Image != strategy.stiBuilderImage {
-		t.Errorf("Expected %s image, got %s!", container.Image,
-			strategy.stiBuilderImage)
+		t.Errorf("Expected %s image, got %s!", container.Image, strategy.stiBuilderImage)
+	}
+	if container.ImagePullPolicy != kubeapi.PullIfNotPresent {
+		t.Errorf("Expected %v, got %v", kubeapi.PullIfNotPresent, container.ImagePullPolicy)
 	}
 	if actual.DesiredState.Manifest.RestartPolicy.Never == nil {
 		t.Errorf("Expected never, got %#v", actual.DesiredState.Manifest.RestartPolicy)

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -234,10 +234,12 @@ func (c *MasterConfig) RunBuildController() {
 	// initialize build controller
 	dockerBuilderImage := env("OPENSHIFT_DOCKER_BUILDER_IMAGE", "openshift/docker-builder")
 	stiBuilderImage := env("OPENSHIFT_STI_BUILDER_IMAGE", "openshift/sti-builder")
+	useLocalImages := env("USE_LOCAL_IMAGES", "false") == "true"
 
 	buildStrategies := map[buildapi.BuildType]build.BuildJobStrategy{
-		buildapi.DockerBuildType: strategy.NewDockerBuildStrategy(dockerBuilderImage),
-		buildapi.STIBuildType:    strategy.NewSTIBuildStrategy(stiBuilderImage, strategy.STITempDirectoryCreator),
+		buildapi.DockerBuildType: strategy.NewDockerBuildStrategy(dockerBuilderImage, useLocalImages),
+		buildapi.STIBuildType: strategy.NewSTIBuildStrategy(stiBuilderImage,
+			strategy.STITempDirectoryCreator, useLocalImages),
 	}
 
 	buildController := build.NewBuildController(c.KubeClient, c.OSClient, buildStrategies, 1200)


### PR DESCRIPTION
While talking with @bparees about adding docker builds to tests we've decided to include this fix to prefer local images instead of always reaching the docker hub. 
The only question we've stumbled upon is how and when to sync those images? So far we've came up with `--sync-images` flag which would also allow to define which images should be synced. What's more important here is also how to sync those while OpenShift is running? Comments welcome...
