### PR TITLE
Run node/etcd over https

### DIFF
--- a/hack/make-p12-cert.sh
+++ b/hack/make-p12-cert.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+CERT=${1:-}
+KEY=${2:-}
+P12=${3:-}
+PASSWORD=${4:-}
+
+if [ "${CERT}" == "" ] || [ "${KEY}" == "" ] || [ "${P12}" == "" ] || [ "${PASSWORD}" == "" ]; then
+	echo "Usage: make-p12-cert.sh cert.crt key.key out.p12 password"
+	exit 1
+fi
+
+openssl pkcs12 -export -inkey "${KEY}" -in "${CERT}" -out "${P12}" -password "pass:${PASSWORD}"

--- a/hack/test-extended.sh
+++ b/hack/test-extended.sh
@@ -56,23 +56,24 @@ start_server() {
 
   echo "[INFO] Create certificates for the OpenShift master"
   env "PATH=${PATH}" openshift admin create-master-certs \
-  --overwrite=false \
-  --cert-dir="${CERT_DIR}" \
-  --hostnames="${SERVER_HOSTNAME_LIST}" \
-  --master="https://${OS_MASTER_ADDR}" \
-  --public-master="https://${OS_MASTER_ADDR}"
+    --overwrite=false \
+    --cert-dir="${CERT_DIR}" \
+    --hostnames="${SERVER_HOSTNAME_LIST}" \
+    --master="https://${OS_MASTER_ADDR}" \
+    --public-master="https://${OS_MASTER_ADDR}"
 
   echo "[INFO] Create certificates for the OpenShift node"
   env "PATH=${PATH}" openshift admin create-node-config \
-  --listen="https://0.0.0.0:10250" \
-  --node-dir="${CERT_DIR}/node-127.0.0.1" \
-  --node="127.0.0.1" \
-  --hostnames="${SERVER_HOSTNAME_LIST}" \
-  --master="https://${OS_MASTER_ADDR}" \
-  --certificate-authority="${CERT_DIR}/ca/cert.crt" \
-  --signer-cert="${CERT_DIR}/ca/cert.crt" \
-  --signer-key="${CERT_DIR}/ca/key.key" \
-  --signer-serial="${CERT_DIR}/ca/serial.txt"
+    --listen="https://0.0.0.0:10250" \
+    --node-dir="${CERT_DIR}/node-127.0.0.1" \
+    --node="127.0.0.1" \
+    --hostnames="${SERVER_HOSTNAME_LIST}" \
+    --master="https://${OS_MASTER_ADDR}" \
+    --node-client-certificate-authority="${CERT_DIR}/ca/cert.crt" \
+    --certificate-authority="${CERT_DIR}/ca/cert.crt" \
+    --signer-cert="${CERT_DIR}/ca/cert.crt" \
+    --signer-key="${CERT_DIR}/ca/key.key" \
+    --signer-serial="${CERT_DIR}/ca/serial.txt"
 
   echo "[INFO] Starting OpenShift server"
   sudo env "PATH=${PATH}" openshift start \

--- a/pkg/client/buildlogs.go
+++ b/pkg/client/buildlogs.go
@@ -11,7 +11,7 @@ type BuildLogsNamespacer interface {
 
 // BuildLogsInterface exposes methods on BuildLogs resources.
 type BuildLogsInterface interface {
-	Redirect(name string) *kclient.Request
+	Get(name string) *kclient.Request
 }
 
 // buildLogs implements BuildLogsNamespacer interface
@@ -28,7 +28,7 @@ func newBuildLogs(c *Client, namespace string) *buildLogs {
 	}
 }
 
-// Redirect builds and returns a buildLog request
-func (c *buildLogs) Redirect(name string) *kclient.Request {
-	return c.r.Get().Namespace(c.ns).Prefix("redirect").Resource("buildLogs").Name(name)
+// Get builds and returns a buildLog request
+func (c *buildLogs) Get(name string) *kclient.Request {
+	return c.r.Get().Namespace(c.ns).Prefix("proxy").Resource("buildLogs").Name(name)
 }

--- a/pkg/client/fake_buildlogs.go
+++ b/pkg/client/fake_buildlogs.go
@@ -11,8 +11,8 @@ type FakeBuildLogs struct {
 	Namespace string
 }
 
-// Redirect builds and returns a buildLog request
-func (c *FakeBuildLogs) Redirect(name string) *kclient.Request {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "redirect"})
+// Get builds and returns a buildLog request
+func (c *FakeBuildLogs) Get(name string) *kclient.Request {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "proxy"})
 	return &kclient.Request{}
 }

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -35,9 +35,7 @@ func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobr
 			c, _, err := f.Clients()
 			checkErr(err)
 
-			request := c.BuildLogs(namespace).Redirect(args[0])
-
-			readCloser, err := request.Stream()
+			readCloser, err := c.BuildLogs(namespace).Get(args[0]).Stream()
 			checkErr(err)
 			defer readCloser.Close()
 

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -65,7 +65,7 @@ func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, out io.Writer) *co
 					glog.V(2).Infof("Build %v has not yet generated any logs.", buildName)
 
 				} else {
-					response, err := client.BuildLogs(namespace).Redirect(buildName).Do().Raw()
+					response, err := client.BuildLogs(namespace).Get(buildName).Do().Raw()
 					if err != nil {
 						glog.Errorf("Could not fetch build logs for %s: %v", buildName, err)
 					} else {

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -85,7 +85,7 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 					if build.Name == newBuild.Name {
 						switch build.Status {
 						case buildapi.BuildStatusRunning, buildapi.BuildStatusComplete, buildapi.BuildStatusFailed:
-							rd, err := client.BuildLogs(namespace).Redirect(newBuild.Name).Stream()
+							rd, err := client.BuildLogs(namespace).Get(newBuild.Name).Stream()
 							checkErr(err)
 							defer rd.Close()
 

--- a/pkg/cmd/server/admin/create_nodeconfig_test.go
+++ b/pkg/cmd/server/admin/create_nodeconfig_test.go
@@ -42,7 +42,7 @@ func TestNodeConfigTLS(t *testing.T) {
 	defer os.Remove(signerKey)
 	defer os.Remove(signerSerial)
 
-	configDirName := executeNodeConfig([]string{"--node=my-node", "--hostnames=example.org", "--listen=https://0.0.0.0", "--certificate-authority=" + signerCert, "--signer-cert=" + signerCert, "--signer-key=" + signerKey, "--signer-serial=" + signerSerial})
+	configDirName := executeNodeConfig([]string{"--node=my-node", "--hostnames=example.org", "--listen=https://0.0.0.0", "--certificate-authority=" + signerCert, "--node-client-certificate-authority=" + signerCert, "--signer-cert=" + signerCert, "--signer-key=" + signerKey, "--signer-serial=" + signerSerial})
 	defer os.Remove(configDirName)
 
 	configDir, err := os.Open(configDirName)
@@ -56,7 +56,7 @@ func TestNodeConfigTLS(t *testing.T) {
 	}
 	filenames := util.NewStringSet(fileNameSlice...)
 
-	expectedNames := util.NewStringSet("client.crt", "client.key", "server.crt", "server.key", ".kubeconfig", "node-config.yaml", "node-registration.json", "ca.crt")
+	expectedNames := util.NewStringSet("client.crt", "client.key", "server.crt", "server.key", "node-client-ca.crt", ".kubeconfig", "node-config.yaml", "node-registration.json", "ca.crt")
 	if !filenames.HasAll(expectedNames.List()...) || !expectedNames.HasAll(filenames.List()...) {
 		t.Errorf("expected %v, got %v", expectedNames.List(), filenames.List())
 	}

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	DefaultCADir = "ca"
+	DefaultCADir     = "ca"
+	DefaultMasterDir = "master"
 )
 
 type ClientCertInfo struct {
@@ -30,7 +31,51 @@ func DefaultRootCAFile(certDir string) string {
 	return DefaultCertFilename(certDir, DefaultCADir)
 }
 
-func DefaultClientCerts(certDir string) []ClientCertInfo {
+func DefaultKubeletClientCAFile(certDir string) string {
+	return DefaultRootCAFile(certDir)
+}
+
+func DefaultKubeletClientCerts(certDir string) []ClientCertInfo {
+	return []ClientCertInfo{
+		DefaultMasterKubeletClientCertInfo(certDir),
+	}
+}
+
+func DefaultMasterKubeletClientCertInfo(certDir string) ClientCertInfo {
+	return ClientCertInfo{
+		CertLocation: configapi.CertInfo{
+			CertFile: path.Join(certDir, DefaultMasterDir, "kubelet-client.crt"),
+			KeyFile:  path.Join(certDir, DefaultMasterDir, "kubelet-client.key"),
+		},
+		User: "system:master",
+	}
+}
+
+func DefaultEtcdClientCAFile(certDir string) string {
+	return DefaultRootCAFile(certDir)
+}
+
+func DefaultEtcdClientCerts(certDir string) []ClientCertInfo {
+	return []ClientCertInfo{
+		DefaultMasterEtcdClientCertInfo(certDir),
+	}
+}
+
+func DefaultMasterEtcdClientCertInfo(certDir string) ClientCertInfo {
+	return ClientCertInfo{
+		CertLocation: configapi.CertInfo{
+			CertFile: path.Join(certDir, DefaultMasterDir, "etcd-client.crt"),
+			KeyFile:  path.Join(certDir, DefaultMasterDir, "etcd-client.key"),
+		},
+		User: "system:master",
+	}
+}
+
+func DefaultAPIClientCAFile(certDir string) string {
+	return DefaultRootCAFile(certDir)
+}
+
+func DefaultAPIClientCerts(certDir string) []ClientCertInfo {
 	return []ClientCertInfo{
 		DefaultDeployerClientCertInfo(certDir),
 		DefaultOpenshiftLoopbackClientCertInfo(certDir),
@@ -115,13 +160,26 @@ func DefaultServerCerts(certDir string) []configapi.CertInfo {
 	return []configapi.CertInfo{
 		DefaultMasterServingCertInfo(certDir),
 		DefaultAssetServingCertInfo(certDir),
+		DefaultEtcdServingCertInfo(certDir),
 	}
 }
 
 func DefaultMasterServingCertInfo(certDir string) configapi.CertInfo {
 	return configapi.CertInfo{
-		CertFile: DefaultCertFilename(certDir, "master"),
-		KeyFile:  DefaultKeyFilename(certDir, "master"),
+		CertFile: path.Join(certDir, DefaultMasterDir, "server.crt"),
+		KeyFile:  path.Join(certDir, DefaultMasterDir, "server.key"),
+	}
+}
+
+func DefaultAssetServingCertInfo(certDir string) configapi.CertInfo {
+	// Use master certs for assets also
+	return DefaultMasterServingCertInfo(certDir)
+}
+
+func DefaultEtcdServingCertInfo(certDir string) configapi.CertInfo {
+	return configapi.CertInfo{
+		CertFile: path.Join(certDir, "etcd", "server.crt"),
+		KeyFile:  path.Join(certDir, "etcd", "server.key"),
 	}
 }
 
@@ -137,19 +195,12 @@ func DefaultNodeServingCertInfo(certDir, nodeName string) configapi.CertInfo {
 }
 func DefaultNodeClientCertInfo(certDir, nodeName string) configapi.CertInfo {
 	return configapi.CertInfo{
-		CertFile: path.Join(certDir, DefaultNodeDir(nodeName), "client.crt"),
-		KeyFile:  path.Join(certDir, DefaultNodeDir(nodeName), "client.key"),
+		CertFile: path.Join(certDir, DefaultNodeDir(nodeName), "master-client.crt"),
+		KeyFile:  path.Join(certDir, DefaultNodeDir(nodeName), "master-client.key"),
 	}
 }
 func DefaultNodeKubeConfigFile(certDir, nodeName string) string {
 	return path.Join(certDir, DefaultNodeDir(nodeName), ".kubeconfig")
-}
-
-func DefaultAssetServingCertInfo(certDir string) configapi.CertInfo {
-	return configapi.CertInfo{
-		CertFile: DefaultCertFilename(certDir, "master"),
-		KeyFile:  DefaultKeyFilename(certDir, "master"),
-	}
 }
 
 func DefaultCertDir(certDir, username string) string {

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -92,7 +92,7 @@ func (o OverwriteBootstrapPolicyOptions) OverwriteBootstrapPolicy() error {
 		return utilerrors.NewAggregate(err)
 	}
 
-	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo.URL)
+	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -48,7 +48,9 @@ type MasterConfig struct {
 	CORSAllowedOrigins []string
 
 	// EtcdClientInfo contains information about how to connect to etcd
-	EtcdClientInfo RemoteConnectionInfo
+	EtcdClientInfo EtcdConnectionInfo
+	// KubeletClientInfo contains information about how to connect to kubelets
+	KubeletClientInfo KubeletConnectionInfo
 
 	// KubernetesMasterConfig, if present start the kubernetes master in this process
 	KubernetesMasterConfig *KubernetesMasterConfig
@@ -89,12 +91,29 @@ type ImageConfig struct {
 }
 
 type RemoteConnectionInfo struct {
-	// URL is the URL for etcd
+	// URL is the remote URL to connect to
 	URL string
-	// CA is the CA for confirming that the server at the etcdURL is the actual server
+	// CA is the CA for verifying TLS connections
 	CA string
-	// EtcdClientCertInfo is the TLS client cert information for securing communication to  etcd
-	// this is anonymous so that we can inline it for serialization
+	// CertInfo is the TLS client cert information to present
+	ClientCert CertInfo
+}
+
+type KubeletConnectionInfo struct {
+	// Port is the port to connect to kubelets on
+	Port uint
+	// CA is the CA for verifying TLS connections to kubelets
+	CA string
+	// CertInfo is the TLS client cert information for securing communication to kubelets
+	ClientCert CertInfo
+}
+
+type EtcdConnectionInfo struct {
+	// URLs are the URLs for etcd
+	URLs []string
+	// CA is a file containing trusted roots for the etcd server certificates
+	CA string
+	// ClientCert is the TLS client cert information for securing communication to etcd
 	ClientCert CertInfo
 }
 
@@ -264,10 +283,14 @@ const (
 var ValidGrantHandlerTypes = util.NewStringSet(string(GrantHandlerAuto), string(GrantHandlerPrompt), string(GrantHandlerDeny))
 
 type EtcdConfig struct {
+	// ServingInfo describes how to start serving the etcd master
 	ServingInfo ServingInfo
-
-	PeerAddress   string
-	MasterAddress string
+	// Address is the advertised host:port for client connections to etcd
+	Address string
+	// PeerServingInfo describes how to start serving the etcd peer
+	PeerServingInfo ServingInfo
+	// PeerAddress is the advertised host:port for peer connections to etcd
+	PeerAddress string
 	// StorageDir indicates where to save the etcd data
 	StorageDir string
 }

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -22,15 +22,29 @@ func init() {
 			out.KeyFile = in.ServerCert.KeyFile
 			return nil
 		},
-		func(in *RemoteConnectionInfo, out *newer.RemoteConnectionInfo, s conversion.Scope) error {
-			out.URL = in.URL
+		func(in *EtcdConnectionInfo, out *newer.EtcdConnectionInfo, s conversion.Scope) error {
+			out.URLs = in.URLs
 			out.CA = in.CA
 			out.ClientCert.CertFile = in.CertFile
 			out.ClientCert.KeyFile = in.KeyFile
 			return nil
 		},
-		func(in *newer.RemoteConnectionInfo, out *RemoteConnectionInfo, s conversion.Scope) error {
-			out.URL = in.URL
+		func(in *newer.EtcdConnectionInfo, out *EtcdConnectionInfo, s conversion.Scope) error {
+			out.URLs = in.URLs
+			out.CA = in.CA
+			out.CertFile = in.ClientCert.CertFile
+			out.KeyFile = in.ClientCert.KeyFile
+			return nil
+		},
+		func(in *KubeletConnectionInfo, out *newer.KubeletConnectionInfo, s conversion.Scope) error {
+			out.Port = in.Port
+			out.CA = in.CA
+			out.ClientCert.CertFile = in.CertFile
+			out.ClientCert.KeyFile = in.KeyFile
+			return nil
+		},
+		func(in *newer.KubeletConnectionInfo, out *KubeletConnectionInfo, s conversion.Scope) error {
+			out.Port = in.Port
 			out.CA = in.CA
 			out.CertFile = in.ClientCert.CertFile
 			out.KeyFile = in.ClientCert.KeyFile

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -47,7 +47,9 @@ type MasterConfig struct {
 	CORSAllowedOrigins []string `json:"corsAllowedOrigins"`
 
 	// EtcdClientInfo contains information about how to connect to etcd
-	EtcdClientInfo RemoteConnectionInfo `json:"etcdClientInfo"`
+	EtcdClientInfo EtcdConnectionInfo `json:"etcdClientInfo"`
+	// KubeletClientInfo contains information about how to connect to kubelets
+	KubeletClientInfo KubeletConnectionInfo `json:"kubeletClientInfo"`
 
 	// KubernetesMasterConfig, if present start the kubernetes master in this process
 	KubernetesMasterConfig *KubernetesMasterConfig `json:"kubernetesMasterConfig"`
@@ -84,11 +86,31 @@ type ImageConfig struct {
 }
 
 type RemoteConnectionInfo struct {
-	// URL is the URL for etcd
+	// URL is the remote URL to connect to
 	URL string `json:"url"`
-	// CA is the CA for confirming that the server at the etcdURL is the actual server
+	// CA is the CA for verifying TLS connections
 	CA string `json:"ca"`
-	// EtcdClientCertInfo is the TLS client cert information for securing communication to  etcd
+	// CertInfo is the TLS client cert information to present
+	// this is anonymous so that we can inline it for serialization
+	CertInfo `json:",inline"`
+}
+
+type KubeletConnectionInfo struct {
+	// Port is the port to connect to kubelets on
+	Port uint `json:"port"`
+	// CA is the CA for verifying TLS connections to kubelets
+	CA string `json:"ca"`
+	// CertInfo is the TLS client cert information for securing communication to kubelets
+	// this is anonymous so that we can inline it for serialization
+	CertInfo `json:",inline"`
+}
+
+type EtcdConnectionInfo struct {
+	// URLs are the URLs for etcd
+	URLs []string `json:"urls"`
+	// CA is a file containing trusted roots for the etcd server certificates
+	CA string `json:"ca"`
+	// CertInfo is the TLS client cert information for securing communication to etcd
 	// this is anonymous so that we can inline it for serialization
 	CertInfo `json:",inline"`
 }
@@ -243,11 +265,16 @@ const (
 )
 
 type EtcdConfig struct {
+	// ServingInfo describes how to start serving the etcd master
 	ServingInfo ServingInfo `json:"servingInfo"`
+	// Address is the advertised host:port for client connections to etcd
+	Address string `json:"address"`
+	// PeerServingInfo describes how to start serving the etcd peer
+	PeerServingInfo ServingInfo `json:"peerServingInfo"`
+	// PeerAddress is the advertised host:port for peer connections to etcd
+	PeerAddress string `json:"peerAddress"`
 
-	PeerAddress   string `json:"peerAddress"`
-	MasterAddress string `json:"masterAddress"`
-	StorageDir    string `json:"storageDirectory"`
+	StorageDir string `json:"storageDirectory"`
 }
 
 type KubernetesMasterConfig struct {

--- a/pkg/cmd/server/api/validation/allinone.go
+++ b/pkg/cmd/server/api/validation/allinone.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func ValidateAllInOneConfig(master *api.MasterConfig, node *api.NodeConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	allErrs = append(allErrs, ValidateMasterConfig(master).Prefix("masterConfig")...)
+
+	allErrs = append(allErrs, ValidateNodeConfig(node).Prefix("nodeConfig")...)
+
+	// Validation between the configs
+
+	return allErrs
+}

--- a/pkg/cmd/server/api/validation/etcd.go
+++ b/pkg/cmd/server/api/validation/etcd.go
@@ -1,0 +1,73 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+// ValidateEtcdConnectionInfo validates the connection info. If a server EtcdConfig is provided,
+// it ensures the connection info includes a URL for it, and has a client cert/key if the server requires
+// client certificate authentication
+func ValidateEtcdConnectionInfo(config api.EtcdConnectionInfo, server *api.EtcdConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.URLs) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("urls"))
+	}
+	for i, u := range config.URLs {
+		_, urlErrs := ValidateURL(u, fmt.Sprintf("urls[%d]", i))
+		if len(urlErrs) > 0 {
+			allErrs = append(allErrs, urlErrs...)
+		}
+	}
+
+	if len(config.CA) > 0 {
+		allErrs = append(allErrs, ValidateFile(config.CA, "ca")...)
+	}
+	allErrs = append(allErrs, ValidateCertInfo(config.ClientCert, false)...)
+
+	// If we have server config info, make sure the client connection info will work with it
+	if server != nil {
+		var builtInAddress string
+		if api.UseTLS(server.ServingInfo) {
+			builtInAddress = fmt.Sprintf("https://%s", server.Address)
+		} else {
+			builtInAddress = fmt.Sprintf("http://%s", server.Address)
+		}
+
+		// Require a client cert to connect to an etcd that requires client certs
+		if len(server.ServingInfo.ClientCA) > 0 {
+			if len(config.ClientCert.CertFile) == 0 {
+				allErrs = append(allErrs, fielderrors.NewFieldRequired("certFile"))
+			}
+		}
+
+		// Require the etcdClientInfo to include the address of the internal etcd
+		clientURLs := util.NewStringSet(config.URLs...)
+		if !clientURLs.Has(builtInAddress) {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("urls", strings.Join(clientURLs.List(), ","), fmt.Sprintf("must include the etcd address %s", builtInAddress)))
+		}
+	}
+
+	return allErrs
+}
+
+func ValidateEtcdConfig(config *api.EtcdConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	allErrs = append(allErrs, ValidateServingInfo(config.PeerServingInfo).Prefix("peerServingInfo")...)
+
+	allErrs = append(allErrs, ValidateHostPort(config.Address, "address")...)
+	allErrs = append(allErrs, ValidateHostPort(config.PeerAddress, "peerAddress")...)
+
+	if len(config.StorageDir) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("storageDirectory"))
+	}
+
+	return allErrs
+}

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -1,0 +1,151 @@
+package validation
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func ValidateMasterConfig(config *api.MasterConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if config.AssetConfig != nil {
+		allErrs = append(allErrs, ValidateAssetConfig(config.AssetConfig).Prefix("assetConfig")...)
+		colocated := config.AssetConfig.ServingInfo.BindAddress == config.ServingInfo.BindAddress
+		if colocated {
+			publicURL, _ := url.Parse(config.AssetConfig.PublicURL)
+			if publicURL.Path == "/" {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("assetConfig.publicURL", config.AssetConfig.PublicURL, "path can not be / when colocated with master API"))
+			}
+		}
+
+		if config.OAuthConfig != nil {
+			if config.OAuthConfig.AssetPublicURL != config.AssetConfig.PublicURL {
+				allErrs = append(allErrs,
+					fielderrors.NewFieldInvalid("assetConfig.publicURL", config.AssetConfig.PublicURL, "must match oauthConfig.assetPublicURL"),
+					fielderrors.NewFieldInvalid("oauthConfig.assetPublicURL", config.OAuthConfig.AssetPublicURL, "must match assetConfig.publicURL"),
+				)
+			}
+		}
+
+		// TODO warn when the CORS list does not include the assetConfig.publicURL host:port
+		// only warn cause they could handle CORS headers themselves in a proxy
+	}
+
+	if config.DNSConfig != nil {
+		allErrs = append(allErrs, ValidateHostPort(config.DNSConfig.BindAddress, "bindAddress").Prefix("dnsConfig")...)
+	}
+
+	if config.EtcdConfig != nil {
+		etcdConfigErrs := ValidateEtcdConfig(config.EtcdConfig).Prefix("etcdConfig")
+		allErrs = append(allErrs, etcdConfigErrs...)
+
+		if len(etcdConfigErrs) == 0 {
+			// Validate the etcdClientInfo with the internal etcdConfig
+			allErrs = append(allErrs, ValidateEtcdConnectionInfo(config.EtcdClientInfo, config.EtcdConfig).Prefix("etcdClientInfo")...)
+		} else {
+			// Validate the etcdClientInfo by itself
+			allErrs = append(allErrs, ValidateEtcdConnectionInfo(config.EtcdClientInfo, nil).Prefix("etcdClientInfo")...)
+		}
+	} else {
+		// Validate the etcdClientInfo by itself
+		allErrs = append(allErrs, ValidateEtcdConnectionInfo(config.EtcdClientInfo, nil).Prefix("etcdClientInfo")...)
+	}
+
+	allErrs = append(allErrs, ValidateImageConfig(config.ImageConfig).Prefix("imageConfig")...)
+
+	allErrs = append(allErrs, ValidateKubeletConnectionInfo(config.KubeletClientInfo).Prefix("kubeletClientInfo")...)
+
+	if config.KubernetesMasterConfig != nil {
+		allErrs = append(allErrs, ValidateKubernetesMasterConfig(config.KubernetesMasterConfig).Prefix("kubernetesMasterConfig")...)
+	}
+
+	allErrs = append(allErrs, ValidateKubeConfig(config.MasterClients.DeployerKubeConfig, "deployerKubeConfig").Prefix("masterClients")...)
+	allErrs = append(allErrs, ValidateKubeConfig(config.MasterClients.OpenShiftLoopbackKubeConfig, "openShiftLoopbackKubeConfig").Prefix("masterClients")...)
+	allErrs = append(allErrs, ValidateKubeConfig(config.MasterClients.KubernetesKubeConfig, "kubernetesKubeConfig").Prefix("masterClients")...)
+
+	allErrs = append(allErrs, ValidatePolicyConfig(config.PolicyConfig).Prefix("policyConfig")...)
+	if config.OAuthConfig != nil {
+		allErrs = append(allErrs, ValidateOAuthConfig(config.OAuthConfig).Prefix("oauthConfig")...)
+	}
+
+	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+
+	return allErrs
+}
+
+func ValidateAssetConfig(config *api.AssetConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+
+	urlObj, urlErrs := ValidateURL(config.PublicURL, "publicURL")
+	if len(urlErrs) > 0 {
+		allErrs = append(allErrs, urlErrs...)
+	}
+	if urlObj != nil {
+		if !strings.HasSuffix(urlObj.Path, "/") {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("publicURL", config.PublicURL, "must have a trailing slash in path"))
+		}
+	}
+
+	return allErrs
+}
+
+func ValidateImageConfig(config api.ImageConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.Format) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("format"))
+	}
+
+	return allErrs
+}
+
+func ValidateKubeletConnectionInfo(config api.KubeletConnectionInfo) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+	if config.Port == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("port"))
+	}
+
+	if len(config.CA) > 0 {
+		allErrs = append(allErrs, ValidateFile(config.CA, "ca")...)
+	}
+	allErrs = append(allErrs, ValidateCertInfo(config.ClientCert, false)...)
+
+	return allErrs
+}
+
+func ValidateKubernetesMasterConfig(config *api.KubernetesMasterConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.MasterIP) > 0 {
+		allErrs = append(allErrs, ValidateSpecifiedIP(config.MasterIP, "masterIP")...)
+	}
+
+	if len(config.ServicesSubnet) > 0 {
+		if _, _, err := net.ParseCIDR(strings.TrimSpace(config.ServicesSubnet)); err != nil {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("servicesSubnet", config.ServicesSubnet, "must be a valid CIDR notation IP range (e.g. 172.30.17.0/24)"))
+		}
+	}
+
+	if len(config.SchedulerConfigFile) > 0 {
+		allErrs = append(allErrs, ValidateFile(config.SchedulerConfigFile, "schedulerConfigFile")...)
+	}
+
+	return allErrs
+}
+
+func ValidatePolicyConfig(config api.PolicyConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	allErrs = append(allErrs, ValidateFile(config.BootstrapPolicyFile, "bootstrapPolicyFile")...)
+	allErrs = append(allErrs, ValidateNamespace(config.MasterAuthorizationNamespace, "masterAuthorizationNamespace")...)
+	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftSharedResourcesNamespace, "openShiftSharedResourcesNamespace")...)
+
+	return allErrs
+}

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -1,0 +1,28 @@
+package validation
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.NodeName) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("nodeName"))
+	}
+
+	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	allErrs = append(allErrs, ValidateKubeConfig(config.MasterKubeConfig, "masterKubeConfig")...)
+
+	if len(config.DNSIP) > 0 {
+		allErrs = append(allErrs, ValidateSpecifiedIP(config.DNSIP, "dnsIP")...)
+	}
+
+	if len(config.NetworkContainerImage) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("networkContainerImage"))
+	}
+
+	return allErrs
+}

--- a/pkg/cmd/server/api/validation/oauth.go
+++ b/pkg/cmd/server/api/validation/oauth.go
@@ -1,0 +1,125 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func ValidateOAuthConfig(config *api.OAuthConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.MasterURL) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("masterURL"))
+	}
+
+	if len(config.MasterPublicURL) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("masterPublicURL"))
+	}
+
+	if len(config.AssetPublicURL) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("assetPublicURL"))
+	}
+
+	if config.SessionConfig != nil {
+		allErrs = append(allErrs, ValidateSessionConfig(config.SessionConfig).Prefix("sessionConfig")...)
+	}
+
+	allErrs = append(allErrs, ValidateGrantConfig(config.GrantConfig).Prefix("grantConfig")...)
+
+	redirectingIdentityProviders := []int{}
+	for i, identityProvider := range config.IdentityProviders {
+		if identityProvider.Usage.UseAsLogin {
+			redirectingIdentityProviders = append(redirectingIdentityProviders, i)
+
+			if api.IsPasswordAuthenticator(identityProvider) {
+				if config.SessionConfig == nil {
+					allErrs = append(allErrs, fielderrors.NewFieldInvalid("sessionConfig", config, "sessionConfig is required if a password identity provider is used for browser based login"))
+				}
+			}
+		}
+
+		allErrs = append(allErrs, ValidateIdentityProvider(identityProvider).Prefix(fmt.Sprintf("identityProvider[%d]", i))...)
+	}
+
+	if len(redirectingIdentityProviders) > 1 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("identityProviders", config.IdentityProviders, fmt.Sprintf("only one identity provider can support login for a browser, found: %v", redirectingIdentityProviders)))
+	}
+
+	return allErrs
+}
+
+func ValidateIdentityProvider(identityProvider api.IdentityProvider) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(identityProvider.Usage.ProviderName) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("usage.providerName"))
+	}
+
+	if !api.IsIdentityProviderType(identityProvider.Provider) {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider", identityProvider.Provider, fmt.Sprintf("%v is invalid in this context", identityProvider.Provider)))
+	} else {
+		switch provider := identityProvider.Provider.Object.(type) {
+		case (*api.RequestHeaderIdentityProvider):
+			if len(provider.ClientCA) > 0 {
+				allErrs = append(allErrs, ValidateFile(provider.ClientCA, "provider.clientCA")...)
+			}
+			if len(provider.Headers) == 0 {
+				allErrs = append(allErrs, fielderrors.NewFieldRequired("provider.headers"))
+			}
+			if identityProvider.Usage.UseAsChallenger {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.useAsChallenger", identityProvider.Usage.UseAsChallenger, "request header providers cannot be used for challenges"))
+			}
+			if identityProvider.Usage.UseAsLogin {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.useAsLogin", identityProvider.Usage.UseAsChallenger, "request header providers cannot be used for browser login"))
+			}
+
+		case (*api.BasicAuthPasswordIdentityProvider):
+			allErrs = append(allErrs, ValidateRemoteConnectionInfo(provider.RemoteConnectionInfo).Prefix("provider")...)
+
+		case (*api.HTPasswdPasswordIdentityProvider):
+			allErrs = append(allErrs, ValidateFile(provider.File, "provider.file")...)
+
+		case (*api.OAuthRedirectingIdentityProvider):
+			if len(provider.ClientID) == 0 {
+				allErrs = append(allErrs, fielderrors.NewFieldRequired("provider.clientID"))
+			}
+			if len(provider.ClientSecret) == 0 {
+				allErrs = append(allErrs, fielderrors.NewFieldRequired("provider.clientSecret"))
+			}
+			if !api.IsOAuthProviderType(provider.Provider) {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.provider", provider.Provider, fmt.Sprintf("%v is invalid in this context", identityProvider.Provider)))
+			}
+			if identityProvider.Usage.UseAsChallenger {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.useAsChallenger", identityProvider.Usage.UseAsChallenger, "oauth providers cannot be used for challenges"))
+			}
+		}
+
+	}
+
+	return allErrs
+}
+
+func ValidateGrantConfig(config api.GrantConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if !api.ValidGrantHandlerTypes.Has(string(config.Method)) {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("grantConfig.method", config.Method, fmt.Sprintf("must be one of: %v", api.ValidGrantHandlerTypes.List())))
+	}
+
+	return allErrs
+}
+
+func ValidateSessionConfig(config *api.SessionConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.SessionSecrets) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("sessionSecrets"))
+	}
+	if len(config.SessionName) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("sessionName"))
+	}
+
+	return allErrs
+}

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -1,11 +1,9 @@
 package validation
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"os"
-	"strings"
 
 	kvalidation "github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
@@ -13,13 +11,36 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-func ValidateBindAddress(bindAddress string) fielderrors.ValidationErrorList {
+func ValidateHostPort(value string, field string) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
-	if len(bindAddress) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("bindAddress"))
-	} else if _, _, err := net.SplitHostPort(bindAddress); err != nil {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("bindAddress", bindAddress, "must be a host:port"))
+	if len(value) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired(field))
+	} else if _, _, err := net.SplitHostPort(value); err != nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid(field, value, "must be a host:port"))
+	}
+
+	return allErrs
+}
+
+func ValidateCertInfo(certInfo api.CertInfo, required bool) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if required || len(certInfo.CertFile) > 0 || len(certInfo.KeyFile) > 0 {
+		if len(certInfo.CertFile) == 0 {
+			allErrs = append(allErrs, fielderrors.NewFieldRequired("certFile"))
+		}
+		if len(certInfo.KeyFile) == 0 {
+			allErrs = append(allErrs, fielderrors.NewFieldRequired("keyFile"))
+		}
+	}
+
+	if len(certInfo.CertFile) > 0 {
+		allErrs = append(allErrs, ValidateFile(certInfo.CertFile, "certFile")...)
+	}
+
+	if len(certInfo.KeyFile) > 0 {
+		allErrs = append(allErrs, ValidateFile(certInfo.KeyFile, "keyFile")...)
 	}
 
 	return allErrs
@@ -28,15 +49,17 @@ func ValidateBindAddress(bindAddress string) fielderrors.ValidationErrorList {
 func ValidateServingInfo(info api.ServingInfo) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
-	allErrs = append(allErrs, ValidateBindAddress(info.BindAddress)...)
-	allErrs = append(allErrs, ValidateCertInfo(info.ServerCert)...)
+	allErrs = append(allErrs, ValidateHostPort(info.BindAddress, "bindAddress")...)
+	allErrs = append(allErrs, ValidateCertInfo(info.ServerCert, false)...)
 
-	if len(info.ClientCA) > 0 {
-		if (len(info.ServerCert.CertFile) == 0) || (len(info.ServerCert.KeyFile) == 0) {
+	if len(info.ServerCert.CertFile) > 0 {
+		if len(info.ClientCA) > 0 {
+			allErrs = append(allErrs, ValidateFile(info.ClientCA, "clientCA")...)
+		}
+	} else {
+		if len(info.ClientCA) > 0 {
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("clientCA", info.ClientCA, "cannot specify a clientCA without a certFile"))
 		}
-
-		allErrs = append(allErrs, ValidateFile(info.ClientCA, "clientCA")...)
 	}
 
 	return allErrs
@@ -47,120 +70,6 @@ func ValidateKubeConfig(path string, field string) fielderrors.ValidationErrorLi
 
 	allErrs = append(allErrs, ValidateFile(path, field)...)
 	// TODO: load and parse
-
-	return allErrs
-}
-
-func ValidateKubernetesMasterConfig(config *api.KubernetesMasterConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(config.MasterIP) > 0 {
-		allErrs = append(allErrs, ValidateSpecifiedIP(config.MasterIP, "masterIP")...)
-	}
-
-	if len(config.ServicesSubnet) > 0 {
-		if _, _, err := net.ParseCIDR(strings.TrimSpace(config.ServicesSubnet)); err != nil {
-			allErrs = append(allErrs, fielderrors.NewFieldInvalid("servicesSubnet", config.ServicesSubnet, "must be a valid CIDR notation IP range (e.g. 172.30.17.0/24)"))
-		}
-	}
-
-	if len(config.SchedulerConfigFile) > 0 {
-		allErrs = append(allErrs, ValidateFile(config.SchedulerConfigFile, "schedulerConfigFile")...)
-	}
-
-	return allErrs
-}
-
-func ValidateOAuthConfig(config *api.OAuthConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(config.MasterURL) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("masterURL"))
-	}
-
-	if len(config.MasterPublicURL) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("masterPublicURL"))
-	}
-
-	if len(config.AssetPublicURL) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("assetPublicURL"))
-	}
-
-	if config.SessionConfig != nil {
-		allErrs = append(allErrs, ValidateSessionConfig(config.SessionConfig).Prefix("sessionConfig")...)
-	}
-
-	allErrs = append(allErrs, ValidateGrantConfig(config.GrantConfig).Prefix("grantConfig")...)
-
-	redirectingIdentityProviders := []int{}
-	for i, identityProvider := range config.IdentityProviders {
-		if identityProvider.Usage.UseAsLogin {
-			redirectingIdentityProviders = append(redirectingIdentityProviders, i)
-
-			if api.IsPasswordAuthenticator(identityProvider) {
-				if config.SessionConfig == nil {
-					allErrs = append(allErrs, fielderrors.NewFieldInvalid("sessionConfig", config, "sessionConfig is required if a password identity provider is used for browser based login"))
-				}
-			}
-		}
-
-		allErrs = append(allErrs, ValidateIdentityProvider(identityProvider).Prefix(fmt.Sprintf("identityProvider[%d]", i))...)
-	}
-
-	if len(redirectingIdentityProviders) > 1 {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("identityProviders", config.IdentityProviders, fmt.Sprintf("only one identity provider can support login for a browser, found: %v", redirectingIdentityProviders)))
-	}
-
-	return allErrs
-}
-
-func ValidateIdentityProvider(identityProvider api.IdentityProvider) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(identityProvider.Usage.ProviderName) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("usage.providerName"))
-	}
-
-	if !api.IsIdentityProviderType(identityProvider.Provider) {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider", identityProvider.Provider, fmt.Sprintf("%v is invalid in this context", identityProvider.Provider)))
-	} else {
-		switch provider := identityProvider.Provider.Object.(type) {
-		case (*api.RequestHeaderIdentityProvider):
-			if len(provider.ClientCA) > 0 {
-				allErrs = append(allErrs, ValidateFile(provider.ClientCA, "provider.clientCA")...)
-			}
-			if len(provider.Headers) == 0 {
-				allErrs = append(allErrs, fielderrors.NewFieldRequired("provider.headers"))
-			}
-			if identityProvider.Usage.UseAsChallenger {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.useAsChallenger", identityProvider.Usage.UseAsChallenger, "request header providers cannot be used for challenges"))
-			}
-			if identityProvider.Usage.UseAsLogin {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.useAsLogin", identityProvider.Usage.UseAsChallenger, "request header providers cannot be used for browser login"))
-			}
-
-		case (*api.BasicAuthPasswordIdentityProvider):
-			allErrs = append(allErrs, ValidateRemoteConnectionInfo(provider.RemoteConnectionInfo).Prefix("provider")...)
-
-		case (*api.HTPasswdPasswordIdentityProvider):
-			allErrs = append(allErrs, ValidateFile(provider.File, "provider.file")...)
-
-		case (*api.OAuthRedirectingIdentityProvider):
-			if len(provider.ClientID) == 0 {
-				allErrs = append(allErrs, fielderrors.NewFieldRequired("provider.clientID"))
-			}
-			if len(provider.ClientSecret) == 0 {
-				allErrs = append(allErrs, fielderrors.NewFieldRequired("provider.clientSecret"))
-			}
-			if !api.IsOAuthProviderType(provider.Provider) {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.provider", provider.Provider, fmt.Sprintf("%v is invalid in this context", identityProvider.Provider)))
-			}
-			if identityProvider.Usage.UseAsChallenger {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("provider.useAsChallenger", identityProvider.Usage.UseAsChallenger, "oauth providers cannot be used for challenges"))
-			}
-		}
-
-	}
 
 	return allErrs
 }
@@ -176,52 +85,7 @@ func ValidateRemoteConnectionInfo(remoteConnectionInfo api.RemoteConnectionInfo)
 		allErrs = append(allErrs, ValidateFile(remoteConnectionInfo.CA, "ca")...)
 	}
 
-	allErrs = append(allErrs, ValidateCertInfo(remoteConnectionInfo.ClientCert)...)
-
-	return allErrs
-}
-
-func ValidateCertInfo(certInfo api.CertInfo) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(certInfo.CertFile) > 0 {
-		if len(certInfo.KeyFile) == 0 {
-			allErrs = append(allErrs, fielderrors.NewFieldRequired("keyFile"))
-		}
-
-		allErrs = append(allErrs, ValidateFile(certInfo.CertFile, "certFile")...)
-	}
-
-	if len(certInfo.KeyFile) > 0 {
-		if len(certInfo.CertFile) == 0 {
-			allErrs = append(allErrs, fielderrors.NewFieldRequired("certFile"))
-		}
-
-		allErrs = append(allErrs, ValidateFile(certInfo.KeyFile, "keyFile")...)
-	}
-
-	return allErrs
-}
-
-func ValidateGrantConfig(config api.GrantConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if !api.ValidGrantHandlerTypes.Has(string(config.Method)) {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("grantConfig.method", config.Method, fmt.Sprintf("must be one of: %v", api.ValidGrantHandlerTypes.List())))
-	}
-
-	return allErrs
-}
-
-func ValidateSessionConfig(config *api.SessionConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(config.SessionSecrets) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("sessionSecrets"))
-	}
-	if len(config.SessionName) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("sessionName"))
-	}
+	allErrs = append(allErrs, ValidateCertInfo(remoteConnectionInfo.ClientCert, false)...)
 
 	return allErrs
 }
@@ -256,78 +120,6 @@ func ValidateURL(urlString string, field string) (*url.URL, fielderrors.Validati
 	return urlObj, allErrs
 }
 
-func ValidateAssetConfig(config *api.AssetConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
-
-	urlObj, urlErrs := ValidateURL(config.PublicURL, "publicURL")
-	if len(urlErrs) > 0 {
-		allErrs = append(allErrs, urlErrs...)
-	}
-	if urlObj != nil {
-		if !strings.HasSuffix(urlObj.Path, "/") {
-			allErrs = append(allErrs, fielderrors.NewFieldInvalid("publicURL", config.PublicURL, "must have a trailing slash in path"))
-		}
-	}
-
-	return allErrs
-}
-
-func ValidateMasterConfig(config *api.MasterConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
-
-	if config.AssetConfig != nil {
-		allErrs = append(allErrs, ValidateAssetConfig(config.AssetConfig).Prefix("assetConfig")...)
-		colocated := config.AssetConfig.ServingInfo.BindAddress == config.ServingInfo.BindAddress
-		if colocated {
-			publicURL, _ := url.Parse(config.AssetConfig.PublicURL)
-			if publicURL.Path == "/" {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("assetConfig.publicURL", config.AssetConfig.PublicURL, "path can not be / when colocated with master API"))
-			}
-		}
-
-		if config.OAuthConfig != nil && config.OAuthConfig.AssetPublicURL != config.AssetConfig.PublicURL {
-			allErrs = append(allErrs,
-				fielderrors.NewFieldInvalid("assetConfig.publicURL", config.AssetConfig.PublicURL, "must match oauthConfig.assetPublicURL"),
-				fielderrors.NewFieldInvalid("oauthConfig.assetPublicURL", config.OAuthConfig.AssetPublicURL, "must match assetConfig.publicURL"),
-			)
-		}
-
-		// TODO warn when the CORS list does not include the assetConfig.publicURL host:port
-		// only warn cause they could handle CORS headers themselves in a proxy
-	}
-
-	if config.DNSConfig != nil {
-		allErrs = append(allErrs, ValidateBindAddress(config.DNSConfig.BindAddress).Prefix("dnsConfig")...)
-	}
-
-	if config.KubernetesMasterConfig != nil {
-		allErrs = append(allErrs, ValidateKubernetesMasterConfig(config.KubernetesMasterConfig).Prefix("kubernetesMasterConfig")...)
-	}
-
-	allErrs = append(allErrs, ValidatePolicyConfig(config.PolicyConfig).Prefix("policyConfig")...)
-	allErrs = append(allErrs, ValidateOAuthConfig(config.OAuthConfig).Prefix("oauthConfig")...)
-
-	allErrs = append(allErrs, ValidateKubeConfig(config.MasterClients.DeployerKubeConfig, "deployerKubeConfig").Prefix("masterClients")...)
-	allErrs = append(allErrs, ValidateKubeConfig(config.MasterClients.OpenShiftLoopbackKubeConfig, "openShiftLoopbackKubeConfig").Prefix("masterClients")...)
-	allErrs = append(allErrs, ValidateKubeConfig(config.MasterClients.KubernetesKubeConfig, "kubernetesKubeConfig").Prefix("masterClients")...)
-
-	return allErrs
-}
-
-func ValidatePolicyConfig(config api.PolicyConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	allErrs = append(allErrs, ValidateFile(config.BootstrapPolicyFile, "bootstrapPolicyFile")...)
-	allErrs = append(allErrs, ValidateNamespace(config.MasterAuthorizationNamespace, "masterAuthorizationNamespace")...)
-	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftSharedResourcesNamespace, "openShiftSharedResourcesNamespace")...)
-
-	return allErrs
-}
-
 func ValidateNamespace(namespace, field string) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
@@ -335,27 +127,6 @@ func ValidateNamespace(namespace, field string) fielderrors.ValidationErrorList 
 		allErrs = append(allErrs, fielderrors.NewFieldRequired(field))
 	} else if ok, _ := kvalidation.ValidateNamespaceName(namespace, false); !ok {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid(field, namespace, "must be a valid namespace"))
-	}
-
-	return allErrs
-}
-
-func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(config.NodeName) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("nodeName"))
-	}
-
-	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
-	allErrs = append(allErrs, ValidateKubeConfig(config.MasterKubeConfig, "masterKubeConfig")...)
-
-	if len(config.DNSIP) > 0 {
-		allErrs = append(allErrs, ValidateSpecifiedIP(config.DNSIP, "dnsIP")...)
-	}
-
-	if len(config.NetworkContainerImage) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("networkContainerImage"))
 	}
 
 	return allErrs
@@ -369,18 +140,6 @@ func ValidateFile(path string, field string) fielderrors.ValidationErrorList {
 	} else if _, err := os.Stat(path); err != nil {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid(field, path, "could not read file"))
 	}
-
-	return allErrs
-}
-
-func ValidateAllInOneConfig(master *api.MasterConfig, node *api.NodeConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	allErrs = append(allErrs, ValidateMasterConfig(master).Prefix("masterConfig")...)
-
-	allErrs = append(allErrs, ValidateNodeConfig(node).Prefix("nodeConfig")...)
-
-	// Validation between the configs
 
 	return allErrs
 }

--- a/pkg/cmd/server/crypto/crypto.go
+++ b/pkg/cmd/server/crypto/crypto.go
@@ -101,21 +101,41 @@ func GetTLSCertificateConfig(certFile, keyFile string) (*TLSCertificateConfig, e
 }
 
 func CertPoolFromFile(filename string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	if len(filename) == 0 {
+		return pool, nil
+	}
+
 	pemBlock, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
+
 	certs, err := certsFromPEM(pemBlock)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading %s: %s", filename, err)
 	}
 
-	roots := x509.NewCertPool()
-	for _, root := range certs {
-		roots.AddCert(root)
+	for _, cert := range certs {
+		pool.AddCert(cert)
 	}
 
-	return roots, nil
+	return pool, nil
+}
+
+func CertificatesFromFile(file string) ([]*x509.Certificate, error) {
+	if len(file) == 0 {
+		return nil, nil
+	}
+	pemBlock, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := certsFromPEM(pemBlock)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading %s: %s", file, err)
+	}
+	return certs, nil
 }
 
 func certsFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {

--- a/pkg/cmd/server/etcd/etcd.go
+++ b/pkg/cmd/server/etcd/etcd.go
@@ -13,23 +13,33 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/api/latest"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-// Config is an object that can run an etcd server
-type Config struct {
-	BindAddr     string
-	PeerBindAddr string
-	MasterAddr   string
-	EtcdDir      string
-}
+// RunEtcd starts an etcd server and runs it forever
+func RunEtcd(etcdServerConfig *configapi.EtcdConfig) {
 
-// Run starts an etcd server and runs it forever
-func (c *Config) Run() {
 	config := etcdconfig.New()
-	config.Addr = c.MasterAddr
-	config.BindAddr = c.BindAddr
-	config.Peer.BindAddr = c.PeerBindAddr
-	config.DataDir = c.EtcdDir
+
+	config.Addr = etcdServerConfig.Address
+	config.BindAddr = etcdServerConfig.ServingInfo.BindAddress
+
+	if configapi.UseTLS(etcdServerConfig.ServingInfo) {
+		config.CAFile = etcdServerConfig.ServingInfo.ClientCA
+		config.CertFile = etcdServerConfig.ServingInfo.ServerCert.CertFile
+		config.KeyFile = etcdServerConfig.ServingInfo.ServerCert.KeyFile
+	}
+
+	config.Peer.Addr = etcdServerConfig.PeerAddress
+	config.Peer.BindAddr = etcdServerConfig.PeerServingInfo.BindAddress
+
+	if configapi.UseTLS(etcdServerConfig.PeerServingInfo) {
+		config.Peer.CAFile = etcdServerConfig.PeerServingInfo.ClientCA
+		config.Peer.CertFile = etcdServerConfig.PeerServingInfo.ServerCert.CertFile
+		config.Peer.KeyFile = etcdServerConfig.PeerServingInfo.ServerCert.KeyFile
+	}
+
+	config.DataDir = etcdServerConfig.StorageDir
 	config.Name = "openshift.local"
 
 	server := etcd.New(config)
@@ -44,9 +54,29 @@ func (c *Config) Run() {
 // getAndTestEtcdClient creates an etcd client based on the provided config and waits
 // until etcd server is reachable. It errors out and exits if the server cannot
 // be reached for a certain amount of time.
-func GetAndTestEtcdClient(etcdURL string) (*etcdclient.Client, error) {
-	etcdServers := []string{etcdURL}
-	etcdClient := etcdclient.NewClient(etcdServers)
+func GetAndTestEtcdClient(etcdClientInfo configapi.EtcdConnectionInfo) (*etcdclient.Client, error) {
+	var etcdClient *etcdclient.Client
+
+	if len(etcdClientInfo.ClientCert.CertFile) > 0 {
+		tlsClient, err := etcdclient.NewTLSClient(
+			etcdClientInfo.URLs,
+			etcdClientInfo.ClientCert.CertFile,
+			etcdClientInfo.ClientCert.KeyFile,
+			etcdClientInfo.CA,
+		)
+		if err != nil {
+			return nil, err
+		}
+		etcdClient = tlsClient
+	} else if len(etcdClientInfo.CA) > 0 {
+		etcdClient = etcdclient.NewClient(etcdClientInfo.URLs)
+		err := etcdClient.AddRootCA(etcdClientInfo.CA)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		etcdClient = etcdclient.NewClient(etcdClientInfo.URLs)
+	}
 
 	for i := 0; ; i++ {
 		// TODO: make sure this works with etcd2 (root key may not exist)
@@ -65,9 +95,9 @@ func GetAndTestEtcdClient(etcdURL string) (*etcdclient.Client, error) {
 
 // newOpenShiftEtcdHelper returns an EtcdHelper for the provided arguments or an error if the version
 // is incorrect.
-func NewOpenShiftEtcdHelper(etcdURL string) (helper tools.EtcdHelper, err error) {
+func NewOpenShiftEtcdHelper(etcdClientInfo configapi.EtcdConnectionInfo) (helper tools.EtcdHelper, err error) {
 	// Connect and setup etcd interfaces
-	client, err := GetAndTestEtcdClient(etcdURL)
+	client, err := GetAndTestEtcdClient(etcdClientInfo)
 	if err != nil {
 		return tools.EtcdHelper{}, err
 	}

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -44,11 +44,7 @@ func (c *MasterConfig) EnsurePortalFlags() {
 // endpoints were started (these are format strings that will expect to be sent
 // a single string value).
 func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
-	kubeletClient, err := kclient.NewKubeletClient(
-		&kclient.KubeletConfig{
-			Port: 10250,
-		},
-	)
+	kubeletClient, err := kclient.NewKubeletClient(c.KubeletClientConfig)
 	if err != nil {
 		glog.Fatalf("Unable to configure Kubelet client: %v", err)
 	}
@@ -123,11 +119,7 @@ func (c *MasterConfig) RunMinionController() {
 		},
 	}
 
-	// TODO: enable this for TLS and make configurable
-	kubeletClient, err := kclient.NewKubeletClient(&kclient.KubeletConfig{
-		Port:        10250,
-		EnableHttps: false,
-	})
+	kubeletClient, err := kclient.NewKubeletClient(c.KubeletClientConfig)
 	if err != nil {
 		glog.Fatalf("Failure to create kubelet client: %v", err)
 	}

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -29,8 +29,9 @@ type MasterConfig struct {
 
 	RequestContextMapper kapi.RequestContextMapper
 
-	EtcdHelper tools.EtcdHelper
-	KubeClient *kclient.Client
+	EtcdHelper          tools.EtcdHelper
+	KubeClient          *kclient.Client
+	KubeletClientConfig *kclient.KubeletConfig
 
 	Authorizer       authorizer.Authorizer
 	AdmissionControl admission.Interface
@@ -44,7 +45,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	}
 
 	// Connect and setup etcd interfaces
-	etcdClient, err := etcd.GetAndTestEtcdClient(options.EtcdClientInfo.URL)
+	etcdClient, err := etcd.GetAndTestEtcdClient(options.EtcdClientInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +53,8 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up Kubernetes server storage: %v", err)
 	}
+
+	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
 	portalNet := net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 
@@ -77,6 +80,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 		RequestContextMapper: requestContextMapper,
 		EtcdHelper:           ketcdHelper,
 		KubeClient:           kubeClient,
+		KubeletClientConfig:  kubeletClientConfig,
 		Authorizer:           apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:     admissionController,
 		SchedulerConfigFile:  options.KubernetesMasterConfig.SchedulerConfigFile,

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -174,7 +174,7 @@ func (c *NodeConfig) RunKubelet() {
 	}
 
 	go util.Forever(func() {
-		glog.Infof("Started Kubelet for node %s, server at %s", c.NodeHost, c.BindAddress)
+		glog.Infof("Started Kubelet for node %s, server at %s, tls=%v", c.NodeHost, c.BindAddress, c.TLS)
 		if clusterDNS != nil {
 			glog.Infof("  Kubelet is setting %s as a DNS nameserver for domain %q", clusterDNS, c.ClusterDomain)
 		}
@@ -183,9 +183,8 @@ func (c *NodeConfig) RunKubelet() {
 			server.TLSConfig = &tls.Config{
 				// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
 				MinVersion: tls.VersionTLS10,
-				// Populate PeerCertificates in requests, but don't reject connections without certificates
-				// This allows certificates to be validated by authenticators, while still allowing other auth types
-				ClientAuth: tls.RequestClientCert,
+				// RequireAndVerifyClientCert lets us limit requests to ones with a valid client certificate
+				ClientAuth: tls.RequireAndVerifyClientCert,
 				ClientCAs:  c.ClientCAs,
 			}
 			glog.Fatal(server.ListenAndServeTLS(c.KubeletCertFile, c.KubeletKeyFile))

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -31,12 +31,6 @@ import (
 	"github.com/openshift/origin/pkg/service"
 )
 
-// NodeScheme is the default scheme for serving information about the node.
-const NodeScheme = "http"
-
-// NodePort is the default Kubelet port for serving information about the node.
-const NodePort = 10250
-
 type commandExecutor interface {
 	LookPath(executable string) (string, error)
 	Run(command string, args ...string) error

--- a/pkg/cmd/server/origin/auth_config.go
+++ b/pkg/cmd/server/origin/auth_config.go
@@ -31,7 +31,7 @@ type AuthConfig struct {
 }
 
 func BuildAuthConfig(options configapi.MasterConfig) (*AuthConfig, error) {
-	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(options.EtcdClientInfo.URL)
+	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(options.EtcdClientInfo)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up server storage: %v", err)
 	}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -129,6 +129,11 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		glog.Fatalf("OPENSHIFT_DEFAULT_REGISTRY variable is invalid %q: %v", defaultRegistry, err)
 	}
 
+	kubeletClient, err := kclient.NewKubeletClient(c.KubeletClientConfig)
+	if err != nil {
+		glog.Fatalf("Unable to configure Kubelet client: %v", err)
+	}
+
 	buildEtcd := buildetcd.New(c.EtcdHelper)
 	deployEtcd := deployetcd.New(c.EtcdHelper)
 	routeEtcd := routeetcd.New(c.EtcdHelper)
@@ -184,7 +189,7 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		"builds/clone":             buildClone,
 		"buildConfigs":             buildconfigregistry.NewREST(buildEtcd),
 		"buildConfigs/instantiate": buildConfigInstantiate,
-		"buildLogs":                buildlogregistry.NewREST(buildEtcd, c.BuildLogClient()),
+		"buildLogs":                buildlogregistry.NewREST(buildEtcd, c.BuildLogClient(), kubeletClient),
 
 		"images":                   imageStorage,
 		"imageStreams":             imageRepositoryStorage,

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -91,7 +91,7 @@ type MasterConfig struct {
 
 func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
-	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(options.EtcdClientInfo.URL)
+	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(options.EtcdClientInfo)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up server storage: %v", err)
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -62,7 +62,8 @@ type MasterConfig struct {
 	// a function that returns the appropriate image to use for a named component
 	ImageFor func(component string) string
 
-	EtcdHelper tools.EtcdHelper
+	EtcdHelper          tools.EtcdHelper
+	KubeletClientConfig *kclient.KubeletConfig
 
 	// ClientCAs will be used to request client certificates in connections to the API.
 	// This CertPool should contain all the CAs that will be used for client certificate verification.
@@ -125,6 +126,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	policyCache := newPolicyCache(etcdHelper)
 	requestContextMapper := kapi.NewRequestContextMapper()
 
+	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
+
 	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
 	admissionControlPluginNames := []string{"AlwaysAdmit"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
@@ -145,8 +148,9 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 		TLS: configapi.UseTLS(options.ServingInfo),
 
-		ImageFor:   imageTemplate.ExpandOrDie,
-		EtcdHelper: etcdHelper,
+		ImageFor:            imageTemplate.ExpandOrDie,
+		EtcdHelper:          etcdHelper,
+		KubeletClientConfig: kubeletClientConfig,
 
 		ClientCAs:    clientCAs,
 		APIClientCAs: apiClientCAs,

--- a/pkg/cmd/server/start/config_test.go
+++ b/pkg/cmd/server/start/config_test.go
@@ -209,11 +209,30 @@ func TestKubernetesAddressExplicit(t *testing.T) {
 }
 
 func TestEtcdAddressDefaulting(t *testing.T) {
-	expected := "http://example.com:4001"
-	master := "https://example.com:9012"
+	expected := "https://example.com:4001"
+	master := "http://example.com:9012"
 
 	masterArgs := NewDefaultMasterArgs()
 	masterArgs.MasterAddr.Set(master)
+
+	actual, err := masterArgs.GetEtcdAddress()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expected != actual.String() {
+		t.Fatalf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestEtcdAddressUseListenScheme(t *testing.T) {
+	// Scheme from --listen arg
+	// Host from --master arg
+	// Port from default
+	expected := "http://example.com:4001"
+
+	masterArgs := NewDefaultMasterArgs()
+	masterArgs.MasterAddr.Set("https://example.com:9012")
+	masterArgs.ListenArg.ListenAddr.Set("http://0.0.0.0:8043")
 
 	actual, err := masterArgs.GetEtcdAddress()
 	if err != nil {

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
@@ -19,7 +20,6 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	latestconfigapi "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
@@ -185,7 +185,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		},
 
 		KubeletClientInfo: configapi.KubeletConnectionInfo{
-			Port: kubernetes.NodePort,
+			Port: ports.KubeletPort,
 		},
 
 		PolicyConfig: configapi.PolicyConfig{

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -19,6 +19,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	latestconfigapi "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
@@ -70,7 +71,7 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 func NewDefaultMasterArgs() *MasterArgs {
 	config := &MasterArgs{
 		MasterAddr:           flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
-		EtcdAddr:             flagtypes.Addr{Value: "0.0.0.0:4001", DefaultScheme: "http", DefaultPort: 4001}.Default(),
+		EtcdAddr:             flagtypes.Addr{Value: "0.0.0.0:4001", DefaultScheme: "https", DefaultPort: 4001}.Default(),
 		PortalNet:            flagtypes.DefaultIPNet("172.30.17.0/24"),
 		MasterPublicAddr:     flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
 		KubernetesPublicAddr: flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
@@ -120,15 +121,18 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		return nil, err
 	}
 
+	builtInEtcd := !args.EtcdAddr.Provided
 	var etcdConfig *configapi.EtcdConfig
-	if !args.EtcdAddr.Provided {
+	if builtInEtcd {
 		etcdConfig, err = args.BuildSerializeableEtcdConfig()
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	builtInKubernetes := !args.KubeConnectionArgs.KubernetesAddr.Provided && len(args.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath) == 0
 	var kubernetesMasterConfig *configapi.KubernetesMasterConfig
-	if !args.KubeConnectionArgs.KubernetesAddr.Provided && len(args.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath) == 0 {
+	if builtInKubernetes {
 		kubernetesMasterConfig, err = args.BuildSerializeableKubeMasterConfig()
 		if err != nil {
 			return nil, err
@@ -139,6 +143,10 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 	if err != nil {
 		return nil, err
 	}
+
+	kubeletClientInfo := admin.DefaultMasterKubeletClientCertInfo(args.CertArgs.CertDir)
+
+	etcdClientInfo := admin.DefaultMasterEtcdClientCertInfo(args.CertArgs.CertDir)
 
 	config := &configapi.MasterConfig{
 		ServingInfo: configapi.ServingInfo{
@@ -172,11 +180,12 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 			KubernetesKubeConfig:        admin.DefaultKubeConfigFilename(args.CertArgs.CertDir, "kube-client"),
 		},
 
-		EtcdClientInfo: configapi.RemoteConnectionInfo{
-			URL: etcdAddress.String(),
-			// TODO allow for https etcd
-			CA:         "",
-			ClientCert: configapi.CertInfo{},
+		EtcdClientInfo: configapi.EtcdConnectionInfo{
+			URLs: []string{etcdAddress.String()},
+		},
+
+		KubeletClientInfo: configapi.KubeletConnectionInfo{
+			Port: kubernetes.NodePort,
 		},
 
 		PolicyConfig: configapi.PolicyConfig{
@@ -193,10 +202,21 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 
 	if args.ListenArg.UseTLS() {
 		config.ServingInfo.ServerCert = admin.DefaultMasterServingCertInfo(args.CertArgs.CertDir)
-		config.ServingInfo.ClientCA = admin.DefaultRootCAFile(args.CertArgs.CertDir)
+		config.ServingInfo.ClientCA = admin.DefaultAPIClientCAFile(args.CertArgs.CertDir)
 
 		config.AssetConfig.ServingInfo.ServerCert = admin.DefaultAssetServingCertInfo(args.CertArgs.CertDir)
-		config.AssetConfig.ServingInfo.ClientCA = admin.DefaultRootCAFile(args.CertArgs.CertDir)
+
+		// Only set up ca/cert info for kubelet connections if we're self-hosting Kubernetes
+		if builtInKubernetes {
+			config.KubeletClientInfo.CA = admin.DefaultRootCAFile(args.CertArgs.CertDir)
+			config.KubeletClientInfo.ClientCert = kubeletClientInfo.CertLocation
+		}
+
+		// Only set up ca/cert info for etcd connections if we're self-hosting etcd
+		if builtInEtcd {
+			config.EtcdClientInfo.CA = admin.DefaultRootCAFile(args.CertArgs.CertDir)
+			config.EtcdClientInfo.ClientCert = etcdClientInfo.CertLocation
+		}
 	}
 
 	return config, nil
@@ -288,16 +308,33 @@ func (args MasterArgs) BuildSerializeableEtcdConfig() (*configapi.EtcdConfig, er
 		return nil, err
 	}
 
+	etcdPeerAddr, err := args.GetEtcdPeerAddress()
+	if err != nil {
+		return nil, err
+	}
+
 	config := &configapi.EtcdConfig{
 		ServingInfo: configapi.ServingInfo{
 			BindAddress: args.GetEtcdBindAddress(),
 		},
-		PeerAddress:   args.GetEtcdPeerBindAddress(),
-		MasterAddress: etcdAddr.Host,
-		StorageDir:    args.EtcdDir,
+		PeerServingInfo: configapi.ServingInfo{
+			BindAddress: args.GetEtcdPeerBindAddress(),
+		},
+		Address:     etcdAddr.Host,
+		PeerAddress: etcdPeerAddr.Host,
+		StorageDir:  args.EtcdDir,
+	}
+
+	if args.ListenArg.UseTLS() {
+		config.ServingInfo.ServerCert = admin.DefaultEtcdServingCertInfo(args.CertArgs.CertDir)
+		config.ServingInfo.ClientCA = admin.DefaultEtcdClientCAFile(args.CertArgs.CertDir)
+
+		config.PeerServingInfo.ServerCert = admin.DefaultEtcdServingCertInfo(args.CertArgs.CertDir)
+		config.PeerServingInfo.ClientCA = admin.DefaultEtcdClientCAFile(args.CertArgs.CertDir)
 	}
 
 	return config, nil
+
 }
 
 // BuildSerializeableKubeMasterConfig creates a fully specified kubernetes master startup configuration based on MasterArgs
@@ -398,17 +435,11 @@ func (args MasterArgs) GetMasterAddress() (*url.URL, error) {
 		return args.MasterAddr.URL, nil
 	}
 
-	// If the user specifies a bind address, and the master is not provided, use the bind port by default
-	port := args.MasterAddr.Port
-	if args.ListenArg.ListenAddr.Provided {
-		port = args.ListenArg.ListenAddr.Port
-	}
+	// Use the bind port by default
+	port := args.ListenArg.ListenAddr.Port
 
-	// If the user specifies a bind address, and the master is not provided, use the bind scheme by default
-	scheme := args.MasterAddr.URL.Scheme
-	if args.ListenArg.ListenAddr.Provided {
-		scheme = args.ListenArg.ListenAddr.URL.Scheme
-	}
+	// Use the bind scheme by default
+	scheme := args.ListenArg.ListenAddr.URL.Scheme
 
 	addr := ""
 	if ip, err := cmdutil.DefaultLocalIP4(); err == nil {
@@ -460,8 +491,29 @@ func (args MasterArgs) GetEtcdAddress() (*url.URL, error) {
 		return nil, err
 	}
 
-	etcdAddr := net.JoinHostPort(getHost(*masterAddr), strconv.Itoa(args.EtcdAddr.DefaultPort))
-	return url.Parse(args.EtcdAddr.DefaultScheme + "://" + etcdAddr)
+	return &url.URL{
+		// Use the bind scheme by default
+		Scheme: args.ListenArg.ListenAddr.URL.Scheme,
+
+		Host: net.JoinHostPort(getHost(*masterAddr), strconv.Itoa(args.EtcdAddr.DefaultPort)),
+	}, nil
+}
+
+func (args MasterArgs) GetEtcdPeerAddress() (*url.URL, error) {
+	// Derive from the etcd address, on port 7001
+	etcdAddress, err := args.GetEtcdAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	host, _, err := net.SplitHostPort(etcdAddress.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	etcdAddress.Host = net.JoinHostPort(host, "7001")
+
+	return etcdAddress, nil
 }
 func (args MasterArgs) GetKubernetesPublicAddress() (*url.URL, error) {
 	if args.KubernetesPublicAddr.Provided {

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -98,6 +98,7 @@ func (args NodeArgs) BuildSerializeableNodeConfig() (*configapi.NodeConfig, erro
 
 	if args.ListenArg.UseTLS() {
 		config.ServingInfo.ServerCert = admin.DefaultNodeServingCertInfo(args.CertArgs.CertDir, args.NodeName)
+		config.ServingInfo.ClientCA = admin.DefaultKubeletClientCAFile(args.CertArgs.CertDir)
 	}
 
 	return config, nil

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -295,18 +295,11 @@ func ReadMasterConfig(filename string) (*configapi.MasterConfig, error) {
 }
 
 func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
-	glog.Infof("Starting an OpenShift master, reachable at %s (etcd: %s)", openshiftMasterConfig.ServingInfo.BindAddress, openshiftMasterConfig.EtcdClientInfo.URL)
+	glog.Infof("Starting an OpenShift master, reachable at %s (etcd: %v)", openshiftMasterConfig.ServingInfo.BindAddress, openshiftMasterConfig.EtcdClientInfo.URLs)
 	glog.Infof("OpenShift master public address is %s", openshiftMasterConfig.AssetConfig.MasterPublicURL)
 
 	if openshiftMasterConfig.EtcdConfig != nil {
-		etcdConfig := &etcd.Config{
-			BindAddr:     openshiftMasterConfig.EtcdConfig.ServingInfo.BindAddress,
-			PeerBindAddr: openshiftMasterConfig.EtcdConfig.PeerAddress,
-			MasterAddr:   openshiftMasterConfig.EtcdConfig.MasterAddress,
-			EtcdDir:      openshiftMasterConfig.EtcdConfig.StorageDir,
-		}
-
-		etcdConfig.Run()
+		etcd.RunEtcd(openshiftMasterConfig.EtcdConfig)
 	}
 
 	// Allow privileged containers

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -241,6 +241,8 @@ func (o NodeOptions) CreateCerts() error {
 
 		APIServerURL:    masterAddr.String(),
 		APIServerCAFile: getSignerOptions.CertFile,
+
+		NodeClientCAFile: getSignerOptions.CertFile,
 	}
 
 	if err := createNodeConfigOptions.Validate(nil); err != nil {

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -94,7 +94,7 @@ func TestOverwritePolicyCommand(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo.URL)
+	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -158,7 +158,7 @@ func TestOAuthRequestHeader(t *testing.T) {
 		t.Fatalf("expected unsuccessful token request, got redirected to %v", redirect.String())
 	}
 
-	// Use the server  d CA info, with cert info
+	// Use the server and CA info, with cert info
 	authProxyConfig := anonConfig
 	authProxyConfig.CertData = clientCert
 	authProxyConfig.KeyData = clientKey

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -78,7 +78,7 @@ func TestUserInitialization(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo.URL)
+	etcdHelper, err := etcd.NewOpenShiftEtcdHelper(masterConfig.EtcdClientInfo)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -152,6 +152,7 @@ func CreateNodeCerts(nodeArgs *start.NodeArgs) error {
 	createNodeConfig.Hostnames = []string{nodeArgs.NodeName}
 	createNodeConfig.ListenAddr = nodeArgs.ListenArg.ListenAddr
 	createNodeConfig.APIServerCAFile = admin.DefaultCertFilename(nodeArgs.CertArgs.CertDir, "ca")
+	createNodeConfig.NodeClientCAFile = admin.DefaultCertFilename(nodeArgs.CertArgs.CertDir, "ca")
 
 	if err := createNodeConfig.Validate(nil); err != nil {
 		return err

--- a/vagrant/provision-master-sdn.sh
+++ b/vagrant/provision-master-sdn.sh
@@ -26,7 +26,7 @@ Requires=openshift-master.service
 After=openshift-master.service
 
 [Service]
-ExecStart=/usr/bin/openshift-sdn -etcd-endpoints=http://${MASTER_IP}:4001 
+ExecStart=/usr/bin/openshift-sdn -etcd-endpoints=https://${MASTER_IP}:4001 -etcd-keyfile=${ETCD_KEYFILE} -etcd-certfile=${ETCD_CERTFILE} -etcd-cafile=${ETCD_CAFILE}
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/provision-node-sdn.sh
+++ b/vagrant/provision-node-sdn.sh
@@ -28,7 +28,7 @@ After=openvswitch.service
 Before=openshift-node.service
 
 [Service]
-ExecStart=/usr/bin/openshift-sdn -minion -etcd-endpoints=http://${MASTER_IP}:4001 -public-ip=${MINION_IP} 
+ExecStart=/usr/bin/openshift-sdn -minion -etcd-endpoints=https://${MASTER_IP}:4001 -public-ip=${MINION_IP} -etcd-keyfile=${ETCD_CLIENT_KEY} -etcd-certfile=${ETCD_CLIENT_CERT} -etcd-cafile=${ETCD_CAFILE}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- [x] osc build-logs using https
- [x] osc log using https
- [x] proxy to node using https
- [x] osc exec
- [x] update create-node-config to specify clientCA, update help

Follow-ups:

- [ ] Separate listen args for etcd and node to allow starting them in http-mode when the master is in https mode