### PR TITLE
Refactoring router.go to handle errors.

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -3,7 +3,9 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/golang/glog"
 	"io/ioutil"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -21,7 +23,7 @@ const (
 )
 
 const (
-	RouteFile = "/var/lib/containers/router/routes.json"
+	DefaultRouteFile = "/var/lib/containers/router/routes.json"
 )
 
 type Frontend struct {
@@ -56,20 +58,29 @@ type Endpoint struct {
 
 type Routes struct {
 	GlobalRoutes map[string]Frontend
+	RouteFile    string
 }
 
 type Router interface {
-	ReadRoutes()
-	WriteRoutes()
+	ReadRoutes() (*Routes, error)
+	WriteRoutes() (*Routes, error)
 	FindFrontend(name string) (v Frontend, ok bool)
 	DeleteBackends(name string)
-	CreateFrontend(name string, url string)
-	DeleteFrontend(frontendname string)
-	AddAlias(alias string, frontendname string)
-	RemoveAlias(alias string, frontendname string)
-	AddRoute(frontendname string, fePath string, bePath string, protocols []string, endpoints []Endpoint)
+	CreateFrontend(name string, url string) (*Routes, error)
+	DeleteFrontend(frontendname string) (*Routes, error)
+	AddAlias(alias string, frontendname string) (*Routes, error)
+	RemoveAlias(alias string, frontendname string) (*Routes, error)
+	AddRoute(frontendname string, fePath string, bePath string, protocols []string, endpoints []Endpoint) (*Routes, error)
 	WriteConfig()
 	ReloadRouter() bool
+}
+
+func NewRoutes(filename ...string) *Routes {
+	file := DefaultRouteFile
+	if filename != nil && len(filename) > 0 {
+		file = filename[0]
+	}
+	return &Routes{make(map[string]Frontend), file}
 }
 
 func makeID() string {
@@ -78,30 +89,39 @@ func makeID() string {
 	return s
 }
 
-func (routes *Routes) ReadRoutes() {
-	//fmt.Printf("Reading routes file (%s)\n", RouteFile)
-	dat, err := ioutil.ReadFile(RouteFile)
+func (routes *Routes) ReadRoutes() (*Routes, error) {
+	file := routes.RouteFile
+	glog.V(4).Infof("Reading routes file (%s)\n", file)
+	dat, err := ioutil.ReadFile(file)
 	if err != nil {
+		glog.Errorf("Error while reading file (%s)", file)
 		routes.GlobalRoutes = make(map[string]Frontend)
-		return
+		return nil, err
 	}
 	json.Unmarshal(dat, &routes.GlobalRoutes)
+	glog.V(4).Infof("Marshall result %+v\n", routes.GlobalRoutes)
+	return routes, nil
 }
 
-func (routes *Routes) WriteRoutes() {
+func (routes *Routes) WriteRoutes() (*Routes, error) {
 	dat, err := json.MarshalIndent(routes.GlobalRoutes, "", "  ")
 	if err != nil {
-		fmt.Println("Failed to marshal routes - %s", err.Error())
+		glog.Errorf("Failed to marshal routes - %s", err.Error())
+		return nil, err
 	}
-	err = ioutil.WriteFile(RouteFile, dat, 0644)
+	file := routes.RouteFile
+	glog.V(4).Infof("Writing routes tofile (%s)\n", file)
+	err = ioutil.WriteFile(file, dat, 0644)
 	if err != nil {
-		fmt.Println("Failed to write to routes file - %s", err.Error())
+		glog.Errorf("Failed to write to routes file - %s", err.Error())
+		return nil, err
 	}
+	return routes, nil
 }
 
 func (routes *Routes) FindFrontend(name string) (v Frontend, ok bool) {
 	v, ok = routes.GlobalRoutes[name]
-	return
+	return v, ok
 }
 
 func (routes *Routes) DeleteBackends(name string) {
@@ -114,7 +134,7 @@ func (routes *Routes) DeleteBackends(name string) {
 	routes.GlobalRoutes[name] = a
 }
 
-func (routes *Routes) CreateFrontend(name string, url string) {
+func (routes *Routes) CreateFrontend(name string, url string) (*Routes, error) {
 	a := Frontend{}
 	a.Backends = make(map[string]Backend)
 	a.EndpointTable = make(map[string]Endpoint)
@@ -124,29 +144,41 @@ func (routes *Routes) CreateFrontend(name string, url string) {
 		a.HostAliases = append(a.HostAliases, url)
 	}
 	routes.GlobalRoutes[a.Name] = a
-	routes.WriteRoutes()
+	return routes.WriteRoutes()
 }
 
-func (routes *Routes) DeleteFrontend(frontendname string) {
+func (routes *Routes) DeleteFrontend(frontendname string) (*Routes, error) {
 	delete(routes.GlobalRoutes, frontendname)
 	routes.WriteRoutes()
+	return routes, nil
 }
 
-func (routes *Routes) AddAlias(alias string, frontendname string) {
-	a := routes.GlobalRoutes[frontendname]
+func (routes *Routes) AddAlias(alias string, frontendname string) (*Routes, error) {
+	a, ok := routes.GlobalRoutes[frontendname]
+	if !ok {
+		err := fmt.Errorf("Error getting frontend with name: %v, ensure that the frontend has been previously created using the CreateFronted method", frontendname)
+		glog.Errorf("%s\n", err.Error())
+		return nil, err
+	}
 	for _, v := range a.HostAliases {
 		if v == alias {
-			return
+			return routes, nil
 		}
 	}
 
 	a.HostAliases = append(a.HostAliases, alias)
 	routes.GlobalRoutes[frontendname] = a
 	routes.WriteRoutes()
+	return routes, nil
 }
 
-func (routes *Routes) RemoveAlias(alias string, frontendname string) {
-	a := routes.GlobalRoutes[frontendname]
+func (routes *Routes) RemoveAlias(alias string, frontendname string) (*Routes, error) {
+	a, ok := routes.GlobalRoutes[frontendname]
+	if !ok {
+		err := fmt.Errorf("Error getting frontend with name: %v, ensure that the frontend has been previously created using the CreateFronted method", frontendname)
+		glog.Errorf("%s\n", err.Error())
+		return nil, err
+	}
 	newAliases := make([]string, 0)
 	for _, v := range a.HostAliases {
 		if v == alias || v == "" {
@@ -157,11 +189,18 @@ func (routes *Routes) RemoveAlias(alias string, frontendname string) {
 	a.HostAliases = newAliases
 	routes.GlobalRoutes[frontendname] = a
 	routes.WriteRoutes()
+	return routes, nil
 }
 
-func (routes *Routes) AddRoute(frontendname string, fePath string, bePath string, protocols []string, endpoints []Endpoint) {
+func (routes *Routes) AddRoute(frontendname string, fePath string, bePath string, protocols []string, endpoints []Endpoint) (*Routes, error) {
 	var id string
-	a := routes.GlobalRoutes[frontendname]
+	a, ok := routes.GlobalRoutes[frontendname]
+	if !ok {
+		err := fmt.Errorf("Error getting frontend with name: %v, ensure that the frontend has been previously created using the CreateFronted method", frontendname)
+		glog.Errorf("%s\n", err.Error())
+		return nil, err
+	}
+	a.Name = frontendname
 
 	epIDs := make([]string, 1)
 	for newEpId := range endpoints {
@@ -180,14 +219,24 @@ func (routes *Routes) AddRoute(frontendname string, fePath string, bePath string
 		if !found {
 			id = makeID()
 			ep := Endpoint{id, newEndpoint.IP, newEndpoint.Port}
+			glog.V(4).Infof("Frontend  %+v\n", a)
+			glog.V(4).Infof("Endpoint %+v\n", ep)
+			glog.V(4).Infof("Routes %+v\n", a.EndpointTable[id])
 			a.EndpointTable[id] = ep
+			glog.V(4).Infof("Routes after %+v\n", a.EndpointTable[id])
 			epIDs = append(epIDs, ep.ID)
 		}
 	}
+
 	// locate a backend that may already exist with this protocol and fe/be path
 	found := false
+	glog.V(4).Infof("Backends  %+v\n", a.Backends)
 	for _, be := range a.Backends {
-		if be.FePath == fePath && be.BePath == bePath && cmpStrSlices(protocols, be.Protocols) {
+		sort.Strings(protocols)
+		sort.Strings(be.Protocols)
+		strProtocols := fmt.Sprintf("%v", protocols)
+		strBeProtocols := fmt.Sprintf("%v", be.Protocols)
+		if be.FePath == fePath && be.BePath == bePath && strProtocols == strBeProtocols {
 			for _, epId := range epIDs {
 				be.EndpointIDs = append(be.EndpointIDs, epId)
 			}
@@ -200,25 +249,7 @@ func (routes *Routes) AddRoute(frontendname string, fePath string, bePath string
 		id = makeID()
 		a.Backends[id] = Backend{id, fePath, bePath, protocols, epIDs, TERM_EDGE, nil}
 	}
-	routes.GlobalRoutes[a.Name] = a
+	glog.V(4).Infof("Frontend %+v\n", a)
 	routes.WriteRoutes()
-}
-
-func cmpStrSlices(first []string, second []string) bool {
-	if len(first) != len(second) {
-		return false
-	}
-	for _, fi := range first {
-		found := false
-		for _, si := range second {
-			if fi == si {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
+	return routes, nil
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,33 +1,37 @@
 package router
 
-import "testing"
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"math/rand"
+	"testing"
+)
 
 //Test that when removing an alias that only the single alias is removed and not the entire host alias structure for the
 //frontend
 func TestRemoveAlias(t *testing.T) {
-	router := &Routes{
-		make(map[string]Frontend),
-	}
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
 
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+	router.AddAlias("alias1", "frontend1")
+	// Adding the same alias twice to also check that adding and existing alias does not add it twice
 	router.AddAlias("alias1", "frontend1")
 	router.AddAlias("alias2", "frontend1")
 
 	frontend := router.GlobalRoutes["frontend1"]
-
-	if len(frontend.HostAliases) != 2 {
+	// Creating a frontend with an URL autmatically adds an alias
+	if len(frontend.HostAliases) != 3 {
 		t.Error("Expected 2 aliases got %i", len(frontend.HostAliases))
 	}
 
 	router.RemoveAlias("alias1", "frontend1")
-
 	frontend = router.GlobalRoutes["frontend1"]
-
-	if len(frontend.HostAliases) != 1 {
+	if len(frontend.HostAliases) != 2 {
 		t.Error("Expected 1 aliases got %i", len(frontend.HostAliases))
 	}
-
-	alias := frontend.HostAliases[0]
-
+	alias := frontend.HostAliases[1]
 	if alias != "alias2" {
 		t.Error("Expected to have alias2 remaining, found %s", alias)
 	}
@@ -35,10 +39,10 @@ func TestRemoveAlias(t *testing.T) {
 
 //test deleting a frontend removes it from global routes
 func TestDeleteFrontend(t *testing.T) {
-	router := &Routes{
-		make(map[string]Frontend),
-	}
-
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
 	router.AddAlias("alias1", "frontend1")
 
 	frontend, ok := router.GlobalRoutes["frontend1"]
@@ -47,15 +51,225 @@ func TestDeleteFrontend(t *testing.T) {
 		t.Error("Expected to find frontend")
 	}
 
-	if len(frontend.HostAliases) != 1 {
+	if len(frontend.HostAliases) != 2 {
 		t.Error("Expected 1 host alias")
 	}
 
 	router.DeleteFrontend("frontend1")
-
 	frontend, ok = router.GlobalRoutes["frontend1"]
-
 	if ok {
 		t.Error("Expected to not find frontend but it was found")
+	}
+}
+
+//Test that when adding a route, the route is indeed added
+func TestAddRoute(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+
+	frontend := router.GlobalRoutes["frontend1"]
+	frontend.EndpointTable = make(map[string]Endpoint)
+	frontend.Backends = make(map[string]Backend)
+
+	protocols := []string{"http", "https", "Sti"}
+	endpoint := Endpoint{ID: "my-endpoint", IP: "127.0.0.1", Port: "8080"}
+	endpoints := []Endpoint{endpoint}
+	glog.V(4).Infof("Frontend before adding routes %+v\n", frontend)
+
+	router.AddRoute("frontend1", "fe_server1", "be_server1", protocols, endpoints)
+
+	router.ReadRoutes()
+	frontendAfter := router.GlobalRoutes["frontend1"]
+	glog.V(4).Infof("Frontend after adding routes %+v\n", frontendAfter)
+
+	if len(frontendAfter.Backends) == 0 || len(frontendAfter.Backends) < len(frontend.Backends) {
+		t.Error("Expected that frontend has more routes after RouteAdd ")
+	}
+
+	// Creating and endpoint with empty port or IP to check that it is not added
+	endpointEmpty := Endpoint{ID: "my-endpoint", IP: "", Port: ""}
+	endpointsEmpty := []Endpoint{endpointEmpty}
+	glog.V(4).Infof("Frontend before adding routes %+v\n", frontend)
+
+	router.AddRoute("frontend1", "fe_server1", "be_server1", protocols, endpointsEmpty)
+	if len(frontendAfter.Backends) != 1 {
+		t.Error("Expected that frontend has only backend ")
+	}
+
+	// Adding the same route twice to check and that the backend end is not added twice
+	router.AddRoute("frontend1", "fe_server1", "be_server1", protocols, endpoints)
+	if len(frontendAfter.Backends) != 1 {
+		t.Error("Expected that frontend has only backend ")
+	}
+
+}
+
+//Test that when adding a route, the route is indeed added
+func TestReadRoute(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+	router.AddAlias("alias1", "frontend1")
+
+}
+
+//test deleting a backend removes it from global routes
+func TestDeleteBackends(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+	router.AddAlias("alias1", "frontend1")
+
+	protocols := []string{"http", "https", "Sti"}
+	endpoint := Endpoint{ID: "my-endpoint", IP: "127.0.0.1", Port: "8080"}
+	endpoints := []Endpoint{endpoint}
+
+	router.AddRoute("frontend1", "fe_server1", "be_server1", protocols, endpoints)
+	frontend, ok := router.GlobalRoutes["frontend1"]
+	if !ok {
+		t.Error("Expected to find frontend")
+	}
+
+	router.DeleteBackends("frontend1")
+	frontend = router.GlobalRoutes["frontend1"]
+	if len(frontend.Backends) != 0 {
+		t.Error("Expected that frontend has empty backend")
+	}
+
+	// Deleting an non existing frontend
+	router.DeleteBackends("frontend1_NOT_EXISTENT")
+	frontend = router.GlobalRoutes["frontend1_NOT_EXISTENT"]
+	if len(frontend.Backends) != 0 {
+		t.Error("Expected that frontend has empty backend")
+	}
+
+}
+
+//test creation of a frontend
+func TestCreateFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+	frontend := router.GlobalRoutes["frontend1"]
+	glog.V(4).Infof("Frontend after creation %+v\n", frontend)
+
+	if len(frontend.HostAliases) != 1 {
+		t.Error("Expected that frontend has 1 host aliases")
+	}
+
+}
+
+//test creation of a frontend
+func TestCreateFrontendWithEmptyUrl(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "")
+	frontend := router.GlobalRoutes["frontend1"]
+
+	glog.V(4).Infof("Frontend after creation %+v\n", frontend)
+	if len(frontend.HostAliases) != 0 {
+		t.Error("Expected that frontend has no host aliases")
+	}
+
+}
+
+//test creation of a frontend
+func TestAddAliasWithNoFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	// router.CreateFrontend("frontend1", "")
+	_, err := router.AddAlias("alias1", "frontend1")
+	if err == nil {
+		t.Error("Adding an alias to a non existing fronted must fail")
+	}
+}
+
+func TestAddRouteWithNoFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	// router.CreateFrontend("frontend1", "")
+	protocols := []string{"http", "https", "Sti"}
+	endpoint := Endpoint{ID: "my-endpoint", IP: "127.0.0.1", Port: "8080"}
+	endpoints := []Endpoint{endpoint}
+	_, err := router.AddRoute("frontend1", "fe_server1", "be_server1", protocols, endpoints)
+
+	if err == nil {
+		t.Error("Adding a route to a non existing fronted must fail")
+	}
+}
+
+func TestRemoveAliasWithNoFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	// router.CreateFrontend("frontend1", "")
+	_, err := router.RemoveAlias("alias1", "frontend1")
+	if err == nil {
+		t.Error("Removing an alias to a non existing fronted must fail")
+	}
+}
+
+func TestWriteRoutes(t *testing.T) {
+	router := NewRoutes("/dev/null")
+	_, err := router.WriteRoutes()
+	if err != nil {
+		t.Error("Writing route file failed")
+	}
+}
+
+func TestWriteRoutesFailure(t *testing.T) {
+	router := NewRoutes("/root/AAAtmpAAA/test")
+	_, err := router.WriteRoutes()
+	if err == nil {
+		t.Error("Writing route file should have failed")
+	}
+}
+
+func TestReadRoutes(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	_, err := router.WriteRoutes()
+	if err != nil {
+		t.Error("Writing route file failed")
+	}
+	_, err = router.ReadRoutes()
+	if err != nil {
+		t.Error("Reading route file failed")
+	}
+}
+
+func TestReadRoutesFailure(t *testing.T) {
+	router := NewRoutes("/dev/tmp/test")
+	_, err := router.ReadRoutes()
+	if err == nil {
+		t.Error("Reading route should have failed")
+	}
+}
+
+func TestFindFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "")
+	_, ok := router.FindFrontend("frontend1")
+	if !ok {
+		t.Error("Failre to find frontend")
 	}
 }


### PR DESCRIPTION
- Refactoring router.go to handle errors.
- Improving code coverage.
- Adding a constructor to Routes structure to pass filename to persist in.
- Turns the class testable
- Use blog instead of fmt.printf
