### PR TITLE
Make Clients API consistent

### DIFF
--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -47,7 +47,7 @@ func NewCommandDeployer(name string) *cobra.Command {
 		Short: "Run the OpenShift deployer",
 		Long:  longCommandDesc,
 		Run: func(c *cobra.Command, args []string) {
-			kClient, _, err := cfg.Config.Clients()
+			_, kClient, err := cfg.Config.Clients()
 			if err != nil {
 				glog.Fatal(err)
 			}

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -75,7 +75,7 @@ func makeTemplatePlugin(cfg *templateRouterConfig) (*templateplugin.TemplatePlug
 
 // start launches the load balancer.
 func start(cfg *clientcmd.Config, plugin router.Plugin) error {
-	kubeClient, osClient, err := cfg.Clients()
+	osClient, kubeClient, err := cfg.Clients()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util/clientcmd/clientcmd.go
+++ b/pkg/cmd/util/clientcmd/clientcmd.go
@@ -115,7 +115,7 @@ func (cfg *Config) OpenShiftConfig() *kclient.Config {
 	return &osConfig
 }
 
-func (cfg *Config) Clients() (kclient.Interface, osclient.Interface, error) {
+func (cfg *Config) Clients() (osclient.Interface, kclient.Interface, error) {
 	cfg.bindEnv()
 
 	kubeClient, err := kclient.New(cfg.KubeConfig())
@@ -128,5 +128,5 @@ func (cfg *Config) Clients() (kclient.Interface, osclient.Interface, error) {
 		return nil, nil, fmt.Errorf("Unable to configure OpenShift client: %v", err)
 	}
 
-	return kubeClient, osClient, nil
+	return osClient, kubeClient, nil
 }


### PR DESCRIPTION
The Factory call on Clients first returns the OpenShift client
and seconds it with the Kube client [1]. Use the same convention
for the Config call.

[1] https://github.com/openshift/origin/blob/9137b8815aad9517f2d5699773f120d95ba081ac/pkg/cmd/util/clientcmd/factory.go#L119