### PR TITLE
Make auth interfaces more flexible

### DIFF
--- a/pkg/auth/oauth/external/github/github.go
+++ b/pkg/auth/oauth/external/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -75,7 +76,7 @@ func (p provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentit
 	}
 
 	if userdata.ID == 0 {
-		return nil, false, fmt.Errorf("Could not retrieve GitHub id")
+		return nil, false, errors.New("Could not retrieve GitHub id")
 	}
 
 	identity := &authapi.DefaultUserIdentityInfo{

--- a/pkg/auth/oauth/external/github/github_test.go
+++ b/pkg/auth/oauth/external/github/github_test.go
@@ -1,0 +1,11 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/auth/oauth/external"
+)
+
+func TestGithub(t *testing.T) {
+	_ = external.Provider(NewProvider("", ""))
+}

--- a/pkg/auth/oauth/external/google/google.go
+++ b/pkg/auth/oauth/external/google/google.go
@@ -3,6 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -62,7 +63,7 @@ func (p provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentit
 	id, _ := userdata["id"].(string)
 	email, _ := userdata["email"].(string)
 	if id == "" || email == "" {
-		return nil, false, fmt.Errorf("Could not retrieve Google id")
+		return nil, false, errors.New("Could not retrieve Google id")
 	}
 
 	identity := &authapi.DefaultUserIdentityInfo{

--- a/pkg/auth/oauth/external/google/google_test.go
+++ b/pkg/auth/oauth/external/google/google_test.go
@@ -1,0 +1,11 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/auth/oauth/external"
+)
+
+func TestGoogle(t *testing.T) {
+	_ = external.Provider(NewProvider("", ""))
+}

--- a/pkg/auth/oauth/external/handler_test.go
+++ b/pkg/auth/oauth/external/handler_test.go
@@ -1,0 +1,11 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/auth/oauth/handlers"
+)
+
+func TestHandler(t *testing.T) {
+	_ = handlers.AuthenticationHandler(&Handler{})
+}

--- a/pkg/auth/oauth/handlers/authenticator_test.go
+++ b/pkg/auth/oauth/handlers/authenticator_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RangelReale/osin"
+	"github.com/openshift/origin/pkg/oauth/server/osinserver"
+)
+
+func TestAuthorizeAuthenticator(t *testing.T) {
+	_ = osinserver.AuthorizeHandler(&AuthorizeAuthenticator{})
+}
+
+func TestAuthenticator(t *testing.T) {
+	testCases := map[osin.AccessRequestType]struct {
+		ExpectedAuthorized bool
+		ExpectedError      bool
+	}{
+		osin.AUTHORIZATION_CODE: {true, false},
+		osin.REFRESH_TOKEN:      {true, false},
+		osin.PASSWORD:           {false, false},
+		osin.ASSERTION:          {false, false},
+		osin.CLIENT_CREDENTIALS: {false, false},
+		osin.IMPLICIT:           {false, false},
+	}
+
+	for requestType, testCase := range testCases {
+		deny := osinserver.AccessHandler(NewAccessAuthenticator(Deny, Deny, Deny))
+		req := &osin.AccessRequest{Type: requestType}
+		w := httptest.NewRecorder()
+		err := deny.HandleAccess(req, w)
+		if testCase.ExpectedError && err == nil {
+			t.Fatalf("%s: Expected error, got success", requestType)
+		}
+		if !testCase.ExpectedError && err != nil {
+			t.Fatalf("%s: Unexpected error: %s", requestType, err)
+		}
+		if req.Authorized != testCase.ExpectedAuthorized {
+			t.Fatalf("%s: Expected Authorized=%b, got Authorized=%b", requestType, testCase.ExpectedAuthorized, req.Authorized)
+		}
+	}
+}
+
+func TestDenyPassword(t *testing.T) {
+	user, ok, err := Deny.AuthenticatePassword("", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if ok {
+		t.Fatalf("Unexpected success")
+	}
+	if user != nil {
+		t.Fatalf("Unexpected user info: %v", user)
+	}
+}
+
+func TestDenyAssertion(t *testing.T) {
+	user, ok, err := Deny.AuthenticateAssertion("", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if ok {
+		t.Fatalf("Unexpected success")
+	}
+	if user != nil {
+		t.Fatalf("Unexpected user info: %v", user)
+	}
+}
+
+func TestDenyClient(t *testing.T) {
+	user, ok, err := Deny.AuthenticateClient(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if ok {
+		t.Fatalf("Unexpected success")
+	}
+	if user != nil {
+		t.Fatalf("Unexpected user info: %v", user)
+	}
+}
+
+func TestAllowPassword(t *testing.T) {
+	user, ok, err := Allow.AuthenticatePassword("", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("Unexpected failure")
+	}
+	if user != nil {
+		t.Fatalf("Unexpected user info: %v", user)
+	}
+}
+
+func TestAllowAssertion(t *testing.T) {
+	user, ok, err := Allow.AuthenticateAssertion("", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("Unexpected failure")
+	}
+	if user != nil {
+		t.Fatalf("Unexpected user info: %v", user)
+	}
+}
+
+func TestAllowClient(t *testing.T) {
+	user, ok, err := Allow.AuthenticateClient(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if !ok {
+		t.Fatalf("Unexpected failure")
+	}
+	if user != nil {
+		t.Fatalf("Unexpected user info: %v", user)
+	}
+}

--- a/pkg/auth/oauth/handlers/grant_test.go
+++ b/pkg/auth/oauth/handlers/grant_test.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/oauth/registry/test"
+	"github.com/openshift/origin/pkg/oauth/server/osinserver"
+)
+
+func TestGrant(t *testing.T) {
+	_ = osinserver.AuthorizeHandler(&GrantCheck{})
+}
+
+func TestEmptyGrant(t *testing.T) {
+	_ = NewEmptyGrant()
+}
+
+func TestAutoGrant(t *testing.T) {
+	_ = NewAutoGrant(&test.ClientAuthorizationRegistry{})
+}
+
+func TestRedirectGrant(t *testing.T) {
+	_ = NewRedirectGrant("/")
+}

--- a/pkg/auth/oauth/handlers/interfaces.go
+++ b/pkg/auth/oauth/handlers/interfaces.go
@@ -6,42 +6,55 @@ import (
 	"github.com/openshift/origin/pkg/auth/api"
 )
 
+// AuthenticationHandler reacts to unauthenticated requests
 type AuthenticationHandler interface {
-	AuthenticationNeeded(w http.ResponseWriter, req *http.Request)
-	AuthenticationError(err error, w http.ResponseWriter, req *http.Request)
+	// AuthenticationNeeded reacts to unauthenticated requests, and returns true if the response was written,
+	AuthenticationNeeded(w http.ResponseWriter, req *http.Request) (handled bool, err error)
 }
 
-type AuthenticationSuccessHandler interface {
-	AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) error
-}
-
+// AuthenticationErrorHandler reacts to authentication errors
 type AuthenticationErrorHandler interface {
-	AuthenticationError(err error, w http.ResponseWriter, req *http.Request)
+	// AuthenticationNeeded reacts to authentication errors, returns true if the response was written,
+	// and returns any unhandled error (which could be the original error)
+	AuthenticationError(error, http.ResponseWriter, *http.Request) (handled bool, err error)
+}
+
+// AuthenticationSuccessHandler reacts to a user authenticating
+type AuthenticationSuccessHandler interface {
+	// AuthenticationSucceeded reacts to a user authenticating, returns true if the response was written,
+	// and returns false if the response was not written.
+	AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) (bool, error)
 }
 
 // GrantChecker is responsible for determining if a user has authorized a client for a requested grant
 type GrantChecker interface {
 	// HasAuthorizedClient returns true if the user has authorized the client for the requested grant
-	HasAuthorizedClient(client api.Client, user api.UserInfo, grant *api.Grant) (bool, error)
+	HasAuthorizedClient(user api.UserInfo, grant *api.Grant) (bool, error)
 }
 
 // GrantHandler handles errors during the grant process, or the client requests an unauthorized grant
 type GrantHandler interface {
-	// GrantNeeded reacts when a client requests an unauthorized grant
-	GrantNeeded(client api.Client, user api.UserInfo, grant *api.Grant, w http.ResponseWriter, req *http.Request)
-	// GrantError handles an error during the grant process
-	GrantError(err error, w http.ResponseWriter, req *http.Request)
+	// GrantNeeded reacts when a client requests an unauthorized grant, and returns true if the response was written
+	GrantNeeded(user api.UserInfo, grant *api.Grant, w http.ResponseWriter, req *http.Request) (handled bool, err error)
+}
+
+// GrantErrorHandler reacts to grant errors
+type GrantErrorHandler interface {
+	// AuthenticationNeeded reacts to grant errors, returns true if the response was written,
+	// and returns any unhandled error (which could be the original error)
+	GrantError(error, http.ResponseWriter, *http.Request) (handled bool, err error)
 }
 
 // AuthenticationSuccessHandlers combines multiple AuthenticationSuccessHandler objects into a chain.
-// On success, each handler is called. If any handler returns an error, the chain is aborted.
+// On success, each handler is called. If any handler writes the response or returns an error,
+// the chain is aborted.
 type AuthenticationSuccessHandlers []AuthenticationSuccessHandler
 
-func (all AuthenticationSuccessHandlers) AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) error {
+func (all AuthenticationSuccessHandlers) AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
 	for _, h := range all {
-		if err := h.AuthenticationSucceeded(user, state, w, req); err != nil {
-			return err
+		if handled, err := h.AuthenticationSucceeded(user, state, w, req); handled || err != nil {
+			return handled, err
 		}
 	}
-	return nil
+	return false, nil
 }

--- a/pkg/auth/oauth/registry/grantchecker.go
+++ b/pkg/auth/oauth/registry/grantchecker.go
@@ -18,8 +18,8 @@ func NewClientAuthorizationGrantChecker(registry clientauthorization.Registry) *
 	return &ClientAuthorizationGrantChecker{registry}
 }
 
-func (c *ClientAuthorizationGrantChecker) HasAuthorizedClient(client api.Client, user api.UserInfo, grant *api.Grant) (bool, error) {
-	id := c.registry.ClientAuthorizationID(user.GetName(), client.GetId())
+func (c *ClientAuthorizationGrantChecker) HasAuthorizedClient(user api.UserInfo, grant *api.Grant) (approved bool, err error) {
+	id := c.registry.ClientAuthorizationID(user.GetName(), grant.Client.GetId())
 	authorization, err := c.registry.GetClientAuthorization(id)
 	if errors.IsNotFound(err) {
 		return false, nil

--- a/pkg/auth/server/login/implicit_test.go
+++ b/pkg/auth/server/login/implicit_test.go
@@ -27,11 +27,11 @@ func (t *testImplicit) AuthenticateRequest(req *http.Request) (api.UserInfo, boo
 	return t.User, t.Success, t.Err
 }
 
-func (t *testImplicit) AuthenticationSucceeded(user api.UserInfo, then string, w http.ResponseWriter, req *http.Request) error {
+func (t *testImplicit) AuthenticationSucceeded(user api.UserInfo, then string, w http.ResponseWriter, req *http.Request) (bool, error) {
 	t.Called = true
 	t.User = user
 	t.Then = then
-	return nil
+	return false, nil
 }
 
 func TestImplicit(t *testing.T) {

--- a/pkg/auth/server/login/login_test.go
+++ b/pkg/auth/server/login/login_test.go
@@ -29,11 +29,11 @@ func (t *testAuth) AuthenticatePassword(user, password string) (api.UserInfo, bo
 	return t.User, t.Success, t.Err
 }
 
-func (t *testAuth) AuthenticationSucceeded(user api.UserInfo, then string, w http.ResponseWriter, req *http.Request) error {
+func (t *testAuth) AuthenticationSucceeded(user api.UserInfo, then string, w http.ResponseWriter, req *http.Request) (bool, error) {
 	t.Called = true
 	t.User = user
 	t.Then = then
-	return nil
+	return false, nil
 }
 
 func TestLogin(t *testing.T) {

--- a/pkg/auth/server/session/authenticator.go
+++ b/pkg/auth/server/session/authenticator.go
@@ -43,14 +43,14 @@ func (a *SessionAuthenticator) AuthenticateRequest(req *http.Request) (api.UserI
 	}, true, nil
 }
 
-func (a *SessionAuthenticator) AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) error {
+func (a *SessionAuthenticator) AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
 	session, err := a.store.Get(req, a.name)
 	if err != nil {
-		return err
+		return false, err
 	}
 	values := session.Values()
 	values[UserNameKey] = user.GetName()
-	return a.store.Save(w, req)
+	return false, a.store.Save(w, req)
 }
 
 func (a *SessionAuthenticator) InvalidateAuthentication(context api.UserInfo, w http.ResponseWriter, req *http.Request) error {

--- a/pkg/oauth/registry/accesstoken/rest.go
+++ b/pkg/oauth/registry/accesstoken/rest.go
@@ -1,6 +1,7 @@
 package accesstoken
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -69,7 +70,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 
 // Update is not supported for AccessTokens, as they are immutable.
 func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("AccessTokens may not be changed.")
+	return nil, errors.New("AccessTokens may not be changed.")
 }
 
 // Delete asynchronously deletes an AccessToken specified by its id.

--- a/pkg/oauth/registry/authorizetoken/rest.go
+++ b/pkg/oauth/registry/authorizetoken/rest.go
@@ -1,6 +1,7 @@
 package authorizetoken
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -70,7 +71,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 
 // Update is not supported for AuthorizeTokens, as they are immutable.
 func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("AuthorizeTokens may not be changed.")
+	return nil, errors.New("AuthorizeTokens may not be changed.")
 }
 
 // Delete asynchronously deletes an AuthorizeToken specified by its id.

--- a/pkg/oauth/registry/client/rest.go
+++ b/pkg/oauth/registry/client/rest.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -70,7 +71,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 
 // Update is not supported for Clients, as they are immutable.
 func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("Clients may not be changed.")
+	return nil, errors.New("Clients may not be changed.")
 }
 
 // Delete asynchronously deletes an Client specified by its id.

--- a/pkg/oauth/registry/clientauthorization/rest.go
+++ b/pkg/oauth/registry/clientauthorization/rest.go
@@ -1,6 +1,7 @@
 package clientauthorization
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -49,7 +50,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 	}
 
 	if authorization.UserName == "" || authorization.ClientName == "" {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, errors.New("invalid authorization")
 	}
 
 	authorization.Name = s.registry.ClientAuthorizationID(authorization.UserName, authorization.ClientName)

--- a/pkg/oauth/server/osinserver/defaults.go
+++ b/pkg/oauth/server/osinserver/defaults.go
@@ -1,6 +1,9 @@
 package osinserver
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/RangelReale/osin"
 )
 
@@ -22,4 +25,18 @@ func NewDefaultServerConfig() *osin.ServerConfig {
 	config.RedirectUriSeparator = ","
 
 	return config
+}
+
+// defaultError implements ErrorHandler
+type defaultErrorHandler struct{}
+
+// NewDefaultErrorHandler returns a simple ErrorHandler
+func NewDefaultErrorHandler() ErrorHandler {
+	return defaultErrorHandler{}
+}
+
+// HandleError implements ErrorHandler
+func (defaultErrorHandler) HandleError(err error, w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprintf(w, "Error: %s", err)
 }

--- a/pkg/oauth/server/osinserver/osinserver_test.go
+++ b/pkg/oauth/server/osinserver/osinserver_test.go
@@ -22,14 +22,16 @@ func TestClientCredentialFlow(t *testing.T) {
 	oauthServer := New(
 		NewDefaultServerConfig(),
 		storage,
-		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter, r *http.Request) bool {
+		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
 			ar.Authorized = true
-			return false
+			return false, nil
 		}),
-		AccessHandlerFunc(func(ar *osin.AccessRequest, w http.ResponseWriter, r *http.Request) {
+		AccessHandlerFunc(func(ar *osin.AccessRequest, w http.ResponseWriter) error {
 			ar.Authorized = true
 			ar.GenerateRefresh = false
+			return nil
 		}),
+		NewDefaultErrorHandler(),
 	)
 	mux := http.NewServeMux()
 	oauthServer.Install(mux, "")
@@ -57,14 +59,16 @@ func TestAuthorizeStartFlow(t *testing.T) {
 	oauthServer := New(
 		NewDefaultServerConfig(),
 		storage,
-		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter, r *http.Request) bool {
+		AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
 			ar.Authorized = true
-			return false
+			return false, nil
 		}),
-		AccessHandlerFunc(func(ar *osin.AccessRequest, w http.ResponseWriter, r *http.Request) {
+		AccessHandlerFunc(func(ar *osin.AccessRequest, w http.ResponseWriter) error {
 			ar.Authorized = true
 			ar.GenerateRefresh = false
+			return nil
 		}),
+		NewDefaultErrorHandler(),
 	)
 	mux := http.NewServeMux()
 	oauthServer.Install(mux, "")

--- a/pkg/user/registry/user/rest.go
+++ b/pkg/user/registry/user/rest.go
@@ -1,7 +1,7 @@
 package user
 
 import (
-	"fmt"
+	"errors"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
@@ -33,20 +33,20 @@ func (s *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 
 // List retrieves a list of UserIdentityMappings that match selector.
 func (s *REST) List(ctx kapi.Context, selector, fields labels.Selector) (runtime.Object, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Create registers the given UserIdentityMapping.
 func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Update is not supported for UserIdentityMappings, as they are immutable.
 func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Delete asynchronously deletes an UserIdentityMapping specified by its id.
 func (s *REST) Delete(ctx kapi.Context, id string) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }

--- a/pkg/user/registry/useridentitymapping/rest.go
+++ b/pkg/user/registry/useridentitymapping/rest.go
@@ -1,6 +1,7 @@
 package useridentitymapping
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -28,17 +29,17 @@ func (s *REST) New() runtime.Object {
 
 // Get retrieves an UserIdentityMapping by id.
 func (s *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // List retrieves a list of UserIdentityMappings that match selector.
 func (s *REST) List(ctx kapi.Context, selector, fields labels.Selector) (runtime.Object, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Create is not supported for UserIdentityMappings
 func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Update will create or update a UserIdentityMapping
@@ -58,5 +59,5 @@ func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 
 // Delete asynchronously deletes an UserIdentityMapping specified by its id.
 func (s *REST) Delete(ctx kapi.Context, id string) (<-chan apiserver.RESTResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -64,16 +64,18 @@ func TestOAuthStorage(t *testing.T) {
 	oauthServer := osinserver.New(
 		osinserver.NewDefaultServerConfig(),
 		storage,
-		osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter, r *http.Request) bool {
+		osinserver.AuthorizeHandlerFunc(func(ar *osin.AuthorizeRequest, w http.ResponseWriter) (bool, error) {
 			ar.UserData = "test"
 			ar.Authorized = true
-			return false
+			return false, nil
 		}),
-		osinserver.AccessHandlerFunc(func(ar *osin.AccessRequest, w http.ResponseWriter, r *http.Request) {
+		osinserver.AccessHandlerFunc(func(ar *osin.AccessRequest, w http.ResponseWriter) error {
 			ar.UserData = "test"
 			ar.Authorized = true
 			ar.GenerateRefresh = false
+			return nil
 		}),
+		osinserver.NewDefaultErrorHandler(),
 	)
 	mux := http.NewServeMux()
 	oauthServer.Install(mux, "")


### PR DESCRIPTION
Allow AuthenticationNeeded/GrantNeeded interfaces to decide whether to handle the request, or let the default error response be written by the oauth server
