### PR TITLE
path based acls for routing

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -29,7 +29,12 @@ frontend public
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
 
-  use_backend be_http_%[hdr(host),map(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
+  # map to http backend
+  use_backend be_http_%[base,map_beg(/var/lib/haproxy/conf/os_http_be.map)]
+
+  # if a specific path based lookup was not found then revert to a host header lookup
+  use_backend be_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
+
   default_backend openshift_default
 
 # public ssl accepts all connections and isn't checking certificates yet certificates to use will be
@@ -75,8 +80,11 @@ frontend fe_sni
   acl reencrypt hdr(host),map(/var/lib/haproxy/conf/os_reencrypt.map) -m found
   use_backend be_secure_%[hdr(host),map(/var/lib/haproxy/conf/os_tcp_be.map)] if reencrypt
 
-  # regular http
-  use_backend be_http_%[hdr(host),map(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
+  # map to http backend
+  use_backend be_http_%[base,map_beg(/var/lib/haproxy/conf/os_http_be.map)]
+
+  # if a specific path based lookup was not found then revert to a host header lookup
+  use_backend be_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
 
   default_backend openshift_default
 
@@ -131,7 +139,11 @@ backend openshift_default
 {{ range $id, $serviceUnit := . }}
         {{ range $cfgIdx, $cfg := $serviceUnit.ServiceAliasConfigs }}
             {{ if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
+                {{ if eq $cfg.Path "" }}
 backend be_http_{{$serviceUnit.TemplateSafeName}}
+                {{ else }}
+backend be_http_{{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+                {{ end }}
   mode http
   balance leastconn
   timeout check 5000ms
@@ -172,11 +184,12 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge"))}}
-{{$cfg.Host}} {{$serviceUnit.TemplateSafeName}}
+{{$cfg.Host}}{{$cfg.Path}} {{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
 {{       end }}
 {{     end }}
 {{   end }}
 {{ end }}{{/* end http host map template */}}
+
 
 {{/*
     os_tcp_be.map: contains a mapping of www.example.com -> <service name>.  This map is used to discover the correct backend
@@ -185,7 +198,7 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{ define "/var/lib/haproxy/conf/os_tcp_be.map" }}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "passthrough") (eq $cfg.TLSTermination "reencrypt")) }}
+{{       if and (eq $cfg.Path "") (and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "passthrough") (eq $cfg.TLSTermination "reencrypt"))) }}
 {{$cfg.Host}} {{$serviceUnit.TemplateSafeName}}
 {{       end }}
 {{     end }}
@@ -199,7 +212,7 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{ define "/var/lib/haproxy/conf/os_sni_passthrough.map" }}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if eq $cfg.TLSTermination "passthrough" }}
+{{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "passthrough") }}
 {{$cfg.Host}} 1
 {{       end }}
 {{     end }}
@@ -214,7 +227,7 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{ define "/var/lib/haproxy/conf/os_reencrypt.map" }}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if eq $cfg.TLSTermination "reencrypt" }}
+{{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "reencrypt") }}
 {{$cfg.Host}} 1
 {{       end }}
 {{     end }}

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -3,6 +3,10 @@
 config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
 old_pid=""
+path_map_file=/var/lib/haproxy/conf/os_http_be.map
+
+# sort the path based map file for the haproxy map_beg function
+sort -r $path_map_file -o $path_map_file
 
 if [ -f $pid_file ]; then
   old_pid=$(<$pid_file)

--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"strings"
+
 	errs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kval "github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -20,6 +22,10 @@ func ValidateRoute(route *routeapi.Route) errs.ValidationErrorList {
 		if !util.IsDNSSubdomain(route.Host) {
 			result = append(result, errs.NewFieldInvalid("host", route.Host, "Host must conform to DNS 952 subdomain conventions"))
 		}
+	}
+
+	if len(route.Path) > 0 && !strings.HasPrefix(route.Path, "/") {
+		result = append(result, errs.NewFieldInvalid("path", route.Path, "Path must begin with /"))
 	}
 
 	if len(route.ServiceName) == 0 {

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -83,6 +83,32 @@ func TestValidateRoute(t *testing.T) {
 			},
 			expectedErrors: 0,
 		},
+		{
+			name: "Valid route with path",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Host:        "www.example.com",
+				Path:        "/test",
+				ServiceName: "serviceName",
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid route with path",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Host:        "www.example.com",
+				Path:        "test",
+				ServiceName: "serviceName",
+			},
+			expectedErrors: 1,
+		},
 	}
 
 	for _, tc := range tests {

--- a/plugins/router/template/types.go
+++ b/plugins/router/template/types.go
@@ -47,5 +47,15 @@ type Endpoint struct {
 //TemplateSafeName provides a name that can be used in the template that does not contain restricted
 //characters like / which is used to concat namespace and name in the service unit key
 func (s ServiceUnit) TemplateSafeName() string {
-	return strings.Replace(s.Name, "/", "-", -1)
+	return templateSafeString(s.Name)
+}
+
+//TemplateSafePath provides a name that can be used in the template that does not contain restricted
+//characters like / which is used to concat namespace and name in the service unit key
+func (s ServiceAliasConfig) TemplateSafePath() string {
+	return templateSafeString(s.Path)
+}
+
+func templateSafeString(s string) string {
+	return strings.Replace(s, "/", "-", -1)
 }

--- a/test/integration/router/router_http_server.go
+++ b/test/integration/router/router_http_server.go
@@ -24,6 +24,7 @@ func NewTestHttpService() *TestHttpService {
 		PodHttpAddr:      "0.0.0.0:8888",
 		PodHttpsAddr:     "0.0.0.0:8443",
 		PodWebSocketPath: "echo",
+		PodTestPath:      "test",
 		PodHttpsCert:     []byte(Example2Cert),
 		PodHttpsKey:      []byte(Example2Key),
 		PodHttpsCaCert:   []byte(ExampleCACert),
@@ -48,6 +49,7 @@ type TestHttpService struct {
 	PodHttpsKey      []byte
 	PodHttpsCaCert   []byte
 	PodWebSocketPath string
+	PodTestPath      string
 	EndpointChannel  chan string
 	RouteChannel     chan string
 
@@ -59,6 +61,8 @@ const (
 	HelloMaster = "Hello OpenShift!"
 	// HelloPod is the expected response to a call to PodHttpAddr (usually called through a route)
 	HelloPod = "Hello Pod!"
+	// HelloPod is the expected response to a call to PodHttpAddr (usually called through a route)
+	HelloPodPath = "Hello Pod Path!"
 	// HelloPodSecure is the expected response to a call to PodHttpsAddr (usually called through a route)
 	HelloPodSecure = "Hello Pod Secure!"
 )
@@ -71,6 +75,11 @@ func (s *TestHttpService) handleHelloMaster(w http.ResponseWriter, r *http.Reque
 // handleHelloPod handles calls to PodHttpAddr (usually called through a route)
 func (s *TestHttpService) handleHelloPod(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, HelloPod)
+}
+
+// handleHelloPodTest handles calls to PodHttpAddr (usually called through a route) with the /test/ path
+func (s *TestHttpService) handleHelloPodTest(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, HelloPodPath)
 }
 
 // handleHelloPodSecure handles calls to PodHttpsAddr (usually called through a route)
@@ -155,6 +164,7 @@ func (s *TestHttpService) startMaster() error {
 func (s *TestHttpService) startPod() error {
 	unsecurePodServer := http.NewServeMux()
 	unsecurePodServer.HandleFunc("/", s.handleHelloPod)
+	unsecurePodServer.HandleFunc("/"+s.PodTestPath, s.handleHelloPodTest)
 	unsecurePodServer.Handle("/"+s.PodWebSocketPath, websocket.Handler(s.handleWebSocket))
 
 	if err := s.startServing(s.PodHttpAddr, unsecurePodServer); err != nil {


### PR DESCRIPTION
@rajatchopra @pmorie @ramr @akram @smarterclayton 

All, this is the initial implementation of path based routing in the HAProxy router.  Right now the router assumes that you're putting a / at the beginning of the route so a path based routing rule would look like the example below.  I'd like some feedback on that assumption, if it is fine I'll add a validation rule to ensure the slash, if not then we can add the slash for users if preferrable.

Some notes for reviewers: 

* paths are matched based on the path_beg function in HAProxy AND the host name, both must match to trigger the ACL
* path based routing rules use a lookup map with map_beg rules
* path based routing rules have priority over the plain host rules
* path based routes are supported (right now) for unsecure and edge terminated routes.  I think we can do it for reencrypt routes too but I haven't addressed that use case in this PR

TODO:  

* get input on validations
* sort the path based routes for the lookup map (see @rajatchopra 's comments below)

```
{
    "metadata": {
        "name": "route-unsecure-path"
    },
    "id": "route-unsecure-path",
    "apiVersion": "v1beta1",
    "kind": "Route",
    "host": "www.example.com",
    "path": "/test",
    "serviceName": "hello-nginx"
}
```