### PR TITLE
bump(github.com/openshift/source-to-image) add9ff4973d949b4c82fb6a217e6919bb6e6be23

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -467,7 +467,7 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/sti",
-			"Rev": "a5aff8d6941d7494aec1bda63e6190af64e3affe"
+			"Rev": "add9ff4973d949b4c82fb6a217e6919bb6e6be23"
 		},
 		{
 			"ImportPath": "github.com/racker/perigee",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/sti/docker/docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/sti/docker/docker.go
@@ -294,9 +294,12 @@ func (d *stiDocker) GetImageId(imageName string) (string, error) {
 // CommitContainer commits a container to an image with a specific tag.
 // The new image ID is returned
 func (d *stiDocker) CommitContainer(opts CommitContainerOptions) (string, error) {
+
+	repository, tag := docker.ParseRepositoryTag(opts.Repository)
 	dockerOpts := docker.CommitContainerOptions{
 		Container:  opts.ContainerID,
-		Repository: opts.Repository,
+		Repository: repository,
+		Tag:        tag,
 	}
 	if opts.Command != nil {
 		config := docker.Config{


### PR DESCRIPTION
Update vendored STI to fix issue with the handling of repository names containing tags
