### PR TITLE
Bug 1190578 - Should prompt clear error when generate an application list code in a non-source code repository.

### DIFF
--- a/pkg/generate/generator/sourceref.go
+++ b/pkg/generate/generator/sourceref.go
@@ -48,7 +48,7 @@ func (g *SourceRefGenerator) FromDirectory(directory string) (*app.SourceRef, er
 	// Make sure that this is a git directory
 	gitRoot, err := g.repository.GetRootDir(directory)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not obtain git repository root for %s. The directory may not be part of a valid source repository.", directory)
 	}
 
 	// Get URL


### PR DESCRIPTION
Add a better error message when a git repository cannot be detected.