### PR TITLE
Double error print in the OpenShift command

### DIFF
--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -12,7 +11,6 @@ func main() {
 	basename := filepath.Base(os.Args[0])
 	command := openshift.CommandFor(basename)
 	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
In cobra, it is not necessary to print the returned error, because it has already
been printed by command.Execute().