### PR TITLE
refactor build interfaces

### DIFF
--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -1,7 +1,7 @@
 package builder
 
 import (
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 type Builder interface {
@@ -10,7 +10,7 @@ type Builder interface {
 
 // getBuildEnvVars returns a map with the environment variables that should be added
 // to the built image
-func getBuildEnvVars(build *api.Build) map[string]string {
+func getBuildEnvVars(build *buildapi.Build) map[string]string {
 	envVars := map[string]string{
 		"OPENSHIFT_BUILD_NAME":      build.Name,
 		"OPENSHIFT_BUILD_NAMESPACE": build.Namespace,

--- a/pkg/build/client/clients.go
+++ b/pkg/build/client/clients.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	osclient "github.com/openshift/origin/pkg/client"
+)
+
+// BuildConfigGetter provides methods for getting BuildConfigs
+type BuildConfigGetter interface {
+	Get(namespace, name string) (*buildapi.BuildConfig, error)
+}
+
+// BuildConfigUpdater provides methods for updating BuildConfigs
+type BuildConfigUpdater interface {
+	Update(buildConfig *buildapi.BuildConfig) error
+}
+
+// OSClientBuildConfigClient delegates get and update operations to the OpenShift client interface
+type OSClientBuildConfigClient struct {
+	Client osclient.Interface
+}
+
+// NewOSClientBuildConfigClient creates a new build config client that uses an openshift client to create and get BuildConfigs
+func NewOSClientBuildConfigClient(client osclient.Interface) *OSClientBuildConfigClient {
+	return &OSClientBuildConfigClient{Client: client}
+}
+
+// Get returns a BuildConfig using the OpenShift client.
+func (c OSClientBuildConfigClient) Get(namespace, name string) (*buildapi.BuildConfig, error) {
+	return c.Client.BuildConfigs(namespace).Get(name)
+}
+
+// Update updates a BuildConfig using the OpenShift client.
+func (c OSClientBuildConfigClient) Update(buildConfig *buildapi.BuildConfig) error {
+	_, err := c.Client.BuildConfigs(buildConfig.Namespace).Update(buildConfig)
+	return err
+}
+
+// BuildCreator provides methods for creating new Builds
+type BuildCreator interface {
+	Create(namespace string, build *buildapi.Build) error
+}
+
+// BuildUpdater provides methods for updating existing Builds.
+type BuildUpdater interface {
+	Update(namespace string, build *buildapi.Build) error
+}
+
+// OSClientBuildClient deletes build create and update operations to the OpenShift client interface
+type OSClientBuildClient struct {
+	Client osclient.Interface
+}
+
+// NewOSClientBuildClient creates a new build client that uses an openshift client to create builds
+func NewOSClientBuildClient(client osclient.Interface) *OSClientBuildClient {
+	return &OSClientBuildClient{Client: client}
+}
+
+// Create creates builds using the OpenShift client.
+func (c OSClientBuildClient) Create(namespace string, build *buildapi.Build) error {
+	_, e := c.Client.Builds(namespace).Create(build)
+	return e
+}
+
+// Update updates builds using the OpenShift client.
+func (c OSClientBuildClient) Update(namespace string, build *buildapi.Build) error {
+	_, e := c.Client.Builds(namespace).Update(build)
+	return e
+}

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -8,20 +8,21 @@ import (
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildtest "github.com/openshift/origin/pkg/build/controller/test"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 type okBuildUpdater struct{}
 
-func (obu *okBuildUpdater) UpdateBuild(namespace string, build *buildapi.Build) (*buildapi.Build, error) {
-	return &buildapi.Build{}, nil
+func (okc *okBuildUpdater) Update(namespace string, build *buildapi.Build) error {
+	return nil
 }
 
 type errBuildUpdater struct{}
 
-func (ebu *errBuildUpdater) UpdateBuild(namespace string, build *buildapi.Build) (*buildapi.Build, error) {
-	return &buildapi.Build{}, errors.New("UpdateBuild error!")
+func (ec *errBuildUpdater) Update(namespace string, build *buildapi.Build) error {
+	return errors.New("UpdateBuild error!")
 }
 
 type okStrategy struct {
@@ -153,7 +154,7 @@ func TestHandleBuild(t *testing.T) {
 		outStatus     buildapi.BuildStatus
 		buildOutput   buildapi.BuildOutput
 		buildStrategy BuildStrategy
-		buildUpdater  buildUpdater
+		buildUpdater  buildclient.BuildUpdater
 		imageClient   imageRepositoryClient
 		podManager    podManager
 		outputSpec    string
@@ -316,7 +317,7 @@ func TestHandlePod(t *testing.T) {
 		outStatus    buildapi.BuildStatus
 		podStatus    kapi.PodPhase
 		exitCode     int
-		buildUpdater buildUpdater
+		buildUpdater buildclient.BuildUpdater
 	}
 
 	tests := []handlePodTest{

--- a/pkg/build/util/generate.go
+++ b/pkg/build/util/generate.go
@@ -4,35 +4,40 @@ import (
 	"github.com/golang/glog"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/openshift/origin/pkg/build/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 // GenerateBuildFromConfig creates a new build based on a given BuildConfig. Optionally a SourceRevision for the new
-// build can be specified
-func GenerateBuildFromConfig(bc *api.BuildConfig, r *api.SourceRevision) (build *api.Build) {
+// build can be specified.  Also optionally a list of image names to be substituted can be supplied.  Values in the BuildConfig
+// that have a substitution provided will be replaced in the resulting Build
+func GenerateBuildFromConfig(bc *buildapi.BuildConfig, r *buildapi.SourceRevision, imageSubstitutions map[string]string) (build *buildapi.Build) {
 	// Need to copy the buildConfig here so that it doesn't share pointers with
 	// the build object which could be (will be) modified later.
 	obj, _ := kapi.Scheme.Copy(bc)
-	bcCopy := obj.(*api.BuildConfig)
+	bcCopy := obj.(*buildapi.BuildConfig)
 
-	return &api.Build{
-		Parameters: api.BuildParameters{
+	b := &buildapi.Build{
+		Parameters: buildapi.BuildParameters{
 			Source:   bcCopy.Parameters.Source,
 			Strategy: bcCopy.Parameters.Strategy,
 			Output:   bcCopy.Parameters.Output,
 			Revision: r,
 		},
 		ObjectMeta: kapi.ObjectMeta{
-			Labels: map[string]string{api.BuildConfigLabel: bcCopy.Name},
+			Labels: map[string]string{buildapi.BuildConfigLabel: bcCopy.Name},
 		},
 	}
+	for originalImage, newImage := range imageSubstitutions {
+		SubstituteImageReferences(b, originalImage, newImage)
+	}
+	return b
 }
 
 // GenerateBuildFromBuild creates a new build based on a given Build.
-func GenerateBuildFromBuild(build *api.Build) *api.Build {
+func GenerateBuildFromBuild(build *buildapi.Build) *buildapi.Build {
 	obj, _ := kapi.Scheme.Copy(build)
-	buildCopy := obj.(*api.Build)
-	return &api.Build{
+	buildCopy := obj.(*buildapi.Build)
+	return &buildapi.Build{
 		Parameters: buildCopy.Parameters,
 		ObjectMeta: kapi.ObjectMeta{
 			Labels: buildCopy.ObjectMeta.Labels,
@@ -41,27 +46,27 @@ func GenerateBuildFromBuild(build *api.Build) *api.Build {
 }
 
 // SubstituteImageReferences replaces references to an image with a new value
-func SubstituteImageReferences(build *api.Build, oldImage string, newImage string) {
+func SubstituteImageReferences(build *buildapi.Build, oldImage string, newImage string) {
 	switch {
-	case build.Parameters.Strategy.Type == api.DockerBuildStrategyType &&
+	case build.Parameters.Strategy.Type == buildapi.DockerBuildStrategyType &&
 		build.Parameters.Strategy.DockerStrategy != nil &&
 		build.Parameters.Strategy.DockerStrategy.BaseImage == oldImage:
 		build.Parameters.Strategy.DockerStrategy.BaseImage = newImage
-	case build.Parameters.Strategy.Type == api.STIBuildStrategyType &&
+	case build.Parameters.Strategy.Type == buildapi.STIBuildStrategyType &&
 		build.Parameters.Strategy.STIStrategy != nil &&
 		build.Parameters.Strategy.STIStrategy.Image == oldImage:
 		build.Parameters.Strategy.STIStrategy.Image = newImage
-	case build.Parameters.Strategy.Type == api.CustomBuildStrategyType:
+	case build.Parameters.Strategy.Type == buildapi.CustomBuildStrategyType:
 		// update env variable references to the old image with the new image
 		strategy := build.Parameters.Strategy.CustomStrategy
 		if strategy.Env == nil {
 			strategy.Env = make([]kapi.EnvVar, 1)
-			strategy.Env[0] = kapi.EnvVar{Name: api.CustomBuildStrategyBaseImageKey, Value: newImage}
+			strategy.Env[0] = kapi.EnvVar{Name: buildapi.CustomBuildStrategyBaseImageKey, Value: newImage}
 		} else {
 			found := false
 			for i := range strategy.Env {
 				glog.V(4).Infof("Checking env variable %s %s", strategy.Env[i].Name, strategy.Env[i].Value)
-				if strategy.Env[i].Name == api.CustomBuildStrategyBaseImageKey {
+				if strategy.Env[i].Name == buildapi.CustomBuildStrategyBaseImageKey {
 					found = true
 					if strategy.Env[i].Value == oldImage {
 						strategy.Env[i].Value = newImage
@@ -71,7 +76,7 @@ func SubstituteImageReferences(build *api.Build, oldImage string, newImage strin
 				}
 			}
 			if !found {
-				strategy.Env = append(strategy.Env, kapi.EnvVar{Name: api.CustomBuildStrategyBaseImageKey, Value: newImage})
+				strategy.Env = append(strategy.Env, kapi.EnvVar{Name: buildapi.CustomBuildStrategyBaseImageKey, Value: newImage})
 			}
 		}
 		// update the actual custom build image with the new image, if applicable

--- a/pkg/build/util/generate_test.go
+++ b/pkg/build/util/generate_test.go
@@ -38,7 +38,7 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 			Commit: "abcd",
 		},
 	}
-	build := GenerateBuildFromConfig(bc, revision)
+	build := GenerateBuildFromConfig(bc, revision, nil)
 	if !reflect.DeepEqual(source, build.Parameters.Source) {
 		t.Errorf("Build source does not match BuildConfig source")
 	}
@@ -88,7 +88,7 @@ func TestSubstituteImageDockerNil(t *testing.T) {
 	strategy := mockDockerStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Docker build with nil base image
 	// base image should still be nil
@@ -103,7 +103,7 @@ func TestSubstituteImageDockerMatch(t *testing.T) {
 	strategy := mockDockerStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Docker build with a matched base image
 	// base image should be replaced.
@@ -122,7 +122,7 @@ func TestSubstituteImageDockerMismatch(t *testing.T) {
 	strategy := mockDockerStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Docker build with an unmatched base image
 	// base image should not be replaced.
@@ -137,7 +137,7 @@ func TestSubstituteImageSTIMatch(t *testing.T) {
 	strategy := mockSTIStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// STI build with a matched base image
 	// base image should be replaced
@@ -156,7 +156,7 @@ func TestSubstituteImageSTIMismatch(t *testing.T) {
 	strategy := mockSTIStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// STI build with an unmatched base image
 	// base image should not be replaced
@@ -171,7 +171,7 @@ func TestSubstituteImageCustomAllMatch(t *testing.T) {
 	strategy := mockCustomStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Full custom build with a BaseImage and a well defined environment variable image value,
 	// both should be replaced.  Additional environment variables should not be touched.
@@ -205,7 +205,7 @@ func TestSubstituteImageCustomAllMismatch(t *testing.T) {
 	strategy := mockCustomStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Full custom build with base image that is not matched
 	// Base image name should be unchanged
@@ -220,7 +220,7 @@ func TestSubstituteImageCustomBaseMatchEnvMismatch(t *testing.T) {
 	strategy := mockCustomStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Full custom build with a BaseImage and a well defined environment variable image value that does not match the new image
 	// Only base image should be replaced.  Environment variables should not be touched.
@@ -247,7 +247,7 @@ func TestSubstituteImageCustomBaseMatchEnvMissing(t *testing.T) {
 	strategy := mockCustomStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Custom build with a base Image but no image environment variable.
 	// base image should be replaced, new image environment variable should be added,
@@ -274,7 +274,7 @@ func TestSubstituteImageCustomBaseMatchEnvNil(t *testing.T) {
 	strategy := mockCustomStrategy()
 	output := mockOutput()
 	bc := mockBuildConfig(source, strategy, output)
-	build := GenerateBuildFromConfig(bc, nil)
+	build := GenerateBuildFromConfig(bc, nil, nil)
 
 	// Custom build with a base Image but no environment variables
 	// base image should be replaced, new image environment variable should be added

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -44,7 +44,7 @@ Examples:
 				config, err := client.BuildConfigs(namespace).Get(args[0])
 				checkErr(err)
 
-				newBuild = util.GenerateBuildFromConfig(config, nil)
+				newBuild = util.GenerateBuildFromConfig(config, nil, nil)
 			} else {
 				build, err := client.Builds(namespace).Get(buildName)
 				checkErr(err)

--- a/pkg/cmd/client/kubecfg.go
+++ b/pkg/cmd/client/kubecfg.go
@@ -531,7 +531,7 @@ func (c *KubeConfig) executeBuildRequest(method string, client *osclient.Client)
 		if err != nil {
 			glog.Fatalf("failed to trigger build manually: %v", err)
 		}
-		build = buildutil.GenerateBuildFromConfig(buildConfig, buildConfig.Parameters.Revision)
+		build = buildutil.GenerateBuildFromConfig(buildConfig, buildConfig.Parameters.Revision, nil)
 	}
 	request := client.Post().Namespace(c.getNamespace()).Resource("/builds").Body(build)
 	if err := request.Do().Error(); err != nil {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -31,7 +31,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	authcontext "github.com/openshift/origin/pkg/auth/context"
 	authfilter "github.com/openshift/origin/pkg/auth/handlers"
-	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	buildregistry "github.com/openshift/origin/pkg/build/registry/build"
@@ -148,24 +148,37 @@ func (c *MasterConfig) BuildClients() {
 	c.osClient = osclient
 }
 
+// KubeClient returns the kubernetes client object
 func (c *MasterConfig) KubeClient() *kclient.Client {
 	return c.kubeClient
 }
+
+// DeploymentClient returns the deployment client object
 func (c *MasterConfig) DeploymentClient() *kclient.Client {
 	return c.kubeClient
 }
+
+// BuildLogClient returns the build log client object
 func (c *MasterConfig) BuildLogClient() *kclient.Client {
 	return c.kubeClient
 }
+
+// WebHookClient returns the webhook client object
 func (c *MasterConfig) WebHookClient() *osclient.Client {
 	return c.osClient
 }
+
+// BuildControllerClients returns the build controller client objects
 func (c *MasterConfig) BuildControllerClients() (*osclient.Client, *kclient.Client) {
 	return c.osClient, c.kubeClient
 }
+
+// ImageChangeControllerClient returns the openshift client object
 func (c *MasterConfig) ImageChangeControllerClient() *osclient.Client {
 	return c.osClient
 }
+
+// DeploymentControllerClients returns the deployment controller client object
 func (c *MasterConfig) DeploymentControllerClients() (*osclient.Client, *kclient.Client) {
 	return c.osClient, c.kubeClient
 }
@@ -263,8 +276,9 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 	}
 
 	whPrefix := OpenShiftAPIPrefixV1Beta1 + "/buildConfigHooks/"
+	bcClient, _ := c.BuildControllerClients()
 	container.ServeMux.Handle(whPrefix, http.StripPrefix(whPrefix,
-		webhook.NewController(ClientWebhookInterface{c.WebHookClient()}, map[string]webhook.Plugin{
+		webhook.NewController(buildclient.NewOSClientBuildConfigClient(bcClient), buildclient.NewOSClientBuildClient(bcClient), map[string]webhook.Plugin{
 			"generic": generic.New(),
 			"github":  github.New(),
 		})))
@@ -487,8 +501,9 @@ func (c *MasterConfig) RunBuildController() {
 
 	osclient, kclient := c.BuildControllerClients()
 	factory := buildcontrollerfactory.BuildControllerFactory{
-		Client:     osclient,
-		KubeClient: kclient,
+		OSClient:     osclient,
+		KubeClient:   kclient,
+		BuildUpdater: buildclient.NewOSClientBuildClient(osclient),
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
 			Image:          dockerImage,
 			UseLocalImages: useLocalImages,
@@ -515,7 +530,10 @@ func (c *MasterConfig) RunBuildController() {
 
 // RunDeploymentController starts the build image change trigger controller process.
 func (c *MasterConfig) RunBuildImageChangeTriggerController() {
-	factory := buildcontrollerfactory.ImageChangeControllerFactory{Client: c.ImageChangeControllerClient()}
+	bcClient, _ := c.BuildControllerClients()
+	bcUpdater := buildclient.NewOSClientBuildConfigClient(bcClient)
+	bCreator := buildclient.NewOSClientBuildClient(bcClient)
+	factory := buildcontrollerfactory.ImageChangeControllerFactory{Client: bcClient, BuildCreator: bCreator, BuildConfigUpdater: bcUpdater}
 	factory.Create().Run()
 }
 
@@ -590,21 +608,6 @@ func env(key string, defaultValue string) string {
 		return defaultValue
 	}
 	return val
-}
-
-// ClientWebhookInterface is a webhookBuildInterface which delegates to the OpenShift client interfaces
-type ClientWebhookInterface struct {
-	Client osclient.Interface
-}
-
-// CreateBuild creates build using OpenShift client.
-func (c ClientWebhookInterface) CreateBuild(namespace string, build *buildapi.Build) (*buildapi.Build, error) {
-	return c.Client.Builds(namespace).Create(build)
-}
-
-// GetBuildConfig returns buildConfig using OpenShift client.
-func (c ClientWebhookInterface) GetBuildConfig(namespace, name string) (*buildapi.BuildConfig, error) {
-	return c.Client.BuildConfigs(namespace).Get(name)
 }
 
 type clientDeploymentInterface struct {


### PR DESCRIPTION
Attempting to bring some structure to the build interfaces we had scattered about the code...  the intent is to define all the interfaces and the "standard" implementation in the util.go file, define the mock impls in the test cases that use them, and reduce the number of interfaces (rather than having an interface per build operation, have an interface that aggregates all the build operations).

this makes it slightly harder to mock the interface since you have to provide more dummy implementations, but it makes it much easier (imho) to understand the set of interfaces involved in the build process and where they're implemented.
