### PR TITLE
Turn on quota related admission control plug-ins

### DIFF
--- a/pkg/cmd/server/origin/config.go
+++ b/pkg/cmd/server/origin/config.go
@@ -12,7 +12,6 @@ import (
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/auth/authenticator"
@@ -117,6 +116,10 @@ func BuildMasterConfig(configParams MasterConfigParameters) (*MasterConfig, erro
 	policyCache := configParams.newPolicyCache()
 	requestContextMapper := kapi.NewRequestContextMapper()
 
+	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
+	admissionControlPluginNames := []string{"AlwaysAdmit"}
+	admissionController := admission.NewFromPlugins(configParams.KubeClient, admissionControlPluginNames, "")
+
 	config := &MasterConfig{
 		MasterConfigParameters: configParams,
 
@@ -129,7 +132,7 @@ func BuildMasterConfig(configParams MasterConfigParameters) (*MasterConfig, erro
 
 		RequestContextMapper: requestContextMapper,
 
-		AdmissionControl: admit.NewAlwaysAdmit(),
+		AdmissionControl: admissionController,
 
 		TLS: strings.HasPrefix(configParams.MasterAddr, "https://"),
 	}

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -18,13 +18,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
 	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
-
-	// Admission control plugins from upstream Kubernetes
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcedefaults"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
 )
 
 const (


### PR DESCRIPTION
Turn on the admission control plug-ins from upstream Kubernetes that control quota usage.

This change will cause LimitRange and ResourceQuota to be enforced on admission.

Note: If and only if you add a ResourceQuota to a project, all create and update operations in that project will not work until #1047 is merged.  This is because the manager needs to update actual usage stats before new requests are accepted by these plug-ins.

Review please @jwforres @smarterclayton @deads2k 