### PR TITLE
prevent privilege escalation

### DIFF
--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func ExpandResources(rawResources kutil.StringSet) kutil.StringSet {
+	ret := kutil.StringSet{}
+	toVisit := rawResources.List()
+	visited := kutil.StringSet{}
+
+	for i := 0; i < len(toVisit); i++ {
+		currResource := toVisit[i]
+		if visited.Has(currResource) {
+			continue
+		}
+		visited.Insert(currResource)
+
+		if strings.Index(currResource, ResourceGroupPrefix+":") != 0 {
+			ret.Insert(strings.ToLower(currResource))
+			continue
+		}
+
+		if resourceTypes, exists := GroupsToResources[currResource]; exists {
+			toVisit = append(toVisit, resourceTypes...)
+		}
+	}
+
+	return ret
+}
+
+func (r PolicyRule) String() string {
+	return fmt.Sprintf("PolicyRule{Verbs:%v, Resources:%v, ResourceNames:%v, Restrictions:%v}", r.Verbs.List(), r.Resources.List(), r.ResourceNames.List(), r.AttributeRestrictions)
+}

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -16,6 +16,7 @@ func init() {
 		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
+		&RoleBindingList{},
 	)
 }
 
@@ -29,3 +30,4 @@ func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
 func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
 func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
+func (*RoleBindingList) IsAnAPIObject()              {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -70,12 +70,12 @@ var (
 // about who the rule applies to or which namespace the rule applies to.
 type PolicyRule struct {
 	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
-	Verbs []string
+	Verbs kutil.StringSet
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
 	AttributeRestrictions kruntime.EmbeddedObject
 	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
-	Resources []string
+	Resources kutil.StringSet `json:"resources"`
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames kutil.StringSet
 	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
@@ -100,9 +100,9 @@ type RoleBinding struct {
 	kapi.ObjectMeta
 
 	// UserNames holds all the usernames directly bound to the role
-	UserNames []string
+	Users kutil.StringSet
 	// GroupNames holds all the groups directly bound to the role
-	GroupNames []string
+	Groups kutil.StringSet
 
 	// Since Policy is a singleton, this is sufficient knowledge to locate a role
 	// RoleRefs can only reference the current namespace and the global namespace
@@ -207,4 +207,11 @@ type PolicyBindingList struct {
 	kapi.TypeMeta
 	kapi.ListMeta
 	Items []PolicyBinding
+}
+
+// RoleBindingList is a collection of PolicyBindings
+type RoleBindingList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []RoleBinding
 }

--- a/pkg/authorization/api/v1beta1/conversion.go
+++ b/pkg/authorization/api/v1beta1/conversion.go
@@ -17,12 +17,12 @@ func init() {
 				return err
 			}
 
-			out.Verbs = []string{}
-			out.Verbs = append(out.Verbs, in.Verbs...)
+			out.Resources = util.StringSet{}
+			out.Resources.Insert(in.Resources...)
+			out.Resources.Insert(in.ResourceKinds...)
 
-			out.Resources = []string{}
-			out.Resources = append(out.Resources, in.Resources...)
-			out.Resources = append(out.Resources, in.ResourceKinds...)
+			out.Verbs = util.StringSet{}
+			out.Verbs.Insert(in.Verbs...)
 
 			out.ResourceNames = util.NewStringSet(in.ResourceNames...)
 
@@ -35,11 +35,11 @@ func init() {
 				return err
 			}
 
-			out.Verbs = []string{}
-			out.Verbs = append(out.Verbs, in.Verbs...)
-
 			out.Resources = []string{}
-			out.Resources = append(out.Resources, in.Resources...)
+			out.Resources = append(out.Resources, in.Resources.List()...)
+
+			out.Verbs = []string{}
+			out.Verbs = append(out.Verbs, in.Verbs.List()...)
 
 			out.ResourceNames = in.ResourceNames.List()
 
@@ -56,6 +56,26 @@ func init() {
 			out.LastModified = in.LastModified
 			out.Roles = make([]NamedRole, 0, 0)
 			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *RoleBinding, out *newer.RoleBinding, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
+				return err
+			}
+
+			out.Users = util.NewStringSet(in.UserNames...)
+			out.Groups = util.NewStringSet(in.GroupNames...)
+
+			return nil
+		},
+		func(in *newer.RoleBinding, out *RoleBinding, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields|conversion.AllowDifferentFieldTypeNames); err != nil {
+				return err
+			}
+
+			out.UserNames = in.Users.List()
+			out.GroupNames = in.Groups.List()
+
+			return nil
 		},
 		func(in *[]NamedRole, out *map[string]newer.Role, s conversion.Scope) error {
 			for _, curr := range *in {

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -16,6 +16,7 @@ func init() {
 		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
+		&RoleBindingList{},
 	)
 }
 
@@ -29,3 +30,4 @@ func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
 func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
 func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
+func (*RoleBindingList) IsAnAPIObject()              {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -168,3 +168,10 @@ type PolicyBindingList struct {
 	kapi.ListMeta `json:"metadata,omitempty"`
 	Items         []PolicyBinding `json:"items"`
 }
+
+// RoleBindingList is a collection of PolicyBindings
+type RoleBindingList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []RoleBinding
+}

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -5,391 +5,414 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
 func TestViewerGetAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Victor"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Victor",
-			},
-			Verb:      "get",
-			Resource:  "pods",
-			Namespace: "mallet",
+			Verb:     "get",
+			Resource: "pods",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestViewerGetAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Victor"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Victor",
-			},
-			Verb:      "get",
-			Resource:  "pods",
-			Namespace: "adze",
+			Verb:     "get",
+			Resource: "pods",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestViewerGetDisallowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Victor"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Victor",
-			},
-			Verb:      "get",
-			Resource:  "policies",
-			Namespace: "mallet",
+			Verb:     "get",
+			Resource: "policies",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestViewerGetDisallowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Victor"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Victor",
-			},
-			Verb:      "get",
-			Resource:  "policies",
-			Namespace: "adze",
+			Verb:     "get",
+			Resource: "policies",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestViewerCreateAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Victor"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Victor",
-			},
-			Verb:      "create",
-			Resource:  "pods",
-			Namespace: "mallet",
+			Verb:     "create",
+			Resource: "pods",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestViewerCreateAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Victor"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Victor",
-			},
-			Verb:      "create",
-			Resource:  "pods",
-			Namespace: "adze",
+			Verb:     "create",
+			Resource: "pods",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestEditorUpdateAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Edgar"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Edgar",
-			},
-			Verb:      "update",
-			Resource:  "pods",
-			Namespace: "mallet",
+			Verb:     "update",
+			Resource: "pods",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestEditorUpdateAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Edgar"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Edgar",
-			},
-			Verb:      "update",
-			Resource:  "pods",
-			Namespace: "adze",
+			Verb:     "update",
+			Resource: "pods",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestEditorUpdateDisallowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Edgar"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Edgar",
-			},
-			Verb:      "update",
-			Resource:  "roleBindings",
-			Namespace: "mallet",
+			Verb:     "update",
+			Resource: "roleBindings",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestEditorUpdateDisallowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Edgar"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Edgar",
-			},
-			Verb:      "update",
-			Resource:  "roleBindings",
-			Namespace: "adze",
+			Verb:     "update",
+			Resource: "roleBindings",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestEditorGetAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Edgar"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Edgar",
-			},
-			Verb:      "get",
-			Resource:  "pods",
-			Namespace: "mallet",
+			Verb:     "get",
+			Resource: "pods",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestEditorGetAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Edgar"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Edgar",
-			},
-			Verb:      "get",
-			Resource:  "pods",
-			Namespace: "adze",
+			Verb:     "get",
+			Resource: "pods",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestAdminUpdateAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Matthew",
-			},
-			Verb:      "update",
-			Resource:  "roleBindings",
-			Namespace: "mallet",
+			Verb:     "update",
+			Resource: "roleBindings",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestAdminUpdateAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Matthew",
-			},
-			Verb:      "update",
-			Resource:  "roleBindings",
-			Namespace: "adze",
+			Verb:     "update",
+			Resource: "roleBindings",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestAdminUpdateDisallowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Matthew",
-			},
-			Verb:      "update",
-			Resource:  "policies",
-			Namespace: "mallet",
+			Verb:     "update",
+			Resource: "policies",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestAdminUpdateDisallowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Matthew",
-			},
-			Verb:      "update",
-			Resource:  "roles",
-			Namespace: "adze",
+			Verb:     "update",
+			Resource: "roles",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
 func TestAdminGetAllowedKindInMallet(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Matthew",
-			},
-			Verb:      "get",
-			Resource:  "policies",
-			Namespace: "mallet",
+			Verb:     "get",
+			Resource: "policies",
 		},
 		expectedAllowed: true,
 		expectedReason:  "allowed by rule in mallet",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 func TestAdminGetAllowedKindInAdze(t *testing.T) {
 	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Matthew"}),
 		attributes: &DefaultAuthorizationAttributes{
-			User: &user.DefaultInfo{
-				Name: "Matthew",
-			},
-			Verb:      "get",
-			Resource:  "policies",
-			Namespace: "adze",
+			Verb:     "get",
+			Resource: "policies",
 		},
 		expectedAllowed: false,
 		expectedReason:  "denied by default",
 	}
-	test.globalPolicy, test.globalPolicyBinding = newDefaultGlobalPolicy()
-	test.namespacedPolicy, test.namespacedPolicyBinding = allNamespacedPolicies()
+	test.policies = newDefaultGlobalPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.policies = append(test.policies, newMalletPolicies()...)
+	test.bindings = newDefaultGlobalBinding()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.bindings = append(test.bindings, newMalletBindings()...)
+
 	test.test(t)
 }
 
-func allNamespacedPolicies() ([]authorizationapi.Policy, []authorizationapi.PolicyBinding) {
-	adzePolicy, adzeBinding := newMalletPolicy()
-	malletPolicy, malletBinding := newMalletPolicy()
-
-	policies := make([]authorizationapi.Policy, 0)
-	policies = append(policies, adzePolicy...)
-	policies = append(policies, malletPolicy...)
-
-	bindings := make([]authorizationapi.PolicyBinding, 0)
-	bindings = append(bindings, adzeBinding...)
-	bindings = append(bindings, malletBinding...)
-
-	return policies, bindings
-
+func newMalletPolicies() []authorizationapi.Policy {
+	return []authorizationapi.Policy{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      authorizationapi.PolicyName,
+				Namespace: "mallet",
+			},
+			Roles: map[string]authorizationapi.Role{},
+		}}
 }
-
-func newMalletPolicy() ([]authorizationapi.Policy, []authorizationapi.PolicyBinding) {
-	return append(make([]authorizationapi.Policy, 0, 0),
-			authorizationapi.Policy{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      authorizationapi.PolicyName,
-					Namespace: "mallet",
+func newMalletBindings() []authorizationapi.PolicyBinding {
+	return []authorizationapi.PolicyBinding{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      testMasterNamespace,
+				Namespace: "mallet",
+			},
+			RoleBindings: map[string]authorizationapi.RoleBinding{
+				"projectAdmins": {
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "projectAdmins",
+						Namespace: "mallet",
+					},
+					RoleRef: kapi.ObjectReference{
+						Name:      "admin",
+						Namespace: testMasterNamespace,
+					},
+					Users: util.NewStringSet("Matthew"),
 				},
-				Roles: map[string]authorizationapi.Role{},
-			}),
-		append(make([]authorizationapi.PolicyBinding, 0, 0),
-			authorizationapi.PolicyBinding{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      testMasterNamespace,
-					Namespace: "mallet",
+				"viewers": {
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "viewers",
+						Namespace: "mallet",
+					},
+					RoleRef: kapi.ObjectReference{
+						Name:      "view",
+						Namespace: testMasterNamespace,
+					},
+					Users: util.NewStringSet("Victor"),
 				},
-				RoleBindings: map[string]authorizationapi.RoleBinding{
-					"projectAdmins": {
-						ObjectMeta: kapi.ObjectMeta{
-							Name:      "projectAdmins",
-							Namespace: "mallet",
-						},
-						RoleRef: kapi.ObjectReference{
-							Name:      "admin",
-							Namespace: testMasterNamespace,
-						},
-						UserNames: append(make([]string, 0), "Matthew"),
+				"editors": {
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "editors",
+						Namespace: "mallet",
 					},
-					"viewers": {
-						ObjectMeta: kapi.ObjectMeta{
-							Name:      "viewers",
-							Namespace: "mallet",
-						},
-						RoleRef: kapi.ObjectReference{
-							Name:      "view",
-							Namespace: testMasterNamespace,
-						},
-						UserNames: append(make([]string, 0), "Victor"),
+					RoleRef: kapi.ObjectReference{
+						Name:      "edit",
+						Namespace: testMasterNamespace,
 					},
-					"editors": {
-						ObjectMeta: kapi.ObjectMeta{
-							Name:      "editors",
-							Namespace: "mallet",
-						},
-						RoleRef: kapi.ObjectReference{
-							Name:      "edit",
-							Namespace: testMasterNamespace,
-						},
-						UserNames: append(make([]string, 0), "Edgar"),
-					},
+					Users: util.NewStringSet("Edgar"),
 				},
 			},
-		)
+		},
+	}
 }

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -36,12 +36,11 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	namespace := kapi.NamespaceValue(ctx)
 
 	attributes := &authorizer.DefaultAuthorizationAttributes{
-		Verb:      resourceAccessReview.Verb,
-		Resource:  resourceAccessReview.Resource,
-		Namespace: namespace,
+		Verb:     resourceAccessReview.Verb,
+		Resource: resourceAccessReview.Resource,
 	}
 
-	users, groups, err := r.authorizer.GetAllowedSubjects(attributes)
+	users, groups, err := r.authorizer.GetAllowedSubjects(ctx, attributes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/registry/resourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest_test.go
@@ -25,10 +25,10 @@ type testAuthorizer struct {
 	actualAttributes *authorizer.DefaultAuthorizationAttributes
 }
 
-func (a *testAuthorizer) Authorize(attributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
+func (a *testAuthorizer) Authorize(ctx kapi.Context, attributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
 	return false, "", errors.New("unsupported")
 }
-func (a *testAuthorizer) GetAllowedSubjects(passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
+func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
 	attributes, ok := passedAttributes.(*authorizer.DefaultAuthorizationAttributes)
 	if !ok {
 		return nil, nil, errors.New("unexpected type for test")
@@ -99,9 +99,8 @@ func (r *resourceAccessTest) runTest(t *testing.T) {
 	}
 
 	expectedAttributes := &authorizer.DefaultAuthorizationAttributes{
-		Verb:      r.reviewRequest.Verb,
-		Resource:  r.reviewRequest.Resource,
-		Namespace: namespace,
+		Verb:     r.reviewRequest.Verb,
+		Resource: r.reviewRequest.Resource,
 	}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)

--- a/pkg/authorization/registry/role/rest_test.go
+++ b/pkg/authorization/registry/role/rest_test.go
@@ -11,10 +11,9 @@ import (
 )
 
 func TestCreateValidationError(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-	storage := REST{
-		registry: registry,
-	}
+	registry := test.NewPolicyRegistry([]authorizationapi.Policy{}, nil)
+	storage := REST{registry: registry}
+
 	role := &authorizationapi.Role{}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
@@ -25,12 +24,9 @@ func TestCreateValidationError(t *testing.T) {
 }
 
 func TestCreateStorageError(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-	registry.Err = errors.New("Sample Error")
+	registry := test.NewPolicyRegistry([]authorizationapi.Policy{}, errors.New("Sample Error"))
+	storage := REST{registry: registry}
 
-	storage := REST{
-		registry: registry,
-	}
 	role := &authorizationapi.Role{
 		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
 	}
@@ -47,14 +43,12 @@ func TestCreateStorageError(t *testing.T) {
 }
 
 func TestCreateValid(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-	storage := REST{
-		registry: registry,
-	}
-	registry.Policies = append(make([]authorizationapi.Policy, 0),
-		authorizationapi.Policy{
-			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
-		})
+	registry := test.NewPolicyRegistry(
+		[]authorizationapi.Policy{
+			{ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"}},
+		},
+		nil)
+	storage := REST{registry: registry}
 
 	role := &authorizationapi.Role{
 		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
@@ -77,17 +71,17 @@ func TestCreateValid(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-	storage := REST{
-		registry: registry,
-	}
-	registry.Policies = append(make([]authorizationapi.Policy, 0),
-		authorizationapi.Policy{
-			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
-			Roles: map[string]authorizationapi.Role{
-				"my-role": {ObjectMeta: kapi.ObjectMeta{Name: "my-role"}},
+	registry := test.NewPolicyRegistry(
+		[]authorizationapi.Policy{
+			{
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+				Roles: map[string]authorizationapi.Role{
+					"my-role": {ObjectMeta: kapi.ObjectMeta{Name: "my-role"}},
+				},
 			},
-		})
+		},
+		nil)
+	storage := REST{registry: registry}
 
 	role := &authorizationapi.Role{
 		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
@@ -114,14 +108,14 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdateError(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-	storage := REST{
-		registry: registry,
-	}
-	registry.Policies = append(make([]authorizationapi.Policy, 0),
-		authorizationapi.Policy{
-			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
-		})
+	registry := test.NewPolicyRegistry(
+		[]authorizationapi.Policy{
+			{
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+			},
+		},
+		nil)
+	storage := REST{registry: registry}
 
 	role := &authorizationapi.Role{
 		ObjectMeta: kapi.ObjectMeta{Name: "my-role"},
@@ -140,12 +134,8 @@ func TestUpdateError(t *testing.T) {
 }
 
 func TestDeleteError(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-
-	registry.Err = errors.New("Sample Error")
-	storage := REST{
-		registry: registry,
-	}
+	registry := test.NewPolicyRegistry([]authorizationapi.Policy{}, errors.New("Sample Error"))
+	storage := REST{registry: registry}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
 	_, err := storage.Delete(ctx, "foo")
@@ -155,17 +145,17 @@ func TestDeleteError(t *testing.T) {
 }
 
 func TestDeleteValid(t *testing.T) {
-	registry := &test.PolicyRegistry{}
-	storage := REST{
-		registry: registry,
-	}
-	registry.Policies = append(make([]authorizationapi.Policy, 0),
-		authorizationapi.Policy{
-			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
-			Roles: map[string]authorizationapi.Role{
-				"foo": {ObjectMeta: kapi.ObjectMeta{Name: "foo"}},
+	registry := test.NewPolicyRegistry(
+		[]authorizationapi.Policy{
+			{
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
+				Roles: map[string]authorizationapi.Role{
+					"foo": {ObjectMeta: kapi.ObjectMeta{Name: "foo"}},
+				},
 			},
-		})
+		},
+		nil)
+	storage := REST{registry: registry}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
 	obj, err := storage.Delete(ctx, "foo")

--- a/pkg/authorization/registry/rolebinding/registry.go
+++ b/pkg/authorization/registry/rolebinding/registry.go
@@ -1,0 +1,22 @@
+package rolebinding
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// Registry is an interface for things that know how to store RoleBindings.
+type Registry interface {
+	// ListRoleBindings obtains list of policyRoleBindings that match a selector.
+	ListRoleBindings(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.RoleBindingList, error)
+	// GetRoleBinding retrieves a specific policyRoleBinding.
+	GetRoleBinding(ctx kapi.Context, id string) (*authorizationapi.RoleBinding, error)
+	// CreateRoleBinding creates a new policyRoleBinding.
+	CreateRoleBinding(ctx kapi.Context, policyRoleBinding *authorizationapi.RoleBinding) error
+	// UpdateRoleBinding updates a policyRoleBinding.
+	UpdateRoleBinding(ctx kapi.Context, policyRoleBinding *authorizationapi.RoleBinding) error
+	// DeleteRoleBinding deletes a policyRoleBinding.
+	DeleteRoleBinding(ctx kapi.Context, id string) error
+}

--- a/pkg/authorization/registry/rolebinding/rest.go
+++ b/pkg/authorization/registry/rolebinding/rest.go
@@ -2,36 +2,26 @@ package rolebinding
 
 import (
 	"fmt"
-	"strings"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
-	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/api/validation"
-	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
-	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
-	userregistry "github.com/openshift/origin/pkg/user/registry/user"
 )
 
 // TODO add get and list
-// TODO prevent privilege escalation
 
 // REST implements the RESTStorage interface in terms of an Registry.
 type REST struct {
-	bindingRegistry              policybindingregistry.Registry
-	policyRegistry               policyregistry.Registry
-	userRegistry                 userregistry.Registry
-	masterAuthorizationNamespace string
+	registry Registry
 }
 
 // NewREST creates a new REST for policies.
-func NewREST(bindingRegistry policybindingregistry.Registry, policyRegistry policyregistry.Registry, userRegistry userregistry.Registry, masterAuthorizationNamespace string) apiserver.RESTStorage {
-	return &REST{bindingRegistry, policyRegistry, userRegistry, masterAuthorizationNamespace}
+func NewREST(registry Registry) apiserver.RESTStorage {
+	return &REST{registry}
 }
 
 // New creates a new RoleBinding object
@@ -39,23 +29,12 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.RoleBinding{}
 }
 
-// Delete asynchronously deletes the Policy specified by its id.
-func (r *REST) Delete(ctx kapi.Context, id string) (runtime.Object, error) {
-	owningPolicyBinding, err := r.LocatePolicyBinding(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	if owningPolicyBinding == nil {
-		return nil, fmt.Errorf("roleBinding %v does not exist", id)
-	}
-
-	delete(owningPolicyBinding.RoleBindings, id)
-	owningPolicyBinding.LastModified = util.Now()
-
-	return &kapi.Status{Status: kapi.StatusSuccess}, r.bindingRegistry.UpdatePolicyBinding(ctx, owningPolicyBinding)
+// Delete asynchronously deletes the PolicyBinding specified by its name.
+func (r *REST) Delete(ctx kapi.Context, name string) (runtime.Object, error) {
+	return &kapi.Status{Status: kapi.StatusSuccess}, r.registry.DeleteRoleBinding(ctx, name)
 }
 
-// Create registers a given new RoleBinding inside the Policy instance to r.bindingRegistry.
+// Create registers a given new RoleBinding inside the PolicyBinding instance to r.bindingRegistry.
 func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
 	roleBinding, ok := obj.(*authorizationapi.RoleBinding)
 	if !ok {
@@ -70,33 +49,14 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 		return nil, kerrors.NewInvalid("roleBinding", roleBinding.Name, errs)
 	}
 
-	if err := r.validateReferentialIntegrity(ctx, roleBinding); err != nil {
-		return nil, err
-	}
-	if err := r.confirmRoleBindingNameUnique(ctx, roleBinding.Name); err != nil {
-		return nil, err
-	}
-
-	policyBinding, err := r.GetPolicyBinding(ctx, roleBinding.RoleRef.Namespace)
+	err := r.registry.CreateRoleBinding(ctx, roleBinding)
 	if err != nil {
-		return nil, err
-	}
-
-	_, exists := policyBinding.RoleBindings[roleBinding.Name]
-	if exists {
-		return nil, fmt.Errorf("roleBinding %v already exists", roleBinding.Name)
-	}
-
-	policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
-	policyBinding.LastModified = util.Now()
-
-	if err := r.bindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
 		return nil, err
 	}
 	return roleBinding, nil
 }
 
-// Update replaces a given RoleBinding inside the Policy instance with an existing instance in r.bindingRegistry.
+// Update replaces a given RoleBinding inside the PolicyBinding instance with an existing instance in r.bindingRegistry.
 func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
 	roleBinding, ok := obj.(*authorizationapi.RoleBinding)
 	if !ok {
@@ -110,160 +70,9 @@ func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, boo
 		return nil, false, kerrors.NewInvalid("roleBinding", roleBinding.Name, errs)
 	}
 
-	if err := r.validateReferentialIntegrity(ctx, roleBinding); err != nil {
-		return nil, false, err
-	}
-
-	existingRoleBinding, err := r.GetRoleBinding(ctx, roleBinding.Name)
+	err := r.registry.UpdateRoleBinding(ctx, roleBinding)
 	if err != nil {
-		return nil, false, err
-	}
-	if existingRoleBinding == nil {
-		return nil, false, fmt.Errorf("roleBinding %v does not exist", roleBinding.Name)
-	}
-	if existingRoleBinding.RoleRef.Namespace != roleBinding.RoleRef.Namespace {
-		return nil, false, fmt.Errorf("cannot change roleBinding.RoleRef.Namespace from %v to %v", existingRoleBinding.RoleRef.Namespace, roleBinding.RoleRef.Namespace)
-	}
-
-	policyBinding, err := r.GetPolicyBinding(ctx, roleBinding.RoleRef.Namespace)
-	if err != nil {
-		return nil, false, err
-	}
-
-	_, exists := policyBinding.RoleBindings[roleBinding.Name]
-	if !exists {
-		return nil, false, fmt.Errorf("roleBinding %v does not exist", roleBinding.Name)
-	}
-
-	policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
-	policyBinding.LastModified = util.Now()
-
-	if err := r.bindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
 		return nil, false, err
 	}
 	return roleBinding, false, nil
-}
-
-func (r *REST) validateReferentialIntegrity(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
-	if err := r.confirmRoleExists(roleBinding.RoleRef); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *REST) confirmRoleBindingNameUnique(ctx kapi.Context, bindingName string) error {
-	policyBinding, err := r.LocatePolicyBinding(ctx, bindingName)
-	if err != nil {
-		return err
-	}
-
-	if policyBinding != nil {
-		return fmt.Errorf("%v already exists", bindingName)
-	}
-
-	return nil
-}
-
-func (r *REST) confirmRoleExists(roleRef kapi.ObjectReference) error {
-	ctx := kapi.WithNamespace(kapi.NewContext(), roleRef.Namespace)
-
-	policy, err := r.policyRegistry.GetPolicy(ctx, authorizationapi.PolicyName)
-	if err != nil {
-		return fmt.Errorf("policy %v not found: %v", roleRef.Namespace, err)
-	}
-
-	if _, exists := policy.Roles[roleRef.Name]; !exists {
-		return fmt.Errorf("role %v not found", roleRef.Name)
-	}
-
-	return nil
-}
-
-func (r *REST) confirmUsersExist(userNames []string) error {
-	for _, userName := range userNames {
-		if _, err := r.userRegistry.GetUser(userName); err != nil {
-			return fmt.Errorf("user %v not found: %v", userName, err)
-		}
-	}
-
-	return nil
-}
-
-// EnsurePolicyBindingToMaster returns a PolicyBinding object that has a PolicyRef pointing to the Policy in the passed namespace.
-func (r *REST) EnsurePolicyBindingToMaster(ctx kapi.Context) (*authorizationapi.PolicyBinding, error) {
-	policyBinding, err := r.bindingRegistry.GetPolicyBinding(ctx, r.masterAuthorizationNamespace)
-	if err != nil {
-		if !strings.Contains(err.Error(), "not found") {
-			return nil, err
-		}
-
-		// if we have no policyBinding, go ahead and make one.  creating one here collapses code paths below.  We only take this hit once
-		policyBinding = policybindingregistry.NewEmptyPolicyBinding(kapi.NamespaceValue(ctx), r.masterAuthorizationNamespace)
-		if err := r.bindingRegistry.CreatePolicyBinding(ctx, policyBinding); err != nil {
-			return nil, err
-		}
-
-		policyBinding, err = r.bindingRegistry.GetPolicyBinding(ctx, r.masterAuthorizationNamespace)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if policyBinding.RoleBindings == nil {
-		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
-	}
-
-	return policyBinding, nil
-}
-
-// Returns a PolicyBinding that points to the specified policyNamespace.  It will autocreate ONLY if policyNamespace equals the master namespace
-func (r *REST) GetPolicyBinding(ctx kapi.Context, policyNamespace string) (*authorizationapi.PolicyBinding, error) {
-	// we can autocreate a PolicyBinding object if the RoleBinding is for the master namespace
-	if policyNamespace == r.masterAuthorizationNamespace {
-		return r.EnsurePolicyBindingToMaster(ctx)
-	}
-
-	policyBinding, err := r.bindingRegistry.GetPolicyBinding(ctx, policyNamespace)
-	if err != nil {
-		return nil, err
-	}
-
-	if policyBinding.RoleBindings == nil {
-		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
-	}
-
-	return policyBinding, nil
-}
-
-func (r *REST) LocatePolicyBinding(ctx kapi.Context, roleBindingName string) (*authorizationapi.PolicyBinding, error) {
-	policyBindingList, err := r.bindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, policyBinding := range policyBindingList.Items {
-		_, exists := policyBinding.RoleBindings[roleBindingName]
-		if exists {
-			return &policyBinding, nil
-		}
-	}
-
-	return nil, nil
-}
-
-func (r *REST) GetRoleBinding(ctx kapi.Context, roleBindingName string) (*authorizationapi.RoleBinding, error) {
-	policyBindingList, err := r.bindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, policyBinding := range policyBindingList.Items {
-		roleBinding, exists := policyBinding.RoleBindings[roleBindingName]
-		if exists {
-			return &roleBinding, nil
-		}
-	}
-
-	return nil, nil
 }

--- a/pkg/authorization/registry/rolebinding/virtual_registry.go
+++ b/pkg/authorization/registry/rolebinding/virtual_registry.go
@@ -1,0 +1,252 @@
+package rolebinding
+
+import (
+	"fmt"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+)
+
+type VirtualRegistry struct {
+	bindingRegistry              policybindingregistry.Registry
+	policyRegistry               policyregistry.Registry
+	masterAuthorizationNamespace string
+}
+
+// NewVirtualRegistry creates a new REST for policies.
+func NewVirtualRegistry(bindingRegistry policybindingregistry.Registry, policyRegistry policyregistry.Registry, masterAuthorizationNamespace string) Registry {
+	return &VirtualRegistry{bindingRegistry, policyRegistry, masterAuthorizationNamespace}
+}
+
+func (m *VirtualRegistry) ListRoleBindings(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.RoleBindingList, error) {
+	policyBindingList, err := m.bindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	roleBindingList := &authorizationapi.RoleBindingList{}
+
+	for _, policyBinding := range policyBindingList.Items {
+		for _, roleBinding := range policyBinding.RoleBindings {
+			roleBindingList.Items = append(roleBindingList.Items, roleBinding)
+		}
+	}
+
+	return roleBindingList, nil
+}
+
+func (m *VirtualRegistry) GetRoleBinding(ctx kapi.Context, name string) (*authorizationapi.RoleBinding, error) {
+	policyBinding, err := m.getPolicyBindingOwningRoleBinding(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if policyBinding == nil {
+		return nil, fmt.Errorf("RoleBinding %v not found", name)
+	}
+
+	binding := policyBinding.RoleBindings[name]
+	return &binding, nil
+}
+
+func (m *VirtualRegistry) DeleteRoleBinding(ctx kapi.Context, name string) error {
+	owningPolicyBinding, err := m.getPolicyBindingOwningRoleBinding(ctx, name)
+	if err != nil {
+		return err
+	}
+	if owningPolicyBinding == nil {
+		return fmt.Errorf("roleBinding %v does not exist", name)
+	}
+
+	delete(owningPolicyBinding.RoleBindings, name)
+	owningPolicyBinding.LastModified = util.Now()
+
+	return m.bindingRegistry.UpdatePolicyBinding(ctx, owningPolicyBinding)
+}
+
+func (m *VirtualRegistry) CreateRoleBinding(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
+	if err := m.validateReferentialIntegrity(ctx, roleBinding); err != nil {
+		return err
+	}
+	if err := m.confirmNoEscalaton(ctx, roleBinding); err != nil {
+		return err
+	}
+
+	policyBinding, err := m.getPolicyBindingForPolicy(ctx, roleBinding.RoleRef.Namespace)
+	if err != nil {
+		return err
+	}
+
+	_, exists := policyBinding.RoleBindings[roleBinding.Name]
+	if exists {
+		return fmt.Errorf("roleBinding %v already exists", roleBinding.Name)
+	}
+
+	policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
+	policyBinding.LastModified = util.Now()
+
+	if err := m.bindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *VirtualRegistry) UpdateRoleBinding(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
+	if err := m.validateReferentialIntegrity(ctx, roleBinding); err != nil {
+		return err
+	}
+	if err := m.confirmNoEscalaton(ctx, roleBinding); err != nil {
+		return err
+	}
+
+	existingRoleBinding, err := m.GetRoleBinding(ctx, roleBinding.Name)
+	if err != nil {
+		return err
+	}
+	if existingRoleBinding == nil {
+		return fmt.Errorf("roleBinding %v does not exist", roleBinding.Name)
+	}
+	if existingRoleBinding.RoleRef.Namespace != roleBinding.RoleRef.Namespace {
+		return fmt.Errorf("cannot change roleBinding.RoleRef.Namespace from %v to %v", existingRoleBinding.RoleRef.Namespace, roleBinding.RoleRef.Namespace)
+	}
+
+	policyBinding, err := m.getPolicyBindingForPolicy(ctx, roleBinding.RoleRef.Namespace)
+	if err != nil {
+		return err
+	}
+
+	_, exists := policyBinding.RoleBindings[roleBinding.Name]
+	if !exists {
+		return fmt.Errorf("roleBinding %v does not exist", roleBinding.Name)
+	}
+
+	policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
+	policyBinding.LastModified = util.Now()
+
+	if err := m.bindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *VirtualRegistry) validateReferentialIntegrity(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
+	if _, err := m.getReferencedRole(roleBinding.RoleRef); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *VirtualRegistry) getReferencedRole(roleRef kapi.ObjectReference) (*authorizationapi.Role, error) {
+	ctx := kapi.WithNamespace(kapi.NewContext(), roleRef.Namespace)
+
+	policy, err := m.policyRegistry.GetPolicy(ctx, authorizationapi.PolicyName)
+	if err != nil {
+		return nil, fmt.Errorf("policy %v not found: %v", roleRef.Namespace, err)
+	}
+
+	role, exists := policy.Roles[roleRef.Name]
+	if !exists {
+		return nil, fmt.Errorf("role %v not found", roleRef.Name)
+	}
+
+	return &role, nil
+}
+
+func (m *VirtualRegistry) confirmNoEscalaton(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
+	modifyingRole, err := m.getReferencedRole(roleBinding.RoleRef)
+	if err != nil {
+		return err
+	}
+
+	ruleResolver := rulevalidation.NewDefaultRuleResolver(m.policyRegistry, m.bindingRegistry)
+	ownerLocalRules, err := ruleResolver.GetEffectivePolicyRules(ctx)
+	if err != nil {
+		return err
+	}
+	masterContext := kapi.WithNamespace(ctx, m.masterAuthorizationNamespace)
+	ownerGlobalRules, err := ruleResolver.GetEffectivePolicyRules(masterContext)
+	if err != nil {
+		return err
+	}
+
+	ownerRules := make([]authorizationapi.PolicyRule, 0, len(ownerGlobalRules)+len(ownerLocalRules))
+	ownerRules = append(ownerRules, ownerLocalRules...)
+	ownerRules = append(ownerRules, ownerGlobalRules...)
+
+	ownerRightsCover, missingRights := rulevalidation.Covers(ownerRules, modifyingRole.Rules)
+	if !ownerRightsCover {
+		user, _ := kapi.UserFrom(ctx)
+		return fmt.Errorf("attempt to grant extra privileges: %v\nuser=%v\nownerrules%v\n", missingRights, user, ownerRules)
+	}
+
+	return nil
+}
+
+// ensurePolicyBindingToMaster returns a PolicyBinding object that has a PolicyRef pointing to the Policy in the passed namespace.
+func (m *VirtualRegistry) ensurePolicyBindingToMaster(ctx kapi.Context) (*authorizationapi.PolicyBinding, error) {
+	policyBinding, err := m.bindingRegistry.GetPolicyBinding(ctx, m.masterAuthorizationNamespace)
+	if err != nil {
+		if !strings.Contains(err.Error(), "not found") {
+			return nil, err
+		}
+
+		// if we have no policyBinding, go ahead and make one.  creating one here collapses code paths below.  We only take this hit once
+		policyBinding = policybindingregistry.NewEmptyPolicyBinding(kapi.NamespaceValue(ctx), m.masterAuthorizationNamespace)
+		if err := m.bindingRegistry.CreatePolicyBinding(ctx, policyBinding); err != nil {
+			return nil, err
+		}
+
+		policyBinding, err = m.bindingRegistry.GetPolicyBinding(ctx, m.masterAuthorizationNamespace)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if policyBinding.RoleBindings == nil {
+		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+	}
+
+	return policyBinding, nil
+}
+
+// Returns a PolicyBinding that points to the specified policyNamespace.  It will autocreate ONLY if policyNamespace equals the master namespace
+func (m *VirtualRegistry) getPolicyBindingForPolicy(ctx kapi.Context, policyNamespace string) (*authorizationapi.PolicyBinding, error) {
+	// we can autocreate a PolicyBinding object if the RoleBinding is for the master namespace
+	if policyNamespace == m.masterAuthorizationNamespace {
+		return m.ensurePolicyBindingToMaster(ctx)
+	}
+
+	policyBinding, err := m.bindingRegistry.GetPolicyBinding(ctx, policyNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if policyBinding.RoleBindings == nil {
+		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+	}
+
+	return policyBinding, nil
+}
+
+func (m *VirtualRegistry) getPolicyBindingOwningRoleBinding(ctx kapi.Context, bindingName string) (*authorizationapi.PolicyBinding, error) {
+	policyBindingList, err := m.bindingRegistry.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, policyBinding := range policyBindingList.Items {
+		_, exists := policyBinding.RoleBindings[bindingName]
+		if exists {
+			return &policyBinding, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -35,20 +35,18 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	}
 
 	namespace := kapi.NamespaceValue(ctx)
-
 	user := &user.DefaultInfo{
 		Name:   subjectAccessReview.User,
 		Groups: subjectAccessReview.Groups,
 	}
+	requestContext := kapi.WithUser(kapi.WithNamespace(kapi.NewDefaultContext(), namespace), user)
 
 	attributes := &authorizer.DefaultAuthorizationAttributes{
-		User:      user,
-		Verb:      subjectAccessReview.Verb,
-		Resource:  subjectAccessReview.Resource,
-		Namespace: namespace,
+		Verb:     subjectAccessReview.Verb,
+		Resource: subjectAccessReview.Resource,
 	}
 
-	allowed, reason, err := r.authorizer.Authorize(attributes)
+	allowed, reason, err := r.authorizer.Authorize(requestContext, attributes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/registry/subjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -26,7 +25,7 @@ type testAuthorizer struct {
 	actualAttributes *authorizer.DefaultAuthorizationAttributes
 }
 
-func (a *testAuthorizer) Authorize(passedAttributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
+func (a *testAuthorizer) Authorize(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
 	attributes, ok := passedAttributes.(*authorizer.DefaultAuthorizationAttributes)
 	if !ok {
 		return false, "ERROR", errors.New("unexpected type for test")
@@ -39,7 +38,7 @@ func (a *testAuthorizer) Authorize(passedAttributes authorizer.AuthorizationAttr
 	}
 	return a.allowed, a.reason, errors.New(a.err)
 }
-func (a *testAuthorizer) GetAllowedSubjects(passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
+func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
 	return nil, nil, nil
 }
 
@@ -104,13 +103,8 @@ func (r *subjectAccessTest) runTest(t *testing.T) {
 	}
 
 	expectedAttributes := &authorizer.DefaultAuthorizationAttributes{
-		User: &user.DefaultInfo{
-			Name:   r.reviewRequest.User,
-			Groups: r.reviewRequest.Groups,
-		},
-		Verb:      r.reviewRequest.Verb,
-		Resource:  r.reviewRequest.Resource,
-		Namespace: namespace,
+		Verb:     r.reviewRequest.Verb,
+		Resource: r.reviewRequest.Resource,
 	}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)

--- a/pkg/authorization/registry/test/policy.go
+++ b/pkg/authorization/registry/test/policy.go
@@ -12,13 +12,22 @@ import (
 )
 
 type PolicyRegistry struct {
-	Err               error
-	MasterNamespace   string
-	Policies          []authorizationapi.Policy
-	DeletedPolicyName string
+	// Policies is a of namespace->name->Policy
+	Policies map[string]map[string]authorizationapi.Policy
+	Err      error
 }
 
-// ListPolicies obtains list of policies that match a selector.
+func NewPolicyRegistry(policies []authorizationapi.Policy, err error) *PolicyRegistry {
+	policyMap := make(map[string]map[string]authorizationapi.Policy)
+
+	for _, policy := range policies {
+		addPolicy(policyMap, policy)
+	}
+
+	return &PolicyRegistry{policyMap, err}
+}
+
+// ListPolicies obtains list of ListPolicy that match a selector.
 func (r *PolicyRegistry) ListPolicies(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.PolicyList, error) {
 	if r.Err != nil {
 		return nil, r.Err
@@ -30,16 +39,17 @@ func (r *PolicyRegistry) ListPolicies(ctx kapi.Context, labels, fields klabels.S
 	}
 
 	list := make([]authorizationapi.Policy, 0)
-	for _, curr := range r.Policies {
-		if curr.Namespace == namespace {
+	if namespacedPolicies, ok := r.Policies[namespace]; ok {
+		for _, curr := range namespacedPolicies {
 			list = append(list, curr)
 		}
+
 	}
 
 	return &authorizationapi.PolicyList{
 			Items: list,
 		},
-		r.Err
+		nil
 }
 
 // GetPolicy retrieves a specific policy.
@@ -53,9 +63,9 @@ func (r *PolicyRegistry) GetPolicy(ctx kapi.Context, id string) (*authorizationa
 		return nil, errors.New("invalid request.  Namespace parameter required.")
 	}
 
-	for _, curr := range r.Policies {
-		if curr.Namespace == namespace && id == curr.Name {
-			return &curr, nil
+	if namespacedPolicies, ok := r.Policies[namespace]; ok {
+		if policy, ok := namespacedPolicies[id]; ok {
+			return &policy, nil
 		}
 	}
 
@@ -64,20 +74,71 @@ func (r *PolicyRegistry) GetPolicy(ctx kapi.Context, id string) (*authorizationa
 
 // CreatePolicy creates a new policy.
 func (r *PolicyRegistry) CreatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error {
-	return r.Err
+	if r.Err != nil {
+		return r.Err
+	}
+
+	namespace := kapi.NamespaceValue(ctx)
+	if len(namespace) == 0 {
+		return errors.New("invalid request.  Namespace parameter required.")
+	}
+	if existing, _ := r.GetPolicy(ctx, policy.Name); existing != nil {
+		return fmt.Errorf("Policy %v::%v already exists", namespace, policy.Name)
+	}
+
+	addPolicy(r.Policies, *policy)
+
+	return nil
 }
 
 // UpdatePolicy updates a policy.
 func (r *PolicyRegistry) UpdatePolicy(ctx kapi.Context, policy *authorizationapi.Policy) error {
-	return r.Err
+	if r.Err != nil {
+		return r.Err
+	}
+
+	namespace := kapi.NamespaceValue(ctx)
+	if len(namespace) == 0 {
+		return errors.New("invalid request.  Namespace parameter required.")
+	}
+	if existing, _ := r.GetPolicy(ctx, policy.Name); existing == nil {
+		return fmt.Errorf("Policy %v::%v not found", namespace, policy.Name)
+	}
+
+	addPolicy(r.Policies, *policy)
+
+	return nil
 }
 
 // DeletePolicy deletes a policy.
 func (r *PolicyRegistry) DeletePolicy(ctx kapi.Context, id string) error {
-	r.DeletedPolicyName = id
-	return r.Err
+	if r.Err != nil {
+		return r.Err
+	}
+
+	namespace := kapi.NamespaceValue(ctx)
+	if len(namespace) == 0 {
+		return errors.New("invalid request.  Namespace parameter required.")
+	}
+
+	namespacedPolicies, ok := r.Policies[namespace]
+	if ok {
+		delete(namespacedPolicies, id)
+	}
+
+	return nil
 }
 
 func (r *PolicyRegistry) WatchPolicies(ctx kapi.Context, label, field klabels.Selector, resourceVersion string) (watch.Interface, error) {
-	return nil, r.Err
+	return nil, errors.New("unsupported")
+}
+
+func addPolicy(policies map[string]map[string]authorizationapi.Policy, policy authorizationapi.Policy) {
+	namespacedPolicies, ok := policies[policy.Namespace]
+	if !ok {
+		namespacedPolicies = make(map[string]authorizationapi.Policy)
+		policies[policy.Namespace] = namespacedPolicies
+	}
+
+	namespacedPolicies[policy.Name] = policy
 }

--- a/pkg/authorization/rulevalidation/find_rules.go
+++ b/pkg/authorization/rulevalidation/find_rules.go
@@ -1,0 +1,145 @@
+package rulevalidation
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type DefaultRuleResolver struct {
+	policyGetter  PolicyGetter
+	bindingLister BindingLister
+}
+
+func NewDefaultRuleResolver(policyGetter PolicyGetter, bindingLister BindingLister) *DefaultRuleResolver {
+	return &DefaultRuleResolver{policyGetter, bindingLister}
+}
+
+type AuthorizationRuleResolver interface {
+	GetRoleBindings(ctx kapi.Context) ([]authorizationapi.RoleBinding, error)
+	GetRole(roleBinding authorizationapi.RoleBinding) (*authorizationapi.Role, error)
+	// getEffectivePolicyRules returns the list of rules that apply to a given user in a given namespace and error.  If an error is returned, the slice of
+	// PolicyRules may not be complete, but it contains all retrievable rules.  This is done because policy rules are purely additive and policy determinations
+	// can be made on the basis of those rules that are found.
+	GetEffectivePolicyRules(ctx kapi.Context) ([]authorizationapi.PolicyRule, error)
+}
+
+type PolicyGetter interface {
+	// GetPolicy retrieves a specific policy.
+	GetPolicy(ctx kapi.Context, id string) (*authorizationapi.Policy, error)
+}
+
+type BindingLister interface {
+	// ListPolicyBindings obtains list of policyBindings that match a selector.
+	ListPolicyBindings(ctx kapi.Context, labels, fields klabels.Selector) (*authorizationapi.PolicyBindingList, error)
+}
+
+// getPolicy provides a point for easy caching
+func (a *DefaultRuleResolver) getPolicy(ctx kapi.Context) (*authorizationapi.Policy, error) {
+	policy, err := a.policyGetter.GetPolicy(ctx, authorizationapi.PolicyName)
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+// getPolicyBindings provides a point for easy caching
+func (a *DefaultRuleResolver) getPolicyBindings(ctx kapi.Context) ([]authorizationapi.PolicyBinding, error) {
+	policyBindingList, err := a.bindingLister.ListPolicyBindings(ctx, klabels.Everything(), klabels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	return policyBindingList.Items, nil
+}
+
+// getRoleBindings provides a point for easy caching
+func (a *DefaultRuleResolver) GetRoleBindings(ctx kapi.Context) ([]authorizationapi.RoleBinding, error) {
+	policyBindings, err := a.getPolicyBindings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]authorizationapi.RoleBinding, 0, len(policyBindings))
+	for _, policyBinding := range policyBindings {
+		for _, value := range policyBinding.RoleBindings {
+			ret = append(ret, value)
+		}
+	}
+
+	return ret, nil
+}
+
+func (a *DefaultRuleResolver) GetRole(roleBinding authorizationapi.RoleBinding) (*authorizationapi.Role, error) {
+	namespace := roleBinding.RoleRef.Namespace
+	name := roleBinding.RoleRef.Name
+
+	ctx := kapi.WithNamespace(kapi.NewContext(), namespace)
+	policy, err := a.getPolicy(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	role, exists := policy.Roles[name]
+	if !exists {
+		return nil, fmt.Errorf("role %#v not found", roleBinding.RoleRef)
+	}
+
+	return &role, nil
+}
+
+// getEffectivePolicyRules returns the list of rules that apply to a given user in a given namespace and error.  If an error is returned, the slice of
+// PolicyRules may not be complete, but it contains all retrievable rules.  This is done because policy rules are purely additive and policy determinations
+// can be made on the basis of those rules that are found.
+func (a *DefaultRuleResolver) GetEffectivePolicyRules(ctx kapi.Context) ([]authorizationapi.PolicyRule, error) {
+	roleBindings, err := a.GetRoleBindings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	errs := []error{}
+	rules := make([]authorizationapi.PolicyRule, 0, len(roleBindings))
+	for _, roleBinding := range roleBindings {
+		role, err := a.GetRole(roleBinding)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		for _, curr := range role.Rules {
+			user, exists := kapi.UserFrom(ctx)
+			if !exists {
+				errs = append(errs, errors.New("user missing from context"))
+			}
+
+			if doesApplyToUser(roleBinding.Users, roleBinding.Groups, user) {
+				rules = append(rules, curr)
+			}
+		}
+	}
+
+	return rules, kerrors.NewAggregate(errs)
+}
+
+func doesApplyToUser(ruleUsers, ruleGroups util.StringSet, user user.Info) bool {
+	if ruleUsers.Has(user.GetName()) {
+		return true
+	}
+
+	for _, currGroup := range user.GetGroups() {
+		if ruleGroups.Has(currGroup) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/authorization/rulevalidation/policy_comparator.go
+++ b/pkg/authorization/rulevalidation/policy_comparator.go
@@ -1,0 +1,81 @@
+package rulevalidation
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// Covers determines whether or not the ownerRules cover the servantRules in terms of allowed actions.
+// It returns whether or not the ownerRules cover and a list of the rules that the ownerRules do not cover.
+func Covers(ownerRules, servantRules []authorizationapi.PolicyRule) (bool, []authorizationapi.PolicyRule) {
+	// 1.  Break every servantRule into individual rule tuples: verb, resource, resourceName
+	// 2.  Compare the mini-rules against each owner rule.  Because the breakdown is down to the most atomic level, we're guaranteed that each mini-servant rule will be either fully covered or not covered by a single owner rule
+	// 3.  Any left over mini-rules means that we are not covered and we have a nice list of them.
+	// TODO: it might be nice to collapse the list down into something more human readable
+
+	subrules := []authorizationapi.PolicyRule{}
+	for _, servantRule := range servantRules {
+		subrules = append(subrules, breakdownRule(servantRule)...)
+	}
+
+	// fmt.Printf("subrules: %v\n", subrules)
+	// fmt.Printf("ownerRules: %v\n", ownerRules)
+
+	uncoveredRules := []authorizationapi.PolicyRule{}
+	for _, subrule := range subrules {
+		covered := false
+		for _, ownerRule := range ownerRules {
+			if ruleCovers(ownerRule, subrule) {
+				covered = true
+				break
+			}
+		}
+
+		if !covered {
+			uncoveredRules = append(uncoveredRules, subrule)
+		}
+	}
+
+	return (len(uncoveredRules) == 0), uncoveredRules
+}
+
+// breadownRule takes a rule and builds an equivalent list of rules that each have at most one verb, one
+// resource, and one resource name
+func breakdownRule(rule authorizationapi.PolicyRule) []authorizationapi.PolicyRule {
+	subrules := []authorizationapi.PolicyRule{}
+
+	for resource := range authorizationapi.ExpandResources(rule.Resources) {
+		for verb := range rule.Verbs {
+			if len(rule.ResourceNames) > 0 {
+				for _, resourceName := range rule.ResourceNames.List() {
+					subrules = append(subrules, authorizationapi.PolicyRule{Resources: util.NewStringSet(resource), Verbs: util.NewStringSet(verb), ResourceNames: util.NewStringSet(resourceName)})
+				}
+
+			} else {
+				subrules = append(subrules, authorizationapi.PolicyRule{Resources: util.NewStringSet(resource), Verbs: util.NewStringSet(verb)})
+			}
+
+		}
+	}
+
+	return subrules
+}
+
+// ruleCovers determines whether the ownerRule (which may have multiple verbs, resources, and resourceNames) covers
+// the subrule (which may only contain at most one verb, resource, and resourceName)
+func ruleCovers(ownerRule, subrule authorizationapi.PolicyRule) bool {
+	allResources := authorizationapi.ExpandResources(ownerRule.Resources)
+
+	verbMatches := ownerRule.Verbs.Has("*") || ownerRule.Verbs.HasAll(subrule.Verbs.List()...)
+	resourceMatches := ownerRule.Resources.Has("*") || allResources.HasAll(subrule.Resources.List()...)
+	resourceNameMatches := false
+
+	if len(subrule.ResourceNames) == 0 {
+		resourceNameMatches = (len(ownerRule.ResourceNames) == 0)
+	} else {
+		resourceNameMatches = (len(ownerRule.ResourceNames) == 0) || ownerRule.ResourceNames.HasAll(subrule.ResourceNames.List()...)
+	}
+
+	return verbMatches && resourceMatches && resourceNameMatches
+}

--- a/pkg/authorization/rulevalidation/policy_comparator_test.go
+++ b/pkg/authorization/rulevalidation/policy_comparator_test.go
@@ -1,0 +1,262 @@
+package rulevalidation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type escalationTest struct {
+	ownerRules   []authorizationapi.PolicyRule
+	servantRules []authorizationapi.PolicyRule
+
+	expectedCovered        bool
+	expectedUncoveredRules []authorizationapi.PolicyRule
+}
+
+func TestExactMatch(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("builds")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("builds")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestMultipleRulesCoveringSingleRule(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete"), Resources: util.NewStringSet("deployments")},
+			{Verbs: util.NewStringSet("delete"), Resources: util.NewStringSet("builds")},
+			{Verbs: util.NewStringSet("update"), Resources: util.NewStringSet("builds", "deployments")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("builds", "deployments")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+
+}
+
+func TestMultipleRulesMissingSingleVerbResourceCombination(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("builds", "deployments")},
+			{Verbs: util.NewStringSet("delete"), Resources: util.NewStringSet("pods")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("builds", "deployments", "pods")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("update"), Resources: util.NewStringSet("pods")},
+		},
+	}.test(t)
+}
+
+func TestResourceGroupCoveringEnumerated(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("create", "delete", "update"), Resources: util.NewStringSet("resourcegroup:builds")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("builds", "buildconfigs")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestEnumeratedCoveringResourceGroup(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("builds", "buildconfigs", "buildlogs")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("resourcegroup:builds")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestEnumeratedMissingPartOfResourceGroup(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("builds", "buildconfigs")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete", "update"), Resources: util.NewStringSet("resourcegroup:builds")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("delete"), Resources: util.NewStringSet("buildlogs")},
+			{Verbs: util.NewStringSet("update"), Resources: util.NewStringSet("buildlogs")},
+		},
+	}.test(t)
+}
+
+func TestVerbStarCoveringMultiple(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("roles")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("watch", "list"), Resources: util.NewStringSet("roles")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestEnumerationNotCoveringVerbStar(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get", "list", "watch", "create", "update", "delete", "exec"), Resources: util.NewStringSet("roles")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("roles")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("roles")},
+		},
+	}.test(t)
+}
+
+func TestVerbStarCoveringStar(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("roles")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("roles")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestResourceStarCoveringMultiple(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("*")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("resourcegroup:deployments")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestEnumerationNotCoveringResourceStar(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("roles", "resourcegroup:deployments")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("*")},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("*")},
+		},
+	}.test(t)
+}
+
+func TestResourceStarCoveringStar(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("*")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("*")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestResourceNameEmptyCoveringMultiple(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("pods"), ResourceNames: util.NewStringSet()},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("pods"), ResourceNames: util.NewStringSet("foo", "bar")},
+		},
+
+		expectedCovered:        true,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{},
+	}.test(t)
+}
+
+func TestEnumerationNotCoveringResourceNameEmpty(t *testing.T) {
+	escalationTest{
+		ownerRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("pods"), ResourceNames: util.NewStringSet("foo", "bar")},
+		},
+		servantRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("pods"), ResourceNames: util.NewStringSet()},
+		},
+
+		expectedCovered: false,
+		expectedUncoveredRules: []authorizationapi.PolicyRule{
+			{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("pods")},
+		},
+	}.test(t)
+}
+
+func (test escalationTest) test(t *testing.T) {
+	actualCovered, actualUncoveredRules := Covers(test.ownerRules, test.servantRules)
+
+	if actualCovered != test.expectedCovered {
+		t.Errorf("expected %v, but got %v", test.expectedCovered, actualCovered)
+	}
+
+	if !rulesMatch(test.expectedUncoveredRules, actualUncoveredRules) {
+		t.Errorf("expected %v, but got %v", test.expectedUncoveredRules, actualUncoveredRules)
+	}
+}
+
+func rulesMatch(expectedRules, actualRules []authorizationapi.PolicyRule) bool {
+	if len(expectedRules) != len(actualRules) {
+		return false
+	}
+
+	for _, expectedRule := range expectedRules {
+		found := false
+		for _, actualRule := range actualRules {
+			if reflect.DeepEqual(expectedRule, actualRule) {
+				found = true
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -334,8 +334,8 @@ func (d *PolicyBindingDescriber) Describe(namespace, name string) (string, error
 			roleBinding := policyBinding.RoleBindings[key]
 			formatString(out, "RoleBinding["+key+"]", " ")
 			formatString(out, "\tRole", roleBinding.RoleRef.Name)
-			formatString(out, "\tUsers", roleBinding.UserNames)
-			formatString(out, "\tGroups", roleBinding.GroupNames)
+			formatString(out, "\tUsers", roleBinding.Users.List())
+			formatString(out, "\tGroups", roleBinding.Groups.List())
 		}
 
 		return nil

--- a/pkg/cmd/experimental/policy/remove_group.go
+++ b/pkg/cmd/experimental/policy/remove_group.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
@@ -17,7 +16,7 @@ type removeGroupOptions struct {
 	bindingNamespace string
 	client           client.Interface
 
-	groupNames []string
+	groups []string
 }
 
 func NewCmdRemoveGroup(f *clientcmd.Factory) *cobra.Command {
@@ -58,7 +57,7 @@ func (o *removeGroupOptions) complete(cmd *cobra.Command) bool {
 	}
 
 	o.roleName = args[0]
-	o.groupNames = args[1:]
+	o.groups = args[1:]
 	return true
 }
 
@@ -72,10 +71,7 @@ func (o *removeGroupOptions) run() error {
 	}
 
 	for _, roleBinding := range roleBindings {
-		groups := util.StringSet{}
-		groups.Insert(roleBinding.GroupNames...)
-		groups.Delete(o.groupNames...)
-		roleBinding.GroupNames = groups.List()
+		roleBinding.Groups.Delete(o.groups...)
 
 		_, err = o.client.RoleBindings(o.bindingNamespace).Update(roleBinding)
 		if err != nil {

--- a/pkg/cmd/experimental/policy/remove_group_from_project.go
+++ b/pkg/cmd/experimental/policy/remove_group_from_project.go
@@ -1,10 +1,10 @@
 package policy
 
 import (
-	labels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
+	labels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -14,7 +14,7 @@ type removeGroupFromProjectOptions struct {
 	bindingNamespace string
 	client           client.Interface
 
-	groupNames []string
+	groups []string
 }
 
 func NewCmdRemoveGroupFromProject(f *clientcmd.Factory) *cobra.Command {
@@ -53,7 +53,7 @@ func (o *removeGroupFromProjectOptions) complete(cmd *cobra.Command) bool {
 		return false
 	}
 
-	o.groupNames = args
+	o.groups = args
 	return true
 }
 
@@ -65,11 +65,7 @@ func (o *removeGroupFromProjectOptions) run() error {
 
 	for _, currBindings := range bindingList.Items {
 		for _, currBinding := range currBindings.RoleBindings {
-			groupsForBinding := util.StringSet{}
-			groupsForBinding.Insert(currBinding.GroupNames...)
-			groupsForBinding.Delete(o.groupNames...)
-
-			currBinding.GroupNames = groupsForBinding.List()
+			currBinding.Groups.Delete(o.groups...)
 
 			_, err = o.client.RoleBindings(o.bindingNamespace).Update(&currBinding)
 			if err != nil {

--- a/pkg/cmd/experimental/policy/remove_user.go
+++ b/pkg/cmd/experimental/policy/remove_user.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
@@ -17,7 +16,7 @@ type removeUserOptions struct {
 	bindingNamespace string
 	client           client.Interface
 
-	userNames []string
+	users []string
 }
 
 func NewCmdRemoveUser(f *clientcmd.Factory) *cobra.Command {
@@ -58,7 +57,7 @@ func (o *removeUserOptions) complete(cmd *cobra.Command) bool {
 	}
 
 	o.roleName = args[0]
-	o.userNames = args[1:]
+	o.users = args[1:]
 	return true
 }
 
@@ -72,10 +71,7 @@ func (o *removeUserOptions) run() error {
 	}
 
 	for _, roleBinding := range roleBindings {
-		users := util.StringSet{}
-		users.Insert(roleBinding.UserNames...)
-		users.Delete(o.userNames...)
-		roleBinding.UserNames = users.List()
+		roleBinding.Users.Delete(o.users...)
 
 		_, err = o.client.RoleBindings(o.bindingNamespace).Update(roleBinding)
 		if err != nil {

--- a/pkg/cmd/experimental/policy/remove_user_from_project.go
+++ b/pkg/cmd/experimental/policy/remove_user_from_project.go
@@ -1,10 +1,10 @@
 package policy
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -14,7 +14,7 @@ type removeUserFromProjectOptions struct {
 	bindingNamespace string
 	client           client.Interface
 
-	userNames []string
+	users []string
 }
 
 func NewCmdRemoveUserFromProject(f *clientcmd.Factory) *cobra.Command {
@@ -52,7 +52,7 @@ func (o *removeUserFromProjectOptions) complete(cmd *cobra.Command) bool {
 		return false
 	}
 
-	o.userNames = args
+	o.users = args
 	return true
 }
 
@@ -64,11 +64,7 @@ func (o *removeUserFromProjectOptions) run() error {
 
 	for _, currBindings := range bindingList.Items {
 		for _, currBinding := range currBindings.RoleBindings {
-			usersForBinding := util.StringSet{}
-			usersForBinding.Insert(currBinding.UserNames...)
-			usersForBinding.Delete(o.userNames...)
-
-			currBinding.UserNames = usersForBinding.List()
+			currBinding.Users.Delete(o.users...)
 
 			_, err = o.client.RoleBindings(o.bindingNamespace).Update(&currBinding)
 			if err != nil {

--- a/pkg/cmd/experimental/project/new_project.go
+++ b/pkg/cmd/experimental/project/new_project.go
@@ -3,9 +3,11 @@ package project
 import (
 	"fmt"
 
-	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
@@ -94,7 +96,7 @@ func (o *newProjectOptions) run() error {
 		adminRoleBinding.Name = "admins"
 		adminRoleBinding.RoleRef.Namespace = o.masterPolicyNamespace
 		adminRoleBinding.RoleRef.Name = o.adminRole
-		adminRoleBinding.UserNames = []string{o.adminUser}
+		adminRoleBinding.Users = util.NewStringSet(o.adminUser)
 
 		_, err := o.client.RoleBindings(project.Name).Create(adminRoleBinding)
 		if err != nil {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/authenticator/request/x509request"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	authorizationetcd "github.com/openshift/origin/pkg/authorization/registry/etcd"
+	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 
 	"github.com/openshift/origin/pkg/auth/group"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
@@ -646,7 +647,7 @@ func start(cfg *config, args []string) error {
 
 func newAuthorizer(etcdHelper tools.EtcdHelper, masterAuthorizationNamespace string) authorizer.Authorizer {
 	authorizationEtcd := authorizationetcd.New(etcdHelper)
-	authorizer := authorizer.NewAuthorizer(masterAuthorizationNamespace, authorizationEtcd, authorizationEtcd)
+	authorizer := authorizer.NewAuthorizer(masterAuthorizationNamespace, rulevalidation.NewDefaultRuleResolver(authorizationEtcd, authorizationEtcd))
 	return authorizer
 }
 


### PR DESCRIPTION
Prevent a user who has rights to modify role bindings from binding a user to a role that has more power than the granting user has.

/cc @liggitt 