### PR TITLE
add skip build flag support for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,13 @@ check:
 #   make test GOFLAGS=-v
 test: export KUBE_COVER= -cover -covermode=atomic
 test: export KUBE_RACE=  -race
+ifeq ($(SKIP_BUILD), true)
+$(info build is being skipped)
+test: check
+else
 test: build check
+endif 
+test:
 	hack/test-cmd.sh
 	hack/test-integration.sh $(GOFLAGS)
 	hack/test-integration-docker.sh $(GOFLAGS)


### PR DESCRIPTION
Adding a flag that allows the test target to skip the build dependency.  Must be merged prior to https://github.com/openshift/vagrant-openshift/pull/195/files

Testing:

```
[vagrant@openshiftdev origin]$ make test
hack/build-go.sh 
++ Building go targets for linux/amd64:  cmd/openshift
++ Placing binaries
hack/test-go.sh  
^Cmake: *** [check] Error 2

[vagrant@openshiftdev origin]$ make test SKIP_BUILD=true
build is being skipped
hack/test-go.sh  
```