### PR TITLE
Implement scaffolding to purge project content on deletion

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -71,6 +71,7 @@ import (
 	clientregistry "github.com/openshift/origin/pkg/oauth/registry/client"
 	clientauthorizationregistry "github.com/openshift/origin/pkg/oauth/registry/clientauthorization"
 	oauthetcd "github.com/openshift/origin/pkg/oauth/registry/etcd"
+	projectcontroller "github.com/openshift/origin/pkg/project/controller"
 	projectregistry "github.com/openshift/origin/pkg/project/registry/project"
 	routeallocationcontroller "github.com/openshift/origin/pkg/route/controller/allocation"
 	routeetcd "github.com/openshift/origin/pkg/route/registry/etcd"
@@ -463,6 +464,17 @@ func (c *MasterConfig) RunProjectAuthorizationCache() {
 	// TODO: look at exposing a configuration option in future to control how often we run this loop
 	period := 1 * time.Second
 	c.ProjectAuthorizationCache.Run(period)
+}
+
+// RunOriginNamespaceController starts the controller that takes part in namespace termination of openshift content
+func (c *MasterConfig) RunOriginNamespaceController() {
+	osclient, kclient := c.OriginNamespaceControllerClients()
+	factory := projectcontroller.NamespaceControllerFactory{
+		Client:     osclient,
+		KubeClient: kclient,
+	}
+	controller := factory.Create()
+	controller.Run()
 }
 
 // RunPolicyCache starts the policy cache

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -295,3 +295,10 @@ func (c *MasterConfig) DeploymentConfigChangeControllerClients() (*osclient.Clie
 func (c *MasterConfig) DeploymentImageChangeControllerClient() *osclient.Client {
 	return c.OSClient
 }
+
+// OriginNamespaceControllerClients returns a client for openshift and kubernetes.
+// The openshift client object must have authority to delete openshift content in any namespace
+// The kubernetes client object must have authority to execute a finalize request on a namespace
+func (c *MasterConfig) OriginNamespaceControllerClients() (*osclient.Client, *kclient.Client) {
+	return c.OSClient, c.KubernetesClient
+}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -404,6 +404,7 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	openshiftConfig.RunDeploymentConfigChangeController()
 	openshiftConfig.RunDeploymentImageChangeTriggerController()
 	openshiftConfig.RunImageImportController()
+	openshiftConfig.RunOriginNamespaceController()
 	openshiftConfig.RunProjectAuthorizationCache()
 
 	return nil

--- a/pkg/project/controller/controller.go
+++ b/pkg/project/controller/controller.go
@@ -1,0 +1,220 @@
+package controller
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	osclient "github.com/openshift/origin/pkg/client"
+)
+
+// NamespaceController is responsible for participating in Kubernetes Namespace termination
+// Use the NamespaceControllerFactory to create this controller.
+type NamespaceController struct {
+	// Client is an OpenShift client.
+	Client osclient.Interface
+	// KubeClient is a Kubernetes client.
+	KubeClient kclient.Interface
+}
+
+// fatalError is an error which can't be retried.
+type fatalError string
+
+func (e fatalError) Error() string { return "fatal error handling namespace: " + string(e) }
+
+// Handle processes a namespace and deletes content in origin if its terminating
+func (c *NamespaceController) Handle(namespace *kapi.Namespace) error {
+	// ignore namespaces that are not terminating
+	if namespace.Status.Phase != kapi.NamespaceTerminating {
+		return nil
+	}
+
+	deleteAllContent(c.Client, namespace.Name)
+	// TODO: finalize namespace (remove openshift.com/origin)
+	return nil
+}
+
+// deleteAllContent will purge all content in openshift in the specified namespace
+func deleteAllContent(client osclient.Interface, namespace string) (err error) {
+	err = deleteBuildConfigs(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteBuilds(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteDeploymentConfigs(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteDeployments(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteImageRepositories(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deletePolicies(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deletePolicyBindings(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteRoleBindings(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteRoles(client, namespace)
+	if err != nil {
+		return err
+	}
+	err = deleteRoutes(client, namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteRoutes(client osclient.Interface, ns string) error {
+	items, err := client.Routes(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.Routes(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteRoles(client osclient.Interface, ns string) error {
+	items, err := client.Roles(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.Roles(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteRoleBindings(client osclient.Interface, ns string) error {
+	items, err := client.RoleBindings(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.RoleBindings(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deletePolicyBindings(client osclient.Interface, ns string) error {
+	items, err := client.PolicyBindings(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.PolicyBindings(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deletePolicies(client osclient.Interface, ns string) error {
+	items, err := client.Policies(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.Policies(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteImageRepositories(client osclient.Interface, ns string) error {
+	items, err := client.ImageRepositories(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.ImageRepositories(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteDeployments(client osclient.Interface, ns string) error {
+	items, err := client.Deployments(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.Deployments(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteDeploymentConfigs(client osclient.Interface, ns string) error {
+	items, err := client.DeploymentConfigs(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.DeploymentConfigs(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteBuilds(client osclient.Interface, ns string) error {
+	items, err := client.Builds(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.Builds(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteBuildConfigs(client osclient.Interface, ns string) error {
+	items, err := client.BuildConfigs(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.BuildConfigs(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/project/controller/controller_test.go
+++ b/pkg/project/controller/controller_test.go
@@ -1,0 +1,98 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	osclient "github.com/openshift/origin/pkg/client"
+)
+
+func TestSyncNamespaceThatIsTerminating(t *testing.T) {
+	mockKubeClient := &kclient.Fake{}
+	mockOriginClient := &osclient.Fake{}
+	nm := NamespaceController{
+		KubeClient: mockKubeClient,
+		Client:     mockOriginClient,
+	}
+	//now := util.Now()
+	testNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "test",
+			ResourceVersion: "1",
+			//			DeletionTimestamp: &now,
+		},
+		//		Spec: api.NamespaceSpec{
+		//			Finalizers: []api.FinalizerName{"kubernetes"},
+		//		},
+		Status: api.NamespaceStatus{
+			Phase: api.NamespaceTerminating,
+		},
+	}
+	err := nm.Handle(testNamespace)
+	if err != nil {
+		t.Errorf("Unexpected error when handling namespace %v", err)
+	}
+
+	// TODO: we will expect a finalize namespace call after rebase
+	expectedActionSet := util.NewStringSet(
+		"list-buildconfig",
+		"list-policies",
+		"list-imagerepositries",
+		"list-policyBindings",
+		"list-roleBinding",
+		"list-role",
+		"list-routes",
+		"list-builds",
+		"list-deploymentconfig",
+		"list-deployment")
+	actionSet := util.NewStringSet()
+	for i := range mockKubeClient.Actions {
+		actionSet.Insert(mockKubeClient.Actions[i].Action)
+	}
+	for i := range mockOriginClient.Actions {
+		actionSet.Insert(mockOriginClient.Actions[i].Action)
+	}
+	if !actionSet.HasAll(expectedActionSet.List()...) {
+		t.Errorf("Expected actions: %v, but got: %v", expectedActionSet, actionSet)
+	}
+}
+
+func TestSyncNamespaceThatIsActive(t *testing.T) {
+	mockKubeClient := &kclient.Fake{}
+	mockOriginClient := &osclient.Fake{}
+	nm := NamespaceController{
+		KubeClient: mockKubeClient,
+		Client:     mockOriginClient,
+	}
+	//now := util.Now()
+	testNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "test",
+			ResourceVersion: "1",
+			//      DeletionTimestamp: &now,
+		},
+		//    Spec: api.NamespaceSpec{
+		//      Finalizers: []api.FinalizerName{"kubernetes"},
+		//    },
+		Status: api.NamespaceStatus{
+			Phase: api.NamespaceActive,
+		},
+	}
+	err := nm.Handle(testNamespace)
+	if err != nil {
+		t.Errorf("Unexpected error when handling namespace %v", err)
+	}
+	actionSet := util.NewStringSet()
+	for i := range mockKubeClient.Actions {
+		actionSet.Insert(mockKubeClient.Actions[i].Action)
+	}
+	for i := range mockOriginClient.Actions {
+		actionSet.Insert(mockOriginClient.Actions[i].Action)
+	}
+	if len(actionSet) != 0 {
+		t.Errorf("Expected no action from controller, but got: %v", actionSet)
+	}
+}

--- a/pkg/project/controller/factory.go
+++ b/pkg/project/controller/factory.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	controller "github.com/openshift/origin/pkg/controller"
+)
+
+type NamespaceControllerFactory struct {
+	// Client is an OpenShift client.
+	Client osclient.Interface
+	// KubeClient is a Kubernetes client.
+	KubeClient kclient.Interface
+}
+
+// Create creates a NamespaceController.
+func (factory *NamespaceControllerFactory) Create() controller.RunnableController {
+	namespaceLW := &cache.ListWatch{
+		ListFunc: func() (runtime.Object, error) {
+			return factory.KubeClient.Namespaces().List(labels.Everything())
+		},
+		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			return factory.KubeClient.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
+		},
+	}
+	queue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+	cache.NewReflector(namespaceLW, &kapi.Namespace{}, queue, 1*time.Minute).Run()
+
+	namespaceController := &NamespaceController{
+		Client:     factory.Client,
+		KubeClient: factory.KubeClient,
+	}
+
+	return &controller.RetryController{
+		Queue: queue,
+		RetryManager: controller.NewQueueRetryManager(
+			queue,
+			cache.MetaNamespaceKeyFunc,
+			func(obj interface{}, err error, count int) bool {
+				kutil.HandleError(err)
+				if _, isFatal := err.(fatalError); isFatal {
+					return false
+				}
+				if count > 0 {
+					return false
+				}
+				return true
+			},
+		),
+		Handle: func(obj interface{}) error {
+			namespace := obj.(*kapi.Namespace)
+			return namespaceController.Handle(namespace)
+		},
+	}
+}


### PR DESCRIPTION
This is the basic scaffolding to purge project content on deletion.

Once a Kubernetes rebase occurs, I can actually invoke the finalize command, and ensure that namespaces we provision in Kubernetes have the openshift.com/origin finalizer on it to ensure we have time to do the deletion.