### PR TITLE
Improvements to kubectl/cli process command

### DIFF
--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -3,10 +3,14 @@ package cmd
 import (
 	"io"
 	"os"
+	"strings"
 
 	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/cmd/client"
+	"github.com/openshift/origin/pkg/template"
+	"github.com/openshift/origin/pkg/template/api"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +36,7 @@ Examples:
 
 			schema, err := f.Validator(cmd)
 			checkErr(err)
-			_, namespace, _, data := kubecmd.ResourceFromFile(filename, f.Typer, f.Mapper, schema)
+			mappings, namespace, _, data := kubecmd.ResourceFromFile(filename, f.Typer, f.Mapper, schema)
 			if len(namespace) == 0 {
 				namespace = getOriginNamespace(cmd)
 			} else {
@@ -44,6 +48,49 @@ Examples:
 			checkErr(err)
 			c, err := f.Client(cmd, mapping)
 			checkErr(err)
+
+			// User can override Template parameters by using --value(-v) option with
+			// list of key-value pairs.
+			// TODO: This should be done on server-side to make other clients life
+			//			 easier.
+			if cmd.Flag("value").Changed {
+				values := util.StringList{}
+				values.Set(kubecmd.GetFlagString(cmd, "value"))
+				templateObj, err := mappings.Codec.Decode(data)
+				checkErr(err)
+				t := templateObj.(*api.Template)
+				for _, keypair := range values {
+					p := strings.SplitN(keypair, "=", 2)
+					if len(p) != 2 {
+						glog.Errorf("Invalid parameter assignment '%s'", keypair)
+						continue
+					}
+					if v := template.GetParameterByName(t, p[0]); v != nil {
+						v.Value = p[1]
+						v.Generate = ""
+						template.AddParameter(t, *v)
+					} else {
+						glog.Errorf("Unknown parameter name '%s'", p[0])
+					}
+				}
+				data, err = mapping.Codec.Encode(t)
+				checkErr(err)
+			}
+
+			// Print template parameters will cause template stop processing.
+			// Users can see what parameters can be overriden and will be set in the
+			// template.
+			if kubecmd.GetFlagBool(cmd, "parameters") {
+				obj, err := mapping.Codec.Decode(data)
+				checkErr(err)
+				printer, err := f.Printer(cmd, mapping, kubecmd.GetFlagBool(cmd, "no-headers"))
+				checkErr(err)
+				if t, ok := obj.(*api.Template); ok {
+					err = printer.PrintObj(t, out)
+					checkErr(err)
+				}
+				return
+			}
 
 			request := c.Post().Namespace(namespace).Path(mapping.Resource).Body(data)
 			result := request.Do()
@@ -58,5 +105,8 @@ Examples:
 		},
 	}
 	cmd.Flags().StringP("filename", "f", "", "Filename or URL to file to use to update the resource")
+	cmd.Flags().StringP("value", "v", "", "Specify a list of key-value pairs (eg. -v FOO=BAR,BAR=FOO) to set/override parameter values")
+	cmd.Flags().BoolP("parameters", "", false, "Do not process but only print available parameters")
+	cmd.Flags().Bool("no-headers", false, "When using the default output, don't print headers")
 	return cmd
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -84,8 +84,8 @@ func (p *Processor) Process(template *api.Template) (*configapi.Config, errs.Val
 
 // AddParameter adds new custom parameter to the Template. It overrides
 // the existing parameter, if already defined.
-func (p *Processor) AddParameter(t *api.Template, param api.Parameter) {
-	if existing := p.GetParameterByName(t, param.Name); existing != nil {
+func AddParameter(t *api.Template, param api.Parameter) {
+	if existing := GetParameterByName(t, param.Name); existing != nil {
 		*existing = param
 	} else {
 		t.Parameters = append(t.Parameters, param)
@@ -94,7 +94,7 @@ func (p *Processor) AddParameter(t *api.Template, param api.Parameter) {
 
 // GetParameterByName searches for a Parameter in the Template
 // based on it's name.
-func (p *Processor) GetParameterByName(t *api.Template, name string) *api.Parameter {
+func GetParameterByName(t *api.Template, name string) *api.Parameter {
 	for i, param := range t.Parameters {
 		if param.Name == name {
 			return &(t.Parameters[i])

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -38,11 +38,10 @@ func TestAddParameter(t *testing.T) {
 	jsonData, _ := ioutil.ReadFile("../../examples/guestbook/template.json")
 	json.Unmarshal(jsonData, &template)
 
-	processor := NewProcessor(nil)
-	processor.AddParameter(&template, makeParameter("CUSTOM_PARAM", "1", ""))
-	processor.AddParameter(&template, makeParameter("CUSTOM_PARAM", "2", ""))
+	AddParameter(&template, makeParameter("CUSTOM_PARAM", "1", ""))
+	AddParameter(&template, makeParameter("CUSTOM_PARAM", "2", ""))
 
-	if p := processor.GetParameterByName(&template, "CUSTOM_PARAM"); p == nil {
+	if p := GetParameterByName(&template, "CUSTOM_PARAM"); p == nil {
 		t.Errorf("Unable to add a custom parameter to the template")
 	} else {
 		if p.Value != "2" {
@@ -126,7 +125,7 @@ func ExampleProcessTemplateParameters() {
 	processor := NewProcessor(generators)
 
 	// Define custom parameter for the transformation:
-	processor.AddParameter(&template, makeParameter("CUSTOM_PARAM1", "1", ""))
+	AddParameter(&template, makeParameter("CUSTOM_PARAM1", "1", ""))
 
 	// Transform the template config into the result config
 	config, err := processor.Process(&template)


### PR DESCRIPTION
This patch will allow to:

1) Print out all parameters from the template to console to inspect them (this will stop further processing):
```
$ openshift cli process -f template.json --parameters
```

2) Override/set values for multiple parameters using command-line:
```
$ openshift cli process -f template.json -v ADMIN_USERNAME=foo,ADMIN_PASSWORD=bar
```

You can combine these two together.