### PR TITLE
pretty up policy describe

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/set.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"reflect"
 	"sort"
 )
 
@@ -30,6 +31,18 @@ func NewStringSet(items ...string) StringSet {
 	ss := StringSet{}
 	ss.Insert(items...)
 	return ss
+}
+
+// KeySet creates a StringSet from a keys of a map[string](? extends interface{}).  Since you can't describe that map type in the Go type system
+// the reflected value is required.
+func KeySet(theMap reflect.Value) StringSet {
+	ret := StringSet{}
+
+	for _, keyValue := range theMap.MapKeys() {
+		ret.Insert(keyValue.String())
+	}
+
+	return ret
 }
 
 // Insert adds items to the set.

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -2,7 +2,7 @@ package describe
 
 import (
 	"fmt"
-	"sort"
+	"reflect"
 	"strings"
 	"text/tabwriter"
 
@@ -11,6 +11,7 @@ import (
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	kctl "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
@@ -276,14 +277,8 @@ func (d *PolicyDescriber) Describe(namespace, name string) (string, error) {
 		formatMeta(out, policy.ObjectMeta)
 		formatString(out, "Last Modified", policy.LastModified)
 
-		// display the rules in a consistent order
-		sortedKeys := make([]string, 0)
-		for key := range policy.Roles {
-			sortedKeys = append(sortedKeys, key)
-		}
-		sort.Strings(sortedKeys)
-
-		for _, key := range sortedKeys {
+		// using .List() here because I always want the sorted order that it provides
+		for _, key := range util.KeySet(reflect.ValueOf(policy.Roles)).List() {
 			role := policy.Roles[key]
 			fmt.Fprint(out, key+"\tVerbs\tResources\tExtension\n")
 			for _, rule := range role.Rules {
@@ -294,8 +289,8 @@ func (d *PolicyDescriber) Describe(namespace, name string) (string, error) {
 
 				fmt.Fprintf(out, "%v\t%v\t%v\t%v\n",
 					"",
-					rule.Verbs,
-					rule.Resources,
+					rule.Verbs.List(),
+					rule.Resources.List(),
 					extensionString)
 
 			}
@@ -323,14 +318,8 @@ func (d *PolicyBindingDescriber) Describe(namespace, name string) (string, error
 		formatString(out, "Last Modified", policyBinding.LastModified)
 		formatString(out, "Policy", policyBinding.PolicyRef.Namespace)
 
-		// display the rules in a consistent order
-		sortedKeys := make([]string, 0)
-		for key := range policyBinding.RoleBindings {
-			sortedKeys = append(sortedKeys, key)
-		}
-		sort.Strings(sortedKeys)
-
-		for _, key := range sortedKeys {
+		// using .List() here because I always want the sorted order that it provides
+		for _, key := range util.KeySet(reflect.ValueOf(policyBinding.RoleBindings)).List() {
 			roleBinding := policyBinding.RoleBindings[key]
 			formatString(out, "RoleBinding["+key+"]", " ")
 			formatString(out, "\tRole", roleBinding.RoleRef.Name)


### PR DESCRIPTION
The change to using string sets for PolicyRules produced some ugly output on describe.  This just tidies it back up.