### PR TITLE
Disable certificate creation in openshift-node.service

### DIFF
--- a/rel-eng/openshift-node.service
+++ b/rel-eng/openshift-node.service
@@ -8,7 +8,7 @@ Documentation=https://github.com/openshift/origin
 Type=notify
 TimeoutStartSec=300s
 EnvironmentFile=-/etc/sysconfig/openshift-node
-ExecStart=/usr/bin/openshift start $ROLE --images=${IMAGES} --kubeconfig=${KUBECONFIG} $OPTIONS
+ExecStart=/usr/bin/openshift start $ROLE --create-certs=false --images=${IMAGES} --kubeconfig=${KUBECONFIG} $OPTIONS
 WorkingDirectory=/var/lib/openshift/
 
 [Install]


### PR DESCRIPTION
This ensures that running openshift-master and openshift-node services doesn't inadvertently create new signer certs, etc. Cert management is expected to be an explicit task, which will generally be handled by ansible installer.