### PR TITLE
Restore CORS outside of go-restful

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -344,6 +344,8 @@ func start(cfg *config, args []string) error {
 			KubernetesAddr:       cfg.KubernetesAddr.URL.String(),
 			KubernetesPublicAddr: k8sPublicAddr.URL.String(),
 
+			CORSAllowedOrigins: cfg.CORSAllowedOrigins,
+
 			EtcdHelper: etcdHelper,
 
 			AdmissionControl:             admit.NewAlwaysAdmit(),


### PR DESCRIPTION
Only applies to webservices, so does not protect regular resources.

@jwforres (we need to create some integration tests for this eventually...)