### PR TITLE
tweaking formatting of build statement

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -208,10 +208,10 @@ the present working directory is the same directory as this README.
     is no image to deploy and no application to visit.
 
 14. Trigger an initial build of your application
- * If you setup the GitHub webhook, push a change to app.rb in your ruby sample repository from step 10.
- * Otherwise you can request a new build by running:
+    * If you setup the GitHub webhook, push a change to app.rb in your ruby sample repository from step 10.
+    * Otherwise you can request a new build by running:
 
-        $ osc start-build ruby-sample-build
+            $ osc start-build ruby-sample-build
 
 15. Monitor the builds and wait for the status to go to "complete" (this can take a few minutes):
 


### PR DESCRIPTION
There was a formatting issue with the build statement in the sample app. It needed some more indenting to properly display inside of a markdown code block.