### PR TITLE
stop "OpenShift will terminate as soon as a panic occurs" from spamming ...

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -29,8 +29,6 @@ trap "cleanup" EXIT
 
 set -e
 
-export OPENSHIFT_ON_PANIC=crash
-
 USE_LOCAL_IMAGES=${USE_LOCAL_IMAGES:-true}
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
@@ -68,7 +66,7 @@ echo openshift: $out
 export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
 
 # Start openshift
-openshift start --master="${API_SCHEME}://${API_HOST}:${API_PORT}" --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" --hostname="${API_HOST}" --volume-dir="${VOLUME_DIR}" --cert-dir="${CERT_DIR}" --etcd-dir="${ETCD_DATA_DIR}" 1>&2 &
+OPENSHIFT_ON_PANIC=crash openshift start --master="${API_SCHEME}://${API_HOST}:${API_PORT}" --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" --hostname="${API_HOST}" --volume-dir="${VOLUME_DIR}" --cert-dir="${CERT_DIR}" --etcd-dir="${ETCD_DATA_DIR}" 1>&2 &
 OS_PID=$!
 
 if [[ "${API_SCHEME}" == "https" ]]; then

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -25,7 +25,6 @@ source "${OS_ROOT}/hack/util.sh"
 
 echo "[INFO] Starting end-to-end test"
 
-export OPENSHIFT_ON_PANIC=crash
 USE_LOCAL_IMAGES="${USE_LOCAL_IMAGES:-true}"
 ROUTER_TESTS_ENABLED="${ROUTER_TESTS_ENABLED:-true}"
 
@@ -158,7 +157,7 @@ echo "[INFO] Certs dir is:              ${CERT_DIR}"
 # Start All-in-one server and wait for health
 # Specify the scheme and port for the master, but let the IP auto-discover
 echo "[INFO] Starting OpenShift server"
-sudo env "PATH=${PATH}" openshift start --listen="${API_SCHEME}://0.0.0.0:${API_PORT}" --hostname="127.0.0.1" --volume-dir="${VOLUME_DIR}" --etcd-dir="${ETCD_DATA_DIR}" --cert-dir="${CERT_DIR}" --loglevel=4 &> "${LOG_DIR}/openshift.log" &
+sudo env "PATH=${PATH}" OPENSHIFT_ON_PANIC=crash openshift start --listen="${API_SCHEME}://0.0.0.0:${API_PORT}" --hostname="127.0.0.1" --volume-dir="${VOLUME_DIR}" --etcd-dir="${ETCD_DATA_DIR}" --cert-dir="${CERT_DIR}" --loglevel=4 &> "${LOG_DIR}/openshift.log" &
 OS_PID=$!
 
 if [[ "${API_SCHEME}" == "https" ]]; then


### PR DESCRIPTION
...during e2e

I suspect the intent was to make the main openshift process crash if there was a panic during e2e.  Since we share a single executable, that meant that ever `osc` command dumped the same output.  Since we wait using `osc` the e2e log fillls with 
```
OpenShift will terminate as soon as a panic occurs.
```

@smarterclayton can you confirm your intent?