### PR TITLE
relativize paths for master config

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -49,9 +49,15 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.AssetConfig.ServingInfo.ClientCA)
 	}
 
+	if config.KubernetesMasterConfig != nil {
+		refs = append(refs, &config.KubernetesMasterConfig.SchedulerConfigFile)
+	}
+
 	refs = append(refs, &config.MasterClients.DeployerKubeConfig)
 	refs = append(refs, &config.MasterClients.OpenShiftLoopbackKubeConfig)
 	refs = append(refs, &config.MasterClients.KubernetesKubeConfig)
+
+	refs = append(refs, &config.PolicyConfig.BootstrapPolicyFile)
 
 	return refs
 }


### PR DESCRIPTION
I found two files we forgot to relativize.  This causes pain when creating a config and running that config from a docker run.

@liggitt oops.