### PR TITLE
Make systemd service dependencies considerably more strict

### DIFF
--- a/rel-eng/openshift-master.service
+++ b/rel-eng/openshift-master.service
@@ -2,6 +2,10 @@
 Description=OpenShift Master
 Documentation=https://github.com/openshift/origin
 After=network.target
+After=etcd.service
+Before=openshift-node.service
+Before=openshift-sdn-node.service
+Before=openshift-sdn-master.service
 Requires=network.target
 
 [Service]
@@ -12,3 +16,5 @@ WorkingDirectory=/var/lib/openshift/
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=openshift-sdn-master.service
+WantedBy=openshift-node.service

--- a/rel-eng/openshift-node.service
+++ b/rel-eng/openshift-node.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=OpenShift Node
 After=docker.service
+After=openshift-master.service
+After=openshift-sdn-master.service
+After=openshift-sdn-node.service
 Requires=docker.service
 Documentation=https://github.com/openshift/origin
 


### PR DESCRIPTION
Before/After enforces ordering and ordering only.
Wants triggers the named dependency to start but will not prevent the service from starting in the event that the dependency has failed. I've only used Requires in the case of the openshift-node->docker dependency because the other services could potentially be located on other hosts or may not even be used/installed like etcd so I believe Wants is more appropriate for those.