### PR TITLE
Allow builds to reference image repositories by name

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
@@ -378,7 +378,7 @@ func ValidatePod(pod *api.Pod) errs.ValidationErrorList {
 		allErrs = append(allErrs, errs.NewFieldInvalid("namespace", pod.Namespace, ""))
 	}
 	allErrs = append(allErrs, ValidatePodSpec(&pod.Spec).Prefix("spec")...)
-	allErrs = append(allErrs, validateLabels(pod.Labels, "labels")...)
+	allErrs = append(allErrs, ValidateLabels(pod.Labels, "labels")...)
 	return allErrs
 }
 
@@ -394,11 +394,11 @@ func ValidatePodSpec(spec *api.PodSpec) errs.ValidationErrorList {
 	allErrs = append(allErrs, validateContainers(spec.Containers, allVolumes).Prefix("containers")...)
 	allErrs = append(allErrs, validateRestartPolicy(&spec.RestartPolicy).Prefix("restartPolicy")...)
 	allErrs = append(allErrs, validateDNSPolicy(&spec.DNSPolicy).Prefix("dnsPolicy")...)
-	allErrs = append(allErrs, validateLabels(spec.NodeSelector, "nodeSelector")...)
+	allErrs = append(allErrs, ValidateLabels(spec.NodeSelector, "nodeSelector")...)
 	return allErrs
 }
 
-func validateLabels(labels map[string]string, field string) errs.ValidationErrorList {
+func ValidateLabels(labels map[string]string, field string) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	for k := range labels {
 		if !util.IsQualifiedName(k) {
@@ -458,9 +458,9 @@ func ValidateService(service *api.Service, lister ServiceLister, ctx api.Context
 	}
 
 	if service.Spec.Selector != nil {
-		allErrs = append(allErrs, validateLabels(service.Spec.Selector, "spec.selector")...)
+		allErrs = append(allErrs, ValidateLabels(service.Spec.Selector, "spec.selector")...)
 	}
-	allErrs = append(allErrs, validateLabels(service.Labels, "labels")...)
+	allErrs = append(allErrs, ValidateLabels(service.Labels, "labels")...)
 
 	if service.Spec.CreateExternalLoadBalancer {
 		services, err := lister.ListServices(ctx)
@@ -496,7 +496,7 @@ func ValidateReplicationController(controller *api.ReplicationController) errs.V
 		allErrs = append(allErrs, errs.NewFieldInvalid("namespace", controller.Namespace, ""))
 	}
 	allErrs = append(allErrs, ValidateReplicationControllerSpec(&controller.Spec).Prefix("spec")...)
-	allErrs = append(allErrs, validateLabels(controller.Labels, "labels")...)
+	allErrs = append(allErrs, ValidateLabels(controller.Labels, "labels")...)
 	return allErrs
 }
 
@@ -533,7 +533,7 @@ func ValidateReplicationControllerSpec(spec *api.ReplicationControllerSpec) errs
 // ValidatePodTemplateSpec validates the spec of a pod template
 func ValidatePodTemplateSpec(spec *api.PodTemplateSpec) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	allErrs = append(allErrs, validateLabels(spec.Labels, "labels")...)
+	allErrs = append(allErrs, ValidateLabels(spec.Labels, "labels")...)
 	allErrs = append(allErrs, ValidatePodSpec(&spec.Spec).Prefix("spec")...)
 	allErrs = append(allErrs, ValidateReadOnlyPersistentDisks(spec.Spec.Volumes).Prefix("spec.volumes")...)
 	return allErrs
@@ -577,7 +577,7 @@ func ValidateMinion(minion *api.Node) errs.ValidationErrorList {
 	if len(minion.Name) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("name", minion.Name))
 	}
-	allErrs = append(allErrs, validateLabels(minion.Labels, "labels")...)
+	allErrs = append(allErrs, ValidateLabels(minion.Labels, "labels")...)
 	return allErrs
 }
 

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/poller.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/poller.go
@@ -57,14 +57,22 @@ func NewPoller(getFunc GetFunc, period time.Duration, store Store) *Poller {
 
 // Run begins polling. It starts a goroutine and returns immediately.
 func (p *Poller) Run() {
-	go util.Forever(func() {
-		e, err := p.getFunc()
-		if err != nil {
-			glog.Errorf("failed to list: %v", err)
-			return
-		}
-		p.sync(e)
-	}, p.period)
+	go util.Forever(p.run, p.period)
+}
+
+// RunUntil begins polling. It starts a goroutine and returns immediately.
+// It will stop when the stopCh is closed.
+func (p *Poller) RunUntil(stopCh <-chan struct{}) {
+	go util.Until(p.run, p.period, stopCh)
+}
+
+func (p *Poller) run() {
+	e, err := p.getFunc()
+	if err != nil {
+		glog.Errorf("failed to list: %v", err)
+		return
+	}
+	p.sync(e)
 }
 
 func (p *Poller) sync(e Enumerator) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/reflector.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/reflector.go
@@ -72,6 +72,12 @@ func (r *Reflector) Run() {
 	go util.Forever(func() { r.listAndWatch() }, r.period)
 }
 
+// RunUntil starts a watch and handles watch events. Will restart the watch if it is closed.
+// RunUntil starts a goroutine and returns immediately. It will exit when stopCh is closed.
+func (r *Reflector) RunUntil(stopCh <-chan struct{}) {
+	go util.Until(func() { r.listAndWatch() }, r.period, stopCh)
+}
+
 func (r *Reflector) listAndWatch() {
 	var resourceVersion string
 

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,11 @@ clean:
 	rm -rf $(OUT_DIR) $(OUT_PKG_DIR)
 .PHONY: clean
 
+# Build an official release of OpenShift, including the official images.
+#
+# Example:
+#   make clean
+release: clean
+	hack/build-release.sh
+	hack/build-images.sh
+.PHONY: release

--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -5,9 +5,12 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/origin/pkg/cmd/openshift"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
 )
 
 func main() {
+	serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))
+
 	basename := filepath.Base(os.Args[0])
 	command := openshift.CommandFor(basename)
 	if err := command.Execute(); err != nil {

--- a/examples/jenkins/jenkins-config.json
+++ b/examples/jenkins/jenkins-config.json
@@ -19,7 +19,7 @@
     },
     {
       "metadata": {
-       "id":"jenkins"
+        "name":"jenkins"
       },
       "kind":"DeploymentConfig",
       "apiVersion":"v1beta1",

--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -1,7 +1,7 @@
 {
   "metadata":{
     "name": "ruby-helloworld-sample",
-  }, 
+  },
   "kind": "Template",
   "apiVersion": "v1beta1",
   "description": "This example shows how to create a simple ruby application in openshift origin v3",
@@ -44,10 +44,9 @@
     {
       "metadata":{
         "name": "origin-ruby-sample",
-      }, 
+      },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "172.30.17.3:5001/custom/origin-ruby-sample",
       "labels": {
         "name": "origin-ruby-sample"
       }
@@ -58,7 +57,6 @@
       },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "172.30.17.3:5001/openshift/origin-custom-docker-builder",
       "labels": {
         "name": "custom-docker-builder"
       }
@@ -85,8 +83,10 @@
         {
           "type": "imageChange",
           "imageChange": {
-            "image": "172.30.17.3:5001/openshift/origin-custom-docker-builder",
-            "imageRepositoryRef": { "name": "origin-custom-docker-builder"},
+            "image": "openshift/origin-custom-docker-builder",
+            "from": {
+              "name": "origin-custom-docker-builder"
+            },
             "tag":"latest"
           }
         }
@@ -107,8 +107,9 @@
           }
         },
         "output": {
-          "imageTag": "custom/origin-ruby-sample:latest",
-          "registry": "172.30.17.3:5001"
+          "to": {
+            "name": "origin-ruby-sample"
+          }
         },
       },
       "labels": {
@@ -129,7 +130,9 @@
             "containerNames": [
               "ruby-helloworld"
             ],
-            "repositoryName": "172.30.17.3:5001/custom/origin-ruby-sample",
+            "from": {
+              "name": "origin-ruby-sample"
+            },
             "tag": "latest"
           }
         }
@@ -150,7 +153,7 @@
                 "containers": [
                   {
                     "name": "ruby-helloworld",
-                    "image": "172.30.17.3:5001/custom/origin-ruby-sample",
+                    "image": "origin-ruby-sample",
                     "env": [
                       {
                         "name": "ADMIN_USERNAME",

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -1,7 +1,7 @@
 {
   "metadata":{
     "name": "ruby-helloworld-sample",
-  }, 
+  },
   "kind": "Template",
   "apiVersion": "v1beta1",
   "description": "This example shows how to create a simple ruby application in openshift origin v3",
@@ -44,10 +44,9 @@
     {
       "metadata":{
         "name": "origin-ruby-sample",
-      }, 
+      },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "172.30.17.3:5001/docker/origin-ruby-sample",
       "labels": {
         "name": "origin-ruby-sample"
       }
@@ -58,7 +57,6 @@
       },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "172.30.17.3:5001/openshift/ruby-20-centos",
       "labels": {
         "name": "ruby-20-centos"
       }
@@ -85,8 +83,10 @@
         {
           "type": "imageChange",
           "imageChange": {
-            "image": "172.30.17.3:5001/openshift/ruby-20-centos",
-            "imageRepositoryRef": { "name": "ruby-20-centos"},
+            "image": "openshift/ruby-20-centos",
+            "from": {
+              "name": "ruby-20-centos"
+            },
             "tag":"latest"
           }
         }
@@ -102,8 +102,9 @@
           "type": "Docker"
         },
         "output": {
-          "imageTag": "docker/origin-ruby-sample:latest",
-          "registry": "172.30.17.3:5001"
+          "to": {
+            "name": "origin-ruby-sample"
+          },
         },
       },
       "labels": {
@@ -124,7 +125,9 @@
             "containerNames": [
               "ruby-helloworld"
             ],
-            "repositoryName": "172.30.17.3:5001/docker/origin-ruby-sample",
+            "from": {
+              "name": "origin-ruby-sample"
+            },
             "tag": "latest"
           }
         }
@@ -145,7 +148,7 @@
                 "containers": [
                   {
                     "name": "ruby-helloworld",
-                    "image": "172.30.17.3:5001/docker/origin-ruby-sample",
+                    "image": "origin-ruby-sample",
                     "env": [
                       {
                         "name": "ADMIN_USERNAME",

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -47,7 +47,6 @@
       },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "172.30.17.3:5001/test/origin-ruby-sample",
       "labels": {
         "name": "origin-ruby-sample"
       }
@@ -58,7 +57,6 @@
       },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "172.30.17.3:5001/openshift/ruby-20-centos",
       "labels": {
         "name": "ruby-20-centos"
       }
@@ -85,8 +83,8 @@
         {
           "type": "imageChange",
           "imageChange": {
-            "image": "172.30.17.3:5001/openshift/ruby-20-centos",
-            "imageRepositoryRef": { "name": "ruby-20-centos"},
+            "image": "openshift/ruby-20-centos",
+            "from": { "name": "ruby-20-centos"},
             "tag":"latest"
           }
         }
@@ -106,8 +104,9 @@
           }
         },
         "output": {
-          "imageTag": "test/origin-ruby-sample:latest",
-          "registry": "172.30.17.3:5001"
+          "to": {
+            "name": "origin-ruby-sample"
+          }
         },
       },
       "labels": {
@@ -128,7 +127,9 @@
             "containerNames": [
               "ruby-helloworld"
             ],
-            "repositoryName": "172.30.17.3:5001/test/origin-ruby-sample",
+            "from": {
+              "name": "origin-ruby-sample"
+            },
             "tag": "latest"
           }
         }
@@ -149,7 +150,7 @@
                 "containers": [
                   {
                     "name": "ruby-helloworld",
-                    "image": "172.30.17.3:5001/test/origin-ruby-sample",
+                    "image": "origin-ruby-sample",
                     "env": [
                       {
                         "name": "ADMIN_USERNAME",

--- a/examples/sample-app/docker-registry-template.json
+++ b/examples/sample-app/docker-registry-template.json
@@ -33,7 +33,6 @@
       "creationTimestamp":null,
       "id":"docker-registry",
       "kind":"Service",
-      "portalIp": "172.30.17.3",
       "port":5001,
       "containerPort":5000,
       "selector":{

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -37,7 +37,7 @@ KUBELET_PORT=${KUBELET_PORT:-10250}
 
 ETCD_DATA_DIR=$(mktemp -d /tmp/openshift.local.etcd.XXXX)
 VOLUME_DIR=$(mktemp -d /tmp/openshift.local.volumes.XXXX)
-CERT_DIR=$(mktemp -d /tmp/openshift.local.certificates.XXXX)
+CERT_DIR="${CERT_DIR:-$(mktemp -d /tmp/openshift.local.certificates.XXXX)}"
 
 # set path so OpenShift is available
 GO_OUT="${OS_ROOT}/_output/local/go/bin"
@@ -48,26 +48,22 @@ out=$(openshift version)
 echo openshift: $out
 
 # Start openshift
-if [[ "$API_SCHEME" == "https" ]]; then
-    export CURL_CA_BUNDLE="$CERT_DIR/admin/root.crt"
-fi
-
-openshift start --master="${API_SCHEME}://${API_HOST}:${API_PORT}" --listen="${API_SCHEME}://0.0.0.0:${API_PORT}" --hostname=${API_HOST} --volume-dir="${VOLUME_DIR}" --cert-dir="${CERT_DIR}" --etcd-dir="${ETCD_DATA_DIR}" 1>&2 &
+openshift start --master="${API_SCHEME}://${API_HOST}:${API_PORT}" --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" --hostname="${API_HOST}" --volume-dir="${VOLUME_DIR}" --cert-dir="${CERT_DIR}" --etcd-dir="${ETCD_DATA_DIR}" 1>&2 &
 OS_PID=$!
 
-wait_for_url "http://localhost:${KUBELET_PORT}/healthz" "kubelet: " 0.2 60
-wait_for_url "http://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.2 60
-wait_for_url "http://${API_HOST}:${API_PORT}/api/v1beta1/minions/127.0.0.1" "apiserver(minions): " 0.2 60
-
-wait_for_url "${KUBELET_SCHEME}://${API_HOST}:${KUBELET_PORT}/healthz" "kubelet: " 1 30
-wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: "
+if [[ "${API_SCHEME}" == "https" ]]; then
+    export CURL_CA_BUNDLE="${CERT_DIR}/admin/root.crt"
+fi
+wait_for_url "http://${API_HOST}:${KUBELET_PORT}/healthz" "kubelet: " 0.2 60
+wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.2 60
+wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1beta1/minions/127.0.0.1" "apiserver(minions): " 0.2 60
 
 # Set KUBERNETES_MASTER for osc
 export KUBERNETES_MASTER="${API_SCHEME}://${API_HOST}:${API_PORT}"
-if [[ "$API_SCHEME" == "https" ]]; then
-	# Make osc use $CERT_DIR/admin/.kubeconfig, and ignore anything in the running user's $HOME dir
-	export HOME=$CERT_DIR/admin
-	export KUBECONFIG=$CERT_DIR/admin/.kubeconfig
+if [[ "${API_SCHEME}" == "https" ]]; then
+	# Make osc use ${CERT_DIR}/admin/.kubeconfig, and ignore anything in the running user's $HOME dir
+	export HOME="${CERT_DIR}/admin"
+	export KUBECONFIG="${CERT_DIR}/admin/.kubeconfig"
 fi
 
 #
@@ -129,3 +125,5 @@ echo "start-build: ok"
 
 osc cancel-build "${started}" --dump-logs --restart
 echo "cancel-build: ok"
+
+osc get minions,pods

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -25,6 +25,8 @@ trap cleanup EXIT SIGINT
 
 set -e
 
+export OPENSHIFT_ON_PANIC=crash
+
 USE_LOCAL_IMAGES=${USE_LOCAL_IMAGES:-true}
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -25,6 +25,7 @@ source "${OS_ROOT}/hack/util.sh"
 
 echo "[INFO] Starting end-to-end test"
 
+export OPENSHIFT_ON_PANIC=crash
 USE_LOCAL_IMAGES="${USE_LOCAL_IMAGES:-true}"
 ROUTER_TESTS_ENABLED="${ROUTER_TESTS_ENABLED:-true}"
 

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -47,6 +47,8 @@ fi
 
 OUTPUT_COVERAGE=${OUTPUT_COVERAGE:-""}
 
+export OPENSHIFT_ON_PANIC=crash
+
 if [[ -n "${KUBE_COVER}" && -n "${OUTPUT_COVERAGE}" ]]; then
   # Iterate over packages to run coverage
   test_packages=( $test_packages )

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -22,4 +22,5 @@ trap cleanup EXIT SIGINT
 echo
 echo Integration test cases ...
 echo
-KUBE_RACE="${KUBE_RACE:--race}" KUBE_COVER=" " "${OS_ROOT}/hack/test-go.sh" test/integration -tags 'integration no-docker' "${@:1}"
+# TODO: race is disabled because of origin #731
+KUBE_RACE="${KUBE_RACE:-}" KUBE_COVER=" " "${OS_ROOT}/hack/test-go.sh" test/integration -tags 'integration no-docker' "${@:1}"

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -256,8 +256,12 @@ type ImageChangeTrigger struct {
 	// Image is used to specify the value in the BuildConfig to replace with the
 	// immutable image id supplied by the ImageRepository when this trigger fires.
 	Image string `json:"image"`
-	// ImageRepositoryRef a reference to a Docker image repository to watch for changes.
-	ImageRepositoryRef *kapi.ObjectReference `json:"imageRepositoryRef"`
+	// From is a reference to a Docker image repository to watch for changes. This field takes
+	// precedence over ImageRepositoryRef, which is deprecated and will be removed in v1beta2. The
+	// Kind may be left blank, in which case it defaults to "ImageRepository". The "Name" is
+	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// trigger will be used.
+	From kapi.ObjectReference `json:"from"`
 	// Tag is the name of an image repository tag to watch for changes.
 	Tag string `json:"tag,omitempty"`
 	// LastTriggeredImageID is used internally by the ImageChangeController to save last

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -206,11 +206,22 @@ type STIBuildStrategy struct {
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy
 // should produce.
 type BuildOutput struct {
-	// ImageTag is the tag to give to the image resulting from the build.
-	ImageTag string `json:"imageTag,omitempty"`
+	// To defines an optional ImageRepository to push the output of this build to. The namespace
+	// may be empty, in which case the named ImageRepository will be retrieved from the namespace
+	// of the build. Kind must be set to 'ImageRepository' and is the only supported value. If set,
+	// this field takes priority over DockerImageReference. This value will be used to look up
+	// a Docker image repository to push to.
+	To *kapi.ObjectReference `json:"to,omitempty"`
 
-	// Registry is the Docker registry which should receive the resulting built image via push.
-	Registry string `json:"registry,omitempty"`
+	// Tag is the "version name" that will be associated with the output image. This
+	// field is only used if the To field is set, and is ignored when DockerImageReference is used.
+	// This value represents a consistent name for a set of related changes (v1, 5.x, 5.5, dev, stable)
+	// and defaults to the preferred tag for "To" if not specified.
+	Tag string `json:"tag,omitempty"`
+
+	// DockerImageReference is the full name of an image ([registry/]name[:tag]), and will be the
+	// value sent to Docker push at the end of a build.
+	DockerImageReference string `json:"dockerImageReference,omitempty"`
 }
 
 // BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -16,6 +16,9 @@ type Build struct {
 	// Status is the current status of the build.
 	Status BuildStatus `json:"status,omitempty"`
 
+	// A human readable message indicating details about why the build has this status
+	Message string `json:"message,omitempty"`
+
 	// PodName is the name of the pod that is used to execute the build
 	PodName string `json:"podName,omitempty"`
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -213,7 +213,7 @@ type BuildOutput struct {
 	// may be empty, in which case the named ImageRepository will be retrieved from the namespace
 	// of the build. Kind must be set to 'ImageRepository' and is the only supported value. If set,
 	// this field takes priority over DockerImageReference. This value will be used to look up
-	// a Docker image repository to push to.
+	// a Docker image repository to push to. Failure to find the To will result in a build error.
 	To *kapi.ObjectReference `json:"to,omitempty"`
 
 	// Tag is the "version name" that will be associated with the output image. This
@@ -223,7 +223,7 @@ type BuildOutput struct {
 	Tag string `json:"tag,omitempty"`
 
 	// DockerImageReference is the full name of an image ([registry/]name[:tag]), and will be the
-	// value sent to Docker push at the end of a build.
+	// value sent to Docker push at the end of a build if the To field is not defined.
 	DockerImageReference string `json:"dockerImageReference,omitempty"`
 }
 
@@ -240,7 +240,8 @@ type BuildConfig struct {
 	// are defined, a new build can only occur as a result of an explicit client build creation.
 	Triggers []BuildTriggerPolicy `json:"triggers,omitempty"`
 
-	// Parameters holds all the input necessary to produce a new build.
+	// Parameters holds all the input necessary to produce a new build. A build config may only
+	// define either the Output.To or Output.DockerImageReference fields, but not both.
 	Parameters BuildParameters `json:"parameters,omitempty"`
 }
 

--- a/pkg/build/api/v1beta1/conversion.go
+++ b/pkg/build/api/v1beta1/conversion.go
@@ -4,6 +4,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	newer "github.com/openshift/origin/pkg/build/api"
+	image "github.com/openshift/origin/pkg/image/api"
 )
 
 func init() {
@@ -23,6 +24,38 @@ func init() {
 				out.Image = in.Image
 			} else {
 				out.Image = in.BuilderImage
+			}
+			return nil
+		},
+		// Deprecate ImageTag and Registry, replace with To / Tag / DockerImageReference
+		func(in *newer.BuildOutput, out *BuildOutput, s conversion.Scope) error {
+			if err := s.Convert(&in.To, &out.To, 0); err != nil {
+				return err
+			}
+			out.Tag = in.Tag
+			if len(in.DockerImageReference) > 0 {
+				out.DockerImageReference = in.DockerImageReference
+				registry, namespace, name, tag, _ := image.SplitDockerPullSpec(in.DockerImageReference)
+				out.Registry = registry
+				out.ImageTag = image.JoinDockerPullSpec("", namespace, name, tag)
+			}
+			return nil
+		},
+		func(in *BuildOutput, out *newer.BuildOutput, s conversion.Scope) error {
+			if err := s.Convert(&in.To, &out.To, 0); err != nil {
+				return err
+			}
+			out.Tag = in.Tag
+			if len(in.DockerImageReference) > 0 {
+				out.DockerImageReference = in.DockerImageReference
+				return nil
+			}
+			if len(in.ImageTag) != 0 {
+				_, namespace, name, tag, err := image.SplitDockerPullSpec(in.ImageTag)
+				if err != nil {
+					return err
+				}
+				out.DockerImageReference = image.JoinDockerPullSpec(in.Registry, namespace, name, tag)
 			}
 			return nil
 		},

--- a/pkg/build/api/v1beta1/conversion_test.go
+++ b/pkg/build/api/v1beta1/conversion_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+
 	newer "github.com/openshift/origin/pkg/build/api"
 	current "github.com/openshift/origin/pkg/build/api/v1beta1"
 )
@@ -11,15 +13,60 @@ import (
 var Convert = api.Scheme.Convert
 
 func TestSTIBuildStrategyConversion(t *testing.T) {
-	var got newer.STIBuildStrategy
+	var actual newer.STIBuildStrategy
 	oldVersion := current.STIBuildStrategy{
 		BuilderImage: "testimage",
 	}
-	err := Convert(&oldVersion, &got)
+	err := Convert(&oldVersion, &actual)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.Image != oldVersion.BuilderImage {
-		t.Error("expected %v, got %v", oldVersion.BuilderImage, got.Image)
+	if actual.Image != oldVersion.BuilderImage {
+		t.Errorf("expected %v, actual %v", oldVersion.BuilderImage, actual.Image)
+	}
+}
+
+func TestImageChangeTriggerFromRename(t *testing.T) {
+	old := current.ImageChangeTrigger{
+		From: kapi.ObjectReference{
+			Name: "foo",
+		},
+		ImageRepositoryRef: &kapi.ObjectReference{
+			Name: "bar",
+		},
+	}
+	actual := newer.ImageChangeTrigger{}
+	if err := Convert(&old, &actual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actual.From.Name != "bar" {
+		t.Error("expected %#v, actual %#v", old, actual)
+	}
+
+	old = current.ImageChangeTrigger{
+		From: kapi.ObjectReference{
+			Name: "foo",
+		},
+	}
+	actual = newer.ImageChangeTrigger{}
+	if err := Convert(&old, &actual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actual.From.Name != "foo" {
+		t.Error("expected %#v, actual %#v", old, actual)
+	}
+
+	old = current.ImageChangeTrigger{
+		From: kapi.ObjectReference{
+			Name: "foo",
+		},
+		ImageRepositoryRef: &kapi.ObjectReference{},
+	}
+	actual = newer.ImageChangeTrigger{}
+	if err := Convert(&old, &actual); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actual.From.Name != "" {
+		t.Errorf("expected %#v, actual %#v", old, actual)
 	}
 }

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -259,8 +259,16 @@ type WebHookTrigger struct {
 type ImageChangeTrigger struct {
 	// Image is used to specify the value in the BuildConfig to replace with the
 	// immutable image id supplied by the ImageRepository when this trigger fires.
-	Image string `json:"image"`
+	Image          string `json:"image"`
+	RepositoryName string `json:"repositoryName,omitempty"`
+	// From is a reference to a Docker image repository to watch for changes. This field takes
+	// precedence over ImageRepositoryRef, which is deprecated and will be removed in v1beta2. The
+	// Kind may be left blank, in which case it defaults to "ImageRepository". The "Name" is
+	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// trigger will be used.
+	From kapi.ObjectReference `json:"from"`
 	// ImageRepositoryRef a reference to a Docker image repository to watch for changes.
+	// DEPRECATED: replaced by From
 	ImageRepositoryRef *kapi.ObjectReference `json:"imageRepositoryRef"`
 	// Tag is the name of an image repository tag to watch for changes.
 	Tag string `json:"tag,omitempty"`

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -201,10 +201,30 @@ type STIBuildStrategy struct {
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy
 // should produce.
 type BuildOutput struct {
+	// To defines an optional ImageRepository to push the output of this build to. The namespace
+	// may be empty, in which case the ImageRepository will be looked for in the namespace of
+	// the build. Kind must be set to 'ImageRepository' and is the only supported value. If set,
+	// this field takes priority over DockerImageReference. This value will be used to look up
+	// a Docker image repository to push to.
+	To *kapi.ObjectReference `json:"to,omitempty"`
+
+	// Tag is the "version" that will be set on the remote server when the image is created. This
+	// field is only used if the To field is set, and is ignored when DockerImageReference is used.
+	// This value represents a consistent name for a set of related changes (v1, 5.x, 5.5, dev, stable)
+	// and defaults to the preferred label for "To" if not specified.
+	Tag string `json:"tag,omitempty"`
+
+	// DockerImageReference is the full name of an image ([registry/]name[:tag]), and will be the
+	// value sent to Docker push at the end of a build.  If set, this field takes priority over
+	// ImageTag and Registry.
+	DockerImageReference string `json:"dockerImageReference,omitempty"`
+
 	// ImageTag is the tag to give to the image resulting from the build.
+	// DEPRECATED: use DockerImageReference
 	ImageTag string `json:"imageTag,omitempty"`
 
 	// Registry is the Docker registry which should receive the resulting built image via push.
+	// DEPRECATED: use DockerImageReference
 	Registry string `json:"registry,omitempty"`
 }
 

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -244,7 +244,8 @@ type BuildConfig struct {
 	// are defined, a new build can only occur as a result of an explicit client build creation.
 	Triggers []BuildTriggerPolicy `json:"triggers,omitempty"`
 
-	// Parameters holds all the input necessary to produce a new build.
+	// Parameters holds all the input necessary to produce a new build. A build config may only
+	// define either the Output.To or Output.DockerImageReference fields, but not both.
 	Parameters BuildParameters `json:"parameters,omitempty"`
 }
 

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -16,6 +16,9 @@ type Build struct {
 	// Status is the current status of the build.
 	Status BuildStatus `json:"status,omitempty"`
 
+	// A human readable message indicating details about why the build has this status
+	Message string `json:"message,omitempty"`
+
 	// PodName is the name of the pod that is used to execute the build
 	PodName string `json:"podName,omitempty"`
 

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -237,12 +237,10 @@ func validateImageChange(imageChange *buildapi.ImageChangeTrigger) errs.Validati
 	if len(imageChange.Image) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("image", ""))
 	}
-	if imageChange.ImageRepositoryRef == nil {
-		allErrs = append(allErrs, errs.NewFieldRequired("imageRepositoryRef", ""))
-	} else if len(imageChange.ImageRepositoryRef.Name) == 0 {
-		nestedErrs := errs.ValidationErrorList{errs.NewFieldRequired("name", "")}
-		nestedErrs.Prefix("imageRepositoryRef")
-		allErrs = append(allErrs, nestedErrs...)
+	if len(imageChange.From.Name) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("from", ""))
+	} else if len(imageChange.From.Name) == 0 {
+		allErrs = append(allErrs, errs.ValidationErrorList{errs.NewFieldRequired("name", "")}.Prefix("from")...)
 	}
 	return allErrs
 }

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
-	image "github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // ValidateBuild tests required fields for a Build.
@@ -126,7 +126,7 @@ func validateOutput(output *buildapi.BuildOutput) errs.ValidationErrorList {
 	}
 
 	if len(output.DockerImageReference) != 0 {
-		if _, _, _, _, err := image.SplitDockerPullSpec(output.DockerImageReference); err != nil {
+		if _, _, _, _, err := imageapi.SplitDockerPullSpec(output.DockerImageReference); err != nil {
 			allErrs = append(allErrs, errs.NewFieldInvalid("dockerImageReference", output.DockerImageReference, err.Error()))
 		}
 	}

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -4,8 +4,11 @@ import (
 	"net/url"
 
 	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	image "github.com/openshift/origin/pkg/image/api"
 )
 
 // ValidateBuild tests required fields for a Build.
@@ -13,7 +16,15 @@ func ValidateBuild(build *buildapi.Build) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	if len(build.Name) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("name", build.Name))
+	} else if !util.IsDNSSubdomain(build.Name) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("name", build.Name, "name must be a valid subdomain"))
 	}
+	if len(build.Namespace) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("namespace", build.Namespace))
+	} else if !util.IsDNSSubdomain(build.Namespace) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("namespace", build.Namespace, "namespace must be a valid subdomain"))
+	}
+	allErrs = append(allErrs, validation.ValidateLabels(build.Labels, "labels")...)
 	allErrs = append(allErrs, validateBuildParameters(&build.Parameters).Prefix("parameters")...)
 	return allErrs
 }
@@ -23,11 +34,20 @@ func ValidateBuildConfig(config *buildapi.BuildConfig) errs.ValidationErrorList 
 	allErrs := errs.ValidationErrorList{}
 	if len(config.Name) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("name", config.Name))
+	} else if !util.IsDNSSubdomain(config.Name) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("name", config.Name, "name must be a valid subdomain"))
 	}
+	if len(config.Namespace) == 0 {
+		allErrs = append(allErrs, errs.NewFieldRequired("namespace", config.Namespace))
+	} else if !util.IsDNSSubdomain(config.Namespace) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("namespace", config.Namespace, "namespace must be a valid subdomain"))
+	}
+	allErrs = append(allErrs, validation.ValidateLabels(config.Labels, "labels")...)
 	for i := range config.Triggers {
 		allErrs = append(allErrs, validateTrigger(&config.Triggers[i]).PrefixIndex(i).Prefix("triggers")...)
 	}
 	allErrs = append(allErrs, validateBuildParameters(&config.Parameters).Prefix("parameters")...)
+	allErrs = append(allErrs, validateBuildConfigOutput(&config.Parameters.Output).Prefix("parameters.output")...)
 	return allErrs
 }
 
@@ -44,10 +64,7 @@ func validateBuildParameters(params *buildapi.BuildParameters) errs.ValidationEr
 		}
 	}
 
-	if !isCustomBuild || (isCustomBuild && len(params.Output.ImageTag) != 0) {
-		allErrs = append(allErrs, validateOutput(&params.Output).Prefix("output")...)
-	}
-
+	allErrs = append(allErrs, validateOutput(&params.Output).Prefix("output")...)
 	allErrs = append(allErrs, validateStrategy(&params.Strategy).Prefix("strategy")...)
 
 	return allErrs
@@ -82,6 +99,45 @@ func validateRevision(revision *buildapi.SourceRevision) errs.ValidationErrorLis
 		allErrs = append(allErrs, errs.NewFieldRequired("type", revision.Type))
 	}
 	// TODO: validate other stuff
+	return allErrs
+}
+
+func validateOutput(output *buildapi.BuildOutput) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	// TODO: make part of a generic ValidateObjectReference method upstream.
+	if output.To != nil {
+		kind, name, namespace := output.To.Kind, output.To.Name, output.To.Namespace
+		if len(kind) == 0 {
+			kind = "ImageRepository"
+			output.To.Kind = kind
+		}
+		if kind != "ImageRepository" {
+			allErrs = append(allErrs, errs.NewFieldInvalid("to.kind", kind, "the target of build output must be 'ImageRepository'"))
+		}
+		if len(name) == 0 {
+			allErrs = append(allErrs, errs.NewFieldRequired("to.name", name))
+		} else if !util.IsDNSSubdomain(name) {
+			allErrs = append(allErrs, errs.NewFieldInvalid("to.name", name, "name must be a valid subdomain"))
+		}
+		if len(namespace) != 0 && !util.IsDNSSubdomain(namespace) {
+			allErrs = append(allErrs, errs.NewFieldInvalid("to.namespace", namespace, "namespace must be a valid subdomain"))
+		}
+	}
+
+	if len(output.DockerImageReference) != 0 {
+		if _, _, _, _, err := image.SplitDockerPullSpec(output.DockerImageReference); err != nil {
+			allErrs = append(allErrs, errs.NewFieldInvalid("dockerImageReference", output.DockerImageReference, err.Error()))
+		}
+	}
+	return allErrs
+}
+
+func validateBuildConfigOutput(output *buildapi.BuildOutput) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	if len(output.DockerImageReference) != 0 && output.To != nil {
+		allErrs = append(allErrs, errs.NewFieldInvalid("dockerImageReference", output.DockerImageReference, "only one of 'dockerImageReference' and 'to' may be set"))
+	}
 	return allErrs
 }
 
@@ -124,14 +180,6 @@ func validateSTIStrategy(strategy *buildapi.STIBuildStrategy) errs.ValidationErr
 	allErrs := errs.ValidationErrorList{}
 	if len(strategy.Image) == 0 {
 		allErrs = append(allErrs, errs.NewFieldRequired("image", strategy.Image))
-	}
-	return allErrs
-}
-
-func validateOutput(output *buildapi.BuildOutput) errs.ValidationErrorList {
-	allErrs := errs.ValidationErrorList{}
-	if len(output.ImageTag) == 0 {
-		allErrs = append(allErrs, errs.NewFieldRequired("imageTag", output.ImageTag))
 	}
 	return allErrs
 }

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -65,7 +65,7 @@ func (d *DockerBuilder) Build() error {
 		return err
 	}
 	defer removeImage(d.dockerClient, imageTag(d.build))
-	if d.build.Parameters.Output.Registry != "" || d.authPresent {
+	if len(d.build.Parameters.Output.DockerImageReference) != 0 {
 		return pushImage(d.dockerClient, imageTag(d.build), d.auth)
 	}
 	return nil

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -64,9 +64,10 @@ func (d *DockerBuilder) Build() error {
 	if err = d.dockerBuild(buildDir); err != nil {
 		return err
 	}
-	defer removeImage(d.dockerClient, imageTag(d.build))
+	tag := d.build.Parameters.Output.DockerImageReference
+	defer removeImage(d.dockerClient, tag)
 	if len(d.build.Parameters.Output.DockerImageReference) != 0 {
-		return pushImage(d.dockerClient, imageTag(d.build), d.auth)
+		return pushImage(d.dockerClient, tag, d.auth)
 	}
 	return nil
 }
@@ -175,5 +176,5 @@ func (d *DockerBuilder) dockerBuild(dir string) error {
 		}
 		noCache = d.build.Parameters.Strategy.DockerStrategy.NoCache
 	}
-	return buildImage(d.dockerClient, dir, noCache, imageTag(d.build), d.tar)
+	return buildImage(d.dockerClient, dir, noCache, d.build.Parameters.Output.DockerImageReference, d.tar)
 }

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -29,11 +29,12 @@ func NewSTIBuilder(client DockerClient, dockerSocket string, authCfg docker.Auth
 
 // Build executes the STI build
 func (s *STIBuilder) Build() error {
+	tag := s.build.Parameters.Output.DockerImageReference
 	request := &stiapi.Request{
 		BaseImage:    s.build.Parameters.Strategy.STIStrategy.Image,
 		DockerSocket: s.dockerSocket,
 		Source:       s.build.Parameters.Source.Git.URI,
-		Tag:          imageTag(s.build),
+		Tag:          tag,
 		ScriptsURL:   s.build.Parameters.Strategy.STIStrategy.Scripts,
 		Environment:  getBuildEnvVars(s.build),
 		Clean:        s.build.Parameters.Strategy.STIStrategy.Clean,
@@ -48,12 +49,12 @@ func (s *STIBuilder) Build() error {
 	if err != nil {
 		return err
 	}
-	defer removeImage(s.dockerClient, imageTag(s.build))
+	defer removeImage(s.dockerClient, tag)
 	if _, err = builder.Build(); err != nil {
 		return err
 	}
 	if len(s.build.Parameters.Output.DockerImageReference) != 0 {
-		return pushImage(s.dockerClient, imageTag(s.build), s.auth)
+		return pushImage(s.dockerClient, tag, s.auth)
 	}
 	return nil
 }

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -52,7 +52,7 @@ func (s *STIBuilder) Build() error {
 	if _, err = builder.Build(); err != nil {
 		return err
 	}
-	if s.build.Parameters.Output.Registry != "" || s.authPresent {
+	if len(s.build.Parameters.Output.DockerImageReference) != 0 {
 		return pushImage(s.dockerClient, imageTag(s.build), s.auth)
 	}
 	return nil

--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -8,12 +8,6 @@ type Builder interface {
 	Build() error
 }
 
-// imageTag returns the tag to be used for the build. If a registry has been
-// specified, it will prepend the registry to the name
-func imageTag(build *api.Build) string {
-	return build.Parameters.Output.DockerImageReference
-}
-
 // getBuildEnvVars returns a map with the environment variables that should be added
 // to the built image
 func getBuildEnvVars(build *api.Build) map[string]string {

--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -1,9 +1,6 @@
 package builder
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/openshift/origin/pkg/build/api"
 )
 
@@ -14,11 +11,7 @@ type Builder interface {
 // imageTag returns the tag to be used for the build. If a registry has been
 // specified, it will prepend the registry to the name
 func imageTag(build *api.Build) string {
-	tag := build.Parameters.Output.ImageTag
-	if !strings.HasPrefix(tag, build.Parameters.Output.Registry) {
-		tag = fmt.Sprintf("%s/%s", build.Parameters.Output.Registry, tag)
-	}
-	return tag
+	return build.Parameters.Output.DockerImageReference
 }
 
 // getBuildEnvVars returns a map with the environment variables that should be added

--- a/pkg/build/builder/util_test.go
+++ b/pkg/build/builder/util_test.go
@@ -17,7 +17,7 @@ func TestImageTag(t *testing.T) {
 			build: api.Build{
 				Parameters: api.BuildParameters{
 					Output: api.BuildOutput{
-						ImageTag: "test/tag",
+						DockerImageReference: "test/tag",
 					},
 				},
 			},
@@ -27,19 +27,7 @@ func TestImageTag(t *testing.T) {
 			build: api.Build{
 				Parameters: api.BuildParameters{
 					Output: api.BuildOutput{
-						ImageTag: "test/tag",
-						Registry: "registry-server.test:5000",
-					},
-				},
-			},
-			expected: "registry-server.test:5000/test/tag",
-		},
-		{
-			build: api.Build{
-				Parameters: api.BuildParameters{
-					Output: api.BuildOutput{
-						ImageTag: "registry-server.test:5000/test/tag",
-						Registry: "registry-server.test:5000",
+						DockerImageReference: "registry-server.test:5000/test/tag",
 					},
 				},
 			},

--- a/pkg/build/builder/util_test.go
+++ b/pkg/build/builder/util_test.go
@@ -35,7 +35,7 @@ func TestImageTag(t *testing.T) {
 		},
 	}
 	for _, x := range tests {
-		result := imageTag(&x.build)
+		result := x.build.Parameters.Output.DockerImageReference
 		if result != x.expected {
 			t.Errorf("Unexpected imageTag result. Expected: %s, Actual: %s",
 				result, x.expected)

--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	image "github.com/openshift/origin/pkg/image/api"
 )
 
 // BuildController watches build resources and manages their state
@@ -21,6 +22,8 @@ type BuildController struct {
 	BuildUpdater  buildUpdater
 	PodManager    podManager
 	BuildStrategy BuildStrategy
+
+	ImageRepositoryClient imageRepositoryClient
 }
 
 // BuildStrategy knows how to create a pod spec for a pod which can execute a build.
@@ -37,6 +40,10 @@ type podManager interface {
 	DeletePod(namespace string, pod *kapi.Pod) error
 }
 
+type imageRepositoryClient interface {
+	GetImageRepository(namespace, name string) (*image.ImageRepository, error)
+}
+
 // Run begins watching and syncing build jobs onto the cluster.
 func (bc *BuildController) Run() {
 	go util.Forever(func() { bc.HandleBuild(bc.NextBuild()) }, 0)
@@ -51,39 +58,77 @@ func (bc *BuildController) HandleBuild(build *buildapi.Build) {
 		return
 	}
 
-	nextStatus := buildapi.BuildStatusFailed
-	build.PodName = fmt.Sprintf("build-%s", build.Name)
+	if err := bc.nextBuildStatus(build); err != nil {
+		glog.V(4).Infof("Build failed with error %s/%s: %#v", build.Namespace, build.Name, err)
+		build.Status = buildapi.BuildStatusError
+		build.Message = err.Error()
+	}
 
+	if _, err := bc.BuildUpdater.UpdateBuild(build.Namespace, build); err != nil {
+		glog.V(2).Infof("Failed to record changes to build %s/%s: %#v", build.Namespace, build.Name, err)
+	}
+}
+
+// nextBuildStatus updates build with any appropriate changes, or returns an error if
+// the change cannot occur. When returning nil, be sure to set build.Status and optionally
+// build.Message.
+func (bc *BuildController) nextBuildStatus(build *buildapi.Build) error {
 	// If a cancelling event was triggered for the build, update build status.
 	if build.Cancelled {
-		glog.V(2).Infof("Cancelling build %s.", build.Name)
-		nextStatus = buildapi.BuildStatusCancelled
+		glog.V(4).Infof("Cancelling build %s.", build.Name)
+		build.Status = buildapi.BuildStatusCancelled
+		return nil
+	}
 
-	} else {
-
-		var podSpec *kapi.Pod
-		var err error
-		if podSpec, err = bc.BuildStrategy.CreateBuildPod(build); err != nil {
-			glog.V(2).Infof("Strategy failed to create build pod definition: %v", err)
-			nextStatus = buildapi.BuildStatusFailed
-		} else {
-
-			if _, err := bc.PodManager.CreatePod(build.Namespace, podSpec); err != nil {
-				if !errors.IsAlreadyExists(err) {
-					glog.V(2).Infof("Failed to create pod for build %s: %#v", build.Name, err)
-					nextStatus = buildapi.BuildStatusFailed
-				}
-			} else {
-				glog.V(2).Infof("Created build pod: %#v", podSpec)
-				nextStatus = buildapi.BuildStatusPending
-			}
+	// lookup the destination from the referenced image repository
+	spec := build.Parameters.Output.DockerImageReference
+	if ref := build.Parameters.Output.To; ref != nil {
+		// TODO: security, ensure that the reference image stream is actually visible
+		namespace := ref.Namespace
+		if len(namespace) == 0 {
+			namespace = build.Namespace
 		}
+
+		repo, err := bc.ImageRepositoryClient.GetImageRepository(namespace, ref.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				build.Status = buildapi.BuildStatusFailed
+				build.Message = fmt.Sprintf("The referenced output image repository %s/%s does not exist", namespace, ref.Name)
+				return nil
+			}
+			return fmt.Errorf("the referenced output repo %s/%s could not be found by %s/%s: %v", namespace, ref.Name, build.Namespace, build.Name, err)
+		}
+		spec = repo.Status.DockerImageRepository
 	}
 
-	build.Status = nextStatus
-	if _, err := bc.BuildUpdater.UpdateBuild(build.Namespace, build); err != nil {
-		glog.V(2).Infof("Failed to update build %s: %#v", build.Name, err)
+	// set the expected build parameters, which will be saved if no error occurs
+	build.Status = buildapi.BuildStatusPending
+	build.PodName = fmt.Sprintf("build-%s", build.Name)
+
+	// override DockerImageReference in the strategy for the copy we send to the server
+	copy, err := kapi.Scheme.Copy(build)
+	if err != nil {
+		return fmt.Errorf("unable to copy build: %v", err)
 	}
+	buildCopy := copy.(*buildapi.Build)
+	buildCopy.Parameters.Output.DockerImageReference = spec
+
+	// invoke the strategy to get a build pod
+	podSpec, err := bc.BuildStrategy.CreateBuildPod(buildCopy)
+	if err != nil {
+		return fmt.Errorf("the strategy failed to create a build pod for %s/%s: %v", build.Namespace, build.Name, err)
+	}
+
+	if _, err := bc.PodManager.CreatePod(build.Namespace, podSpec); err != nil {
+		if errors.IsAlreadyExists(err) {
+			glog.V(4).Infof("Build pod already existed: %#v", podSpec)
+			return nil
+		}
+		return fmt.Errorf("failed to create pod for build %s/%s: s", build.Namespace, build.Name, err)
+	}
+
+	glog.V(4).Infof("Created pod for build: %#v", podSpec)
+	return nil
 }
 
 func (bc *BuildController) HandlePod(pod *kapi.Pod) {

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildtest "github.com/openshift/origin/pkg/build/controller/test"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type okBuildUpdater struct{}
@@ -23,9 +24,12 @@ func (ebu *errBuildUpdater) UpdateBuild(namespace string, build *buildapi.Build)
 	return &buildapi.Build{}, errors.New("UpdateBuild error!")
 }
 
-type okStrategy struct{}
+type okStrategy struct {
+	build *buildapi.Build
+}
 
 func (os *okStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
+	os.build = build
 	return &kapi.Pod{}, nil
 }
 
@@ -65,10 +69,34 @@ func (_ *errExistsPodManager) DeletePod(namespace string, pod *kapi.Pod) error {
 	return kerrors.NewNotFound("kind", "name")
 }
 
-func mockBuildAndController(status buildapi.BuildStatus) (build *buildapi.Build, controller *BuildController) {
+type okImageRepositoryClient struct{}
+
+func (_ *okImageRepositoryClient) GetImageRepository(namespace, name string) (*imageapi.ImageRepository, error) {
+	return &imageapi.ImageRepository{
+		ObjectMeta: kapi.ObjectMeta{Name: name, Namespace: namespace},
+		Status: imageapi.ImageRepositoryStatus{
+			DockerImageRepository: "image/repo",
+		},
+	}, nil
+}
+
+type errImageRepositoryClient struct{}
+
+func (_ *errImageRepositoryClient) GetImageRepository(namespace, name string) (*imageapi.ImageRepository, error) {
+	return nil, errors.New("GetImageRepository error!")
+}
+
+type errNotFoundImageRepositoryClient struct{}
+
+func (_ *errNotFoundImageRepositoryClient) GetImageRepository(namespace, name string) (*imageapi.ImageRepository, error) {
+	return nil, kerrors.NewNotFound("ImageRepository", name)
+}
+
+func mockBuildAndController(status buildapi.BuildStatus, output buildapi.BuildOutput) (build *buildapi.Build, controller *BuildController) {
 	build = &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
-			Name: "dataBuild",
+			Name:      "data-build",
+			Namespace: "namespace",
 			Labels: map[string]string{
 				"name": "dataBuild",
 			},
@@ -86,20 +114,19 @@ func mockBuildAndController(status buildapi.BuildStatus) (build *buildapi.Build,
 					ContextDir: "contextimage",
 				},
 			},
-			Output: buildapi.BuildOutput{
-				DockerImageReference: "repository/dataBuild",
-			},
+			Output: output,
 		},
 		Status:  status,
 		PodName: "-the-pod-id",
 	}
 	controller = &BuildController{
-		BuildStore:    buildtest.NewFakeBuildStore(build),
-		BuildUpdater:  &okBuildUpdater{},
-		PodManager:    &okPodManager{},
-		NextBuild:     func() *buildapi.Build { return nil },
-		NextPod:       func() *kapi.Pod { return nil },
-		BuildStrategy: &okStrategy{},
+		BuildStore:            buildtest.NewFakeBuildStore(build),
+		BuildUpdater:          &okBuildUpdater{},
+		PodManager:            &okPodManager{},
+		NextBuild:             func() *buildapi.Build { return nil },
+		NextPod:               func() *kapi.Pod { return nil },
+		BuildStrategy:         &okStrategy{},
+		ImageRepositoryClient: &okImageRepositoryClient{},
 	}
 	return
 }
@@ -124,60 +151,134 @@ func TestHandleBuild(t *testing.T) {
 	type handleBuildTest struct {
 		inStatus      buildapi.BuildStatus
 		outStatus     buildapi.BuildStatus
+		buildOutput   buildapi.BuildOutput
 		buildStrategy BuildStrategy
 		buildUpdater  buildUpdater
+		imageClient   imageRepositoryClient
 		podManager    podManager
+		outputSpec    string
 	}
 
 	tests := []handleBuildTest{
 		{ // 0
 			inStatus:  buildapi.BuildStatusNew,
 			outStatus: buildapi.BuildStatusPending,
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 1
 			inStatus:  buildapi.BuildStatusPending,
 			outStatus: buildapi.BuildStatusPending,
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 2
 			inStatus:  buildapi.BuildStatusRunning,
 			outStatus: buildapi.BuildStatusRunning,
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 3
 			inStatus:  buildapi.BuildStatusComplete,
 			outStatus: buildapi.BuildStatusComplete,
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 4
 			inStatus:  buildapi.BuildStatusFailed,
 			outStatus: buildapi.BuildStatusFailed,
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 5
 			inStatus:  buildapi.BuildStatusError,
 			outStatus: buildapi.BuildStatusError,
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 6
 			inStatus:      buildapi.BuildStatusNew,
-			outStatus:     buildapi.BuildStatusFailed,
+			outStatus:     buildapi.BuildStatusError,
 			buildStrategy: &errStrategy{},
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 7
 			inStatus:   buildapi.BuildStatusNew,
-			outStatus:  buildapi.BuildStatusFailed,
+			outStatus:  buildapi.BuildStatusError,
 			podManager: &errPodManager{},
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 8
 			inStatus:   buildapi.BuildStatusNew,
-			outStatus:  buildapi.BuildStatusFailed,
+			outStatus:  buildapi.BuildStatusPending,
 			podManager: &errExistsPodManager{},
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
 		},
 		{ // 9
 			inStatus:     buildapi.BuildStatusNew,
 			outStatus:    buildapi.BuildStatusPending,
 			buildUpdater: &errBuildUpdater{},
+			buildOutput: buildapi.BuildOutput{
+				DockerImageReference: "repository/dataBuild",
+			},
+		},
+		{ // 10
+			inStatus:  buildapi.BuildStatusNew,
+			outStatus: buildapi.BuildStatusPending,
+			buildOutput: buildapi.BuildOutput{
+				To: &kapi.ObjectReference{
+					Name: "foo",
+				},
+			},
+			outputSpec: "image/repo",
+		},
+		{ // 11
+			inStatus:  buildapi.BuildStatusNew,
+			outStatus: buildapi.BuildStatusPending,
+			buildOutput: buildapi.BuildOutput{
+				To: &kapi.ObjectReference{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			outputSpec: "image/repo",
+		},
+		{ // 12
+			inStatus:    buildapi.BuildStatusNew,
+			outStatus:   buildapi.BuildStatusFailed,
+			imageClient: &errNotFoundImageRepositoryClient{},
+			buildOutput: buildapi.BuildOutput{
+				To: &kapi.ObjectReference{
+					Name: "foo",
+				},
+			},
+		},
+		{ // 13
+			inStatus:    buildapi.BuildStatusNew,
+			outStatus:   buildapi.BuildStatusError,
+			imageClient: &errImageRepositoryClient{},
+			buildOutput: buildapi.BuildOutput{
+				To: &kapi.ObjectReference{
+					Name: "foo",
+				},
+			},
 		},
 	}
 
 	for i, tc := range tests {
-		build, ctrl := mockBuildAndController(tc.inStatus)
+		build, ctrl := mockBuildAndController(tc.inStatus, tc.buildOutput)
 		if tc.buildStrategy != nil {
 			ctrl.BuildStrategy = tc.buildStrategy
 		}
@@ -187,11 +288,23 @@ func TestHandleBuild(t *testing.T) {
 		if tc.podManager != nil {
 			ctrl.PodManager = tc.podManager
 		}
+		if tc.imageClient != nil {
+			ctrl.ImageRepositoryClient = tc.imageClient
+		}
 
 		ctrl.HandleBuild(build)
 
 		if build.Status != tc.outStatus {
 			t.Errorf("(%d) Expected %s, got %s!", i, tc.outStatus, build.Status)
+		}
+		if tc.inStatus != buildapi.BuildStatusError && build.Status == buildapi.BuildStatusError && len(build.Message) == 0 {
+			t.Errorf("(%d) errored build should set message: %#v", i, build)
+		}
+		if len(tc.outputSpec) != 0 {
+			build := ctrl.BuildStrategy.(*okStrategy).build
+			if build.Parameters.Output.DockerImageReference != tc.outputSpec {
+				t.Errorf("(%d) expected build sent to strategy to have docker spec %q: %#v", i, tc.outputSpec, build)
+			}
 		}
 	}
 }
@@ -253,7 +366,7 @@ func TestHandlePod(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		build, ctrl := mockBuildAndController(tc.inStatus)
+		build, ctrl := mockBuildAndController(tc.inStatus, buildapi.BuildOutput{})
 		pod := mockPod(tc.podStatus, tc.exitCode)
 		if tc.matchID {
 			build.PodName = pod.Name
@@ -311,7 +424,7 @@ func TestCancelBuild(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		build, ctrl := mockBuildAndController(tc.inStatus)
+		build, ctrl := mockBuildAndController(tc.inStatus, buildapi.BuildOutput{})
 		pod := mockPod(tc.podStatus, tc.exitCode)
 
 		ctrl.CancelBuild(build, pod)

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -87,7 +87,7 @@ func mockBuildAndController(status buildapi.BuildStatus) (build *buildapi.Build,
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "repository/dataBuild",
+				DockerImageReference: "repository/dataBuild",
 			},
 		},
 		Status:  status,

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -257,7 +257,7 @@ func TestHandleBuild(t *testing.T) {
 		},
 		{ // 12
 			inStatus:    buildapi.BuildStatusNew,
-			outStatus:   buildapi.BuildStatusFailed,
+			outStatus:   buildapi.BuildStatusError, // TODO: this should be a retry
 			imageClient: &errNotFoundImageRepositoryClient{},
 			buildOutput: buildapi.BuildOutput{
 				To: &kapi.ObjectReference{

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -51,10 +51,12 @@ func (factory *BuildControllerFactory) Create() *controller.BuildController {
 	podQueue := cache.NewFIFO()
 	cache.NewPoller(factory.pollPods, 10*time.Second, podQueue).RunUntil(factory.Stop)
 
+	client := ControllerClient{factory.KubeClient, factory.Client}
 	return &controller.BuildController{
-		BuildStore:   factory.buildStore,
-		BuildUpdater: ClientBuildUpdater{factory.Client},
-		PodManager:   ClientPodManager{factory.KubeClient},
+		BuildStore:            factory.buildStore,
+		BuildUpdater:          client,
+		ImageRepositoryClient: client,
+		PodManager:            client,
 		NextBuild: func() *buildapi.Build {
 			build := buildQueue.Pop().(*buildapi.Build)
 			panicIfStopped(factory.Stop, "build controller stopped")
@@ -90,10 +92,11 @@ func (factory *ImageChangeControllerFactory) Create() *controller.ImageChangeCon
 	store := cache.NewStore()
 	cache.NewReflector(&buildConfigLW{client: factory.Client}, &buildapi.BuildConfig{}, store).RunUntil(factory.Stop)
 
+	client := ControllerClient{nil, factory.Client}
 	return &controller.ImageChangeController{
 		BuildConfigStore:   store,
-		BuildConfigUpdater: &ClientBuildConfigUpdater{factory.Client},
-		BuildCreator:       &ClientBuildCreator{factory.Client},
+		BuildConfigUpdater: client,
+		BuildCreator:       client,
 		NextImageRepository: func() *imageapi.ImageRepository {
 			repo := queue.Pop().(*imageapi.ImageRepository)
 			panicIfStopped(factory.Stop, "build image change controller stopped")
@@ -216,38 +219,29 @@ func (lw *imageRepositoryLW) Watch(resourceVersion string) (watch.Interface, err
 	return lw.client.ImageRepositories(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
 }
 
-// ClientPodManager is a PodManager which delegates to the Kubernetes client interface.
-type ClientPodManager struct {
+// ControllerClient implements the common interfaces needed for build controllers
+type ControllerClient struct {
 	KubeClient kclient.Interface
+	Client     osclient.Interface
 }
 
 // CreatePod creates a pod using the Kubernetes client.
-func (c ClientPodManager) CreatePod(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+func (c ControllerClient) CreatePod(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
 	return c.KubeClient.Pods(namespace).Create(pod)
 }
 
 // DeletePod destroys a pod using the Kubernetes client.
-func (c ClientPodManager) DeletePod(namespace string, pod *kapi.Pod) error {
+func (c ControllerClient) DeletePod(namespace string, pod *kapi.Pod) error {
 	return c.KubeClient.Pods(namespace).Delete(pod.Name)
 }
 
-// ClientBuildUpdater is a buildUpdater which delegates to the OpenShift client interfaces.
-type ClientBuildUpdater struct {
-	Client osclient.Interface
-}
-
 // UpdateBuild updates build using the OpenShift client.
-func (c ClientBuildUpdater) UpdateBuild(namespace string, build *buildapi.Build) (*buildapi.Build, error) {
+func (c ControllerClient) UpdateBuild(namespace string, build *buildapi.Build) (*buildapi.Build, error) {
 	return c.Client.Builds(namespace).Update(build)
 }
 
-// ClientBuildCreator is a buildCreator which delegates to the OpenShift client interfaces.
-type ClientBuildCreator struct {
-	Client osclient.Interface
-}
-
-// UpdateBuild updates build using the OpenShift client.
-func (c *ClientBuildCreator) CreateBuild(config *buildapi.BuildConfig, imageSubstitutions map[string]string) error {
+// CreateBuild updates build using the OpenShift client.
+func (c ControllerClient) CreateBuild(config *buildapi.BuildConfig, imageSubstitutions map[string]string) error {
 	build := buildutil.GenerateBuildFromConfig(config, nil)
 	for originalImage, newImage := range imageSubstitutions {
 		buildutil.SubstituteImageReferences(build, originalImage, newImage)
@@ -259,13 +253,13 @@ func (c *ClientBuildCreator) CreateBuild(config *buildapi.BuildConfig, imageSubs
 	return nil
 }
 
-// ClientBuildConfigUpdater is a buildConfigUpdater which delegates to the OpenShift client interfaces.
-type ClientBuildConfigUpdater struct {
-	Client osclient.Interface
-}
-
 // UpdateBuildConfig updates buildConfig using the OpenShift client.
-func (c *ClientBuildConfigUpdater) UpdateBuildConfig(buildConfig *buildapi.BuildConfig) error {
+func (c ControllerClient) UpdateBuildConfig(buildConfig *buildapi.BuildConfig) error {
 	_, err := c.Client.BuildConfigs(buildConfig.Namespace).Update(buildConfig)
 	return err
+}
+
+// GetImageRepository retrieves an image repository by namespace and name
+func (c ControllerClient) GetImageRepository(namespace, name string) (*imageapi.ImageRepository, error) {
+	return c.Client.ImageRepositories(namespace).Get(name)
 }

--- a/pkg/build/controller/image_change_controller.go
+++ b/pkg/build/controller/image_change_controller.go
@@ -66,7 +66,7 @@ func (c *ImageChangeController) HandleImageRepo() {
 			}
 
 			// (must be different) to trigger a build
-			if icTrigger.ImageRepositoryRef.Name == imageRepo.Name && icTrigger.LastTriggeredImageID != imageID {
+			if icTrigger.From.Name == imageRepo.Name && icTrigger.LastTriggeredImageID != imageID {
 				imageSubstitutions[icTrigger.Image] = imageRepo.DockerImageRepository + ":" + imageID
 				shouldTriggerBuild = true
 				icTrigger.LastTriggeredImageID = imageID

--- a/pkg/build/controller/image_change_controller.go
+++ b/pkg/build/controller/image_change_controller.go
@@ -42,6 +42,7 @@ func (c *ImageChangeController) HandleImageRepo() {
 	glog.V(4).Infof("Build image change controller detected imagerepo change %s", imageRepo.DockerImageRepository)
 	imageSubstitutions := make(map[string]string)
 
+	// TODO: this is inefficient
 	for _, bc := range c.BuildConfigStore.List() {
 		config := bc.(*buildapi.BuildConfig)
 		glog.V(4).Infof("Detecting changed images for buildConfig %s", config.Name)
@@ -52,10 +53,13 @@ func (c *ImageChangeController) HandleImageRepo() {
 			if trigger.Type != buildapi.ImageChangeBuildTriggerType {
 				continue
 			}
+			icTrigger := trigger.ImageChange
+			if icTrigger.From.Name != imageRepo.Name {
+				continue
+			}
 			// for every ImageChange trigger, record the image it substitutes for and get the latest
 			// image id from the imagerepository.  We will substitute all images in the buildconfig
 			// with the latest values from the imagerepositories.
-			icTrigger := trigger.ImageChange
 			tag := icTrigger.Tag
 			if len(tag) == 0 {
 				tag = buildapi.DefaultImageTag
@@ -66,7 +70,7 @@ func (c *ImageChangeController) HandleImageRepo() {
 			}
 
 			// (must be different) to trigger a build
-			if icTrigger.From.Name == imageRepo.Name && icTrigger.LastTriggeredImageID != imageID {
+			if icTrigger.LastTriggeredImageID != imageID {
 				imageSubstitutions[icTrigger.Image] = imageRepo.DockerImageRepository + ":" + imageID
 				shouldTriggerBuild = true
 				icTrigger.LastTriggeredImageID = imageID

--- a/pkg/build/controller/image_change_controller_test.go
+++ b/pkg/build/controller/image_change_controller_test.go
@@ -51,7 +51,7 @@ func mockBuildConfig(baseImage, triggerImage, repoName, repoTag string) *buildap
 				Type: buildapi.ImageChangeBuildTriggerType,
 				ImageChange: &buildapi.ImageChangeTrigger{
 					Image: triggerImage,
-					ImageRepositoryRef: &kapi.ObjectReference{
+					From: kapi.ObjectReference{
 						Name: repoName,
 					},
 					Tag: repoTag,
@@ -66,7 +66,7 @@ func appendTrigger(buildcfg *buildapi.BuildConfig, triggerImage, repoName, repoT
 		Type: buildapi.ImageChangeBuildTriggerType,
 		ImageChange: &buildapi.ImageChangeTrigger{
 			Image: triggerImage,
-			ImageRepositoryRef: &kapi.ObjectReference{
+			From: kapi.ObjectReference{
 				Name: repoName,
 			},
 			Tag: repoTag,

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -1,12 +1,12 @@
 package strategy
 
 import (
-	"encoding/json"
 	"errors"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/golang/glog"
 
+	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -17,14 +17,14 @@ type CustomBuildStrategy struct {
 
 // CreateBuildPod creates the pod to be used for the Custom build
 func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
-	buildJSON, err := json.Marshal(build)
+	data, err := v1beta1.Codec.Encode(build)
 	if err != nil {
 		return nil, err
 	}
 
 	strategy := build.Parameters.Strategy.CustomStrategy
 	containerEnv := []kapi.EnvVar{
-		{Name: "BUILD", Value: string(buildJSON)},
+		{Name: "BUILD", Value: string(data)},
 		{Name: "SOURCE_REPOSITORY", Value: build.Parameters.Source.Git.URI},
 	}
 

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -1,11 +1,11 @@
 package strategy
 
 import (
-	"encoding/json"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
+	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -41,7 +41,7 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	if actual.Spec.RestartPolicy.Never == nil {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
-	buildJSON, _ := json.Marshal(expected)
+	buildJSON, _ := v1beta1.Codec.Encode(expected)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
 	}
@@ -94,8 +94,7 @@ func mockCustomBuild() *buildapi.Build {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "repository/customBuild",
-				Registry: "docker-registry",
+				DockerImageReference: "docker-registry/repository/customBuild",
 			},
 		},
 		Status:  buildapi.BuildStatusNew,

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -12,6 +12,7 @@ import (
 func TestCustomCreateBuildPod(t *testing.T) {
 	strategy := CustomBuildStrategy{
 		UseLocalImages: true,
+		Codec:          v1beta1.Codec,
 	}
 
 	expectedBad := mockCustomBuild()

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -2,8 +2,8 @@ package strategy
 
 import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
-	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -11,12 +11,16 @@ import (
 type DockerBuildStrategy struct {
 	Image          string
 	UseLocalImages bool
+	// Codec is the codec to use for encoding the output pod.
+	// IMPORTANT: This may break backwards compatibility when
+	// it changes.
+	Codec runtime.Codec
 }
 
 // CreateBuildPod creates the pod to be used for the Docker build
 // TODO: Make the Pod definition configurable
 func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
-	data, err := v1beta1.Codec.Encode(build)
+	data, err := bs.Codec.Encode(build)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -1,10 +1,9 @@
 package strategy
 
 import (
-	"encoding/json"
-
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
+	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -17,7 +16,7 @@ type DockerBuildStrategy struct {
 // CreateBuildPod creates the pod to be used for the Docker build
 // TODO: Make the Pod definition configurable
 func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
-	buildJSON, err := json.Marshal(build)
+	data, err := v1beta1.Codec.Encode(build)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +31,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 					Name:  "docker-build",
 					Image: bs.Image,
 					Env: []kapi.EnvVar{
-						{Name: "BUILD", Value: string(buildJSON)},
+						{Name: "BUILD", Value: string(data)},
 					},
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 					Privileged: true,

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -1,11 +1,11 @@
 package strategy
 
 import (
-	"encoding/json"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
+	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -38,7 +38,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if len(container.Env) != 1 {
 		t.Fatalf("Expected 1 elements in Env table, got %d", len(container.Env))
 	}
-	buildJSON, _ := json.Marshal(expected)
+	buildJSON, _ := v1beta1.Codec.Encode(expected)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
 	}
@@ -71,8 +71,7 @@ func mockDockerBuild() *buildapi.Build {
 				DockerStrategy: &buildapi.DockerBuildStrategy{ContextDir: "my/test/dir"},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "repository/dockerBuild",
-				Registry: "docker-registry",
+				DockerImageReference: "docker-registry/repository/dockerBuild",
 			},
 		},
 		Status:  buildapi.BuildStatusNew,

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -13,6 +13,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	strategy := DockerBuildStrategy{
 		Image:          "docker-test-image",
 		UseLocalImages: true,
+		Codec:          v1beta1.Codec,
 	}
 
 	expected := mockDockerBuild()

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -1,11 +1,11 @@
 package strategy
 
 import (
-	"encoding/json"
 	"io/ioutil"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
+	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -31,7 +31,7 @@ var STITempDirectoryCreator = &tempDirectoryCreator{}
 // CreateBuildPod creates a pod that will execute the STI build
 // TODO: Make the Pod definition configurable
 func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
-	buildJSON, err := json.Marshal(build)
+	data, err := v1beta1.Codec.Encode(build)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, er
 					Name:  "sti-build",
 					Image: bs.Image,
 					Env: []kapi.EnvVar{
-						{Name: "BUILD", Value: string(buildJSON)},
+						{Name: "BUILD", Value: string(data)},
 					},
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662
 					Privileged: true,

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
-	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -14,6 +14,10 @@ type STIBuildStrategy struct {
 	Image                string
 	TempDirectoryCreator TempDirectoryCreator
 	UseLocalImages       bool
+	// Codec is the codec to use for encoding the output pod.
+	// IMPORTANT: This may break backwards compatibility when
+	// it changes.
+	Codec runtime.Codec
 }
 
 type TempDirectoryCreator interface {
@@ -31,7 +35,7 @@ var STITempDirectoryCreator = &tempDirectoryCreator{}
 // CreateBuildPod creates a pod that will execute the STI build
 // TODO: Make the Pod definition configurable
 func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
-	data, err := v1beta1.Codec.Encode(build)
+	data, err := bs.Codec.Encode(build)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -1,11 +1,11 @@
 package strategy
 
 import (
-	"encoding/json"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
+	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -44,7 +44,7 @@ func TestSTICreateBuildPod(t *testing.T) {
 	if len(container.Env) != 1 {
 		t.Fatalf("Expected 1 elements in Env table, got %d", len(container.Env))
 	}
-	buildJSON, _ := json.Marshal(expected)
+	buildJSON, _ := v1beta1.Codec.Encode(expected)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
 	}
@@ -80,8 +80,7 @@ func mockSTIBuild() *buildapi.Build {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "repository/stiBuild",
-				Registry: "docker-registry",
+				DockerImageReference: "docker-registry/repository/stiBuild",
 			},
 		},
 		Status:  buildapi.BuildStatusNew,

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -20,6 +20,7 @@ func TestSTICreateBuildPod(t *testing.T) {
 		Image:                "sti-test-image",
 		TempDirectoryCreator: &FakeTempDirCreator{},
 		UseLocalImages:       true,
+		Codec:                v1beta1.Codec,
 	}
 
 	expected := mockSTIBuild()

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -6,7 +6,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
-	image "github.com/openshift/origin/pkg/image/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // dockerSocketPath is the default path for the Docker socket inside the builder
@@ -77,8 +77,8 @@ func setupBuildEnv(build *buildapi.Build, pod *kapi.Pod) {
 		// Do nothing for unknown source types
 	}
 
-	if registry, namespace, name, tag, err := image.SplitDockerPullSpec(build.Parameters.Output.DockerImageReference); err == nil {
-		outputImage := image.JoinDockerPullSpec("", namespace, name, tag)
+	if registry, namespace, name, tag, err := imageapi.SplitDockerPullSpec(build.Parameters.Output.DockerImageReference); err == nil {
+		outputImage := imageapi.JoinDockerPullSpec("", namespace, name, tag)
 		vars = append(vars, kapi.EnvVar{"OUTPUT_IMAGE", outputImage})
 		vars = append(vars, kapi.EnvVar{"OUTPUT_REGISTRY", registry})
 	}

--- a/pkg/build/registry/build/rest_test.go
+++ b/pkg/build/registry/build/rest_test.go
@@ -342,7 +342,7 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "repository/dataBuild",
+					DockerImageReference: "repository/data-build",
 				},
 			},
 		},
@@ -365,10 +365,10 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 func mockBuild() *api.Build {
 	return &api.Build{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      "dataBuild",
+			Name:      "data-build",
 			Namespace: kapi.NamespaceDefault,
 			Labels: map[string]string{
-				"name": "dataBuild",
+				"name": "data-build",
 			},
 		},
 		Parameters: api.BuildParameters{
@@ -385,7 +385,7 @@ func mockBuild() *api.Build {
 				},
 			},
 			Output: api.BuildOutput{
-				ImageTag: "repository/dataBuild",
+				DockerImageReference: "repository/data-build",
 			},
 		},
 		Status:  api.BuildStatusPending,

--- a/pkg/build/registry/buildconfig/rest_test.go
+++ b/pkg/build/registry/buildconfig/rest_test.go
@@ -254,10 +254,10 @@ func TestCreateBuildConfig(t *testing.T) {
 func mockBuildConfig() *api.BuildConfig {
 	return &api.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      "dataBuild",
+			Name:      "data-build",
 			Namespace: kapi.NamespaceDefault,
 			Labels: map[string]string{
-				"name": "dataBuild",
+				"name": "data-build",
 			},
 		},
 		Parameters: api.BuildParameters{
@@ -274,7 +274,7 @@ func mockBuildConfig() *api.BuildConfig {
 				},
 			},
 			Output: api.BuildOutput{
-				ImageTag: "repository/dataBuild",
+				DockerImageReference: "repository/data-build",
 			},
 		},
 	}
@@ -350,11 +350,11 @@ func TestBuildConfigRESTValidatesCreate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "data/image",
+					DockerImageReference: "data/image",
 				},
 			},
 		},
-		"blank ImageTag": {
+		"blank DockerImageReference": {
 			ObjectMeta: kapi.ObjectMeta{Name: "abc"},
 			Parameters: api.BuildParameters{
 				Source: api.BuildSource{
@@ -364,7 +364,7 @@ func TestBuildConfigRESTValidatesCreate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "",
+					DockerImageReference: "",
 				},
 			},
 		},
@@ -384,7 +384,7 @@ func TestBuildConfigRESTValidatesCreate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "data/image",
+					DockerImageReference: "data/image",
 				},
 			},
 		},
@@ -414,7 +414,7 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "data/image",
+					DockerImageReference: "data/image",
 				},
 			},
 		},
@@ -434,11 +434,11 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "data/image",
+					DockerImageReference: "data/image",
 				},
 			},
 		},
-		"blank ImageTag": {
+		"blank DockerImageReference": {
 			ObjectMeta: kapi.ObjectMeta{Name: "abc"},
 			Parameters: api.BuildParameters{
 				Source: api.BuildSource{
@@ -448,7 +448,7 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "",
+					DockerImageReference: "",
 				},
 			},
 		},
@@ -468,7 +468,7 @@ func TestBuildRESTValidatesUpdate(t *testing.T) {
 					},
 				},
 				Output: api.BuildOutput{
-					ImageTag: "data/image",
+					DockerImageReference: "data/image",
 				},
 			},
 		},

--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -51,6 +51,8 @@ func (r *REST) ResourceLocation(ctx kapi.Context, id string) (string, error) {
 		return "", errors.NewFieldNotFound("Build", id)
 	}
 
+	// TODO: these must be status errors, not field errors
+	// TODO: choose a more appropriate "try again later" status code, like 202
 	if len(build.PodName) == 0 {
 		return "", errors.NewFieldRequired("Build.PodName", build.PodName)
 	}

--- a/pkg/build/registry/etcd/etcd_test.go
+++ b/pkg/build/registry/etcd/etcd_test.go
@@ -113,7 +113,7 @@ func TestEtcdCreateBuild(t *testing.T) {
 				},
 			},
 			Output: api.BuildOutput{
-				ImageTag: "repository/dataBuild",
+				DockerImageReference: "repository/dataBuild",
 			},
 		},
 		Status:  api.BuildStatusPending,
@@ -335,7 +335,7 @@ func TestEtcdCreateBuildConfig(t *testing.T) {
 				},
 			},
 			Output: api.BuildOutput{
-				ImageTag: "repository/dataBuild",
+				DockerImageReference: "repository/dataBuild",
 			},
 		},
 	})

--- a/pkg/build/util/generate_test.go
+++ b/pkg/build/util/generate_test.go
@@ -330,8 +330,7 @@ func mockCustomStrategy() api.BuildStrategy {
 
 func mockOutput() api.BuildOutput {
 	return api.BuildOutput{
-		Registry: "http://localhost:5000",
-		ImageTag: "test/image-tag",
+		DockerImageReference: "http://localhost:5000/test/image-tag",
 	}
 }
 

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -242,7 +242,7 @@ func (d *ImageRepositoryDescriber) Describe(namespace, name string) (string, err
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageRepository.ObjectMeta)
 		formatString(out, "Tags", formatLabels(imageRepository.Tags))
-		formatString(out, "Registry", imageRepository.DockerImageRepository)
+		formatString(out, "Registry", imageRepository.Status.DockerImageRepository)
 		return nil
 	})
 }

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -133,7 +133,7 @@ func (d *BuildConfigDescriber) DescribeTriggers(bc *buildapi.BuildConfig, host s
 		if trigger.Type != buildapi.ImageChangeBuildTriggerType {
 			continue
 		}
-		formatString(out, "Image Repository Trigger", trigger.ImageChange.ImageRepositoryRef.Name)
+		formatString(out, "Image Repository Trigger", trigger.ImageChange.From.Name)
 		formatString(out, "- Tag", trigger.ImageChange.Tag)
 		formatString(out, "- Image", trigger.ImageChange.Image)
 		formatString(out, "- LastTriggeredImageID", trigger.ImageChange.LastTriggeredImageID)

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -86,8 +86,8 @@ func (d *BuildDescriber) DescribeParameters(p buildapi.BuildParameters, out *tab
 			formatString(out, "Ref", p.Source.Git.Ref)
 		}
 	}
-	formatString(out, "Output Image", p.Output.ImageTag)
-	formatString(out, "Output Registry", p.Output.Registry)
+	formatString(out, "Output To", p.Output.To)
+	formatString(out, "Output Spec", p.Output.DockerImageReference)
 	if p.Revision != nil && p.Revision.Type == buildapi.BuildSourceGit && p.Revision.Git != nil {
 		formatString(out, "Git Commit", p.Revision.Git.Commit)
 		d.DescribeUser(out, "Revision Author", p.Revision.Git.Author)

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -119,7 +119,7 @@ func printImageRepository(repo *imageapi.ImageRepository, w io.Writer) error {
 		}
 		tags = strings.Join(t, ",")
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", repo.Name, repo.DockerImageRepository, tags)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", repo.Name, repo.Status.DockerImageRepository, tags)
 	return err
 }
 

--- a/pkg/cmd/server/etcd/etcd.go
+++ b/pkg/cmd/server/etcd/etcd.go
@@ -1,6 +1,8 @@
 package etcd
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	etcdconfig "github.com/coreos/etcd/config"
 	"github.com/coreos/etcd/etcd"
@@ -29,6 +31,6 @@ func (c *Config) Run() {
 		glog.Infof("Started etcd at %s", config.Addr)
 		server.Run()
 		glog.Fatalf("etcd died, exiting.")
-	}, 0)
+	}, 500*time.Millisecond)
 	<-server.ReadyNotify()
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -470,14 +470,20 @@ func (c *MasterConfig) RunBuildController() {
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
 			Image:          dockerImage,
 			UseLocalImages: useLocalImages,
+			// TODO: this will be set to --storage-version (the internal schema we use)
+			Codec: v1beta1.Codec,
 		},
 		STIBuildStrategy: &buildstrategy.STIBuildStrategy{
 			Image:                stiImage,
 			TempDirectoryCreator: buildstrategy.STITempDirectoryCreator,
 			UseLocalImages:       useLocalImages,
+			// TODO: this will be set to --storage-version (the internal schema we use)
+			Codec: v1beta1.Codec,
 		},
 		CustomBuildStrategy: &buildstrategy.CustomBuildStrategy{
 			UseLocalImages: useLocalImages,
+			// TODO: this will be set to --storage-version (the internal schema we use)
+			Codec: v1beta1.Codec,
 		},
 	}
 

--- a/pkg/cmd/util/serviceability/panic.go
+++ b/pkg/cmd/util/serviceability/panic.go
@@ -1,0 +1,16 @@
+package serviceability
+
+import (
+	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// BehaviorOnPanic is a helper for setting the crash mode of OpenShift when a panic is caught.
+func BehaviorOnPanic(mode string) {
+	switch mode {
+	case "crash":
+		glog.V(4).Infof("OpenShift will terminate as soon as a panic occurs.")
+		util.ReallyCrash = true
+	}
+}

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -172,7 +172,14 @@ type DeploymentTriggerImageChangeParams struct {
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string `json:"containerNames,omitempty"`
 	// RepositoryName is the identifier for a Docker image repository to watch for changes.
+	// DEPRECATED: will be removed in v1beta2.
 	RepositoryName string `json:"repositoryName,omitempty"`
+	// From is a reference to a Docker image repository to watch for changes. This field takes
+	// precedence over RepositoryName, which is deprecated and will be removed in v1beta2. The
+	// Kind may be left blank, in which case it defaults to "ImageRepository". The "Name" is
+	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// trigger will be used.
+	From kapi.ObjectReference `json:"from"`
 	// Tag is the name of an image repository tag to watch for changes.
 	Tag string `json:"tag,omitempty"`
 }

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	v1beta1 "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
-	v1beta3 "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 )
 
 // A deployment represents a single configuration of a pod deployed into the cluster, and may
@@ -11,8 +11,8 @@ import (
 // DEPRECATED: This type longer drives any system behavior. Deployments are now represented directly
 // by ReplicationControllers. Use DeploymentConfig to drive deployments.
 type Deployment struct {
-	v1beta3.TypeMeta   `json:",inline"`
-	v1beta3.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Strategy describes how a deployment is executed.
 	Strategy DeploymentStrategy `json:"strategy,omitempty"`
@@ -70,7 +70,7 @@ type CustomDeploymentStrategyParams struct {
 	// Image specifies a Docker image which can carry out a deployment.
 	Image string `json:"image,omitempty"`
 	// Environment holds the environment which will be given to the container for Image.
-	Environment []v1beta3.EnvVar `json:"environment,omitempty"`
+	Environment []kapi.EnvVar `json:"environment,omitempty"`
 	// Command is optional and overrides CMD in the container Image.
 	Command []string `json:"command,omitempty"`
 }
@@ -78,9 +78,9 @@ type CustomDeploymentStrategyParams struct {
 // A DeploymentList is a collection of deployments.
 // DEPRECATED: Like Deployment, this is no longer used.
 type DeploymentList struct {
-	v1beta3.TypeMeta `json:",inline"`
-	v1beta3.ListMeta `json:"metadata,omitempty"`
-	Items            []Deployment `json:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Deployment `json:"items"`
 }
 
 // These constants represent keys used for correlating objects related to deployments.
@@ -120,8 +120,8 @@ const (
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in
 // a new deployment results in an increment of LatestVersion.
 type DeploymentConfig struct {
-	v1beta3.TypeMeta   `json:",inline"`
-	v1beta3.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
 	// are defined, a new deployment can only occur as a result of an explicit client update to the
 	// DeploymentConfig with a new LatestVersion.
@@ -173,7 +173,14 @@ type DeploymentTriggerImageChangeParams struct {
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string `json:"containerNames,omitempty"`
 	// RepositoryName is the identifier for a Docker image repository to watch for changes.
+	// DEPRECATED: will be removed in v1beta2.
 	RepositoryName string `json:"repositoryName,omitempty"`
+	// From is a reference to a Docker image repository to watch for changes. This field takes
+	// precedence over RepositoryName, which is deprecated and will be removed in v1beta2. The
+	// Kind may be left blank, in which case it defaults to "ImageRepository". The "Name" is
+	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// trigger will be used.
+	From kapi.ObjectReference `json:"from"`
 	// Tag is the name of an image repository tag to watch for changes.
 	Tag string `json:"tag,omitempty"`
 }
@@ -203,9 +210,9 @@ type DeploymentCauseImageTrigger struct {
 
 // A DeploymentConfigList is a collection of deployment configs.
 type DeploymentConfigList struct {
-	v1beta3.TypeMeta `json:",inline"`
-	v1beta3.ListMeta `json:"metadata,omitempty"`
-	Items            []DeploymentConfig `json:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []DeploymentConfig `json:"items"`
 }
 
 // DeploymentConfigRollback provides the input to rollback generation.

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -217,7 +217,7 @@ type DeploymentConfigList struct {
 
 // DeploymentConfigRollback provides the input to rollback generation.
 type DeploymentConfigRollback struct {
-	v1beta3.TypeMeta `json:",inline"`
+	kapi.TypeMeta `json:",inline"`
 	// Spec defines the options to rollback generation.
 	Spec DeploymentConfigRollbackSpec `json:"spec"`
 }
@@ -225,7 +225,7 @@ type DeploymentConfigRollback struct {
 // DeploymentConfigRollbackSpec represents the options for rollback generation.
 type DeploymentConfigRollbackSpec struct {
 	// From points to a ReplicationController which is a deployment.
-	From v1beta3.ObjectReference `json:"from"`
+	From kapi.ObjectReference `json:"from"`
 	// IncludeTriggers specifies whether to include config Triggers.
 	IncludeTriggers bool `json:"includeTriggers`
 	// IncludeTemplate specifies whether to include the PodTemplateSpec.

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -3,6 +3,8 @@ package validation
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
@@ -11,25 +13,42 @@ import (
 //       upstream and fix when it goes in.
 
 func ValidateDeployment(deployment *deployapi.Deployment) errors.ValidationErrorList {
-	result := validateDeploymentStrategy(&deployment.Strategy).Prefix("strategy")
-	controllerStateErrors := validation.ValidateReplicationControllerSpec(&deployment.ControllerTemplate)
-	result = append(result, controllerStateErrors.Prefix("controllerTemplate")...)
-
-	return result
+	errs := validateDeploymentStrategy(&deployment.Strategy).Prefix("strategy")
+	if len(deployment.Name) == 0 {
+		errs = append(errs, errors.NewFieldRequired("name", deployment.Name))
+	} else if !util.IsDNSSubdomain(deployment.Name) {
+		errs = append(errs, errors.NewFieldInvalid("name", deployment.Name, "name must be a valid subdomain"))
+	}
+	if len(deployment.Namespace) == 0 {
+		errs = append(errs, errors.NewFieldRequired("namespace", deployment.Namespace))
+	} else if !util.IsDNSSubdomain(deployment.Namespace) {
+		errs = append(errs, errors.NewFieldInvalid("namespace", deployment.Namespace, "namespace must be a valid subdomain"))
+	}
+	errs = append(errs, validation.ValidateLabels(deployment.Labels, "labels")...)
+	errs = append(errs, validation.ValidateReplicationControllerSpec(&deployment.ControllerTemplate).Prefix("controllerTemplate")...)
+	return errs
 }
 
 func ValidateDeploymentConfig(config *deployapi.DeploymentConfig) errors.ValidationErrorList {
-	result := errors.ValidationErrorList{}
+	errs := errors.ValidationErrorList{}
+	if len(config.Name) == 0 {
+		errs = append(errs, errors.NewFieldRequired("name", config.Name))
+	} else if !util.IsDNSSubdomain(config.Name) {
+		errs = append(errs, errors.NewFieldInvalid("name", config.Name, "name must be a valid subdomain"))
+	}
+	if len(config.Namespace) == 0 {
+		errs = append(errs, errors.NewFieldRequired("namespace", config.Namespace))
+	} else if !util.IsDNSSubdomain(config.Namespace) {
+		errs = append(errs, errors.NewFieldInvalid("namespace", config.Namespace, "namespace must be a valid subdomain"))
+	}
+	errs = append(errs, validation.ValidateLabels(config.Labels, "labels")...)
 
 	for i := range config.Triggers {
-		result = append(result, validateTrigger(&config.Triggers[i]).PrefixIndex(i).Prefix("triggers")...)
+		errs = append(errs, validateTrigger(&config.Triggers[i]).PrefixIndex(i).Prefix("triggers")...)
 	}
-
-	result = append(result, validateDeploymentStrategy(&config.Template.Strategy).Prefix("template.strategy")...)
-	controllerStateErrors := validation.ValidateReplicationControllerSpec(&config.Template.ControllerTemplate)
-	result = append(result, controllerStateErrors.Prefix("template.controllerTemplate")...)
-
-	return result
+	errs = append(errs, validateDeploymentStrategy(&config.Template.Strategy).Prefix("template.strategy")...)
+	errs = append(errs, validation.ValidateReplicationControllerSpec(&config.Template.ControllerTemplate).Prefix("template.controllerTemplate")...)
+	return errs
 }
 
 func ValidateDeploymentConfigRollback(rollback *deployapi.DeploymentConfigRollback) errors.ValidationErrorList {
@@ -51,62 +70,82 @@ func ValidateDeploymentConfigRollback(rollback *deployapi.DeploymentConfigRollba
 }
 
 func validateDeploymentStrategy(strategy *deployapi.DeploymentStrategy) errors.ValidationErrorList {
-	result := errors.ValidationErrorList{}
+	errs := errors.ValidationErrorList{}
 
 	if len(strategy.Type) == 0 {
-		result = append(result, errors.NewFieldRequired("type", ""))
+		errs = append(errs, errors.NewFieldRequired("type", ""))
 	}
 
 	switch strategy.Type {
 	case deployapi.DeploymentStrategyTypeCustom:
 		if strategy.CustomParams == nil {
-			result = append(result, errors.NewFieldRequired("customParams", ""))
+			errs = append(errs, errors.NewFieldRequired("customParams", ""))
 		} else {
-			result = append(result, validateCustomParams(strategy.CustomParams).Prefix("customParams")...)
+			errs = append(errs, validateCustomParams(strategy.CustomParams).Prefix("customParams")...)
 		}
 	}
 
-	return result
+	return errs
 }
 
 func validateCustomParams(params *deployapi.CustomDeploymentStrategyParams) errors.ValidationErrorList {
-	result := errors.ValidationErrorList{}
+	errs := errors.ValidationErrorList{}
 
 	if len(params.Image) == 0 {
-		result = append(result, errors.NewFieldRequired("image", ""))
+		errs = append(errs, errors.NewFieldRequired("image", ""))
 	}
 
-	return result
+	return errs
 }
 
 func validateTrigger(trigger *deployapi.DeploymentTriggerPolicy) errors.ValidationErrorList {
-	result := errors.ValidationErrorList{}
+	errs := errors.ValidationErrorList{}
 
 	if len(trigger.Type) == 0 {
-		result = append(result, errors.NewFieldRequired("type", ""))
+		errs = append(errs, errors.NewFieldRequired("type", ""))
 	}
 
 	if trigger.Type == deployapi.DeploymentTriggerOnImageChange {
 		if trigger.ImageChangeParams == nil {
-			result = append(result, errors.NewFieldRequired("imageChangeParams", nil))
+			errs = append(errs, errors.NewFieldRequired("imageChangeParams", nil))
 		} else {
-			result = append(result, validateImageChangeParams(trigger.ImageChangeParams).Prefix("imageChangeParams")...)
+			errs = append(errs, validateImageChangeParams(trigger.ImageChangeParams).Prefix("imageChangeParams")...)
 		}
 	}
 
-	return result
+	return errs
 }
 
 func validateImageChangeParams(params *deployapi.DeploymentTriggerImageChangeParams) errors.ValidationErrorList {
-	result := errors.ValidationErrorList{}
+	errs := errors.ValidationErrorList{}
 
-	if len(params.RepositoryName) == 0 {
-		result = append(result, errors.NewFieldRequired("repositoryName", ""))
+	if len(params.From.Name) != 0 {
+		if len(params.From.Kind) == 0 {
+			params.From.Kind = "ImageRepository"
+		}
+		if params.From.Kind != "ImageRepository" {
+			errs = append(errs, errors.NewFieldInvalid("from.kind", params.From.Kind, "only 'ImageRepository' is allowed"))
+		}
+
+		if !util.IsDNSSubdomain(params.From.Name) {
+			errs = append(errs, errors.NewFieldInvalid("from.name", params.From.Name, "name must be a valid subdomain"))
+		}
+		if len(params.From.Namespace) != 0 && !util.IsDNSSubdomain(params.From.Namespace) {
+			errs = append(errs, errors.NewFieldInvalid("from.namespace", params.From.Namespace, "namespace must be a valid subdomain"))
+		}
+
+		if len(params.RepositoryName) != 0 {
+			errs = append(errs, errors.NewFieldInvalid("repositoryName", params.RepositoryName, "only one of 'from', 'repository' name may be specified"))
+		}
+	} else {
+		if len(params.RepositoryName) == 0 {
+			errs = append(errs, errors.NewFieldRequired("from", ""))
+		}
 	}
 
 	if len(params.ContainerNames) == 0 {
-		result = append(result, errors.NewFieldRequired("containerNames", ""))
+		errs = append(errs, errors.NewFieldRequired("containerNames", ""))
 	}
 
-	return result
+	return errs
 }

--- a/pkg/deploy/controller/deployment_config_controller.go
+++ b/pkg/deploy/controller/deployment_config_controller.go
@@ -70,7 +70,7 @@ func (c *DeploymentConfigController) shouldDeploy(config *deployapi.DeploymentCo
 		return false, nil
 	}
 
-	latestDeploymentID := deployutil.LatestDeploymentIDForConfig(config)
+	latestDeploymentID := deployutil.LatestDeploymentNameForConfig(config)
 	deployment, err := c.DeploymentInterface.GetDeployment(config.Namespace, latestDeploymentID)
 
 	if err != nil {

--- a/pkg/deploy/registry/deployconfig/rest.go
+++ b/pkg/deploy/registry/deployconfig/rest.go
@@ -118,6 +118,6 @@ func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		if err != nil {
 			return nil, err
 		}
-		return deploymentConfig, nil
+		return s.Get(ctx, deploymentConfig.Name)
 	}), nil
 }

--- a/pkg/deploy/rollback/rest.go
+++ b/pkg/deploy/rollback/rest.go
@@ -15,34 +15,39 @@ import (
 
 // REST provides a rollback generation endpoint. Only the Create method is implemented.
 type REST struct {
-	generator              GeneratorClient
-	deploymentGetter       DeploymentGetter
-	deploymentConfigGetter DeploymentConfigGetter
-	codec                  runtime.Codec
+	generator GeneratorClient
+	codec     runtime.Codec
 }
 
 // GeneratorClient defines a local interface to a rollback generator for testability.
 type GeneratorClient interface {
-	Generate(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error)
+	GenerateRollback(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error)
+	GetDeployment(ctx kapi.Context, name string) (*kapi.ReplicationController, error)
+	GetDeploymentConfig(ctx kapi.Context, name string) (*deployapi.DeploymentConfig, error)
 }
 
-// DeploymentGetter is a local interface to ReplicationControllers for testability.
-type DeploymentGetter interface {
-	GetDeployment(namespace, name string) (*kapi.ReplicationController, error)
+// Client provides an implementation of Generator client
+type Client struct {
+	GRFn func(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error)
+	RCFn func(ctx kapi.Context, name string) (*kapi.ReplicationController, error)
+	DCFn func(ctx kapi.Context, name string) (*deployapi.DeploymentConfig, error)
 }
 
-// DeploymentConfigGetter is a local interface to DeploymentConfigs for testability.
-type DeploymentConfigGetter interface {
-	GetDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
+func (c Client) GetDeploymentConfig(ctx kapi.Context, name string) (*deployapi.DeploymentConfig, error) {
+	return c.DCFn(ctx, name)
+}
+func (c Client) GetDeployment(ctx kapi.Context, name string) (*kapi.ReplicationController, error) {
+	return c.RCFn(ctx, name)
+}
+func (c Client) GenerateRollback(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+	return c.GRFn(from, to, spec)
 }
 
 // NewREST safely creates a new REST.
-func NewREST(generator GeneratorClient, deploymentGetter DeploymentGetter, configGetter DeploymentConfigGetter, codec runtime.Codec) apiserver.RESTStorage {
+func NewREST(generator GeneratorClient, codec runtime.Codec) apiserver.RESTStorage {
 	return &REST{
-		generator:              generator,
-		deploymentGetter:       deploymentGetter,
-		deploymentConfigGetter: configGetter,
-		codec: codec,
+		generator: generator,
+		codec:     codec,
 	}
 }
 
@@ -61,33 +66,28 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, kerrors.NewInvalid("deploymentConfigRollback", "", errs)
 	}
 
-	namespace, namespaceOk := kapi.NamespaceFrom(ctx)
-	if !namespaceOk {
-		return nil, fmt.Errorf("namespace %s is invalid", ctx.Value)
-	}
-
 	// Roll back "from" the current deployment "to" a target deployment
-	var from, to *deployapi.DeploymentConfig
-	var err error
 
 	// Find the target ("to") deployment and decode the DeploymentConfig
-	if targetDeployment, err := s.deploymentGetter.GetDeployment(namespace, rollback.Spec.From.Name); err != nil {
+	targetDeployment, err := s.generator.GetDeployment(ctx, rollback.Spec.From.Name)
+	if err != nil {
 		// TODO: correct error type?
 		return nil, kerrors.NewBadRequest(fmt.Sprintf("Couldn't get specified deployment: %v", err))
-	} else {
-		if to, err = deployutil.DecodeDeploymentConfig(targetDeployment, s.codec); err != nil {
-			// TODO: correct error type?
-			return nil, kerrors.NewBadRequest(fmt.Sprintf("deploymentConfig on target deployment is invalid: %v", err))
-		}
+	}
+	to, err := deployutil.DecodeDeploymentConfig(targetDeployment, s.codec)
+	if err != nil {
+		// TODO: correct error type?
+		return nil, kerrors.NewBadRequest(fmt.Sprintf("deploymentConfig on target deployment is invalid: %v", err))
 	}
 
 	// Find the current ("from") version of the target deploymentConfig
-	if from, err = s.deploymentConfigGetter.GetDeploymentConfig(namespace, to.Name); err != nil {
+	from, err := s.generator.GetDeploymentConfig(ctx, to.Name)
+	if err != nil {
 		// TODO: correct error type?
-		return nil, kerrors.NewBadRequest(fmt.Sprintf("Couldn't find current deploymentConfig %s/%s: %v", namespace, to.Name, err))
+		return nil, kerrors.NewBadRequest(fmt.Sprintf("Couldn't find current deploymentConfig %s/%s: %v", targetDeployment.Namespace, to.Name, err))
 	}
 
 	return apiserver.MakeAsync(func() (runtime.Object, error) {
-		return s.generator.Generate(from, to, &rollback.Spec)
+		return s.generator.GenerateRollback(from, to, &rollback.Spec)
 	}), nil
 }

--- a/pkg/deploy/rollback/rollback_generator.go
+++ b/pkg/deploy/rollback/rollback_generator.go
@@ -10,13 +10,12 @@ import (
 
 // RollbackGenerator generates a new DeploymentConfig by merging a pair of DeploymentConfigs
 // in a configurable way.
-type RollbackGenerator struct {
-}
+type RollbackGenerator struct{}
 
 // Generate creates a new DeploymentConfig by merging to onto from based on the options provided
 // by spec. The LatestVersion of the result is unconditionally incremented, as rollback candidates are
 // should be possible to be deployed manually regardless of other system behavior such as triggering.
-func (g *RollbackGenerator) Generate(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
+func (g *RollbackGenerator) GenerateRollback(from, to *deployapi.DeploymentConfig, spec *deployapi.DeploymentConfigRollbackSpec) (*deployapi.DeploymentConfig, error) {
 	rollback := &deployapi.DeploymentConfig{}
 
 	if err := kapi.Scheme.Convert(&from, &rollback); err != nil {

--- a/pkg/deploy/rollback/rollback_generator_test.go
+++ b/pkg/deploy/rollback/rollback_generator_test.go
@@ -47,7 +47,7 @@ func TestGeneration(t *testing.T) {
 	for _, spec := range rollbackSpecs {
 		t.Logf("testing spec %#v", spec)
 
-		if rollback, err := generator.Generate(from, to, spec); err != nil {
+		if rollback, err := generator.GenerateRollback(from, to, spec); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		} else {
 			if hasStrategyDiff(from, rollback) && !spec.IncludeStrategy {

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -7,8 +7,8 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-// dockerDefaultNamespace is the value for namespace when a single segment name is provided.
-const dockerDefaultNamespace = "library"
+// DockerDefaultNamespace is the value for namespace when a single segment name is provided.
+const DockerDefaultNamespace = "library"
 
 // SplitDockerPullSpec breaks a Docker pull specification into its components, or returns
 // an error if those components are not valid. Attempts to match as closely as possible the
@@ -17,9 +17,6 @@ func SplitDockerPullSpec(spec string) (registry, namespace, name, tag string, er
 	registry, namespace, name, tag, err = SplitOpenShiftPullSpec(spec)
 	if err != nil {
 		return
-	}
-	if len(namespace) == 0 {
-		namespace = dockerDefaultNamespace
 	}
 	return
 }
@@ -51,11 +48,11 @@ func SplitOpenShiftPullSpec(spec string) (registry, namespace, name, tag string,
 // string. Attempts to match as closely as possible the Docker spec up to 1.3. Future API
 // revisions may change the pull syntax.
 func JoinDockerPullSpec(registry, namespace, name, tag string) string {
-	if len(namespace) == 0 {
-		namespace = dockerDefaultNamespace
-	}
 	if len(tag) != 0 {
 		tag = ":" + tag
+	}
+	if len(namespace) == 0 {
+		return fmt.Sprintf("%s%s", name, tag)
 	}
 	if len(registry) == 0 {
 		return fmt.Sprintf("%s/%s%s", namespace, name, tag)

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -52,7 +52,10 @@ func JoinDockerPullSpec(registry, namespace, name, tag string) string {
 		tag = ":" + tag
 	}
 	if len(namespace) == 0 {
-		return fmt.Sprintf("%s%s", name, tag)
+		if len(registry) == 0 {
+			return fmt.Sprintf("%s%s", name, tag)
+		}
+		namespace = DockerDefaultNamespace
 	}
 	if len(registry) == 0 {
 		return fmt.Sprintf("%s/%s%s", namespace, name, tag)

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -11,9 +11,8 @@ func TestSplitDockerPullSpec(t *testing.T) {
 		Err                            bool
 	}{
 		{
-			From:      "foo",
-			Namespace: "library",
-			Name:      "foo",
+			From: "foo",
+			Name: "foo",
 		},
 		{
 			From:      "bar/foo",

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -54,7 +54,7 @@ type ImageRepository struct {
 type ImageRepositoryStatus struct {
 	// Represents the effective location this repository may be accessed at. May be empty until the server
 	// determines where the repository is located
-	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
+	DockerImageRepository string `json:"dockerImageRepository"`
 }
 
 // TODO add metadata overrides

--- a/pkg/image/registry/imagerepository/rest_test.go
+++ b/pkg/image/registry/imagerepository/rest_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/openshift/origin/pkg/image/api"
@@ -18,10 +17,12 @@ import (
 func TestGetImageRepositoryError(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
 	mockRepositoryRegistry.Err = fmt.Errorf("test error")
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	image, err := storage.Get(kapi.NewDefaultContext(), "image1")
-	if image != nil {
+	if image != (*api.ImageRepository)(nil) {
 		t.Errorf("Unexpected non-nil image: %#v", image)
 	}
 	if err != mockRepositoryRegistry.Err {
@@ -35,7 +36,9 @@ func TestGetImageRepositoryOK(t *testing.T) {
 		ObjectMeta:            kapi.ObjectMeta{Name: "foo"},
 		DockerImageRepository: "openshift/ruby-19-centos",
 	}
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	repo, err := storage.Get(kapi.NewDefaultContext(), "foo")
 	if repo == nil {
@@ -62,7 +65,7 @@ func TestListImageRepositoriesError(t *testing.T) {
 		t.Errorf("Expected %#v, Got %#v", mockRepositoryRegistry.Err, err)
 	}
 
-	if imageRepositories != nil {
+	if imageRepositories != (*api.ImageRepositoryList)(nil) {
 		t.Errorf("Unexpected non-nil imageRepositories list: %#v", imageRepositories)
 	}
 }
@@ -122,9 +125,11 @@ func TestListImageRepositoriesPopulatedList(t *testing.T) {
 
 func TestCreateImageRepositoryOK(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
-	storage := NewREST(mockRepositoryRegistry, "test")
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
-	channel, err := storage.(apiserver.RESTCreater).Create(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
+	channel, err := storage.Create(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
 	if err != nil {
 		t.Fatalf("Unexpected non-nil error: %#v", err)
 	}
@@ -143,15 +148,14 @@ func TestCreateImageRepositoryOK(t *testing.T) {
 	if repo.DockerImageRepository != "" {
 		t.Errorf("unexpected repository: %#v", repo)
 	}
-	if repo.Status.DockerImageRepository != "test/default/foo" {
-		t.Errorf("unexpected Status values: %#v", repo)
-	}
 }
 
 func TestCreateRegistryErrorSaving(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
 	mockRepositoryRegistry.Err = fmt.Errorf("foo")
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	channel, err := storage.Create(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
 	if err != nil {
@@ -182,7 +186,9 @@ func TestUpdateImageRepositoryMissingID(t *testing.T) {
 func TestUpdateRegistryErrorSaving(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
 	mockRepositoryRegistry.Err = fmt.Errorf("foo")
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	channel, err := storage.Update(kapi.NewDefaultContext(), &api.ImageRepository{
 		ObjectMeta: kapi.ObjectMeta{Name: "bar"},
@@ -202,7 +208,9 @@ func TestUpdateRegistryErrorSaving(t *testing.T) {
 
 func TestUpdateImageRepositoryOK(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	channel, err := storage.Update(kapi.NewDefaultContext(), &api.ImageRepository{
 		ObjectMeta: kapi.ObjectMeta{Name: "bar"},
@@ -222,7 +230,9 @@ func TestUpdateImageRepositoryOK(t *testing.T) {
 
 func TestDeleteImageRepository(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	channel, err := storage.Delete(kapi.NewDefaultContext(), "foo")
 	if err != nil {
@@ -254,7 +264,9 @@ func TestCreateImageRepositoryConflictingNamespace(t *testing.T) {
 
 func TestUpdateImageRepositoryConflictingNamespace(t *testing.T) {
 	mockRepositoryRegistry := test.NewImageRepositoryRegistry()
-	storage := REST{registry: mockRepositoryRegistry}
+	storage := REST{
+		registry: mockRepositoryRegistry,
+	}
 
 	channel, err := storage.Update(kapi.WithNamespace(kapi.NewContext(), "legal-name"), &api.ImageRepository{
 		ObjectMeta: kapi.ObjectMeta{Name: "bar", Namespace: "some-value"},

--- a/pkg/image/registry/imagerepositorymapping/rest.go
+++ b/pkg/image/registry/imagerepositorymapping/rest.go
@@ -87,6 +87,9 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 
 // findRepositoryForMapping retrieves an ImageRepository whose DockerImageRepository matches dockerRepo.
 func (s *REST) findRepositoryForMapping(ctx kapi.Context, mapping *api.ImageRepositoryMapping) (*api.ImageRepository, error) {
+	if len(mapping.Name) > 0 {
+		return s.imageRepositoryRegistry.GetImageRepository(ctx, mapping.Name)
+	}
 	if len(mapping.DockerImageRepository) != 0 {
 		//TODO make this more efficient
 		list, err := s.imageRepositoryRegistry.ListImageRepositories(ctx, labels.Everything())
@@ -102,7 +105,7 @@ func (s *REST) findRepositoryForMapping(ctx kapi.Context, mapping *api.ImageRepo
 			errors.NewFieldNotFound("dockerImageRepository", mapping.DockerImageRepository),
 		})
 	}
-	return s.imageRepositoryRegistry.GetImageRepository(ctx, mapping.Name)
+	return nil, errors.NewNotFound("ImageRepository", "")
 }
 
 // Update is not supported.

--- a/pkg/service/environmentresolvercache.go
+++ b/pkg/service/environmentresolvercache.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+type ServiceRetriever interface {
+	Get(name string) (*api.Service, error)
+}
+
+type serviceEntry struct {
+	host string
+	port string
+}
+
+type ResolverCacheFunc func(name string) (*api.Service, error)
+
+type ServiceResolverCache struct {
+	fill  ResolverCacheFunc
+	cache map[string]serviceEntry
+	lock  sync.RWMutex
+}
+
+func NewServiceResolverCache(fill ResolverCacheFunc) *ServiceResolverCache {
+	return &ServiceResolverCache{
+		cache: make(map[string]serviceEntry),
+		fill:  fill,
+	}
+}
+
+func (c *ServiceResolverCache) get(name string) (host, port string, ok bool) {
+	// check
+	c.lock.RLock()
+	entry, found := c.cache[name]
+	c.lock.RUnlock()
+	if found {
+		return entry.host, entry.port, true
+	}
+
+	// fill the cache
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if entry, found := c.cache[name]; found {
+		return entry.host, entry.port, true
+	}
+	service, err := c.fill(name)
+	if err != nil {
+		return
+	}
+	host, port, ok = service.Spec.PortalIP, strconv.Itoa(service.Spec.Port), true
+	c.cache[name] = serviceEntry{
+		host: host,
+		port: port,
+	}
+	return
+}
+
+func toServiceName(envName string) string {
+	return strings.TrimSpace(strings.ToLower(strings.Replace(envName, "_", "-", -1)))
+}
+
+func recognizeVariable(name string) (service string, host bool, ok bool) {
+	switch {
+	case strings.HasSuffix(name, "_SERVICE_HOST"):
+		service = toServiceName(strings.TrimSuffix(name, "_SERVICE_HOST"))
+		host = true
+	case strings.HasSuffix(name, "_SERVICE_PORT"):
+		service = toServiceName(strings.TrimSuffix(name, "_SERVICE_PORT"))
+	default:
+		return "", false, false
+	}
+	if len(service) == 0 {
+		return "", false, false
+	}
+	ok = true
+	return
+}
+
+func (c *ServiceResolverCache) resolve(name string) (string, bool) {
+	service, isHost, ok := recognizeVariable(name)
+	if !ok {
+		return "", false
+	}
+	host, port, ok := c.get(service)
+	if !ok {
+		return "", false
+	}
+	if isHost {
+		return host, true
+	}
+	return port, true
+}
+
+// Defer takes a string (with optional variables) and an expansion function and returns
+// a function that can be called to get the value. This method will optimize the
+// expansion away in the event that no expansion is necessary.
+func (c *ServiceResolverCache) Defer(env string) (func() (string, bool), error) {
+	hasExpansion := false
+	invalid := []string{}
+	os.Expand(env, func(name string) string {
+		hasExpansion = true
+		if _, _, ok := recognizeVariable(name); !ok {
+			invalid = append(invalid, name)
+		}
+		return ""
+	})
+	if len(invalid) != 0 {
+		return nil, fmt.Errorf("invalid variable name(s): %s", strings.Join(invalid, ", "))
+	}
+	if !hasExpansion {
+		return func() (string, bool) { return env, true }, nil
+	}
+
+	// only load the value once
+	lock := sync.Mutex{}
+	loaded := false
+	return func() (string, bool) {
+		lock.Lock()
+		defer lock.Unlock()
+		if loaded {
+			return env, true
+		}
+		resolved := true
+		expand := os.Expand(env, func(s string) string {
+			s, ok := c.resolve(s)
+			resolved = resolved && ok
+			return s
+		})
+		if !resolved {
+			return "", false
+		}
+		loaded = true
+		env = expand
+		return env, true
+	}, nil
+}

--- a/pkg/service/environmentresolvercache_test.go
+++ b/pkg/service/environmentresolvercache_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+)
+
+func TestServiceResolverCacheEmpty(t *testing.T) {
+	fakeClient := &client.Fake{}
+	cache := NewServiceResolverCache(fakeClient.Services("default").Get)
+	if v, ok := cache.resolve("FOO_SERVICE_HOST"); v != "" || !ok {
+		t.Errorf("unexpected cache item")
+	}
+	if len(fakeClient.Actions) != 1 {
+		t.Errorf("unexpected client actions: %#v", fakeClient.Actions)
+	}
+	cache.resolve("FOO_SERVICE_HOST")
+	if len(fakeClient.Actions) != 1 {
+		t.Errorf("unexpected cache miss: %#v", fakeClient.Actions)
+	}
+	cache.resolve("FOO_SERVICE_PORT")
+	if len(fakeClient.Actions) != 1 {
+		t.Errorf("unexpected cache miss: %#v", fakeClient.Actions)
+	}
+}
+
+type fakeRetriever struct {
+	service *api.Service
+	err     error
+}
+
+func (r fakeRetriever) Get(name string) (*api.Service, error) {
+	return r.service, r.err
+}
+
+func TestServiceResolverCache(t *testing.T) {
+	c := fakeRetriever{
+		err: errors.NewNotFound("Service", "bar"),
+	}
+	cache := NewServiceResolverCache(c.Get)
+	if v, ok := cache.resolve("FOO_SERVICE_HOST"); v != "" || ok {
+		t.Errorf("unexpected cache item")
+	}
+
+	c = fakeRetriever{
+		service: &api.Service{
+			Spec: api.ServiceSpec{
+				PortalIP: "127.0.0.1",
+				Port:     80,
+			},
+		},
+	}
+	cache = NewServiceResolverCache(c.Get)
+	if v, ok := cache.resolve("FOO_SERVICE_HOST"); v != "127.0.0.1" || !ok {
+		t.Errorf("unexpected cache item")
+	}
+	if v, ok := cache.resolve("FOO_SERVICE_PORT"); v != "80" || !ok {
+		t.Errorf("unexpected cache item")
+	}
+	if _, err := cache.Defer("${UNKNOWN}"); err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	fn, err := cache.Defer("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := fn(); v != "test" || !ok {
+		t.Errorf("unexpected cache item")
+	}
+	fn, err = cache.Defer("${FOO_SERVICE_HOST}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := fn(); v != "127.0.0.1" || !ok {
+		t.Errorf("unexpected cache item")
+	}
+	if v, ok := fn(); v != "127.0.0.1" || !ok {
+		t.Errorf("unexpected cache item")
+	}
+}

--- a/test/integration/basic_auth_test.go
+++ b/test/integration/basic_auth_test.go
@@ -3,13 +3,11 @@ package integration
 import (
 	"log"
 	"net/http"
-
-	"github.com/golang/glog"
 )
 
 func ExampleNewBasicAuthChallenger() {
 	challenger := NewBasicAuthChallenger("realm", []User{{"username", "password", "Brave Butcher", "cowardly_butcher@example.org"}}, NewIdentifyingHandler())
 	http.Handle("/", challenger)
-	glog.Infoln("Auth server listening on http://localhost:1234")
+	log.Printf("Auth server listening on http://localhost:1234")
 	log.Fatal(http.ListenAndServe(":1234", nil))
 }

--- a/test/integration/buildcfgclient_test.go
+++ b/test/integration/buildcfgclient_test.go
@@ -135,7 +135,7 @@ func mockBuildConfig() *buildapi.BuildConfig {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "namespace/builtimage",
+				DockerImageReference: "namespace/builtimage",
 			},
 		},
 	}
@@ -175,7 +175,7 @@ func TestBuildConfigClient(t *testing.T) {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "namespace/builtimage",
+				DockerImageReference: "namespace/builtimage",
 			},
 		},
 	}

--- a/test/integration/buildcfgclient_test.go
+++ b/test/integration/buildcfgclient_test.go
@@ -18,6 +18,7 @@ func init() {
 func TestListBuildConfigs(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 
 	buildConfigs, err := openshift.Client.BuildConfigs(testNamespace).List(labels.Everything(), labels.Everything())
 	if err != nil {
@@ -31,6 +32,7 @@ func TestListBuildConfigs(t *testing.T) {
 func TestCreateBuildConfig(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 	buildConfig := mockBuildConfig()
 
 	expected, err := openshift.Client.BuildConfigs(testNamespace).Create(buildConfig)
@@ -53,6 +55,7 @@ func TestCreateBuildConfig(t *testing.T) {
 func TestUpdateBuildConfig(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 	buildConfig := mockBuildConfig()
 
 	actual, err := openshift.Client.BuildConfigs(testNamespace).Create(buildConfig)
@@ -71,6 +74,7 @@ func TestUpdateBuildConfig(t *testing.T) {
 func TestDeleteBuildConfig(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 	buildConfig := mockBuildConfig()
 
 	actual, err := openshift.Client.BuildConfigs(testNamespace).Create(buildConfig)
@@ -85,12 +89,14 @@ func TestDeleteBuildConfig(t *testing.T) {
 func TestWatchBuildConfigs(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 	buildConfig := mockBuildConfig()
 
 	watch, err := openshift.Client.BuildConfigs(testNamespace).Watch(labels.Everything(), labels.Everything(), "0")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer watch.Stop()
 
 	expected, err := openshift.Client.BuildConfigs(testNamespace).Create(buildConfig)
 	if err != nil {
@@ -144,6 +150,7 @@ func mockBuildConfig() *buildapi.BuildConfig {
 func TestBuildConfigClient(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 
 	buildConfigs, err := openshift.Client.BuildConfigs(testNamespace).List(labels.Everything(), labels.Everything())
 	if err != nil {

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -151,6 +151,8 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 		stop: make(chan struct{}),
 	}
 
+	openshift.lock.Lock()
+	defer openshift.lock.Unlock()
 	etcdClient := newEtcdClient()
 	etcdHelper, _ := master.NewEtcdHelper(etcdClient, klatest.Version)
 

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -127,7 +127,7 @@ func mockBuild() *buildapi.Build {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "namespace/builtimage",
+				DockerImageReference: "namespace/builtimage",
 			},
 		},
 	}

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	klatest "github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
@@ -80,7 +79,8 @@ func TestGetToken(t *testing.T) {
 	mux := http.NewServeMux()
 	server.Install(mux, origin.OpenShiftOAuthAPIPrefix)
 	oauthServer := httptest.NewServer(http.Handler(mux))
-	glog.Infof("oauth server is on %v\n", oauthServer.URL)
+	defer oauthServer.Close()
+	t.Logf("oauth server is on %v\n", oauthServer.URL)
 
 	// create the default oauth clients with redirects to our server
 	origin.CreateOrUpdateDefaultOAuthClients(oauthServer.URL, oauthEtcd)

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"flag"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -111,6 +110,7 @@ func TestSimpleImageChangeTrigger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Deployments %v", err)
 	}
+	defer watch.Stop()
 
 	imageRepo, err = openshift.Client.ImageRepositories(testNamespace).Create(imageRepo)
 	if err != nil {
@@ -168,6 +168,7 @@ func TestSimpleConfigChangeTrigger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Deployments %v", err)
 	}
+	defer watch.Stop()
 
 	// submit the initial deployment config
 	if _, err := openshift.Client.DeploymentConfigs(testNamespace).Create(config); err != nil {
@@ -241,7 +242,6 @@ type testOpenshift struct {
 }
 
 func NewTestOpenshift(t *testing.T) *testOpenshift {
-	flag.Set("v", "4")
 	t.Logf("Starting test openshift")
 
 	openshift := &testOpenshift{
@@ -346,6 +346,7 @@ func NewTestOpenshift(t *testing.T) *testOpenshift {
 			TempDirectoryCreator: buildstrategy.STITempDirectoryCreator,
 			UseLocalImages:       false,
 		},
+		Stop: openshift.stop,
 	}
 
 	bcFactory.Create().Run()

--- a/test/integration/fixtures/test-image-repository.json
+++ b/test/integration/fixtures/test-image-repository.json
@@ -7,7 +7,6 @@
       "color": "blue"
     }
   },
-  "dockerImageRepository": "openshift/ruby-19-centos",
   "tags": {
     "latest": "foo",
     "another": "bar",

--- a/test/integration/fixtures/test-mapping.json
+++ b/test/integration/fixtures/test-mapping.json
@@ -1,7 +1,9 @@
 {
+  "metadata": {
+    "name": "test"
+  },
   "kind": "ImageRepositoryMapping",
   "apiVersion": "v1beta1",
-  "dockerImageRepository": "openshift/ruby-19-centos",
   "image": {
     "kind": "Image",
     "version": "v1beta1",
@@ -9,7 +11,7 @@
       "name": "abcd1234"
     },
     "dockerImageReference": "openshift/ruby-19-centos:latest",
-    "meta": {
+    "dockerImageMetadata": {
       "Architecture": "amd64",
       "Author": "Michal Fojtik \u003cmfojtik@redhat.com\u003e",
       "Comment": "",

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -109,7 +109,7 @@ func imageChangeBuildConfig() *buildapi.BuildConfig {
 				Type: buildapi.ImageChangeBuildTriggerType,
 				ImageChange: &buildapi.ImageChangeTrigger{
 					Image: "registry:8080/openshift/test-image",
-					ImageRepositoryRef: &kapi.ObjectReference{
+					From: kapi.ObjectReference{
 						Name: "test-image-repo",
 					},
 					Tag: "latest",

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -84,7 +84,7 @@ func TestSimpleImageChangeBuildTrigger(t *testing.T) {
 func imageChangeBuildConfig() *buildapi.BuildConfig {
 	buildcfg := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
-			Name: "testBuildCfg",
+			Name: "test-build-cfg",
 		},
 		Parameters: buildapi.BuildParameters{
 			Source: buildapi.BuildSource{
@@ -101,7 +101,7 @@ func imageChangeBuildConfig() *buildapi.BuildConfig {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "tag",
+				DockerImageReference: "foo:tag",
 			},
 		},
 		Triggers: []buildapi.BuildTriggerPolicy{

--- a/test/integration/imageclient_test.go
+++ b/test/integration/imageclient_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
-	"github.com/golang/glog"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -193,15 +192,19 @@ type testImageOpenshift struct {
 	Client       *osclient.Client
 	server       *httptest.Server
 	dockerServer *httptest.Server
+	stop         chan struct{}
 }
 
 func (o *testImageOpenshift) Close() {
+	close(o.stop)
 	o.server.Close()
 	o.dockerServer.Close()
 }
 
 func NewTestImageOpenShift(t *testing.T) *testImageOpenshift {
-	openshift := &testImageOpenshift{}
+	openshift := &testImageOpenshift{
+		stop: make(chan struct{}),
+	}
 
 	etcdClient := newEtcdClient()
 	etcdHelper, _ := master.NewEtcdHelper(etcdClient, klatest.Version)
@@ -219,7 +222,7 @@ func NewTestImageOpenShift(t *testing.T) *testImageOpenshift {
 
 	kubeletClient, err := kclient.NewKubeletClient(&kclient.KubeletConfig{Port: 10250})
 	if err != nil {
-		glog.Fatalf("Unable to configure Kubelet client: %v", err)
+		t.Fatalf("Unable to configure Kubelet client: %v", err)
 	}
 
 	kmaster := master.New(&master.Config{

--- a/test/integration/imageclient_test.go
+++ b/test/integration/imageclient_test.go
@@ -232,11 +232,11 @@ func NewTestImageOpenShift(t *testing.T) *testImageOpenshift {
 
 	interfaces, _ := latest.InterfacesFor(latest.Version)
 
-	imageEtcd := imageetcd.New(etcdHelper)
+	imageEtcd := imageetcd.New(etcdHelper, imageetcd.DefaultRegistryFunc(func() (string, bool) { return openshift.dockerServer.URL, true }))
 
 	storage := map[string]apiserver.RESTStorage{
 		"images":                  image.NewREST(imageEtcd),
-		"imageRepositories":       imagerepository.NewREST(imageEtcd, openshift.dockerServer.URL),
+		"imageRepositories":       imagerepository.NewREST(imageEtcd),
 		"imageRepositoryMappings": imagerepositorymapping.NewREST(imageEtcd, imageEtcd),
 		"imageRepositoryTags":     imagerepositorytag.NewREST(imageEtcd, imageEtcd),
 	}

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -80,6 +80,7 @@ func TestOAuthStorage(t *testing.T) {
 	mux := http.NewServeMux()
 	oauthServer.Install(mux, "")
 	server := httptest.NewServer(mux)
+	defer server.Close()
 
 	ch := make(chan *osincli.AccessData, 1)
 	var oaclient *osincli.Client

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -45,6 +45,7 @@ func TestUserInitialization(t *testing.T) {
 	}
 
 	server := httptest.NewServer(apiserver.Handle(storage, v1beta1.Codec, "/osapi", "v1beta1", interfaces.MetadataAccessor, admit.NewAlwaysAdmit()))
+	defer server.Close()
 
 	mapping := api.UserIdentityMapping{
 		Identity: api.Identity{

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -3,12 +3,16 @@
 package integration
 
 import (
+	"flag"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 )
 
 const testNamespace = "integration-test"
@@ -22,6 +26,17 @@ func newEtcdClient() *etcd.Client {
 	}
 
 	return etcd.NewClient(etcdServers)
+}
+
+func init() {
+	capabilities.SetForTests(capabilities.Capabilities{
+		AllowPrivileged: true,
+	})
+	flag.Set("v", "5")
+}
+
+func logEtcd() {
+	etcd.SetLogger(log.New(os.Stderr, "go-etcd", log.LstdFlags))
 }
 
 func requireEtcd() {

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -50,7 +50,7 @@ func TestWebhookGithubPush(t *testing.T) {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "namespace/builtimage",
+				DockerImageReference: "namespace/builtimage",
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func TestWebhookGithubPing(t *testing.T) {
 				},
 			},
 			Output: buildapi.BuildOutput{
-				ImageTag: "namespace/builtimage",
+				DockerImageReference: "namespace/builtimage",
 			},
 		},
 	}

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -22,6 +22,7 @@ func init() {
 func TestWebhookGithubPush(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 
 	// create buildconfig
 	buildConfig := &buildapi.BuildConfig{
@@ -78,6 +79,7 @@ func TestWebhookGithubPush(t *testing.T) {
 func TestWebhookGithubPing(t *testing.T) {
 	deleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
+	defer openshift.Close()
 
 	// create buildconfig
 	buildConfig := &buildapi.BuildConfig{


### PR DESCRIPTION
First two parts of a three part change (the third part is ensuring the default
registry is configured automatically). 

Generalized cleanup of build code, including more validations, handling build
error states, and encoding build JSON into the build pod as our external (not
internal) schema.