### PR TITLE
Updating ruby-20 links and image name so they point to new repo and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ FAQ
     OpenShift is designed to run any existing Docker images.  In addition you can define builds that will produce new Docker images from a Dockerfile.  However the real magic of OpenShift can be seen when using [Source-To-Image](https://github.com/openshift/source-to-image)(STI) builds which allow you to simply supply an application source repository which will be combined with an existing STI-enabled Docker image to produce a new runnable image that runs your application.  We are continuing to grow the ecosystem of STI-enabled images and documenting them [here](https://ci.openshift.redhat.com/openshift-docs-master-testing/latest/openshift_sti_images/overview.html).  We also have a few more experimental images available:
 
     * [Wildfly](https://github.com/openshift/wildfly-8-centos)
-    * [Ruby](https://github.com/openshift/ruby-20-centos/)
 
 Contributing
 ------------

--- a/examples/image-repositories/image-repositories.json
+++ b/examples/image-repositories/image-repositories.json
@@ -3,10 +3,10 @@
   "items": [
     {
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "openshift/ruby-20-centos",
+      "dockerImageRepository": "openshift/ruby-20-centos7",
       "kind": "ImageRepository",
       "metadata": {
-        "name": "ruby-20-centos"
+        "name": "ruby-20-centos7"
       },
       "tags": {
         "latest": "latest"

--- a/examples/jenkins/application-template.json
+++ b/examples/jenkins/application-template.json
@@ -35,7 +35,7 @@
                 },
                 "strategy": {
                     "stiStrategy": {
-                        "image": "openshift/ruby-20-centos"
+                        "image": "openshift/ruby-20-centos7"
                     },
                     "type": "STI"
                 }

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -207,7 +207,7 @@ the present working directory is the same directory as this README.
     * A BuildConfig (ruby-sample-build) to specify a build that uses
       your ruby-hello-world fork as the input for a source-to-image (STI) build
     * ImageRepositories for the images used and created in the build:
-      * The ruby-20-centos STI builder will build an image from your source
+      * The ruby-20-centos7 STI builder will build an image from your source
       * The output image will be called origin-ruby-sample
     * DeploymentConfigs (frontend, backend) for defining Deployments once the images are available
     * Services (routable endpoints) for the ruby frontend and database backend deployments

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -38,7 +38,7 @@
       "apiVersion": "v1beta1",
       "kind": "ImageRepository",
       "metadata": {
-        "name": "ruby-20-centos"
+        "name": "ruby-20-centos7"
       }
     },
     {
@@ -82,9 +82,9 @@
         {
           "imageChange": {
             "from": {
-              "name": "ruby-20-centos"
+              "name": "ruby-20-centos7"
             },
-            "image": "openshift/ruby-20-centos",
+            "image": "openshift/ruby-20-centos7",
             "tag": "latest"
           },
           "type": "imageChange"

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -38,7 +38,7 @@
       "apiVersion": "v1beta1",
       "kind": "ImageRepository",
       "metadata": {
-        "name": "ruby-20-centos"
+        "name": "ruby-20-centos7"
       }
     },
     {
@@ -64,8 +64,7 @@
         },
         "strategy": {
           "stiStrategy": {
-            "image": "openshift/ruby-20-centos",
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+            "image": "openshift/ruby-20-centos7"
           },
           "type": "STI"
         }
@@ -86,9 +85,9 @@
         {
           "imageChange": {
             "from": {
-              "name": "ruby-20-centos"
+              "name": "ruby-20-centos7"
             },
-            "image": "openshift/ruby-20-centos",
+            "image": "openshift/ruby-20-centos7",
             "tag": "latest"
           },
           "type": "imageChange"

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -180,13 +180,13 @@ osc delete -f examples/sample-app/docker-registry-config.json
 osc delete imageRepositories test
 [ -z "$(osc get imageRepositories test -t "{{.status.dockerImageRepository}}")" ]
 osc create -f examples/image-repositories/image-repositories.json
-[ -n "$(osc get imageRepositories ruby-20-centos -t "{{.status.dockerImageRepository}}")" ]
+[ -n "$(osc get imageRepositories ruby-20-centos7 -t "{{.status.dockerImageRepository}}")" ]
 [ -n "$(osc get imageRepositories nodejs-010-centos7 -t "{{.status.dockerImageRepository}}")" ]
 [ -n "$(osc get imageRepositories wildfly-8-centos -t "{{.status.dockerImageRepository}}")" ]
-osc delete imageRepositories ruby-20-centos
+osc delete imageRepositories ruby-20-centos7
 osc delete imageRepositories nodejs-010-centos7
 osc delete imageRepositories wildfly-8-centos
-[ -z "$(osc get imageRepositories ruby-20-centos -t "{{.status.dockerImageRepository}}")" ]
+[ -z "$(osc get imageRepositories ruby-20-centos7 -t "{{.status.dockerImageRepository}}")" ]
 [ -z "$(osc get imageRepositories nodejs-010-centos7 -t "{{.status.dockerImageRepository}}")" ]
 [ -z "$(osc get imageRepositories wildfly-8-centos -t "{{.status.dockerImageRepository}}")" ]
 echo "imageRepositories: ok"
@@ -233,14 +233,14 @@ osc create -f test/integration/fixtures/test-buildcli.json
 # the build should use the image field as defined in the buildconfig
 started=$(osc start-build ruby-sample-build-invalidtag)
 echo "start-build: ok"
-osc describe build ${started} | grep openshift/ruby-20-centos$
+osc describe build ${started} | grep openshift/ruby-20-centos7$
 
 osc cancel-build "${started}" --dump-logs --restart
 # a build for which there is an upstream tag in the corresponding imagerepo, so
 # the build should use that specific tag of the image instead of the image field
 # as defined in the buildconfig
 started=$(osc start-build ruby-sample-build-validtag)
-osc describe build ${started} | grep openshift/ruby-20-centos:success$
+osc describe build ${started} | grep openshift/ruby-20-centos7:success$
 osc cancel-build "${started}" --dump-logs --restart
 echo "cancel-build: ok"
 

--- a/images/builder/docker/sti-image-builder/README.md
+++ b/images/builder/docker/sti-image-builder/README.md
@@ -18,7 +18,7 @@ The sample custom BuildConfig definition might look as following:
   "kind": "BuildConfig",
   "apiVersion": "v1beta1",
   "metadata":{
-    "name": "ruby-20-centos-build"
+    "name": "ruby-20-centos7-build"
   },
   "triggers": [
     {
@@ -32,7 +32,7 @@ The sample custom BuildConfig definition might look as following:
     "source" : {
       "type" : "Git",
       "git" : {
-        "uri": "git://github.com/openshift/ruby-20-centos.git"
+        "uri": "git://github.com/openshift/sti-ruby.git"
       }
     },
     "strategy": {
@@ -41,27 +41,27 @@ The sample custom BuildConfig definition might look as following:
         "image": "openshift/sti-image-builder",
         "exposeDockerSocket": true,
         "env": [
-          { "name": "IMAGE_NAME", "value": "openshift/ruby-20-centos"}
-          { "name": "CONTEXT_DIR", "value": "."}
+          { "name": "IMAGE_NAME", "value": "openshift/ruby-20-centos7"}
+          { "name": "CONTEXT_DIR", "value": "/2.0/"}
         ]
       }
     },
     "output": {
-      "to": "ruby-20-centos-repository",
+      "to": "ruby-20-centos7-repository",
       "tag": "latest",
     },
   },
   "labels": {
-    "name": "ruby-20-centos-build"
+    "name": "ruby-20-centos7-build"
   }
 }
 
 ```
 
-This example will trigger a build for the 'ruby-20-centos' everytime there is a
+This example will trigger a build for the 'ruby-20-centos7' everytime there is a
 push into its Github repository. It will set the name of the resulting image to
-"openshift/ruby-20-centos" and it expects the Dockerfile to be present in the
+"openshift/ruby-20-centos7" and it expects the Dockerfile to be present in the
 root directory of the GIT repository.
 
-After a successful build, the 'openshift/ruby-20-centos' image will be pushed
-into "ruby-20-centos-repository" ImageRepository and tagged as 'latest'.
+After a successful build, the 'openshift/ruby-20-centos7' image will be pushed
+into "ruby-20-centos7-repository" ImageRepository and tagged as 'latest'.

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -23,9 +23,9 @@ tools to interact with each component of your system.
 At the present time, the CLI wraps many of the upstream Kubernetes commands and works generically
 on all resources.  To create a new application, try:
 
-    $ %[1]s new-app openshift/ruby-20-centos~git@github.com/mfojtik/sinatra-app-example
+    $ %[1]s new-app openshift/ruby-20-centos7~git@github.com/mfojtik/sinatra-app-example
 
-This will create an application based on the Docker image 'openshift/ruby-20-centos' that builds
+This will create an application based on the Docker image 'openshift/ruby-20-centos7' that builds
 the source code at 'github.com/mfojtik/sinatra-app-example'. To start the build, run
 
     $ %[1]s start-build sinatra-app-example

--- a/pkg/cmd/experimental/generate/generate.go
+++ b/pkg/cmd/experimental/generate/generate.go
@@ -62,7 +62,7 @@ Examples:
     $ openshift ex generate https://github.com/openshift/ruby-hello-world.git
 
     # Force the application to use the specific builder-image
-    $ openshift ex generate --builder-image=openshift/ruby-20-centos
+    $ openshift ex generate --builder-image=openshift/ruby-20-centos7
 `
 
 type params struct {

--- a/test/integration/fixtures/test-buildcli.json
+++ b/test/integration/fixtures/test-buildcli.json
@@ -3,10 +3,10 @@
   "items": [
     {
       "apiVersion": "v1beta1",
-      "dockerImageRepository": "openshift/ruby-20-centos",
+      "dockerImageRepository": "openshift/ruby-20-centos7",
       "kind": "ImageRepository",
       "metadata": {
-        "name": "ruby-20-centos-buildcli"
+        "name": "ruby-20-centos7-buildcli"
       },
       "tags": {
         "valid": "success"
@@ -35,8 +35,8 @@
         },
         "strategy": {
           "stiStrategy": {
-            "image": "openshift/ruby-20-centos",
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+            "image": "openshift/ruby-20-centos7",
+            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos7/master/.sti/bin"
           },
           "type": "STI"
         }
@@ -45,9 +45,9 @@
         {
           "imageChange": {
             "from": {
-              "name": "ruby-20-centos-buildcli"
+              "name": "ruby-20-centos7-buildcli"
             },
-            "image": "openshift/ruby-20-centos",
+            "image": "openshift/ruby-20-centos7",
             "tag": "valid"
           },
           "type": "imageChange"
@@ -77,8 +77,8 @@
         },
         "strategy": {
           "stiStrategy": {
-            "image": "openshift/ruby-20-centos",
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+            "image": "openshift/ruby-20-centos7",
+            "scripts": "https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin"
           },
           "type": "STI"
         }
@@ -87,9 +87,9 @@
         {
           "imageChange": {
             "from": {
-              "name": "ruby-20-centos-buildcli"
+              "name": "ruby-20-centos7-buildcli"
             },
-            "image": "openshift/ruby-20-centos",
+            "image": "openshift/ruby-20-centos7",
             "tag": "invalid"
           },
           "type": "imageChange"


### PR DESCRIPTION
This is a part of work on https://trello.com/c/UJG1mPZf/364-3-v3-ruby-image-image-beta2
Also last step before we cant get rid of the ruby-20-centos repository