### PR TITLE
Check SELinux labels when building in docker

### DIFF
--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -8,5 +8,16 @@ set -o nounset
 set -o pipefail
 
 origin_path="src/github.com/openshift/origin"
-docker run --rm -v ${GOPATH}/${origin_path}:/go/${origin_path} \
-  openshift/origin-release /usr/bin/openshift-origin-build.sh $@
+
+# TODO: Remove this check and fix the docker command instead after the
+#       following PR is merged: https://github.com/docker/docker/pull/5910
+#       should be done in docker 1.6.
+if [ -d /sys/fs/selinux ]; then
+    if ! ls --context "${GOPATH}/${origin_path}" | grep --quiet svirt_sandbox_file_t; then
+        echo "$(tput setaf 1)Warning: SELinux labels are not set correctly; run chcon -Rt svirt_sandbox_file_t ${GOPATH}/${origin_path}$(tput sgr0)"
+        exit 1
+    fi
+fi
+
+docker run --rm -v "${GOPATH}/${origin_path}:/go/${origin_path}" \
+  openshift/origin-release /usr/bin/openshift-origin-build.sh "$@"


### PR DESCRIPTION
If the source repository is not labeled svirt_sandbox_file_t, the build
will fail with a SELinux denial. Should be fixed better with docker 1.6
after https://github.com/docker/docker/pull/5910 is merged.