### PR TITLE
Add CONTEXT_DIR support for sti-image-builder image

### DIFF
--- a/images/builder/docker/sti-image-builder/README.md
+++ b/images/builder/docker/sti-image-builder/README.md
@@ -4,7 +4,14 @@ openshift/sti-image-builder
 This image is used as a builder image for all STI images. It is used as part of
 a [CustomBuild](https://github.com/openshift/origin/blob/master/docs/builds.md#custom-builds).
 
-The sample CustomBuild JSON might look as following:
+The following list of environment variables is used in the STI build:
+
+| Name        | Description                  | Default  |
+| ----------- |:----------------------------:|----------|
+| IMAGE_NAME  | The output Docker image name | required |
+| CONTEXT_DIR | Relative path to Dockerfile  | "."      |
+
+The sample custom BuildConfig definition might look as following:
 
 ```json
 {
@@ -35,9 +42,14 @@ The sample CustomBuild JSON might look as following:
         "exposeDockerSocket": true,
         "env": [
           { "name": "IMAGE_NAME", "value": "openshift/ruby-20-centos"}
+          { "name": "CONTEXT_DIR", "value": "."}
         ]
       }
-    }
+    },
+    "output": {
+      "to": "ruby-20-centos-repository",
+      "tag": "latest",
+    },
   },
   "labels": {
     "name": "ruby-20-centos-build"
@@ -45,3 +57,11 @@ The sample CustomBuild JSON might look as following:
 }
 
 ```
+
+This example will trigger a build for the 'ruby-20-centos' everytime there is a
+push into its Github repository. It will set the name of the resulting image to
+"openshift/ruby-20-centos" and it expects the Dockerfile to be present in the
+root directory of the GIT repository.
+
+After a successful build, the 'openshift/ruby-20-centos' image will be pushed
+into "ruby-20-centos-repository" ImageRepository and tagged as 'latest'.

--- a/images/builder/docker/sti-image-builder/bin/build.sh
+++ b/images/builder/docker/sti-image-builder/bin/build.sh
@@ -17,8 +17,11 @@ if ! [ $? -eq 0 ]; then
   exit $result
 fi
 
+# If the STI image Dockerfile does not exists in the root of the repository,
+# you can specify the CONTEXT_DIR.
+context_dir=${CONTEXT_DIR:-"."}
 
-pushd $source_dir >/dev/null
+pushd "${source_dir}/${context_dir}" >/dev/null
   # Checkout desired ref
   if ! [ -z "$SOURCE_REF" ]; then
     git checkout $SOURCE_REF


### PR DESCRIPTION
Right now, the 'openshift/sti-image-builder' expect the Dockerfile to be at 'root' of the GIT repository. This path allows to configure the relative path to the Dockerfile from where the build will be triggered.

@bparees fyi (we will need this re: git layout discussion)