### PR TITLE
Ignore .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .DS_Store
 .idea
 origin.iml
+*.pyc


### PR DESCRIPTION
These are generated when doing tito operations and should not be checked in.