### PR TITLE
Better management of the systemd services + workdir change

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,6 +129,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.vm.provision "shell", inline: "/vagrant/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{ENV['OPENSHIFT_SDN']}"
       config.vm.network "private_network", ip: "#{master_ip}"
       config.vm.hostname = "openshift-master"
+      config.vm.provision "shell", inline: "systemctl start openshift-master-sdn", run: "always"
     end
 
     # OpenShift minion

--- a/vagrant/provision-master-sdn.sh
+++ b/vagrant/provision-master-sdn.sh
@@ -21,7 +21,8 @@ popd
 # Create systemd service
 cat <<EOF > /usr/lib/systemd/system/openshift-master-sdn.service
 [Unit]
-Description=openshift SDN master
+Description=OpenShift SDN Master
+Requires=openshift-master.service
 After=openshift-master.service
 
 [Service]
@@ -33,5 +34,4 @@ EOF
 
 # Start the service
 systemctl daemon-reload
-systemctl enable openshift-master-sdn.service
 systemctl start openshift-master-sdn.service

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -37,8 +37,8 @@ systemctl start docker.service
 # Create systemd service
 cat <<EOF > /usr/lib/systemd/system/openshift-master.service
 [Unit]
-Description=openshift master
-Requires=docker.service
+Description=OpenShift Master
+Requires=docker.service network.service
 After=network.service
 
 [Service]
@@ -51,7 +51,6 @@ EOF
 
 # Start the service
 systemctl daemon-reload
-systemctl enable openshift-master.service
 systemctl start openshift-master.service
 
 # if SDN requires service on master, then set it up

--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -47,8 +47,8 @@ sed -ie "s/10.0.2.15/${MASTER_IP}/g" /openshift.local.certificates/admin/.kubeco
 # Create systemd service
 cat <<EOF > /usr/lib/systemd/system/openshift-node.service
 [Unit]
-Description=openshift node
-Requires=docker.service
+Description=OpenShift Node
+Requires=docker.service network.service
 After=network.service
 
 [Service]

--- a/vagrant/provision-node-sdn.sh
+++ b/vagrant/provision-node-sdn.sh
@@ -23,6 +23,7 @@ popd
 cat <<EOF > /usr/lib/systemd/system/openshift-node-sdn.service
 [Unit]
 Description=openshift SDN node
+Requires=openvswitch.service
 After=openvswitch.service
 Before=openshift-node.service
 


### PR DESCRIPTION
This commit includes a few fixes:

1. Adds `Requires` where it is justified
2. Adds the restart guards to all services
3. Changes the working directory for openshift-master service

Ad 2. For the SDN services `always` was used because of bug reported upstream: https://github.com/openshift/openshift-sdn/issues/12

Ad 3. The problem is that when vagrant boots the VM, it mounts the `/vagrant` directory when `openshift-master` is already running. This makes it impossible to remove the `openshift.local.*` directories to start with a fresh environment. This change moves the work dir to `/home/vagrant` to make it possible.