### PR TITLE
Always use port 8053 in integration tests

### DIFF
--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -13,12 +12,13 @@ import (
 )
 
 func TestDNS(t *testing.T) {
-	cfg, err := StartTestAllInOne()
+	_, err := StartTestAllInOne()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	port := cfg.DNSBindAddr.Port
-	server := fmt.Sprintf("127.0.0.1:%d", port)
+
+	// ugly...
+	server := "127.0.0.1:8053"
 
 	// verify service DNS entry is visible
 	stop := make(chan struct{})

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -28,6 +28,8 @@ func StartTestServer(args ...string) (start.Config, error) {
 	deleteAllEtcdKeys()
 
 	startConfig := start.NewDefaultConfig()
+	startConfig.DNSBindAddr.DefaultPort = 8053
+	startConfig.DNSBindAddr = startConfig.DNSBindAddr.Default()
 
 	basedir := path.Join(os.TempDir(), "openshift-integration-tests")
 


### PR DESCRIPTION
DNS tests were failing on travis

[merge]