### PR TITLE
Split master and node rpms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .vimrc
 .vagrant-openshift.json
 .DS_Store
+*.pyc

--- a/rel-eng/lib/embeddedcommitbuilder/__init__.py
+++ b/rel-eng/lib/embeddedcommitbuilder/__init__.py
@@ -1,0 +1,23 @@
+"""
+Code for tagging Spacewalk/Satellite packages.
+"""
+
+from tito.common import get_latest_commit, run_command
+from tito.builder import Builder
+
+class EmbeddedCommitBuilder(Builder):
+  """
+  builder which defines 'commit' as the git hash prior to building
+
+  Used For:
+    - Packages that want to know the commit in all situations
+  """
+
+  def _get_rpmbuild_dir_options(self):
+      git_hash = get_latest_commit()
+      return ('--define "_topdir %s" --define "_sourcedir %s" --define "_builddir %s" --define '
+            '"_srcrpmdir %s" --define "_rpmdir %s" --define "commit %s" ' % (
+                self.rpmbuild_dir,
+                self.rpmbuild_sourcedir, self.rpmbuild_builddir,
+                self.rpmbuild_basedir, self.rpmbuild_basedir,
+                git_hash))

--- a/rel-eng/lib/embeddedcommittagger/__init__.py
+++ b/rel-eng/lib/embeddedcommittagger/__init__.py
@@ -1,0 +1,35 @@
+"""
+Code for tagging Spacewalk/Satellite packages.
+"""
+
+from tito.common import get_latest_commit, run_command
+from tito.tagger import VersionTagger
+
+class EmbeddedCommitTagger(VersionTagger):
+  """
+  Tagger which defines a specfile global with the git hash at which the tag was
+  created.
+
+  Requires that your commit is written on one single line as:
+  %global commit 460abe2a3abe0fa22ac96c551fe71c0fc36f7475
+
+  Used For:
+    - Packages that are to be built via dist-git and need to have the git hash
+      available to them.
+  """
+
+  def _tag_release(self):
+    """
+    Tag a new release of the package, add specfile global named commit. (ie: x.y.z-r+1)
+    """
+    self._make_changelog()
+    new_version = self._bump_version(release=True)
+    git_hash = get_latest_commit()
+    update_commit = "sed -i 's/^%%global commit .*$/%%global commit %s/' %s" % \
+      (git_hash, self.spec_file)
+    output = run_command(update_commit)
+
+
+    self._check_tag_does_not_exist(self._get_new_tag(new_version))
+    self._update_changelog(new_version)
+    self._update_package_metadata(new_version)

--- a/rel-eng/openshift-master.service
+++ b/rel-eng/openshift-master.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenShift Master
+Documentation=https://github.com/openshift/origin
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/sysconfig/openshift-master
+ExecStart=/usr/bin/openshift start $ROLE $OPTIONS
+WorkingDirectory=/var/lib/openshift/
+
+[Install]
+WantedBy=multi-user.target

--- a/rel-eng/openshift-master.sysconfig
+++ b/rel-eng/openshift-master.sysconfig
@@ -1,0 +1,2 @@
+ROLE="master"
+OPTIONS="--loglevel=0"

--- a/rel-eng/openshift-node.service
+++ b/rel-eng/openshift-node.service
@@ -1,14 +1,14 @@
 [Unit]
-Description=OpenShift
+Description=OpenShift Node
 After=docker.service
 Requires=docker.service
 Documentation=https://github.com/openshift/origin
 
 [Service]
 Type=simple
-EnvironmentFile=-/etc/sysconfig/openshift
+EnvironmentFile=-/etc/sysconfig/openshift-node
 ExecStart=/usr/bin/openshift start $ROLE $OPTIONS
-WorkingDirectory=/var/lib/origin/
+WorkingDirectory=/var/lib/openshift/
 
 [Install]
 WantedBy=multi-user.target

--- a/rel-eng/openshift-node.sysconfig
+++ b/rel-eng/openshift-node.sysconfig
@@ -1,0 +1,2 @@
+ROLE="node"
+OPTIONS="--loglevel=0"

--- a/rel-eng/openshift.sysconfig
+++ b/rel-eng/openshift.sysconfig
@@ -1,2 +1,0 @@
-ROLE=""
-OPTIONS=""

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,5 +1,6 @@
 [buildconfig]
-builder = tito.builder.Builder
-tagger = tito.tagger.VersionTagger
+builder = embeddedcommitbuilder.EmbeddedCommitBuilder
+tagger = embeddedcommittagger.EmbeddedCommitTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+lib_dir = rel-eng/lib

--- a/tuned/openshift-node/tuned.conf
+++ b/tuned/openshift-node/tuned.conf
@@ -1,0 +1,16 @@
+#
+# tuned configuration
+#
+
+[main]
+include=throughput-performance
+
+[selinux]
+avc_cache_threshold=65536
+
+[net]
+nf_conntrack_hashsize=131072
+
+[sysctl]
+kernel.pid_max=131072
+net.netfilter.nf_conntrack_max=1048576


### PR DESCRIPTION
* Rename package from 'origin' to 'openshift'
* Provide node and master specific sysconfig files, systemd services packaged in 'openshift-node' and 'openshift-master' subpackages. These subpackages depend on 'openshift'
* Add openshift-node tuned profile 

If you install both master and node rpms on the same host it will work with no additional configuration.

If you install the RPMS on separate hosts you'll need to add --master=https://masterhostname:8443 and --nodes=node-hostname1,node-hostname2 to /etc/sysconfig/openshift-node and /etc/sysconfig/openshift-master on your node and master hosts respectively.