### PR TITLE
router websocket support

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -119,7 +119,7 @@ backend openshift_default
   option http-pretend-keepalive
   server openshift_backend 127.0.0.1:8080
 
-##-------------- app level unencrypted backends ----------------
+##-------------- app level backends ----------------
 {{/*
     Create backends as follows:
         1. if the config is terminated at the edge or termination is not set create a be_http_<service> backend,
@@ -151,6 +151,7 @@ backend be_tcp_{{$id}}
 
             {{ if eq $cfg.TLSTermination "reencrypt" }}
 backend be_secure_{{$id}}
+  mode http
   balance leastconn
   timeout check 5000ms
                 {{ range $endpointID, $endpoint := $serviceUnit.EndpointTable }}


### PR DESCRIPTION
Add support for websockets in the HAProxy router impl.  The only thing required was ensuring the secure backend was running in http mode. 

Also added test case support and included a small refactoring of the tests that took the execution time of `TestRouter` down from ~20 seconds to ~7 seconds on my local machine.

Of note: currently the websocket client in golang does not allow you to send a host header different than what is used in the dial location host.  This means the routes for websockets are using aliases that are exactly the same as the router ip (which just looks weird but works).  I raised this to the golang-nuts mailing list as a request to honor the host header set on the config returned by `NewConfig` a la https://github.com/pweil-/net/compare/golang:master...master

/cc @pmorie @smarterclayton 