### PR TITLE
make remove-group from role check all bindings

### DIFF
--- a/pkg/cmd/experimental/policy/add_group.go
+++ b/pkg/cmd/experimental/policy/add_group.go
@@ -70,14 +70,18 @@ func (o *addGroupOptions) run() error {
 		return err
 	}
 
-	roleBinding, roleBindingNames, err := getExistingRoleBindingForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, roleBindingNames, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
 	if err != nil {
 		return err
 	}
+	roleBinding := (*authorizationapi.RoleBinding)(nil)
 	isUpdate := true
-	if roleBinding == nil {
+	if len(roleBindings) == 0 {
 		roleBinding = &authorizationapi.RoleBinding{}
 		isUpdate = false
+	} else {
+		// only need to add the user or group to a single roleBinding on the role.  Just choose the first one
+		roleBinding = roleBindings[0]
 	}
 
 	roleBinding.RoleRef.Namespace = o.roleNamespace

--- a/pkg/cmd/experimental/policy/add_user.go
+++ b/pkg/cmd/experimental/policy/add_user.go
@@ -70,14 +70,18 @@ func (o *addUserOptions) run() error {
 		return err
 	}
 
-	roleBinding, roleBindingNames, err := getExistingRoleBindingForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, roleBindingNames, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
 	if err != nil {
 		return err
 	}
+	roleBinding := (*authorizationapi.RoleBinding)(nil)
 	isUpdate := true
-	if roleBinding == nil {
+	if len(roleBindings) == 0 {
 		roleBinding = &authorizationapi.RoleBinding{}
 		isUpdate = false
+	} else {
+		// only need to add the user or group to a single roleBinding on the role.  Just choose the first one
+		roleBinding = roleBindings[0]
 	}
 
 	roleBinding.RoleRef.Namespace = o.roleNamespace

--- a/pkg/cmd/experimental/policy/policy.go
+++ b/pkg/cmd/experimental/policy/policy.go
@@ -79,23 +79,23 @@ func getUniqueName(basename string, existingNames *util.StringSet) string {
 	return string(util.NewUUID())
 }
 
-func getExistingRoleBindingForRole(roleNamespace, role, bindingNamespace string, client *client.Client) (*authorizationapi.RoleBinding, *util.StringSet, error) {
+func getExistingRoleBindingsForRole(roleNamespace, role, bindingNamespace string, client *client.Client) ([]*authorizationapi.RoleBinding, *util.StringSet, error) {
 	existingBindings, err := client.PolicyBindings(bindingNamespace).Get(roleNamespace)
 	if err != nil && !strings.Contains(err.Error(), " not found") {
 		return nil, &util.StringSet{}, err
 	}
 
+	ret := make([]*authorizationapi.RoleBinding, 0)
 	roleBindingNames := &util.StringSet{}
-	roleBinding := (*authorizationapi.RoleBinding)(nil)
 	// see if we can find an existing binding that points to the role in question.
 	for _, currBinding := range existingBindings.RoleBindings {
 		roleBindingNames.Insert(currBinding.Name)
 
 		if currBinding.RoleRef.Name == role {
 			t := currBinding
-			roleBinding = &t
+			ret = append(ret, &t)
 		}
 	}
 
-	return roleBinding, roleBindingNames, nil
+	return ret, roleBindingNames, nil
 }

--- a/pkg/cmd/experimental/policy/remove_group.go
+++ b/pkg/cmd/experimental/policy/remove_group.go
@@ -69,22 +69,24 @@ func (o *removeGroupOptions) run() error {
 		return err
 	}
 
-	roleBinding, _, err := getExistingRoleBindingForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
 	if err != nil {
 		return err
 	}
-	if roleBinding == nil {
+	if len(roleBindings) == 0 {
 		return fmt.Errorf("unable to locate RoleBinding for %v::%v in %v", o.roleNamespace, o.roleName, namespace)
 	}
 
-	groups := util.StringSet{}
-	groups.Insert(roleBinding.GroupNames...)
-	groups.Delete(o.groupNames...)
-	roleBinding.GroupNames = groups.List()
+	for _, roleBinding := range roleBindings {
+		groups := util.StringSet{}
+		groups.Insert(roleBinding.GroupNames...)
+		groups.Delete(o.groupNames...)
+		roleBinding.GroupNames = groups.List()
 
-	_, err = client.RoleBindings(namespace).Update(roleBinding)
-	if err != nil {
-		return err
+		_, err = client.RoleBindings(namespace).Update(roleBinding)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/experimental/policy/remove_user.go
+++ b/pkg/cmd/experimental/policy/remove_user.go
@@ -69,22 +69,24 @@ func (o *removeUserOptions) run() error {
 		return err
 	}
 
-	roleBinding, _, err := getExistingRoleBindingForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
 	if err != nil {
 		return err
 	}
-	if roleBinding == nil {
+	if len(roleBindings) == 0 {
 		return fmt.Errorf("unable to locate RoleBinding for %v::%v in %v", o.roleNamespace, o.roleName, namespace)
 	}
 
-	users := util.StringSet{}
-	users.Insert(roleBinding.UserNames...)
-	users.Delete(o.userNames...)
-	roleBinding.UserNames = users.List()
+	for _, roleBinding := range roleBindings {
+		users := util.StringSet{}
+		users.Insert(roleBinding.UserNames...)
+		users.Delete(o.userNames...)
+		roleBinding.UserNames = users.List()
 
-	_, err = client.RoleBindings(namespace).Update(roleBinding)
-	if err != nil {
-		return err
+		_, err = client.RoleBindings(namespace).Update(roleBinding)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Bug fix.  If you have a single role bound as multiple bindings, then doing a remove-user or remove-group would only check one of those bindings for the matching user or group.  It must check all bindings that reference the role.

@liggitt this exists in the beta as well.  How do I get it into both?