### PR TITLE
make login test avoid default kubeconfig chain

### DIFF
--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -6,15 +6,19 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/pflag"
+
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/config"
 	newproject "github.com/openshift/origin/pkg/cmd/experimental/project"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/test/util"
-	"github.com/spf13/pflag"
 )
 
 func init() {
@@ -22,7 +26,10 @@ func init() {
 }
 
 func TestLogin(t *testing.T) {
+	clientcmd.DefaultCluster = clientcmdapi.Cluster{Server: ""}
+
 	_, clusterAdminKubeConfig, err := util.StartTestMaster()
+
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -113,7 +120,6 @@ func TestLogin(t *testing.T) {
 
 func newLoginOptions(server string, username string, password string, context string, insecure bool) *cmd.LoginOptions {
 	flagset := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
-	factory := clientcmd.New(flagset)
 
 	flags := []string{}
 
@@ -127,14 +133,14 @@ func newLoginOptions(server string, username string, password string, context st
 		flags = append(flags, "--insecure-skip-tls-verify")
 	}
 
-	flagset.Parse(flags)
-
 	loginOptions := &cmd.LoginOptions{
-		ClientConfig: factory.OpenShiftClientConfig,
+		ClientConfig: defaultClientConfig(flagset),
 		Reader:       os.Stdin,
 		Username:     username,
 		Password:     password,
 	}
+
+	flagset.Parse(flags)
 
 	return loginOptions
 }
@@ -151,4 +157,19 @@ func whoami(clientCfg *kclient.Config) (*api.User, error) {
 	}
 
 	return me, nil
+}
+
+func defaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: ""}
+
+	flags.StringVar(&loadingRules.ExplicitPath, config.OpenShiftConfigFlagName, "", "Path to the config file to use for CLI requests.")
+
+	overrides := &clientcmd.ConfigOverrides{}
+	overrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
+	overrideFlags.ContextOverrideFlags.NamespaceShort = "n"
+	clientcmd.BindOverrideFlags(overrides, flags, overrideFlags)
+
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+
+	return clientConfig
 }


### PR DESCRIPTION
Login integration test fails if part .kubeconfig chain exists locally.

@mfojtik This fixes the problem you have with the Login test.

