### PR TITLE
move kubernetes capabilities to server start

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/authorizer"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	"github.com/emicklei/go-restful"
 	"github.com/golang/glog"
 
@@ -58,12 +57,6 @@ func (c *MasterConfig) EnsurePortalFlags() {
 // endpoints were started (these are format strings that will expect to be sent
 // a single string value).
 func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
-	// Allow privileged containers
-	// TODO: make this configurable and not the default https://github.com/openshift/origin/issues/662
-	capabilities.Initialize(capabilities.Capabilities{
-		AllowPrivileged: true,
-	})
-
 	kubeletClient, err := kclient.NewKubeletClient(
 		&kclient.KubeletConfig{
 			Port: 10250,

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -16,6 +16,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	klatest "github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/capabilities"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
@@ -477,6 +478,12 @@ func start(cfg *config, args []string) error {
 			GithubClientID:     env("ORIGIN_OAUTH_GITHUB_CLIENT_ID", ""),
 			GithubClientSecret: env("ORIGIN_OAUTH_GITHUB_CLIENT_SECRET", ""),
 		}
+
+		// Allow privileged containers
+		// TODO: make this configurable and not the default https://github.com/openshift/origin/issues/662
+		capabilities.Initialize(capabilities.Capabilities{
+			AllowPrivileged: true,
+		})
 
 		if startKube {
 			portalNet := net.IPNet(cfg.PortalNet)


### PR DESCRIPTION
Template processing uses kubernetes libs for validation. Previously capabilities were only set when using bundled kubernetes. Thus when using an external kubernetes, privileged templates would fail to validate.