### PR TITLE
tighten authorization rules

### DIFF
--- a/pkg/authorization/authorizer/bootstrap_policy.go
+++ b/pkg/authorization/authorizer/bootstrap_policy.go
@@ -194,18 +194,6 @@ func GetBootstrapPolicyBinding(masterNamespace string) *authorizationapi.PolicyB
 				},
 				Groups: util.NewStringSet("system:authenticated"),
 			},
-			"insecure-cluster-admin-binding": {
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      "insecure-cluster-admin-binding",
-					Namespace: masterNamespace,
-				},
-				RoleRef: kapi.ObjectReference{
-					Name:      "cluster-admin",
-					Namespace: masterNamespace,
-				},
-				// TODO until we decide to enforce policy, simply allow every one access
-				Groups: util.NewStringSet("system:authenticated", "system:unauthenticated"),
-			},
 			"system:delete-tokens-binding": {
 				ObjectMeta: kapi.ObjectMeta{
 					Name:      "system:delete-tokens-binding",

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -32,7 +32,7 @@ func TestSubjects(t *testing.T) {
 			Resource: "pods",
 		},
 		expectedUsers:  []string{"Anna", "ClusterAdmin", "Ellen", "Valerie", "system:kube-client", "system:openshift-client", "system:openshift-deployer"},
-		expectedGroups: []string{"RootUsers", "system:authenticated", "system:cluster-admins", "system:unauthenticated"},
+		expectedGroups: []string{"RootUsers", "system:cluster-admins"},
 	}
 	test.policies = newDefaultGlobalPolicies()
 	test.policies = append(test.policies, newAdzePolicies()...)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -26,18 +26,6 @@ func TestRestrictedAccessForProjectAdmins(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// TODO remove once bootstrap authorization rules are tightened
-	removeInsecureOptions := &policy.RemoveGroupOptions{
-		RoleNamespace:    "master",
-		RoleName:         "cluster-admin",
-		BindingNamespace: "master",
-		Client:           openshiftClient,
-		Groups:           []string{"system:authenticated", "system:unauthenticated"},
-	}
-	if err := removeInsecureOptions.Run(); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
 	haroldClient, err := CreateNewProject(openshiftClient, *openshiftClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -102,18 +90,6 @@ func TestResourceAccessReview(t *testing.T) {
 
 	openshiftClient, openshiftClientConfig, err := startConfig.GetOpenshiftClient()
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// TODO remove once bootstrap authorization rules are tightened
-	removeInsecureOptions := &policy.RemoveGroupOptions{
-		RoleNamespace:    "master",
-		RoleName:         "cluster-admin",
-		BindingNamespace: "master",
-		Client:           openshiftClient,
-		Groups:           []string{"system:authenticated", "system:unauthenticated"},
-	}
-	if err := removeInsecureOptions.Run(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
Removes cluster-admin rights from system:authenticated and system:unauthenticated.