### PR TITLE
delegate to kube method for unknown resource kinds

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -68,6 +68,8 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 		}
 	}
 
+	// Save original Describer function
+	kDescriberFunc := w.Factory.Describer
 	w.Describer = func(mapping *meta.RESTMapping) (kubectl.Describer, error) {
 		oClient, kClient, err := w.Clients()
 		if err != nil {
@@ -86,7 +88,7 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 			}
 			return describer, nil
 		}
-		return w.Factory.Describer(mapping)
+		return kDescriberFunc(mapping)
 	}
 
 	w.Printer = func(mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error) {


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/1364

We need to delegate to the kube factory describer function if we don't recognize the type as openshift's.

@fabianofranz review.