### PR TITLE
DO NOT MERGE: example of keeping track of bound flags

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/overrides.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/overrides.go
@@ -47,6 +47,7 @@ type ConfigOverrideFlags struct {
 // AuthOverrideFlags holds the flag names to be used for binding command line flags for AuthInfo objects
 type AuthOverrideFlags struct {
 	AuthPath          string
+	AuthPathShort     string
 	ClientCertificate string
 	ClientKey         string
 	Token             string
@@ -55,6 +56,7 @@ type AuthOverrideFlags struct {
 // ClusterOverride holds the flag names to be used for binding command line flags for Cluster objects
 type ClusterOverrideFlags struct {
 	APIServer             string
+	APIServerShort        string
 	APIVersion            string
 	CertificateAuthority  string
 	InsecureSkipTLSVerify string
@@ -109,8 +111,12 @@ func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
 
 // BindAuthInfoFlags is a convenience method to bind the specified flags to their associated variables
 func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, flagNames AuthOverrideFlags) {
-	// TODO short flag names are impossible to prefix, decide whether to keep them or not
-	flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, "a", "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
+	if len(flagNames.AuthPathShort) > 0 {
+		flags.StringVarP(&authInfo.AuthPath, flagNames.AuthPath, flagNames.AuthPathShort, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	} else {
+		flags.StringVar(&authInfo.AuthPath, flagNames.AuthPath, "", "Path to the auth info file. If missing, prompt the user. Only used if using https.")
+	}
 	flags.StringVar(&authInfo.ClientCertificate, flagNames.ClientCertificate, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.ClientKey, flagNames.ClientKey, "", "Path to a client key file for TLS.")
 	flags.StringVar(&authInfo.Token, flagNames.Token, "", "Bearer token for authentication to the API server.")
@@ -118,8 +124,12 @@ func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, fl
 
 // BindClusterFlags is a convenience method to bind the specified flags to their associated variables
 func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, flagNames ClusterOverrideFlags) {
-	// TODO short flag names are impossible to prefix, decide whether to keep them or not
-	flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, "s", "", "The address of the Kubernetes API server")
+	// TODO short flag names are impossible to prefix.  code gets cleaner if we remove them
+	if len(flagNames.APIServerShort) > 0 {
+		flags.StringVarP(&clusterInfo.Server, flagNames.APIServer, flagNames.APIServerShort, "", "The address of the Kubernetes API server")
+	} else {
+		flags.StringVar(&clusterInfo.Server, flagNames.APIServer, "", "The address of the Kubernetes API server")
+	}
 	flags.StringVar(&clusterInfo.APIVersion, flagNames.APIVersion, "", "The API version to use when talking to the server")
 	flags.StringVar(&clusterInfo.CertificateAuthority, flagNames.CertificateAuthority, "", "Path to a cert. file for the certificate authority.")
 	flags.BoolVar(&clusterInfo.InsecureSkipTLSVerify, flagNames.InsecureSkipTLSVerify, false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/cmd.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/cmd.go
@@ -67,11 +67,14 @@ type Factory struct {
 }
 
 // NewFactory creates a factory with the default Kubernetes resources defined
-func NewFactory() *Factory {
+func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 	mapper := kubectl.ShortcutExpander{latest.RESTMapper}
 
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	clientConfig := DefaultClientConfig(flags)
+	clientConfig := optionalClientConfig
+	if optionalClientConfig == nil {
+		clientConfig = DefaultClientConfig(flags)
+	}
 	clients := &clientCache{
 		clients: make(map[string]*client.Client),
 		loader:  clientConfig,

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
-	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
 	"github.com/spf13/cobra"
 
@@ -39,9 +37,7 @@ func NewCommandCLI(name string) *cobra.Command {
 		},
 	}
 
-	// TODO: there should be two client builders, one for OpenShift, and one for Kubernetes
-	clientConfig := clientcmd.NewInteractiveClientConfig(clientcmdapi.Config{}, "", &clientcmd.ConfigOverrides{}, os.Stdin)
-	f := cmd.NewFactory(clientConfig)
+	f := cmd.NewFactory(cmds.PersistentFlags())
 	f.BindFlags(cmds.PersistentFlags())
 	out := os.Stdout
 


### PR DESCRIPTION
@liggitt @fabianofranz @smarterclayton 

I think we'll probably want the upstream changes.  Doing this has the interesting side effect of having `osc get pods --server=foo` fail and `osc get pods --kubernetes-server=foo` succeed.  Your initial reaction is **ick**, but if we need to support a single `osc create -f file` that can create resources on both origin and kubernetes, this may be ugliness we have to deal with.