### PR TITLE
make sure rolebinding names are unique

### DIFF
--- a/pkg/cmd/experimental/policy/add_group.go
+++ b/pkg/cmd/experimental/policy/add_group.go
@@ -62,10 +62,15 @@ func (o *addGroupOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *addGroupOptions) run() error {
-	roleBindings, roleBindingNames, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
+	roleBindings, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.client.PolicyBindings(o.bindingNamespace))
 	if err != nil {
 		return err
 	}
+	roleBindingNames, err := getExistingRoleBindingNames(o.client.PolicyBindings(o.bindingNamespace))
+	if err != nil {
+		return err
+	}
+
 	roleBinding := (*authorizationapi.RoleBinding)(nil)
 	isUpdate := true
 	if len(roleBindings) == 0 {

--- a/pkg/cmd/experimental/policy/add_user.go
+++ b/pkg/cmd/experimental/policy/add_user.go
@@ -62,10 +62,15 @@ func (o *addUserOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *addUserOptions) run() error {
-	roleBindings, roleBindingNames, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
+	roleBindings, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.client.PolicyBindings(o.bindingNamespace))
 	if err != nil {
 		return err
 	}
+	roleBindingNames, err := getExistingRoleBindingNames(o.client.PolicyBindings(o.bindingNamespace))
+	if err != nil {
+		return err
+	}
+
 	roleBinding := (*authorizationapi.RoleBinding)(nil)
 	isUpdate := true
 	if len(roleBindings) == 0 {

--- a/pkg/cmd/experimental/policy/remove_group.go
+++ b/pkg/cmd/experimental/policy/remove_group.go
@@ -63,7 +63,7 @@ func (o *removeGroupOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *removeGroupOptions) run() error {
-	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
+	roleBindings, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.client.PolicyBindings(o.bindingNamespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/experimental/policy/remove_user.go
+++ b/pkg/cmd/experimental/policy/remove_user.go
@@ -63,7 +63,7 @@ func (o *removeUserOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *removeUserOptions) run() error {
-	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
+	roleBindings, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.client.PolicyBindings(o.bindingNamespace))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Bug 1192307

RoleBindings are virtual resources, so we have to enforce uniqueness ourselves.  This ensures uniqueness and updates the commands to pick names that are unique in the namespace.
