### PR TITLE
sample-app docs: update for TLS, namespace, context

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -3,7 +3,11 @@ OpenShift 3 Application Lifecycle Sample
 
 This is a set of configuration files and scripts which work with OpenShift 3 to create a new application and perform application builds.
 
-This example assumes you have successfully built the `openshift` binary executable and have Docker installed/working.  See https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc.
+This example assumes you have successfully built the `openshift`
+binary executable (normally located under origin/\_output/local/go/bin),
+you have that and its symlink/copy `osc` in your `PATH` and root's,
+and Docker is installed and working.  See
+https://github.com/openshift/origin/blob/master/CONTRIBUTING.adoc.
 
 Alternatively, if you are using the openshift/origin Docker container, please
 make sure you follow these instructions first:
@@ -26,7 +30,7 @@ At this stage of OpenShift 3 development, there are a few things that you will n
 
 - - -
 
-**NOTE:** You do not need to do this is you are using [Vagrant](https://vagrantup.com/) to work with OpenShift (see the [Vagrantfile](https://github.com/openshift/origin/blob/master/Vagrantfile) for more info). These changes are only necessary when you have set up the host system yourself. If you are using Vagrant, [jump to the next section](#application-build-deploy-and-update-flow).
+**NOTE:** You do not need to do this if you are using [Vagrant](https://vagrantup.com/) to work with OpenShift (see the [Vagrantfile](https://github.com/openshift/origin/blob/master/Vagrantfile) for more info). These changes are only necessary when you have set up the host system yourself. If you are using Vagrant, [jump to the next section](#application-build-deploy-and-update-flow).
 
 - - -
 
@@ -40,7 +44,8 @@ To do this, you need to add "--insecure-registry 172.30.17.0/24" to the docker d
 
 If you are running docker as a service via `systemd`, you can add this argument to the options value in `/etc/sysconfig/docker`
 
-This will instruct the docker daemon to trust any docker registry on the 172.30.17.0/24 subnet, rather than requiring a certificate.
+This will instruct the docker daemon to trust any docker registry on the 172.30.17.0/24 subnet,
+rather than requiring the registry to have a verifiable certificate.
 
 These instructions assume you have not changed the kubernetes/openshift service subnet configuration from the default value of 172.30.17.0/24.
 
@@ -63,25 +68,55 @@ Application Build, Deploy, and Update Flow
 
 This section covers how to perform all the steps of building, deploying, and updating an application on the OpenShift platform.
 
-All commands assume the `openshift` binary is in your path (normally located under origin/_output/local/go/bin):
+NOTE: All commands assume the `osc` binary/symlink is in your path and
+the present working directory is the same directory as this README.
 
-1. Pre-pull the docker images used in this sample.  This is not strictly necessary as OpenShift will pull the images as it needs them, but by doing it up front it will prevent lengthy operations during build and deployment which might otherwise lead you to believe the process has failed or hung.
+1. *Optional*: Pre-pull the docker images used in this sample.  This is
+    not strictly necessary as OpenShift will pull the images as it needs them,
+    but by doing it up front it will prevent lengthy operations during build
+    and deployment which might otherwise lead you to believe the process
+    has failed or hung.
 
         $ ./pullimages.sh
 
-2. Launch `openshift`
+2. Launch an all-in-one `openshift` instance
 
         $ sudo openshift start &> logs/openshift.log &
 
-    Note: sudo is required so the kubernetenes proxy can manipulate iptables rules to expose service ports.
+    Note: sudo is required so the kubernetes proxy can manipulate iptables rules to expose service ports.
 
-3. Deploy the private docker registry within OpenShift:
+3. Set up your client to reach the OpenShift master now running.
 
-        $ openshift cli apply -f docker-registry-config.json
+    Since OpenShift services are secured by TLS, your client will
+    need to accept the server certificates and present its own client
+    certificate. These are generated as part of the `openshift start`
+    command in whatever the current directory is at the time. You will
+    need to point osc and curl at the appropriate CA bundle and client
+    key/cert in order to connect to OpenShift. Assuming you are running as
+    a user other than root, you will also need to make the private client
+    key readable by that user. (Note: this is just for example purposes;
+    in a real installation, users would generate their own keys and not
+    have access to the system keys.)
 
-4. Confirm the registry is started (this can take a few mins):
+        $ export KUBECONFIG=`pwd`/openshift.local.certificates/admin/.kubeconfig
+        $ export CURL_CA_BUNDLE=`pwd`/openshift.local.certificates/admin/root.crt
+        $ sudo chmod +r `pwd`/openshift.local.certificates/admin/key.key
 
-        $ openshift cli get pods
+4. Deploy a private docker registry within OpenShift with the certs necessary for access to master:
+
+        $ sudo chmod +r ./openshift.local.certificates/master/key.key
+        $ pushd ../..
+        $ CERT_DIR=examples/sample-app/openshift.local.certificates/master hack/install-registry.sh
+        $ popd
+
+    Note that the private docker registry is using ephemeral storage,
+    so when it is stopped, the image will be lost. An external volume
+    could be used for persistent storage, but that is beyond the scope
+    of this tutorial.
+
+5. Confirm the registry is started (this can take a few minutes):
+
+        $ osc get pods
 
     You should see:
 
@@ -89,9 +124,9 @@ All commands assume the `openshift` binary is in your path (normally located und
         ----------                             ----------                  ----------               ----------                                                                                               ----------
         94679170-54dc-11e4-88cc-3c970e3bf0b7   openshift/docker-registry   localhost.localdomain/   deployment=registry-config,name=registrypod,replicationController=946583f6-54dc-11e4-88cc-3c970e3bf0b7   Running
 
-5. Confirm the registry service is running.  Note that the actual IP address may vary.
+6. Confirm the registry service is running.  Note that the actual IP address may vary.
 
-        $ openshift cli get services
+        $ osc get services
 
     You should see:
 
@@ -99,48 +134,92 @@ All commands assume the `openshift` binary is in your path (normally located und
         ----------          ----------          ----------          ----------          ----------
         docker-registry                         name=registrypod    172.30.17.3        5001
 
-6. Confirm the registry is accessible (you may need to run this more than once):
+7. Confirm the registry is accessible (you may need to run this more than once):
 
-        $ curl `openshift cli get services docker-registry -o template --template="{{ .portalIP}}:{{ .port }}"`
+        $ curl `osc get services docker-registry -o template --template="{{ .portalIP}}:{{ .port }}"`
 
     You should see:
 
         "docker-registry server (dev) (v0.9.0)"
 
 
-7. Create a new project in OpenShift
+8. Create a new project in OpenShift. This creates a namespace `test` to contain the builds and app that we will generate below.
 
-        $ openshift cli create project -f project.json
+        $ osc create -f project.json
 
-8. *Optional:* View the OpenShift web console in your browser by browsing to `https://<host>:8444`
-    If you click the `Hello OpenShift` project and leave the tab open, you'll see the page update as you deploy objects into the project and run builds.
+    Ensure that all further `osc` usage is scoped to this project:
 
-9. Fork the [ruby sample repository](https://github.com/openshift/ruby-hello-world)
+        $ osc namespace test
 
-10. *Optional:* Add the following webhook to your new github repository:
+9. *Optional:* View the OpenShift web console in your browser by browsing to `https://<host>:8444`
+
+    * You will need to have the browser accept the certificate at
+      `https://<host>:8443` before the console can consult the OpenShift
+      API. Of course this would not be necessary with a legitimate
+      certificate.
+    * If you click the `Hello OpenShift` project and leave the tab open,
+      you'll see the page update as you deploy objects into the project
+      and run builds.
+
+10. *Optional:* Fork the [ruby sample repository](https://github.com/openshift/ruby-hello-world)
+    to an OpenShift-visible git account that you control, preferably
+    somewhere that can also reach your OpenShift server with a webhook.
+    A github.com account is an obvious place for this, but an in-house
+    git hosting site may work better for reaching your OpenShift server.
+
+    We will demonstrate building from a repository and then triggering
+    a new build from changing that repository. If you do not have an
+    account that will work for this purpose, that is fine; just use
+    a GitHub account and simulate the webhook (demonstrated below).
+    Without your own fork, you can still run the initial build from
+    OpenShift's public repository, just not a changed build.
+
+11. *Optional:* Add the following webhook under the settings in your new GitHub repository:
 
         $ https://<host>:8443/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/github?namespace=test
-  * Note: Using the webhook requires your OpenShift server be publicly accessible so github can reach it to invoke the hook.
 
-11. Edit application-template-stibuild.json
+  * Note: Using the webhook requires that your OpenShift server be
+    publicly accessible so GitHub can reach it to invoke the hook. You
+    will almost certainly need to "Disable SSL Verification" for your test
+    instance as the certificate chain generated is not publicly verified.
+
+12. Edit application-template-stibuild.json which will define the sample application
+
  * Update the BuildConfig's sourceURI (git://github.com/openshift/ruby-hello-world.git) to point to your forked repository.
- * Replace occurences of `172.30.17.3` with the IP address of the docker-registry service as seen in step 5.
+   *Note:* You can skip this step if you did not create a forked repository.
 
- *Note:* You can skip this step if your registry service ip is 172.30.17.3, which should normally be the case.
+13. Submit the application template for processing (generating shared parameters requested in the template)
+    and then request creation of the processed template:
 
-12. Submit the application template for processing and create the application using the processed template:
+        $ osc process -f application-template-stibuild.json | osc create -f -
 
-        $ openshift cli process -f application-template-stibuild.json | openshift cli apply --namespace=test -f -
+    This will define a number of related OpenShift entities in the project:
 
-13. Trigger an initial build of your application
- * If you setup the github webhook in step 10, push a change to app.rb in your ruby sample repository from step 9.
+    * A BuildConfig (ruby-sample-build) to specify a build that uses
+      your ruby-hello-world fork as the input for a source-to-image (STI) build
+    * ImageRepositories for the images used and created in the build:
+      * The ruby-20-centos STI builder will build an image from your source
+      * The output image will be called origin-ruby-sample
+    * DeploymentConfigs (frontend, backend) for defining Deployments once the images are available
+    * Services (routable endpoints) for the ruby frontend and database backend deployments
+      that will deployed as output of the build
+
+    Note that no build has actually occurred yet, so at this time there
+    is no image to deploy and no application to visit.
+
+14. Trigger an initial build of your application
+ * If you setup the GitHub webhook, push a change to app.rb in your ruby sample repository from step 10.
  * Otherwise you can simulate the webhook invocation by running:
 
-            $ curl -X POST https://localhost:8443/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic?namespace=test
+        $ curl -X POST https://localhost:8443/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic?namespace=test
 
-14. Monitor the builds and wait for the status to go to "complete" (this can take a few mins):
+15. Monitor the builds and wait for the status to go to "complete" (this can take a few minutes):
 
-        $ openshift cli get builds --namespace=test
+        $ osc get builds
+
+    You can add the --watch flag to wait for updates until the build completes:
+
+        $ osc get builds --watch
 
     Sample output:
 
@@ -148,19 +227,25 @@ All commands assume the `openshift` binary is in your path (normally located und
         ----------                             ----------          ----------
         20f54507-3dcd-11e4-984b-3c970e3bf0b7   complete            build-docker-20f54507-3dcd-11e4-984b-3c970e3bf0b7
 
-     The build will be automatically pushed to the private docker registry running in OpenShift and tagged with the imageTag listed
-     in the buildcfg.json.  Note that the private docker registry is using ephemeral storage, so when it is stopped, the image will
-     be lost.  An external volume can be used for storage, but is beyond the scope of this tutorial.
+     The built image will be named with the ImageRepository
+     (origin-ruby-sample) named in the BuildConfig and pushed to the
+     private Docker registry running in OpenShift.  (Note that the private
+     docker registry is using ephemeral storage, so when it is stopped,
+     the image will be lost.)
 
-     If you want to see the build logs of a complete build, use this command (substituting your build id from the "openshift cli get builds" output):
+     If you want to see the build logs of a complete build, use this
+     command (substituting your build name from the "osc get builds"
+     output):
 
-         $ openshift cli build-logs 20f54507-3dcd-11e4-984b-3c970e3bf0b7 --namespace=test
+         $ osc build-logs 20f54507-3dcd-11e4-984b-3c970e3bf0b7
 
-    The creation of the new image will automatically trigger a deployment of the application.
+    The creation of the new image in the Docker registry will
+    automatically trigger a deployment of the application, creating a
+    pod each for the frontend (your Ruby code) and backend.
 
-15. Wait for the application's frontend pod and database pods to be started (this can take a few mins):
+16. Wait for the application's frontend pod and database pods to be started (this can take a few minutes):
 
-        $ openshift cli get pods --namespace=test
+        $ osc get pods
 
     Sample output:
 
@@ -169,56 +254,57 @@ All commands assume the `openshift` binary is in your path (normally located und
         1b978f62-605f-11e4-b0db-3c970e3bf0b7                mysql                                                                                                             localhost.localdomain/   deploymentConfig=,deploymentID=database,name=database,replicationController=1b960e56-605f-11e4-b0db-3c970e3bf0b7,template=ruby-helloworld-sample             Running
         4a792f55-605f-11e4-b0db-3c970e3bf0b7                172.30.17.3:5001/openshift/origin-ruby-sample:9477bdb99a409b9c747e699361ae7934fd83bb4092627e2ee35f9f0b0869885b   localhost.localdomain/   deploymentConfig=frontend,deploymentID=frontend-1,name=frontend,replicationController=4a749831-605f-11e4-b0db-3c970e3bf0b7,template=ruby-helloworld-sample   Running
 
-16. Determine the IP for the frontend service:
+17. Determine the IP for the frontend service:
 
-        $ openshift cli get services --namespace=test
+        $ osc get services
 
     Sample output:
 
         Name                Labels                            Selector            IP                  Port
         ----------          ----------                        ----------          ----------          ----------
         database            template=ruby-helloworld-sample   name=database       172.30.17.5        5434
-        docker-registry                                       name=registrypod    172.30.17.3        5001
         frontend            template=ruby-helloworld-sample   name=frontend       172.30.17.4        5432
 
 
     In this case, the IP for frontend is 172.30.17.4 and it is on port 5432.
 
-    *Note:* you can also get this information from the web console if you launched it in step 8.
+    *Note:* you can also get this information from the web console if you launched it in step 9.
 
-17. Confirm the application is now accessible via the frontend service on port 5432.  Go to http://172.30.17.4:5432 (or whatever IP address was reported above) in your browser.
+18. Confirm the application is now accessible via the frontend service on port 5432.  Go to http://172.30.17.4:5432 (or whatever IP address was reported above) in your browser if you're running this locally; otherwise you can use curl to see the HTML, or port forward the address to your local workstation to visit it.
 
     You should see a welcome page and a form that allows you to query and update key/value pairs.  The keys are stored in the database container running in the database pod.
 
-18. Make a change to your ruby sample main.html file and push it.
+19. Make a change to your ruby sample main.html file, commit, and push it via git.
 
  * If you do not have the webhook enabled, you'll have to manually trigger another build:
 
             $ curl -X POST https://localhost:8443/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic?namespace=test
 
 
-19. Repeat step 14 (waiting for the build to complete).  Once the build is complete, refreshing your browser should show your changes.
+20. Repeat step 15 (waiting for the build to complete).  Once the build is complete, refreshing your browser should show your changes.
 
-Congratulations, you've successfully deployed and updated an application on OpenShift.  
+Congratulations, you've successfully deployed and updated an application on OpenShift.
+
+Cleaning up
+-----------
 
 In addition to creating resources, you can delete resources based on IDs. For example, if you want to remove only the containers or services created during the demo:
 
   - List the existing services:
 
-        $ openshift cli get services --namespace=test
+        $ osc get services
 
     Sample output:
 
         Name                Labels                            Selector            IP                  Port
         ----------          ----------                        ----------          ----------          ----------
-        docker-registry                                       name=registrypod    172.30.17.3        5001
         frontend            template=ruby-helloworld-sample   name=frontend       172.30.17.4        5432
         database            template=ruby-helloworld-sample   name=database       172.30.17.5        5434
 
 
   - To remove the **frontend** service use the command:
 
-        $ openshift cli delete service frontend --namespace=test
+        $ osc delete service frontend
 
     Sample output:
 
@@ -228,13 +314,12 @@ In addition to creating resources, you can delete resources based on IDs. For ex
 
   - Check the service was removed:
 
-        $ openshift cli get services --namespace=test
+        $ osc get services
 
     Sample output:
 
         Name                Labels                            Selector            IP                  Port
         ----------          ----------                        ----------          ----------          ----------
-        docker-registry                                       name=registrypod    172.30.17.3        5001
         database            template=ruby-helloworld-sample   name=database       172.30.17.5        5434
 
 
@@ -250,19 +335,18 @@ Another interesting example is deleting a pod.
 
   - List available pods:
 
-        $ openshift cli get pods --namespace=test
+        $ osc get pods
 
     Sample output:
 
         Name                                                Image(s)                                                                                                          Host                     Labels                                                                                                                                                       Status
         ----------                                          ----------                                                                                                        ----------               ----------                                                                                                                                                   ----------
-        b8f087b7-605e-11e4-b0db-3c970e3bf0b7                openshift/docker-registry                                                                                         localhost.localdomain/   name=registrypod,replicationController=docker-registry                                                                                                       Running
         1b978f62-605f-11e4-b0db-3c970e3bf0b7                mysql                                                                                                             localhost.localdomain/   deploymentConfig=,deploymentID=database,name=database,replicationController=1b960e56-605f-11e4-b0db-3c970e3bf0b7,template=ruby-helloworld-sample             Running
         4a792f55-605f-11e4-b0db-3c970e3bf0b7                172.30.17.3:5001/openshift/origin-ruby-sample:9477bdb99a409b9c747e699361ae7934fd83bb4092627e2ee35f9f0b0869885b   localhost.localdomain/   deploymentConfig=frontend,deploymentID=frontend-1,name=frontend,replicationController=4a749831-605f-11e4-b0db-3c970e3bf0b7,template=ruby-helloworld-sample   Running
 
   - Delete the **frontend** pod by specifying its ID:
 
-        $ openshift cli delete pod 4a792f55-605f-11e4-b0db-3c970e3bf0b7 --namespace=test
+        $ osc delete pod 4a792f55-605f-11e4-b0db-3c970e3bf0b7
 
   - Verify that the pod has been removed by listing the available pods. This also stopped the associated Docker container, you can check using the command:
 

--- a/hack/install-registry.sh
+++ b/hack/install-registry.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+# This uses osc to bootstrap a Docker registry image as a pod under a running OpenShift.
+# It uses the key/certs in the directory specified by CERT_DIR to configure the registry
+# for connecting securely to the OpenShift master's.
+#
+# To use key/certs generated automatically by "openshift start", look for the
+# openshift.local.certificates/master/ directory underneath where it was started.
+# For instance, if the openshift home directory is /var/lib/openshift, then run:
+# CERT_DIR=/var/lib/openshift/openshift.local.certificates/master hack/install-registry.sh
+#
+# You may also need to set KUBERNETES_MASTER if the master is not listening at https://localhost:8443/
+
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
Now that the default openshift runs with generated TLS CA/certs/keys, it
is necessary to discuss navigating these during the sample instructions.
Also, introduced the "osc namespace" command rather than append
--namespace everywhere.
Provided more context about what is going on at some of the points.