### PR TITLE
More flaky test fixes

### DIFF
--- a/pkg/deploy/registry/deploy/rest_test.go
+++ b/pkg/deploy/registry/deploy/rest_test.go
@@ -121,12 +121,11 @@ func TestCreateRegistrySaveError(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected status type, got: %#v", result)
 		}
-		if status.Status != "failure" || status.Message != "foo" {
+		if status.Status != kapi.StatusFailure || status.Message != "test error" {
 			t.Errorf("Expected failure status, got %#v", status)
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -157,7 +156,6 @@ func TestCreateDeploymentOk(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -281,7 +279,6 @@ func TestDeleteDeployment(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 

--- a/pkg/deploy/registry/deployconfig/rest_test.go
+++ b/pkg/deploy/registry/deployconfig/rest_test.go
@@ -123,12 +123,11 @@ func TestCreateRegistrySaveError(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected status type, got: %#v", result)
 		}
-		if status.Status != kapi.StatusFailure || status.Message != "foo" {
+		if status.Status != kapi.StatusFailure || status.Message != "test error" {
 			t.Errorf("Expected failure status, got %#v", status)
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -161,7 +160,6 @@ func TestCreateDeploymentConfigOK(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -285,7 +283,6 @@ func TestDeleteDeploymentConfig(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 

--- a/pkg/project/registry/project/rest_test.go
+++ b/pkg/project/registry/project/rest_test.go
@@ -129,12 +129,11 @@ func TestCreateRegistrySaveError(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected status type, got: %#v", result)
 		}
-		if status.Status != kapi.StatusFailure || status.Message != "foo" {
-			t.Errorf("Expected failure status, got %#V", status)
+		if status.Status != kapi.StatusFailure || status.Message != "test error" {
+			t.Errorf("Expected failure status, got %#v", status)
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -163,7 +162,6 @@ func TestCreateProjectOK(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -236,6 +234,5 @@ func TestDeleteProject(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }

--- a/pkg/route/registry/route/rest_test.go
+++ b/pkg/route/registry/route/rest_test.go
@@ -105,7 +105,6 @@ func TestCreateRouteOK(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 
@@ -276,7 +275,6 @@ func TestDeleteRouteOk(t *testing.T) {
 		}
 	case <-time.After(50 * time.Millisecond):
 		t.Errorf("Timed out waiting for result")
-	default:
 	}
 }
 


### PR DESCRIPTION
Remove default cases in select statements.
Correct error message expectation.

This is the same root cause as #211.
