### PR TITLE
Bug 119409 - fix source URI generated by new-app

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -99,6 +99,11 @@ type SourceRef struct {
 	ContextDir string
 }
 
+func urlWithoutRef(url url.URL) string {
+	url.Fragment = ""
+	return url.String()
+}
+
 // SuggestName returns a name derived from the source URL
 func (r *SourceRef) SuggestName() (string, bool) {
 	if len(r.Name) > 0 {
@@ -112,7 +117,7 @@ func (r *SourceRef) BuildSource() (*buildapi.BuildSource, []buildapi.BuildTrigge
 	return &buildapi.BuildSource{
 			Type: buildapi.BuildSourceGit,
 			Git: &buildapi.GitBuildSource{
-				URI: r.URL.String(),
+				URI: urlWithoutRef(*r.URL),
 				Ref: r.Ref,
 			},
 			ContextDir: r.ContextDir,

--- a/pkg/generate/app/app_test.go
+++ b/pkg/generate/app/app_test.go
@@ -199,6 +199,35 @@ func TestImageRefDeployableContainerPorts(t *testing.T) {
 	}
 }
 
+func TestSourceRefBuildSourceURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL without hash",
+			input:    "https://github.com/openshift/ruby-hello-world.git",
+			expected: "https://github.com/openshift/ruby-hello-world.git",
+		},
+		{
+			name:     "URL with hash",
+			input:    "https://github.com/openshift/ruby-hello-world.git#testref",
+			expected: "https://github.com/openshift/ruby-hello-world.git",
+		},
+	}
+	for _, tst := range tests {
+		u, _ := url.Parse(tst.input)
+		s := SourceRef{
+			URL: u,
+		}
+		buildSource, _ := s.BuildSource()
+		if buildSource.Git.URI != tst.expected {
+			t.Errorf("%s: unexpected build source URI: %s. Expected: %s", tst.name, buildSource.Git.URI, tst.expected)
+		}
+	}
+}
+
 func ExampleGenerateSimpleDockerApp() {
 	// TODO: determine if the repo is secured prior to fetching
 	// TODO: determine whether we want to clone this repo, or use it directly. Using it directly would require setting hooks


### PR DESCRIPTION
The generated BuildSource URI should not include a hash.
https://bugzilla.redhat.com/show_bug.cgi?id=1199409