### PR TITLE
Add dockerImageRepository to custom-build template builder image repo

### DIFF
--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -38,8 +38,9 @@
       "apiVersion": "v1beta1",
       "kind": "ImageRepository",
       "metadata": {
-        "name": "custom-docker-builder"
-      }
+        "name": "origin-custom-docker-builder"
+      },
+      "dockerImageRepository": "openshift/origin-custom-docker-builder"
     },
     {
       "apiVersion": "v1beta1",


### PR DESCRIPTION
Allows the build to start automatically just like for the docker and sti builder templates.