### PR TITLE
(DO NOT MERGE) Minor adjustment to deploy int test assertion

### DIFF
--- a/pkg/deploy/controller/deployment_config_controller.go
+++ b/pkg/deploy/controller/deployment_config_controller.go
@@ -107,6 +107,7 @@ func (c *DeploymentConfigController) deploy(ctx kapi.Context, config *deployapi.
 		Details:            config.Details,
 	}
 
+	glog.Infof("!!!! DeploymentConfigController creating deployment.\nDeploymentConfig:\n%#v\nDeployment:\n%#v", config, deployment)
 	glog.V(4).Infof("Creating new deployment from config %s", config.ID)
 	_, err := c.DeploymentInterface.CreateDeployment(ctx, deployment)
 	return err

--- a/pkg/deploy/registry/etcd/etcd.go
+++ b/pkg/deploy/registry/etcd/etcd.go
@@ -78,6 +78,7 @@ func (r *Etcd) GetDeployment(ctx kapi.Context, id string) (*api.Deployment, erro
 	if err != nil {
 		return nil, etcderr.InterpretGetError(err, "deployment", id)
 	}
+
 	return &deployment, nil
 }
 
@@ -88,6 +89,7 @@ func (r *Etcd) CreateDeployment(ctx kapi.Context, deployment *api.Deployment) er
 		return err
 	}
 	err = r.CreateObj(key, deployment, 0)
+	glog.Infof("!!!!! Deployment registry created deployment: %#v", deployment)
 	return etcderr.InterpretCreateError(err, "deployment", deployment.ID)
 }
 
@@ -231,6 +233,7 @@ func (r *Etcd) UpdateDeploymentConfig(ctx kapi.Context, deploymentConfig *api.De
 	}
 
 	err = r.SetObj(key, deploymentConfig)
+	glog.Infof("!!!!! Deployment registry updated deploymentConfig: %#v", deploymentConfig)
 	return etcderr.InterpretUpdateError(err, "deploymentConfig", deploymentConfig.ID)
 }
 

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -188,11 +188,14 @@ func TestSimpleConfigChangeTrigger(t *testing.T) {
 	}
 	newDeployment := event.Object.(*deployapi.Deployment)
 
-	assertEnvVarEquals("ENV_TEST", "UPDATED", newDeployment, t)
-
 	if newDeployment.ID == deployment.ID {
 		t.Fatalf("expected new deployment; old=%s, new=%s", deployment.ID, newDeployment.ID)
 	}
+
+	// TODO: remove this. 9.
+	t.Logf("ORIGINAL:\n%#v\nNEW:%#v\n", deployment, newDeployment)
+
+	assertEnvVarEquals("ENV_TEST", "UPDATED", newDeployment, t)
 }
 
 func assertEnvVarEquals(name string, value string, deployment *deployapi.Deployment, t *testing.T) {


### PR DESCRIPTION
Check the object IDs from the event channel before making other
assertions, as the ID check is essential to weeding out race conditions
with the event channel.
