### PR TITLE
Allow multiple tags to refer to the same image

### DIFF
--- a/pkg/image/registry/imagerepositorymapping/rest.go
+++ b/pkg/image/registry/imagerepositorymapping/rest.go
@@ -59,7 +59,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	}
 	repo.Tags[mapping.Tag] = image.Name
 
-	if err := s.imageRegistry.CreateImage(ctx, &image); err != nil {
+	if err := s.imageRegistry.CreateImage(ctx, &image); err != nil && !errors.IsAlreadyExists(err) {
 		return nil, err
 	}
 	if err := s.imageRepositoryRegistry.UpdateImageRepository(ctx, repo); err != nil {


### PR DESCRIPTION
Modify ImageRepositoryMapping so it doesn't fail if the image specified
already exists.

Fixes #1154