### PR TITLE
Comprehensive fixes for deployment image triggering

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -173,7 +173,6 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 			IRFn:   imageRepositoryRegistry.GetImageRepository,
 			LIRFn2: imageRepositoryRegistry.ListImageRepositories,
 		},
-		Codec: latest.Codec,
 	}
 	_, kclient := c.DeploymentConfigControllerClients()
 	deployRollback := &deployrollback.RollbackGenerator{}

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -95,8 +95,25 @@ func OkImageChangeTrigger() deployapi.DeploymentTriggerPolicy {
 			ContainerNames: []string{
 				"container1",
 			},
-			RepositoryName: "registry:8080/repo1",
-			Tag:            "tag1",
+			From: kapi.ObjectReference{
+				Kind: "ImageRepository",
+				Name: "test-image-repo",
+			},
+			Tag: "latest",
+		},
+	}
+}
+
+func OkImageChangeTriggerDeprecated() deployapi.DeploymentTriggerPolicy {
+	return deployapi.DeploymentTriggerPolicy{
+		Type: deployapi.DeploymentTriggerOnImageChange,
+		ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
+			Automatic: true,
+			ContainerNames: []string{
+				"container1",
+			},
+			RepositoryName: "registry:8080/repo1:ref1",
+			Tag:            "latest",
 		},
 	}
 }
@@ -104,8 +121,7 @@ func OkImageChangeTrigger() deployapi.DeploymentTriggerPolicy {
 func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
 	return &deployapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{
-			Namespace: kapi.NamespaceDefault,
-			Name:      "config",
+			Name: "config",
 		},
 		LatestVersion: version,
 		Triggers: []deployapi.DeploymentTriggerPolicy{

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -182,6 +182,8 @@ type DeploymentTriggerImageChangeParams struct {
 	From kapi.ObjectReference `json:"from"`
 	// Tag is the name of an image repository tag to watch for changes.
 	Tag string `json:"tag,omitempty"`
+	// LastTriggeredImage is the last image to be triggered.
+	LastTriggeredImage string `json:"lastTriggeredImage"`
 }
 
 // DeploymentDetails captures information about the causes of a deployment.

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -183,6 +183,8 @@ type DeploymentTriggerImageChangeParams struct {
 	From kapi.ObjectReference `json:"from"`
 	// Tag is the name of an image repository tag to watch for changes.
 	Tag string `json:"tag,omitempty"`
+	// LastTriggeredImage is the last image to be triggered.
+	LastTriggeredImage string `json:"lastTriggeredImage"`
 }
 
 // DeploymentDetails captures information about the causes of a deployment.

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -26,72 +24,56 @@ func (e fatalError) Error() string { return "fatal error handling imageRepositor
 
 // Handle processes image change triggers associated with imageRepo.
 func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageRepository) error {
-	configsToGenerate := []*deployapi.DeploymentConfig{}
-	firedTriggersForConfig := make(map[string][]deployapi.DeploymentTriggerImageChangeParams)
-
 	configs, err := c.deploymentConfigClient.listDeploymentConfigs()
 	if err != nil {
 		return fmt.Errorf("couldn't get list of deploymentConfigs while handling imageRepo %s: %v", labelForRepo(imageRepo), err)
 	}
 
+	// Find any configs which should be updated based on the new image state
+	configsToUpdate := map[string]*deployapi.DeploymentConfig{}
 	for _, config := range configs {
 		glog.V(4).Infof("Detecting changed images for deploymentConfig %s", labelFor(config))
 
-		// Extract relevant triggers for this imageRepo for this config
-		triggersForConfig := []deployapi.DeploymentTriggerImageChangeParams{}
 		for _, trigger := range config.Triggers {
-			if trigger.Type != deployapi.DeploymentTriggerOnImageChange ||
-				!trigger.ImageChangeParams.Automatic {
+			params := trigger.ImageChangeParams
+
+			// Only automatic image change triggers should fire
+			if trigger.Type != deployapi.DeploymentTriggerOnImageChange || !params.Automatic {
 				continue
 			}
-			if triggerMatchesImage(config, trigger.ImageChangeParams, imageRepo) {
-				glog.V(4).Infof("Found matching %s trigger for deploymentConfig %s: %#v", trigger.Type, labelFor(config), trigger.ImageChangeParams)
-				triggersForConfig = append(triggersForConfig, *trigger.ImageChangeParams)
+
+			// Check if the image repo matches the trigger
+			if !triggerMatchesImage(config, params, imageRepo) {
+				continue
 			}
-		}
 
-		for _, params := range triggersForConfig {
-			glog.V(4).Infof("Processing image triggers for deploymentConfig %s", labelFor(config))
-			containerNames := util.NewStringSet(params.ContainerNames...)
-			for _, container := range config.Template.ControllerTemplate.Template.Spec.Containers {
-				if !containerNames.Has(container.Name) {
-					continue
-				}
+			// Find the latest tag event for the trigger tag
+			latestEvent, err := imageapi.LatestTaggedImage(imageRepo, params.Tag)
+			if err != nil {
+				glog.V(4).Infof("Couldn't find latest tag event for tag %s in imageRepo %s: %s", params.Tag, labelForRepo(imageRepo), err)
+				continue
+			}
 
-				ref, err := imageapi.ParseDockerImageReference(container.Image)
-				if err != nil {
-					glog.V(4).Infof("Skipping container %s for config %s; container's image is invalid: %v", container.Name, labelFor(config), err)
-					continue
-				}
-
-				latest, err := imageapi.LatestTaggedImage(imageRepo, params.Tag)
-				if err != nil {
-					glog.V(4).Infof("Skipping container %s for config %s; %s", container.Name, labelFor(config), err)
-					continue
-				}
-
-				containerImageID := ref.ID
-				if len(containerImageID) == 0 {
-					// For v1 images, the container image's tag name is by convention the same as the image ID it references
-					containerImageID = ref.Tag
-				}
-				if latest.Image != containerImageID {
-					glog.V(4).Infof("Container %s for config %s: image id changed from %q to %q; regenerating config", container.Name, labelFor(config), containerImageID, latest.Image)
-					configsToGenerate = append(configsToGenerate, config)
-					firedTriggersForConfig[config.Name] = append(firedTriggersForConfig[config.Name], params)
-				}
+			// Ensure a change occured
+			if len(latestEvent.DockerImageReference) > 0 &&
+				latestEvent.DockerImageReference != params.LastTriggeredImage {
+				// Mark the config for regeneration
+				configsToUpdate[config.Name] = config
 			}
 		}
 	}
 
+	// Attempt to regenerate all configs which may contain image updates
 	anyFailed := false
-	for _, config := range configsToGenerate {
-		err := c.regenerate(imageRepo, config, firedTriggersForConfig[config.Name])
+	for _, config := range configsToUpdate {
+		err := c.regenerate(config)
 		if err != nil {
 			anyFailed = true
+			glog.Infof("couldn't regenerate depoymentConfig %s: %s", labelFor(config), err)
 			continue
 		}
-		glog.V(4).Infof("Updated deploymentConfig %s in response to image change trigger", labelFor(config))
+
+		glog.V(4).Infof("Regenerated deploymentConfig %s in response to image change trigger", labelFor(config))
 	}
 
 	if anyFailed {
@@ -106,64 +88,41 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageRepository) erro
 // When matching:
 // - The trigger From field is preferred over the deprecated RepositoryName field.
 // - The namespace of the trigger is preferred over the config's namespace.
-func triggerMatchesImage(config *deployapi.DeploymentConfig, trigger *deployapi.DeploymentTriggerImageChangeParams, repo *imageapi.ImageRepository) bool {
-	if len(trigger.From.Name) > 0 {
-		namespace := trigger.From.Namespace
+func triggerMatchesImage(config *deployapi.DeploymentConfig, params *deployapi.DeploymentTriggerImageChangeParams, repo *imageapi.ImageRepository) bool {
+	if len(params.From.Name) > 0 {
+		namespace := params.From.Namespace
 		if len(namespace) == 0 {
 			namespace = config.Namespace
 		}
 
-		return repo.Namespace == namespace && repo.Name == trigger.From.Name
+		return repo.Namespace == namespace && repo.Name == params.From.Name
 	}
 
 	// This is an invalid state (as one of From.Name or RepositoryName is required), but
 	// account for it anyway.
-	if len(trigger.RepositoryName) == 0 {
+	if len(params.RepositoryName) == 0 {
 		return false
 	}
 
 	// If the repo's repository information isn't yet available, we can't assume it'll match.
 	return len(repo.Status.DockerImageRepository) > 0 &&
-		trigger.RepositoryName == repo.Status.DockerImageRepository
+		params.RepositoryName == repo.Status.DockerImageRepository
 }
 
-func (c *ImageChangeController) regenerate(imageRepo *imageapi.ImageRepository, config *deployapi.DeploymentConfig, triggers []deployapi.DeploymentTriggerImageChangeParams) error {
+// regenerate calls the generator to get a new config. If the newly generated
+// config's version is newer, update the old config to be the new config.
+// Otherwise do nothing.
+func (c *ImageChangeController) regenerate(config *deployapi.DeploymentConfig) error {
 	// Get a regenerated config which includes the new image repo references
 	newConfig, err := c.deploymentConfigClient.generateDeploymentConfig(config.Namespace, config.Name)
 	if err != nil {
 		return fmt.Errorf("error generating new version of deploymentConfig %s: %v", labelFor(config), err)
 	}
 
-	// Update the deployment config with the trigger that resulted in the new config
-	causes := []*deployapi.DeploymentCause{}
-	for _, trigger := range triggers {
-		repoName := trigger.RepositoryName
-
-		if len(repoName) == 0 {
-			if len(imageRepo.Status.DockerImageRepository) == 0 {
-				// If the trigger relies on a image repo reference, and we don't know what docker repo
-				// it points at, we can't build a cause for the reference yet.
-				continue
-			}
-
-			latest, err := imageapi.LatestTaggedImage(imageRepo, trigger.Tag)
-			if err != nil {
-				return fmt.Errorf("error generating new version of deploymentConfig: %s: %s", labelFor(config), err)
-			}
-			repoName = latest.DockerImageReference
-		}
-
-		causes = append(causes,
-			&deployapi.DeploymentCause{
-				Type: deployapi.DeploymentTriggerOnImageChange,
-				ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
-					RepositoryName: repoName,
-					Tag:            trigger.Tag,
-				},
-			})
-	}
-	newConfig.Details = &deployapi.DeploymentDetails{
-		Causes: causes,
+	// No update occured
+	if config.LatestVersion == newConfig.LatestVersion {
+		glog.V(4).Infof("No version difference for generated config %s", labelFor(config))
+		return nil
 	}
 
 	// Persist the new config
@@ -172,6 +131,7 @@ func (c *ImageChangeController) regenerate(imageRepo *imageapi.ImageRepository, 
 		return err
 	}
 
+	glog.Infof("Regenerated depoymentConfig %s for image updates", labelFor(config))
 	return nil
 }
 

--- a/pkg/deploy/generator/config_generator.go
+++ b/pkg/deploy/generator/config_generator.go
@@ -6,7 +6,6 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 
@@ -19,7 +18,126 @@ import (
 // state differs from the input state, the LatestVersion field of the output is incremented.
 type DeploymentConfigGenerator struct {
 	Client GeneratorClient
-	Codec  runtime.Codec
+}
+
+// Generate returns a potential future DeploymentConfig based on the DeploymentConfig specified
+// by namespace and name. Returns a RESTful error.
+func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*deployapi.DeploymentConfig, error) {
+	config, err := g.Client.GetDeploymentConfig(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the containers with new images based on defined triggers
+	configChanged := false
+	errs := fielderrors.ValidationErrorList{}
+	causes := []*deployapi.DeploymentCause{}
+	for i, trigger := range config.Triggers {
+		params := trigger.ImageChangeParams
+
+		// Only process image change triggers
+		if trigger.Type != deployapi.DeploymentTriggerOnImageChange {
+			continue
+		}
+
+		// Find the image repo referred to by the trigger params
+		imageRepo, err := g.findImageRepo(config, params)
+		if err != nil {
+			f := fmt.Sprintf("triggers[%d].imageChange.from", i)
+			v := params.From.Name
+			if len(params.RepositoryName) > 0 {
+				f = fmt.Sprintf("triggers[%d].imageChange.repositoryName", i)
+				v = params.RepositoryName
+			}
+			errs = append(errs, fielderrors.NewFieldInvalid(f, v, err.Error()))
+			continue
+		}
+
+		// Find the latest tag event for the trigger tag
+		latestEvent, err := imageapi.LatestTaggedImage(imageRepo, params.Tag)
+		if err != nil {
+			f := fmt.Sprintf("triggers[%d].imageChange.tag", i)
+			errs = append(errs, fielderrors.NewFieldInvalid(f, params.Tag, err.Error()))
+			continue
+		}
+
+		// Update containers
+		template := config.Template.ControllerTemplate.Template
+		names := util.NewStringSet(params.ContainerNames...)
+		containerChanged := false
+		for i := range template.Spec.Containers {
+			container := &template.Spec.Containers[i]
+			if !names.Has(container.Name) {
+				continue
+			}
+			if len(latestEvent.DockerImageReference) > 0 &&
+				container.Image != latestEvent.DockerImageReference {
+				// Update the image
+				container.Image = latestEvent.DockerImageReference
+				// Log the last triggered image ID
+				params.LastTriggeredImage = latestEvent.DockerImageReference
+				containerChanged = true
+			}
+		}
+
+		// If any container was updated, create a cause for the change
+		if containerChanged {
+			configChanged = true
+			causes = append(causes,
+				&deployapi.DeploymentCause{
+					Type: deployapi.DeploymentTriggerOnImageChange,
+					ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
+						RepositoryName: latestEvent.DockerImageReference,
+						Tag:            params.Tag,
+					},
+				})
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.NewInvalid("DeploymentConfig", config.Name, errs)
+	}
+
+	// Bump the version if we updated containers or if this is an initial
+	// deployment
+	if configChanged || config.LatestVersion == 0 {
+		config.Details = &deployapi.DeploymentDetails{
+			Causes: causes,
+		}
+		config.LatestVersion++
+	}
+
+	return config, nil
+}
+
+func (g *DeploymentConfigGenerator) findImageRepo(config *deployapi.DeploymentConfig, params *deployapi.DeploymentTriggerImageChangeParams) (*imageapi.ImageRepository, error) {
+	// Try to find the repo by ObjectReference
+	if len(params.From.Name) > 0 {
+		namespace := params.From.Namespace
+		if len(namespace) == 0 {
+			namespace = config.Namespace
+		}
+
+		return g.Client.GetImageRepository(kapi.WithNamespace(kapi.NewContext(), namespace), params.From.Name)
+	}
+
+	// Fall back to a list based lookup on RepositoryName
+	repos, err := g.Client.ListImageRepositories(kapi.WithNamespace(kapi.NewContext(), config.Namespace))
+	if err != nil {
+		return nil, err
+	}
+	for _, repo := range repos.Items {
+		if len(repo.Status.DockerImageRepository) > 0 &&
+			params.RepositoryName == repo.Status.DockerImageRepository {
+			return &repo, nil
+		}
+	}
+	return nil, fmt.Errorf("couldn't find imageRepository for config %s trigger params", labelFor(config))
+}
+
+// labelFor builds a string identifier for a DeploymentConfig.
+func labelFor(config *deployapi.DeploymentConfig) string {
+	return fmt.Sprintf("%s/%s:%d", config.Namespace, config.Name, config.LatestVersion)
 }
 
 type GeneratorClient interface {
@@ -48,198 +166,4 @@ func (c Client) ListImageRepositories(ctx kapi.Context) (*imageapi.ImageReposito
 		return c.LIRFn2(ctx, labels.Everything())
 	}
 	return c.LIRFn(ctx)
-}
-
-// Generate returns a potential future DeploymentConfig based on the DeploymentConfig specified
-// by namespace and name. Returns a RESTful error.
-func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*deployapi.DeploymentConfig, error) {
-	dc, err := g.Client.GetDeploymentConfig(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	refs, legacy := findReferences(dc)
-	if errs := retrieveReferences(g.Client, ctx, refs, legacy); len(errs) > 0 {
-		return nil, errors.NewInvalid("DeploymentConfig", name, errs)
-	}
-	indexed := referencesByIndex(refs, legacy)
-	changed, errs := replaceReferences(dc, indexed)
-	if len(errs) > 0 {
-		return nil, errors.NewInvalid("DeploymentConfig", name, errs)
-	}
-	if changed || dc.LatestVersion == 0 {
-		dc.LatestVersion++
-	}
-
-	return dc, nil
-}
-
-type refKey struct {
-	namespace string
-	name      string
-}
-
-type triggerEntry struct {
-	positions []int
-	field     string
-	repo      *imageapi.ImageRepository
-}
-
-type triggersByRef map[refKey]*triggerEntry
-type triggersByName map[string]*triggerEntry
-
-// findReferences looks up triggers with references and maps them back to their position in the trigger array.
-func findReferences(dc *deployapi.DeploymentConfig) (refs triggersByRef, legacy triggersByName) {
-	refs, legacy = make(triggersByRef), make(triggersByName)
-
-	for i := range dc.Triggers {
-		trigger := &dc.Triggers[i]
-		if trigger.Type != deployapi.DeploymentTriggerOnImageChange {
-			continue
-		}
-
-		// use the object reference to find the image repository
-		if from := &trigger.ImageChangeParams.From; len(from.Name) != 0 {
-			k := refKey{
-				namespace: from.Namespace,
-				name:      from.Name,
-			}
-			if len(k.namespace) == 0 {
-				k.namespace = dc.Namespace
-			}
-			trigger, ok := refs[k]
-			if !ok {
-				trigger = &triggerEntry{
-					field: fmt.Sprintf("triggers[%d].imageChange.from", i),
-				}
-				refs[k] = trigger
-			}
-			trigger.positions = append(trigger.positions, i)
-			continue
-		}
-
-		// use the old way of looking up the name
-		// DEPRECATED: this path will be removed soon
-		if k := trigger.ImageChangeParams.RepositoryName; len(k) != 0 {
-			trigger, ok := legacy[k]
-			if !ok {
-				trigger = &triggerEntry{
-					field: fmt.Sprintf("triggers[%d].imageChange.repositoryName", i),
-				}
-				legacy[k] = trigger
-			}
-			trigger.positions = append(trigger.positions, i)
-			continue
-		}
-	}
-	return
-}
-
-// retrieveReferences loads the repositories referenced by a deployment config
-func retrieveReferences(client GeneratorClient, ctx kapi.Context, refs triggersByRef, legacy triggersByName) fielderrors.ValidationErrorList {
-	errs := fielderrors.ValidationErrorList{}
-
-	// fetch repositories directly
-	for k, v := range refs {
-		repo, err := client.GetImageRepository(kapi.WithNamespace(ctx, k.namespace), k.name)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				errs = append(errs, fielderrors.NewFieldNotFound(v.field, k.name))
-			} else {
-				errs = append(errs, fielderrors.NewFieldInvalid(v.field, k.name, err.Error()))
-			}
-			continue
-		}
-		v.repo = repo
-	}
-
-	// look for legacy references that we've already loaded
-	// DEPRECATED: remove all code below this line when the reference logic is removed
-	missing := make(triggersByName)
-	for k, v := range legacy {
-		for _, ref := range refs {
-			if ref.repo.Status.DockerImageRepository == k {
-				v.repo = ref.repo
-				break
-			}
-		}
-		if v.repo == nil {
-			missing[k] = v
-		}
-	}
-
-	// if we haven't loaded the references, do the more expensive list all
-	if len(missing) != 0 {
-		repos, err := client.ListImageRepositories(ctx)
-		if err != nil {
-			for k, ref := range missing {
-				errs = append(errs, fielderrors.NewFieldInvalid(ref.field, k, err.Error()))
-			}
-			return errs
-		}
-
-		for k, ref := range missing {
-			for i := range repos.Items {
-				repo := &repos.Items[i]
-				if repo.DockerImageRepository == k {
-					ref.repo = repo
-					break
-				}
-			}
-			if ref.repo == nil {
-				errs = append(errs, fielderrors.NewFieldNotFound(ref.field, k))
-			}
-		}
-	}
-	return errs
-}
-
-type reposByIndex map[int]*imageapi.ImageRepository
-
-func referencesByIndex(refs triggersByRef, legacy triggersByName) reposByIndex {
-	repos := make(reposByIndex)
-	for _, v := range refs {
-		for _, i := range v.positions {
-			repos[i] = v.repo
-		}
-	}
-	for _, v := range legacy {
-		for _, i := range v.positions {
-			repos[i] = v.repo
-		}
-	}
-	return repos
-}
-
-func replaceReferences(dc *deployapi.DeploymentConfig, repos reposByIndex) (changed bool, errs fielderrors.ValidationErrorList) {
-	template := dc.Template.ControllerTemplate.Template
-	for i, repo := range repos {
-		if len(repo.Status.DockerImageRepository) == 0 {
-			errs = append(errs, fielderrors.NewFieldInvalid(fmt.Sprintf("triggers[%d].imageChange.from", i), repo.Name, fmt.Sprintf("image repository %s/%s does not have a Docker image repository reference set and can't be used in a deployment config trigger", repo.Namespace, repo.Name)))
-			continue
-		}
-		params := dc.Triggers[i].ImageChangeParams
-
-		// get the image ref from the repo's tag history
-		latest, err := imageapi.LatestTaggedImage(repo, params.Tag)
-		if err != nil {
-			errs = append(errs, fielderrors.NewFieldInvalid(fmt.Sprintf("triggers[%d].imageChange.from", i), repo.Name, err.Error()))
-			continue
-		}
-		image := latest.DockerImageReference
-
-		// update containers
-		names := util.NewStringSet(params.ContainerNames...)
-		for i := range template.Spec.Containers {
-			container := &template.Spec.Containers[i]
-			if !names.Has(container.Name) {
-				continue
-			}
-			if container.Image != image {
-				container.Image = image
-				changed = true
-			}
-		}
-	}
-	return
 }


### PR DESCRIPTION
The current deployment image triggering logic is not accounting for various edge cases related to image IDs (or lack thereof). Define all the triggering scenarios in the comprehensive unit test and plug the holes in the triggering code so that triggers work consistently.

One known side effect of the current flawed code is mis-firing triggers which update the container to a nil image ID, causing races described in #1443.

Base all comparisons on image ID, and add new state to image change trigger params to store the last image ID used for triggering.