### PR TITLE
ignore setSelfLink errors

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/resthandler.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/resthandler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/emicklei/go-restful"
+	"github.com/golang/glog"
 )
 
 // ContextFunc returns a Context given a request - a context must be returned
@@ -347,7 +348,8 @@ func setSelfLink(obj runtime.Object, req *restful.Request, namer ScopeNamer) err
 		return nil
 	}
 	if err != nil {
-		return err
+		glog.Errorf("error generating link: %v", err)
+		return nil
 	}
 
 	newURL := *req.Request.URL


### PR DESCRIPTION
We think this is fixed in upstream, but it doesn't patch in cleanly, so we'll ignore the setSelfLink errors for now so that we can continue with other features.

The failure breaks *AccessReview and blocks list projects.

@smarterclayton ptal

/cc @derekwaynecarr 