### PR TITLE
Implement deployments without Deployment

### DIFF
--- a/assets/app/scripts/controllers/project.js
+++ b/assets/app/scripts/controllers/project.js
@@ -117,14 +117,18 @@ angular.module('openshiftConsole')
     // Sets up subscription for deployments and deploymentsByConfig
     var deploymentsCallback = function(action, deployment) {
       $scope.$apply(function() {
-        DataService.objectByAttribute(deployment, "metadata.name", $scope.deployments, action);
-        DataService.objectByAttribute(deployment, "metadata.annotations.deploymentConfig", $scope.deploymentsByConfig, action, "id");
+        if (deployment.annotations && deployment.annotations.encodedDeploymentConfig) {
+          var depConfig = $.parseJSON(deployment.annotations.encodedDeploymentConfig);
+          deployment.details = depConfig.details;
+        }
+        DataService.objectByAttribute(deployment, "id", $scope.deployments, action);
+        DataService.objectByAttribute(deployment, "annotations.deploymentConfig", $scope.deploymentsByConfig, action, "id");
       });
 
       console.log("deployments (subscribe)", $scope.deployments);
       console.log("deploymentsByConfig (subscribe)", $scope.deploymentsByConfig);
     };
-    DataService.subscribe("deployments", deploymentsCallback, $scope);
+    DataService.subscribe("replicationControllers", deploymentsCallback, $scope);
 
     // Sets up subscription for images and imagesByDockerReference
     var imagesCallback = function(action, image) {

--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -12,7 +12,8 @@ angular.module('openshiftConsole')
     images : "osapi",
     projects : "osapi",
     pods : "api",
-    services : "api"
+    services : "api",
+    replicationControllers: "api"
   };
 
   function DataService() {

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -32,9 +32,9 @@
               </div>
             </div>
             <div ng-repeat="deployment in deploymentsByConfig[deploymentConfigId]" style="margin-top: 10px; text-align: center;">
-              <div ng-if="servicePodsByLabel.deployment[deployment.metadata.name]">
+              <div ng-if="servicePodsByLabel.deployment[deployment.id]">
                 <div class="small muted" ng-if="deployment" style="margin-bottom: 10px;">
-                  <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp>
+                  <relative-timestamp timestamp="deployment.creationTimestamp"></relative-timestamp>
                   <span ng-if="deployment.details && deployment.details.causes && deployment.details.causes.length > 0">
                     <span>, triggered by 
                       <span ng-repeat="cause in deployment.details.causes">
@@ -48,8 +48,8 @@
                 </div>
                 <div style="display: inline-block;">
                   <!-- TODO figure out why podTemplate can't be done the same way as pods -->
-                  <pod-template ng-init="podTemplate = deployment.controllerTemplate.podTemplate"></pod-template>
-                  <pods pods="servicePodsByLabel.deployment[deployment.metadata.name]"></pods>
+                  <pod-template ng-init="podTemplate = deployment.desiredState.podTemplate"></pod-template>
+                  <pods pods="servicePodsByLabel.deployment[deployment.id]"></pods>
                 </div>
               </div>
             </div>

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -6,6 +6,9 @@ import (
 
 // A deployment represents a single configuration of a pod deployed into the cluster, and may
 // represent both a current deployment or a historical deployment.
+//
+// DEPRECATED: This type longer drives any system behavior. Deployments are now represented directly
+// by ReplicationControllers. Use DeploymentConfig to drive deployments.
 type Deployment struct {
 	kapi.TypeMeta   `json:",inline" yaml:",inline"`
 	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
@@ -25,7 +28,7 @@ type Deployment struct {
 	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
 }
 
-// DeploymentStatus decribes the possible states a Deployment can be in.
+// DeploymentStatus decribes the possible states a deployment can be in.
 type DeploymentStatus string
 
 const (
@@ -72,30 +75,49 @@ type CustomDeploymentStrategyParams struct {
 }
 
 // A DeploymentList is a collection of deployments.
+// DEPRECATED: Like Deployment, this is no longer used.
 type DeploymentList struct {
 	kapi.TypeMeta `json:",inline" yaml:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	Items         []Deployment `json:"items" yaml:"items"`
 }
 
-// These constants represent annotation keys used for correlating objects related to deployments.
+// These constants represent keys used for correlating objects related to deployments.
 const (
+	// DeploymentConfigAnnotation is an annotation name used to correlate a deployment with the
+	// DeploymentConfig on which the deployment is based.
 	DeploymentConfigAnnotation = "deploymentConfig"
-	DeploymentAnnotation       = "deployment"
-	DeploymentPodAnnotation    = "pod"
+	// DeploymentAnnotation is an annotation on a deployer Pod. The annotation value is the name
+	// of the deployment (a ReplicationController) on which the deployer Pod acts.
+	DeploymentAnnotation = "deployment"
+	// DeploymentPodAnnotation is an annotation on a deployment (a ReplicationController). The
+	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
+	// to implement the deployment behavior.
+	DeploymentPodAnnotation = "pod"
+	// DeploymentStatusAnnotation is an annotation name used to retrieve the DeploymentStatus of
+	// a deployment.
+	DeploymentStatusAnnotation = "deploymentStatus"
+	// DeploymentEncodedConfigAnnotation is an annotation name used to retrieve specific encoded
+	// DeploymentConfig on which a given deployment is based.
+	DeploymentEncodedConfigAnnotation = "encodedDeploymentConfig"
+	// DeploymentVersionAnnotation is an annotation on a deployment (a ReplicationController). The
+	// annotation value is the LatestVersion value of the DeploymentConfig which was the basis for
+	// the deployment.
+	DeploymentVersionAnnotation = "deploymentVersion"
+	// DeploymentLabel is the name of a label used to correlate a deployment with the Pod created
+	// to execute the deployment logic.
 	// TODO: This is a workaround for upstream's lack of annotation support on PodTemplate. Once
 	// annotations are available on PodTemplate, audit this constant with the goal of removing it.
 	DeploymentLabel = "deployment"
-)
-
-// These constants represent label keys used for correlating objects related to deployment.
-const (
+	// DeploymentConfigLabel is the name of a label used to correlate a deployment with the
+	// DeploymentConfigs on which the deployment is based.
 	DeploymentConfigLabel = "deploymentconfig"
 )
 
-// DeploymentConfig represents a configuration for a single deployment of a replication controller:
-// what the template is for the deployment, how new deployments are triggered, what the desired
-// deployment state is.
+// DeploymentConfig represents a configuration for a single deployment (represented as a
+// ReplicationController). It also contains details about changes which resulted in the current
+// state of the DeploymentConfig. Each change to the DeploymentConfig which should result in
+// a new deployment results in an increment of LatestVersion.
 type DeploymentConfig struct {
 	kapi.TypeMeta   `json:",inline" yaml:",inline"`
 	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
@@ -113,7 +135,7 @@ type DeploymentConfig struct {
 	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
 }
 
-// DeploymentTemplate contains all the necessary information to create a Deployment from a
+// DeploymentTemplate contains all the necessary information to create a deployment from a
 // DeploymentStrategy.
 type DeploymentTemplate struct {
 	// Strategy describes how a deployment is executed.
@@ -122,7 +144,7 @@ type DeploymentTemplate struct {
 	ControllerTemplate kapi.ReplicationControllerSpec `json:"controllerTemplate,omitempty" yaml:"controllerTemplate,omitempty"`
 }
 
-// DeploymentTriggerPolicy describes a policy for a single trigger that results in a new Deployment.
+// DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
 type DeploymentTriggerPolicy struct {
 	Type DeploymentTriggerType `json:"type,omitempty" yaml:"type,omitempty"`
 	// ImageChangeParams represents the parameters for the ImageChange trigger.

--- a/pkg/deploy/controller/test/fake_deployment_store.go
+++ b/pkg/deploy/controller/test/fake_deployment_store.go
@@ -1,15 +1,15 @@
 package test
 
 import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
 type FakeDeploymentStore struct {
-	Deployment *deployapi.Deployment
+	Deployment *kapi.ReplicationController
 }
 
-func NewFakeDeploymentStore(deployment *deployapi.Deployment) FakeDeploymentStore {
+func NewFakeDeploymentStore(deployment *kapi.ReplicationController) FakeDeploymentStore {
 	return FakeDeploymentStore{deployment}
 }
 


### PR DESCRIPTION
## What?
This PR implements deployments without using the Deployment API object. ReplicationControllers are used as a replacement for Deployment.

## Why?
Since the metadata represented by Deployment can also be represented by ReplicationController annotations, the Deployment resource is a potentially unnecessary and complicating layer of indirection. Removing the resource would reduce the API surface area and bring tighter upstream integration. The original design discussion took place in #507.

Note that this PR does not actually remove Deployment from the public or internal API- that structure can be deprecated and removed separately.

#### TODO
- [x] Implement core design
- [x] Fix unit tests
- [x] Fix integration tests
- [x] Fix e2e tests
- [x] Update godocs
- [x] Address any existing UI code
