### PR TITLE
separate out bootstrap policy

### DIFF
--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/infra/builder"
 	"github.com/openshift/origin/pkg/cmd/infra/deployer"
 	"github.com/openshift/origin/pkg/cmd/infra/router"
-	"github.com/openshift/origin/pkg/cmd/server/certs"
+	"github.com/openshift/origin/pkg/cmd/server/admin"
 	"github.com/openshift/origin/pkg/cmd/server/start"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -81,7 +81,7 @@ func NewCommandOpenShift() *cobra.Command {
 
 	startAllInOne, _ := start.NewCommandStartAllInOne()
 	root.AddCommand(startAllInOne)
-	root.AddCommand(certs.NewCommandAdmin())
+	root.AddCommand(admin.NewCommandAdmin())
 	root.AddCommand(cli.NewCommandCLI("cli", "openshift cli"))
 	root.AddCommand(cli.NewCmdKubectl("kube"))
 	root.AddCommand(newExperimentalCommand("openshift", "ex"))

--- a/pkg/cmd/server/admin/create_allcerts.go
+++ b/pkg/cmd/server/admin/create_allcerts.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"

--- a/pkg/cmd/server/admin/create_bootstrappolicy_file.go
+++ b/pkg/cmd/server/admin/create_bootstrappolicy_file.go
@@ -1,0 +1,111 @@
+package admin
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/template/api"
+)
+
+const (
+	DefaultPolicyFile                    = "openshift.local.policy/policy.json"
+	CreateBootstrapPolicyFileCommand     = "create-bootstrap-policy-file"
+	CreateBootstrapPolicyFileFullCommand = "openshift admin " + CreateBootstrapPolicyFileCommand
+)
+
+type CreateBootstrapPolicyFileOptions struct {
+	File string
+
+	MasterAuthorizationNamespace      string
+	OpenShiftSharedResourcesNamespace string
+}
+
+func NewCommandCreateBootstrapPolicyFile() *cobra.Command {
+	options := &CreateBootstrapPolicyFileOptions{}
+
+	cmd := &cobra.Command{
+		Use:   CreateBootstrapPolicyFileCommand,
+		Short: "Create bootstrap policy for OpenShift.",
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Validate(args); err != nil {
+				fmt.Println(err.Error())
+				c.Help()
+				return
+			}
+
+			if err := options.CreateBootstrapPolicyFile(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&options.File, "filename", DefaultPolicyFile, "The policy template file that will be written with roles and bindings.")
+
+	flags.StringVar(&options.MasterAuthorizationNamespace, "master-namespace", "master", "Global authorization namespace.")
+	flags.StringVar(&options.OpenShiftSharedResourcesNamespace, "openshift-namespace", "openshift", "Namespace for shared openshift resources.")
+
+	return cmd
+}
+
+func (o CreateBootstrapPolicyFileOptions) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+	if len(o.File) == 0 {
+		return errors.New("filename must be provided")
+	}
+	if len(o.MasterAuthorizationNamespace) == 0 {
+		return errors.New("master-namespace must be provided")
+	}
+	if len(o.OpenShiftSharedResourcesNamespace) == 0 {
+		return errors.New("openshift-namespace must be provided")
+	}
+
+	return nil
+}
+
+func (o CreateBootstrapPolicyFileOptions) CreateBootstrapPolicyFile() error {
+	if err := os.MkdirAll(path.Dir(o.File), os.FileMode(0755)); err != nil {
+		return err
+	}
+
+	policyTemplate := &api.Template{}
+
+	roles := bootstrappolicy.GetBootstrapRoles(o.MasterAuthorizationNamespace, o.OpenShiftSharedResourcesNamespace)
+	for i := range roles {
+		policyTemplate.Objects = append(policyTemplate.Objects, &roles[i])
+	}
+
+	roleBindings := bootstrappolicy.GetBootstrapRoleBindings(o.MasterAuthorizationNamespace, o.OpenShiftSharedResourcesNamespace)
+	for i := range roleBindings {
+		policyTemplate.Objects = append(policyTemplate.Objects, &roleBindings[i])
+	}
+
+	versionedPolicyTemplate, err := kapi.Scheme.ConvertToVersion(policyTemplate, latest.Version)
+	if err != nil {
+		return err
+	}
+
+	buffer := &bytes.Buffer{}
+	(&kubectl.JSONPrinter{}).PrintObj(versionedPolicyTemplate, buffer)
+
+	if err := ioutil.WriteFile(o.File, buffer.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/server/admin/create_clientcert.go
+++ b/pkg/cmd/server/admin/create_clientcert.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"
@@ -7,27 +7,30 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 )
 
-type CreateServerCertOptions struct {
+type CreateClientCertOptions struct {
 	GetSignerCertOptions *GetSignerCertOptions
 
 	CertFile string
 	KeyFile  string
 
-	Hostnames util.StringList
+	User   string
+	Groups util.StringList
+
 	Overwrite bool
 }
 
-func NewCommandCreateServerCert() *cobra.Command {
-	options := &CreateServerCertOptions{GetSignerCertOptions: &GetSignerCertOptions{}}
+func NewCommandCreateClientCert() *cobra.Command {
+	options := &CreateClientCertOptions{GetSignerCertOptions: &GetSignerCertOptions{}}
 
 	cmd := &cobra.Command{
-		Use:   "create-server-cert",
-		Short: "Create server certificate",
+		Use:   "create-client-cert",
+		Short: "Create client certificate",
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Validate(args); err != nil {
 				fmt.Println(err.Error())
@@ -35,8 +38,10 @@ func NewCommandCreateServerCert() *cobra.Command {
 				return
 			}
 
-			if _, err := options.CreateServerCert(); err != nil {
-				glog.Fatal(err)
+			if _, err := options.CreateClientCert(); err != nil {
+				fmt.Println(err.Error())
+				c.Help()
+				return
 			}
 		},
 	}
@@ -47,18 +52,16 @@ func NewCommandCreateServerCert() *cobra.Command {
 	flags.StringVar(&options.CertFile, "cert", "openshift.local.certificates/user/cert.crt", "The certificate file.")
 	flags.StringVar(&options.KeyFile, "key", "openshift.local.certificates/user/key.key", "The key file.")
 
-	flags.Var(&options.Hostnames, "hostnames", "Every hostname or IP you want server certs to be valid for. Comma delimited list")
+	flags.StringVar(&options.User, "user", "", "The scope qualified username.")
+	flags.Var(&options.Groups, "groups", "The list of groups this user belongs to. Comma delimited list")
 	flags.BoolVar(&options.Overwrite, "overwrite", true, "Overwrite existing cert files if found.  If false, any existing file will be left as-is.")
 
 	return cmd
 }
 
-func (o CreateServerCertOptions) Validate(args []string) error {
+func (o CreateClientCertOptions) Validate(args []string) error {
 	if len(args) != 0 {
 		return errors.New("no arguments are supported")
-	}
-	if len(o.Hostnames) == 0 {
-		return errors.New("at least one hostname must be provided")
 	}
 	if len(o.CertFile) == 0 {
 		return errors.New("cert must be provided")
@@ -66,21 +69,25 @@ func (o CreateServerCertOptions) Validate(args []string) error {
 	if len(o.KeyFile) == 0 {
 		return errors.New("key must be provided")
 	}
+	if len(o.User) == 0 {
+		return errors.New("user must be provided")
+	}
 
 	return o.GetSignerCertOptions.Validate()
 }
 
-func (o CreateServerCertOptions) CreateServerCert() (*crypto.TLSCertificateConfig, error) {
-	glog.V(2).Infof("Creating a server cert with: %#v", o)
+func (o CreateClientCertOptions) CreateClientCert() (*crypto.TLSCertificateConfig, error) {
+	glog.V(2).Infof("Creating a client cert with: %#v and %#v", o, o.GetSignerCertOptions)
 
 	signerCert, err := o.GetSignerCertOptions.GetSignerCert()
 	if err != nil {
 		return nil, err
 	}
 
+	userInfo := &user.DefaultInfo{Name: o.User, Groups: o.Groups}
 	if o.Overwrite {
-		return signerCert.MakeServerCert(o.CertFile, o.KeyFile, util.NewStringSet([]string(o.Hostnames)...))
+		return signerCert.MakeClientCertificate(o.CertFile, o.KeyFile, userInfo)
 	} else {
-		return signerCert.EnsureServerCert(o.CertFile, o.KeyFile, util.NewStringSet([]string(o.Hostnames)...))
+		return signerCert.EnsureClientCertificate(o.CertFile, o.KeyFile, userInfo)
 	}
 }

--- a/pkg/cmd/server/admin/create_comands.go
+++ b/pkg/cmd/server/admin/create_comands.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"github.com/spf13/cobra"
@@ -13,6 +13,8 @@ func NewCommandAdmin() *cobra.Command {
 		},
 	}
 
+	cmd.AddCommand(NewCommandOverwriteBootstrapPolicy())
+	cmd.AddCommand(NewCommandCreateBootstrapPolicyFile())
 	cmd.AddCommand(NewCommandCreateKubeConfig())
 	cmd.AddCommand(NewCommandCreateAllCerts())
 	cmd.AddCommand(NewCommandCreateClientCert())

--- a/pkg/cmd/server/admin/create_kubeconfig.go
+++ b/pkg/cmd/server/admin/create_kubeconfig.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"

--- a/pkg/cmd/server/admin/create_nodeclientcerts.go
+++ b/pkg/cmd/server/admin/create_nodeclientcerts.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"

--- a/pkg/cmd/server/admin/create_servercert.go
+++ b/pkg/cmd/server/admin/create_servercert.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"
@@ -7,30 +7,27 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 )
 
-type CreateClientCertOptions struct {
+type CreateServerCertOptions struct {
 	GetSignerCertOptions *GetSignerCertOptions
 
 	CertFile string
 	KeyFile  string
 
-	User   string
-	Groups util.StringList
-
+	Hostnames util.StringList
 	Overwrite bool
 }
 
-func NewCommandCreateClientCert() *cobra.Command {
-	options := &CreateClientCertOptions{GetSignerCertOptions: &GetSignerCertOptions{}}
+func NewCommandCreateServerCert() *cobra.Command {
+	options := &CreateServerCertOptions{GetSignerCertOptions: &GetSignerCertOptions{}}
 
 	cmd := &cobra.Command{
-		Use:   "create-client-cert",
-		Short: "Create client certificate",
+		Use:   "create-server-cert",
+		Short: "Create server certificate",
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Validate(args); err != nil {
 				fmt.Println(err.Error())
@@ -38,10 +35,8 @@ func NewCommandCreateClientCert() *cobra.Command {
 				return
 			}
 
-			if _, err := options.CreateClientCert(); err != nil {
-				fmt.Println(err.Error())
-				c.Help()
-				return
+			if _, err := options.CreateServerCert(); err != nil {
+				glog.Fatal(err)
 			}
 		},
 	}
@@ -52,16 +47,18 @@ func NewCommandCreateClientCert() *cobra.Command {
 	flags.StringVar(&options.CertFile, "cert", "openshift.local.certificates/user/cert.crt", "The certificate file.")
 	flags.StringVar(&options.KeyFile, "key", "openshift.local.certificates/user/key.key", "The key file.")
 
-	flags.StringVar(&options.User, "user", "", "The scope qualified username.")
-	flags.Var(&options.Groups, "groups", "The list of groups this user belongs to. Comma delimited list")
+	flags.Var(&options.Hostnames, "hostnames", "Every hostname or IP you want server certs to be valid for. Comma delimited list")
 	flags.BoolVar(&options.Overwrite, "overwrite", true, "Overwrite existing cert files if found.  If false, any existing file will be left as-is.")
 
 	return cmd
 }
 
-func (o CreateClientCertOptions) Validate(args []string) error {
+func (o CreateServerCertOptions) Validate(args []string) error {
 	if len(args) != 0 {
 		return errors.New("no arguments are supported")
+	}
+	if len(o.Hostnames) == 0 {
+		return errors.New("at least one hostname must be provided")
 	}
 	if len(o.CertFile) == 0 {
 		return errors.New("cert must be provided")
@@ -69,25 +66,21 @@ func (o CreateClientCertOptions) Validate(args []string) error {
 	if len(o.KeyFile) == 0 {
 		return errors.New("key must be provided")
 	}
-	if len(o.User) == 0 {
-		return errors.New("user must be provided")
-	}
 
 	return o.GetSignerCertOptions.Validate()
 }
 
-func (o CreateClientCertOptions) CreateClientCert() (*crypto.TLSCertificateConfig, error) {
-	glog.V(2).Infof("Creating a client cert with: %#v and %#v", o, o.GetSignerCertOptions)
+func (o CreateServerCertOptions) CreateServerCert() (*crypto.TLSCertificateConfig, error) {
+	glog.V(2).Infof("Creating a server cert with: %#v", o)
 
 	signerCert, err := o.GetSignerCertOptions.GetSignerCert()
 	if err != nil {
 		return nil, err
 	}
 
-	userInfo := &user.DefaultInfo{Name: o.User, Groups: o.Groups}
 	if o.Overwrite {
-		return signerCert.MakeClientCertificate(o.CertFile, o.KeyFile, userInfo)
+		return signerCert.MakeServerCert(o.CertFile, o.KeyFile, util.NewStringSet([]string(o.Hostnames)...))
 	} else {
-		return signerCert.EnsureClientCertificate(o.CertFile, o.KeyFile, userInfo)
+		return signerCert.EnsureServerCert(o.CertFile, o.KeyFile, util.NewStringSet([]string(o.Hostnames)...))
 	}
 }

--- a/pkg/cmd/server/admin/create_signercert.go
+++ b/pkg/cmd/server/admin/create_signercert.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"fmt"

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -1,0 +1,141 @@
+package admin
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
+	utilerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/openshift/origin/pkg/api/latest"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationetcd "github.com/openshift/origin/pkg/authorization/registry/etcd"
+	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
+	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	configvalidation "github.com/openshift/origin/pkg/cmd/server/api/validation"
+	"github.com/openshift/origin/pkg/cmd/server/etcd"
+	cmdclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+)
+
+type OverwriteBootstrapPolicyOptions struct {
+	File             string
+	MasterConfigFile string
+}
+
+func NewCommandOverwriteBootstrapPolicy() *cobra.Command {
+	options := &OverwriteBootstrapPolicyOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "overwrite-policy",
+		Short: "Overwrite policy for OpenShift.  DANGER: THIS BYPASSES ALL ACCESS CONTROL CHECKS AND WRITES DIRECTLY TO ETCD!",
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Validate(args); err != nil {
+				fmt.Println(err.Error())
+				c.Help()
+				return
+			}
+
+			if err := options.OverwriteBootstrapPolicy(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&options.File, "filename", "", "The policy template file containing roles and bindings.  One can be created with '"+CreateBootstrapPolicyFileFullCommand+"'.")
+	flags.StringVar(&options.MasterConfigFile, "master-config", "master.yaml", "Location of the master configuration file to run from in order to connect to etcd and directly modify the policy.")
+
+	return cmd
+}
+
+func (o OverwriteBootstrapPolicyOptions) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+	if len(o.File) == 0 {
+		return errors.New("filename must be provided")
+	}
+	if len(o.MasterConfigFile) == 0 {
+		return errors.New("master-config must be provided")
+	}
+
+	return nil
+}
+
+func (o OverwriteBootstrapPolicyOptions) OverwriteBootstrapPolicy() error {
+	masterConfig, err := configapilatest.ReadAndResolveMasterConfig(o.MasterConfigFile)
+	if err != nil {
+		return err
+	}
+	if err := configvalidation.ValidateNamespace(masterConfig.PolicyConfig.MasterAuthorizationNamespace, "masterAuthorizationNamespace"); len(err) > 0 {
+		return utilerrors.NewAggregate(err)
+	}
+
+	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo.URL)
+	if err != nil {
+		return err
+	}
+
+	return OverwriteBootstrapPolicy(etcdHelper, masterConfig.PolicyConfig.MasterAuthorizationNamespace, o.File)
+}
+
+func OverwriteBootstrapPolicy(etcdHelper tools.EtcdHelper, masterNamespace, policyFile string) error {
+	mapper := cmdclientcmd.ShortcutExpander{kubectl.ShortcutExpander{latest.RESTMapper}}
+	typer := api.Scheme
+	clientMapper := resource.ClientMapperFunc(func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+		return nil, nil
+	})
+
+	r := resource.NewBuilder(mapper, typer, clientMapper).
+		FilenameParam(policyFile).
+		Flatten().
+		Do()
+
+	if r.Err() != nil {
+		return r.Err()
+	}
+
+	registry := authorizationetcd.New(etcdHelper)
+	roleRegistry := roleregistry.NewVirtualRegistry(registry)
+	roleBindingRegistry := rolebindingregistry.NewVirtualRegistry(registry, registry, masterNamespace)
+
+	return r.Visit(func(info *resource.Info) error {
+		template, ok := info.Object.(*templateapi.Template)
+		if !ok {
+			return errors.New("policy must be contained in a template.  One can be created with '" + CreateBootstrapPolicyFileFullCommand + "'.")
+		}
+
+		for _, item := range template.Objects {
+			switch castObject := item.(type) {
+			case *authorizationapi.Role:
+				ctx := api.WithNamespace(api.NewContext(), castObject.Namespace)
+				roleRegistry.DeleteRole(ctx, castObject.Name)
+				if err := roleRegistry.CreateRole(ctx, castObject); err != nil {
+					return err
+				}
+
+			case *authorizationapi.RoleBinding:
+				ctx := api.WithNamespace(api.NewContext(), castObject.Namespace)
+				roleBindingRegistry.DeleteRoleBinding(ctx, castObject.Name)
+				if err := roleBindingRegistry.CreateRoleBinding(ctx, castObject, true); err != nil {
+					return err
+				}
+
+			default:
+				return errors.New("only roles and rolebindings may be created in this mode")
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/cmd/server/admin/signer_cert_args.go
+++ b/pkg/cmd/server/admin/signer_cert_args.go
@@ -1,4 +1,4 @@
-package certs
+package admin
 
 import (
 	"errors"

--- a/pkg/cmd/server/api/latest/helpers.go
+++ b/pkg/cmd/server/api/latest/helpers.go
@@ -1,0 +1,32 @@
+package latest
+
+import (
+	"io/ioutil"
+	"path"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func ReadMasterConfig(filename string) (*configapi.MasterConfig, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &configapi.MasterConfig{}
+
+	if err := Codec.DecodeInto(data, config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func ReadAndResolveMasterConfig(filename string) (*configapi.MasterConfig, error) {
+	masterConfig, err := ReadMasterConfig(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	configapi.ResolveMasterConfigPaths(masterConfig, path.Dir(filename))
+	return masterConfig, nil
+}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -64,6 +64,13 @@ type MasterConfig struct {
 
 	ImageConfig ImageConfig
 
+	PolicyConfig PolicyConfig
+}
+
+type PolicyConfig struct {
+	// BootstrapPolicyFile points to a template that contains roles and rolebindings that will be created if no policy object exists in the master namespace
+	BootstrapPolicyFile string
+
 	// MasterAuthorizationNamespace is the global namespace for Policy
 	MasterAuthorizationNamespace string
 	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -64,6 +64,13 @@ type MasterConfig struct {
 
 	ImageConfig ImageConfig `json:"imageConfig"`
 
+	PolicyConfig PolicyConfig
+}
+
+type PolicyConfig struct {
+	// BootstrapPolicyFile points to a template that contains roles and rolebindings that will be created if no policy object exists in the master namespace
+	BootstrapPolicyFile string `json:"bootstrapPolicyFile"`
+
 	// MasterAuthorizationNamespace is the global namespace for Policy
 	MasterAuthorizationNamespace string `json:"masterAuthorizationNamespace"`
 	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -8,6 +8,11 @@ import (
 )
 
 const (
+	DefaultMasterAuthorizationNamespace      = "master"
+	DefaultOpenShiftSharedResourcesNamespace = "openshift"
+)
+
+const (
 	UnauthenticatedUsername       = "system:anonymous"
 	InternalComponentUsername     = "system:openshift-client"
 	InternalComponentKubeUsername = "system:kube-client"

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -133,11 +133,11 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		Options: options,
 
 		Authenticator:                 newAuthenticator(options.ServingInfo, etcdHelper, apiClientCAs),
-		Authorizer:                    newAuthorizer(policyCache, options.MasterAuthorizationNamespace),
+		Authorizer:                    newAuthorizer(policyCache, options.PolicyConfig.MasterAuthorizationNamespace),
 		AuthorizationAttributeBuilder: newAuthorizationAttributeBuilder(requestContextMapper),
 
 		PolicyCache:               policyCache,
-		ProjectAuthorizationCache: newProjectAuthorizationCache(options.MasterAuthorizationNamespace, openshiftClient, kubeClient),
+		ProjectAuthorizationCache: newProjectAuthorizationCache(options.PolicyConfig.MasterAuthorizationNamespace, openshiftClient, kubeClient),
 
 		RequestContextMapper: requestContextMapper,
 

--- a/pkg/cmd/server/start/certs_args.go
+++ b/pkg/cmd/server/start/certs_args.go
@@ -11,10 +11,13 @@ type CertArgs struct {
 }
 
 func BindCertArgs(args *CertArgs, flags *pflag.FlagSet, prefix string) {
-	flags.BoolVar(&args.CreateCerts, prefix+"create-certs", true, "Create any missing certificates required for launch or for writing the config file.")
-	flags.StringVar(&args.CertDir, prefix+"cert-dir", "openshift.local.certificates", "The certificate data directory.")
+	flags.BoolVar(&args.CreateCerts, prefix+"create-certs", args.CreateCerts, "Create any missing certificates required for launch or for writing the config file.")
+	flags.StringVar(&args.CertDir, prefix+"cert-dir", args.CertDir, "The certificate data directory.")
 }
 
 func NewDefaultCertArgs() *CertArgs {
-	return &CertArgs{CreateCerts: true}
+	return &CertArgs{
+		CreateCerts: true,
+		CertDir:     "openshift.local.certificates",
+	}
 }

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -13,9 +13,9 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
+	"github.com/openshift/origin/pkg/cmd/server/admin"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	latestconfigapi "github.com/openshift/origin/pkg/cmd/server/api/latest"
-	"github.com/openshift/origin/pkg/cmd/server/certs"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
@@ -94,11 +94,11 @@ func (args NodeArgs) BuildSerializeableNodeConfig() (*configapi.NodeConfig, erro
 		DNSDomain: args.ClusterDomain,
 		DNSIP:     dnsIP,
 
-		MasterKubeConfig: certs.DefaultNodeKubeConfigFile(args.CertArgs.CertDir, args.NodeName),
+		MasterKubeConfig: admin.DefaultNodeKubeConfigFile(args.CertArgs.CertDir, args.NodeName),
 	}
 
 	if args.ListenArg.UseTLS() {
-		config.ServingInfo.ServerCert = certs.DefaultNodeServingCertInfo(args.CertArgs.CertDir, args.NodeName)
+		config.ServingInfo.ServerCert = admin.DefaultNodeServingCertInfo(args.CertArgs.CertDir, args.NodeName)
 	}
 
 	return config, nil

--- a/pkg/cmd/server/start/policy_args.go
+++ b/pkg/cmd/server/start/policy_args.go
@@ -1,0 +1,24 @@
+package start
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/openshift/origin/pkg/cmd/server/admin"
+)
+
+type PolicyArgs struct {
+	PolicyFile          string
+	CreatePolicyFile    bool
+	OverwritePolicyFile bool
+}
+
+func BindPolicyArgs(args *PolicyArgs, flags *pflag.FlagSet, prefix string) {
+	flags.BoolVar(&args.CreatePolicyFile, prefix+"create-policy-file", args.CreatePolicyFile, "Create bootstrap policy if none is present.")
+}
+
+func NewDefaultPolicyArgs() *PolicyArgs {
+	return &PolicyArgs{
+		CreatePolicyFile: true,
+		PolicyFile:       admin.DefaultPolicyFile,
+	}
+}

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
-	"github.com/openshift/origin/pkg/cmd/server/certs"
+	"github.com/openshift/origin/pkg/cmd/server/admin"
 
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger"
@@ -93,6 +93,7 @@ func NewCommandStartAllInOne() (*cobra.Command, *AllInOneOptions) {
 	BindMasterArgs(masterArgs, flags, "")
 	BindNodeArgs(nodeArgs, flags, "")
 	BindListenArg(listenArg, flags, "")
+	BindPolicyArgs(options.MasterArgs.PolicyArgs, flags, "")
 	BindImageFormatArgs(imageFormatArgs, flags, "")
 	BindKubeConnectionArgs(kubeConnectionArgs, flags, "")
 	BindCertArgs(certArgs, flags, "")
@@ -172,11 +173,11 @@ func (o AllInOneOptions) StartAllInOne() error {
 
 	// if either one of these wants to mint certs, make sure the signer is present BEFORE they start up to make sure they always share
 	if o.MasterArgs.CertArgs.CreateCerts || o.NodeArgs.CertArgs.CreateCerts {
-		signerOptions := &certs.CreateSignerCertOptions{
-			CertFile:   certs.DefaultCertFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-			KeyFile:    certs.DefaultKeyFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-			SerialFile: certs.DefaultSerialFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-			Name:       certs.DefaultSignerName(),
+		signerOptions := &admin.CreateSignerCertOptions{
+			CertFile:   admin.DefaultCertFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+			KeyFile:    admin.DefaultKeyFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+			SerialFile: admin.DefaultSerialFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+			Name:       admin.DefaultSignerName(),
 		}
 
 		if _, err := signerOptions.CreateSignerCert(); err != nil {

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -19,10 +19,10 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 
+	"github.com/openshift/origin/pkg/cmd/server/admin"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	"github.com/openshift/origin/pkg/cmd/server/api/validation"
-	"github.com/openshift/origin/pkg/cmd/server/certs"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/docker"
 )
@@ -204,23 +204,23 @@ func (o NodeOptions) RunNode() error {
 }
 
 func (o NodeOptions) CreateCerts() error {
-	signerOptions := &certs.CreateSignerCertOptions{
-		CertFile:   certs.DefaultCertFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-		KeyFile:    certs.DefaultKeyFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-		SerialFile: certs.DefaultSerialFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-		Name:       certs.DefaultSignerName(),
+	signerOptions := &admin.CreateSignerCertOptions{
+		CertFile:   admin.DefaultCertFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+		KeyFile:    admin.DefaultKeyFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+		SerialFile: admin.DefaultSerialFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+		Name:       admin.DefaultSignerName(),
 	}
 	if _, err := signerOptions.CreateSignerCert(); err != nil {
 		return err
 	}
-	getSignerOptions := &certs.GetSignerCertOptions{
-		CertFile:   certs.DefaultCertFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-		KeyFile:    certs.DefaultKeyFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
-		SerialFile: certs.DefaultSerialFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+	getSignerOptions := &admin.GetSignerCertOptions{
+		CertFile:   admin.DefaultCertFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+		KeyFile:    admin.DefaultKeyFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
+		SerialFile: admin.DefaultSerialFilename(o.NodeArgs.CertArgs.CertDir, "ca"),
 	}
 
-	serverCertInfo := certs.DefaultNodeServingCertInfo(o.NodeArgs.CertArgs.CertDir, o.NodeArgs.NodeName)
-	nodeServerCertOptions := certs.CreateServerCertOptions{
+	serverCertInfo := admin.DefaultNodeServingCertInfo(o.NodeArgs.CertArgs.CertDir, o.NodeArgs.NodeName)
+	nodeServerCertOptions := admin.CreateServerCertOptions{
 		GetSignerCertOptions: getSignerOptions,
 
 		CertFile: serverCertInfo.CertFile,
@@ -233,8 +233,8 @@ func (o NodeOptions) CreateCerts() error {
 		return err
 	}
 
-	clientCertInfo := certs.DefaultNodeClientCertInfo(o.NodeArgs.CertArgs.CertDir, o.NodeArgs.NodeName)
-	mintNodeClientCert := certs.CreateNodeClientCertOptions{
+	clientCertInfo := admin.DefaultNodeClientCertInfo(o.NodeArgs.CertArgs.CertDir, o.NodeArgs.NodeName)
+	mintNodeClientCert := admin.CreateNodeClientCertOptions{
 		GetSignerCertOptions: getSignerOptions,
 		CertFile:             clientCertInfo.CertFile,
 		KeyFile:              clientCertInfo.KeyFile,
@@ -249,7 +249,7 @@ func (o NodeOptions) CreateCerts() error {
 		return err
 	}
 
-	createKubeConfigOptions := certs.CreateKubeConfigOptions{
+	createKubeConfigOptions := admin.CreateKubeConfigOptions{
 		APIServerURL:    masterAddr.String(),
 		APIServerCAFile: getSignerOptions.CertFile,
 		ServerNick:      "master",
@@ -258,7 +258,7 @@ func (o NodeOptions) CreateCerts() error {
 		KeyFile:  mintNodeClientCert.KeyFile,
 		UserNick: o.NodeArgs.NodeName,
 
-		KubeConfigFile: certs.DefaultNodeKubeConfigFile(o.NodeArgs.CertArgs.CertDir, o.NodeArgs.NodeName),
+		KubeConfigFile: admin.DefaultNodeKubeConfigFile(o.NodeArgs.CertArgs.CertDir, o.NodeArgs.NodeName),
 	}
 	if _, err := createKubeConfigOptions.CreateKubeConfig(); err != nil {
 		return err

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -31,6 +31,7 @@ func setupStartOptions() (*start.MasterArgs, *start.NodeArgs, *start.ListenArg, 
 	basedir := path.Join(os.TempDir(), "openshift-integration-tests")
 	nodeArgs.VolumeDir = path.Join(basedir, "volume")
 	masterArgs.EtcdDir = path.Join(basedir, "etcd")
+	masterArgs.PolicyArgs.PolicyFile = path.Join(basedir, "policy", "policy.json")
 	certArgs.CertDir = path.Join(basedir, "cert")
 
 	// don't wait for nodes to come up


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1336

This pulls the bootstrap policy out into a separate config stanza.  It changes the bootstrapping rules to prevent the "ensure" loop from running.  Bootstrap policy is written to a file and that file is referenced from the master config.

Two new commands are added for `create-bootstrap-policy-file` and `overwrite-policy`.  The names aren't congruent because they do different things.  One of them creates a template file based on the bootstrap policy in code.  The other takes any template file containing policy and forcibly writes it directly into etcd.

Both commands are called from inside of starting the master.  A separate integration test makes sure that overwriting the created file works correctly after all permissions are removed.

@liggitt 