### PR TITLE
add missing reencrypt validations

### DIFF
--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -33,8 +33,20 @@ func validateTLS(tls *routeapi.TLSConfig) errs.ValidationErrorList {
 		return nil
 	}
 
-	//reencrypt must specify pod cert
+	//reencrypt must specify cert, key, cacert, and destination ca cert
 	if tls.Termination == routeapi.TLSTerminationReencrypt {
+		if len(tls.Certificate) == 0 {
+			result = append(result, errs.NewFieldRequired("certificate", tls.Certificate))
+		}
+
+		if len(tls.Key) == 0 {
+			result = append(result, errs.NewFieldRequired("key", tls.Key))
+		}
+
+		if len(tls.CACertificate) == 0 {
+			result = append(result, errs.NewFieldRequired("caCertificate", tls.CACertificate))
+		}
+
 		if len(tls.DestinationCACertificate) == 0 {
 			result = append(result, errs.NewFieldRequired("destinationCACertificate", tls.DestinationCACertificate))
 		}

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -29,6 +29,9 @@ func TestValidateTLSReencryptTermOKCert(t *testing.T) {
 	errs := validateTLS(&api.TLSConfig{
 		Termination:              api.TLSTerminationReencrypt,
 		DestinationCACertificate: "abc",
+		Certificate:              "def",
+		Key:                      "ghi",
+		CACertificate:            "jkl",
 	})
 
 	if len(errs) > 0 {
@@ -100,12 +103,13 @@ func TestValidatePodTermInvalid(t *testing.T) {
 	}
 }
 
+// TestValidateReencryptTermInvalid ensures reencrypt must specify cert, key, cacert, and dest cert
 func TestValidateReencryptTermInvalid(t *testing.T) {
 	errs := validateTLS(&api.TLSConfig{
 		Termination: api.TLSTerminationReencrypt,
 	})
 
-	if len(errs) != 1 {
-		t.Errorf("Unexpected error list encountered: %#v.  Expected 1 error, got %v", errs, len(errs))
+	if len(errs) != 4 {
+		t.Errorf("Unexpected error list encountered: %#v.  Expected 4 errors, got %v", errs, len(errs))
 	}
 }


### PR DESCRIPTION
:bug: Bug: Re-encrypt was not validating that it had cert, key, and ca cert as well as the destination ca cert.  

cc @pmorie