### PR TITLE
Add a Status field on ImageRepository

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -134,6 +134,8 @@ func (c *MasterConfig) RunAPI(installers ...APIInstaller) {
 		ImageRepositoryInterface:  imageEtcd,
 	}
 
+	defaultRegistry := env("OPENSHIFT_DEFAULT_REGISTRY", "")
+
 	// initialize OpenShift API
 	storage := map[string]apiserver.RESTStorage{
 		"builds":       buildregistry.NewREST(buildEtcd),
@@ -141,7 +143,7 @@ func (c *MasterConfig) RunAPI(installers ...APIInstaller) {
 		"buildLogs":    buildlogregistry.NewREST(buildEtcd, c.KubeClient),
 
 		"images":                  image.NewREST(imageEtcd),
-		"imageRepositories":       imagerepository.NewREST(imageEtcd),
+		"imageRepositories":       imagerepository.NewREST(imageEtcd, defaultRegistry),
 		"imageRepositoryMappings": imagerepositorymapping.NewREST(imageEtcd, imageEtcd),
 
 		"deployments":               deployregistry.NewREST(deployEtcd),

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+// dockerDefaultNamespace is the value for namespace when a single segment name is provided.
+const dockerDefaultNamespace = "library"
+
+// SplitDockerPullSpec breaks a Docker pull specification into its components, or returns
+// an error if those components are not valid. Attempts to match as closely as possible the
+// Docker spec up to 1.3. Future API revisions may change the pull syntax.
+func SplitDockerPullSpec(spec string) (registry, namespace, name, tag string, err error) {
+	spec, tag = docker.ParseRepositoryTag(spec)
+	arr := strings.Split(spec, "/")
+	switch len(arr) {
+	case 2:
+		return "", arr[0], arr[1], tag, nil
+	case 3:
+		return arr[0], arr[1], arr[2], tag, nil
+	case 1:
+		if len(arr[0]) == 0 {
+			err = fmt.Errorf("the docker pull spec %q must be two or three segments separated by slashes", spec)
+			return
+		}
+		return "", dockerDefaultNamespace, arr[0], tag, nil
+	default:
+		err = fmt.Errorf("the docker pull spec %q must be two or three segments separated by slashes", spec)
+		return
+	}
+}
+
+// JoinDockerPullSpec turns a set of components of a Docker pull specification into a single
+// string. Attempts to match as closely as possible the Docker spec up to 1.3. Future API
+// revisions may change the pull syntax.
+func JoinDockerPullSpec(registry, namespace, name, tag string) string {
+	if len(namespace) == 0 {
+		namespace = dockerDefaultNamespace
+	}
+	if len(tag) != 0 {
+		tag = ":" + tag
+	}
+	if len(registry) == 0 {
+		return fmt.Sprintf("%s/%s%s", namespace, name, tag)
+	}
+	return fmt.Sprintf("%s/%s/%s%s", registry, namespace, name, tag)
+}
+
+// parseImageName parses image name including a tag and returns image name and tag.
+// copied from kubernetes/pkg/kubelet/dockertools/docker.go#parseImageName
+func parseImageName(image string) (string, string) {
+	tag := ""
+	parts := strings.SplitN(image, "/", 2)
+	repo := ""
+	if len(parts) == 2 {
+		repo = parts[0]
+		image = parts[1]
+	}
+	parts = strings.SplitN(image, ":", 2)
+	if len(parts) == 2 {
+		image = parts[0]
+		tag = parts[1]
+	}
+	if repo != "" {
+		image = fmt.Sprintf("%s/%s", repo, image)
+	}
+	return image, tag
+}

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestSplitDockerPullSpec(t *testing.T) {
+	testCases := []struct {
+		From                           string
+		Registry, Namespace, Name, Tag string
+		Err                            bool
+	}{
+		{
+			From:      "foo",
+			Namespace: "library",
+			Name:      "foo",
+		},
+		{
+			From:      "bar/foo",
+			Namespace: "bar",
+			Name:      "foo",
+		},
+		{
+			From:      "bar/foo/baz",
+			Registry:  "bar",
+			Namespace: "foo",
+			Name:      "baz",
+		},
+		{
+			From:      "bar/foo/baz:tag",
+			Registry:  "bar",
+			Namespace: "foo",
+			Name:      "baz",
+			Tag:       "tag",
+		},
+		{
+			From:      "bar:5000/foo/baz:tag",
+			Registry:  "bar:5000",
+			Namespace: "foo",
+			Name:      "baz",
+			Tag:       "tag",
+		},
+		{
+			From: "bar/foo/baz/biz",
+			Err:  true,
+		},
+		{
+			From: "",
+			Err:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		r, ns, n, tag, err := SplitDockerPullSpec(testCase.From)
+		switch {
+		case err != nil && !testCase.Err:
+			t.Errorf("%s: unexpected error: %v", testCase.From, err)
+			continue
+		case err == nil && testCase.Err:
+			t.Errorf("%s: unexpected non-error", testCase.From)
+			continue
+		}
+		if r != testCase.Registry || ns != testCase.Namespace || n != testCase.Name || tag != testCase.Tag {
+			t.Errorf("%s: unexpected result: %q %q %q %q", testCase.From, r, ns, n, tag)
+		}
+	}
+}

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -9,32 +9,50 @@ import (
 type ImageList struct {
 	kapi.TypeMeta `json:",inline" yaml:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Image `json:"items" yaml:"items"`
+
+	Items []Image `json:"items" yaml:"items"`
 }
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.
 type Image struct {
-	kapi.TypeMeta        `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	DockerImageReference string       `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
-	DockerImageMetadata  docker.Image `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
+	kapi.TypeMeta   `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// The string that can be used to pull this image.
+	DockerImageReference string `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
+	// Metadata about this image
+	DockerImageMetadata docker.Image `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
 }
 
 // ImageRepositoryList is a list of ImageRepository objects.
 type ImageRepositoryList struct {
 	kapi.TypeMeta `json:",inline" yaml:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []ImageRepository `json:"items" yaml:"items"`
+
+	Items []ImageRepository `json:"items" yaml:"items"`
 }
 
 // ImageRepository stores a mapping of tags to images, metadata overrides that are applied
 // when images are tagged in a repository, and an optional reference to a Docker image
 // repository on a registry.
 type ImageRepository struct {
-	kapi.TypeMeta         `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	DockerImageRepository string            `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
-	Tags                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	kapi.TypeMeta   `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Optional, if specified this repository is backed by a Docker repository on this server
+	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	// Tags map arbitrary string values to specific image locators
+	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	// Status describes the current state of this repository
+	Status ImageRepositoryStatus `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// ImageRepositoryStatus contains information about the state of this image repository.
+type ImageRepositoryStatus struct {
+	// Represents the effective location this repository may be accessed at. May be empty until the server
+	// determines where the repository is located
+	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
 }
 
 // TODO add metadata overrides
@@ -42,9 +60,13 @@ type ImageRepository struct {
 // ImageRepositoryMapping represents a mapping from a single tag to a Docker image as
 // well as the reference to the Docker image repository the image came from.
 type ImageRepositoryMapping struct {
-	kapi.TypeMeta         `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// The Docker image repository the specified image is located in
 	DockerImageRepository string `json:"dockerImageRepository" yaml:"dockerImageRepository"`
-	Image                 Image  `json:"image" yaml:"image"`
-	Tag                   string `json:"tag" yaml:"tag"`
+	// A Docker image.
+	Image Image `json:"image" yaml:"image"`
+	// A string value this image can be located with inside the repository.
+	Tag string `json:"tag" yaml:"tag"`
 }

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -9,32 +9,50 @@ import (
 type ImageList struct {
 	kapi.TypeMeta `json:",inline" yaml:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Image `json:"items" yaml:"items"`
+
+	Items []Image `json:"items" yaml:"items"`
 }
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.
 type Image struct {
-	kapi.TypeMeta        `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	DockerImageReference string       `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
-	DockerImageMetadata  docker.Image `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
+	kapi.TypeMeta   `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// The string that can be used to pull this image.
+	DockerImageReference string `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
+	// Metadata about this image
+	DockerImageMetadata docker.Image `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
 }
 
 // ImageRepositoryList is a list of ImageRepository objects.
 type ImageRepositoryList struct {
 	kapi.TypeMeta `json:",inline" yaml:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []ImageRepository `json:"items" yaml:"items"`
+
+	Items []ImageRepository `json:"items" yaml:"items"`
 }
 
 // ImageRepository stores a mapping of tags to images, metadata overrides that are applied
 // when images are tagged in a repository, and an optional reference to a Docker image
 // repository on a registry.
 type ImageRepository struct {
-	kapi.TypeMeta         `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	DockerImageRepository string            `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
-	Tags                  map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	kapi.TypeMeta   `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Optional, if specified this repository is backed by a Docker repository on this server
+	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	// Tags map arbitrary string values to specific image locators
+	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	// Status describes the current state of this repository
+	Status ImageRepositoryStatus `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// ImageRepositoryStatus contains information about the state of this image repository.
+type ImageRepositoryStatus struct {
+	// Represents the effective location this repository may be accessed at. May be empty until the server
+	// determines where the repository is located
+	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
 }
 
 // TODO add metadata overrides
@@ -42,9 +60,13 @@ type ImageRepository struct {
 // ImageRepositoryMapping represents a mapping from a single tag to a Docker image as
 // well as the reference to the Docker image repository the image came from.
 type ImageRepositoryMapping struct {
-	kapi.TypeMeta         `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// The Docker image repository the specified image is located in
 	DockerImageRepository string `json:"dockerImageRepository" yaml:"dockerImageRepository"`
-	Image                 Image  `json:"image" yaml:"image"`
-	Tag                   string `json:"tag" yaml:"tag"`
+	// A Docker image.
+	Image Image `json:"image" yaml:"image"`
+	// A string value this image can be located with inside the repository.
+	Tag string `json:"tag" yaml:"tag"`
 }

--- a/pkg/image/registry/image/rest.go
+++ b/pkg/image/registry/image/rest.go
@@ -20,7 +20,7 @@ type REST struct {
 	registry Registry
 }
 
-// NewStorage returns a new REST.
+// NewREST returns a new REST.
 func NewREST(registry Registry) apiserver.RESTStorage {
 	return &REST{registry}
 }

--- a/pkg/image/registry/imagerepository/rest_test.go
+++ b/pkg/image/registry/imagerepository/rest_test.go
@@ -120,7 +120,7 @@ func TestListImageRepositoriesPopulatedList(t *testing.T) {
 }
 
 func TestCreateImageRepositoryBadObject(t *testing.T) {
-	storage := REST{}
+	storage := NewREST(nil, "")
 
 	channel, err := storage.Create(kapi.NewDefaultContext(), &api.ImageList{})
 	if channel != nil {
@@ -133,9 +133,9 @@ func TestCreateImageRepositoryBadObject(t *testing.T) {
 
 func TestCreateImageRepositoryOK(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := NewREST(mockRepositoryRegistry, "test")
 
-	channel, err := storage.Create(kapi.NewDefaultContext(), &api.ImageRepository{})
+	channel, err := storage.Create(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
 	if err != nil {
 		t.Errorf("Unexpected non-nil error: %#v", err)
 	}
@@ -150,6 +150,12 @@ func TestCreateImageRepositoryOK(t *testing.T) {
 	}
 	if repo.CreationTimestamp.IsZero() {
 		t.Error("Unexpected zero CreationTimestamp")
+	}
+	if repo.DockerImageRepository != "" {
+		t.Errorf("unexpected repository: %#v", repo)
+	}
+	if repo.Status.DockerImageRepository != "test/default/foo" {
+		t.Errorf("unexpected Status values: %#v", repo)
 	}
 }
 

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -266,7 +266,7 @@ func NewTestOpenshift(t *testing.T) *testOpenshift {
 
 	storage := map[string]apiserver.RESTStorage{
 		"images":                    image.NewREST(imageEtcd),
-		"imageRepositories":         imagerepository.NewREST(imageEtcd),
+		"imageRepositories":         imagerepository.NewREST(imageEtcd, ""),
 		"imageRepositoryMappings":   imagerepositorymapping.NewREST(imageEtcd, imageEtcd),
 		"deployments":               deployregistry.NewREST(deployEtcd),
 		"deploymentConfigs":         deployconfigregistry.NewREST(deployEtcd),


### PR DESCRIPTION
When clients want to use internal ImageRepositories (an ImageRepository that is backed by an OpenShift registry that can be automatically created on demand when a user pushes or pulls to it) a client needs to be able to know what registry URL that is in order to push images.

This pull adds a Status struct to an ImageRepository (as defined upstream, a set of attributes that represent the current condition of a resource) that conveys the _real_ DockerImageRepository name (vs the value set on creation or update by a consumer).  It is populated when Get/List is called and defaults to a value set by an ENV attribute (although discussion in https://github.com/GoogleCloudPlatform/kubernetes/issues/1319 is leaning towards a service with a known name and namespace).

When a client requests an ImageRepository, the "status.dockerImageRepository" will be set to "dockerImageRepository" or to the value of `<defaultRegistry>/<namespace>/<name>`.  A properly configured default registry would know how to lookup `<namespace>/<name>` when pulling the image.

@ncdc review
