### PR TITLE
[WIP] Add selector filter to 'cli delete' cmd

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/delete.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/delete.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/spf13/cobra"
 )
 
@@ -49,16 +50,21 @@ Examples:
   $ kubectl delete pod 1234-56-7890-234234-456456
   <delete a pod with ID 1234-56-7890-234234-456456>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			selector := GetFlagString(cmd, "selector")
+			labelSelector, err := labels.ParseSelector(selector)
+			checkErr(err)
+
 			filename := GetFlagString(cmd, "filename")
 			mapping, namespace, name := ResourceFromArgsOrFile(cmd, args, filename, f.Typer, f.Mapper)
 			client, err := f.Client(cmd, mapping)
 			checkErr(err)
 
-			err = kubectl.NewRESTHelper(client, mapping).Delete(namespace, name)
+			err = kubectl.NewRESTHelper(client, mapping).Delete(namespace, name, labelSelector)
 			checkErr(err)
 			fmt.Fprintf(out, "%s\n", name)
 		},
 	}
 	cmd.Flags().StringP("filename", "f", "", "Filename or URL to file to use to delete the resource")
+	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
 	return cmd
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resthelper.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resthelper.go
@@ -61,8 +61,8 @@ func (m *RESTHelper) Watch(namespace, resourceVersion string, labelSelector, fie
 		Watch()
 }
 
-func (m *RESTHelper) Delete(namespace, name string) error {
-	return m.RESTClient.Delete().Path(m.Resource).Namespace(namespace).Path(name).Do().Error()
+func (m *RESTHelper) Delete(namespace, name string, selector labels.Selector) error {
+	return m.RESTClient.Delete().Path(m.Resource).Namespace(namespace).SelectorParam("labels", selector).Path(name).Do().Error()
 }
 
 func (m *RESTHelper) Create(namespace string, modify bool, data []byte) error {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resthelper_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resthelper_test.go
@@ -86,7 +86,7 @@ func TestRESTHelperDelete(t *testing.T) {
 		modifier := &RESTHelper{
 			RESTClient: client,
 		}
-		err := modifier.Delete("bar", "foo")
+		err := modifier.Delete("bar", "foo", labels.Everything())
 		if (err != nil) != test.Err {
 			t.Errorf("unexpected error: %t %v", test.Err, err)
 		}


### PR DESCRIPTION
Most of these changes will probably go UPSTREAM, unless I'm proven wrong. Let's discuss here first.

@smarterclayton @fabianofranz feedback would be appreciated.
- [x] `openshift cli delete -l template=guestbook-example pods redis-master`
- [ ] `openshift cli delete -l template=guestbook-example pods`
- [ ] `openshift cli delete -l template=guestbook-example pods,services`
