### PR TITLE
WIP: Replace deploy controller FIFOs with Store reconciliation

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -46,6 +46,7 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	deploycontroller "github.com/openshift/origin/pkg/deploy/controller"
 	deploycontrollerfactory "github.com/openshift/origin/pkg/deploy/controller/factory"
 	deployconfiggenerator "github.com/openshift/origin/pkg/deploy/generator"
 	deployregistry "github.com/openshift/origin/pkg/deploy/registry/deploy"
@@ -675,12 +676,8 @@ func (c *MasterConfig) RunDeploymentController() {
 
 func (c *MasterConfig) RunDeploymentConfigController() {
 	osclient, kclient := c.DeploymentConfigControllerClients()
-	factory := deploycontrollerfactory.DeploymentConfigControllerFactory{
-		Client:     osclient,
-		KubeClient: kclient,
-		Codec:      latest.Codec,
-	}
-	controller := factory.Create()
+	controller := deploycontroller.NewDeploymentConfigController(osclient, kclient, latest.Codec,
+		make(chan struct{}), 30*time.Second)
 	controller.Run()
 }
 

--- a/pkg/deploy/controller/deployment_config_controller.go
+++ b/pkg/deploy/controller/deployment_config_controller.go
@@ -2,13 +2,19 @@ package controller
 
 import (
 	"fmt"
+	"time"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	cache "github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 
+	osclient "github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -20,73 +26,212 @@ import (
 // Deployments are represented by ReplicationControllers. The DeploymentConfig used to create the
 // ReplicationController is encoded and stored in an annotation on the ReplicationController.
 type DeploymentConfigController struct {
-	// DeploymentInterface provides access to Deployments.
-	DeploymentInterface dccDeploymentInterface
-	// NextDeploymentConfig blocks until the next DeploymentConfig is available.
-	NextDeploymentConfig func() *deployapi.DeploymentConfig
-	// Codec is used to encode DeploymentConfigs which are stored on deployments.
-	Codec runtime.Codec
-	// Stop is an optional channel that controls when the controller exits.
-	Stop <-chan struct{}
+	deploymentConfigStore cache.Store
+	deploymentStore       cache.Store
+	client                deploymentConfigControllerClient
+	codec                 runtime.Codec
+	handleError           func(error)
+	sync                  <-chan struct{}
+	stop                  <-chan struct{}
 }
 
-// dccDeploymentInterface is a small private interface for dealing with Deployments.
-type dccDeploymentInterface interface {
-	GetDeployment(namespace, name string) (*kapi.ReplicationController, error)
+// NewDeploymentConfigController creates a DeploymentConfigController using API clients. The
+// controller returned will be configured to perform a sync:
+//
+//   1. Every fullSyncPeriod.
+//   2. Any time a watch event for DeploymentConfig is observed.
+//
+// Errors are delegated to util.HandleError.
+func NewDeploymentConfigController(osClient osclient.DeploymentConfigsNamespacer, kClient kclient.ReplicationControllersNamespacer,
+	codec runtime.Codec, stop <-chan struct{}, fullSyncPeriod time.Duration) *DeploymentConfigController {
+	// Make the ListWatcher for deploymentConfigs
+	deploymentConfigLW := &deployutil.ListWatcherImpl{
+		ListFunc: func() (runtime.Object, error) {
+			return osClient.DeploymentConfigs(kapi.NamespaceAll).List(labels.Everything(), labels.Everything())
+		},
+		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			return osClient.DeploymentConfigs(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
+		},
+	}
+
+	// Make the ListWatcher for deployments
+	deploymentLW := &deployutil.ListWatcherImpl{
+		ListFunc: func() (runtime.Object, error) {
+			return kClient.ReplicationControllers(kapi.NamespaceAll).List(labels.Everything())
+		},
+		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			return kClient.ReplicationControllers(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
+		},
+	}
+
+	// Initialize the stores with reflectors
+	deploymentConfigStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	cache.NewReflector(deploymentConfigLW, &deployapi.DeploymentConfig{}, deploymentConfigStore).RunUntil(stop)
+
+	deploymentStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	cache.NewReflector(deploymentLW, &kapi.ReplicationController{}, deploymentStore).RunUntil(stop)
+
+	// Create a deploymentClient impl backed by the kube client
+	deploymentClient := &deploymentConfigControllerClientImpl{
+		CreateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+			return kClient.ReplicationControllers(namespace).Create(deployment)
+		},
+	}
+
+	// Sync every fullSyncPeriod, or every time a deploymentConfig watch event is observed.
+	// TODO: Compress events to prevent sync spamming.
+	// TODO: Extract this into something more generic.
+	sync := make(chan struct{})
+	go func() {
+		// TODO: error handling
+		configWatch, _ := osClient.DeploymentConfigs(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), "")
+		ticker := time.NewTicker(fullSyncPeriod)
+		for {
+			select {
+			case <-ticker.C:
+				sync <- struct{}{}
+			case event, ok := <-configWatch.ResultChan():
+				if !ok || event.Type == watch.Error {
+					glog.Errorf("Re-establishing deploymentConfig watch")
+					configWatch, _ = osClient.DeploymentConfigs(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), "")
+					continue
+				}
+				sync <- struct{}{}
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	handleError := func(err error) {
+		// TODO: This is the point where more intelligent error handling
+		// decisions can be made after each iteration. For example, if the error
+		// contained enough context, we could choose whether or not to sync
+		// based on a stateful backoff construct. Or, if the errors were fatal,
+		// we may choose to never retry, wait even longer, or even actively
+		// purge invalid states or otherwise quarantine them (e.g. via labels)
+		// to get them out of the processing dataset.
+		glog.Errorf("Scheduling sync of deploymentConfigs because the last sync failed: %v", err)
+		sync <- struct{}{}
+	}
+
+	return &DeploymentConfigController{
+		client:                deploymentClient,
+		deploymentConfigStore: deploymentConfigStore,
+		deploymentStore:       deploymentStore,
+		codec:                 codec,
+		sync:                  sync,
+		stop:                  stop,
+		handleError:           handleError,
+	}
+}
+
+// Run performs a full sync every period, or when a message is received on
+// sync, until a message is received on the stop channel. If a sync iteration
+// returns an error, the handleError function is called and receives the error
+// for processing before the next iteration occurs.
+func (c *DeploymentConfigController) Run() {
+	go util.Until(func() {
+		select {
+		case <-c.sync:
+			err := c.syncAll()
+			if err != nil {
+				c.handleError(err)
+			}
+		}
+	}, 0, c.stop)
+}
+
+// syncAll performs a sync on every config in the store. If any individual
+// sync operation returns an error, the syncAll call returns an error. Even
+// when an individual sync operation fails, sync will stil be called for each
+// config.
+func (c *DeploymentConfigController) syncAll() error {
+	failed := false
+	for _, config := range c.deploymentConfigStore.List() {
+		err := c.syncOne(config.(*deployapi.DeploymentConfig))
+		if err != nil {
+			failed = true
+		}
+	}
+
+	if failed {
+		return fmt.Errorf("Failed to process one or more configs")
+	}
+
+	return nil
+}
+
+// sync examines the current state of a DeploymentConfig, and creates a new
+// deployment for the config if the following conditions are true:
+//
+//   1. The config version is greater than 0
+//   2. No deployment exists corresponding to  the config's version
+//
+// If the config can't be processed, an error is returned.
+func (c *DeploymentConfigController) syncOne(config *deployapi.DeploymentConfig) error {
+	// Only deploy when the version has advanced past 0.
+	if config.LatestVersion == 0 {
+		glog.V(5).Infof("Waiting for first version of %s", labelFor(config))
+		return nil
+	}
+
+	var deploymentExists bool
+	var err error
+	var deployment *kapi.ReplicationController
+
+	// Find any existing deployment.
+	_, deploymentExists, err = c.deploymentStore.Get(&kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: config.Namespace,
+			Name:      deployutil.LatestDeploymentNameForConfig(config),
+		}})
+	if err != nil {
+		return fmt.Errorf("Couldn't retrieve deployment from store: %v", err)
+	}
+
+	// Only deploy if there's no existing deployment for this config.
+	if deploymentExists {
+		return nil
+	}
+
+	// Try and build a deployment for the config.
+	deployment, err = deployutil.MakeDeployment(config, c.codec)
+	if err != nil {
+		return fmt.Errorf("Couldn't make deployment from (potentially invalid) config %s: %v", labelFor(config), err)
+	}
+
+	// Create the deployment.
+	_, err = c.client.CreateDeployment(config.Namespace, deployment)
+	if err != nil {
+		// If the deployment was already created, just move on. The cache could be stale, or another
+		// process could have already handled this update.
+		if kerrors.IsAlreadyExists(err) {
+			glog.V(4).Infof("Deployment already exists for config %s", labelFor(config))
+			return nil
+		}
+		return fmt.Errorf("Couldn't create deployment for config %s: %v", labelFor(config), err)
+	}
+
+	glog.V(4).Infof("Created deployment for config %s", labelFor(config))
+	return nil
+}
+
+// labelFor builds a string identifier for a DeploymentConfig.
+func labelFor(config *deployapi.DeploymentConfig) string {
+	return fmt.Sprintf("%s/%s:%d", config.Namespace, config.Name, config.LatestVersion)
+}
+
+// deploymentConfigControllerClient is a private API client abstraction.
+type deploymentConfigControllerClient interface {
 	CreateDeployment(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error)
 }
 
-// Process DeploymentConfig events one at a time.
-func (c *DeploymentConfigController) Run() {
-	go util.Until(c.HandleDeploymentConfig, 0, c.Stop)
+// deploymentConfigControllerClientImpl is a generic deploymentConfigControllerClient implementation.
+type deploymentConfigControllerClientImpl struct {
+	CreateDeploymentFunc func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error)
 }
 
-// Process a single DeploymentConfig event.
-func (c *DeploymentConfigController) HandleDeploymentConfig() {
-	config := c.NextDeploymentConfig()
-	deploy, err := c.shouldDeploy(config)
-	if err != nil {
-		util.HandleError(fmt.Errorf("unable to decide whether to redeploy %s: %v", labelFor(config), err))
-		return
-	}
-	if !deploy {
-		return
-	}
-
-	deployment, err := deployutil.MakeDeployment(config, c.Codec)
-	if err != nil {
-		util.HandleError(fmt.Errorf("unable to create deployment for %s: %v", labelFor(config), err))
-		return
-	}
-
-	glog.V(4).Infof("Deploying %s", labelFor(config))
-	if _, deployErr := c.DeploymentInterface.CreateDeployment(config.Namespace, deployment); deployErr != nil {
-		util.HandleError(fmt.Errorf("unable to create deployment %s: %v", labelFor(config), err))
-		return
-	}
-}
-
-// shouldDeploy returns true if the DeploymentConfig should have a new Deployment created.
-func (c *DeploymentConfigController) shouldDeploy(config *deployapi.DeploymentConfig) (bool, error) {
-	if config.LatestVersion == 0 {
-		glog.V(5).Infof("Waiting for first version of %s", labelFor(config))
-		return false, nil
-	}
-
-	latestDeploymentID := deployutil.LatestDeploymentNameForConfig(config)
-	deployment, err := c.DeploymentInterface.GetDeployment(config.Namespace, latestDeploymentID)
-
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	}
-
-	glog.V(5).Infof("Found deployment for %s - %s:%s", labelFor(config), deployment.UID, deployment.ResourceVersion)
-	return false, nil
-}
-
-func labelFor(config *deployapi.DeploymentConfig) string {
-	return fmt.Sprintf("%s/%s:%d", config.Namespace, config.Name, config.LatestVersion)
+func (i *deploymentConfigControllerClientImpl) CreateDeployment(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+	return i.CreateDeploymentFunc(namespace, deployment)
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
@@ -141,4 +142,17 @@ func MakeDeployment(config *deployapi.DeploymentConfig, codec runtime.Codec) (*a
 	}
 
 	return deployment, nil
+}
+
+type ListWatcherImpl struct {
+	ListFunc  func() (runtime.Object, error)
+	WatchFunc func(resourceVersion string) (watch.Interface, error)
+}
+
+func (lw *ListWatcherImpl) List() (runtime.Object, error) {
+	return lw.ListFunc()
+}
+
+func (lw *ListWatcherImpl) Watch(resourceVersion string) (watch.Interface, error) {
+	return lw.WatchFunc(resourceVersion)
 }


### PR DESCRIPTION
This PR is a POC to open discussion around replacing the use of `cache.FIFO` with state reconciliation loops over one or more `cache.Store`. It is an extension of upstream discussions ([#3521](https://github.com/GoogleCloudPlatform/kubernetes/pull/3521) and [#4330](https://github.com/GoogleCloudPlatform/kubernetes/issues/4330)) which pertain to the use of FIFO in the context of a state reconciling controller (such as the Kubernetes ReplicationController and Scheduler, and the Build and Deployment family of controllers in OpenShift). Our problems aren't unique.

The error handling/retry issues with our controllers described in #824 aren't easily resolved. There are some partial solutions upstream, and some other ideas proposed in [#4330](https://github.com/GoogleCloudPlatform/kubernetes/issues/4330), but they aren't proven and are added complexity.

Even if retry handling were fully accounted for with FIFO, there are still outstanding issues with how to handle delete events in general (something the DeltaStore sought to partially address in [#3521](https://github.com/GoogleCloudPlatform/kubernetes/pull/3521)).

Given the lack of a unified solution which solves these problems in the context of FIFO use, and based on conversation with @pmorie, @derekwaynecarr, and upstream within [#4330](https://github.com/GoogleCloudPlatform/kubernetes/issues/4330) and [#3521](https://github.com/GoogleCloudPlatform/kubernetes/pull/3521), I suggest we port the controllers to a model which hinges on triggered full state reconciliation against `cache.Store`s (similar to how the ReplicationController currently works, but more flexible).

This PR contains a prototype of this methodology applied to the DeploymentConfigController. Some features:

1. Sync triggering via channel allows for arbitrary, abstracted sync frequency: sync can be periodic, combined with watches, or any other criteria
2. Resync triggering via a channel combined with abstracted error handling allows for external control of retry behavior: retries could result in an immediate resync, could incorporate backoff logic, etc.
3. Missed events are handled naturally: full system state will eventually be be reconciled during the next interval
4. Deletes become simple to handle via analysis of multiple stores at a single point in time

There are some obvious concerns about performance when introducing a linear iteration over unbounded sets, but also some benefits.

Compared to the FIFO:

1. In terms of max possible memory usage, use of a cache is no worse than the `FIFO` at certain points in time in practice (consider the initial seeding of the FIFO with the Reflector, or a mass resource update, both of which result in all system resources being loaded into memory)

There are some interesting optimization opportunities with this model:

1. Memory and parallelism optimization can be abstracted at a higher tier transparent to consumers (for example, partitioning data sets provided to individual controller caches in order to limit total memory consumption and distribute processing workload)
2. Store abstraction allows for the possibility of implementing offloading/spooling data if necessary with no change to consumers

The net effect of this switch is a pattern which is far easier to reason about and which is more easily made correct for our event handling use cases, while keeping open the door to creative performance optimization.

If we can reach consensus on the pattern, my intent is to continue this work by revising the tests and formalizing this PR as model the next controllers should be refactored towards separately.
