### PR TITLE
Refactor deploy package for error handling support

### DIFF
--- a/pkg/deploy/controller/config_change_controller.go
+++ b/pkg/deploy/controller/config_change_controller.go
@@ -1,15 +1,17 @@
 package controller
 
 import (
+	"fmt"
+
+	"github.com/golang/glog"
+
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	cache "github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	runtime "github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	util "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
-
-	"github.com/golang/glog"
 )
 
 // DeploymentConfigChangeController watches for changes to DeploymentConfigs and regenerates them only
@@ -17,27 +19,23 @@ import (
 type DeploymentConfigChangeController struct {
 	ChangeStrategy       ChangeStrategy
 	NextDeploymentConfig func() *deployapi.DeploymentConfig
-	DeploymentStore      cache.Store
 	Codec                runtime.Codec
 	// Stop is an optional channel that controls when the controller exits
 	Stop <-chan struct{}
 }
 
-// ChangeStrategy knows how to generate and update DeploymentConfigs.
-type ChangeStrategy interface {
-	GenerateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
-	UpdateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-}
-
 // Run watches for config change events.
 func (dc *DeploymentConfigChangeController) Run() {
-	go util.Until(func() { dc.HandleDeploymentConfig() }, 0, dc.Stop)
+	go util.Until(func() {
+		err := dc.HandleDeploymentConfig(dc.NextDeploymentConfig())
+		if err != nil {
+			glog.Errorf("%v", err)
+		}
+	}, 0, dc.Stop)
 }
 
 // HandleDeploymentConfig handles the next DeploymentConfig change that happens.
-func (dc *DeploymentConfigChangeController) HandleDeploymentConfig() {
-	config := dc.NextDeploymentConfig()
-
+func (dc *DeploymentConfigChangeController) HandleDeploymentConfig(config *deployapi.DeploymentConfig) error {
 	hasChangeTrigger := false
 	for _, trigger := range config.Triggers {
 		if trigger.Type == deployapi.DeploymentTriggerOnConfigChange {
@@ -47,57 +45,55 @@ func (dc *DeploymentConfigChangeController) HandleDeploymentConfig() {
 	}
 
 	if !hasChangeTrigger {
-		glog.V(4).Infof("Config has no change trigger; skipping")
-		return
+		glog.V(4).Infof("Ignoring config %s; no change triggers detected", labelFor(config))
+		return nil
 	}
 
 	if config.LatestVersion == 0 {
-		glog.V(4).Infof("Creating new deployment for config %v", config.Name)
-		dc.generateDeployment(config, nil)
-		return
+		_, _, err := dc.generateDeployment(config)
+		if err != nil {
+			return fmt.Errorf("couldn't create initial deployment for config %s: %v", labelFor(config), err)
+		}
+		glog.V(4).Infof("Created initial deployment for config %s", labelFor(config))
+		return nil
 	}
 
-	latestDeploymentID := deployutil.LatestDeploymentNameForConfig(config)
-	obj, exists, err := dc.DeploymentStore.Get(&kapi.ReplicationController{ObjectMeta: kapi.ObjectMeta{Name: latestDeploymentID, Namespace: config.Namespace}})
+	latestDeploymentName := deployutil.LatestDeploymentNameForConfig(config)
+	deployment, err := dc.ChangeStrategy.GetDeployment(config.Namespace, latestDeploymentName)
 	if err != nil {
-		glog.Errorf("Unable to retrieve deployment from store: %v", err)
+		if kerrors.IsNotFound(err) {
+			glog.V(4).Info("Ignoring config change for %s; no existing deployment found", labelFor(config))
+			return nil
+		}
+		return fmt.Errorf("couldn't retrieve deployment for %s: %v", labelFor(config), err)
 	}
-
-	if !exists {
-		glog.V(4).Info("Ignoring config change due to lack of existing deployment")
-		return
-	}
-
-	deployment := obj.(*kapi.ReplicationController)
 
 	deployedConfig, err := deployutil.DecodeDeploymentConfig(deployment, dc.Codec)
 	if err != nil {
-		glog.V(0).Infof("Error decoding deploymentConfig from deployment %s: %v", deployment.Name, err)
-		return
+		return fmt.Errorf("error decoding deploymentConfig from deployment %s for config %s: %v", labelForDeployment(deployment), labelFor(config), err)
 	}
 
 	if deployutil.PodSpecsEqual(config.Template.ControllerTemplate.Template.Spec, deployedConfig.Template.ControllerTemplate.Template.Spec) {
-		glog.V(4).Infof("Ignoring updated config %s with LatestVersion=%d because it matches deployed config %s", config.Name, config.LatestVersion, deployment.Name)
-		return
+		glog.V(4).Infof("Ignoring config change for %s (latestVersion=%d); same as deployment %s", labelFor(config), config.LatestVersion, labelForDeployment(deployment))
+		return nil
 	}
-	glog.V(4).Infof("Diff:\n%s", util.ObjectDiff(config.Template.ControllerTemplate.Template.Spec, deployedConfig.Template.ControllerTemplate.Template.Spec))
 
-	dc.generateDeployment(config, deployment)
+	fromVersion, toVersion, err := dc.generateDeployment(config)
+	if err != nil {
+		return fmt.Errorf("couldn't generate deployment for config %s: %v", labelFor(config), err)
+	}
+	glog.V(4).Infof("Updated config %s from version %d to %d for existing deployment %s", labelFor(config), fromVersion, toVersion, labelForDeployment(deployment))
+	return nil
 }
 
-func (dc *DeploymentConfigChangeController) generateDeployment(config *deployapi.DeploymentConfig, deployment *kapi.ReplicationController) {
+func (dc *DeploymentConfigChangeController) generateDeployment(config *deployapi.DeploymentConfig) (int, int, error) {
 	newConfig, err := dc.ChangeStrategy.GenerateDeploymentConfig(config.Namespace, config.Name)
 	if err != nil {
-		glog.V(2).Infof("Error generating new version of deploymentConfig %v: %#v", config.Name, err)
-		return
+		return config.LatestVersion, 0, fmt.Errorf("Error generating new version of deploymentConfig %s: %v", labelFor(config), err)
 	}
 
 	if newConfig.LatestVersion == config.LatestVersion {
 		newConfig.LatestVersion++
-	}
-
-	if deployment != nil {
-		glog.V(4).Infof("Updating config %s (LatestVersion: %d -> %d) to advance existing deployment %s", config.Name, config.LatestVersion, newConfig.LatestVersion, deployment.Name)
 	}
 
 	// set the trigger details for the new deployment config
@@ -114,6 +110,34 @@ func (dc *DeploymentConfigChangeController) generateDeployment(config *deployapi
 	// okay - we can just ignore the update for the old resource and any changes to the more
 	// current config will be captured in future events.
 	if _, err = dc.ChangeStrategy.UpdateDeploymentConfig(config.Namespace, newConfig); err != nil {
-		glog.V(2).Infof("Error updating deploymentConfig %v: %#v", config.Name, err)
+		return config.LatestVersion, newConfig.LatestVersion, fmt.Errorf("couldn't update deploymentConfig %s: %v", labelFor(config), err)
 	}
+
+	return config.LatestVersion, newConfig.LatestVersion, nil
+}
+
+// ChangeStrategy knows how to generate and update DeploymentConfigs.
+type ChangeStrategy interface {
+	GetDeployment(namespace, name string) (*kapi.ReplicationController, error)
+	GenerateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error)
+	UpdateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
+}
+
+// ChangeStrategyImpl is a pluggable ChangeStrategy.
+type ChangeStrategyImpl struct {
+	GetDeploymentFunc            func(namespace, name string) (*kapi.ReplicationController, error)
+	GenerateDeploymentConfigFunc func(namespace, name string) (*deployapi.DeploymentConfig, error)
+	UpdateDeploymentConfigFunc   func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
+}
+
+func (i *ChangeStrategyImpl) GetDeployment(namespace, name string) (*kapi.ReplicationController, error) {
+	return i.GetDeploymentFunc(namespace, name)
+}
+
+func (i *ChangeStrategyImpl) GenerateDeploymentConfig(namespace, name string) (*deployapi.DeploymentConfig, error) {
+	return i.GenerateDeploymentConfigFunc(namespace, name)
+}
+
+func (i *ChangeStrategyImpl) UpdateDeploymentConfig(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
+	return i.UpdateDeploymentConfigFunc(namespace, config)
 }

--- a/pkg/deploy/controller/deployment_config_controller_test.go
+++ b/pkg/deploy/controller/deployment_config_controller_test.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
+	"fmt"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 
 	api "github.com/openshift/origin/pkg/api/latest"
-	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -15,7 +15,7 @@ import (
 func TestHandleNewDeploymentConfig(t *testing.T) {
 	controller := &DeploymentConfigController{
 		Codec: api.Codec,
-		DeploymentInterface: &testDeploymentInterface{
+		DeploymentClient: &DeploymentConfigControllerDeploymentClientImpl{
 			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
 				t.Fatalf("unexpected call with name %s", name)
 				return nil, nil
@@ -25,47 +25,70 @@ func TestHandleNewDeploymentConfig(t *testing.T) {
 				return nil, nil
 			},
 		},
-		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return deploytest.OkDeploymentConfig(0)
-		},
 	}
 
-	controller.HandleDeploymentConfig()
+	err := controller.HandleDeploymentConfig(deploytest.OkDeploymentConfig(0))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
-func TestHandleInitialDeployment(t *testing.T) {
+func TestHandleUpdatedDeploymentConfigOk(t *testing.T) {
 	deploymentConfig := deploytest.OkDeploymentConfig(1)
 	var deployed *kapi.ReplicationController
 
 	controller := &DeploymentConfigController{
 		Codec: api.Codec,
-		DeploymentInterface: &testDeploymentInterface{
+		DeploymentClient: &DeploymentConfigControllerDeploymentClientImpl{
 			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return nil, kerrors.NewNotFound("replicationController", name)
+				return nil, kerrors.NewNotFound("ReplicationController", name)
 			},
 			CreateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 				deployed = deployment
 				return deployment, nil
 			},
 		},
-		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return deploymentConfig
-		},
 	}
 
-	controller.HandleDeploymentConfig()
+	err := controller.HandleDeploymentConfig(deploymentConfig)
 
 	if deployed == nil {
 		t.Fatalf("expected a deployment")
 	}
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
-func TestHandleConfigChangeLatestAlreadyDeployed(t *testing.T) {
+func TestHandleUpdatedDeploymentConfigLookupFailure(t *testing.T) {
+	controller := &DeploymentConfigController{
+		Codec: api.Codec,
+		DeploymentClient: &DeploymentConfigControllerDeploymentClientImpl{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				return nil, kerrors.NewInternalError(fmt.Errorf("test error"))
+			},
+			CreateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+				t.Fatalf("unexpected call with deployment %v", deployment)
+				return nil, nil
+			},
+		},
+	}
+
+	err := controller.HandleDeploymentConfig(deploytest.OkDeploymentConfig(1))
+
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestHandleUpdatedDeploymentConfigAlreadyDeployed(t *testing.T) {
 	deploymentConfig := deploytest.OkDeploymentConfig(0)
 
 	controller := &DeploymentConfigController{
 		Codec: api.Codec,
-		DeploymentInterface: &testDeploymentInterface{
+		DeploymentClient: &DeploymentConfigControllerDeploymentClientImpl{
 			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
 				deployment, _ := deployutil.MakeDeployment(deploymentConfig, kapi.Codec)
 				return deployment, nil
@@ -75,23 +98,31 @@ func TestHandleConfigChangeLatestAlreadyDeployed(t *testing.T) {
 				return nil, nil
 			},
 		},
-		NextDeploymentConfig: func() *deployapi.DeploymentConfig {
-			return deploymentConfig
+	}
+
+	err := controller.HandleDeploymentConfig(deploymentConfig)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleUpdatedDeploymentConfigError(t *testing.T) {
+	controller := &DeploymentConfigController{
+		Codec: api.Codec,
+		DeploymentClient: &DeploymentConfigControllerDeploymentClientImpl{
+			GetDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				return nil, kerrors.NewNotFound("ReplicationController", name)
+			},
+			CreateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+				return nil, kerrors.NewInternalError(fmt.Errorf("test error"))
+			},
 		},
 	}
 
-	controller.HandleDeploymentConfig()
-}
+	err := controller.HandleDeploymentConfig(deploytest.OkDeploymentConfig(1))
 
-type testDeploymentInterface struct {
-	GetDeploymentFunc    func(namespace, name string) (*kapi.ReplicationController, error)
-	CreateDeploymentFunc func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error)
-}
-
-func (i *testDeploymentInterface) GetDeployment(namespace, name string) (*kapi.ReplicationController, error) {
-	return i.GetDeploymentFunc(namespace, name)
-}
-
-func (i *testDeploymentInterface) CreateDeployment(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-	return i.CreateDeploymentFunc(namespace, deployment)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
 }


### PR DESCRIPTION
Refactor the deploy package to support error handling abstractions at
a layer higher than the controllers. No error handling is provided with
this commit.