### PR TITLE
document git requirement

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -32,8 +32,9 @@ You can develop OpenShift 3 on Windows, Mac, or Linux, but you'll need Docker in
 
 Here's how to get set up:
 
-1. For Go and optionally also Docker, follow the links below to get to installation information for these tools: +
+1. For Go, Git and optionally also Docker, follow the links below to get to installation information for these tools: +
 ** http://golang.org/doc/install[Installing Go]
+** http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Installing Git]
 ** https://docs.docker.com/installation/#installation[Installing Docker]
 2. Next, create a Go workspace directory: +
 +


### PR DESCRIPTION
On a bare minimum system like fedora 21 cloud product, git is not installed by default. If user does not install `git`, then `go get` does not work (and user can't submit patches and PR also).
Might be obvious but thought it's nice to be in there.