### PR TITLE
Improve error handling and logging for builds

### DIFF
--- a/images/builder/docker/docker-builder/Dockerfile
+++ b/images/builder/docker/docker-builder/Dockerfile
@@ -13,4 +13,4 @@
 FROM openshift/origin
 
 ENV HOME /root
-ENTRYPOINT ["/usr/bin/openshift-docker-build"]
+ENTRYPOINT ["/usr/bin/openshift-docker-build", "--loglevel=5"]

--- a/images/builder/docker/sti-builder/Dockerfile
+++ b/images/builder/docker/sti-builder/Dockerfile
@@ -13,4 +13,4 @@
 FROM openshift/origin
 
 ENV HOME /root
-ENTRYPOINT ["/usr/bin/openshift-sti-build"]
+ENTRYPOINT ["/usr/bin/openshift-sti-build", "--loglevel=5"]

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -2,9 +2,11 @@ package builder
 
 import (
 	"github.com/fsouza/go-dockerclient"
-	"github.com/openshift/origin/pkg/build/api"
+	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/sti"
 	stiapi "github.com/openshift/source-to-image/pkg/sti/api"
+
+	"github.com/openshift/origin/pkg/build/api"
 )
 
 // STIBuilder performs an STI build given the build object
@@ -45,6 +47,7 @@ func (s *STIBuilder) Build() error {
 	} else if s.build.Parameters.Source.Git.Ref != "" {
 		request.Ref = s.build.Parameters.Source.Git.Ref
 	}
+	glog.V(2).Infof("Creating a new STI builder with build request: %#v\n", request)
 	builder, err := sti.NewBuilder(request)
 	if err != nil {
 		return err


### PR DESCRIPTION
Errors out if a valid dockerImageReference is not set for output. Enables loglevel=5 by default on builder images.