### PR TITLE
Compile images/pod with linux target only

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -39,7 +39,7 @@ cp -f "${imagedir}/openshift" images/router/haproxy/bin
 
 # build pod binary
 # TODO: move me to build release
-"${OS_ROOT}/hack/build-go.sh" images/pod
+"${OS_ROOT}/hack/build-go.sh" -tags=linux images/pod
 cp -f "_output/local/go/bin/pod" images/pod/bin
 
 # images that depend on scratch


### PR DESCRIPTION
Add the linux tag to the images/pod build to ensure no attempt is
made to compile it for unsupported (non-linux) platforms. This fixes
native build-images.sh builds on OSX.