### PR TITLE
extend the wait time for the project authorization cache

### DIFF
--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -71,7 +71,7 @@ func TestRestrictedAccessForProjectAdmins(t *testing.T) {
 	}
 
 	// wait for the project authorization cache to catch the change.  It is on a one second period
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	haroldProjects, err := haroldClient.Projects().List(labels.Everything(), labels.Everything())
 	if err != nil {


### PR DESCRIPTION
The merge queue tests are often failing on empty project listings even after waiting for twice the refresh interval.  Note that policy caches themselves are updated before that, as evidenced by the specific gets succeeding.

Increasing the wait time to five times the interval, to unstick this over the weekend.  We should revisit.