### PR TITLE
add server arg to osc command to support remote masters

### DIFF
--- a/hack/install-router.sh
+++ b/hack/install-router.sh
@@ -64,5 +64,5 @@ if [ "${OPENSHIFT}" == "" ]; then
     echo "/tmp/router.json has been created.  In order to start the router please run:"
     echo "openshift cli create -f /tmp/router.json"
 else
-    "${OPENSHIFT}" create -f /tmp/router.json
+    "${OPENSHIFT}" --server="${MASTER_URL}" create -f /tmp/router.json
 fi


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/744

Tested on multi node vagrant by installing router from a minion.  Still makes the assumption that if you're using a secure master that you have the certs (`KUBECONFIG` and `OPENSHIFT_CA_DATA`) set.

```
[vagrant@openshift-minion-1 vagrant]$ sudo ln -s /usr/bin/openshift /usr/bin/osc
[vagrant@openshift-minion-1 vagrant]$ hack/install-router.sh router http://10.245.1.2:8080
Creating router file and starting pod...
router
[vagrant@openshift-minion-1 vagrant]$ openshift cli --server=http://10.245.1.2:8080 get pods
POD                 CONTAINER(S)                   IMAGE(S)                          HOST                  LABELS              STATUS
router/             origin-haproxy-router-router   openshift/origin-haproxy-router   openshift-minion-2/   <none>              Pending
```