### PR TITLE
Bug 1194487 - Fix generate command repository detection

### DIFF
--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	argumentGit         = regexp.MustCompile("^(http://|https://|git@|git://).*\\.git(?:#([a-zA-Z0-9]*))?$")
+	argumentGit         = regexp.MustCompile("^(http://|https://|git@|git://).*(?:#([a-zA-Z0-9]*))?$")
 	argumentGitProtocol = regexp.MustCompile("^(git@|git://)")
 	argumentPath        = regexp.MustCompile("^\\.|^\\/[^/]+")
 )


### PR DESCRIPTION
Git repositories may not have a path that ends in .git 
https://bugzilla.redhat.com/show_bug.cgi?id=1194487