### PR TITLE
Kubelet stops existing pods on restart, rather than letting them run

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config/etcd.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config/etcd.go
@@ -59,8 +59,7 @@ func NewSourceEtcd(key string, client tools.EtcdClient, updates chan<- interface
 
 func (s *sourceEtcd) run() {
 	boundPods := api.BoundPods{}
-	err := s.helper.ExtractToList(s.key, &boundPods)
-	if err != nil {
+	if err := s.helper.ExtractObj(s.key, &boundPods, true); err != nil {
 		glog.Errorf("etcd failed to retrieve the value for the key %q. Error: %v", s.key, err)
 		return
 	}


### PR DESCRIPTION
An upstream bug was introduced with our rebase, but not the resulting fix in
GoogleCloudPlatform/kubernetes#3497.  

Fixes #700