### PR TITLE
ImageRepository fixes

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -58,7 +58,7 @@ type ImageInterface interface {
 type ImageRepositoryInterface interface {
 	ListImageRepositories(ctx kapi.Context, labels labels.Selector) (*imageapi.ImageRepositoryList, error)
 	GetImageRepository(ctx kapi.Context, id string) (*imageapi.ImageRepository, error)
-	WatchImageRepositories(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error)
+	WatchImageRepositories(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 	CreateImageRepository(ctx kapi.Context, repo *imageapi.ImageRepository) (*imageapi.ImageRepository, error)
 	UpdateImageRepository(ctx kapi.Context, repo *imageapi.ImageRepository) (*imageapi.ImageRepository, error)
 }
@@ -247,7 +247,7 @@ func (c *Client) GetImageRepository(ctx kapi.Context, id string) (result *imagea
 }
 
 // WatchImageRepositories returns a watch.Interface that watches the requested imagerepositories.
-func (c *Client) WatchImageRepositories(ctx kapi.Context, field, label labels.Selector, resourceVersion string) (watch.Interface, error) {
+func (c *Client) WatchImageRepositories(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.Get().
 		Namespace(kapi.Namespace(ctx)).
 		Path("watch").

--- a/pkg/image/registry/imagerepository/registry.go
+++ b/pkg/image/registry/imagerepository/registry.go
@@ -15,7 +15,7 @@ type Registry interface {
 	// GetImageRepository retrieves a specific image repository.
 	GetImageRepository(ctx kapi.Context, id string) (*api.ImageRepository, error)
 	// WatchImageRepositories watches for new/changed/deleted image repositories.
-	WatchImageRepositories(ctx kapi.Context, resourceVersion string, filter func(repo *api.ImageRepository) bool) (watch.Interface, error)
+	WatchImageRepositories(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error)
 	// CreateImageRepository creates a new image repository.
 	CreateImageRepository(ctx kapi.Context, repo *api.ImageRepository) error
 	// UpdateImageRepository updates an image repository.

--- a/pkg/image/registry/imagerepository/rest.go
+++ b/pkg/image/registry/imagerepository/rest.go
@@ -51,13 +51,7 @@ func (s *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 
 // Watch begins watching for new, changed, or deleted ImageRepositories.
 func (s *REST) Watch(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
-	return s.registry.WatchImageRepositories(ctx, resourceVersion, func(repo *api.ImageRepository) bool {
-		fields := labels.Set{
-			"Name":                  repo.Name,
-			"DockerImageRepository": repo.DockerImageRepository,
-		}
-		return label.Matches(labels.Set(repo.Labels)) && field.Matches(fields)
-	})
+	return s.registry.WatchImageRepositories(ctx, label, field, resourceVersion)
 }
 
 // Create registers the given ImageRepository.

--- a/pkg/image/registry/test/imagerepository.go
+++ b/pkg/image/registry/test/imagerepository.go
@@ -35,7 +35,7 @@ func (r *ImageRepositoryRegistry) GetImageRepository(ctx kapi.Context, id string
 	return r.ImageRepository, r.Err
 }
 
-func (r *ImageRepositoryRegistry) WatchImageRepositories(ctx kapi.Context, resourceVersion string, filter func(repo *api.ImageRepository) bool) (watch.Interface, error) {
+func (r *ImageRepositoryRegistry) WatchImageRepositories(ctx kapi.Context, label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return nil, r.Err
 }
 


### PR DESCRIPTION
Move filter logic from rest to etcd for ImageRepositories.

Remove parseWatchResourceVersion now that it's available from
Kubernetes.

Fix label, field order in WatchImageRepositories.

Convert watch test to use a table and add more table cases.
