### PR TITLE
create identities and roles for router and registry

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -32,10 +32,10 @@ Once it is pulled it will start and be visible in the `docker ps` list of contai
     [vagrant@openshiftdev origin]$ sudo /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/openshift start &
 
     If running in https mode, ensure osc can authenticate to the master
-    [vagrant@openshiftdev origin]$ export KUBECONFIG=/data/src/github.com/openshift/origin/openshift.local.certificates/openshift-client/.kubeconfig
+    [vagrant@openshiftdev origin]$ export KUBECONFIG=/data/src/github.com/openshift/origin/openshift.local.certificates/admin/.kubeconfig
     [vagrant@openshiftdev origin]$ sudo chmod a+r "$KUBECONFIG"
-    [vagrant@openshiftdev origin]$ sudo chmod a+r openshift.local.certificates/openshift-client/key.key
-    [vagrant@openshiftdev origin]$ openshift ex router --create --credentials="${KUBECONFIG}"
+    [vagrant@openshiftdev origin]$ sudo chmod a+r openshift.local.certificates/openshift-router/.kubeconfig
+    [vagrant@openshiftdev origin]$ openshift ex router --create --credentials="openshift.local.certificates/openshift-router/.kubeconfig"
     [vagrant@openshiftdev origin]$ osc get pods
 
 #### Clustered vagrant environment

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -128,7 +128,7 @@ This section covers how to perform all the steps of building, deploying, and upd
     to the system keys.)
 
         $ export KUBECONFIG=`pwd`/openshift.local.certificates/admin/.kubeconfig
-        $ export CURL_CA_BUNDLE=`pwd`/openshift.local.certificates/admin/root.crt
+        $ export CURL_CA_BUNDLE=`pwd`/openshift.local.certificates/ca/cert.crt
         $ sudo chmod +r "$KUBECONFIG"
 
 4. Bind a user to the `view` role in the default namespace so you can observe progress in the web console
@@ -148,8 +148,8 @@ This section covers how to perform all the steps of building, deploying, and upd
 
 6. Deploy a private docker registry within OpenShift with the certs necessary for access to master:
 
-        $ sudo chmod +r ./openshift.local.certificates/openshift-client/key.key
-        $ openshift ex registry --create --credentials="${KUBECONFIG}"
+        $ sudo chmod +r ./openshift.local.certificates/openshift-registry/.kubeconfig
+        $ openshift ex registry --create --credentials=./openshift.local.certificates/openshift-registry/.kubeconfig
           docker-registry # the service
           docker-registry # the deployment config
 
@@ -354,7 +354,8 @@ the ip address shown below with the correct one for your environment.
             # take some time.  Your pod will stay in Pending state while the pull is completed
             $ docker pull openshift/origin-haproxy-router
 
-            $ openshift ex router --create --credentials="${KUBECONFIG}"
+            $ sudo chmod +r `pwd`/openshift.local.certificates/openshift-router/.kubeconfig
+            $ openshift ex router --create --credentials="`pwd`/openshift.local.certificates/openshift-router/.kubeconfig"
               router # the service
               router # the deployment config
 

--- a/examples/sample-app/container-setup.md
+++ b/examples/sample-app/container-setup.md
@@ -60,7 +60,7 @@ bits that are used in the sample app.
 
 ## Configure client security
 
-    $ export CURL_CA_BUNDLE=`pwd`/openshift.local.certificates/admin/root.crt
+    $ export CURL_CA_BUNDLE=`pwd`/openshift.local.certificates/ca/cert.crt
 
 For more information on this step, see [Application Build, Deploy, and Update
 Flow](https://github.com/openshift/origin/blob/master/examples/sample-app/README.md#application-build-deploy-and-update-flow),

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -197,11 +197,7 @@ if [[ "${API_SCHEME}" == "https" ]]; then
 	export CURL_CERT="${CERT_DIR}/admin/cert.crt"
 	export CURL_KEY="${CERT_DIR}/admin/key.key"
 
-	# Read client cert data in to send to containerized components
-	sudo chmod -R a+rX "${CERT_DIR}/openshift-client/"
-
 	# Make osc use ${CERT_DIR}/admin/.kubeconfig, and ignore anything in the running user's $HOME dir
-	sudo chmod -R a+rwX "${CERT_DIR}/admin/"
 	export HOME="${CERT_DIR}/admin"
 	export KUBECONFIG="${CERT_DIR}/admin/.kubeconfig"
 	echo "[INFO] To debug: export KUBECONFIG=$KUBECONFIG"
@@ -225,12 +221,12 @@ echo "Log in as 'e2e-user' to see the 'test' project."
 
 # install the router
 echo "[INFO] Installing the router"
-openshift ex router --create --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
+openshift ex router --create --credentials="${CERT_DIR}/openshift-router/.kubeconfig" --images="${USE_IMAGES}"
 
 # install the registry. The --mount-host option is provided to reuse local storage.
 echo "[INFO] Installing the registry"
 # TODO: add --images="${USE_IMAGES}" when the Docker registry is built alongside OpenShift
-openshift ex registry --create --credentials="${KUBECONFIG}" --mount-host="/tmp/openshift.local.registry" --images='openshift/origin-${component}:latest'
+openshift ex registry --create --credentials="${CERT_DIR}/openshift-registry/.kubeconfig" --mount-host="/tmp/openshift.local.registry" --images='openshift/origin-${component}:latest'
 
 echo "[INFO] Pre-pulling and pushing centos7"
 docker pull centos:centos7
@@ -295,7 +291,7 @@ registry_pod=$(osc get pod | grep docker-registry | awk '{print $1}')
 osc exec -p ${registry_pod} whoami | grep root
 
 # Port forwarding
-osc port-forward -p ${registry_pod} 5001:5000 &
+osc port-forward -p ${registry_pod} 5001:5000  &> "${LOG_DIR}/port-forward.log" &
 wait_for_url_timed "http://localhost:5001/" "[INFO] Docker registry says: " $((10*TIME_SEC))
 
 # UI e2e tests can be found in assets/test/e2e

--- a/pkg/cmd/server/admin/create_client.go
+++ b/pkg/cmd/server/admin/create_client.go
@@ -1,0 +1,128 @@
+package admin
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+type CreateClientOptions struct {
+	GetSignerCertOptions *GetSignerCertOptions
+
+	ClientDir string
+
+	User   string
+	Groups util.StringList
+
+	APIServerCAFile    string
+	APIServerURL       string
+	PublicAPIServerURL string
+}
+
+func NewCommandCreateClient() *cobra.Command {
+	options := &CreateClientOptions{GetSignerCertOptions: &GetSignerCertOptions{}}
+
+	cmd := &cobra.Command{
+		Use:   "create-api-client-config",
+		Short: "Create a portable client folder containing a client certificate, a client key, a server certificate authority, and a .kubeconfig file.",
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Validate(args); err != nil {
+				fmt.Println(err.Error())
+				c.Help()
+				return
+			}
+
+			if err := options.CreateClientFolder(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+
+	BindGetSignerCertOptions(options.GetSignerCertOptions, flags, "")
+
+	flags.StringVar(&options.ClientDir, "client-dir", "", "The client data directory.")
+
+	flags.StringVar(&options.User, "user", "", "The scope qualified username.")
+	flags.Var(&options.Groups, "groups", "The list of groups this user belongs to. Comma delimited list")
+
+	flags.StringVar(&options.APIServerURL, "master", "https://localhost:8443", "The API server's URL.")
+	flags.StringVar(&options.PublicAPIServerURL, "public-master", "", "The API public facing server's URL (if applicable).")
+	flags.StringVar(&options.APIServerCAFile, "certificate-authority", "openshift.local.certificates/ca/cert.crt", "Path to the API server's CA file.")
+
+	return cmd
+}
+
+func (o CreateClientOptions) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+	if len(o.ClientDir) == 0 {
+		return errors.New("client-dir must be provided")
+	}
+	if len(o.User) == 0 {
+		return errors.New("user must be provided")
+	}
+	if len(o.APIServerURL) == 0 {
+		return errors.New("master must be provided")
+	}
+	if len(o.APIServerCAFile) == 0 {
+		return errors.New("certificate-authority must be provided")
+	}
+
+	return nil
+}
+
+func (o CreateClientOptions) CreateClientFolder() error {
+	glog.V(2).Infof("creating a .kubeconfig with: %#v", o)
+
+	clientCertFile := path.Join(o.ClientDir, "cert.crt")
+	clientKeyFile := path.Join(o.ClientDir, "key.key")
+	clientCopyOfCAFile := path.Join(o.ClientDir, "ca.crt")
+	kubeConfigFile := path.Join(o.ClientDir, ".kubeconfig")
+
+	createClientCertOptions := CreateClientCertOptions{
+		GetSignerCertOptions: o.GetSignerCertOptions,
+		CertFile:             clientCertFile,
+		KeyFile:              clientKeyFile,
+
+		User:      o.User,
+		Groups:    o.Groups,
+		Overwrite: true,
+	}
+	if _, err := createClientCertOptions.CreateClientCert(); err != nil {
+		return err
+	}
+
+	// copy the CA file over
+	if caBytes, err := ioutil.ReadFile(o.APIServerCAFile); err != nil {
+		return err
+	} else if err := ioutil.WriteFile(clientCopyOfCAFile, caBytes, 0644); err != nil {
+		return nil
+	}
+
+	createKubeConfigOptions := CreateKubeConfigOptions{
+		APIServerURL:       o.APIServerURL,
+		PublicAPIServerURL: o.PublicAPIServerURL,
+		APIServerCAFile:    clientCopyOfCAFile,
+		ServerNick:         "master",
+
+		CertFile: clientCertFile,
+		KeyFile:  clientKeyFile,
+		UserNick: o.User,
+
+		KubeConfigFile: kubeConfigFile,
+	}
+	if _, err := createKubeConfigOptions.CreateKubeConfig(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/server/admin/create_comands.go
+++ b/pkg/cmd/server/admin/create_comands.go
@@ -21,6 +21,7 @@ func NewCommandAdmin() *cobra.Command {
 	cmd.AddCommand(NewCommandCreateNodeClientCert())
 	cmd.AddCommand(NewCommandCreateServerCert())
 	cmd.AddCommand(NewCommandCreateSignerCert())
+	cmd.AddCommand(NewCommandCreateClient())
 
 	return cmd
 }

--- a/pkg/cmd/server/admin/create_nodeclientcerts.go
+++ b/pkg/cmd/server/admin/create_nodeclientcerts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 )
 
@@ -81,7 +82,7 @@ func (o CreateNodeClientCertOptions) CreateNodeClientCert() (*crypto.TLSCertific
 		KeyFile:  o.KeyFile,
 
 		User:      "system:node-" + o.NodeName,
-		Groups:    util.StringList([]string{"system:nodes"}),
+		Groups:    util.StringList([]string{bootstrappolicy.NodesGroup}),
 		Overwrite: o.Overwrite,
 	}
 

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 const (
@@ -35,6 +36,32 @@ func DefaultClientCerts(certDir string) []ClientCertInfo {
 		DefaultOpenshiftLoopbackClientCertInfo(certDir),
 		DefaultKubeClientClientCertInfo(certDir),
 		DefaultClusterAdminClientCertInfo(certDir),
+		DefaultRouterClientCertInfo(certDir),
+		DefaultRegistryClientCertInfo(certDir),
+	}
+}
+
+func DefaultRouterClientCertInfo(certDir string) ClientCertInfo {
+	return ClientCertInfo{
+		CertLocation: configapi.CertInfo{
+			CertFile: DefaultCertFilename(certDir, bootstrappolicy.RouterUnqualifiedUsername),
+			KeyFile:  DefaultKeyFilename(certDir, bootstrappolicy.RouterUnqualifiedUsername),
+		},
+		SubDir: bootstrappolicy.RouterUnqualifiedUsername,
+		User:   bootstrappolicy.RouterUsername,
+		Groups: util.NewStringSet(bootstrappolicy.RouterGroup),
+	}
+}
+
+func DefaultRegistryClientCertInfo(certDir string) ClientCertInfo {
+	return ClientCertInfo{
+		CertLocation: configapi.CertInfo{
+			CertFile: DefaultCertFilename(certDir, bootstrappolicy.RegistryUnqualifiedUsername),
+			KeyFile:  DefaultKeyFilename(certDir, bootstrappolicy.RegistryUnqualifiedUsername),
+		},
+		SubDir: bootstrappolicy.RegistryUnqualifiedUsername,
+		User:   bootstrappolicy.RegistryUsername,
+		Groups: util.NewStringSet(bootstrappolicy.RegistryGroup),
 	}
 }
 

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -1,0 +1,64 @@
+package bootstrappolicy
+
+import ()
+
+// known namespaces
+const (
+	DefaultMasterAuthorizationNamespace      = "master"
+	DefaultOpenShiftSharedResourcesNamespace = "openshift"
+)
+
+// users
+const (
+	RouterUnqualifiedUsername   = "openshift-router"
+	RegistryUnqualifiedUsername = "openshift-registry"
+
+	RouterUsername   = "system:" + RouterUnqualifiedUsername
+	RegistryUsername = "system:" + RegistryUnqualifiedUsername
+)
+
+// groups
+const (
+	UnauthenticatedUsername       = "system:anonymous"
+	InternalComponentUsername     = "system:openshift-client"
+	InternalComponentKubeUsername = "system:kube-client"
+	DeployerUsername              = "system:openshift-deployer"
+
+	AuthenticatedGroup   = "system:authenticated"
+	UnauthenticatedGroup = "system:unauthenticated"
+	ClusterAdminGroup    = "system:cluster-admins"
+	NodesGroup           = "system:nodes"
+	RouterGroup          = "system:routers"
+	RegistryGroup        = "system:registries"
+)
+
+// Roles
+const (
+	ClusterAdminRoleName      = "cluster-admin"
+	AdminRoleName             = "admin"
+	EditRoleName              = "edit"
+	ViewRoleName              = "view"
+	BasicUserRoleName         = "basic-user"
+	StatusCheckerRoleName     = "cluster-status"
+	DeployerRoleName          = "system:deployer"
+	RouterRoleName            = "system:router"
+	RegistryRoleName          = "system:registry"
+	InternalComponentRoleName = "system:component"
+	DeleteTokensRoleName      = "system:delete-tokens"
+
+	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
+)
+
+// RoleBindings
+const (
+	InternalComponentRoleBindingName = InternalComponentRoleName + "-binding"
+	DeployerRoleBindingName          = DeployerRoleName + "-binding"
+	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "-binding"
+	BasicUserRoleBindingName         = BasicUserRoleName + "-binding"
+	DeleteTokensRoleBindingName      = DeleteTokensRoleName + "-binding"
+	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"
+	RouterRoleBindingName            = RouterRoleName + "-binding"
+	RegistryRoleBindingName          = RegistryRoleName + "-binding"
+
+	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "-binding"
+)

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -7,48 +7,6 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
-const (
-	DefaultMasterAuthorizationNamespace      = "master"
-	DefaultOpenShiftSharedResourcesNamespace = "openshift"
-)
-
-const (
-	UnauthenticatedUsername       = "system:anonymous"
-	InternalComponentUsername     = "system:openshift-client"
-	InternalComponentKubeUsername = "system:kube-client"
-	DeployerUsername              = "system:openshift-deployer"
-
-	AuthenticatedGroup   = "system:authenticated"
-	UnauthenticatedGroup = "system:unauthenticated"
-	ClusterAdminGroup    = "system:cluster-admins"
-	NodesGroup           = "system:nodes"
-)
-
-const (
-	ClusterAdminRoleName      = "cluster-admin"
-	AdminRoleName             = "admin"
-	EditRoleName              = "edit"
-	ViewRoleName              = "view"
-	BasicUserRoleName         = "basic-user"
-	StatusCheckerRoleName     = "cluster-status"
-	DeployerRoleName          = "system:deployer"
-	InternalComponentRoleName = "system:component"
-	DeleteTokensRoleName      = "system:delete-tokens"
-
-	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
-)
-
-const (
-	InternalComponentRoleBindingName = InternalComponentRoleName + "-binding"
-	DeployerRoleBindingName          = DeployerRoleName + "-binding"
-	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "-binding"
-	BasicUserRoleBindingName         = BasicUserRoleName + "-binding"
-	DeleteTokensRoleBindingName      = DeleteTokensRoleName + "-binding"
-	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"
-
-	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "-binding"
-)
-
 func GetBootstrapRoles(masterNamespace, openshiftNamespace string) []authorizationapi.Role {
 	masterRoles := GetBootstrapMasterRoles(masterNamespace)
 	openshiftRoles := GetBootstrapOpenshiftRoles(openshiftNamespace)
@@ -194,6 +152,34 @@ func GetBootstrapMasterRoles(masterNamespace string) []authorizationapi.Role {
 				},
 			},
 		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      RouterRoleName,
+				Namespace: masterNamespace,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("routes", "endpoints"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      RegistryRoleName,
+				Namespace: masterNamespace,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get", "delete"),
+					Resources: util.NewStringSet("images"),
+				},
+				{
+					Verbs:     util.NewStringSet("create"),
+					Resources: util.NewStringSet("imagerepositorymappings"),
+				},
+			},
+		},
 	}
 }
 
@@ -289,6 +275,28 @@ func GetBootstrapMasterRoleBindings(masterNamespace string) []authorizationapi.R
 				Namespace: masterNamespace,
 			},
 			Groups: util.NewStringSet(AuthenticatedGroup, UnauthenticatedGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      RouterRoleBindingName,
+				Namespace: masterNamespace,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name:      RouterRoleName,
+				Namespace: masterNamespace,
+			},
+			Groups: util.NewStringSet(RouterGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      RegistryRoleBindingName,
+				Namespace: masterNamespace,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name:      RegistryRoleName,
+				Namespace: masterNamespace,
+			},
+			Groups: util.NewStringSet(RegistryGroup),
 		},
 	}
 }


### PR DESCRIPTION
Also adds a create-client command.

I can separate the two until we properly delegeate to create-client instead of create-client-certs and create-all-certs if you like.

@liggitt 