### PR TITLE
add how to disable security to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Once the container is started, you can jump into a console inside the container 
     $ docker exec -it openshift-origin bash
     $ osc --help
 
+If you just want to experiment with the API without worrying about security privileges, you can disable authorization checks by running this from the host system.  This command grants full access to anyone.
+
+    $ docker exec -it openshift-origin bash -c "openshift admin --config=/var/lib/openshift/openshift.local.certificates/admin/.kubeconfig policy add-role-to-group cluster-admin system:authenticated system:unauthenticated"
+
 
 ### Start Developing
 


### PR DESCRIPTION
@smarterclayton added `docker exec` example that shows how to add all users to the `cluster-admin` role.