### PR TITLE
tighten validation on client gets

### DIFF
--- a/pkg/client/buildconfigs.go
+++ b/pkg/client/buildconfigs.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -51,6 +53,10 @@ func (c *buildConfigs) List(label, field labels.Selector) (result *buildapi.Buil
 
 // Get returns information about a particular buildconfig and error if one occurs.
 func (c *buildConfigs) Get(name string) (result *buildapi.BuildConfig, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &buildapi.BuildConfig{}
 	err = c.r.Get().Namespace(c.ns).Path("buildConfigs").Path(name).Do().Into(result)
 	return

--- a/pkg/client/builds.go
+++ b/pkg/client/builds.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -51,6 +53,10 @@ func (c *builds) List(label, field labels.Selector) (result *buildapi.BuildList,
 
 // Get returns information about a particular build and error if one occurs.
 func (c *builds) Get(name string) (result *buildapi.Build, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &buildapi.Build{}
 	err = c.r.Get().Path("builds").Path(name).Do().Into(result)
 	return

--- a/pkg/client/deploymentconfigs.go
+++ b/pkg/client/deploymentconfigs.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -52,6 +54,10 @@ func (c *deploymentConfigs) List(label, field labels.Selector) (result *deployap
 
 // Get returns information about a particular deploymentConfig
 func (c *deploymentConfigs) Get(name string) (result *deployapi.DeploymentConfig, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &deployapi.DeploymentConfig{}
 	err = c.r.Get().Namespace(c.ns).Path("deploymentConfigs").Path(name).Do().Into(result)
 	return

--- a/pkg/client/deployments.go
+++ b/pkg/client/deployments.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -51,6 +53,10 @@ func (c *deployments) List(label, field labels.Selector) (result *deployapi.Depl
 
 // Get returns information about a particular deployment
 func (c *deployments) Get(name string) (result *deployapi.Deployment, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &deployapi.Deployment{}
 	err = c.r.Get().Namespace(c.ns).Path("deployments").Path(name).Do().Into(result)
 	return

--- a/pkg/client/imagerepositories.go
+++ b/pkg/client/imagerepositories.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -50,6 +52,10 @@ func (c *imageRepositories) List(label, field labels.Selector) (result *imageapi
 
 // Get returns information about a particular imagerepository and error if one occurs.
 func (c *imageRepositories) Get(name string) (result *imageapi.ImageRepository, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &imageapi.ImageRepository{}
 	err = c.r.Get().Namespace(c.ns).Path("imageRepositories").Path(name).Do().Into(result)
 	return

--- a/pkg/client/images.go
+++ b/pkg/client/images.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -47,6 +49,10 @@ func (c *images) List(label, field labels.Selector) (result *imageapi.ImageList,
 
 // Get returns information about a particular image and error if one occurs.
 func (c *images) Get(name string) (result *imageapi.Image, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &imageapi.Image{}
 	err = c.r.Get().Namespace(c.ns).Path("images").Path(name).Do().Into(result)
 	return

--- a/pkg/client/projects.go
+++ b/pkg/client/projects.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	_ "github.com/openshift/origin/pkg/user/api/v1beta1"
@@ -30,6 +32,10 @@ func newProjects(c *Client) *projects {
 
 // Get returns information about a particular user or an error
 func (c *projects) Get(name string) (result *projectapi.Project, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &projectapi.Project{}
 	err = c.r.Get().Path("projects").Path(name).Do().Into(result)
 	return

--- a/pkg/client/routes.go
+++ b/pkg/client/routes.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
@@ -51,6 +53,10 @@ func (c *routes) List(label, field labels.Selector) (result *routeapi.RouteList,
 
 // Get takes the name of the route, and returns the corresponding Route object, and an error if it occurs
 func (c *routes) Get(name string) (result *routeapi.Route, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &routeapi.Route{}
 	err = c.r.Get().Namespace(c.ns).Path("routes").Path(name).Do().Into(result)
 	return

--- a/pkg/client/users.go
+++ b/pkg/client/users.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+
 	userapi "github.com/openshift/origin/pkg/user/api"
 	_ "github.com/openshift/origin/pkg/user/api/v1beta1"
 )
@@ -29,6 +31,10 @@ func newUsers(c *Client) *users {
 
 // Get returns information about a particular user or an error
 func (c *users) Get(name string) (result *userapi.User, err error) {
+	if len(name) == 0 {
+		return nil, errors.New("name is required parameter to Get")
+	}
+
 	result = &userapi.User{}
 	err = c.r.Get().Path("users").Path(name).Do().Into(result)
 	return


### PR DESCRIPTION
This is corresponding origin change for: https://github.com/GoogleCloudPlatform/kubernetes/pull/2864

Currently, client Get calls that are missing names end up building a URL that hits the list API, but attempt to cast that resource list into a resource.  That produces an error message that looks like this: 
```
data of kind '<Resource>List', obj of type '<Resource>'
```

The cli protects you making such a call, but direct client API callers can still make the mistake. Even though it is caller error, the error message could be more obvious.

@derekwaynecarr you reviewed the kubernetes change.  This is just the matching one.