### PR TITLE
Vagrant: fix var name that prevented machine from coming up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "cpus"              => 2,
       "memory"            => 1024,
       "virtualbox"        => {
-        "name" => "fedora20_openshift",
+        "box_name" => "fedora20_openshift",
         "box_url" => "https://mirror.openshift.com/pub/vagrant/boxes/openshift3/fedora_20_latest.box"
       },
       "vmware"            => {


### PR DESCRIPTION
After rebase the following message appears when doing vagrant up.  Looks like a variable got renamed and checked in.  

```
[pweil@localhost origin]$ vagrant up
Bringing machine 'openshiftdev' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* A box must be specified.
```