### PR TITLE
Install assets more quietly

### DIFF
--- a/hack/install-assets.sh
+++ b/hack/install-assets.sh
@@ -5,6 +5,20 @@ set -e
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
 
+TMPDIR="${TMPDIR:-"/tmp"}"
+LOG_DIR="${LOG_DIR:-$(mktemp -d ${TMPDIR}/openshift.assets.logs.XXXX)}"
+
+function cmd() {
+  local cmd="$1"
+  local log_file=$(mktemp ${LOG_DIR}/install-assets.XXXX)}
+  echo "[install-assets] ${cmd}"
+  rc="0"
+  $cmd &> ${log_file} || rc=$?
+  if [ "$rc" != "0" ]; then
+    echo "[ERROR] Command '${cmd}' failed with ${rc}, logs:" && cat ${log_file}
+  fi
+}
+
 # If we are running inside of Travis then do not run the rest of this
 # script unless we want to TEST_ASSETS
 if [[ "${TRAVIS-}" == "true" && "${TEST_ASSETS-}" == "false" ]]; then
@@ -13,35 +27,35 @@ fi
 
 # Lock version of npm to work around https://github.com/npm/npm/issues/6309
 if [[ "${TRAVIS-}" == "true" ]]; then
-  npm install npm@2.1.1 -g
+  cmd "npm install npm@2.1.1" "npm.log"
 fi
 
 # Install bower if needed
 if ! which bower > /dev/null 2>&1 ; then
   if [[ "${TRAVIS-}" == "true" ]]; then
-    npm install -g bower
+    cmd "npm install -g bower"
   else
-    sudo npm install -g bower
+    cmd "sudo npm install -g bower"
   fi
 fi
  
 # Install grunt if needed
 if ! which grunt > /dev/null 2>&1 ; then
   if [[ "${TRAVIS-}" == "true" ]]; then
-    npm install -g grunt-cli
+    cmd "npm install -g grunt-cli"
   else
-    sudo npm install -g grunt-cli
+    cmd "sudo npm install -g grunt-cli"
   fi
 fi
 
 pushd ${OS_ROOT}/assets > /dev/null
-  npm install
+  cmd "npm install"
 
   # In case upstream components change things without incrementing versions
-  bower cache clean
-  bower install
+  cmd "bower cache clean"
+  cmd "bower install"
 
-  bundle install --path ${OS_ROOT}/assets/.bundle
+  cmd "bundle install --path ${OS_ROOT}/assets/.bundle"
 popd > /dev/null
 
 pushd ${OS_ROOT}/Godeps/_workspace > /dev/null


### PR DESCRIPTION
@jwforres @bparees I modified install-assets.sh to be more quiet, the main reason is that the npm install is flooding the Jenkins logs. This patch will return nothing when a successful install and print the log when an error happen.
