### PR TITLE
use bootstrap policy constants for namespace and role default

### DIFF
--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -377,7 +377,7 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 	return []authorizationapi.PolicyBinding{
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name:      testMasterNamespace,
+				Name:      bootstrappolicy.DefaultMasterAuthorizationNamespace,
 				Namespace: "mallet",
 			},
 			RoleBindings: map[string]authorizationapi.RoleBinding{
@@ -387,8 +387,8 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 						Namespace: "mallet",
 					},
 					RoleRef: kapi.ObjectReference{
-						Name:      "admin",
-						Namespace: testMasterNamespace,
+						Name:      bootstrappolicy.AdminRoleName,
+						Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 					},
 					Users: util.NewStringSet("Matthew"),
 				},
@@ -398,8 +398,8 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 						Namespace: "mallet",
 					},
 					RoleRef: kapi.ObjectReference{
-						Name:      "view",
-						Namespace: testMasterNamespace,
+						Name:      bootstrappolicy.ViewRoleName,
+						Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 					},
 					Users: util.NewStringSet("Victor"),
 				},
@@ -409,8 +409,8 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 						Namespace: "mallet",
 					},
 					RoleRef: kapi.ObjectReference{
-						Name:      "edit",
-						Namespace: testMasterNamespace,
+						Name:      bootstrappolicy.EditRoleName,
+						Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 					},
 					Users: util.NewStringSet("Edgar"),
 				},

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -9,6 +9,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 type subjectsTest struct {
@@ -46,7 +47,7 @@ func TestSubjects(t *testing.T) {
 func (test *subjectsTest) test(t *testing.T) {
 	policyRegistry := testpolicyregistry.NewPolicyRegistry(test.policies, test.policyRetrievalError)
 	policyBindingRegistry := testpolicyregistry.NewPolicyBindingRegistry(test.bindings, test.bindingRetrievalError)
-	authorizer := NewAuthorizer(testMasterNamespace, rulevalidation.NewDefaultRuleResolver(policyRegistry, policyBindingRegistry))
+	authorizer := NewAuthorizer(bootstrappolicy.DefaultMasterAuthorizationNamespace, rulevalidation.NewDefaultRuleResolver(policyRegistry, policyBindingRegistry))
 
 	actualUsers, actualGroups, actualError := authorizer.GetAllowedSubjects(test.context, *test.attributes)
 

--- a/pkg/authorization/registry/policybinding/rest_test.go
+++ b/pkg/authorization/registry/policybinding/rest_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/test"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 func TestCreateValidationError(t *testing.T) {
@@ -31,8 +32,8 @@ func TestCreateStorageError(t *testing.T) {
 	storage := REST{registry: registry}
 
 	policyBinding := &authorizationapi.PolicyBinding{
-		ObjectMeta: kapi.ObjectMeta{Name: "master"},
-		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+		ObjectMeta: kapi.ObjectMeta{Name: bootstrappolicy.DefaultMasterAuthorizationNamespace},
+		PolicyRef:  kapi.ObjectReference{Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace},
 	}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
@@ -47,8 +48,8 @@ func TestCreateValid(t *testing.T) {
 	storage := REST{registry: registry}
 
 	policyBinding := &authorizationapi.PolicyBinding{
-		ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
-		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+		ObjectMeta: kapi.ObjectMeta{Name: bootstrappolicy.DefaultMasterAuthorizationNamespace, Namespace: "unittest"},
+		PolicyRef:  kapi.ObjectReference{Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace},
 	}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
@@ -88,14 +89,14 @@ func TestGetError(t *testing.T) {
 
 func TestGetValid(t *testing.T) {
 	testBinding := authorizationapi.PolicyBinding{
-		ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
-		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+		ObjectMeta: kapi.ObjectMeta{Name: bootstrappolicy.DefaultMasterAuthorizationNamespace, Namespace: "unittest"},
+		PolicyRef:  kapi.ObjectReference{Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace},
 	}
 	registry := test.NewPolicyBindingRegistry([]authorizationapi.PolicyBinding{testBinding}, nil)
 	storage := REST{registry: registry}
 
 	ctx := kapi.WithNamespace(kapi.NewContext(), "unittest")
-	policyBinding, err := storage.Get(ctx, "master")
+	policyBinding, err := storage.Get(ctx, bootstrappolicy.DefaultMasterAuthorizationNamespace)
 	if err != nil {
 		t.Errorf("got unexpected error: %v", err)
 		return
@@ -148,8 +149,8 @@ func TestListEmpty(t *testing.T) {
 
 func TestList(t *testing.T) {
 	testBinding := authorizationapi.PolicyBinding{
-		ObjectMeta: kapi.ObjectMeta{Name: "master", Namespace: "unittest"},
-		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+		ObjectMeta: kapi.ObjectMeta{Name: bootstrappolicy.DefaultMasterAuthorizationNamespace, Namespace: "unittest"},
+		PolicyRef:  kapi.ObjectReference{Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace},
 	}
 	registry := test.NewPolicyBindingRegistry([]authorizationapi.PolicyBinding{testBinding}, nil)
 	storage := REST{registry: registry}
@@ -189,7 +190,7 @@ func TestDeleteError(t *testing.T) {
 func TestDeleteValid(t *testing.T) {
 	testBinding := authorizationapi.PolicyBinding{
 		ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "unittest"},
-		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
+		PolicyRef:  kapi.ObjectReference{Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace},
 	}
 	registry := test.NewPolicyBindingRegistry([]authorizationapi.PolicyBinding{testBinding}, nil)
 	storage := REST{registry: registry}

--- a/pkg/authorization/registry/role/rest_test.go
+++ b/pkg/authorization/registry/role/rest_test.go
@@ -10,12 +10,13 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/registry/test"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 func testNewBasePolicies() []authorizationapi.Policy {
 	return []authorizationapi.Policy{
 		{
-			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "master"},
+			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace},
 			Roles: map[string]authorizationapi.Role{
 				"cluster-admin": {
 					ObjectMeta: kapi.ObjectMeta{Name: "cluster-admin"},

--- a/pkg/authorization/registry/subjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest_test.go
@@ -10,6 +10,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 type subjectAccessTest struct {
@@ -66,7 +67,7 @@ func TestNoErrors(t *testing.T) {
 			reason:  "because good things",
 		},
 		reviewRequest: &authorizationapi.SubjectAccessReview{
-			Groups:   util.NewStringSet("master"),
+			Groups:   util.NewStringSet(bootstrappolicy.DefaultMasterAuthorizationNamespace),
 			Verb:     "delete",
 			Resource: "deploymentConfigs",
 		},

--- a/pkg/cmd/experimental/policy/add_group.go
+++ b/pkg/cmd/experimental/policy/add_group.go
@@ -8,6 +8,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -45,7 +46,7 @@ func NewCmdAddGroup(f *clientcmd.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.roleNamespace, "role-namespace", "master", "namespace where the role is located.")
+	cmd.Flags().StringVar(&options.roleNamespace, "role-namespace", bootstrappolicy.DefaultMasterAuthorizationNamespace, "namespace where the role is located.")
 
 	return cmd
 }

--- a/pkg/cmd/experimental/policy/add_user.go
+++ b/pkg/cmd/experimental/policy/add_user.go
@@ -8,6 +8,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -45,7 +46,7 @@ func NewCmdAddUser(f *clientcmd.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.RoleNamespace, "role-namespace", "master", "namespace where the role is located.")
+	cmd.Flags().StringVar(&options.RoleNamespace, "role-namespace", bootstrappolicy.DefaultMasterAuthorizationNamespace, "namespace where the role is located.")
 
 	return cmd
 }

--- a/pkg/cmd/experimental/policy/remove_group.go
+++ b/pkg/cmd/experimental/policy/remove_group.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -44,7 +45,7 @@ func NewCmdRemoveGroup(f *clientcmd.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.RoleNamespace, "role-namespace", "master", "namespace where the role is located.")
+	cmd.Flags().StringVar(&options.RoleNamespace, "role-namespace", bootstrappolicy.DefaultMasterAuthorizationNamespace, "namespace where the role is located.")
 
 	return cmd
 }

--- a/pkg/cmd/experimental/policy/remove_user.go
+++ b/pkg/cmd/experimental/policy/remove_user.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -44,7 +45,7 @@ func NewCmdRemoveUser(f *clientcmd.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.roleNamespace, "role-namespace", "master", "namespace where the role is located.")
+	cmd.Flags().StringVar(&options.roleNamespace, "role-namespace", bootstrappolicy.DefaultMasterAuthorizationNamespace, "namespace where the role is located.")
 
 	return cmd
 }

--- a/pkg/cmd/experimental/project/new_project.go
+++ b/pkg/cmd/experimental/project/new_project.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/experimental/policy"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 )
@@ -49,8 +50,8 @@ func NewCmdNewProject(f *clientcmd.Factory, parentName, name string) *cobra.Comm
 	}
 
 	// TODO remove once we have global policy objects
-	cmd.Flags().StringVar(&options.MasterPolicyNamespace, "master-policy-namespace", "master", "master policy namespace")
-	cmd.Flags().StringVar(&options.AdminRole, "admin-role", "admin", "project admin role name in the master policy namespace")
+	cmd.Flags().StringVar(&options.MasterPolicyNamespace, "master-policy-namespace", bootstrappolicy.DefaultMasterAuthorizationNamespace, "master policy namespace")
+	cmd.Flags().StringVar(&options.AdminRole, "admin-role", bootstrappolicy.AdminRoleName, "project admin role name in the master policy namespace")
 	cmd.Flags().StringVar(&options.AdminUser, "admin", "", "project admin username")
 	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
 	cmd.Flags().StringVar(&options.Description, "description", "", "project description")

--- a/pkg/cmd/server/admin/create_bootstrappolicy_file.go
+++ b/pkg/cmd/server/admin/create_bootstrappolicy_file.go
@@ -55,7 +55,7 @@ func NewCommandCreateBootstrapPolicyFile() *cobra.Command {
 
 	flags.StringVar(&options.File, "filename", DefaultPolicyFile, "The policy template file that will be written with roles and bindings.")
 
-	flags.StringVar(&options.MasterAuthorizationNamespace, "master-namespace", "master", "Global authorization namespace.")
+	flags.StringVar(&options.MasterAuthorizationNamespace, "master-namespace", bootstrappolicy.DefaultMasterAuthorizationNamespace, "Global authorization namespace.")
 	flags.StringVar(&options.OpenShiftSharedResourcesNamespace, "openshift-namespace", "openshift", "Namespace for shared openshift resources.")
 
 	return cmd

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -14,6 +14,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
 	policy "github.com/openshift/origin/pkg/cmd/experimental/policy"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 func TestRestrictedAccessForProjectAdmins(t *testing.T) {
@@ -92,9 +93,9 @@ func TestOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 	}
 
 	addValerie := &policy.AddUserOptions{
-		RoleNamespace:    "master",
-		RoleName:         "view",
-		BindingNamespace: "master",
+		RoleNamespace:    bootstrappolicy.DefaultMasterAuthorizationNamespace,
+		RoleName:         bootstrappolicy.ViewRoleName,
+		BindingNamespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 		Client:           clusterAdminClient,
 		Users:            []string{"anypassword:valerie"},
 	}
@@ -102,14 +103,14 @@ func TestOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if err = clusterAdminClient.Roles("master").Delete("view"); err != nil {
+	if err = clusterAdminClient.Roles(bootstrappolicy.DefaultMasterAuthorizationNamespace).Delete(bootstrappolicy.ViewRoleName); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	addEdgar := &policy.AddUserOptions{
-		RoleNamespace:    "master",
-		RoleName:         "edit",
-		BindingNamespace: "master",
+		RoleNamespace:    bootstrappolicy.DefaultMasterAuthorizationNamespace,
+		RoleName:         bootstrappolicy.EditRoleName,
+		BindingNamespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 		Client:           clusterAdminClient,
 		Users:            []string{"anypassword:edgar"},
 	}
@@ -176,8 +177,8 @@ func TestResourceAccessReview(t *testing.T) {
 	}
 
 	addValerie := &policy.AddUserOptions{
-		RoleNamespace:    "master",
-		RoleName:         "view",
+		RoleNamespace:    bootstrappolicy.DefaultMasterAuthorizationNamespace,
+		RoleName:         bootstrappolicy.ViewRoleName,
 		BindingNamespace: "hammer-project",
 		Client:           haroldClient,
 		Users:            []string{"anypassword:valerie"},
@@ -187,8 +188,8 @@ func TestResourceAccessReview(t *testing.T) {
 	}
 
 	addEdgar := &policy.AddUserOptions{
-		RoleNamespace:    "master",
-		RoleName:         "edit",
+		RoleNamespace:    bootstrappolicy.DefaultMasterAuthorizationNamespace,
+		RoleName:         bootstrappolicy.EditRoleName,
 		BindingNamespace: "mallet-project",
 		Client:           markClient,
 		Users:            []string{"anypassword:edgar"},
@@ -298,8 +299,8 @@ func TestSubjectAccessReview(t *testing.T) {
 	}
 
 	addValerie := &policy.AddUserOptions{
-		RoleNamespace:    "master",
-		RoleName:         "view",
+		RoleNamespace:    bootstrappolicy.DefaultMasterAuthorizationNamespace,
+		RoleName:         bootstrappolicy.ViewRoleName,
 		BindingNamespace: "hammer-project",
 		Client:           haroldClient,
 		Users:            []string{"anypassword:valerie"},
@@ -309,8 +310,8 @@ func TestSubjectAccessReview(t *testing.T) {
 	}
 
 	addEdgar := &policy.AddUserOptions{
-		RoleNamespace:    "master",
-		RoleName:         "edit",
+		RoleNamespace:    bootstrappolicy.DefaultMasterAuthorizationNamespace,
+		RoleName:         bootstrappolicy.EditRoleName,
 		BindingNamespace: "mallet-project",
 		Client:           markClient,
 		Users:            []string{"anypassword:edgar"},

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	newproject "github.com/openshift/origin/pkg/cmd/experimental/project"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/user/api"
 	"github.com/spf13/pflag"
@@ -63,8 +64,8 @@ func TestLogin(t *testing.T) {
 	newProjectOptions := &newproject.NewProjectOptions{
 		Client:                clusterAdminClient,
 		ProjectName:           project,
-		AdminRole:             "admin",
-		MasterPolicyNamespace: "master",
+		AdminRole:             bootstrappolicy.AdminRoleName,
+		MasterPolicyNamespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 		AdminUser:             "anypassword:" + username,
 	}
 	if err := newProjectOptions.Run(); err != nil {

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	newproject "github.com/openshift/origin/pkg/cmd/experimental/project"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/server/start"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
@@ -105,7 +106,7 @@ func StartTestAllInOne() (*configapi.MasterConfig, string, error) {
 		// confirm that we can actually query from the api server
 
 		if client, _, _, err := GetClusterAdminClient(adminKubeConfigFile); err == nil {
-			if _, err := client.Policies("master").List(labels.Everything(), labels.Everything()); err == nil {
+			if _, err := client.Policies(bootstrappolicy.DefaultMasterAuthorizationNamespace).List(labels.Everything(), labels.Everything()); err == nil {
 				break
 			}
 		}
@@ -160,7 +161,7 @@ func StartTestMaster() (*configapi.MasterConfig, string, error) {
 			if err != nil {
 				return
 			}
-			if _, err := client.Policies("master").List(labels.Everything(), labels.Everything()); err == nil {
+			if _, err := client.Policies(bootstrappolicy.DefaultMasterAuthorizationNamespace).List(labels.Everything(), labels.Everything()); err == nil {
 				close(stopChannel)
 			}
 		}, 100*time.Millisecond, stopChannel)
@@ -175,8 +176,8 @@ func CreateNewProject(clusterAdminClient *client.Client, clientConfig kclient.Co
 	newProjectOptions := &newproject.NewProjectOptions{
 		Client:                clusterAdminClient,
 		ProjectName:           projectName,
-		AdminRole:             "admin",
-		MasterPolicyNamespace: "master",
+		AdminRole:             bootstrappolicy.AdminRoleName,
+		MasterPolicyNamespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 		AdminUser:             qualifiedUser,
 	}
 


### PR DESCRIPTION
@liggitt This is the follow on I mentioned.  Only the last commit is... well not interesting, but useful.