### PR TITLE
Provide useful message when CERT_DIR is not set in install-registry.sh

### DIFF
--- a/hack/install-registry.sh
+++ b/hack/install-registry.sh
@@ -11,6 +11,13 @@
 #
 # You may also need to set KUBERNETES_MASTER if the master is not listening at https://localhost:8443/
 
+if [ -z "${CERT_DIR}" ]; then
+  echo "You have to set the CERT_DIR environment variable to point into master certificate"
+  echo "Example:"
+  echo "$ CERT_DIR='/var/lib/openshift/openshift.local.certificates/master' hack/install-registry.sh"
+  exit 1
+fi
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -40,4 +47,4 @@ export KUBERNETES_MASTER
 
 # Deploy private docker registry
 echo "[INFO] Submitting docker-registry template file for processing"
-osc process -f examples/sample-app/docker-registry-template.json -v "OPENSHIFT_MASTER=$API_SCHEME://${CONTAINER_ACCESSIBLE_API_HOST}:${API_PORT},OPENSHIFT_CA_DATA=${OPENSHIFT_CA_DATA},OPENSHIFT_CERT_DATA=${OPENSHIFT_CERT_DATA},OPENSHIFT_KEY_DATA=${OPENSHIFT_KEY_DATA}" | osc apply -f -
+osc process -f examples/sample-app/docker-registry-template.json -v "OPENSHIFT_MASTER=$API_SCHEME://${CONTAINER_ACCESSIBLE_API_HOST}:${API_PORT},OPENSHIFT_CA_DATA=${OPENSHIFT_CA_DATA},OPENSHIFT_CERT_DATA=${OPENSHIFT_CERT_DATA},OPENSHIFT_KEY_DATA=${OPENSHIFT_KEY_DATA}" | osc create -f -


### PR DESCRIPTION
 + replace "apply" with "create".

@smarterclayton @bparees PTAL.