### PR TITLE
Bug 1191982: Return error when Template generator failed to generate parameter value

### DIFF
--- a/pkg/template/registry/rest.go
+++ b/pkg/template/registry/rest.go
@@ -91,9 +91,8 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	processor := template.NewProcessor(generators)
 	cfg, err := processor.Process(tpl)
 	if len(err) > 0 {
-		// TODO: We don't report the processing errors to users as there is no
-		// good way how to do it for just some items.
 		glog.V(1).Infof(utilerr.NewAggregate(err).Error())
+		return nil, errors.NewInvalid("template", tpl.Name, err)
 	}
 
 	if tpl.ObjectLabels != nil {

--- a/pkg/template/registry/rest_test.go
+++ b/pkg/template/registry/rest_test.go
@@ -34,6 +34,25 @@ func TestNewRESTDefaultsName(t *testing.T) {
 	}
 }
 
+func TestNewRESTInvalidParameter(t *testing.T) {
+	storage := NewREST()
+	_, err := storage.Create(nil, &template.Template{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "test",
+		},
+		Parameters: []template.Parameter{
+			{
+				Name:     "TEST_PARAM",
+				Generate: "[a-z0-Z0-9]{8}",
+			},
+		},
+		Objects: []runtime.Object{},
+	})
+	if err == nil {
+		t.Fatalf("Expected 'invalid parameter error', got nothing")
+	}
+}
+
 func TestNewRESTTemplateLabels(t *testing.T) {
 	testLabels := map[string]string{
 		"label1": "value1",


### PR DESCRIPTION
After this:

```
osc process -f examples/sample-app/application-template-stibuild.json 
F0304 15:24:01.395405   14195 process.go:98] parameters: invalid value '<*>(0xc20955b770)Invalid range specified: 0-Z': failure to generate parameter value
```