### PR TITLE
Require network when starting openshift-master

### DIFF
--- a/rel-eng/openshift-master.service
+++ b/rel-eng/openshift-master.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=OpenShift Master
 Documentation=https://github.com/openshift/origin
+After=network.target
+Requires=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
`openshift-master.service` fails to start if the network isn't up. This
change adds a dependency on `network.target` in the `openshift-master`
unit file.

Bug: 1189422
https://bugzilla.redhat.com/show_bug.cgi?id=1189422