### PR TITLE
Fix temporary platform builder image names for generation tools

### DIFF
--- a/pkg/generate/app/builder.go
+++ b/pkg/generate/app/builder.go
@@ -18,3 +18,16 @@ func IsBuilderImage(image *imageapi.DockerImage) bool {
 	}
 	return false
 }
+
+//TODO: Remove once a real image searcher is implemented
+func BuilderForPlatform(platform string) string {
+	switch strings.ToLower(platform) {
+	case "ruby":
+		return "openshift/ruby-20-centos7"
+	case "jee":
+		return "openshift/wildfly-8-centos"
+	case "nodejs":
+		return "openshift/nodejs-010-centos7"
+	}
+	return ""
+}

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -402,16 +402,9 @@ func (s *simpleSearcher) Search(terms []string) ([]*app.ComponentMatch, error) {
 	if len(terms) == 0 {
 		return nil, fmt.Errorf("No search terms were specified.")
 	}
-	term := strings.ToLower(terms[0])
-	builder := ""
-	switch term {
-	case "jee":
-		builder = "openshift/wildfly-8-centos"
-	case "ruby":
-		builder = "openshift/ruby-20-centos7"
-	case "nodejs":
-		builder = "openshift/node-0-10-centos"
-	default:
+	term := terms[0]
+	builder := app.BuilderForPlatform(term)
+	if len(builder) == 0 {
 		return nil, fmt.Errorf("No matching image found for %s", term)
 	}
 	match, err := s.resolver.Resolve(builder)

--- a/pkg/generate/generator/strategyref.go
+++ b/pkg/generate/generator/strategyref.go
@@ -128,16 +128,9 @@ func (g *BuildStrategyRefGenerator) FromSTIBuilderImage(image *app.ImageRef) (*a
 }
 
 func (g *BuildStrategyRefGenerator) imageForSourceInfo(s *source.Info) (*app.ImageRef, error) {
-	var imageName string
 	// TODO: More sophisticated matching
-	switch s.Platform {
-	case "Ruby":
-		imageName = "openshift/ruby-20-centos7"
-	case "JEE":
-		imageName = "openshift/wildfly-8-centos"
-	case "NodeJS":
-		imageName = "openshift/nodejs-010-centos7"
-	default:
+	imageName := app.BuilderForPlatform(s.Platform)
+	if len(imageName) == 0 {
 		return nil, errors.NoBuilderFound
 	}
 	if g.resolver != nil {


### PR DESCRIPTION
new-app was not using the right builder image name for NodeJS repos.