### PR TITLE
retry build errors

### DIFF
--- a/pkg/build/controller/image_change_controller_test.go
+++ b/pkg/build/controller/image_change_controller_test.go
@@ -13,11 +13,12 @@ import (
 
 type mockBuildConfigUpdater struct {
 	buildcfg *buildapi.BuildConfig
+	err      error
 }
 
 func (m *mockBuildConfigUpdater) Update(buildcfg *buildapi.BuildConfig) error {
 	m.buildcfg = buildcfg
-	return nil
+	return m.err
 }
 
 type mockBuildCreator struct {
@@ -71,8 +72,8 @@ func appendTrigger(buildcfg *buildapi.BuildConfig, triggerImage, repoName, repoT
 	})
 }
 
-func mockImageChangeController(buildcfg *buildapi.BuildConfig, repoName, dockerImageRepo string, tags map[string]string) *ImageChangeController {
-	imageRepo := imageapi.ImageRepository{
+func mockImageRepo(repoName, dockerImageRepo string, tags map[string]string) *imageapi.ImageRepository {
+	return &imageapi.ImageRepository{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: repoName,
 		},
@@ -81,23 +82,28 @@ func mockImageChangeController(buildcfg *buildapi.BuildConfig, repoName, dockerI
 		},
 		Tags: tags,
 	}
+}
 
+func mockImageChangeController(buildcfg *buildapi.BuildConfig) *ImageChangeController {
 	return &ImageChangeController{
-		NextImageRepository: func() *imageapi.ImageRepository { return &imageRepo },
-		BuildConfigStore:    buildtest.NewFakeBuildConfigStore(buildcfg),
-		BuildCreator:        &mockBuildCreator{},
-		BuildConfigUpdater:  &mockBuildConfigUpdater{},
+		BuildConfigStore:   buildtest.NewFakeBuildConfigStore(buildcfg),
+		BuildCreator:       &mockBuildCreator{},
+		BuildConfigUpdater: &mockBuildConfigUpdater{},
 	}
 }
 
 func TestNewImageID(t *testing.T) {
 	// valid configuration, new build should be triggered.
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build == nil {
 		t.Error("Expected new build when new image was created!")
 	}
@@ -115,11 +121,15 @@ func TestNewImageID(t *testing.T) {
 func TestNewImageIDDefaultTag(t *testing.T) {
 	// valid configuration using default tag, new build should be triggered.
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "")
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "registry.com/namespace/imagename", map[string]string{buildapi.DefaultImageTag: "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{buildapi.DefaultImageTag: "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build == nil {
 		t.Error("Expected new build when new image was created!")
 	}
@@ -138,11 +148,15 @@ func TestNonExistentImageRepository(t *testing.T) {
 	// this buildconfig references a non-existent imagerepo, so an update to the real imagerepo should not
 	// trigger a build here.
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
-	controller := mockImageChangeController(buildcfg, "otherImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("otherImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when a different repository was updated!")
 	}
@@ -154,11 +168,15 @@ func TestNonExistentImageRepository(t *testing.T) {
 func TestNewImageDifferentTagUpdate(t *testing.T) {
 	// this buildconfig references a different tag than the one that will be updated
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "registry.com/namespace/imagename", map[string]string{"otherTag": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{"otherTag": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when a different repository was updated!")
 	}
@@ -172,12 +190,15 @@ func TestNewImageDifferentTagUpdate2(t *testing.T) {
 	// it has previously run a build for the testTagID123 tag.
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
 	buildcfg.Triggers[0].ImageChange.LastTriggeredImageID = "testTagID123"
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "registry.com/namespace/imagename",
-		map[string]string{"otherTag": "newImageID123", "testTag": "testTagID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{"otherTag": "newImageID123", "testTag": "testTagID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when a different repository was updated!")
 	}
@@ -189,11 +210,15 @@ func TestNewImageDifferentTagUpdate2(t *testing.T) {
 func TestNewDifferentImageUpdate(t *testing.T) {
 	// this buildconfig references a different image than the one that will be updated
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename1", "registry.com/namespace/imagename1", "testImageRepo1", "testTag1")
-	controller := mockImageChangeController(buildcfg, "testImageRepo2", "registry.com/namespace/imagename2", map[string]string{"testTag2": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo2", "registry.com/namespace/imagename2", map[string]string{"testTag2": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when a different repository was updated!")
 	}
@@ -206,11 +231,15 @@ func TestMultipleTriggers(t *testing.T) {
 	// this buildconfig references multiple images
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename1", "registry.com/namespace/imagename1", "testImageRepo1", "testTag1")
 	appendTrigger(buildcfg, "registry.com/namespace/imagename2", "testImageRepo2", "testTag2")
-	controller := mockImageChangeController(buildcfg, "testImageRepo2", "registry.com/namespace/imagename2", map[string]string{"testTag2": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo2", "registry.com/namespace/imagename2", map[string]string{"testTag2": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build == nil {
 		t.Error("Expected new build when new image was created!")
 	}
@@ -230,11 +259,15 @@ func TestBuildConfigWithDifferentTriggerType(t *testing.T) {
 	// this buildconfig has different (than ImageChangeTrigger) trigger defined
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename1", "", "", "")
 	buildcfg.Triggers[0].Type = buildapi.GenericWebHookBuildTriggerType
-	controller := mockImageChangeController(buildcfg, "testImageRepo2", "registry.com/namespace/imagename2", map[string]string{"testTag2": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo2", "registry.com/namespace/imagename2", map[string]string{"testTag2": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when a different trigger type was defined!")
 	}
@@ -248,11 +281,15 @@ func TestNoImageIDChange(t *testing.T) {
 	// startup when we're checking all the imageRepos
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
 	buildcfg.Triggers[0].ImageChange.LastTriggeredImageID = "imageID123"
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "imageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "imageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when no change happened!")
 	}
@@ -264,12 +301,19 @@ func TestNoImageIDChange(t *testing.T) {
 func TestBuildCreateError(t *testing.T) {
 	// valid configuration, but build creation fails, in that situation the buildconfig should not be updated
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildCreator.err = fmt.Errorf("error")
-	controller.HandleImageRepo()
+	err := controller.HandleImageRepo(imagerepo)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err == nil {
+		t.Error("Expected error from HandleImageRepo")
+	}
+	if _, ok := err.(ImageChangeControllerFatalError); ok {
+		t.Error("Expected retryable error from HandleImageRepo")
+	}
 	if buildCreator.build == nil {
 		t.Error("Expected new build when new image was created!")
 	}
@@ -281,14 +325,39 @@ func TestBuildCreateError(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateError(t *testing.T) {
+	// valid configuration, but build creation fails, in that situation the buildconfig should not be updated
+	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
+	imagerepo := mockImageRepo("testImageRepo", "registry.com/namespace/imagename", map[string]string{"testTag": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	buildCreator := controller.BuildCreator.(*mockBuildCreator)
+	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
+	buildConfigUpdater.err = fmt.Errorf("error")
+	err := controller.HandleImageRepo(imagerepo)
+
+	if _, ok := err.(ImageChangeControllerFatalError); !ok {
+		t.Error("Expected fatal error from HandleImageRepo")
+	}
+	if buildCreator.build == nil {
+		t.Error("Expected new build when new image was created!")
+	}
+	if buildCreator.build.Parameters.Strategy.DockerStrategy.Image != "registry.com/namespace/imagename:newImageID123" {
+		t.Errorf("Image substitutions not properly setup for new build.  Expected %s, got %s |", "registry.com/namespace/imagename:newImageID123", buildCreator.build.Parameters.Strategy.DockerStrategy.Image)
+	}
+}
+
 func TestNewImageIDNoDockerRepo(t *testing.T) {
 	// No docker repository associated with the imagerepo, so no build can be created
 	buildcfg := mockBuildConfig("registry.com/namespace/imagename", "registry.com/namespace/imagename", "testImageRepo", "testTag")
-	controller := mockImageChangeController(buildcfg, "testImageRepo", "", map[string]string{"testTag": "newImageID123"})
-	controller.HandleImageRepo()
+	imagerepo := mockImageRepo("testImageRepo", "", map[string]string{"testTag": "newImageID123"})
+	controller := mockImageChangeController(buildcfg)
+	err := controller.HandleImageRepo(imagerepo)
 	buildCreator := controller.BuildCreator.(*mockBuildCreator)
 	buildConfigUpdater := controller.BuildConfigUpdater.(*mockBuildConfigUpdater)
 
+	if err != nil {
+		t.Errorf("Unexpected error %v from HandleImageRepo", err)
+	}
 	if buildCreator.build != nil {
 		t.Error("New build created when no change happened!")
 	}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -596,6 +596,18 @@ func (c *MasterConfig) RunBuildController() {
 	controller.Run()
 }
 
+// RunBuildPodController starts the build/pod status sync loop for build status
+func (c *MasterConfig) RunBuildPodController() {
+	osclient, kclient := c.BuildControllerClients()
+	factory := buildcontrollerfactory.BuildPodControllerFactory{
+		OSClient:     osclient,
+		KubeClient:   kclient,
+		BuildUpdater: buildclient.NewOSClientBuildClient(osclient),
+	}
+	controller := factory.Create()
+	controller.Run()
+}
+
 // RunDeploymentController starts the build image change trigger controller process.
 func (c *MasterConfig) RunBuildImageChangeTriggerController() {
 	bcClient, _ := c.BuildControllerClients()

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -98,6 +98,7 @@ func (cfg Config) startMaster() error {
 
 	openshiftConfig.RunAssetServer()
 	openshiftConfig.RunBuildController()
+	openshiftConfig.RunBuildPodController()
 	openshiftConfig.RunBuildImageChangeTriggerController()
 	openshiftConfig.RunDeploymentController()
 	openshiftConfig.RunDeployerPodController()

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -203,7 +203,7 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 			"github": github.New(),
 		})))
 
-	factory := buildcontrollerfactory.BuildControllerFactory{
+	bcFactory := buildcontrollerfactory.BuildControllerFactory{
 		OSClient:     osClient,
 		KubeClient:   kubeClient,
 		BuildUpdater: buildclient.NewOSClientBuildClient(osClient),
@@ -219,7 +219,16 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 		Stop: openshift.stop,
 	}
 
-	factory.Create().Run()
+	bcFactory.Create().Run()
+
+	bpcFactory := buildcontrollerfactory.BuildPodControllerFactory{
+		OSClient:     osClient,
+		KubeClient:   kubeClient,
+		BuildUpdater: buildclient.NewOSClientBuildClient(osClient),
+		Stop:         openshift.stop,
+	}
+
+	bpcFactory.Create().Run()
 
 	return openshift
 }


### PR DESCRIPTION
For now this will retry retryable failures forever on a tight loop.  I'm still contemplating switching it to something like 100.  The problem is that without backoff (which the current retrycontroller logic does not offer for good reason), if there's a temporary API outage we'll burn through any reasonable number of retries rapidly.
