### PR TITLE
Use --from-build flag only for re-running builds

### DIFF
--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -61,6 +61,6 @@ Examples:
 			fmt.Fprintf(out, "%s\n", newBuild.Name)
 		},
 	}
-	cmd.Flags().StringP("from-build", "", "", "Specify the name of a build which should be re-run")
+	cmd.Flags().String("from-build", "", "Specify the name of a build which should be re-run")
 	return cmd
 }


### PR DESCRIPTION
Since no shorthand name has been specified, there is no reason for StringP to be used here.