### PR TITLE
make useLocalImages the default and remove configurability

### DIFF
--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -12,7 +12,6 @@ import (
 
 // CustomBuildStrategy creates a build using a custom builder image.
 type CustomBuildStrategy struct {
-	UseLocalImages bool
 	// Codec is the codec to use for encoding the output pod.
 	// IMPORTANT: This may break backwards compatibility when
 	// it changes.
@@ -69,10 +68,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 		return nil, err
 	}
 
-	if bs.UseLocalImages {
-		pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
-	}
-
+	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 	if strategy.ExposeDockerSocket {
 		setupDockerSocket(pod)
 		setupDockerConfig(pod)

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -11,8 +11,7 @@ import (
 
 func TestCustomCreateBuildPod(t *testing.T) {
 	strategy := CustomBuildStrategy{
-		UseLocalImages: true,
-		Codec:          v1beta1.Codec,
+		Codec: v1beta1.Codec,
 	}
 
 	expectedBad := mockCustomBuild()

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -9,8 +9,7 @@ import (
 
 // DockerBuildStrategy creates a Docker build using a Docker builder image.
 type DockerBuildStrategy struct {
-	Image          string
-	UseLocalImages bool
+	Image string
 	// Codec is the codec to use for encoding the output pod.
 	// IMPORTANT: This may break backwards compatibility when
 	// it changes.
@@ -47,9 +46,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 		},
 	}
 
-	if bs.UseLocalImages {
-		pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
-	}
+	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 
 	setupDockerSocket(pod)
 	setupDockerConfig(pod)

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -11,9 +11,8 @@ import (
 
 func TestDockerCreateBuildPod(t *testing.T) {
 	strategy := DockerBuildStrategy{
-		Image:          "docker-test-image",
-		UseLocalImages: true,
-		Codec:          v1beta1.Codec,
+		Image: "docker-test-image",
+		Codec: v1beta1.Codec,
 	}
 
 	expected := mockDockerBuild()

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -13,7 +13,6 @@ import (
 type STIBuildStrategy struct {
 	Image                string
 	TempDirectoryCreator TempDirectoryCreator
-	UseLocalImages       bool
 	// Codec is the codec to use for encoding the output pod.
 	// IMPORTANT: This may break backwards compatibility when
 	// it changes.
@@ -69,9 +68,7 @@ func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, er
 		},
 	}
 
-	if bs.UseLocalImages {
-		pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
-	}
+	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 
 	setupDockerSocket(pod)
 	setupDockerConfig(pod)

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -19,7 +19,6 @@ func TestSTICreateBuildPod(t *testing.T) {
 	strategy := &STIBuildStrategy{
 		Image:                "sti-test-image",
 		TempDirectoryCreator: &FakeTempDirCreator{},
-		UseLocalImages:       true,
 		Codec:                v1beta1.Codec,
 	}
 

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -275,7 +275,6 @@ func start(cfg *config, args []string) error {
 
 	// define a function for resolving components to names
 	imageResolverFn := cfg.ImageTemplate.ExpandOrDie
-	useLocalImages := env("USE_LOCAL_IMAGES", "false") == "true"
 
 	// the node can reuse an existing client
 	var existingKubeClient *kclient.Client
@@ -372,8 +371,7 @@ func start(cfg *config, args []string) error {
 			MasterAuthorizationNamespace:  masterAuthorizationNamespace,
 			RequestContextMapper:          requestContextMapper,
 
-			UseLocalImages: useLocalImages,
-			ImageFor:       imageResolverFn,
+			ImageFor: imageResolverFn,
 		}
 
 		if startKube {

--- a/pkg/deploy/controller/deployment_controller.go
+++ b/pkg/deploy/controller/deployment_controller.go
@@ -32,8 +32,6 @@ type DeploymentController struct {
 	// Environment is a set of environment which should be injected into all deployment pod
 	// containers, in addition to whatever environment is specified by the ContainerCreator.
 	Environment []kapi.EnvVar
-	// UseLocalImages configures the ImagePullPolicy for containers in the deployment pod.
-	UseLocalImages bool
 	// Codec is used to decode DeploymentConfigs.
 	Codec runtime.Codec
 	// Stop is an optional channel that controls when the controller exits.
@@ -197,9 +195,7 @@ func (dc *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationCont
 		},
 	}
 
-	if dc.UseLocalImages {
-		pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
-	}
+	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 
 	return pod, nil
 }

--- a/pkg/deploy/controller/factory/factory.go
+++ b/pkg/deploy/controller/factory/factory.go
@@ -70,8 +70,6 @@ type DeploymentControllerFactory struct {
 	KubeClient *kclient.Client
 	// Environment is a set of environment which should be injected into all deployment pod containers.
 	Environment []kapi.EnvVar
-	// UseLocalImages configures the ImagePullPolicy for containers deployment pods.
-	UseLocalImages bool
 	// RecreateStrategyImage specifies which Docker image which should implement the Recreate strategy.
 	RecreateStrategyImage string
 	// Codec is used to decode DeploymentConfigs.
@@ -152,9 +150,8 @@ func (factory *DeploymentControllerFactory) Create() *controller.DeploymentContr
 			panicIfStopped(factory.Stop, "deployment controller stopped")
 			return pod
 		},
-		UseLocalImages: factory.UseLocalImages,
-		Codec:          factory.Codec,
-		Stop:           factory.Stop,
+		Codec: factory.Codec,
+		Stop:  factory.Stop,
 	}
 }
 

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -209,14 +209,12 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 		KubeClient:   kubeClient,
 		BuildUpdater: buildclient.NewOSClientBuildClient(osClient),
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
-			Image:          "test-docker-builder",
-			UseLocalImages: false,
-			Codec:          latest.Codec,
+			Image: "test-docker-builder",
+			Codec: latest.Codec,
 		},
 		STIBuildStrategy: &buildstrategy.STIBuildStrategy{
 			Image:                "test-sti-builder",
 			TempDirectoryCreator: buildstrategy.STITempDirectoryCreator,
-			UseLocalImages:       false,
 			Codec:                latest.Codec,
 		},
 		Stop: openshift.stop,


### PR DESCRIPTION
all containers for deployment/build will now just use the k8s default "pullIfNotPresent" behavior and there will be no way to override the behavior (the USE_LOCAL_IMAGES env variable is removed)
