### PR TITLE
Turn on resource quota manager to collect usage stats

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -13,6 +13,7 @@ import (
 	minionControllerPkg "github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/resourcequota"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/service"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	kubeutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -124,6 +125,11 @@ func (c *MasterConfig) RunScheduler() {
 	s := scheduler.New(config)
 	s.Run()
 	glog.Infof("Started Kubernetes Scheduler")
+}
+
+func (c *MasterConfig) RunResourceQuotaManager() {
+	resourceQuotaManager := resourcequota.NewResourceQuotaManager(c.KubeClient)
+	resourceQuotaManager.Run(10 * time.Second)
 }
 
 func (c *MasterConfig) RunMinionController() {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -579,6 +579,7 @@ func start(cfg *config, args []string) error {
 			kmaster.RunReplicationController()
 			kmaster.RunEndpointController()
 			kmaster.RunMinionController()
+			kmaster.RunResourceQuotaManager()
 
 		} else {
 			proxy := &kubernetes.ProxyConfig{


### PR DESCRIPTION
When running Origin all-in-one, we need to start the ResourceQuotaManager to collect usage stats against the quota in the background.

With this PR, you will be able to now see usage against your quota.

review please: @smarterclayton @jwforres 