### PR TITLE
Rebase STI to pickup .sti/environment support

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -594,42 +594,42 @@
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/git",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
 			"Comment": "v0.2",
-			"Rev": "ad5adc054311686baf316cd8bf91c4d42ae1bd4e"
+			"Rev": "c0c154efcba27ea5693c428bfe28560c220b4850"
 		},
 		{
 			"ImportPath": "github.com/pkg/profile",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/scripts.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/scripts.go
@@ -9,6 +9,11 @@ const (
 	SaveArtifacts = "save-artifacts"
 	// Usage is the name of the script responsible for printing the builder image's short info.
 	Usage = "usage"
+
+	// Environment contains list of key value pairs that will be set during the
+	// STI build. Users can use this file to provide extra configuration
+	// depending on the builder image used.
+	Environment = "environment"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/types.go
@@ -21,8 +21,8 @@ type Request struct {
 	// Tag is a result image tag name.
 	Tag string
 
-	// Clean describes whether to perform full build even if the build is eligible for incremental build.
-	Clean bool
+	// Incremental describes whether to try to perform incremental build.
+	Incremental bool
 
 	// RemovePreviousImage describes if previous image should be removed after successful build.
 	// This applies only to incremental builds.
@@ -42,9 +42,6 @@ type Request struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool
-
-	// Incremental describes incremental status of current build
-	Incremental bool
 
 	// WorkingDir describes temporary directory used for downloading sources, scripts and tar operations.
 	WorkingDir string

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/build/strategies/sti"
 	"github.com/openshift/source-to-image/pkg/docker"
 	"github.com/openshift/source-to-image/pkg/git"
+	"github.com/openshift/source-to-image/pkg/scripts"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
 )
@@ -123,6 +124,12 @@ func (b *OnBuild) CreateDockerfile(request *api.Request) error {
 	entrypoint, err := GuessEntrypoint(b.fs, uploadDir)
 	if err != nil {
 		return err
+	}
+	env, err := scripts.GetEnvironment(request)
+	if err != nil {
+		glog.V(1).Infof("Environment: %v", err)
+	} else {
+		buffer.WriteString(scripts.ConvertEnvironmentToDocker(env))
 	}
 	// If there is an assemble script present, run it as part of the build process
 	// as the last thing.

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
@@ -51,6 +51,7 @@ type STI struct {
 	optionalScripts  []string
 	externalScripts  map[string]bool
 	installedScripts map[string]bool
+	incremental      bool
 
 	// Interfaces
 	preparer  build.Preparer
@@ -112,14 +113,14 @@ func (b *STI) Build(request *api.Request) (*api.Result, error) {
 		return nil, err
 	}
 
-	if b.request.Incremental = b.artifacts.Exists(request); b.request.Incremental {
+	if b.incremental = b.artifacts.Exists(request); b.incremental {
 		glog.V(1).Infof("Existing image for tag %s detected for incremental build", request.Tag)
 	} else {
 		glog.V(1).Infof("Clean build will be performed")
 	}
 
 	glog.V(2).Infof("Performing source build from %s", request.Source)
-	if request.Incremental {
+	if b.incremental {
 		if err := b.artifacts.Save(request); err != nil {
 			glog.Warningf("Error saving previous build artifacts: %v", err)
 			glog.Warning("Clean build will be performed!")
@@ -202,16 +203,23 @@ func (b *STI) PostExecute(containerID string, location string) error {
 		previousImageID string
 	)
 
-	if b.request.Incremental && b.request.RemovePreviousImage {
+	if b.incremental && b.request.RemovePreviousImage {
 		if previousImageID, err = b.docker.GetImageID(b.request.Tag); err != nil {
 			glog.Errorf("Error retrieving previous image's metadata: %v", err)
 		}
 	}
 
+	env, err := scripts.GetEnvironment(b.request)
+	if err != nil {
+		glog.V(1).Infof("No .sti/environment provided (%v)", err)
+	}
+
+	buildEnv := append(scripts.ConvertEnvironment(env), b.generateConfigEnv()...)
+
 	cmd := []string{}
 	opts := docker.CommitContainerOptions{
 		Command:     append(cmd, filepath.Join(location, api.Run)),
-		Env:         b.generateConfigEnv(),
+		Env:         buildEnv,
 		ContainerID: containerID,
 		Repository:  b.request.Tag,
 	}
@@ -225,7 +233,7 @@ func (b *STI) PostExecute(containerID string, location string) error {
 	b.result.ImageID = imageID
 	glog.V(1).Infof("Tagged %s as %s", imageID, b.request.Tag)
 
-	if b.request.Incremental && b.request.RemovePreviousImage && previousImageID != "" {
+	if b.incremental && b.request.RemovePreviousImage && previousImageID != "" {
 		glog.V(1).Infof("Removing previously-tagged image %s", previousImageID)
 		if err = b.docker.RemoveImage(previousImageID); err != nil {
 			glog.Errorf("Unable to remove previous image: %v", err)
@@ -244,7 +252,7 @@ func (b *STI) PostExecute(containerID string, location string) error {
 // It checks if the previous image exists in the system and if so, then it
 // verifies that the save-artifacts script is present.
 func (b *STI) Exists(request *api.Request) bool {
-	if request.Clean {
+	if !request.Incremental {
 		return false
 	}
 
@@ -295,6 +303,13 @@ func (b *STI) Save(request *api.Request) (err error) {
 func (b *STI) Execute(command string, request *api.Request) error {
 	glog.V(2).Infof("Using image name %s", request.BaseImage)
 
+	env, err := scripts.GetEnvironment(request)
+	if err != nil {
+		glog.V(1).Infof("No .sti/environment provided (%v)", err)
+	}
+
+	buildEnv := append(scripts.ConvertEnvironment(env), b.generateConfigEnv()...)
+
 	uploadDir := filepath.Join(request.WorkingDir, "upload")
 	tarFileName, err := b.tar.CreateTarFile(request.WorkingDir, uploadDir)
 	if err != nil {
@@ -328,7 +343,7 @@ func (b *STI) Execute(command string, request *api.Request) error {
 		ScriptsURL:      request.ScriptsURL,
 		Location:        request.Location,
 		Command:         command,
-		Env:             b.generateConfigEnv(),
+		Env:             buildEnv,
 		PostExec:        b.postExecutor,
 	}
 	if !request.LayeredBuild {

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/config/config.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/config/config.go
@@ -45,7 +45,7 @@ func Save(req *api.Request, cmd *cobra.Command) {
 	return
 }
 
-// Restore loads the arguments from disk and prefill the Request
+// Restore loads the arguments from disk and prefills the Request
 func Restore(req *api.Request, cmd *cobra.Command) {
 	data, err := ioutil.ReadFile(DefaultConfigPath)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/create.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/create.go
@@ -14,8 +14,7 @@ type Bootstrap struct {
 	ImageName      string
 }
 
-// NewCreate returns a new bootstrap for given image name and destination
-// directory
+// New returns a new bootstrap for given image name and destination directory
 func New(name, dst string) *Bootstrap {
 	return &Bootstrap{ImageName: name, DestinationDir: dst}
 }

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/templates/docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/templates/docker.go
@@ -2,44 +2,18 @@ package templates
 
 const Dockerfile = `
 # {{.ImageName}}
-FROM centos:centos7
+FROM openshift/base-centos7
 
-# TODO: Install required packages:
-#
-# RUN yum install -y --enablerepo=centosplus epel-release <packages>
+ENV STI_NODEJS_VERSION 0.10
 
+# TODO: Install required packages here:
+# RUN yum install -y ... ; yum clean all -y
 
-# Add STI usage script
-ADD ./.sti/bin/usage /usage
+USER default
 
-# You can add any other required files/configurations here
-# ADD conf /app-root/conf
+# TODO (optional): Copy the builder files into /opt/openshift
+# COPY ./<builder_folder>/ /opt/openshift/
 
-# TODO: Define the URL from where the default STI script will be fetched:
-#
-# ENV STI_SCRIPTS_URL https://raw.githubusercontent.com/<repository>/master/.sti/bin
-
-# Default destination of scripts and sources, this is where assemble will look for them
-ENV STI_LOCATION /tmp
-
-# TODO: Create the application runtime user account and app-root directory:
-RUN mkdir -p /app-root/src && \
-    groupadd -r appuser -f -g 433 && \
-    useradd -u 431 -r -g appuser -d /app-root -s /sbin/nologin -c "Application user" appuser && \
-    chown -R appuser:appuser /app-root
-
-# TODO: Specify the application root folder (if other than root folder), application user
-#				and working directory.
-#
-ENV APP_ROOT .
-ENV HOME     /app-root
-ENV PATH     $HOME/bin:$PATH
-
-WORKDIR     /app-root/src
-USER        appuser
-
-# TODO: Specify the default port your application is running on
-EXPOSE 8080
-
-CMD ["/usage"]
+# TODO: Set the default port for applications built using this image
+# EXPOSE 3000
 `

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/templates/scripts.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/templates/scripts.go
@@ -10,38 +10,25 @@ const AssembleScript = `
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
-# The $HOME variable points to the application root
-HOME=${HOME-"/app-root"}
-
-# The application sources are mounted during the STI build into /tmp/src
-APP_SRC_DIR="/tmp/src"
-
-# The directory where the sources should be installed
-APP_RUNTIME_DIR="${HOME}/src"
-
-# Display assemble script usage
-#
 if [ "$1" = "-h" ]; then
 	# If the '{{.ImageName}}' assemble script is executed with '-h' flag,
 	# print the usage.
-	exit 0
+	exec /usr/local/sti/usage
 fi
 
 # Restore artifacts from the previous build (if exists).
 #
 if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
-	echo "Restoring build artifacts"
-	mv /tmp/artifacts/* $HOME/.
+  echo "---> Restoring build artifacts"
+  mv /tmp/artifacts/* ./
 fi
 
 echo "---> Installing application source"
-mkdir -p ${APP_RUNTIME_DIR}
-cp -Rf ${APP_SRC_DIR}/* ${APP_RUNTIME_DIR}/
+cp -Rf /tmp/src/* ./
 
-pushd "$APP_RUNTIME_DIR/${APP_ROOT}" >/dev/null
 echo "---> Building application from source"
-# TODO: Add build steps for your application
-popd >/dev/null
+# TODO: Add build steps for your application, for example npm install or
+#       bundle install, etc...
 `
 
 const RunScript = `
@@ -53,9 +40,7 @@ const RunScript = `
 # For more informations see the documentation:
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
-APP_ROOT_DIR="${HOME}/src/${APP_ROOT:-.}"
 
-cd $APP_ROOT_DIR
 exec <start your server here>
 `
 
@@ -85,7 +70,5 @@ const SaveArtifactsScript = `
 # For more informations see the documentation:
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
-pushd ${HOME} >/dev/null
 # tar cf - <list of files and folders>
-popd >/dev/null
 `

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/templates/test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/create/templates/test.go
@@ -155,5 +155,4 @@ build:
 test:
 	docker build -t $(IMAGE_NAME)-candidate .
 	IMAGE_NAME=$(IMAGE_NAME)-candidate test/run
-
 `

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/environment.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/environment.go
@@ -1,0 +1,73 @@
+package scripts
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+// Environment represents a single environment variable definition
+type Environment struct {
+	Name  string
+	Value string
+}
+
+// GetEnvironment gets the .sti/environment file located in the sources and
+// parse it into []environment
+func GetEnvironment(request *api.Request) ([]Environment, error) {
+	envPath := filepath.Join(request.WorkingDir, api.Source, ".sti", api.Environment)
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		return nil, errors.New("no evironment file found in application sources")
+	}
+
+	f, err := os.Open(envPath)
+	if err != nil {
+		return nil, errors.New("unable to read .sti/environment file")
+	}
+	defer f.Close()
+
+	result := []Environment{}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		s := scanner.Text()
+		// Allow for comments in environment file
+		if strings.HasPrefix(s, "#") {
+			continue
+		}
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		e := Environment{
+			Name:  strings.TrimSpace(parts[0]),
+			Value: strings.TrimSpace(parts[1]),
+		}
+		glog.V(1).Infof("Setting '%s' to '%s'", e.Name, e.Value)
+		result = append(result, e)
+	}
+
+	return result, scanner.Err()
+}
+
+// ConvertEnvironment converts the []Environment to "key=val" strings
+func ConvertEnvironment(env []Environment) (result []string) {
+	for _, e := range env {
+		result = append(result, fmt.Sprintf("%s=%s", e.Name, e.Value))
+	}
+	return
+}
+
+// ConvertEnvironmentToDocker converts the []Environment into Dockerfile format
+func ConvertEnvironmentToDocker(env []Environment) (result string) {
+	for _, e := range env {
+		result += fmt.Sprintf("ENV %s %s\n", e.Name, e.Value)
+	}
+	return
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/environment_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scripts/environment_test.go
@@ -1,0 +1,16 @@
+package scripts
+
+import "testing"
+
+func TestConvertEnvironment(t *testing.T) {
+	env := []Environment{
+		{"FOO", "BAR"},
+	}
+	result := ConvertEnvironment(env)
+	if len(result) != 1 {
+		t.Errorf("Expected 1 item, got %d", len(result))
+	}
+	if result[0] != "FOO=BAR" {
+		t.Errorf("Expected FOO=BAR, got %v", result)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/test/docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/test/docker.go
@@ -36,6 +36,8 @@ type FakeDocker struct {
 	RemoveImageError             error
 	BuildImageOpts               docker.BuildImageOptions
 	BuildImageError              error
+	PullResult                   bool
+	PullError                    error
 
 	mutex sync.Mutex
 }
@@ -105,7 +107,11 @@ func (f *FakeDocker) RemoveImage(name string) error {
 
 // PullImage pulls a fake docker image
 func (f *FakeDocker) PullImage(imageName string) (*dockerclient.Image, error) {
-	return nil, nil
+	if f.PullResult {
+		return &dockerclient.Image{}, nil
+	}
+
+	return nil, f.PullError
 }
 
 // CheckAndPull pulls a fake docker image

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/test/download.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/test/download.go
@@ -7,19 +7,19 @@ import (
 
 // FakeDownloader provides a fake downloader interface
 type FakeDownloader struct {
-	URL   []url.URL
-	File  []string
-	Err   map[string]error
-	mutex sync.Mutex
+	URL    []url.URL
+	Target []string
+	Err    map[string]error
+	mutex  sync.Mutex
 }
 
-// DownloadFile downloads a fake file from the URL
-func (f *FakeDownloader) DownloadFile(url *url.URL, targetFile string) (bool, error) {
+// Download downloads a fake file from the URL
+func (f *FakeDownloader) Download(url *url.URL, target string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
 	f.URL = append(f.URL, *url)
-	f.File = append(f.File, targetFile)
+	f.Target = append(f.Target, target)
 
-	return true, f.Err[url.String()]
+	return f.Err[url.String()]
 }

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/test/install.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/test/install.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+// FakeInstaller provides a fake installer
+type FakeInstaller struct {
+	Scripts [][]string
+	DstDir  []string
+	Error   error
+}
+
+func (f *FakeInstaller) run(scripts []string, dstDir string) []api.InstallResult {
+	result := []api.InstallResult{}
+	f.Scripts = append(f.Scripts, scripts)
+	f.DstDir = append(f.DstDir, dstDir)
+	return result
+}
+
+func (f *FakeInstaller) InstallRequired(scripts []string, dstDir string) ([]api.InstallResult, error) {
+	return f.run(scripts, dstDir), f.Error
+}
+
+func (f *FakeInstaller) InstallOptional(scripts []string, dstDir string) []api.InstallResult {
+	return f.run(scripts, dstDir)
+}

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -40,8 +40,9 @@ func (s *STIBuilder) Build() error {
 		Tag:          tag,
 		ScriptsURL:   s.build.Parameters.Strategy.STIStrategy.Scripts,
 		Environment:  getBuildEnvVars(s.build),
-		Clean:        !s.build.Parameters.Strategy.STIStrategy.Incremental,
+		Incremental:  s.build.Parameters.Strategy.STIStrategy.Incremental,
 	}
+
 	if s.build.Parameters.Revision != nil && s.build.Parameters.Revision.Git != nil &&
 		s.build.Parameters.Revision.Git.Commit != "" {
 		request.Ref = s.build.Parameters.Revision.Git.Commit


### PR DESCRIPTION
This rebase brings the support for `.sti/environment` file to Origin (see: https://github.com/openshift/source-to-image/pull/145) (Trello#499)