### PR TITLE
remove test-integration.sh from make test.  Resolves #1255

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ test: build check
 endif
 test:
 	hack/test-cmd.sh
-	KUBE_RACE=" " hack/test-integration.sh $(GOFLAGS)
 	KUBE_RACE=" " hack/test-integration-docker.sh $(GOFLAGS)
 	hack/test-end-to-end.sh
 .PHONY: test


### PR DESCRIPTION
remove test-integration.sh from make test. Resolves #1255