### PR TITLE
Create an openshift/origin-pod image (pause) and flag its use

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -37,6 +37,15 @@ cp -f "${imagedir}/openshift" images/router/haproxy/bin
 # build hello-openshift binary
 "${OS_ROOT}/hack/build-go.sh" examples/hello-openshift
 
+# build pod binary
+# TODO: move me to build release
+"${OS_ROOT}/hack/build-go.sh" images/pod
+cp -f "_output/local/go/bin/pod" images/pod/bin
+
+# images that depend on scratch
+echo "--- openshift/origin-pod ---"
+docker build -t openshift/origin-pod            images/pod
+
 # images that depend on openshift/origin-base
 echo "--- openshift/origin ---"
 docker build -t openshift/origin                images/origin

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -28,6 +28,7 @@ base_images=(
 )
 images=(
   openshift/origin
+  openshift/origin-pod
   openshift/origin-deployer
   openshift/origin-docker-builder
   openshift/origin-sti-builder

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -157,7 +157,7 @@ echo "[INFO] Certs dir is:              ${CERT_DIR}"
 # Start All-in-one server and wait for health
 # Specify the scheme and port for the listen address, but let the IP auto-discover.  Set --public-master to localhost, for a stable link to the console.
 echo "[INFO] Starting OpenShift server"
-sudo env "PATH=${PATH}" OPENSHIFT_ON_PANIC=crash openshift start --listen="${API_SCHEME}://0.0.0.0:${API_PORT}" --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}" --hostname="127.0.0.1" --volume-dir="${VOLUME_DIR}" --etcd-dir="${ETCD_DATA_DIR}" --cert-dir="${CERT_DIR}" --loglevel=4 &> "${LOG_DIR}/openshift.log" &
+sudo env "PATH=${PATH}" OPENSHIFT_ON_PANIC=crash openshift start --listen="${API_SCHEME}://0.0.0.0:${API_PORT}" --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}" --hostname="127.0.0.1" --volume-dir="${VOLUME_DIR}" --etcd-dir="${ETCD_DATA_DIR}" --cert-dir="${CERT_DIR}" --loglevel=4 --latest-images &> "${LOG_DIR}/openshift.log" &
 OS_PID=$!
 
 if [[ "${API_SCHEME}" == "https" ]]; then

--- a/images/pod/Dockerfile
+++ b/images/pod/Dockerfile
@@ -1,0 +1,13 @@
+#
+# This is the official OpenShift Origin pod infrastructure image. It will stay running
+# until terminated by a signal and is the heart of each running pod. It holds on to
+# the network and IPC namespaces as containers come and go during the lifetime of the
+# pod.
+#
+# The standard name for this image is openshift/origin-pod
+#
+FROM scratch
+
+ADD bin/pod /pod
+
+ENTRYPOINT ["/pod"]

--- a/images/pod/bin/.gitignore
+++ b/images/pod/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/images/pod/pod.go
+++ b/images/pod/pod.go
@@ -1,0 +1,33 @@
+// +build linux
+
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, os.Kill, syscall.SIGTERM)
+
+	// Block until a signal is received.
+	<-c
+}

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/util/variable"
+	"github.com/openshift/origin/pkg/version"
+)
+
+func TestExpandDefaultImage(t *testing.T) {
+	variable.OverrideVersion = version.Get()
+	variable.OverrideVersion.GitVersion = "v1.0"
+
+	os.Setenv("OPENSHIFT_COMPONENT_IMAGE", "test")
+
+	tests := []struct {
+		component string
+		template  string
+		latest    bool
+		output    string
+	}{
+		{"*", "openshift/origin-${component}", true, "openshift/origin-*"},
+		{"version", "openshift/origin-${component}", true, "openshift/origin-version"},
+		{"version", "openshift/origin-${component}:${version}", true, "openshift/origin-version:latest"},
+		{"version", "openshift/origin-${component}:${version}", false, "openshift/origin-version:v1.0"},
+		{"component", "openshift/origin-${component}:${version}", true, "test"},
+	}
+	for _, test := range tests {
+		if s := expandImage(test.component, test.template, test.latest); s != test.output {
+			t.Errorf("unexpected image expansion for %#v: %s", test, s)
+		}
+	}
+}

--- a/pkg/cmd/util/variable/variable.go
+++ b/pkg/cmd/util/variable/variable.go
@@ -1,0 +1,90 @@
+package variable
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openshift/origin/pkg/version"
+)
+
+// KeyFunc returns the value associated with the provided key or false if no
+// such key exists.
+type KeyFunc func(key string) (string, bool)
+
+// Expand expands a string and ignores any errors that occur - keys that are
+// not recognized are replaced with the empty string.
+func Expand(s string, fns ...KeyFunc) string {
+	val, _ := ExpandStrict(s, append(fns, Empty)...)
+	return val
+}
+
+// ExpandStrict expands a string using a series of common format functions
+func ExpandStrict(s string, fns ...KeyFunc) (string, error) {
+	unmatched := []string{}
+	result := os.Expand(s, func(key string) string {
+		for _, fn := range fns {
+			val, ok := fn(key)
+			if !ok {
+				continue
+			}
+			return val
+		}
+		unmatched = append(unmatched, key)
+		return ""
+	})
+
+	switch len(unmatched) {
+	case 0:
+		return result, nil
+	case 1:
+		return "", fmt.Errorf("the key %q in %q is not recognized", unmatched[0], s)
+	default:
+		return "", fmt.Errorf("multiple keys in %q were not recognized: %s", s, strings.Join(unmatched, ", "))
+	}
+}
+
+// Empty is a KeyFunc which always returns true and the empty string.
+func Empty(s string) (string, bool) {
+	return "", true
+}
+
+// Identity is a KeyFunc that returns the same format rules.
+func Identity(key string) (string, bool) {
+	return fmt.Sprintf("${%s}", key), true
+}
+
+// Versions is a KeyFunc for retrieving information about the current version.
+func Versions(key string) (string, bool) {
+	switch key {
+	case "shortcommit":
+		s := OverrideVersion.GitCommit
+		if len(s) > 7 {
+			s = s[:7]
+		}
+		return s, true
+	case "version":
+		s := OverrideVersion.GitVersion
+		seg := strings.SplitN(s, "-", 2)
+		return seg[0], true
+	default:
+		return "", false
+	}
+}
+
+// Env is a KeyFunc which always returns a string
+func Env(key string) (string, bool) {
+	return os.Getenv(key), true
+}
+
+// EnvPresent is a KeyFunc which returns an environment variable if it is present.
+func EnvPresent(key string) (string, bool) {
+	s := os.Getenv(key)
+	if len(s) == 0 {
+		return "", false
+	}
+	return s, true
+}
+
+// OverrideVersion is the latest version, exposed for testing.
+var OverrideVersion = version.Get()


### PR DESCRIPTION
Allow consumers to define the pattern for component image pulls - by 
default, Origin will now pull the most recent build images for the tag that
OpenShift was built with.