### PR TITLE
Fix off-by-1 error

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -118,7 +118,10 @@ func applyToCreate(dst *cobra.Command) *cobra.Command {
 	dst.Aliases = append(dst.Aliases, "apply")
 	oldRun := dst.Run
 	dst.Run = func(c *cobra.Command, args []string) {
-		if len(os.Args) >= 2 && os.Args[2] == "apply" {
+		calledApply := false
+		calledApply = calledApply || len(os.Args) >= 2 && os.Args[1] == "apply" // `osc apply`
+		calledApply = calledApply || len(os.Args) >= 3 && os.Args[2] == "apply" // `openshift cli apply`
+		if calledApply {
 			glog.Errorf("DEPRECATED: The 'apply' command is now deprecated, use 'create' instead.")
 		}
 		oldRun(c, args)


### PR DESCRIPTION
Was getting a panic when calling `osc create` or `osc apply` with no args