### PR TITLE
Set user fullname correctly, initialize identity mappings fully

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -41,7 +41,7 @@
           <li class="dropdown" ng-if="user">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               <span class="pficon pficon-user"></span>
-              {{user.metadata.name}} <b class="caret"></b>
+              {{user.fullName || user.metadata.name}} <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
               <!--

--- a/pkg/user/initializer.go
+++ b/pkg/user/initializer.go
@@ -13,13 +13,11 @@ func NewDefaultUserInitStrategy() Initializer {
 
 // InitializeUser implements Initializer
 func (*DefaultUserInitStrategy) InitializeUser(identity *api.Identity, user *api.User) error {
-	if identity.Extra == nil {
-		return nil
+	user.FullName = identity.UserName
+	if identity.Extra != nil {
+		if name, ok := identity.Extra["name"]; ok && len(name) > 0 {
+			user.FullName = name
+		}
 	}
-	name, ok := identity.Extra["name"]
-	if !ok {
-		name = identity.UserName
-	}
-	user.FullName = name
 	return nil
 }

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -72,16 +72,57 @@ func TestUserInitialization(t *testing.T) {
 	}
 
 	expectedUser := api.User{
-		ObjectMeta: kapi.ObjectMeta{Name: ":test"},
-		FullName:   "Mr. Test",
+		ObjectMeta: kapi.ObjectMeta{
+			Name: ":test",
+			// Copy the UID and timestamp from the actual one
+			UID:               actual.User.UID,
+			CreationTimestamp: actual.User.CreationTimestamp,
+		},
+		FullName: "Mr. Test",
 	}
-	expectedUser.Name = ":test"
-	expectedUser.UID = actual.User.UID
+	// Copy the UID and timestamp from the actual one
+	mapping.Identity.UID = actual.Identity.UID
+	mapping.Identity.CreationTimestamp = actual.Identity.CreationTimestamp
 	expected := &api.UserIdentityMapping{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: ":test",
+			// Copy the UID and timestamp from the actual one
+			UID:               actual.UID,
+			CreationTimestamp: actual.CreationTimestamp,
+		},
 		Identity: mapping.Identity,
 		User:     expectedUser,
 	}
 	compareIgnoringSelfLinkAndVersion(t, expected, actual)
+
+	// Make sure uid, name, and creation timestamp get initialized
+	if len(actual.UID) == 0 {
+		t.Fatalf("Expected UID to be set")
+	}
+	if len(actual.Name) == 0 {
+		t.Fatalf("Expected Name to be set")
+	}
+	if actual.CreationTimestamp.IsZero() {
+		t.Fatalf("Expected CreationTimestamp to be set")
+	}
+	if len(actual.User.UID) == 0 {
+		t.Fatalf("Expected UID to be set")
+	}
+	if len(actual.User.Name) == 0 {
+		t.Fatalf("Expected Name to be set")
+	}
+	if actual.User.CreationTimestamp.IsZero() {
+		t.Fatalf("Expected CreationTimestamp to be set")
+	}
+	if len(actual.Identity.UID) == 0 {
+		t.Fatalf("Expected UID to be set")
+	}
+	if len(actual.Identity.Name) == 0 {
+		t.Fatalf("Expected Name to be set")
+	}
+	if actual.Identity.CreationTimestamp.IsZero() {
+		t.Fatalf("Expected CreationTimestamp to be set")
+	}
 
 	user, err := userRegistry.GetUser(expected.User.Name)
 	if err != nil {
@@ -158,12 +199,24 @@ func TestUserLookup(t *testing.T) {
 		// TODO: t.Errorf("expected created to be true")
 	}
 	expectedUser := api.User{
-		ObjectMeta: kapi.ObjectMeta{Name: ":test"},
-		FullName:   "Mr. Test",
+		ObjectMeta: kapi.ObjectMeta{
+			Name: ":test",
+			// Copy the UID and timestamp from the actual one
+			UID:               actual.User.UID,
+			CreationTimestamp: actual.User.CreationTimestamp,
+		},
+		FullName: "Mr. Test",
 	}
-	expectedUser.Name = ":test"
-	expectedUser.UID = actual.User.UID
+	// Copy the UID and timestamp from the actual one
+	mapping.Identity.UID = actual.Identity.UID
+	mapping.Identity.CreationTimestamp = actual.Identity.CreationTimestamp
 	expected := &api.UserIdentityMapping{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: ":test",
+			// Copy the UID and timestamp from the actual one
+			UID:               actual.UID,
+			CreationTimestamp: actual.CreationTimestamp,
+		},
 		Identity: mapping.Identity,
 		User:     expectedUser,
 	}


### PR DESCRIPTION
1. Added the primary identity username as the user's "FullName" field, so we can display what the user expects in the UI
2. Fully initialized the uid, name, and creationtimestamp fields for the useridentitymapping objects