### PR TITLE
More 'help' usability improvements

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -52,8 +52,8 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	f.BindFlags(cmds.PersistentFlags())
 	out := os.Stdout
 
-	cmds.SetUsageTemplate(templates.CliUsageTemplate)
-	cmds.SetHelpTemplate(templates.CliHelpTemplate)
+	cmds.SetUsageTemplate(templates.CliUsageTemplate())
+	cmds.SetHelpTemplate(templates.CliHelpTemplate())
 
 	// Kubernetes CRUD commands
 	cmds.AddCommand(f.NewCmdGet(out))

--- a/pkg/cmd/cli/cmd/options.go
+++ b/pkg/cmd/cli/cmd/options.go
@@ -15,8 +15,8 @@ func NewCmdOptions(f *Factory, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.SetUsageTemplate(templates.OptionsUsageTemplate)
-	cmd.SetHelpTemplate(templates.OptionsHelpTemplate)
+	cmd.SetUsageTemplate(templates.OptionsUsageTemplate())
+	cmd.SetHelpTemplate(templates.OptionsHelpTemplate())
 
 	return cmd
 }

--- a/pkg/cmd/cli/cmd/options.go
+++ b/pkg/cmd/cli/cmd/options.go
@@ -16,7 +16,7 @@ func NewCmdOptions(f *Factory, out io.Writer) *cobra.Command {
 	}
 
 	cmd.SetUsageTemplate(templates.OptionsUsageTemplate)
-	cmd.SetHelpTemplate("")
+	cmd.SetHelpTemplate(templates.OptionsHelpTemplate)
 
 	return cmd
 }

--- a/pkg/cmd/infra/builder/builder.go
+++ b/pkg/cmd/infra/builder/builder.go
@@ -26,8 +26,8 @@ func NewCommandSTIBuilder(name string) *cobra.Command {
 			cmd.RunSTIBuild()
 		},
 	}
-	cmd.SetUsageTemplate(templates.MainUsageTemplate)
-	cmd.SetHelpTemplate(templates.MainHelpTemplate)
+	cmd.SetUsageTemplate(templates.MainUsageTemplate())
+	cmd.SetHelpTemplate(templates.MainHelpTemplate())
 	return cmd
 }
 
@@ -48,7 +48,7 @@ func NewCommandDockerBuilder(name string) *cobra.Command {
 			cmd.RunDockerBuild()
 		},
 	}
-	cmd.SetUsageTemplate(templates.MainUsageTemplate)
-	cmd.SetHelpTemplate(templates.MainHelpTemplate)
+	cmd.SetUsageTemplate(templates.MainUsageTemplate())
+	cmd.SetHelpTemplate(templates.MainHelpTemplate())
 	return cmd
 }

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -67,8 +67,8 @@ func NewCommandDeployer(name string) *cobra.Command {
 		},
 	}
 
-	cmd.SetUsageTemplate(templates.MainUsageTemplate)
-	cmd.SetHelpTemplate(templates.MainHelpTemplate)
+	cmd.SetUsageTemplate(templates.MainUsageTemplate())
+	cmd.SetHelpTemplate(templates.MainHelpTemplate())
 
 	flag := cmd.Flags()
 	cfg.Config.Bind(flag)

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -50,8 +50,8 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 		},
 	}
 
-	cmd.SetUsageTemplate(templates.MainUsageTemplate)
-	cmd.SetHelpTemplate(templates.MainHelpTemplate)
+	cmd.SetUsageTemplate(templates.MainUsageTemplate())
+	cmd.SetHelpTemplate(templates.MainHelpTemplate())
 
 	flag := cmd.Flags()
 	cfg.Config.Bind(flag)

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -76,8 +76,8 @@ func NewCommandOpenShift() *cobra.Command {
 		},
 	}
 
-	root.SetUsageTemplate(templates.MainUsageTemplate)
-	root.SetHelpTemplate(templates.MainHelpTemplate)
+	root.SetUsageTemplate(templates.MainUsageTemplate())
+	root.SetHelpTemplate(templates.MainHelpTemplate())
 
 	root.AddCommand(server.NewCommandStartServer("start"))
 	root.AddCommand(cli.NewCommandCLI("cli", "openshift cli"))

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -27,7 +27,7 @@ Use "{{.Root.Name}} help [command]" for more information about that command.{{en
 `
 	CliUsageTemplate = `{{ $cmd := . }}{{ if .HasSubCommands}}
 Available Commands: {{range .Commands}}{{if .Runnable}}{{if ne .Name "options"}}
- {{rpad .Use .UsagePadding }} {{.Short}}{{end}}{{end}}{{end}}
+ {{rpad .Name 20 }} {{.Short}}{{end}}{{end}}{{end}}
 {{end}}
 {{ if .HasLocalFlags}}Options:
 {{.LocalFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -69,7 +69,7 @@ Available Commands: {{range .Commands}}{{if .Runnable}}{{if ne .Name "options"}}
 {{.LocalFlags.FlagUsages}}
 {{end}}{{ if not $isRootCmd}}Use "{{template "rootCli" .}} --help" for a list of all commands available in {{template "rootCli" .}}.
 {{end}}{{ if .HasSubCommands }}Use "{{template "rootCli" .}} <command> --help" for more information about a given command.
-{{end}}{{ if .HasAnyPersistentFlags}}Use "{{template "rootCli" .}} options --help" for a list of global command-line options (applies to all commands).
+{{end}}{{ if .HasAnyPersistentFlags}}Use "{{template "rootCli" .}} options" for a list of global command-line options (applies to all commands).
 {{end}}`
 
 	optionsHelpTemplate = `{{ if .HasAnyPersistentFlags}}The following options can be passed to any command:

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -2,40 +2,41 @@ package templates
 
 import "strings"
 
-func decorate(template string) string {
-	if len(strings.Trim(template, " ")) > 0 {
+func decorate(template string, trim bool) string {
+	if trim && len(strings.Trim(template, " ")) > 0 {
 		trimmed := strings.Trim(template, "\n")
-		return trimmed
-	} else {
-		return template
+		return funcs + trimmed
 	}
+	return funcs + template
 }
 
 func MainHelpTemplate() string {
-	return mainHelpTemplate
+	return decorate(mainHelpTemplate, false)
 }
 
 func MainUsageTemplate() string {
-	return mainUsageTemplate
+	return decorate(mainUsageTemplate, false)
 }
 
 func CliHelpTemplate() string {
-	return cliHelpTemplate
+	return decorate(cliHelpTemplate, false)
 }
 
 func CliUsageTemplate() string {
-	return decorate(cliUsageTemplate)
+	return decorate(cliUsageTemplate, true)
 }
 
 func OptionsHelpTemplate() string {
-	return optionsHelpTemplate
+	return decorate(optionsHelpTemplate, false)
 }
 
 func OptionsUsageTemplate() string {
-	return optionsUsageTemplate
+	return decorate(optionsUsageTemplate, false)
 }
 
 const (
+	funcs = `{{$isRootCmd := or (eq .Name "cli") (eq .Name "osc")}}{{define "rootCli"}}{{if eq .Root.Name "osc"}}osc{{else}}openshift cli{{end}}{{end}}`
+
 	mainHelpTemplate = `{{.Long | trim}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
@@ -65,9 +66,10 @@ Available Commands: {{range .Commands}}{{if .Runnable}}{{if ne .Name "options"}}
   {{rpad .Name 20 }}{{.Short}}{{end}}{{end}}{{end}}
 {{end}}
 {{ if .HasLocalFlags}}Options:
-{{.LocalFlags.FlagUsages}}{{end}}{{ if ne .Name .Root.Name}}Use "{{.Root.Name}} --help" for a list of all commands available in {{.Root.Name}}.
-{{end}}{{ if .HasSubCommands }}Use "{{.Root.Name}} <command> --help" for more information about a given command.
-{{end}}{{ if .HasAnyPersistentFlags}}Use "{{.Root.Name}} options --help" for a list of global command-line options (applies to all commands).
+{{.LocalFlags.FlagUsages}}
+{{end}}{{ if not $isRootCmd}}Use "{{template "rootCli" .}} --help" for a list of all commands available in {{template "rootCli" .}}.
+{{end}}{{ if .HasSubCommands }}Use "{{template "rootCli" .}} <command> --help" for more information about a given command.
+{{end}}{{ if .HasAnyPersistentFlags}}Use "{{template "rootCli" .}} options --help" for a list of global command-line options (applies to all commands).
 {{end}}`
 
 	optionsHelpTemplate = `{{ if .HasAnyPersistentFlags}}The following options can be passed to any command:

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -35,7 +35,7 @@ func OptionsUsageTemplate() string {
 }
 
 const (
-	funcs = `{{$isRootCmd := or (eq .Name "cli") (eq .Name "osc")}}{{define "rootCli"}}{{if eq .Root.Name "osc"}}osc{{else}}openshift cli{{end}}{{end}}`
+	funcs = `{{$isRootCmd := or (and (eq .Name "cli") (eq .Root.Name "openshift")) (eq .Name "osc")}}{{define "rootCli"}}{{if eq .Root.Name "osc"}}osc{{else}}openshift cli{{end}}{{end}}`
 
 	mainHelpTemplate = `{{.Long | trim}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
@@ -43,7 +43,7 @@ const (
 	mainUsageTemplate = `{{ $cmd := . }}
 Usage: {{if .Runnable}}
   {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{end}}{{if .HasSubCommands}}
-  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+  {{ .CommandPath}} <command>{{end}}{{if gt .Aliases 0}}
 
 Aliases:
   {{.NameAndAliases}}{{end}}
@@ -55,7 +55,7 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasAnyPersistentFlags}}Global Options:
 {{.AllPersistentFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}
-Use "{{.Root.Name}} help [command]" for more information about that command.
+Use "{{.Root.Name}} <command> --help" for more information about a given command.
 {{end}}`
 
 	cliHelpTemplate = `{{.Long | trim}}

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -2,8 +2,7 @@ package templates
 
 const (
 	MainHelpTemplate = `{{.Long | trim}}
-{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
-`
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
 	MainUsageTemplate = `{{ $cmd := . }}
 Usage: {{if .Runnable}}
@@ -20,21 +19,24 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasAnyPersistentFlags}}Global Options:
 {{.AllPersistentFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}
-Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}`
+Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}
+`
 
 	CliHelpTemplate = `{{.Long | trim}}
-{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
-`
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+
 	CliUsageTemplate = `{{ $cmd := . }}{{ if .HasSubCommands}}
 Available Commands: {{range .Commands}}{{if .Runnable}}{{if ne .Name "options"}}
  {{rpad .Name 20 }} {{.Short}}{{end}}{{end}}{{end}}
 {{end}}
 {{ if .HasLocalFlags}}Options:
-{{.LocalFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}
-Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}{{ if .HasAnyPersistentFlags}}
-Use "{{.Root.Name}} options" for a list of global command-line options.{{end}}`
+{{.LocalFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}{{ if .HasAnyPersistentFlags}}
+Use "{{.Root.Name}} options" for a list of global command-line options.{{end}}
+`
 
-	OptionsUsageTemplate = `{{ if .HasAnyPersistentFlags}}The following options can be passed to any command:
+	OptionsHelpTemplate = `{{ if .HasAnyPersistentFlags}}The following options can be passed to any command:
 
 {{.AllPersistentFlags.FlagUsages}}{{end}}`
+
+	OptionsUsageTemplate = ``
 )

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -1,10 +1,45 @@
 package templates
 
+import "strings"
+
+func decorate(template string) string {
+	if len(strings.Trim(template, " ")) > 0 {
+		trimmed := strings.Trim(template, "\n")
+		return trimmed
+	} else {
+		return template
+	}
+}
+
+func MainHelpTemplate() string {
+	return mainHelpTemplate
+}
+
+func MainUsageTemplate() string {
+	return mainUsageTemplate
+}
+
+func CliHelpTemplate() string {
+	return cliHelpTemplate
+}
+
+func CliUsageTemplate() string {
+	return decorate(cliUsageTemplate)
+}
+
+func OptionsHelpTemplate() string {
+	return optionsHelpTemplate
+}
+
+func OptionsUsageTemplate() string {
+	return optionsUsageTemplate
+}
+
 const (
-	MainHelpTemplate = `{{.Long | trim}}
+	mainHelpTemplate = `{{.Long | trim}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
-	MainUsageTemplate = `{{ $cmd := . }}
+	mainUsageTemplate = `{{ $cmd := . }}
 Usage: {{if .Runnable}}
   {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{end}}{{if .HasSubCommands}}
   {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
@@ -19,24 +54,25 @@ Available Commands: {{range .Commands}}{{if .Runnable}}
 {{.LocalFlags.FlagUsages}}{{end}}
 {{ if .HasAnyPersistentFlags}}Global Options:
 {{.AllPersistentFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}
-Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}
-`
+Use "{{.Root.Name}} help [command]" for more information about that command.
+{{end}}`
 
-	CliHelpTemplate = `{{.Long | trim}}
+	cliHelpTemplate = `{{.Long | trim}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
-	CliUsageTemplate = `{{ $cmd := . }}{{ if .HasSubCommands}}
+	cliUsageTemplate = `{{ $cmd := . }}{{ if .HasSubCommands}}
 Available Commands: {{range .Commands}}{{if .Runnable}}{{if ne .Name "options"}}
- {{rpad .Name 20 }} {{.Short}}{{end}}{{end}}{{end}}
+  {{rpad .Name 20 }}{{.Short}}{{end}}{{end}}{{end}}
 {{end}}
 {{ if .HasLocalFlags}}Options:
-{{.LocalFlags.FlagUsages}}{{end}}{{ if .HasSubCommands }}Use "{{.Root.Name}} help [command]" for more information about that command.{{end}}{{ if .HasAnyPersistentFlags}}
-Use "{{.Root.Name}} options" for a list of global command-line options.{{end}}
-`
+{{.LocalFlags.FlagUsages}}{{end}}{{ if ne .Name .Root.Name}}Use "{{.Root.Name}} --help" for a list of all commands available in {{.Root.Name}}.
+{{end}}{{ if .HasSubCommands }}Use "{{.Root.Name}} <command> --help" for more information about a given command.
+{{end}}{{ if .HasAnyPersistentFlags}}Use "{{.Root.Name}} options --help" for a list of global command-line options (applies to all commands).
+{{end}}`
 
-	OptionsHelpTemplate = `{{ if .HasAnyPersistentFlags}}The following options can be passed to any command:
+	optionsHelpTemplate = `{{ if .HasAnyPersistentFlags}}The following options can be passed to any command:
 
 {{.AllPersistentFlags.FlagUsages}}{{end}}`
 
-	OptionsUsageTemplate = ``
+	optionsUsageTemplate = ``
 )


### PR DESCRIPTION
- Remove usage from the list of available commands in help
- Fix help line breaks
- Better footer messages in help
- Fixes base command reference (osc || openshift cli) in help
- ~~Makes global options osc options --help~~ actually back to `osc options`
