### PR TITLE
ImageStreamImage/ImageRepositoryTag virtual rsrcs

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -12,10 +12,12 @@ import (
 	kctl "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/docker/docker/pkg/parsers"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
+	imageapi "github.com/openshift/origin/pkg/image/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
@@ -35,6 +37,10 @@ func DescriberFor(kind string, c *client.Client, kclient kclient.Interface, host
 		return &ImageDescriber{c}, true
 	case "ImageRepository":
 		return &ImageRepositoryDescriber{c}, true
+	case "ImageRepositoryTag":
+		return &ImageRepositoryTagDescriber{c}, true
+	case "ImageStreamImage":
+		return &ImageStreamImageDescriber{c}, true
 	case "Route":
 		return &RouteDescriber{c}, true
 	case "Project":
@@ -230,11 +236,51 @@ func (d *ImageDescriber) Describe(namespace, name string) (string, error) {
 		return "", err
 	}
 
+	return describeImage(image)
+}
+
+func describeImage(image *imageapi.Image) (string, error) {
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, image.ObjectMeta)
 		formatString(out, "Docker Image", image.DockerImageReference)
 		return nil
 	})
+}
+
+// ImageRepositoryTagDescriber generates information about a ImageRepositoryTag (Image).
+type ImageRepositoryTagDescriber struct {
+	client.Interface
+}
+
+func (d *ImageRepositoryTagDescriber) Describe(namespace, name string) (string, error) {
+	c := d.ImageRepositoryTags(namespace)
+	repo, tag := parsers.ParseRepositoryTag(name)
+	if tag == "" {
+		// TODO use repo's preferred default, when that's coded
+		tag = "latest"
+	}
+	image, err := c.Get(repo, tag)
+	if err != nil {
+		return "", err
+	}
+
+	return describeImage(image)
+}
+
+// ImageStreamImageDescriber generates information about a ImageStreamImage (Image).
+type ImageStreamImageDescriber struct {
+	client.Interface
+}
+
+func (d *ImageStreamImageDescriber) Describe(namespace, name string) (string, error) {
+	c := d.ImageStreamImages(namespace)
+	repo, id := parsers.ParseRepositoryTag(name)
+	image, err := c.Get(repo, id)
+	if err != nil {
+		return "", err
+	}
+
+	return describeImage(image)
 }
 
 // ImageRepositoryDescriber generates information about a ImageRepository

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -26,7 +26,8 @@ func TestDescribeFor(t *testing.T) {
 	c := &client.Client{}
 	testTypesList := []string{
 		"Build", "BuildConfig", "BuildLog", "Deployment", "DeploymentConfig",
-		"Image", "ImageRepository", "Route", "Project",
+		"Image", "ImageRepository", "ImageRepositoryTag", "ImageStreamImage",
+		"Route", "Project",
 	}
 	for _, o := range testTypesList {
 		_, ok := DescriberFor(o, c, &kclient.Fake{}, "")
@@ -47,6 +48,8 @@ func TestDescribers(t *testing.T) {
 		&DeploymentDescriber{c},
 		&ImageDescriber{c},
 		&ImageRepositoryDescriber{c},
+		&ImageRepositoryTagDescriber{c},
+		&ImageStreamImageDescriber{c},
 		&RouteDescriber{c},
 		&ProjectDescriber{c},
 		&PolicyDescriber{c},

--- a/pkg/image/api/register.go
+++ b/pkg/image/api/register.go
@@ -11,6 +11,8 @@ func init() {
 		&ImageRepository{},
 		&ImageRepositoryList{},
 		&ImageRepositoryMapping{},
+		&ImageRepositoryTag{},
+		&ImageStreamImage{},
 		&DockerImage{},
 	)
 }

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -28,6 +28,16 @@ type Image struct {
 	DockerImageManifest string `json:"rawManifest,omitempty"`
 }
 
+// ImageRepositoryTag exists to allow calls to `osc get imageRepositoryTag ...` to function.
+type ImageRepositoryTag struct {
+	Image
+}
+
+// ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
+type ImageStreamImage struct {
+	Image
+}
+
 // ImageRepositoryList is a list of ImageRepository objects.
 type ImageRepositoryList struct {
 	kapi.TypeMeta `json:",inline"`

--- a/pkg/image/api/v1beta1/register.go
+++ b/pkg/image/api/v1beta1/register.go
@@ -14,6 +14,8 @@ func init() {
 		&ImageRepository{},
 		&ImageRepositoryList{},
 		&ImageRepositoryMapping{},
+		&ImageRepositoryTag{},
+		&ImageStreamImage{},
 	)
 }
 

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -29,6 +29,16 @@ type Image struct {
 	DockerImageManifest string `json:"dockerImageManifest,omitempty"`
 }
 
+// ImageRepositoryTag exists to allow calls to `osc get imageRepositoryTag ...` to function.
+type ImageRepositoryTag struct {
+	Image
+}
+
+// ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
+type ImageStreamImage struct {
+	Image
+}
+
 // ImageRepositoryList is a list of ImageRepository objects.
 type ImageRepositoryList struct {
 	kapi.TypeMeta `json:",inline"`


### PR DESCRIPTION
Add ImageStreamImage and ImageRepositoryTag virtual resources so you can
get them via `osc get` and `osc describe`.