### PR TITLE
tweaked getting started readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,25 @@ Getting Started
 ---------------
 The simplest way to start is to run OpenShift Origin in a Docker container:
 
-    $ docker run -v /var/run/docker.sock:/var/run/docker.sock --net=host --privileged openshift/origin start
+    $ docker run -d --name "openshift-origin" --net=host --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    openshift/origin start
 
-Note that this won't hold any data after a restart, so you'll need to use a data container or mount a volume at `/var/lib/openshift` to preserve that data.  Once the container is started, run:
+Note that this won't hold any data after a restart, so you'll need to use a data
+container or mount a volume at `/var/lib/openshift` to preserve that data. For
+example, create a `/var/lib/openshift` folder on your Docker host, and then
+start origin with the following:
 
-    $ docker run --net=host openshift/origin kubectl --help
+    $ docker run -d --name "openshift-origin" --net=host --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /var/lib/openshift:/var/lib/openshift \
+    openshift/origin start
 
-to see the command line options you can use (if you don't specify `--net=host`, you'll need to pass `-h <hostip>` to the CLI to connect).
+Once the container is started, you will likely want to attach to it in order to
+execute commands:
+
+    $ docker exec -it openshift-origin bash
+    $ openshift cli --help
 
 ### Start Developing
 

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -5,6 +5,10 @@ This is a set of configuration files and scripts which work with OpenShift 3 to 
 
 This example assumes you have successfully built the `openshift` binary executable and have Docker installed/working.  See https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc.
 
+Alternatively, if you are using the openshift/origin Docker container, please
+make sure you follow these instructions first:
+https://github.com/openshift/origin/blob/master/examples/sample-app/container-setup.md
+
 Setup
 -----
 Before running these steps, you'll need to configure the docker daemon on your host to trust the docker registry service you'll be starting.

--- a/examples/sample-app/container-setup.md
+++ b/examples/sample-app/container-setup.md
@@ -1,0 +1,67 @@
+# Container Setup for the Sample Application
+OpenShift Origin is available as a [Docker](https://www.docker.io) container. It
+has all of the software prebuilt and pre-installed, but you do need to do a few
+things to get it going.
+
+## Download and Run OpenShift Origin
+If you have not already, perform the following to (download and) run the Origin
+Docker container:
+
+    $ docker run -d --name "openshift-origin" --net=host --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    openshift/origin start
+
+Note that this won't hold any data after a restart, so you'll need to use a data
+container or mount a volume at `/var/lib/openshift` to preserve that data. For
+example, create a `/var/lib/openshift` folder on your Docker host, and then
+start origin with the following:
+
+    $ docker run -d --name "openshift-origin" --net=host --privileged \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /var/lib/openshift:/var/lib/openshift \
+    openshift/origin start
+
+## Preparing the Docker Host
+On your **Docker host** you will need to fetch some images. You can do so by
+running the pullimages.sh script like so:
+
+    $ sh <(curl \
+    https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/pullimages.sh)
+
+This will fetch several Docker images that are used as part of the Sample
+Application.
+
+Next, be sure to follow the **Setup** instructions for the Sample Application
+regarding an "insecure" Docker registry.
+
+## Connect to the OpenShift Container
+Once the container is started, you need to attach to it in order to execute
+commands:
+
+    $ docker exec -it openshift-origin bash
+
+You may or may not want to change the bash prompt inside this container so that
+you know where you are:
+
+    $ PS1="openshift-dock: [\u@\h \W]\$ "
+
+## Get the Sample Application Code
+Inside the OpenShift Docker container, you'll need to fetch some of the code
+bits that are used in the sample app.
+
+    $ wget \
+    https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/docker-registry-config.json
+    $ wget \
+    https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/application-template-stibuild.json
+
+## Continue With Sample Application
+At this point you can continue with the steps in the [Sample
+Application](https://github.com/openshift/origin/blob/master/examples/sample-app/README.md),
+starting from [Application Build, Deploy, and Update
+Flow](https://github.com/openshift/origin/blob/master/examples/sample-app/README.md#application-build-deploy-and-update-flow),
+step #3.
+
+You can watch the OpenShift logs by issuing the following on your **Docker
+host**:
+
+    $ docker attach openshift-origin


### PR DESCRIPTION
There was some confusion in the getting started readme section about the "quickest" way to get up and going. Here are a couple of tweaks to the documentation of that section.

Now, instead of a separate docker container to run kubectl (which is now really openshift cli), you connect to the existing openshift container with bash. This makes following some of the subsequent exercises a touch easier.

There are also instructions for following the "sample app" example when using the all-in-one docker container.