### PR TITLE
Add RemoteTemplate resource to fetch remote templates

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -213,6 +213,7 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 
 		"templateConfigs": templateregistry.NewREST(),
 		"templates":       templateetcd.NewREST(c.EtcdHelper),
+		"remoteTemplates": templateregistry.NewRemoteREST(v1beta1.Codec),
 
 		"routes": routeregistry.NewREST(routeEtcd),
 

--- a/pkg/template/api/register.go
+++ b/pkg/template/api/register.go
@@ -8,8 +8,10 @@ func init() {
 	api.Scheme.AddKnownTypes("",
 		&Template{},
 		&TemplateList{},
+		&RemoteTemplate{},
 	)
 }
 
-func (*Template) IsAnAPIObject()     {}
-func (*TemplateList) IsAnAPIObject() {}
+func (*Template) IsAnAPIObject()       {}
+func (*TemplateList) IsAnAPIObject()   {}
+func (*RemoteTemplate) IsAnAPIObject() {}

--- a/pkg/template/api/types.go
+++ b/pkg/template/api/types.go
@@ -53,3 +53,12 @@ type Parameter struct {
 	// Optional: From is an input value for the generator.
 	From string
 }
+
+// RemoteTemplate is a resource that points to a URL-accessible template
+type RemoteTemplate struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	// URL for the remote template
+	RemoteURL string
+}

--- a/pkg/template/api/v1beta1/register.go
+++ b/pkg/template/api/v1beta1/register.go
@@ -10,7 +10,9 @@ func init() {
 		&TemplateList{},
 	)
 	api.Scheme.AddKnownTypeWithName("v1beta1", "TemplateConfig", &Template{})
+	api.Scheme.AddKnownTypeWithName("v1beta1", "RemoteTemplate", &RemoteTemplate{})
 }
 
-func (*Template) IsAnAPIObject()     {}
-func (*TemplateList) IsAnAPIObject() {}
+func (*Template) IsAnAPIObject()       {}
+func (*TemplateList) IsAnAPIObject()   {}
+func (*RemoteTemplate) IsAnAPIObject() {}

--- a/pkg/template/api/v1beta1/types.go
+++ b/pkg/template/api/v1beta1/types.go
@@ -54,3 +54,12 @@ type Parameter struct {
 	// Optional: From is an input value for the generator.
 	From string `json:"from,omitempty"`
 }
+
+// RemoteTemplate is a resource that points to a template accessible via URL
+type RemoteTemplate struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	// URL for the remote template
+	RemoteURL string
+}

--- a/pkg/template/api/validation/validation.go
+++ b/pkg/template/api/validation/validation.go
@@ -51,3 +51,10 @@ func validateTemplateBody(template *api.Template) (errs errors.ValidationErrorLi
 	errs = append(errs, validation.ValidateLabels(template.ObjectLabels, "labels")...)
 	return
 }
+
+func ValidateRemoteTemplate(remote *api.RemoteTemplate) (errs errors.ValidationErrorList) {
+	if len(remote.RemoteURL) == 0 {
+		errs = append(errs, errors.NewFieldRequired("RemoteURL", ""))
+	}
+	return
+}

--- a/pkg/template/api/validation/validation_test.go
+++ b/pkg/template/api/validation/validation_test.go
@@ -190,3 +190,19 @@ func TestValidateTemplate(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateRemoteTemplate(t *testing.T) {
+	valid := &api.RemoteTemplate{
+		RemoteURL: "http://a.test.url/test",
+	}
+	invalid := &api.RemoteTemplate{}
+
+	errs := ValidateRemoteTemplate(valid)
+	if len(errs) > 0 {
+		t.Errorf("Unexpected error on valid remote template: %v", errors.NewAggregate(errs))
+	}
+	errs = ValidateRemoteTemplate(invalid)
+	if len(errs) == 0 {
+		t.Errorf("Did not validate remote template properly. Error expected.")
+	}
+}


### PR DESCRIPTION
We need to be able to fetch a template in the UI from a user-supplied URL. This PR does that via a virtual resource that points to the location of the template. 