### PR TITLE
Extract cli usage and help to our own templates

### DIFF
--- a/Godeps/_workspace/src/github.com/spf13/cobra/command.go
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/command.go
@@ -40,9 +40,9 @@ type Command struct {
 	Short string
 	// The long message shown in the 'help <this-command>' output.
 	Long string
-	// Set of flags specific to this command.
+	// Full set of flags
 	flags *flag.FlagSet
-	// Set of flags children commands will inherit
+	// Set of flags childrens of this command will inherit
 	pflags *flag.FlagSet
 	// Run runs the command.
 	// The args are the arguments after the command name.
@@ -200,8 +200,10 @@ Aliases:
 Available Commands: {{range .Commands}}{{if .Runnable}}
   {{rpad .Use .UsagePadding }} {{.Short}}{{end}}{{end}}
 {{end}}
-{{ if .HasFlags}} Available Flags:
-{{.Flags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
+{{ if .HasLocalFlags}}Flags:
+{{.LocalFlags.FlagUsages}}{{end}}
+{{ if .HasAnyPersistentFlags}}Global Flags:
+{{.AllPersistentFlags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
 Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
 {{end}}{{ if .HasSubCommands }}
@@ -682,7 +684,7 @@ func (c *Command) HasParent() bool {
 	return c.parent != nil
 }
 
-// Get the Commands FlagSet
+// Get the complete FlagSet that applies to this command (local and persistent declared here and by all parents)
 func (c *Command) Flags() *flag.FlagSet {
 	if c.flags == nil {
 		c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
@@ -695,7 +697,23 @@ func (c *Command) Flags() *flag.FlagSet {
 	return c.flags
 }
 
-// Get the Commands Persistent FlagSet
+// Get the local FlagSet specifically set in the current command
+func (c *Command) LocalFlags() *flag.FlagSet {
+	c.mergePersistentFlags()
+
+	local := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	allPersistent := c.AllPersistentFlags()
+
+	c.Flags().VisitAll(func(f *flag.Flag) {
+		if allPersistent.Lookup(f.Name) == nil {
+			local.AddFlag(f)
+		}
+	})
+
+	return local
+}
+
+// Get the Persistent FlagSet specifically set in the current command
 func (c *Command) PersistentFlags() *flag.FlagSet {
 	if c.pflags == nil {
 		c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
@@ -705,6 +723,29 @@ func (c *Command) PersistentFlags() *flag.FlagSet {
 		c.pflags.SetOutput(c.flagErrorBuf)
 	}
 	return c.pflags
+}
+
+// Get the Persistent FlagSet traversing the Command hierarchy
+func (c *Command) AllPersistentFlags() *flag.FlagSet {
+	allPersistent := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+
+	var visit func(x *Command)
+	visit = func(x *Command) {
+		if x.HasPersistentFlags() {
+			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
+				if allPersistent.Lookup(f.Name) == nil {
+					allPersistent.AddFlag(f)
+				}
+			})
+		}
+		if x.HasParent() {
+			visit(x.parent)
+		}
+	}
+
+	visit(c)
+
+	return allPersistent
 }
 
 // For use in testing
@@ -717,7 +758,7 @@ func (c *Command) ResetFlags() {
 	c.pflags.SetOutput(c.flagErrorBuf)
 }
 
-// Does the command contain flags (local not persistent)
+// Does the command contain any flags (local plus persistent from the entire structure)
 func (c *Command) HasFlags() bool {
 	return c.Flags().HasFlags()
 }
@@ -725,6 +766,16 @@ func (c *Command) HasFlags() bool {
 // Does the command contain persistent flags
 func (c *Command) HasPersistentFlags() bool {
 	return c.PersistentFlags().HasFlags()
+}
+
+// Does the command hierarchy contain persistent flags
+func (c *Command) HasAnyPersistentFlags() bool {
+	return c.AllPersistentFlags().HasFlags()
+}
+
+// Does the command has flags specifically declared locally
+func (c *Command) HasLocalFlags() bool {
+	return c.LocalFlags().HasFlags()
 }
 
 // Climbs up the command tree looking for matching flag
@@ -766,6 +817,10 @@ func (c *Command) ParseFlags(args []string) (err error) {
 	return nil
 }
 
+func (c *Command) Parent() *Command {
+	return c.parent
+}
+
 func (c *Command) mergePersistentFlags() {
 	var rmerge func(x *Command)
 
@@ -783,8 +838,4 @@ func (c *Command) mergePersistentFlags() {
 	}
 
 	rmerge(c)
-}
-
-func (c *Command) Parent() *Command {
-	return c.parent
 }

--- a/Godeps/_workspace/src/github.com/spf13/cobra/command.go
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/command.go
@@ -563,7 +563,6 @@ func (c *Command) Usage() error {
 // Used when a user calls help [command]
 // by the default HelpFunc in the commander
 func (c *Command) Help() error {
-	c.mergePersistentFlags()
 	err := tmpl(c.Out(), c.HelpTemplate(), c)
 	return err
 }

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -40,6 +40,7 @@ for the latest information on OpenShift.
 // or the global OpenShift command
 func CommandFor(basename string) *cobra.Command {
 	var cmd *cobra.Command
+
 	switch basename {
 	case "openshift-router":
 		cmd = router.NewCommandTemplateRouter(basename)
@@ -54,7 +55,12 @@ func CommandFor(basename string) *cobra.Command {
 	default:
 		cmd = NewCommandOpenShift()
 	}
+
+	cmd.SetUsageTemplate(usageTemplate)
+	cmd.SetHelpTemplate(helpTemplate)
+
 	flagtypes.GLog(cmd.PersistentFlags())
+
 	return cmd
 }
 

--- a/pkg/cmd/openshift/templates.go
+++ b/pkg/cmd/openshift/templates.go
@@ -17,9 +17,5 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{ if .HasLocalFlags}}Options:
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasAnyPersistentFlags}}Global Options:
-{{.AllPersistentFlags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
-Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
-{{end}}{{ if .HasSubCommands }}
-Use "{{.Root.Name}} help [command]" for more information about that command.
-{{end}}`
+{{.AllPersistentFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}
+Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}`

--- a/pkg/cmd/openshift/templates.go
+++ b/pkg/cmd/openshift/templates.go
@@ -1,0 +1,25 @@
+package openshift
+
+const helpTemplate = `{{.Long | trim}}
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+`
+const usageTemplate = `{{ $cmd := . }}
+Usage: {{if .Runnable}}
+  {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{end}}{{if .HasSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}
+{{ if .HasSubCommands}}
+Available Commands: {{range .Commands}}{{if .Runnable}}
+  {{rpad .Use .UsagePadding }} {{.Short}}{{end}}{{end}}
+{{end}}
+{{ if .HasLocalFlags}}Options:
+{{.LocalFlags.FlagUsages}}{{end}}
+{{ if .HasAnyPersistentFlags}}Global Options:
+{{.AllPersistentFlags.FlagUsages}}{{end}}{{if .HasParent}}{{if and (gt .Commands 0) (gt .Parent.Commands 1) }}
+Additional help topics: {{if gt .Commands 0 }}{{range .Commands}}{{if not .Runnable}} {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if gt .Parent.Commands 1 }}{{range .Parent.Commands}}{{if .Runnable}}{{if not (eq .Name $cmd.Name) }}{{end}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{end}}
+{{end}}{{ if .HasSubCommands }}
+Use "{{.Root.Name}} help [command]" for more information about that command.
+{{end}}`


### PR DESCRIPTION
Result looks like:

```
$ osc help get

(...)

Local Flags:
      --no-headers=false: When using the default output, don't print headers
  -o, --output="": Output format: json|yaml|template|templatefile
      --output-version="": Output the formatted object with the given version (default api-version)
  -l, --selector="": Selector (label query) to filter on
  -t, --template="": Template string or path to template file to use when -o=template or -o=templatefile.
  -w, --watch=false: After listing/getting the requested object, watch for changes.
      --watch-only=false: Watch for changes to the requseted object(s), without listing/getting first.

Global Flags:
      --alsologtostderr=false: log to standard error as well as files
      --api-version="": The API version to use when talking to the server
  -a, --auth-path="": Path to the auth info file. If missing, prompt the user. Only used if using https.
      --certificate-authority="": Path to a cert. file for the certificate authority.
      --client-certificate="": Path to a client key file for TLS.
      --client-key="": Path to a client key file for TLS.
      --cluster="": The name of the kubeconfig cluster to use
      --context="": The name of the kubeconfig context to use
```