### PR TITLE
use public address for deployer pod environment

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -609,8 +609,8 @@ func (c *MasterConfig) RunBuildImageChangeTriggerController() {
 func (c *MasterConfig) RunDeploymentController() {
 	_, kclient := c.DeploymentControllerClients()
 	env := []api.EnvVar{
-		{Name: "KUBERNETES_MASTER", Value: c.MasterAddr},
-		{Name: "OPENSHIFT_MASTER", Value: c.MasterAddr},
+		{Name: "KUBERNETES_MASTER", Value: c.MasterPublicAddr},
+		{Name: "OPENSHIFT_MASTER", Value: c.MasterPublicAddr},
 	}
 	env = append(env, clientcmd.EnvVarsFromConfig(c.DeployerClientConfig())...)
 


### PR DESCRIPTION
@ramr noticed an issue that in the multi-machine vagrant environment his deployer was not connecting back to master.  After inspecting the deployer pod it looks like it was getting the 10.0.2.15 master address which was not accessible from a minion.  

We checked with @rajatchopra to see if the ip should be accessible and his thoughts were that it was probably a bug.  Switching to use the public address fixed the issue.

@ironcladlou @smarterclayton PTAL