### PR TITLE
Use GOFLAGS with go test - useful for debugging/passing down extra flags

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -78,5 +78,8 @@ if [[ -n "${KUBE_COVER}" && -n "${OUTPUT_COVERAGE}" ]]; then
     fi
   done
 else
-  go test $KUBE_RACE $KUBE_TIMEOUT $KUBE_COVER "${@:2}" $test_packages
+  # Allow specific tests (e.g. TestRoute1) to be run via make.
+  # Example:
+  #   make check WHAT=pkg/route/api/validation/ GOFLAGS="-v -run TestRoute1"
+  go test ${GOFLAGS:-} $KUBE_RACE $KUBE_TIMEOUT $KUBE_COVER "${@:2}" $test_packages
 fi


### PR DESCRIPTION
Allow individual/small subset of test unit(s) to be run.

```make check WHAT=pkg/route/api/validation/ GOFLAGS="-v -run TestRoute1"```    

will run a single test (TestRoute1)   

@pweil-  as per comments on https://github.com/openshift/origin/pull/1250, split into a separate PR.
PTAL.

Thanks.