### PR TITLE
Fixed bug: the master was advertising its internal IP when running the d...

### DIFF
--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -40,7 +40,7 @@ Description=openshift master
 After=network.service
 
 [Service]
-ExecStart=/usr/bin/openshift start master --nodes=${node_list}
+ExecStart=/usr/bin/openshift start master --master=http://${MASTER_IP}:8080 --nodes=${node_list}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
...ev cluster through Vagrant

This bug was causing the kubernetes and kubernetes-ro services to be inaccessible from the minions