### PR TITLE
Give our local built docker images unique ids, and push that id

### DIFF
--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -34,6 +34,7 @@ gzip -f "${context}/archive.tar"
 # Perform the build and release in Docker.
 cat "${context}/archive.tar.gz" | docker run -i --cidfile="${context}/cid" openshift/origin-release
 docker cp $(cat ${context}/cid):/go/src/github.com/openshift/origin/_output/local/releases "${OS_ROOT}/_output/local"
+echo "${OS_GIT_COMMIT}" > "${OS_ROOT}/_output/local/releases/.commit"
 
 # Copy the linux release archives release back to the local _output/local/go/bin directory.
 os::build::detect_local_release_tars "linux"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -348,6 +348,7 @@ os::build::detect_local_release_tars() {
 
   export OS_PRIMARY_RELEASE_TAR="${primary}"
   export OS_IMAGE_RELEASE_TAR="${image}"
+  export OS_RELEASE_COMMIT="$(cat ${OS_LOCAL_RELEASEPATH}/.commit)"
 }
 
 # os::build::get_version_vars loads the standard version variables as


### PR DESCRIPTION
Prevents hack/test-end-to-end.sh from mucking with the canonical images.
Tags images as both "latest" and the git commit id.

@bparees review