### PR TITLE
Enhance deployment list and watch APIs

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -70,8 +70,8 @@ type ImageRepositoryMappingInterface interface {
 
 // DeploymentConfigInterface contains methods for working with DeploymentConfigs
 type DeploymentConfigInterface interface {
-	ListDeploymentConfigs(ctx kapi.Context, selector labels.Selector) (*deployapi.DeploymentConfigList, error)
-	WatchDeploymentConfigs(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error)
+	ListDeploymentConfigs(ctx kapi.Context, label, field labels.Selector) (*deployapi.DeploymentConfigList, error)
+	WatchDeploymentConfigs(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 	GetDeploymentConfig(ctx kapi.Context, id string) (*deployapi.DeploymentConfig, error)
 	CreateDeploymentConfig(ctx kapi.Context, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
 	UpdateDeploymentConfig(ctx kapi.Context, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
@@ -81,12 +81,12 @@ type DeploymentConfigInterface interface {
 
 // DeploymentInterface contains methods for working with Deployments
 type DeploymentInterface interface {
-	ListDeployments(ctx kapi.Context, selector labels.Selector) (*deployapi.DeploymentList, error)
+	ListDeployments(ctx kapi.Context, label, field labels.Selector) (*deployapi.DeploymentList, error)
 	GetDeployment(ctx kapi.Context, id string) (*deployapi.Deployment, error)
 	CreateDeployment(ctx kapi.Context, deployment *deployapi.Deployment) (*deployapi.Deployment, error)
 	UpdateDeployment(ctx kapi.Context, deployment *deployapi.Deployment) (*deployapi.Deployment, error)
 	DeleteDeployment(ctx kapi.Context, id string) error
-	WatchDeployments(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error)
+	WatchDeployments(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }
 
 // RouteInterface exposes methods on Route resources
@@ -278,13 +278,19 @@ func (c *Client) CreateImageRepositoryMapping(ctx kapi.Context, mapping *imageap
 }
 
 // ListDeploymentConfigs takes a selector, and returns the list of deploymentConfigs that match that selector
-func (c *Client) ListDeploymentConfigs(ctx kapi.Context, selector labels.Selector) (result *deployapi.DeploymentConfigList, err error) {
+func (c *Client) ListDeploymentConfigs(ctx kapi.Context, label, field labels.Selector) (result *deployapi.DeploymentConfigList, err error) {
 	result = &deployapi.DeploymentConfigList{}
-	err = c.Get().Namespace(kapi.Namespace(ctx)).Path("deploymentConfigs").SelectorParam("labels", selector).Do().Into(result)
+	err = c.Get().
+		Namespace(kapi.Namespace(ctx)).
+		Path("deploymentConfigs").
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Do().
+		Into(result)
 	return
 }
 
-func (c *Client) WatchDeploymentConfigs(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *Client) WatchDeploymentConfigs(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.Get().
 		Namespace(kapi.Namespace(ctx)).
 		Path("watch").
@@ -329,9 +335,15 @@ func (c *Client) GenerateDeploymentConfig(ctx kapi.Context, id string) (result *
 }
 
 // ListDeployments takes a selector, and returns the list of deployments that match that selector
-func (c *Client) ListDeployments(ctx kapi.Context, selector labels.Selector) (result *deployapi.DeploymentList, err error) {
+func (c *Client) ListDeployments(ctx kapi.Context, label, field labels.Selector) (result *deployapi.DeploymentList, err error) {
 	result = &deployapi.DeploymentList{}
-	err = c.Get().Namespace(kapi.Namespace(ctx)).Path("deployments").SelectorParam("labels", selector).Do().Into(result)
+	err = c.Get().
+		Namespace(kapi.Namespace(ctx)).
+		Path("deployments").
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Do().
+		Into(result)
 	return
 }
 
@@ -362,7 +374,7 @@ func (c *Client) DeleteDeployment(ctx kapi.Context, id string) error {
 }
 
 // WatchDeployments returns a watch.Interface that watches the requested deployments.
-func (c *Client) WatchDeployments(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *Client) WatchDeployments(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.Get().
 		Namespace(kapi.Namespace(ctx)).
 		Path("watch").

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -80,7 +80,7 @@ func (c *Fake) DeleteBuildConfig(ctx kapi.Context, id string) error {
 	return nil
 }
 
-func (c *Fake) WatchDeploymentConfigs(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *Fake) WatchDeploymentConfigs(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "watch-deploymentconfig"})
 	return nil, nil
 }
@@ -130,7 +130,7 @@ func (c *Fake) CreateImageRepositoryMapping(ctx kapi.Context, mapping *imageapi.
 	return nil
 }
 
-func (c *Fake) ListDeploymentConfigs(ctx kapi.Context, selector labels.Selector) (*deployapi.DeploymentConfigList, error) {
+func (c *Fake) ListDeploymentConfigs(ctx kapi.Context, label, field labels.Selector) (*deployapi.DeploymentConfigList, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "list-deploymentconfig", Ctx: ctx})
 	return &deployapi.DeploymentConfigList{}, nil
 }
@@ -160,7 +160,7 @@ func (c *Fake) GenerateDeploymentConfig(ctx kapi.Context, id string) (*deployapi
 	return nil, nil
 }
 
-func (c *Fake) ListDeployments(ctx kapi.Context, selector labels.Selector) (*deployapi.DeploymentList, error) {
+func (c *Fake) ListDeployments(ctx kapi.Context, label, field labels.Selector) (*deployapi.DeploymentList, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "list-deployment"})
 	return &deployapi.DeploymentList{}, nil
 }
@@ -185,7 +185,7 @@ func (c *Fake) DeleteDeployment(ctx kapi.Context, id string) error {
 	return nil
 }
 
-func (c *Fake) WatchDeployments(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *Fake) WatchDeployments(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	c.Actions = append(c.Actions, FakeAction{Action: "watch-deployments"})
 	return nil, nil
 }

--- a/pkg/deploy/registry/deploy/registry.go
+++ b/pkg/deploy/registry/deploy/registry.go
@@ -4,15 +4,16 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-	api "github.com/openshift/origin/pkg/deploy/api"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 // Registry is an interface for things that know how to store Deployments.
 type Registry interface {
-	ListDeployments(ctx kapi.Context, selector labels.Selector) (*api.DeploymentList, error)
-	GetDeployment(ctx kapi.Context, id string) (*api.Deployment, error)
-	CreateDeployment(ctx kapi.Context, deployment *api.Deployment) error
-	UpdateDeployment(ctx kapi.Context, deployment *api.Deployment) error
+	ListDeployments(ctx kapi.Context, label, field labels.Selector) (*deployapi.DeploymentList, error)
+	GetDeployment(ctx kapi.Context, id string) (*deployapi.Deployment, error)
+	CreateDeployment(ctx kapi.Context, deployment *deployapi.Deployment) error
+	UpdateDeployment(ctx kapi.Context, deployment *deployapi.Deployment) error
 	DeleteDeployment(ctx kapi.Context, id string) error
-	WatchDeployments(ctx kapi.Context, resourceVersion string, filter func(repo *api.Deployment) bool) (watch.Interface, error)
+	WatchDeployments(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 }

--- a/pkg/deploy/registry/deploy/rest.go
+++ b/pkg/deploy/registry/deploy/rest.go
@@ -35,8 +35,8 @@ func (s *REST) New() runtime.Object {
 }
 
 // List obtains a list of Deployments that match selector.
-func (s *REST) List(ctx kapi.Context, selector, fields labels.Selector) (runtime.Object, error) {
-	deployments, err := s.registry.ListDeployments(ctx, selector)
+func (s *REST) List(ctx kapi.Context, label, field labels.Selector) (runtime.Object, error) {
+	deployments, err := s.registry.ListDeployments(ctx, label, field)
 	if err != nil {
 		return nil, err
 	}
@@ -114,13 +114,6 @@ func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan runtime.Obje
 	}), nil
 }
 
-// Watch begins watching for new, changed, or deleted Deployments.
 func (s *REST) Watch(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return s.registry.WatchDeployments(ctx, resourceVersion, func(deployment *deployapi.Deployment) bool {
-		fields := labels.Set{
-			"ID":       deployment.ID,
-			"Strategy": string(deployment.Strategy.Type),
-		}
-		return label.Matches(labels.Set(deployment.Labels)) && field.Matches(fields)
-	})
+	return s.registry.WatchDeployments(ctx, label, field, resourceVersion)
 }

--- a/pkg/deploy/registry/deployconfig/registry.go
+++ b/pkg/deploy/registry/deployconfig/registry.go
@@ -4,15 +4,16 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-	api "github.com/openshift/origin/pkg/deploy/api"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 // Registry is an interface for things that know how to store DeploymentConfigs.
 type Registry interface {
-	ListDeploymentConfigs(ctx kapi.Context, selector labels.Selector) (*api.DeploymentConfigList, error)
-	WatchDeploymentConfigs(ctx kapi.Context, resourceVersion string, filter func(repo *api.DeploymentConfig) bool) (watch.Interface, error)
-	GetDeploymentConfig(ctx kapi.Context, id string) (*api.DeploymentConfig, error)
-	CreateDeploymentConfig(ctx kapi.Context, deploymentConfig *api.DeploymentConfig) error
-	UpdateDeploymentConfig(ctx kapi.Context, deploymentConfig *api.DeploymentConfig) error
+	ListDeploymentConfigs(ctx kapi.Context, label, field labels.Selector) (*deployapi.DeploymentConfigList, error)
+	WatchDeploymentConfigs(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+	GetDeploymentConfig(ctx kapi.Context, id string) (*deployapi.DeploymentConfig, error)
+	CreateDeploymentConfig(ctx kapi.Context, deploymentConfig *deployapi.DeploymentConfig) error
+	UpdateDeploymentConfig(ctx kapi.Context, deploymentConfig *deployapi.DeploymentConfig) error
 	DeleteDeploymentConfig(ctx kapi.Context, id string) error
 }

--- a/pkg/deploy/registry/deployconfig/rest.go
+++ b/pkg/deploy/registry/deployconfig/rest.go
@@ -36,8 +36,8 @@ func (s *REST) New() runtime.Object {
 }
 
 // List obtains a list of DeploymentConfigs that match selector.
-func (s *REST) List(ctx kapi.Context, selector, fields labels.Selector) (runtime.Object, error) {
-	deploymentConfigs, err := s.registry.ListDeploymentConfigs(ctx, selector)
+func (s *REST) List(ctx kapi.Context, label, field labels.Selector) (runtime.Object, error) {
+	deploymentConfigs, err := s.registry.ListDeploymentConfigs(ctx, label, field)
 	if err != nil {
 		return nil, err
 	}
@@ -47,12 +47,7 @@ func (s *REST) List(ctx kapi.Context, selector, fields labels.Selector) (runtime
 
 // Watch begins watching for new, changed, or deleted ImageRepositories.
 func (s *REST) Watch(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return s.registry.WatchDeploymentConfigs(ctx, resourceVersion, func(config *deployapi.DeploymentConfig) bool {
-		fields := labels.Set{
-			"ID": config.ID,
-		}
-		return label.Matches(labels.Set(config.Labels)) && field.Matches(fields)
-	})
+	return s.registry.WatchDeploymentConfigs(ctx, label, field, resourceVersion)
 }
 
 // Get obtains the DeploymentConfig specified by its id.

--- a/pkg/deploy/registry/test/deploy.go
+++ b/pkg/deploy/registry/test/deploy.go
@@ -20,7 +20,7 @@ func NewDeploymentRegistry() *DeploymentRegistry {
 	return &DeploymentRegistry{}
 }
 
-func (r *DeploymentRegistry) ListDeployments(ctx kapi.Context, selector labels.Selector) (*api.DeploymentList, error) {
+func (r *DeploymentRegistry) ListDeployments(ctx kapi.Context, label, field labels.Selector) (*api.DeploymentList, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -57,6 +57,6 @@ func (r *DeploymentRegistry) DeleteDeployment(ctx kapi.Context, id string) error
 	return r.Err
 }
 
-func (r *DeploymentRegistry) WatchDeployments(ctx kapi.Context, resourceVersion string, filter func(repo *api.Deployment) bool) (watch.Interface, error) {
+func (r *DeploymentRegistry) WatchDeployments(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return nil, r.Err
 }

--- a/pkg/deploy/registry/test/deployconfig.go
+++ b/pkg/deploy/registry/test/deployconfig.go
@@ -20,7 +20,7 @@ func NewDeploymentConfigRegistry() *DeploymentConfigRegistry {
 	return &DeploymentConfigRegistry{}
 }
 
-func (r *DeploymentConfigRegistry) ListDeploymentConfigs(ctx kapi.Context, selector labels.Selector) (*api.DeploymentConfigList, error) {
+func (r *DeploymentConfigRegistry) ListDeploymentConfigs(ctx kapi.Context, label, field labels.Selector) (*api.DeploymentConfigList, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -57,6 +57,6 @@ func (r *DeploymentConfigRegistry) DeleteDeploymentConfig(ctx kapi.Context, id s
 	return r.Err
 }
 
-func (r *DeploymentConfigRegistry) WatchDeploymentConfigs(ctx kapi.Context, resourceVersion string, filter func(repo *api.DeploymentConfig) bool) (watch.Interface, error) {
+func (r *DeploymentConfigRegistry) WatchDeploymentConfigs(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return nil, r.Err
 }

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -46,8 +46,8 @@ func TestSuccessfulManualDeployment(t *testing.T) {
 	ctx := kapi.NewContext()
 	var err error
 
-	watch, err := openshift.Client.WatchDeployments(ctx, labels.Everything(),
-		labels.Set{deployapi.DeploymentConfigLabel: config.ID}.AsSelector(), "0")
+	labelSelector := labels.SelectorFromSet(labels.Set{deployapi.DeploymentConfigLabel: config.ID})
+	watch, err := openshift.Client.WatchDeployments(ctx, labelSelector, labels.Everything(), "0")
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Deployments: %v", err)
 	}
@@ -88,8 +88,8 @@ func TestSimpleImageChangeTrigger(t *testing.T) {
 	ctx := kapi.NewContext()
 	var err error
 
-	watch, err := openshift.Client.WatchDeployments(ctx, labels.Everything(),
-		labels.Set{deployapi.DeploymentConfigLabel: config.ID}.AsSelector(), "0")
+	labelSelector := labels.SelectorFromSet(labels.Set{deployapi.DeploymentConfigLabel: config.ID})
+	watch, err := openshift.Client.WatchDeployments(ctx, labelSelector, labels.Everything(), "0")
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Deployments %v", err)
 	}
@@ -143,8 +143,8 @@ func TestSimpleConfigChangeTrigger(t *testing.T) {
 	ctx := kapi.NewContext()
 	var err error
 
-	watch, err := openshift.Client.WatchDeployments(ctx, labels.Everything(),
-		labels.Set{deployapi.DeploymentConfigLabel: config.ID}.AsSelector(), "0")
+	labelSelector := labels.SelectorFromSet(labels.Set{deployapi.DeploymentConfigLabel: config.ID})
+	watch, err := openshift.Client.WatchDeployments(ctx, labelSelector, labels.Everything(), "0")
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Deployments %v", err)
 	}


### PR DESCRIPTION
Clean up and enhance the deployment list and watch APIs. Support field
selectors across all deployment list and watch interfaces. Re-order field
and label arguments to list and watch interfaces to match upstream.

Introduce enhanced selector testing support.
