### PR TITLE
Fix how OPENSHIFT_INSECURE is parsed

### DIFF
--- a/pkg/dockerregistry/middleware/repository/openshift.go
+++ b/pkg/dockerregistry/middleware/repository/openshift.go
@@ -47,7 +47,7 @@ func newRepository(repo distribution.Repository, options map[string]interface{})
 		return nil, errors.New("REGISTRY_URL is required")
 	}
 
-	insecure := len(os.Getenv("OPENSHIFT_INSECURE")) > 0
+	insecure := os.Getenv("OPENSHIFT_INSECURE") == "true"
 	var tlsClientConfig kclient.TLSClientConfig
 	if !insecure {
 		caData := os.Getenv("OPENSHIFT_CA_DATA")

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -88,7 +88,7 @@ middleware:
     - name: openshift
 `
 
-	os.Setenv("OPENSHIFT_INSECURE", "1")
+	os.Setenv("OPENSHIFT_INSECURE", "true")
 	os.Setenv("OPENSHIFT_MASTER", openshift.Server.URL)
 	os.Setenv("REGISTRY_URL", "127.0.0.1:5000")
 


### PR DESCRIPTION
For the v2 registry, we need to check if OPENSHIFT_INSECURE is true, as
the env vars from 'openshift ex registry --create' set it to false, and
the length check was incorrectly resulting in the registry thinking it
should speak to OpenShift insecurely.