### PR TITLE
add auth-proxy-test

### DIFF
--- a/pkg/auth/oauth/handlers/empties.go
+++ b/pkg/auth/oauth/handlers/empties.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/auth/api"
+)
+
+type EmptyAuth struct{}
+
+func (EmptyAuth) AuthenticationNeeded(w http.ResponseWriter, req *http.Request) (bool, error) {
+	return false, nil
+}
+
+type EmptySuccess struct{}
+
+func (EmptySuccess) AuthenticationSucceeded(user api.UserInfo, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
+	glog.V(4).Infof("AuthenticationSucceeded: %v (state=%s)", user, state)
+	return false, nil
+}
+
+type EmptyError struct{}
+
+func (EmptyError) AuthenticationError(err error, w http.ResponseWriter, req *http.Request) (bool, error) {
+	glog.V(4).Infof("AuthenticationError: %v", err)
+	return false, err
+}
+
+func (EmptyError) GrantError(err error, w http.ResponseWriter, req *http.Request) (bool, error) {
+	glog.V(4).Infof("GrantError: %v", err)
+	return false, err
+}

--- a/pkg/auth/userregistry/identitymapper/identitymapper.go
+++ b/pkg/auth/userregistry/identitymapper/identitymapper.go
@@ -1,8 +1,6 @@
 package identitymapper
 
 import (
-	"errors"
-
 	authapi "github.com/openshift/origin/pkg/auth/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/useridentitymapping"
@@ -27,12 +25,9 @@ func (p *alwaysCreateUserIdentityToUserMapper) UserFor(identityInfo authapi.User
 			Extra:    identityInfo.GetExtra(),
 		},
 	}
-	authoritativeMapping, ok, err := p.userIdentityRegistry.CreateOrUpdateUserIdentityMapping(userIdentityMapping)
+	authoritativeMapping, _ /*created*/, err := p.userIdentityRegistry.CreateOrUpdateUserIdentityMapping(userIdentityMapping)
 	if err != nil {
 		return nil, err
-	}
-	if !ok {
-		return nil, errors.New("Could not map identity to user")
 	}
 
 	ret := &authapi.DefaultUserInfo{

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -1,0 +1,159 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/golang/glog"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klatest "github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+
+	"github.com/openshift/origin/pkg/auth/authenticator/requestheader"
+	oauthhandlers "github.com/openshift/origin/pkg/auth/oauth/handlers"
+	oauthregistry "github.com/openshift/origin/pkg/auth/oauth/registry"
+	"github.com/openshift/origin/pkg/auth/userregistry/identitymapper"
+	"github.com/openshift/origin/pkg/cmd/server/origin"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	oauthclient "github.com/openshift/origin/pkg/oauth/registry/client"
+	oauthetcd "github.com/openshift/origin/pkg/oauth/registry/etcd"
+	"github.com/openshift/origin/pkg/oauth/server/osinserver"
+	"github.com/openshift/origin/pkg/oauth/server/osinserver/registrystorage"
+	"github.com/openshift/origin/pkg/user"
+	useretcd "github.com/openshift/origin/pkg/user/registry/etcd"
+)
+
+func init() {
+	requireEtcd()
+}
+
+var (
+	validUsers = []User{
+		{ID: "sanefarmer", Password: "who?", Name: "Sane Farmer", Email: "insane_farmer@example.org"},
+		{ID: "unsightlycook", Password: "what?", Name: "Unsightly Cook", Email: "beautiful_cook@example.org"},
+		{ID: "novelresearcher", Password: "why?", Name: "Novel Researcher", Email: "trite_researcher@example.org"},
+	}
+)
+
+func TestFrontProxyOnAuthorize(t *testing.T) {
+	deleteAllEtcdKeys()
+
+	// setup
+	etcdClient := newEtcdClient()
+	etcdHelper, _ := master.NewEtcdHelper(etcdClient, klatest.Version)
+	oauthEtcd := oauthetcd.New(etcdHelper)
+	userRegistry := useretcd.New(etcdHelper, user.NewDefaultUserInitStrategy())
+	identityMapper := identitymapper.NewAlwaysCreateUserIdentityToUserMapper("front-proxy-test" /*for now*/, userRegistry)
+
+	// this auth request handler is the one that is supposed to recognize information from a front proxy
+	authRequestHandler := requestheader.NewAuthenticator(requestheader.NewDefaultConfig(), identityMapper)
+	authHandler := &oauthhandlers.EmptyAuth{}
+
+	storage := registrystorage.New(oauthEtcd, oauthEtcd, oauthEtcd, oauthregistry.NewUserConversion())
+	config := osinserver.NewDefaultServerConfig()
+
+	grantChecker := oauthregistry.NewClientAuthorizationGrantChecker(oauthEtcd)
+	grantHandler := oauthhandlers.NewAutoGrant(oauthEtcd)
+
+	server := osinserver.New(
+		config,
+		storage,
+		osinserver.AuthorizeHandlers{
+			oauthhandlers.NewAuthorizeAuthenticator(
+				authRequestHandler,
+				authHandler,
+				oauthhandlers.EmptyError{},
+			),
+			oauthhandlers.NewGrantCheck(
+				grantChecker,
+				grantHandler,
+				oauthhandlers.EmptyError{},
+			),
+		},
+		osinserver.AccessHandlers{
+			oauthhandlers.NewDenyAccessAuthenticator(),
+		},
+		osinserver.NewDefaultErrorHandler(),
+	)
+
+	mux := http.NewServeMux()
+	server.Install(mux, origin.OpenShiftOAuthAPIPrefix)
+	oauthServer := httptest.NewServer(http.Handler(mux))
+	glog.Infof("oauth server is on %v\n", oauthServer.URL)
+
+	// set up a front proxy guarding the oauth server
+	proxyHttpHandler := NewBasicAuthChallenger("TestRegistryAndServer", validUsers, NewXRemoteUserProxyingHandler(oauthServer.URL))
+	proxyServer := httptest.NewServer(proxyHttpHandler)
+	glog.Infof("proxy server is on %v\n", proxyServer.URL)
+
+	// need to prime clients so that we can get back a code.  the client must be valid
+	createClient(oauthEtcd, &oauthapi.Client{ObjectMeta: kapi.ObjectMeta{Name: "test"}, Secret: "secret", RedirectURIs: []string{oauthServer.URL}})
+
+	// our simple URL to get back a code.  We want to go through the front proxy
+	rawAuthorizeRequest := proxyServer.URL + origin.OpenShiftOAuthAPIPrefix + "/authorize?response_type=code&client_id=test"
+
+	// the first request we make to the front proxy should challenge us for authentication info
+	shouldBeAChallengeResponse, err := http.Get(rawAuthorizeRequest)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if shouldBeAChallengeResponse.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected Unauthorized, but got %v", shouldBeAChallengeResponse.StatusCode)
+	}
+
+	// create an http.Client to make our next request.  We need a custom Transport to authenticate us through our front proxy
+	// and a custom CheckRedirect so that we can keep track of the redirect responses we're getting
+	// OAuth requests a few redirects that we don't really care about checking, so this simpler than using a round tripper
+	// and manually handling redirects and setting our auth information every time for the front proxy
+	redirectedUrls := make([]url.URL, 10)
+	httpClient := http.Client{
+		CheckRedirect: getRedirectMethod(&redirectedUrls),
+		Transport:     kclient.NewBasicAuthRoundTripper("sanefarmer", "who?", http.DefaultTransport),
+	}
+
+	// make our authorize request again, but this time our transport has properly set the auth info for the front proxy
+	req, err := http.NewRequest("GET", rawAuthorizeRequest, nil)
+	_, err = httpClient.Do(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// check the last redirect and see if we got a code
+	foundCode := ""
+	if len(redirectedUrls) > 0 {
+		foundCode = redirectedUrls[len(redirectedUrls)-1].Query().Get("code")
+	}
+
+	if len(foundCode) == 0 {
+		t.Errorf("Did not find code in any redirect: %v", redirectedUrls)
+	} else {
+		glog.Infof("Found code %v\n", foundCode)
+	}
+}
+
+func createClient(oauthEtcd oauthclient.Registry, client *oauthapi.Client) {
+	if err := oauthEtcd.CreateClient(client); err != nil {
+		glog.Errorf("Error creating client: %v due to %v\n", client, err)
+	}
+}
+
+type checkRedirect func(req *http.Request, via []*http.Request) error
+
+func getRedirectMethod(redirectRecord *[]url.URL) checkRedirect {
+	return func(req *http.Request, via []*http.Request) error {
+		glog.Infof("Going to %v\n", req.URL)
+		*redirectRecord = append(*redirectRecord, *req.URL)
+
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+}

--- a/test/integration/basic_auth.go
+++ b/test/integration/basic_auth.go
@@ -1,0 +1,148 @@
+package integration
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/context"
+)
+
+type User struct {
+	ID       string
+	Password string
+	Name     string
+	Email    string
+}
+
+type BasicAuthChallenger struct {
+	realm                string
+	users                map[string]User
+	authenticatedHandler http.Handler
+}
+
+// NewBasicAuthChallenger provides a simple basic auth server that is compatible with our basic auth password validator
+func NewBasicAuthChallenger(realm string, users []User, authenticatedHandler http.Handler) BasicAuthChallenger {
+	userMap := make(map[string]User, len(users))
+	for _, user := range users {
+		userMap[user.ID] = user
+	}
+
+	return BasicAuthChallenger{realm, userMap, authenticatedHandler}
+}
+
+func (challenger BasicAuthChallenger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	glog.Infof("--- %v\n", r.URL)
+
+	authHeader := r.Header["Authorization"]
+	if len(authHeader) == 0 {
+		challenger.Challenge(w)
+		return
+	}
+
+	auth := strings.SplitN(authHeader[0], " ", 2)
+	if len(auth) != 2 || auth[0] != "Basic" {
+		Error("bad syntax", http.StatusBadRequest, w)
+		return
+	}
+
+	payload, err := base64.StdEncoding.DecodeString(auth[1])
+	if err != nil {
+		Error("bad syntax", http.StatusBadRequest, w)
+		return
+	}
+
+	pair := strings.SplitN(string(payload), ":", 2)
+	if len(pair) != 2 {
+		Error("bad syntax", http.StatusBadRequest, w)
+		return
+	}
+
+	if !challenger.Validate(pair[0], pair[1]) {
+		challenger.Challenge(w)
+		return
+	}
+
+	context.Set(r, "username", challenger.users[pair[0]])
+
+	challenger.authenticatedHandler.ServeHTTP(w, r)
+}
+
+func (challenger *BasicAuthChallenger) Challenge(w http.ResponseWriter) {
+	glog.Infof("Sending challenge\n")
+
+	w.Header().Set("WWW-Authenticate", "Basic realm=\""+challenger.realm+"\"")
+	Error("Authorization failed", http.StatusUnauthorized, w)
+}
+
+func Error(message string, status int, w http.ResponseWriter) {
+	glog.Infof("Writing error: %s\n", message)
+
+	data := map[string]string{"error": message}
+	json, _ := json.Marshal(data)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	io.WriteString(w, string(json))
+}
+
+func (challenger *BasicAuthChallenger) Validate(username, password string) bool {
+	knownUser, exists := challenger.users[username]
+	if !exists {
+		return false
+	}
+
+	if knownUser.Password == password {
+		glog.Infof("Validated user: %s\n", username)
+		return true
+	}
+
+	glog.Infof("Rejected user: %s\n", username)
+	return false
+}
+
+type identifyingHandler struct {
+}
+
+func (handler *identifyingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	user := context.Get(r, "username")
+	if user == nil {
+		Error("No user found", http.StatusBadRequest, w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	result, _ := json.Marshal(user)
+	io.WriteString(w, string(result))
+}
+
+func NewIdentifyingHandler() http.Handler {
+	return &identifyingHandler{}
+}
+
+type xRemoteUserProxyingHandler struct {
+	proxier *httputil.ReverseProxy
+}
+
+func (handler *xRemoteUserProxyingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	user := context.Get(r, "username")
+	if user == nil {
+		Error("No user found", http.StatusBadRequest, w)
+		return
+	}
+
+	r.Header.Add("X-Remote-User", user.(User).ID)
+	handler.proxier.ServeHTTP(w, r)
+}
+
+func NewXRemoteUserProxyingHandler(rawUrl string) http.Handler {
+	parsedUrl, _ := url.Parse(rawUrl)
+	proxier := httputil.NewSingleHostReverseProxy(parsedUrl)
+	// proxier.Transport = NewBasicAuthRoundTripper(http.DefaultTransport)
+	return &xRemoteUserProxyingHandler{proxier}
+}

--- a/test/integration/basic_auth_test.go
+++ b/test/integration/basic_auth_test.go
@@ -1,0 +1,15 @@
+package integration
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+func ExampleNewBasicAuthChallenger() {
+	challenger := NewBasicAuthChallenger("realm", []User{{"username", "password", "Brave Butcher", "cowardly_butcher@example.org"}}, NewIdentifyingHandler())
+	http.Handle("/", challenger)
+	glog.Infoln("Auth server listening on http://localhost:1234")
+	log.Fatal(http.ListenAndServe(":1234", nil))
+}


### PR DESCRIPTION
Adds the first auth proxy test. This sets up a front proxy ahead of the oauth/authorize endpoint and proves that you pass an X-Remote-User header to our requestheader authentication request handler, you get back a code.

@liggitt Probably of interest to you.
