### PR TITLE
Use constants for deployment annotations

### DIFF
--- a/pkg/deploy/controller/factory/factory.go
+++ b/pkg/deploy/controller/factory/factory.go
@@ -123,7 +123,7 @@ func (factory *DeploymentControllerFactory) pollPods() (cache.Enumerator, error)
 		switch deployment.Status {
 		case deployapi.DeploymentStatusPending, deployapi.DeploymentStatusRunning:
 			// Validate the correlating pod annotation
-			podID, hasPodID := deployment.Annotations["pod"]
+			podID, hasPodID := deployment.Annotations[deployapi.DeploymentPodAnnotation]
 			if !hasPodID {
 				glog.V(2).Infof("Unexpected state: Deployment %s has no pod annotation; skipping pod polling", deployment.ID)
 				continue

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -66,7 +66,7 @@ func TestSuccessfulManualDeployment(t *testing.T) {
 	event := <-watch.ResultChan()
 	deployment := event.Object.(*deployapi.Deployment)
 
-	if e, a := config.ID, deployment.Annotations["deploymentConfig"]; e != a {
+	if e, a := config.ID, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
 }
@@ -111,7 +111,7 @@ func TestSimpleImageChangeTrigger(t *testing.T) {
 	event := <-watch.ResultChan()
 	deployment := event.Object.(*deployapi.Deployment)
 
-	if e, a := config.ID, deployment.Annotations["deploymentConfig"]; e != a {
+	if e, a := config.ID, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
 
@@ -124,7 +124,7 @@ func TestSimpleImageChangeTrigger(t *testing.T) {
 	event = <-watch.ResultChan()
 	deployment = event.Object.(*deployapi.Deployment)
 
-	if e, a := config.ID, deployment.Annotations["deploymentConfig"]; e != a {
+	if e, a := config.ID, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
 
@@ -155,7 +155,7 @@ func TestSimpleConfigChangeTrigger(t *testing.T) {
 	event := <-watch.ResultChan()
 	deployment := event.Object.(*deployapi.Deployment)
 
-	if e, a := config.ID, deployment.Annotations["deploymentConfig"]; e != a {
+	if e, a := config.ID, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
 


### PR DESCRIPTION
Fix some places where constants weren't in use for annotation lookups.
