### PR TITLE
Correlate Pods to Deployments during Recreate

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -83,6 +83,9 @@ const (
 	DeploymentConfigAnnotation = "deploymentConfig"
 	DeploymentAnnotation       = "deployment"
 	DeploymentPodAnnotation    = "pod"
+	// TODO: This is a workaround for upstream's lack of annotation support on PodTemplate. Once
+	// annotations are available on PodTemplate, audit this constant with the goal of removing it.
+	DeploymentLabel = "deployment"
 )
 
 // These constants represent label keys used for correlating objects related to deployment.

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -83,6 +83,9 @@ const (
 	DeploymentConfigAnnotation = "deploymentConfig"
 	DeploymentAnnotation       = "deployment"
 	DeploymentPodAnnotation    = "pod"
+	// TODO: This is a workaround for upstream's lack of annotation support on PodTemplate. Once
+	// annotations are available on PodTemplate, audit this constant with the goal of removing it.
+	DeploymentLabel = "deployment"
 )
 
 // These constants represent label keys used for correlating objects related to deployment.

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -82,11 +82,13 @@ func (s *RecreateDeploymentStrategy) Deploy(deployment *deployapi.Deployment) er
 		DesiredState: deploymentCopy.(*deployapi.Deployment).ControllerTemplate,
 	}
 
-	// Correlate pods created by the ReplicationController to the deployment config
+	// Correlate pods created by the ReplicationController to the deployment objects
 	if controller.DesiredState.PodTemplate.Labels == nil {
 		controller.DesiredState.PodTemplate.Labels = make(map[string]string)
 	}
 	controller.DesiredState.PodTemplate.Labels[deployapi.DeploymentConfigLabel] = configID
+	// TODO: Switch this to an annotation once upstream supports annotations on a PodTemplate
+	controller.DesiredState.PodTemplate.Labels[deployapi.DeploymentLabel] = deployment.Name
 
 	glog.Infof("Creating replicationController for deployment %s", deployment.Name)
 	if _, err := s.ReplicationController.createReplicationController(namespace, controller); err != nil {

--- a/pkg/deploy/strategy/recreate/recreate_test.go
+++ b/pkg/deploy/strategy/recreate/recreate_test.go
@@ -57,6 +57,10 @@ func TestFirstDeployment(t *testing.T) {
 		t.Fatalf("expected controller podtemplate label %s, got %s", e, a)
 	}
 
+	if e, a := "deploy1", createdController.DesiredState.PodTemplate.Labels[deployapi.DeploymentLabel]; e != a {
+		t.Fatalf("expected controller podtemplate label %s, got %s", e, a)
+	}
+
 	if e, a := 2, createdController.DesiredState.Replicas; e != a {
 		t.Fatalf("expected controller replicas to be %d, got %d", e, a)
 	}


### PR DESCRIPTION
Use a label for now until upstream's PodTemplate supports annotations.
