### PR TITLE
kill openshift process during e2e

### DIFF
--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -91,7 +91,7 @@ function cleanup()
   if [ "$SKIP_TEARDOWN" != "1" ]; then
     set +e
     echo "[INFO] Tearing down test"
-    stop_openshift_server
+    pkill -P $$
     echo "[INFO] Stopping docker containers"; docker ps -aq | xargs -l -r docker stop
     set +u
     if [ "$SKIP_IMAGE_CLEANUP" != "1" ]; then
@@ -107,7 +107,6 @@ function cleanup()
   find ${ARTIFACT_DIR} -size +20M -exec echo Deleting {} because it is too big. \; -exec rm -f {} \;
   find ${LOG_DIR} -size +20M -exec echo Deleting {} because it is too big. \; -exec rm -f {} \;
 
-  pkill -P $$
   echo "[INFO] Exiting"
   exit $out
 }


### PR DESCRIPTION
For some reason `kill -INT` is not ending the openshift process.  That results in all sorts of weirdness when trying to re-run hack/test-end-to-end.sh and ugliness in the log.  I don't know why we're not responding properly to polite kill requests, but we get this in e2e
```
[INFO] Removing docker containers
a96691b2495f
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
FATA[0000] Error: failed to remove one or more containers 
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
FATA[0000] Error: failed to remove one or more containers 
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
FATA[0000] Error: failed to remove one or more containers 
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
FATA[0000] Error: failed to remove one or more containers 
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
FATA[0000] Error: failed to remove one or more containers 
Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f
FATA[0000] Error: failed to remove one or more containers 
```

and these processes left over:
```
[deads@deads-dev-01 origin]$ ps ax | grep openshift | grep -v grep
 1526 pts/1    S+     0:00 sudo env PATH=hack/../_output/local/go/bin:/sbin:/bin:/usr/sbin:/usr/bin openshift start --listen=https://0.0.0.0:8443 --hostname=127.0.0.1 --volume-dir=/tmp/openshift-e2e.YNVh/volumes --etcd-dir=/tmp/openshift-e2e.YNVh/etcd --cert-dir=/tmp/openshift-e2e.YNVh/certs --loglevel=4
 1531 pts/1    Sl+    0:27 openshift start --listen=https://0.0.0.0:8443 --hostname=127.0.0.1 --volume-dir=/tmp/openshift-e2e.YNVh/volumes --etcd-dir=/tmp/openshift-e2e.YNVh/etcd --cert-dir=/tmp/openshift-e2e.YNVh/certs --loglevel=4
```

@smarterclayton You added the `-INT`, I'm not entirely certain why we wanted to change it.  Politeness?