### PR TITLE
Use a versioned printer for rollback configs

### DIFF
--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kubectl "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/spf13/cobra"
 
+	latest "github.com/openshift/origin/pkg/api/latest"
 	describe "github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -88,7 +90,8 @@ func NewCmdRollback(parentName string, name string, f *clientcmd.Factory, out io
 			if len(outputFormat) > 0 {
 				printer, _, perr := kubectl.GetPrinter(outputFormat, outputTemplate)
 				checkErr(perr)
-				printer.PrintObj(newConfig, out)
+				versionedPrinter := kubectl.NewVersionedPrinter(printer, kapi.Scheme, latest.Version)
+				versionedPrinter.PrintObj(newConfig, out)
 				return
 			}
 


### PR DESCRIPTION
When rendering rollback deployment configs, use a versioned printer
to ensure that the rendered output can be safely fed back to the REST
API for updates. Failing to use a versioned printer omits key fields
like Kind and ApiVersion.