### PR TITLE
Make project.Namespace always equal to project.Name 

### DIFF
--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -13,11 +13,13 @@ func ValidateProject(project *api.Project) errors.ValidationErrorList {
 	result := errors.ValidationErrorList{}
 	if len(project.Name) == 0 {
 		result = append(result, errors.NewFieldRequired("Name", project.Name))
-	} else if !util.IsDNS952Label(project.Name) {
-		result = append(result, errors.NewFieldInvalid("Name", project.Name, "does not conform to lower-cased dns952"))
+	} else if !util.IsDNSSubdomain(project.Name) {
+		result = append(result, errors.NewFieldInvalid("Name", project.Name, ""))
 	}
-	if !util.IsDNSSubdomain(project.Namespace) {
-		result = append(result, errors.NewFieldInvalid("Namespace", project.Namespace, "does not conform to lower-cased dns952"))
+	if len(project.Namespace) == 0 {
+		result = append(result, errors.NewFieldRequired("namespace", project.Namespace))
+	} else if !util.IsDNSSubdomain(project.Namespace) {
+		result = append(result, errors.NewFieldInvalid("namespace", project.Namespace, ""))
 	}
 	if !validateNoNewLineOrTab(project.DisplayName) {
 		result = append(result, errors.NewFieldInvalid("DisplayName", project.DisplayName, "may not contain a new line or tab"))

--- a/pkg/project/registry/project/rest.go
+++ b/pkg/project/registry/project/rest.go
@@ -58,11 +58,10 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("not a project: %#v", obj)
 	}
 
-	// TODO decide if we should set namespace == name, think longer term we need some type of reservation here
-	// but i want to be able to let existing kubernetes ns grow into a project as well
-	if len(project.Namespace) == 0 {
-		project.Namespace = project.Name
-	}
+	// BETA 1: A project will reserve a namespace == project.Name
+	// When Namespace As Kind lands upstream, we will change this so Project project has an ObjectReference to Namespace
+	// Or Project will just be a virtual wrapper on Namespace and not its own object
+	project.Namespace = project.Name
 
 	kapi.FillObjectMetaSystemFields(ctx, &project.ObjectMeta)
 


### PR DESCRIPTION
openshift cli create -f <project.json> is inserting the current CLI context namespace as the project namespace.  As a result, the project appears to have reserved the 'default' namespace, rather than a new one.

I am introducing Namespace As Kind upstream:
https://github.com/GoogleCloudPlatform/kubernetes/pull/3613

Once that lands, the behavior of Project will have to change.  At that time, Project will alias Namespace, and most-likely carry annotations for Project specific fields (i.e. DisplayName).  Pending that PR landing upstream, I will always set the current project.Namespace to project.Name