### PR TITLE
Do not tag with GIT ref when the SOURCE_REF is not set (sti-image-builder)

### DIFF
--- a/images/builder/docker/sti-image-builder/bin/build.sh
+++ b/images/builder/docker/sti-image-builder/bin/build.sh
@@ -48,8 +48,15 @@ pushd $source_dir >/dev/null
 popd >/dev/null
 
 # After successfull build, retag the image to 'qa-ready'
-# TODO: Define image promotion process
 #
 image_id=$(docker inspect --format="{{ .Id }}" ${IMAGE_NAME}-candidate:latest)
 docker tag ${image_id} ${IMAGE_NAME}:qa-ready
-docker tag ${image_id} ${IMAGE_NAME}:git-$SOURCE_REF
+
+# Tag the image with the GIT ref if the SOURCE_REF is set
+#
+if ! [ -z "${SOURCE_REF}" ]; then
+  docker tag ${image_id} ${IMAGE_NAME}:git-$SOURCE_REF
+fi
+
+# Remove the candidate image after build
+docker rmi ${IMAGE_NAME}-candidate


### PR DESCRIPTION
This PR just prevents sti-imagebuilder from tagging the image with GIT ref if it is not set (IOW. you start the build using 'start-build' command).

Also it will remove the -candidate image as it is not longer needed.