### PR TITLE
Use a custom Vagrant box for direct-lvm support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,8 +56,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Single VM dev environment
     # Set VirtualBox provider settings
     config.vm.provider "virtualbox" do |v, override|
-      override.vm.box = "fedora20-virtualbox"
-      override.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box"
+      override.vm.box = "origin-dev-fedora-20-vbox"
+      override.vm.box_url = "https://mirror.openshift.com/pub/vagrant/boxes/origin-dev-fedora-20-vbox.box"
+      override.vm.provision "shell", path: "hack/vm-provision-directlvm.sh", id: "setup"
       v.memory = 1024
       v.cpus = 2
       v.customize ["modifyvm", :id, "--cpus", "2"]
@@ -78,7 +79,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if ENV['REBUILD_YUM_CACHE'] && ENV['REBUILD_YUM_CACHE'] != ""
         config.vm.provision "shell", inline: "yum clean all && yum makecache"
       end
-      config.vm.provision "shell", path: "hack/vm-provision.sh"
+      config.vm.provision "shell", path: "hack/vm-provision.sh", id: "setup"
       config.vm.synced_folder ENV["VAGRANT_SYNC_FROM"] || '.', ENV["VAGRANT_SYNC_TO"] || "/home/vagrant/go/src/github.com/openshift/origin"
     end
   end

--- a/hack/vm-provision-directlvm.sh
+++ b/hack/vm-provision-directlvm.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+if [[ $(grep openshift /home/vagrant/.bash_profile) = "" ]]; then
+	echo "export PATH=\$GOPATH/src/github.com/openshift/origin/_output/go/bin:\$GOPATH/bin:\$PATH" >> /home/vagrant/.bash_profile
+  echo "cd \$GOPATH/src/github.com/openshift/origin" >> /home/vagrant/.bash_profile
+
+  echo "bind '\"\e[A\":history-search-backward'" >> /home/vagrant/.bashrc
+  echo "bind '\"\e[B\":history-search-forward'" >> /home/vagrant/.bashrc
+else
+  echo "vagrant bash shell already configured"
+fi
+
+if [[ $(grep openshift /root/.bash_profile) = "" ]]; then
+  echo "export GOPATH=/home/vagrant/go" >> /root/.bash_profile
+  echo "export PATH=\$GOPATH/src/github.com/openshift/origin/_output/go/bin:\$GOPATH/bin:\$PATH" >> /root/.bash_profile
+  echo "cd \$GOPATH/src/github.com/openshift/origin" >> /root/.bash_profile
+
+  echo "bind '\"\e[A\":history-search-backward'" >> /root/.bashrc
+  echo "bind '\"\e[B\":history-search-forward'" >> /root/.bashrc
+else
+  echo "root bash shell already configured"
+fi
+
+echo To install etcd, run hack/install-etcd.sh


### PR DESCRIPTION
This change is to improve the single-VM developer experience. Currently, the changes are only for the VirtualBox provider. A new base box hosted on mirrors.openshift.com is used.

Changes between the old and new base box:
- A separate 20GB LVM volume group with a pair of direct-lvm logical volumes is configured for Docker use.
- Git, Docker, and Go are pre-installed as essential tools.
- The NAT adapter uses virt-io.
- The vagrant user is properly configured for password-less sudo and no-tty access.

Developer experience improvements:
- Time from zero to hacking improved (tested on a 2.5ghz i5 w/ 8GB RAM and SSD, assuming the box files are already downloaded and the VMs don't yet exist):
  
  ```
  Current:
   vagrant up:      6m
   build-images.sh: 5m47s (5min load avg: 0.86)
  
  New:
   vagrant up:      39s
   build-images.sh: 4m18s (5min load avg: 0.46)
  ```
- Docker is pre-configured to use direct-lvm and xfs for storage, improving performance by eliminating filesystem and network overhead caused by the direct-loop approach (resulting in reduced IO waits).
- Separate logical volume enables further experimentation with other storage approaches (e.g. btrfs) - just replace the volumes in the docker storage group while the VM is online and reconfigure docker (this could be incorporated into provisioner options).
- GOPATH is pre-created with /home/vagrant/go/{bin,src,pkg} which solves the Vagrant mount/provisioner chicken-and-egg problem when mounting a host GOPATH/src into the guest (previously, GOPATH was root-owned, preventing standard go usage within the VM).
