### PR TITLE
Exclude .git and node_modules from test search

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -23,6 +23,8 @@ find_test_dirs() {
         -o -wholename './target' \
         -o -wholename '*/Godeps/*' \
         -o -wholename '*/_output/*' \
+        -o -wholename './.git' \
+        -o -wholename './assets/node_modules' \
       \) -prune \
     \) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u | xargs -n1 printf "${OS_GO_PACKAGE}/%s\n"
 }


### PR DESCRIPTION
Don't scan .git and assets/node_modules when searching for tests. This
greatly improves test startup performance, especially in VMs where these
directories grow very large (30k+ files).