### PR TITLE
add liveness probe to default router spec

### DIFF
--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -12,6 +12,7 @@ import (
 	kclientcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
@@ -195,6 +196,15 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 												Image: image,
 												Ports: ports,
 												Env:   env.List(),
+												LivenessProbe: &kapi.Probe{
+													Handler: kapi.Handler{
+														TCPSocket: &kapi.TCPSocketAction{
+															Port: kutil.IntOrString{
+																IntVal: ports[0].ContainerPort,
+															},
+														},
+													},
+												},
 											},
 										},
 									},


### PR DESCRIPTION
Just FYI, I did not use an http probe because the current implementation expects an OK  (well, technically >=200, < 400) response but in this case we expect a 503 from the router for pinging an unknown route.

@abhgupta @bparees - relevant to our email discussion about router using a probe 