### PR TITLE
Add retry logic to recreate deployment strategy

### DIFF
--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -83,11 +83,7 @@ func deploy(kClient kclient.Interface, namespace, deploymentName string) error {
 	}
 
 	// TODO: Choose a strategy based on some input
-	strategy := &strategy.DeploymentStrategy{
-		ReplicationController: strategy.RealReplicationController{KubeClient: kClient},
-		Codec: latest.Codec,
-	}
-
+	strategy := strategy.NewRecreateDeploymentStrategy(kClient, latest.Codec)
 	return strategy.Deploy(newDeployment, oldDeployments)
 }
 

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -106,7 +106,10 @@ func OkImageChangeTrigger() deployapi.DeploymentTriggerPolicy {
 
 func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
 	return &deployapi.DeploymentConfig{
-		ObjectMeta:    kapi.ObjectMeta{Name: "config"},
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: kapi.NamespaceDefault,
+			Name:      "config",
+		},
 		LatestVersion: version,
 		Triggers: []deployapi.DeploymentTriggerPolicy{
 			OkImageChangeTrigger(),

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -2,10 +2,12 @@ package recreate
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
@@ -13,52 +15,50 @@ import (
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
-// DeploymentStrategy is a simple strategy appropriate as a default. Its behavior is to increase the
+// RecreateDeploymentStrategy is a simple strategy appropriate as a default. Its behavior is to increase the
 // replica count of the new deployment to 1, and to decrease the replica count of previous deployments
 // to zero.
 //
 // A failure to disable any existing deployments will be considered a deployment failure.
-type DeploymentStrategy struct {
-	// ReplicationController is used to interact with ReplicatonControllers.
-	ReplicationController ReplicationControllerInterface
-	// Codec is used to decode DeploymentConfigs contained in deployments.
-	Codec runtime.Codec
+type RecreateDeploymentStrategy struct {
+	// client is used to interact with ReplicatonControllers.
+	client replicationControllerClient
+	// codec is used to decode DeploymentConfigs contained in deployments.
+	codec runtime.Codec
+
+	retryTimeout time.Duration
+	retryPeriod  time.Duration
+}
+
+func NewRecreateDeploymentStrategy(client kclient.Interface, codec runtime.Codec) *RecreateDeploymentStrategy {
+	return &RecreateDeploymentStrategy{
+		client:       &realReplicationController{client},
+		codec:        codec,
+		retryTimeout: 10 * time.Second,
+		retryPeriod:  1 * time.Second,
+	}
 }
 
 // Deploy makes deployment active and disables oldDeployments.
-func (s *DeploymentStrategy) Deploy(deployment *kapi.ReplicationController, oldDeployments []kapi.ObjectReference) error {
+func (s *RecreateDeploymentStrategy) Deploy(deployment *kapi.ReplicationController, oldDeployments []kapi.ObjectReference) error {
 	var err error
 	var deploymentConfig *deployapi.DeploymentConfig
 
-	if deploymentConfig, err = deployutil.DecodeDeploymentConfig(deployment, s.Codec); err != nil {
+	if deploymentConfig, err = deployutil.DecodeDeploymentConfig(deployment, s.codec); err != nil {
 		return fmt.Errorf("Couldn't decode DeploymentConfig from deployment %s: %v", deployment.Name, err)
 	}
 
-	deployment.Spec.Replicas = deploymentConfig.Template.ControllerTemplate.Replicas
-	glog.Infof("Updating deployment %s replica count to %d", deployment.Name, deployment.Spec.Replicas)
-	if _, err := s.ReplicationController.updateReplicationController(deployment.Namespace, deployment); err != nil {
-		return fmt.Errorf("Error updating deployment %s replica count to %d: %v", deployment.Name, deployment.Spec.Replicas, err)
+	if err = s.updateReplicas(deployment.Namespace, deployment.Name, deploymentConfig.Template.ControllerTemplate.Replicas); err != nil {
+		return err
 	}
 
 	// For this simple deploy, disable previous replication controllers.
-	// TODO: This isn't transactional, and we don't actually wait for the replica count to
-	// become zero before deleting them.
 	glog.Infof("Found %d prior deployments to disable", len(oldDeployments))
 	allProcessed := true
 	for _, oldDeployment := range oldDeployments {
-		oldController, oldErr := s.ReplicationController.getReplicationController(oldDeployment.Namespace, oldDeployment.Name)
-		if oldErr != nil {
-			glog.Errorf("Error getting old deployment %s for disabling: %v", oldDeployment.Name, oldErr)
+		if err = s.updateReplicas(oldDeployment.Namespace, oldDeployment.Name, 0); err != nil {
+			glog.Errorf("%v", err)
 			allProcessed = false
-			continue
-		}
-
-		glog.Infof("Setting replicas to zero for old deployment %s", oldController.Name)
-		oldController.Spec.Replicas = 0
-		if _, err := s.ReplicationController.updateReplicationController(oldController.Namespace, oldController); err != nil {
-			glog.Errorf("Error updating replicas to zero for old deployment %s: %#v", oldController.Name, err)
-			allProcessed = false
-			continue
 		}
 	}
 
@@ -70,19 +70,50 @@ func (s *DeploymentStrategy) Deploy(deployment *kapi.ReplicationController, oldD
 	return nil
 }
 
-type ReplicationControllerInterface interface {
+// updateReplicas attempts to set the given deployment's replicaCount using retry logic.
+func (s *RecreateDeploymentStrategy) updateReplicas(namespace, name string, replicaCount int) error {
+	var err error
+	var deployment *kapi.ReplicationController
+
+	timeout := time.After(s.retryTimeout)
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("Couldn't successfully update deployment %s replica count to %d (timeout exceeded)", deployment.Name, replicaCount)
+		default:
+			if deployment, err = s.client.getReplicationController(namespace, name); err != nil {
+				glog.Errorf("Couldn't get deployment %s/%s: %v", namespace, name, err)
+			} else {
+				deployment.Spec.Replicas = replicaCount
+				glog.Infof("Updating deployment %s/%s replica count to %d", namespace, name, replicaCount)
+				if _, err = s.client.updateReplicationController(namespace, deployment); err == nil {
+					return nil
+				}
+				// For conflict errors, retry immediately
+				if kerrors.IsConflict(err) {
+					continue
+				}
+				glog.Errorf("Error updating deployment %s/%s replica count to %d: %v", namespace, name, replicaCount, err)
+			}
+
+			time.Sleep(s.retryPeriod)
+		}
+	}
+}
+
+type replicationControllerClient interface {
 	getReplicationController(namespace, name string) (*kapi.ReplicationController, error)
 	updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error)
 }
 
-type RealReplicationController struct {
-	KubeClient kclient.Interface
+type realReplicationController struct {
+	client kclient.Interface
 }
 
-func (r RealReplicationController) getReplicationController(namespace string, name string) (*kapi.ReplicationController, error) {
-	return r.KubeClient.ReplicationControllers(namespace).Get(name)
+func (r realReplicationController) getReplicationController(namespace string, name string) (*kapi.ReplicationController, error) {
+	return r.client.ReplicationControllers(namespace).Get(name)
 }
 
-func (r RealReplicationController) updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-	return r.KubeClient.ReplicationControllers(namespace).Update(ctrl)
+func (r realReplicationController) updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+	return r.client.ReplicationControllers(namespace).Update(ctrl)
 }


### PR DESCRIPTION
Support retries in the Recreate deployment strategy. This is a simple
fix for update race conditions as described in #836.