### PR TITLE
enable personal subject access review

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -145,9 +145,9 @@ type ResourceAccessReviewResponse struct {
 	// Namespace is the namespace used for the access review
 	Namespace string
 	// Users is the list of users who can perform the action
-	Users []string
+	Users kutil.StringSet
 	// Groups is the list of groups who can perform the action
-	Groups []string
+	Groups kutil.StringSet
 }
 
 // ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the
@@ -188,7 +188,7 @@ type SubjectAccessReview struct {
 	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
 	User string
 	// Groups is optional.  Groups is the list of groups to which the User belongs.
-	Groups []string
+	Groups kutil.StringSet
 	// Content is the actual content of the request for create and update
 	Content kruntime.EmbeddedObject
 	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"

--- a/pkg/authorization/api/v1beta1/conversion.go
+++ b/pkg/authorization/api/v1beta1/conversion.go
@@ -12,6 +12,44 @@ import (
 
 func init() {
 	err := api.Scheme.AddConversionFuncs(
+		func(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
+
+			out.Groups = util.NewStringSet(in.GroupsSlice...)
+
+			return nil
+		},
+		func(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
+
+			out.GroupsSlice = in.Groups.List()
+
+			return nil
+		},
+		func(in *ResourceAccessReviewResponse, out *newer.ResourceAccessReviewResponse, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
+
+			out.Users = util.NewStringSet(in.UsersSlice...)
+			out.Groups = util.NewStringSet(in.GroupsSlice...)
+
+			return nil
+		},
+		func(in *newer.ResourceAccessReviewResponse, out *ResourceAccessReviewResponse, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
+
+			out.UsersSlice = in.Users.List()
+			out.GroupsSlice = in.Groups.List()
+
+			return nil
+		},
 		func(in *PolicyRule, out *newer.PolicyRule, s conversion.Scope) error {
 			if err := s.Convert(&in.AttributeRestrictions, &out.AttributeRestrictions, 0); err != nil {
 				return err

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -95,9 +95,9 @@ type ResourceAccessReviewResponse struct {
 	// Namespace is the namespace used for the access review
 	Namespace string `json:"namespace,omitempty"`
 	// Users is the list of users who can perform the action
-	Users []string `json:"users"`
+	UsersSlice []string `json:"users"`
 	// Groups is the list of groups who can perform the action
-	Groups []string `json:"groups"`
+	GroupsSlice []string `json:"groups"`
 }
 
 // ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the
@@ -148,7 +148,7 @@ type SubjectAccessReview struct {
 	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
 	User string `json:"user"`
 	// Groups is optional.  Groups is the list of groups to which the User belongs.
-	Groups []string `json:"groups"`
+	GroupsSlice []string `json:"groups"`
 	// Content is the actual content of the request for create and update
 	Content kruntime.RawExtension `json:"content,omitempty"`
 	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -55,7 +55,7 @@ func (a *openshiftAuthorizer) Authorize(ctx kapi.Context, passedAttributes Autho
 	return false, "denied by default", nil
 }
 
-func (a *openshiftAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes AuthorizationAttributes) ([]string, []string, error) {
+func (a *openshiftAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes AuthorizationAttributes) (util.StringSet, util.StringSet, error) {
 	masterContext := kapi.WithNamespace(ctx, a.masterAuthorizationNamespace)
 	globalUsers, globalGroups, err := a.getAllowedSubjectsFromNamespaceBindings(masterContext, attributes)
 	if err != nil {
@@ -74,7 +74,7 @@ func (a *openshiftAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes Au
 	groups.Insert(globalGroups.List()...)
 	groups.Insert(localGroups.List()...)
 
-	return users.List(), groups.List(), nil
+	return users, groups, nil
 }
 
 func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.Context, passedAttributes AuthorizationAttributes) (util.StringSet, util.StringSet, error) {

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -4,11 +4,12 @@ import (
 	"net/http"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 type Authorizer interface {
 	Authorize(ctx kapi.Context, a AuthorizationAttributes) (allowed bool, reason string, err error)
-	GetAllowedSubjects(ctx kapi.Context, attributes AuthorizationAttributes) ([]string, []string, error)
+	GetAllowedSubjects(ctx kapi.Context, attributes AuthorizationAttributes) (util.StringSet, util.StringSet, error)
 }
 
 type AuthorizationAttributeBuilder interface {

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
@@ -19,8 +20,8 @@ type subjectsTest struct {
 	context    kapi.Context
 	attributes *DefaultAuthorizationAttributes
 
-	expectedUsers  []string
-	expectedGroups []string
+	expectedUsers  util.StringSet
+	expectedGroups util.StringSet
 	expectedError  string
 }
 
@@ -31,8 +32,8 @@ func TestSubjects(t *testing.T) {
 			Verb:     "get",
 			Resource: "pods",
 		},
-		expectedUsers:  []string{"Anna", "ClusterAdmin", "Ellen", "Valerie", "system:kube-client", "system:openshift-client", "system:openshift-deployer"},
-		expectedGroups: []string{"RootUsers", "system:cluster-admins"},
+		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:kube-client", "system:openshift-client", "system:openshift-deployer"),
+		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins"),
 	}
 	test.policies = newDefaultGlobalPolicies()
 	test.policies = append(test.policies, newAdzePolicies()...)
@@ -49,7 +50,7 @@ func (test *subjectsTest) test(t *testing.T) {
 
 	actualUsers, actualGroups, actualError := authorizer.GetAllowedSubjects(test.context, *test.attributes)
 
-	matchStringSlice(test.expectedUsers, actualUsers, "users", t)
-	matchStringSlice(test.expectedGroups, actualGroups, "groups", t)
+	matchStringSlice(test.expectedUsers.List(), actualUsers.List(), "users", t)
+	matchStringSlice(test.expectedGroups.List(), actualGroups.List(), "groups", t)
 	matchError(test.expectedError, actualError, "error", t)
 }

--- a/pkg/authorization/registry/resourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest_test.go
@@ -28,7 +28,7 @@ type testAuthorizer struct {
 func (a *testAuthorizer) Authorize(ctx kapi.Context, attributes authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
 	return false, "", errors.New("unsupported")
 }
-func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
+func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) (util.StringSet, util.StringSet, error) {
 	attributes, ok := passedAttributes.(*authorizer.DefaultAuthorizationAttributes)
 	if !ok {
 		return nil, nil, errors.New("unexpected type for test")
@@ -36,9 +36,9 @@ func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes a
 
 	a.actualAttributes = attributes
 	if len(a.err) == 0 {
-		return a.users.List(), a.groups.List(), nil
+		return a.users, a.groups, nil
 	}
-	return a.users.List(), a.groups.List(), errors.New(a.err)
+	return a.users, a.groups, errors.New(a.err)
 }
 
 func TestEmptyReturn(t *testing.T) {
@@ -94,8 +94,8 @@ func (r *resourceAccessTest) runTest(t *testing.T) {
 
 	expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 		Namespace: namespace,
-		Users:     r.authorizer.users.List(),
-		Groups:    r.authorizer.groups.List(),
+		Users:     r.authorizer.users,
+		Groups:    r.authorizer.groups,
 	}
 
 	expectedAttributes := &authorizer.DefaultAuthorizationAttributes{

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -37,7 +37,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	namespace := kapi.NamespaceValue(ctx)
 	user := &user.DefaultInfo{
 		Name:   subjectAccessReview.User,
-		Groups: subjectAccessReview.Groups,
+		Groups: subjectAccessReview.Groups.List(),
 	}
 	requestContext := kapi.WithUser(kapi.WithNamespace(kapi.NewDefaultContext(), namespace), user)
 

--- a/pkg/authorization/registry/subjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest_test.go
@@ -38,8 +38,8 @@ func (a *testAuthorizer) Authorize(ctx kapi.Context, passedAttributes authorizer
 	}
 	return a.allowed, a.reason, errors.New(a.err)
 }
-func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) ([]string, []string, error) {
-	return nil, nil, nil
+func (a *testAuthorizer) GetAllowedSubjects(ctx kapi.Context, passedAttributes authorizer.AuthorizationAttributes) (util.StringSet, util.StringSet, error) {
+	return util.StringSet{}, util.StringSet{}, nil
 }
 
 func TestEmptyReturn(t *testing.T) {
@@ -50,7 +50,7 @@ func TestEmptyReturn(t *testing.T) {
 		},
 		reviewRequest: &authorizationapi.SubjectAccessReview{
 			User:     "foo",
-			Groups:   []string{},
+			Groups:   util.NewStringSet(),
 			Verb:     "get",
 			Resource: "pods",
 		},
@@ -66,7 +66,7 @@ func TestNoErrors(t *testing.T) {
 			reason:  "because good things",
 		},
 		reviewRequest: &authorizationapi.SubjectAccessReview{
-			Groups:   []string{"master"},
+			Groups:   util.NewStringSet("master"),
 			Verb:     "delete",
 			Resource: "deploymentConfigs",
 		},
@@ -82,7 +82,7 @@ func TestErrors(t *testing.T) {
 		},
 		reviewRequest: &authorizationapi.SubjectAccessReview{
 			User:     "foo",
-			Groups:   []string{"first", "second"},
+			Groups:   util.NewStringSet("first", "second"),
 			Verb:     "get",
 			Resource: "pods",
 		},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -132,6 +132,10 @@ func (c *Client) SubjectAccessReviews(namespace string) SubjectAccessReviewInter
 	return newSubjectAccessReviews(c, namespace)
 }
 
+func (c *Client) RootSubjectAccessReviews() SubjectAccessReviewInterface {
+	return newRootSubjectAccessReviews(c)
+}
+
 // Client is an OpenShift client object
 type Client struct {
 	*kclient.RESTClient

--- a/pkg/client/subjectaccessreview.go
+++ b/pkg/client/subjectaccessreview.go
@@ -34,3 +34,22 @@ func (c *subjectAccessReviews) Create(policy *authorizationapi.SubjectAccessRevi
 	err = c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews").Body(policy).Do().Into(result)
 	return
 }
+
+// rootSubjectAccessReviews implements RootSubjectAccessReviews interface
+type rootSubjectAccessReviews struct {
+	r *Client
+}
+
+// newRootSubjectAccessReviews returns a rootSubjectAccessReviews
+func newRootSubjectAccessReviews(c *Client) *rootSubjectAccessReviews {
+	return &rootSubjectAccessReviews{
+		r: c,
+	}
+}
+
+// Create creates new policy. Returns the server's representation of the policy and error if one occurs.
+func (c *rootSubjectAccessReviews) Create(policy *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
+	result = &authorizationapi.SubjectAccessReviewResponse{}
+	err = c.r.Post().Resource("subjectAccessReviews").Body(policy).Do().Into(result)
+	return
+}

--- a/pkg/project/auth/reviewer.go
+++ b/pkg/project/auth/reviewer.go
@@ -17,12 +17,12 @@ type review struct {
 
 // Users returns the users that can access a resource
 func (r *review) Users() []string {
-	return r.response.Users
+	return r.response.Users.List()
 }
 
 // Groups returns the groups that can access a resource
 func (r *review) Groups() []string {
-	return r.response.Groups
+	return r.response.Groups.List()
 }
 
 // Reviewer performs access reviews for a project by name

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -87,7 +87,6 @@ type resourceAccessReviewTest struct {
 	clientInterface client.ResourceAccessReviewInterface
 	review          *authorizationapi.ResourceAccessReview
 
-	// TODO use resource access review response once internal types use util.StringSet
 	response authorizationapi.ResourceAccessReviewResponse
 	err      string
 }
@@ -233,7 +232,6 @@ func (test subjectAccessReviewTest) run(t *testing.T) {
 	}
 }
 
-// TODO add test for "this user" once the subject access review supports it
 func TestSubjectAccessReview(t *testing.T) {
 	startConfig, err := StartTestMaster()
 	if err != nil {
@@ -338,4 +336,26 @@ func TestSubjectAccessReview(t *testing.T) {
 		review:          askCanClusterAdminsCreateProject,
 		err:             "Forbidden",
 	}.run(t)
+
+	askCanICreatePods := &authorizationapi.SubjectAccessReview{Verb: "create", Resource: "projects"}
+	subjectAccessReviewTest{
+		clientInterface: haroldClient.SubjectAccessReviews("hammer-project"),
+		review:          askCanICreatePods,
+		response: authorizationapi.SubjectAccessReviewResponse{
+			Allowed:   true,
+			Reason:    "allowed by rule in hammer-project",
+			Namespace: "hammer-project",
+		},
+	}.run(t)
+	askCanICreatePolicyBindings := &authorizationapi.SubjectAccessReview{Verb: "create", Resource: "policybindings"}
+	subjectAccessReviewTest{
+		clientInterface: haroldClient.SubjectAccessReviews("hammer-project"),
+		review:          askCanICreatePolicyBindings,
+		response: authorizationapi.SubjectAccessReviewResponse{
+			Allowed:   false,
+			Reason:    "denied by default",
+			Namespace: "hammer-project",
+		},
+	}.run(t)
+
 }


### PR DESCRIPTION
adds
 1. integration tests for subject access review
 1. switch types to using stringsets where appropriate
 1. enable subject access review for self

Keep in my that default policy doesn't allow subject access reviews for self.  We need find grained policy controls before that is possible

@liggitt  supercedes #1180 