### PR TITLE
Make docker push quiet in builders

### DIFF
--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -3,6 +3,8 @@ package builder
 import (
 	"os"
 
+	"github.com/golang/glog"
+
 	"github.com/fsouza/go-dockerclient"
 	"github.com/openshift/source-to-image/pkg/tar"
 )
@@ -17,11 +19,11 @@ type DockerClient interface {
 
 // pushImage pushes a docker image to the registry specified in its tag
 func pushImage(client DockerClient, name string, authConfig docker.AuthConfiguration) error {
+	glog.Infof("Pushing %s ...", name)
 	repository, tag := docker.ParseRepositoryTag(name)
 	opts := docker.PushImageOptions{
-		Name:         repository,
-		Tag:          tag,
-		OutputStream: os.Stdout,
+		Name: repository,
+		Tag:  tag,
 	}
 	return client.PushImage(opts, authConfig)
 }


### PR DESCRIPTION
@bparees @mfojtik I've completely removed the logging, adding only information about push start. Eventual push errors are logged at higher level (in `sti.go` and `docker.go`) as build failures that's why I decided not to repeat it here.