### PR TITLE
Copy openshift client binary into the tar

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -15,5 +15,7 @@ os::build::build_binaries "${OS_COMPILE_TARGETS[@]-}"
 OS_BUILD_PLATFORMS=("${OS_CROSS_COMPILE_PLATFORMS[@]}")
 os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
 
+os::build::make_openshift_binary_copy
+
 OS_RELEASE_ARCHIVES="${OS_OUTPUT}/releases"
 os::build::place_bins

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -53,6 +53,9 @@ readonly OPENSHIFT_BINARY_SYMLINKS=(
   osc
   openshift-experimental
 )
+readonly OPENSHIFT_BINARY_COPY=(
+  osc
+)
 
 # os::build::binaries_from_targets take a list of build targets and return the
 # full go package to be built
@@ -268,6 +271,15 @@ os::build::place_bins() {
   )
 }
 
+# os::build::make_openshift_binary_copy makes copies for the openshift
+# binary in _output/local/go/bin
+os::build::make_openshift_binary_copy() {
+  if [[ -f "${OS_LOCAL_BINPATH}/openshift" ]]; then
+    for linkname in "${OPENSHIFT_BINARY_COPY[@]}"; do
+      cp "${OS_LOCAL_BINPATH}/openshift" "${OS_LOCAL_BINPATH}/${linkname}"
+    done
+  fi
+}
 # os::build::make_openshift_binary_symlinks makes symlinks for the openshift
 # binary in _output/local/go/bin
 os::build::make_openshift_binary_symlinks() {


### PR DESCRIPTION
Ensure the release binary has a copy of 'openshift' as 'osc' for ease of consumption.