### PR TITLE
Nuke yaml from all objects

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -7,36 +7,36 @@ import (
 // Build encapsulates the inputs needed to produce a new deployable image, as well as
 // the status of the execution and a reference to the Pod which executed the build.
 type Build struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Parameters are all the inputs used to create the build pod.
-	Parameters BuildParameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters BuildParameters `json:"parameters,omitempty"`
 
 	// Status is the current status of the build.
-	Status BuildStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status BuildStatus `json:"status,omitempty"`
 
 	// PodName is the name of the pod that is used to execute the build
-	PodName string `json:"podName,omitempty" yaml:"podName,omitempty"`
+	PodName string `json:"podName,omitempty"`
 
 	// Cancelled describes if a cancelling event was triggered for the build.
-	Cancelled bool `json:"cancelled,omitempty" yaml:"cancelled,omitempty"`
+	Cancelled bool `json:"cancelled,omitempty"`
 }
 
 // BuildParameters encapsulates all the inputs necessary to represent a build.
 type BuildParameters struct {
 	// Source describes the SCM in use.
-	Source BuildSource `json:"source,omitempty" yaml:"source,omitempty"`
+	Source BuildSource `json:"source,omitempty"`
 
 	// Revision is the information from the source for a specific repo snapshot.
 	// This is optional.
-	Revision *SourceRevision `json:"revision,omitempty" yaml:"revision,omitempty"`
+	Revision *SourceRevision `json:"revision,omitempty"`
 
 	// Strategy defines how to perform a build.
-	Strategy BuildStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Strategy BuildStrategy `json:"strategy,omitempty"`
 
 	// Output describes the Docker image the Strategy should produce.
-	Output BuildOutput `json:"output,omitempty" yaml:"output,omitempty"`
+	Output BuildOutput `json:"output,omitempty"`
 }
 
 // BuildStatus represents the status of a build at a point in time.
@@ -78,60 +78,60 @@ const (
 
 // BuildSource is the SCM used for the build
 type BuildSource struct {
-	Type BuildSourceType `json:"type,omitempty" yaml:"type,omitempty"`
-	Git  *GitBuildSource `json:"git,omitempty" yaml:"git,omitempty"`
+	Type BuildSourceType `json:"type,omitempty"`
+	Git  *GitBuildSource `json:"git,omitempty"`
 }
 
 // SourceRevision is the revision or commit information from the source for the build
 type SourceRevision struct {
-	Type BuildSourceType    `json:"type,omitempty" yaml:"type,omitempty"`
-	Git  *GitSourceRevision `json:"git,omitempty" yaml:"git,omitempty"`
+	Type BuildSourceType    `json:"type,omitempty"`
+	Git  *GitSourceRevision `json:"git,omitempty"`
 }
 
 // GitSourceRevision is the commit information from a git source for a build
 type GitSourceRevision struct {
 	// Commit is the commit hash identifying a specific commit
-	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	Commit string `json:"commit,omitempty"`
 
 	// Author is the author of a specific commit
-	Author SourceControlUser `json:"author,omitempty" yaml:"author,omitempty"`
+	Author SourceControlUser `json:"author,omitempty"`
 
 	// Committer is the commiter of a specific commit
-	Committer SourceControlUser `json:"committer,omitempty" yaml:"committer,omitempty"`
+	Committer SourceControlUser `json:"committer,omitempty"`
 
 	// Message is the description of a specific commit
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // GitBuildSource defines the parameters of a Git SCM
 type GitBuildSource struct {
 	// URI points to the source that will be built. The structure of the source
 	// will depend on the type of build to run
-	URI string `json:"uri,omitempty" yaml:"uri,omitempty"`
+	URI string `json:"uri,omitempty"`
 
 	// Ref is the branch/tag/ref to build.
-	Ref string `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Ref string `json:"ref,omitempty"`
 }
 
 // SourceControlUser defines the identity of a user of source control
 type SourceControlUser struct {
-	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
-	Email string `json:"email,omitempty" yaml:"email,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
 }
 
 // BuildStrategy contains the details of how to perform a build.
 type BuildStrategy struct {
 	// Type is the kind of build strategy.
-	Type BuildStrategyType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type BuildStrategyType `json:"type,omitempty"`
 
 	// DockerStrategy holds the parameters to the Docker build strategy.
-	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty" yaml:"dockerStrategy,omitempty"`
+	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty"`
 
 	// STIStrategy holds the parameters to the STI build strategy.
-	STIStrategy *STIBuildStrategy `json:"stiStrategy,omitempty" yaml:"stiStrategy,omitempty"`
+	STIStrategy *STIBuildStrategy `json:"stiStrategy,omitempty"`
 
 	// CustomStrategy holds the parameters to the Custom build strategy.
-	CustomStrategy *CustomBuildStrategy `json:"customStrategy,omitempty" yaml:"customStrategy,omitempty"`
+	CustomStrategy *CustomBuildStrategy `json:"customStrategy,omitempty"`
 }
 
 // BuildStrategyType describes a particular way of performing a build.
@@ -163,7 +163,7 @@ const (
 type CustomBuildStrategy struct {
 	// Image is the image required to execute the build. If not specified
 	// a validation error is returned.
-	Image string `json:"image" yaml:"image"`
+	Image string `json:"image"`
 
 	// Additional environment variables you want to pass into a builder container
 	Env []kapi.EnvVar `json:"env,omitempty"`
@@ -171,7 +171,7 @@ type CustomBuildStrategy struct {
 	// ExposeDockerSocket will allow running Docker commands (and build Docker images) from
 	// inside the Docker container.
 	// TODO: Allow admins to enforce 'false' for this option
-	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty" yaml:"exposeDockerSocket,omitempty"`
+	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty"`
 }
 
 // DockerBuildStrategy defines input parameters specific to Docker build.
@@ -179,38 +179,38 @@ type DockerBuildStrategy struct {
 	// ContextDir is used as the Docker build context. It is a path for a directory within the
 	// application source directory structure (as referenced in the BuildSource. See GitBuildSource
 	// for an example.)
-	ContextDir string `json:"contextDir,omitempty" yaml:"contextDir,omitempty"`
+	ContextDir string `json:"contextDir,omitempty"`
 
 	// NoCache if set to true indicates that the docker build must be executed with the
 	// --no-cache=true flag
-	NoCache bool `json:"noCache,omitempty" yaml:"noCache,omitempty"`
+	NoCache bool `json:"noCache,omitempty"`
 
 	// BaseImage is optional and indicates the image that the dockerfile for this
 	// build should "FROM".  If present, the build process will substitute this value
 	// into the FROM line of the dockerfile.
-	BaseImage string `json:"baseImage,omitempty" yaml:"baseImage,omitempty"`
+	BaseImage string `json:"baseImage,omitempty"`
 }
 
 // STIBuildStrategy defines input parameters specific to an STI build.
 type STIBuildStrategy struct {
 	// Image is the image used to execute the build.
-	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 
 	// Scripts is the location of STI scripts
-	Scripts string `json:"scripts,omitempty" yaml:"scripts,omitempty"`
+	Scripts string `json:"scripts,omitempty"`
 
 	// Clean flag forces the STI build to not do incremental builds if true.
-	Clean bool `json:"clean,omitempty" yaml:"clean,omitempty"`
+	Clean bool `json:"clean,omitempty"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy
 // should produce.
 type BuildOutput struct {
 	// ImageTag is the tag to give to the image resulting from the build.
-	ImageTag string `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
+	ImageTag string `json:"imageTag,omitempty"`
 
 	// Registry is the Docker registry which should receive the resulting built image via push.
-	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Registry string `json:"registry,omitempty"`
 }
 
 // BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig
@@ -219,50 +219,50 @@ const BuildConfigLabel = "buildconfig"
 
 // BuildConfig is a template which can be used to create new builds.
 type BuildConfig struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Triggers determine how new Builds can be launched from a BuildConfig. If no triggers
 	// are defined, a new build can only occur as a result of an explicit client build creation.
-	Triggers []BuildTriggerPolicy `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	Triggers []BuildTriggerPolicy `json:"triggers,omitempty"`
 
 	// Parameters holds all the input necessary to produce a new build.
-	Parameters BuildParameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters BuildParameters `json:"parameters,omitempty"`
 }
 
 // WebHookTrigger is a trigger that gets invoked using a webhook type of post
 type WebHookTrigger struct {
 	// Secret used to validate requests.
-	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Secret string `json:"secret,omitempty"`
 }
 
 // ImageChangeTrigger allows builds to be triggered when an ImageRepository changes
 type ImageChangeTrigger struct {
 	// Image is used to specify the value in the BuildConfig to replace with the
 	// immutable image id supplied by the ImageRepository when this trigger fires.
-	Image string `json:"image" yaml:"image"`
+	Image string `json:"image"`
 	// ImageRepositoryRef a reference to a Docker image repository to watch for changes.
-	ImageRepositoryRef *kapi.ObjectReference `json:"imageRepositoryRef" yaml:"imageRepositoryRef"`
+	ImageRepositoryRef *kapi.ObjectReference `json:"imageRepositoryRef"`
 	// Tag is the name of an image repository tag to watch for changes.
-	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Tag string `json:"tag,omitempty"`
 	// LastTriggeredImageID is used internally by the ImageChangeController to save last
 	// used image ID for build
-	LastTriggeredImageID string `json:"lastTriggeredImageID,omitempty" yaml:"lastTriggeredImageID,omitempty"`
+	LastTriggeredImageID string `json:"lastTriggeredImageID,omitempty"`
 }
 
 // BuildTriggerPolicy describes a policy for a single trigger that results in a new Build.
 type BuildTriggerPolicy struct {
 	// Type is the type of build trigger
-	Type BuildTriggerType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type BuildTriggerType `json:"type,omitempty"`
 
 	// GithubWebHook contains the parameters for a Github webhook type of trigger
-	GithubWebHook *WebHookTrigger `json:"github,omitempty" yaml:"github,omitempty"`
+	GithubWebHook *WebHookTrigger `json:"github,omitempty"`
 
 	// GenericWebHook contains the parameters for a Generic webhook type of trigger
-	GenericWebHook *WebHookTrigger `json:"generic,omitempty" yaml:"generic,omitempty"`
+	GenericWebHook *WebHookTrigger `json:"generic,omitempty"`
 
 	// ImageChange contains parameters for an ImageChange type of trigger
-	ImageChange *ImageChangeTrigger `json:"imageChange,omitempty" yaml:"imageChange,omitempty"`
+	ImageChange *ImageChangeTrigger `json:"imageChange,omitempty"`
 }
 
 // BuildTriggerType refers to a specific BuildTriggerPolicy implementation.
@@ -284,29 +284,29 @@ const (
 
 // BuildList is a collection of Builds.
 type BuildList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Build `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Build `json:"items"`
 }
 
 // BuildConfigList is a collection of BuildConfigs.
 type BuildConfigList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []BuildConfig `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []BuildConfig `json:"items"`
 }
 
 // GenericWebHookEvent is the payload expected for a generic webhook post
 type GenericWebHookEvent struct {
 	// Type is the type of source repository
-	Type BuildSourceType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type BuildSourceType `json:"type,omitempty"`
 
 	// Git is the git information if the Type is BuildSourceGit
-	Git *GitInfo `json:"git,omitempty" yaml:"git,omitempty"`
+	Git *GitInfo `json:"git,omitempty"`
 }
 
 // GitInfo is the aggregated git information for a generic webhook post
 type GitInfo struct {
-	GitBuildSource    `json:",inline" yaml:",inline"`
-	GitSourceRevision `json:",inline" yaml:",inline"`
+	GitBuildSource    `json:",inline"`
+	GitSourceRevision `json:",inline"`
 }

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -7,36 +7,36 @@ import (
 // Build encapsulates the inputs needed to produce a new deployable image, as well as
 // the status of the execution and a reference to the Pod which executed the build.
 type Build struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Parameters are all the inputs used to create the build pod.
-	Parameters BuildParameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters BuildParameters `json:"parameters,omitempty"`
 
 	// Status is the current status of the build.
-	Status BuildStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status BuildStatus `json:"status,omitempty"`
 
 	// PodName is the name of the pod that is used to execute the build
-	PodName string `json:"podName,omitempty" yaml:"podName,omitempty"`
+	PodName string `json:"podName,omitempty"`
 
 	// Cancelled describes if a cancelling event was triggered for the build.
-	Cancelled bool `json:"cancelled,omitempty" yaml:"cancelled,omitempty"`
+	Cancelled bool `json:"cancelled,omitempty"`
 }
 
 // BuildParameters encapsulates all the inputs necessary to represent a build.
 type BuildParameters struct {
 	// Source describes the SCM in use.
-	Source BuildSource `json:"source,omitempty" yaml:"source,omitempty"`
+	Source BuildSource `json:"source,omitempty"`
 
 	// Revision is the information from the source for a specific repo snapshot.
 	// This is optional.
-	Revision *SourceRevision `json:"revision,omitempty" yaml:"revision,omitempty"`
+	Revision *SourceRevision `json:"revision,omitempty"`
 
 	// Strategy defines how to perform a build.
-	Strategy BuildStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Strategy BuildStrategy `json:"strategy,omitempty"`
 
 	// Output describes the Docker image the Strategy should produce.
-	Output BuildOutput `json:"output,omitempty" yaml:"output,omitempty"`
+	Output BuildOutput `json:"output,omitempty"`
 }
 
 // BuildStatus represents the status of a build at a point in time.
@@ -78,60 +78,60 @@ const (
 
 // BuildSource is the SCM used for the build
 type BuildSource struct {
-	Type BuildSourceType `json:"type,omitempty" yaml:"type,omitempty"`
-	Git  *GitBuildSource `json:"git,omitempty" yaml:"git,omitempty"`
+	Type BuildSourceType `json:"type,omitempty"`
+	Git  *GitBuildSource `json:"git,omitempty"`
 }
 
 // SourceRevision is the revision or commit information from the source for the build
 type SourceRevision struct {
-	Type BuildSourceType    `json:"type,omitempty" yaml:"type,omitempty"`
-	Git  *GitSourceRevision `json:"git,omitempty" yaml:"git,omitempty"`
+	Type BuildSourceType    `json:"type,omitempty"`
+	Git  *GitSourceRevision `json:"git,omitempty"`
 }
 
 // GitSourceRevision is the commit information from a git source for a build
 type GitSourceRevision struct {
 	// Commit is the commit hash identifying a specific commit
-	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	Commit string `json:"commit,omitempty"`
 
 	// Author is the author of a specific commit
-	Author SourceControlUser `json:"author,omitempty" yaml:"author,omitempty"`
+	Author SourceControlUser `json:"author,omitempty"`
 
 	// Committer is the commiter of a specific commit
-	Committer SourceControlUser `json:"committer,omitempty" yaml:"committer,omitempty"`
+	Committer SourceControlUser `json:"committer,omitempty"`
 
 	// Message is the description of a specific commit
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // GitBuildSource defines the parameters of a Git SCM
 type GitBuildSource struct {
 	// URI points to the source that will be built. The structure of the source
 	// will depend on the type of build to run
-	URI string `json:"uri,omitempty" yaml:"uri,omitempty"`
+	URI string `json:"uri,omitempty"`
 
 	// Ref is the branch/tag/ref to build.
-	Ref string `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Ref string `json:"ref,omitempty"`
 }
 
 // SourceControlUser defines the identity of a user of source control
 type SourceControlUser struct {
-	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
-	Email string `json:"email,omitempty" yaml:"email,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
 }
 
 // BuildStrategy contains the details of how to perform a build.
 type BuildStrategy struct {
 	// Type is the kind of build strategy.
-	Type BuildStrategyType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type BuildStrategyType `json:"type,omitempty"`
 
 	// DockerStrategy holds the parameters to the Docker build strategy.
-	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty" yaml:"dockerStrategy,omitempty"`
+	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty"`
 
 	// STIStrategy holds the parameters to the STI build strategy.
-	STIStrategy *STIBuildStrategy `json:"stiStrategy,omitempty" yaml:"stiStrategy,omitempty"`
+	STIStrategy *STIBuildStrategy `json:"stiStrategy,omitempty"`
 
 	// CustomStrategy holds the parameters to the Custom build strategy
-	CustomStrategy *CustomBuildStrategy `json:"customStrategy,omitempty" yaml:"customStrategy,omitempty"`
+	CustomStrategy *CustomBuildStrategy `json:"customStrategy,omitempty"`
 }
 
 // BuildStrategyType describes a particular way of performing a build.
@@ -154,7 +154,7 @@ const (
 type CustomBuildStrategy struct {
 	// Image is the image required to execute the build. If not specified
 	// a validation error is returned.
-	Image string `json:"image" yaml:"image"`
+	Image string `json:"image"`
 
 	// Additional environment variables you want to pass into a builder container
 	Env []kapi.EnvVar `json:"env,omitempty"`
@@ -162,7 +162,7 @@ type CustomBuildStrategy struct {
 	// ExposeDockerSocket will allow running Docker commands (and build Docker images) from
 	// inside the Docker container.
 	// TODO: Allow admins to enforce 'false' for this option
-	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty" yaml:"exposeDockerSocket,omitempty"`
+	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty"`
 }
 
 // DockerBuildStrategy defines input parameters specific to Docker build.
@@ -170,42 +170,42 @@ type DockerBuildStrategy struct {
 	// ContextDir is used as the Docker build context. It is a path for a directory within the
 	// application source directory structure (as referenced in the BuildSource. See GitBuildSource
 	// for an example.)
-	ContextDir string `json:"contextDir,omitempty" yaml:"contextDir,omitempty"`
+	ContextDir string `json:"contextDir,omitempty"`
 
 	// NoCache if set to true indicates that the docker build must be executed with the
 	// --no-cache=true flag
-	NoCache bool `json:"noCache,omitempty" yaml:"noCache,omitempty"`
+	NoCache bool `json:"noCache,omitempty"`
 
 	// BaseImage is optional and indicates the image that the dockerfile for this
 	// build should "FROM".  If present, the build process will substitute this value
 	// into the FROM line of the dockerfile.
-	BaseImage string `json:"baseImage,omitempty" yaml:"baseImage,omitempty"`
+	BaseImage string `json:"baseImage,omitempty"`
 }
 
 // STIBuildStrategy defines input parameters specific to an STI build.
 type STIBuildStrategy struct {
 	// BuilderImage is the image used to execute the build.
 	// Deprecated: will be removed in v1beta2, use Image.
-	BuilderImage string `json:"builderImage,omitempty" yaml:"builderImage,omitempty"`
+	BuilderImage string `json:"builderImage,omitempty"`
 
 	// Image is the image used to execute the build.
-	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 
 	// Scripts is the location of STI scripts
-	Scripts string `json:"scripts,omitempty" yaml:"scripts,omitempty"`
+	Scripts string `json:"scripts,omitempty"`
 
 	// Clean flag forces the STI build to not do incremental builds if true.
-	Clean bool `json:"clean,omitempty" yaml:"clean,omitempty"`
+	Clean bool `json:"clean,omitempty"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy
 // should produce.
 type BuildOutput struct {
 	// ImageTag is the tag to give to the image resulting from the build.
-	ImageTag string `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
+	ImageTag string `json:"imageTag,omitempty"`
 
 	// Registry is the Docker registry which should receive the resulting built image via push.
-	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Registry string `json:"registry,omitempty"`
 }
 
 // BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig
@@ -214,50 +214,50 @@ const BuildConfigLabel = "buildconfig"
 
 // BuildConfig is a template which can be used to create new builds.
 type BuildConfig struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Triggers determine how new Builds can be launched from a BuildConfig. If no triggers
 	// are defined, a new build can only occur as a result of an explicit client build creation.
-	Triggers []BuildTriggerPolicy `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	Triggers []BuildTriggerPolicy `json:"triggers,omitempty"`
 
 	// Parameters holds all the input necessary to produce a new build.
-	Parameters BuildParameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters BuildParameters `json:"parameters,omitempty"`
 }
 
 // WebHookTrigger is a trigger that gets invoked using a webhook type of post
 type WebHookTrigger struct {
 	// Secret used to validate requests.
-	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Secret string `json:"secret,omitempty"`
 }
 
 // ImageChangeTrigger allows builds to be triggered when an ImageRepository changes
 type ImageChangeTrigger struct {
 	// Image is used to specify the value in the BuildConfig to replace with the
 	// immutable image id supplied by the ImageRepository when this trigger fires.
-	Image string `json:"image" yaml:"image"`
+	Image string `json:"image"`
 	// ImageRepositoryRef a reference to a Docker image repository to watch for changes.
-	ImageRepositoryRef *kapi.ObjectReference `json:"imageRepositoryRef" yaml:"imageRepositoryRef"`
+	ImageRepositoryRef *kapi.ObjectReference `json:"imageRepositoryRef"`
 	// Tag is the name of an image repository tag to watch for changes.
-	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Tag string `json:"tag,omitempty"`
 	// LastTriggeredImageID is used internally by the ImageChangeController to save last
 	// used image ID for build
-	LastTriggeredImageID string `json:"lastTriggeredImageID,omitempty" yaml:"lastTriggeredImageID,omitempty"`
+	LastTriggeredImageID string `json:"lastTriggeredImageID,omitempty"`
 }
 
 // BuildTriggerPolicy describes a policy for a single trigger that results in a new Build.
 type BuildTriggerPolicy struct {
 	// Type is the type of build trigger
-	Type BuildTriggerType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type BuildTriggerType `json:"type,omitempty"`
 
 	// GithubWebHook contains the parameters for a Github webhook type of trigger
-	GithubWebHook *WebHookTrigger `json:"github,omitempty" yaml:"github,omitempty"`
+	GithubWebHook *WebHookTrigger `json:"github,omitempty"`
 
 	// GenericWebHook contains the parameters for a Generic webhook type of trigger
-	GenericWebHook *WebHookTrigger `json:"generic,omitempty" yaml:"generic,omitempty"`
+	GenericWebHook *WebHookTrigger `json:"generic,omitempty"`
 
 	// ImageChange contains parameters for an ImageChange type of trigger
-	ImageChange *ImageChangeTrigger `json:"imageChange,omitempty" yaml:"imageChange,omitempty"`
+	ImageChange *ImageChangeTrigger `json:"imageChange,omitempty"`
 }
 
 // BuildTriggerType refers to a specific BuildTriggerPolicy implementation.
@@ -279,29 +279,29 @@ const (
 
 // BuildList is a collection of Builds.
 type BuildList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Build `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Build `json:"items"`
 }
 
 // BuildConfigList is a collection of BuildConfigs.
 type BuildConfigList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []BuildConfig `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []BuildConfig `json:"items"`
 }
 
 // GenericWebHookEvent is the payload expected for a generic webhook post
 type GenericWebHookEvent struct {
 	// Type is the type of source repository
-	Type BuildSourceType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type BuildSourceType `json:"type,omitempty"`
 
 	// Git is the git information if the Type is BuildSourceGit
-	Git *GitInfo `json:"git,omitempty" yaml:"git,omitempty"`
+	Git *GitInfo `json:"git,omitempty"`
 }
 
 // GitInfo is the aggregated git information for a generic webhook post
 type GitInfo struct {
-	GitBuildSource    `json:",inline" yaml:",inline"`
-	GitSourceRevision `json:",inline" yaml:",inline"`
+	GitBuildSource    `json:",inline"`
+	GitSourceRevision `json:",inline"`
 }

--- a/pkg/build/webhook/github/github.go
+++ b/pkg/build/webhook/github/github.go
@@ -22,16 +22,16 @@ func New() *WebHook {
 }
 
 type commit struct {
-	ID        string                `json:"id,omitempty" yaml:"id,omitempty"`
-	Author    api.SourceControlUser `json:"author,omitempty" yaml:"author,omitempty"`
-	Committer api.SourceControlUser `json:"committer,omitempty" yaml:"committer,omitempty"`
-	Message   string                `json:"message,omitempty" yaml:"message,omitempty"`
+	ID        string                `json:"id,omitempty"`
+	Author    api.SourceControlUser `json:"author,omitempty"`
+	Committer api.SourceControlUser `json:"committer,omitempty"`
+	Message   string                `json:"message,omitempty"`
 }
 
 type pushEvent struct {
-	Ref        string `json:"ref,omitempty" yaml:"ref,omitempty"`
-	After      string `json:"after,omitempty" yaml:"after,omitempty"`
-	HeadCommit commit `json:"head_commit,omitempty" yaml:"head_commit,omitempty"`
+	Ref        string `json:"ref,omitempty"`
+	After      string `json:"after,omitempty"`
+	HeadCommit commit `json:"head_commit,omitempty"`
 }
 
 // Extract services webhooks from github.com

--- a/pkg/config/api/types.go
+++ b/pkg/config/api/types.go
@@ -9,10 +9,10 @@ import (
 // TODO: Unify with Kubernetes Config
 //       https://github.com/GoogleCloudPlatform/kubernetes/pull/1007
 type Config struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Required: Items is an array of Kubernetes resources of Service,
 	// Pod and/or ReplicationController kind.
-	Items []runtime.RawExtension `json:"items" yaml:"items"`
+	Items []runtime.RawExtension `json:"items"`
 }

--- a/pkg/config/api/v1beta1/types.go
+++ b/pkg/config/api/v1beta1/types.go
@@ -9,10 +9,10 @@ import (
 // TODO: Unify with Kubernetes Config
 //       https://github.com/GoogleCloudPlatform/kubernetes/pull/1007
 type Config struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Required: Items is an array of Kubernetes resources of Service,
 	// Pod and/or ReplicationController kind.
-	Items []runtime.RawExtension `json:"items" yaml:"items"`
+	Items []runtime.RawExtension `json:"items"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -113,8 +113,8 @@ func ExampleApply() {
 }
 
 type FakeLabelsResource struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 }
 
 func (*FakeLabelsResource) IsAnAPIObject() {}

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -10,22 +10,22 @@ import (
 // DEPRECATED: This type longer drives any system behavior. Deployments are now represented directly
 // by ReplicationControllers. Use DeploymentConfig to drive deployments.
 type Deployment struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Strategy DeploymentStrategy `json:"strategy,omitempty"`
 	// ControllerTemplate is the desired replication state the deployment works to materialize.
-	ControllerTemplate kapi.ReplicationControllerSpec `json:"controllerTemplate,omitempty" yaml:"controllerTemplate,omitempty"`
+	ControllerTemplate kapi.ReplicationControllerSpec `json:"controllerTemplate,omitempty"`
 	// Status is the execution status of the deployment.
-	Status DeploymentStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status DeploymentStatus `json:"status,omitempty"`
 	// Details captures the causes for the creation of this deployment resource.
 	// This could be based on a change made by the user to the deployment config
 	// or caused by an automatic trigger that was specified in the deployment config.
 	// Multiple triggers could have caused this deployment.
 	// If no trigger is specified here, then the deployment was likely created as a result of an
 	// explicit client request to create a new deployment resource.
-	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	Details *DeploymentDetails `json:"details,omitempty"`
 }
 
 // DeploymentStatus decribes the possible states a deployment can be in.
@@ -49,9 +49,9 @@ const (
 // DeploymentStrategy describes how to perform a deployment.
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
-	Type DeploymentStrategyType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type DeploymentStrategyType `json:"type,omitempty"`
 	// CustomParams are the input to the Custom deployment strategy.
-	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty" yaml:"customParams,omitempty"`
+	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
@@ -67,19 +67,19 @@ const (
 // CustomParams are the input to the Custom deployment strategy.
 type CustomDeploymentStrategyParams struct {
 	// Image specifies a Docker image which can carry out a deployment.
-	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 	// Environment holds the environment which will be given to the container for Image.
-	Environment []kapi.EnvVar `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Environment []kapi.EnvVar `json:"environment,omitempty"`
 	// Command is optional and overrides CMD in the container Image.
-	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+	Command []string `json:"command,omitempty"`
 }
 
 // A DeploymentList is a collection of deployments.
 // DEPRECATED: Like Deployment, this is no longer used.
 type DeploymentList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Deployment `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Deployment `json:"items"`
 }
 
 // These constants represent keys used for correlating objects related to deployments.
@@ -119,36 +119,36 @@ const (
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in
 // a new deployment results in an increment of LatestVersion.
 type DeploymentConfig struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
 	// are defined, a new deployment can only occur as a result of an explicit client update to the
 	// DeploymentConfig with a new LatestVersion.
-	Triggers []DeploymentTriggerPolicy `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	Triggers []DeploymentTriggerPolicy `json:"triggers,omitempty"`
 	// Template represents a desired deployment state and how to deploy it.
-	Template DeploymentTemplate `json:"template,omitempty" yaml:"template,omitempty"`
+	Template DeploymentTemplate `json:"template,omitempty"`
 	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
 	// is out of sync.
-	LatestVersion int `json:"latestVersion,omitempty" yaml:"latestVersion,omitempty"`
+	LatestVersion int `json:"latestVersion,omitempty"`
 	// The reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
-	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	Details *DeploymentDetails `json:"details,omitempty"`
 }
 
 // DeploymentTemplate contains all the necessary information to create a deployment from a
 // DeploymentStrategy.
 type DeploymentTemplate struct {
 	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Strategy DeploymentStrategy `json:"strategy,omitempty"`
 	// ControllerTemplate is the desired replication state the deployment works to materialize.
-	ControllerTemplate kapi.ReplicationControllerSpec `json:"controllerTemplate,omitempty" yaml:"controllerTemplate,omitempty"`
+	ControllerTemplate kapi.ReplicationControllerSpec `json:"controllerTemplate,omitempty"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
 type DeploymentTriggerPolicy struct {
-	Type DeploymentTriggerType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type DeploymentTriggerType `json:"type,omitempty"`
 	// ImageChangeParams represents the parameters for the ImageChange trigger.
-	ImageChangeParams *DeploymentTriggerImageChangeParams `json:"imageChangeParams,omitempty" yaml:"imageChangeParams,omitempty"`
+	ImageChangeParams *DeploymentTriggerImageChangeParams `json:"imageChangeParams,omitempty"`
 }
 
 // DeploymentTriggerType refers to a specific DeploymentTriggerPolicy implementation.
@@ -168,41 +168,41 @@ const (
 // DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.
 type DeploymentTriggerImageChangeParams struct {
 	// Automatic means that the detection of a new tag value should result in a new deployment.
-	Automatic bool `json:"automatic,omitempty" yaml:"automatic,omitempty"`
+	Automatic bool `json:"automatic,omitempty"`
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
-	ContainerNames []string `json:"containerNames,omitempty" yaml:"containerNames,omitempty"`
+	ContainerNames []string `json:"containerNames,omitempty"`
 	// RepositoryName is the identifier for a Docker image repository to watch for changes.
-	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+	RepositoryName string `json:"repositoryName,omitempty"`
 	// Tag is the name of an image repository tag to watch for changes.
-	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Tag string `json:"tag,omitempty"`
 }
 
 // DeploymentDetails captures information about the causes of a deployment.
 type DeploymentDetails struct {
 	// The user specified change message, if this deployment was triggered manually by the user
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	Message string `json:"message,omitempty"`
 	// Extended data associated with all the causes for creating a new deployment
-	Causes []*DeploymentCause `json:"causes,omitempty" yaml:"causes,omitempty"`
+	Causes []*DeploymentCause `json:"causes,omitempty"`
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.
 type DeploymentCause struct {
 	// The type of the trigger that resulted in the creation of a new deployment
-	Type DeploymentTriggerType `json:"type" yaml:"type"`
+	Type DeploymentTriggerType `json:"type"`
 	// The image trigger details, if this trigger was fired based on an image change
-	ImageTrigger *DeploymentCauseImageTrigger `json:"imageTrigger,omitempty" yaml:"imageTrigger,omitempty"`
+	ImageTrigger *DeploymentCauseImageTrigger `json:"imageTrigger,omitempty"`
 }
 
 type DeploymentCauseImageTrigger struct {
 	// RepositoryName is the identifier for a Docker image repository that was updated.
-	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+	RepositoryName string `json:"repositoryName,omitempty"`
 	// Tag is the name of an image repository tag that is now pointing to a new image.
-	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Tag string `json:"tag,omitempty"`
 }
 
 // A DeploymentConfigList is a collection of deployment configs.
 type DeploymentConfigList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []DeploymentConfig `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []DeploymentConfig `json:"items"`
 }

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -11,22 +11,22 @@ import (
 // DEPRECATED: This type longer drives any system behavior. Deployments are now represented directly
 // by ReplicationControllers. Use DeploymentConfig to drive deployments.
 type Deployment struct {
-	v1beta3.TypeMeta   `json:",inline" yaml:",inline"`
-	v1beta3.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	v1beta3.TypeMeta   `json:",inline"`
+	v1beta3.ObjectMeta `json:"metadata,omitempty"`
 
 	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Strategy DeploymentStrategy `json:"strategy,omitempty"`
 	// ControllerTemplate is the desired replication state the deployment works to materialize.
-	ControllerTemplate v1beta1.ReplicationControllerState `json:"controllerTemplate,omitempty" yaml:"controllerTemplate,omitempty"`
+	ControllerTemplate v1beta1.ReplicationControllerState `json:"controllerTemplate,omitempty"`
 	// Status is the execution status of the deployment.
-	Status DeploymentStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status DeploymentStatus `json:"status,omitempty"`
 	// Details captures the causes for the creation of this deployment resource.
 	// This could be based on a change made by the user to the deployment config
 	// or caused by an automatic trigger that was specified in the deployment config.
 	// Multiple triggers could have caused this deployment.
 	// If no trigger is specified here, then the deployment was likely created as a result of an
 	// explicit client request to create a new deployment resource.
-	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	Details *DeploymentDetails `json:"details,omitempty"`
 }
 
 // DeploymentStatus decribes the possible states a deployment can be in.
@@ -50,9 +50,9 @@ const (
 // DeploymentStrategy describes how to perform a deployment.
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
-	Type DeploymentStrategyType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type DeploymentStrategyType `json:"type,omitempty"`
 	// CustomParams are the input to the Custom deployment strategy.
-	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty" yaml:"customParams,omitempty"`
+	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
@@ -68,19 +68,19 @@ const (
 // CustomParams are the input to the Custom deployment strategy.
 type CustomDeploymentStrategyParams struct {
 	// Image specifies a Docker image which can carry out a deployment.
-	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 	// Environment holds the environment which will be given to the container for Image.
-	Environment []v1beta3.EnvVar `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Environment []v1beta3.EnvVar `json:"environment,omitempty"`
 	// Command is optional and overrides CMD in the container Image.
-	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+	Command []string `json:"command,omitempty"`
 }
 
 // A DeploymentList is a collection of deployments.
 // DEPRECATED: Like Deployment, this is no longer used.
 type DeploymentList struct {
-	v1beta3.TypeMeta `json:",inline" yaml:",inline"`
-	v1beta3.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items            []Deployment `json:"items" yaml:"items"`
+	v1beta3.TypeMeta `json:",inline"`
+	v1beta3.ListMeta `json:"metadata,omitempty"`
+	Items            []Deployment `json:"items"`
 }
 
 // These constants represent keys used for correlating objects related to deployments.
@@ -120,36 +120,36 @@ const (
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in
 // a new deployment results in an increment of LatestVersion.
 type DeploymentConfig struct {
-	v1beta3.TypeMeta   `json:",inline" yaml:",inline"`
-	v1beta3.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	v1beta3.TypeMeta   `json:",inline"`
+	v1beta3.ObjectMeta `json:"metadata,omitempty"`
 	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
 	// are defined, a new deployment can only occur as a result of an explicit client update to the
 	// DeploymentConfig with a new LatestVersion.
-	Triggers []DeploymentTriggerPolicy `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	Triggers []DeploymentTriggerPolicy `json:"triggers,omitempty"`
 	// Template represents a desired deployment state and how to deploy it.
-	Template DeploymentTemplate `json:"template,omitempty" yaml:"template,omitempty"`
+	Template DeploymentTemplate `json:"template,omitempty"`
 	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
 	// is out of sync.
-	LatestVersion int `json:"latestVersion,omitempty" yaml:"latestVersion,omitempty"`
+	LatestVersion int `json:"latestVersion,omitempty"`
 	// The reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
-	Details *DeploymentDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	Details *DeploymentDetails `json:"details,omitempty"`
 }
 
 // DeploymentTemplate contains all the necessary information to create a deployment from a
 // DeploymentStrategy.
 type DeploymentTemplate struct {
 	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+	Strategy DeploymentStrategy `json:"strategy,omitempty"`
 	// ControllerTemplate is the desired replication state the deployment works to materialize.
-	ControllerTemplate v1beta1.ReplicationControllerState `json:"controllerTemplate,omitempty" yaml:"controllerTemplate,omitempty"`
+	ControllerTemplate v1beta1.ReplicationControllerState `json:"controllerTemplate,omitempty"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
 type DeploymentTriggerPolicy struct {
-	Type DeploymentTriggerType `json:"type,omitempty" yaml:"type,omitempty"`
+	Type DeploymentTriggerType `json:"type,omitempty"`
 	// ImageChangeParams represents the parameters for the ImageChange trigger.
-	ImageChangeParams *DeploymentTriggerImageChangeParams `json:"imageChangeParams,omitempty" yaml:"imageChangeParams,omitempty"`
+	ImageChangeParams *DeploymentTriggerImageChangeParams `json:"imageChangeParams,omitempty"`
 }
 
 // DeploymentTriggerType refers to a specific DeploymentTriggerPolicy implementation.
@@ -169,41 +169,41 @@ const (
 // DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.
 type DeploymentTriggerImageChangeParams struct {
 	// Automatic means that the detection of a new tag value should result in a new deployment.
-	Automatic bool `json:"automatic,omitempty" yaml:"automatic,omitempty"`
+	Automatic bool `json:"automatic,omitempty"`
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
-	ContainerNames []string `json:"containerNames,omitempty" yaml:"containerNames,omitempty"`
+	ContainerNames []string `json:"containerNames,omitempty"`
 	// RepositoryName is the identifier for a Docker image repository to watch for changes.
-	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+	RepositoryName string `json:"repositoryName,omitempty"`
 	// Tag is the name of an image repository tag to watch for changes.
-	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Tag string `json:"tag,omitempty"`
 }
 
 // DeploymentDetails captures information about the causes of a deployment.
 type DeploymentDetails struct {
 	// The user specified change message, if this deployment was triggered manually by the user
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+	Message string `json:"message,omitempty"`
 	// Extended data associated with all the causes for creating a new deployment
-	Causes []*DeploymentCause `json:"causes,omitempty" yaml:"causes,omitempty"`
+	Causes []*DeploymentCause `json:"causes,omitempty"`
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.
 type DeploymentCause struct {
 	// The type of the trigger that resulted in the creation of a new deployment
-	Type DeploymentTriggerType `json:"type" yaml:"type"`
+	Type DeploymentTriggerType `json:"type"`
 	// The image trigger details, if this trigger was fired based on an image change
-	ImageTrigger *DeploymentCauseImageTrigger `json:"imageTrigger,omitempty" yaml:"imageTrigger,omitempty"`
+	ImageTrigger *DeploymentCauseImageTrigger `json:"imageTrigger,omitempty"`
 }
 
 type DeploymentCauseImageTrigger struct {
 	// RepositoryName is the identifier for a Docker image repository that was updated.
-	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+	RepositoryName string `json:"repositoryName,omitempty"`
 	// Tag is the name of an image repository tag that is now pointing to a new image.
-	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Tag string `json:"tag,omitempty"`
 }
 
 // A DeploymentConfigList is a collection of deployment configs.
 type DeploymentConfigList struct {
-	v1beta3.TypeMeta `json:",inline" yaml:",inline"`
-	v1beta3.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items            []DeploymentConfig `json:"items" yaml:"items"`
+	v1beta3.TypeMeta `json:",inline"`
+	v1beta3.ListMeta `json:"metadata,omitempty"`
+	Items            []DeploymentConfig `json:"items"`
 }

--- a/pkg/image/api/docker10/dockertypes.go
+++ b/pkg/image/api/docker10/dockertypes.go
@@ -8,45 +8,45 @@ import (
 // Image is the type representing a docker image and its various properties when
 // retrieved from the Docker client API.
 type DockerImage struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
+	kapi.TypeMeta `json:",inline"`
 
-	ID              string       `json:"Id" yaml:"Id"`
-	Parent          string       `json:"Parent,omitempty" yaml:"Parent,omitempty"`
-	Comment         string       `json:"Comment,omitempty" yaml:"Comment,omitempty"`
-	Created         util.Time    `json:"Created,omitempty" yaml:"Created,omitempty"`
-	Container       string       `json:"Container,omitempty" yaml:"Container,omitempty"`
-	ContainerConfig DockerConfig `json:"ContainerConfig,omitempty" yaml:"ContainerConfig,omitempty"`
-	DockerVersion   string       `json:"DockerVersion,omitempty" yaml:"DockerVersion,omitempty"`
-	Author          string       `json:"Author,omitempty" yaml:"Author,omitempty"`
-	Config          DockerConfig `json:"Config,omitempty" yaml:"Config,omitempty"`
-	Architecture    string       `json:"Architecture,omitempty" yaml:"Architecture,omitempty"`
-	Size            int64        `json:"Size,omitempty" yaml:"Size,omitempty"`
+	ID              string       `json:"Id"`
+	Parent          string       `json:"Parent,omitempty"`
+	Comment         string       `json:"Comment,omitempty"`
+	Created         util.Time    `json:"Created,omitempty"`
+	Container       string       `json:"Container,omitempty"`
+	ContainerConfig DockerConfig `json:"ContainerConfig,omitempty"`
+	DockerVersion   string       `json:"DockerVersion,omitempty"`
+	Author          string       `json:"Author,omitempty"`
+	Config          DockerConfig `json:"Config,omitempty"`
+	Architecture    string       `json:"Architecture,omitempty"`
+	Size            int64        `json:"Size,omitempty"`
 }
 
 // DockerConfig is the list of configuration options used when creating a container.
 type DockerConfig struct {
-	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
-	Domainname      string              `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
-	User            string              `json:"User,omitempty" yaml:"User,omitempty"`
-	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
-	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
-	CPUShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CPUSet          string              `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
-	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
-	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
-	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
-	PortSpecs       []string            `json:"PortSpecs,omitempty" yaml:"PortSpecs,omitempty"`
-	ExposedPorts    map[string]struct{} `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty"`
-	Tty             bool                `json:"Tty,omitempty" yaml:"Tty,omitempty"`
-	OpenStdin       bool                `json:"OpenStdin,omitempty" yaml:"OpenStdin,omitempty"`
-	StdinOnce       bool                `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
-	Env             []string            `json:"Env,omitempty" yaml:"Env,omitempty"`
-	Cmd             []string            `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
-	DNS             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
-	Image           string              `json:"Image,omitempty" yaml:"Image,omitempty"`
-	Volumes         map[string]struct{} `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
-	VolumesFrom     string              `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
-	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
-	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
-	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
+	Hostname        string              `json:"Hostname,omitempty"`
+	Domainname      string              `json:"Domainname,omitempty"`
+	User            string              `json:"User,omitempty"`
+	Memory          int64               `json:"Memory,omitempty"`
+	MemorySwap      int64               `json:"MemorySwap,omitempty"`
+	CPUShares       int64               `json:"CpuShares,omitempty"`
+	CPUSet          string              `json:"Cpuset,omitempty"`
+	AttachStdin     bool                `json:"AttachStdin,omitempty"`
+	AttachStdout    bool                `json:"AttachStdout,omitempty"`
+	AttachStderr    bool                `json:"AttachStderr,omitempty"`
+	PortSpecs       []string            `json:"PortSpecs,omitempty"`
+	ExposedPorts    map[string]struct{} `json:"ExposedPorts,omitempty"`
+	Tty             bool                `json:"Tty,omitempty"`
+	OpenStdin       bool                `json:"OpenStdin,omitempty"`
+	StdinOnce       bool                `json:"StdinOnce,omitempty"`
+	Env             []string            `json:"Env,omitempty"`
+	Cmd             []string            `json:"Cmd,omitempty"`
+	DNS             []string            `json:"Dns,omitempty"` // For Docker API v1.9 and below only
+	Image           string              `json:"Image,omitempty"`
+	Volumes         map[string]struct{} `json:"Volumes,omitempty"`
+	VolumesFrom     string              `json:"VolumesFrom,omitempty"`
+	WorkingDir      string              `json:"WorkingDir,omitempty"`
+	Entrypoint      []string            `json:"Entrypoint,omitempty"`
+	NetworkDisabled bool                `json:"NetworkDisabled,omitempty"`
 }

--- a/pkg/image/api/dockerpre012/dockertypes.go
+++ b/pkg/image/api/dockerpre012/dockertypes.go
@@ -8,7 +8,7 @@ import (
 // DockerImage is for earlier versions of the Docker API (pre-012 to be specific). It is also the
 // version of metadata that the Docker registry uses to persist metadata.
 type DockerImage struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
+	kapi.TypeMeta `json:",inline"`
 
 	ID              string       `json:"id"`
 	Parent          string       `json:"parent,omitempty"`
@@ -25,28 +25,28 @@ type DockerImage struct {
 
 // DockerConfig is the list of configuration options used when creating a container.
 type DockerConfig struct {
-	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
-	Domainname      string              `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
-	User            string              `json:"User,omitempty" yaml:"User,omitempty"`
-	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
-	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
-	CPUShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CPUSet          string              `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
-	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
-	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
-	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
-	PortSpecs       []string            `json:"PortSpecs,omitempty" yaml:"PortSpecs,omitempty"`
-	ExposedPorts    map[string]struct{} `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty"`
-	Tty             bool                `json:"Tty,omitempty" yaml:"Tty,omitempty"`
-	OpenStdin       bool                `json:"OpenStdin,omitempty" yaml:"OpenStdin,omitempty"`
-	StdinOnce       bool                `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
-	Env             []string            `json:"Env,omitempty" yaml:"Env,omitempty"`
-	Cmd             []string            `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
-	DNS             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
-	Image           string              `json:"Image,omitempty" yaml:"Image,omitempty"`
-	Volumes         map[string]struct{} `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
-	VolumesFrom     string              `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
-	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
-	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
-	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
+	Hostname        string              `json:"Hostname,omitempty"`
+	Domainname      string              `json:"Domainname,omitempty"`
+	User            string              `json:"User,omitempty"`
+	Memory          int64               `json:"Memory,omitempty"`
+	MemorySwap      int64               `json:"MemorySwap,omitempty"`
+	CPUShares       int64               `json:"CpuShares,omitempty"`
+	CPUSet          string              `json:"Cpuset,omitempty"`
+	AttachStdin     bool                `json:"AttachStdin,omitempty"`
+	AttachStdout    bool                `json:"AttachStdout,omitempty"`
+	AttachStderr    bool                `json:"AttachStderr,omitempty"`
+	PortSpecs       []string            `json:"PortSpecs,omitempty"`
+	ExposedPorts    map[string]struct{} `json:"ExposedPorts,omitempty"`
+	Tty             bool                `json:"Tty,omitempty"`
+	OpenStdin       bool                `json:"OpenStdin,omitempty"`
+	StdinOnce       bool                `json:"StdinOnce,omitempty"`
+	Env             []string            `json:"Env,omitempty"`
+	Cmd             []string            `json:"Cmd,omitempty"`
+	DNS             []string            `json:"Dns,omitempty"` // For Docker API v1.9 and below only
+	Image           string              `json:"Image,omitempty"`
+	Volumes         map[string]struct{} `json:"Volumes,omitempty"`
+	VolumesFrom     string              `json:"VolumesFrom,omitempty"`
+	WorkingDir      string              `json:"WorkingDir,omitempty"`
+	Entrypoint      []string            `json:"Entrypoint,omitempty"`
+	NetworkDisabled bool                `json:"NetworkDisabled,omitempty"`
 }

--- a/pkg/image/api/dockertypes.go
+++ b/pkg/image/api/dockertypes.go
@@ -8,45 +8,45 @@ import (
 // Image is the type representing a docker image and its various properties when
 // retrieved from the Docker client API.
 type DockerImage struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
+	kapi.TypeMeta `json:",inline"`
 
-	ID              string       `json:"Id" yaml:"Id"`
-	Parent          string       `json:"Parent,omitempty" yaml:"Parent,omitempty"`
-	Comment         string       `json:"Comment,omitempty" yaml:"Comment,omitempty"`
-	Created         util.Time    `json:"Created,omitempty" yaml:"Created,omitempty"`
-	Container       string       `json:"Container,omitempty" yaml:"Container,omitempty"`
-	ContainerConfig DockerConfig `json:"ContainerConfig,omitempty" yaml:"ContainerConfig,omitempty"`
-	DockerVersion   string       `json:"DockerVersion,omitempty" yaml:"DockerVersion,omitempty"`
-	Author          string       `json:"Author,omitempty" yaml:"Author,omitempty"`
-	Config          DockerConfig `json:"Config,omitempty" yaml:"Config,omitempty"`
-	Architecture    string       `json:"Architecture,omitempty" yaml:"Architecture,omitempty"`
-	Size            int64        `json:"Size,omitempty" yaml:"Size,omitempty"`
+	ID              string       `json:"Id"`
+	Parent          string       `json:"Parent,omitempty"`
+	Comment         string       `json:"Comment,omitempty"`
+	Created         util.Time    `json:"Created,omitempty"`
+	Container       string       `json:"Container,omitempty"`
+	ContainerConfig DockerConfig `json:"ContainerConfig,omitempty"`
+	DockerVersion   string       `json:"DockerVersion,omitempty"`
+	Author          string       `json:"Author,omitempty"`
+	Config          DockerConfig `json:"Config,omitempty"`
+	Architecture    string       `json:"Architecture,omitempty"`
+	Size            int64        `json:"Size,omitempty"`
 }
 
 // DockerConfig is the list of configuration options used when creating a container.
 type DockerConfig struct {
-	Hostname        string              `json:"Hostname,omitempty" yaml:"Hostname,omitempty"`
-	Domainname      string              `json:"Domainname,omitempty" yaml:"Domainname,omitempty"`
-	User            string              `json:"User,omitempty" yaml:"User,omitempty"`
-	Memory          int64               `json:"Memory,omitempty" yaml:"Memory,omitempty"`
-	MemorySwap      int64               `json:"MemorySwap,omitempty" yaml:"MemorySwap,omitempty"`
-	CPUShares       int64               `json:"CpuShares,omitempty" yaml:"CpuShares,omitempty"`
-	CPUSet          string              `json:"Cpuset,omitempty" yaml:"Cpuset,omitempty"`
-	AttachStdin     bool                `json:"AttachStdin,omitempty" yaml:"AttachStdin,omitempty"`
-	AttachStdout    bool                `json:"AttachStdout,omitempty" yaml:"AttachStdout,omitempty"`
-	AttachStderr    bool                `json:"AttachStderr,omitempty" yaml:"AttachStderr,omitempty"`
-	PortSpecs       []string            `json:"PortSpecs,omitempty" yaml:"PortSpecs,omitempty"`
-	ExposedPorts    map[string]struct{} `json:"ExposedPorts,omitempty" yaml:"ExposedPorts,omitempty"`
-	Tty             bool                `json:"Tty,omitempty" yaml:"Tty,omitempty"`
-	OpenStdin       bool                `json:"OpenStdin,omitempty" yaml:"OpenStdin,omitempty"`
-	StdinOnce       bool                `json:"StdinOnce,omitempty" yaml:"StdinOnce,omitempty"`
-	Env             []string            `json:"Env,omitempty" yaml:"Env,omitempty"`
-	Cmd             []string            `json:"Cmd,omitempty" yaml:"Cmd,omitempty"`
-	DNS             []string            `json:"Dns,omitempty" yaml:"Dns,omitempty"` // For Docker API v1.9 and below only
-	Image           string              `json:"Image,omitempty" yaml:"Image,omitempty"`
-	Volumes         map[string]struct{} `json:"Volumes,omitempty" yaml:"Volumes,omitempty"`
-	VolumesFrom     string              `json:"VolumesFrom,omitempty" yaml:"VolumesFrom,omitempty"`
-	WorkingDir      string              `json:"WorkingDir,omitempty" yaml:"WorkingDir,omitempty"`
-	Entrypoint      []string            `json:"Entrypoint,omitempty" yaml:"Entrypoint,omitempty"`
-	NetworkDisabled bool                `json:"NetworkDisabled,omitempty" yaml:"NetworkDisabled,omitempty"`
+	Hostname        string              `json:"Hostname,omitempty"`
+	Domainname      string              `json:"Domainname,omitempty"`
+	User            string              `json:"User,omitempty"`
+	Memory          int64               `json:"Memory,omitempty"`
+	MemorySwap      int64               `json:"MemorySwap,omitempty"`
+	CPUShares       int64               `json:"CpuShares,omitempty"`
+	CPUSet          string              `json:"Cpuset,omitempty"`
+	AttachStdin     bool                `json:"AttachStdin,omitempty"`
+	AttachStdout    bool                `json:"AttachStdout,omitempty"`
+	AttachStderr    bool                `json:"AttachStderr,omitempty"`
+	PortSpecs       []string            `json:"PortSpecs,omitempty"`
+	ExposedPorts    map[string]struct{} `json:"ExposedPorts,omitempty"`
+	Tty             bool                `json:"Tty,omitempty"`
+	OpenStdin       bool                `json:"OpenStdin,omitempty"`
+	StdinOnce       bool                `json:"StdinOnce,omitempty"`
+	Env             []string            `json:"Env,omitempty"`
+	Cmd             []string            `json:"Cmd,omitempty"`
+	DNS             []string            `json:"Dns,omitempty"` // For Docker API v1.9 and below only
+	Image           string              `json:"Image,omitempty"`
+	Volumes         map[string]struct{} `json:"Volumes,omitempty"`
+	VolumesFrom     string              `json:"VolumesFrom,omitempty"`
+	WorkingDir      string              `json:"WorkingDir,omitempty"`
+	Entrypoint      []string            `json:"Entrypoint,omitempty"`
+	NetworkDisabled bool                `json:"NetworkDisabled,omitempty"`
 }

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -6,54 +6,54 @@ import (
 
 // ImageList is a list of Image objects.
 type ImageList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
 
-	Items []Image `json:"items" yaml:"items"`
+	Items []Image `json:"items"`
 }
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.
 type Image struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// The string that can be used to pull this image.
-	DockerImageReference string `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
+	DockerImageReference string `json:"dockerImageReference,omitempty"`
 	// Metadata about this image
-	DockerImageMetadata DockerImage `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
+	DockerImageMetadata DockerImage `json:"dockerImageMetadata,omitempty"`
 	// This attribute conveys the version of docker metadata the JSON should be stored in, which if empty defaults to "1.0"
-	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty" yaml:"dockerImageMetadata,omitempty"`
+	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty"`
 }
 
 // ImageRepositoryList is a list of ImageRepository objects.
 type ImageRepositoryList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
 
-	Items []ImageRepository `json:"items" yaml:"items"`
+	Items []ImageRepository `json:"items"`
 }
 
 // ImageRepository stores a mapping of tags to images, metadata overrides that are applied
 // when images are tagged in a repository, and an optional reference to a Docker image
 // repository on a registry.
 type ImageRepository struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Optional, if specified this repository is backed by a Docker repository on this server
-	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
 	// Tags map arbitrary string values to specific image locators
-	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Tags map[string]string `json:"tags,omitempty"`
 
 	// Status describes the current state of this repository
-	Status ImageRepositoryStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status ImageRepositoryStatus `json:"status,omitempty"`
 }
 
 // ImageRepositoryStatus contains information about the state of this image repository.
 type ImageRepositoryStatus struct {
 	// Represents the effective location this repository may be accessed at. May be empty until the server
 	// determines where the repository is located
-	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
 }
 
 // TODO add metadata overrides
@@ -61,13 +61,13 @@ type ImageRepositoryStatus struct {
 // ImageRepositoryMapping represents a mapping from a single tag to a Docker image as
 // well as the reference to the Docker image repository the image came from.
 type ImageRepositoryMapping struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// The Docker image repository the specified image is located in
-	DockerImageRepository string `json:"dockerImageRepository" yaml:"dockerImageRepository"`
+	DockerImageRepository string `json:"dockerImageRepository"`
 	// A Docker image.
-	Image Image `json:"image" yaml:"image"`
+	Image Image `json:"image"`
 	// A string value this image can be located with inside the repository.
-	Tag string `json:"tag" yaml:"tag"`
+	Tag string `json:"tag"`
 }

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -7,54 +7,54 @@ import (
 
 // ImageList is a list of Image objects.
 type ImageList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
 
-	Items []Image `json:"items" yaml:"items"`
+	Items []Image `json:"items"`
 }
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.
 type Image struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// The string that can be used to pull this image.
-	DockerImageReference string `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
+	DockerImageReference string `json:"dockerImageReference,omitempty"`
 	// Metadata about this image
-	DockerImageMetadata runtime.RawExtension `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
+	DockerImageMetadata runtime.RawExtension `json:"dockerImageMetadata,omitempty"`
 	// This attribute conveys the version of the object, which if empty defaults to "1.0"
-	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty" yaml:"dockerImageMetadata,omitempty"`
+	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty"`
 }
 
 // ImageRepositoryList is a list of ImageRepository objects.
 type ImageRepositoryList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
 
-	Items []ImageRepository `json:"items" yaml:"items"`
+	Items []ImageRepository `json:"items"`
 }
 
 // ImageRepository stores a mapping of tags to images, metadata overrides that are applied
 // when images are tagged in a repository, and an optional reference to a Docker image
 // repository on a registry.
 type ImageRepository struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Optional, if specified this repository is backed by a Docker repository on this server
-	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
 	// Tags map arbitrary string values to specific image locators
-	Tags map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Tags map[string]string `json:"tags,omitempty"`
 
 	// Status describes the current state of this repository
-	Status ImageRepositoryStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status ImageRepositoryStatus `json:"status,omitempty"`
 }
 
 // ImageRepositoryStatus contains information about the state of this image repository.
 type ImageRepositoryStatus struct {
 	// Represents the effective location this repository may be accessed at. May be empty until the server
 	// determines where the repository is located
-	DockerImageRepository string `json:"dockerImageRepository,omitempty" yaml:"dockerImageRepository,omitempty"`
+	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
 }
 
 // TODO add metadata overrides
@@ -62,13 +62,13 @@ type ImageRepositoryStatus struct {
 // ImageRepositoryMapping represents a mapping from a single tag to a Docker image as
 // well as the reference to the Docker image repository the image came from.
 type ImageRepositoryMapping struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// The Docker image repository the specified image is located in
-	DockerImageRepository string `json:"dockerImageRepository" yaml:"dockerImageRepository"`
+	DockerImageRepository string `json:"dockerImageRepository"`
 	// A Docker image.
-	Image Image `json:"image" yaml:"image"`
+	Image Image `json:"image"`
 	// A string value this image can be located with inside the repository.
-	Tag string `json:"tag" yaml:"tag"`
+	Tag string `json:"tag"`
 }

--- a/pkg/oauth/api/types.go
+++ b/pkg/oauth/api/types.go
@@ -5,113 +5,113 @@ import (
 )
 
 type AccessToken struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// ClientName references the client that created this token.
-	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
 
 	// ExpiresIn is the seconds from CreationTime before this token expires.
-	ExpiresIn int64 `json:"expiresIn,omitempty" yaml:"expiresIn,omitempty"`
+	ExpiresIn int64 `json:"expiresIn,omitempty"`
 
 	// Scopes is an array of the requested scopes.
-	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 
 	// RedirectURI is the redirection associated with the token.
-	RedirectURI string `json:"redirectURI,omitempty" yaml:"redirectURI,omitempty"`
+	RedirectURI string `json:"redirectURI,omitempty"`
 
 	// UserName is the user name associated with this token
-	UserName string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserName string `json:"userName,omitempty"`
 
 	// UserUID is the unique UID associated with this token
-	UserUID string `json:"userUID,omitempty" yaml:"userUID,omitempty"`
+	UserUID string `json:"userUID,omitempty"`
 
 	// AuthorizeToken contains the token that authorized this token
-	AuthorizeToken string `json:"authorizeToken,omitempty" yaml:"authorizeToken,omitempty"`
+	AuthorizeToken string `json:"authorizeToken,omitempty"`
 
 	// RefreshToken is the value by which this token can be renewed. Can be blank.
-	RefreshToken string `json:"refreshToken,omitempty" yaml:"refreshToken,omitempty"`
+	RefreshToken string `json:"refreshToken,omitempty"`
 }
 
 type AuthorizeToken struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// ClientName references the client that created this token.
-	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
 
 	// ExpiresIn is the seconds from CreationTime before this token expires.
-	ExpiresIn int64 `json:"expiresIn,omitempty" yaml:"expiresIn,omitempty"`
+	ExpiresIn int64 `json:"expiresIn,omitempty"`
 
 	// Scopes is an array of the requested scopes.
-	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 
 	// RedirectURI is the redirection associated with the token.
-	RedirectURI string `json:"redirectURI,omitempty" yaml:"redirectURI,omitempty"`
+	RedirectURI string `json:"redirectURI,omitempty"`
 
 	// State data from request
-	State string `json:"state,omitempty" yaml:"state,omitempty"`
+	State string `json:"state,omitempty"`
 
 	// UserName is the user name associated with this token
-	UserName string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserName string `json:"userName,omitempty"`
 
 	// UserUID is the unique UID associated with this token. UserUID and UserName must both match
 	// for this token to be valid.
-	UserUID string `json:"userUID,omitempty" yaml:"userUID,omitempty"`
+	UserUID string `json:"userUID,omitempty"`
 }
 
 type Client struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Secret is the unique secret associated with a client
-	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Secret string `json:"secret,omitempty"`
 
 	// RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects
-	RespondWithChallenges bool `json:"respondWithChallenges,omitempty" yaml:"respondWithChallenges,omitempty"`
+	RespondWithChallenges bool `json:"respondWithChallenges,omitempty"`
 
 	// RedirectURIs is the valid redirection URIs associated with a client
-	RedirectURIs []string `json:"redirectURIs,omitempty" yaml:"redirectURIs,omitempty"`
+	RedirectURIs []string `json:"redirectURIs,omitempty"`
 }
 
 type ClientAuthorization struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// ClientName references the client that created this authorization
-	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
 
 	// UserName is the user name that authorized this client
-	UserName string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserName string `json:"userName,omitempty"`
 
 	// UserUID is the unique UID associated with this authorization. UserUID and UserName
 	// must both match for this authorization to be valid.
-	UserUID string `json:"userUID,omitempty" yaml:"userUID,omitempty"`
+	UserUID string `json:"userUID,omitempty"`
 
 	// Scopes is an array of the granted scopes.
-	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 type AccessTokenList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []AccessToken `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []AccessToken `json:"items"`
 }
 
 type AuthorizeTokenList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []AuthorizeToken `json:"items," yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []AuthorizeToken `json:"items,"`
 }
 
 type ClientList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Client `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Client `json:"items"`
 }
 
 type ClientAuthorizationList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []ClientAuthorization `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClientAuthorization `json:"items"`
 }

--- a/pkg/oauth/api/v1beta1/types.go
+++ b/pkg/oauth/api/v1beta1/types.go
@@ -5,113 +5,113 @@ import (
 )
 
 type AccessToken struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// ClientName references the client that created this token.
-	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
 
 	// ExpiresIn is the seconds from CreationTime before this token expires.
-	ExpiresIn int64 `json:"expiresIn,omitempty" yaml:"expiresIn,omitempty"`
+	ExpiresIn int64 `json:"expiresIn,omitempty"`
 
 	// Scopes is an array of the requested scopes.
-	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 
 	// RedirectURI is the redirection associated with the token.
-	RedirectURI string `json:"redirectURI,omitempty" yaml:"redirectURI,omitempty"`
+	RedirectURI string `json:"redirectURI,omitempty"`
 
 	// UserName is the user name associated with this token
-	UserName string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserName string `json:"userName,omitempty"`
 
 	// UserUID is the unique UID associated with this token
-	UserUID string `json:"userUID,omitempty" yaml:"userUID,omitempty"`
+	UserUID string `json:"userUID,omitempty"`
 
 	// AuthorizeToken contains the token that authorized this token
-	AuthorizeToken string `json:"authorizeToken,omitempty" yaml:"authorizeToken,omitempty"`
+	AuthorizeToken string `json:"authorizeToken,omitempty"`
 
 	// RefreshToken is the value by which this token can be renewed. Can be blank.
-	RefreshToken string `json:"refreshToken,omitempty" yaml:"refreshToken,omitempty"`
+	RefreshToken string `json:"refreshToken,omitempty"`
 }
 
 type AuthorizeToken struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// ClientName references the client that created this token.
-	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
 
 	// ExpiresIn is the seconds from CreationTime before this token expires.
-	ExpiresIn int64 `json:"expiresIn,omitempty" yaml:"expiresIn,omitempty"`
+	ExpiresIn int64 `json:"expiresIn,omitempty"`
 
 	// Scopes is an array of the requested scopes.
-	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 
 	// RedirectURI is the redirection associated with the token.
-	RedirectURI string `json:"redirectURI,omitempty" yaml:"redirectURI,omitempty"`
+	RedirectURI string `json:"redirectURI,omitempty"`
 
 	// State data from request
-	State string `json:"state,omitempty" yaml:"state,omitempty"`
+	State string `json:"state,omitempty"`
 
 	// UserName is the user name associated with this token
-	UserName string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserName string `json:"userName,omitempty"`
 
 	// UserUID is the unique UID associated with this token. UserUID and UserName must both match
 	// for this token to be valid.
-	UserUID string `json:"userUID,omitempty" yaml:"userUID,omitempty"`
+	UserUID string `json:"userUID,omitempty"`
 }
 
 type Client struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Secret is the unique secret associated with a client
-	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Secret string `json:"secret,omitempty"`
 
 	// RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects
-	RespondWithChallenges bool `json:"respondWithChallenges,omitempty" yaml:"respondWithChallenges,omitempty"`
+	RespondWithChallenges bool `json:"respondWithChallenges,omitempty"`
 
 	// RedirectURIs is the valid redirection URIs associated with a client
-	RedirectURIs []string `json:"redirectURIs,omitempty" yaml:"redirectURIs,omitempty"`
+	RedirectURIs []string `json:"redirectURIs,omitempty"`
 }
 
 type ClientAuthorization struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// ClientName references the client that created this authorization
-	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
 
 	// UserName is the user name that authorized this client
-	UserName string `json:"userName,omitempty" yaml:"userName,omitempty"`
+	UserName string `json:"userName,omitempty"`
 
 	// UserUID is the unique UID associated with this authorization. UserUID and UserName
 	// must both match for this authorization to be valid.
-	UserUID string `json:"userUID,omitempty" yaml:"userUID,omitempty"`
+	UserUID string `json:"userUID,omitempty"`
 
 	// Scopes is an array of the granted scopes.
-	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 type AccessTokenList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []AccessToken `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []AccessToken `json:"items"`
 }
 
 type AuthorizeTokenList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []AuthorizeToken `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []AuthorizeToken `json:"items"`
 }
 
 type ClientList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Client `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Client `json:"items"`
 }
 
 type ClientAuthorizationList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []ClientAuthorization `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClientAuthorization `json:"items"`
 }

--- a/pkg/oauth/osintypes/types.go
+++ b/pkg/oauth/osintypes/types.go
@@ -8,10 +8,10 @@ package osintypes
 
 // InfoResponseData is a type that matches the information returned from osin.FinishInfoRequest (/oauth/info).
 type InfoResponseData struct {
-	Error            string `json:"error" yaml:"error"`
-	ErrorDescription string `json:"error_description" yaml:"error_description"`
-	TokenType        string `json:"token_type" yaml:"token_type"`
-	AccessToken      string `json:"access_token" yaml:"access_token"`
-	RefreshToken     string `json:"refresh_token" yaml:"refresh_token"`
-	Expiration       int32  `json:"expires_in" yaml:"expires_in"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	TokenType        string `json:"token_type"`
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	Expiration       int32  `json:"expires_in"`
 }

--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -6,14 +6,14 @@ import (
 
 // ProjectList is a list of Project objects.
 type ProjectList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Project `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Project `json:"items"`
 }
 
 // Project is a logical top-level container for a set of origin resources
 type Project struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	DisplayName     string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+	DisplayName     string `json:"displayName,omitempty"`
 }

--- a/pkg/project/api/v1beta1/types.go
+++ b/pkg/project/api/v1beta1/types.go
@@ -6,14 +6,14 @@ import (
 
 // ProjectList is a list of Project objects.
 type ProjectList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Project `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Project `json:"items"`
 }
 
 // Project is a logical top-level container for a set of origin resources
 type Project struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	DisplayName     string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+	DisplayName     string `json:"displayName,omitempty"`
 }

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -6,23 +6,23 @@ import (
 
 // Route encapsulates the inputs needed to connect a DNS/alias to a service proxy.
 type Route struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Required: Alias/DNS that points to the service
 	// Can be host or host:port
 	// host and port are combined to follow the net/url URL struct
-	Host string `json:"host" yaml:"host"`
+	Host string `json:"host"`
 	// Optional: Path that the router watches for, to route traffic for to the service
-	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	Path string `json:"path,omitempty"`
 
 	// the name of the service that this route points to
-	ServiceName string `json:"serviceName" yaml:"serviceName"`
+	ServiceName string `json:"serviceName"`
 }
 
 // RouteList is a collection of Routes.
 type RouteList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Route `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Route `json:"items"`
 }

--- a/pkg/route/api/v1beta1/types.go
+++ b/pkg/route/api/v1beta1/types.go
@@ -6,23 +6,23 @@ import (
 
 // Route encapsulates the inputs needed to connect a DNS/alias to a service proxy.
 type Route struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Required: Alias/DNS that points to the service
 	// Can be host or host:port
 	// host and port are combined to follow the net/url URL struct
-	Host string `json:"host" yaml:"host"`
+	Host string `json:"host"`
 	// Optional: Path that the router watches for, to route traffic for to the service
-	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	Path string `json:"path,omitempty"`
 
 	// the name of the service that this route points to
-	ServiceName string `json:"serviceName" yaml:"serviceName"`
+	ServiceName string `json:"serviceName"`
 }
 
 // RouteList is a collection of Routes.
 type RouteList struct {
-	kapi.TypeMeta `json:",inline" yaml:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items         []Route `json:"items" yaml:"items"`
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Route `json:"items"`
 }

--- a/pkg/template/api/types.go
+++ b/pkg/template/api/types.go
@@ -7,18 +7,18 @@ import (
 
 // Template contains the inputs needed to produce a Config.
 type Template struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Required: Items is an array of Kubernetes resources of Service,
 	// Pod and/or ReplicationController kind.
 	// TODO: Handle unregistered types. Define custom []runtime.Object
 	//       type and its unmarshaller instead of []runtime.Object.
-	Items []runtime.RawExtension `json:"items" yaml:"items"`
+	Items []runtime.RawExtension `json:"items"`
 
 	// Optional: Parameters is an array of Parameters used during the
 	// Template to Config transformation.
-	Parameters []Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters []Parameter `json:"parameters,omitempty"`
 }
 
 // Parameter defines a name/value variable that is to be processed during
@@ -26,23 +26,23 @@ type Template struct {
 type Parameter struct {
 	// Required: Parameter name must be set and it can be referenced in Template
 	// Items using ${PARAMETER_NAME}
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name"`
 
 	// Optional: Parameter can have description
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 
 	// Optional: Generate specifies the generator to be used to generate
 	// random string from an input value specified by From field. The result
 	// string is stored into Value field. If empty, no generator is being
 	// used, leaving the result Value untouched.
-	Generate string `json:"generate,omitempty" yaml:"generate,omitempty"`
+	Generate string `json:"generate,omitempty"`
 
 	// Optional: From is an input value for the generator.
-	From string `json:"from,omitempty" yaml:"from,omitempty"`
+	From string `json:"from,omitempty"`
 
 	// Optional: Value holds the Parameter data. The Value data can be
 	// overwritten by the generator. The value replaces all occurances
 	// of the Parameter ${Name} expression during the Template to Config
 	// transformation.
-	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+	Value string `json:"value,omitempty"`
 }

--- a/pkg/template/api/v1beta1/types.go
+++ b/pkg/template/api/v1beta1/types.go
@@ -7,16 +7,16 @@ import (
 
 // Template contains the inputs needed to produce a Config.
 type Template struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Required: Items is an array of Kubernetes resources of Service,
 	// Pod and/or ReplicationController kind.
-	Items []runtime.RawExtension `json:"items" yaml:"items"`
+	Items []runtime.RawExtension `json:"items"`
 
 	// Optional: Parameters is an array of Parameters used during the
 	// Template to Config transformation.
-	Parameters []Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Parameters []Parameter `json:"parameters,omitempty"`
 }
 
 // Parameter defines a name/value variable that is to be processed during
@@ -24,23 +24,23 @@ type Template struct {
 type Parameter struct {
 	// Required: Parameter name must be set and it can be referenced in Template
 	// Items using ${PARAMETER_NAME}
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name"`
 
 	// Optional: Parameter can have description
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 
 	// Optional: Generate specifies the generator to be used to generate
 	// random string from an input value specified by From field. The result
 	// string is stored into Value field. If empty, no generator is being
 	// used, leaving the result Value untouched.
-	Generate string `json:"generate,omitempty" yaml:"generate,omitempty"`
+	Generate string `json:"generate,omitempty"`
 
 	// Optional: From is an input value for the generator.
-	From string `json:"from,omitempty" yaml:"from,omitempty"`
+	From string `json:"from,omitempty"`
 
 	// Optional: Value holds the Parameter data. The Value data can be
 	// overwritten by the generator. The value replaces all occurances
 	// of the Parameter ${Name} expression during the Template to Config
 	// transformation.
-	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+	Value string `json:"value,omitempty"`
 }

--- a/pkg/user/api/types.go
+++ b/pkg/user/api/types.go
@@ -8,38 +8,38 @@ import (
 // POST to UserIdentityMapping, get back error or a filled out UserIdentityMapping object
 
 type User struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
-	FullName string `json:"fullName,omitempty" yaml:"fullName,omitempty"`
+	FullName string `json:"fullName,omitempty"`
 }
 
 type UserList struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items           []User `json:"items" yaml:"items"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+	Items           []User `json:"items"`
 }
 
 type Identity struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Provider is the source of identity information - if empty, the default provider
 	// is assumed.
-	Provider string `json:"provider" yaml:"provider"`
+	Provider string `json:"provider"`
 
 	// UserName uniquely represents this identity in the scope of the identity provider
-	UserName string `json:"userName" yaml:"userName"`
+	UserName string `json:"userName"`
 
-	Extra map[string]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	Extra map[string]string `json:"extra,omitempty"`
 }
 
 type UserIdentityMapping struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
-	Identity Identity `json:"identity,omitempty" yaml:"identity,omitempty"`
-	User     User     `json:"user,omitempty" yaml:"user,omitempty"`
+	Identity Identity `json:"identity,omitempty"`
+	User     User     `json:"user,omitempty"`
 }
 
 func (*User) IsAnAPIObject()                {}

--- a/pkg/user/api/v1beta1/types.go
+++ b/pkg/user/api/v1beta1/types.go
@@ -8,38 +8,38 @@ import (
 // POST to UserIdentityMapping, get back error or a filled out UserIdentityMapping object
 
 type User struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
-	FullName string `json:"fullName,omitempty" yaml:"fullName,omitempty"`
+	FullName string `json:"fullName,omitempty"`
 }
 
 type UserList struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Items           []User `json:"items" yaml:"items"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+	Items           []User `json:"items"`
 }
 
 type Identity struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Provider is the source of identity information - if empty, the default provider
 	// is assumed.
-	Provider string `json:"provider" yaml:"provider"`
+	Provider string `json:"provider"`
 
 	// UserName uniquely represents this identity in the scope of the identity provider
-	UserName string `json:"userName" yaml:"userName"`
+	UserName string `json:"userName"`
 
-	Extra map[string]string `json:"extra,omitempty" yaml:"extra,omitempty"`
+	Extra map[string]string `json:"extra,omitempty"`
 }
 
 type UserIdentityMapping struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
 
-	Identity Identity `json:"identity,omitempty" yaml:"identity,omitempty"`
-	User     User     `json:"user,omitempty" yaml:"user,omitempty"`
+	Identity Identity `json:"identity,omitempty"`
+	User     User     `json:"user,omitempty"`
 }
 
 func (*User) IsAnAPIObject()                {}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,9 +12,9 @@ var commitFromGit string
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
 type Info struct {
-	Major     string `json:"major" yaml:"major"`
-	Minor     string `json:"minor" yaml:"minor"`
-	GitCommit string `json:"gitCommit" yaml:"gitCommit"`
+	Major     string `json:"major"`
+	Minor     string `json:"minor"`
+	GitCommit string `json:"gitCommit"`
 }
 
 // Get returns the overall codebase version. It's for detecting


### PR DESCRIPTION
Yaml is nuked in upstream, so remove it from our objects as well to make things look consistent:

https://github.com/openshift/origin/pull/679/files#r23234265

@smarterclayton fyi