### PR TITLE
Introduce a deployment rollback API

### DIFF
--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -1,18 +1,22 @@
 package deployer
 
 import (
-	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	strategy "github.com/openshift/origin/pkg/deploy/strategy/recreate"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
 const longCommandDesc = `
@@ -27,7 +31,12 @@ type config struct {
 	Namespace      string
 }
 
-// NewCommandDeployer provides a CLI handler for deploy
+type replicationControllerGetter interface {
+	Get(namespace, name string) (*kapi.ReplicationController, error)
+	List(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error)
+}
+
+// NewCommandDeployer provides a CLI handler for deploy.
 func NewCommandDeployer(name string) *cobra.Command {
 	cfg := &config{
 		Config: clientcmd.NewConfig(),
@@ -38,7 +47,20 @@ func NewCommandDeployer(name string) *cobra.Command {
 		Short: "Run the OpenShift deployer",
 		Long:  longCommandDesc,
 		Run: func(c *cobra.Command, args []string) {
-			if err := deploy(cfg); err != nil {
+			kClient, _, err := cfg.Config.Clients()
+			if err != nil {
+				glog.Fatal(err)
+			}
+
+			if len(cfg.DeploymentName) == 0 {
+				glog.Fatal("deployment is required")
+			}
+
+			if len(cfg.Namespace) == 0 {
+				glog.Fatal("namespace is required")
+			}
+
+			if err = deploy(kClient, cfg.Namespace, cfg.DeploymentName); err != nil {
 				glog.Fatal(err)
 			}
 		},
@@ -52,18 +74,11 @@ func NewCommandDeployer(name string) *cobra.Command {
 	return cmd
 }
 
-// deploy starts the deployer
-func deploy(cfg *config) error {
-	kClient, _, err := cfg.Config.Clients()
-	if err != nil {
-		return err
-	}
-	if len(cfg.DeploymentName) == 0 {
-		return errors.New("No deployment name was specified.")
-	}
+// deploy executes a deployment strategy.
+func deploy(kClient kclient.Interface, namespace, deploymentName string) error {
+	newDeployment, oldDeployments, err := getDeployerContext(&realReplicationControllerGetter{kClient}, namespace, deploymentName)
 
-	var deployment *kapi.ReplicationController
-	if deployment, err = kClient.ReplicationControllers(cfg.Namespace).Get(cfg.DeploymentName); err != nil {
+	if err != nil {
 		return err
 	}
 
@@ -72,5 +87,76 @@ func deploy(cfg *config) error {
 		ReplicationController: strategy.RealReplicationController{KubeClient: kClient},
 		Codec: latest.Codec,
 	}
-	return strategy.Deploy(deployment)
+
+	return strategy.Deploy(newDeployment, oldDeployments)
+}
+
+// getDeployerContext finds the target deployment and any deployments it considers to be prior to the
+// target deployment. Only deployments whose LatestVersion is less than the target deployment are
+// considered to be prior.
+func getDeployerContext(controllerGetter replicationControllerGetter, namespace, deploymentName string) (*kapi.ReplicationController, []kapi.ObjectReference, error) {
+	var err error
+	var newDeployment *kapi.ReplicationController
+	var newConfig *deployapi.DeploymentConfig
+
+	// Look up the new deployment and its associated config.
+	if newDeployment, err = controllerGetter.Get(namespace, deploymentName); err != nil {
+		return nil, nil, err
+	}
+
+	if newConfig, err = deployutil.DecodeDeploymentConfig(newDeployment, latest.Codec); err != nil {
+		return nil, nil, err
+	}
+
+	glog.Infof("Found new deployment %s for config %s with latestVersion %d", newDeployment.Name, newConfig.Name, newConfig.LatestVersion)
+
+	// Collect all deployments that predate the new one by comparing all old ReplicationControllers with
+	// encoded DeploymentConfigs to the new one by LatestVersion. Treat a failure to interpret a given
+	// old deployment as a fatal error to prevent overlapping deployments.
+	var allControllers *kapi.ReplicationControllerList
+	oldDeployments := []kapi.ObjectReference{}
+
+	if allControllers, err = controllerGetter.List(newDeployment.Namespace, labels.Everything()); err != nil {
+		return nil, nil, fmt.Errorf("Unable to get list replication controllers in deployment namespace %s: %v", newDeployment.Namespace, err)
+	}
+
+	glog.Infof("Inspecting %d potential prior deployments", len(allControllers.Items))
+	for _, controller := range allControllers.Items {
+		if configName, hasConfigName := controller.Annotations[deployapi.DeploymentConfigAnnotation]; !hasConfigName {
+			glog.Infof("Disregarding replicationController %s (not a deployment)", controller.Name)
+			continue
+		} else if configName != newConfig.Name {
+			glog.Infof("Disregarding deployment %s (doesn't match target deploymentConfig %s)", controller.Name, configName)
+			continue
+		}
+
+		var oldVersion int
+		if oldVersion, err = strconv.Atoi(controller.Annotations[deployapi.DeploymentVersionAnnotation]); err != nil {
+			return nil, nil, fmt.Errorf("Couldn't determine version of deployment %s: %v", controller.Name, err)
+		}
+
+		if oldVersion < newConfig.LatestVersion {
+			glog.Infof("Marking deployment %s as a prior deployment", controller.Name)
+			oldDeployments = append(oldDeployments, kapi.ObjectReference{
+				Namespace: controller.Namespace,
+				Name:      controller.Name,
+			})
+		} else {
+			glog.Infof("Disregarding deployment %s (same as or newer than target)", controller.Name)
+		}
+	}
+
+	return newDeployment, oldDeployments, nil
+}
+
+type realReplicationControllerGetter struct {
+	kClient kclient.Interface
+}
+
+func (r *realReplicationControllerGetter) Get(namespace, name string) (*kapi.ReplicationController, error) {
+	return r.kClient.ReplicationControllers(namespace).Get(name)
+}
+
+func (r *realReplicationControllerGetter) List(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+	return r.kClient.ReplicationControllers(namespace).List(selector)
 }

--- a/pkg/cmd/infra/deployer/deployer_test.go
+++ b/pkg/cmd/infra/deployer/deployer_test.go
@@ -1,0 +1,188 @@
+package deployer
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+func TestGetDeploymentContextMissingDeployment(t *testing.T) {
+	getter := &testReplicationControllerGetter{
+		getFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+			return nil, kerrors.NewNotFound("replicationController", name)
+		},
+		listFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+			t.Fatal("unexpected list call")
+			return nil, nil
+		},
+	}
+
+	newDeployment, oldDeployments, err := getDeployerContext(getter, kapi.NamespaceDefault, "deployment")
+
+	if newDeployment != nil {
+		t.Fatalf("unexpected newDeployment: %#v", newDeployment)
+	}
+
+	if oldDeployments != nil {
+		t.Fatalf("unexpected oldDeployments: %#v", oldDeployments)
+	}
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+func TestGetDeploymentContextInvalidEncodedConfig(t *testing.T) {
+	getter := &testReplicationControllerGetter{
+		getFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+			return &kapi.ReplicationController{}, nil
+		},
+		listFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+			return &kapi.ReplicationControllerList{}, nil
+		},
+	}
+
+	newDeployment, oldDeployments, err := getDeployerContext(getter, kapi.NamespaceDefault, "deployment")
+
+	if newDeployment != nil {
+		t.Fatalf("unexpected newDeployment: %#v", newDeployment)
+	}
+
+	if oldDeployments != nil {
+		t.Fatalf("unexpected oldDeployments: %#v", oldDeployments)
+	}
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+func TestGetDeploymentContextNoPriorDeployments(t *testing.T) {
+	getter := &testReplicationControllerGetter{
+		getFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+			deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+			return deployment, nil
+		},
+		listFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+			return &kapi.ReplicationControllerList{}, nil
+		},
+	}
+
+	newDeployment, oldDeployments, err := getDeployerContext(getter, kapi.NamespaceDefault, "deployment")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if newDeployment == nil {
+		t.Fatal("expected deployment")
+	}
+
+	if oldDeployments == nil {
+		t.Fatal("expected non-nil oldDeployments")
+	}
+
+	if len(oldDeployments) > 0 {
+		t.Fatalf("unexpected non-empty oldDeployments: %#v", oldDeployments)
+	}
+}
+
+func TestGetDeploymentContextWithPriorDeployments(t *testing.T) {
+	getter := &testReplicationControllerGetter{
+		getFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+			deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(2), kapi.Codec)
+			return deployment, nil
+		},
+		listFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+			deployment1, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+			deployment2, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(2), kapi.Codec)
+			deployment3, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(3), kapi.Codec)
+			deployment4, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+			deployment4.Annotations[deployapi.DeploymentConfigAnnotation] = "another-config"
+			return &kapi.ReplicationControllerList{
+				Items: []kapi.ReplicationController{
+					*deployment1,
+					*deployment2,
+					*deployment3,
+					*deployment4,
+					{},
+				},
+			}, nil
+		},
+	}
+
+	newDeployment, oldDeployments, err := getDeployerContext(getter, kapi.NamespaceDefault, "deployment")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if newDeployment == nil {
+		t.Fatal("expected deployment")
+	}
+
+	if oldDeployments == nil {
+		t.Fatal("expected non-nil oldDeployments")
+	}
+
+	if e, a := 1, len(oldDeployments); e != a {
+		t.Fatalf("expected oldDeployments with size %d, got %d: %#v", e, a, oldDeployments)
+	}
+}
+
+func TestGetDeploymentContextInvalidPriorDeployment(t *testing.T) {
+	getter := &testReplicationControllerGetter{
+		getFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+			deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+			return deployment, nil
+		},
+		listFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+			return &kapi.ReplicationControllerList{
+				Items: []kapi.ReplicationController{
+					{
+						ObjectMeta: kapi.ObjectMeta{
+							Name: "corrupt-deployment",
+							Annotations: map[string]string{
+								deployapi.DeploymentConfigAnnotation:  "config",
+								deployapi.DeploymentVersionAnnotation: "junk",
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	newDeployment, oldDeployments, err := getDeployerContext(getter, kapi.NamespaceDefault, "deployment")
+
+	if newDeployment != nil {
+		t.Fatalf("unexpected newDeployment: %#v", newDeployment)
+	}
+
+	if oldDeployments != nil {
+		t.Fatalf("unexpected oldDeployments: %#v", oldDeployments)
+	}
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+type testReplicationControllerGetter struct {
+	getFunc  func(namespace, name string) (*kapi.ReplicationController, error)
+	listFunc func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error)
+}
+
+func (t *testReplicationControllerGetter) Get(namespace, name string) (*kapi.ReplicationController, error) {
+	return t.getFunc(namespace, name)
+}
+
+func (t *testReplicationControllerGetter) List(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+	return t.listFunc(namespace, selector)
+}

--- a/pkg/deploy/api/register.go
+++ b/pkg/deploy/api/register.go
@@ -10,10 +10,12 @@ func init() {
 		&DeploymentList{},
 		&DeploymentConfig{},
 		&DeploymentConfigList{},
+		&DeploymentConfigRollback{},
 	)
 }
 
-func (*Deployment) IsAnAPIObject()           {}
-func (*DeploymentList) IsAnAPIObject()       {}
-func (*DeploymentConfig) IsAnAPIObject()     {}
-func (*DeploymentConfigList) IsAnAPIObject() {}
+func (*Deployment) IsAnAPIObject()               {}
+func (*DeploymentList) IsAnAPIObject()           {}
+func (*DeploymentConfig) IsAnAPIObject()         {}
+func (*DeploymentConfigList) IsAnAPIObject()     {}
+func (*DeploymentConfigRollback) IsAnAPIObject() {}

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -206,3 +206,24 @@ type DeploymentConfigList struct {
 	kapi.ListMeta `json:"metadata,omitempty"`
 	Items         []DeploymentConfig `json:"items"`
 }
+
+// DeploymentConfigRollback provides the input to rollback generation.
+type DeploymentConfigRollback struct {
+	kapi.TypeMeta `json:",inline"`
+	// Spec defines the options to rollback generation.
+	Spec DeploymentConfigRollbackSpec `json:"spec"`
+}
+
+// DeploymentConfigRollbackSpec represents the options for rollback generation.
+type DeploymentConfigRollbackSpec struct {
+	// From points to a ReplicationController which is a deployment.
+	From kapi.ObjectReference `json:"from"`
+	// IncludeTriggers specifies whether to include config Triggers.
+	IncludeTriggers bool `json:"includeTriggers`
+	// IncludeTemplate specifies whether to include the PodTemplateSpec.
+	IncludeTemplate bool `json:"includeTemplate`
+	// IncludeReplicationMeta specifies whether to include the replica count and selector.
+	IncludeReplicationMeta bool `json:"includeReplicationMeta`
+	// IncludeStrategy specifies whether to include the deployment Strategy.
+	IncludeStrategy bool `json:"includeStrategy`
+}

--- a/pkg/deploy/api/v1beta1/register.go
+++ b/pkg/deploy/api/v1beta1/register.go
@@ -10,10 +10,12 @@ func init() {
 		&DeploymentList{},
 		&DeploymentConfig{},
 		&DeploymentConfigList{},
+		&DeploymentConfigRollback{},
 	)
 }
 
-func (*Deployment) IsAnAPIObject()           {}
-func (*DeploymentList) IsAnAPIObject()       {}
-func (*DeploymentConfig) IsAnAPIObject()     {}
-func (*DeploymentConfigList) IsAnAPIObject() {}
+func (*Deployment) IsAnAPIObject()               {}
+func (*DeploymentList) IsAnAPIObject()           {}
+func (*DeploymentConfig) IsAnAPIObject()         {}
+func (*DeploymentConfigList) IsAnAPIObject()     {}
+func (*DeploymentConfigRollback) IsAnAPIObject() {}

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -207,3 +207,24 @@ type DeploymentConfigList struct {
 	v1beta3.ListMeta `json:"metadata,omitempty"`
 	Items            []DeploymentConfig `json:"items"`
 }
+
+// DeploymentConfigRollback provides the input to rollback generation.
+type DeploymentConfigRollback struct {
+	v1beta3.TypeMeta `json:",inline"`
+	// Spec defines the options to rollback generation.
+	Spec DeploymentConfigRollbackSpec `json:"spec"`
+}
+
+// DeploymentConfigRollbackSpec represents the options for rollback generation.
+type DeploymentConfigRollbackSpec struct {
+	// From points to a ReplicationController which is a deployment.
+	From v1beta3.ObjectReference `json:"from"`
+	// IncludeTriggers specifies whether to include config Triggers.
+	IncludeTriggers bool `json:"includeTriggers`
+	// IncludeTemplate specifies whether to include the PodTemplateSpec.
+	IncludeTemplate bool `json:"includeTemplate`
+	// IncludeReplicationMeta specifies whether to include the replica count and selector.
+	IncludeReplicationMeta bool `json:"includeReplicationMeta`
+	// IncludeStrategy specifies whether to include the deployment Strategy.
+	IncludeStrategy bool `json:"includeStrategy`
+}

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -32,6 +32,24 @@ func ValidateDeploymentConfig(config *deployapi.DeploymentConfig) errors.Validat
 	return result
 }
 
+func ValidateDeploymentConfigRollback(rollback *deployapi.DeploymentConfigRollback) errors.ValidationErrorList {
+	result := errors.ValidationErrorList{}
+
+	if len(rollback.Spec.From.Name) == 0 {
+		result = append(result, errors.NewFieldRequired("spec.from.name", ""))
+	}
+
+	if len(rollback.Spec.From.Kind) == 0 {
+		rollback.Spec.From.Kind = "ReplicationController"
+	}
+
+	if rollback.Spec.From.Kind != "ReplicationController" {
+		result = append(result, errors.NewFieldInvalid("spec.from.kind", rollback.Spec.From.Kind, "the kind of the rollback target must be 'ReplicationController'"))
+	}
+
+	return result
+}
+
 func validateDeploymentStrategy(strategy *deployapi.DeploymentStrategy) errors.ValidationErrorList {
 	result := errors.ValidationErrorList{}
 

--- a/pkg/deploy/api/validation/validation_test.go
+++ b/pkg/deploy/api/validation/validation_test.go
@@ -3,7 +3,9 @@ package validation
 import (
 	"testing"
 
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+
 	"github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/api/test"
 )
@@ -167,6 +169,70 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 
 	for k, v := range errorCases {
 		errs := ValidateDeploymentConfig(&v.D)
+		if len(errs) == 0 {
+			t.Errorf("Expected failure for scenario %s", k)
+		}
+		for i := range errs {
+			if errs[i].(*errors.ValidationError).Type != v.T {
+				t.Errorf("%s: expected errors to have type %s: %v", k, v.T, errs[i])
+			}
+			if errs[i].(*errors.ValidationError).Field != v.F {
+				t.Errorf("%s: expected errors to have field %s: %v", k, v.F, errs[i])
+			}
+		}
+	}
+}
+
+func TestValidateDeploymentConfigRollbackOK(t *testing.T) {
+	rollback := &api.DeploymentConfigRollback{
+		Spec: api.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name: "deployment",
+			},
+		},
+	}
+
+	errs := ValidateDeploymentConfigRollback(rollback)
+	if len(errs) > 0 {
+		t.Errorf("Unxpected non-empty error list: %v", errs)
+	}
+
+	if e, a := "ReplicationController", rollback.Spec.From.Kind; e != a {
+		t.Errorf("expected kind %s, got %s")
+	}
+}
+
+func TestValidateDeploymentConfigRollbackInvalidFields(t *testing.T) {
+	errorCases := map[string]struct {
+		D api.DeploymentConfigRollback
+		T errors.ValidationErrorType
+		F string
+	}{
+		"missing spec.from.name": {
+			api.DeploymentConfigRollback{
+				Spec: api.DeploymentConfigRollbackSpec{
+					From: kapi.ObjectReference{},
+				},
+			},
+			errors.ValidationErrorTypeRequired,
+			"spec.from.name",
+		},
+		"wrong spec.from.kind": {
+			api.DeploymentConfigRollback{
+				Spec: api.DeploymentConfigRollbackSpec{
+					From: kapi.ObjectReference{
+						Kind: "unknown",
+						Name: "deployment",
+					},
+				},
+			},
+			errors.ValidationErrorTypeInvalid,
+			"spec.from.kind",
+		},
+	}
+
+	for k, v := range errorCases {
+		errs := ValidateDeploymentConfigRollback(&v.D)
 		if len(errs) == 0 {
 			t.Errorf("Expected failure for scenario %s", k)
 		}

--- a/pkg/deploy/controller/config_change_controller.go
+++ b/pkg/deploy/controller/config_change_controller.go
@@ -13,10 +13,9 @@ import (
 )
 
 // DeploymentConfigChangeController watches for changes to DeploymentConfigs and regenerates them only
-// when detecting a change to the PodTemplate of a DeploymentConfig containing a ConfigChange
-// trigger.
+// when detecting a change to the PodTemplate of a DeploymentConfig containing a ConfigChange trigger.
 type DeploymentConfigChangeController struct {
-	ChangeStrategy       changeStrategy
+	ChangeStrategy       ChangeStrategy
 	NextDeploymentConfig func() *deployapi.DeploymentConfig
 	DeploymentStore      cache.Store
 	Codec                runtime.Codec
@@ -24,7 +23,8 @@ type DeploymentConfigChangeController struct {
 	Stop <-chan struct{}
 }
 
-type changeStrategy interface {
+// ChangeStrategy knows how to generate and update DeploymentConfigs.
+type ChangeStrategy interface {
 	GenerateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
 	UpdateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
 }

--- a/pkg/deploy/controller/config_change_controller_test.go
+++ b/pkg/deploy/controller/config_change_controller_test.go
@@ -3,13 +3,11 @@ package controller
 import (
 	"testing"
 
-	"speter.net/go/exp/math/dec/inf"
-
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 
 	api "github.com/openshift/origin/pkg/api/latest"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapitest "github.com/openshift/origin/pkg/deploy/api/test"
 	deploytest "github.com/openshift/origin/pkg/deploy/controller/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -32,7 +30,9 @@ func TestNewConfigWithoutTrigger(t *testing.T) {
 			},
 		},
 		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return newConfigWithoutTrigger()
+			config := deployapitest.OkDeploymentConfig(1)
+			config.Triggers = []deployapi.DeploymentTriggerPolicy{}
+			return config
 		},
 		DeploymentStore: deploytest.NewFakeDeploymentStore(nil),
 	}
@@ -49,17 +49,13 @@ func TestNewConfigWithoutTrigger(t *testing.T) {
 }
 
 func TestNewConfigWithTrigger(t *testing.T) {
-	var (
-		generatedName string
-		updated       *deployapi.DeploymentConfig
-	)
+	var updated *deployapi.DeploymentConfig
 
 	controller := &DeploymentConfigChangeController{
 		Codec: api.Codec,
 		ChangeStrategy: &testChangeStrategy{
 			GenerateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
-				generatedName = name
-				return generatedConfig(), nil
+				return deployapitest.OkDeploymentConfig(1), nil
 			},
 			UpdateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
 				updated = config
@@ -67,20 +63,24 @@ func TestNewConfigWithTrigger(t *testing.T) {
 			},
 		},
 		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return newConfigWithTrigger()
+			config := deployapitest.OkDeploymentConfig(0)
+			config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
+			return config
 		},
 		DeploymentStore: deploytest.NewFakeDeploymentStore(nil),
 	}
 
 	controller.HandleDeploymentConfig()
 
-	if generatedName != "test-deploy-config" {
-		t.Fatalf("Unexpected generated config id.  Expected test-deploy-config, got: %v", generatedName)
+	if updated == nil {
+		t.Fatalf("expected config to be updated")
 	}
 
-	if updated.Name != "test-deploy-config" {
-		t.Fatalf("Unexpected updated config id.  Expected test-deploy-config, got: %v", updated.Name)
-	} else if updated.Details == nil {
+	if e, a := 1, updated.LatestVersion; e != a {
+		t.Fatalf("expected update to latestversion=%d, got %d", e, a)
+	}
+
+	if updated.Details == nil {
 		t.Fatalf("expected config change details to be set")
 	} else if updated.Details.Causes == nil {
 		t.Fatalf("expected config change causes to be set")
@@ -91,17 +91,14 @@ func TestNewConfigWithTrigger(t *testing.T) {
 
 // Test the controller's response when the pod template is changed
 func TestChangeWithTemplateDiff(t *testing.T) {
-	var (
-		generatedName string
-		updated       *deployapi.DeploymentConfig
-	)
+	var updated *deployapi.DeploymentConfig
+	deployment, _ := deployutil.MakeDeployment(deployapitest.OkDeploymentConfig(1), kapi.Codec)
 
 	controller := &DeploymentConfigChangeController{
 		Codec: api.Codec,
 		ChangeStrategy: &testChangeStrategy{
 			GenerateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
-				generatedName = name
-				return generatedExistingConfig(), nil
+				return deployapitest.OkDeploymentConfig(2), nil
 			},
 			UpdateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
 				updated = config
@@ -109,20 +106,25 @@ func TestChangeWithTemplateDiff(t *testing.T) {
 			},
 		},
 		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return diffedConfig()
+			config := deployapitest.OkDeploymentConfig(1)
+			config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
+			config.Template.ControllerTemplate.Template.Spec.Containers[1].Name = "modified"
+			return config
 		},
-		DeploymentStore: deploytest.NewFakeDeploymentStore(matchingInitialDeployment(generatedConfig())),
+		DeploymentStore: deploytest.NewFakeDeploymentStore(deployment),
 	}
 
 	controller.HandleDeploymentConfig()
 
-	if generatedName != "test-deploy-config" {
-		t.Fatalf("Unexpected generated config id.  Expected test-deploy-config, got: %v", generatedName)
+	if updated == nil {
+		t.Fatalf("expected config to be updated")
 	}
 
-	if updated.Name != "test-deploy-config" {
-		t.Fatalf("Unexpected updated config id.  Expected test-deploy-config, got: %v", updated.Name)
-	} else if updated.Details == nil {
+	if e, a := 2, updated.LatestVersion; e != a {
+		t.Fatalf("expected update to latestversion=%d, got %d", e, a)
+	}
+
+	if updated.Details == nil {
 		t.Fatalf("expected config change details to be set")
 	} else if updated.Details.Causes == nil {
 		t.Fatalf("expected config change causes to be set")
@@ -132,7 +134,11 @@ func TestChangeWithTemplateDiff(t *testing.T) {
 }
 
 func TestChangeWithoutTemplateDiff(t *testing.T) {
-	config := existingConfigWithTrigger()
+	config := deployapitest.OkDeploymentConfig(1)
+	config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
+
+	deployment, _ := deployutil.MakeDeployment(deployapitest.OkDeploymentConfig(1), kapi.Codec)
+
 	generated := false
 	updated := false
 
@@ -151,7 +157,7 @@ func TestChangeWithoutTemplateDiff(t *testing.T) {
 		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
 			return config
 		},
-		DeploymentStore: deploytest.NewFakeDeploymentStore(matchingInitialDeployment(config)),
+		DeploymentStore: deploytest.NewFakeDeploymentStore(deployment),
 	}
 
 	controller.HandleDeploymentConfig()
@@ -176,146 +182,4 @@ func (i *testChangeStrategy) GenerateDeploymentConfig(namespace, name string) (*
 
 func (i *testChangeStrategy) UpdateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
 	return i.UpdateDeploymentConfigFunc(namespace, config)
-}
-
-func existingConfigWithTrigger() *deployapi.DeploymentConfig {
-	return &deployapi.DeploymentConfig{
-		ObjectMeta: kapi.ObjectMeta{Name: "test-deploy-config"},
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			{
-				Type: deployapi.DeploymentTriggerOnConfigChange,
-			},
-		},
-		LatestVersion: 2,
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: 1,
-				Selector: map[string]string{
-					"name": "test-pod",
-				},
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: map[string]string{
-							"name": "test-pod",
-						},
-					},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:   "container-1",
-								Image:  "registry:8080/openshift/test-image:ref-1",
-								CPU:    resource.Quantity{Amount: inf.NewDec(0, 3), Format: "DecimalSI"},
-								Memory: resource.Quantity{Amount: inf.NewDec(0, 0), Format: "DecimalSI"},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func newConfigWithTrigger() *deployapi.DeploymentConfig {
-	config := existingConfigWithTrigger()
-	config.LatestVersion = 0
-	return config
-}
-
-func newConfigWithoutTrigger() *deployapi.DeploymentConfig {
-	config := existingConfigWithTrigger()
-	config.LatestVersion = 0
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{}
-	return config
-}
-
-func diffedConfig() *deployapi.DeploymentConfig {
-	return &deployapi.DeploymentConfig{
-		ObjectMeta: kapi.ObjectMeta{Name: "test-deploy-config"},
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			{
-				Type: deployapi.DeploymentTriggerOnConfigChange,
-			},
-		},
-		LatestVersion: 2,
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: 1,
-				Selector: map[string]string{
-					"name": "test-pod-2",
-				},
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: map[string]string{
-							"name": "test-pod-2",
-						},
-					},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:  "container-2",
-								Image: "registry:8080/openshift/test-image:ref-1",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func generatedExistingConfig() *deployapi.DeploymentConfig {
-	return &deployapi.DeploymentConfig{
-		ObjectMeta: kapi.ObjectMeta{Name: "test-deploy-config"},
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			{
-				Type: deployapi.DeploymentTriggerOnConfigChange,
-			},
-		},
-		LatestVersion: 3,
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: 1,
-				Selector: map[string]string{
-					"name": "test-pod",
-				},
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: map[string]string{
-							"name": "test-pod",
-						},
-					},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:  "container-1",
-								Image: "registry:8080/openshift/test-image:ref-2",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func generatedConfig() *deployapi.DeploymentConfig {
-	config := generatedExistingConfig()
-	config.LatestVersion = 0
-	return config
-}
-
-func matchingInitialDeployment(config *deployapi.DeploymentConfig) *kapi.ReplicationController {
-	encodedConfig, _ := deployutil.EncodeDeploymentConfig(config, api.Codec)
-
-	return &kapi.ReplicationController{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: deployutil.LatestDeploymentIDForConfig(config),
-			Annotations: map[string]string{
-				deployapi.DeploymentConfigAnnotation:        config.Name,
-				deployapi.DeploymentStatusAnnotation:        string(deployapi.DeploymentStatusNew),
-				deployapi.DeploymentEncodedConfigAnnotation: encodedConfig,
-			},
-		},
-		Spec: config.Template.ControllerTemplate,
-	}
 }

--- a/pkg/deploy/controller/deployment_config_controller_test.go
+++ b/pkg/deploy/controller/deployment_config_controller_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"strconv"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -9,6 +8,7 @@ import (
 
 	api "github.com/openshift/origin/pkg/api/latest"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
@@ -26,9 +26,7 @@ func TestHandleNewDeploymentConfig(t *testing.T) {
 			},
 		},
 		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			deploymentConfig := manualDeploymentConfig()
-			deploymentConfig.LatestVersion = 0
-			return deploymentConfig
+			return deploytest.OkDeploymentConfig(0)
 		},
 	}
 
@@ -36,9 +34,7 @@ func TestHandleNewDeploymentConfig(t *testing.T) {
 }
 
 func TestHandleInitialDeployment(t *testing.T) {
-	deploymentConfig := manualDeploymentConfig()
-	deploymentConfig.LatestVersion = 1
-
+	deploymentConfig := deploytest.OkDeploymentConfig(1)
 	var deployed *kapi.ReplicationController
 
 	controller := &DeploymentConfigController{
@@ -62,35 +58,17 @@ func TestHandleInitialDeployment(t *testing.T) {
 	if deployed == nil {
 		t.Fatalf("expected a deployment")
 	}
-
-	expectedAnnotations := map[string]string{
-		deployapi.DeploymentConfigAnnotation:  deploymentConfig.Name,
-		deployapi.DeploymentStatusAnnotation:  string(deployapi.DeploymentStatusNew),
-		deployapi.DeploymentVersionAnnotation: strconv.Itoa(deploymentConfig.LatestVersion),
-	}
-
-	for key, expected := range expectedAnnotations {
-		if actual := deployed.Annotations[key]; actual != expected {
-			t.Fatalf("expected deployment annotation %s=%s, got %s", key, expected, actual)
-		}
-	}
-
-	// TODO: add stronger assertion on the encoded value once the controller methods are free
-	// of side effects on the deploymentConfig
-	if len(deployed.Annotations[deployapi.DeploymentEncodedConfigAnnotation]) == 0 {
-		t.Fatalf("expected deployment with DeploymentEncodedConfigAnnotation annotation")
-	}
 }
 
-func TestHandleConfigChangeNoPodTemplateDiff(t *testing.T) {
-	deploymentConfig := manualDeploymentConfig()
-	deploymentConfig.LatestVersion = 0
+func TestHandleConfigChangeLatestAlreadyDeployed(t *testing.T) {
+	deploymentConfig := deploytest.OkDeploymentConfig(0)
 
 	controller := &DeploymentConfigController{
 		Codec: api.Codec,
 		DeploymentInterface: &testDeploymentInterface{
 			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return matchingDeployment(deploymentConfig), nil
+				deployment, _ := deployutil.MakeDeployment(deploymentConfig, kapi.Codec)
+				return deployment, nil
 			},
 			CreateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 				t.Fatalf("unexpected call to to create deployment: %v", deployment)
@@ -105,40 +83,6 @@ func TestHandleConfigChangeNoPodTemplateDiff(t *testing.T) {
 	controller.HandleDeploymentConfig()
 }
 
-func TestHandleConfigChangeWithPodTemplateDiff(t *testing.T) {
-	deploymentConfig := manualDeploymentConfig()
-	deploymentConfig.LatestVersion = 2
-	deploymentConfig.Template.ControllerTemplate.Template.Labels["foo"] = "bar"
-
-	var deployed *kapi.ReplicationController
-
-	controller := &DeploymentConfigController{
-		Codec: api.Codec,
-		DeploymentInterface: &testDeploymentInterface{
-			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return nil, kerrors.NewNotFound("deployment", name)
-			},
-			CreateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-				deployed = deployment
-				return deployment, nil
-			},
-		},
-		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return deploymentConfig
-		},
-	}
-
-	controller.HandleDeploymentConfig()
-
-	if deployed == nil {
-		t.Fatalf("expected a deployment")
-	}
-
-	if e, a := deploymentConfig.Name, deployed.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
-		t.Fatalf("expected deployment annotated with deploymentConfig %s, got %s", e, a)
-	}
-}
-
 type testDeploymentInterface struct {
 	GetDeploymentFunc    func(namespace, name string) (*kapi.ReplicationController, error)
 	CreateDeploymentFunc func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error)
@@ -150,76 +94,4 @@ func (i *testDeploymentInterface) GetDeployment(namespace, name string) (*kapi.R
 
 func (i *testDeploymentInterface) CreateDeployment(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 	return i.CreateDeploymentFunc(namespace, deployment)
-}
-
-func manualDeploymentConfig() *deployapi.DeploymentConfig {
-	return &deployapi.DeploymentConfig{
-		ObjectMeta: kapi.ObjectMeta{Name: "manual-deploy-config"},
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			{
-				Type: deployapi.DeploymentTriggerManual,
-			},
-		},
-		Template: deployapi.DeploymentTemplate{
-			Strategy: deployapi.DeploymentStrategy{
-				Type: deployapi.DeploymentStrategyTypeRecreate,
-			},
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: 1,
-				Selector: map[string]string{
-					"name": "test-pod",
-				},
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: map[string]string{
-							"name": "test-pod",
-						},
-					},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:  "container-1",
-								Image: "registry:8080/openshift/test-image:ref-1",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func matchingDeployment(config *deployapi.DeploymentConfig) *kapi.ReplicationController {
-	encodedConfig, _ := deployutil.EncodeDeploymentConfig(config, api.Codec)
-	return &kapi.ReplicationController{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: deployutil.LatestDeploymentIDForConfig(config),
-			Annotations: map[string]string{
-				deployapi.DeploymentConfigAnnotation:        config.Name,
-				deployapi.DeploymentEncodedConfigAnnotation: encodedConfig,
-			},
-			Labels: config.Labels,
-		},
-		Spec: kapi.ReplicationControllerSpec{
-			Replicas: 1,
-			Selector: map[string]string{
-				"name": "test-pod",
-			},
-			Template: &kapi.PodTemplateSpec{
-				ObjectMeta: kapi.ObjectMeta{
-					Labels: map[string]string{
-						"name": "test-pod",
-					},
-				},
-				Spec: kapi.PodSpec{
-					Containers: []kapi.Container{
-						{
-							Name:  "container-1",
-							Image: "registry:8080/openshift/test-image:ref-1",
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/pkg/deploy/controller/image_change_controller_test.go
+++ b/pkg/deploy/controller/image_change_controller_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployapitest "github.com/openshift/origin/pkg/deploy/api/test"
 	deploytest "github.com/openshift/origin/pkg/deploy/controller/test"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -26,8 +28,8 @@ const (
 )
 
 func TestUnregisteredContainer(t *testing.T) {
-	config := unregisteredConfig()
-	config.Triggers[0].ImageChangeParams.Automatic = false
+	config := deployapitest.OkDeploymentConfig(1)
+	config.Triggers[0].ImageChangeParams.ContainerNames = []string{"container-3"}
 
 	controller := &ImageChangeController{
 		DeploymentConfigInterface: &testIcDeploymentConfigInterface{
@@ -51,7 +53,7 @@ func TestUnregisteredContainer(t *testing.T) {
 }
 
 func TestImageChangeForNonAutomaticTag(t *testing.T) {
-	config := imageChangeDeploymentConfig()
+	config := deployapitest.OkDeploymentConfig(1)
 	config.Triggers[0].ImageChangeParams.Automatic = false
 
 	controller := &ImageChangeController{

--- a/pkg/deploy/generator/config_generator_test.go
+++ b/pkg/deploy/generator/config_generator_test.go
@@ -3,15 +3,13 @@ package generator
 import (
 	"testing"
 
-	"speter.net/go/exp/math/dec/inf"
-
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
 	api "github.com/openshift/origin/pkg/api/latest"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -42,17 +40,18 @@ func TestGenerateFromConfigWithoutTagChange(t *testing.T) {
 		Codec: api.Codec,
 		DeploymentConfigInterface: &testDeploymentConfigInterface{
 			GetDeploymentConfigFunc: func(id string) (*deployapi.DeploymentConfig, error) {
-				return basicDeploymentConfig(), nil
+				return deploytest.OkDeploymentConfig(1), nil
 			},
 		},
 		ImageRepositoryInterface: &testImageRepositoryInterface{
 			ListImageRepositoriesFunc: func(labels labels.Selector) (*imageapi.ImageRepositoryList, error) {
-				return basicImageRepo(), nil
+				return okImageRepoList(), nil
 			},
 		},
 		DeploymentInterface: &testDeploymentInterface{
 			GetDeploymentFunc: func(id string) (*kapi.ReplicationController, error) {
-				return basicDeployment(), nil
+				deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+				return deployment, nil
 			},
 		},
 	}
@@ -77,12 +76,12 @@ func TestGenerateFromConfigWithNoDeployment(t *testing.T) {
 		Codec: api.Codec,
 		DeploymentConfigInterface: &testDeploymentConfigInterface{
 			GetDeploymentConfigFunc: func(id string) (*deployapi.DeploymentConfig, error) {
-				return basicDeploymentConfig(), nil
+				return deploytest.OkDeploymentConfig(1), nil
 			},
 		},
 		ImageRepositoryInterface: &testImageRepositoryInterface{
 			ListImageRepositoriesFunc: func(labels labels.Selector) (*imageapi.ImageRepositoryList, error) {
-				return basicImageRepo(), nil
+				return okImageRepoList(), nil
 			},
 		},
 		DeploymentInterface: &testDeploymentInterface{
@@ -112,17 +111,20 @@ func TestGenerateFromConfigWithUpdatedImageRef(t *testing.T) {
 		Codec: api.Codec,
 		DeploymentConfigInterface: &testDeploymentConfigInterface{
 			GetDeploymentConfigFunc: func(id string) (*deployapi.DeploymentConfig, error) {
-				return basicDeploymentConfig(), nil
+				return deploytest.OkDeploymentConfig(1), nil
 			},
 		},
 		ImageRepositoryInterface: &testImageRepositoryInterface{
 			ListImageRepositoriesFunc: func(labels labels.Selector) (*imageapi.ImageRepositoryList, error) {
-				return updatedImageRepo(), nil
+				list := okImageRepoList()
+				list.Items[0].Tags["tag1"] = "ref2"
+				return list, nil
 			},
 		},
 		DeploymentInterface: &testDeploymentInterface{
 			GetDeploymentFunc: func(id string) (*kapi.ReplicationController, error) {
-				return basicDeployment(), nil
+				deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+				return deployment, nil
 			},
 		},
 	}
@@ -172,72 +174,7 @@ func (i *testImageRepositoryInterface) ListImageRepositories(ctx kapi.Context, l
 	return i.ListImageRepositoriesFunc(labels)
 }
 
-func basicPodTemplate() *kapi.PodTemplateSpec {
-	return &kapi.PodTemplateSpec{
-		Spec: kapi.PodSpec{
-			Containers: []kapi.Container{
-				{
-					Name:   "container1",
-					Image:  "registry:8080/repo1:ref1",
-					CPU:    resource.Quantity{Amount: inf.NewDec(0, 3), Format: "DecimalSI"},
-					Memory: resource.Quantity{Amount: inf.NewDec(0, 0), Format: "DecimalSI"},
-				},
-				{
-					Name:   "container2",
-					Image:  "registry:8080/repo1:ref2",
-					CPU:    resource.Quantity{Amount: inf.NewDec(0, 3), Format: "DecimalSI"},
-					Memory: resource.Quantity{Amount: inf.NewDec(0, 0), Format: "DecimalSI"},
-				},
-			},
-		},
-	}
-}
-
-func basicDeploymentConfig() *deployapi.DeploymentConfig {
-	return &deployapi.DeploymentConfig{
-		ObjectMeta:    kapi.ObjectMeta{Name: "deploy1"},
-		LatestVersion: 1,
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			{
-				Type: deployapi.DeploymentTriggerOnImageChange,
-				ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
-					ContainerNames: []string{
-						"container1",
-					},
-					RepositoryName: "registry:8080/repo1",
-					Tag:            "tag1",
-				},
-			},
-		},
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Template: basicPodTemplate(),
-			},
-		},
-	}
-}
-
-func basicDeployment() *kapi.ReplicationController {
-	config := basicDeploymentConfig()
-	encodedConfig, _ := deployutil.EncodeDeploymentConfig(config, api.Codec)
-
-	return &kapi.ReplicationController{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: deployutil.LatestDeploymentIDForConfig(config),
-			Annotations: map[string]string{
-				deployapi.DeploymentConfigAnnotation:        config.Name,
-				deployapi.DeploymentStatusAnnotation:        string(deployapi.DeploymentStatusNew),
-				deployapi.DeploymentEncodedConfigAnnotation: encodedConfig,
-			},
-			Labels: config.Labels,
-		},
-		Spec: kapi.ReplicationControllerSpec{
-			Template: basicPodTemplate(),
-		},
-	}
-}
-
-func basicImageRepo() *imageapi.ImageRepositoryList {
+func okImageRepoList() *imageapi.ImageRepositoryList {
 	return &imageapi.ImageRepositoryList{
 		Items: []imageapi.ImageRepository{
 			{
@@ -245,20 +182,6 @@ func basicImageRepo() *imageapi.ImageRepositoryList {
 				DockerImageRepository: "registry:8080/repo1",
 				Tags: map[string]string{
 					"tag1": "ref1",
-				},
-			},
-		},
-	}
-}
-
-func updatedImageRepo() *imageapi.ImageRepositoryList {
-	return &imageapi.ImageRepositoryList{
-		Items: []imageapi.ImageRepository{
-			{
-				ObjectMeta:            kapi.ObjectMeta{Name: "imageRepo1"},
-				DockerImageRepository: "registry:8080/repo1",
-				Tags: map[string]string{
-					"tag1": "ref2",
 				},
 			},
 		},

--- a/pkg/deploy/rollback/doc.go
+++ b/pkg/deploy/rollback/doc.go
@@ -1,0 +1,3 @@
+// Package rollback contains the code for generating DeploymentConfigs representing
+// rollbacks as well as REST support for API clients.
+package rollback

--- a/pkg/deploy/rollback/rest.go
+++ b/pkg/deploy/rollback/rest.go
@@ -1,0 +1,93 @@
+package rollback
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	"github.com/openshift/origin/pkg/deploy/api/validation"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+// REST provides a rollback generation endpoint. Only the Create method is implemented.
+type REST struct {
+	generator              GeneratorClient
+	deploymentGetter       DeploymentGetter
+	deploymentConfigGetter DeploymentConfigGetter
+	codec                  runtime.Codec
+}
+
+// GeneratorClient defines a local interface to a rollback generator for testability.
+type GeneratorClient interface {
+	Generate(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error)
+}
+
+// DeploymentGetter is a local interface to ReplicationControllers for testability.
+type DeploymentGetter interface {
+	GetDeployment(namespace, name string) (*kapi.ReplicationController, error)
+}
+
+// DeploymentConfigGetter is a local interface to DeploymentConfigs for testability.
+type DeploymentConfigGetter interface {
+	GetDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
+}
+
+// NewREST safely creates a new REST.
+func NewREST(generator GeneratorClient, deploymentGetter DeploymentGetter, configGetter DeploymentConfigGetter, codec runtime.Codec) apiserver.RESTStorage {
+	return &REST{
+		generator:              generator,
+		deploymentGetter:       deploymentGetter,
+		deploymentConfigGetter: configGetter,
+		codec: codec,
+	}
+}
+
+func (s *REST) New() runtime.Object {
+	return &deployapi.DeploymentConfigRollback{}
+}
+
+// Create generates a new DeploymentConfig representing a rollback.
+func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	rollback, ok := obj.(*deployapi.DeploymentConfigRollback)
+	if !ok {
+		return nil, fmt.Errorf("not a rollback spec: %#v", obj)
+	}
+
+	if errs := validation.ValidateDeploymentConfigRollback(rollback); len(errs) > 0 {
+		return nil, kerrors.NewInvalid("deploymentConfigRollback", "", errs)
+	}
+
+	namespace, namespaceOk := kapi.NamespaceFrom(ctx)
+	if !namespaceOk {
+		return nil, fmt.Errorf("namespace %s is invalid", ctx.Value)
+	}
+
+	// Roll back "from" the current deployment "to" a target deployment
+	var from, to *deployapi.DeploymentConfig
+	var err error
+
+	// Find the target ("to") deployment and decode the DeploymentConfig
+	if targetDeployment, err := s.deploymentGetter.GetDeployment(namespace, rollback.Spec.From.Name); err != nil {
+		// TODO: correct error type?
+		return nil, kerrors.NewBadRequest(fmt.Sprintf("Couldn't get specified deployment: %v", err))
+	} else {
+		if to, err = deployutil.DecodeDeploymentConfig(targetDeployment, s.codec); err != nil {
+			// TODO: correct error type?
+			return nil, kerrors.NewBadRequest(fmt.Sprintf("deploymentConfig on target deployment is invalid: %v", err))
+		}
+	}
+
+	// Find the current ("from") version of the target deploymentConfig
+	if from, err = s.deploymentConfigGetter.GetDeploymentConfig(namespace, to.Name); err != nil {
+		// TODO: correct error type?
+		return nil, kerrors.NewBadRequest(fmt.Sprintf("Couldn't find current deploymentConfig %s/%s: %v", namespace, to.Name, err))
+	}
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		return s.generator.Generate(from, to, &rollback.Spec)
+	}), nil
+}

--- a/pkg/deploy/rollback/rest_test.go
+++ b/pkg/deploy/rollback/rest_test.go
@@ -1,0 +1,296 @@
+package rollback
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+
+	api "github.com/openshift/origin/pkg/api/latest"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+func TestCreateError(t *testing.T) {
+	rest := REST{}
+
+	obj, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfig{})
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	if obj != nil {
+		t.Errorf("Unexpected non-nil object: %#v", obj)
+	}
+}
+
+func TestCreateInvalid(t *testing.T) {
+	rest := REST{}
+
+	obj, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfigRollback{})
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	if obj != nil {
+		t.Errorf("Unexpected non-nil object: %#v", obj)
+	}
+}
+
+func TestCreateOk(t *testing.T) {
+	rest := REST{
+		generator: &testGenerator{
+			generateFunc: func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+				return &deployapi.DeploymentConfig{}, nil
+			},
+		},
+		codec: api.Codec,
+		deploymentGetter: &testDeploymentGetter{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+				return deployment, nil
+			},
+		},
+		deploymentConfigGetter: &testDeploymentConfigGetter{
+			GetDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
+				return deploytest.OkDeploymentConfig(1), nil
+			},
+		},
+	}
+
+	channel, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfigRollback{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name:      "deployment",
+				Namespace: kapi.NamespaceDefault,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if channel == nil {
+		t.Errorf("Expected a result channel")
+	}
+
+	select {
+	case result := <-channel:
+		if _, ok := result.Object.(*deployapi.DeploymentConfig); !ok {
+			t.Errorf("expected a DeploymentConfig, got a %#v", result.Object)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	}
+}
+
+func TestCreateGeneratorError(t *testing.T) {
+	rest := REST{
+		generator: &testGenerator{
+			generateFunc: func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+				return nil, errors.New("something terrible happened")
+			},
+		},
+		codec: api.Codec,
+		deploymentGetter: &testDeploymentGetter{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+				return deployment, nil
+			},
+		},
+		deploymentConfigGetter: &testDeploymentConfigGetter{
+			GetDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
+				return deploytest.OkDeploymentConfig(1), nil
+			},
+		},
+	}
+
+	channel, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfigRollback{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name:      "deployment",
+				Namespace: kapi.NamespaceDefault,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if channel == nil {
+		t.Errorf("Expected a result channel")
+	}
+
+	select {
+	case result := <-channel:
+		status, ok := result.Object.(*kapi.Status)
+		if !ok {
+			t.Errorf("Expected status, got %#v", result)
+		}
+		if status.Status != kapi.StatusFailure {
+			t.Errorf("Expected status=failure, message=foo, got %#v", status)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Errorf("Timed out waiting for result")
+	}
+}
+
+func TestCreateMissingDeployment(t *testing.T) {
+	rest := REST{
+		generator: &testGenerator{
+			generateFunc: func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+				t.Fatal("unexpected call to generator")
+				return nil, errors.New("something terrible happened")
+			},
+		},
+		codec: api.Codec,
+		deploymentGetter: &testDeploymentGetter{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				return nil, kerrors.NewNotFound("replicationController", name)
+			},
+		},
+		deploymentConfigGetter: &testDeploymentConfigGetter{
+			GetDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
+				t.Fatalf("unexpected call to GetDeploymentConfig(%s/%s)", namespace, name)
+				return nil, kerrors.NewNotFound("deploymentConfig", name)
+			},
+		},
+	}
+
+	channel, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfigRollback{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name:      "deployment",
+				Namespace: kapi.NamespaceDefault,
+			},
+		},
+	})
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	if channel != nil {
+		t.Error("Unexpected result channel")
+	}
+}
+
+func TestCreateInvalidDeployment(t *testing.T) {
+	rest := REST{
+		generator: &testGenerator{
+			generateFunc: func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+				t.Fatal("unexpected call to generator")
+				return nil, errors.New("something terrible happened")
+			},
+		},
+		codec: api.Codec,
+		deploymentGetter: &testDeploymentGetter{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				// invalidate the encoded config
+				deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+				deployment.Annotations[deployapi.DeploymentEncodedConfigAnnotation] = ""
+				return deployment, nil
+			},
+		},
+		deploymentConfigGetter: &testDeploymentConfigGetter{
+			GetDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
+				t.Fatalf("unexpected call to GetDeploymentConfig(%s/%s)", namespace, name)
+				return nil, kerrors.NewNotFound("deploymentConfig", name)
+			},
+		},
+	}
+
+	channel, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfigRollback{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name:      "deployment",
+				Namespace: kapi.NamespaceDefault,
+			},
+		},
+	})
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	if channel != nil {
+		t.Error("Unexpected result channel")
+	}
+}
+
+func TestCreateMissingDeploymentConfig(t *testing.T) {
+	rest := REST{
+		generator: &testGenerator{
+			generateFunc: func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+				t.Fatal("unexpected call to generator")
+				return nil, errors.New("something terrible happened")
+			},
+		},
+		codec: api.Codec,
+		deploymentGetter: &testDeploymentGetter{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+				return deployment, nil
+			},
+		},
+		deploymentConfigGetter: &testDeploymentConfigGetter{
+			GetDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
+				return nil, kerrors.NewNotFound("deploymentConfig", name)
+			},
+		},
+	}
+
+	channel, err := rest.Create(kapi.NewDefaultContext(), &deployapi.DeploymentConfigRollback{
+		Spec: deployapi.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name:      "deployment",
+				Namespace: kapi.NamespaceDefault,
+			},
+		},
+	})
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+
+	if channel != nil {
+		t.Error("Unexpected result channel")
+	}
+}
+
+func TestNew(t *testing.T) {
+	// :)
+	rest := NewREST(&testGenerator{}, &testDeploymentGetter{}, &testDeploymentConfigGetter{}, api.Codec)
+	rest.New()
+}
+
+type testGenerator struct {
+	generateFunc func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error)
+}
+
+func (g *testGenerator) Generate(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+	return g.generateFunc(from, to, spec)
+}
+
+type testDeploymentGetter struct {
+	GetDeploymentFunc func(namespace, name string) (*kapi.ReplicationController, error)
+}
+
+func (i *testDeploymentGetter) GetDeployment(namespace, name string) (*kapi.ReplicationController, error) {
+	return i.GetDeploymentFunc(namespace, name)
+}
+
+type testDeploymentConfigGetter struct {
+	GetDeploymentConfigFunc func(namespace, name string) (*deployapi.DeploymentConfig, error)
+}
+
+func (i *testDeploymentConfigGetter) GetDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error) {
+	return i.GetDeploymentConfigFunc(namespace, name)
+}

--- a/pkg/deploy/rollback/rollback_generator.go
+++ b/pkg/deploy/rollback/rollback_generator.go
@@ -1,0 +1,57 @@
+package rollback
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+// RollbackGenerator generates a new DeploymentConfig by merging a pair of DeploymentConfigs
+// in a configurable way.
+type RollbackGenerator struct {
+}
+
+// Generate creates a new DeploymentConfig by merging to onto from based on the options provided
+// by spec. The LatestVersion of the result is unconditionally incremented, as rollback candidates are
+// should be possible to be deployed manually regardless of other system behavior such as triggering.
+func (g *RollbackGenerator) Generate(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+	rollback := &deployapi.DeploymentConfig{}
+
+	if err := kapi.Scheme.Convert(&from, &rollback); err != nil {
+		return nil, fmt.Errorf("Couldn't clone 'from' deploymentConfig: %v", err)
+	}
+
+	// construct the candidate deploymentConfig based on the rollback spec
+	if spec.IncludeTemplate {
+		if err := kapi.Scheme.Convert(&to.Template.ControllerTemplate.Template, &rollback.Template.ControllerTemplate.Template); err != nil {
+			return nil, fmt.Errorf("Couldn't copy template to rollback:: %v", err)
+		}
+	}
+
+	if spec.IncludeReplicationMeta {
+		rollback.Template.ControllerTemplate.Replicas = to.Template.ControllerTemplate.Replicas
+		rollback.Template.ControllerTemplate.Selector = map[string]string{}
+		for k, v := range to.Template.ControllerTemplate.Selector {
+			rollback.Template.ControllerTemplate.Selector[k] = v
+		}
+	}
+
+	if spec.IncludeTriggers {
+		if err := kapi.Scheme.Convert(&to.Triggers, &rollback.Triggers); err != nil {
+			return nil, fmt.Errorf("Couldn't copy triggers to rollback:: %v", err)
+		}
+	}
+
+	if spec.IncludeStrategy {
+		if err := kapi.Scheme.Convert(&to.Template.Strategy, &rollback.Template.Strategy); err != nil {
+			return nil, fmt.Errorf("Couldn't copy strategy to rollback:: %v", err)
+		}
+	}
+
+	// TODO: add a new cause?
+	rollback.LatestVersion++
+
+	return rollback, nil
+}

--- a/pkg/deploy/rollback/rollback_generator_test.go
+++ b/pkg/deploy/rollback/rollback_generator_test.go
@@ -1,0 +1,114 @@
+package rollback
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+func TestGeneration(t *testing.T) {
+	from := deploytest.OkDeploymentConfig(2)
+	from.Template.Strategy = deployapi.DeploymentStrategy{
+		Type: deployapi.DeploymentStrategyTypeCustom,
+	}
+	from.Triggers = append(from.Triggers, deployapi.DeploymentTriggerPolicy{Type: deployapi.DeploymentTriggerOnConfigChange})
+	from.Template.ControllerTemplate.Template.Spec.Containers[0].Name = "changed"
+	from.Template.ControllerTemplate.Replicas = 5
+	from.Template.ControllerTemplate.Selector = map[string]string{
+		"new1": "new2",
+		"new2": "new2",
+	}
+
+	to := deploytest.OkDeploymentConfig(1)
+
+	// Generate a rollback for every combination of flag (using 1 bit per flag).
+	rollbackSpecs := []*deployapi.DeploymentConfigRollbackSpec{}
+	for i := 0; i < 15; i++ {
+		spec := &deployapi.DeploymentConfigRollbackSpec{
+			From: kapi.ObjectReference{
+				Name:      "deployment",
+				Namespace: kapi.NamespaceDefault,
+			},
+			IncludeTriggers:        i&(1<<0) > 0,
+			IncludeTemplate:        i&(1<<1) > 0,
+			IncludeReplicationMeta: i&(1<<2) > 0,
+			IncludeStrategy:        i&(1<<3) > 0,
+		}
+		rollbackSpecs = append(rollbackSpecs, spec)
+	}
+
+	generator := &RollbackGenerator{}
+
+	// Test every combination.
+	for _, spec := range rollbackSpecs {
+		t.Logf("testing spec %#v", spec)
+
+		if rollback, err := generator.Generate(from, to, spec); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		} else {
+			if hasStrategyDiff(from, rollback) && !spec.IncludeStrategy {
+				t.Fatalf("unexpected strategy diff: from=%v, rollback=%v", from, rollback)
+			}
+
+			if hasTriggerDiff(from, rollback) && !spec.IncludeTriggers {
+				t.Fatalf("unexpected trigger diff: from=%v, rollback=%v", from, rollback)
+			}
+
+			if hasPodTemplateDiff(from, rollback) && !spec.IncludeTemplate {
+				t.Fatalf("unexpected template diff: from=%v, rollback=%v", from, rollback)
+			}
+
+			if hasReplicationMetaDiff(from, rollback) && !spec.IncludeReplicationMeta {
+				t.Fatalf("unexpected replication meta diff: from=%v, rollback=%v", from, rollback)
+			}
+		}
+	}
+}
+
+func hasStrategyDiff(a, b *deployapi.DeploymentConfig) bool {
+	return a.Template.Strategy.Type != b.Template.Strategy.Type
+}
+
+func hasTriggerDiff(a, b *deployapi.DeploymentConfig) bool {
+	if len(a.Triggers) != len(b.Triggers) {
+		return true
+	}
+
+	for _, triggerA := range a.Triggers {
+		bHasTrigger := false
+		for _, triggerB := range b.Triggers {
+			if triggerB.Type == triggerA.Type {
+				bHasTrigger = true
+				break
+			}
+		}
+
+		if !bHasTrigger {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasReplicationMetaDiff(a, b *deployapi.DeploymentConfig) bool {
+	if a.Template.ControllerTemplate.Replicas != b.Template.ControllerTemplate.Replicas {
+		return true
+	}
+
+	for keyA, valueA := range a.Template.ControllerTemplate.Selector {
+		if valueB, exists := b.Template.ControllerTemplate.Selector[keyA]; !exists || valueA != valueB {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasPodTemplateDiff(a, b *deployapi.DeploymentConfig) bool {
+	return !deployutil.PodSpecsEqual(a.Template.ControllerTemplate.Template.Spec, b.Template.ControllerTemplate.Template.Spec)
+}

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -10,12 +10,14 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
+// LatestDeploymentIDForConfig returns a stable identifier for config based on its version.
 func LatestDeploymentIDForConfig(config *deployapi.DeploymentConfig) string {
 	return config.Name + "-" + strconv.Itoa(config.LatestVersion)
 }
@@ -72,7 +74,16 @@ func ParseContainerImage(image string) (string, string) {
 	return tokens[0], tokens[1]
 }
 
+// HashPodSpecs hashes a PodSpec into a uint64.
+// TODO: Resources are currently ignored due to the formats not surviving encoding/decoding
+// in a consistent manner (e.g. 0 is represented sometimes as 0.000)
 func HashPodSpec(t api.PodSpec) uint64 {
+
+	for i := range t.Containers {
+		t.Containers[i].CPU = resource.Quantity{}
+		t.Containers[i].Memory = resource.Quantity{}
+	}
+
 	jsonString, err := json.Marshal(t)
 	if err != nil {
 		glog.Errorf("An error occurred marshalling pod state: %v", err)
@@ -83,10 +94,13 @@ func HashPodSpec(t api.PodSpec) uint64 {
 	return uint64(hash.Sum32())
 }
 
+// PodSpecsEqual returns true if the given PodSpecs are the same.
 func PodSpecsEqual(a, b api.PodSpec) bool {
 	return HashPodSpec(a) == HashPodSpec(b)
 }
 
+// DecodeDeploymentConfig decodes a DeploymentConfig from controller using codec. An error is returned
+// if the controller doesn't contain an encoded config.
 func DecodeDeploymentConfig(controller *api.ReplicationController, codec runtime.Codec) (*deployapi.DeploymentConfig, error) {
 	encodedConfig := []byte(controller.Annotations[deployapi.DeploymentEncodedConfigAnnotation])
 	if decoded, err := codec.Decode(encodedConfig); err == nil {
@@ -100,10 +114,49 @@ func DecodeDeploymentConfig(controller *api.ReplicationController, codec runtime
 	}
 }
 
+// EncodeDeploymentConfig encodes config as a string using codec.
 func EncodeDeploymentConfig(config *deployapi.DeploymentConfig, codec runtime.Codec) (string, error) {
 	if bytes, err := codec.Encode(config); err == nil {
 		return string(bytes[:]), nil
 	} else {
 		return "", err
 	}
+}
+
+// MakeDeployment creates a deployment represented as a ReplicationController and based on the given
+// DeploymentConfig. The controller replica count will be zero.
+func MakeDeployment(config *deployapi.DeploymentConfig, codec runtime.Codec) (*api.ReplicationController, error) {
+	var err error
+	var encodedConfig string
+
+	if encodedConfig, err = EncodeDeploymentConfig(config, codec); err != nil {
+		return nil, err
+	}
+
+	deployment := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name: LatestDeploymentIDForConfig(config),
+			Annotations: map[string]string{
+				deployapi.DeploymentConfigAnnotation:        config.Name,
+				deployapi.DeploymentStatusAnnotation:        string(deployapi.DeploymentStatusNew),
+				deployapi.DeploymentEncodedConfigAnnotation: encodedConfig,
+				deployapi.DeploymentVersionAnnotation:       strconv.Itoa(config.LatestVersion),
+			},
+			Labels: config.Labels,
+		},
+		Spec: config.Template.ControllerTemplate,
+	}
+
+	// The deployment should be inactive initially
+	deployment.Spec.Replicas = 0
+
+	// Ensure that pods created by this deployment controller can be safely associated back
+	// to the controller, and that multiple deployment controllers for the same config don't
+	// manipulate each others' pods.
+	deployment.Spec.Template.Labels[deployapi.DeploymentConfigLabel] = config.Name
+	deployment.Spec.Template.Labels[deployapi.DeploymentLabel] = deployment.Name
+	deployment.Spec.Selector[deployapi.DeploymentConfigLabel] = config.Name
+	deployment.Spec.Selector[deployapi.DeploymentLabel] = deployment.Name
+
+	return deployment, nil
 }

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"strconv"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 )
 
@@ -71,5 +73,59 @@ func TestPodSpecsEqualAdditionalContainerInManifest(t *testing.T) {
 
 	if result {
 		t.Fatalf("Unexpected true result for PodSpecsEqual")
+	}
+}
+
+func TestMakeDeploymentOk(t *testing.T) {
+	config := deploytest.OkDeploymentConfig(1)
+	deployment, err := MakeDeployment(config, kapi.Codec)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	expectedAnnotations := map[string]string{
+		deployapi.DeploymentConfigAnnotation:  config.Name,
+		deployapi.DeploymentStatusAnnotation:  string(deployapi.DeploymentStatusNew),
+		deployapi.DeploymentVersionAnnotation: strconv.Itoa(config.LatestVersion),
+	}
+
+	for key, expected := range expectedAnnotations {
+		if actual := deployment.Annotations[key]; actual != expected {
+			t.Fatalf("expected deployment annotation %s=%s, got %s", key, expected, actual)
+		}
+	}
+
+	if len(deployment.Annotations[deployapi.DeploymentEncodedConfigAnnotation]) == 0 {
+		t.Fatalf("expected deployment with DeploymentEncodedConfigAnnotation annotation")
+	}
+
+	if decodedConfig, err := DecodeDeploymentConfig(deployment, kapi.Codec); err != nil {
+		t.Fatalf("invalid encoded config on deployment: %v", err)
+	} else {
+		if e, a := config.Name, decodedConfig.Name; e != a {
+			t.Fatalf("encoded config name doesn't match source config")
+		}
+		// TODO: more assertions
+	}
+
+	if deployment.Spec.Replicas != 0 {
+		t.Fatalf("expected deployment replicas to be 0")
+	}
+
+	if e, a := config.Name, deployment.Spec.Template.Labels[deployapi.DeploymentConfigLabel]; e != a {
+		t.Fatalf("expected label DeploymentConfigLabel=%s, got %s", e, a)
+	}
+
+	if e, a := deployment.Name, deployment.Spec.Template.Labels[deployapi.DeploymentLabel]; e != a {
+		t.Fatalf("expected label DeploymentLabel=%s, got %s", e, a)
+	}
+
+	if e, a := config.Name, deployment.Spec.Selector[deployapi.DeploymentConfigLabel]; e != a {
+		t.Fatalf("expected selector DeploymentConfigLabel=%s, got %s", e, a)
+	}
+
+	if e, a := deployment.Name, deployment.Spec.Selector[deployapi.DeploymentLabel]; e != a {
+		t.Fatalf("expected selector DeploymentLabel=%s, got %s", e, a)
 	}
 }


### PR DESCRIPTION
## Deployment Rollback API

This PR is to open discussion about a concrete rollback API. It builds on the discussion and documentation started with #435. The prototype here promotes a rollback system which builds on the core deployment API by providing a new generator endpoint which can provide clients with new DeploymentConfigs based on old deployments.

#### Example workflow

1. POST new deploymentConfig `config` to /deploymentConfigs (results in replicationController `deployment-1`)
2. PUT updated deploymentConfig (results in replicationController `deployment-2`)
3. POST /generateRollback (returns a valid DeploymentConfig based on `deployment-1`)
4. PUT output of 3 to /deploymentConfigs/config (results in replicationController `deployment-3` based on `deployment-1`)

