### PR TITLE
Add default template label to sample app templates

### DIFF
--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -269,5 +269,8 @@
       "name": "MYSQL_DATABASE",
       "value": "root"
     }
-  ]
+  ],
+  "labels": {
+    "template": "application-template-custombuild"
+  }
 }

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -259,5 +259,8 @@
       "name": "MYSQL_DATABASE",
       "value": "root"
     }
-  ]
+  ],
+  "labels": {
+    "template": "application-template-dockerbuild"
+  }
 }

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -262,5 +262,8 @@
       "name": "MYSQL_DATABASE",
       "value": "root"
     }
-  ]
+  ],
+  "labels": {
+    "template": "application-template-stibuild"
+  }
 }


### PR DESCRIPTION
The process command no longer adds a template label by default to all items in a template. This PR adds the 'template' label back to the sample app templates.