### PR TITLE
[WIP] [DO NOT MERGE] - Deployment Rollbacks

### DIFF
--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -48,6 +48,8 @@ func CommandFor(basename string) *cobra.Command {
 		return builder.NewCommandDockerBuilder(basename)
 	case "kubectl":
 		return kubectl.NewCommandKubectl(basename)
+	case "openshift-rollback":
+		return NewCommandRollback()
 	default:
 		return NewCommandOpenShift()
 	}

--- a/pkg/cmd/openshift/rollback.go
+++ b/pkg/cmd/openshift/rollback.go
@@ -1,0 +1,114 @@
+package openshift
+
+import (
+	"flag"
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/spf13/cobra"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	"encoding/json"
+	"io/ioutil"
+)
+
+type config struct {
+	ClientConfig         *clientcmd.Config
+	RollbackConfigName   string
+}
+
+func NewCommandRollback() *cobra.Command {
+	flag.Set("v", "4")
+
+	cfg := &config{
+		ClientConfig: clientcmd.NewConfig(),
+	}
+
+	cmd := &cobra.Command{
+		Use: "rollback",
+		Run: func(c *cobra.Command, args []string) {
+			if err := rollback(cfg, args); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	flag := cmd.Flags()
+	cfg.ClientConfig.Bind(flag)
+	flag.StringVar(&cfg.RollbackConfigName, "f", "", "path/name of the rollback config file")
+
+	return cmd
+}
+
+func rollback(cfg *config, args []string) error {
+	glog.Info("------------------ Executing a rollback ----------------------")
+	_, osClient, err := cfg.ClientConfig.Clients()
+
+	if err != nil {
+		return err
+	}
+
+	/*
+		This is a mock up of the minimal viable product for rollbacks.  It is NOT a complete solution.
+
+		A rollback is essentially a posting of an old deployment config on top of the current config.  However,
+		the user will indicate which version of the deployment config they'd like to use by specifying a deployment
+		from 'list deployments' or whatever the replication controller version evolves into.
+
+		To demonstrate the mechanics the code below mocks what an actual api call would do.  In an actual solution
+		I envision that it would be something like:
+
+		1. user posts to rollback endpoint with .json containing config parameters or with GET params
+		2. endpoint uses parameters to call DeploymentConfigRollbackGenerator.Generate(deploymentId) and receives
+			a new deployment config back that is based on the old deployment
+		3. endpoint performs validation
+		4. endpoint calls DeploymentConfig.Update(newConfig)
+	 */
+
+	//1. user posts to rollback endpoint with .json containing config parameters or with GET params - currently bootstrapped on top of the DeploymentConfig
+	glog.V(4).Infof("Reading rollback config")
+	rollbackConfig, err := ReadRollbackFile(cfg.RollbackConfigName)
+	if err != nil {
+		return err
+	}
+
+	//2. endpoint uses parameters to call DeploymentConfigRollbackGenerator.Generate(deploymentId) and receives
+	//   a new deployment config back that is based on the old deployment
+	glog.V(4).Infof("Finding current deploy config named %s", rollbackConfig.ObjectMeta.Name)
+	currentConfig, err := osClient.DeploymentConfigs("").Get(rollbackConfig.ObjectMeta.Name)
+	if err != nil {
+		return err
+	}
+
+
+	glog.V(4).Infof("Finding rollback deployment with name %s", rollbackConfig.Rollback.To)
+	oldConfig, err := osClient.Deployments("").Get(rollbackConfig.Rollback.To)
+	if err != nil {
+		return err
+	}
+
+	currentConfig.Template.ControllerTemplate = oldConfig.ControllerTemplate
+
+	//3. endpoint performs validation (todo)
+	//4. endpoint calls DeploymentConfig.Update(newConfig)
+	osClient.DeploymentConfigs("").Update(currentConfig)
+
+	glog.Info("-------------------  Rollback Complete  ----------------------")
+	return nil
+}
+
+func ReadRollbackFile(fileName string) (*deployapi.DeploymentConfig, error) {
+	data, err := ioutil.ReadFile(fileName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	rollbackConfig := &deployapi.DeploymentConfig{}
+	err = json.Unmarshal(data, rollbackConfig)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rollbackConfig, nil
+}

--- a/pkg/cmd/openshift/rollback_readme.md
+++ b/pkg/cmd/openshift/rollback_readme.md
@@ -1,0 +1,108 @@
+## Steps
+
+    #start kube
+    sudo _output/local/bin/linux/amd64/openshift start --loglevel=4
+    
+    #deploy 1st config
+    openshift kube create -c paul_temp/hello_deploy_1.json deploymentConfigs
+    openshift kube list deployments
+    Name                Status              Cause
+    ----------          ----------          ----------
+    frontend-1          Complete            ConfigChange
+
+    #validate 1st config
+    docker ps | grep hello-openshift | cut -d' ' -f1 | xargs docker inspect | grep TEST
+                "TEST_VAL=1",
+
+    
+    #deploy 2nd config
+    openshift kube create -c paul_temp/hello_deploy_2.json deploymentConfigs
+    openshift kube list deployments
+    Name                Status              Cause
+    ----------          ----------          ----------
+    frontend-1          Complete            ConfigChange
+    frontend-2          Complete            ConfigChange
+    
+    #validate 2nd config
+    docker ps | grep hello-openshift | cut -d' ' -f1 | xargs docker inspect | grep TEST
+                "TEST_VAL=2",
+                
+    #rollback
+    openshift-rollback --f=paul_temp/rollback.json
+    I1203 11:56:27.408591 19973 rollback.go:43] ------------------ Executing a rollback ----------------------
+    I1203 11:56:27.410176 19973 rollback.go:51] Reading rollback config
+    I1203 11:56:27.412969 19973 rollback.go:58] Finding current deploy config named frontend
+    I1203 11:56:27.432268 19973 rollback.go:66] Finding rollback deployment with name frontend-1
+    I1203 11:56:27.454106 19973 rollback.go:78] -------------------  Rollback Complete  ----------------------
+
+    openshift kube list deployments
+    Name                Status              Cause
+    ----------          ----------          ----------
+    frontend-1          Complete            ConfigChange
+    frontend-2          Complete            ConfigChange
+    frontend-3          Complete            ConfigChange
+
+    docker ps | grep hello-openshift | cut -d' ' -f1 | xargs docker inspect | grep TEST
+                "TEST_VAL=1",
+
+
+## Configs
+hello_deploy_1.json
+
+     {
+         "metadata":{
+             "name": "frontend"
+         },
+         "kind": "DeploymentConfig",
+         "apiVersion": "v1beta1",
+         "triggers": [
+             {"type": "ConfigChange"}
+         ],
+         "template": {
+             "strategy": {
+                 "type":"Recreate"
+             },
+             "controllerTemplate": {
+                 "replicas": 1,
+                 "replicaSelector": {
+                     "name": "frontend"
+                 },
+                 "podTemplate": {
+                     "desiredState": {
+                         "manifest": {
+                             "version": "v1beta1",
+                             "containers": [
+                                 {
+                                     "name": "hello-openshift",
+                                     "image": "openshift/hello-openshift",
+                                     "ports": [{
+                                         "containerPort": 8080
+                                     }],
+                                     "env": [
+                                         {
+                                             "name": "TEST_VAL",
+                                             "value": "1"
+                                         }
+                                     ]
+                                 }
+                             ]
+     
+                         }
+                     },
+                     "labels": {
+                         "name": "frontend"
+                     }
+                 }
+             }
+         }
+     }
+
+hello_deploy_2.json: same as `hello_deploy_1.json` but with the value for `TEST_VAL` updated to 2
+
+rollback.json:
+
+     {
+         "metadata": {"name":"frontend"},
+         "kind":"DeploymentConfig",
+         "rollback": { "to": "frontend-1" }
+     }

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -111,6 +111,13 @@ type DeploymentConfig struct {
 	// The reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	// Rollback indicates that this is a special deployment config intended to move
+	// from an existing deployment state to another previously defined state
+	Rollback *RollbackConfig `json:"rollback,omitempty" yaml:"rollback,omitempty"`
+}
+
+type RollbackConfig struct {
+	To string
 }
 
 // DeploymentTemplate contains all the necessary information to create a Deployment from a

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -111,6 +111,13 @@ type DeploymentConfig struct {
 	// The reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	// Rollback indicates that this is a special deployment config intended to move
+	// from an existing deployment state to another previously defined state
+	Rollback *RollbackConfig `json:"rollback,omitempty" yaml:"rollback,omitempty"`
+}
+
+type RollbackConfig struct {
+	To string
 }
 
 // DeploymentTemplate templatizes the configurable fields of a Deployment.


### PR DESCRIPTION
## Description

Rollback is meant to be a temporary fix to an incorrect environment.  A rollback is movement of application from current deployed state to an approximation of a previous deployed state that was recorded  in the OpenShift system.  This includes system configuration (hooks, deployment strategies, etc) and application (template, images, environment variables).  

## Definitions

* Pod rollback: rollback that includes only ControllerTemplate items
* Process rollback: rollback that includes only labels, triggers, and Template.Strategy does not include ControllerTemplate items
* Full rollback: rollback of application and process
* Deployment: point in time in OpenShift that was created from a deployment config and is tagged in the format of <id>-<release number>
* Example: my-deployment-1, my-deployment-2

## Proposal Summary

* Offer rollbacks to deployment.  
* Rollbacks should be initiated via the CLI or web interface.  
* Rollbacks should be configurable to include deployment process and/or template.  See rollback configuration.  This allows the user to control which part of the deployment is rolled back.  Pod, deployment processes, or both.
* OpenShift cannot always prevent application specific inconsistencies, but it should work to communicate to users where possible that an inconsistency may occur
     * inconsistencies include database schemas that are not compatible with the rollback code, passwords that may have changed in the code, configuration differences in portions of distributed apps after rollback
* OpenShift should be able to intelligently validate rollback requests to prevent issues like rollbacks to non-existing images and other issues as much as possible.  This information should be presented in an easily digestible format (see dry run use case).

## Constraints

* Config changes in a distributed app may leave that app in an invalid state (see dry run use case).  This could occur if changes in the back end of an app occur before front end code changes.  For instance, a database schema change that is incompatible with the application code accessing the database. 
* Incompatible application changes like a new deployment that changes schemas are outside the scope of rollback validation since OpenShift does not have insight into application implementation details and how they relate to deployments.  In this case a new deployment with schema changes is dependent on an earlier state.

## Use Cases

1. **Rollback to Previous Deployment**
     1. User requests rollback but does not provide a named release
     1. System validates that rollback is possible to N-1
     1. System creates new deployment config

1. **Rollback to Specific Deployment**
     1. User requests rollback to a specific deployment (other than n-1).  This use case may occur when a user discovers a critical bug that has occurred in deployment n-x and immediate rollback is necessary.  
     1. System validates that rollback is possible
     1. System creates new deployment config

1. **Rollback Only Pod**
     1. User requests a rollback and specifies a rollback configuration that indicates only the pod definition is to be rolled back.
     1. System validates that rollback is possible
     1. System modifies the existing deployment config that includes all process items from the current deployment configuration and replaces the ControllerTemplate with the previous version

1. **Rollback Only Process**
     1. User requests a rollback and specifies a rollback configuration that indicates only the process is to be rolledback
     1. System validates that rollback is possible (in this case checking the deployment strategy image, no application images are changing)
     1. System creates a new deployment config that includes the ControllerTemplate from the current deployment configuration and replaces all other items with process definition from previous version

1. **Rollback With Unknown Incompatibilities**
     1. System performs rollback.  Application is left in an incompatible state
It is up to the application administrator to resolve incompatibilities

1. **Rollback With Known Incompatibilities**
     1. System does not rollback
     1. Application administrator is displayed a message as to why the rollback could not be completed

1. **Rollback Dry Run**
     1. User requests a rollback dry run
     1. System compares the current and proposed deployment configuration
     1. If the specified configuration includes selectors for other pods a comparison of environment variables is done by matching on variable names to find potential issues
     1. System details the changes to the user

## Use Case Justification

1. **Rollback to Previous Deployment** - This allows a user who notices an immediate break in the current deployment to revert to n-1.  This seems to be the most obvious use case for rollbacks when something goes wrong with the deployment

1. **Rollback to Specific Deployment** - Rolling back to a specific deployment would likely be required if a critical bug has been found, more deployments have occurred that were not substantial, and the bug must be eliminated as fast as possible.  This is probably a rare occurrence in production since most users would probably patch as a new deployment (n+1) but may be more common in development or test environments.  

1. **Rollback Only Pod** - Rolling back only the pod is the likely use case for most rollbacks.  This allows you to roll back the pod without rolling back any changes in the deployment process.  

1. **Rollback Only Process** - This use case occurs if you’ve made changes to the deployment process and the pod definitions but something failed during the deployment process.  This allows you to revert the process to a previously known working state but retain the current pod definition.  This use case is only necessary if a user has made a change to the deployment config that does not affect the template and they would like to roll back the change.  This is likely a rare use case.

1. **Rollback Dry Run** - allowing the user to discover known incompatibilities prior to entering the deployment process would help them avoid potential application downtime and correct the issues prior to a real deployment.  Incompatibilities are validations performed by OpenShift prior to the rollback.  See deployments.md for details on actual validations.

Quick link to implementation details added to deployments.md: https://github.com/pweil-/origin/blob/deployment-rollback-proposal/docs/deployments.md#proposed-design---rollbacks