### PR TITLE
update readme to use generic webhook.

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -74,7 +74,7 @@ All commands assume the `openshift` binary is in your path (normally located und
  * If you setup the github webhook in step 7, push a change to app.rb in your ruby sample repository from step 6.
  * Otherwise you can simulate the webhook invocation by running:
 
-            $ curl -s -A "GitHub-Hookshot/github" -H "Content-Type:application/json" -H "X-Github-Event:push" -d @github-webhook-example.json http://localhost:8080/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/github
+            $ curl -X POST http://localhost:8080/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic
 
     In the OpenShift logs (logs/openshift.log) you should see something like:
 

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -64,6 +64,12 @@
           "github": {
             "secret": "secret101"
           }
+        },
+        {
+          "type": "generic",
+          "generic": {
+            "secret": "secret101"
+          }
         }
       ],
       "parameters": {

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -64,6 +64,12 @@
           "github": {
             "secret": "secret101"
           }
+        },
+        {
+          "type": "generic",
+          "generic": {
+            "secret": "secret101"
+          }
         }
       ],
       "parameters": {

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -149,8 +149,8 @@ echo "[INFO] Applying application config"
 $openshift kube apply --ns=${NAMESPACE} -c $CONFIG_FILE
 
 # Trigger build
-echo "[INFO] Simulating github hook to trigger new build using curl"
-curl -s -A "GitHub-Hookshot/github" -H "Content-Type:application/json" -H "X-Github-Event:push" -d @${FIXTURE_DIR}/github-webhook-example.json http://localhost:8080/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/github?namespace=${NAMESPACE}
+echo "[INFO]  Invoking generic web hook to trigger new build using curl"
+curl -X POST http://localhost:8080/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic?namespace=${NAMESPACE}
 
 # Wait for build to complete
 echo "[INFO] Waiting for build to complete"


### PR DESCRIPTION
this will avoid the problem of mismatched branch names when users fork the repo and create their own build configs (the github webhook specifies the branch and it needs to match)
