### PR TITLE
Fix deployment image change trigger bug

### DIFF
--- a/pkg/deploy/controller/image_change_controller.go
+++ b/pkg/deploy/controller/image_change_controller.go
@@ -62,8 +62,9 @@ func (c *ImageChangeController) HandleImageRepo() {
 					continue
 				}
 
-				_, tag := parseImage(container.Image)
-				if tag != imageRepo.Tags[params.Tag] {
+				// The container image's tag name is by convention the same as the image ID it references
+				_, containerImageID := parseImage(container.Image)
+				if repoImageID, repoHasTag := imageRepo.Tags[params.Tag]; repoHasTag && repoImageID != containerImageID {
 					configIDs = append(configIDs, config.Name)
 					firedTriggersForConfig[config.Name] = append(firedTriggersForConfig[config.Name], params)
 				}


### PR DESCRIPTION
Don't trigger an image tag change when the image repo being checked
doesn't contain the tag defined in the trigger.
