### PR TITLE
Bug 1191960 - Remove --master from usage text for ex generate

### DIFF
--- a/pkg/cmd/experimental/generate/generate.go
+++ b/pkg/cmd/experimental/generate/generate.go
@@ -81,7 +81,7 @@ func NewCmdGenerate(f *clientcmd.Factory, parentName, name string) *cobra.Comman
 	input := params{}
 
 	c := &cobra.Command{
-		Use:   fmt.Sprintf("%s%s", name, clientcmd.ConfigSyntax),
+		Use:   fmt.Sprintf("%s [source]", name),
 		Short: "Generates an application configuration from a source repository",
 		Long:  longDescription,
 		Run: func(c *cobra.Command, args []string) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1191960