### PR TITLE
Improve release tar naming

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -9,7 +9,7 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
 
-# Build the core client/server for all platforms
+# Build the primary client/server for all platforms
 OS_BUILD_PLATFORMS=("${OS_CROSS_COMPILE_PLATFORMS[@]}")
 os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
 
@@ -19,8 +19,8 @@ os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
 OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
 CGO_ENABLED=0 OS_GOFLAGS="-a" os::build::build_binaries "${OS_IMAGE_COMPILE_TARGETS[@]-}"
 
-# Make the core client/server release.
-OS_RELEASE_ARCHIVE="openshift-origin-core"
+# Make the primary client/server release.
+OS_RELEASE_ARCHIVE="openshift-origin"
 OS_RELEASE_PLATFORMS=("${OS_CROSS_COMPILE_PLATFORMS[@]}")
 OS_RELEASE_BINARIES=("${OS_CROSS_COMPILE_BINARIES[@]}")
 os::build::place_bins

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -23,16 +23,16 @@ fi
 os::build::detect_local_release_tars "linux"
 
 echo "Building images from release tars:"
-echo " core:   $(basename ${OS_CORE_RELEASE_TAR})"
-echo " image:  $(basename ${OS_IMAGE_RELEASE_TAR})"
+echo " primary: $(basename ${OS_PRIMARY_RELEASE_TAR})"
+echo " image:   $(basename ${OS_IMAGE_RELEASE_TAR})"
 
 imagedir="_output/imagecontext"
 rm -rf "${imagedir}"
 mkdir -p "${imagedir}"
-tar xzf "${OS_CORE_RELEASE_TAR}" -C "${imagedir}"
+tar xzf "${OS_PRIMARY_RELEASE_TAR}" -C "${imagedir}"
 tar xzf "${OS_IMAGE_RELEASE_TAR}" -C "${imagedir}"
 
-# Copy core binaries to the appropriate locations.
+# Copy primary binaries to the appropriate locations.
 cp -f "${imagedir}/openshift" images/origin/bin
 cp -f "${imagedir}/openshift" images/router/haproxy/bin
 

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -39,7 +39,7 @@ docker cp $(cat ${context}/cid):/go/src/github.com/openshift/origin/_output/loca
 os::build::detect_local_release_tars "linux"
 
 mkdir -p "${OS_LOCAL_BINPATH}"
-tar mxzf "${OS_CORE_RELEASE_TAR}" -C "${OS_LOCAL_BINPATH}"
+tar mxzf "${OS_PRIMARY_RELEASE_TAR}" -C "${OS_LOCAL_BINPATH}"
 tar mxzf "${OS_IMAGE_RELEASE_TAR}" -C "${OS_LOCAL_BINPATH}"
 
 os::build::make_openshift_binary_symlinks

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -323,30 +323,30 @@ os::build::make_openshift_binary_symlinks() {
   fi
 }
 
-# os::build::detect_local_release_tars verifies there is only one core and one
+# os::build::detect_local_release_tars verifies there is only one primary and one
 # image binaries release tar in OS_LOCAL_RELEASEPATH for the given platform specified by
 # argument 1, exiting if more than one of either is found.
 #
 # If the tars are discovered, their full paths are exported to the following env vars:
 #
-#   OS_CORE_RELEASE_TAR
+#   OS_PRIMARY_RELEASE_TAR
 #   OS_IMAGE_RELEASE_TAR
 os::build::detect_local_release_tars() {
   local platform="$1"
 
-  local core=$(find ${OS_LOCAL_RELEASEPATH} -type f -maxdepth 1 -name openshift-origin-core*-${platform}-*)
-  if [[ $(echo "${core}" | wc -l) -ne 1 ]]; then
-    echo "There should be exactly one ${platform} core tar in $OS_LOCAL_RELEASEPATH"
+  local primary=$(find ${OS_LOCAL_RELEASEPATH} -maxdepth 1 -type f -name openshift-origin-*-${platform}-* | grep -v image)
+  if [[ $(echo "${primary}" | wc -l) -ne 1 ]]; then
+    echo "There should be exactly one ${platform} primary tar in $OS_LOCAL_RELEASEPATH"
     exit 2
   fi
 
-  local image=$(find ${OS_LOCAL_RELEASEPATH} -type f -maxdepth 1 -name openshift-origin-image*-${platform}-*)
+  local image=$(find ${OS_LOCAL_RELEASEPATH} -maxdepth 1 -type f -name openshift-origin-image*-${platform}-*)
   if [[ $(echo "${image}" | wc -l) -ne 1 ]]; then
     echo "There should be exactly one ${platform} image tar in $OS_LOCAL_RELEASEPATH"
     exit 3
   fi
 
-  export OS_CORE_RELEASE_TAR="${core}"
+  export OS_PRIMARY_RELEASE_TAR="${primary}"
   export OS_IMAGE_RELEASE_TAR="${image}"
 }
 


### PR DESCRIPTION
Remove the 'core' prefix from the primary release tar name.