### PR TITLE
fix nodelist access for kube master

### DIFF
--- a/pkg/cmd/server/kube_master.go
+++ b/pkg/cmd/server/kube_master.go
@@ -47,7 +47,7 @@ func (cfg Config) BuildKubernetesMasterConfig(requestContextMapper kapi.RequestC
 	kmaster := &kubernetes.MasterConfig{
 		MasterIP:             masterIP,
 		MasterPort:           cfg.MasterAddr.Port,
-		NodeHosts:            cfg.NodeList,
+		NodeHosts:            cfg.GetNodeList(),
 		PortalNet:            &portalNet,
 		RequestContextMapper: requestContextMapper,
 		EtcdHelper:           ketcdHelper,


### PR DESCRIPTION
I think the problem was caused by pulling the NodeList from the actual argument (used to mutate) as opposed to the getter.  Any brave soul want to try it?

@liggitt @bparees @ironcladlou @jwforres 