### PR TITLE
Add clean build flag

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -150,6 +150,9 @@ type DockerBuildStrategy struct {
 type STIBuildStrategy struct {
 	// BuilderImage is the image used to execute the build.
 	BuilderImage string `json:"builderImage,omitempty" yaml:"builderImage,omitempty"`
+
+	// Clean flag forces the STI build to not do incremental builds if true.
+	Clean bool `json:"clean,omitempty" yaml:"clean,omitempty"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -150,6 +150,9 @@ type DockerBuildStrategy struct {
 type STIBuildStrategy struct {
 	// BuilderImage is the image used to execute the build.
 	BuilderImage string `json:"builderImage,omitempty" yaml:"builderImage,omitempty"`
+
+	// Clean flag forces the STI build to not do incremental builds if true.
+	Clean bool `json:"clean,omitempty" yaml:"clean,omitempty"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -34,6 +34,7 @@ func (s *STIBuilder) Build() error {
 		Source:       s.build.Parameters.Source.Git.URI,
 		Tag:          imageTag(s.build),
 		Environment:  getBuildEnvVars(s.build),
+		Clean:        s.build.Parameters.Strategy.STIStrategy.Clean,
 	}
 	if s.build.Parameters.Revision != nil && s.build.Parameters.Revision.Git != nil &&
 		s.build.Parameters.Revision.Git.Commit != "" {


### PR DESCRIPTION
Adds an attribute to the STI build strategy to always run a clean build.
