### PR TITLE
Add ./hack/verify-jsonformat.sh to have properly formatted JSON files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
 
 install:
   - ./hack/verify-gofmt.sh
+  - ./hack/verify-jsonformat.sh
   - ./hack/install-etcd.sh
   - ./hack/install-std-race.sh
   - ./hack/install-tools.sh

--- a/examples/hello-openshift/hello-pod.json
+++ b/examples/hello-openshift/hello-pod.json
@@ -1,22 +1,26 @@
 {
-  "id": "hello-openshift",
-  "kind": "Pod",
-  "apiVersion":"v1beta2",
-  "labels": {
-    "name": "hello-openshift"
-  },
+  "apiVersion": "v1beta2",
   "desiredState": {
     "manifest": {
-      "version": "v1beta1",
+      "containers": [
+        {
+          "image": "openshift/hello-openshift",
+          "name": "hello-openshift",
+          "ports": [
+            {
+              "containerPort": 8080,
+              "hostPort": 6061
+            }
+          ]
+        }
+      ],
       "id": "hello-openshift",
-      "containers": [{
-        "name": "hello-openshift",
-        "image": "openshift/hello-openshift",
-        "ports": [{
-          "hostPort": 6061,
-          "containerPort": 8080
-        }]
-      }]
+      "version": "v1beta1"
     }
+  },
+  "id": "hello-openshift",
+  "kind": "Pod",
+  "labels": {
+    "name": "hello-openshift"
   }
 }

--- a/examples/hello-openshift/hello-project.json
+++ b/examples/hello-openshift/hello-project.json
@@ -1,14 +1,14 @@
 {
-  "kind": "Project",
   "apiVersion": "v1beta1",
+  "displayName": "Hello OpenShift",
+  "kind": "Project",
   "metadata": {
-    "name": "hello-openshift-project",
+    "annotations": {
+      "description": "This is an example project to demonstrate OpenShift v3"
+    },
     "labels": {
       "name": "hello-openshift-project"
     },
-    "annotations": {
-      "description": "This is an example project to demonstrate OpenShift v3"
-    }
-  },    
-  "displayName": "Hello OpenShift"
+    "name": "hello-openshift-project"
+  }
 }

--- a/examples/image-repositories/image-repositories.json
+++ b/examples/image-repositories/image-repositories.json
@@ -1,39 +1,39 @@
 {
-    "kind": "ImageRepositoryList",
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "apiVersion": "v1beta1",
-            "dockerImageRepository": "openshift/ruby-20-centos",
-            "kind": "ImageRepository",
-            "metadata": {
-                "name": "ruby-20-centos"
-            },
-            "tags": {
-                "latest": "latest"
-            }
-        },
-        {
-            "apiVersion": "v1beta1",
-            "dockerImageRepository": "openshift/nodejs-010-centos7",
-            "kind": "ImageRepository",
-            "metadata": {
-                "name": "nodejs-010-centos7"
-            },
-            "tags": {
-                "latest": "latest"
-            }
-        },
-        {
-            "apiVersion": "v1beta1",
-            "dockerImageRepository": "openshift/wildfly-8-centos",
-            "kind": "ImageRepository",
-            "metadata": {
-                "name": "wildfly-8-centos"
-            },
-            "tags": {
-                "latest": "latest"
-            }
-        }
-    ]
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "apiVersion": "v1beta1",
+      "dockerImageRepository": "openshift/ruby-20-centos",
+      "kind": "ImageRepository",
+      "metadata": {
+        "name": "ruby-20-centos"
+      },
+      "tags": {
+        "latest": "latest"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "dockerImageRepository": "openshift/nodejs-010-centos7",
+      "kind": "ImageRepository",
+      "metadata": {
+        "name": "nodejs-010-centos7"
+      },
+      "tags": {
+        "latest": "latest"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "dockerImageRepository": "openshift/wildfly-8-centos",
+      "kind": "ImageRepository",
+      "metadata": {
+        "name": "wildfly-8-centos"
+      },
+      "tags": {
+        "latest": "latest"
+      }
+    }
+  ],
+  "kind": "ImageRepositoryList"
 }

--- a/examples/jenkins/application-template.json
+++ b/examples/jenkins/application-template.json
@@ -1,394 +1,394 @@
 {
-    "annotations": {
-        "description": "This example shows how to create a simple ruby application in openshift origin v3"
-    },
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "apiVersion": "v1beta1",
-            "kind": "BuildConfig",
-            "metadata": {
-                "name": "ruby-test-build",
-                "labels": {
-                    "name": "ruby-test-build"
-                }
-            },
-            "parameters": {
-                "output": {
-                    "imageTag": "openshift/origin-ruby-sample:test",
-                    "registry": "172.30.17.3:5001"
-                },
-                "source": {
-                    "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
-                    },
-                    "type": "Git"
-                },
-                "strategy": {
-                    "stiStrategy": {
-                        "image": "openshift/ruby-20-centos"
-                    },
-                    "type": "STI"
-                }
-            },
-            "triggers": [
-                {
-                    "github": {
-                        "secret": "secret101"
-                    },
-                    "type": "github"
-                },
-                {
-                    "generic": {
-                        "secret": "secret101"
-                    },
-                    "type": "generic"
-                }
-            ]
+  "annotations": {
+    "description": "This example shows how to create a simple ruby application in openshift origin v3"
+  },
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "apiVersion": "v1beta1",
+      "kind": "BuildConfig",
+      "metadata": {
+        "labels": {
+          "name": "ruby-test-build"
         },
-        {
-            "apiVersion": "v1beta1",
-            "dockerImageRepository": "172.30.17.3:5001/openshift/origin-ruby-sample",
-            "kind": "ImageRepository",
-            "metadata": {
-                "name": "origin-ruby-sample",
-                "labels": {
-                    "name": "origin-ruby-sample"
-                }
-            }
+        "name": "ruby-test-build"
+      },
+      "parameters": {
+        "output": {
+          "imageTag": "openshift/origin-ruby-sample:test",
+          "registry": "172.30.17.3:5001"
         },
-        {
-            "apiVersion": "v1beta2",
-            "containerPort": 8080,
-            "id": "frontend-prod",
-            "kind": "Service",
-            "port": 5432,
-            "selector": {
-                "name": "frontend-prod"
-            }
+        "source": {
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "type": "Git"
         },
-        {
-            "apiVersion": "v1beta1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-                "name": "frontend-prod"
-            },
-            "template": {
-                "controllerTemplate": {
-                    "podTemplate": {
-                        "desiredState": {
-                            "manifest": {
-                                "containers": [
-                                    {
-                                        "env": [
-                                            {
-                                                "name": "ADMIN_USERNAME",
-                                                "value": "${ADMIN_USERNAME}"
-                                            },
-                                            {
-                                                "name": "ADMIN_PASSWORD",
-                                                "value": "${ADMIN_PASSWORD}"
-                                            },
-                                            {
-                                                "name": "MYSQL_ROOT_PASSWORD",
-                                                "value": "${MYSQL_ROOT_PASSWORD}"
-                                            },
-                                            {
-                                                "name": "MYSQL_DATABASE",
-                                                "value": "${MYSQL_DATABASE}"
-                                            },
-                                            {
-                                                "name": "RACK_ENV",
-                                                "value": "production"
-                                            },
-                                            {
-                                                "name": "RAILS_ENV",
-                                                "value": "production"
-                                            }
-                                        ],
-                                        "image": "172.30.17.3:5001/openshift/origin-ruby-sample:prod",
-                                        "name": "ruby-helloworld-prod",
-                                        "ports": [
-                                            {
-                                                "containerPort": 8080
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "version": "v1beta1"
-                            }
-                        },
-                        "labels": {
-                            "name": "frontend-prod"
-                        }
-                    },
-                    "replicaSelector": {
-                        "name": "frontend-prod"
-                    },
-                    "replicas": 1
-                },
-                "strategy": {
-                    "type": "Recreate"
-                }
-            },
-            "triggers": [
-                {
-                    "imageChangeParams": {
-                        "automatic": true,
-                        "containerNames": [
-                            "ruby-helloworld-prod"
-                        ],
-                        "repositoryName": "172.30.17.3:5001/openshift/origin-ruby-sample",
-                        "tag": "prod"
-                    },
-                    "type": "ImageChange"
-                }
-            ]
-        },
-        {
-            "apiVersion": "v1beta2",
-            "containerPort": 3306,
-            "id": "database",
-            "kind": "Service",
-            "port": 5434,
-            "selector": {
-                "name": "database-prod"
-            }
-        },
-        {
-            "apiVersion": "v1beta1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-                "name": "database-prod"
-            },
-            "template": {
-                "controllerTemplate": {
-                    "podTemplate": {
-                        "desiredState": {
-                            "manifest": {
-                                "containers": [
-                                    {
-                                        "env": [
-                                            {
-                                                "name": "MYSQL_ROOT_PASSWORD",
-                                                "value": "${MYSQL_ROOT_PASSWORD}"
-                                            },
-                                            {
-                                                "name": "MYSQL_DATABASE",
-                                                "value": "${MYSQL_DATABASE}"
-                                            }
-                                        ],
-                                        "image": "mysql",
-                                        "name": "ruby-helloworld-database",
-                                        "ports": [
-                                            {
-                                                "containerPort": 3306
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "version": "v1beta1"
-                            }
-                        },
-                        "labels": {
-                            "name": "database-prod"
-                        }
-                    },
-                    "replicaSelector": {
-                        "name": "database-prod"
-                    },
-                    "replicas": 1
-                },
-                "strategy": {
-                    "type": "Recreate"
-                }
-            },
-            "triggers": [
-                {
-                    "type": "ConfigChange"
-                }
-            ]
-        },
-        {
-            "apiVersion": "v1beta2",
-            "containerPort": 8080,
-            "id": "frontend-test",
-            "kind": "Service",
-            "port": 5432,
-            "selector": {
-                "name": "frontend-test"
-            }
-        },
-        {
-            "apiVersion": "v1beta1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-                "name": "frontend-test"
-            },
-            "template": {
-                "controllerTemplate": {
-                    "podTemplate": {
-                        "desiredState": {
-                            "manifest": {
-                                "containers": [
-                                    {
-                                        "env": [
-                                            {
-                                                "name": "ADMIN_USERNAME",
-                                                "value": "${ADMIN_USERNAME}"
-                                            },
-                                            {
-                                                "name": "ADMIN_PASSWORD",
-                                                "value": "${ADMIN_PASSWORD}"
-                                            },
-                                            {
-                                                "name": "MYSQL_ROOT_PASSWORD",
-                                                "value": "${MYSQL_ROOT_PASSWORD}"
-                                            },
-                                            {
-                                                "name": "MYSQL_DATABASE",
-                                                "value": "${MYSQL_DATABASE}"
-                                            },
-                                            {
-                                                "name": "RACK_ENV",
-                                                "value": "test"
-                                            },
-                                            {
-                                                "name": "RAILS_ENV",
-                                                "value": "test"
-                                            }
-                                        ],
-                                        "image": "172.30.17.3:5001/openshift/origin-ruby-sample:test",
-                                        "name": "ruby-helloworld-test",
-                                        "ports": [
-                                            {
-                                                "containerPort": 8080
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "version": "v1beta1"
-                            }
-                        },
-                        "labels": {
-                            "name": "frontend-test"
-                        }
-                    },
-                    "replicaSelector": {
-                        "name": "frontend-test"
-                    },
-                    "replicas": 1
-                },
-                "strategy": {
-                    "type": "Recreate"
-                }
-            },
-            "triggers": [
-                {
-                    "imageChangeParams": {
-                        "automatic": true,
-                        "containerNames": [
-                            "ruby-helloworld-test"
-                        ],
-                        "repositoryName": "172.30.17.3:5001/openshift/origin-ruby-sample",
-                        "tag": "test"
-                    },
-                    "type": "ImageChange"
-                }
-            ]
-        },
-        {
-            "apiVersion": "v1beta2",
-            "containerPort": 3306,
-            "id": "database-test",
-            "kind": "Service",
-            "port": 6434,
-            "selector": {
-                "name": "database-test"
-            }
-        },
-        {
-            "apiVersion": "v1beta1",
-            "kind": "DeploymentConfig",
-            "metadata": {
-                "name": "database-test"
-            },
-            "template": {
-                "controllerTemplate": {
-                    "podTemplate": {
-                        "desiredState": {
-                            "manifest": {
-                                "containers": [
-                                    {
-                                        "env": [
-                                            {
-                                                "name": "MYSQL_ROOT_PASSWORD",
-                                                "value": "${MYSQL_ROOT_PASSWORD}"
-                                            },
-                                            {
-                                                "name": "MYSQL_DATABASE",
-                                                "value": "${MYSQL_DATABASE}"
-                                            }
-                                        ],
-                                        "image": "mysql",
-                                        "name": "ruby-helloworld-database",
-                                        "ports": [
-                                            {
-                                                "containerPort": 3306
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "version": "v1beta1"
-                            }
-                        },
-                        "labels": {
-                            "name": "database-test"
-                        }
-                    },
-                    "replicaSelector": {
-                        "name": "database-test"
-                    },
-                    "replicas": 1
-                },
-                "strategy": {
-                    "type": "Recreate"
-                }
-            },
-            "triggers": [
-                {
-                    "type": "ConfigChange"
-                }
-            ]
+        "strategy": {
+          "stiStrategy": {
+            "image": "openshift/ruby-20-centos"
+          },
+          "type": "STI"
         }
-    ],
-    "kind": "Template",
-    "metadata": {
-        "name": "ruby-helloworld-sample"
-    },
-    "parameters": [
+      },
+      "triggers": [
         {
-            "description": "administrator username",
-            "from": "admin[A-Z0-9]{3}",
-            "generate": "expression",
-            "name": "ADMIN_USERNAME"
+          "github": {
+            "secret": "secret101"
+          },
+          "type": "github"
         },
         {
-            "description": "administrator password",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "name": "ADMIN_PASSWORD"
-        },
-        {
-            "description": "database password",
-            "from": "[a-zA-Z0-9]{8}",
-            "generate": "expression",
-            "name": "MYSQL_ROOT_PASSWORD"
-        },
-        {
-            "description": "database name",
-            "name": "MYSQL_DATABASE",
-            "value": "root"
+          "generic": {
+            "secret": "secret101"
+          },
+          "type": "generic"
         }
-    ]
+      ]
+    },
+    {
+      "apiVersion": "v1beta1",
+      "dockerImageRepository": "172.30.17.3:5001/openshift/origin-ruby-sample",
+      "kind": "ImageRepository",
+      "metadata": {
+        "labels": {
+          "name": "origin-ruby-sample"
+        },
+        "name": "origin-ruby-sample"
+      }
+    },
+    {
+      "apiVersion": "v1beta2",
+      "containerPort": 8080,
+      "id": "frontend-prod",
+      "kind": "Service",
+      "port": 5432,
+      "selector": {
+        "name": "frontend-prod"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "frontend-prod"
+      },
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
+                    "env": [
+                      {
+                        "name": "ADMIN_USERNAME",
+                        "value": "${ADMIN_USERNAME}"
+                      },
+                      {
+                        "name": "ADMIN_PASSWORD",
+                        "value": "${ADMIN_PASSWORD}"
+                      },
+                      {
+                        "name": "MYSQL_ROOT_PASSWORD",
+                        "value": "${MYSQL_ROOT_PASSWORD}"
+                      },
+                      {
+                        "name": "MYSQL_DATABASE",
+                        "value": "${MYSQL_DATABASE}"
+                      },
+                      {
+                        "name": "RACK_ENV",
+                        "value": "production"
+                      },
+                      {
+                        "name": "RAILS_ENV",
+                        "value": "production"
+                      }
+                    ],
+                    "image": "172.30.17.3:5001/openshift/origin-ruby-sample:prod",
+                    "name": "ruby-helloworld-prod",
+                    "ports": [
+                      {
+                        "containerPort": 8080
+                      }
+                    ]
+                  }
+                ],
+                "version": "v1beta1"
+              }
+            },
+            "labels": {
+              "name": "frontend-prod"
+            }
+          },
+          "replicaSelector": {
+            "name": "frontend-prod"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "triggers": [
+        {
+          "imageChangeParams": {
+            "automatic": true,
+            "containerNames": [
+              "ruby-helloworld-prod"
+            ],
+            "repositoryName": "172.30.17.3:5001/openshift/origin-ruby-sample",
+            "tag": "prod"
+          },
+          "type": "ImageChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta2",
+      "containerPort": 3306,
+      "id": "database",
+      "kind": "Service",
+      "port": 5434,
+      "selector": {
+        "name": "database-prod"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "database-prod"
+      },
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
+                    "env": [
+                      {
+                        "name": "MYSQL_ROOT_PASSWORD",
+                        "value": "${MYSQL_ROOT_PASSWORD}"
+                      },
+                      {
+                        "name": "MYSQL_DATABASE",
+                        "value": "${MYSQL_DATABASE}"
+                      }
+                    ],
+                    "image": "mysql",
+                    "name": "ruby-helloworld-database",
+                    "ports": [
+                      {
+                        "containerPort": 3306
+                      }
+                    ]
+                  }
+                ],
+                "version": "v1beta1"
+              }
+            },
+            "labels": {
+              "name": "database-prod"
+            }
+          },
+          "replicaSelector": {
+            "name": "database-prod"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta2",
+      "containerPort": 8080,
+      "id": "frontend-test",
+      "kind": "Service",
+      "port": 5432,
+      "selector": {
+        "name": "frontend-test"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "frontend-test"
+      },
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
+                    "env": [
+                      {
+                        "name": "ADMIN_USERNAME",
+                        "value": "${ADMIN_USERNAME}"
+                      },
+                      {
+                        "name": "ADMIN_PASSWORD",
+                        "value": "${ADMIN_PASSWORD}"
+                      },
+                      {
+                        "name": "MYSQL_ROOT_PASSWORD",
+                        "value": "${MYSQL_ROOT_PASSWORD}"
+                      },
+                      {
+                        "name": "MYSQL_DATABASE",
+                        "value": "${MYSQL_DATABASE}"
+                      },
+                      {
+                        "name": "RACK_ENV",
+                        "value": "test"
+                      },
+                      {
+                        "name": "RAILS_ENV",
+                        "value": "test"
+                      }
+                    ],
+                    "image": "172.30.17.3:5001/openshift/origin-ruby-sample:test",
+                    "name": "ruby-helloworld-test",
+                    "ports": [
+                      {
+                        "containerPort": 8080
+                      }
+                    ]
+                  }
+                ],
+                "version": "v1beta1"
+              }
+            },
+            "labels": {
+              "name": "frontend-test"
+            }
+          },
+          "replicaSelector": {
+            "name": "frontend-test"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "triggers": [
+        {
+          "imageChangeParams": {
+            "automatic": true,
+            "containerNames": [
+              "ruby-helloworld-test"
+            ],
+            "repositoryName": "172.30.17.3:5001/openshift/origin-ruby-sample",
+            "tag": "test"
+          },
+          "type": "ImageChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta2",
+      "containerPort": 3306,
+      "id": "database-test",
+      "kind": "Service",
+      "port": 6434,
+      "selector": {
+        "name": "database-test"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "database-test"
+      },
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
+                    "env": [
+                      {
+                        "name": "MYSQL_ROOT_PASSWORD",
+                        "value": "${MYSQL_ROOT_PASSWORD}"
+                      },
+                      {
+                        "name": "MYSQL_DATABASE",
+                        "value": "${MYSQL_DATABASE}"
+                      }
+                    ],
+                    "image": "mysql",
+                    "name": "ruby-helloworld-database",
+                    "ports": [
+                      {
+                        "containerPort": 3306
+                      }
+                    ]
+                  }
+                ],
+                "version": "v1beta1"
+              }
+            },
+            "labels": {
+              "name": "database-test"
+            }
+          },
+          "replicaSelector": {
+            "name": "database-test"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "name": "ruby-helloworld-sample"
+  },
+  "parameters": [
+    {
+      "description": "administrator username",
+      "from": "admin[A-Z0-9]{3}",
+      "generate": "expression",
+      "name": "ADMIN_USERNAME"
+    },
+    {
+      "description": "administrator password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "ADMIN_PASSWORD"
+    },
+    {
+      "description": "database password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "MYSQL_ROOT_PASSWORD"
+    },
+    {
+      "description": "database name",
+      "name": "MYSQL_DATABASE",
+      "value": "root"
+    }
+  ]
 }

--- a/examples/jenkins/docker-registry-config.json
+++ b/examples/jenkins/docker-registry-config.json
@@ -1,94 +1,96 @@
 {
-  "metadata":{
-    "name":"docker-registry"
-  },
-  "kind":"Config",
-  "apiVersion":"v1beta1",
-  "creationTimestamp":"2014-09-18T18:28:38-04:00",
-  "items":[
+  "apiVersion": "v1beta1",
+  "creationTimestamp": "2014-09-18T18:28:38-04:00",
+  "items": [
     {
-      "apiVersion":"v1beta2",
-      "creationTimestamp":null,
-      "id":"docker-registry",
-      "kind":"Service",
-      "port":5001,
-      "containerPort":5000,
-      "selector":{
-        "name":"registrypod"
+      "apiVersion": "v1beta2",
+      "containerPort": 5000,
+      "creationTimestamp": null,
+      "id": "docker-registry",
+      "kind": "Service",
+      "port": 5001,
+      "selector": {
+        "name": "registrypod"
       }
     },
     {
-      "metadata":{
-        "name":"docker-registry"
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "docker-registry"
       },
-      "kind":"DeploymentConfig",
-      "apiVersion":"v1beta1",
-      "triggers":[
-        {
-          "type":"ConfigChange"
-        }
-      ],
-      "template":{
-        "strategy":{
-          "type":"Recreate"
-        },
-        "controllerTemplate":{
-          "replicas":1,
-          "replicaSelector":{
-            "name":"registrypod"
-          },
-          "podTemplate":{
-            "desiredState":{
-              "manifest":{
-                "containers":[
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
                   {
-                    "image":"openshift/docker-registry",
-                    "imagePullPolicy":"PullIfNotPresent",
-                    "name":"registry-container",
-                    "ports":[
+                    "command": [
+                      "sh",
+                      "-c",
+                      "REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} OPENSHIFT_URL=https://${KUBERNETES_SERVICE_HOST}:443/osapi/v1beta1 OPENSHIFT_INSECURE=true exec docker-registry"
+                    ],
+                    "env": [
                       {
-                        "containerPort":5000,
-                        "protocol":"TCP"
+                        "name": "STORAGE_PATH",
+                        "value": "/tmp/openshift.local.registry"
                       }
                     ],
-                    "env":[
+                    "image": "openshift/docker-registry",
+                    "imagePullPolicy": "PullIfNotPresent",
+                    "name": "registry-container",
+                    "ports": [
                       {
-                        "name":"STORAGE_PATH",
-                        "value":"/tmp/openshift.local.registry"
+                        "containerPort": 5000,
+                        "protocol": "TCP"
                       }
                     ],
-                    "volumeMounts":[
+                    "volumeMounts": [
                       {
-                        "name":"registry-storage",
-                        "mountPath":"/tmp/openshift.local.registry",
-                        "readOnly":false
+                        "mountPath": "/tmp/openshift.local.registry",
+                        "name": "registry-storage",
+                        "readOnly": false
                       }
-                    ],
-                    "command": ["sh", "-c", "REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} OPENSHIFT_URL=https://${KUBERNETES_SERVICE_HOST}:443/osapi/v1beta1 OPENSHIFT_INSECURE=true exec docker-registry"]
+                    ]
                   }
                 ],
-                "version":"v1beta1",
-                "volumes":[
+                "version": "v1beta1",
+                "volumes": [
                   {
-                    "name":"registry-storage",
-                    "source":{
-                      "hostDir":{
-                        "path":"/tmp/openshift.local.registry"
+                    "name": "registry-storage",
+                    "source": {
+                      "hostDir": {
+                        "path": "/tmp/openshift.local.registry"
                       }
                     }
                   }
                 ]
               },
-              "restartpolicy":{
-
-              }
+              "restartpolicy": {}
             },
-            "labels":{
-              "name":"registrypod"
+            "labels": {
+              "name": "registrypod"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "registrypod"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
     }
-  ]
+  ],
+  "kind": "Config",
+  "metadata": {
+    "name": "docker-registry"
+  }
 }

--- a/examples/jenkins/jenkins-config.json
+++ b/examples/jenkins/jenkins-config.json
@@ -1,69 +1,67 @@
 {
-  "metadata":{
-    "name":"jenkins"
-  },
-  "kind":"Config",
-  "apiVersion":"v1beta1",
-  "creationTimestamp":"2014-09-18T18:28:38-04:00",
-  "items":[
+  "apiVersion": "v1beta1",
+  "creationTimestamp": "2014-09-18T18:28:38-04:00",
+  "items": [
     {
-      "apiVersion":"v1beta2",
-      "creationTimestamp":null,
-      "id":"jenkins",
-      "kind":"Service",
-      "port":5002,
-      "containerPort":8080,
-      "selector":{
-        "name":"jenkinspod"
+      "apiVersion": "v1beta2",
+      "containerPort": 8080,
+      "creationTimestamp": null,
+      "id": "jenkins",
+      "kind": "Service",
+      "port": 5002,
+      "selector": {
+        "name": "jenkinspod"
       }
     },
     {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
       "metadata": {
-        "name":"jenkins"
+        "name": "jenkins"
       },
-      "kind":"DeploymentConfig",
-      "apiVersion":"v1beta1",
-      "triggers":[
-        {
-          "type":"ConfigChange"
-        }
-      ],
-      "template":{
-        "strategy":{
-          "type":"Recreate"
-        },
-        "controllerTemplate":{
-          "replicas":1,
-          "replicaSelector":{
-            "name":"jenkinspod"
-          },
-          "podTemplate":{
-            "desiredState":{
-              "manifest":{
-                "containers":[
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
                   {
-                    "image":"openshift/jenkins-1-centos",
-                    "name":"jenkins-container",
-                    "ports":[
+                    "image": "openshift/jenkins-1-centos",
+                    "name": "jenkins-container",
+                    "ports": [
                       {
-                        "containerPort":8080,
-                        "protocol":"TCP"
+                        "containerPort": 8080,
+                        "protocol": "TCP"
                       }
                     ]
                   }
                 ],
-                "version":"v1beta1"
+                "version": "v1beta1"
               },
-              "restartpolicy":{
-
-              }
+              "restartpolicy": {}
             },
-            "labels":{
-              "name":"jenkinspod"
+            "labels": {
+              "name": "jenkinspod"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "jenkinspod"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
     }
-  ]
+  ],
+  "kind": "Config",
+  "metadata": {
+    "name": "jenkins"
+  }
 }

--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -1,171 +1,119 @@
 {
-  "metadata":{
-    "name": "ruby-helloworld-sample",
-    "annotations": {
-      "description": "This example shows how to create a simple ruby application in openshift origin v3"
-    }
-  },
-  "kind": "Template",
   "apiVersion": "v1beta1",
-  "parameters": [
-    {
-      "name": "ADMIN_USERNAME",
-      "description": "administrator username",
-      "generate": "expression",
-      "from": "admin[A-Z0-9]{3}"
-    },
-    {
-      "name": "ADMIN_PASSWORD",
-      "description": "administrator password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "MYSQL_ROOT_PASSWORD",
-      "description": "database password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "MYSQL_DATABASE",
-      "description": "database name",
-      "value": "root"
-    }
-  ],
   "items": [
     {
+      "apiVersion": "v1beta1",
+      "containerPort": 8080,
       "id": "frontend",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5432,
-      "containerPort": 8080,
       "selector": {
         "name": "frontend"
       }
     },
     {
-      "metadata": {
-          "name": "route-edge"
-      },
-      "id": "sample-app-secure",
       "apiVersion": "v1beta1",
-      "kind": "Route",
       "host": "www.example.com",
+      "id": "sample-app-secure",
+      "kind": "Route",
+      "metadata": {
+        "name": "route-edge"
+      },
       "serviceName": "frontend",
       "tls": {
-          "termination": "edge",
-          "certificate": "-----BEGIN CERTIFICATE-----\\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE-----",
-          "key": "-----BEGIN PRIVATE KEY-----\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\\nTcFT4touIo7oriFJ\\n-----END PRIVATE KEY-----",
-          "caCertificate": "-----BEGIN CERTIFICATE-----\\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\\n-----END CERTIFICATE-----"
+        "caCertificate": "-----BEGIN CERTIFICATE-----\\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\\n-----END CERTIFICATE-----",
+        "certificate": "-----BEGIN CERTIFICATE-----\\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE-----",
+        "key": "-----BEGIN PRIVATE KEY-----\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\\nTcFT4touIo7oriFJ\\n-----END PRIVATE KEY-----",
+        "termination": "edge"
       }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "ImageRepository",
+      "metadata": {
         "name": "origin-ruby-sample"
-      },
-      "kind": "ImageRepository",
-      "apiVersion": "v1beta1"
+      }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "ImageRepository",
+      "metadata": {
         "name": "custom-docker-builder"
-      },
-      "kind": "ImageRepository",
-      "apiVersion": "v1beta1"
+      }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "BuildConfig",
+      "labels": {
         "name": "ruby-sample-build"
       },
-      "kind": "BuildConfig",
-      "apiVersion": "v1beta1",
-      "triggers": [
-        {
-          "type": "github",
-          "github": {
-            "secret": "secret101"
-          }
-        },
-        {
-          "type": "generic",
-          "generic": {
-            "secret": "secret101"
-          }
-        },
-        {
-          "type": "imageChange",
-          "imageChange": {
-            "image": "openshift/origin-custom-docker-builder",
-            "from": {
-              "name": "origin-custom-docker-builder"
-            },
-            "tag":"latest"
-          }
-        }
-      ],
+      "metadata": {
+        "name": "ruby-sample-build"
+      },
       "parameters": {
-        "source" : {
-          "type" : "Git",
-          "git" : {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
-          }
-        },
-        "strategy": {
-          "type": "Custom",
-          "customStrategy": {
-            "image": "openshift/origin-custom-docker-builder",
-            "env": [{"name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE", "value": "openshift/origin-custom-docker-builder"}],
-            "exposeDockerSocket":true
-          }
-        },
         "output": {
           "to": {
             "name": "origin-ruby-sample"
           }
+        },
+        "source": {
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "type": "Git"
+        },
+        "strategy": {
+          "customStrategy": {
+            "env": [
+              {
+                "name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
+                "value": "openshift/origin-custom-docker-builder"
+              }
+            ],
+            "exposeDockerSocket": true,
+            "image": "openshift/origin-custom-docker-builder"
+          },
+          "type": "Custom"
         }
       },
-      "labels": {
-        "name": "ruby-sample-build"
-      }
-    },
-    {
-      "metadata":{
-        "name": "frontend"
-      },
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1beta1",
       "triggers": [
         {
-          "type": "ImageChange",
-          "imageChangeParams": {
-            "automatic": true,
-            "containerNames": [
-              "ruby-helloworld"
-            ],
-            "from": {
-              "name": "origin-ruby-sample"
-            },
-            "tag": "latest"
-          }
-        }
-      ],
-      "template": {
-        "strategy":{
-          "type":"Recreate"
-        },
-        "controllerTemplate": {
-          "replicas": 1,
-          "replicaSelector": {
-            "name": "frontend"
+          "github": {
+            "secret": "secret101"
           },
+          "type": "github"
+        },
+        {
+          "generic": {
+            "secret": "secret101"
+          },
+          "type": "generic"
+        },
+        {
+          "imageChange": {
+            "from": {
+              "name": "origin-custom-docker-builder"
+            },
+            "image": "openshift/origin-custom-docker-builder",
+            "tag": "latest"
+          },
+          "type": "imageChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "frontend"
+      },
+      "template": {
+        "controllerTemplate": {
           "podTemplate": {
             "desiredState": {
               "manifest": {
-                "version": "v1beta1",
                 "containers": [
                   {
-                    "name": "ruby-helloworld",
-                    "image": "origin-ruby-sample",
                     "env": [
                       {
                         "name": "ADMIN_USERNAME",
@@ -184,60 +132,70 @@
                         "value": "${MYSQL_DATABASE}"
                       }
                     ],
+                    "image": "origin-ruby-sample",
+                    "name": "ruby-helloworld",
                     "ports": [
                       {
                         "containerPort": 8080
                       }
                     ]
                   }
-                ]
+                ],
+                "version": "v1beta1"
               }
             },
             "labels": {
               "name": "frontend"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "frontend"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "imageChangeParams": {
+            "automatic": true,
+            "containerNames": [
+              "ruby-helloworld"
+            ],
+            "from": {
+              "name": "origin-ruby-sample"
+            },
+            "tag": "latest"
+          },
+          "type": "ImageChange"
+        }
+      ]
     },
     {
+      "apiVersion": "v1beta1",
+      "containerPort": 3306,
       "id": "database",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5434,
-      "containerPort": 3306,
       "selector": {
         "name": "database"
       }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
         "name": "database"
       },
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1beta1",
-      "triggers": [
-        {
-          "type": "ConfigChange"
-        }
-      ],
       "template": {
-        "strategy": {
-          "type":"Recreate"
-        },
         "controllerTemplate": {
-          "replicas": 1,
-          "replicaSelector": {
-            "name": "database"
-        },
-        "podTemplate": {
-          "desiredState": {
-            "manifest": {
-              "version": "v1beta1",
-              "containers": [
-                {
-                   "name": "ruby-helloworld-database",
-                   "image": "mysql",
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
                     "env": [
                       {
                         "name": "MYSQL_ROOT_PASSWORD",
@@ -248,21 +206,68 @@
                         "value": "${MYSQL_DATABASE}"
                       }
                     ],
+                    "image": "mysql",
+                    "name": "ruby-helloworld-database",
                     "ports": [
                       {
                         "containerPort": 3306
                       }
                     ]
                   }
-                ]
+                ],
+                "version": "v1beta1"
               }
             },
             "labels": {
               "name": "database"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "database"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3"
+    },
+    "name": "ruby-helloworld-sample"
+  },
+  "parameters": [
+    {
+      "description": "administrator username",
+      "from": "admin[A-Z0-9]{3}",
+      "generate": "expression",
+      "name": "ADMIN_USERNAME"
+    },
+    {
+      "description": "administrator password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "ADMIN_PASSWORD"
+    },
+    {
+      "description": "database password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "MYSQL_ROOT_PASSWORD"
+    },
+    {
+      "description": "database name",
+      "name": "MYSQL_DATABASE",
+      "value": "root"
     }
   ]
 }

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -1,166 +1,109 @@
 {
-  "metadata":{
-    "name": "ruby-helloworld-sample",
-    "annotations": {
-      "description": "This example shows how to create a simple ruby application in openshift origin v3"
-    }
-  },
-  "kind": "Template",
   "apiVersion": "v1beta1",
-  "parameters": [
-    {
-      "name": "ADMIN_USERNAME",
-      "description": "administrator username",
-      "generate": "expression",
-      "from": "admin[A-Z0-9]{3}"
-    },
-    {
-      "name": "ADMIN_PASSWORD",
-      "description": "administrator password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "MYSQL_ROOT_PASSWORD",
-      "description": "database password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "MYSQL_DATABASE",
-      "description": "database name",
-      "value": "root"
-    }
-  ],
   "items": [
     {
+      "apiVersion": "v1beta1",
+      "containerPort": 8080,
       "id": "frontend",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5432,
-      "containerPort": 8080,
       "selector": {
         "name": "frontend"
       }
     },
     {
-      "metadata": {
-          "name": "route-edge"
-      },
-      "id": "sample-app-secure",
       "apiVersion": "v1beta1",
-      "kind": "Route",
       "host": "www.example.com",
+      "id": "sample-app-secure",
+      "kind": "Route",
+      "metadata": {
+        "name": "route-edge"
+      },
       "serviceName": "frontend",
       "tls": {
-          "termination": "edge",
-          "certificate": "-----BEGIN CERTIFICATE-----\\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE-----",
-          "key": "-----BEGIN PRIVATE KEY-----\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\\nTcFT4touIo7oriFJ\\n-----END PRIVATE KEY-----",
-          "caCertificate": "-----BEGIN CERTIFICATE-----\\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\\n-----END CERTIFICATE-----"
+        "caCertificate": "-----BEGIN CERTIFICATE-----\\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\\n-----END CERTIFICATE-----",
+        "certificate": "-----BEGIN CERTIFICATE-----\\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE-----",
+        "key": "-----BEGIN PRIVATE KEY-----\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\\nTcFT4touIo7oriFJ\\n-----END PRIVATE KEY-----",
+        "termination": "edge"
       }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "ImageRepository",
+      "metadata": {
         "name": "origin-ruby-sample"
-      },
-      "kind": "ImageRepository",
-      "apiVersion": "v1beta1"
+      }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "ImageRepository",
+      "metadata": {
         "name": "ruby-20-centos"
-      },
-      "kind": "ImageRepository",
-      "apiVersion": "v1beta1"
+      }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "BuildConfig",
+      "labels": {
         "name": "ruby-sample-build"
       },
-      "kind": "BuildConfig",
-      "apiVersion": "v1beta1",
-      "triggers": [
-        {
-          "type": "github",
-          "github": {
-            "secret": "secret101"
-          }
-        },
-        {
-          "type": "generic",
-          "generic": {
-            "secret": "secret101"
-          }
-        },
-        {
-          "type": "imageChange",
-          "imageChange": {
-            "image": "openshift/ruby-20-centos",
-            "from": {
-              "name": "ruby-20-centos"
-            },
-            "tag":"latest"
-          }
-        }
-      ],
+      "metadata": {
+        "name": "ruby-sample-build"
+      },
       "parameters": {
-        "source" : {
-          "type" : "Git",
-          "git" : {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
-          }
-        },
-        "strategy": {
-          "type": "Docker"
-        },
         "output": {
           "to": {
             "name": "origin-ruby-sample"
           }
+        },
+        "source": {
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "type": "Git"
+        },
+        "strategy": {
+          "type": "Docker"
         }
       },
-      "labels": {
-        "name": "ruby-sample-build"
-      }
-    },
-    {
-      "metadata":{
-        "name": "frontend"
-      },
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1beta1",
       "triggers": [
         {
-          "type": "ImageChange",
-          "imageChangeParams": {
-            "automatic": true,
-            "containerNames": [
-              "ruby-helloworld"
-            ],
-            "from": {
-              "name": "origin-ruby-sample"
-            },
-            "tag": "latest"
-          }
-        }
-      ],
-      "template": {
-        "strategy":{
-          "type":"Recreate"
-        },
-        "controllerTemplate": {
-          "replicas": 1,
-          "replicaSelector": {
-            "name": "frontend"
+          "github": {
+            "secret": "secret101"
           },
+          "type": "github"
+        },
+        {
+          "generic": {
+            "secret": "secret101"
+          },
+          "type": "generic"
+        },
+        {
+          "imageChange": {
+            "from": {
+              "name": "ruby-20-centos"
+            },
+            "image": "openshift/ruby-20-centos",
+            "tag": "latest"
+          },
+          "type": "imageChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "frontend"
+      },
+      "template": {
+        "controllerTemplate": {
           "podTemplate": {
             "desiredState": {
               "manifest": {
-                "version": "v1beta1",
                 "containers": [
                   {
-                    "name": "ruby-helloworld",
-                    "image": "origin-ruby-sample",
                     "env": [
                       {
                         "name": "ADMIN_USERNAME",
@@ -179,60 +122,70 @@
                         "value": "${MYSQL_DATABASE}"
                       }
                     ],
+                    "image": "origin-ruby-sample",
+                    "name": "ruby-helloworld",
                     "ports": [
                       {
                         "containerPort": 8080
                       }
                     ]
                   }
-                ]
+                ],
+                "version": "v1beta1"
               }
             },
             "labels": {
               "name": "frontend"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "frontend"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "imageChangeParams": {
+            "automatic": true,
+            "containerNames": [
+              "ruby-helloworld"
+            ],
+            "from": {
+              "name": "origin-ruby-sample"
+            },
+            "tag": "latest"
+          },
+          "type": "ImageChange"
+        }
+      ]
     },
     {
+      "apiVersion": "v1beta1",
+      "containerPort": 3306,
       "id": "database",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5434,
-      "containerPort": 3306,
       "selector": {
         "name": "database"
       }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
         "name": "database"
       },
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1beta1",
-      "triggers": [
-        {
-          "type": "ConfigChange"
-        }
-      ],
       "template": {
-        "strategy":{
-          "type":"Recreate"
-        },
         "controllerTemplate": {
-          "replicas": 1,
-          "replicaSelector": {
-            "name": "database"
-        },
-        "podTemplate": {
-          "desiredState": {
-            "manifest": {
-              "version": "v1beta1",
-              "containers": [
-                {
-                   "name": "ruby-helloworld-database",
-                   "image": "mysql",
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
                     "env": [
                       {
                         "name": "MYSQL_ROOT_PASSWORD",
@@ -243,21 +196,68 @@
                         "value": "${MYSQL_DATABASE}"
                       }
                     ],
+                    "image": "mysql",
+                    "name": "ruby-helloworld-database",
                     "ports": [
                       {
                         "containerPort": 3306
                       }
                     ]
                   }
-                ]
+                ],
+                "version": "v1beta1"
               }
             },
             "labels": {
               "name": "database"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "database"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3"
+    },
+    "name": "ruby-helloworld-sample"
+  },
+  "parameters": [
+    {
+      "description": "administrator username",
+      "from": "admin[A-Z0-9]{3}",
+      "generate": "expression",
+      "name": "ADMIN_USERNAME"
+    },
+    {
+      "description": "administrator password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "ADMIN_PASSWORD"
+    },
+    {
+      "description": "database password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "MYSQL_ROOT_PASSWORD"
+    },
+    {
+      "description": "database name",
+      "name": "MYSQL_DATABASE",
+      "value": "root"
     }
   ]
 }

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -1,168 +1,113 @@
 {
-  "metadata":{
-    "name": "ruby-helloworld-sample",
-    "annotations": {
-      "description": "This example shows how to create a simple ruby application in openshift origin v3"
-    }
-  },
-  "kind": "Template",
   "apiVersion": "v1beta1",
-  "parameters": [
-    {
-      "name": "ADMIN_USERNAME",
-      "description": "administrator username",
-      "generate": "expression",
-      "from": "admin[A-Z0-9]{3}"
-    },
-    {
-      "name": "ADMIN_PASSWORD",
-      "description": "administrator password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "MYSQL_ROOT_PASSWORD",
-      "description": "database password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "MYSQL_DATABASE",
-      "description": "database name",
-      "value": "root"
-    }
-  ],
   "items": [
     {
+      "apiVersion": "v1beta1",
+      "containerPort": 8080,
       "id": "frontend",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5432,
-      "containerPort": 8080,
       "selector": {
         "name": "frontend"
       }
     },
     {
-      "metadata": {
-          "name": "route-edge"
-      },
-      "id": "sample-app-secure",
       "apiVersion": "v1beta1",
-      "kind": "Route",
       "host": "www.example.com",
+      "id": "sample-app-secure",
+      "kind": "Route",
+      "metadata": {
+        "name": "route-edge"
+      },
       "serviceName": "frontend",
       "tls": {
-          "termination": "edge",
-          "certificate": "-----BEGIN CERTIFICATE-----\\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE-----",
-          "key": "-----BEGIN PRIVATE KEY-----\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\\nTcFT4touIo7oriFJ\\n-----END PRIVATE KEY-----",
-          "caCertificate": "-----BEGIN CERTIFICATE-----\\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\\n-----END CERTIFICATE-----"
+        "caCertificate": "-----BEGIN CERTIFICATE-----\\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\\n-----END CERTIFICATE-----",
+        "certificate": "-----BEGIN CERTIFICATE-----\\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE-----",
+        "key": "-----BEGIN PRIVATE KEY-----\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\\nTcFT4touIo7oriFJ\\n-----END PRIVATE KEY-----",
+        "termination": "edge"
       }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "ImageRepository",
+      "metadata": {
         "name": "origin-ruby-sample"
-      },
-      "kind": "ImageRepository",
-      "apiVersion": "v1beta1"
+      }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "ImageRepository",
+      "metadata": {
         "name": "ruby-20-centos"
-      },
-      "kind": "ImageRepository",
-      "apiVersion": "v1beta1"
+      }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "BuildConfig",
+      "labels": {
         "name": "ruby-sample-build"
       },
-      "kind": "BuildConfig",
-      "apiVersion": "v1beta1",
-      "triggers": [
-        {
-          "type": "github",
-          "github": {
-            "secret": "secret101"
-          }
-        },
-        {
-          "type": "generic",
-          "generic": {
-            "secret": "secret101"
-          }
-        },
-        {
-          "type": "imageChange",
-          "imageChange": {
-            "image": "openshift/ruby-20-centos",
-            "from": { "name": "ruby-20-centos"},
-            "tag":"latest"
-          }
-        }
-      ],
+      "metadata": {
+        "name": "ruby-sample-build"
+      },
       "parameters": {
-        "source" : {
-          "type" : "Git",
-          "git" : {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
-          }
-        },
-        "strategy": {
-          "type": "STI",
-          "stiStrategy": {
-            "image": "openshift/ruby-20-centos",
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
-          }
-        },
         "output": {
           "to": {
             "name": "origin-ruby-sample"
           }
+        },
+        "source": {
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "type": "Git"
+        },
+        "strategy": {
+          "stiStrategy": {
+            "image": "openshift/ruby-20-centos",
+            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+          },
+          "type": "STI"
         }
       },
-      "labels": {
-        "name": "ruby-sample-build"
-      }
-    },
-    {
-      "metadata":{
-        "name": "frontend"
-      },
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1beta1",
       "triggers": [
         {
-          "type": "ImageChange",
-          "imageChangeParams": {
-            "automatic": true,
-            "containerNames": [
-              "ruby-helloworld"
-            ],
-            "from": {
-              "name": "origin-ruby-sample"
-            },
-            "tag": "latest"
-          }
-        }
-      ],
-      "template": {
-        "strategy": {
-          "type":"Recreate"
-        },
-        "controllerTemplate": {
-          "replicas": 1,
-          "replicaSelector": {
-            "name": "frontend"
+          "github": {
+            "secret": "secret101"
           },
+          "type": "github"
+        },
+        {
+          "generic": {
+            "secret": "secret101"
+          },
+          "type": "generic"
+        },
+        {
+          "imageChange": {
+            "from": {
+              "name": "ruby-20-centos"
+            },
+            "image": "openshift/ruby-20-centos",
+            "tag": "latest"
+          },
+          "type": "imageChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "frontend"
+      },
+      "template": {
+        "controllerTemplate": {
           "podTemplate": {
             "desiredState": {
               "manifest": {
-                "version": "v1beta1",
                 "containers": [
                   {
-                    "name": "ruby-helloworld",
-                    "image": "origin-ruby-sample",
                     "env": [
                       {
                         "name": "ADMIN_USERNAME",
@@ -181,60 +126,70 @@
                         "value": "${MYSQL_DATABASE}"
                       }
                     ],
+                    "image": "origin-ruby-sample",
+                    "name": "ruby-helloworld",
                     "ports": [
                       {
                         "containerPort": 8080
                       }
                     ]
                   }
-                ]
+                ],
+                "version": "v1beta1"
               }
             },
             "labels": {
               "name": "frontend"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "frontend"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "imageChangeParams": {
+            "automatic": true,
+            "containerNames": [
+              "ruby-helloworld"
+            ],
+            "from": {
+              "name": "origin-ruby-sample"
+            },
+            "tag": "latest"
+          },
+          "type": "ImageChange"
+        }
+      ]
     },
     {
+      "apiVersion": "v1beta1",
+      "containerPort": 3306,
       "id": "database",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5434,
-      "containerPort": 3306,
       "selector": {
         "name": "database"
       }
     },
     {
-      "metadata":{
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
         "name": "database"
       },
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1beta1",
-      "triggers": [
-        {
-          "type": "ConfigChange"
-        }
-      ],
       "template": {
-        "strategy": {
-          "type":"Recreate"
-        },
         "controllerTemplate": {
-          "replicas": 1,
-          "replicaSelector": {
-            "name": "database"
-        },
-        "podTemplate": {
-          "desiredState": {
-            "manifest": {
-              "version": "v1beta1",
-              "containers": [
-                {
-                   "name": "ruby-helloworld-database",
-                   "image": "mysql",
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {
                     "env": [
                       {
                         "name": "MYSQL_ROOT_PASSWORD",
@@ -245,21 +200,68 @@
                         "value": "${MYSQL_DATABASE}"
                       }
                     ],
+                    "image": "mysql",
+                    "name": "ruby-helloworld-database",
                     "ports": [
                       {
                         "containerPort": 3306
                       }
                     ]
                   }
-                ]
+                ],
+                "version": "v1beta1"
               }
             },
             "labels": {
               "name": "database"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "database"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3"
+    },
+    "name": "ruby-helloworld-sample"
+  },
+  "parameters": [
+    {
+      "description": "administrator username",
+      "from": "admin[A-Z0-9]{3}",
+      "generate": "expression",
+      "name": "ADMIN_USERNAME"
+    },
+    {
+      "description": "administrator password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "ADMIN_PASSWORD"
+    },
+    {
+      "description": "database password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "MYSQL_ROOT_PASSWORD"
+    },
+    {
+      "description": "database name",
+      "name": "MYSQL_DATABASE",
+      "value": "root"
     }
   ]
 }

--- a/examples/sample-app/docker-registry-config.json
+++ b/examples/sample-app/docker-registry-config.json
@@ -1,96 +1,98 @@
 {
-  "metadata":{
-    "name":"docker-registry"
-  },
-  "kind":"Config",
-  "apiVersion":"v1beta1",
-  "creationTimestamp":"2014-09-18T18:28:38-04:00",
-  "items":[
+  "apiVersion": "v1beta1",
+  "creationTimestamp": "2014-09-18T18:28:38-04:00",
+  "items": [
     {
-      "apiVersion":"v1beta2",
-      "creationTimestamp":null,
-      "id":"docker-registry",
-      "kind":"Service",
+      "apiVersion": "v1beta2",
+      "containerPort": 5000,
+      "creationTimestamp": null,
+      "id": "docker-registry",
+      "kind": "Service",
+      "port": 5001,
       "portalIp": "172.30.17.3",
-      "port":5001,
-      "containerPort":5000,
-      "selector":{
-        "name":"registrypod"
+      "selector": {
+        "name": "registrypod"
       }
     },
     {
-      "metadata":{
-        "name":"docker-registry"
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "docker-registry"
       },
-      "kind":"DeploymentConfig",
-      "apiVersion":"v1beta1",
-      "triggers":[
-        {
-          "type":"ConfigChange"
-        }
-      ],
-      "template":{
-        "strategy":{
-          "type":"Recreate"
-        },
-        "controllerTemplate":{
-          "replicas":1,
-          "replicaSelector":{
-            "name":"registrypod"
-          },
-          "podTemplate":{
-            "desiredState":{
-              "manifest":{
-                "containers":[
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
                   {
-                    "image":"openshift/docker-registry",
-                    "imagePullPolicy":"PullIfNotPresent",
-                    "name":"registry-container",
-                    "ports":[
+                    "command": [
+                      "sh",
+                      "-c",
+                      "REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} OPENSHIFT_URL=https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/osapi/v1beta1 OPENSHIFT_INSECURE=true exec docker-registry"
+                    ],
+                    "env": [
                       {
-                        "containerPort":5000,
-                        "protocol":"TCP"
+                        "name": "STORAGE_PATH",
+                        "value": "/tmp/openshift.local.registry"
                       }
                     ],
-                    "env":[
+                    "image": "openshift/docker-registry",
+                    "imagePullPolicy": "PullIfNotPresent",
+                    "name": "registry-container",
+                    "ports": [
                       {
-                        "name":"STORAGE_PATH",
-                        "value":"/tmp/openshift.local.registry"
+                        "containerPort": 5000,
+                        "protocol": "TCP"
                       }
                     ],
-                    "volumeMounts":[
+                    "privileged": true,
+                    "volumeMounts": [
                       {
-                        "name":"registry-storage",
-                        "mountPath":"/tmp/openshift.local.registry",
-                        "readOnly":false
+                        "mountPath": "/tmp/openshift.local.registry",
+                        "name": "registry-storage",
+                        "readOnly": false
                       }
-                    ],
-                    "command": ["sh", "-c", "REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} OPENSHIFT_URL=https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/osapi/v1beta1 OPENSHIFT_INSECURE=true exec docker-registry"],
-                    "privileged": true
+                    ]
                   }
                 ],
-                "version":"v1beta1",
-                "volumes":[
+                "version": "v1beta1",
+                "volumes": [
                   {
-                    "name":"registry-storage",
-                    "source":{
-                      "hostDir":{
-                        "path":"/tmp/openshift.local.registry"
+                    "name": "registry-storage",
+                    "source": {
+                      "hostDir": {
+                        "path": "/tmp/openshift.local.registry"
                       }
                     }
                   }
                 ]
               },
-              "restartpolicy":{
-
-              }
+              "restartpolicy": {}
             },
-            "labels":{
-              "name":"registrypod"
+            "labels": {
+              "name": "registrypod"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "registrypod"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
     }
-  ]
+  ],
+  "kind": "Config",
+  "metadata": {
+    "name": "docker-registry"
+  }
 }

--- a/examples/sample-app/docker-registry-template.json
+++ b/examples/sample-app/docker-registry-template.json
@@ -1,134 +1,135 @@
 {
-  "kind":"Template",
-  "metadata": {
-      "name": "docker-registry-template",
-      "annotations": {
-          "description": "Template for launching a docker-registry pod"
-      }
-  },
-  "parameters": [
-      {
-          "name": "OPENSHIFT_MASTER",
-          "description": "OpenShift master",
-          "value": "http://localhost:8080"
-      },
-      {
-          "name": "OPENSHIFT_CA_DATA",
-          "description": "OpenShift root certificates"
-      },
-      {
-          "name": "OPENSHIFT_CERT_DATA",
-          "description": "OpenShift client certificate"
-      },
-      {
-          "name": "OPENSHIFT_KEY_DATA",
-          "description": "OpenShift client certificate key"
-      }
-  ],
-  "apiVersion":"v1beta1",
-  "creationTimestamp":"2014-09-18T18:28:38-04:00",
-  "items":[
+  "apiVersion": "v1beta1",
+  "creationTimestamp": "2014-09-18T18:28:38-04:00",
+  "items": [
     {
-      "apiVersion":"v1beta2",
-      "creationTimestamp":null,
-      "id":"docker-registry",
-      "kind":"Service",
-      "port":5001,
-      "containerPort":5000,
-      "selector":{
-        "name":"registrypod"
+      "apiVersion": "v1beta2",
+      "containerPort": 5000,
+      "creationTimestamp": null,
+      "id": "docker-registry",
+      "kind": "Service",
+      "port": 5001,
+      "selector": {
+        "name": "registrypod"
       }
     },
     {
-      "metadata":{
-        "name":"docker-registry"
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "docker-registry"
       },
-      "kind":"DeploymentConfig",
-      "apiVersion":"v1beta1",
-      "triggers":[
-        {
-          "type":"ConfigChange"
-        }
-      ],
-      "template":{
-        "strategy":{
-          "type":"Recreate"
-        },
-        "controllerTemplate":{
-          "replicas":1,
-          "replicaSelector":{
-            "name":"registrypod"
-          },
-          "podTemplate":{
-            "desiredState":{
-              "manifest":{
-                "containers":[
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
                   {
-                    "image":"openshift/docker-registry",
-                    "imagePullPolicy":"PullIfNotPresent",
-                    "name":"registry-container",
-                    "ports":[
+                    "command": [
+                      "sh",
+                      "-c",
+                      "echo \"$OPENSHIFT_KEY_DATA\" \u003e $STORAGE_PATH/key.key \u0026\u0026 echo \"$OPENSHIFT_CERT_DATA\" \u003e $STORAGE_PATH/cert.crt \u0026\u0026 echo \"$OPENSHIFT_CA_DATA\" \u003e $STORAGE_PATH/root.crt \u0026\u0026 echo \"$OPENSHIFT_CA_DATA\" \u003e $STORAGE_PATH/root.crt \u0026\u0026 REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} OPENSHIFT_URL=${OPENSHIFT_MASTER}/osapi/v1beta1 OPENSHIFT_CA_BUNDLE=$STORAGE_PATH/root.crt OPENSHIFT_CLIENT_CERT=$STORAGE_PATH/cert.crt OPENSHIFT_CLIENT_KEY=$STORAGE_PATH/key.key exec docker-registry"
+                    ],
+                    "env": [
                       {
-                        "containerPort":5000,
-                        "protocol":"TCP"
+                        "name": "STORAGE_PATH",
+                        "value": "/tmp/openshift.local.registry"
+                      },
+                      {
+                        "name": "OPENSHIFT_MASTER",
+                        "value": "${OPENSHIFT_MASTER}"
+                      },
+                      {
+                        "name": "OPENSHIFT_CA_DATA",
+                        "value": "${OPENSHIFT_CA_DATA}"
+                      },
+                      {
+                        "name": "OPENSHIFT_CERT_DATA",
+                        "value": "${OPENSHIFT_CERT_DATA}"
+                      },
+                      {
+                        "name": "OPENSHIFT_KEY_DATA",
+                        "value": "${OPENSHIFT_KEY_DATA}"
                       }
                     ],
-                    "env":[
+                    "image": "openshift/docker-registry",
+                    "imagePullPolicy": "PullIfNotPresent",
+                    "name": "registry-container",
+                    "ports": [
                       {
-                        "name":"STORAGE_PATH",
-                        "value":"/tmp/openshift.local.registry"
-                      },
-                      {
-                          "name": "OPENSHIFT_MASTER",
-                          "value": "${OPENSHIFT_MASTER}"
-                      },
-                      {
-                          "name": "OPENSHIFT_CA_DATA",
-                          "value": "${OPENSHIFT_CA_DATA}"
-                      },
-                      {
-                          "name": "OPENSHIFT_CERT_DATA",
-                          "value": "${OPENSHIFT_CERT_DATA}"
-                      },
-                      {
-                          "name": "OPENSHIFT_KEY_DATA",
-                          "value": "${OPENSHIFT_KEY_DATA}"
+                        "containerPort": 5000,
+                        "protocol": "TCP"
                       }
                     ],
-                    "volumeMounts":[
+                    "privileged": true,
+                    "volumeMounts": [
                       {
-                        "name":"registry-storage",
-                        "mountPath":"/tmp/openshift.local.registry",
-                        "readOnly":false
+                        "mountPath": "/tmp/openshift.local.registry",
+                        "name": "registry-storage",
+                        "readOnly": false
                       }
-                    ],
-
-                    "command": ["sh", "-c", "echo \"$OPENSHIFT_KEY_DATA\" > $STORAGE_PATH/key.key && echo \"$OPENSHIFT_CERT_DATA\" > $STORAGE_PATH/cert.crt && echo \"$OPENSHIFT_CA_DATA\" > $STORAGE_PATH/root.crt && echo \"$OPENSHIFT_CA_DATA\" > $STORAGE_PATH/root.crt && REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} OPENSHIFT_URL=${OPENSHIFT_MASTER}/osapi/v1beta1 OPENSHIFT_CA_BUNDLE=$STORAGE_PATH/root.crt OPENSHIFT_CLIENT_CERT=$STORAGE_PATH/cert.crt OPENSHIFT_CLIENT_KEY=$STORAGE_PATH/key.key exec docker-registry"],
-                    "privileged":true
+                    ]
                   }
                 ],
-                "version":"v1beta1",
-                "volumes":[
+                "version": "v1beta1",
+                "volumes": [
                   {
-                    "name":"registry-storage",
-                    "source":{
-                      "hostDir":{
-                        "path":"/tmp/openshift.local.registry"
+                    "name": "registry-storage",
+                    "source": {
+                      "hostDir": {
+                        "path": "/tmp/openshift.local.registry"
                       }
                     }
                   }
                 ]
               },
-              "restartpolicy":{
-
-              }
+              "restartpolicy": {}
             },
-            "labels":{
-              "name":"registrypod"
+            "labels": {
+              "name": "registrypod"
             }
-          }
+          },
+          "replicaSelector": {
+            "name": "registrypod"
+          },
+          "replicas": 1
+        },
+        "strategy": {
+          "type": "Recreate"
         }
-      }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "annotations": {
+      "description": "Template for launching a docker-registry pod"
+    },
+    "name": "docker-registry-template"
+  },
+  "parameters": [
+    {
+      "description": "OpenShift master",
+      "name": "OPENSHIFT_MASTER",
+      "value": "http://localhost:8080"
+    },
+    {
+      "description": "OpenShift root certificates",
+      "name": "OPENSHIFT_CA_DATA"
+    },
+    {
+      "description": "OpenShift client certificate",
+      "name": "OPENSHIFT_CERT_DATA"
+    },
+    {
+      "description": "OpenShift client certificate key",
+      "name": "OPENSHIFT_KEY_DATA"
     }
   ]
 }

--- a/examples/sample-app/github-webhook-example.json
+++ b/examples/sample-app/github-webhook-example.json
@@ -1,136 +1,128 @@
 {
-   "ref":"refs/heads/master",
-   "after":"9bdc3a26ff933b32f3e558636b58aea86a69f051",
-   "before":"0000000000000000000000000000000000000000",
-   "created":true,
-   "deleted":false,
-   "forced":true,
-   "compare":"https://github.com/anonUser/anonRepo/commit/9bdc3a26ff93",
-   "commits":[
-      {
-         "id":"9bdc3a26ff933b32f3e558636b58aea86a69f051",
-         "distinct":true,
-         "message":"Added license",
-         "timestamp":"2014-08-28T16:55:36+02:00",
-         "url":"https://github.com/anonUser/anonRepo/commit/9bdc3a26ff933b32f3e558636b58aea86a69f051",
-         "author":{
-            "name":"Anonymous User",
-            "email":"anonUser@example.com"
-         },
-         "committer":{
-            "name":"Anonymous User",
-            "email":"anonUser@example.com"
-         },
-         "added":[
-            "LICENSE"
-         ],
-         "removed":[
-
-         ],
-         "modified":[
-
-         ]
-      }
-   ],
-   "head_commit":{
-      "id":"",
-      "distinct":true,
-      "message":"Added license",
-      "timestamp":"2014-08-28T16:55:36+02:00",
-      "url":"https://github.com/anonUser/anonRepo/commit/9bdc3a26ff933b32f3e558636b58aea86a69f051",
-      "author":{
-         "name":"Anonymous User",
-         "email":"anonUser@example.com"
-      },
-      "committer":{
-         "name":"Anonymous User",
-         "email":"anonUser@example.com"
-      },
-      "added":[
-         "LICENSE"
+  "after": "9bdc3a26ff933b32f3e558636b58aea86a69f051",
+  "before": "0000000000000000000000000000000000000000",
+  "commits": [
+    {
+      "added": [
+        "LICENSE"
       ],
-      "removed":[
-
-      ],
-      "modified":[
-
-      ]
-   },
-   "repository":{
-      "id":23354788,
-      "name":"anonRepo",
-      "full_name":"anonUser/anonRepo",
-      "owner":{
-         "name":"anonUser",
-         "email":"anonUser@example.com"
+      "author": {
+        "email": "anonUser@example.com",
+        "name": "Anonymous User"
       },
-      "private":false,
-      "html_url":"https://github.com/anonUser/anonRepo",
-      "description":"Git webhook implementation in Go.",
-      "fork":false,
-      "url":"https://github.com/anonUser/anonRepo",
-      "forks_url":"https://api.github.com/repos/anonUser/anonRepo/forks",
-      "keys_url":"https://api.github.com/repos/anonUser/anonRepo/keys{/key_id}",
-      "collaborators_url":"https://api.github.com/repos/anonUser/anonRepo/collaborators{/collaborator}",
-      "teams_url":"https://api.github.com/repos/anonUser/anonRepo/teams",
-      "hooks_url":"https://api.github.com/repos/anonUser/anonRepo/hooks",
-      "issue_events_url":"https://api.github.com/repos/anonUser/anonRepo/issues/events{/number}",
-      "events_url":"https://api.github.com/repos/anonUser/anonRepo/events",
-      "assignees_url":"https://api.github.com/repos/anonUser/anonRepo/assignees{/user}",
-      "branches_url":"https://api.github.com/repos/anonUser/anonRepo/branches{/branch}",
-      "tags_url":"https://api.github.com/repos/anonUser/anonRepo/tags",
-      "blobs_url":"https://api.github.com/repos/anonUser/anonRepo/git/blobs{/sha}",
-      "git_tags_url":"https://api.github.com/repos/anonUser/anonRepo/git/tags{/sha}",
-      "git_refs_url":"https://api.github.com/repos/anonUser/anonRepo/git/refs{/sha}",
-      "trees_url":"https://api.github.com/repos/anonUser/anonRepo/git/trees{/sha}",
-      "statuses_url":"https://api.github.com/repos/anonUser/anonRepo/statuses/{sha}",
-      "languages_url":"https://api.github.com/repos/anonUser/anonRepo/languages",
-      "stargazers_url":"https://api.github.com/repos/anonUser/anonRepo/stargazers",
-      "contributors_url":"https://api.github.com/repos/anonUser/anonRepo/contributors",
-      "subscribers_url":"https://api.github.com/repos/anonUser/anonRepo/subscribers",
-      "subscription_url":"https://api.github.com/repos/anonUser/anonRepo/subscription",
-      "commits_url":"https://api.github.com/repos/anonUser/anonRepo/commits{/sha}",
-      "git_commits_url":"https://api.github.com/repos/anonUser/anonRepo/git/commits{/sha}",
-      "comments_url":"https://api.github.com/repos/anonUser/anonRepo/comments{/number}",
-      "issue_comment_url":"https://api.github.com/repos/anonUser/anonRepo/issues/comments/{number}",
-      "contents_url":"https://api.github.com/repos/anonUser/anonRepo/contents/{+path}",
-      "compare_url":"https://api.github.com/repos/anonUser/anonRepo/compare/{base}...{head}",
-      "merges_url":"https://api.github.com/repos/anonUser/anonRepo/merges",
-      "archive_url":"https://api.github.com/repos/anonUser/anonRepo/{archive_format}{/ref}",
-      "downloads_url":"https://api.github.com/repos/anonUser/anonRepo/downloads",
-      "issues_url":"https://api.github.com/repos/anonUser/anonRepo/issues{/number}",
-      "pulls_url":"https://api.github.com/repos/anonUser/anonRepo/pulls{/number}",
-      "milestones_url":"https://api.github.com/repos/anonUser/anonRepo/milestones{/number}",
-      "notifications_url":"https://api.github.com/repos/anonUser/anonRepo/notifications{?since,all,participating}",
-      "labels_url":"https://api.github.com/repos/anonUser/anonRepo/labels{/name}",
-      "releases_url":"https://api.github.com/repos/anonUser/anonRepo/releases{/id}",
-      "created_at":1409063699,
-      "updated_at":"2014-08-26T14:34:59Z",
-      "pushed_at":1409238007,
-      "git_url":"git://github.com/anonUser/anonRepo.git",
-      "ssh_url":"git@github.com:anonUser/anonRepo.git",
-      "clone_url":"https://github.com/anonUser/anonRepo.git",
-      "svn_url":"https://github.com/anonUser/anonRepo",
-      "homepage":null,
-      "size":0,
-      "stargazers_count":0,
-      "watchers_count":0,
-      "language":null,
-      "has_issues":true,
-      "has_downloads":true,
-      "has_wiki":true,
-      "forks_count":0,
-      "mirror_url":null,
-      "open_issues_count":0,
-      "forks":0,
-      "open_issues":0,
-      "watchers":0,
-      "default_branch":"master",
-      "stargazers":0,
-      "master_branch":"master"
-   },
-   "pusher":{
-      "name":"anonUser",
-      "email":"anonUser@example.com"
-   }
+      "committer": {
+        "email": "anonUser@example.com",
+        "name": "Anonymous User"
+      },
+      "distinct": true,
+      "id": "9bdc3a26ff933b32f3e558636b58aea86a69f051",
+      "message": "Added license",
+      "modified": [],
+      "removed": [],
+      "timestamp": "2014-08-28T16:55:36+02:00",
+      "url": "https://github.com/anonUser/anonRepo/commit/9bdc3a26ff933b32f3e558636b58aea86a69f051"
+    }
+  ],
+  "compare": "https://github.com/anonUser/anonRepo/commit/9bdc3a26ff93",
+  "created": true,
+  "deleted": false,
+  "forced": true,
+  "head_commit": {
+    "added": [
+      "LICENSE"
+    ],
+    "author": {
+      "email": "anonUser@example.com",
+      "name": "Anonymous User"
+    },
+    "committer": {
+      "email": "anonUser@example.com",
+      "name": "Anonymous User"
+    },
+    "distinct": true,
+    "id": "",
+    "message": "Added license",
+    "modified": [],
+    "removed": [],
+    "timestamp": "2014-08-28T16:55:36+02:00",
+    "url": "https://github.com/anonUser/anonRepo/commit/9bdc3a26ff933b32f3e558636b58aea86a69f051"
+  },
+  "pusher": {
+    "email": "anonUser@example.com",
+    "name": "anonUser"
+  },
+  "ref": "refs/heads/master",
+  "repository": {
+    "archive_url": "https://api.github.com/repos/anonUser/anonRepo/{archive_format}{/ref}",
+    "assignees_url": "https://api.github.com/repos/anonUser/anonRepo/assignees{/user}",
+    "blobs_url": "https://api.github.com/repos/anonUser/anonRepo/git/blobs{/sha}",
+    "branches_url": "https://api.github.com/repos/anonUser/anonRepo/branches{/branch}",
+    "clone_url": "https://github.com/anonUser/anonRepo.git",
+    "collaborators_url": "https://api.github.com/repos/anonUser/anonRepo/collaborators{/collaborator}",
+    "comments_url": "https://api.github.com/repos/anonUser/anonRepo/comments{/number}",
+    "commits_url": "https://api.github.com/repos/anonUser/anonRepo/commits{/sha}",
+    "compare_url": "https://api.github.com/repos/anonUser/anonRepo/compare/{base}...{head}",
+    "contents_url": "https://api.github.com/repos/anonUser/anonRepo/contents/{+path}",
+    "contributors_url": "https://api.github.com/repos/anonUser/anonRepo/contributors",
+    "created_at": 1.409063699e+09,
+    "default_branch": "master",
+    "description": "Git webhook implementation in Go.",
+    "downloads_url": "https://api.github.com/repos/anonUser/anonRepo/downloads",
+    "events_url": "https://api.github.com/repos/anonUser/anonRepo/events",
+    "fork": false,
+    "forks": 0,
+    "forks_count": 0,
+    "forks_url": "https://api.github.com/repos/anonUser/anonRepo/forks",
+    "full_name": "anonUser/anonRepo",
+    "git_commits_url": "https://api.github.com/repos/anonUser/anonRepo/git/commits{/sha}",
+    "git_refs_url": "https://api.github.com/repos/anonUser/anonRepo/git/refs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/anonUser/anonRepo/git/tags{/sha}",
+    "git_url": "git://github.com/anonUser/anonRepo.git",
+    "has_downloads": true,
+    "has_issues": true,
+    "has_wiki": true,
+    "homepage": null,
+    "hooks_url": "https://api.github.com/repos/anonUser/anonRepo/hooks",
+    "html_url": "https://github.com/anonUser/anonRepo",
+    "id": 2.3354788e+07,
+    "issue_comment_url": "https://api.github.com/repos/anonUser/anonRepo/issues/comments/{number}",
+    "issue_events_url": "https://api.github.com/repos/anonUser/anonRepo/issues/events{/number}",
+    "issues_url": "https://api.github.com/repos/anonUser/anonRepo/issues{/number}",
+    "keys_url": "https://api.github.com/repos/anonUser/anonRepo/keys{/key_id}",
+    "labels_url": "https://api.github.com/repos/anonUser/anonRepo/labels{/name}",
+    "language": null,
+    "languages_url": "https://api.github.com/repos/anonUser/anonRepo/languages",
+    "master_branch": "master",
+    "merges_url": "https://api.github.com/repos/anonUser/anonRepo/merges",
+    "milestones_url": "https://api.github.com/repos/anonUser/anonRepo/milestones{/number}",
+    "mirror_url": null,
+    "name": "anonRepo",
+    "notifications_url": "https://api.github.com/repos/anonUser/anonRepo/notifications{?since,all,participating}",
+    "open_issues": 0,
+    "open_issues_count": 0,
+    "owner": {
+      "email": "anonUser@example.com",
+      "name": "anonUser"
+    },
+    "private": false,
+    "pulls_url": "https://api.github.com/repos/anonUser/anonRepo/pulls{/number}",
+    "pushed_at": 1.409238007e+09,
+    "releases_url": "https://api.github.com/repos/anonUser/anonRepo/releases{/id}",
+    "size": 0,
+    "ssh_url": "git@github.com:anonUser/anonRepo.git",
+    "stargazers": 0,
+    "stargazers_count": 0,
+    "stargazers_url": "https://api.github.com/repos/anonUser/anonRepo/stargazers",
+    "statuses_url": "https://api.github.com/repos/anonUser/anonRepo/statuses/{sha}",
+    "subscribers_url": "https://api.github.com/repos/anonUser/anonRepo/subscribers",
+    "subscription_url": "https://api.github.com/repos/anonUser/anonRepo/subscription",
+    "svn_url": "https://github.com/anonUser/anonRepo",
+    "tags_url": "https://api.github.com/repos/anonUser/anonRepo/tags",
+    "teams_url": "https://api.github.com/repos/anonUser/anonRepo/teams",
+    "trees_url": "https://api.github.com/repos/anonUser/anonRepo/git/trees{/sha}",
+    "updated_at": "2014-08-26T14:34:59Z",
+    "url": "https://github.com/anonUser/anonRepo",
+    "watchers": 0,
+    "watchers_count": 0
+  }
 }

--- a/hack/jsonformat.go
+++ b/hack/jsonformat.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+)
+
+import "io/ioutil"
+import "os"
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatal("Usage: jsonformat.go <filename>")
+	}
+
+	byt, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		log.Fatalf("ERROR: Unable to read file: %v\n", os.Args[1])
+	}
+
+	var dat map[string]interface{}
+
+	if err := json.Unmarshal(byt, &dat); err != nil {
+		log.Fatalf("ERROR: Invalid JSON file  '%v': %v\n", os.Args[1], err)
+	}
+
+	if output, err := json.MarshalIndent(dat, "", "  "); err != nil {
+		log.Fatalf("ERROR: Unable to indent JSON file: %v\n", os.Args[1])
+	} else {
+		os.Stdout.Write(append(output, '\n'))
+	}
+}

--- a/hack/verify-jsonformat.sh
+++ b/hack/verify-jsonformat.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Usage:
+#
+# To only verify that there are no errors in JSON files, run:
+# $ ./hack/verify-jsonformat.sh
+#
+# Additionally, to verify also the formatting of JSON file, run:
+# $ ./hack/verify-jsonformat.sh --format
+#
+# In case there is a formatting error, you can use this command to fix it
+# automatically:
+# $ ./hack/verify-jsonformat.sh --format --fix
+#
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+
+cd "${OS_ROOT}"
+
+json_files=$(find {api,examples,docs,images,plugins,test} -name "*.json")
+tmp_dir=$(mktemp -d --suffix=jsonformat)
+found=0
+
+set +e
+
+format="${1:-""}"
+fix="${2:-""}"
+
+for f in $json_files; do
+  tmp_file="${tmp_dir}$(basename $f)"
+  go run ./hack/jsonformat.go ${f} > ${tmp_file}
+  result=$?
+  if [ "${format}" == "--format" ]; then
+    if ! diff --brief ${f} ${tmp_file} > /dev/null; then
+      if [ "$result" == "0" -a "${fix}" == "--fix" ]; then
+        echo "Fixing JSON formatting for '${f}'"
+        cp ${tmp_file} ${f}
+      else
+        echo "JSON formatting problem: '${f}'"
+        found=1
+      fi
+      continue
+    fi
+  fi
+  [ "$result" != "0" ] && found=1
+done
+
+rm -rf ${tmp_dir}
+
+if [ "$found" == "1" ]; then
+  echo -e "\nThere are problems with some JSON files, to verify them you can run:"
+  echo -e "$ go run ./hack/jsonformat.go <filename>\n"
+  exit
+fi

--- a/images/router/haproxy/pod.json
+++ b/images/router/haproxy/pod.json
@@ -1,53 +1,55 @@
 {
-    "kind": "Pod",
-    "apiVersion": "v1beta1",
-    "id": "ROUTER_ID",
-    "desiredState": {
-        "manifest": {
-            "version": "v1beta2",
-            "containers": [
-                {
-                    "name": "origin-haproxy-router-ROUTER_ID",
-                    "image": "openshift/origin-haproxy-router",
-                    "ports": [
-                        {
-                            "containerPort": 80,
-                            "hostPort": 80
-                        },
-                        {
-                            "containerPort": 443,
-                            "hostPort": 443
-                        }
-                    ],
-                    "env": [
-                        {
-                            "name": "OPENSHIFT_MASTER",
-                            "value": "${OPENSHIFT_MASTER}"
-                        },
-                        {
-                            "name": "OPENSHIFT_CA_DATA",
-                            "value": "${OPENSHIFT_CA_DATA}"
-                        },
-                        {
-                            "name": "OPENSHIFT_KEY_DATA",
-                            "value": "${OPENSHIFT_KEY_DATA}"
-                        },
-                        {
-                            "name": "OPENSHIFT_CERT_DATA",
-                            "value": "${OPENSHIFT_CERT_DATA}"
-                        },
-                        {
-                            "name": "OPENSHIFT_INSECURE",
-                            "value": "${OPENSHIFT_INSECURE}"
-                        }
-                    ],
-                    "command": ["--loglevel=4"],
-                    "imagePullPolicy": "PullIfNotPresent"
-                }
-            ],
-            "restartPolicy": {
-                "always": {}
+  "apiVersion": "v1beta1",
+  "desiredState": {
+    "manifest": {
+      "containers": [
+        {
+          "command": [
+            "--loglevel=4"
+          ],
+          "env": [
+            {
+              "name": "OPENSHIFT_MASTER",
+              "value": "${OPENSHIFT_MASTER}"
+            },
+            {
+              "name": "OPENSHIFT_CA_DATA",
+              "value": "${OPENSHIFT_CA_DATA}"
+            },
+            {
+              "name": "OPENSHIFT_KEY_DATA",
+              "value": "${OPENSHIFT_KEY_DATA}"
+            },
+            {
+              "name": "OPENSHIFT_CERT_DATA",
+              "value": "${OPENSHIFT_CERT_DATA}"
+            },
+            {
+              "name": "OPENSHIFT_INSECURE",
+              "value": "${OPENSHIFT_INSECURE}"
             }
+          ],
+          "image": "openshift/origin-haproxy-router",
+          "imagePullPolicy": "PullIfNotPresent",
+          "name": "origin-haproxy-router-ROUTER_ID",
+          "ports": [
+            {
+              "containerPort": 80,
+              "hostPort": 80
+            },
+            {
+              "containerPort": 443,
+              "hostPort": 443
+            }
+          ]
         }
+      ],
+      "restartPolicy": {
+        "always": {}
+      },
+      "version": "v1beta2"
     }
+  },
+  "id": "ROUTER_ID",
+  "kind": "Pod"
 }

--- a/test/fixtures/app-scenarios/k8s-lonely-pod.json
+++ b/test/fixtures/app-scenarios/k8s-lonely-pod.json
@@ -1,28 +1,32 @@
 {
-    "kind": "List",
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-          "id": "lonely-pod",
-          "kind": "Pod",
-          "apiVersion":"v1beta2",
-          "namespace": "example",          
-          "labels": {
-            "name": "lonely-pod"
-          },
-          "desiredState": {
-            "manifest": {
-              "version": "v1beta1",
-              "id": "lonely-pod",
-              "containers": [{
-                "name": "lonely-pod",
-                "image": "openshift/hello-openshift",
-                "ports": [{
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "apiVersion": "v1beta2",
+      "desiredState": {
+        "manifest": {
+          "containers": [
+            {
+              "image": "openshift/hello-openshift",
+              "name": "lonely-pod",
+              "ports": [
+                {
                   "containerPort": 8080
-                }]
-              }]
+                }
+              ]
             }
-          },
+          ],
+          "id": "lonely-pod",
+          "version": "v1beta1"
         }
-    ]
+      },
+      "id": "lonely-pod",
+      "kind": "Pod",
+      "labels": {
+        "name": "lonely-pod"
+      },
+      "namespace": "example"
+    }
+  ],
+  "kind": "List"
 }

--- a/test/fixtures/app-scenarios/k8s-sample-app.json
+++ b/test/fixtures/app-scenarios/k8s-sample-app.json
@@ -1,168 +1,166 @@
 {
-    "kind": "List",
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "kind": "ReplicationController",
-            "id": "database-1",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "annotations": {
-            },
-            "desiredState": {
-                "replicas": 1,
-                "replicaSelector": {
-                    "name": "database"
-                },
-                "podTemplate": {
-                    "desiredState": {
-                        "manifest": {
-                            "version": "v1beta2",
-                            "id": "",
-                            "volumes": null,
-                            "containers": [
-                                {
-                                    "name": "ruby-helloworld-database",
-                                    "image": "mysql",
-                                    "ports": [
-                                        {
-                                            "containerPort": 3306,
-                                            "protocol": "TCP"
-                                        }
-                                    ],
-                                    "env": [
-                                        {
-                                            "name": "MYSQL_ROOT_PASSWORD",
-                                            "key": "MYSQL_ROOT_PASSWORD",
-                                            "value": "rQHfVnTo"
-                                        },
-                                        {
-                                            "name": "MYSQL_DATABASE",
-                                            "key": "MYSQL_DATABASE",
-                                            "value": "root"
-                                        }
-                                    ],
-                                    "imagePullPolicy": "PullIfNotPresent",
-                                    "capabilities": {}
-                                }
-                            ],
-                            "restartPolicy": {
-                                "always": {}
-                            },
-                            "dnsPolicy": "ClusterFirst"
-                        }
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "annotations": {},
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "containers": [
+                {
+                  "capabilities": {},
+                  "env": [
+                    {
+                      "key": "MYSQL_ROOT_PASSWORD",
+                      "name": "MYSQL_ROOT_PASSWORD",
+                      "value": "rQHfVnTo"
                     },
-                    "labels": {
-                        "name": "database",
-                        "template": "ruby-helloworld-sample"
+                    {
+                      "key": "MYSQL_DATABASE",
+                      "name": "MYSQL_DATABASE",
+                      "value": "root"
                     }
+                  ],
+                  "image": "mysql",
+                  "imagePullPolicy": "PullIfNotPresent",
+                  "name": "ruby-helloworld-database",
+                  "ports": [
+                    {
+                      "containerPort": 3306,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
-            },
-            "labels": {
-                "template": "ruby-helloworld-sample"
+              ],
+              "dnsPolicy": "ClusterFirst",
+              "id": "",
+              "restartPolicy": {
+                "always": {}
+              },
+              "version": "v1beta2",
+              "volumes": null
             }
+          },
+          "labels": {
+            "name": "database",
+            "template": "ruby-helloworld-sample"
+          }
         },
-        {
-            "kind": "ReplicationController",
-            "id": "frontend-1",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "annotations": {
-            },
-            "desiredState": {
-                "replicas": 3,
-                "replicaSelector": {
-                    "name": "frontend"
-                },
-                "podTemplate": {
-                    "desiredState": {
-                        "manifest": {
-                            "version": "v1beta2",
-                            "id": "",
-                            "volumes": null,
-                            "containers": [
-                                {
-                                    "name": "ruby-helloworld",
-                                    "image": "openshift/ruby-hello-world",
-                                    "ports": [
-                                        {
-                                            "containerPort": 8080,
-                                            "protocol": "TCP"
-                                        }
-                                    ],
-                                    "env": [
-                                        {
-                                            "name": "ADMIN_USERNAME",
-                                            "key": "ADMIN_USERNAME",
-                                            "value": "admin6TM"
-                                        },
-                                        {
-                                            "name": "ADMIN_PASSWORD",
-                                            "key": "ADMIN_PASSWORD",
-                                            "value": "xImx1tHR"
-                                        },
-                                        {
-                                            "name": "MYSQL_ROOT_PASSWORD",
-                                            "key": "MYSQL_ROOT_PASSWORD",
-                                            "value": "rQHfVnTo"
-                                        },
-                                        {
-                                            "name": "MYSQL_DATABASE",
-                                            "key": "MYSQL_DATABASE",
-                                            "value": "root"
-                                        }
-                                    ],
-                                    "imagePullPolicy": "PullIfNotPresent",
-                                    "capabilities": {}
-                                }
-                            ],
-                            "restartPolicy": {
-                                "always": {}
-                            },
-                            "dnsPolicy": "ClusterFirst"
-                        }
+        "replicaSelector": {
+          "name": "database"
+        },
+        "replicas": 1
+      },
+      "id": "database-1",
+      "kind": "ReplicationController",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example"
+    },
+    {
+      "annotations": {},
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "containers": [
+                {
+                  "capabilities": {},
+                  "env": [
+                    {
+                      "key": "ADMIN_USERNAME",
+                      "name": "ADMIN_USERNAME",
+                      "value": "admin6TM"
                     },
-                    "labels": {
-                        "name": "frontend",
-                        "template": "ruby-helloworld-sample"
+                    {
+                      "key": "ADMIN_PASSWORD",
+                      "name": "ADMIN_PASSWORD",
+                      "value": "xImx1tHR"
+                    },
+                    {
+                      "key": "MYSQL_ROOT_PASSWORD",
+                      "name": "MYSQL_ROOT_PASSWORD",
+                      "value": "rQHfVnTo"
+                    },
+                    {
+                      "key": "MYSQL_DATABASE",
+                      "name": "MYSQL_DATABASE",
+                      "value": "root"
                     }
+                  ],
+                  "image": "openshift/ruby-hello-world",
+                  "imagePullPolicy": "PullIfNotPresent",
+                  "name": "ruby-helloworld",
+                  "ports": [
+                    {
+                      "containerPort": 8080,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
-            },
-            "labels": {
-                "template": "ruby-helloworld-sample"
+              ],
+              "dnsPolicy": "ClusterFirst",
+              "id": "",
+              "restartPolicy": {
+                "always": {}
+              },
+              "version": "v1beta2",
+              "volumes": null
             }
+          },
+          "labels": {
+            "name": "frontend",
+            "template": "ruby-helloworld-sample"
+          }
         },
-        {
-            "kind": "Service",
-            "id": "database",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "port": 5434,
-            "protocol": "TCP",
-            "labels": {
-                "template": "ruby-helloworld-sample"
-            },
-            "selector": {
-                "name": "database"
-            },
-            "containerPort": 3306,
-            "sessionAffinity": "None"
+        "replicaSelector": {
+          "name": "frontend"
         },
-        {
-            "kind": "Service",
-            "id": "frontend",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "port": 5432,
-            "protocol": "TCP",
-            "labels": {
-                "template": "ruby-helloworld-sample"
-            },
-            "selector": {
-                "name": "frontend"
-            },
-            "containerPort": 8080,
-            "sessionAffinity": "None"
-        }
-    ]
+        "replicas": 3
+      },
+      "id": "frontend-1",
+      "kind": "ReplicationController",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example"
+    },
+    {
+      "apiVersion": "v1beta1",
+      "containerPort": 3306,
+      "id": "database",
+      "kind": "Service",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example",
+      "port": 5434,
+      "protocol": "TCP",
+      "selector": {
+        "name": "database"
+      },
+      "sessionAffinity": "None"
+    },
+    {
+      "apiVersion": "v1beta1",
+      "containerPort": 8080,
+      "id": "frontend",
+      "kind": "Service",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example",
+      "port": 5432,
+      "protocol": "TCP",
+      "selector": {
+        "name": "frontend"
+      },
+      "sessionAffinity": "None"
+    }
+  ],
+  "kind": "List"
 }

--- a/test/fixtures/app-scenarios/k8s-service-pod-no-rc.json
+++ b/test/fixtures/app-scenarios/k8s-service-pod-no-rc.json
@@ -1,44 +1,48 @@
 {
-    "kind": "List",
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "kind": "Service",
-            "id": "hello-openshift",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "port": 5432,
-            "protocol": "TCP",
-            "labels": {
-                "template": "hello-openshift"
-            },
-            "selector": {
-                "name": "hello-openshift"
-            },
-            "containerPort": 8080,
-            "sessionAffinity": "None"
-        },
-        {
-          "id": "hello-openshift",
-          "kind": "Pod",
-          "apiVersion":"v1beta2",
-          "namespace": "example",          
-          "labels": {
-            "name": "hello-openshift"
-          },
-          "desiredState": {
-            "manifest": {
-              "version": "v1beta1",
-              "id": "hello-openshift",
-              "containers": [{
-                "name": "hello-openshift",
-                "image": "openshift/hello-openshift",
-                "ports": [{
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "apiVersion": "v1beta1",
+      "containerPort": 8080,
+      "id": "hello-openshift",
+      "kind": "Service",
+      "labels": {
+        "template": "hello-openshift"
+      },
+      "namespace": "example",
+      "port": 5432,
+      "protocol": "TCP",
+      "selector": {
+        "name": "hello-openshift"
+      },
+      "sessionAffinity": "None"
+    },
+    {
+      "apiVersion": "v1beta2",
+      "desiredState": {
+        "manifest": {
+          "containers": [
+            {
+              "image": "openshift/hello-openshift",
+              "name": "hello-openshift",
+              "ports": [
+                {
                   "containerPort": 8080
-                }]
-              }]
+                }
+              ]
             }
-          },
-        }        
-    ]
+          ],
+          "id": "hello-openshift",
+          "version": "v1beta1"
+        }
+      },
+      "id": "hello-openshift",
+      "kind": "Pod",
+      "labels": {
+        "name": "hello-openshift"
+      },
+      "namespace": "example"
+    }
+  ],
+  "kind": "List"
 }

--- a/test/fixtures/app-scenarios/k8s-service-with-nothing.json
+++ b/test/fixtures/app-scenarios/k8s-service-with-nothing.json
@@ -1,22 +1,22 @@
 {
-    "kind": "List",
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "kind": "Service",
-            "id": "empty-service",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "port": 5432,
-            "protocol": "TCP",
-            "labels": {
-                "template": "empty-service"
-            },
-            "selector": {
-                "name": "empty-service"
-            },
-            "containerPort": 8080,
-            "sessionAffinity": "None"
-        }
-    ]
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "apiVersion": "v1beta1",
+      "containerPort": 8080,
+      "id": "empty-service",
+      "kind": "Service",
+      "labels": {
+        "template": "empty-service"
+      },
+      "namespace": "example",
+      "port": 5432,
+      "protocol": "TCP",
+      "selector": {
+        "name": "empty-service"
+      },
+      "sessionAffinity": "None"
+    }
+  ],
+  "kind": "List"
 }

--- a/test/fixtures/app-scenarios/k8s-unserviced-rc.json
+++ b/test/fixtures/app-scenarios/k8s-unserviced-rc.json
@@ -1,152 +1,150 @@
 {
-    "kind": "List",
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "kind": "ReplicationController",
-            "id": "database-1",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "annotations": {
-            },
-            "desiredState": {
-                "replicas": 1,
-                "replicaSelector": {
-                    "name": "database"
-                },
-                "podTemplate": {
-                    "desiredState": {
-                        "manifest": {
-                            "version": "v1beta2",
-                            "id": "",
-                            "volumes": null,
-                            "containers": [
-                                {
-                                    "name": "ruby-helloworld-database",
-                                    "image": "mysql",
-                                    "ports": [
-                                        {
-                                            "containerPort": 3306,
-                                            "protocol": "TCP"
-                                        }
-                                    ],
-                                    "env": [
-                                        {
-                                            "name": "MYSQL_ROOT_PASSWORD",
-                                            "key": "MYSQL_ROOT_PASSWORD",
-                                            "value": "rQHfVnTo"
-                                        },
-                                        {
-                                            "name": "MYSQL_DATABASE",
-                                            "key": "MYSQL_DATABASE",
-                                            "value": "root"
-                                        }
-                                    ],
-                                    "imagePullPolicy": "PullIfNotPresent",
-                                    "capabilities": {}
-                                }
-                            ],
-                            "restartPolicy": {
-                                "always": {}
-                            },
-                            "dnsPolicy": "ClusterFirst"
-                        }
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "annotations": {},
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "containers": [
+                {
+                  "capabilities": {},
+                  "env": [
+                    {
+                      "key": "MYSQL_ROOT_PASSWORD",
+                      "name": "MYSQL_ROOT_PASSWORD",
+                      "value": "rQHfVnTo"
                     },
-                    "labels": {
-                        "name": "database",
-                        "template": "ruby-helloworld-sample"
+                    {
+                      "key": "MYSQL_DATABASE",
+                      "name": "MYSQL_DATABASE",
+                      "value": "root"
                     }
+                  ],
+                  "image": "mysql",
+                  "imagePullPolicy": "PullIfNotPresent",
+                  "name": "ruby-helloworld-database",
+                  "ports": [
+                    {
+                      "containerPort": 3306,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
-            },
-            "labels": {
-                "template": "ruby-helloworld-sample"
+              ],
+              "dnsPolicy": "ClusterFirst",
+              "id": "",
+              "restartPolicy": {
+                "always": {}
+              },
+              "version": "v1beta2",
+              "volumes": null
             }
+          },
+          "labels": {
+            "name": "database",
+            "template": "ruby-helloworld-sample"
+          }
         },
-        {
-            "kind": "ReplicationController",
-            "id": "frontend-1",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "annotations": {
-            },
-            "desiredState": {
-                "replicas": 3,
-                "replicaSelector": {
-                    "name": "frontend"
-                },
-                "podTemplate": {
-                    "desiredState": {
-                        "manifest": {
-                            "version": "v1beta2",
-                            "id": "",
-                            "volumes": null,
-                            "containers": [
-                                {
-                                    "name": "ruby-helloworld",
-                                    "image": "openshift/ruby-hello-world",
-                                    "ports": [
-                                        {
-                                            "containerPort": 8080,
-                                            "protocol": "TCP"
-                                        }
-                                    ],
-                                    "env": [
-                                        {
-                                            "name": "ADMIN_USERNAME",
-                                            "key": "ADMIN_USERNAME",
-                                            "value": "admin6TM"
-                                        },
-                                        {
-                                            "name": "ADMIN_PASSWORD",
-                                            "key": "ADMIN_PASSWORD",
-                                            "value": "xImx1tHR"
-                                        },
-                                        {
-                                            "name": "MYSQL_ROOT_PASSWORD",
-                                            "key": "MYSQL_ROOT_PASSWORD",
-                                            "value": "rQHfVnTo"
-                                        },
-                                        {
-                                            "name": "MYSQL_DATABASE",
-                                            "key": "MYSQL_DATABASE",
-                                            "value": "root"
-                                        }
-                                    ],
-                                    "imagePullPolicy": "PullIfNotPresent",
-                                    "capabilities": {}
-                                }
-                            ],
-                            "restartPolicy": {
-                                "always": {}
-                            },
-                            "dnsPolicy": "ClusterFirst"
-                        }
+        "replicaSelector": {
+          "name": "database"
+        },
+        "replicas": 1
+      },
+      "id": "database-1",
+      "kind": "ReplicationController",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example"
+    },
+    {
+      "annotations": {},
+      "apiVersion": "v1beta1",
+      "desiredState": {
+        "podTemplate": {
+          "desiredState": {
+            "manifest": {
+              "containers": [
+                {
+                  "capabilities": {},
+                  "env": [
+                    {
+                      "key": "ADMIN_USERNAME",
+                      "name": "ADMIN_USERNAME",
+                      "value": "admin6TM"
                     },
-                    "labels": {
-                        "name": "frontend",
-                        "template": "ruby-helloworld-sample"
+                    {
+                      "key": "ADMIN_PASSWORD",
+                      "name": "ADMIN_PASSWORD",
+                      "value": "xImx1tHR"
+                    },
+                    {
+                      "key": "MYSQL_ROOT_PASSWORD",
+                      "name": "MYSQL_ROOT_PASSWORD",
+                      "value": "rQHfVnTo"
+                    },
+                    {
+                      "key": "MYSQL_DATABASE",
+                      "name": "MYSQL_DATABASE",
+                      "value": "root"
                     }
+                  ],
+                  "image": "openshift/ruby-hello-world",
+                  "imagePullPolicy": "PullIfNotPresent",
+                  "name": "ruby-helloworld",
+                  "ports": [
+                    {
+                      "containerPort": 8080,
+                      "protocol": "TCP"
+                    }
+                  ]
                 }
-            },
-            "labels": {
-                "template": "ruby-helloworld-sample"
+              ],
+              "dnsPolicy": "ClusterFirst",
+              "id": "",
+              "restartPolicy": {
+                "always": {}
+              },
+              "version": "v1beta2",
+              "volumes": null
             }
+          },
+          "labels": {
+            "name": "frontend",
+            "template": "ruby-helloworld-sample"
+          }
         },
-        {
-            "kind": "Service",
-            "id": "database",
-            "apiVersion": "v1beta1",
-            "namespace": "example",
-            "port": 5434,
-            "protocol": "TCP",
-            "labels": {
-                "template": "ruby-helloworld-sample"
-            },
-            "selector": {
-                "name": "database"
-            },
-            "containerPort": 3306,
-            "sessionAffinity": "None"
-        }
-    ]
+        "replicaSelector": {
+          "name": "frontend"
+        },
+        "replicas": 3
+      },
+      "id": "frontend-1",
+      "kind": "ReplicationController",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example"
+    },
+    {
+      "apiVersion": "v1beta1",
+      "containerPort": 3306,
+      "id": "database",
+      "kind": "Service",
+      "labels": {
+        "template": "ruby-helloworld-sample"
+      },
+      "namespace": "example",
+      "port": 5434,
+      "protocol": "TCP",
+      "selector": {
+        "name": "database"
+      },
+      "sessionAffinity": "None"
+    }
+  ],
+  "kind": "List"
 }

--- a/test/integration/fixtures/test-buildcli.json
+++ b/test/integration/fixtures/test-buildcli.json
@@ -1,101 +1,101 @@
 {
-    "apiVersion": "v1beta1",
-    "items": [
-        {
-            "apiVersion": "v1beta1",
-            "dockerImageRepository": "openshift/ruby-20-centos",
-            "kind": "ImageRepository",
-            "metadata": {
-                "name": "ruby-20-centos-buildcli"
-            },
-            "tags": {
-                "valid": "success"
-            }
+  "apiVersion": "v1beta1",
+  "items": [
+    {
+      "apiVersion": "v1beta1",
+      "dockerImageRepository": "openshift/ruby-20-centos",
+      "kind": "ImageRepository",
+      "metadata": {
+        "name": "ruby-20-centos-buildcli"
+      },
+      "tags": {
+        "valid": "success"
+      }
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "BuildConfig",
+      "labels": {
+        "name": "ruby-sample-build"
+      },
+      "metadata": {
+        "name": "ruby-sample-build-validtag"
+      },
+      "parameters": {
+        "output": {
+          "to": {
+            "name": "origin-ruby-sample"
+          }
         },
-        {
-            "apiVersion": "v1beta1",
-            "kind": "BuildConfig",
-            "labels": {
-                "name": "ruby-sample-build"
-            },
-            "metadata": {
-                "name": "ruby-sample-build-validtag"
-            },
-            "parameters": {
-                "output": {
-                    "to": {
-                        "name": "origin-ruby-sample"
-                    }
-                },
-                "source": {
-                    "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
-                    },
-                    "type": "Git"
-                },
-                "strategy": {
-                    "stiStrategy": {
-                        "image": "openshift/ruby-20-centos",
-                        "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
-                    },
-                    "type": "STI"
-                }
-            },
-            "triggers": [
-                {
-                    "imageChange": {
-                        "from": {
-                            "name": "ruby-20-centos-buildcli"
-                        },
-                        "image": "openshift/ruby-20-centos",
-                        "tag": "valid"
-                    },
-                    "type": "imageChange"
-                }
-            ]
+        "source": {
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "type": "Git"
         },
-        {
-            "apiVersion": "v1beta1",
-            "kind": "BuildConfig",
-            "labels": {
-                "name": "ruby-sample-build"
-            },
-            "metadata": {
-                "name": "ruby-sample-build-invalidtag"
-            },
-            "parameters": {
-                "output": {
-                    "to": {
-                        "name": "origin-ruby-sample"
-                    }
-                },
-                "source": {
-                    "git": {
-                        "uri": "git://github.com/openshift/ruby-hello-world.git"
-                    },
-                    "type": "Git"
-                },
-                "strategy": {
-                    "stiStrategy": {
-                        "image": "openshift/ruby-20-centos",
-                        "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
-                    },
-                    "type": "STI"
-                }
-            },
-            "triggers": [
-                {
-                    "imageChange": {
-                        "from": {
-                            "name": "ruby-20-centos-buildcli"
-                        },
-                        "image": "openshift/ruby-20-centos",
-                        "tag": "invalid"
-                    },
-                    "type": "imageChange"
-                }
-            ]
+        "strategy": {
+          "stiStrategy": {
+            "image": "openshift/ruby-20-centos",
+            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+          },
+          "type": "STI"
         }
-    ],
-    "kind": "List"
+      },
+      "triggers": [
+        {
+          "imageChange": {
+            "from": {
+              "name": "ruby-20-centos-buildcli"
+            },
+            "image": "openshift/ruby-20-centos",
+            "tag": "valid"
+          },
+          "type": "imageChange"
+        }
+      ]
+    },
+    {
+      "apiVersion": "v1beta1",
+      "kind": "BuildConfig",
+      "labels": {
+        "name": "ruby-sample-build"
+      },
+      "metadata": {
+        "name": "ruby-sample-build-invalidtag"
+      },
+      "parameters": {
+        "output": {
+          "to": {
+            "name": "origin-ruby-sample"
+          }
+        },
+        "source": {
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "type": "Git"
+        },
+        "strategy": {
+          "stiStrategy": {
+            "image": "openshift/ruby-20-centos",
+            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+          },
+          "type": "STI"
+        }
+      },
+      "triggers": [
+        {
+          "imageChange": {
+            "from": {
+              "name": "ruby-20-centos-buildcli"
+            },
+            "image": "openshift/ruby-20-centos",
+            "tag": "invalid"
+          },
+          "type": "imageChange"
+        }
+      ]
+    }
+  ],
+  "kind": "List"
 }

--- a/test/integration/fixtures/test-image-repository.json
+++ b/test/integration/fixtures/test-image-repository.json
@@ -1,14 +1,14 @@
 {
-  "kind": "ImageRepository",
   "apiVersion": "v1beta1",
+  "kind": "ImageRepository",
   "metadata": {
-    "name": "test",
     "labels": {
       "color": "blue"
-    }
+    },
+    "name": "test"
   },
   "tags": {
-    "latest": "foo",
     "another": "bar",
+    "latest": "foo"
   }
 }

--- a/test/integration/fixtures/test-image.json
+++ b/test/integration/fixtures/test-image.json
@@ -1,84 +1,81 @@
 {
-  "kind": "Image",
   "apiVersion": "v1beta1",
-  "metadata": {
-    "name": "test"
-  },
   "dockerImageReference": "openshift/ruby-19-centos:latest",
+  "kind": "Image",
   "meta": {
     "Architecture": "amd64",
     "Author": "Michal Fojtik \u003cmfojtik@redhat.com\u003e",
     "Comment": "",
     "Config": {
-        "AttachStderr": false,
-        "AttachStdin": false,
-        "AttachStdout": false,
-        "Cmd": [
-            "/opt/ruby/bin/usage"
-        ],
-        "CpuShares": 0,
-        "Cpuset": "",
-        "Domainname": "",
-        "Entrypoint": null,
-        "Env": [
-            "HOME=/opt/ruby",
-            "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
-            "APP_ROOT=."
-        ],
-        "ExposedPorts": {
-            "9292/tcp": {}
-        },
-        "Hostname": "df1704c4368e",
-        "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
-        "Memory": 0,
-        "MemorySwap": 0,
-        "NetworkDisabled": false,
-        "OnBuild": [],
-        "OpenStdin": false,
-        "PortSpecs": null,
-        "StdinOnce": false,
-        "Tty": false,
-        "User": "ruby",
-        "Volumes": null,
-        "WorkingDir": "/opt/ruby/src"
+      "AttachStderr": false,
+      "AttachStdin": false,
+      "AttachStdout": false,
+      "Cmd": [
+        "/opt/ruby/bin/usage"
+      ],
+      "CpuShares": 0,
+      "Cpuset": "",
+      "Domainname": "",
+      "Entrypoint": null,
+      "Env": [
+        "HOME=/opt/ruby",
+        "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+        "APP_ROOT=."
+      ],
+      "ExposedPorts": {
+        "9292/tcp": {}
+      },
+      "Hostname": "df1704c4368e",
+      "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+      "Memory": 0,
+      "MemorySwap": 0,
+      "NetworkDisabled": false,
+      "OnBuild": [],
+      "OpenStdin": false,
+      "PortSpecs": null,
+      "StdinOnce": false,
+      "Tty": false,
+      "User": "ruby",
+      "Volumes": null,
+      "WorkingDir": "/opt/ruby/src"
     },
     "Container": "72ce367abbc2862232b5e5e3485e51f096983e4e28b8dbefba9a6fd5ce0d6e48",
     "ContainerConfig": {
-        "AttachStderr": false,
-        "AttachStdin": false,
-        "AttachStdout": false,
-        "Cmd": [
-            "/bin/sh",
-            "-c",
-            "#(nop) CMD [/opt/ruby/bin/usage]"
-        ],
-"CpuShares": 0,
-        "Cpuset": "",
-        "Domainname": "",
-        "Entrypoint": null,
-        "Env": [
-            "HOME=/opt/ruby",
-            "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
-            "APP_ROOT=."
-        ],
-        "ExposedPorts": {
-            "9292/tcp": {}
-        },
-        "Hostname": "df1704c4368e",
-        "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
-        "Memory": 0,
-        "MemorySwap": 0,
-        "NetworkDisabled": false,
-        "OnBuild": [],
-        "OpenStdin": false,
-        "PortSpecs": null,
-        "StdinOnce": false,
-        "Tty": false,
-        "User": "ruby",
-        "Volumes": null,
-        "WorkingDir": "/opt/ruby/src"
+      "AttachStderr": false,
+      "AttachStdin": false,
+      "AttachStdout": false,
+      "Cmd": [
+        "/bin/sh",
+        "-c",
+        "#(nop) CMD [/opt/ruby/bin/usage]"
+      ],
+      "CpuShares": 0,
+      "Cpuset": "",
+      "Domainname": "",
+      "Entrypoint": null,
+      "Env": [
+        "HOME=/opt/ruby",
+        "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+        "APP_ROOT=."
+      ],
+      "ExposedPorts": {
+        "9292/tcp": {}
+      },
+      "Hostname": "df1704c4368e",
+      "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+      "Memory": 0,
+      "MemorySwap": 0,
+      "NetworkDisabled": false,
+      "OnBuild": [],
+      "OpenStdin": false,
+      "PortSpecs": null,
+      "StdinOnce": false,
+      "Tty": false,
+      "User": "ruby",
+      "Volumes": null,
+      "WorkingDir": "/opt/ruby/src"
     },
     "Created": "2014-08-08T14:36:01.303084707Z",
     "DockerVersion": "1.1.2-dev",
@@ -86,5 +83,8 @@
     "Os": "linux",
     "Parent": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
     "Size": 0
+  },
+  "metadata": {
+    "name": "test"
   }
 }

--- a/test/integration/fixtures/test-mapping.json
+++ b/test/integration/fixtures/test-mapping.json
@@ -1,90 +1,80 @@
 {
-  "metadata": {
-    "name": "test"
-  },
-  "kind": "ImageRepositoryMapping",
   "apiVersion": "v1beta1",
   "image": {
-    "kind": "Image",
-    "version": "v1beta1",
-    "metadata": {
-      "name": "abcd1234"
-    },
-    "dockerImageReference": "openshift/ruby-19-centos:latest",
     "dockerImageMetadata": {
       "Architecture": "amd64",
       "Author": "Michal Fojtik \u003cmfojtik@redhat.com\u003e",
       "Comment": "",
       "Config": {
-          "AttachStderr": false,
-          "AttachStdin": false,
-          "AttachStdout": false,
-          "Cmd": [
-              "/opt/ruby/bin/usage"
-          ],
-          "CpuShares": 0,
-          "Cpuset": "",
-          "Domainname": "",
-          "Entrypoint": null,
-          "Env": [
-              "HOME=/opt/ruby",
-              "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-              "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
-              "APP_ROOT=."
-          ],
-          "ExposedPorts": {
-              "9292/tcp": {}
-          },
-          "Hostname": "df1704c4368e",
-          "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
-          "Memory": 0,
-          "MemorySwap": 0,
-          "NetworkDisabled": false,
-          "OnBuild": [],
-          "OpenStdin": false,
-          "PortSpecs": null,
-          "StdinOnce": false,
-          "Tty": false,
-          "User": "ruby",
-          "Volumes": null,
-          "WorkingDir": "/opt/ruby/src"
+        "AttachStderr": false,
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "Cmd": [
+          "/opt/ruby/bin/usage"
+        ],
+        "CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+          "HOME=/opt/ruby",
+          "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+          "APP_ROOT=."
+        ],
+        "ExposedPorts": {
+          "9292/tcp": {}
+        },
+        "Hostname": "df1704c4368e",
+        "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": [],
+        "OpenStdin": false,
+        "PortSpecs": null,
+        "StdinOnce": false,
+        "Tty": false,
+        "User": "ruby",
+        "Volumes": null,
+        "WorkingDir": "/opt/ruby/src"
       },
       "Container": "72ce367abbc2862232b5e5e3485e51f096983e4e28b8dbefba9a6fd5ce0d6e48",
       "ContainerConfig": {
-          "AttachStderr": false,
-          "AttachStdin": false,
-          "AttachStdout": false,
-          "Cmd": [
-              "/bin/sh",
-              "-c",
-              "#(nop) CMD [/opt/ruby/bin/usage]"
-          ],
-  "CpuShares": 0,
-          "Cpuset": "",
-          "Domainname": "",
-          "Entrypoint": null,
-          "Env": [
-              "HOME=/opt/ruby",
-              "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-              "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
-              "APP_ROOT=."
-          ],
-          "ExposedPorts": {
-              "9292/tcp": {}
-          },
-          "Hostname": "df1704c4368e",
-          "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
-          "Memory": 0,
-          "MemorySwap": 0,
-          "NetworkDisabled": false,
-          "OnBuild": [],
-          "OpenStdin": false,
-          "PortSpecs": null,
-          "StdinOnce": false,
-          "Tty": false,
-          "User": "ruby",
-          "Volumes": null,
-          "WorkingDir": "/opt/ruby/src"
+        "AttachStderr": false,
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "Cmd": [
+          "/bin/sh",
+          "-c",
+          "#(nop) CMD [/opt/ruby/bin/usage]"
+        ],
+        "CpuShares": 0,
+        "Cpuset": "",
+        "Domainname": "",
+        "Entrypoint": null,
+        "Env": [
+          "HOME=/opt/ruby",
+          "PATH=/opt/ruby/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "STI_SCRIPTS_URL=https://raw.githubusercontent.com/openshift/ruby-19-centos/master/.sti/bin",
+          "APP_ROOT=."
+        ],
+        "ExposedPorts": {
+          "9292/tcp": {}
+        },
+        "Hostname": "df1704c4368e",
+        "Image": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
+        "Memory": 0,
+        "MemorySwap": 0,
+        "NetworkDisabled": false,
+        "OnBuild": [],
+        "OpenStdin": false,
+        "PortSpecs": null,
+        "StdinOnce": false,
+        "Tty": false,
+        "User": "ruby",
+        "Volumes": null,
+        "WorkingDir": "/opt/ruby/src"
       },
       "Created": "2014-08-08T14:36:01.303084707Z",
       "DockerVersion": "1.1.2-dev",
@@ -92,7 +82,17 @@
       "Os": "linux",
       "Parent": "dde5ee6a036d5d2c69240413fa8f3bb9bb1fea25166996eadf42e2f113736401",
       "Size": 0
-    }
+    },
+    "dockerImageReference": "openshift/ruby-19-centos:latest",
+    "kind": "Image",
+    "metadata": {
+      "name": "abcd1234"
+    },
+    "version": "v1beta1"
+  },
+  "kind": "ImageRepositoryMapping",
+  "metadata": {
+    "name": "test"
   },
   "tag": "sometag"
 }

--- a/test/integration/fixtures/test-route.json
+++ b/test/integration/fixtures/test-route.json
@@ -1,12 +1,12 @@
 {
-  "kind": "Route",
   "apiVersion": "v1beta1",
+  "host": "test.example.com",
+  "kind": "Route",
+  "labels": {
+    "name": "test"
+  },
   "metadata": {
     "name": "testroute"
   },
-  "host": "test.example.com",
-  "serviceName": "testservice",
-  "labels": {
-    "name": "test"
-  }
+  "serviceName": "testservice"
 }

--- a/test/integration/fixtures/test-service.json
+++ b/test/integration/fixtures/test-service.json
@@ -1,7 +1,7 @@
 {
+  "apiVersion": "v1beta2",
   "id": "frontend",
   "kind": "Service",
-  "apiVersion": "v1beta2",
   "port": 9998,
   "selector": {
     "name": "frontend"

--- a/test/templates/fixtures/crunchydata-pod.json
+++ b/test/templates/fixtures/crunchydata-pod.json
@@ -1,47 +1,14 @@
 {
-  "id": "node",
-  "kind": "Template",
   "apiVersion": "v1beta1",
-  "metadata": {
-    "name": "node-example"
-  },
-  "description": "
-    Example shows how to build a CPM node.
-
-    // This example demonstrates an early beta version of a template. It does not validate
-    // because it lacks `metadata.name` (as opposed to the earlier `.name`).  However, it
-    // is still valid input to /templateConfigs.
-  ",
+  "description": "Example shows how to build a CPM node.",
+  "id": "node",
   "items": [
     {
-      "id": "pg-standalone-1",
-      "kind": "Pod",
       "apiVersion": "v1beta1",
       "desiredState": {
         "manifest": {
-          "version": "v1beta1",
-          "id": "pg-standalone-1",
-          "volumes": [
-            {
-              "name": "pgdata",
-              "source": {
-                "hostDir": {
-                  "path": "/var/lib/pgsql/exampleuser"
-                }
-              }
-            }
-          ],
           "containers": [
             {
-              "name": "master",
-              "image": "registry:5000/crunchy-node",
-              "volumeMounts": [
-                {
-                  "name": "pgdata",
-                  "mountPath": "/pgdata",
-                  "readOnly": false
-                }
-              ],
               "env": [
                 {
                   "name": "PG_USERNAME",
@@ -52,19 +19,46 @@
                   "value": "example"
                 }
               ],
+              "image": "registry:5000/crunchy-node",
+              "name": "master",
               "ports": [
                 {
-                  "hostPort": 9000,
-                  "containerPort": 5432
+                  "containerPort": 5432,
+                  "hostPort": 9000
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/pgdata",
+                  "name": "pgdata",
+                  "readOnly": false
                 }
               ]
+            }
+          ],
+          "id": "pg-standalone-1",
+          "version": "v1beta1",
+          "volumes": [
+            {
+              "name": "pgdata",
+              "source": {
+                "hostDir": {
+                  "path": "/var/lib/pgsql/exampleuser"
+                }
+              }
             }
           ]
         }
       },
+      "id": "pg-standalone-1",
+      "kind": "Pod",
       "labels": {
         "name": "crunchy-node"
       }
     }
-  ]
+  ],
+  "kind": "Template",
+  "metadata": {
+    "name": "node-example"
+  }
 }

--- a/test/templates/fixtures/guestbook.json
+++ b/test/templates/fixtures/guestbook.json
@@ -1,160 +1,188 @@
 {
-  "kind": "Template",
   "apiVersion": "v1beta1",
-  "metadata": {
-    "name": "guestbook-example",
-    "annotations": {
-      "description": "Example shows how to build a simple multi-tier application using Kubernetes and Docker"
-    }
-  },
-  "parameters": [
-    {
-      "name": "ADMIN_USERNAME",
-      "description": "Guestbook administrator username",
-      "generate": "expression",
-      "from": "admin[A-Z0-9]{3}"
-    },
-    {
-      "name": "ADMIN_PASSWORD",
-      "description": "Guestbook administrator password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    },
-    {
-      "name": "REDIS_PASSWORD",
-      "description": "Redis password",
-      "generate": "expression",
-      "from": "[a-zA-Z0-9]{8}"
-    }
-  ],
   "items": [
     {
+      "apiVersion": "v1beta1",
+      "host": "guestbook.example.com",
       "id": "frontend-route",
+      "kind": "Route",
       "metadata": {
         "name": "frontend-route"
       },
-      "kind": "Route",
-      "apiVersion": "v1beta1",
-      "host": "guestbook.example.com",
       "serviceName": "frontend-service"
     },
     {
+      "apiVersion": "v1beta1",
       "id": "frontend-service",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 5432,
       "selector": {
         "name": "frontend-service"
       }
     },
     {
+      "apiVersion": "v1beta1",
       "id": "redis-master",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 10000,
       "selector": {
         "name": "redis-master"
       }
     },
     {
+      "apiVersion": "v1beta1",
       "id": "redis-slave",
       "kind": "Service",
-      "apiVersion": "v1beta1",
       "port": 10001,
       "selector": {
         "name": "redis-slave"
       }
     },
     {
-      "id": "redis-master",
-      "kind": "Pod",
       "apiVersion": "v1beta1",
-      "labels": {"name": "redis-master"},
       "desiredState": {
         "manifest": {
-          "version": "v1beta1",
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "REDIS_PASSWORD",
+                  "value": "${REDIS_PASSWORD}"
+                }
+              ],
+              "image": "dockerfile/redis",
+              "name": "master",
+              "ports": [
+                {
+                  "containerPort": 6379
+                }
+              ]
+            }
+          ],
           "name": "redis-master",
-          "containers": [{
-            "name": "master",
-            "image": "dockerfile/redis",
-            "env": [
-              {
-                "name": "REDIS_PASSWORD",
-                "value": "${REDIS_PASSWORD}"
-              }
-            ],
-            "ports": [{
-              "containerPort": 6379
-            }]
-          }]
+          "version": "v1beta1"
         }
+      },
+      "id": "redis-master",
+      "kind": "Pod",
+      "labels": {
+        "name": "redis-master"
       }
     },
     {
-      "id": "guestbook",
-      "kind": "ReplicationController",
       "apiVersion": "v1beta1",
       "desiredState": {
-        "replicas": 3,
-        "replicaSelector": {"name": "frontend-service"},
         "podTemplate": {
-          "labels": {"name": "frontend-service"},
           "desiredState": {
             "manifest": {
-              "version": "v1beta1",
+              "containers": [
+                {
+                  "env": [
+                    {
+                      "name": "ADMIN_USERNAME",
+                      "value": "${ADMIN_USERNAME}"
+                    },
+                    {
+                      "name": "ADMIN_PASSWORD",
+                      "value": "${ADMIN_PASSWORD}"
+                    },
+                    {
+                      "name": "REDIS_PASSWORD",
+                      "value": "${REDIS_PASSWORD}"
+                    }
+                  ],
+                  "image": "brendanburns/php-redis",
+                  "name": "php-redis",
+                  "ports": [
+                    {
+                      "containerPort": 80,
+                      "hostPort": 8000
+                    }
+                  ]
+                }
+              ],
               "name": "guestbook",
-              "containers": [{
-                "name": "php-redis",
-                "image": "brendanburns/php-redis",
-                "env": [
-                  {
-                    "name": "ADMIN_USERNAME",
-                    "value": "${ADMIN_USERNAME}"
-                  },
-                  {
-                    "name": "ADMIN_PASSWORD",
-                    "value": "${ADMIN_PASSWORD}"
-                  },
-                  {
-                    "name": "REDIS_PASSWORD",
-                    "value": "${REDIS_PASSWORD}"
-                  }
-                ],
-                "ports": [{"containerPort": 80, "hostPort": 8000}]
-              }]
+              "version": "v1beta1"
             }
+          },
+          "labels": {
+            "name": "frontend-service"
           }
-        }
-      }
+        },
+        "replicaSelector": {
+          "name": "frontend-service"
+        },
+        "replicas": 3
+      },
+      "id": "guestbook",
+      "kind": "ReplicationController"
     },
     {
-      "id": "redis-slave",
-      "kind": "ReplicationController",
       "apiVersion": "v1beta1",
       "desiredState": {
-        "replicas": 2,
-        "replicaSelector": {"name": "redis-slave"},
         "podTemplate": {
-          "labels": {"name": "redis-slave"},
           "desiredState": {
             "manifest": {
-              "version": "v1beta1",
+              "containers": [
+                {
+                  "env": [
+                    {
+                      "name": "REDIS_PASSWORD",
+                      "value": "${REDIS_PASSWORD}"
+                    }
+                  ],
+                  "image": "brendanburns/redis-slave",
+                  "name": "slave",
+                  "ports": [
+                    {
+                      "containerPort": 6379,
+                      "hostPort": 6380
+                    }
+                  ]
+                }
+              ],
               "id": "redis-slave",
-              "containers": [{
-                "name": "slave",
-                "image": "brendanburns/redis-slave",
-                "env": [
-                  {
-                    "name": "REDIS_PASSWORD",
-                    "value": "${REDIS_PASSWORD}"
-                  }
-                ],
-                "ports": [{"containerPort": 6379, "hostPort": 6380}]
-              }]
+              "version": "v1beta1"
             }
+          },
+          "labels": {
+            "name": "redis-slave"
           }
-        }
-      }
+        },
+        "replicaSelector": {
+          "name": "redis-slave"
+        },
+        "replicas": 2
+      },
+      "id": "redis-slave",
+      "kind": "ReplicationController"
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "annotations": {
+      "description": "Example shows how to build a simple multi-tier application using Kubernetes and Docker"
+    },
+    "name": "guestbook-example"
+  },
+  "parameters": [
+    {
+      "description": "Guestbook administrator username",
+      "from": "admin[A-Z0-9]{3}",
+      "generate": "expression",
+      "name": "ADMIN_USERNAME"
+    },
+    {
+      "description": "Guestbook administrator password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "ADMIN_PASSWORD"
+    },
+    {
+      "description": "Redis password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "REDIS_PASSWORD"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a new command:
````
./hack/verify-jsonformat.sh [--fix]
```

This command scans the repository for JSON file and verify that all JSON files are properly formatted, without errors, etc.

It also comes with handy --fix option that will format the JSON file for you. In this way all JSON files will look consistent.