### PR TITLE
Unify all client Factories into one location

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -104,24 +104,24 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 [ "$(openshift ex config 2>&1)" ]
 [ "$(openshift ex tokens)" ]
 [ "$(openshift ex policy  2>&1)" ]
-[ "$(openshift kubectl)" ]
+[ "$(openshift kubectl 2>&1)" ]
 [ "$(openshift kube 2>&1)" ]
 
 # help for root commands must be consistent
 [ "$(openshift | grep 'OpenShift for Admins')" ]
 [ "$(osc | grep 'OpenShift Client')" ]
 [ "$(openshift cli | grep 'OpenShift Client')" ]
-[ "$(openshift kubectl | grep 'OpenShift Client')" ]
+[ "$(openshift kubectl 2>&1 | grep 'Kubernetes cluster')" ]
 
 # help for root commands with --help flag must be consistent
 [ "$(openshift --help 2>&1 | grep 'OpenShift for Admins')" ]
 [ "$(osc --help 2>&1 | grep 'OpenShift Client')" ]
 [ "$(openshift cli --help 2>&1 | grep 'OpenShift Client')" ]
-[ "$(openshift kubectl --help 2>&1 | grep 'OpenShift Client')" ]
+[ "$(openshift kubectl --help 2>&1 | grep 'Kubernetes cluster')" ]
 
 # help for root commands through help command must be consistent
 [ "$(openshift help cli 2>&1 | grep 'OpenShift Client')" ]
-[ "$(openshift help kubectl 2>&1 | grep 'OpenShift Client')" ]
+[ "$(openshift help kubectl 2>&1 | grep 'Kubernetes cluster')" ]
 
 # help for given command with --help flag must be consistent
 [ "$(osc get --help 2>&1 | grep 'Display one or many resources')" ]
@@ -184,6 +184,10 @@ osc get images
 osc get imageRepositories
 osc delete imageRepositories test
 echo "imageRepositoryMappings: ok"
+
+[ "$(osc new-app php mysql -o yaml | grep 3306)" ]
+osc new-app php mysql
+echo "new-app: ok"
 
 osc get routes
 osc create -f test/integration/fixtures/test-route.json create routes

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-func NewCmdBuildLogs(f *Factory, out io.Writer) *cobra.Command {
+func NewCmdBuildLogs(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build-logs <build>",
 		Short: "Show container logs from the build container",

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -11,12 +11,13 @@ import (
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 // NewCmdCancelBuild manages a build cancelling event.
 // To cancel a build its name has to be specified, and two options
 // are available: displaying logs and restarting.
-func NewCmdCancelBuild(f *Factory, out io.Writer) *cobra.Command {
+func NewCmdCancelBuild(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "cancel-build <build>",

--- a/pkg/cmd/cli/cmd/options.go
+++ b/pkg/cmd/cli/cmd/options.go
@@ -6,9 +6,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-func NewCmdOptions(f *Factory, out io.Writer) *cobra.Command {
+func NewCmdOptions(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "options",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/template"
 	"github.com/openshift/origin/pkg/template/api"
 )
@@ -35,7 +36,7 @@ func injectUserVars(cmd *cobra.Command, t *api.Template) {
 }
 
 // NewCmdProcess returns a 'process' command
-func NewCmdProcess(f *Factory, out io.Writer) *cobra.Command {
+func NewCmdProcess(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "process -f filename",
 		Short: "Process template into list of resources",

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	describe "github.com/openshift/origin/pkg/cmd/cli/describe"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
@@ -41,7 +42,7 @@ Examples:
   $ %[1]s %[2]s deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -
 `
 
-func NewCmdRollback(parentName string, name string, f *Factory, out io.Writer) *cobra.Command {
+func NewCmdRollback(parentName string, name string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	rollback := &deployapi.DeploymentConfigRollback{
 		Spec: deployapi.DeploymentConfigRollbackSpec{
 			IncludeTemplate: true,

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -11,9 +11,10 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-func NewCmdStartBuild(f *Factory, out io.Writer) *cobra.Command {
+func NewCmdStartBuild(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start-build (<buildConfig>|--from-build=<build>)",
 		Short: "Starts a new build from existing build or buildConfig",

--- a/pkg/cmd/experimental/generate/generate.go
+++ b/pkg/cmd/experimental/generate/generate.go
@@ -15,8 +15,6 @@ import (
 
 	"github.com/openshift/origin/pkg/api/latest"
 	osclient "github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/cli"
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	dh "github.com/openshift/origin/pkg/cmd/util/docker"
@@ -77,18 +75,16 @@ type params struct {
 	env cmdutil.Environment
 }
 
-func NewCmdGenerate(name string) *cobra.Command {
-	cfg := clientcmd.NewConfig()
+func NewCmdGenerate(f *clientcmd.Factory, parentName, name string) *cobra.Command {
 	dockerHelper := dh.NewHelper()
 	input := params{}
-	var factory *cmd.Factory
 
 	c := &cobra.Command{
 		Use:   fmt.Sprintf("%s%s", name, clientcmd.ConfigSyntax),
 		Short: "Generates an application configuration from a source repository",
 		Long:  longDescription,
 		Run: func(c *cobra.Command, args []string) {
-			_, osClient, err := cfg.Clients()
+			osClient, _, err := f.Clients(c)
 			if err != nil {
 				osClient = nil
 			}
@@ -116,7 +112,7 @@ func NewCmdGenerate(name string) *cobra.Command {
 				}
 				input.env = env
 			}
-			namespace, err := factory.DefaultNamespace(c)
+			namespace, err := f.DefaultNamespace(c)
 			if err != nil {
 				namespace = ""
 			}
@@ -127,9 +123,6 @@ func NewCmdGenerate(name string) *cobra.Command {
 			}
 		},
 	}
-	clientConfig := cli.DefaultClientConfig(c.PersistentFlags())
-	factory = cmd.NewFactory(clientConfig)
-	factory.BindFlags(c.PersistentFlags())
 
 	flag := c.Flags()
 	flag.StringVar(&input.name, "name", "", "Set name to use for generated application artifacts")

--- a/pkg/cmd/experimental/login/login.go
+++ b/pkg/cmd/experimental/login/login.go
@@ -14,23 +14,18 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 )
 
-func NewCmdLogin(name string, parent *cobra.Command) *cobra.Command {
-	clientConfig := cmdutil.DefaultClientConfig(parent.PersistentFlags())
-	f := cmd.NewFactory(clientConfig)
-	f.BindFlags(parent.PersistentFlags())
-
+func NewCmdLogin(f *osclientcmd.Factory, parentName, name string) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Logs in and returns a session token",
 		Long: `Logs in to the OpenShift server and prints out a session token.
 
-Username and password can be provided through flags, the command will 
+Username and password can be provided through flags, the command will
 prompt for user input if not provided.
 `,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/experimental/policy/add_user.go
+++ b/pkg/cmd/experimental/policy/add_user.go
@@ -1,26 +1,26 @@
 package policy
 
 import (
-	"fmt"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 type addUserOptions struct {
-	roleNamespace string
-	roleName      string
-	clientConfig  clientcmd.ClientConfig
+	roleNamespace    string
+	roleName         string
+	bindingNamespace string
+	client           client.Interface
 
 	userNames []string
 }
 
-func NewCmdAddUser(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	options := &addUserOptions{clientConfig: clientConfig}
+func NewCmdAddUser(f *clientcmd.Factory) *cobra.Command {
+	options := &addUserOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "add-user <role> <user> [user]...",
@@ -31,9 +31,15 @@ func NewCmdAddUser(clientConfig clientcmd.ClientConfig) *cobra.Command {
 				return
 			}
 
-			err := options.run()
-			if err != nil {
-				fmt.Printf("%v\n", err)
+			var err error
+			if options.client, _, err = f.Clients(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if options.bindingNamespace, err = f.DefaultNamespace(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if err := options.run(); err != nil {
+				glog.Fatal(err)
 			}
 		},
 	}
@@ -56,20 +62,7 @@ func (o *addUserOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *addUserOptions) run() error {
-	clientConfig, err := o.clientConfig.ClientConfig()
-	if err != nil {
-		return err
-	}
-	client, err := client.New(clientConfig)
-	if err != nil {
-		return err
-	}
-	namespace, err := o.clientConfig.Namespace()
-	if err != nil {
-		return err
-	}
-
-	roleBindings, roleBindingNames, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, roleBindingNames, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
 	if err != nil {
 		return err
 	}
@@ -92,10 +85,10 @@ func (o *addUserOptions) run() error {
 	roleBinding.UserNames = users.List()
 
 	if isUpdate {
-		_, err = client.RoleBindings(namespace).Update(roleBinding)
+		_, err = o.client.RoleBindings(o.bindingNamespace).Update(roleBinding)
 	} else {
 		roleBinding.Name = getUniqueName(o.roleName, roleBindingNames)
-		_, err = client.RoleBindings(namespace).Create(roleBinding)
+		_, err = o.client.RoleBindings(o.bindingNamespace).Create(roleBinding)
 	}
 	if err != nil {
 		return err

--- a/pkg/cmd/experimental/policy/remove_group.go
+++ b/pkg/cmd/experimental/policy/remove_group.go
@@ -3,23 +3,25 @@ package policy
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 type removeGroupOptions struct {
-	roleNamespace string
-	roleName      string
-	clientConfig  clientcmd.ClientConfig
+	roleNamespace    string
+	roleName         string
+	bindingNamespace string
+	client           client.Interface
 
 	groupNames []string
 }
 
-func NewCmdRemoveGroup(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	options := &removeGroupOptions{clientConfig: clientConfig}
+func NewCmdRemoveGroup(f *clientcmd.Factory) *cobra.Command {
+	options := &removeGroupOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "remove-group <role> <group> [group]...",
@@ -30,9 +32,15 @@ func NewCmdRemoveGroup(clientConfig clientcmd.ClientConfig) *cobra.Command {
 				return
 			}
 
-			err := options.run()
-			if err != nil {
-				fmt.Printf("%v\n", err)
+			var err error
+			if options.client, _, err = f.Clients(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if options.bindingNamespace, err = f.DefaultNamespace(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if err := options.run(); err != nil {
+				glog.Fatal(err)
 			}
 		},
 	}
@@ -55,25 +63,12 @@ func (o *removeGroupOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *removeGroupOptions) run() error {
-	clientConfig, err := o.clientConfig.ClientConfig()
-	if err != nil {
-		return err
-	}
-	client, err := client.New(clientConfig)
-	if err != nil {
-		return err
-	}
-	namespace, err := o.clientConfig.Namespace()
-	if err != nil {
-		return err
-	}
-
-	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
 	if err != nil {
 		return err
 	}
 	if len(roleBindings) == 0 {
-		return fmt.Errorf("unable to locate RoleBinding for %v::%v in %v", o.roleNamespace, o.roleName, namespace)
+		return fmt.Errorf("unable to locate RoleBinding for %v::%v in %v", o.roleNamespace, o.roleName, o.bindingNamespace)
 	}
 
 	for _, roleBinding := range roleBindings {
@@ -82,7 +77,7 @@ func (o *removeGroupOptions) run() error {
 		groups.Delete(o.groupNames...)
 		roleBinding.GroupNames = groups.List()
 
-		_, err = client.RoleBindings(namespace).Update(roleBinding)
+		_, err = o.client.RoleBindings(o.bindingNamespace).Update(roleBinding)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/experimental/policy/remove_user.go
+++ b/pkg/cmd/experimental/policy/remove_user.go
@@ -3,23 +3,25 @@ package policy
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 type removeUserOptions struct {
-	roleNamespace string
-	roleName      string
-	clientConfig  clientcmd.ClientConfig
+	roleNamespace    string
+	roleName         string
+	bindingNamespace string
+	client           client.Interface
 
 	userNames []string
 }
 
-func NewCmdRemoveUser(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	options := &removeUserOptions{clientConfig: clientConfig}
+func NewCmdRemoveUser(f *clientcmd.Factory) *cobra.Command {
+	options := &removeUserOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "remove-user <role> <user> [user]...",
@@ -30,9 +32,15 @@ func NewCmdRemoveUser(clientConfig clientcmd.ClientConfig) *cobra.Command {
 				return
 			}
 
-			err := options.run()
-			if err != nil {
-				fmt.Printf("%v\n", err)
+			var err error
+			if options.client, _, err = f.Clients(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if options.bindingNamespace, err = f.DefaultNamespace(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if err := options.run(); err != nil {
+				glog.Fatal(err)
 			}
 		},
 	}
@@ -55,25 +63,12 @@ func (o *removeUserOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *removeUserOptions) run() error {
-	clientConfig, err := o.clientConfig.ClientConfig()
-	if err != nil {
-		return err
-	}
-	client, err := client.New(clientConfig)
-	if err != nil {
-		return err
-	}
-	namespace, err := o.clientConfig.Namespace()
-	if err != nil {
-		return err
-	}
-
-	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, namespace, client)
+	roleBindings, _, err := getExistingRoleBindingsForRole(o.roleNamespace, o.roleName, o.bindingNamespace, o.client)
 	if err != nil {
 		return err
 	}
 	if len(roleBindings) == 0 {
-		return fmt.Errorf("unable to locate RoleBinding for %v::%v in %v", o.roleNamespace, o.roleName, namespace)
+		return fmt.Errorf("unable to locate RoleBinding for %v::%v in %v", o.roleNamespace, o.roleName, o.bindingNamespace)
 	}
 
 	for _, roleBinding := range roleBindings {
@@ -82,7 +77,7 @@ func (o *removeUserOptions) run() error {
 		users.Delete(o.userNames...)
 		roleBinding.UserNames = users.List()
 
-		_, err = client.RoleBindings(namespace).Update(roleBinding)
+		_, err = o.client.RoleBindings(o.bindingNamespace).Update(roleBinding)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/experimental/policy/remove_user_from_project.go
+++ b/pkg/cmd/experimental/policy/remove_user_from_project.go
@@ -1,24 +1,24 @@
 package policy
 
 import (
-	"fmt"
-
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
-	klabels "github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 type removeUserFromProjectOptions struct {
-	clientConfig clientcmd.ClientConfig
+	bindingNamespace string
+	client           client.Interface
 
 	userNames []string
 }
 
-func NewCmdRemoveUserFromProject(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	options := &removeUserFromProjectOptions{clientConfig: clientConfig}
+func NewCmdRemoveUserFromProject(f *clientcmd.Factory) *cobra.Command {
+	options := &removeUserFromProjectOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "remove-user-from-project  <user> [user]...",
@@ -29,9 +29,15 @@ func NewCmdRemoveUserFromProject(clientConfig clientcmd.ClientConfig) *cobra.Com
 				return
 			}
 
-			err := options.run()
-			if err != nil {
-				fmt.Printf("%v\n", err)
+			var err error
+			if options.client, _, err = f.Clients(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if options.bindingNamespace, err = f.DefaultNamespace(cmd); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if err := options.run(); err != nil {
+				glog.Fatal(err)
 			}
 		},
 	}
@@ -51,20 +57,7 @@ func (o *removeUserFromProjectOptions) complete(cmd *cobra.Command) bool {
 }
 
 func (o *removeUserFromProjectOptions) run() error {
-	clientConfig, err := o.clientConfig.ClientConfig()
-	if err != nil {
-		return err
-	}
-	client, err := client.New(clientConfig)
-	if err != nil {
-		return err
-	}
-	namespace, err := o.clientConfig.Namespace()
-	if err != nil {
-		return err
-	}
-
-	bindingList, err := client.PolicyBindings(namespace).List(klabels.Everything(), klabels.Everything())
+	bindingList, err := o.client.PolicyBindings(o.bindingNamespace).List(labels.Everything(), labels.Everything())
 	if err != nil {
 		return err
 	}
@@ -77,7 +70,7 @@ func (o *removeUserFromProjectOptions) run() error {
 
 			currBinding.UserNames = usersForBinding.List()
 
-			_, err = client.RoleBindings(namespace).Update(&currBinding)
+			_, err = o.client.RoleBindings(o.bindingNamespace).Update(&currBinding)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/experimental/tokens/request.go
+++ b/pkg/cmd/experimental/tokens/request.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 )
 
-func NewCmdRequestToken(f *cmd.Factory) *cobra.Command {
+func NewCmdRequestToken(f *clientcmd.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "request-token",
 		Short: "request an access token",

--- a/pkg/cmd/experimental/tokens/tokens.go
+++ b/pkg/cmd/experimental/tokens/tokens.go
@@ -4,21 +4,19 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/auth/server/tokenrequest"
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 const (
 	TOKEN_FILE_PARAM = "token-file"
 )
 
-func NewCmdTokens(name string) *cobra.Command {
+func NewCmdTokens(f *osclientcmd.Factory, parentName, name string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
@@ -29,13 +27,6 @@ func NewCmdTokens(name string) *cobra.Command {
 			c.Help()
 		},
 	}
-
-	// Override global default to https and port 8443
-	clientcmd.DefaultCluster.Server = "https://localhost:8443"
-
-	// TODO: there should be two client configs, one for OpenShift, and one for Kubernetes
-	f := cmd.NewFactory(cmdutil.DefaultClientConfig(cmds.PersistentFlags()))
-	f.BindFlags(cmds.PersistentFlags())
 
 	cmds.AddCommand(NewCmdValidateToken(f))
 	cmds.AddCommand(NewCmdRequestToken(f))

--- a/pkg/cmd/experimental/tokens/validate.go
+++ b/pkg/cmd/experimental/tokens/validate.go
@@ -9,11 +9,11 @@ import (
 	"github.com/spf13/cobra"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/oauth/osintypes"
 )
 
-func NewCmdValidateToken(f *cmd.Factory) *cobra.Command {
+func NewCmdValidateToken(f *clientcmd.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate-token",
 		Short: "validate an access token",

--- a/pkg/cmd/experimental/tokens/whoami.go
+++ b/pkg/cmd/experimental/tokens/whoami.go
@@ -9,11 +9,11 @@ import (
 	"github.com/spf13/cobra"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 )
 
-func NewCmdWhoAmI(f *cmd.Factory) *cobra.Command {
+func NewCmdWhoAmI(f *clientcmd.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "checks the identity associated with an access token",

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/infra/router"
 	"github.com/openshift/origin/pkg/cmd/server"
 	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/version"
 )
 
@@ -110,12 +111,17 @@ func newExperimentalCommand(parentName, name string) *cobra.Command {
 			c.Help()
 		},
 	}
-	experimental.AddCommand(config.NewCmdConfig(fmt.Sprintf("%s %s", parentName, name), "config"))
-	experimental.AddCommand(tokens.NewCmdTokens("tokens"))
-	experimental.AddCommand(policy.NewCommandPolicy("policy"))
-	experimental.AddCommand(generate.NewCmdGenerate("generate"))
-	experimental.AddCommand(login.NewCmdLogin("login", experimental))
-	experimental.AddCommand(project.NewCmdNewProject("new-project"))
+
+	f := clientcmd.New(experimental.PersistentFlags())
+
+	subName := fmt.Sprintf("%s %s", parentName, name)
+	experimental.AddCommand(project.NewCmdNewProject(f, subName, "new-project"))
+	experimental.AddCommand(config.NewCmdConfig(subName, "config"))
+	experimental.AddCommand(tokens.NewCmdTokens(f, subName, "tokens"))
+	experimental.AddCommand(policy.NewCommandPolicy(f, subName, "policy"))
+	experimental.AddCommand(generate.NewCmdGenerate(f, subName, "generate"))
+	experimental.AddCommand(login.NewCmdLogin(f, subName, "login"))
+	//experimental.AddCommand(exrouter.NewCmdRouter(f, subName, "router", os.Stdout))
 	return experimental
 }
 

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -109,6 +109,8 @@ type config struct {
 	ImageFormat         string
 	LatestReleaseImages bool
 
+	ImageTemplate variable.ImageTemplate
+
 	Hostname  string
 	VolumeDir string
 
@@ -147,6 +149,8 @@ func NewCommandStartServer(name string) *cobra.Command {
 		MasterPublicAddr:     flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
 		KubernetesPublicAddr: flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
 
+		ImageTemplate: variable.NewDefaultImageTemplate(),
+
 		Hostname: hostname,
 		NodeList: flagtypes.StringList{"127.0.0.1"},
 	}
@@ -172,8 +176,8 @@ func NewCommandStartServer(name string) *cobra.Command {
 	flag.Var(&cfg.KubernetesPublicAddr, "public-kubernetes", "The Kubernetes server address for use by public clients, if different. (host, host:port, or URL). Defaults to same as --kubernetes.")
 	flag.Var(&cfg.PortalNet, "portal-net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
 
-	flag.StringVar(&cfg.ImageFormat, "images", "openshift/origin-${component}:${version}", "When fetching images used by the cluster for important components, use this format on both master and nodes. The latest release will be used by default.")
-	flag.BoolVar(&cfg.LatestReleaseImages, "latest-images", false, "If true, attempt to use the latest images for the cluster instead of the latest release.")
+	flag.StringVar(&cfg.ImageTemplate.Format, "images", cfg.ImageTemplate.Format, "When fetching images used by the cluster for important components, use this format on both master and nodes. The latest release will be used by default.")
+	flag.BoolVar(&cfg.ImageTemplate.Latest, "latest-images", cfg.ImageTemplate.Latest, "If true, attempt to use the latest images for the cluster instead of the latest release.")
 
 	flag.StringVar(&cfg.VolumeDir, "volume-dir", "openshift.local.volumes", "The volume storage directory.")
 	flag.StringVar(&cfg.EtcdDir, "etcd-dir", "openshift.local.etcd", "The etcd data directory.")
@@ -263,9 +267,7 @@ func start(cfg *config, args []string) error {
 	}
 
 	// define a function for resolving components to names
-	imageResolverFn := func(component string) string {
-		return expandImage(component, cfg.ImageFormat, cfg.LatestReleaseImages)
-	}
+	imageResolverFn := cfg.ImageTemplate.ExpandOrDie
 	useLocalImages := env("USE_LOCAL_IMAGES", "false") == "true"
 
 	// the node can reuse an existing client

--- a/pkg/cmd/util/variable/imagetemplate.go
+++ b/pkg/cmd/util/variable/imagetemplate.go
@@ -1,0 +1,70 @@
+package variable
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// ImageTemplate is a class to assist in expanding parameterized Docker image references
+// from configuration or a file
+type ImageTemplate struct {
+	// Required, set to the image template to pull
+	Format string
+	Latest bool
+	// Optional, if set will substitute the value of ${component} with any env
+	// var that matches this format. Is a printf format string accepting a single
+	// string parameter.
+	EnvFormat string
+}
+
+const defaultImageFormat = "openshift/origin-${component}:${version}"
+const defaultImageEnvFormat = "OPENSHIFT_%s_IMAGE"
+
+func NewDefaultImageTemplate() ImageTemplate {
+	return ImageTemplate{
+		Format:    defaultImageFormat,
+		Latest:    false,
+		EnvFormat: defaultImageEnvFormat,
+	}
+}
+
+func (t *ImageTemplate) ExpandOrDie(component string) string {
+	value, err := t.Expand(component)
+	if err != nil {
+		glog.Fatalf("Unable to find an image for %q due to an error processing the format: %v", err)
+	}
+	return value
+}
+
+func (t *ImageTemplate) Expand(component string) (string, error) {
+	template := t.Format
+	if len(t.EnvFormat) > 0 {
+		if s, ok := t.imageComponentEnvExpander(component); ok {
+			template = s
+		}
+	}
+	value, err := ExpandStrict(template, func(key string) (string, bool) {
+		switch key {
+		case "component":
+			return component, true
+		case "version":
+			if t.Latest {
+				return "latest", true
+			}
+		}
+		return "", false
+	}, Versions)
+	return value, err
+}
+
+func (t *ImageTemplate) imageComponentEnvExpander(key string) (string, bool) {
+	s := strings.Replace(strings.ToUpper(key), "-", "_", -1)
+	val := os.Getenv(fmt.Sprintf(t.EnvFormat, s))
+	if len(val) == 0 {
+		return "", false
+	}
+	return val, true
+}

--- a/pkg/config/cmd/cmd.go
+++ b/pkg/config/cmd/cmd.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
+	"github.com/spf13/cobra"
+)
+
+// Bulk provides helpers for iterating over a list of items
+type Bulk struct {
+	Factory *kubecmd.Factory
+	Command *cobra.Command
+	After   func(*resource.Info, error)
+}
+
+func NewPrintNameOrErrorAfter(out, errs io.Writer) func(*resource.Info, error) {
+	return func(info *resource.Info, err error) {
+		if err == nil {
+			fmt.Fprintf(out, "%s\n", info.Name)
+		} else {
+			fmt.Fprintf(errs, "%v\n", err)
+		}
+	}
+}
+
+// Create attempts to create each item generically, gathering all errors in the
+// event a failure occurs. The contents of list will be updated to include the
+// version from the server.
+func (b *Bulk) Create(list *kapi.List, namespace string) []error {
+	mapper, typer := b.Factory.Object(b.Command)
+	resourceMapper := &resource.Mapper{typer, mapper, b.Factory.ClientMapperForCommand(b.Command)}
+	after := b.After
+	if after == nil {
+		after = func(*resource.Info, error) {}
+	}
+
+	errs := []error{}
+	for i, item := range list.Items {
+		info, err := resourceMapper.InfoForObject(item)
+		if err != nil {
+			errs = append(errs, err)
+			after(info, err)
+			continue
+		}
+		data, err := info.Mapping.Codec.Encode(item)
+		if err != nil {
+			errs = append(errs, err)
+			after(info, err)
+			continue
+		}
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, data)
+		if err != nil {
+			errs = append(errs, err)
+			after(info, err)
+			continue
+		}
+		info.Refresh(obj, true)
+		list.Items[i] = obj
+		after(info, nil)
+	}
+	return errs
+}

--- a/pkg/deploy/registry/deployconfig/rest.go
+++ b/pkg/deploy/registry/deployconfig/rest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-	"github.com/golang/glog"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	validation "github.com/openshift/origin/pkg/deploy/api/validation"
@@ -82,8 +81,6 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	if !kapi.ValidNamespace(ctx, &deploymentConfig.ObjectMeta) {
 		return nil, kerrors.NewConflict("deploymentConfig", deploymentConfig.Namespace, fmt.Errorf("DeploymentConfig.Namespace does not match the provided context"))
 	}
-
-	glog.Infof("Creating deploymentConfig with namespace::Name: %v::%v", deploymentConfig.Namespace, deploymentConfig.Name)
 
 	if errs := validation.ValidateDeploymentConfig(deploymentConfig); len(errs) > 0 {
 		return nil, kerrors.NewInvalid("deploymentConfig", deploymentConfig.Name, errs)

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -184,6 +184,7 @@ func AddServices(objects Objects) Objects {
 						ObjectMeta: kapi.ObjectMeta{
 							Name:         name,
 							GenerateName: generateName,
+							Labels:       t.Labels,
 						},
 						Spec: kapi.ServiceSpec{
 							ContainerPort: kutil.NewIntOrStringFromInt(p),


### PR DESCRIPTION
Cleanup policy, login, token, project commands to follow common
patterns.

Extract image template logic so other commands can use it.

Create a new Bulk{} operator for creating multiple items at the same
time.

Move the 'kubectl' alias to 'openshift kube'

[merge]