### PR TITLE
Align project with upstream resources that exist outside of namespace

### DIFF
--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -178,7 +178,7 @@ angular.module('openshiftConsole')
       if (context.projectPromise && type !== "projects") {
         context.projectPromise.done($.proxy(function(project) {
           $.ajax({
-            url: this._urlForType(type, name, context, false, {namespace: project.metadata.namespace}),
+            url: this._urlForType(type, name, context, false, {namespace: project.metadata.name}),
             success: callback
           });
         }, this));
@@ -371,7 +371,7 @@ angular.module('openshiftConsole')
     if (context.projectPromise && type !== "projects") {
       context.projectPromise.done($.proxy(function(project) {
         $.ajax({
-          url: this._urlForType(type, null, context, false, {namespace: project.metadata.namespace}),
+          url: this._urlForType(type, null, context, false, {namespace: project.metadata.name}),
           success: $.proxy(this, "_listOpComplete", type, context)
         });
       }, this));
@@ -420,7 +420,7 @@ angular.module('openshiftConsole')
       }
       if (context.projectPromise && type !== "projects") {
         context.projectPromise.done($.proxy(function(project) {
-          params.namespace = project.metadata.namespace;
+          params.namespace = project.metadata.name;
           var wsUrl = this._urlForType(type, null, context, true, params);
           var ws = new WebSocket(wsUrl);
           this._watchWebsockets(type, context, ws);

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -68,6 +68,8 @@ func validateObject(obj runtime.Object) (errors []error) {
 	case *deployapi.Deployment:
 		errors = deployv.ValidateDeployment(t)
 	case *projectapi.Project:
+		// this is a global resource that should not have a namespace
+		t.Namespace = ""
 		errors = projectv.ValidateProject(t)
 	case *routeapi.Route:
 		errors = routev.ValidateRoute(t)

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -16,8 +16,8 @@ func ValidateProject(project *api.Project) errors.ValidationErrorList {
 	} else if !util.IsDNS952Label(project.Name) {
 		result = append(result, errors.NewFieldInvalid("Name", project.Name, "does not conform to lower-cased dns952"))
 	}
-	if !util.IsDNSSubdomain(project.Namespace) {
-		result = append(result, errors.NewFieldInvalid("Namespace", project.Namespace, "does not conform to lower-cased dns952"))
+	if len(project.Namespace) > 0 {
+		result = append(result, errors.NewFieldInvalid("Namespace", project.Namespace, "must be the empty-string"))
 	}
 	if !validateNoNewLineOrTab(project.DisplayName) {
 		result = append(result, errors.NewFieldInvalid("DisplayName", project.DisplayName, "may not contain a new line or tab"))

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -17,7 +17,6 @@ func TestValidateProject(t *testing.T) {
 			name: "missing id",
 			project: api.Project{
 				ObjectMeta: kapi.ObjectMeta{
-					Namespace: kapi.NamespaceDefault,
 					Annotations: map[string]string{
 						"description": "This is a description",
 					},
@@ -31,8 +30,7 @@ func TestValidateProject(t *testing.T) {
 			name: "invalid id",
 			project: api.Project{
 				ObjectMeta: kapi.ObjectMeta{
-					Name:      "141-.124.$",
-					Namespace: kapi.NamespaceDefault,
+					Name: "141-.124.$",
 					Annotations: map[string]string{
 						"description": "This is a description",
 					},
@@ -43,27 +41,18 @@ func TestValidateProject(t *testing.T) {
 			numErrs: 1,
 		},
 		{
-			name: "missing namespace",
+			name: "has namespace",
 			project: api.Project{
-				ObjectMeta:  kapi.ObjectMeta{Name: "foo", Namespace: ""},
+				ObjectMeta:  kapi.ObjectMeta{Name: "foo", Namespace: "foo"},
 				DisplayName: "hi",
 			},
-			// Should fail because the namespace is missing.
-			numErrs: 1,
-		},
-		{
-			name: "invalid namespace",
-			project: api.Project{
-				ObjectMeta:  kapi.ObjectMeta{Name: "foo", Namespace: "141-.124.$"},
-				DisplayName: "hi",
-			},
-			// Should fail because the namespace is missing.
+			// Should fail because the namespace is supplied.
 			numErrs: 1,
 		},
 		{
 			name: "invalid display name",
 			project: api.Project{
-				ObjectMeta:  kapi.ObjectMeta{Name: "foo", Namespace: "foo"},
+				ObjectMeta:  kapi.ObjectMeta{Name: "foo", Namespace: ""},
 				DisplayName: "h\t\ni",
 			},
 			// Should fail because the display name has \t \n
@@ -80,8 +69,7 @@ func TestValidateProject(t *testing.T) {
 
 	project := api.Project{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      "foo",
-			Namespace: kapi.NamespaceDefault,
+			Name: "foo",
 			Annotations: map[string]string{
 				"description": "This is a description",
 			},

--- a/pkg/project/registry/project/rest.go
+++ b/pkg/project/registry/project/rest.go
@@ -58,16 +58,10 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 		return nil, fmt.Errorf("not a project: %#v", obj)
 	}
 
-	// TODO decide if we should set namespace == name, think longer term we need some type of reservation here
-	// but i want to be able to let existing kubernetes ns grow into a project as well
-	if len(project.Namespace) == 0 {
-		project.Namespace = project.Name
-	}
-
 	kapi.FillObjectMetaSystemFields(ctx, &project.ObjectMeta)
 
-	// TODO set an id if not provided?, set a Namespace attribute if not provided?
-
+	// kubectl auto-inserts a value, we need to ignore this value until we have cluster-scoped actions in kubectl
+	project.Namespace = ""
 	if errs := validation.ValidateProject(project); len(errs) > 0 {
 		return nil, errors.NewInvalid("project", project.Name, errs)
 	}


### PR DESCRIPTION
@jwforres - FYI, this is the change I want to make to align with Kubernetes:

https://github.com/GoogleCloudPlatform/kubernetes/pull/3613

We will need to update our UI to use project.Name only.