### PR TITLE
Autogenerate routes if host is not specified - based on service and namespace ala OS v{1,2}

### DIFF
--- a/pkg/route/api/allocator/allocator.go
+++ b/pkg/route/api/allocator/allocator.go
@@ -1,0 +1,30 @@
+package allocator
+
+import (
+	"fmt"
+
+	"code.google.com/p/go-uuid/uuid"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+// This should be something we get from config but we would still need a
+// default name if nothing's passed. The first pass uses the default name.
+// Would be better if we could use "v3.openshift.app", someone bought that!
+const defaultDNSSuffix = "v3.openshift.com"
+
+func Generate(route *routeapi.Route, shard *routeapi.RouterShard) string {
+	name := route.ServiceName
+	if len(name) == 0 {
+		name = uuid.NewUUID().String()
+	}
+
+	if len(route.Namespace) <= 0 {
+		return fmt.Sprintf("%s.%s", name, shard.DNSSuffix)
+	}
+
+	return fmt.Sprintf("%s-%s.%s", name, route.Namespace, shard.DNSSuffix)
+}
+
+func Allocate(route *routeapi.Route) *routeapi.RouterShard {
+	return &routeapi.RouterShard{ShardName: "global", DNSSuffix: defaultDNSSuffix}
+}

--- a/pkg/route/api/allocator/allocator.go
+++ b/pkg/route/api/allocator/allocator.go
@@ -12,6 +12,8 @@ import (
 // Would be better if we could use "v3.openshift.app", someone bought that!
 const defaultDNSSuffix = "v3.openshift.com"
 
+// Generate a host name for a route - using the service name,
+// namespace (if provided) and the router shard dns suffix.
 func Generate(route *routeapi.Route, shard *routeapi.RouterShard) string {
 	name := route.ServiceName
 	if len(name) == 0 {
@@ -25,6 +27,8 @@ func Generate(route *routeapi.Route, shard *routeapi.RouterShard) string {
 	return fmt.Sprintf("%s-%s.%s", name, route.Namespace, shard.DNSSuffix)
 }
 
+// Allocate a router shard for the given route.
+// Placeholder for now ... returns the "global" router shard.
 func Allocate(route *routeapi.Route) *routeapi.RouterShard {
 	return &routeapi.RouterShard{ShardName: "global", DNSSuffix: defaultDNSSuffix}
 }

--- a/pkg/route/api/allocator/allocator_test.go
+++ b/pkg/route/api/allocator/allocator_test.go
@@ -1,0 +1,63 @@
+package allocator
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/openshift/origin/pkg/route/api"
+)
+
+func TestAllocateRoute(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *api.Route
+	}{
+		{
+			name: "No Name",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "namespace",
+				},
+				ServiceName: "service",
+			},
+		},
+		{
+			name: "No namespace",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "name",
+				},
+				ServiceName: "nonamespace",
+			},
+		},
+		{
+			name: "No service name",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+			},
+		},
+		{
+			name: "Valid route",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Host:        "www.example.com",
+				ServiceName: "serviceName",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		shard := Allocate(tc.route)
+		name := Generate(tc.route, shard)
+
+		if len(name) <= 0 {
+			t.Errorf("Test case %s got %d length name.", tc.name, len(name))
+		}
+	}
+}

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -30,9 +30,17 @@ type RouteList struct {
 	Items         []Route `json:"items"`
 }
 
-// RouterShard defines a routing shard.
+// RouterShard has information of a routing shard and is used to
+// generate host names and routing table entries when a routing shard is
+// allocated for a specific route.
+// Caveat: This is WIP and will likely undergo modifications when sharding
+//         support is added.
 type RouterShard struct {
+	// Shard name uniquely identifies a router shard in the "set" of
+	// routers used for routing traffic to the services.
 	ShardName string
+
+	// The DNS suffix for the shard ala: shard-1.v3.openshift.com
 	DNSSuffix string
 }
 

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -30,6 +30,12 @@ type RouteList struct {
 	Items         []Route `json:"items"`
 }
 
+// RouterShard defines a routing shard.
+type RouterShard struct {
+	ShardName string
+	DNSSuffix string
+}
+
 // TLSConfig defines config used to secure a route and provide termination
 type TLSConfig struct {
 	// Termination indicates termination type.  If termination type is not set, any termination config will be ignored

--- a/pkg/route/registry/route/rest.go
+++ b/pkg/route/registry/route/rest.go
@@ -72,18 +72,18 @@ func (rs *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, er
 		return nil, errors.NewConflict("route", route.Namespace, fmt.Errorf("Route.Namespace does not match the provided context"))
 	}
 
-	if errs := validation.ValidateRoute(route); len(errs) > 0 {
-		return nil, errors.NewInvalid("route", route.Name, errs)
-	}
-	if len(route.Name) == 0 {
-		route.Name = uuid.NewUUID().String()
-	}
-
 	//  shards will be eventually allocated via a separate controller.
 	shard := allocator.Allocate(route)
 
 	if len(route.Host) == 0 {
 		route.Host = allocator.Generate(route, shard)
+	}
+
+	if errs := validation.ValidateRoute(route); len(errs) > 0 {
+		return nil, errors.NewInvalid("route", route.Name, errs)
+	}
+	if len(route.Name) == 0 {
+		route.Name = uuid.NewUUID().String()
 	}
 
 	kapi.FillObjectMetaSystemFields(ctx, &route.ObjectMeta)

--- a/pkg/route/registry/route/rest.go
+++ b/pkg/route/registry/route/rest.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/route/api"
+	"github.com/openshift/origin/pkg/route/api/allocator"
 	"github.com/openshift/origin/pkg/route/api/validation"
 )
 
@@ -76,6 +77,13 @@ func (rs *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, er
 	}
 	if len(route.Name) == 0 {
 		route.Name = uuid.NewUUID().String()
+	}
+
+	//  shards will be eventually allocated via a separate controller.
+	shard := allocator.Allocate(route)
+
+	if len(route.Host) == 0 {
+		route.Host = allocator.Generate(route, shard)
 	}
 
 	kapi.FillObjectMetaSystemFields(ctx, &route.ObjectMeta)


### PR DESCRIPTION
Autogenerate host names (if none are specified) for routes based on service and namespace ala 
openshift v{1,2}.

@pweil-  PTAL
Let me know if I got this right, still a newb.  There's probably some additional work to pass a config variable/value down to the API - still figuring that out - probably via kubeconfig would be the right answer, I dunno (will chat w/ you on Monday). Thanks.

Unit tests pass (make check) and integration tested this with the sample app https://github.com/ramr/origin/tree/master/examples/sample-app   - removing the "host" defined for the frontend in examples/sample-app/application-template-stibuild.json  and getting one to autogenerate based on the service + namespace. 

```    
[vagrant@openshiftdev sample-app]$ osc get -n test routes    
NAME                HOST/PORT                        PATH                SERVICE             LABELS    
route-edge          frontend-test.v3.openshift.com                       frontend            template=application-template-stibuild    
```    
