### PR TITLE
Remove GOPATH from build-in-docker.sh script

### DIFF
--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -7,17 +7,23 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function absolute_path() { 
+  pushd . > /dev/null
+  [ -d "$1" ] && cd "$1" && dirs -l +0
+  popd > /dev/null
+}
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 origin_path="src/github.com/openshift/origin"
 
 # TODO: Remove this check and fix the docker command instead after the
 #       following PR is merged: https://github.com/docker/docker/pull/5910
 #       should be done in docker 1.6.
 if [ -d /sys/fs/selinux ]; then
-    if ! ls --context "${GOPATH}/${origin_path}" | grep --quiet svirt_sandbox_file_t; then
-        echo "$(tput setaf 1)Warning: SELinux labels are not set correctly; run chcon -Rt svirt_sandbox_file_t ${GOPATH}/${origin_path}$(tput sgr0)"
+    if ! ls --context "${absolute_path $OS_ROOT}" | grep --quiet svirt_sandbox_file_t; then
+        echo "$(tput setaf 1)Warning: SELinux labels are not set correctly; run chcon -Rt svirt_sandbox_file_t ${absolute_path $OS_ROOT}$(tput sgr0)"
         exit 1
     fi
 fi
 
-docker run -e "OWNER_GROUP=$UID:$GROUPS" --rm -v "${GOPATH}/${origin_path}:/go/${origin_path}" \
-  openshift/origin-release /usr/bin/openshift-origin-build.sh "$@"
+docker run -e "OWNER_GROUP=$UID:$GROUPS" --rm -v "$(absolute_path $OS_ROOT):/go/${origin_path}" openshift/origin-release /usr/bin/openshift-origin-build.sh $@


### PR DESCRIPTION
@smarterclayton since we mount only the origin path into container, we can get rid of GOPATH from the ./hack/build-in-docker.sh script which make it useful if you don't have Go installed in your system and you just want to get the sources compiled.