### PR TITLE
Fix Build API JSON tags for BuildStrategy

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -119,7 +119,7 @@ type BuildStrategy struct {
 	Type BuildStrategyType `json:"type,omitempty" yaml:"type,omitempty"`
 
 	// DockerStrategy holds the parameters to the Docker build strategy.
-	DockerStrategy *DockerBuildStrategy `json:"dockerBuildStrategy,omitempty" yaml:"dockerBuildStrategy,omitempty"`
+	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty" yaml:"dockerStrategy,omitempty"`
 
 	// STIStrategy holds the parameters to the STI build strategy.
 	STIStrategy *STIBuildStrategy `json:"stiStrategy,omitempty" yaml:"stiStrategy,omitempty"`


### PR DESCRIPTION
The tags in pkg/build/api/types.go don't match the tags in pkg/build/api/v1beta1/types.go
