### PR TITLE
add rule to allow self-subject access reviews

### DIFF
--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -18,6 +18,8 @@ func init() {
 		&PolicyBindingList{},
 		&RoleBindingList{},
 		&RoleList{},
+
+		&IsPersonalSubjectAccessReview{},
 	)
 }
 
@@ -33,3 +35,5 @@ func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
 func (*RoleBindingList) IsAnAPIObject()              {}
 func (*RoleList) IsAnAPIObject()                     {}
+
+func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -83,6 +83,11 @@ type PolicyRule struct {
 	NonResourceURLs kutil.StringSet
 }
 
+// IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
+type IsPersonalSubjectAccessReview struct {
+	kapi.TypeMeta
+}
+
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
 type Role struct {
 	kapi.TypeMeta

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -18,6 +18,8 @@ func init() {
 		&PolicyBindingList{},
 		&RoleBindingList{},
 		&RoleList{},
+
+		&IsPersonalSubjectAccessReview{},
 	)
 }
 
@@ -33,3 +35,5 @@ func (*PolicyList) IsAnAPIObject()                   {}
 func (*PolicyBindingList) IsAnAPIObject()            {}
 func (*RoleBindingList) IsAnAPIObject()              {}
 func (*RoleList) IsAnAPIObject()                     {}
+
+func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -20,7 +20,7 @@ type PolicyRule struct {
 	Verbs []string `json:"verbs"`
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
-	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions"`
+	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions,omitempty"`
 	// ResourceKinds is a list of resources this rule applies to.  ResourceAll represents all resources.
 	// DEPRECATED
 	ResourceKinds []string `json:"resourceKinds,omitempty"`
@@ -31,6 +31,11 @@ type PolicyRule struct {
 	// NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 	// This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.
 	NonResourceURLsSlice []string `json:"nonResourceURLs,omitempty"`
+}
+
+// IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
+type IsPersonalSubjectAccessReview struct {
+	kapi.TypeMeta `json:",inline"`
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.

--- a/pkg/authorization/authorizer/attributes.go
+++ b/pkg/authorization/authorizer/attributes.go
@@ -1,6 +1,7 @@
 package authorizer
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -34,6 +35,16 @@ func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.Policy
 
 		if a.resourceMatches(allowedResourceTypes) {
 			if a.nameMatches(rule.ResourceNames) {
+				// this rule matches the request, so we should check the additional restrictions to be sure that it's allowed
+				if rule.AttributeRestrictions.Object != nil {
+					switch rule.AttributeRestrictions.Object.(type) {
+					case (*authorizationapi.IsPersonalSubjectAccessReview):
+						return IsPersonalAccessReview(a)
+					default:
+						return false, fmt.Errorf("unable to interpret: %#v", rule.AttributeRestrictions.Object)
+					}
+				}
+
 				return true, nil
 			}
 		}

--- a/pkg/authorization/authorizer/attributes_builder.go
+++ b/pkg/authorization/authorizer/attributes_builder.go
@@ -40,7 +40,7 @@ func (a *openshiftAuthorizationAttributeBuilder) GetAttributes(req *http.Request
 		Verb:              requestInfo.Verb,
 		Resource:          requestInfo.Resource,
 		ResourceName:      requestInfo.Name,
-		RequestAttributes: nil,
+		RequestAttributes: req,
 		NonResourceURL:    false,
 		URL:               req.URL.Path,
 	}, nil

--- a/pkg/authorization/authorizer/personal_subjectaccessreview.go
+++ b/pkg/authorization/authorizer/personal_subjectaccessreview.go
@@ -1,0 +1,37 @@
+package authorizer
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func IsPersonalAccessReview(a AuthorizationAttributes) (bool, error) {
+	req, ok := a.GetRequestAttributes().(*http.Request)
+	if !ok {
+		return false, errors.New("expected request, but did not get one")
+	}
+
+	// TODO once we're integrated with the api installer, we should have direct access to the deserialized content
+	// for now, this only happens on subjectaccessreviews with a personal check, pay the double retrieve and decode cost
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return false, err
+	}
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	subjectAccessReview := &authorizationapi.SubjectAccessReview{}
+	if err := latest.Codec.DecodeInto(body, subjectAccessReview); err != nil {
+		return false, err
+	}
+
+	if (len(subjectAccessReview.User) == 0) && (len(subjectAccessReview.Groups) == 0) {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -2,6 +2,7 @@ package bootstrappolicy
 
 import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -102,6 +103,7 @@ func GetBootstrapMasterRoles(masterNamespace string) []authorizationapi.Role {
 			Rules: []authorizationapi.PolicyRule{
 				{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("users"), ResourceNames: util.NewStringSet("~")},
 				{Verbs: util.NewStringSet("list"), Resources: util.NewStringSet("projects")},
+				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("subjectaccessreviews"), AttributeRestrictions: runtime.EmbeddedObject{&authorizationapi.IsPersonalSubjectAccessReview{}}},
 			},
 		},
 		{

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -10,6 +10,7 @@ import (
 	kapierror "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
@@ -105,4 +106,57 @@ func TestOverwritePolicyCommand(t *testing.T) {
 	if _, err := client.Policies(masterConfig.PolicyConfig.MasterAuthorizationNamespace).List(labels.Everything(), fields.Everything()); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+func TestSelfSubjectAccessReviews(t *testing.T) {
+	_, clusterAdminKubeConfig, err := testutil.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	valerieClientConfig := *clusterAdminClientConfig
+	valerieClientConfig.Username = ""
+	valerieClientConfig.Password = ""
+	valerieClientConfig.BearerToken = ""
+	valerieClientConfig.CertFile = ""
+	valerieClientConfig.KeyFile = ""
+	valerieClientConfig.CertData = nil
+	valerieClientConfig.KeyData = nil
+
+	accessToken, err := tokencmd.RequestToken(&valerieClientConfig, nil, "valerie", "security!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	valerieClientConfig.BearerToken = accessToken
+	valerieOpenshiftClient, err := client.New(&valerieClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// can I get a subjectaccessreview on myself even if I have no rights to do it generally
+	askCanICreatePolicyBindings := &authorizationapi.SubjectAccessReview{Verb: "create", Resource: "policybindings"}
+	subjectAccessReviewTest{
+		clientInterface: valerieOpenshiftClient.SubjectAccessReviews("openshift"),
+		review:          askCanICreatePolicyBindings,
+		response: authorizationapi.SubjectAccessReviewResponse{
+			Allowed:   false,
+			Reason:    "denied by default",
+			Namespace: "openshift",
+		},
+	}.run(t)
+
+	// I shouldn't be allowed to ask whether someone else can perform an action
+	askCanClusterAdminsCreateProject := &authorizationapi.SubjectAccessReview{Groups: util.NewStringSet("system:cluster-admins"), Verb: "create", Resource: "projects"}
+	subjectAccessReviewTest{
+		clientInterface: valerieOpenshiftClient.SubjectAccessReviews("openshift"),
+		review:          askCanClusterAdminsCreateProject,
+		err:             "Forbidden",
+	}.run(t)
+
 }


### PR DESCRIPTION
This adds a fine-grained policy rule that checks to see if a subject access review request is for "self".  If it is, then the additional check allows it.

@liggitt It fell out pretty clean.  Almost exactly as planned, except for needing to parse the content.