### PR TITLE
packaging: openshift won't start: remove invalid options in /etc/sysconfing/openshift

### DIFF
--- a/rel-eng/openshift.sysconfig
+++ b/rel-eng/openshift.sysconfig
@@ -1,2 +1,2 @@
-ROLE="node"
-OPTIONS="--master=http://10.0.0.1:8080 --logging=0"
+ROLE=""
+OPTIONS=""


### PR DESCRIPTION
There are three invalid options: `--logging`, `--master=http://10.0.0.1:8080` and `ROLE="node"`. This PR will remove those.