### PR TITLE
Improve help for creating / being added to new projects

### DIFF
--- a/assets/app/scripts/controllers/projects.js
+++ b/assets/app/scripts/controllers/projects.js
@@ -16,7 +16,7 @@ angular.module('openshiftConsole')
     AuthService.withUser().then(function() {
       DataService.list("projects", $scope, function(projects) {
         $scope.projects = projects.by("metadata.name");
-        $scope.emptyMessage = "You have no projects. For an <a href='https://github.com/openshift/origin/tree/master/examples/sample-app'>example</a>, run <code>openshift cli create -f https://raw.githubusercontent.com/openshift/origin/master/examples/sample-app/project.json</code>";
+        $scope.emptyMessage = "No projects to show.";
       });
     });
   

--- a/assets/app/views/projects.html
+++ b/assets/app/views/projects.html
@@ -1,12 +1,16 @@
 <div class="container">
   <div>
     <h1 style="margin-top: 10px;">Projects</h1>
-    <div ng-if="(projects | hashSize) == 0">
-      <div ng-bind-html="emptyMessage"></div>
-    </div>
     <div class="tile tile-click" ng-click="tileClickHandler($event)" style="margin-bottom: 10px;" ng-repeat="project in projects">
       <h2><a class="tile-target" href="/project/{{project.metadata.name}}">{{project.displayName || project.metadata.name}}</a></h2>
       <div class="muted" style="margin-top: -5px;" ng-if="project | annotation : 'description'">{{project | annotation : 'description'}}</div>
+    </div>
+    <div ng-if="emptyMessage && (projects | hashSize) == 0">{{emptyMessage}}</div>
+    <div style="margin-top: 10px;">
+      To create a new project, run <code>openshift ex new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code>
+    </div>
+    <div style="margin-top: 10px;">
+      To be added as an admin to an existing project, run <code>openshift ex policy add-user admin {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>
     </div>
   </div>
 </div>

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -252,3 +252,11 @@ openshift ex policy add-user cluster-admin system:no-user
 openshift ex policy remove-user cluster-admin system:no-user
 openshift ex policy remove-user-from-project system:no-user
 echo "ex policy: ok"
+
+# Test the commands the UI projects page tells users to run
+# These should match what is described in projects.html
+openshift ex new-project ui-test-project --admin="anypassword:createuser"
+openshift ex policy add-user admin anypassword:adduser -n ui-test-project
+osc describe policybinding master -n ui-test-project | grep createuser
+osc describe policybinding master -n ui-test-project | grep adduser
+echo "UI project commands: ok"


### PR DESCRIPTION
Updates help text shown on the project page to describe how to create a new project or add the current user to an existing project