### PR TITLE
Handle unexpected server errors more thoroughly in RequestToken

### DIFF
--- a/pkg/oauth/server/osinserver/defaults.go
+++ b/pkg/oauth/server/osinserver/defaults.go
@@ -24,6 +24,7 @@ func NewDefaultServerConfig() *osin.ServerConfig {
 	config.AllowClientSecretInParams = true
 	config.AllowGetAccessRequest = true
 	config.RedirectUriSeparator = ","
+	config.ErrorStatusCode = http.StatusBadRequest
 
 	return config
 }

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -27,42 +27,43 @@ func TestRestrictedAccessForProjectAdmins(t *testing.T) {
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	haroldClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
+
 	markClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	_, err = haroldClient.Deployments("hammer-project").List(labels.Everything(), fields.Everything())
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	_, err = markClient.Deployments("hammer-project").List(labels.Everything(), fields.Everything())
 	if (err == nil) || !kapierror.IsForbidden(err) {
-		t.Errorf("expected forbidden error, but didn't get one")
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// projects are a special case where a get of a project actually sets a namespace.  Make sure that
 	// the namespace is properly special cased and set for authorization rules
 	_, err = haroldClient.Projects().Get("hammer-project")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	_, err = markClient.Projects().Get("hammer-project")
 	if (err == nil) || !kapierror.IsForbidden(err) {
-		t.Errorf("expected forbidden error, but didn't get one")
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// TODO restore this once we have detection for whether the cache is up to date.
@@ -94,7 +95,7 @@ func TestOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	addValerie := &policy.AddUserOptions{
@@ -105,11 +106,11 @@ func TestOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 		Users:            []string{"anypassword:valerie"},
 	}
 	if err := addValerie.Run(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if err = clusterAdminClient.Roles(bootstrappolicy.DefaultMasterAuthorizationNamespace).Delete(bootstrappolicy.ViewRoleName); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	addEdgar := &policy.AddUserOptions{
@@ -120,12 +121,12 @@ func TestOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 		Users:            []string{"anypassword:edgar"},
 	}
 	if err := addEdgar.Run(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// try to add Valerie to a non-existent role
 	if err := addValerie.Run(); err == nil || !kapierror.IsNotFound(err) {
-		t.Errorf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 }
@@ -169,22 +170,22 @@ func TestResourceAccessReview(t *testing.T) {
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	haroldClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	markClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 
+	markClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	addValerie := &policy.AddUserOptions{
@@ -195,7 +196,7 @@ func TestResourceAccessReview(t *testing.T) {
 		Users:            []string{"anypassword:valerie"},
 	}
 	if err := addValerie.Run(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	addEdgar := &policy.AddUserOptions{
@@ -206,7 +207,7 @@ func TestResourceAccessReview(t *testing.T) {
 		Users:            []string{"anypassword:edgar"},
 	}
 	if err := addEdgar.Run(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	requestWhoCanViewDeployments := &authorizationapi.ResourceAccessReview{Verb: "get", Resource: "deployments"}
@@ -297,22 +298,22 @@ func TestSubjectAccessReview(t *testing.T) {
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	haroldClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	markClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 
+	markClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	addValerie := &policy.AddUserOptions{
@@ -334,7 +335,7 @@ func TestSubjectAccessReview(t *testing.T) {
 		Users:            []string{"anypassword:edgar"},
 	}
 	if err := addEdgar.Run(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	askCanValerieGetProject := &authorizationapi.SubjectAccessReview{User: "anypassword:valerie", Verb: "get", Resource: "projects"}


### PR DESCRIPTION
Also ensures the OSIN server returns a 500 on generic error cases
as per the OAuth2 spec.

@deads2k