### PR TITLE
ignore local .kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /examples/sample-app/logs/openshift.log
 *.swp
 .vimrc
+.kubeconfig
 .vagrant-openshift.json*
 .DS_Store
 .idea


### PR DESCRIPTION
Having a local .kubeconfig is handy for running `osc` commands, but we don't want it checked in.