### PR TITLE
Set master IP correctly when starting kubernetes

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -158,6 +158,7 @@ type EtcdConfig struct {
 }
 
 type KubernetesMasterConfig struct {
+	MasterIP        string
 	ServicesSubnet  string
 	StaticNodeNames []string
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -159,6 +159,7 @@ type EtcdConfig struct {
 }
 
 type KubernetesMasterConfig struct {
+	MasterIP        string   `json:"masterIP"`
 	ServicesSubnet  string   `json:"servicesSubnet"`
 	StaticNodeNames []string `json:"staticNodeNames"`
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -58,7 +58,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	admissionControlPluginNames := []string{"LimitRanger", "ResourceQuota"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
 
-	host, portString, err := net.SplitHostPort(options.ServingInfo.BindAddress)
+	_, portString, err := net.SplitHostPort(options.ServingInfo.BindAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	}
 
 	kmaster := &MasterConfig{
-		MasterIP:             net.ParseIP(host),
+		MasterIP:             net.ParseIP(options.KubernetesMasterConfig.MasterIP),
 		MasterPort:           port,
 		NodeHosts:            options.KubernetesMasterConfig.StaticNodeNames,
 		PortalNet:            &portalNet,

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -229,7 +229,21 @@ func (args MasterArgs) BuildSerializeableEtcdConfig() (*configapi.EtcdConfig, er
 func (args MasterArgs) BuildSerializeableKubeMasterConfig() (*configapi.KubernetesMasterConfig, error) {
 	servicesSubnet := net.IPNet(args.PortalNet)
 
+	masterAddr, err := args.GetMasterAddress()
+	if err != nil {
+		return nil, err
+	}
+	masterHost, _, err := net.SplitHostPort(masterAddr.Host)
+	if err != nil {
+
+	}
+	masterIP := ""
+	if ip := net.ParseIP(masterHost); ip != nil {
+		masterIP = ip.String()
+	}
+
 	config := &configapi.KubernetesMasterConfig{
+		MasterIP:        masterIP,
 		ServicesSubnet:  servicesSubnet.String(),
 		StaticNodeNames: args.NodeList,
 	}


### PR DESCRIPTION
Saves the specified --master host, if it is an IP, to set as the kubernetes MasterIP. Validates masterIP and dnsIP to make sure they are valid IP addresses and are not 0.0.0.0

@deads2k 