### PR TITLE
handle non resource urls

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -15,9 +15,10 @@ import (
 
 const (
 	// Policy is a singleton and this is its name
-	PolicyName  = "default"
-	ResourceAll = "*"
-	VerbAll     = "*"
+	PolicyName     = "default"
+	ResourceAll    = "*"
+	VerbAll        = "*"
+	NonResourceAll = "*"
 )
 
 const (
@@ -77,6 +78,9 @@ type PolicyRule struct {
 	Resources []string
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames kutil.StringSet
+	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// If an action is not a resource API request, then the URL is split on '/' and is checked against the NonResourceURLs to look for a match.
+	NonResourceURLs kutil.StringSet
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.

--- a/pkg/authorization/api/v1beta1/conversion.go
+++ b/pkg/authorization/api/v1beta1/conversion.go
@@ -3,10 +3,10 @@ package v1beta1
 import (
 	"sort"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
 	newer "github.com/openshift/origin/pkg/authorization/api"
 )
 
@@ -26,6 +26,8 @@ func init() {
 
 			out.ResourceNames = util.NewStringSet(in.ResourceNames...)
 
+			out.NonResourceURLs = util.NewStringSet(in.NonResourceURLsSlice...)
+
 			return nil
 		},
 		func(in *newer.PolicyRule, out *PolicyRule, s conversion.Scope) error {
@@ -40,6 +42,8 @@ func init() {
 			out.Resources = append(out.Resources, in.Resources...)
 
 			out.ResourceNames = in.ResourceNames.List()
+
+			out.NonResourceURLsSlice = in.NonResourceURLs.List()
 
 			return nil
 		},

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -28,6 +28,9 @@ type PolicyRule struct {
 	Resources []string `json:"resources"`
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames []string `json:"resourceNames,omitempty"`
+	// NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.
+	NonResourceURLsSlice []string `json:"nonResourceURLs,omitempty"`
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.

--- a/pkg/authorization/authorizer/non_resource_match_test.go
+++ b/pkg/authorization/authorizer/non_resource_match_test.go
@@ -1,0 +1,76 @@
+package authorizer
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type nonResourceMatchTest struct {
+	url            string
+	matcher        string
+	expectedResult bool
+}
+
+func TestNonResourceMatchStar(t *testing.T) {
+	test := &nonResourceMatchTest{
+		url:            "first/second",
+		matcher:        "first/*",
+		expectedResult: true,
+	}
+	test.run(t)
+}
+
+func TestNonResourceMatchExact(t *testing.T) {
+	test := &nonResourceMatchTest{
+		url:            "first/second",
+		matcher:        "first/second",
+		expectedResult: true,
+	}
+	test.run(t)
+}
+
+func TestNonResourceMatchMatcherEndsShort(t *testing.T) {
+	test := &nonResourceMatchTest{
+		url:            "first/second",
+		matcher:        "first",
+		expectedResult: false,
+	}
+	test.run(t)
+}
+
+func TestNonResourceMatchURLEndsShort(t *testing.T) {
+	test := &nonResourceMatchTest{
+		url:            "first",
+		matcher:        "first/second",
+		expectedResult: false,
+	}
+	test.run(t)
+}
+
+func TestNonResourceMatchNoSimilarity(t *testing.T) {
+	test := &nonResourceMatchTest{
+		url:            "first/second",
+		matcher:        "foo",
+		expectedResult: false,
+	}
+	test.run(t)
+}
+
+func (test *nonResourceMatchTest) run(t *testing.T) {
+	attributes := &DefaultAuthorizationAttributes{
+		NonResourceURL: true,
+		URL:            test.url,
+	}
+
+	rule := authorizationapi.PolicyRule{NonResourceURLs: util.NewStringSet(test.matcher)}
+
+	result := attributes.nonResourceMatches(rule)
+
+	if result != test.expectedResult {
+		t.Errorf("Expected %v, got %v", test.expectedResult, result)
+	}
+
+}

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -27,8 +27,8 @@ func TestSubjects(t *testing.T) {
 			Resource:  "pods",
 			Namespace: "adze",
 		},
-		expectedUsers:  []string{"Anna", "ClusterAdmin", "Ellen", "Valerie"},
-		expectedGroups: []string{"RootUsers"},
+		expectedUsers:  []string{"Anna", "ClusterAdmin", "Ellen", "Valerie", "system:admin", "system:kube-client", "system:openshift-client", "system:openshift-deployer"},
+		expectedGroups: []string{"RootUsers", "system:authenticated", "system:unauthenticated"},
 	}
 	globalPolicy, globalPolicyBinding := newDefaultGlobalPolicy()
 	namespacedPolicy, namespacedPolicyBinding := newAdzePolicy()


### PR DESCRIPTION
Depends on #991 

Adds the ability to describe non-resources for policy matching.  This can be used to allow access to one off endpoints like `healthz` and `version`.

You can now specify a path with an ending wildcard that will be evaluated against the remainder of a request path to determine a match or not.  The evaluation takes the remainder of a URL and attempts to match it against a series of explicitly allowed steps that can end in a wildcard.

@liggitt last two commits?