### PR TITLE
Ensure namespace will work when moved as path param

### DIFF
--- a/pkg/client/buildconfigs.go
+++ b/pkg/client/buildconfigs.go
@@ -78,8 +78,8 @@ func (c *buildConfigs) Delete(name string) error {
 // Watch returns a watch.Interface that watches the requested buildConfigs.
 func (c *buildConfigs) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
-		Namespace(c.ns).
 		Path("watch").
+		Namespace(c.ns).
 		Path("buildConfigs").
 		Param("resourceVersion", resourceVersion).
 		SelectorParam("labels", label).

--- a/pkg/client/builds.go
+++ b/pkg/client/builds.go
@@ -52,7 +52,7 @@ func (c *builds) List(label, field labels.Selector) (result *buildapi.BuildList,
 // Get returns information about a particular build and error if one occurs.
 func (c *builds) Get(name string) (result *buildapi.Build, err error) {
 	result = &buildapi.Build{}
-	err = c.r.Get().Path("builds").Path(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Path("builds").Path(name).Do().Into(result)
 	return
 }
 
@@ -79,8 +79,8 @@ func (c *builds) Delete(name string) (err error) {
 // Watch returns a watch.Interfac that watches the requested builds
 func (c *builds) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
-		Namespace(c.ns).
 		Path("watch").
+		Namespace(c.ns).
 		Path("builds").
 		Param("resourceVersion", resourceVersion).
 		SelectorParam("labels", label).

--- a/pkg/client/deploymentconfigs.go
+++ b/pkg/client/deploymentconfigs.go
@@ -79,8 +79,8 @@ func (c *deploymentConfigs) Delete(name string) error {
 // Watch returns a watch.Interface that watches the requested deploymentConfigs.
 func (c *deploymentConfigs) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
-		Namespace(c.ns).
 		Path("watch").
+		Namespace(c.ns).
 		Path("deploymentConfigs").
 		Param("resourceVersion", resourceVersion).
 		SelectorParam("labels", label).

--- a/pkg/client/deployments.go
+++ b/pkg/client/deployments.go
@@ -78,8 +78,8 @@ func (c *deployments) Delete(name string) error {
 // Watch returns a watch.Interface that watches the requested deployments.
 func (c *deployments) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
-		Namespace(c.ns).
 		Path("watch").
+		Namespace(c.ns).
 		Path("deployments").
 		Param("resourceVersion", resourceVersion).
 		SelectorParam("labels", label).

--- a/pkg/client/imagerepositories.go
+++ b/pkg/client/imagerepositories.go
@@ -72,8 +72,8 @@ func (c *imageRepositories) Update(repo *imageapi.ImageRepository) (result *imag
 // Watch returns a watch.Interface that watches the requested imagerepositories.
 func (c *imageRepositories) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
-		Namespace(c.ns).
 		Path("watch").
+		Namespace(c.ns).
 		Path("imageRepositories").
 		Param("resourceVersion", resourceVersion).
 		SelectorParam("labels", label).

--- a/pkg/client/routes.go
+++ b/pkg/client/routes.go
@@ -78,8 +78,8 @@ func (c *routes) Update(route *routeapi.Route) (result *routeapi.Route, err erro
 // Watch returns a watch.Interface that watches the requested routes.
 func (c *routes) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
-		Namespace(c.ns).
 		Path("watch").
+		Namespace(c.ns).
 		Path("routes").
 		Param("resourceVersion", resourceVersion).
 		SelectorParam("labels", label).


### PR DESCRIPTION
This is the client side change to ensure that when we get Kubernetes upstream:
https://github.com/GoogleCloudPlatform/kubernetes/pull/2813

And we enable namespace as path param in our client, that the client will output proper URLs.

Main change fixed here is to ensure that watch URLs are of form:

/watch/{ns}/{namespace}/{resource}
