### PR TITLE
pull router image if not present

### DIFF
--- a/hack/test-integration-docker.sh
+++ b/hack/test-integration-docker.sh
@@ -22,4 +22,6 @@ trap cleanup EXIT SIGINT
 echo
 echo Docker integration test cases ...
 echo
-KUBE_RACE="${KUBE_RACE:--race}" KUBE_COVER=" " "${OS_ROOT}/hack/test-go.sh" test/integration -tags 'integration docker' "${@:1}"
+# A long timeout is set here in case the docker images do not exist.  To speed execution of this test
+# either pre-build or pre-pull the docker images that are being used.
+KUBE_TIMEOUT="-timeout 600s" KUBE_RACE="${KUBE_RACE:--race}" KUBE_COVER=" " "${OS_ROOT}/hack/test-go.sh" test/integration -tags 'integration docker' "${@:1}"


### PR DESCRIPTION
Add code to pull the router image if it is not present.  Updated docker script to add a longer (than 45s) timeout to account for a pull.  

Beta1 item