### PR TITLE
Support multiple Dockerfiles with custom-docker-builder

### DIFF
--- a/images/builder/docker/custom-docker-builder/build.sh
+++ b/images/builder/docker/custom-docker-builder/build.sh
@@ -25,6 +25,8 @@ if [[ "${SOURCE_REPOSITORY}" != "git://"* ]] && [[ "${SOURCE_REPOSITORY}" != "gi
   fi
 fi
 
+[ -n "${DOCKERFILE_PATH}" ] && DOCKERFILE_PATH=Dockerfile
+
 if [ -n "${SOURCE_REF}" ]; then
   BUILD_DIR=$(mktemp --directory --suffix=docker-build)
   git clone --recursive "${SOURCE_REPOSITORY}" "${BUILD_DIR}"
@@ -41,9 +43,9 @@ if [ -n "${SOURCE_REF}" ]; then
     fi
   fi
   popd
-  docker build --rm -t "${TAG}" "${BUILD_DIR}"
+  docker build --rm -f "${DOCKERFILE_PATH}" -t "${TAG}" "${BUILD_DIR}"
 else
-  docker build --rm -t "${TAG}" "${SOURCE_REPOSITORY}"
+  docker build --rm -f "${DOCKERFILE_PATH}" -t "${TAG}" "${SOURCE_REPOSITORY}"
 fi
 
 if [ -n "${OUTPUT_IMAGE}" ] || [ -s "/root/.dockercfg" ]; then


### PR DESCRIPTION
This would enable me to use the custom docker build with my project that utilizes many dockerfiles at the same level in a repository to build various docker images from one repo.