### PR TITLE
Make grunt hostname/port configurable

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -70,9 +70,9 @@ module.exports = function (grunt) {
     // The actual grunt server settings
     connect: {
       options: {
-        port: 9000,
+        port: grunt.option('port') || 9000,
         // Change this to '0.0.0.0' to access the server from outside.
-        hostname: 'localhost',
+        hostname: grunt.option('hostname') || 'localhost',
         livereload: 35729
       },
       livereload: {

--- a/hack/serve-local-assets.sh
+++ b/hack/serve-local-assets.sh
@@ -5,6 +5,9 @@ set -e
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
 
+GRUNT_PORT=${GRUNT_PORT:-9000}
+GRUNT_HOSTNAME=${GRUNT_HOSTNAME:-localhost}
+
 pushd "${OS_ROOT}/assets" > /dev/null
-  bundle exec grunt serve
+  bundle exec grunt serve --port=$GRUNT_PORT --hostname=$GRUNT_HOSTNAME
 popd > /dev/null


### PR DESCRIPTION
Add GRUNT_HOSTNAME and GRUNT_PORT env var support to the local grunt server
script for local development flexibility (e.g. forwarded ports from a VM).