### PR TITLE
buildlogs: dont redirect to host but to IP instead

### DIFF
--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -62,7 +62,7 @@ func (r *REST) ResourceLocation(ctx kapi.Context, id string) (string, error) {
 	}
 
 	buildPodID := build.PodName
-	buildPodHost := pod.Status.Host
+	buildPodHost := pod.Status.HostIP
 	buildPodNamespace := pod.Namespace
 	// Build will take place only in one container
 	buildContainerName := pod.Spec.Containers[0].Name


### PR DESCRIPTION
since host might not have DNS set up