### PR TITLE
Added ./hack/verify-golint.sh command

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which golint &>/dev/null; then
+  echo "Unable to detect 'golint' package"
+  echo "To install it, run: 'go get github.com/golang/lint/golint'"
+  exit 1
+fi
+
+GO_VERSION=($(go version))
+echo "Detected go version: $(go version)"
+
+if [[ ${GO_VERSION[2]} != "go1.2" && ${GO_VERSION[2]} != "go1.3.1" && ${GO_VERSION[2]} != "go1.3.3" ]]; then
+  echo "Unknown go version, skipping golint."
+  exit 0
+fi
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+
+cd "${OS_ROOT}"
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './release' \
+        -o -wholename './pkg/assets/bindata.go' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/Godeps/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+bad_files=$(find_files | xargs golint)
+if [[ -n "${bad_files}" ]]; then
+  echo "golint detected following problems:"
+  echo "${bad_files}"
+  exit 1
+fi


### PR DESCRIPTION
Golint detects the coding style mistakes, like missing godocs or wrong func/vars names: https://github.com/golang/lint

The sample output:

```
./pkg/oauth/scope/scope.go:24:1: exported function Split should have comment or be unexported
./pkg/oauth/scope/scope.go:32:1: exported function Join should have comment or be unexported
./pkg/oauth/scope/scope.go:36:1: exported function Covers should have comment or be unexported
./pkg/oauth/server/osinserver/registrystorage/storage.go:19:6: exported type UserConversion should have comment or be unexported
./pkg/oauth/server/osinserver/registrystorage/storage.go:33:1: exported function New should have comment or be unexported
```

There are tons of problems with our codebase right now, but I do believe that golint might be too restrictive, so I don't think we should add it into our CI flow. But it is nice tool to use for development and debugging ;-)
