### PR TITLE
Fix broken deployer pod GenerateName reference

### DIFF
--- a/pkg/deploy/controller/deployment_controller.go
+++ b/pkg/deploy/controller/deployment_controller.go
@@ -64,12 +64,13 @@ func (dc *DeploymentController) HandleDeployment(deployment *kapi.ReplicationCon
 
 	switch currentStatus {
 	case deployapi.DeploymentStatusNew:
-		deploymentPod, makeDeployerPodErr := dc.makeDeployerPod(deployment)
-		if makeDeployerPodErr != nil {
-			return fmt.Errorf("couldn't make deployer pod for %s: %v", labelForDeployment(deployment), makeDeployerPodErr)
+		podTemplate, err := dc.makeDeployerPod(deployment)
+		if err != nil {
+			return fmt.Errorf("couldn't make deployer pod for %s: %v", labelForDeployment(deployment), err)
 		}
 
-		if _, err := dc.PodClient.CreatePod(deployment.Namespace, deploymentPod); err != nil {
+		deploymentPod, err := dc.PodClient.CreatePod(deployment.Namespace, podTemplate)
+		if err != nil {
 			// If the pod already exists, it's possible that a previous CreatePod succeeded but
 			// the deployment state update failed and now we're re-entering.
 			if !kerrors.IsAlreadyExists(err) {

--- a/pkg/deploy/controller/deployment_controller_test.go
+++ b/pkg/deploy/controller/deployment_controller_test.go
@@ -63,8 +63,16 @@ func TestHandleNewDeploymentCreatePodOk(t *testing.T) {
 		t.Fatalf("expected a pod to be created")
 	}
 
+	if _, hasPodAnnotation := updatedDeployment.Annotations[deployapi.DeploymentPodAnnotation]; !hasPodAnnotation {
+		t.Fatalf("missing deployment pod annotation")
+	}
+
 	if e, a := createdPod.Name, updatedDeployment.Annotations[deployapi.DeploymentPodAnnotation]; e != a {
 		t.Fatalf("expected deployment pod annotation %s, got %s", e, a)
+	}
+
+	if _, hasDeploymentAnnotation := createdPod.Annotations[deployapi.DeploymentAnnotation]; !hasDeploymentAnnotation {
+		t.Fatalf("missing deployment annotation")
 	}
 
 	if e, a := updatedDeployment.Name, createdPod.Annotations[deployapi.DeploymentAnnotation]; e != a {


### PR DESCRIPTION
A refactor to use GenerateName in the DeploymentController's pod
template generation failed to take into account the field change
in subsequent pod references within the calling code. The omission
resulted in the pod never being properly correlated with the
deployment.