### PR TITLE
Handle wildcard resolution of services

### DIFF
--- a/pkg/dns/serviceresolver.go
+++ b/pkg/dns/serviceresolver.go
@@ -45,9 +45,8 @@ func (b *ServiceResolver) Records(name string, exact bool) ([]msg.Service, error
 	}
 	prefix := strings.Trim(strings.TrimSuffix(name, b.base), ".")
 	segments := strings.Split(prefix, ".")
-	switch len(segments) {
-	case 0:
-	case 1:
+	switch c := len(segments); {
+	case c == 1:
 		items, err := b.accessor.Services(segments[0]).List(labels.Everything())
 		if err != nil {
 			return nil, err
@@ -67,8 +66,8 @@ func (b *ServiceResolver) Records(name string, exact bool) ([]msg.Service, error
 			})
 		}
 		return services, nil
-	case 2:
-		svc, err := b.accessor.Services(segments[1]).Get(segments[0])
+	case c >= 2:
+		svc, err := b.accessor.Services(segments[c-1]).Get(segments[c-2])
 		if err != nil {
 			return nil, err
 		}
@@ -85,8 +84,6 @@ func (b *ServiceResolver) Records(name string, exact bool) ([]msg.Service, error
 				Key:  msg.Path(name),
 			},
 		}, nil
-	default:
-		return nil, nil
 	}
 	return nil, nil
 }

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -50,9 +50,30 @@ func TestDNS(t *testing.T) {
 	// verify recursive DNS lookup is visible
 	m1 := &dns.Msg{
 		MsgHdr:   dns.MsgHdr{Id: dns.Id(), RecursionDesired: true},
-		Question: []dns.Question{{"www.google.com.", dns.TypeA, dns.ClassINET}},
+		Question: []dns.Question{{"foo.kubernetes.default.local.", dns.TypeA, dns.ClassINET}},
 	}
 	in, err := dns.Exchange(m1, server)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(in.Answer) != 1 {
+		t.Fatalf("unexpected response: %#v", in)
+	}
+	if a, ok := in.Answer[0].(*dns.A); ok {
+		if a.A == nil {
+			t.Errorf("expected an A record with an IP: %#v", a)
+		}
+	} else {
+		t.Errorf("expected an A record: %#v", in)
+	}
+	t.Log(in)
+
+	// verify recursive DNS lookup is visible
+	m1 = &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: dns.Id(), RecursionDesired: true},
+		Question: []dns.Question{{"www.google.com.", dns.TypeA, dns.ClassINET}},
+	}
+	in, err = dns.Exchange(m1, server)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
`foo.bar.something.<service>.<namespace>.local` should resolve to the
service IP.