### PR TITLE
reconnect --image (bug 1196982)

### DIFF
--- a/pkg/cmd/server/config.go
+++ b/pkg/cmd/server/config.go
@@ -44,9 +44,6 @@ type Config struct {
 	MasterPublicAddr     flagtypes.Addr
 	KubernetesPublicAddr flagtypes.Addr
 
-	ImageFormat         string
-	LatestReleaseImages bool
-
 	ImageTemplate variable.ImageTemplate
 
 	Hostname  string

--- a/pkg/cmd/server/origin/config.go
+++ b/pkg/cmd/server/origin/config.go
@@ -27,7 +27,6 @@ import (
 	authorizationetcd "github.com/openshift/origin/pkg/authorization/registry/etcd"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	osclient "github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/variable"
 	oauthetcd "github.com/openshift/origin/pkg/oauth/registry/etcd"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 )
@@ -71,6 +70,9 @@ type MasterConfigParameters struct {
 
 	MasterAuthorizationNamespace string
 
+	// a function that returns the appropriate image to use for a named component
+	ImageFor func(component string) string
+
 	// kubeClient is the client used to call Kubernetes APIs from system components, built from KubeClientConfig.
 	// It should only be accessed via the *Client() helper methods.
 	// To apply different access control to a system component, create a separate client/config specifically for that component.
@@ -107,9 +109,6 @@ type MasterConfig struct {
 
 	AdmissionControl admission.Interface
 
-	// a function that returns the appropriate image to use for a named component
-	ImageFor func(component string) string
-
 	TLS bool
 }
 
@@ -117,8 +116,6 @@ func BuildMasterConfig(configParams MasterConfigParameters) (*MasterConfig, erro
 
 	policyCache := configParams.newPolicyCache()
 	requestContextMapper := kapi.NewRequestContextMapper()
-
-	imageTemplate := variable.NewDefaultImageTemplate()
 
 	config := &MasterConfig{
 		MasterConfigParameters: configParams,
@@ -133,8 +130,6 @@ func BuildMasterConfig(configParams MasterConfigParameters) (*MasterConfig, erro
 		RequestContextMapper: requestContextMapper,
 
 		AdmissionControl: admit.NewAlwaysAdmit(),
-
-		ImageFor: imageTemplate.ExpandOrDie,
 
 		TLS: strings.HasPrefix(configParams.MasterAddr, "https://"),
 	}

--- a/pkg/cmd/server/origin_master.go
+++ b/pkg/cmd/server/origin_master.go
@@ -110,6 +110,8 @@ func (cfg Config) BuildOriginMasterConfig() (*origin.MasterConfig, error) {
 		OSClient:               openshiftClient,
 		OSClientConfig:         *openshiftClientConfig,
 		DeployerOSClientConfig: *deployerClientConfig,
+
+		ImageFor: cfg.ImageTemplate.ExpandOrDie,
 	}
 	openshiftConfig, err := origin.BuildMasterConfig(openshiftConfigParameters)
 	if err != nil {

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -94,6 +94,8 @@ func (cfg Config) startMaster() error {
 	// TODO: recording should occur in individual components
 	record.StartRecording(openshiftConfig.KubeClient().Events(""), kapi.EventSource{Component: "master"})
 
+	glog.Infof("Using images from %q", openshiftConfig.ImageFor("<component>"))
+
 	openshiftConfig.RunAssetServer()
 	openshiftConfig.RunBuildController()
 	openshiftConfig.RunBuildImageChangeTriggerController()


### PR DESCRIPTION
The --image flag was bound, but dropped from the origin.MasterConfig object.  I've reconnect them.

@sdodson Can you confirm success?
@liggitt Can you review?
@brenton Want to assign the bugzilla defect to me?

I'll look to see if there's some reasonable test we can add (obviously there wasn't one before), but i'd like to get reviews on the actual change moving ahead.