### PR TITLE
use master ip address so that minions can reach master in multi-node setup

### DIFF
--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -42,7 +42,7 @@ Requires=docker.service network.service
 After=network.service
 
 [Service]
-ExecStart=/usr/bin/openshift start master --public-master=${MASTER_IP} --nodes=${node_list}
+ExecStart=/usr/bin/openshift start master --master=${MASTER_IP} --nodes=${node_list}
 WorkingDirectory=/vagrant/
 
 [Install]


### PR DESCRIPTION
Based on discussions from https://github.com/openshift/origin/pull/1226

/cc @liggitt @ramr @ironcladlou @rajatchopra 

I was able to successfully install a router in the multi-node vagrant environment with this change.