### PR TITLE
Fix vagrant rsync

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -152,7 +152,7 @@ runcmd:
       end
       config.vm.provision "shell", path: "hack/vm-provision.sh", id: "setup"
       config.vm.synced_folder ".", "/vagrant", disabled: true
-      config.vm.synced_folder sync_from, sync_to
+      config.vm.synced_folder sync_from, sync_to, :rsync__args => ["--verbose", "--archive", "--delete", "-z"]
     end
   end
 


### PR DESCRIPTION
The git repository contains some blind symlink that cause issues when syncing 
with default vagrant rsync setting.

E.g. Godeps/_workspace/src/github.com/docker/docker/pkg/symlink/testdata/fs/g 
is pointing to non-existing path, causing vagrant to fail on:

```
rsync error: some files/attrs were not transferred
```
