### PR TITLE
Restore logic to disregard resources in pod diff

### DIFF
--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	//	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -24,10 +23,10 @@ func LatestDeploymentNameForConfig(config *deployapi.DeploymentConfig) string {
 // TODO: Resources are currently ignored due to the formats not surviving encoding/decoding
 // in a consistent manner (e.g. 0 is represented sometimes as 0.000)
 func HashPodSpec(t api.PodSpec) uint64 {
-	/*for i := range t.Containers {
-		t.Containers[i].CPU = resource.Quantity{}
-		t.Containers[i].Memory = resource.Quantity{}
-	}*/
+	// Ignore resources by making them uniformly empty
+	for i := range t.Containers {
+		t.Containers[i].Resources = api.ResourceRequirementSpec{}
+	}
 
 	jsonString, err := json.Marshal(t)
 	if err != nil {


### PR DESCRIPTION
The HashPodSpec utility should be disregarding PodSpec.Resources
until it can be proven that such diffing works correctly. The logic
to disregard resources was inadvertently removed with a model refactor.
Restore the logic in a way consistent with the new upstream APIs.