### PR TITLE
Set uid, creation timestamp using standard utility from kube

### DIFF
--- a/pkg/build/registry/build/rest.go
+++ b/pkg/build/registry/build/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/build/api"
@@ -73,7 +72,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 	if len(build.Status) == 0 {
 		build.Status = api.BuildStatusNew
 	}
-	build.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &build.ObjectMeta)
 	if errs := validation.ValidateBuild(build); len(errs) > 0 {
 		return nil, errors.NewInvalid("build", build.Name, errs)
 	}

--- a/pkg/build/registry/buildconfig/rest.go
+++ b/pkg/build/registry/buildconfig/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/build/api"
@@ -69,7 +68,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 	if len(buildConfig.Name) == 0 {
 		buildConfig.Name = uuid.NewUUID().String()
 	}
-	buildConfig.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &buildConfig.ObjectMeta)
 	if errs := validation.ValidateBuildConfig(buildConfig); len(errs) > 0 {
 		return nil, errors.NewInvalid("buildConfig", buildConfig.Name, errs)
 	}

--- a/pkg/deploy/registry/deploy/rest.go
+++ b/pkg/deploy/registry/deploy/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 
@@ -70,7 +69,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, kerrors.NewConflict("deployment", deployment.Namespace, fmt.Errorf("Deployment.Namespace does not match the provided context"))
 	}
 
-	deployment.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &deployment.ObjectMeta)
 
 	if len(deployment.Name) == 0 {
 		deployment.Name = uuid.NewUUID().String()

--- a/pkg/deploy/registry/deployconfig/rest.go
+++ b/pkg/deploy/registry/deployconfig/rest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 
@@ -73,7 +72,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("not a deploymentConfig: %#v", obj)
 	}
 
-	deploymentConfig.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &deploymentConfig.ObjectMeta)
 
 	if len(deploymentConfig.Name) == 0 {
 		deploymentConfig.Name = uuid.NewUUID().String()

--- a/pkg/image/registry/image/rest.go
+++ b/pkg/image/registry/image/rest.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/image/api"
@@ -59,7 +58,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, errors.NewConflict("image", image.Namespace, fmt.Errorf("Image.Namespace does not match the provided context"))
 	}
 
-	image.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &image.ObjectMeta)
 
 	if errs := validation.ValidateImage(image); len(errs) > 0 {
 		return nil, errors.NewInvalid("image", image.Name, errs)

--- a/pkg/image/registry/imagerepository/rest.go
+++ b/pkg/image/registry/imagerepository/rest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/image/api"
@@ -82,7 +81,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		repo.Tags = make(map[string]string)
 	}
 
-	repo.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &repo.ObjectMeta)
 	repo.Status = api.ImageRepositoryStatus{}
 
 	return apiserver.MakeAsync(func() (runtime.Object, error) {

--- a/pkg/image/registry/imagerepositorymapping/rest.go
+++ b/pkg/image/registry/imagerepositorymapping/rest.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
@@ -73,7 +72,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 
 	image := mapping.Image
 
-	image.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &image.ObjectMeta)
 
 	//TODO apply metadata overrides
 	if repo.Tags == nil {

--- a/pkg/oauth/registry/accesstoken/rest.go
+++ b/pkg/oauth/registry/accesstoken/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
@@ -56,8 +55,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("not an token: %#v", obj)
 	}
 
-	token.CreationTimestamp = util.Now()
-	token.UID = util.NewUUID().String()
+	kapi.FillObjectMetaSystemFields(ctx, &token.ObjectMeta)
 
 	if errs := validation.ValidateAccessToken(token); len(errs) > 0 {
 		return nil, kerrors.NewInvalid("token", token.Name, errs)

--- a/pkg/oauth/registry/authorizetoken/rest.go
+++ b/pkg/oauth/registry/authorizetoken/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
@@ -57,8 +56,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("not an token: %#v", obj)
 	}
 
-	token.CreationTimestamp = util.Now()
-	token.UID = util.NewUUID().String()
+	kapi.FillObjectMetaSystemFields(ctx, &token.ObjectMeta)
 
 	if errs := validation.ValidateAuthorizeToken(token); len(errs) > 0 {
 		return nil, kerrors.NewInvalid("token", token.Name, errs)

--- a/pkg/oauth/registry/client/rest.go
+++ b/pkg/oauth/registry/client/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
@@ -57,8 +56,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("not an client: %#v", obj)
 	}
 
-	client.CreationTimestamp = util.Now()
-	client.UID = util.NewUUID().String()
+	kapi.FillObjectMetaSystemFields(ctx, &client.ObjectMeta)
 
 	if errs := validation.ValidateClient(client); len(errs) > 0 {
 		return nil, kerrors.NewInvalid("client", client.Name, errs)

--- a/pkg/oauth/registry/clientauthorization/rest.go
+++ b/pkg/oauth/registry/clientauthorization/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/api/validation"
@@ -56,8 +55,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 	}
 
 	authorization.Name = s.registry.ClientAuthorizationName(authorization.UserName, authorization.ClientName)
-	authorization.CreationTimestamp = util.Now()
-	authorization.UID = util.NewUUID().String()
+	kapi.FillObjectMetaSystemFields(ctx, &authorization.ObjectMeta)
 
 	if errs := validation.ValidateClientAuthorization(authorization); len(errs) > 0 {
 		return nil, kerrors.NewInvalid("clientAuthorization", authorization.Name, errs)

--- a/pkg/project/registry/project/rest.go
+++ b/pkg/project/registry/project/rest.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/project/api"
 	"github.com/openshift/origin/pkg/project/api/validation"
@@ -61,8 +60,9 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		project.Namespace = project.Name
 	}
 
+	kapi.FillObjectMetaSystemFields(ctx, &project.ObjectMeta)
+
 	// TODO set an id if not provided?, set a Namespace attribute if not provided?
-	project.CreationTimestamp = util.Now()
 
 	if errs := validation.ValidateProject(project); len(errs) > 0 {
 		return nil, errors.NewInvalid("project", project.Name, errs)

--- a/pkg/route/registry/route/rest.go
+++ b/pkg/route/registry/route/rest.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/route/api"
@@ -77,7 +76,7 @@ func (rs *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.R
 		route.Name = uuid.NewUUID().String()
 	}
 
-	route.CreationTimestamp = util.Now()
+	kapi.FillObjectMetaSystemFields(ctx, &route.ObjectMeta)
 
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
 		err := rs.registry.CreateRoute(ctx, route)

--- a/pkg/template/registry/rest.go
+++ b/pkg/template/registry/rest.go
@@ -43,6 +43,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 	if !ok {
 		return nil, errors.New("Not a template config.")
 	}
+	kapi.FillObjectMetaSystemFields(ctx, &tpl.ObjectMeta)
 	if errs := validation.ValidateTemplate(tpl); len(errs) > 0 {
 		return nil, fmt.Errorf("Invalid template config: %#v", errs)
 	}


### PR DESCRIPTION
Took a pass through existing resources in origin repo and ensured that uid / creation timestamp is being set using the upstream kube utility.
