### PR TITLE
authorization continued

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -76,7 +76,7 @@ var originTypes = []string{
 	"Project",
 	"User", "UserIdentityMapping",
 	"OAuthClient", "OAuthClientAuthorization", "OAuthAccessToken", "OAuthAuthorizeToken",
-	"Role", "RoleBinding", "Policy", "PolicyBinding",
+	"Role", "RoleBinding", "Policy", "PolicyBinding", "ResourceAccessReview", "SubjectAccessReview",
 }
 
 // OriginKind returns true if OpenShift owns the kind described in a given apiVersion.

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -10,14 +10,22 @@ func init() {
 		&RoleBinding{},
 		&Policy{},
 		&PolicyBinding{},
+		&ResourceAccessReview{},
+		&SubjectAccessReview{},
+		&ResourceAccessReviewResponse{},
+		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
 	)
 }
 
-func (*Role) IsAnAPIObject()              {}
-func (*Policy) IsAnAPIObject()            {}
-func (*PolicyBinding) IsAnAPIObject()     {}
-func (*RoleBinding) IsAnAPIObject()       {}
-func (*PolicyList) IsAnAPIObject()        {}
-func (*PolicyBindingList) IsAnAPIObject() {}
+func (*Role) IsAnAPIObject()                         {}
+func (*Policy) IsAnAPIObject()                       {}
+func (*PolicyBinding) IsAnAPIObject()                {}
+func (*RoleBinding) IsAnAPIObject()                  {}
+func (*ResourceAccessReview) IsAnAPIObject()         {}
+func (*SubjectAccessReview) IsAnAPIObject()          {}
+func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
+func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
+func (*PolicyList) IsAnAPIObject()                   {}
+func (*PolicyBindingList) IsAnAPIObject()            {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -133,6 +133,63 @@ type PolicyBinding struct {
 	RoleBindings map[string]RoleBinding
 }
 
+// ResourceAccessReviewResponse describes who can perform the action
+type ResourceAccessReviewResponse struct {
+	kapi.TypeMeta
+
+	// Namespace is the namespace used for the access review
+	Namespace string
+	// Users is the list of users who can perform the action
+	Users []string
+	// Groups is the list of groups who can perform the action
+	Groups []string
+}
+
+// ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the
+// action specified by spec
+type ResourceAccessReview struct {
+	kapi.TypeMeta
+
+	// Verb is one of: get, list, watch, create, update, delete
+	Verb string
+	// Resource is one of the existing resource types
+	Resource string
+	// Content is the actual content of the request for create and update
+	Content kruntime.EmbeddedObject
+	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
+	ResourceName string
+}
+
+// SubjectAccessReviewResponse describes whether or not a user or group can perform an action
+type SubjectAccessReviewResponse struct {
+	kapi.TypeMeta
+
+	// Namespace is the namespace used for the access review
+	Namespace string
+	// Allowed is required.  True if the action would be allowed, false otherwise.
+	Allowed bool
+	// Reason is optional.  It indicates why a request was allowed or denied.
+	Reason string
+}
+
+// SubjectAccessReview is an object for requesting information about whether a user or group can perform an action
+type SubjectAccessReview struct {
+	kapi.TypeMeta
+
+	// Verb is one of: get, list, watch, create, update, delete
+	Verb string
+	// Resource is one of the existing resource types
+	Resource string
+	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
+	User string
+	// Groups is optional.  Groups is the list of groups to which the User belongs.
+	Groups []string
+	// Content is the actual content of the request for create and update
+	Content kruntime.EmbeddedObject
+	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
+	ResourceName string
+}
+
 // PolicyList is a collection of Policies
 type PolicyList struct {
 	kapi.TypeMeta

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -10,14 +10,22 @@ func init() {
 		&RoleBinding{},
 		&Policy{},
 		&PolicyBinding{},
+		&ResourceAccessReview{},
+		&SubjectAccessReview{},
+		&ResourceAccessReviewResponse{},
+		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
 	)
 }
 
-func (*Role) IsAnAPIObject()              {}
-func (*Policy) IsAnAPIObject()            {}
-func (*PolicyBinding) IsAnAPIObject()     {}
-func (*RoleBinding) IsAnAPIObject()       {}
-func (*PolicyList) IsAnAPIObject()        {}
-func (*PolicyBindingList) IsAnAPIObject() {}
+func (*Role) IsAnAPIObject()                         {}
+func (*Policy) IsAnAPIObject()                       {}
+func (*PolicyBinding) IsAnAPIObject()                {}
+func (*RoleBinding) IsAnAPIObject()                  {}
+func (*ResourceAccessReview) IsAnAPIObject()         {}
+func (*SubjectAccessReview) IsAnAPIObject()          {}
+func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
+func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
+func (*PolicyList) IsAnAPIObject()                   {}
+func (*PolicyBindingList) IsAnAPIObject()            {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -84,6 +84,33 @@ type PolicyBinding struct {
 	RoleBindings []NamedRoleBinding `json:"roleBindings"`
 }
 
+// ResourceAccessReviewResponse describes who can perform the action
+type ResourceAccessReviewResponse struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// Namespace is the namespace used for the access review
+	Namespace string `json:"namespace,omitempty"`
+	// Users is the list of users who can perform the action
+	Users []string `json:"users"`
+	// Groups is the list of groups who can perform the action
+	Groups []string `json:"groups"`
+}
+
+// ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the
+// action specified by spec
+type ResourceAccessReview struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// Verb is one of: get, list, watch, create, update, delete
+	Verb string `json:"verb"`
+	// Resource is one of the existing resource types
+	Resource string `json:"resource"`
+	// Content is the actual content of the request for create and update
+	Content kruntime.RawExtension `json:"content,omitempty"`
+	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
+	ResourceName string `json:"resourceName,omitempty"`
+}
+
 type NamedRole struct {
 	Name string `json:"name"`
 	Role Role   `json:"role"`
@@ -92,6 +119,36 @@ type NamedRole struct {
 type NamedRoleBinding struct {
 	Name        string      `json:"name"`
 	RoleBinding RoleBinding `json:"roleBinding"`
+}
+
+// SubjectAccessReviewResponse describes whether or not a user or group can perform an action
+type SubjectAccessReviewResponse struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// Namespace is the namespace used for the access review
+	Namespace string `json:"namespace,omitempty"`
+	// Allowed is required.  True if the action would be allowed, false otherwise.
+	Allowed bool `json:"allowed"`
+	// Reason is optional.  It indicates why a request was allowed or denied.
+	Reason string `json:"reason,omitempty"`
+}
+
+// SubjectAccessReview is an object for requesting information about whether a user or group can perform an action
+type SubjectAccessReview struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// Verb is one of: get, list, watch, create, update, delete
+	Verb string `json:"verb"`
+	// Resource is one of the existing resource types
+	Resource string `json:"resource"`
+	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
+	User string `json:"user"`
+	// Groups is optional.  Groups is the list of groups to which the User belongs.
+	Groups []string `json:"groups"`
+	// Content is the actual content of the request for create and update
+	Content kruntime.RawExtension `json:"content,omitempty"`
+	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
+	ResourceName string `json:"resourceName"`
 }
 
 // PolicyList is a collection of Policies

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestViewerGetAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Victor",
 			},
-			verb:      "get",
-			resource:  "pods",
-			namespace: "mallet",
+			Verb:      "get",
+			Resource:  "pods",
+			Namespace: "mallet",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
@@ -28,13 +28,13 @@ func TestViewerGetAllowedKindInMallet(t *testing.T) {
 }
 func TestViewerGetAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Victor",
 			},
-			verb:      "get",
-			resource:  "pods",
-			namespace: "adze",
+			Verb:      "get",
+			Resource:  "pods",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -46,13 +46,13 @@ func TestViewerGetAllowedKindInAdze(t *testing.T) {
 
 func TestViewerGetDisallowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Victor",
 			},
-			verb:      "get",
-			resource:  "policies",
-			namespace: "mallet",
+			Verb:      "get",
+			Resource:  "policies",
+			Namespace: "mallet",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -63,13 +63,13 @@ func TestViewerGetDisallowedKindInMallet(t *testing.T) {
 }
 func TestViewerGetDisallowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Victor",
 			},
-			verb:      "get",
-			resource:  "policies",
-			namespace: "adze",
+			Verb:      "get",
+			Resource:  "policies",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -81,13 +81,13 @@ func TestViewerGetDisallowedKindInAdze(t *testing.T) {
 
 func TestViewerCreateAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Victor",
 			},
-			verb:      "create",
-			resource:  "pods",
-			namespace: "mallet",
+			Verb:      "create",
+			Resource:  "pods",
+			Namespace: "mallet",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -98,13 +98,13 @@ func TestViewerCreateAllowedKindInMallet(t *testing.T) {
 }
 func TestViewerCreateAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Victor",
 			},
-			verb:      "create",
-			resource:  "pods",
-			namespace: "adze",
+			Verb:      "create",
+			Resource:  "pods",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -116,13 +116,13 @@ func TestViewerCreateAllowedKindInAdze(t *testing.T) {
 
 func TestEditorUpdateAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Edgar",
 			},
-			verb:      "update",
-			resource:  "pods",
-			namespace: "mallet",
+			Verb:      "update",
+			Resource:  "pods",
+			Namespace: "mallet",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
@@ -133,13 +133,13 @@ func TestEditorUpdateAllowedKindInMallet(t *testing.T) {
 }
 func TestEditorUpdateAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Edgar",
 			},
-			verb:      "update",
-			resource:  "pods",
-			namespace: "adze",
+			Verb:      "update",
+			Resource:  "pods",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -151,13 +151,13 @@ func TestEditorUpdateAllowedKindInAdze(t *testing.T) {
 
 func TestEditorUpdateDisallowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Edgar",
 			},
-			verb:      "update",
-			resource:  "roleBindings",
-			namespace: "mallet",
+			Verb:      "update",
+			Resource:  "roleBindings",
+			Namespace: "mallet",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -168,13 +168,13 @@ func TestEditorUpdateDisallowedKindInMallet(t *testing.T) {
 }
 func TestEditorUpdateDisallowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Edgar",
 			},
-			verb:      "update",
-			resource:  "roleBindings",
-			namespace: "adze",
+			Verb:      "update",
+			Resource:  "roleBindings",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -186,13 +186,13 @@ func TestEditorUpdateDisallowedKindInAdze(t *testing.T) {
 
 func TestEditorGetAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Edgar",
 			},
-			verb:      "get",
-			resource:  "pods",
-			namespace: "mallet",
+			Verb:      "get",
+			Resource:  "pods",
+			Namespace: "mallet",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
@@ -203,13 +203,13 @@ func TestEditorGetAllowedKindInMallet(t *testing.T) {
 }
 func TestEditorGetAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Edgar",
 			},
-			verb:      "get",
-			resource:  "pods",
-			namespace: "adze",
+			Verb:      "get",
+			Resource:  "pods",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -221,13 +221,13 @@ func TestEditorGetAllowedKindInAdze(t *testing.T) {
 
 func TestAdminUpdateAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Matthew",
 			},
-			verb:      "update",
-			resource:  "roleBindings",
-			namespace: "mallet",
+			Verb:      "update",
+			Resource:  "roleBindings",
+			Namespace: "mallet",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
@@ -238,13 +238,13 @@ func TestAdminUpdateAllowedKindInMallet(t *testing.T) {
 }
 func TestAdminUpdateAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Matthew",
 			},
-			verb:      "update",
-			resource:  "roleBindings",
-			namespace: "adze",
+			Verb:      "update",
+			Resource:  "roleBindings",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -256,13 +256,13 @@ func TestAdminUpdateAllowedKindInAdze(t *testing.T) {
 
 func TestAdminUpdateDisallowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Matthew",
 			},
-			verb:      "update",
-			resource:  "policies",
-			namespace: "mallet",
+			Verb:      "update",
+			Resource:  "policies",
+			Namespace: "mallet",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -273,13 +273,13 @@ func TestAdminUpdateDisallowedKindInMallet(t *testing.T) {
 }
 func TestAdminUpdateDisallowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Matthew",
 			},
-			verb:      "update",
-			resource:  "roles",
-			namespace: "adze",
+			Verb:      "update",
+			Resource:  "roles",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
@@ -291,13 +291,13 @@ func TestAdminUpdateDisallowedKindInAdze(t *testing.T) {
 
 func TestAdminGetAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Matthew",
 			},
-			verb:      "get",
-			resource:  "policies",
-			namespace: "mallet",
+			Verb:      "get",
+			Resource:  "policies",
+			Namespace: "mallet",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
@@ -308,13 +308,13 @@ func TestAdminGetAllowedKindInMallet(t *testing.T) {
 }
 func TestAdminGetAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
-		attributes: &openshiftAuthorizationAttributes{
-			user: &user.DefaultInfo{
+		attributes: &DefaultAuthorizationAttributes{
+			User: &user.DefaultInfo{
 				Name: "Matthew",
 			},
-			verb:      "get",
-			resource:  "policies",
-			namespace: "adze",
+			Verb:      "get",
+			Resource:  "policies",
+			Namespace: "adze",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -1,0 +1,64 @@
+package authorizer
+
+import (
+	"testing"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
+)
+
+type subjectsTest struct {
+	policies                    []authorizationapi.Policy
+	bindings                    []authorizationapi.PolicyBinding
+	policyRetrievalError        error
+	policyBindingRetrievalError error
+
+	attributes *DefaultAuthorizationAttributes
+
+	expectedUsers  []string
+	expectedGroups []string
+	expectedError  string
+}
+
+func TestSubjects(t *testing.T) {
+	test := &subjectsTest{
+		attributes: &DefaultAuthorizationAttributes{
+			Verb:      "get",
+			Resource:  "pods",
+			Namespace: "adze",
+		},
+		expectedUsers:  []string{"Anna", "ClusterAdmin", "Ellen", "Valerie"},
+		expectedGroups: []string{"RootUsers"},
+	}
+	globalPolicy, globalPolicyBinding := newDefaultGlobalPolicy()
+	namespacedPolicy, namespacedPolicyBinding := newAdzePolicy()
+	test.policies = make([]authorizationapi.Policy, 0, 0)
+	test.policies = append(test.policies, namespacedPolicy...)
+	test.policies = append(test.policies, globalPolicy...)
+	test.bindings = make([]authorizationapi.PolicyBinding, 0, 0)
+	test.bindings = append(test.bindings, namespacedPolicyBinding...)
+	test.bindings = append(test.bindings, globalPolicyBinding...)
+
+	test.test(t)
+}
+
+func (test *subjectsTest) test(t *testing.T) {
+	policyRegistry := &testpolicyregistry.PolicyRegistry{
+		Err:             test.policyRetrievalError,
+		MasterNamespace: testMasterNamespace,
+		Policies:        test.policies,
+	}
+
+	policyBindingRegistry := &testpolicyregistry.PolicyBindingRegistry{
+		Err:             test.policyBindingRetrievalError,
+		MasterNamespace: testMasterNamespace,
+		PolicyBindings:  test.bindings,
+	}
+	authorizer := NewAuthorizer(testMasterNamespace, policyRegistry, policyBindingRegistry)
+
+	actualUsers, actualGroups, actualError := authorizer.GetAllowedSubjects(*test.attributes)
+
+	matchStringSlice(test.expectedUsers, actualUsers, "users", t)
+	matchStringSlice(test.expectedGroups, actualGroups, "groups", t)
+	matchError(test.expectedError, actualError, "error", t)
+}

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -1,0 +1,59 @@
+package resourceaccessreview
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	authorizer authorizer.Authorizer
+}
+
+// NewREST creates a new REST for policies.
+func NewREST(authorizer authorizer.Authorizer) apiserver.RESTStorage {
+	return &REST{authorizer}
+}
+
+// New creates a new ResourceAccessReview object
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.ResourceAccessReview{}
+}
+
+// Create registers a given new ResourceAccessReview instance to r.registry.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	resourceAccessReview, ok := obj.(*authorizationapi.ResourceAccessReview)
+	if !ok {
+		return nil, fmt.Errorf("not a resourceAccessReview: %#v", obj)
+	}
+
+	namespace := kapi.Namespace(ctx)
+
+	attributes := &authorizer.DefaultAuthorizationAttributes{
+		Verb:      resourceAccessReview.Verb,
+		Resource:  resourceAccessReview.Resource,
+		Namespace: namespace,
+	}
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		users, groups, err := r.authorizer.GetAllowedSubjects(attributes)
+		if err != nil {
+			return nil, err
+		}
+
+		response := &authorizationapi.ResourceAccessReviewResponse{
+			Namespace: namespace,
+			Users:     users,
+			Groups:    groups,
+		}
+
+		return response, nil
+	}), nil
+
+}

--- a/pkg/authorization/registry/resourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest_test.go
@@ -1,0 +1,137 @@
+package resourceaccessreview
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+type resourceAccessTest struct {
+	authorizer    *testAuthorizer
+	reviewRequest *authorizationapi.ResourceAccessReview
+}
+
+type testAuthorizer struct {
+	users  util.StringSet
+	groups util.StringSet
+	err    string
+
+	actualAttributes *authorizer.DefaultAuthorizationAttributes
+}
+
+func (a *testAuthorizer) Authorize(attributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
+	return false, "", errors.New("unsupported")
+}
+func (a *testAuthorizer) GetAllowedSubjects(passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
+	attributes, ok := passedAttributes.(*authorizer.DefaultAuthorizationAttributes)
+	if !ok {
+		return nil, nil, errors.New("unexpected type for test")
+	}
+
+	a.actualAttributes = attributes
+	if len(a.err) == 0 {
+		return a.users.List(), a.groups.List(), nil
+	}
+	return a.users.List(), a.groups.List(), errors.New(a.err)
+}
+
+func TestEmptyReturn(t *testing.T) {
+	test := &resourceAccessTest{
+		authorizer: &testAuthorizer{
+			users:  util.StringSet{},
+			groups: util.StringSet{},
+		},
+		reviewRequest: &authorizationapi.ResourceAccessReview{
+			Verb:     "get",
+			Resource: "pods",
+		},
+	}
+
+	test.runTest(t)
+}
+
+func TestNoErrors(t *testing.T) {
+	test := &resourceAccessTest{
+		authorizer: &testAuthorizer{
+			users:  util.NewStringSet("one", "two"),
+			groups: util.NewStringSet("three", "four"),
+		},
+		reviewRequest: &authorizationapi.ResourceAccessReview{
+			Verb:     "delete",
+			Resource: "deploymentConfig",
+		},
+	}
+
+	test.runTest(t)
+}
+
+func TestErrors(t *testing.T) {
+	test := &resourceAccessTest{
+		authorizer: &testAuthorizer{
+			users:  util.StringSet{},
+			groups: util.StringSet{},
+			err:    "some-random-failure",
+		},
+		reviewRequest: &authorizationapi.ResourceAccessReview{
+			Verb:     "get",
+			Resource: "pods",
+		},
+	}
+
+	test.runTest(t)
+}
+
+func (r *resourceAccessTest) runTest(t *testing.T) {
+	const namespace = "unittest"
+
+	storage := REST{r.authorizer}
+
+	expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
+		Namespace: namespace,
+		Users:     r.authorizer.users.List(),
+		Groups:    r.authorizer.groups.List(),
+	}
+
+	expectedAttributes := &authorizer.DefaultAuthorizationAttributes{
+		Verb:      r.reviewRequest.Verb,
+		Resource:  r.reviewRequest.Resource,
+		Namespace: namespace,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
+	channel, err := storage.Create(ctx, r.reviewRequest)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case result := <-channel:
+		switch obj := result.Object.(type) {
+		case *kapi.Status:
+			if len(r.authorizer.err) == 0 {
+				t.Errorf("Unexpected operation error: %v", obj)
+			}
+
+		case *authorizationapi.ResourceAccessReviewResponse:
+			if !reflect.DeepEqual(expectedResponse, obj) {
+				t.Errorf("diff %v", util.ObjectGoPrintDiff(expectedResponse, obj))
+			}
+
+		default:
+			t.Errorf("Unexpected result type: %v", result)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+
+	if !reflect.DeepEqual(expectedAttributes, r.authorizer.actualAttributes) {
+		t.Errorf("diff %v", util.ObjectGoPrintDiff(expectedAttributes, r.authorizer.actualAttributes))
+	}
+}

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -1,0 +1,66 @@
+package subjectaccessreview
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	authorizer authorizer.Authorizer
+}
+
+// NewREST creates a new REST for policies.
+func NewREST(authorizer authorizer.Authorizer) apiserver.RESTStorage {
+	return &REST{authorizer}
+}
+
+// New creates a new ResourceAccessReview object
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.SubjectAccessReview{}
+}
+
+// Create registers a given new ResourceAccessReview instance to r.registry.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RESTResult, error) {
+	subjectAccessReview, ok := obj.(*authorizationapi.SubjectAccessReview)
+	if !ok {
+		return nil, fmt.Errorf("not a subjectAccessReview: %#v", obj)
+	}
+
+	namespace := kapi.Namespace(ctx)
+
+	user := &user.DefaultInfo{
+		Name:   subjectAccessReview.User,
+		Groups: subjectAccessReview.Groups,
+	}
+
+	attributes := &authorizer.DefaultAuthorizationAttributes{
+		User:      user,
+		Verb:      subjectAccessReview.Verb,
+		Resource:  subjectAccessReview.Resource,
+		Namespace: namespace,
+	}
+
+	return apiserver.MakeAsync(func() (runtime.Object, error) {
+		allowed, reason, err := r.authorizer.Authorize(attributes)
+		if err != nil {
+			return nil, err
+		}
+
+		response := &authorizationapi.SubjectAccessReviewResponse{
+			Namespace: namespace,
+			Allowed:   allowed,
+			Reason:    reason,
+		}
+
+		return response, nil
+	}), nil
+
+}

--- a/pkg/authorization/registry/subjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest_test.go
@@ -1,0 +1,146 @@
+package subjectaccessreview
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+type subjectAccessTest struct {
+	authorizer    *testAuthorizer
+	reviewRequest *authorizationapi.SubjectAccessReview
+}
+
+type testAuthorizer struct {
+	allowed bool
+	reason  string
+	err     string
+
+	actualAttributes *authorizer.DefaultAuthorizationAttributes
+}
+
+func (a *testAuthorizer) Authorize(passedAttributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
+	attributes, ok := passedAttributes.(*authorizer.DefaultAuthorizationAttributes)
+	if !ok {
+		return false, "ERROR", errors.New("unexpected type for test")
+	}
+
+	a.actualAttributes = attributes
+
+	if len(a.err) == 0 {
+		return a.allowed, a.reason, nil
+	}
+	return a.allowed, a.reason, errors.New(a.err)
+}
+func (a *testAuthorizer) GetAllowedSubjects(passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
+	return nil, nil, nil
+}
+
+func TestEmptyReturn(t *testing.T) {
+	test := &subjectAccessTest{
+		authorizer: &testAuthorizer{
+			allowed: false,
+			reason:  "because reasons",
+		},
+		reviewRequest: &authorizationapi.SubjectAccessReview{
+			User:     "foo",
+			Groups:   []string{},
+			Verb:     "get",
+			Resource: "pods",
+		},
+	}
+
+	test.runTest(t)
+}
+
+func TestNoErrors(t *testing.T) {
+	test := &subjectAccessTest{
+		authorizer: &testAuthorizer{
+			allowed: true,
+			reason:  "because good things",
+		},
+		reviewRequest: &authorizationapi.SubjectAccessReview{
+			Groups:   []string{"master"},
+			Verb:     "delete",
+			Resource: "deploymentConfigs",
+		},
+	}
+
+	test.runTest(t)
+}
+
+func TestErrors(t *testing.T) {
+	test := &subjectAccessTest{
+		authorizer: &testAuthorizer{
+			err: "some-random-failure",
+		},
+		reviewRequest: &authorizationapi.SubjectAccessReview{
+			User:     "foo",
+			Groups:   []string{"first", "second"},
+			Verb:     "get",
+			Resource: "pods",
+		},
+	}
+
+	test.runTest(t)
+}
+
+func (r *subjectAccessTest) runTest(t *testing.T) {
+	const namespace = "unittest"
+
+	storage := REST{r.authorizer}
+
+	expectedResponse := &authorizationapi.SubjectAccessReviewResponse{
+		Namespace: namespace,
+		Allowed:   r.authorizer.allowed,
+		Reason:    r.authorizer.reason,
+	}
+
+	expectedAttributes := &authorizer.DefaultAuthorizationAttributes{
+		User: &user.DefaultInfo{
+			Name:   r.reviewRequest.User,
+			Groups: r.reviewRequest.Groups,
+		},
+		Verb:      r.reviewRequest.Verb,
+		Resource:  r.reviewRequest.Resource,
+		Namespace: namespace,
+	}
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
+	channel, err := storage.Create(ctx, r.reviewRequest)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	select {
+	case result := <-channel:
+		switch obj := result.Object.(type) {
+		case *kapi.Status:
+			if len(r.authorizer.err) == 0 {
+				t.Errorf("Unexpected operation error: %v", obj)
+			}
+
+		case *authorizationapi.SubjectAccessReviewResponse:
+			if !reflect.DeepEqual(expectedResponse, obj) {
+				t.Errorf("diff %v", util.ObjectGoPrintDiff(expectedResponse, obj))
+			}
+
+		default:
+			t.Errorf("Unexpected result type: %v", result)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Error("Unexpected timeout from async channel")
+	}
+
+	if !reflect.DeepEqual(expectedAttributes, r.authorizer.actualAttributes) {
+		t.Errorf("diff %v", util.ObjectGoPrintDiff(expectedAttributes, r.authorizer.actualAttributes))
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -31,6 +31,8 @@ type Interface interface {
 	RolesNamespacer
 	RoleBindingsNamespacer
 	PolicyBindingsNamespacer
+	ResourceAccessReviewsNamespacer
+	SubjectAccessReviewsNamespacer
 }
 
 func (c *Client) Builds(namespace string) BuildInterface {
@@ -109,6 +111,14 @@ func (c *Client) Roles(namespace string) RoleInterface {
 
 func (c *Client) RoleBindings(namespace string) RoleBindingInterface {
 	return newRoleBindings(c, namespace)
+}
+
+func (c *Client) ResourceAccessReviews(namespace string) ResourceAccessReviewInterface {
+	return newResourceAccessReviews(c, namespace)
+}
+
+func (c *Client) SubjectAccessReviews(namespace string) SubjectAccessReviewInterface {
+	return newSubjectAccessReviews(c, namespace)
 }
 
 // Client is an OpenShift client object

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -75,3 +75,11 @@ func (c *Fake) RoleBindings(namespace string) RoleBindingInterface {
 func (c *Fake) PolicyBindings(namespace string) PolicyBindingInterface {
 	return &FakePolicyBindings{Fake: c}
 }
+
+func (c *Fake) ResourceAccessReviews(namespace string) ResourceAccessReviewInterface {
+	return &FakeResourceAccessReviews{Fake: c}
+}
+
+func (c *Fake) SubjectAccessReviews(namespace string) SubjectAccessReviewInterface {
+	return &FakeSubjectAccessReviews{Fake: c}
+}

--- a/pkg/client/fake_resourceaccessreview.go
+++ b/pkg/client/fake_resourceaccessreview.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeResourceAccessReviews struct {
+	Fake *Fake
+}
+
+func (c *FakeResourceAccessReviews) Create(resourceAccessReview *authorizationapi.ResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-resourceAccessReview", Value: resourceAccessReview})
+	return &authorizationapi.ResourceAccessReviewResponse{}, nil
+}

--- a/pkg/client/fake_subjectaccessreview.go
+++ b/pkg/client/fake_subjectaccessreview.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeSubjectAccessReviews struct {
+	Fake *Fake
+}
+
+func (c *FakeSubjectAccessReviews) Create(subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-subjectAccessReview", Value: subjectAccessReview})
+	return &authorizationapi.SubjectAccessReviewResponse{}, nil
+}

--- a/pkg/client/resourceaccessreview.go
+++ b/pkg/client/resourceaccessreview.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// ResourceAccessReviewsNamespacer has methods to work with ResourceAccessReview resources in a namespace
+type ResourceAccessReviewsNamespacer interface {
+	ResourceAccessReviews(namespace string) ResourceAccessReviewInterface
+}
+
+// ResourceAccessReviewInterface exposes methods on ResourceAccessReview resources.
+type ResourceAccessReviewInterface interface {
+	Create(policy *authorizationapi.ResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error)
+}
+
+// resourceAccessReviews implements ResourceAccessReviewsNamespacer interface
+type resourceAccessReviews struct {
+	r  *Client
+	ns string
+}
+
+// newResourceAccessReviews returns a resourceAccessReviews
+func newResourceAccessReviews(c *Client, namespace string) *resourceAccessReviews {
+	return &resourceAccessReviews{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// Create creates new policy. Returns the server's representation of the policy and error if one occurs.
+func (c *resourceAccessReviews) Create(policy *authorizationapi.ResourceAccessReview) (result *authorizationapi.ResourceAccessReviewResponse, err error) {
+	result = &authorizationapi.ResourceAccessReviewResponse{}
+	err = c.r.Post().Namespace(c.ns).Resource("resourceAccessReviews").Body(policy).Do().Into(result)
+	return
+}

--- a/pkg/client/subjectaccessreview.go
+++ b/pkg/client/subjectaccessreview.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// SubjectAccessReviewsNamespacer has methods to work with SubjectAccessReview resources in a namespace
+type SubjectAccessReviewsNamespacer interface {
+	SubjectAccessReviews(namespace string) SubjectAccessReviewInterface
+}
+
+// SubjectAccessReviewInterface exposes methods on SubjectAccessReview resources.
+type SubjectAccessReviewInterface interface {
+	Create(policy *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error)
+}
+
+// subjectAccessReviews implements SubjectAccessReviewsNamespacer interface
+type subjectAccessReviews struct {
+	r  *Client
+	ns string
+}
+
+// newSubjectAccessReviews returns a subjectAccessReviews
+func newSubjectAccessReviews(c *Client, namespace string) *subjectAccessReviews {
+	return &subjectAccessReviews{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// Create creates new policy. Returns the server's representation of the policy and error if one occurs.
+func (c *subjectAccessReviews) Create(policy *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
+	result = &authorizationapi.SubjectAccessReviewResponse{}
+	err = c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews").Body(policy).Do().Into(result)
+	return
+}

--- a/pkg/cmd/experimental/policy/policy.go
+++ b/pkg/cmd/experimental/policy/policy.go
@@ -34,6 +34,7 @@ func NewCommandPolicy(name string) *cobra.Command {
 	cmds.AddCommand(NewCmdAddGroup(clientConfig))
 	cmds.AddCommand(NewCmdRemoveGroup(clientConfig))
 	cmds.AddCommand(NewCmdRemoveGroupFromProject(clientConfig))
+	cmds.AddCommand(NewCmdWhoCan(clientConfig))
 
 	return cmds
 }

--- a/pkg/cmd/experimental/policy/who_can.go
+++ b/pkg/cmd/experimental/policy/who_can.go
@@ -1,0 +1,82 @@
+package policy
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+)
+
+type whoCanOptions struct {
+	clientConfig clientcmd.ClientConfig
+
+	verb     string
+	resource string
+}
+
+func NewCmdWhoCan(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	options := &whoCanOptions{clientConfig: clientConfig}
+
+	cmd := &cobra.Command{
+		Use:   "who-can",
+		Short: "who-can <verb> <resource>",
+		Long:  `who-can <verb> <resource>`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if !options.complete(cmd) {
+				return
+			}
+
+			err := options.run()
+			if err != nil {
+				fmt.Printf("%v\n", err)
+			}
+		},
+	}
+
+	return cmd
+}
+
+func (o *whoCanOptions) complete(cmd *cobra.Command) bool {
+	args := cmd.Flags().Args()
+	if len(args) != 2 {
+		cmd.Help()
+		return false
+	}
+
+	o.verb = args[0]
+	o.resource = args[1]
+	return true
+}
+
+func (o *whoCanOptions) run() error {
+	clientConfig, err := o.clientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+	client, err := client.New(clientConfig)
+	if err != nil {
+		return err
+	}
+	namespace, err := o.clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	resourceAccessReview := &authorizationapi.ResourceAccessReview{}
+	resourceAccessReview.Resource = o.resource
+	resourceAccessReview.Verb = o.verb
+
+	resourceAccessReviewResponse, err := client.ResourceAccessReviews(namespace).Create(resourceAccessReview)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Users: %v\n", resourceAccessReviewResponse.Users)
+	fmt.Printf("Groups: %v\n", resourceAccessReviewResponse.Groups)
+
+	return nil
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -78,8 +78,10 @@ import (
 	authorizationetcd "github.com/openshift/origin/pkg/authorization/registry/etcd"
 	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
 	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+	resourceaccessreviewregistry "github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
 	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
 	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
+	subjectaccessreviewregistry "github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 )
 
 const (
@@ -295,10 +297,12 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		"oAuthClients":              clientregistry.NewREST(oauthEtcd),
 		"oAuthClientAuthorizations": clientauthorizationregistry.NewREST(oauthEtcd),
 
-		"policies":       policyregistry.NewREST(authorizationEtcd),
-		"policyBindings": policybindingregistry.NewREST(authorizationEtcd),
-		"roles":          roleregistry.NewREST(authorizationEtcd),
-		"roleBindings":   rolebindingregistry.NewREST(authorizationEtcd, authorizationEtcd, userEtcd, c.MasterAuthorizationNamespace),
+		"policies":              policyregistry.NewREST(authorizationEtcd),
+		"policyBindings":        policybindingregistry.NewREST(authorizationEtcd),
+		"roles":                 roleregistry.NewREST(authorizationEtcd),
+		"roleBindings":          rolebindingregistry.NewREST(authorizationEtcd, authorizationEtcd, userEtcd, c.MasterAuthorizationNamespace),
+		"resourceAccessReviews": resourceaccessreviewregistry.NewREST(c.Authorizer),
+		"subjectAccessReviews":  subjectaccessreviewregistry.NewREST(c.Authorizer),
 	}
 
 	admissionControl := admit.NewAlwaysAdmit()


### PR DESCRIPTION
This is based on #675 and adds:
 1. cleaner initialization config
 1. experimental cli
 1. resource access review
 1. subject access review