### PR TITLE
Support parameter substitution for all string fields in Template

### DIFF
--- a/pkg/util/stringreplace/object.go
+++ b/pkg/util/stringreplace/object.go
@@ -1,0 +1,53 @@
+package stringreplace
+
+import (
+	"reflect"
+
+	"github.com/golang/glog"
+)
+
+// VisitObjectStrings visits recursively all string fields in the object and call the
+// visitor function on them. The visitor function can be used to modify the
+// value of the string fields.
+func VisitObjectStrings(obj interface{}, visitor func(string) string) {
+	v := reflect.ValueOf(obj).Elem()
+
+	visitField := func(val reflect.Value) {
+		switch val.Kind() {
+		case reflect.Ptr, reflect.Interface:
+			if val.CanInterface() {
+				VisitObjectStrings(val.Interface(), visitor)
+			}
+		case reflect.Struct, reflect.Map, reflect.Slice, reflect.Array:
+			if val.CanInterface() {
+				VisitObjectStrings(val.Addr().Interface(), visitor)
+			}
+		case reflect.String:
+			if !val.CanSet() {
+				glog.V(5).Infof("Unable to set String value '%v'", v)
+			}
+			val.SetString(visitor(val.String()))
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		for c := 0; c < v.Len(); c++ {
+			visitField(v.Index(c))
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			visitField(v.Field(i))
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			c := reflect.New(v.MapIndex(k).Type()).Elem()
+			c.Set(v.MapIndex(k))
+			visitField(c)
+			v.SetMapIndex(k, c)
+		}
+	default:
+		glog.V(5).Infof("Unknown field type '%s': %v", v.Kind(), v)
+		visitField(v)
+	}
+}

--- a/pkg/util/stringreplace/object_test.go
+++ b/pkg/util/stringreplace/object_test.go
@@ -1,0 +1,105 @@
+package stringreplace
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type sampleInnerStruct struct {
+	Name   string
+	Number int
+	List   []string
+	Map    map[string]string
+}
+
+type sampleStruct struct {
+	Name         string
+	Inner        sampleInnerStruct
+	Ptr          *sampleInnerStruct
+	MapInMap     map[string]map[string]string
+	ArrayInArray [][]string
+	Array        []string
+}
+
+func TestVisitObjectStringsOnStruct(t *testing.T) {
+	samples := [][]sampleStruct{
+		{{}, {}},
+		{{Name: "Foo"}, {Name: "sample-Foo"}},
+		{{Ptr: nil}, {Ptr: nil}},
+		{{Ptr: &sampleInnerStruct{Name: "foo"}}, {Ptr: &sampleInnerStruct{Name: "sample-foo"}}},
+		{{Inner: sampleInnerStruct{Name: "foo"}}, {Inner: sampleInnerStruct{Name: "sample-foo"}}},
+		{{Array: []string{"foo", "bar"}}, {Array: []string{"sample-foo", "sample-bar"}}},
+		{
+			{
+				MapInMap: map[string]map[string]string{
+					"foo": {"bar": "test"},
+				},
+			},
+			{
+				MapInMap: map[string]map[string]string{
+					"foo": {"bar": "sample-test"},
+				},
+			},
+		},
+		{
+			{ArrayInArray: [][]string{{"foo", "bar"}}},
+			{ArrayInArray: [][]string{{"sample-foo", "sample-bar"}}},
+		},
+	}
+	for i := range samples {
+		VisitObjectStrings(&samples[i][0], func(in string) string {
+			if len(in) == 0 {
+				return in
+			}
+			return fmt.Sprintf("sample-%s", in)
+		})
+		if !reflect.DeepEqual(samples[i][0], samples[i][1]) {
+			t.Errorf("Got %#v, expected %#v", samples[i][0], samples[i][1])
+		}
+	}
+}
+
+func TestVisitObjectStringsOnMap(t *testing.T) {
+	samples := [][]map[string]string{
+		{
+			{"foo": "bar"},
+			{"foo": "sample-bar"},
+		},
+		{
+			{"empty": ""},
+			{"empty": "sample-"},
+		},
+		{
+			{"": "invalid"},
+			{"": "sample-invalid"},
+		},
+	}
+
+	for i := range samples {
+		VisitObjectStrings(&samples[i][0], func(in string) string {
+			return fmt.Sprintf("sample-%s", in)
+		})
+		if !reflect.DeepEqual(samples[i][0], samples[i][1]) {
+			t.Errorf("Got %#v, expected %#v", samples[i][0], samples[i][1])
+		}
+	}
+}
+
+func TestVisitObjectStringsOnArray(t *testing.T) {
+	samples := [][][]string{
+		{
+			{"foo", "bar"},
+			{"sample-foo", "sample-bar"},
+		},
+	}
+
+	for i := range samples {
+		VisitObjectStrings(&samples[i][0], func(in string) string {
+			return fmt.Sprintf("sample-%s", in)
+		})
+		if !reflect.DeepEqual(samples[i][0], samples[i][1]) {
+			t.Errorf("Got %#v, expected %#v", samples[i][0], samples[i][1])
+		}
+	}
+}

--- a/test/templates/fixtures/guestbook.json
+++ b/test/templates/fixtures/guestbook.json
@@ -31,11 +31,11 @@
     },
     {
       "apiVersion": "v1beta1",
-      "id": "redis-slave",
+      "id": "${SLAVE_SERVICE_NAME}",
       "kind": "Service",
       "port": 10001,
       "selector": {
-        "name": "redis-slave"
+        "name": "${SLAVE_SERVICE_NAME}"
       }
     },
     {
@@ -131,7 +131,7 @@
                       "value": "${REDIS_PASSWORD}"
                     }
                   ],
-                  "image": "brendanburns/redis-slave",
+                  "image": "brendanburns/${SLAVE_SERVICE_NAME}",
                   "name": "slave",
                   "ports": [
                     {
@@ -141,20 +141,20 @@
                   ]
                 }
               ],
-              "id": "redis-slave",
+              "id": "${SLAVE_SERVICE_NAME}",
               "version": "v1beta1"
             }
           },
           "labels": {
-            "name": "redis-slave"
+            "name": "${SLAVE_SERVICE_NAME}"
           }
         },
         "replicaSelector": {
-          "name": "redis-slave"
+          "name": "${SLAVE_SERVICE_NAME}"
         },
         "replicas": 2
       },
-      "id": "redis-slave",
+      "id": "${SLAVE_SERVICE_NAME}",
       "kind": "ReplicationController"
     }
   ],
@@ -183,6 +183,11 @@
       "from": "[a-zA-Z0-9]{8}",
       "generate": "expression",
       "name": "REDIS_PASSWORD"
+    },
+    {
+      "description": "Slave Service name",
+      "name": "SLAVE_SERVICE_NAME",
+      "value": "redis-slave"
     }
   ]
 }


### PR DESCRIPTION
This patch allow generic substitution for **all** `string` fields in any object we have. It allows referencing parameters in fields like 'host', 'output->registry', annotations, etc...

The current state is that we support substitution only for Env fields and only for certain types. There is also no documentation that would say this... I think it would be better to say:

"we support parameter substitution for **all** string fields" vs "we support parameter substitution for all Env fields defined for these types: ...."