### PR TITLE
In case of failure, wait and restart the openshift-node service

### DIFF
--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -44,6 +44,8 @@ After=network.service
 
 [Service]
 ExecStart=/usr/bin/openshift start node --master=http://${MASTER_IP}:8080
+Restart=on-failure
+RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This fixes the issue where sometimes the service fails to start because the etcd service is not available.