### PR TITLE
handle trailing slashes

### DIFF
--- a/pkg/cmd/server/start/config_test.go
+++ b/pkg/cmd/server/start/config_test.go
@@ -1,12 +1,53 @@
 package start
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/openshift/origin/pkg/cmd/util"
 )
+
+func TestMasterURLNoPathAllowed(t *testing.T) {
+	masterArgs := NewDefaultMasterArgs()
+	masterArgs.MasterAddr.Set("http://example.com:9012/")
+	err := masterArgs.Validate()
+
+	if err == nil || !strings.Contains(err.Error(), "may not include a path") {
+		t.Errorf("expected %v, got %v", "may not include a path", err)
+	}
+}
+
+func TestMasterPublicURLNoPathAllowed(t *testing.T) {
+	masterArgs := NewDefaultMasterArgs()
+	masterArgs.MasterPublicAddr.Set("http://example.com:9012/")
+	err := masterArgs.Validate()
+
+	if err == nil || !strings.Contains(err.Error(), "may not include a path") {
+		t.Errorf("expected %v, got %v", "may not include a path", err)
+	}
+}
+
+func TestKubePublicURLNoPathAllowed(t *testing.T) {
+	masterArgs := NewDefaultMasterArgs()
+	masterArgs.KubernetesPublicAddr.Set("http://example.com:9012/")
+	err := masterArgs.Validate()
+
+	if err == nil || !strings.Contains(err.Error(), "may not include a path") {
+		t.Errorf("expected %v, got %v", "may not include a path", err)
+	}
+}
+
+func TestKubeURLNoPathAllowed(t *testing.T) {
+	masterArgs := NewDefaultMasterArgs()
+	masterArgs.KubeConnectionArgs.KubernetesAddr.Set("http://example.com:9012/")
+	err := masterArgs.Validate()
+
+	if err == nil || !strings.Contains(err.Error(), "may not include a path") {
+		t.Errorf("expected %v, got %v", "may not include a path", err)
+	}
+}
 
 func TestMasterPublicAddressDefaulting(t *testing.T) {
 	expected := "http://example.com:9012"

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -251,6 +251,35 @@ func (args MasterArgs) BuildSerializeableKubeMasterConfig() (*configapi.Kubernet
 	return config, nil
 }
 
+func (args MasterArgs) Validate() error {
+	masterAddr, err := args.GetMasterAddress()
+	if addr, err := masterAddr, err; err != nil {
+		return err
+	} else if len(addr.Path) != 0 {
+		return fmt.Errorf("master url may not include a path: '%v'", addr.Path)
+	}
+
+	if addr, err := args.GetMasterPublicAddress(); err != nil {
+		return err
+	} else if len(addr.Path) != 0 {
+		return fmt.Errorf("master public url may not include a path: '%v'", addr.Path)
+	}
+
+	if addr, err := args.KubeConnectionArgs.GetKubernetesAddress(masterAddr); err != nil {
+		return err
+	} else if len(addr.Path) != 0 {
+		return fmt.Errorf("kubernetes url may not include a path: '%v'", addr.Path)
+	}
+
+	if addr, err := args.GetKubernetesPublicAddress(); err != nil {
+		return err
+	} else if len(addr.Path) != 0 {
+		return fmt.Errorf("kubernetes public url may not include a path: '%v'", addr.Path)
+	}
+
+	return nil
+}
+
 // GetServerCertHostnames returns the set of hostnames that any serving certificate for master needs to be valid for.
 func (args MasterArgs) GetServerCertHostnames() (util.StringSet, error) {
 	masterAddr, err := args.GetMasterAddress()

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -144,6 +144,10 @@ func (o AllInOneOptions) Validate(args []string) error {
 		}
 	}
 
+	if err := o.MasterArgs.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -122,6 +122,10 @@ func (o MasterOptions) Validate(args []string) error {
 		}
 	}
 
+	if err := o.MasterArgs.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1352

This prevents anyone from passing a master, public-master, kubernetes, public-kubernetes that contains a `path` part to the URL.  They can still use the config file to pass in such arguments, but not via the simply start commands.

@liggitt 