### PR TITLE
Use chown for build-in-docker.sh output binaries

### DIFF
--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -19,5 +19,5 @@ if [ -d /sys/fs/selinux ]; then
     fi
 fi
 
-docker run --rm -v "${GOPATH}/${origin_path}:/go/${origin_path}" \
+docker run -e "OWNER_GROUP=$UID:$GROUPS" --rm -v "${GOPATH}/${origin_path}:/go/${origin_path}" \
   openshift/origin-release /usr/bin/openshift-origin-build.sh "$@"

--- a/images/release/openshift-origin-build.sh
+++ b/images/release/openshift-origin-build.sh
@@ -5,8 +5,15 @@ build_script_path=`mktemp /tmp/build.XXX.sh`
 
 cat <<EOF > ${build_script_path}
 #!/bin/bash -e
+
+function chown_output {
+    if [ ! -z "$OWNER_GROUP" ]; then
+        chown -R "$OWNER_GROUP" Godeps/_workspace/pkg _output
+    fi
+}
+
 cd ${os_dir}
-OS_VERSION_FILE="" ./hack/build-go.sh && chmod -R go+rw {Godeps/_workspace/pkg,_output}
+OS_VERSION_FILE="" ./hack/build-go.sh && chown_output
 EOF
 
 echo "++ Checking for gofmt errors"


### PR DESCRIPTION
Pass in UID and GID of the user to docker, so the build script can chown
the resulting binaries. Changing user and group IDs of build output
binaries makes more sense than setting access modes to 0777.