### PR TITLE
create test project for e2e

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -110,7 +110,7 @@ All commands assume the `openshift` binary is in your path (normally located und
 
 7. Create a new project in OpenShift
 
-        $ openshift cli create Project -f project.json
+        $ openshift cli create project -f project.json
 
 8. *Optional:* View the OpenShift web console in your browser by browsing to `https://<host>:8444`
     If you click the `Hello OpenShift` project and leave the tab open, you'll see the page update as you deploy objects into the project and run builds.


### PR DESCRIPTION
This makes the console interesting during the e2e test.  This is particularly useful if the test fails and you specified "SKIP_IMAGE_CLEANUP".

@liggitt I pinned --public-master to localhost, figuring that would be ok for an e2e test running locally.  Any concerns?