### PR TITLE
Integration tests need to run in separate processes

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -126,6 +126,9 @@ execute an individual test start etcd and then run:
 
     $ hack/test-go.sh test/integration -tags 'integration no-docker' -test.run=TestBuildClient
 
+Each integration function is executed in its own process so that it cleanly shuts down any background
+goroutines. You will not be able to run more than a single test within a single process.
+
 There is a CLI integration test suite which covers general non-Docker functionality of the CLI tool
 working against the API. Run it with:
 

--- a/hack/listtests.go
+++ b/hack/listtests.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"log"
+)
+
+var reLine = regexp.MustCompile("^\\s*(\\w+)\\s+(\\w+)\\s+(.+)$")
+
+func main() {
+	log.SetFlags(0)
+
+	dir := flag.String("dir", "", "the directory that contains the binary; if empty, the same as the first argument")
+	prefix := flag.String("prefix", "", "the function prefix to scan for; if not specified will use *<dirBasename>.Test*")
+	help := flag.Bool("help", false, "display help")
+	flag.Parse()
+
+	if *help {
+		flag.PrintDefaults()
+		return
+	}
+
+	args := flag.Args()
+	if len(args) == 0 {
+		log.Fatalf("Must specify the name of a single directory, e.g. ./test/integration")
+	}
+
+	path := args[0]
+	_ = args[1:]
+	base := filepath.Base(path)
+
+	execDir := path
+	if len(*dir) > 0 {
+		execDir = *dir
+	}
+
+	pkg := filepath.Join(execDir, fmt.Sprintf("%s.test", base))
+	test, err := filepath.Abs(pkg)
+	if err != nil {
+		log.Fatalf("Unable to make path %q absolute: %v", execDir, err)
+	}
+	if _, err := os.Stat(test); err != nil {
+		log.Fatalf("No test executable %q exits, did you run `go test -c` on the named package?", test)
+	}
+
+	cmd := exec.Command("go", "tool", "nm", "-sort", "name", "-n", test)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("Can't get `go tool nm` output from %q: %v", test, err)
+	}
+
+	names := []string{}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+		match := reLine.FindStringSubmatch(line)
+		if len(match) == 0 {
+			//log.Printf("mismatch: %s", line)
+			continue
+		}
+		// ignore non code segments
+		if match[2] != "T" {
+			continue
+		}
+		name := match[3]
+		// there are always two segments per function, ignore the extra one
+		if strings.HasSuffix(name, ".f") {
+			continue
+		}
+
+		segments := strings.SplitAfter(name, "/")
+		// expect a package and name
+		if len(segments) < 2 {
+			//log.Printf("root_package: %s", name)
+			continue
+		}
+		last := segments[len(segments)-1]
+		_ = segments[len(segments)-2]
+
+		// two parts
+		parts := strings.Split(last, ".")
+		if len(parts) != 2 {
+			//log.Printf("bad_name: %s", last)
+			continue
+		}
+		if parts[0] != base {
+			//log.Printf("ignore: %s", last)
+			continue
+		}
+
+		test := parts[1]
+		if len(*prefix) == 0 {
+			if !strings.HasPrefix(test, "Test") {
+				continue
+			}
+		} else {
+			if !strings.HasPrefix(name, *prefix) {
+				continue
+			}
+		}
+		names = append(names, test)
+	}
+
+	sort.Sort(sort.StringSlice(names))
+	for _, test := range names {
+		fmt.Printf("%s\n", test)
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Unable to scan the symbol output: %v", err)
+	}
+}

--- a/hack/test-integration-docker.sh
+++ b/hack/test-integration-docker.sh
@@ -5,21 +5,8 @@ set -o nounset
 set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${OS_ROOT}/hack/util.sh"
 
-function cleanup()
-{
-    set +e
-    kill ${ETCD_PID} 1>&2 2>/dev/null
-    rm -rf ${ETCD_DIR} 1>&2 2>/dev/null
-    echo
-    echo "Complete"
-}
+# Go to the top of the tree.
+cd "${OS_ROOT}"
 
-start_etcd
-trap cleanup EXIT SIGINT
-
-echo
-echo Docker integration test cases ...
-echo
-KUBE_RACE="${KUBE_RACE:-}" KUBE_COVER=" " "${OS_ROOT}/hack/test-go.sh" test/integration -tags 'integration docker' "${@:1}"
+OS_TEST_TAGS="integration docker" hack/test-integration.sh

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -225,9 +225,4 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 }
 
 func (t *testBuildOpenshift) Close() {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	close(t.stop)
-	t.server.CloseClientConnections()
-	t.server.Close()
 }

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -412,9 +412,6 @@ func NewTestOpenshift(t *testing.T) *testOpenshift {
 }
 
 func (t *testOpenshift) Close() {
-	close(t.stop)
-	t.Server.CloseClientConnections()
-	t.Server.Close()
 }
 
 type clientDeploymentInterface struct {

--- a/test/integration/imageclient_test.go
+++ b/test/integration/imageclient_test.go
@@ -196,9 +196,6 @@ type testImageOpenshift struct {
 }
 
 func (o *testImageOpenshift) Close() {
-	close(o.stop)
-	o.server.Close()
-	o.dockerServer.Close()
 }
 
 func NewTestImageOpenShift(t *testing.T) *testImageOpenshift {


### PR DESCRIPTION
Each test will run as a separate process, and exit after it's done. It's too
difficult today to end goroutines, and this removes a source of unpredictability
in our builds.  Adds a tiny bit to execution time.

@deads2k this is what I was referring too this morning