### PR TITLE
track down flaky travis

### DIFF
--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -50,6 +50,10 @@ func (r *REST) ResourceLocation(ctx kapi.Context, id string) (string, error) {
 		return "", fmt.Errorf("No such build: %v", err)
 	}
 
+	if len(build.PodName) == 0 {
+		return "", fmt.Errorf("build %v, does not have an associated pod name", id)
+	}
+
 	pod, err := r.PodControl.getPod(build.Namespace, build.PodName)
 	if err != nil {
 		return "", fmt.Errorf("No such pod: %v", err)

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -56,9 +56,15 @@ Examples:
 
 			// Print build logs before cancelling build.
 			if kubecmd.GetFlagBool(cmd, "dump-logs") {
-				response, err := client.Get().Namespace(namespace).Path("redirect").Path("buildLogs").Path(buildName).Do().Raw()
-				checkErr(err)
-				glog.V(2).Infof("Build logs for %s: %v", buildName, string(response))
+				// in order to dump logs, you must have a pod assigned to the build.  Since build pod creation is asynchronous, it is possible to cancel a build without a pod being assigned.
+				if len(build.PodName) == 0 {
+					glog.V(2).Infof("Build %v, does not have a pod assigned, so it does not have any logs.", buildName)
+
+				} else {
+					response, err := client.Get().Namespace(namespace).Path("redirect").Path("buildLogs").Path(buildName).Do().Raw()
+					checkErr(err)
+					glog.V(2).Infof("Build logs for %s:\n%v", buildName, string(response))
+				}
 			}
 
 			// Mark build to be cancelled.


### PR DESCRIPTION
Travis periodically flakes out on me in hack/test-cmd.sh on the cancel-build step with a message like:
`F1210 16:03:37.203456    5052 helpers.go:21] No such pod: data of kind 'PodList', obj of type 'Pod'`

I'm trying to track it down, so I'll need something to kick travis several times.

For example: https://travis-ci.org/openshift/origin/jobs/43612890, https://travis-ci.org/openshift/origin/jobs/43634629, https://travis-ci.org/openshift/origin/builds/43634549, and that's just today...
