### PR TITLE
Refactoring router.go to handle errors. Improving code coverage

### DIFF
--- a/pkg/router/controller/controller.go
+++ b/pkg/router/controller/controller.go
@@ -95,10 +95,8 @@ func (c *RouterController) HandleEndpoints() {
 			BePath:    "",
 			Protocols: nil,
 		}
-
 		c.Router.AddRoute(frontend, backend, routerEndpoints)
 	}
-
 	c.Router.WriteConfig()
 	c.Router.ReloadRouter()
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strconv"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 const (
@@ -21,7 +24,7 @@ const (
 )
 
 const (
-	RouteFile = "/var/lib/containers/router/routes.json"
+	DefaultRouteFile = "/var/lib/containers/router/routes.json"
 )
 
 type Frontend struct {
@@ -56,20 +59,29 @@ type Endpoint struct {
 
 type Routes struct {
 	GlobalRoutes map[string]Frontend
+	RouteFile    string
 }
 
 type Router interface {
-	ReadRoutes()
-	WriteRoutes()
+	ReadRoutes() error
+	WriteRoutes() error
 	FindFrontend(name string) (v Frontend, ok bool)
 	DeleteBackends(name string)
-	CreateFrontend(name, url string)
-	DeleteFrontend(name string)
-	AddAlias(alias, frontendName string)
-	RemoveAlias(alias, frontendName string)
-	AddRoute(frontend *Frontend, backend *Backend, endpoints []Endpoint)
+	CreateFrontend(name string, url string) (*Frontend, error)
+	DeleteFrontend(frontendName string) error
+	AddAlias(alias string, frontendName string) error
+	RemoveAlias(alias string, frontendName string) error
+	AddRoute(frontend *Frontend, backend *Backend, endpoints []Endpoint) error
 	WriteConfig()
 	ReloadRouter() bool
+}
+
+func NewRoutes(filename ...string) *Routes {
+	file := DefaultRouteFile
+	if filename != nil && len(filename) > 0 {
+		file = filename[0]
+	}
+	return &Routes{make(map[string]Frontend), file}
 }
 
 func makeID() string {
@@ -78,30 +90,38 @@ func makeID() string {
 	return s
 }
 
-func (routes *Routes) ReadRoutes() {
-	//fmt.Printf("Reading routes file (%s)\n", RouteFile)
-	dat, err := ioutil.ReadFile(RouteFile)
+func (routes *Routes) ReadRoutes() error {
+	file := routes.RouteFile
+	glog.V(4).Infof("Reading routes file (%s)\n", file)
+	dat, err := ioutil.ReadFile(file)
 	if err != nil {
+		glog.Errorf("Error while reading file %v (%s)", file, err)
 		routes.GlobalRoutes = make(map[string]Frontend)
-		return
+		return err
 	}
 	json.Unmarshal(dat, &routes.GlobalRoutes)
+	glog.V(4).Infof("Marshall result %+v", routes.GlobalRoutes)
+	return nil
 }
 
-func (routes *Routes) WriteRoutes() {
+func (routes *Routes) WriteRoutes() error {
 	dat, err := json.MarshalIndent(routes.GlobalRoutes, "", "  ")
 	if err != nil {
-		fmt.Println("Failed to marshal routes - %s", err.Error())
+		glog.Errorf("Failed to marshal routes - %s", err.Error())
+		return err
 	}
-	err = ioutil.WriteFile(RouteFile, dat, 0644)
+	file := routes.RouteFile
+	glog.V(4).Infof("Writing routes tofile (%s)", file)
+	err = ioutil.WriteFile(file, dat, 0644)
 	if err != nil {
-		fmt.Println("Failed to write to routes file - %s", err.Error())
+		glog.Errorf("Failed to write to routes file - %s", err.Error())
 	}
+	return err
 }
 
 func (routes *Routes) FindFrontend(name string) (v Frontend, ok bool) {
 	v, ok = routes.GlobalRoutes[name]
-	return
+	return v, ok
 }
 
 func (routes *Routes) DeleteBackends(name string) {
@@ -115,7 +135,7 @@ func (routes *Routes) DeleteBackends(name string) {
 	routes.GlobalRoutes[name] = frontend
 }
 
-func (routes *Routes) CreateFrontend(name string, url string) {
+func (routes *Routes) CreateFrontend(name string, url string) (*Frontend, error) {
 	frontend := Frontend{
 		Name:          name,
 		Backends:      make(map[string]Backend),
@@ -127,29 +147,38 @@ func (routes *Routes) CreateFrontend(name string, url string) {
 		frontend.HostAliases = append(frontend.HostAliases, url)
 	}
 	routes.GlobalRoutes[frontend.Name] = frontend
-	routes.WriteRoutes()
+	return &frontend, nil
 }
 
-func (routes *Routes) DeleteFrontend(name string) {
-	delete(routes.GlobalRoutes, name)
-	routes.WriteRoutes()
+func (routes *Routes) DeleteFrontend(frontendName string) error {
+	delete(routes.GlobalRoutes, frontendName)
+	return routes.WriteRoutes()
 }
 
-func (routes *Routes) AddAlias(alias, frontendName string) {
-	frontend := routes.GlobalRoutes[frontendName]
+func (routes *Routes) AddAlias(alias string, frontendName string) error {
+	frontend, ok := routes.GlobalRoutes[frontendName]
+	if !ok {
+		err := fmt.Errorf("Error getting frontend with name: %v, ensure that the frontend has backenden previously created using the CreateFronted method", frontendName)
+		glog.Errorf("%s", err.Error())
+		return err
+	}
 	for _, v := range frontend.HostAliases {
 		if v == alias {
-			return
+			return nil
 		}
 	}
-
 	frontend.HostAliases = append(frontend.HostAliases, alias)
 	routes.GlobalRoutes[frontendName] = frontend
-	routes.WriteRoutes()
+	return routes.WriteRoutes()
 }
 
-func (routes *Routes) RemoveAlias(alias, frontendName string) {
-	frontend := routes.GlobalRoutes[frontendName]
+func (routes *Routes) RemoveAlias(alias string, frontendName string) error {
+	frontend, ok := routes.GlobalRoutes[frontendName]
+	if !ok {
+		err := fmt.Errorf("Error getting frontend with name: %v, ensure that the frontend has backenden previously created using the CreateFronted method", frontendName)
+		glog.Errorf("%s\n", err.Error())
+		return err
+	}
 	newAliases := []string{}
 	for _, v := range frontend.HostAliases {
 		if v == alias || v == "" {
@@ -160,11 +189,17 @@ func (routes *Routes) RemoveAlias(alias, frontendName string) {
 	frontend.HostAliases = newAliases
 	routes.GlobalRoutes[frontendName] = frontend
 	routes.WriteRoutes()
+	return nil
 }
 
-func (routes *Routes) AddRoute(frontend *Frontend, backend *Backend, endpoints []Endpoint) {
+func (routes *Routes) AddRoute(frontend *Frontend, backend *Backend, endpoints []Endpoint) error {
 	var id string
-	existingFrontend := routes.GlobalRoutes[frontend.Name]
+	existingFrontend, ok := routes.GlobalRoutes[frontend.Name]
+	if !ok {
+		err := fmt.Errorf("Error getting frontend with name: %v, ensure that the frontend has backenden previously created using the CreateFronted method", frontend.Name)
+		glog.Errorf("%s\n", err.Error())
+		return err
+	}
 
 	epIDs := make([]string, 1)
 	for newEpID := range endpoints {
@@ -205,23 +240,14 @@ func (routes *Routes) AddRoute(frontend *Frontend, backend *Backend, endpoints [
 	}
 	routes.GlobalRoutes[existingFrontend.Name] = existingFrontend
 	routes.WriteRoutes()
+
+	return nil
 }
 
 func cmpStrSlices(first []string, second []string) bool {
-	if len(first) != len(second) {
-		return false
-	}
-	for _, fi := range first {
-		found := false
-		for _, si := range second {
-			if fi == si {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
+	sort.Strings(first)
+	sort.Strings(second)
+	strFirst := fmt.Sprintf("%v", first)
+	strSecond := fmt.Sprintf("%v", second)
+	return strFirst == strSecond
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,20 +1,26 @@
 package router
 
-import "testing"
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
 
 //Test that when removing an alias that only the single alias is removed and not the entire host alias structure for the
 //frontend
 func TestRemoveAlias(t *testing.T) {
-	router := &Routes{
-		make(map[string]Frontend),
-	}
-
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+	router.AddAlias("alias1", "frontend1")
+	// Adding the same alias twice to also check that adding and existing alias does not add it twice
 	router.AddAlias("alias1", "frontend1")
 	router.AddAlias("alias2", "frontend1")
 
 	frontend := router.GlobalRoutes["frontend1"]
-
-	if len(frontend.HostAliases) != 2 {
+	// Creating a frontend with an URL autmatically adds an alias
+	if len(frontend.HostAliases) != 3 {
 		t.Error("Expected 2 aliases got %i", len(frontend.HostAliases))
 	}
 
@@ -22,12 +28,11 @@ func TestRemoveAlias(t *testing.T) {
 
 	frontend = router.GlobalRoutes["frontend1"]
 
-	if len(frontend.HostAliases) != 1 {
+	if len(frontend.HostAliases) != 2 {
 		t.Error("Expected 1 aliases got %i", len(frontend.HostAliases))
 	}
 
-	alias := frontend.HostAliases[0]
-
+	alias := frontend.HostAliases[1]
 	if alias != "alias2" {
 		t.Error("Expected to have alias2 remaining, found %s", alias)
 	}
@@ -35,10 +40,11 @@ func TestRemoveAlias(t *testing.T) {
 
 //test deleting a frontend removes it from global routes
 func TestDeleteFrontend(t *testing.T) {
-	router := &Routes{
-		make(map[string]Frontend),
-	}
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
 
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
 	router.AddAlias("alias1", "frontend1")
 
 	frontend, ok := router.GlobalRoutes["frontend1"]
@@ -47,7 +53,7 @@ func TestDeleteFrontend(t *testing.T) {
 		t.Error("Expected to find frontend")
 	}
 
-	if len(frontend.HostAliases) != 1 {
+	if len(frontend.HostAliases) != 2 {
 		t.Error("Expected 1 host alias")
 	}
 
@@ -57,5 +63,233 @@ func TestDeleteFrontend(t *testing.T) {
 
 	if ok {
 		t.Error("Expected to not find frontend but it was found")
+	}
+}
+
+//Test that when adding a route, the route is indeed added
+func TestAddRoute(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+
+	frontend := router.GlobalRoutes["frontend1"]
+	frontend.EndpointTable = make(map[string]Endpoint)
+	frontend.Backends = make(map[string]Backend)
+
+	protocols := []string{"http", "https", "Sti"}
+	endpoint := Endpoint{ID: "my-endpoint", IP: "127.0.0.1", Port: "8080"}
+	endpoints := []Endpoint{endpoint}
+	fmt.Printf("Frontend before adding routes %+v\n", frontend)
+
+	backend := Backend{FePath: "fe_server1", BePath: "be_server1", Protocols: protocols}
+	router.AddRoute(&frontend, &backend, endpoints)
+
+	router.ReadRoutes()
+	frontendAfter := router.GlobalRoutes["frontend1"]
+	fmt.Printf("Frontend after adding routes %+v\n", frontendAfter)
+
+	if len(frontendAfter.Backends) == 0 || len(frontendAfter.Backends) < len(frontend.Backends) {
+		t.Error("Expected that frontend has more routes after RouteAdd ")
+	}
+
+	// Creating and endpoint with empty port or IP to check that it is not added
+	endpointEmpty := Endpoint{ID: "my-endpoint", IP: "", Port: ""}
+	endpointsEmpty := []Endpoint{endpointEmpty}
+	fmt.Printf("Frontend before adding routes %+v\n", frontend)
+
+	router.AddRoute(&frontend, &backend, endpointsEmpty)
+	if len(frontendAfter.Backends) != 1 {
+		t.Error("Expected that frontend has only backend ")
+	}
+
+	// Adding the same route twice to check and that the backend end is not added twice
+	router.AddRoute(&frontend, &backend, endpoints)
+	if len(frontendAfter.Backends) != 1 {
+		t.Error("Expected that frontend has only backend ")
+	}
+
+}
+
+//Test that when adding a route, the route is indeed added
+func TestReadRoute(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.AddAlias("alias1", "frontend1")
+
+}
+
+//test deleting a backend removes it from global routes
+func TestDeleteBackends(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+	router.AddAlias("alias1", "frontend1")
+
+	frontend := router.GlobalRoutes["frontend1"]
+
+	protocols := []string{"http", "https", "Sti"}
+	endpoint := Endpoint{ID: "my-endpoint", IP: "127.0.0.1", Port: "8080"}
+	endpoints := []Endpoint{endpoint}
+
+	backend := Backend{FePath: "fe_server1", BePath: "be_server1", Protocols: protocols}
+	router.AddRoute(&frontend, &backend, endpoints)
+
+	frontend, ok := router.GlobalRoutes["frontend1"]
+	if !ok {
+		t.Error("Expected to find frontend")
+	}
+
+	router.DeleteBackends("frontend1")
+	frontend = router.GlobalRoutes["frontend1"]
+	if len(frontend.Backends) != 0 {
+		t.Error("Expected that frontend has empty backend")
+	}
+
+	// Deleting an non existing frontend
+	router.DeleteBackends("frontend1_NOT_EXISTENT")
+	frontend = router.GlobalRoutes["frontend1_NOT_EXISTENT"]
+	if len(frontend.Backends) != 0 {
+		t.Error("Expected that frontend has empty backend")
+	}
+
+}
+
+//test creation of a frontend
+func TestCreateFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "http://127.0.0.1/test_frontend")
+	frontend := router.GlobalRoutes["frontend1"]
+	fmt.Printf("Frontend after creation %+v\n", frontend)
+
+	if len(frontend.HostAliases) != 1 {
+		t.Error("Expected that frontend has 1 host aliases")
+	}
+
+}
+
+//test creation of a frontend
+func TestCreateFrontendWithEmptyUrl(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "")
+	frontend := router.GlobalRoutes["frontend1"]
+	fmt.Printf("Frontend after creation %+v\n", frontend)
+
+	if len(frontend.HostAliases) != 0 {
+		t.Error("Expected that frontend has no host aliases")
+	}
+
+}
+
+//test creation of a frontend
+func TestAddAliasWithNoFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	// router.CreateFrontend("frontend1", "")
+	err := router.AddAlias("alias1", "frontend1")
+	if err == nil {
+		t.Error("Adding an alias to a non existing fronted must fail")
+	}
+}
+
+func TestAddRouteWithNoFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+	frontend := router.GlobalRoutes["frontend1"]
+
+	// router.CreateFrontend("frontend1", "")
+	protocols := []string{"http", "https", "Sti"}
+	endpoint := Endpoint{ID: "my-endpoint", IP: "127.0.0.1", Port: "8080"}
+	endpoints := []Endpoint{endpoint}
+	backend := Backend{FePath: "fe_server1", BePath: "be_server1", Protocols: protocols}
+
+	err := router.AddRoute(&frontend, &backend, endpoints)
+	if err == nil {
+		t.Error("Adding a route to a non existing fronted must fail")
+	}
+}
+
+func TestRemoveAliasWithNoFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	// router.CreateFrontend("frontend1", "")
+	err := router.RemoveAlias("alias1", "frontend1")
+	if err == nil {
+		t.Error("Removing an alias to a non existing fronted must fail")
+	}
+}
+
+func TestWriteRoutes(t *testing.T) {
+	router := NewRoutes("/dev/null")
+	err := router.WriteRoutes()
+	if err != nil {
+		t.Error("Writing route file failed")
+	}
+}
+
+func TestWriteRoutesFailure(t *testing.T) {
+	router := NewRoutes("/root/AAAtmpAAA/test")
+	err := router.WriteRoutes()
+	if err == nil {
+		t.Error("Writing route file should have failed")
+	}
+}
+
+func TestReadRoutes(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	err := router.WriteRoutes()
+	if err != nil {
+		t.Error("Writing route file failed")
+	}
+	err = router.ReadRoutes()
+	if err != nil {
+		t.Error("Reading route file failed")
+	}
+}
+
+func TestReadRoutesFailure(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	err := router.WriteRoutes()
+	if err != nil {
+		t.Error("Writing route file failed")
+	}
+	router2 := NewRoutes("/dev/tmp/test")
+	err = router2.ReadRoutes()
+	if err == nil {
+		t.Error("Reading route should have failed")
+	}
+}
+
+func TestFindFrontend(t *testing.T) {
+	suffix := rand.Intn(1000000)
+	filename := fmt.Sprintf("/tmp/test-%v", suffix)
+	router := NewRoutes(filename)
+
+	router.CreateFrontend("frontend1", "")
+	_, ok := router.FindFrontend("frontend1")
+	if !ok {
+		t.Error("Failre to find frontend")
 	}
 }

--- a/pkg/router/test/test_router.go
+++ b/pkg/router/test/test_router.go
@@ -33,12 +33,14 @@ func NewRouter(registeredFrontends map[string]router.Frontend) *Router {
 	}
 }
 
-func (r *Router) ReadRoutes() {
+func (r *Router) ReadRoutes() error {
 	r.RoutesRead = true
+	return nil
 }
 
-func (r *Router) WriteRoutes() {
+func (r *Router) WriteRoutes() error {
 	r.RoutesWritten = true
+	return nil
 }
 
 func (r *Router) FindFrontend(name string) (router.Frontend, bool) {
@@ -50,24 +52,35 @@ func (r *Router) DeleteBackends(name string) {
 	r.DeletedBackends = append(r.DeletedBackends, name)
 }
 
-func (r *Router) CreateFrontend(name, url string) {
+func (r *Router) CreateFrontend(name, url string) (*router.Frontend, error) {
+	frontend := router.Frontend{
+		Name:          name,
+		Backends:      make(map[string]router.Backend),
+		EndpointTable: make(map[string]router.Endpoint),
+		HostAliases:   make([]string, 0),
+	}
 	r.CreatedFrontends = append(r.CreatedFrontends, name)
+	return &frontend, nil
 }
 
-func (r *Router) DeleteFrontend(name string) {
+func (r *Router) DeleteFrontend(name string) error {
 	r.DeletedFrontends = append(r.DeletedFrontends, name)
+	return nil
 }
 
-func (r *Router) AddAlias(alias, frontendName string) {
+func (r *Router) AddAlias(alias, frontendName string) error {
 	r.AddedAliases[alias] = frontendName
+	return nil
 }
 
-func (r *Router) RemoveAlias(alias, frontendName string) {
+func (r *Router) RemoveAlias(alias, frontendName string) error {
 	r.RemovedAliases[alias] = frontendName
+	return nil
 }
 
-func (r *Router) AddRoute(frontend *router.Frontend, backend *router.Backend, endpoints []router.Endpoint) {
+func (r *Router) AddRoute(frontend *router.Frontend, backend *router.Backend, endpoints []router.Endpoint) error {
 	r.AddedRoutes[frontend.Name] = endpoints
+	return nil
 }
 
 func (r *Router) WriteConfig() {


### PR DESCRIPTION
- Add port forwarding from 8080 to localhost:8080 on VirtualBox
- Refactoring router.go to handle errors. Improving code coverage.
- Adding port forwarding from 80 to localhost:1080 on VirtualBox, and comments on how to test locally
- Applying refactor change to controller/test/test_router.go
- Fixing identation
- Fixing unit tests
- Merge
