### PR TITLE
Removing --master flag from the openshift-node service

### DIFF
--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -52,7 +52,7 @@ Requires=docker.service network.service
 After=network.service
 
 [Service]
-ExecStart=/usr/bin/openshift start node --kubeconfig=/openshift.local.certificates/admin/.kubeconfig --master=https://${MASTER_IP}:8443
+ExecStart=/usr/bin/openshift start node --kubeconfig=/openshift.local.certificates/admin/.kubeconfig
 Restart=on-failure
 RestartSec=10s
 


### PR DESCRIPTION
The --master flag is redundant since the information is captured in the kubeconfig file. Moreover, the presence of the master flag is causing the service to fail as it errorneously complains that the --kubeconfig flag is unknown. The latter is a separate issue that is being looked at by @deads2k 

@deads2k @sdodson PTAL