### PR TITLE
packaging: put runtime data to /var/lib/origin

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -76,6 +76,8 @@ install -m 0644 rel-eng/openshift.sysconfig %{buildroot}%{_sysconfdir}/sysconfig
 
 mkdir -p %{buildroot}/var/log/%{name}
 
+mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
+
 ln -s %{_bindir}/openshift %{buildroot}%{_bindir}/osc
 
 %files
@@ -86,6 +88,7 @@ ln -s %{_bindir}/openshift %{buildroot}%{_bindir}/osc
 %{_bindir}/osc
 %{_unitdir}/*.service
 %config(noreplace) %{_sysconfdir}/sysconfig/openshift
+%{_sharedstatedir}/%{name}
 
 %post
 %systemd_post %{basename:openshift.service}

--- a/rel-eng/openshift.service
+++ b/rel-eng/openshift.service
@@ -8,6 +8,7 @@ Documentation=https://github.com/openshift/origin
 Type=simple
 EnvironmentFile=-/etc/sysconfig/openshift
 ExecStart=/usr/bin/openshift start $ROLE $OPTIONS
+WorkingDirectory=/var/lib/origin/
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Runtime data `openshift.local.*` are now placed in / which is not very nice, let's put it to `/var/lib/origin`.