### PR TITLE
correct end-to-end test executable name in HACKING doc

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -126,7 +126,7 @@ End to end tests should be Go tests with the build tag `e2e` in the `test/e2e` d
 
 Run the end to end tests with:
 
-    $ hack/test-e2e.sh
+    $ hack/test-end-to-end.sh
 
 
 ## Installing Godep

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -68,10 +68,13 @@ function teardown()
   done
 
   echo "[INFO] Dumping build log to $LOG_DIR"
+
+  set +e
   BUILD_ID=`osc get -n test builds -o template -t "{{with index .items 0}}{{.metadata.name}}{{end}}"`
   osc build-logs -n test $BUILD_ID > $LOG_DIR/build.log
 
   curl -L http://localhost:4001/v2/keys/?recursive=true > $ARTIFACT_DIR/etcd_dump.json
+  set -e
 
   echo ""
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -130,7 +130,7 @@ echo "[INFO] Pre-pulling and pushing centos7"
 docker pull centos:centos7
 echo "[INFO] Pulled centos7"
 
-docker tag centos:centos7 ${DOCKER_REGISTRY_IP}:5001/cached/centos:centos7
+docker tag -f centos:centos7 ${DOCKER_REGISTRY_IP}:5001/cached/centos:centos7
 docker push ${DOCKER_REGISTRY_IP}:5001/cached/centos:centos7
 echo "[INFO] Pushed centos7"
 


### PR DESCRIPTION
Added a couple of small fixes.

* correct script name in HACKING.md
* continue `teardown()` even if some commands fail
* `docker tag` command needs `-f` flag to avoid failure when doing multiple runs

See some more details in #603 about the latter two.