### PR TITLE
Add an initial importer for Image Repositories

### DIFF
--- a/examples/image-repositories/image-repositories.json
+++ b/examples/image-repositories/image-repositories.json
@@ -9,7 +9,6 @@
         "name": "ruby-20-centos7"
       },
       "tags": {
-        "latest": "latest"
       }
     },
     {
@@ -20,7 +19,6 @@
         "name": "nodejs-010-centos7"
       },
       "tags": {
-        "latest": "latest"
       }
     },
     {
@@ -31,7 +29,6 @@
         "name": "wildfly-8-centos"
       },
       "tags": {
-        "latest": "latest"
       }
     }
   ],

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -39,7 +39,8 @@
       "kind": "ImageRepository",
       "metadata": {
         "name": "ruby-20-centos7"
-      }
+      },
+      "dockerImageRepository": "openshift/ruby-20-centos7"
     },
     {
       "apiVersion": "v1beta1",

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -39,7 +39,8 @@
       "kind": "ImageRepository",
       "metadata": {
         "name": "ruby-20-centos7"
-      }
+      },
+      "dockerImageRepository": "openshift/ruby-20-centos7"
     },
     {
       "apiVersion": "v1beta1",

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -225,10 +225,9 @@ osc create -f examples/image-repositories/image-repositories.json
 [ -n "$(osc get imageRepositories wildfly-8-centos -t "{{.status.dockerImageRepository}}")" ]
 osc delete imageRepositories ruby-20-centos7
 osc delete imageRepositories nodejs-010-centos7
-osc delete imageRepositories wildfly-8-centos
 [ -z "$(osc get imageRepositories ruby-20-centos7 -t "{{.status.dockerImageRepository}}")" ]
 [ -z "$(osc get imageRepositories nodejs-010-centos7 -t "{{.status.dockerImageRepository}}")" ]
-[ -z "$(osc get imageRepositories wildfly-8-centos -t "{{.status.dockerImageRepository}}")" ]
+# don't delete wildfly-8-centos
 echo "imageRepositories: ok"
 
 osc create -f test/integration/fixtures/test-image-repository.json
@@ -323,5 +322,9 @@ echo "ex router: ok"
 openshift ex registry --create --credentials="${OPENSHIFTCONFIG}"
 [ "$(openshift ex registry | grep 'service exists')" ]
 echo "ex registry: ok"
+
+# verify the image repository had its tags populated
+[ -n "$(osc get imageRepositories wildfly-8-centos -t "{{.tags.latest}}")" ]
+[ -n "$(osc get imageRepositories wildfly-8-centos -t "{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}")" ]
 
 osc get minions,pods

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -265,7 +265,7 @@ osc create -n test -f "${STI_CONFIG_FILE}"
 
 # Trigger build
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} and streaming its logs..."
-osc start-build -n test ruby-sample-build --follow
+#osc start-build -n test ruby-sample-build --follow
 wait_for_build "test"
 wait_for_app "test"
 

--- a/pkg/build/util/generate.go
+++ b/pkg/build/util/generate.go
@@ -102,7 +102,7 @@ func GenerateBuildWithImageTag(config *buildapi.BuildConfig, revision *buildapi.
 		if len(tag) == 0 {
 			tag = buildapi.DefaultImageTag
 		}
-		latest, err := imageapi.LatestTaggedImage(*imageRepo, tag)
+		latest, err := imageapi.LatestTaggedImage(imageRepo, tag)
 		if err != nil {
 			continue
 		}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -203,8 +203,8 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 
 	imageStorage := imageetcd.NewREST(c.EtcdHelper)
 	imageRegistry := image.NewRegistry(imageStorage)
-	imageRepositoryStorage := imagerepositoryetcd.NewREST(c.EtcdHelper, imagerepository.DefaultRegistryFunc(defaultRegistryFunc))
-	imageRepositoryRegistry := imagerepository.NewRegistry(imageRepositoryStorage)
+	imageRepositoryStorage, imageRepositoryStatus := imagerepositoryetcd.NewREST(c.EtcdHelper, imagerepository.DefaultRegistryFunc(defaultRegistryFunc))
+	imageRepositoryRegistry := imagerepository.NewRegistry(imageRepositoryStorage, imageRepositoryStatus)
 	imageRepositoryMappingStorage := imagerepositorymapping.NewREST(imageRegistry, imageRepositoryRegistry)
 	imageRepositoryTagStorage := imagerepositorytag.NewREST(imageRegistry, imageRepositoryRegistry)
 	imageStreamImageStorage := imagestreamimage.NewREST(imageRegistry, imageRepositoryRegistry)
@@ -233,14 +233,15 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		"buildConfigs": buildconfigregistry.NewREST(buildEtcd),
 		"buildLogs":    buildlogregistry.NewREST(buildEtcd, c.BuildLogClient()),
 
-		"images":                  imageStorage,
-		"imageStreams":            imageRepositoryStorage,
-		"imageStreamImages":       imageStreamImageStorage,
-		"imageStreamMappings":     imageRepositoryMappingStorage,
-		"imageStreamTags":         imageRepositoryTagStorage,
-		"imageRepositories":       imageRepositoryStorage,
-		"imageRepositoryMappings": imageRepositoryMappingStorage,
-		"imageRepositoryTags":     imageRepositoryTagStorage,
+		"images":                   imageStorage,
+		"imageStreams":             imageRepositoryStorage,
+		"imageStreamImages":        imageStreamImageStorage,
+		"imageStreamMappings":      imageRepositoryMappingStorage,
+		"imageStreamTags":          imageRepositoryTagStorage,
+		"imageRepositories":        imageRepositoryStorage,
+		"imageRepositories/status": imageRepositoryStatus,
+		"imageRepositoryMappings":  imageRepositoryMappingStorage,
+		"imageRepositoryTags":      imageRepositoryTagStorage,
 
 		"deployments":               deployregistry.NewREST(deployEtcd),
 		"deploymentConfigs":         deployconfigregistry.NewREST(deployEtcd),

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -343,6 +343,7 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	openshiftConfig.RunDeploymentConfigController()
 	openshiftConfig.RunDeploymentConfigChangeController()
 	openshiftConfig.RunDeploymentImageChangeTriggerController()
+	openshiftConfig.RunImageImportController()
 	openshiftConfig.RunProjectAuthorizationCache()
 
 	return nil

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -64,7 +64,7 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageRepository) erro
 					continue
 				}
 
-				latest, err := imageapi.LatestTaggedImage(*imageRepo, params.Tag)
+				latest, err := imageapi.LatestTaggedImage(imageRepo, params.Tag)
 				if err != nil {
 					glog.V(4).Infof("Skipping container %s for config %s; %s", container.Name, labelFor(config), err)
 					continue
@@ -146,7 +146,7 @@ func (c *ImageChangeController) regenerate(imageRepo *imageapi.ImageRepository, 
 				continue
 			}
 
-			latest, err := imageapi.LatestTaggedImage(*imageRepo, trigger.Tag)
+			latest, err := imageapi.LatestTaggedImage(imageRepo, trigger.Tag)
 			if err != nil {
 				return fmt.Errorf("error generating new version of deploymentConfig: %s: %s", labelFor(config), err)
 			}

--- a/pkg/deploy/generator/config_generator.go
+++ b/pkg/deploy/generator/config_generator.go
@@ -219,15 +219,8 @@ func replaceReferences(dc *deployapi.DeploymentConfig, repos reposByIndex) (chan
 		}
 		params := dc.Triggers[i].ImageChangeParams
 
-		// lookup image id
-		tag := params.Tag
-		if len(tag) == 0 {
-			// TODO: replace with "preferred tag" from repo
-			tag = "latest"
-		}
-
 		// get the image ref from the repo's tag history
-		latest, err := imageapi.LatestTaggedImage(*repo, tag)
+		latest, err := imageapi.LatestTaggedImage(repo, params.Tag)
 		if err != nil {
 			errs = append(errs, errors.NewFieldInvalid(fmt.Sprintf("triggers[%d].imageChange.from", i), repo.Name, err.Error()))
 			continue

--- a/pkg/generate/app/imagelookup.go
+++ b/pkg/generate/app/imagelookup.go
@@ -271,18 +271,17 @@ func (r ImageStreamResolver) Resolve(value string) (*ComponentMatch, error) {
 			return nil, err
 		}
 		searchTag := ref.Tag
-		// TODO: move to a lookup function on repo, or better yet, have the repo.Status.Tags field automatically infer latest
 		if len(searchTag) == 0 {
 			searchTag = "latest"
 		}
-		latest, err := imageapi.LatestTaggedImage(*repo, searchTag)
+		latest, err := imageapi.LatestTaggedImage(repo, searchTag)
 		if err != nil {
 			return nil, ErrNoMatch{value: value, qualifier: err.Error()}
 		}
 		imageData, err := r.ImageStreamImages.ImageStreamImages(namespace).Get(ref.Name, latest.Image)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				return nil, ErrNoMatch{value: value, qualifier: fmt.Sprintf("tag %q is set, but image %q has been removed", ref.Tag, latest.Image)}
+				return nil, ErrNoMatch{value: value, qualifier: fmt.Sprintf("tag %q is set, but image %q has been removed", searchTag, latest.Image)}
 			}
 			return nil, err
 		}

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -82,6 +82,20 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 	}
 }
 
+// DockerClientDefaults sets the default values used by the Docker client.
+func (r DockerImageReference) DockerClientDefaults() DockerImageReference {
+	if len(r.Namespace) == 0 {
+		r.Namespace = "library"
+	}
+	if len(r.Registry) == 0 {
+		r.Registry = "index.docker.io"
+	}
+	if len(r.Tag) == 0 {
+		r.Tag = "latest"
+	}
+	return r
+}
+
 // String converts a DockerImageReference to a Docker pull spec.
 func (r DockerImageReference) String() string {
 	registry := r.Registry

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -57,6 +57,14 @@ func ValidateImageRepositoryUpdate(newRepo, oldRepo *api.ImageRepository) errors
 	return result
 }
 
+func ValidateImageRepositoryStatusUpdate(newRepo, oldRepo *api.ImageRepository) errors.ValidationErrorList {
+	result := errors.ValidationErrorList{}
+	result = append(result, validation.ValidateObjectMetaUpdate(&oldRepo.ObjectMeta, &newRepo.ObjectMeta).Prefix("metadata")...)
+	newRepo.Tags = oldRepo.Tags
+	newRepo.DockerImageRepository = oldRepo.DockerImageRepository
+	return result
+}
+
 // ValidateImageRepositoryMapping tests required fields for an ImageRepositoryMapping.
 func ValidateImageRepositoryMapping(mapping *api.ImageRepositoryMapping) errors.ValidationErrorList {
 	result := errors.ValidationErrorList{}

--- a/pkg/image/controller/controller.go
+++ b/pkg/image/controller/controller.go
@@ -1,0 +1,147 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/dockerregistry"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+const dockerImageRepositoryCheckAnnotation = "openshift.io/image.dockerRepositoryCheck"
+
+type ImportController struct {
+	repositories client.ImageRepositoriesNamespacer
+	mappings     client.ImageRepositoryMappingsNamespacer
+	client       dockerregistry.Client
+}
+
+// Next processes the given image repository, looking for repos that have DockerImageRepository
+// set but have not yet been marked as "ready". If transient errors occur, err is returned but
+// the image repository is not modified (so it will be tried again later). If a permanent
+// failure occurs the image is marked with an annotation.
+func (c *ImportController) Next(repo *api.ImageRepository) error {
+	name := repo.DockerImageRepository
+	if len(name) == 0 {
+		return nil
+	}
+	if repo.Annotations == nil {
+		repo.Annotations = make(map[string]string)
+	}
+	if len(repo.Annotations[dockerImageRepositoryCheckAnnotation]) != 0 {
+		return nil
+	}
+
+	registry, namespace, name, _, err := api.SplitDockerPullSpec(name)
+	if err != nil {
+		err = fmt.Errorf("invalid docker image repository, cannot import data: %v", err)
+		util.HandleError(err)
+		return c.done(repo, err.Error())
+	}
+
+	conn, err := c.client.Connect(registry)
+	if err != nil {
+		return err
+	}
+	tags, err := conn.ImageTags(namespace, name)
+	switch {
+	case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err):
+		return c.done(repo, err.Error())
+	case err != nil:
+		return err
+	}
+
+	newTags := make(map[string]string, len(repo.Tags))
+	imageToTag := make(map[string][]string)
+	switch {
+	case len(repo.Tags) == 0:
+		// copy all tags
+		for tag, _ := range tags {
+			// TODO: once pull by image is implemented, use tag = imageid
+			newTags[tag] = tag
+		}
+		for tag, image := range tags {
+			imageToTag[image] = append(imageToTag[image], tag)
+		}
+	default:
+		for tag, v := range repo.Tags {
+			if len(v) != 0 {
+				newTags[tag] = v
+				continue
+			}
+			image, ok := tags[tag]
+			if !ok {
+				// tag not found, set empty
+				continue
+			}
+			imageToTag[image] = append(imageToTag[image], tag)
+			// TODO: once pull by image is implemented, use tag = imageid
+			newTags[tag] = tag
+		}
+	}
+
+	// whether we ignore or succeed, ensure the most recent mappings are recorded
+	repo.Tags = newTags
+
+	// nothing to tag - no images in the upstream repo, or we're in sync
+	if len(imageToTag) == 0 {
+		return c.done(repo, "")
+	}
+
+	for id, tags := range imageToTag {
+		dockerImage, err := conn.ImageByID(namespace, name, id)
+		switch {
+		case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err):
+			return c.done(repo, err.Error())
+		case dockerregistry.IsImageNotFound(err):
+			for _, tag := range tags {
+				delete(newTags, tag)
+			}
+			continue
+		case err != nil:
+			return err
+		}
+		var image api.DockerImage
+		if err := kapi.Scheme.Convert(dockerImage, &image); err != nil {
+			err = fmt.Errorf("could not convert image: %#v", err)
+			util.HandleError(err)
+			return c.done(repo, err.Error())
+		}
+		mapping := &api.ImageRepositoryMapping{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      repo.Name,
+				Namespace: repo.Namespace,
+			},
+			Tag: tags[0],
+			Image: api.Image{
+				DockerImageMetadata: image,
+			},
+		}
+		if err := c.mappings.ImageRepositoryMappings(repo.Namespace).Create(mapping); err != nil {
+			if errors.IsNotFound(err) {
+				return c.done(repo, err.Error())
+			}
+			return err
+		}
+	}
+
+	// we've completed our updates
+	return c.done(repo, "")
+}
+
+// ignore marks the repository as being processed due to an error or failure condition
+func (c *ImportController) done(repo *api.ImageRepository, reason string) error {
+	if len(reason) == 0 {
+		reason = util.Now().UTC().Format(time.RFC3339)
+	}
+	repo.Annotations[dockerImageRepositoryCheckAnnotation] = reason
+	if _, err := c.repositories.ImageRepositories(repo.Namespace).Update(repo); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/image/controller/controller_test.go
+++ b/pkg/image/controller/controller_test.go
@@ -132,11 +132,11 @@ func TestControllerRepoTagsAlreadySet(t *testing.T) {
 		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
 		DockerImageRepository: "foo/bar",
 		Tags: map[string]string{
-			"test": "value",
+			"test": "",
 		},
 	}
 	if err := c.Next(&repo); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) == 0 {
 		t.Errorf("did not set annotation: %#v", repo)

--- a/pkg/image/controller/controller_test.go
+++ b/pkg/image/controller/controller_test.go
@@ -1,0 +1,257 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fsouza/go-dockerclient"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/dockerregistry"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+type expectedImage struct {
+	Tag   string
+	ID    string
+	Image *docker.Image
+	Err   error
+}
+
+type fakeDockerRegistryClient struct {
+	Registry                 string
+	Namespace, Name, Tag, ID string
+
+	Tags map[string]string
+	Err  error
+
+	Images []expectedImage
+}
+
+func (f *fakeDockerRegistryClient) Connect(registry string) (dockerregistry.Connection, error) {
+	f.Registry = registry
+	return f, nil
+}
+
+func (f *fakeDockerRegistryClient) ImageTags(namespace, name string) (map[string]string, error) {
+	f.Namespace, f.Name = namespace, name
+	return f.Tags, f.Err
+}
+
+func (f *fakeDockerRegistryClient) ImageByTag(namespace, name, tag string) (*docker.Image, error) {
+	if len(tag) == 0 {
+		tag = "latest"
+	}
+	f.Namespace, f.Name, f.Tag = namespace, name, tag
+	for _, t := range f.Images {
+		if t.Tag == tag {
+			return t.Image, t.Err
+		}
+	}
+	return nil, dockerregistry.NewImageNotFoundError(fmt.Sprintf("%s/%s", namespace, name), tag, tag)
+}
+
+func (f *fakeDockerRegistryClient) ImageByID(namespace, name, id string) (*docker.Image, error) {
+	f.Namespace, f.Name, f.ID = namespace, name, id
+	for _, t := range f.Images {
+		if t.ID == id {
+			return t.Image, t.Err
+		}
+	}
+	return nil, dockerregistry.NewImageNotFoundError(fmt.Sprintf("%s/%s", namespace, name), id, "")
+}
+
+func TestControllerNoDockerRepo(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+
+	repo := api.ImageRepository{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "test",
+			Namespace: "other",
+		},
+	}
+	other := repo
+	if err := c.Next(&repo); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !kapi.Semantic.DeepEqual(repo, other) {
+		t.Errorf("did not expect change to repo")
+	}
+}
+
+func TestControllerRepoHandled(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+
+	repo := api.ImageRepository{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "test",
+			Namespace: "other",
+		},
+		DockerImageRepository: "foo/bar",
+	}
+	if err := c.Next(&repo); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) == 0 {
+		t.Errorf("did not set annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 1 {
+		t.Error("expected an update action: %#v", fake.Actions)
+	}
+}
+
+func TestControllerTagRetrievalFails(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{Err: fmt.Errorf("test error")}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+
+	repo := api.ImageRepository{
+		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
+		DockerImageRepository: "foo/bar",
+	}
+	if err := c.Next(&repo); err != cli.Err {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) != 0 {
+		t.Errorf("should not set annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 0 {
+		t.Error("expected no actions on fake client")
+	}
+}
+
+func TestControllerRepoTagsAlreadySet(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+
+	repo := api.ImageRepository{
+		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
+		DockerImageRepository: "foo/bar",
+		Tags: map[string]string{
+			"test": "value",
+		},
+	}
+	if err := c.Next(&repo); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) == 0 {
+		t.Errorf("did not set annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 1 {
+		t.Error("expected an update action: %#v", fake.Actions)
+	}
+}
+
+func TestControllerImageNotFoundError(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{Tags: map[string]string{"latest": "not_found"}}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+	repo := api.ImageRepository{
+		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
+		DockerImageRepository: "foo/bar",
+	}
+	if err := c.Next(&repo); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) == 0 {
+		t.Errorf("did not set annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 1 {
+		t.Error("expected an update action: %#v", fake.Actions)
+	}
+}
+
+func TestControllerImageWithGenericError(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{
+		Tags: map[string]string{"latest": "found"},
+		Images: []expectedImage{
+			{
+				ID:  "found",
+				Err: fmt.Errorf("test error"),
+			},
+		},
+	}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+	repo := api.ImageRepository{
+		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
+		DockerImageRepository: "foo/bar",
+	}
+	if err := c.Next(&repo); err != cli.Images[0].Err {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) != 0 {
+		t.Errorf("did not expect annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 0 {
+		t.Error("expected no update action: %#v", fake.Actions)
+	}
+}
+
+func TestControllerWithImage(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{
+		Tags: map[string]string{"latest": "found"},
+		Images: []expectedImage{
+			{
+				ID: "found",
+				Image: &docker.Image{
+					Comment: "foo",
+					Config:  &docker.Config{},
+				},
+			},
+		},
+	}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+	repo := api.ImageRepository{
+		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
+		DockerImageRepository: "foo/bar",
+	}
+	if err := c.Next(&repo); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !isRFC3339(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) {
+		t.Fatalf("did not set annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 2 {
+		t.Error("expected an update action: %#v", fake.Actions)
+	}
+}
+
+func TestControllerWithEmptyTag(t *testing.T) {
+	cli, fake := &fakeDockerRegistryClient{
+		Tags: map[string]string{"latest": "found"},
+		Images: []expectedImage{
+			{
+				ID: "found",
+				Image: &docker.Image{
+					Comment: "foo",
+					Config:  &docker.Config{},
+				},
+			},
+		},
+	}, &client.Fake{}
+	c := ImportController{client: cli, repositories: fake, mappings: fake}
+	repo := api.ImageRepository{
+		ObjectMeta:            kapi.ObjectMeta{Name: "test", Namespace: "other"},
+		DockerImageRepository: "foo/bar",
+		Tags: map[string]string{
+			"latest": "",
+		},
+	}
+	if err := c.Next(&repo); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !isRFC3339(repo.Annotations["openshift.io/image.dockerRepositoryCheck"]) {
+		t.Fatalf("did not set annotation: %#v", repo)
+	}
+	if len(fake.Actions) != 2 {
+		t.Error("expected an update action: %#v", fake.Actions)
+	}
+}
+
+func isRFC3339(s string) bool {
+	_, err := time.Parse(time.RFC3339, s)
+	return err == nil
+}

--- a/pkg/image/controller/factory.go
+++ b/pkg/image/controller/factory.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"github.com/golang/glog"
+
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -23,9 +25,11 @@ type ImportControllerFactory struct {
 func (f *ImportControllerFactory) Create() controller.RunnableController {
 	lw := &cache.ListWatch{
 		ListFunc: func() (runtime.Object, error) {
+			glog.Infof("about to list IRs")
 			return f.Client.ImageRepositories(kapi.NamespaceAll).List(labels.Everything(), labels.Everything())
 		},
 		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			glog.Infof("about to watch IRs: %s", resourceVersion)
 			return f.Client.ImageRepositories(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
 		},
 	}
@@ -43,9 +47,9 @@ func (f *ImportControllerFactory) Create() controller.RunnableController {
 		RetryManager: controller.NewQueueRetryManager(
 			q,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, _ int) bool {
+			func(obj interface{}, err error, count int) bool {
 				util.HandleError(err)
-				return true
+				return count < 5
 			},
 		),
 		Handle: func(obj interface{}) error {

--- a/pkg/image/controller/factory.go
+++ b/pkg/image/controller/factory.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/controller"
+	"github.com/openshift/origin/pkg/dockerregistry"
+	"github.com/openshift/origin/pkg/image/api"
+)
+
+// ImportControllerFactory can create an ImportController.
+type ImportControllerFactory struct {
+	Client client.Interface
+}
+
+// Create creates an ImportController.
+func (f *ImportControllerFactory) Create() controller.RunnableController {
+	lw := &cache.ListWatch{
+		ListFunc: func() (runtime.Object, error) {
+			return f.Client.ImageRepositories(kapi.NamespaceAll).List(labels.Everything(), labels.Everything())
+		},
+		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			return f.Client.ImageRepositories(kapi.NamespaceAll).Watch(labels.Everything(), labels.Everything(), resourceVersion)
+		},
+	}
+	q := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+	cache.NewReflector(lw, &api.ImageRepository{}, q).Run()
+
+	c := &ImportController{
+		client:       dockerregistry.NewClient(),
+		repositories: f.Client,
+		mappings:     f.Client,
+	}
+
+	return &controller.RetryController{
+		Queue: q,
+		RetryManager: controller.NewQueueRetryManager(
+			q,
+			cache.MetaNamespaceKeyFunc,
+			func(obj interface{}, err error, _ int) bool {
+				util.HandleError(err)
+				return true
+			},
+		),
+		Handle: func(obj interface{}) error {
+			r := obj.(*api.ImageRepository)
+			return c.Next(r)
+		},
+	}
+}

--- a/pkg/image/registry/imagerepository/etcd/etcd_test.go
+++ b/pkg/image/registry/imagerepository/etcd/etcd_test.go
@@ -38,7 +38,7 @@ func validNewRepo() *api.ImageRepository {
 
 func TestCreate(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 	test := resttest.New(t, storage, fakeEtcdClient.SetError)
 	repo := validNewRepo()
 	repo.ObjectMeta = kapi.ObjectMeta{}
@@ -53,7 +53,7 @@ func TestCreate(t *testing.T) {
 func TestGetImageRepositoryError(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("foo")
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	image, err := storage.Get(kapi.NewDefaultContext(), "image1")
 	if image != nil {
@@ -66,7 +66,7 @@ func TestGetImageRepositoryError(t *testing.T) {
 
 func TestGetImageRepositoryOK(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	ctx := kapi.NewDefaultContext()
 	repoName := "foo"
@@ -89,7 +89,7 @@ func TestGetImageRepositoryOK(t *testing.T) {
 func TestListImageRepositoriesError(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("foo")
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	imageRepositories, err := storage.List(kapi.NewDefaultContext(), nil, nil)
 	if err != fakeEtcdClient.Err {
@@ -108,7 +108,7 @@ func TestListImageRepositoriesEmptyList(t *testing.T) {
 		R: &etcd.Response{},
 		E: fakeEtcdClient.NewError(tools.EtcdErrorCodeNotFound),
 	}
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	imageRepositories, err := storage.List(kapi.NewDefaultContext(), labels.Everything(), labels.Everything())
 	if err != nil {
@@ -124,7 +124,7 @@ func TestListImageRepositoriesEmptyList(t *testing.T) {
 
 func TestListImageRepositoriesPopulatedList(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	fakeEtcdClient.Data["/imageRepositories/default"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
@@ -151,7 +151,7 @@ func TestListImageRepositoriesPopulatedList(t *testing.T) {
 
 func TestCreateImageRepositoryOK(t *testing.T) {
 	_, helper := newHelper(t)
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	repo := &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}
 	_, err := storage.Create(kapi.NewDefaultContext(), repo)
@@ -180,7 +180,7 @@ func TestCreateImageRepositoryOK(t *testing.T) {
 func TestCreateRegistryErrorSaving(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("foo")
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	_, err := storage.Create(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
 	if err != fakeEtcdClient.Err {
@@ -190,7 +190,7 @@ func TestCreateRegistryErrorSaving(t *testing.T) {
 
 func TestUpdateImageRepositoryMissingID(t *testing.T) {
 	_, helper := newHelper(t)
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	obj, created, err := storage.Update(kapi.NewDefaultContext(), &api.ImageRepository{})
 	if obj != nil || created {
@@ -204,7 +204,7 @@ func TestUpdateImageRepositoryMissingID(t *testing.T) {
 func TestUpdateRegistryErrorSaving(t *testing.T) {
 	fakeEtcdClient, helper := newHelper(t)
 	fakeEtcdClient.Err = fmt.Errorf("foo")
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	_, created, err := storage.Update(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "bar"}})
 	if err != fakeEtcdClient.Err || created {
@@ -224,7 +224,7 @@ func TestUpdateImageRepositoryOK(t *testing.T) {
 			},
 		},
 	}
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	obj, created, err := storage.Update(kapi.NewDefaultContext(), &api.ImageRepository{ObjectMeta: kapi.ObjectMeta{Name: "bar", ResourceVersion: "1"}})
 	if err != nil || created {
@@ -251,7 +251,7 @@ func TestDeleteImageRepository(t *testing.T) {
 			},
 		},
 	}
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	obj, err := storage.Delete(kapi.NewDefaultContext(), "foo")
 	if err != nil {
@@ -278,7 +278,7 @@ func TestUpdateImageRepositoryConflictingNamespace(t *testing.T) {
 			},
 		},
 	}
-	storage := NewREST(helper, noDefaultRegistry)
+	storage, _ := NewREST(helper, noDefaultRegistry)
 
 	obj, created, err := storage.Update(kapi.WithNamespace(kapi.NewContext(), "legal-name"), &api.ImageRepository{
 		ObjectMeta: kapi.ObjectMeta{Name: "bar", Namespace: "some-value"},

--- a/pkg/image/registry/imagerepository/registry.go
+++ b/pkg/image/registry/imagerepository/registry.go
@@ -20,6 +20,8 @@ type Registry interface {
 	CreateImageRepository(ctx kapi.Context, repo *api.ImageRepository) error
 	// UpdateImageRepository updates an image repository.
 	UpdateImageRepository(ctx kapi.Context, repo *api.ImageRepository) error
+	// UpdateImageRepository updates an image repository's status.
+	UpdateImageRepositoryStatus(ctx kapi.Context, repo *api.ImageRepository) error
 	// DeleteImageRepository deletes an image repository.
 	DeleteImageRepository(ctx kapi.Context, id string) error
 	// WatchImageRepositories watches for new/changed/deleted image repositories.
@@ -40,12 +42,13 @@ type Storage interface {
 // storage puts strong typing around storage calls
 type storage struct {
 	Storage
+	status apiserver.RESTUpdater
 }
 
 // NewRegistry returns a new Registry interface for the given Storage. Any mismatched
 // types will panic.
-func NewRegistry(s Storage) Registry {
-	return &storage{s}
+func NewRegistry(s Storage, status apiserver.RESTUpdater) Registry {
+	return &storage{s, status}
 }
 
 func (s *storage) ListImageRepositories(ctx kapi.Context, label labels.Selector) (*api.ImageRepositoryList, error) {
@@ -71,6 +74,11 @@ func (s *storage) CreateImageRepository(ctx kapi.Context, imageRepository *api.I
 
 func (s *storage) UpdateImageRepository(ctx kapi.Context, imageRepository *api.ImageRepository) error {
 	_, _, err := s.Update(ctx, imageRepository)
+	return err
+}
+
+func (s *storage) UpdateImageRepositoryStatus(ctx kapi.Context, imageRepository *api.ImageRepository) error {
+	_, _, err := s.status.Update(ctx, imageRepository)
 	return err
 }
 

--- a/pkg/image/registry/imagerepository/strategy_test.go
+++ b/pkg/image/registry/imagerepository/strategy_test.go
@@ -76,20 +76,63 @@ func TestUpdateTagHistory(t *testing.T) {
 		tags               map[string]string
 		existingTagHistory map[string]api.TagEventList
 		expectedTagHistory map[string]api.TagEventList
+		repo               string
+		previous           map[string]string
 	}{
 		"no tags, no history": {
+			repo:               "registry:5000/ns/repo",
 			tags:               make(map[string]string),
 			existingTagHistory: make(map[string]api.TagEventList),
 			expectedTagHistory: make(map[string]api.TagEventList),
 		},
+		"single tag update, preserves history": {
+			repo:     "registry:5000/ns/repo",
+			previous: map[string]string{},
+			tags:     map[string]string{"t1": "t1"},
+			existingTagHistory: map[string]api.TagEventList{
+				"t2": {Items: []api.TagEvent{
+					{
+						DockerImageReference: "registry:5000/ns/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+				}},
+			},
+			expectedTagHistory: map[string]api.TagEventList{
+				"t1": {Items: []api.TagEvent{
+					{
+						DockerImageReference: "registry:5000/ns/repo:t1",
+						Image:                "",
+					},
+				}},
+				"t2": {Items: []api.TagEvent{
+					{
+						DockerImageReference: "registry:5000/ns/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					},
+				}},
+			},
+		},
+		"empty tag ignored on create": {
+			repo:               "registry:5000/ns/repo",
+			tags:               map[string]string{"t1": ""},
+			existingTagHistory: make(map[string]api.TagEventList),
+			expectedTagHistory: map[string]api.TagEventList{},
+		},
+		"tag to missing ignored on create": {
+			repo:               "registry:5000/ns/repo",
+			tags:               map[string]string{"t1": "t2"},
+			existingTagHistory: make(map[string]api.TagEventList),
+			expectedTagHistory: map[string]api.TagEventList{},
+		},
 		"new tags, no history": {
-			tags:               map[string]string{"t1": "v1image1", "t2": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+			repo:               "registry:5000/ns/repo",
+			tags:               map[string]string{"t1": "t1", "t2": "@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 			existingTagHistory: make(map[string]api.TagEventList),
 			expectedTagHistory: map[string]api.TagEventList{
 				"t1": {Items: []api.TagEvent{
 					{
-						DockerImageReference: "registry:5000/ns/repo:v1image1",
-						Image:                "v1image1",
+						DockerImageReference: "registry:5000/ns/repo:t1",
+						Image:                "",
 					},
 				}},
 				"t2": {Items: []api.TagEvent{
@@ -101,7 +144,8 @@ func TestUpdateTagHistory(t *testing.T) {
 			},
 		},
 		"no-op": {
-			tags: map[string]string{"t1": "v1image1", "t2": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+			repo: "registry:5000/ns/repo",
+			tags: map[string]string{"t1": "v1image1", "t2": "@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 			existingTagHistory: map[string]api.TagEventList{
 				"t1": {Items: []api.TagEvent{
 					{
@@ -131,8 +175,10 @@ func TestUpdateTagHistory(t *testing.T) {
 				}},
 			},
 		},
-		"add history to existing entry": {
-			tags: map[string]string{"t1": "v1image2", "t2": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		"new tag copies existing history": {
+			repo:     "registry:5000/ns/repo",
+			previous: map[string]string{"t1": "t1"},
+			tags:     map[string]string{"t1": "t1", "t2": "t1", "t3": "@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 			existingTagHistory: map[string]api.TagEventList{
 				"t1": {Items: []api.TagEvent{
 					{
@@ -140,7 +186,7 @@ func TestUpdateTagHistory(t *testing.T) {
 						Image:                "v1image1",
 					},
 				}},
-				"t2": {Items: []api.TagEvent{
+				"t3": {Items: []api.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -150,15 +196,18 @@ func TestUpdateTagHistory(t *testing.T) {
 			expectedTagHistory: map[string]api.TagEventList{
 				"t1": {Items: []api.TagEvent{
 					{
-						DockerImageReference: "registry:5000/ns/repo:v1image2",
-						Image:                "v1image2",
+						DockerImageReference: "registry:5000/ns/repo:v1image1",
+						Image:                "v1image1",
 					},
+				}},
+				// tag copies existing history
+				"t2": {Items: []api.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/repo:v1image1",
 						Image:                "v1image1",
 					},
 				}},
-				"t2": {Items: []api.TagEvent{
+				"t3": {Items: []api.TagEvent{
 					{
 						DockerImageReference: "registry:5000/ns/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 						Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -172,31 +221,45 @@ func TestUpdateTagHistory(t *testing.T) {
 		repo := &api.ImageRepository{
 			Tags: test.tags,
 			Status: api.ImageRepositoryStatus{
-				DockerImageRepository: "registry:5000/ns/repo",
+				DockerImageRepository: test.repo,
 				Tags: test.existingTagHistory,
 			},
 		}
+		previousRepo := &api.ImageRepository{
+			Tags: test.previous,
+			Status: api.ImageRepositoryStatus{
+				DockerImageRepository: test.repo,
+				Tags: test.existingTagHistory,
+			},
+		}
+		if test.previous == nil {
+			previousRepo = nil
+		}
 
-		updateTagHistory(repo)
+		tagsChanged(previousRepo, repo)
 
 		if !reflect.DeepEqual(test.tags, repo.Tags) {
-			t.Fatalf("%s: repo.Tags was unexpectedly updated: %#v", testName, repo.Tags)
+			t.Errorf("%s: repo.Tags was unexpectedly updated: %#v", testName, repo.Tags)
+			continue
 		}
 
 		for expectedTag, expectedTagHistory := range test.expectedTagHistory {
 			updatedTagHistory, ok := repo.Status.Tags[expectedTag]
 			if !ok {
-				t.Fatalf("%s: missing history for tag %q", testName, expectedTag)
+				t.Errorf("%s: missing history for tag %q", testName, expectedTag)
+				continue
 			}
 			if e, a := len(expectedTagHistory.Items), len(updatedTagHistory.Items); e != a {
-				t.Fatalf("%s: tag %q: expected %d in history, got %d: %#v", testName, expectedTag, e, a, updatedTagHistory)
+				t.Errorf("%s: tag %q: expected %d in history, got %d: %#v", testName, expectedTag, e, a, updatedTagHistory)
+				continue
 			}
 			for i, expectedTagEvent := range expectedTagHistory.Items {
 				if e, a := expectedTagEvent.Image, updatedTagHistory.Items[i].Image; e != a {
-					t.Fatalf("%s: tag %q: docker image id: expected %q, got %q", testName, expectedTag, e, a)
+					t.Errorf("%s: tag %q: docker image id: expected %q, got %q", testName, expectedTag, e, a)
+					continue
 				}
 				if e, a := expectedTagEvent.DockerImageReference, updatedTagHistory.Items[i].DockerImageReference; e != a {
-					t.Fatalf("%s: tag %q: docker image reference: expected %q, got %q", testName, expectedTag, e, a)
+					t.Errorf("%s: tag %q: docker image reference: expected %q, got %q", testName, expectedTag, e, a)
 				}
 			}
 		}

--- a/pkg/image/registry/imagerepositorymapping/rest.go
+++ b/pkg/image/registry/imagerepositorymapping/rest.go
@@ -6,6 +6,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
@@ -73,28 +74,25 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	}
 
 	image := mapping.Image
-
-	pullTag := mapping.Tag
-	// TODO: default tag value to "latest" or the tag latest points to
-	if len(image.DockerImageReference) > 0 {
-		if ref, err := api.ParseDockerImageReference(image.DockerImageReference); err == nil {
-			// TODO: use a canonical comparison (latest -> latest)
-			if ref.Name == repo.Name && ref.Tag != mapping.Tag {
-				pullTag = ref.Tag
-			}
-		}
+	tag := mapping.Tag
+	if len(tag) == 0 {
+		// TODO: redirect this to the stable tag
+		tag = "latest"
 	}
-
-	if repo.Tags == nil {
-		repo.Tags = make(map[string]string)
-	}
-	repo.Tags[mapping.Tag] = pullTag
 
 	if err := s.imageRegistry.CreateImage(ctx, &image); err != nil && !errors.IsAlreadyExists(err) {
 		return nil, err
 	}
-	if err := s.imageRepositoryRegistry.UpdateImageRepository(ctx, repo); err != nil {
-		return nil, err
+
+	next := api.TagEvent{
+		Created:              util.Now(),
+		DockerImageReference: image.DockerImageReference,
+		Image:                image.Name,
+	}
+	if api.AddTagEventToImageRepository(repo, tag, next) {
+		if err := s.imageRepositoryRegistry.UpdateImageRepositoryStatus(ctx, repo); err != nil {
+			return nil, err
+		}
 	}
 
 	return &kapi.Status{Status: kapi.StatusSuccess}, nil

--- a/pkg/image/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/registry/imagestreamimage/rest_test.go
@@ -22,8 +22,8 @@ func setup(t *testing.T) (*tools.FakeEtcdClient, tools.EtcdHelper, *REST) {
 	helper := tools.EtcdHelper{Client: fakeEtcdClient, Codec: latest.Codec, ResourceVersioner: tools.RuntimeVersionAdapter{latest.ResourceVersioner}}
 	imageStorage := imageetcd.NewREST(helper)
 	imageRegistry := image.NewRegistry(imageStorage)
-	imageRepositoryStorage := imagerepositoryetcd.NewREST(helper, testDefaultRegistry)
-	imageRepositoryRegistry := imagerepository.NewRegistry(imageRepositoryStorage)
+	imageRepositoryStorage, imageRepositoryStatus := imagerepositoryetcd.NewREST(helper, testDefaultRegistry)
+	imageRepositoryRegistry := imagerepository.NewRegistry(imageRepositoryStorage, imageRepositoryStatus)
 	storage := NewREST(imageRegistry, imageRepositoryRegistry)
 	return fakeEtcdClient, helper, storage
 }

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -187,12 +187,18 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 	interfaces, _ := latest.InterfacesFor(latest.Version)
 
 	buildEtcd := buildetcd.New(etcdHelper)
-	imageRepositoryStorage := imagerepositoryetcd.NewREST(etcdHelper, imagerepository.DefaultRegistryFunc(func() (string, bool) { return "registry:3000", true }))
+	imageRepositoryStorage, imageRepositoryStatus := imagerepositoryetcd.NewREST(
+		etcdHelper,
+		imagerepository.DefaultRegistryFunc(func() (string, bool) {
+			return "registry:3000", true
+		}),
+	)
 
 	storage := map[string]apiserver.RESTStorage{
-		"builds":            buildregistry.NewREST(buildEtcd),
-		"buildConfigs":      buildconfigregistry.NewREST(buildEtcd),
-		"imageRepositories": imageRepositoryStorage,
+		"builds":                   buildregistry.NewREST(buildEtcd),
+		"buildConfigs":             buildconfigregistry.NewREST(buildEtcd),
+		"imageRepositories":        imageRepositoryStorage,
+		"imageRepositories/status": imageRepositoryStatus,
 	}
 
 	apiserver.NewAPIGroupVersion(storage, latest.Codec, "/osapi", "v1beta1", interfaces.MetadataAccessor, admit.NewAlwaysAdmit(), kapi.NewRequestContextMapper(), latest.RESTMapper).InstallREST(handlerContainer, "/osapi", "v1beta1")

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -357,8 +357,8 @@ func NewTestOpenshift(t *testing.T) *testOpenshift {
 	imageStorage := imageetcd.NewREST(etcdHelper)
 	imageRegistry := image.NewRegistry(imageStorage)
 
-	imageRepositoryStorage := imagerepositoryetcd.NewREST(etcdHelper, imagerepository.DefaultRegistryFunc(func() (string, bool) { return "registry:3000", true }))
-	imageRepositoryRegistry := imagerepository.NewRegistry(imageRepositoryStorage)
+	imageRepositoryStorage, imageRepositoryStatus := imagerepositoryetcd.NewREST(etcdHelper, imagerepository.DefaultRegistryFunc(func() (string, bool) { return "registry:3000", true }))
+	imageRepositoryRegistry := imagerepository.NewRegistry(imageRepositoryStorage, imageRepositoryStatus)
 
 	deployEtcd := deployetcd.New(etcdHelper)
 	deployConfigGenerator := &deployconfiggenerator.DeploymentConfigGenerator{
@@ -375,6 +375,7 @@ func NewTestOpenshift(t *testing.T) *testOpenshift {
 	storage := map[string]apiserver.RESTStorage{
 		"images":                    imageStorage,
 		"imageRepositories":         imageRepositoryStorage,
+		"imageRepositories/status":  imageRepositoryStatus,
 		"imageRepositoryMappings":   imagerepositorymapping.NewREST(imageRegistry, imageRepositoryRegistry),
 		"deployments":               deployregistry.NewREST(deployEtcd),
 		"deploymentConfigs":         deployconfigregistry.NewREST(deployEtcd),

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -26,22 +26,23 @@ func TestSimpleImageChangeBuildTrigger(t *testing.T) {
 		ObjectMeta:            kapi.ObjectMeta{Name: "test-image-trigger-repo"},
 		DockerImageRepository: "registry:8080/openshift/test-image-trigger",
 		Tags: map[string]string{
-			"latest": "ref-1",
+			"latest": "latest",
 		},
 	}
 
 	config := imageChangeBuildConfig()
 
-	watch, err := openshift.Client.Builds(testNamespace).Watch(labels.Everything(), labels.Everything(), "0")
+	created, err := openshift.Client.BuildConfigs(testNamespace).Create(config)
+	if err != nil {
+		t.Fatalf("Couldn't create BuildConfig: %v", err)
+	}
+
+	watch, err := openshift.Client.Builds(testNamespace).Watch(labels.Everything(), labels.Everything(), created.ResourceVersion)
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to Builds %v", err)
 	}
 	defer watch.Stop()
 
-	created, err := openshift.Client.BuildConfigs(testNamespace).Create(config)
-	if err != nil {
-		t.Fatalf("Couldn't create BuildConfig: %v", err)
-	}
 	watch2, err := openshift.Client.BuildConfigs(testNamespace).Watch(labels.Everything(), labels.Everything(), created.ResourceVersion)
 	if err != nil {
 		t.Fatalf("Couldn't subscribe to BuildConfigs %v", err)
@@ -53,16 +54,16 @@ func TestSimpleImageChangeBuildTrigger(t *testing.T) {
 		t.Fatalf("Couldn't create ImageRepository: %v", err)
 	}
 
-	// initial build event from the creation of the imagerepo with tag ref-1
+	// wait for initial build event from the creation of the imagerepo with tag latest
 	event := <-watch.ResultChan()
 	if e, a := watchapi.Added, event.Type; e != a {
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild := event.Object.(*buildapi.Build)
-	if newBuild.Parameters.Strategy.DockerStrategy.Image != "registry:8080/openshift/test-image-trigger:ref-1" {
+	if newBuild.Parameters.Strategy.DockerStrategy.Image != "registry:8080/openshift/test-image-trigger:latest" {
 		i, _ := openshift.Client.ImageRepositories(testNamespace).Get(imageRepo.Name)
 		bc, _ := openshift.Client.BuildConfigs(testNamespace).Get(config.Name)
-		t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-1", newBuild.Parameters.Strategy.DockerStrategy.Image, i, bc.Triggers[0].ImageChange)
+		t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:latest", newBuild.Parameters.Strategy.DockerStrategy.Image, i, bc.Triggers[0].ImageChange)
 	}
 	event = <-watch.ResultChan()
 	if e, a := watchapi.Modified, event.Type; e != a {
@@ -75,21 +76,41 @@ func TestSimpleImageChangeBuildTrigger(t *testing.T) {
 	if newBuild.Labels["testlabel"] != "testvalue" {
 		t.Fatalf("Expected build with label %s=%s from build config got %s=%s", "testlabel", "testvalue", "testlabel", newBuild.Labels["testlabel"])
 	}
-	event = <-watch2.ResultChan()
+
+	// wait for build config to be updated
+	<-watch2.ResultChan()
 	updatedConfig, err := openshift.Client.BuildConfigs(testNamespace).Get(config.Name)
 	if err != nil {
 		t.Fatalf("Couldn't get BuildConfig: %v", err)
 	}
-	if updatedConfig.Triggers[0].ImageChange.LastTriggeredImageID != "ref-1" {
-		t.Errorf("Expected imageID ref-1, got %s", updatedConfig.Triggers[0].ImageChange.LastTriggeredImageID)
+	// the first tag did not have an image id, so the last trigger field is the pull spec
+	if updatedConfig.Triggers[0].ImageChange.LastTriggeredImageID != "registry:8080/openshift/test-image-trigger:latest" {
+		t.Errorf("Expected imageID equal to pull spec, got %s", updatedConfig.Triggers[0].ImageChange)
 	}
 
-	// update the image tag to ref-2 in the imagerepo so we get another build event using that tag.
-	imageRepo.Tags["latest"] = "ref-2"
-	if _, err = openshift.Client.ImageRepositories(testNamespace).Update(imageRepo); err != nil {
-		t.Fatalf("Error updating imageRepo: %v", err)
+	// trigger a build by posting a new image
+	if err := openshift.Client.ImageRepositoryMappings(testNamespace).Create(&imageapi.ImageRepositoryMapping{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      imageRepo.Name,
+		},
+		Tag: "latest",
+		Image: imageapi.Image{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "ref-2-random",
+			},
+			DockerImageReference: "registry:8080/openshift/test-image-trigger:ref-2",
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
+	/*
+		// update the image tag to ref-2 in the imagerepo so we get another build event using that tag.
+		imageRepo.Tags["latest"] = "ref-2"
+		if _, err = openshift.Client.ImageRepositories(testNamespace).Update(imageRepo); err != nil {
+			t.Fatalf("Error updating imageRepo: %v", err)
+		}
+	*/
 	event = <-watch.ResultChan()
 	if e, a := watchapi.Added, event.Type; e != a {
 		t.Fatalf("expected watch event type %s, got %s", e, a)
@@ -117,8 +138,8 @@ func TestSimpleImageChangeBuildTrigger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't get BuildConfig: %v", err)
 	}
-	if updatedConfig.Triggers[0].ImageChange.LastTriggeredImageID != "ref-2" {
-		t.Errorf("Expected imageID ref-2, got %s", updatedConfig.Triggers[0].ImageChange.LastTriggeredImageID)
+	if updatedConfig.Triggers[0].ImageChange.LastTriggeredImageID != "ref-2-random" {
+		t.Errorf("unexpected trigger id: %#v", updatedConfig.Triggers[0].ImageChange)
 	}
 }
 


### PR DESCRIPTION
Image Repositories that have "dockerImageRepository" set will have
images imported if "tags" is empty or if there are "tags" that have
an empty string value. Once complete, or if sufficient failures
occur, the annotation "openshift.io/image.dockerRepositoryCheck"
will be set to a timestamp (time completed) or a string message.

This won't work until we can pull by ID against the local registry.

@ncdc