### PR TITLE
Fix registry pod unnecessary deployments in e2e test

### DIFF
--- a/pkg/deploy/controller/basic_deployment_controller.go
+++ b/pkg/deploy/controller/basic_deployment_controller.go
@@ -80,8 +80,14 @@ func (dc *BasicDeploymentController) handleNew(ctx kapi.Context, deployment *dep
 		}
 	}
 
+	deploymentCopy, err := kapi.Scheme.Copy(deployment)
+	if err != nil {
+		glog.V(2).Infof("Unable to copy deployment %s: %v\n", deployment.ID, err)
+		return deployapi.DeploymentStatusFailed
+	}
+
 	controller := &kapi.ReplicationController{
-		DesiredState: deployment.ControllerTemplate,
+		DesiredState: deploymentCopy.(*deployapi.Deployment).ControllerTemplate,
 		Labels:       map[string]string{deployapi.DeploymentConfigLabel: configID, "deployment": deployment.ID},
 	}
 

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -1,10 +1,13 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"hash/adler32"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -69,8 +72,13 @@ func ParseContainerImage(image string) (string, string) {
 }
 
 func HashPodTemplate(t api.PodState) uint64 {
+	jsonString, err := json.Marshal(t)
+	if err != nil {
+		glog.Errorf("An error occurred marshalling pod state: %v", err)
+		return 0
+	}
 	hash := adler32.New()
-	fmt.Fprintf(hash, "%#v", t)
+	fmt.Fprintf(hash, "%s", jsonString)
 	return uint64(hash.Sum32())
 }
 


### PR DESCRIPTION
There's a couple of reasons the basic deployment controller thinks the pod template of the last deployment and the one in the deployment config are different. 
- The controller is adding tags to the deployment object when it uses the pod template object for the new replication controller. The object still points to the one on the deployment, so any label changes get persisted on the deployment object as well. 
- The volume source pointer (when a volume is specified in the pod template) will always have a different value when printed in %#v form.
