### PR TITLE
add union auth request handler

### DIFF
--- a/pkg/auth/authenticator/requesthandlers/basicauth.go
+++ b/pkg/auth/authenticator/requesthandlers/basicauth.go
@@ -1,0 +1,50 @@
+package requesthandlers
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"strings"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	"github.com/openshift/origin/pkg/auth/authenticator"
+)
+
+type basicAuthRequestHandler struct {
+	passwordAuthenticator authenticator.Password
+}
+
+func NewBasicAuthAuthentication(passwordAuthenticator authenticator.Password) authenticator.Request {
+	return &basicAuthRequestHandler{passwordAuthenticator}
+}
+
+func (authHandler *basicAuthRequestHandler) AuthenticateRequest(req *http.Request) (authapi.UserInfo, bool, error) {
+	username, password, err := getBasicAuthInfo(req)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return authHandler.passwordAuthenticator.AuthenticatePassword(username, password)
+}
+
+func getBasicAuthInfo(r *http.Request) (string, string, error) {
+	// Retrieve the Authorization header and check whether it contains basic auth information
+	const basicScheme string = "Basic "
+	auth := r.Header.Get("Authorization")
+
+	if !strings.HasPrefix(auth, basicScheme) {
+		return "", "", nil
+	}
+
+	str, err := base64.StdEncoding.DecodeString(auth[len(basicScheme):])
+	if err != nil {
+		return "", "", errors.New("No valid base64 data in basic auth scheme found")
+	}
+
+	cred := strings.Split(string(str), ":")
+	if len(cred) != 2 {
+		return "", "", errors.New("Invalid Authorization header")
+	}
+
+	return cred[0], cred[1], nil
+}

--- a/pkg/auth/authenticator/requesthandlers/basicauth_test.go
+++ b/pkg/auth/authenticator/requesthandlers/basicauth_test.go
@@ -1,0 +1,157 @@
+package requesthandlers
+
+import (
+	"net/http"
+	"testing"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+)
+
+const (
+	USERNAME            = "frightened_donut"
+	PASSWORD            = "don't eat me!"
+	VALID_BASE64_STRING = "VGhpc0lzVmFsaWQK" // base64 -- ThisIsValid ctrl+d
+)
+
+type mockPasswordAuthenticator struct {
+	returnUser      authapi.UserInfo
+	isAuthenticated bool
+	err             error
+	passedUser      string
+	passedPassword  string
+}
+
+func (mock *mockPasswordAuthenticator) AuthenticatePassword(username, password string) (authapi.UserInfo, bool, error) {
+	mock.passedUser = username
+	mock.passedPassword = password
+
+	return mock.returnUser, mock.isAuthenticated, mock.err
+}
+
+func TestAuthenticateRequestValid(t *testing.T) {
+	passwordAuthenticator := &mockPasswordAuthenticator{}
+	authRequestHandler := NewBasicAuthAuthentication(passwordAuthenticator)
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req.SetBasicAuth(USERNAME, PASSWORD)
+
+	_, _, _ = authRequestHandler.AuthenticateRequest(req)
+	if passwordAuthenticator.passedUser != USERNAME {
+		t.Errorf("Expected %v, got %v", USERNAME, passwordAuthenticator.passedUser)
+	}
+	if passwordAuthenticator.passedPassword != PASSWORD {
+		t.Errorf("Expected %v, got %v", PASSWORD, passwordAuthenticator.passedPassword)
+	}
+}
+
+func TestAuthenticateRequestInvalid(t *testing.T) {
+	const (
+		EXPECTED_ERROR = "No valid base64 data in basic auth scheme found"
+	)
+	passwordAuthenticator := &mockPasswordAuthenticator{isAuthenticated: true}
+	authRequestHandler := NewBasicAuthAuthentication(passwordAuthenticator)
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req.Header.Add("Authorization", "Basic invalid:string")
+
+	userInfo, authenticated, err := authRequestHandler.AuthenticateRequest(req)
+	if err == nil {
+		t.Errorf("Expected error: %v", EXPECTED_ERROR)
+	}
+	if err.Error() != EXPECTED_ERROR {
+		t.Errorf("Expected %v, got %v", EXPECTED_ERROR, err)
+	}
+	if userInfo != nil {
+		t.Errorf("Unexpected user: %v", userInfo)
+	}
+	if authenticated {
+		t.Errorf("Unexpectedly authenticated: %v", authenticated)
+	}
+}
+
+func TestGetBasicAuthInfo(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req.SetBasicAuth(USERNAME, PASSWORD)
+
+	username, password, err := getBasicAuthInfo(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if username != USERNAME {
+		t.Errorf("Expected %v, got %v", USERNAME, username)
+	}
+	if password != PASSWORD {
+		t.Errorf("Expected %v, got %v", PASSWORD, password)
+	}
+}
+
+func TestGetBasicAuthInfoNoHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+
+	username, password, err := getBasicAuthInfo(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(username) != 0 {
+		t.Errorf("Unexpected username: %v", username)
+	}
+	if len(password) != 0 {
+		t.Errorf("Unexpected password: %v", password)
+	}
+}
+
+func TestGetBasicAuthInfoNotBasicHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req.Header.Add("Authorization", "notbasic")
+
+	username, password, err := getBasicAuthInfo(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(username) != 0 {
+		t.Errorf("Unexpected username: %v", username)
+	}
+	if len(password) != 0 {
+		t.Errorf("Unexpected password: %v", password)
+	}
+}
+func TestGetBasicAuthInfoNotBase64Encoded(t *testing.T) {
+	const (
+		EXPECTED_ERROR = "No valid base64 data in basic auth scheme found"
+	)
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req.Header.Add("Authorization", "Basic invalid:string")
+
+	username, password, err := getBasicAuthInfo(req)
+	if err == nil {
+		t.Errorf("Expected error: %v", EXPECTED_ERROR)
+	}
+	if err.Error() != EXPECTED_ERROR {
+		t.Errorf("Expected %v, got %v", EXPECTED_ERROR, err)
+	}
+	if len(username) != 0 {
+		t.Errorf("Unexpected username: %v", username)
+	}
+	if len(password) != 0 {
+		t.Errorf("Unexpected password: %v", password)
+	}
+}
+func TestGetBasicAuthInfoNotCredentials(t *testing.T) {
+	const (
+		EXPECTED_ERROR = "Invalid Authorization header"
+	)
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+	req.Header.Add("Authorization", "Basic "+VALID_BASE64_STRING)
+
+	username, password, err := getBasicAuthInfo(req)
+	if err == nil {
+		t.Errorf("Expected error: %v", EXPECTED_ERROR)
+	}
+	if err.Error() != EXPECTED_ERROR {
+		t.Errorf("Expected %v, got %v", EXPECTED_ERROR, err)
+	}
+	if len(username) != 0 {
+		t.Errorf("Unexpected username: %v", username)
+	}
+	if len(password) != 0 {
+		t.Errorf("Unexpected password: %v", password)
+	}
+}

--- a/pkg/auth/authenticator/requesthandlers/union.go
+++ b/pkg/auth/authenticator/requesthandlers/union.go
@@ -1,0 +1,32 @@
+package requesthandlers
+
+import (
+	"net/http"
+
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	"github.com/openshift/origin/pkg/auth/authenticator"
+)
+
+type unionAuthRequestHandler []authenticator.Request
+
+func NewUnionAuthentication(authRequestHandlers []authenticator.Request) authenticator.Request {
+	ret := unionAuthRequestHandler(authRequestHandlers)
+	return &ret
+}
+
+func (authHandler unionAuthRequestHandler) AuthenticateRequest(req *http.Request) (authapi.UserInfo, bool, error) {
+	var errors kutil.ErrorList
+	for _, currAuthRequestHandler := range authHandler {
+		info, ok, err := currAuthRequestHandler.AuthenticateRequest(req)
+		if err == nil && ok {
+			return info, ok, err
+		}
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	return nil, false, errors.ToError()
+}

--- a/pkg/auth/authenticator/requesthandlers/unionauth_test.go
+++ b/pkg/auth/authenticator/requesthandlers/unionauth_test.go
@@ -1,0 +1,87 @@
+package requesthandlers
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	"github.com/openshift/origin/pkg/auth/authenticator"
+)
+
+type mockAuthRequestHandler struct {
+	returnUser      authapi.UserInfo
+	isAuthenticated bool
+	err             error
+}
+
+func (mock *mockAuthRequestHandler) AuthenticateRequest(req *http.Request) (authapi.UserInfo, bool, error) {
+	return mock.returnUser, mock.isAuthenticated, mock.err
+}
+
+func TestAuthenticateRequestSecondPasses(t *testing.T) {
+	handler1 := &mockAuthRequestHandler{}
+	handler2 := &mockAuthRequestHandler{isAuthenticated: true}
+	authRequestHandler := NewUnionAuthentication([]authenticator.Request{handler1, handler2})
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+
+	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !isAuthenticated {
+		t.Errorf("Unexpectedly unauthenticated: %v", isAuthenticated)
+	}
+}
+
+func TestAuthenticateRequestSuppressUnnecessaryErrors(t *testing.T) {
+	handler1 := &mockAuthRequestHandler{err: errors.New("first")}
+	handler2 := &mockAuthRequestHandler{isAuthenticated: true}
+	authRequestHandler := NewUnionAuthentication([]authenticator.Request{handler1, handler2})
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+
+	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !isAuthenticated {
+		t.Errorf("Unexpectedly unauthenticated: %v", isAuthenticated)
+	}
+}
+
+func TestAuthenticateRequestNonePass(t *testing.T) {
+	handler1 := &mockAuthRequestHandler{}
+	handler2 := &mockAuthRequestHandler{}
+	authRequestHandler := NewUnionAuthentication([]authenticator.Request{handler1, handler2})
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+
+	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if isAuthenticated {
+		t.Errorf("Unexpectedly authenticated: %v", isAuthenticated)
+	}
+}
+
+func TestAuthenticateRequestAdditiveErrors(t *testing.T) {
+	handler1 := &mockAuthRequestHandler{err: errors.New("first")}
+	handler2 := &mockAuthRequestHandler{err: errors.New("second")}
+	authRequestHandler := NewUnionAuthentication([]authenticator.Request{handler1, handler2})
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+
+	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+	if !strings.Contains(err.Error(), "first") {
+		t.Errorf("Expected error containing %v, got %v", "first", err)
+	}
+	if !strings.Contains(err.Error(), "second") {
+		t.Errorf("Expected error containing %v, got %v", "second", err)
+	}
+	if isAuthenticated {
+		t.Errorf("Unexpectedly authenticated: %v", isAuthenticated)
+	}
+}

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/golang/glog"
@@ -15,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/authenticator/basicauthpassword"
 	"github.com/openshift/origin/pkg/auth/authenticator/bearertoken"
 	authfile "github.com/openshift/origin/pkg/auth/authenticator/file"
+	"github.com/openshift/origin/pkg/auth/authenticator/requesthandlers"
 	"github.com/openshift/origin/pkg/auth/authenticator/requestheader"
 	"github.com/openshift/origin/pkg/auth/oauth/external"
 	"github.com/openshift/origin/pkg/auth/oauth/external/github"
@@ -58,14 +60,7 @@ type AuthConfig struct {
 func (c *AuthConfig) InstallAPI(mux cmdutil.Mux) []string {
 	oauthEtcd := oauthetcd.New(c.EtcdHelper)
 
-	authRequestHandler := c.getAuthenticationRequestHandler()
-
-	// Check if the authentication handler wants to be told when we authenticated
-	success, ok := authRequestHandler.(handlers.AuthenticationSuccessHandler)
-	if !ok {
-		success = emptySuccess{}
-	}
-	authHandler := c.getAuthenticationHandler(mux, success, emptyError{})
+	authRequestHandler, authHandler := c.getAuthorizeAuthenticationHandlers(mux)
 
 	storage := registrystorage.New(oauthEtcd, oauthEtcd, oauthEtcd, registry.NewUserConversion())
 	config := osinserver.NewDefaultServerConfig()
@@ -111,6 +106,18 @@ func getCSRF() csrf.CSRF {
 	return csrf.NewCookieCSRF("csrf", "/", "", false, false)
 }
 
+func (c *AuthConfig) getAuthorizeAuthenticationHandlers(mux cmdutil.Mux) (authenticator.Request, handlers.AuthenticationHandler) {
+	// things based on sessionStore only work if they can share exactly the same instance of sessionStore
+	// this results in really ugly initialization code as we have to pass this concept through to many disparate pieces
+	// of the config that MIGHT need the information.  The first step to fixing it is to see how far it goes, so this
+	// does not attempt to hide the ugly
+	sessionStore := session.NewStore(c.SessionSecrets...)
+	authRequestHandler := c.getAuthenticationRequestHandler(sessionStore)
+	authHandler := c.getAuthenticationHandler(mux, sessionStore, emptyError{})
+
+	return authRequestHandler, authHandler
+}
+
 // getGrantHandler returns the object that handles approving or rejecting grant requests
 func (c *AuthConfig) getGrantHandler(mux cmdutil.Mux, auth authenticator.Request, clientregistry clientregistry.Registry, authregistry clientauthorization.Registry) handlers.GrantHandler {
 	var grantHandler handlers.GrantHandler
@@ -130,7 +137,9 @@ func (c *AuthConfig) getGrantHandler(mux cmdutil.Mux, auth authenticator.Request
 	return grantHandler
 }
 
-func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, success handlers.AuthenticationSuccessHandler, error handlers.AuthenticationErrorHandler) handlers.AuthenticationHandler {
+func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, sessionStore session.Store, error handlers.AuthenticationErrorHandler) handlers.AuthenticationHandler {
+	successHandler := c.getAuthenticationSuccessHandler(sessionStore)
+
 	// TODO presumeably we'll want either a list of what we've got or a way to describe a registry of these
 	// hard-coded strings as a stand-in until it gets sorted out
 	var authHandler handlers.AuthenticationHandler
@@ -149,8 +158,7 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, success handlers.
 		}
 
 		state := external.DefaultState()
-		success := handlers.AuthenticationSuccessHandlers{success, state.(handlers.AuthenticationSuccessHandler)}
-		oauthHandler, err := external.NewHandler(oauthProvider, state, c.MasterAddr+callbackPath, success, error, identityMapper)
+		oauthHandler, err := external.NewHandler(oauthProvider, state, c.MasterAddr+callbackPath, successHandler, error, identityMapper)
 		if err != nil {
 			glog.Fatalf("unexpected error: %v", err)
 		}
@@ -160,8 +168,7 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, success handlers.
 	case "login":
 		passwordAuth := c.getPasswordAuthenticator()
 		authHandler = &redirectAuthHandler{RedirectURL: OpenShiftLoginPrefix, ThenParam: "then"}
-		success := handlers.AuthenticationSuccessHandlers{success, redirectSuccessHandler{}}
-		login := login.NewLogin(getCSRF(), &callbackPasswordAuthenticator{passwordAuth, success}, login.DefaultLoginFormRenderer)
+		login := login.NewLogin(getCSRF(), &callbackPasswordAuthenticator{passwordAuth, successHandler}, login.DefaultLoginFormRenderer)
 		login.Install(mux, OpenShiftLoginPrefix)
 	case "empty":
 		authHandler = emptyAuth{}
@@ -197,11 +204,33 @@ func (c *AuthConfig) getPasswordAuthenticator() authenticator.Password {
 	return passwordAuth
 }
 
-func (c *AuthConfig) getAuthenticationRequestHandler() authenticator.Request {
+func (c *AuthConfig) getAuthenticationSuccessHandler(sessionStore session.Store) handlers.AuthenticationSuccessHandler {
+	successHandlers := handlers.AuthenticationSuccessHandlers{}
+
+	authRequestHandlerTypes := env("ORIGIN_AUTH_REQUEST_HANDLERS", "session")
+	for _, currType := range strings.Split(authRequestHandlerTypes, ",") {
+		currType = strings.TrimSpace(currType)
+		switch currType {
+		case "session":
+			successHandlers = append(successHandlers, session.NewSessionAuthenticator(sessionStore, "ssn"))
+		}
+	}
+
+	authHandlerType := env("ORIGIN_AUTH_HANDLER", "login")
+	switch authHandlerType {
+	case "google", "github":
+		successHandlers = append(successHandlers, external.DefaultState().(handlers.AuthenticationSuccessHandler))
+	case "login":
+		successHandlers = append(successHandlers, redirectSuccessHandler{})
+	}
+
+	return successHandlers
+}
+
+func (c *AuthConfig) getAuthenticationRequestHandlerFromType(authRequestHandlerType string, sessionStore session.Store) authenticator.Request {
 	// TODO presumeably we'll want either a list of what we've got or a way to describe a registry of these
 	// hard-coded strings as a stand-in until it gets sorted out
 	var authRequestHandler authenticator.Request
-	authRequestHandlerType := env("ORIGIN_AUTH_REQUEST_HANDLER", "session")
 	switch authRequestHandlerType {
 	case "bearer":
 		tokenAuthenticator, err := GetTokenAuthenticator(c.EtcdHelper)
@@ -211,13 +240,30 @@ func (c *AuthConfig) getAuthenticationRequestHandler() authenticator.Request {
 		authRequestHandler = bearertoken.New(tokenAuthenticator)
 	case "requestheader":
 		authRequestHandler = requestheader.NewAuthenticator(requestheader.NewDefaultConfig())
+	case "basicauth":
+		passwordAuthenticator := c.getPasswordAuthenticator()
+		authRequestHandler = requesthandlers.NewBasicAuthAuthentication(passwordAuthenticator)
 	case "session":
-		sessionStore := session.NewStore(c.SessionSecrets...)
 		authRequestHandler = session.NewSessionAuthenticator(sessionStore, "ssn")
 	default:
 		glog.Fatalf("No AuthenticationRequestHandler found that matches %v.  The oauth server cannot start!", authRequestHandlerType)
 	}
 
+	return authRequestHandler
+}
+
+func (c *AuthConfig) getAuthenticationRequestHandler(sessionStore session.Store) authenticator.Request {
+	// TODO presumeably we'll want either a list of what we've got or a way to describe a registry of these
+	// hard-coded strings as a stand-in until it gets sorted out
+	var authRequestHandlers []authenticator.Request
+	authRequestHandlerTypes := env("ORIGIN_AUTH_REQUEST_HANDLERS", "session")
+	for _, currType := range strings.Split(authRequestHandlerTypes, ",") {
+		currType = strings.TrimSpace(currType)
+
+		authRequestHandlers = append(authRequestHandlers, c.getAuthenticationRequestHandlerFromType(currType, sessionStore))
+	}
+
+	authRequestHandler := requesthandlers.NewUnionAuthentication(authRequestHandlers)
 	return authRequestHandler
 }
 


### PR DESCRIPTION
@liggitt I chose not to change behavior, but I don't see a reason why AuthenticationSuccessHandlers should be the exact same object as AuthenticationRequestHandlers.  If you agree that such a restriction is unnecessary, I'll turn getAuthenticationSuccessHandlers into a method that checks the configuration and creates the necessary handlers based on knowledge of both AuthenticationRequestHandler config and AuthenticationHandler config.
