### PR TITLE
Make images/pod buildable on Mac OS X

### DIFF
--- a/images/pod/pod.go
+++ b/images/pod/pod.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 /*
 Copyright 2014 Google Inc. All rights reserved.


### PR DESCRIPTION
hack/build-images.sh is broken on Mac. There's no reason to restrict images/pod/pod.go to only build on linux.