### PR TITLE
Enable privileged capabilities in apiserver

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authorizer"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/emicklei/go-restful"
 	"github.com/golang/glog"
 
@@ -55,6 +56,12 @@ func (c *MasterConfig) EnsurePortalFlags() {
 // endpoints were started (these are format strings that will expect to be sent
 // a single string value).
 func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
+	// Allow privileged containers
+	// TODO: make this configurable and not the default https://github.com/openshift/origin/issues/662
+	capabilities.Initialize(capabilities.Capabilities{
+		AllowPrivileged: true,
+	})
+
 	kubeletClient, err := kclient.NewKubeletClient(
 		&kclient.KubeletConfig{
 			Port: 10250,


### PR DESCRIPTION
Temporarily enable priv'd capabilities in apiserver. This matches the similar
enablement in the kubelet. It's necessary to do the setup in both places because
the setting is per-process, and when running the apiserver/kubelet in a multi-node
setup the existing kubelet call won't affect the apiserver.