### PR TITLE
Allow `openshift kube` to talk to two servers

### DIFF
--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -191,7 +191,11 @@ func (c *KubeConfig) Run() {
 		// TODO: eventually apiserver should start on 443 and be secure by default
 		clientConfig.Host = "http://localhost:8080"
 	}
-	clientConfig.Host = strings.TrimRight(clientConfig.Host, "/")
+	hosts := strings.SplitN(clientConfig.Host, ",", 2)
+	for i := range hosts {
+		hosts[i] = strings.TrimRight(hosts[i], "/")
+	}
+	clientConfig.Host = hosts[0]
 
 	if kubeclient.IsConfigTransportSecure(clientConfig) {
 		auth, err := kubecfg.LoadAuthInfo(c.AuthConfig, os.Stdin)
@@ -219,6 +223,9 @@ func (c *KubeConfig) Run() {
 		glog.Fatalf("Unable to set up the Kubernetes API client: %v", err)
 	}
 
+	if len(hosts) > 1 {
+		clientConfig.Host = hosts[1]
+	}
 	clientConfig.Version = c.OSAPIVersion
 	client, err := osclient.New(clientConfig)
 	if err != nil {


### PR DESCRIPTION
OpenShift supports `--kubernetes` to point the master to an existing Kube installation.  When doing that, the CLI can't handle both server URLs at once (because it assumes `--host` points to both).  As a short term workaround, allow clients who are talking to Kube _AND_ OpenShift on two different servers to do:

```
$ openshift kube --host "127.0.0.1:8080,127.0.0.1:8081" list pods
$ openshift kube --host "127.0.0.1:8080,127.0.0.1:8081" list projects
```

The list of hosts must be comma-delimeted - if one is specified, it's used for both.  If two are specified, the first is Kubernetes and the second is OpenShift.  You can set this as an ENV var with:

```
$ export KUBERNETES_MASTER="127.0.0.1:8080,127.0.0.1:8081"
$ openshift kube list pods
$ openshift kube list projects
```

Be advised that setting KUBERNETES_MASTER like this will confuse the Kubernetes command line binary from Kube.
