### PR TITLE
RPMs : out of the box defaults

### DIFF
--- a/rel-eng/openshift-node.sysconfig
+++ b/rel-eng/openshift-node.sysconfig
@@ -1,2 +1,5 @@
 ROLE="node"
 OPTIONS="--loglevel=0"
+# If running node on a separate host please rsync the admin directory ie:
+# rsync root@openshift-master:/var/lib/openshift/openshift.local.certificates/admin /var/lib/openshift/openshift.local.certificates/
+KUBECONFIG="/var/lib/openshift/openshift.local.certificates/admin/.kubeconfig"


### PR DESCRIPTION
This change yields openshift-master and openshift-node configurations that can be run with zero additional configuration assuming that hostname -f is an appropriate hostname for --public-master