### PR TITLE
Resolve 406 response when trying to get osapi versions

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -286,12 +286,20 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 		root = new(restful.WebService)
 		container.Add(root)
 	}
-	versionHandler := apiserver.APIVersionHandler("v1beta1")
-	root.Route(root.GET(OpenShiftAPIPrefix).To(versionHandler).Doc("list supported server API versions"))
+	initAPIVersionRoute(root, "v1beta1")
 
 	return []string{
 		fmt.Sprintf("Started OpenShift API at %%s%s", OpenShiftAPIPrefixV1Beta1),
 	}
+}
+
+//initAPIVersionRoute initializes the osapi endpoint to behave similiar to the upstream api endpoint
+func initAPIVersionRoute(root *restful.WebService, version string) {
+	versionHandler := apiserver.APIVersionHandler(version)
+	root.Route(root.GET(OpenShiftAPIPrefix).To(versionHandler).
+		Doc("list supported server API versions").
+		Produces(restful.MIME_JSON).
+		Consumes(restful.MIME_JSON))
 }
 
 // Run launches the OpenShift master. It takes optional installers that may install additional endpoints into the server.

--- a/pkg/cmd/server/origin/master_test.go
+++ b/pkg/cmd/server/origin/master_test.go
@@ -1,0 +1,32 @@
+package origin
+
+import (
+	"testing"
+
+	"github.com/emicklei/go-restful"
+)
+
+func TestInitializeOpenshiftAPIVersionRouteHandler(t *testing.T) {
+	service := new(restful.WebService)
+	initAPIVersionRoute(service, "v1beta1")
+
+	if len(service.Routes()) != 1 {
+		t.Fatalf("Exp. the OSAPI route but found none")
+	}
+	route := service.Routes()[0]
+	if !contains(route.Produces, restful.MIME_JSON) {
+		t.Fatalf("Exp. route to produce mimetype json")
+	}
+	if !contains(route.Consumes, restful.MIME_JSON) {
+		t.Fatalf("Exp. route to consume mimetype json")
+	}
+}
+
+func contains(list []string, value string) bool {
+	for _, entry := range list {
+		if entry == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Modified code to match upstream to resolve 406 response when checking the supported versions of OpenShift via 'osapi'