### PR TITLE
Prevent browsers from prompting to send bogus client certs

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -73,6 +74,10 @@ type NodeConfig struct {
 
 	KubeletCertFile string
 	KubeletKeyFile  string
+
+	// ClientCAs will be used to request client certificates in connections to the node.
+	// This CertPool should contain all the CAs that will be used for client certificate verification.
+	ClientCAs *x509.CertPool
 
 	// A client to connect to the master.
 	Client *client.Client
@@ -174,6 +179,7 @@ func (c *NodeConfig) RunKubelet() {
 				// Populate PeerCertificates in requests, but don't reject connections without certificates
 				// This allows certificates to be validated by authenticators, while still allowing other auth types
 				ClientAuth: tls.RequestClientCert,
+				ClientCAs:  c.ClientCAs,
 			}
 			glog.Fatal(server.ListenAndServeTLS(c.KubeletCertFile, c.KubeletKeyFile))
 		} else {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -452,6 +452,7 @@ func start(cfg *config, args []string) error {
 			for _, root := range ca.Config.Roots {
 				roots.AddCert(root)
 			}
+			osmaster.ClientCAs = roots
 
 			// build cert authenticator
 			// TODO: add cert users to etcd?


### PR DESCRIPTION
Send the certificate authorities we will accept client certs from, to prevent browsers from prompting to send any old client cert they have their hands on

Also, stop requesting client certs for the UI server, since we're not doing anything with them