### PR TITLE
WIP: pass authorizer into master config

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -76,6 +76,7 @@ var originTypes = []string{
 	"Project",
 	"User",
 	"OAuth",
+	"Role", "RoleBinding", "Policy", "PolicyBinding",
 }
 
 // OriginKind returns true if OpenShift owns the kind described in a given apiVersion.

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -4,6 +4,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
+	_ "github.com/openshift/origin/pkg/authorization/api"
 	_ "github.com/openshift/origin/pkg/build/api"
 	_ "github.com/openshift/origin/pkg/config/api"
 	_ "github.com/openshift/origin/pkg/deploy/api"

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -4,6 +4,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
+	_ "github.com/openshift/origin/pkg/authorization/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/build/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/config/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/deploy/api/v1beta1"

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("",
+		&Role{},
+		&RoleBinding{},
+		&Policy{},
+		&PolicyBinding{},
+		&PolicyList{},
+		&PolicyBindingList{},
+	)
+}
+
+func (*Role) IsAnAPIObject()              {}
+func (*Policy) IsAnAPIObject()            {}
+func (*PolicyBinding) IsAnAPIObject()     {}
+func (*RoleBinding) IsAnAPIObject()       {}
+func (*PolicyList) IsAnAPIObject()        {}
+func (*PolicyBindingList) IsAnAPIObject() {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kruntime "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// Authorization is calculated against
+// 1. all deny RoleBinding PolicyRules in the master namespace - short circuit on match
+// 2. all allow RoleBinding PolicyRules in the master namespace - short circuit on match
+// 3. all deny RoleBinding PolicyRules in the namespace - short circuit on match
+// 4. all allow RoleBinding PolicyRules in the namespace - short circuit on match
+// 5. deny by default
+
+const (
+	// Policy is a singleton and this is its name
+	PolicyName = "Policy"
+)
+
+// PolicyRule holds information that describes a policy rule, but does not contain information
+// about who the rule applies to or which namespace the rule applies to.
+type PolicyRule struct {
+	// Deny is true if any request matching this rule should be denied.  If false, any request matching this rule is allowed.
+	Deny bool `json:"deny"`
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  "*" represents all kinds.
+	Verbs []string `json:"verbs"`
+	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
+	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
+	AttributeRestrictions kruntime.EmbeddedObject `json:"attributeRestrictions"`
+	// ResourceKinds is a list of kinds this rule applies to.  "*" represents all kinds.
+	ResourceKinds []string `json:"resourceKinds"`
+}
+
+// Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
+type Role struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	Rules []PolicyRule `json:"rules"`
+}
+
+// RoleBinding references a Role, but not contain it.  It adds who and namespace information.
+// It can reference any Role in the same namespace or in the global namespace.
+type RoleBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	UserNames  []string `json:"userNames"`
+	GroupNames []string `json:"groupNames"`
+
+	// Since Policy is a singleton, this is sufficient knowledge to locate a role
+	// RoleRefs can only reference the current namespace and the global namespace
+	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef kapi.ObjectReference `json:"roleRef"`
+}
+
+// Policy is a object that holds all the Roles for a particular namespace.  There is at most
+// one Policy document per namespace.
+type Policy struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty" `
+
+	LastModified kutil.Time `json:"lastModified"`
+
+	Roles map[string]Role `json:"roles"`
+}
+
+// PolicyBinding is a object that holds all the RoleBindings for a particular namespace.  There is
+// one PolicyBinding document per referenced Policy namespace
+type PolicyBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	LastModified kutil.Time `json:"lastModified"`
+
+	PolicyRef    kapi.ObjectReference   `json:"policyRef"`
+	RoleBindings map[string]RoleBinding `json:"roleBindings"`
+}
+
+type PolicyList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Policy `json:"items"`
+}
+type PolicyBindingList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []PolicyBinding `json:"items"`
+}

--- a/pkg/authorization/api/v1beta1/conversion.go
+++ b/pkg/authorization/api/v1beta1/conversion.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"sort"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	newer "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func init() {
+	err := api.Scheme.AddConversionFuncs(
+		func(in *Policy, out *newer.Policy, s conversion.Scope) error {
+			out.LastModified = in.LastModified
+			out.Roles = make(map[string]newer.Role)
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *newer.Policy, out *Policy, s conversion.Scope) error {
+			out.LastModified = in.LastModified
+			out.Roles = make([]NamedRole, 0, 0)
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *[]NamedRole, out *map[string]newer.Role, s conversion.Scope) error {
+			for _, curr := range *in {
+				newRole := &newer.Role{}
+				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
+					return err
+				}
+				(*out)[curr.Name] = *newRole
+			}
+
+			return nil
+		},
+		func(in *map[string]newer.Role, out *[]NamedRole, s conversion.Scope) error {
+			allKeys := make([]string, 0, len(*in))
+			for key := range *in {
+				allKeys = append(allKeys, key)
+			}
+			sort.Strings(allKeys)
+
+			for _, key := range allKeys {
+				newRole := (*in)[key]
+				oldRole := &Role{}
+				if err := s.Convert(&newRole, oldRole, 0); err != nil {
+					return err
+				}
+
+				namedRole := NamedRole{key, *oldRole}
+				*out = append(*out, namedRole)
+			}
+
+			return nil
+		},
+		func(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
+			out.LastModified = in.LastModified
+			out.RoleBindings = make(map[string]newer.RoleBinding)
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *newer.PolicyBinding, out *PolicyBinding, s conversion.Scope) error {
+			out.LastModified = in.LastModified
+			out.RoleBindings = make([]NamedRoleBinding, 0, 0)
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *[]NamedRoleBinding, out *map[string]newer.RoleBinding, s conversion.Scope) error {
+			for _, curr := range *in {
+				newRoleBinding := &newer.RoleBinding{}
+				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
+					return err
+				}
+				(*out)[curr.Name] = *newRoleBinding
+			}
+
+			return nil
+		},
+		func(in *map[string]newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
+			allKeys := make([]string, 0, len(*in))
+			for key := range *in {
+				allKeys = append(allKeys, key)
+			}
+			sort.Strings(allKeys)
+
+			for _, key := range allKeys {
+				newRoleBinding := (*in)[key]
+				oldRoleBinding := &RoleBinding{}
+				if err := s.Convert(&newRoleBinding, oldRoleBinding, 0); err != nil {
+					return err
+				}
+
+				namedRoleBinding := NamedRoleBinding{key, *oldRoleBinding}
+				*out = append(*out, namedRoleBinding)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+}

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -1,0 +1,23 @@
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("v1beta1",
+		&Role{},
+		&RoleBinding{},
+		&Policy{},
+		&PolicyBinding{},
+		&PolicyList{},
+		&PolicyBindingList{},
+	)
+}
+
+func (*Role) IsAnAPIObject()              {}
+func (*Policy) IsAnAPIObject()            {}
+func (*PolicyBinding) IsAnAPIObject()     {}
+func (*RoleBinding) IsAnAPIObject()       {}
+func (*PolicyList) IsAnAPIObject()        {}
+func (*PolicyBindingList) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -1,0 +1,99 @@
+package v1beta1
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+	kruntime "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// Authorization is calculated against
+// 1. all deny RoleBinding PolicyRules in the master namespace - short circuit on match
+// 2. all allow RoleBinding PolicyRules in the master namespace - short circuit on match
+// 3. all deny RoleBinding PolicyRules in the namespace - short circuit on match
+// 4. all allow RoleBinding PolicyRules in the namespace - short circuit on match
+// 5. deny by default
+
+const (
+	GlobalNamespace = "global"
+)
+
+// PolicyRule holds information that describes a policy rule, but does not contain information
+// about who the rule applies to or which namespace the rule applies to.
+type PolicyRule struct {
+	// Deny is true if any request matching this rule should be denied.  If false, any request matching this rule is allowed.
+	Deny bool `json:"deny"`
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  "*" represents all kinds.
+	Verbs []string `json:"verbs"`
+	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
+	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
+	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions"`
+	// ResourceKinds is a list of kinds this rule applies to.  "*" represents all kinds.
+	ResourceKinds []string `json:"resourceKinds""`
+}
+
+// Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
+type Role struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	Rules []PolicyRule `json:"rules"`
+}
+
+// RoleBinding references a Role, but not contain it.  It adds who and namespace information.
+// It can reference any Role in the same namespace or in the global namespace.
+type RoleBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	UserNames  []string `json:"userNames"`
+	GroupNames []string `json:"groupNames"`
+
+	// Since Policy is a singleton, this is sufficient knowledge to locate a role
+	// RoleRefs can only reference the current namespace and the global namespace
+	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef kapi.ObjectReference `json:"roleRef"`
+}
+
+// Policy is a object that holds all the Roles for a particular namespace.  There is at most
+// one Policy document per namespace.
+type Policy struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	LastModified kutil.Time `json:"lastModified"`
+
+	Roles []NamedRole `json:"roles"`
+}
+
+// PolicyBinding is a object that holds all the RoleBindings for a particular namespace.  There is
+// one PolicyBinding document per referenced Policy namespace
+type PolicyBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	LastModified kutil.Time `json:"lastModified"`
+
+	PolicyRef    kapi.ObjectReference `json:"policyRef"`
+	RoleBindings []NamedRoleBinding   `json:"roleBindings"`
+}
+
+type NamedRole struct {
+	Name string `json:"name"`
+	Role Role   `json:"role"`
+}
+
+type NamedRoleBinding struct {
+	Name        string      `json:"name"`
+	RoleBinding RoleBinding `json:"roleBinding"`
+}
+
+type PolicyList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Policy `json:"items"`
+}
+type PolicyBindingList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []PolicyBinding `json:"items"`
+}

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -1,0 +1,513 @@
+package authorizer
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
+	authcontext "github.com/openshift/origin/pkg/auth/context"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+)
+
+type openshiftAuthorizer struct {
+	masterAuthorizationNamespace string
+	policyRegistry               policyregistry.Registry
+	policyBindingRegistry        policybindingregistry.Registry
+}
+type openshiftAuthorizationAttributes struct {
+	user              authenticationapi.UserInfo
+	verb              string
+	resourceKind      string
+	namespace         string
+	requestAttributes interface{}
+}
+type openshiftAuthorizationAttributeBuilder struct {
+	requestsToUsers *authcontext.RequestContextMap
+}
+
+type Authorizer interface {
+	Authorize(a AuthorizationAttributes) (allowed bool, reason string, err error)
+}
+
+type AuthorizationAttributeBuilder interface {
+	GetAttributes(request *http.Request) (AuthorizationAttributes, error)
+}
+
+type AuthorizationAttributes interface {
+	GetUserInfo() authenticationapi.UserInfo
+	GetVerb() string
+	GetNamespace() string
+	// GetRequestAttributes is of type interface{} because different verbs and different Authorizer/AuthorizationAttributeBuilder pairs may have different contract requirements
+	GetRequestAttributes() interface{}
+}
+
+func NewAuthorizer(masterAuthorizationNamespace string, policyRuleBindingRegistry policyregistry.Registry, policyBindingRegistry policybindingregistry.Registry) Authorizer {
+	return &openshiftAuthorizer{masterAuthorizationNamespace, policyRuleBindingRegistry, policyBindingRegistry}
+}
+func NewAuthorizationAttributeBuilder(requestsToUsers *authcontext.RequestContextMap) AuthorizationAttributeBuilder {
+	return &openshiftAuthorizationAttributeBuilder{requestsToUsers}
+}
+
+func doesApplyToUser(ruleUsers, ruleGroups []string, user authenticationapi.UserInfo) bool {
+	if contains(ruleUsers, user.GetName()) {
+		return true
+	}
+
+	for _, currGroup := range user.GetGroups() {
+		if contains(ruleGroups, currGroup) {
+			return true
+		}
+	}
+
+	return false
+}
+func contains(list []string, token string) bool {
+	for _, curr := range list {
+		if curr == token {
+			return true
+		}
+	}
+	return false
+}
+
+// getPolicy provides a point for easy caching
+func (a *openshiftAuthorizer) getPolicy(namespace string) (*authorizationapi.Policy, error) {
+	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
+	policy, err := a.policyRegistry.GetPolicy(ctx, authorizationapi.PolicyName)
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+// getPolicy provides a point for easy caching
+func (a *openshiftAuthorizer) getPolicyBindings(namespace string) ([]authorizationapi.PolicyBinding, error) {
+	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
+	policyBindingList, err := a.policyBindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	return policyBindingList.Items, nil
+}
+
+// getRoleBindings provides a point for easy caching
+func (a *openshiftAuthorizer) getRoleBindings(namespace string) ([]authorizationapi.RoleBinding, error) {
+	policyBindings, err := a.getPolicyBindings(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]authorizationapi.RoleBinding, 0, len(policyBindings))
+	for _, policyBinding := range policyBindings {
+		for _, value := range policyBinding.RoleBindings {
+			ret = append(ret, value)
+		}
+	}
+
+	return ret, nil
+}
+
+// getRole
+func (a *openshiftAuthorizer) getRole(roleBinding authorizationapi.RoleBinding) (*authorizationapi.Role, error) {
+	roleNamespace := roleBinding.RoleRef.Namespace
+	roleName := roleBinding.RoleRef.Name
+
+	rolePolicy, err := a.getPolicy(roleNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	role, exists := rolePolicy.Roles[roleName]
+	if !exists {
+		return nil, fmt.Errorf("role %#v not found", roleBinding.RoleRef)
+	}
+
+	return &role, nil
+}
+
+func (a *openshiftAuthorizer) getEffectivePolicyRules(namespace string, user authenticationapi.UserInfo) ([]authorizationapi.PolicyRule, error) {
+	roleBindings, err := a.getRoleBindings(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	effectiveRules := make([]authorizationapi.PolicyRule, 0, len(roleBindings))
+	for _, roleBinding := range roleBindings {
+		role, err := a.getRole(roleBinding)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, curr := range role.Rules {
+			if doesApplyToUser(roleBinding.UserNames, roleBinding.GroupNames, user) {
+				effectiveRules = append(effectiveRules, curr)
+			}
+		}
+	}
+
+	return effectiveRules, nil
+}
+
+func (a *openshiftAuthorizer) Authorize(passedAttributes AuthorizationAttributes) (bool, string, error) {
+	// fmt.Printf("#### checking %#v\n", passedAttributes)
+
+	attributes, ok := passedAttributes.(openshiftAuthorizationAttributes)
+	if !ok {
+		return false, "", fmt.Errorf("attributes are not of expected type: %#v", attributes)
+	}
+
+	globalAllowed, globalDenied, err := a.authorizeWithNamespaceRules(a.masterAuthorizationNamespace, attributes)
+	if err != nil {
+		return false, "", err
+	}
+	if len(globalDenied) > 0 {
+		return false, globalDenied, err
+	}
+	if len(globalAllowed) > 0 {
+		return true, globalAllowed, err
+	}
+
+	if len(attributes.GetNamespace()) != 0 {
+		namespaceAllowed, namespaceDenied, err := a.authorizeWithNamespaceRules(attributes.GetNamespace(), attributes)
+		if err != nil {
+			return false, "", err
+		}
+		if len(namespaceDenied) > 0 {
+			return false, namespaceDenied, err
+		}
+		if len(namespaceAllowed) > 0 {
+			return true, namespaceAllowed, err
+		}
+	}
+
+	return false, "denied by default", nil
+}
+
+func (a *openshiftAuthorizer) authorizeWithNamespaceRules(namespace string, passedAttributes AuthorizationAttributes) (string, string, error) {
+	attributes, ok := passedAttributes.(openshiftAuthorizationAttributes)
+	if !ok {
+		return "", "", fmt.Errorf("attributes are not of expected type: %#v", attributes)
+	}
+
+	allRules, err := a.getEffectivePolicyRules(namespace, attributes.GetUserInfo())
+	if err != nil {
+		return "", "", err
+	}
+
+	// check for denies
+	for _, rule := range allRules {
+		if !rule.Deny {
+			continue
+		}
+
+		matches, err := attributes.ruleMatches(rule)
+		if err != nil {
+			return "", "", err
+		}
+		if matches {
+			return "", fmt.Sprintf("denied by rule in %v: %#v", namespace, rule), nil
+		}
+	}
+
+	// check for allows
+	for _, rule := range allRules {
+		if rule.Deny {
+			continue
+		}
+
+		matches, err := attributes.ruleMatches(rule)
+		if err != nil {
+			return "", "", err
+		}
+		if matches {
+			return fmt.Sprintf("allowed by rule in %v: %#v", namespace, rule), "", nil
+		}
+	}
+
+	return "", "", nil
+}
+
+func (a openshiftAuthorizationAttributes) ruleMatches(rule authorizationapi.PolicyRule) (bool, error) {
+	if a.verbMatches(rule) {
+		if a.kindMatches(rule) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (a openshiftAuthorizationAttributes) verbMatches(rule authorizationapi.PolicyRule) bool {
+	verbMatches := false
+	verbMatches = verbMatches || contains(rule.Verbs, a.GetVerb())
+	verbMatches = verbMatches || contains(rule.Verbs, "*")
+
+	//check for negations that would force this match to false
+	verbMatches = verbMatches && !contains(rule.Verbs, "-"+a.GetVerb())
+	verbMatches = verbMatches && !contains(rule.Verbs, "-*")
+
+	return verbMatches
+}
+
+func (a openshiftAuthorizationAttributes) kindMatches(rule authorizationapi.PolicyRule) bool {
+	kindMatches := false
+	kindMatches = kindMatches || contains(rule.ResourceKinds, a.GetResourceKind())
+	kindMatches = kindMatches || contains(rule.ResourceKinds, "*")
+
+	//check for negations that would force this match to false
+	kindMatches = kindMatches && !contains(rule.ResourceKinds, "-"+a.GetResourceKind())
+	kindMatches = kindMatches && !contains(rule.ResourceKinds, "-*")
+
+	return kindMatches
+}
+
+func (a openshiftAuthorizationAttributes) GetUserInfo() authenticationapi.UserInfo {
+	return a.user
+}
+func (a openshiftAuthorizationAttributes) GetVerb() string {
+	return a.verb
+}
+func (a openshiftAuthorizationAttributes) GetResourceKind() string {
+	return a.resourceKind
+}
+func (a openshiftAuthorizationAttributes) GetNamespace() string {
+	return a.namespace
+}
+func (a openshiftAuthorizationAttributes) GetRequestAttributes() interface{} {
+	return a.requestAttributes
+}
+
+func (a *openshiftAuthorizationAttributeBuilder) GetAttributes(req *http.Request) (AuthorizationAttributes, error) {
+	verb, kind, namespace, _, err := VerbAndKindAndNamespace(req)
+	if err != nil {
+		return nil, err
+	}
+
+	userInterface, ok := a.requestsToUsers.Get(req)
+	if !ok {
+		return nil, errors.New("could not get user")
+	}
+	userInfo, ok := userInterface.(authenticationapi.UserInfo)
+	if !ok {
+		return nil, errors.New("wrong type returned for user")
+	}
+
+	return openshiftAuthorizationAttributes{
+		user:              userInfo,
+		verb:              verb,
+		resourceKind:      kind,
+		namespace:         namespace,
+		requestAttributes: nil,
+	}, nil
+}
+
+// TODO waiting on kube rebase
+// this section is copied from kube.  Need to modify kube to make this pluggable
+var specialVerbs = map[string]bool{
+	"proxy":    true,
+	"redirect": true,
+	"watch":    true,
+}
+
+func VerbAndKindAndNamespace(req *http.Request) (string, string, string, []string, error) {
+	parts := splitPath(req.URL.Path)
+
+	verb := ""
+	switch req.Method {
+	case "POST":
+		verb = "create"
+	case "GET":
+		verb = "get"
+	case "PUT":
+		verb = "update"
+	case "DELETE":
+		verb = "delete"
+	}
+
+	if parts[0] == "osapi" {
+		if len(parts) > 2 {
+			parts = parts[2:]
+		} else {
+			return "", "", "", nil, fmt.Errorf("Unable to determine kind and namespace from url, %v", req.URL)
+		}
+	}
+
+	// TODO tweak upstream to eliminate this copy
+	// handle input of form /api/{version}/* by adjusting special paths
+	if parts[0] == "api" {
+		if len(parts) > 2 {
+			parts = parts[2:]
+		} else {
+			return "", "", "", parts, fmt.Errorf("Unable to determine kind and namespace from url, %v", req.URL)
+		}
+	}
+
+	// handle input of form /{specialVerb}/*
+	if _, ok := specialVerbs[parts[0]]; ok {
+		verb = parts[0]
+		if len(parts) > 1 {
+			parts = parts[1:]
+		} else {
+			return "", "", "", parts, fmt.Errorf("Unable to determine kind and namespace from url, %v", req.URL)
+		}
+	}
+
+	// URL forms: /ns/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
+	if parts[0] == "ns" {
+		if len(parts) < 3 {
+			return "", "", "", parts, fmt.Errorf("ResourceTypeAndNamespace expects a path of form /ns/{namespace}/*")
+		}
+		return verb, parts[1], parts[2], parts[2:], fmt.Errorf("Unable to determine kind and namespace from url, %v", req.URL)
+	}
+
+	// URL forms: /{kind}/*
+	// URL forms: POST /{kind} is a legacy API convention to create in "default" namespace
+	// URL forms: /{kind}/{resourceName} use the "default" namespace if omitted from query param
+	// URL forms: /{kind} assume cross-namespace operation if omitted from query param
+	kind := parts[0]
+	namespace := req.URL.Query().Get("namespace")
+	if len(namespace) == 0 {
+		if len(parts) > 1 || req.Method == "POST" {
+			namespace = kapi.NamespaceDefault
+		} else {
+			namespace = kapi.NamespaceAll
+		}
+	}
+	return verb, kind, namespace, parts, nil
+}
+
+// splitPath returns the segments for a URL path.
+func splitPath(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return []string{}
+	}
+	return strings.Split(path, "/")
+}
+
+func GetBootstrapPolicy(masterNamespace string) *authorizationapi.Policy {
+	return &authorizationapi.Policy{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:              authorizationapi.PolicyName,
+			Namespace:         masterNamespace,
+			CreationTimestamp: util.Now(),
+		},
+		LastModified: util.Now(),
+		Roles: map[string]authorizationapi.Role{
+			"cluster-admin": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "cluster-admin",
+					Namespace: masterNamespace,
+				},
+				Rules: append(make([]authorizationapi.PolicyRule, 0),
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "*"),
+						ResourceKinds: append(make([]string, 0), "*"),
+					}),
+			},
+			"admin": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "admin",
+					Namespace: masterNamespace,
+				},
+				Rules: append(make([]authorizationapi.PolicyRule, 0),
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "*", "-create", "-update", "-delete"),
+						ResourceKinds: append(make([]string, 0), "*"),
+					},
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "create", "update", "delete"),
+						ResourceKinds: append(make([]string, 0), "*", "-roles", "-policyBindings"),
+					},
+				),
+			},
+			"edit": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "edit",
+					Namespace: masterNamespace,
+				},
+				Rules: append(make([]authorizationapi.PolicyRule, 0),
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "*", "-create", "-update", "-delete"),
+						ResourceKinds: append(make([]string, 0), "*", "-roles", "-roleBindings", "-policyBindings", "-policies"),
+					},
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "create", "update", "delete"),
+						ResourceKinds: append(make([]string, 0), "*", "-roles", "-roleBindings", "-policyBindings", "-policies"),
+					},
+				),
+			},
+			"view": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "view",
+					Namespace: masterNamespace,
+				},
+				Rules: append(make([]authorizationapi.PolicyRule, 0),
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "watch", "list", "get"),
+						ResourceKinds: append(make([]string, 0), "*", "-roles", "-roleBindings", "-policyBindings", "-policies"),
+					}),
+			},
+			"ComponentRole": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "ComponentRole",
+					Namespace: masterNamespace,
+				},
+				Rules: append(make([]authorizationapi.PolicyRule, 0),
+					authorizationapi.PolicyRule{
+						Verbs:         append(make([]string, 0), "*"),
+						ResourceKinds: append(make([]string, 0), "*"),
+					}),
+			},
+		},
+	}
+}
+
+func GetBootstrapPolicyBinding(masterNamespace string) *authorizationapi.PolicyBinding {
+	return &authorizationapi.PolicyBinding{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:              masterNamespace,
+			Namespace:         masterNamespace,
+			CreationTimestamp: util.Now(),
+		},
+		LastModified: util.Now(),
+		PolicyRef:    kapi.ObjectReference{Namespace: masterNamespace},
+		RoleBindings: map[string]authorizationapi.RoleBinding{
+			"Components": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "Components",
+					Namespace: masterNamespace,
+				},
+				RoleRef: kapi.ObjectReference{
+					Name:      "ComponentRole",
+					Namespace: masterNamespace,
+				},
+				// until we get components added to their proper groups, enumerate them here
+				UserNames:  append(make([]string, 0), "openshift-client", "kube-client"),
+				GroupNames: append(make([]string, 0), "SystemComponents"),
+			},
+			"Cluster-Admins": {
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "Cluster-Admins",
+					Namespace: masterNamespace,
+				},
+				RoleRef: kapi.ObjectReference{
+					Name:      "cluster-admin",
+					Namespace: masterNamespace,
+				},
+				// until we decide to enforce policy, simply allow every one access
+				GroupNames: append(make([]string, 0), "system:authenticated", "system:unauthenticated"),
+			},
+		},
+	}
+}

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -1,0 +1,460 @@
+package authorizer
+
+import (
+	"strings"
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
+)
+
+const testMasterNamespace = "master"
+
+type authorizeTest struct {
+	globalPolicy         []authorizationapi.Policy
+	namespacedPolicy     []authorizationapi.Policy
+	policyRetrievalError error
+
+	globalPolicyBinding         []authorizationapi.PolicyBinding
+	namespacedPolicyBinding     []authorizationapi.PolicyBinding
+	policyBindingRetrievalError error
+
+	attributes *openshiftAuthorizationAttributes
+
+	expectedAllowed bool
+	expectedReason  string
+	expectedError   string
+}
+
+func TestAdminEditingGlobalDeploymentConfig(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "ClusterAdmin",
+			},
+			verb:         "update",
+			resourceKind: "deploymentConfigs",
+			namespace:    testMasterNamespace,
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in master",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.test(t)
+}
+
+func TestDisallowedViewingGlobalPods(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "SomeYahoo",
+			},
+			verb:         "get",
+			resourceKind: "pods",
+			namespace:    testMasterNamespace,
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.test(t)
+}
+
+func TestNegationKinds(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Valerie",
+			},
+			verb:         "get",
+			resourceKind: "policyBindings",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestNegationVerbs(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Ellen",
+			},
+			verb:         "update",
+			resourceKind: "roleBindings",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestProjectAdminEditPolicy(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Anna",
+			},
+			verb:         "update",
+			resourceKind: "policies",
+			namespace:    "adze",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in adze",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestGlobalPolicyOutranksLocalPolicy(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "ClusterAdmin",
+			},
+			verb:         "update",
+			resourceKind: "policies",
+			namespace:    "adze",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in master",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestAntiAdminDenyLocalPolicy(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "PowerlessUser",
+			},
+			verb:         "update",
+			resourceKind: "policies",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by rule in adze",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestDeniesOutrankAllows(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "TeasedAdmin",
+			},
+			verb:         "update",
+			resourceKind: "policies",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by rule in adze",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestResourceKindRestrictionsWork(t *testing.T) {
+	test1 := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Rachel",
+			},
+			verb:         "get",
+			resourceKind: "buildConfigs",
+			namespace:    "adze",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in adze",
+	}
+	test1.globalPolicy, test1.globalPolicyBinding = newDefaultGlobalPolicy()
+	test1.namespacedPolicy, test1.namespacedPolicyBinding = newAdzePolicy()
+	test1.test(t)
+
+	test2 := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Rachel",
+			},
+			verb:         "get",
+			resourceKind: "pods",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test2.globalPolicy, test2.globalPolicyBinding = newDefaultGlobalPolicy()
+	test2.namespacedPolicy, test2.namespacedPolicyBinding = newAdzePolicy()
+	test2.test(t)
+}
+
+func TestLocalRightsDoNotGrantGlobalRights(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Rachel",
+			},
+			verb:         "get",
+			resourceKind: "buildConfigs",
+			namespace:    "backsaw",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = newAdzePolicy()
+	test.test(t)
+}
+
+func TestVerbRestrictionsWork(t *testing.T) {
+	test1 := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Valerie",
+			},
+			verb:         "get",
+			resourceKind: "buildConfigs",
+			namespace:    "adze",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in adze",
+	}
+	test1.globalPolicy, test1.globalPolicyBinding = newDefaultGlobalPolicy()
+	test1.namespacedPolicy, test1.namespacedPolicyBinding = newAdzePolicy()
+	test1.test(t)
+
+	test2 := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Valerie",
+			},
+			verb:         "create",
+			resourceKind: "buildConfigs",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test2.globalPolicy, test2.globalPolicyBinding = newDefaultGlobalPolicy()
+	test2.namespacedPolicy, test2.namespacedPolicyBinding = newAdzePolicy()
+	test2.test(t)
+}
+
+func (test *authorizeTest) test(t *testing.T) {
+	policies := make([]authorizationapi.Policy, 0, 0)
+	policies = append(policies, test.namespacedPolicy...)
+	policies = append(policies, test.globalPolicy...)
+	policyRegistry := &testpolicyregistry.PolicyRegistry{
+		Err:             test.policyRetrievalError,
+		MasterNamespace: testMasterNamespace,
+		Policies:        policies,
+	}
+
+	policyBindings := make([]authorizationapi.PolicyBinding, 0, 0)
+	policyBindings = append(policyBindings, test.namespacedPolicyBinding...)
+	policyBindings = append(policyBindings, test.globalPolicyBinding...)
+	policyBindingRegistry := &testpolicyregistry.PolicyBindingRegistry{
+		Err:             test.policyBindingRetrievalError,
+		MasterNamespace: testMasterNamespace,
+		PolicyBindings:  policyBindings,
+	}
+	authorizer := NewAuthorizer(testMasterNamespace, policyRegistry, policyBindingRegistry)
+
+	actualAllowed, actualReason, actualError := authorizer.Authorize(*test.attributes)
+
+	matchBool(test.expectedAllowed, actualAllowed, "allowed", t)
+	if actualAllowed {
+		containsString(test.expectedReason, actualReason, "allowReason", t)
+	} else {
+		containsString(test.expectedReason, actualReason, "denyReason", t)
+		matchError(test.expectedError, actualError, "error", t)
+	}
+}
+
+func matchString(expected, actual string, field string, t *testing.T) {
+	if expected != actual {
+		t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+	}
+}
+func containsString(expected, actual string, field string, t *testing.T) {
+	if len(expected) == 0 && len(actual) != 0 {
+		t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+		return
+	}
+	if !strings.Contains(actual, expected) {
+		t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+	}
+}
+func matchBool(expected, actual bool, field string, t *testing.T) {
+	if expected != actual {
+		t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+	}
+}
+func matchError(expected string, actual error, field string, t *testing.T) {
+	if actual == nil {
+		if len(expected) != 0 {
+			t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+			return
+		} else {
+			return
+		}
+	}
+	if actual != nil && len(expected) == 0 {
+		t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+		return
+	}
+	if strings.Contains(actual.Error(), expected) {
+		t.Errorf("%v: Expected %v, got %v", field, expected, actual)
+	}
+}
+
+func newDefaultGlobalPolicy() ([]authorizationapi.Policy, []authorizationapi.PolicyBinding) {
+	return append(make([]authorizationapi.Policy, 0, 0), *GetBootstrapPolicy(testMasterNamespace)),
+		append(make([]authorizationapi.PolicyBinding, 0, 0),
+			authorizationapi.PolicyBinding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      testMasterNamespace,
+					Namespace: testMasterNamespace,
+				},
+				RoleBindings: map[string]authorizationapi.RoleBinding{
+					"cluster-admins": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "cluster-admins",
+							Namespace: testMasterNamespace,
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "cluster-admin",
+							Namespace: testMasterNamespace,
+						},
+						// until we get components authenticating, mssing users will be given all rights.  Yay, security!
+						UserNames: append(make([]string, 0), "ClusterAdmin"),
+					},
+				},
+			},
+		)
+}
+
+func newAdzePolicy() ([]authorizationapi.Policy, []authorizationapi.PolicyBinding) {
+	return append(make([]authorizationapi.Policy, 0, 0),
+			authorizationapi.Policy{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      authorizationapi.PolicyName,
+					Namespace: "adze",
+				},
+				Roles: map[string]authorizationapi.Role{
+					"restrictedViewer": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "admin",
+							Namespace: "adze",
+						},
+						Rules: append(make([]authorizationapi.PolicyRule, 0),
+							authorizationapi.PolicyRule{
+								Verbs:         append(make([]string, 0), "watch", "list", "get"),
+								ResourceKinds: append(make([]string, 0), "buildConfigs"),
+							}),
+					},
+					"anti-admin": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "anti-admin",
+							Namespace: testMasterNamespace,
+						},
+						Rules: append(make([]authorizationapi.PolicyRule, 0),
+							authorizationapi.PolicyRule{
+								Deny:          true,
+								Verbs:         append(make([]string, 0), "*"),
+								ResourceKinds: append(make([]string, 0), "*"),
+							}),
+					},
+				},
+			}),
+		append(make([]authorizationapi.PolicyBinding, 0, 0),
+			authorizationapi.PolicyBinding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      testMasterNamespace,
+					Namespace: "adze",
+				},
+				RoleBindings: map[string]authorizationapi.RoleBinding{
+					"projectAdmins": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "projectAdmins",
+							Namespace: "adze",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "admin",
+							Namespace: testMasterNamespace,
+						},
+						UserNames: append(make([]string, 0), "Anna", "TeasedAdmin"),
+					},
+					"viewers": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "viewers",
+							Namespace: "adze",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "view",
+							Namespace: testMasterNamespace,
+						},
+						UserNames: append(make([]string, 0), "Valerie"),
+					},
+					"editors": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "editors",
+							Namespace: "adze",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "edit",
+							Namespace: testMasterNamespace,
+						},
+						UserNames: append(make([]string, 0), "Ellen"),
+					},
+				},
+			},
+			authorizationapi.PolicyBinding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "adze",
+					Namespace: "adze",
+				},
+				RoleBindings: map[string]authorizationapi.RoleBinding{
+					"anti-admins": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "anti-admins",
+							Namespace: "adze",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "anti-admin",
+							Namespace: "adze",
+						},
+						UserNames: append(make([]string, 0), "ClusterAdmin", "PowerlessUser", "TeasedAdmin"),
+					},
+					"restrictedViewers": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "restrictedViewers",
+							Namespace: "adze",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "restrictedViewer",
+							Namespace: "adze",
+						},
+						UserNames: append(make([]string, 0), "Rachel"),
+					},
+				},
+			},
+		)
+}

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -1,0 +1,395 @@
+package authorizer
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	authenticationapi "github.com/openshift/origin/pkg/auth/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func TestViewerGetAllowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Victor",
+			},
+			verb:         "get",
+			resourceKind: "pods",
+			namespace:    "mallet",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in mallet",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestViewerGetAllowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Victor",
+			},
+			verb:         "get",
+			resourceKind: "pods",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestViewerGetDisallowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Victor",
+			},
+			verb:         "get",
+			resourceKind: "policies",
+			namespace:    "mallet",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestViewerGetDisallowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Victor",
+			},
+			verb:         "get",
+			resourceKind: "policies",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestViewerCreateAllowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Victor",
+			},
+			verb:         "create",
+			resourceKind: "pods",
+			namespace:    "mallet",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestViewerCreateAllowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Victor",
+			},
+			verb:         "create",
+			resourceKind: "pods",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestEditorUpdateAllowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Edgar",
+			},
+			verb:         "update",
+			resourceKind: "pods",
+			namespace:    "mallet",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in mallet",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestEditorUpdateAllowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Edgar",
+			},
+			verb:         "update",
+			resourceKind: "pods",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestEditorUpdateDisallowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Edgar",
+			},
+			verb:         "update",
+			resourceKind: "roleBindings",
+			namespace:    "mallet",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestEditorUpdateDisallowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Edgar",
+			},
+			verb:         "update",
+			resourceKind: "roleBindings",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestEditorGetAllowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Edgar",
+			},
+			verb:         "get",
+			resourceKind: "pods",
+			namespace:    "mallet",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in mallet",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestEditorGetAllowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Edgar",
+			},
+			verb:         "get",
+			resourceKind: "pods",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestAdminUpdateAllowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Matthew",
+			},
+			verb:         "update",
+			resourceKind: "roleBindings",
+			namespace:    "mallet",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in mallet",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestAdminUpdateAllowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Matthew",
+			},
+			verb:         "update",
+			resourceKind: "roleBindings",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestAdminUpdateDisallowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Matthew",
+			},
+			verb:         "update",
+			resourceKind: "roles",
+			namespace:    "mallet",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestAdminUpdateDisallowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Matthew",
+			},
+			verb:         "update",
+			resourceKind: "roles",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func TestAdminGetAllowedKindInMallet(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Matthew",
+			},
+			verb:         "get",
+			resourceKind: "policies",
+			namespace:    "mallet",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in mallet",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+func TestAdminGetAllowedKindInAdze(t *testing.T) {
+	test := &authorizeTest{
+		attributes: &openshiftAuthorizationAttributes{
+			user: &authenticationapi.DefaultUserInfo{
+				Name: "Matthew",
+			},
+			verb:         "get",
+			resourceKind: "policies",
+			namespace:    "adze",
+		},
+		expectedAllowed: false,
+		expectedReason:  "denied by default",
+	}
+	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
+	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.test(t)
+}
+
+func allNamespacedPolicies() ([]authorizationapi.Policy, []authorizationapi.PolicyBinding) {
+	adzePolicy, adzeBinding := newMalletPolicy()
+	malletPolicy, malletBinding := newMalletPolicy()
+
+	policies := make([]authorizationapi.Policy, 0)
+	policies = append(policies, adzePolicy...)
+	policies = append(policies, malletPolicy...)
+
+	bindings := make([]authorizationapi.PolicyBinding, 0)
+	bindings = append(bindings, adzeBinding...)
+	bindings = append(bindings, malletBinding...)
+
+	return policies, bindings
+
+}
+
+func newMalletPolicy() ([]authorizationapi.Policy, []authorizationapi.PolicyBinding) {
+	return append(make([]authorizationapi.Policy, 0, 0),
+			authorizationapi.Policy{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      authorizationapi.PolicyName,
+					Namespace: "mallet",
+				},
+				Roles: map[string]authorizationapi.Role{},
+			}),
+		append(make([]authorizationapi.PolicyBinding, 0, 0),
+			authorizationapi.PolicyBinding{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      testMasterNamespace,
+					Namespace: "mallet",
+				},
+				RoleBindings: map[string]authorizationapi.RoleBinding{
+					"projectAdmins": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "projectAdmins",
+							Namespace: "mallet",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "admin",
+							Namespace: testMasterNamespace,
+						},
+						UserNames: append(make([]string, 0), "Matthew"),
+					},
+					"viewers": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "viewers",
+							Namespace: "mallet",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "view",
+							Namespace: testMasterNamespace,
+						},
+						UserNames: append(make([]string, 0), "Victor"),
+					},
+					"editors": {
+						ObjectMeta: kapi.ObjectMeta{
+							Name:      "editors",
+							Namespace: "mallet",
+						},
+						RoleRef: kapi.ObjectReference{
+							Name:      "edit",
+							Namespace: testMasterNamespace,
+						},
+						UserNames: append(make([]string, 0), "Edgar"),
+					},
+				},
+			},
+		)
+}

--- a/pkg/authorization/registry/etcd/etcd.go
+++ b/pkg/authorization/registry/etcd/etcd.go
@@ -1,0 +1,150 @@
+package etcd
+
+import (
+	"errors"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kmeta "github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	kubeetcd "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// Etcd implements the Policy, AuthorizeToken, and Client registries backed by etcd.
+type Etcd struct {
+	policyRegistry        *etcdgeneric.Etcd
+	policyBindingRegistry *etcdgeneric.Etcd
+}
+
+const (
+	PolicyPath        = "/registry/authorization/policy"
+	PolicyBindingPath = "/registry/authorization/policyBinding"
+)
+
+// New returns a new Etcd.
+func New(helper tools.EtcdHelper) *Etcd {
+	return &Etcd{
+		policyRegistry: &etcdgeneric.Etcd{
+			NewFunc:      func() runtime.Object { return &authorizationapi.Policy{} },
+			NewListFunc:  func() runtime.Object { return &authorizationapi.PolicyList{} },
+			EndpointName: "policy",
+			KeyRootFunc: func(ctx kapi.Context) string {
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, PolicyPath)
+			},
+			KeyFunc: func(ctx kapi.Context, id string) (string, error) {
+				return etcdgeneric.NamespaceKeyFunc(ctx, PolicyPath, id)
+			},
+			Helper: helper,
+		},
+		policyBindingRegistry: &etcdgeneric.Etcd{
+			NewFunc:      func() runtime.Object { return &authorizationapi.PolicyBinding{} },
+			NewListFunc:  func() runtime.Object { return &authorizationapi.PolicyBindingList{} },
+			EndpointName: "policyBinding",
+			KeyRootFunc: func(ctx kapi.Context) string {
+				return etcdgeneric.NamespaceKeyRootFunc(ctx, PolicyBindingPath)
+			},
+			KeyFunc: func(ctx kapi.Context, id string) (string, error) {
+				return etcdgeneric.NamespaceKeyFunc(ctx, PolicyBindingPath, id)
+			},
+			Helper: helper,
+		},
+	}
+}
+
+func getAttrs(obj runtime.Object) (klabels.Set, klabels.Set, error) {
+	metaInterface, err := kmeta.Accessor(obj)
+	if err != nil {
+		return klabels.Set{}, klabels.Set{}, err
+	}
+
+	return metaInterface.Labels(), klabels.Set{}, nil
+}
+
+func (r *Etcd) GetPolicy(ctx kapi.Context, name string) (policy *authorizationapi.Policy, err error) {
+	result, err := r.policyRegistry.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	ret, ok := result.(*authorizationapi.Policy)
+	if !ok {
+		return nil, errors.New("invalid object type")
+	}
+
+	return ret, nil
+}
+
+func (r *Etcd) ListPolicies(ctx kapi.Context, label, field klabels.Selector) (*authorizationapi.PolicyList, error) {
+	result, err := r.policyRegistry.List(ctx, &generic.SelectionPredicate{label, field, getAttrs})
+	if err != nil {
+		return nil, err
+	}
+	ret, ok := result.(*authorizationapi.PolicyList)
+	if !ok {
+		return nil, errors.New("invalid object type")
+	}
+
+	return ret, nil
+}
+
+func (r *Etcd) CreatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error {
+	return r.policyRegistry.Create(ctx, policy.Name, policy)
+}
+
+func (r *Etcd) UpdatePolicy(ctx kapi.Context, newPolicy *authorizationapi.Policy) error {
+	return r.policyRegistry.Update(ctx, newPolicy.Name, newPolicy)
+}
+
+func (r *Etcd) DeletePolicy(ctx kapi.Context, name string) error {
+	return r.policyRegistry.Delete(ctx, name)
+}
+
+func makePolicyBindingListKey(ctx kapi.Context) string {
+	return kubeetcd.MakeEtcdListKey(ctx, PolicyBindingPath)
+}
+
+func makePolicyBindingKey(ctx kapi.Context, id string) (string, error) {
+	return kubeetcd.MakeEtcdItemKey(ctx, PolicyBindingPath, id)
+}
+
+func (r *Etcd) GetPolicyBinding(ctx kapi.Context, name string) (policyBinding *authorizationapi.PolicyBinding, err error) {
+	result, err := r.policyBindingRegistry.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	ret, ok := result.(*authorizationapi.PolicyBinding)
+	if !ok {
+		return nil, errors.New("invalid object type")
+	}
+
+	return ret, nil
+}
+
+func (r *Etcd) ListPolicyBindings(ctx kapi.Context, label, field klabels.Selector) (*authorizationapi.PolicyBindingList, error) {
+	result, err := r.policyBindingRegistry.List(ctx, &generic.SelectionPredicate{label, field, getAttrs})
+	if err != nil {
+		return nil, err
+	}
+	ret, ok := result.(*authorizationapi.PolicyBindingList)
+	if !ok {
+		return nil, errors.New("invalid object type")
+	}
+
+	return ret, nil
+}
+
+func (r *Etcd) CreatePolicyBinding(ctx kapi.Context, binding *authorizationapi.PolicyBinding) error {
+	return r.policyBindingRegistry.Create(ctx, binding.Name, binding)
+}
+
+func (r *Etcd) UpdatePolicyBinding(ctx kapi.Context, newPolicyBinding *authorizationapi.PolicyBinding) error {
+	return r.policyBindingRegistry.Update(ctx, newPolicyBinding.Name, newPolicyBinding)
+}
+
+func (r *Etcd) DeletePolicyBinding(ctx kapi.Context, name string) error {
+	return r.policyBindingRegistry.Delete(ctx, name)
+}

--- a/pkg/authorization/registry/policy/registry.go
+++ b/pkg/authorization/registry/policy/registry.go
@@ -1,0 +1,22 @@
+package policy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// Registry is an interface for things that know how to store Policies.
+type Registry interface {
+	// ListPolicies obtains list of policys that match a selector.
+	ListPolicies(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.PolicyList, error)
+	// GetPolicy retrieves a specific policy.
+	GetPolicy(ctx kapi.Context, id string) (*authorizationapi.Policy, error)
+	// CreatePolicy creates a new policy.
+	CreatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error
+	// UpdatePolicy updates a policy.
+	UpdatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error
+	// DeletePolicy deletes a policy.
+	DeletePolicy(ctx kapi.Context, id string) error
+}

--- a/pkg/authorization/registry/policy/rest.go
+++ b/pkg/authorization/registry/policy/rest.go
@@ -1,0 +1,54 @@
+package policy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	registry Registry
+}
+
+// NewREST creates a new REST for policies.
+func NewREST(registry Registry) apiserver.RESTStorage {
+	return &REST{registry}
+}
+
+// New creates a new Policy object
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.Policy{}
+}
+func (r *REST) NewList() runtime.Object {
+	return &authorizationapi.PolicyList{}
+}
+
+// List obtains a list of Policies that match selector.
+func (r *REST) List(ctx kapi.Context, selector, fields klabels.Selector) (runtime.Object, error) {
+	policies, err := r.registry.ListPolicies(ctx, selector, fields)
+	if err != nil {
+		return nil, err
+	}
+	return policies, err
+
+}
+
+// Get obtains the policy specified by its id.
+func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
+	policy, err := r.registry.GetPolicy(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return policy, err
+}
+
+// Delete asynchronously deletes the Policy specified by its id.
+func (r *REST) Delete(ctx kapi.Context, id string) (<-chan apiserver.RESTResult, error) {
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		return &kapi.Status{Status: kapi.StatusSuccess}, r.registry.DeletePolicy(ctx, id)
+	}), nil
+}

--- a/pkg/authorization/registry/policy/rest_test.go
+++ b/pkg/authorization/registry/policy/rest_test.go
@@ -1,0 +1,186 @@
+package policy
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/registry/test"
+)
+
+func TestGetError(t *testing.T) {
+	registry := test.PolicyRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Get(ctx, "name")
+	if err == nil {
+		t.Errorf("expected error")
+		return
+	}
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+}
+
+func TestGetValid(t *testing.T) {
+	registry := test.PolicyRegistry{
+		Policies: append(make([]authorizationapi.Policy, 0),
+			authorizationapi.Policy{
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+			}),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	policy, err := storage.Get(ctx, authorizationapi.PolicyName)
+	if err != nil {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+	if reflect.DeepEqual(policy, registry.Policies[0]) {
+		t.Errorf("got unexpected policy: %v", policy)
+		return
+	}
+}
+
+func TestListError(t *testing.T) {
+	registry := test.PolicyRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err == nil {
+		t.Errorf("expected error")
+		return
+	}
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	registry := test.PolicyRegistry{
+		Policies: make([]authorizationapi.Policy, 0),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	policies, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+	switch policies := policies.(type) {
+	case *authorizationapi.PolicyList:
+		if len(policies.Items) != 0 {
+			t.Errorf("expected empty list, got %#v", policies)
+		}
+	default:
+		t.Errorf("expected policyList, got: %v", policies)
+		return
+	}
+}
+
+func TestList(t *testing.T) {
+	registry := test.PolicyRegistry{
+		Policies: append(make([]authorizationapi.Policy, 0),
+			authorizationapi.Policy{
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+			}),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	policies, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+	switch policies := policies.(type) {
+	case *authorizationapi.PolicyList:
+		if len(policies.Items) != 1 {
+			t.Errorf("expected list with 1 item, got %#v", policies)
+		}
+	default:
+		t.Errorf("expected policyList, got: %v", policies)
+		return
+	}
+}
+
+func TestDeleteError(t *testing.T) {
+	registry := test.PolicyRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Message == registry.Err.Error() {
+				// expected case
+			} else {
+				t.Errorf("Got back unexpected error: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestDeleteValid(t *testing.T) {
+	registry := test.PolicyRegistry{}
+	storage := REST{
+		registry: &registry,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Status != "Success" {
+				t.Errorf("Got back non-success status: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+
+	if registry.DeletedPolicyName != "foo" {
+		t.Error("Unexpected policy deleted: %s", registry.DeletedPolicyName)
+	}
+}

--- a/pkg/authorization/registry/policybinding/registry.go
+++ b/pkg/authorization/registry/policybinding/registry.go
@@ -1,0 +1,22 @@
+package policybinding
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// Registry is an interface for things that know how to store Policies.
+type Registry interface {
+	// ListPolicyBindings obtains list of policyBindings that match a selector.
+	ListPolicyBindings(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.PolicyBindingList, error)
+	// GetPolicyBinding retrieves a specific policyBinding.
+	GetPolicyBinding(ctx kapi.Context, id string) (*authorizationapi.PolicyBinding, error)
+	// CreatePolicyBinding creates a new policyBinding.
+	CreatePolicyBinding(ctx kapi.Context, policyBinding *authorizationapi.PolicyBinding) error
+	// UpdatePolicyBinding updates a policyBinding.
+	UpdatePolicyBinding(ctx kapi.Context, policyBinding *authorizationapi.PolicyBinding) error
+	// DeletePolicyBinding deletes a policyBinding.
+	DeletePolicyBinding(ctx kapi.Context, id string) error
+}

--- a/pkg/authorization/registry/policybinding/rest.go
+++ b/pkg/authorization/registry/policybinding/rest.go
@@ -1,0 +1,100 @@
+package policybinding
+
+import (
+	"errors"
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	registry Registry
+}
+
+// NewREST creates a new REST for policyBindings.
+func NewREST(registry Registry) apiserver.RESTStorage {
+	return &REST{registry}
+}
+
+// New creates a new PolicyBinding object
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.PolicyBinding{}
+}
+
+func (r *REST) NewList() runtime.Object {
+	return &authorizationapi.PolicyBindingList{}
+}
+
+// List obtains a list of PolicyBindings that match selector.
+func (r *REST) List(ctx kapi.Context, selector, fields klabels.Selector) (runtime.Object, error) {
+	policyBindings, err := r.registry.ListPolicyBindings(ctx, selector, fields)
+	if err != nil {
+		return nil, err
+	}
+	return policyBindings, err
+
+}
+
+// Get obtains the policyBinding specified by its id.
+func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
+	policyBinding, err := r.registry.GetPolicyBinding(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return policyBinding, err
+}
+
+// Delete asynchronously deletes the PolicyBinding specified by its id.
+func (r *REST) Delete(ctx kapi.Context, id string) (<-chan apiserver.RESTResult, error) {
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		return &kapi.Status{Status: kapi.StatusSuccess}, r.registry.DeletePolicyBinding(ctx, id)
+	}), nil
+}
+
+// Create registers a given new PolicyBinding instance to r.registry.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	policyBinding, ok := obj.(*authorizationapi.PolicyBinding)
+	if !ok {
+		return nil, fmt.Errorf("not an policyBinding: %#v", obj)
+	}
+
+	if !kapi.ValidNamespace(ctx, &policyBinding.ObjectMeta) {
+		return nil, kerrors.NewConflict("policyBinding", policyBinding.Namespace, fmt.Errorf("PolicyBinding.Namespace does not match the provided context"))
+	}
+
+	if len(policyBinding.PolicyRef.Namespace) == 0 {
+		return nil, errors.New("policyBinding.PolicyRef.Namespace must have a value")
+	}
+
+	// set values
+	policyBinding.Name = policyBinding.PolicyRef.Namespace
+	policyBinding.CreationTimestamp = util.Now()
+	policyBinding.LastModified = util.Now()
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		if err := r.registry.CreatePolicyBinding(ctx, policyBinding); err != nil {
+			return nil, err
+		}
+		return r.Get(ctx, policyBinding.Name)
+	}), nil
+}
+
+func EmptyPolicyBinding(namespace, policyNamespace string) *authorizationapi.PolicyBinding {
+	policyBinding := &authorizationapi.PolicyBinding{}
+	policyBinding.Name = policyNamespace
+	policyBinding.Namespace = namespace
+	policyBinding.CreationTimestamp = util.Now()
+	policyBinding.LastModified = util.Now()
+	policyBinding.PolicyRef = kapi.ObjectReference{Name: authorizationapi.PolicyName, Namespace: policyNamespace}
+	policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+
+	return policyBinding
+}

--- a/pkg/authorization/registry/policybinding/rest_test.go
+++ b/pkg/authorization/registry/policybinding/rest_test.go
@@ -1,0 +1,269 @@
+package policybinding
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/registry/test"
+)
+
+func TestCreateValidationError(t *testing.T) {
+	registry := test.PolicyBindingRegistry{}
+	storage := REST{
+		registry: &registry,
+	}
+	policyBinding := &authorizationapi.PolicyBinding{
+	// ObjectMeta: kapi.ObjectMeta{Name: "authTokenName"}, // Missing required field
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Create(ctx, policyBinding)
+	if err == nil {
+		t.Errorf("Expected validation error")
+	}
+}
+
+func TestCreateStorageError(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	policyBinding := &authorizationapi.PolicyBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "master"},
+		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Create(ctx, policyBinding)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Message == registry.Err.Error() {
+				// expected case
+			} else {
+				t.Errorf("Got back unexpected error: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestCreateValid(t *testing.T) {
+	registry := test.PolicyBindingRegistry{}
+	storage := REST{
+		registry: &registry,
+	}
+	policyBinding := &authorizationapi.PolicyBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Create(ctx, policyBinding)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			t.Errorf("Got back unexpected status: %#v", r)
+		case *authorizationapi.PolicyBinding:
+			// expected case
+		default:
+			t.Errorf("Got unexpected type: %#v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestGetError(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Get(ctx, "name")
+	if err == nil {
+		t.Errorf("expected error")
+		return
+	}
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+}
+
+func TestGetValid(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		PolicyBindings: append(make([]authorizationapi.PolicyBinding, 0),
+			authorizationapi.PolicyBinding{
+				ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+				PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+			}),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	policyBinding, err := storage.Get(ctx, "master")
+	if err != nil {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+	if reflect.DeepEqual(policyBinding, registry.PolicyBindings[0]) {
+		t.Errorf("got unexpected policyBinding: %v", policyBinding)
+		return
+	}
+}
+
+func TestListError(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err == nil {
+		t.Errorf("expected error")
+		return
+	}
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		PolicyBindings: make([]authorizationapi.PolicyBinding, 0),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	policyBindings, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+	switch policyBindings := policyBindings.(type) {
+	case *authorizationapi.PolicyBindingList:
+		if len(policyBindings.Items) != 0 {
+			t.Errorf("expected empty list, got %#v", policyBindings)
+		}
+	default:
+		t.Errorf("expected policyBindingList, got: %v", policyBindings)
+		return
+	}
+}
+
+func TestList(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		PolicyBindings: append(make([]authorizationapi.PolicyBinding, 0),
+			authorizationapi.PolicyBinding{
+				ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+			}),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	policyBindings, err := storage.List(ctx, labels.Everything(), labels.Everything())
+	if err != registry.Err {
+		t.Errorf("got unexpected error: %v", err)
+		return
+	}
+	switch policyBindings := policyBindings.(type) {
+	case *authorizationapi.PolicyBindingList:
+		if len(policyBindings.Items) != 1 {
+			t.Errorf("expected list with 1 item, got %#v", policyBindings)
+		}
+	default:
+		t.Errorf("expected policyBindingList, got: %v", policyBindings)
+		return
+	}
+}
+
+func TestDeleteError(t *testing.T) {
+	registry := test.PolicyBindingRegistry{
+		Err: errors.New("Sample Error"),
+	}
+	storage := REST{
+		registry: &registry,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Message == registry.Err.Error() {
+				// expected case
+			} else {
+				t.Errorf("Got back unexpected error: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestDeleteValid(t *testing.T) {
+	registry := test.PolicyBindingRegistry{}
+	storage := REST{
+		registry: &registry,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Status != "Success" {
+				t.Errorf("Got back non-success status: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+
+	if registry.DeletedPolicyBindingName != "foo" {
+		t.Error("Unexpected policyBinding deleted: %s", registry.DeletedPolicyBindingName)
+	}
+}

--- a/pkg/authorization/registry/role/rest.go
+++ b/pkg/authorization/registry/role/rest.go
@@ -1,0 +1,176 @@
+package role
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	registry policyregistry.Registry
+}
+
+// NewREST creates a new REST for policies.
+func NewREST(registry policyregistry.Registry) apiserver.RESTStorage {
+	return &REST{registry}
+}
+
+// New creates a new Role object
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.Role{}
+}
+
+// Delete asynchronously deletes the Policy specified by its id.
+func (r *REST) Delete(ctx kapi.Context, id string) (<-chan apiserver.RESTResult, error) {
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		policy, err := r.EnsurePolicy(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if !doesRoleExist(id, policy) {
+			return nil, fmt.Errorf("role %v does not exist", id)
+		}
+
+		delete(policy.Roles, id)
+		policy.LastModified = util.Now()
+
+		return &kapi.Status{Status: kapi.StatusSuccess}, r.registry.UpdatePolicy(ctx, policy)
+	}), nil
+}
+
+// Create registers a given new Role inside the Policy instance to r.registry.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	role, ok := obj.(*authorizationapi.Role)
+	if !ok {
+		return nil, fmt.Errorf("not a role: %#v", obj)
+	}
+
+	err := validateRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := r.EnsurePolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if doesRoleExist(role.Name, policy) {
+		return nil, fmt.Errorf("role %v already exists", role.Name)
+	}
+
+	// set defaults
+	role.CreationTimestamp = util.Now()
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		policy.Roles[role.Name] = *role
+		policy.LastModified = util.Now()
+
+		if err := r.registry.UpdatePolicy(ctx, policy); err != nil {
+			return nil, err
+		}
+		return role, nil
+	}), nil
+}
+
+// Update replaces a given Role inside the Policy instance with an existing instance in r.registry.
+func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	role, ok := obj.(*authorizationapi.Role)
+	if !ok {
+		return nil, fmt.Errorf("not a role: %#v", obj)
+	}
+
+	err := validateRole(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := r.EnsurePolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !doesRoleExist(role.Name, policy) {
+		return nil, fmt.Errorf("role %v does not exist", role.Name)
+	}
+
+	// set defaults
+	role.CreationTimestamp = util.Now()
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		policy.Roles[role.Name] = *role
+		policy.LastModified = util.Now()
+
+		if err := r.registry.UpdatePolicy(ctx, policy); err != nil {
+			return nil, err
+		}
+		return role, nil
+	}), nil
+}
+
+func validateRole(ctx kapi.Context, role *authorizationapi.Role) error {
+	if !kapi.ValidNamespace(ctx, &role.ObjectMeta) {
+		return kerrors.NewConflict("role", role.Namespace, fmt.Errorf("Role.Namespace does not match the provided context"))
+	}
+
+	if len(role.Name) == 0 {
+		return errors.New("role.Name must have a value")
+	}
+
+	return nil
+}
+
+func doesRoleExist(name string, policy *authorizationapi.Policy) bool {
+	_, exists := policy.Roles[name]
+
+	return exists
+}
+
+// EnsurePOlicy returns the policy object for the specified namespace.  If one does not exist, it is created for you.  Permission to
+// create, update, or delete roles in a namespace implies the ability to create a Policy object itself.
+func (r *REST) EnsurePolicy(ctx kapi.Context) (*authorizationapi.Policy, error) {
+	policy, err := r.registry.GetPolicy(ctx, authorizationapi.PolicyName)
+	if err != nil {
+		if !strings.Contains(err.Error(), "not found") {
+			return nil, err
+		}
+
+		// if we have no policy, go ahead and make one.  creating one here collapses code paths below.  We only take this hit once
+		policy = EmptyPolicy(kapi.Namespace(ctx))
+		if err := r.registry.CreatePolicy(ctx, policy); err != nil {
+			return nil, err
+		}
+
+		policy, err = r.registry.GetPolicy(ctx, authorizationapi.PolicyName)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	if policy.Roles == nil {
+		policy.Roles = make(map[string]authorizationapi.Role)
+	}
+
+	return policy, nil
+}
+
+func EmptyPolicy(namespace string) *authorizationapi.Policy {
+	policy := &authorizationapi.Policy{}
+	policy.Name = authorizationapi.PolicyName
+	policy.Namespace = namespace
+	policy.CreationTimestamp = util.Now()
+	policy.LastModified = util.Now()
+	policy.Roles = make(map[string]authorizationapi.Role)
+
+	return policy
+}

--- a/pkg/authorization/registry/role/rest_test.go
+++ b/pkg/authorization/registry/role/rest_test.go
@@ -1,0 +1,216 @@
+package role
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/registry/test"
+)
+
+func TestCreateValidationError(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+	storage := REST{
+		registry: registry,
+	}
+	role := &authorizationapi.Role{}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Create(ctx, role)
+	if err == nil {
+		t.Errorf("Expected validation error")
+	}
+}
+
+func TestCreateStorageError(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+	registry.Err = errors.New("Sample Error")
+
+	storage := REST{
+		registry: registry,
+	}
+	role := &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Create(ctx, role)
+	if err == nil {
+		t.Errorf("Missing expected error")
+		return
+	}
+	if err != registry.Err {
+		t.Errorf("Expected %v, got %v", registry.Err, err)
+	}
+}
+
+func TestCreateValid(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+	storage := REST{
+		registry: registry,
+	}
+	registry.Policies = append(make([]authorizationapi.Policy, 0),
+		authorizationapi.Policy{
+			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+		})
+
+	role := &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Create(ctx, role)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			t.Errorf("Got back unexpected status: %#v", r)
+		case *authorizationapi.Role:
+			// expected case
+		default:
+			t.Errorf("Got unexpected type: %#v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+	storage := REST{
+		registry: registry,
+	}
+	registry.Policies = append(make([]authorizationapi.Policy, 0),
+		authorizationapi.Policy{
+			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+			Roles: map[string]authorizationapi.Role{
+				"my-role": {ObjectMeta: kapi.ObjectMeta{Name: "my-role"}},
+			},
+		})
+
+	role := &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Update(ctx, role)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	select {
+	case result := <-channel:
+		switch obj := result.Object.(type) {
+		case *kapi.Status:
+			t.Errorf("Unexpected operation error: %v", obj)
+
+		case *authorizationapi.Role:
+			if !reflect.DeepEqual(role, obj) {
+				t.Errorf("Updated role does not match input role."+
+					" Expected: %v, Got: %v", role, obj)
+			}
+		default:
+			t.Errorf("Unexpected result type: %v", result)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestUpdateError(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+	storage := REST{
+		registry: registry,
+	}
+	registry.Policies = append(make([]authorizationapi.Policy, 0),
+		authorizationapi.Policy{
+			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+		})
+
+	role := &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Update(ctx, role)
+	if err == nil {
+		t.Errorf("Missing expected error")
+		return
+	}
+	expectedErr := "role my-role does not exist"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected %v, got %v", expectedErr, err)
+	}
+}
+
+func TestDeleteError(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+
+	registry.Err = errors.New("Sample Error")
+	storage := REST{
+		registry: registry,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Message == registry.Err.Error() {
+				// expected case
+			} else {
+				t.Errorf("Got back unexpected error: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestDeleteValid(t *testing.T) {
+	registry := &test.PolicyRegistry{}
+	storage := REST{
+		registry: registry,
+	}
+	registry.Policies = append(make([]authorizationapi.Policy, 0),
+		authorizationapi.Policy{
+			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+			Roles: map[string]authorizationapi.Role{
+				"foo": {ObjectMeta: kapi.ObjectMeta{Name: "foo"}},
+			},
+		})
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Status != "Success" {
+				t.Fatalf("Got back non-success status: %#v", r)
+			}
+		default:
+			t.Fatalf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}

--- a/pkg/authorization/registry/rolebinding/rest.go
+++ b/pkg/authorization/registry/rolebinding/rest.go
@@ -1,0 +1,253 @@
+package rolebinding
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+	userregistry "github.com/openshift/origin/pkg/user/registry/user"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	bindingRegistry              policybindingregistry.Registry
+	policyRegistry               policyregistry.Registry
+	userRegistry                 userregistry.Registry
+	masterAuthorizationNamespace string
+}
+
+// NewREST creates a new REST for policies.
+func NewREST(bindingRegistry policybindingregistry.Registry, policyRegistry policyregistry.Registry, userRegistry userregistry.Registry, masterAuthorizationNamespace string) apiserver.RESTStorage {
+	return &REST{bindingRegistry, policyRegistry, userRegistry, masterAuthorizationNamespace}
+}
+
+// New creates a new RoleBinding object
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.RoleBinding{}
+}
+
+// Delete asynchronously deletes the Policy specified by its id.
+func (r *REST) Delete(ctx kapi.Context, id string) (<-chan apiserver.RESTResult, error) {
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		owningPolicyBinding, err := r.LocatePolicyBinding(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if owningPolicyBinding == nil {
+			return nil, fmt.Errorf("roleBinding %v does not exist", id)
+		}
+
+		delete(owningPolicyBinding.RoleBindings, id)
+		owningPolicyBinding.LastModified = util.Now()
+
+		return &kapi.Status{Status: kapi.StatusSuccess}, r.bindingRegistry.UpdatePolicyBinding(ctx, owningPolicyBinding)
+	}), nil
+}
+
+// Create registers a given new RoleBinding inside the Policy instance to r.bindingRegistry.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	roleBinding, ok := obj.(*authorizationapi.RoleBinding)
+	if !ok {
+		return nil, fmt.Errorf("not a roleBinding: %#v", obj)
+	}
+	if err := r.validateRoleBinding(ctx, roleBinding); err != nil {
+		return nil, err
+	}
+
+	roleBinding.CreationTimestamp = util.Now()
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		policyBinding, err := r.GetPolicyBinding(ctx, roleBinding.RoleRef.Namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		_, exists := policyBinding.RoleBindings[roleBinding.Name]
+		if exists {
+			return nil, fmt.Errorf("roleBinding %v already exists", roleBinding.Name)
+		}
+
+		policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
+		policyBinding.LastModified = util.Now()
+
+		if err := r.bindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
+			return nil, err
+		}
+		return roleBinding, nil
+	}), nil
+}
+
+// Update replaces a given RoleBinding inside the Policy instance with an existing instance in r.bindingRegistry.
+func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	roleBinding, ok := obj.(*authorizationapi.RoleBinding)
+	if !ok {
+		return nil, fmt.Errorf("not a roleBinding: %#v", obj)
+	}
+	if err := r.validateRoleBinding(ctx, roleBinding); err != nil {
+		return nil, err
+	}
+
+	existingRoleBinding, err := r.GetRoleBinding(ctx, roleBinding.Name)
+	if err != nil {
+		return nil, err
+	}
+	if existingRoleBinding == nil {
+		return nil, fmt.Errorf("roleBinding %v does not exist", roleBinding.Name)
+	}
+	if existingRoleBinding.RoleRef.Namespace != roleBinding.RoleRef.Namespace {
+		return nil, fmt.Errorf("cannot change roleBinding.RoleRef.Namespace from %v to %v", existingRoleBinding.RoleRef.Namespace, roleBinding.RoleRef.Namespace)
+	}
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		policyBinding, err := r.GetPolicyBinding(ctx, roleBinding.RoleRef.Namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		_, exists := policyBinding.RoleBindings[roleBinding.Name]
+		if !exists {
+			return nil, fmt.Errorf("roleBinding %v does not exist", roleBinding.Name)
+		}
+
+		policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
+		policyBinding.LastModified = util.Now()
+
+		if err := r.bindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
+			return nil, err
+		}
+		return roleBinding, nil
+	}), nil
+}
+
+func (r *REST) validateRoleBinding(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
+	if !kapi.ValidNamespace(ctx, &roleBinding.ObjectMeta) {
+		return kerrors.NewConflict("roleBinding", roleBinding.Namespace, fmt.Errorf("RoleBinding.Namespace does not match the provided context"))
+	}
+	if len(roleBinding.Name) == 0 {
+		return errors.New("roleBinding.Name must have a value")
+	}
+	if len(roleBinding.RoleRef.Namespace) == 0 {
+		return errors.New("roleBinding.RoleRef.Namespace must have a value")
+	}
+	if err := r.confirmUsersExist(roleBinding.UserNames); err != nil {
+		return err
+	}
+	if err := r.confirmRoleExists(roleBinding.RoleRef); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *REST) confirmRoleExists(roleRef kapi.ObjectReference) error {
+	ctx := kapi.WithNamespace(kapi.NewContext(), roleRef.Namespace)
+
+	policy, err := r.policyRegistry.GetPolicy(ctx, authorizationapi.PolicyName)
+	if err != nil {
+		return fmt.Errorf("policy %v not found: %v", roleRef.Namespace, err)
+	}
+
+	if _, exists := policy.Roles[roleRef.Name]; !exists {
+		return fmt.Errorf("role %v not found", roleRef.Name)
+	}
+
+	return nil
+}
+
+func (r *REST) confirmUsersExist(userNames []string) error {
+	for _, userName := range userNames {
+		if _, err := r.userRegistry.GetUser(userName); err != nil {
+			return fmt.Errorf("user %v not found: %v", userName, err)
+		}
+	}
+
+	return nil
+}
+
+// EnsurePolicyBindingToMaster returns a PolicyBinding object that has a PolicyRef pointing to the Policy in the passed namespace.
+func (r *REST) EnsurePolicyBindingToMaster(ctx kapi.Context) (*authorizationapi.PolicyBinding, error) {
+	policyBinding, err := r.bindingRegistry.GetPolicyBinding(ctx, r.masterAuthorizationNamespace)
+	if err != nil {
+		if !strings.Contains(err.Error(), "not found") {
+			return nil, err
+		}
+
+		// if we have no policyBinding, go ahead and make one.  creating one here collapses code paths below.  We only take this hit once
+		policyBinding = policybindingregistry.EmptyPolicyBinding(kapi.Namespace(ctx), r.masterAuthorizationNamespace)
+		if err := r.bindingRegistry.CreatePolicyBinding(ctx, policyBinding); err != nil {
+			return nil, err
+		}
+
+		policyBinding, err = r.bindingRegistry.GetPolicyBinding(ctx, r.masterAuthorizationNamespace)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if policyBinding.RoleBindings == nil {
+		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+	}
+
+	return policyBinding, nil
+}
+
+// Returns a PolicyBinding that points to the specified policyNamespace.  It will autocreate ONLY if policyNamespace equals the master namespace
+func (r *REST) GetPolicyBinding(ctx kapi.Context, policyNamespace string) (*authorizationapi.PolicyBinding, error) {
+	// we can autocreate a PolicyBinding object if the RoleBinding is for the master namespace
+	if policyNamespace == r.masterAuthorizationNamespace {
+		return r.EnsurePolicyBindingToMaster(ctx)
+	}
+
+	policyBinding, err := r.bindingRegistry.GetPolicyBinding(ctx, policyNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if policyBinding.RoleBindings == nil {
+		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+	}
+
+	return policyBinding, nil
+}
+
+func (r *REST) LocatePolicyBinding(ctx kapi.Context, roleName string) (*authorizationapi.PolicyBinding, error) {
+	policyBindingList, err := r.bindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, policyBinding := range policyBindingList.Items {
+		_, exists := policyBinding.RoleBindings[roleName]
+		if exists {
+			return &policyBinding, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (r *REST) GetRoleBinding(ctx kapi.Context, roleBindingName string) (*authorizationapi.RoleBinding, error) {
+	policyBindingList, err := r.bindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, policyBinding := range policyBindingList.Items {
+		roleBinding, exists := policyBinding.RoleBindings[roleBindingName]
+		if exists {
+			return &roleBinding, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/authorization/registry/rolebinding/rest_test.go
+++ b/pkg/authorization/registry/rolebinding/rest_test.go
@@ -1,0 +1,264 @@
+package rolebinding
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/registry/test"
+	usertest "github.com/openshift/origin/pkg/user/registry/test"
+)
+
+func makeSimpleStorage() (*REST, *test.PolicyBindingRegistry) {
+	bindingRegistry := &test.PolicyBindingRegistry{}
+	policyRegistry := &test.PolicyRegistry{}
+	policyRegistry.Policies = []authorizationapi.Policy{
+		{
+			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "master"},
+			Roles: map[string]authorizationapi.Role{
+				"admin": {ObjectMeta: kapi.ObjectMeta{Name: "admin"}},
+			},
+		}}
+	userRegistry := &usertest.UserRegistry{}
+
+	return &REST{bindingRegistry, policyRegistry, userRegistry, "master"}, bindingRegistry
+}
+
+func TestCreateValidationError(t *testing.T) {
+	storage, _ := makeSimpleStorage()
+	roleBinding := &authorizationapi.RoleBinding{}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Create(ctx, roleBinding)
+	if err == nil {
+		t.Errorf("Expected validation error")
+	}
+}
+
+func TestCreateStorageError(t *testing.T) {
+	storage, registry := makeSimpleStorage()
+	registry.Err = errors.New("Sample Error")
+
+	roleBinding := &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-roleBinding"},
+		RoleRef:    kapi.ObjectReference{Name: "admin", Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Create(ctx, roleBinding)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Message == registry.Err.Error() {
+				// expected case
+			} else {
+				t.Errorf("Got back unexpected error: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestCreateValidAutoCreateMasterPolicyBindings(t *testing.T) {
+	storage, _ := makeSimpleStorage()
+	roleBinding := &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-roleBinding"},
+		RoleRef:    kapi.ObjectReference{Name: "admin", Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Create(ctx, roleBinding)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			t.Errorf("Got back unexpected status: %#v", r)
+		case *authorizationapi.RoleBinding:
+			// expected case
+		default:
+			t.Errorf("Got unexpected type: %#v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestCreateValid(t *testing.T) {
+	storage, registry := makeSimpleStorage()
+	registry.PolicyBindings = append(make([]authorizationapi.PolicyBinding, 0),
+		authorizationapi.PolicyBinding{
+			ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+		})
+
+	roleBinding := &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-roleBinding"},
+		RoleRef:    kapi.ObjectReference{Name: "admin", Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Create(ctx, roleBinding)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			t.Errorf("Got back unexpected status: %#v", r)
+		case *authorizationapi.RoleBinding:
+			// expected case
+		default:
+			t.Errorf("Got unexpected type: %#v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	storage, registry := makeSimpleStorage()
+	registry.PolicyBindings = append(make([]authorizationapi.PolicyBinding, 0),
+		authorizationapi.PolicyBinding{
+			ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+			RoleBindings: map[string]authorizationapi.RoleBinding{
+				"my-roleBinding": {
+					ObjectMeta: kapi.ObjectMeta{Name: "my-roleBinding"},
+					RoleRef:    kapi.ObjectReference{Name: "admin", Namespace: "master"},
+				},
+			},
+		})
+
+	roleBinding := &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-roleBinding"},
+		RoleRef:    kapi.ObjectReference{Name: "admin", Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Update(ctx, roleBinding)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	select {
+	case result := <-channel:
+		switch obj := result.Object.(type) {
+		case *kapi.Status:
+			t.Errorf("Unexpected operation error: %v", obj)
+
+		case *authorizationapi.RoleBinding:
+			if !reflect.DeepEqual(roleBinding, obj) {
+				t.Errorf("Updated roleBinding does not match input roleBinding."+
+					" Expected: %v, Got: %v", roleBinding, obj)
+			}
+		default:
+			t.Errorf("Unexpected result type: %v", result)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestUpdateError(t *testing.T) {
+	storage, registry := makeSimpleStorage()
+	registry.PolicyBindings = append(make([]authorizationapi.PolicyBinding, 0),
+		authorizationapi.PolicyBinding{
+			ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+		})
+
+	roleBinding := &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-roleBinding"},
+		RoleRef:    kapi.ObjectReference{Name: "admin", Namespace: "master"},
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	_, err := storage.Update(ctx, roleBinding)
+	if err == nil {
+		t.Errorf("Missing expected error")
+		return
+	}
+	expectedErr := "roleBinding my-roleBinding does not exist"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected %v, got %v", expectedErr, err)
+	}
+}
+
+func TestDeleteError(t *testing.T) {
+	registry := &test.PolicyBindingRegistry{}
+
+	registry.Err = errors.New("Sample Error")
+	policyRegistry := &test.PolicyRegistry{}
+	userRegistry := &usertest.UserRegistry{}
+	storage := &REST{registry, policyRegistry, userRegistry, "master"}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Message == registry.Err.Error() {
+				// expected case
+			} else {
+				t.Errorf("Got back unexpected error: %#v", r)
+			}
+		default:
+			t.Errorf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}
+
+func TestDeleteValid(t *testing.T) {
+	registry := &test.PolicyBindingRegistry{}
+	policyRegistry := &test.PolicyRegistry{}
+	userRegistry := &usertest.UserRegistry{}
+	storage := &REST{registry, policyRegistry, userRegistry, "master"}
+	registry.PolicyBindings = append(make([]authorizationapi.PolicyBinding, 0),
+		authorizationapi.PolicyBinding{
+			ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
+			RoleBindings: map[string]authorizationapi.RoleBinding{
+				"foo": {ObjectMeta: kapi.ObjectMeta{Name: "foo"}},
+			},
+		})
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
+	channel, err := storage.Delete(ctx, "foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case r := <-channel:
+		switch r := r.Object.(type) {
+		case *kapi.Status:
+			if r.Status != "Success" {
+				t.Fatalf("Got back non-success status: %#v", r)
+			}
+		default:
+			t.Fatalf("Got back non-status result: %v", r)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+}

--- a/pkg/authorization/registry/test/policy.go
+++ b/pkg/authorization/registry/test/policy.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"errors"
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type PolicyRegistry struct {
+	Err               error
+	MasterNamespace   string
+	Policies          []authorizationapi.Policy
+	DeletedPolicyName string
+}
+
+// ListPolicies obtains list of policys that match a selector.
+func (r *PolicyRegistry) ListPolicies(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.PolicyList, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	namespace := kapi.Namespace(ctx)
+	if len(namespace) == 0 {
+		return nil, errors.New("invalid request.  Namespace parameter required.")
+	}
+
+	list := make([]authorizationapi.Policy, 0)
+	for _, curr := range r.Policies {
+		if curr.Namespace == namespace {
+			list = append(list, curr)
+		}
+	}
+
+	return &authorizationapi.PolicyList{
+			Items: list,
+		},
+		r.Err
+}
+
+// GetPolicy retrieves a specific policy.
+func (r *PolicyRegistry) GetPolicy(ctx kapi.Context, id string) (*authorizationapi.Policy, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	namespace := kapi.Namespace(ctx)
+	if len(namespace) == 0 {
+		return nil, errors.New("invalid request.  Namespace parameter required.")
+	}
+
+	for _, curr := range r.Policies {
+		if curr.Namespace == namespace && id == curr.Name {
+			return &curr, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Policy %v::%v not found", namespace, id)
+}
+
+// CreatePolicy creates a new policy.
+func (r *PolicyRegistry) CreatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error {
+	return r.Err
+}
+
+// UpdatePolicy updates a policy.
+func (r *PolicyRegistry) UpdatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error {
+	return r.Err
+}
+
+// DeletePolicy deletes a policy.
+func (r *PolicyRegistry) DeletePolicy(ctx kapi.Context, id string) error {
+	r.DeletedPolicyName = id
+	return r.Err
+}

--- a/pkg/authorization/registry/test/policybinding.go
+++ b/pkg/authorization/registry/test/policybinding.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"errors"
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type PolicyBindingRegistry struct {
+	Err                      error
+	MasterNamespace          string
+	PolicyBindings           []authorizationapi.PolicyBinding
+	DeletedPolicyBindingName string
+}
+
+// ListPolicies obtains list of ListPolicyBinding that match a selector.
+func (r *PolicyBindingRegistry) ListPolicyBindings(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.PolicyBindingList, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	namespace := kapi.Namespace(ctx)
+	if len(namespace) == 0 {
+		return nil, errors.New("invalid request.  Namespace parameter required.")
+	}
+
+	list := make([]authorizationapi.PolicyBinding, 0)
+	for _, curr := range r.PolicyBindings {
+		if curr.Namespace == namespace {
+			list = append(list, curr)
+		}
+	}
+
+	return &authorizationapi.PolicyBindingList{
+			Items: list,
+		},
+		r.Err
+}
+
+// GetPolicyBinding retrieves a specific policyBinding.
+func (r *PolicyBindingRegistry) GetPolicyBinding(ctx kapi.Context, id string) (*authorizationapi.PolicyBinding, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	namespace := kapi.Namespace(ctx)
+	if len(namespace) == 0 {
+		return nil, errors.New("invalid request.  Namespace parameter required.")
+	}
+
+	for _, curr := range r.PolicyBindings {
+		if curr.Namespace == namespace && id == curr.Name {
+			return &curr, nil
+		}
+	}
+
+	return nil, fmt.Errorf("PolicyBinding %v::%v not found", namespace, id)
+}
+
+// CreatePolicyBinding creates a new policyBinding.
+func (r *PolicyBindingRegistry) CreatePolicyBinding(ctx kapi.Context, policyBinding *authorizationapi.PolicyBinding) error {
+	if r.Err == nil {
+		r.PolicyBindings = append(r.PolicyBindings, *policyBinding)
+	}
+	return r.Err
+}
+
+// UpdatePolicyBinding updates a policyBinding.
+func (r *PolicyBindingRegistry) UpdatePolicyBinding(ctx kapi.Context, policyBinding *authorizationapi.PolicyBinding) error {
+	return r.Err
+}
+
+// DeletePolicyBinding deletes a policyBinding.
+func (r *PolicyBindingRegistry) DeletePolicyBinding(ctx kapi.Context, id string) error {
+	r.DeletedPolicyBindingName = id
+	return r.Err
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,10 @@ type Interface interface {
 	UsersInterface
 	UserIdentityMappingsInterface
 	ProjectsInterface
+	PoliciesNamespacer
+	RolesNamespacer
+	RoleBindingsNamespacer
+	PolicyBindingsNamespacer
 }
 
 func (c *Client) Builds(namespace string) BuildInterface {
@@ -68,6 +72,22 @@ func (c *Client) UserIdentityMappings() UserIdentityMappingInterface {
 
 func (c *Client) Projects() ProjectInterface {
 	return newProjects(c)
+}
+
+func (c *Client) Policies(namespace string) PolicyInterface {
+	return newPolicies(c, namespace)
+}
+
+func (c *Client) PolicyBindings(namespace string) PolicyBindingInterface {
+	return newPolicyBindings(c, namespace)
+}
+
+func (c *Client) Roles(namespace string) RoleInterface {
+	return newRoles(c, namespace)
+}
+
+func (c *Client) RoleBindings(namespace string) RoleBindingInterface {
+	return newRoleBindings(c, namespace)
 }
 
 // Client is an OpenShift client object

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -59,3 +59,19 @@ func (c *Fake) UserIdentityMappings() UserIdentityMappingInterface {
 func (c *Fake) Projects() ProjectInterface {
 	return &FakeProjects{Fake: c}
 }
+
+func (c *Fake) Policies(namespace string) PolicyInterface {
+	return &FakePolicies{Fake: c}
+}
+
+func (c *Fake) Roles(namespace string) RoleInterface {
+	return &FakeRoles{Fake: c}
+}
+
+func (c *Fake) RoleBindings(namespace string) RoleBindingInterface {
+	return &FakeRoleBindings{Fake: c}
+}
+
+func (c *Fake) PolicyBindings(namespace string) PolicyBindingInterface {
+	return &FakePolicyBindings{Fake: c}
+}

--- a/pkg/client/fake_policies.go
+++ b/pkg/client/fake_policies.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakePolicies struct {
+	Fake *Fake
+}
+
+func (c *FakePolicies) List(label, field labels.Selector) (*authorizationapi.PolicyList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-policies"})
+	return &authorizationapi.PolicyList{}, nil
+}
+
+func (c *FakePolicies) Get(name string) (*authorizationapi.Policy, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-policy"})
+	return &authorizationapi.Policy{}, nil
+}
+
+func (c *FakePolicies) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-policy", Value: name})
+	return nil
+}

--- a/pkg/client/fake_policybindings.go
+++ b/pkg/client/fake_policybindings.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakePolicyBindings struct {
+	Fake *Fake
+}
+
+func (c *FakePolicyBindings) List(label, field labels.Selector) (*authorizationapi.PolicyBindingList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-policyBindings"})
+	return &authorizationapi.PolicyBindingList{}, nil
+}
+
+func (c *FakePolicyBindings) Get(name string) (*authorizationapi.PolicyBinding, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-policyBinding"})
+	return &authorizationapi.PolicyBinding{}, nil
+}
+
+func (c *FakePolicyBindings) Create(policyBinding *authorizationapi.PolicyBinding) (*authorizationapi.PolicyBinding, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-policyBinding", Value: policyBinding})
+	return &authorizationapi.PolicyBinding{}, nil
+}
+
+func (c *FakePolicyBindings) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-policyBinding", Value: name})
+	return nil
+}

--- a/pkg/client/fake_rolebindings.go
+++ b/pkg/client/fake_rolebindings.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeRoleBindings struct {
+	Fake *Fake
+}
+
+func (c *FakeRoleBindings) Create(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-roleBinding", Value: roleBinding})
+	return &authorizationapi.RoleBinding{}, nil
+}
+
+func (c *FakeRoleBindings) Update(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-roleBinding"})
+	return &authorizationapi.RoleBinding{}, nil
+}
+
+func (c *FakeRoleBindings) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-roleBinding", Value: name})
+	return nil
+}

--- a/pkg/client/fake_roles.go
+++ b/pkg/client/fake_roles.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeRoles struct {
+	Fake *Fake
+}
+
+func (c *FakeRoles) Create(role *authorizationapi.Role) (*authorizationapi.Role, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-role", Value: role})
+	return &authorizationapi.Role{}, nil
+}
+
+func (c *FakeRoles) Update(role *authorizationapi.Role) (*authorizationapi.Role, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-role"})
+	return &authorizationapi.Role{}, nil
+}
+
+func (c *FakeRoles) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-role", Value: name})
+	return nil
+}

--- a/pkg/client/policies.go
+++ b/pkg/client/policies.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// PoliciesNamespacer has methods to work with Policy resources in a namespace
+type PoliciesNamespacer interface {
+	Policies(namespace string) PolicyInterface
+}
+
+// PolicyInterface exposes methods on Policy resources.
+type PolicyInterface interface {
+	List(label, field labels.Selector) (*authorizationapi.PolicyList, error)
+	Get(name string) (*authorizationapi.Policy, error)
+	Delete(name string) error
+}
+
+// policies implements PoliciesNamespacer interface
+type policies struct {
+	r  *Client
+	ns string
+}
+
+// newPolicies returns a policies
+func newPolicies(c *Client, namespace string) *policies {
+	return &policies{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List returns a list of policies that match the label and field selectors.
+func (c *policies) List(label, field labels.Selector) (result *authorizationapi.PolicyList, err error) {
+	result = &authorizationapi.PolicyList{}
+	err = c.r.Get().Namespace(c.ns).Resource("policies").SelectorParam("labels", label).SelectorParam("fields", field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular policy and error if one occurs.
+func (c *policies) Get(name string) (result *authorizationapi.Policy, err error) {
+	result = &authorizationapi.Policy{}
+	err = c.r.Get().Namespace(c.ns).Resource("policies").Name(name).Do().Into(result)
+	return
+}
+
+// Delete deletes a policy, returns error if one occurs.
+func (c *policies) Delete(name string) (err error) {
+	err = c.r.Delete().Namespace(c.ns).Resource("policies").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/policybindings.go
+++ b/pkg/client/policybindings.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// PolicyBindingsNamespacer has methods to work with PolicyBinding resources in a namespace
+type PolicyBindingsNamespacer interface {
+	PolicyBindings(namespace string) PolicyBindingInterface
+}
+
+// PolicyBindingInterface exposes methods on PolicyBinding resources.
+type PolicyBindingInterface interface {
+	List(label, field labels.Selector) (*authorizationapi.PolicyBindingList, error)
+	Get(name string) (*authorizationapi.PolicyBinding, error)
+	Create(policyBinding *authorizationapi.PolicyBinding) (*authorizationapi.PolicyBinding, error)
+	Delete(name string) error
+}
+
+// policyBindings implements PolicyBindingsNamespacer interface
+type policyBindings struct {
+	r  *Client
+	ns string
+}
+
+// newPolicyBindings returns a policyBindings
+func newPolicyBindings(c *Client, namespace string) *policyBindings {
+	return &policyBindings{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List returns a list of policyBindings that match the label and field selectors.
+func (c *policyBindings) List(label, field labels.Selector) (result *authorizationapi.PolicyBindingList, err error) {
+	result = &authorizationapi.PolicyBindingList{}
+	err = c.r.Get().Namespace(c.ns).Resource("policyBindings").SelectorParam("labels", label).SelectorParam("fields", field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular policyBinding and error if one occurs.
+func (c *policyBindings) Get(name string) (result *authorizationapi.PolicyBinding, err error) {
+	result = &authorizationapi.PolicyBinding{}
+	err = c.r.Get().Namespace(c.ns).Resource("policyBindings").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates new policyBinding. Returns the server's representation of the policyBinding and error if one occurs.
+func (c *policyBindings) Create(policyBinding *authorizationapi.PolicyBinding) (result *authorizationapi.PolicyBinding, err error) {
+	result = &authorizationapi.PolicyBinding{}
+	err = c.r.Post().Namespace(c.ns).Resource("policyBindings").Body(policyBinding).Do().Into(result)
+	return
+}
+
+// Delete deletes a policyBinding, returns error if one occurs.
+func (c *policyBindings) Delete(name string) (err error) {
+	err = c.r.Delete().Namespace(c.ns).Resource("policyBindings").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/role_bindings.go
+++ b/pkg/client/role_bindings.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// RoleBindingsNamespacer has methods to work with RoleBinding resources in a namespace
+type RoleBindingsNamespacer interface {
+	RoleBindings(namespace string) RoleBindingInterface
+}
+
+// RoleBindingInterface exposes methods on RoleBinding resources.
+type RoleBindingInterface interface {
+	Create(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error)
+	Update(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error)
+	Delete(name string) error
+}
+
+// roleBindings implements RoleBindingsNamespacer interface
+type roleBindings struct {
+	r  *Client
+	ns string
+}
+
+// newRoleBindings returns a roleBindings
+func newRoleBindings(c *Client, namespace string) *roleBindings {
+	return &roleBindings{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// Create creates new roleBinding. Returns the server's representation of the roleBinding and error if one occurs.
+func (c *roleBindings) Create(roleBinding *authorizationapi.RoleBinding) (result *authorizationapi.RoleBinding, err error) {
+	result = &authorizationapi.RoleBinding{}
+	err = c.r.Post().Namespace(c.ns).Resource("roleBindings").Body(roleBinding).Do().Into(result)
+	return
+}
+
+// Update updates the roleBinding on server. Returns the server's representation of the roleBinding and error if one occurs.
+func (c *roleBindings) Update(roleBinding *authorizationapi.RoleBinding) (result *authorizationapi.RoleBinding, err error) {
+	result = &authorizationapi.RoleBinding{}
+	err = c.r.Put().Namespace(c.ns).Resource("roleBindings").Name(roleBinding.Name).Body(roleBinding).Do().Into(result)
+	return
+}
+
+// Delete deletes a roleBinding, returns error if one occurs.
+func (c *roleBindings) Delete(name string) (err error) {
+	err = c.r.Delete().Namespace(c.ns).Resource("roleBindings").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/roles.go
+++ b/pkg/client/roles.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// RolesNamespacer has methods to work with Role resources in a namespace
+type RolesNamespacer interface {
+	Roles(namespace string) RoleInterface
+}
+
+// RoleInterface exposes methods on Role resources.
+type RoleInterface interface {
+	Create(role *authorizationapi.Role) (*authorizationapi.Role, error)
+	Update(role *authorizationapi.Role) (*authorizationapi.Role, error)
+	Delete(name string) error
+}
+
+// roles implements RolesNamespacer interface
+type roles struct {
+	r  *Client
+	ns string
+}
+
+// newRoles returns a roles
+func newRoles(c *Client, namespace string) *roles {
+	return &roles{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// Create creates new role. Returns the server's representation of the role and error if one occurs.
+func (c *roles) Create(role *authorizationapi.Role) (result *authorizationapi.Role, err error) {
+	result = &authorizationapi.Role{}
+	err = c.r.Post().Namespace(c.ns).Resource("roles").Body(role).Do().Into(result)
+	return
+}
+
+// Update updates the role on server. Returns the server's representation of the role and error if one occurs.
+func (c *roles) Update(role *authorizationapi.Role) (result *authorizationapi.Role, err error) {
+	result = &authorizationapi.Role{}
+	err = c.r.Put().Namespace(c.ns).Resource("roles").Name(role.Name).Body(role).Do().Into(result)
+	return
+}
+
+// Delete deletes a role, returns error if one occurs.
+func (c *roles) Delete(name string) (err error) {
+	err = c.r.Delete().Namespace(c.ns).Resource("roles").Name(name).Do().Error()
+	return
+}

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -2,10 +2,12 @@ package describe
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	kctl "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	kruntime "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
@@ -29,6 +31,10 @@ func DescriberFor(kind string, c *client.Client, host string) (kctl.Describer, b
 		return &RouteDescriber{c}, true
 	case "Project":
 		return &ProjectDescriber{c}, true
+	case "Policy":
+		return &PolicyDescriber{c}, true
+	case "PolicyBinding":
+		return &PolicyBindingDescriber{c}, true
 	}
 	return nil, false
 }
@@ -283,6 +289,95 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, project.ObjectMeta)
 		formatString(out, "Display Name", project.DisplayName)
+		return nil
+	})
+}
+
+// PolicyDescriber generates information about a Project
+type PolicyDescriber struct {
+	client.Interface
+}
+
+// TODO make something a lot prettier
+func (d *PolicyDescriber) Describe(namespace, name string) (string, error) {
+	c := d.Policies(namespace)
+	policy, err := c.Get(name)
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out *tabwriter.Writer) error {
+		formatMeta(out, policy.ObjectMeta)
+		formatString(out, "Last Modified", policy.LastModified)
+
+		// display the rules in a consistent order
+		sortedKeys := make([]string, 0)
+		for key := range policy.Roles {
+			sortedKeys = append(sortedKeys, key)
+		}
+		sort.Strings(sortedKeys)
+
+		for _, key := range sortedKeys {
+			role := policy.Roles[key]
+			fmt.Fprint(out, key+"\tType\tVerbs\tResource Kinds\tExtension\n")
+			for _, rule := range role.Rules {
+				allowString := "allow"
+				if rule.Deny {
+					allowString = "deny"
+				}
+
+				extensionString := ""
+				if rule.AttributeRestrictions != (kruntime.EmbeddedObject{}) {
+					extensionString = fmt.Sprintf("%v", rule.AttributeRestrictions)
+				}
+
+				fmt.Fprintf(out, "%v\t%v\t%v\t%v\t%v\n",
+					"",
+					allowString,
+					rule.Verbs,
+					rule.ResourceKinds,
+					extensionString)
+
+			}
+		}
+
+		return nil
+	})
+}
+
+// PolicyDescriber generates information about a Project
+type PolicyBindingDescriber struct {
+	client.Interface
+}
+
+// TODO make something a lot prettier
+func (d *PolicyBindingDescriber) Describe(namespace, name string) (string, error) {
+	c := d.PolicyBindings(namespace)
+	policyBinding, err := c.Get(name)
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out *tabwriter.Writer) error {
+		formatMeta(out, policyBinding.ObjectMeta)
+		formatString(out, "Last Modified", policyBinding.LastModified)
+		formatString(out, "Policy", policyBinding.PolicyRef.Namespace)
+
+		// display the rules in a consistent order
+		sortedKeys := make([]string, 0)
+		for key := range policyBinding.RoleBindings {
+			sortedKeys = append(sortedKeys, key)
+		}
+		sort.Strings(sortedKeys)
+
+		for _, key := range sortedKeys {
+			roleBinding := policyBinding.RoleBindings[key]
+			formatString(out, "RoleBinding["+key+"]", " ")
+			formatString(out, "\tRole", roleBinding.RoleRef.Name)
+			formatString(out, "\tUsers", roleBinding.UserNames)
+			formatString(out, "\tGroups", roleBinding.GroupNames)
+		}
+
 		return nil
 	})
 }

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -42,6 +42,8 @@ func TestDescribers(t *testing.T) {
 		&ImageRepositoryDescriber{c},
 		&RouteDescriber{c},
 		&ProjectDescriber{c},
+		&PolicyDescriber{c},
+		&PolicyBindingDescriber{c},
 	}
 
 	for _, d := range testDescriberList {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -15,22 +15,23 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/golang/glog"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	kmaster "github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authorizer"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
+
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/api/v1beta1"
 	"github.com/openshift/origin/pkg/assets"
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	authcontext "github.com/openshift/origin/pkg/auth/context"
 	authfilter "github.com/openshift/origin/pkg/auth/handlers"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildcontrollerfactory "github.com/openshift/origin/pkg/build/controller/factory"
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
@@ -71,6 +72,13 @@ import (
 	userregistry "github.com/openshift/origin/pkg/user/registry/user"
 	"github.com/openshift/origin/pkg/user/registry/useridentitymapping"
 	"github.com/openshift/origin/pkg/version"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationetcd "github.com/openshift/origin/pkg/authorization/registry/etcd"
+	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
+	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
 )
 
 const (
@@ -97,10 +105,11 @@ type MasterConfig struct {
 
 	CORSAllowedOrigins []*regexp.Regexp
 	Authenticator      authenticator.Request
+	// TODO Have MasterConfig take a fully formed Authorizer
+	MasterAuthorizationNamespace string
 
 	EtcdHelper tools.EtcdHelper
 
-	Authorizer       authorizer.Authorizer
 	AdmissionControl admission.Interface
 
 	MasterCertFile string
@@ -213,6 +222,7 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 	projectEtcd := projectetcd.New(c.EtcdHelper)
 	userEtcd := useretcd.New(c.EtcdHelper, user.NewDefaultUserInitStrategy())
 	oauthEtcd := oauthetcd.New(c.EtcdHelper)
+	authorizationEtcd := authorizationetcd.New(c.EtcdHelper)
 
 	// TODO: with sharding, this needs to be changed
 	deployConfigGenerator := &deployconfiggenerator.DeploymentConfigGenerator{
@@ -260,6 +270,11 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 		"accessTokens":         accesstokenregistry.NewREST(oauthEtcd),
 		"clients":              clientregistry.NewREST(oauthEtcd),
 		"clientAuthorizations": clientauthorizationregistry.NewREST(oauthEtcd),
+
+		"policies":       policyregistry.NewREST(authorizationEtcd),
+		"policyBindings": policybindingregistry.NewREST(authorizationEtcd),
+		"roles":          roleregistry.NewREST(authorizationEtcd),
+		"roleBindings":   rolebindingregistry.NewREST(authorizationEtcd, authorizationEtcd, userEtcd, c.MasterAuthorizationNamespace),
 	}
 
 	whPrefix := OpenShiftAPIPrefixV1Beta1 + "/buildConfigHooks/"
@@ -309,7 +324,9 @@ func (c *MasterConfig) Run(protectedInstallers []APIInstaller, unprotectedInstal
 	// Add authentication
 	protectedHandler := http.Handler(protectedContainer)
 	if c.Authenticator != nil {
-		protectedHandler = wireAuthenticationHandling(protectedContainer.ServeMux, protectedHandler, c.Authenticator)
+		requestsToUsers := authcontext.NewRequestContextMap()
+		c.ensureComponentAuthorizationRules()
+		protectedHandler = c.wireAuthenticationHandling(protectedContainer.ServeMux, protectedHandler, c.Authenticator, requestsToUsers)
 	}
 
 	// Build container for unprotected endpoints
@@ -360,9 +377,9 @@ func (c *MasterConfig) Run(protectedInstallers []APIInstaller, unprotectedInstal
 // just to make the RunAPI method easier to read.  These resources include the requestsToUsers map that allows callers to know which user
 // is requesting an operation, the handler wrapper that protects the passed handler behind a handler that requires valid authentication
 // information on the request, and an endpoint that only functions properly with an authenticated user.
-func wireAuthenticationHandling(osMux *http.ServeMux, handler http.Handler, authenticator authenticator.Request) http.Handler {
-	// this tracks requests back to users for authorization.  The same instance must be shared between writers and readers
-	requestsToUsers := authcontext.NewRequestContextMap()
+func (c *MasterConfig) wireAuthenticationHandling(osMux *http.ServeMux, handler http.Handler, authenticator authenticator.Request, requestsToUsers *authcontext.RequestContextMap) http.Handler {
+	// wrapHandlerWithAuthorization binds a handler that will force users to be authorized to perform the actions they are requesting
+	handler = c.wrapHandlerWithAuthorization(handler, requestsToUsers)
 
 	// wrapHandlerWithAuthentication binds a handler that will correlate the users and requests
 	handler = wrapHandlerWithAuthentication(handler, authenticator, requestsToUsers)
@@ -382,6 +399,39 @@ func wireAuthenticationHandling(osMux *http.ServeMux, handler http.Handler, auth
 	return handler
 }
 
+func (c *MasterConfig) ensureComponentAuthorizationRules() {
+	registry := authorizationetcd.New(c.EtcdHelper)
+	ctx := kapi.WithNamespace(kapi.NewContext(), c.MasterAuthorizationNamespace)
+
+	if existing, err := registry.GetPolicy(ctx, authorizationapi.PolicyName); err == nil || strings.Contains(err.Error(), " not found") {
+		if existing != nil && existing.Name == authorizationapi.PolicyName {
+			return
+		}
+
+		bootstrapGlobalPolicy := authorizer.GetBootstrapPolicy(c.MasterAuthorizationNamespace)
+		if err = registry.CreatePolicy(ctx, bootstrapGlobalPolicy); err != nil {
+			glog.Errorf("Error creating policy: %v due to %v\n", bootstrapGlobalPolicy, err)
+		}
+
+	} else {
+		glog.Errorf("Error getting policy: %v due to %v\n", authorizationapi.PolicyName, err)
+	}
+
+	if existing, err := registry.GetPolicyBinding(ctx, c.MasterAuthorizationNamespace); err == nil || strings.Contains(err.Error(), " not found") {
+		if existing != nil && existing.Name == c.MasterAuthorizationNamespace {
+			return
+		}
+
+		bootstrapGlobalPolicyBinding := authorizer.GetBootstrapPolicyBinding(c.MasterAuthorizationNamespace)
+		if err = registry.CreatePolicyBinding(ctx, bootstrapGlobalPolicyBinding); err != nil {
+			glog.Errorf("Error creating policy: %v due to %v\n", bootstrapGlobalPolicyBinding, err)
+		}
+
+	} else {
+		glog.Errorf("Error getting policy: %v due to %v\n", c.MasterAuthorizationNamespace, err)
+	}
+}
+
 // wrapHandlerWithAuthentication takes a handler and protects it behind a handler that tests to make sure that a user is authenticated.
 // if the request does have value auth information, then the request is allowed through the passed handler.  If the request does not have
 // valid auth information, then the request is passed to a failure handler.  Until we get authentication for system componenets, the
@@ -396,6 +446,45 @@ func wrapHandlerWithAuthentication(handler http.Handler, authenticator authentic
 			return
 		}),
 		handler)
+}
+
+// TODO Have MasterConfig take a fully formed Authorizer
+func (c *MasterConfig) wrapHandlerWithAuthorization(handler http.Handler, requestsToUsers *authcontext.RequestContextMap) http.Handler {
+	authorizationEtcd := authorizationetcd.New(c.EtcdHelper)
+	authorizationAttributeBuilder := authorizer.NewAuthorizationAttributeBuilder(requestsToUsers)
+	authorizer := authorizer.NewAuthorizer(c.MasterAuthorizationNamespace, authorizationEtcd, authorizationEtcd)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		attributes, err := authorizationAttributeBuilder.GetAttributes(req)
+		if err != nil {
+			// fail
+			forbidden(err.Error(), w, req)
+		}
+		if attributes == nil {
+			// fail
+			forbidden("No attributes", w, req)
+		}
+
+		allowed, _, denyReason, err := authorizer.Authorize(attributes)
+		if err != nil {
+			// fail
+			forbidden(err.Error(), w, req)
+		}
+
+		if allowed {
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		forbidden(denyReason, w, req)
+	})
+}
+
+// forbidden renders a simple forbidden error
+func forbidden(reason string, w http.ResponseWriter, req *http.Request) {
+	glog.V(1).Infof("!!!!!!!!!!!! FORBIDDING because %v!\n", reason)
+	w.WriteHeader(http.StatusForbidden)
+	fmt.Fprintf(w, "Forbidden: \"%#v\" because \"%v\"", req.RequestURI, reason)
 }
 
 // RunAssetServer starts the asset server for the OpenShift UI.

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -465,7 +465,7 @@ func (c *MasterConfig) wrapHandlerWithAuthorization(handler http.Handler, reques
 			forbidden("No attributes", w, req)
 		}
 
-		allowed, _, denyReason, err := authorizer.Authorize(attributes)
+		allowed, reason, err := authorizer.Authorize(attributes)
 		if err != nil {
 			// fail
 			forbidden(err.Error(), w, req)
@@ -476,7 +476,7 @@ func (c *MasterConfig) wrapHandlerWithAuthorization(handler http.Handler, reques
 			return
 		}
 
-		forbidden(denyReason, w, req)
+		forbidden(reason, w, req)
 	})
 }
 

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -282,17 +282,17 @@ func start(cfg *config, args []string) error {
 		}
 
 		osmaster := &origin.MasterConfig{
-			TLS:                  cfg.BindAddr.URL.Scheme == "https",
-			MasterBindAddr:       cfg.BindAddr.URL.Host,
-			MasterAddr:           cfg.MasterAddr.URL.String(),
-			MasterPublicAddr:     masterPublicAddr.URL.String(),
-			AssetBindAddr:        assetBindAddr,
-			AssetPublicAddr:      assetPublicAddr.String(),
-			KubernetesAddr:       cfg.KubernetesAddr.URL.String(),
-			KubernetesPublicAddr: k8sPublicAddr.URL.String(),
-			EtcdHelper:           etcdHelper,
-			Authorizer:           apiserver.NewAlwaysAllowAuthorizer(),
-			AdmissionControl:     admit.NewAlwaysAdmit(),
+			TLS:                          cfg.BindAddr.URL.Scheme == "https",
+			MasterBindAddr:               cfg.BindAddr.URL.Host,
+			MasterAddr:                   cfg.MasterAddr.URL.String(),
+			MasterPublicAddr:             masterPublicAddr.URL.String(),
+			AssetBindAddr:                assetBindAddr,
+			AssetPublicAddr:              assetPublicAddr.String(),
+			KubernetesAddr:               cfg.KubernetesAddr.URL.String(),
+			KubernetesPublicAddr:         k8sPublicAddr.URL.String(),
+			EtcdHelper:                   etcdHelper,
+			AdmissionControl:             admit.NewAlwaysAdmit(),
+			MasterAuthorizationNamespace: "master",
 		}
 
 		if startKube {


### PR DESCRIPTION
Passing fully built objects into the openshift.MasterConfig mirrors how kube.MasterConfig looks.

@liggitt I'm not too excited about still having to deal with RequestsToUsers for authentication, but I'll probably get over it.  Thoughts on whether we can or should slice the authenticator differently?