### PR TITLE
Make cli examples consistent across OpenShift

### DIFF
--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -18,8 +18,10 @@ func NewCmdBuildLogs(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 NOTE: This command may be moved in the future.
 
 Examples:
-$ osc build-logs 566bed879d2d
-<stream logs from container to stdout>`,
+
+	# Stream logs from container to stdout
+	$ osc build-logs 566bed879d2d
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				usageError(cmd, "<build> is a required argument")

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -26,14 +26,16 @@ func NewCmdCancelBuild(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 Cancels a pending or running build.
 
 Examples:
+
+	# Cancel the build with the given name
 	$ osc cancel-build 1da32cvq
-	<cancel the build with the given name>
-
+	
+	# Cancel the named build and print the build logs
 	$ osc cancel-build 1da32cvq --dump-logs
-	<cancel the named build and print the build logs>
 
+	# Cancel the named build and create a new one with the same parameters
 	$ osc cancel-build 1da32cvq --restart
-	<cancel the named build and create a new one with the same parameters>`,
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if len(args) == 0 || len(args[0]) == 0 {

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -34,17 +34,15 @@ image that can run inside of a pod. The images will be deployed via a deployment
 configuration, and a service will be hookup up to the first public port of the app.
 
 Examples:
-  $ osc new-app .
-  <try to create an application based on the source code in the current directory>
 
-  $ osc new-app mysql
-  <use the public Docker Hub MySQL image to create an app>
+	# Try to create an application based on the source code in the current directory
+	$ osc new-app .
 
-  $ osc new-app myregistry.com/mycompany/mysql
-  <use a MySQL image in a private registry to create an app>
+	$ Use the public Docker Hub MySQL image to create an app
+	$ osc new-app mysql
 
-  $ osc new-app openshift/ruby-20-centos~git@github.com/mfojtik/sinatra-app-example
-  <build an application using the OpenShift Ruby Docker Hub image and an example repo>
+	# Use a MySQL image in a private registry to create an app
+	$ osc new-app myregistry.com/mycompany/mysql
 
 If you specify source code, you may need to run a build with 'start-build' after the
 application is created.

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -45,11 +45,13 @@ func NewCmdProcess(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 JSON and YAML formats are accepted.
 
 Examples:
-  $ osc process -f template.json
-  <convert template.json into resource list>
 
-  $ cat template.json | osc process -f -
-  <convert template.json into resource list>`,
+	# Convert template.json into resource list
+	$ osc process -f template.json
+
+	# Convert template.json into resource list
+	$ cat template.json | osc process -f -
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := cmdutil.GetFlagString(cmd, "filename")
 			if len(filename) == 0 {

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -31,17 +31,15 @@ executing the rollback. This is useful if you're not quite sure what the outcome
 will be.
 
 Examples:
-  Perform a rollback:
 
-  $ %[1]s %[2]s deployment-1
+	# Perform a rollback
+	$ %[1]s %[2]s deployment-1
 
-  See what the rollback will look like, but don't perform the rollback:
+	# See what the rollback will look like, but don't perform the rollback
+	$ %[1]s %[2]s deployment-1 --dry-run
 
-  $ %[1]s %[2]s deployment-1 --dry-run
-
-  Perform the rollback manually by piping the JSON of the new config back to %[1]s:
-
-  $ %[1]s %[2]s deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -
+	# Perform the rollback manually by piping the JSON of the new config back to %[1]s
+	$ %[1]s %[2]s deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -
 `
 
 func NewCmdRollback(parentName string, name string, f *clientcmd.Factory, out io.Writer) *cobra.Command {

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -24,11 +24,13 @@ Manually starts build from existing build or buildConfig
 NOTE: This command is experimental and is subject to change in the future.
 
 Examples:
-  $ osc start-build 3bd2ug53b
-  <Starts build from buildConfig matching the name "3bd2ug53b">
 
-  $ osc start-build --from-build=3bd2ug53b
-  <Starts build from build matching the name "3bd2ug53b">`,
+	# Starts build from buildConfig matching the name "3bd2ug53b"
+	$ osc start-build 3bd2ug53b
+
+	# Starts build from build matching the name "3bd2ug53b"
+	$ osc start-build --from-build=3bd2ug53b
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			buildName := cmdutil.GetFlagString(cmd, "from-build")
 			if len(args) != 1 && len(buildName) == 0 {

--- a/pkg/cmd/experimental/generate/generate.go
+++ b/pkg/cmd/experimental/generate/generate.go
@@ -52,17 +52,18 @@ If not specified, the current directory is used.
 
 Examples:
 
+	# Find a git repository in the current directory and build artifacts based on detection
     $ openshift ex generate
-    <finds a git repository in the current directory and builds artifacts based on detection>
 
+    # Specify the directory for the repository to use
     $ openshift ex generate ./repo/dir
-    <specify the directory for the repository to use>
 
+    # Use a remote git repository
     $ openshift ex generate https://github.com/openshift/ruby-hello-world.git
-    <use a remote git repository>
 
+    # Force the application to use the specific builder-image
     $ openshift ex generate --builder-image=openshift/ruby-20-centos
-    <force the application to use the specific builder-image>`
+`
 
 type params struct {
 	name,


### PR DESCRIPTION
There should be four instead of two or no spaces in aligned examples for markdown reasons

Inspired by https://github.com/GoogleCloudPlatform/kubernetes/pull/4295