### PR TITLE
master and node config files should not contain backsteps

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func RelativizeMasterConfigPaths(config *MasterConfig, base string) error {
-	return cmdutil.RelativizePaths(GetMasterFileReferences(config), base)
+	return cmdutil.RelativizePathWithNoBacksteps(GetMasterFileReferences(config), base)
 }
 
 func ResolveMasterConfigPaths(config *MasterConfig, base string) error {
@@ -57,7 +57,7 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 }
 
 func RelativizeNodeConfigPaths(config *NodeConfig, base string) error {
-	return cmdutil.RelativizePaths(GetNodeFileReferences(config), base)
+	return cmdutil.RelativizePathWithNoBacksteps(GetNodeFileReferences(config), base)
 }
 
 func ResolveNodeConfigPaths(config *NodeConfig, base string) error {

--- a/pkg/cmd/util/filepath_test.go
+++ b/pkg/cmd/util/filepath_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestRejectNonAbsolutePathsThatRequireBacksteps(t *testing.T) {
+	path := "../foo"
+	paths := []*string{}
+	paths = append(paths, &path)
+
+	expectedError := "../foo requires backsteps and is not absolute"
+
+	if err := RelativizePathWithNoBacksteps(paths, "."); err == nil || expectedError != err.Error() {
+		t.Errorf("expected %v, got %v", expectedError, err)
+	}
+}
+
+func TestAcceptAbsolutePath(t *testing.T) {
+	path := "/foo"
+	paths := []*string{}
+	paths = append(paths, &path)
+
+	if err := RelativizePathWithNoBacksteps(paths, "/home/deads"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Prevents backsteps inside of master and node config files.

@liggitt Please review.  Also, nicely factored.  I wasn't expecting it so clean.