### PR TITLE
'osc login' (actually 'openshift ex login')

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -118,6 +118,7 @@ func applyToCreate(dst *cobra.Command) *cobra.Command {
 
 // Copy of kubectl/cmd/DefaultClientConfig, using NewNonInteractiveDeferredLoadingClientConfig
 func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
+	// TODO find and merge duplicates, this is also in other places
 	loadingRules := clientcmd.NewClientConfigLoadingRules()
 	loadingRules.EnvVarPath = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	flags.StringVar(&loadingRules.CommandLinePath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")

--- a/pkg/cmd/experimental/login/login.go
+++ b/pkg/cmd/experimental/login/login.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
@@ -40,6 +44,11 @@ prompt for user input if not provided.
 				glog.Fatalf("%v\n", err)
 			}
 
+			err = updateKubeconfigFile(usernameFlag, accessToken, clientCfg)
+			if err != nil {
+				glog.Fatalf("%v\n", err)
+			}
+
 			fmt.Printf("Auth token: %v\n", string(accessToken))
 		},
 	}
@@ -63,4 +72,99 @@ func defaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 
 	return clientConfig
+}
+
+func updateKubeconfigFile(username, token string, clientConfig *kclient.Config) error {
+	config, err := getConfigFromFile(".kubeconfig")
+	if err != nil {
+		return err
+	}
+
+	credentialsName := username
+	if len(credentialsName) == 0 {
+		credentialsName = "osc-login"
+	}
+	credentialsName = getUniqueName(credentialsName, getAuthInfoNames(config))
+	credentials := clientcmdapi.NewAuthInfo()
+	credentials.Token = token
+	config.AuthInfos[credentialsName] = *credentials
+
+	clusterName := getUniqueName("osc-login-cluster", getClusterNames(config))
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = clientConfig.Host
+	cluster.InsecureSkipTLSVerify = clientConfig.Insecure
+	cluster.CertificateAuthority = clientConfig.CAFile
+	config.Clusters[clusterName] = *cluster
+
+	contextName := getUniqueName(clusterName+"-"+credentialsName, getContextNames(config))
+	context := clientcmdapi.NewContext()
+	context.Cluster = clusterName
+	context.AuthInfo = credentialsName
+	config.Contexts[contextName] = *context
+
+	config.CurrentContext = contextName
+
+	err = clientcmd.WriteToFile(*config, ".kubeconfig")
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func getAuthInfoNames(config *clientcmdapi.Config) *util.StringSet {
+	ret := &util.StringSet{}
+	for key := range config.AuthInfos {
+		ret.Insert(key)
+	}
+
+	return ret
+}
+
+func getContextNames(config *clientcmdapi.Config) *util.StringSet {
+	ret := &util.StringSet{}
+	for key := range config.Contexts {
+		ret.Insert(key)
+	}
+
+	return ret
+}
+
+func getClusterNames(config *clientcmdapi.Config) *util.StringSet {
+	ret := &util.StringSet{}
+	for key := range config.Clusters {
+		ret.Insert(key)
+	}
+
+	return ret
+}
+
+func getConfigFromFile(filename string) (*clientcmdapi.Config, error) {
+	var err error
+	config, err := clientcmd.LoadFromFile(filename)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if config == nil {
+		config = clientcmdapi.NewConfig()
+	}
+
+	return config, nil
+}
+
+func getUniqueName(basename string, existingNames *util.StringSet) string {
+	if !existingNames.Has(basename) {
+		return basename
+	}
+
+	for i := 0; i < 100; i++ {
+		trialName := fmt.Sprintf("%v-%d", basename, i)
+		if !existingNames.Has(trialName) {
+			return trialName
+		}
+	}
+
+	return string(util.NewUUID())
 }

--- a/pkg/cmd/experimental/login/login.go
+++ b/pkg/cmd/experimental/login/login.go
@@ -1,0 +1,66 @@
+package login
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func NewCmdLogin(name string, parent *cobra.Command) *cobra.Command {
+	clientConfig := defaultClientConfig(parent.PersistentFlags())
+	f := cmd.NewFactory(clientConfig)
+	f.BindFlags(parent.PersistentFlags())
+
+	cmds := &cobra.Command{
+		Use:   name,
+		Short: "Logs in and returns a session token",
+		Long: `Logs in to the OpenShift server and prints out a session token.
+
+Username and password can be provided through flags, the command will 
+prompt for user input if not provided.
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			clientCfg, err := f.OpenShiftClientConfig.ClientConfig()
+			if err != nil {
+				glog.Fatalf("%v\n", err)
+			}
+
+			usernameFlag := kubecmd.GetFlagString(cmd, "username")
+			passwordFlag := kubecmd.GetFlagString(cmd, "password")
+
+			accessToken, err := tokencmd.RequestToken(clientCfg, os.Stdin, usernameFlag, passwordFlag)
+			if err != nil {
+				glog.Fatalf("%v\n", err)
+			}
+
+			fmt.Printf("Auth token: %v\n", string(accessToken))
+		},
+	}
+
+	cmds.Flags().StringP("username", "u", "", "Username, will prompt if not provided")
+	cmds.Flags().StringP("password", "p", "", "Password, will prompt if not provided")
+	return cmds
+}
+
+// Copy of kubectl/cmd/DefaultClientConfig, using NewNonInteractiveDeferredLoadingClientConfig
+// TODO find and merge duplicates, this is also in other places
+func defaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewClientConfigLoadingRules()
+	loadingRules.EnvVarPath = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+	flags.StringVar(&loadingRules.CommandLinePath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+
+	overrides := &clientcmd.ConfigOverrides{}
+	overrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
+	overrideFlags.ContextOverrideFlags.NamespaceShort = "n"
+	clientcmd.BindOverrideFlags(overrides, flags, overrideFlags)
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+
+	return clientConfig
+}

--- a/pkg/cmd/experimental/tokens/request.go
+++ b/pkg/cmd/experimental/tokens/request.go
@@ -6,20 +6,24 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 )
 
-func NewCmdRequestToken(clientCfg *clientcmd.Config) *cobra.Command {
+func NewCmdRequestToken(f *cmd.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "request-token",
 		Short: "request an access token",
 		Long:  `request an access token`,
 		Run: func(cmd *cobra.Command, args []string) {
-			accessToken, err := tokencmd.RequestToken(clientCfg, os.Stdin)
+			clientCfg, err := f.OpenShiftClientConfig.ClientConfig()
 			if err != nil {
-				fmt.Printf("%v\n", err)
-				return
+				fmt.Errorf("%v\n", err)
+			}
+
+			accessToken, err := tokencmd.RequestToken(clientCfg, os.Stdin, "", "")
+			if err != nil {
+				fmt.Errorf("%v\n", err)
 			}
 
 			fmt.Printf("%v\n", string(accessToken))

--- a/pkg/cmd/experimental/tokens/whoami.go
+++ b/pkg/cmd/experimental/tokens/whoami.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	osclient "github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 )
 
-func NewCmdWhoAmI(clientCfg *clientcmd.Config) *cobra.Command {
+func NewCmdWhoAmI(f *cmd.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "checks the identity associated with an access token",
@@ -21,7 +23,13 @@ func NewCmdWhoAmI(clientCfg *clientcmd.Config) *cobra.Command {
 			if cmd.Flags().Lookup("token") != nil {
 				token = getFlagString(cmd, "token")
 			}
-			whoami(token, clientCfg)
+
+			clientCfg, err := f.OpenShiftClientConfig.ClientConfig()
+			if err != nil {
+				fmt.Errorf("%v\n", err)
+			}
+
+			whoami(token, clientCfg, cmd)
 
 		},
 	}
@@ -29,14 +37,13 @@ func NewCmdWhoAmI(clientCfg *clientcmd.Config) *cobra.Command {
 	return cmd
 }
 
-func whoami(token string, clientCfg *clientcmd.Config) {
-	osCfg := clientCfg.OpenShiftConfig()
-	// This will be pulled out of the auth config file after https://github.com/GoogleCloudPlatform/kubernetes/pull/2437
+func whoami(token string, clientCfg *kclient.Config, cmd *cobra.Command) {
+	// TODO this is now pulled out of the auth config file (https://github.com/GoogleCloudPlatform/kubernetes/pull/2437)
 	if len(token) > 0 {
-		osCfg.BearerToken = token
+		clientCfg.BearerToken = token
 	}
 
-	osClient, err := osclient.New(osCfg)
+	osClient, err := osclient.New(clientCfg)
 	if err != nil {
 		fmt.Printf("Error building osClient: %v\n", err)
 		return
@@ -44,16 +51,17 @@ func whoami(token string, clientCfg *clientcmd.Config) {
 
 	me, err := osClient.Users().Get("~")
 	if err != nil {
+		glog.Errorf("Error fetching user: %v\n", err)
+
 		// let's pretend that we can determine that we got back a 401.  we need an updated kubernetes for this
-		accessToken, err := tokencmd.RequestToken(clientCfg, os.Stdin)
+		accessToken, err := tokencmd.RequestToken(clientCfg, os.Stdin, "", "")
 		if err != nil {
 			fmt.Printf("%v\n", err)
 			return
 		}
 
-		osCfg := clientCfg.OpenShiftConfig()
-		osCfg.BearerToken = accessToken
-		osClient, _ = osclient.New(osCfg)
+		clientCfg.BearerToken = accessToken
+		osClient, _ = osclient.New(clientCfg)
 
 		me, err = osClient.Users().Get("~")
 		if err != nil {

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli"
 	"github.com/openshift/origin/pkg/cmd/experimental/config"
 	"github.com/openshift/origin/pkg/cmd/experimental/generate"
+	"github.com/openshift/origin/pkg/cmd/experimental/login"
 	"github.com/openshift/origin/pkg/cmd/experimental/policy"
 	"github.com/openshift/origin/pkg/cmd/experimental/tokens"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
@@ -116,6 +117,7 @@ func newExperimentalCommand(parentName, name string) *cobra.Command {
 	experimental.AddCommand(tokens.NewCmdTokens("tokens"))
 	experimental.AddCommand(policy.NewCommandPolicy("policy"))
 	experimental.AddCommand(generate.NewCmdGenerate("generate"))
+	experimental.AddCommand(login.NewCmdLogin("login", experimental))
 	return experimental
 }
 

--- a/pkg/cmd/util/terminal.go
+++ b/pkg/cmd/util/terminal.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/docker/docker/pkg/term"
+	"github.com/golang/glog"
+)
+
+func PromptForString(r io.Reader, format string, a ...interface{}) string {
+	fmt.Printf(format, a...)
+	return readInput(r)
+}
+
+// TODO not tested on other platforms
+func PromptForPasswordString(r io.Reader, format string, a ...interface{}) string {
+	if file, ok := r.(*os.File); ok {
+		inFd := file.Fd()
+
+		if term.IsTerminal(inFd) {
+			oldState, err := term.SaveState(inFd)
+			if err != nil {
+				glog.V(3).Infof("Unable to save terminal state")
+				return PromptForString(r, format, a...)
+			}
+
+			fmt.Printf(format, a...)
+
+			term.DisableEcho(inFd, oldState)
+
+			input := readInput(r)
+
+			defer term.RestoreTerminal(inFd, oldState)
+
+			fmt.Printf("\n")
+
+			return input
+		} else {
+			glog.V(3).Infof("Stdin is not a terminal")
+			return PromptForString(r, format, a...)
+		}
+	} else {
+		glog.V(3).Infof("Unable to use a TTY")
+		return PromptForString(r, format, a...)
+	}
+}
+
+func readInput(r io.Reader) string {
+	var result string
+	fmt.Fscan(r, &result)
+	return result
+}

--- a/pkg/cmd/util/tokencmd/challenging_client.go
+++ b/pkg/cmd/util/tokencmd/challenging_client.go
@@ -1,0 +1,71 @@
+package tokencmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util"
+)
+
+// challengingClient conforms the kclient.HTTPClient interface.  It introspects responses for auth challenges and
+// tries to response to those challenges in order to get a token back.
+type challengingClient struct {
+	delegate        *http.Client
+	reader          io.Reader
+	defaultUsername string
+	defaultPassword string
+}
+
+const basicAuthPattern = `[\s]*Basic[\s]*realm="([\w]+)"`
+
+var basicAuthRegex = regexp.MustCompile(basicAuthPattern)
+
+// Do watches for unauthorized challenges.  If we know to respond, we respond to the challenge
+func (client *challengingClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := client.delegate.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		if wantsBasicAuth, realm := isBasicAuthChallenge(resp); wantsBasicAuth {
+			username := client.defaultUsername
+			password := client.defaultPassword
+
+			uDefaulted := len(username) > 0
+			pDefaulted := len(password) > 0
+
+			if !(uDefaulted && pDefaulted) {
+				fmt.Printf("Authenticate for \"%v\"\n", realm)
+				if !uDefaulted {
+					username = util.PromptForString(client.reader, "Username: ")
+				}
+				if !pDefaulted {
+					password = util.PromptForPasswordString(client.reader, "Password: ")
+				}
+			}
+
+			client.delegate.Transport = kclient.NewBasicAuthRoundTripper(username, password, client.delegate.Transport)
+			return client.Do(resp.Request)
+		}
+	}
+	return resp, err
+}
+
+func isBasicAuthChallenge(resp *http.Response) (bool, string) {
+	for currHeader, headerValue := range resp.Header {
+		if strings.EqualFold(currHeader, "WWW-Authenticate") {
+			for _, currAuthorizeHeader := range headerValue {
+				if matches := basicAuthRegex.FindAllStringSubmatch(currAuthorizeHeader, 1); matches != nil {
+					return true, matches[0][1]
+				}
+			}
+		}
+	}
+
+	return false, ""
+}

--- a/pkg/cmd/util/tokencmd/request_token.go
+++ b/pkg/cmd/util/tokencmd/request_token.go
@@ -2,26 +2,19 @@ package tokencmd
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"regexp"
-	"strings"
 
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-
+	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/auth/server/tokenrequest"
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const (
-	accessTokenRedirectPattern = `#access_token=([\w]+)&`
-)
+const accessTokenRedirectPattern = `#access_token=([\w]+)&`
 
-var (
-	accessTokenRedirectRegex = regexp.MustCompile(accessTokenRedirectPattern)
-)
+var accessTokenRedirectRegex = regexp.MustCompile(accessTokenRedirectPattern)
 
 type tokenGetterInfo struct {
 	accessToken string
@@ -29,31 +22,36 @@ type tokenGetterInfo struct {
 
 // RequestToken uses the cmd arguments to locate an openshift oauth server and attempts to authenticate
 // it returns the access token if it gets one.  An error if it does not
-func RequestToken(clientCfg *clientcmd.Config, reader io.Reader) (string, error) {
+func RequestToken(clientCfg *kclient.Config, reader io.Reader, defaultUsername string, defaultPassword string) (string, error) {
 	tokenGetter := &tokenGetterInfo{}
 
-	osCfg := clientCfg.OpenShiftConfig()
-	osClient, err := client.New(osCfg)
+	osClient, err := client.New(clientCfg)
 	if err != nil {
 		return "", err
 	}
 
 	// get the transport, so that we can use it to build our own client that wraps it
 	// our client understands certain challenges and can respond to them
-	clientTransport, err := kclient.TransportFor(osCfg)
+	clientTransport, err := kclient.TransportFor(clientCfg)
 	if err != nil {
 		return "", err
 	}
+
 	httpClient := &http.Client{
 		Transport:     clientTransport,
 		CheckRedirect: tokenGetter.checkRedirect,
 	}
-	osClient.Client = &challengingClient{httpClient, reader}
 
-	_ = osClient.Get().AbsPath("oauth", "authorize").Param("response_type", "token").Param("client_id", "openshift-challenging-client").Do()
+	osClient.Client = &challengingClient{httpClient, reader, defaultUsername, defaultPassword}
+
+	result := osClient.Get().AbsPath("oauth", "authorize").Param("response_type", "token").Param("client_id", "openshift-challenging-client").Do()
 
 	if len(tokenGetter.accessToken) == 0 {
-		requestTokenURL := osCfg.Host + "/oauth" /* clean up after auth.go dies */ + tokenrequest.RequestTokenEndpoint
+		if result.Error() != nil {
+			glog.Errorf("Error making server request: %v", result.Error())
+		}
+
+		requestTokenURL := clientCfg.Host + "/oauth" /* clean up after auth.go dies */ + tokenrequest.RequestTokenEndpoint
 		return "", errors.New("Unable to get token.  Try visiting " + requestTokenURL + " for a new token.")
 	}
 
@@ -72,59 +70,4 @@ func (tokenGetter *tokenGetterInfo) checkRedirect(req *http.Request, via []*http
 	}
 
 	return nil
-}
-
-// challengingClient conforms the kclient.HTTPClient interface.  It introspects responses for auth challenges and
-// tries to response to those challenges in order to get a token back.
-type challengingClient struct {
-	delegate *http.Client
-	reader   io.Reader
-}
-
-const (
-	basicAuthPattern = `[\s]*Basic[\s]*realm="([\w]+)"`
-)
-
-var (
-	basicAuthRegex = regexp.MustCompile(basicAuthPattern)
-)
-
-// Do watches for unauthorized challenges.  If we know to respond, we respond to the challenge
-func (client *challengingClient) Do(req *http.Request) (*http.Response, error) {
-	resp, err := client.delegate.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if wantsBasicAuth, realm := isBasicAuthChallenge(resp); wantsBasicAuth {
-			fmt.Printf("Authenticate for \"%v\"\n", realm)
-			username := promptForString("username", client.reader)
-			password := promptForString("password", client.reader)
-
-			client.delegate.Transport = kclient.NewBasicAuthRoundTripper(username, password, client.delegate.Transport)
-			return client.Do(resp.Request)
-		}
-	}
-	return resp, err
-}
-
-func isBasicAuthChallenge(resp *http.Response) (bool, string) {
-	for currHeader, headerValue := range resp.Header {
-		if strings.EqualFold(currHeader, "WWW-Authenticate") {
-			for _, currAuthorizeHeader := range headerValue {
-				if matches := basicAuthRegex.FindAllStringSubmatch(currAuthorizeHeader, 1); matches != nil {
-					return true, matches[0][1]
-				}
-			}
-		}
-	}
-
-	return false, ""
-}
-
-func promptForString(field string, r io.Reader) string {
-	fmt.Printf("Please enter %s: ", field)
-	var result string
-	fmt.Fscan(r, &result)
-	return result
 }

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -91,7 +91,8 @@ func TestGetToken(t *testing.T) {
 	flags.Parse(strings.Split("--master="+oauthServer.URL, " "))
 
 	reader := bytes.NewBufferString("user\npass")
-	accessToken, err := tokencmd.RequestToken(clientCfg, reader)
+
+	accessToken, err := tokencmd.RequestToken(clientCfg.OpenShiftConfig(), reader, "", "")
 
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
First pass at the `osc login` command. 

**Status**: this command is available and working as an experimental login support, under `openshift ex login`. Will prompt for username and password (or take from the flags) and print the auth token if it succeeds.

Full login support will involve:

- [x] basic `osc login` command structure
- [x] takes `username` and `password` from flags (or prompt if not provided) and prints out the auth token
- [ ] save token to `.kubeconfig` and assure it's used
- [ ] more flags (e.g. server, cluster, etc), should make use of `.kubeconfig` and save config in it
 - `osc login --context=admin` (makes use of user and cluster defined in the context "admin", set `current-context` and `token`)
 - `osc login --user=myself --server=dev` (makes use of user "personal" and cluster "dev" to log in, set `current-context` and `token`)
- [ ] tests
- [ ] better error handling

Testing:

```
openshift ex login [--username=foo] [--password=bar] [--kubeconfig=./openshift.local.certificates/admin/.kubeconfig]
```
Copy the `.kubeconfig` file to `~/.kube/.kubeconfig` to remove the need of the `--kubeconfig` flag. 

If the server doesn't challenge for a basic auth by default (usually older versions of Origin), make sure you start the server with: 
```
sudo ORIGIN_AUTH_REQUEST_HANDLERS=session,basicauth ORIGIN_GRANT_HANDLER=auto _output/local/go/bin/openshift start --cors-allowed-origins=.*
```

Using [golang.org/x/crypto/ssh/terminal](http://golang.org/x/crypto/ssh/terminal) to password input disabling stty echo, might need to reevaluate this, check platforms support, etc.
