### PR TITLE
Implement a Template REST endpoint using the generic store

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -10,17 +10,16 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	//"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 
 	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/api/validation"
 	configapi "github.com/openshift/origin/pkg/config/api"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
-	"github.com/openshift/origin/pkg/util"
 )
 
 type mockService struct{}
@@ -114,7 +113,7 @@ func TestExampleObjectSchemas(t *testing.T) {
 				t.Errorf("%s did not decode correctly: %v\n%s", path, err, string(data))
 				return
 			}
-			if errors := util.ValidateObject(expectedType); len(errors) > 0 {
+			if errors := validation.ValidateObject(expectedType); len(errors) > 0 {
 				t.Errorf("%s did not validate correctly: %v", path, errors)
 			}
 		})

--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -1,10 +1,12 @@
 {
   "metadata":{
     "name": "ruby-helloworld-sample",
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3"
+    }
   },
   "kind": "Template",
   "apiVersion": "v1beta1",
-  "description": "This example shows how to create a simple ruby application in openshift origin v3",
   "parameters": [
     {
       "name": "ADMIN_USERNAME",

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -1,10 +1,12 @@
 {
   "metadata":{
     "name": "ruby-helloworld-sample",
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3"
+    }
   },
   "kind": "Template",
   "apiVersion": "v1beta1",
-  "description": "This example shows how to create a simple ruby application in openshift origin v3",
   "parameters": [
     {
       "name": "ADMIN_USERNAME",

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -1,10 +1,12 @@
 {
   "metadata":{
     "name": "ruby-helloworld-sample",
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3"
+    }
   },
   "kind": "Template",
   "apiVersion": "v1beta1",
-  "description": "This example shows how to create a simple ruby application in openshift origin v3",
   "parameters": [
     {
       "name": "ADMIN_USERNAME",

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -41,7 +41,7 @@ API_HOST=${API_HOST:-127.0.0.1}
 KUBELET_SCHEME=${KUBELET_SCHEME:-http}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 
-TEMP_DIR=$(mktemp -d /tmp/openshift-cmd.XXXX)
+TEMP_DIR=${USE_TEMP:-$(mktemp -d /tmp/openshift-cmd.XXXX)}
 ETCD_DATA_DIR="${TEMP_DIR}/etcd"
 VOLUME_DIR="${TEMP_DIR}/volumes"
 CERT_DIR="${TEMP_DIR}/certs"
@@ -80,7 +80,7 @@ if [[ "${API_SCHEME}" == "https" ]]; then
 fi
 
 wait_for_url "http://${API_HOST}:${KUBELET_PORT}/healthz" "kubelet: " 0.25 80
-wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80        
+wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
 wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1beta1/minions/127.0.0.1" "apiserver(minions): " 0.25 80
 
 # Set KUBERNETES_MASTER for osc
@@ -97,6 +97,17 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 #
 # Begin tests
 #
+
+osc get templates
+osc create -f examples/sample-app/application-template-dockerbuild.json
+osc get templates
+osc get templates ruby-helloworld-sample
+[ -n "$(osc get templates ruby-helloworld-sample -o json | osc process -f -)" ]
+osc describe templates ruby-helloworld-sample
+osc delete templates ruby-helloworld-sample
+osc get templates
+# TODO: create directly from template
+echo "templates: ok"
 
 # verify some default commands
 [ "$(openshift cli)" ]

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -37,7 +37,7 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 			c.Fuzz(&j.ObjectMeta)
 			c.Fuzz(&j.Parameters)
 			// TODO: replace with structured type definition
-			j.Items = []runtime.Object{}
+			j.Objects = []runtime.Object{}
 		},
 		func(j *image.Image, c fuzz.Continue) {
 			c.Fuzz(&j.ObjectMeta)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,6 +33,7 @@ type Interface interface {
 	PolicyBindingsNamespacer
 	ResourceAccessReviewsNamespacer
 	SubjectAccessReviewsNamespacer
+	TemplatesNamespacer
 }
 
 func (c *Client) Builds(namespace string) BuildInterface {
@@ -95,6 +96,11 @@ func (c *Client) Projects() ProjectInterface {
 // TemplateConfigs provides a REST client for TemplateConfig
 func (c *Client) TemplateConfigs(namespace string) TemplateConfigInterface {
 	return newTemplateConfigs(c, namespace)
+}
+
+// TemplateConfigs provides a REST client for TemplateConfig
+func (c *Client) Templates(namespace string) TemplateInterface {
+	return newTemplates(c, namespace)
 }
 
 func (c *Client) Policies(namespace string) PolicyInterface {

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -48,6 +48,10 @@ func (c *Fake) Routes(namespace string) RouteInterface {
 	return &FakeRoutes{Fake: c, Namespace: namespace}
 }
 
+func (c *Fake) Templates(namespace string) TemplateInterface {
+	return &FakeTemplates{Fake: c}
+}
+
 func (c *Fake) Users() UserInterface {
 	return &FakeUsers{Fake: c}
 }

--- a/pkg/client/fake_templates.go
+++ b/pkg/client/fake_templates.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	templateapi "github.com/openshift/origin/pkg/template/api"
+)
+
+// FakeTemplates implements TemplateInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeTemplates struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeTemplates) List(label, field labels.Selector) (*templateapi.TemplateList, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "list-templates"})
+	return &templateapi.TemplateList{}, nil
+}
+
+func (c *FakeTemplates) Get(name string) (*templateapi.Template, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-template"})
+	return &templateapi.Template{}, nil
+}
+
+func (c *FakeTemplates) Create(template *templateapi.Template) (*templateapi.Template, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-template", Value: template})
+	return &templateapi.Template{}, nil
+}
+
+func (c *FakeTemplates) Update(template *templateapi.Template) (*templateapi.Template, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "update-template"})
+	return &templateapi.Template{}, nil
+}
+
+func (c *FakeTemplates) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-template", Value: name})
+	return nil
+}
+
+func (c *FakeTemplates) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-templates"})
+	return nil, nil
+}

--- a/pkg/client/templates.go
+++ b/pkg/client/templates.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	templateapi "github.com/openshift/origin/pkg/template/api"
+)
+
+// TemplatesNamespacer has methods to work with Template resources in a namespace
+type TemplatesNamespacer interface {
+	Templates(namespace string) TemplateInterface
+}
+
+// TemplateInterface exposes methods on Template resources.
+type TemplateInterface interface {
+	List(label, field labels.Selector) (*templateapi.TemplateList, error)
+	Get(name string) (*templateapi.Template, error)
+	Create(template *templateapi.Template) (*templateapi.Template, error)
+	Update(template *templateapi.Template) (*templateapi.Template, error)
+	Delete(name string) error
+	Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// templates implements TemplatesNamespacer interface
+type templates struct {
+	r  *Client
+	ns string
+}
+
+// newTemplates returns a templates
+func newTemplates(c *Client, namespace string) *templates {
+	return &templates{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List returns a list of templates that match the label and field selectors.
+func (c *templates) List(label, field labels.Selector) (result *templateapi.TemplateList, err error) {
+	result = &templateapi.TemplateList{}
+	err = c.r.Get().
+		Namespace(c.ns).
+		Resource("templates").
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Do().
+		Into(result)
+	return
+}
+
+// Get returns information about a particular template and error if one occurs.
+func (c *templates) Get(name string) (result *templateapi.Template, err error) {
+	result = &templateapi.Template{}
+	err = c.r.Get().Namespace(c.ns).Resource("templates").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates new template. Returns the server's representation of the template and error if one occurs.
+func (c *templates) Create(template *templateapi.Template) (result *templateapi.Template, err error) {
+	result = &templateapi.Template{}
+	err = c.r.Post().Namespace(c.ns).Resource("templates").Body(template).Do().Into(result)
+	return
+}
+
+// Update updates the template on server. Returns the server's representation of the template and error if one occurs.
+func (c *templates) Update(template *templateapi.Template) (result *templateapi.Template, err error) {
+	result = &templateapi.Template{}
+	err = c.r.Put().Namespace(c.ns).Resource("templates").Name(template.Name).Body(template).Do().Into(result)
+	return
+}
+
+// Delete deletes a template, returns error if one occurs.
+func (c *templates) Delete(name string) (err error) {
+	err = c.r.Delete().Namespace(c.ns).Resource("templates").Name(name).Do().Error()
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested templates
+func (c *templates) Watch(label, field labels.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("templates").
+		Param("resourceVersion", resourceVersion).
+		SelectorParam("labels", label).
+		SelectorParam("fields", field).
+		Watch()
+}

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -50,6 +50,7 @@ func TestDescribers(t *testing.T) {
 		&ProjectDescriber{c},
 		&PolicyDescriber{c},
 		&PolicyBindingDescriber{c},
+		&TemplateDescriber{c, nil, nil, nil},
 	}
 
 	for _, d := range testDescriberList {
@@ -57,7 +58,7 @@ func TestDescribers(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error for %v: %v", d, err)
 		}
-		if !strings.Contains(out, "Name:") || !strings.Contains(out, "Annotations") {
+		if !strings.Contains(out, "Name:") || !strings.Contains(out, "Labels:") {
 			t.Errorf("unexpected out: %s", out)
 		}
 	}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -67,6 +67,7 @@ import (
 	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
 	"github.com/openshift/origin/pkg/service"
 	templateregistry "github.com/openshift/origin/pkg/template/registry"
+	templateetcd "github.com/openshift/origin/pkg/template/registry/etcd"
 	"github.com/openshift/origin/pkg/user"
 	useretcd "github.com/openshift/origin/pkg/user/registry/etcd"
 	userregistry "github.com/openshift/origin/pkg/user/registry/user"
@@ -288,6 +289,7 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		"deploymentConfigRollbacks": deployrollback.NewREST(deployRollbackClient, latest.Codec),
 
 		"templateConfigs": templateregistry.NewREST(),
+		"templates":       templateetcd.NewREST(c.EtcdHelper),
 
 		"routes": routeregistry.NewREST(routeEtcd),
 

--- a/pkg/template/api/register.go
+++ b/pkg/template/api/register.go
@@ -7,7 +7,9 @@ import (
 func init() {
 	api.Scheme.AddKnownTypes("",
 		&Template{},
+		&TemplateList{},
 	)
 }
 
-func (*Template) IsAnAPIObject() {}
+func (*Template) IsAnAPIObject()     {}
+func (*TemplateList) IsAnAPIObject() {}

--- a/pkg/template/api/types.go
+++ b/pkg/template/api/types.go
@@ -7,15 +7,22 @@ import (
 
 // Template contains the inputs needed to produce a Config.
 type Template struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
-
-	// Required: A list of resources that might reference parameters
-	Items []runtime.Object `json:"items"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// Optional: Parameters is an array of Parameters used during the
 	// Template to Config transformation.
-	Parameters []Parameter `json:"parameters,omitempty"`
+	Parameters []Parameter
+
+	// Required: A list of resources to create
+	Objects []runtime.Object
+}
+
+// TemplateList is a list of Template objects.
+type TemplateList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []Template
 }
 
 // Parameter defines a name/value variable that is to be processed during
@@ -23,23 +30,22 @@ type Template struct {
 type Parameter struct {
 	// Required: Parameter name must be set and it can be referenced in Template
 	// Items using ${PARAMETER_NAME}
-	Name string `json:"name"`
+	Name string
 
 	// Optional: Parameter can have description
-	Description string `json:"description,omitempty"`
+	Description string
+
+	// Optional: Value holds the Parameter data. If specified, the generator
+	// will be ignored. The value replaces all occurrences of the Parameter
+	// ${Name} expression during the Template to Config transformation.
+	Value string
 
 	// Optional: Generate specifies the generator to be used to generate
 	// random string from an input value specified by From field. The result
 	// string is stored into Value field. If empty, no generator is being
 	// used, leaving the result Value untouched.
-	Generate string `json:"generate,omitempty"`
+	Generate string
 
 	// Optional: From is an input value for the generator.
-	From string `json:"from,omitempty"`
-
-	// Optional: Value holds the Parameter data. The Value data can be
-	// overwritten by the generator. The value replaces all occurrences
-	// of the Parameter ${Name} expression during the Template to Config
-	// transformation.
-	Value string `json:"value,omitempty"`
+	From string
 }

--- a/pkg/template/api/v1beta1/conversion.go
+++ b/pkg/template/api/v1beta1/conversion.go
@@ -1,0 +1,29 @@
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+
+	newer "github.com/openshift/origin/pkg/template/api"
+)
+
+func init() {
+	err := api.Scheme.AddConversionFuncs(
+		// TypeMeta must be split into two objects
+		func(in *newer.Template, out *Template, s conversion.Scope) error {
+			if err := s.Convert(&in.Objects, &out.Items, 0); err != nil {
+				return err
+			}
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *Template, out *newer.Template, s conversion.Scope) error {
+			if err := s.Convert(&in.Items, &out.Objects, 0); err != nil {
+				return err
+			}
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/template/api/v1beta1/register.go
+++ b/pkg/template/api/v1beta1/register.go
@@ -7,8 +7,10 @@ import (
 func init() {
 	api.Scheme.AddKnownTypes("v1beta1",
 		&Template{},
+		&TemplateList{},
 	)
 	api.Scheme.AddKnownTypeWithName("v1beta1", "TemplateConfig", &Template{})
 }
 
-func (*Template) IsAnAPIObject() {}
+func (*Template) IsAnAPIObject()     {}
+func (*TemplateList) IsAnAPIObject() {}

--- a/pkg/template/api/v1beta1/types.go
+++ b/pkg/template/api/v1beta1/types.go
@@ -19,6 +19,13 @@ type Template struct {
 	Parameters []Parameter `json:"parameters,omitempty"`
 }
 
+// TemplateList is a list of Template objects.
+type TemplateList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []Template `json:"items"`
+}
+
 // Parameter defines a name/value variable that is to be processed during
 // the Template to Config transformation.
 type Parameter struct {
@@ -29,6 +36,11 @@ type Parameter struct {
 	// Optional: Parameter can have description
 	Description string `json:"description,omitempty"`
 
+	// Optional: Value holds the Parameter data. If specified, the generator
+	// will be ignored. The value replaces all occurrences of the Parameter
+	// ${Name} expression during the Template to Config transformation.
+	Value string `json:"value,omitempty"`
+
 	// Optional: Generate specifies the generator to be used to generate
 	// random string from an input value specified by From field. The result
 	// string is stored into Value field. If empty, no generator is being
@@ -37,10 +49,4 @@ type Parameter struct {
 
 	// Optional: From is an input value for the generator.
 	From string `json:"from,omitempty"`
-
-	// Optional: Value holds the Parameter data. The Value data can be
-	// overwritten by the generator. The value replaces all occurrences
-	// of the Parameter ${Name} expression during the Template to Config
-	// transformation.
-	Value string `json:"value,omitempty"`
 }

--- a/pkg/template/registry/etcd/etcd.go
+++ b/pkg/template/registry/etcd/etcd.go
@@ -1,0 +1,58 @@
+package etcd
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	"github.com/openshift/origin/pkg/template/api"
+	"github.com/openshift/origin/pkg/template/registry"
+)
+
+// REST implements a RESTStorage for templates against etcd
+type REST struct {
+	*etcdgeneric.Etcd
+}
+
+// NewREST returns a RESTStorage object that will work against templates.
+func NewREST(h tools.EtcdHelper) *REST {
+	store := &etcdgeneric.Etcd{
+		NewFunc:     func() runtime.Object { return &api.Template{} },
+		NewListFunc: func() runtime.Object { return &api.TemplateList{} },
+		KeyRootFunc: func(ctx kapi.Context) string {
+			return etcdgeneric.NamespaceKeyRootFunc(ctx, "/registry/templates")
+		},
+		KeyFunc: func(ctx kapi.Context, name string) (string, error) {
+			return etcdgeneric.NamespaceKeyFunc(ctx, "/registry/templates", name)
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*api.Template).Name, nil
+		},
+		EndpointName: "templates",
+
+		CreateStrategy: registry.Strategy,
+		UpdateStrategy: registry.Strategy,
+
+		ReturnDeletedObject: true,
+
+		Helper: h,
+	}
+	return &REST{store}
+}
+
+// New returns a new object
+func (r *REST) New() runtime.Object {
+	return r.NewFunc()
+}
+
+// NewList returns a new list object
+func (r *REST) NewList() runtime.Object {
+	return r.NewListFunc()
+}
+
+// List obtains a list of templates with labels that match selector.
+func (r *REST) List(ctx kapi.Context, label, field labels.Selector) (runtime.Object, error) {
+	return r.Etcd.List(ctx, registry.MatchTemplate(label, field))
+}

--- a/pkg/template/registry/etcd/etcd_test.go
+++ b/pkg/template/registry/etcd/etcd_test.go
@@ -1,0 +1,62 @@
+package etcd
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest/resttest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/template/api"
+)
+
+func newHelper(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper) {
+	fakeEtcdClient := tools.NewFakeEtcdClient(t)
+	fakeEtcdClient.TestIndex = true
+	helper := tools.EtcdHelper{Client: fakeEtcdClient, Codec: latest.Codec, ResourceVersioner: tools.RuntimeVersionAdapter{latest.ResourceVersioner}}
+	return fakeEtcdClient, helper
+}
+
+func validNew() *api.Template {
+	return &api.Template{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "foo",
+			Namespace: kapi.NamespaceDefault,
+		},
+	}
+}
+
+func validChanged() *api.Template {
+	template := validNew()
+	template.ResourceVersion = "1"
+	template.Labels = map[string]string{
+		"foo": "bar",
+	}
+	return template
+}
+
+func TestStorage(t *testing.T) {
+	_, helper := newHelper(t)
+	storage := NewREST(helper)
+	var _ apiserver.RESTCreater = storage
+	var _ apiserver.RESTLister = storage
+	var _ apiserver.RESTDeleter = storage
+	var _ apiserver.RESTUpdater = storage
+	var _ apiserver.RESTGetter = storage
+}
+
+func TestCreate(t *testing.T) {
+	fakeEtcdClient, helper := newHelper(t)
+	storage := NewREST(helper)
+	test := resttest.New(t, storage, fakeEtcdClient.SetError)
+	template := validNew()
+	template.ObjectMeta = kapi.ObjectMeta{}
+	test.TestCreate(
+		// valid
+		template,
+		// invalid
+		&api.Template{},
+	)
+}

--- a/pkg/template/registry/rest_test.go
+++ b/pkg/template/registry/rest_test.go
@@ -1,4 +1,4 @@
-package template
+package registry
 
 import (
 	"testing"


### PR DESCRIPTION
* Expose /templates
* Add a simple describer and get printer for cli
* Changes /templateConfigs to use a looser validation (only parameters are checked)
* Makes template parameter "Value" override "Generate" (like Name and GenerateName, and so clients can preserve recorded values)
* The internal item array on Templates is now called "Objects" to prevent templates from being treated like lists.
* Switch end-to-end to fetch from the server
* Tests in test-cmd.sh

@mfojtik / @bparees review the changes being made