### PR TITLE
store routes under registry in etcd

### DIFF
--- a/pkg/route/registry/etcd/etcd.go
+++ b/pkg/route/registry/etcd/etcd.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// RoutePath is the path to route image in etcd
-	RoutePath string = "/routes"
+	RoutePath string = "/registry/routes"
 )
 
 // Etcd implements route.Registry backed by etcd.


### PR DESCRIPTION
See https://github.com/openshift/origin/issues/1374#issuecomment-83481949.  Stores routes under /v2/keys/registry/routes instead of /v2/keys/routes.  

If we want to let this ride until the upstream issue is resolved let me know and I"ll close this.

@derekwaynecarr 

```
[vagrant@openshiftdev unsecure]$ curl -Ss http://localhost:4001/v2/keys/registry/routes/ | python -m json.tool
{
    "action": "get",
    "node": {
        "createdIndex": 33,
        "dir": true,
        "key": "/registry/routes",
        "modifiedIndex": 33,
        "nodes": [
            {
                "createdIndex": 33,
                "dir": true,
                "key": "/registry/routes/default",
                "modifiedIndex": 33
            },
            {
                "createdIndex": 37,
                "dir": true,
                "key": "/registry/routes/nstest",
                "modifiedIndex": 37
            }
        ]
    }
}
```