### PR TITLE
fix ResetBefore* methods

### DIFF
--- a/pkg/image/registry/image/strategy.go
+++ b/pkg/image/registry/image/strategy.go
@@ -24,7 +24,6 @@ type imageStrategy struct {
 // Image objects via the REST API.
 var Strategy = imageStrategy{kapi.Scheme, kapi.SimpleNameGenerator}
 
-func (imageStrategy) PrepareForCreate(obj runtime.Object)      {}
 func (imageStrategy) PrepareForUpdate(obj, old runtime.Object) {}
 
 // NamespaceScoped is false for images.
@@ -32,8 +31,8 @@ func (imageStrategy) NamespaceScoped() bool {
 	return false
 }
 
-// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
-func (imageStrategy) ResetBeforeCreate(obj runtime.Object) {
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (imageStrategy) PrepareForCreate(obj runtime.Object) {
 }
 
 // Validate validates a new image.

--- a/pkg/image/registry/imagerepository/strategy.go
+++ b/pkg/image/registry/imagerepository/strategy.go
@@ -27,7 +27,6 @@ func NewStrategy(defaultRegistry DefaultRegistry) Strategy {
 	return Strategy{kapi.Scheme, kapi.SimpleNameGenerator, defaultRegistry}
 }
 
-func (Strategy) PrepareForCreate(obj runtime.Object)      {}
 func (Strategy) PrepareForUpdate(obj, old runtime.Object) {}
 
 // NamespaceScoped is true for image repositories.
@@ -35,8 +34,8 @@ func (s Strategy) NamespaceScoped() bool {
 	return true
 }
 
-// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
-func (s Strategy) ResetBeforeCreate(obj runtime.Object) {
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (s Strategy) PrepareForCreate(obj runtime.Object) {
 	repo := obj.(*api.ImageRepository)
 	repo.Status = api.ImageRepositoryStatus{
 		DockerImageRepository: s.dockerImageRepository(repo),

--- a/pkg/image/registry/imagerepositorymapping/rest.go
+++ b/pkg/image/registry/imagerepositorymapping/rest.go
@@ -48,7 +48,6 @@ func (r *REST) New() runtime.Object {
 	return &api.ImageRepositoryMapping{}
 }
 
-func (imageRepositoryMappingStrategy) PrepareForCreate(obj runtime.Object)      {}
 func (imageRepositoryMappingStrategy) PrepareForUpdate(obj, old runtime.Object) {}
 
 // NamespaceScoped is true for image repository mappings.
@@ -56,8 +55,8 @@ func (s imageRepositoryMappingStrategy) NamespaceScoped() bool {
 	return true
 }
 
-// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
-func (s imageRepositoryMappingStrategy) ResetBeforeCreate(obj runtime.Object) {
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (s imageRepositoryMappingStrategy) PrepareForCreate(obj runtime.Object) {
 }
 
 // Validate validates a new ImageRepositoryMapping.

--- a/pkg/template/registry/rest.go
+++ b/pkg/template/registry/rest.go
@@ -36,11 +36,10 @@ func (templateStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (templateStrategy) PrepareForCreate(obj runtime.Object)      {}
 func (templateStrategy) PrepareForUpdate(obj, old runtime.Object) {}
 
-// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
-func (templateStrategy) ResetBeforeCreate(obj runtime.Object) {
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (templateStrategy) PrepareForCreate(obj runtime.Object) {
 }
 
 // Validate validates a new template.

--- a/pkg/user/registry/identity/rest.go
+++ b/pkg/user/registry/identity/rest.go
@@ -23,7 +23,6 @@ type identityStrategy struct {
 // objects via the REST API.
 var Strategy = identityStrategy{kapi.Scheme}
 
-func (identityStrategy) PrepareForCreate(obj runtime.Object)      {}
 func (identityStrategy) PrepareForUpdate(obj, old runtime.Object) {}
 
 // NamespaceScoped is false for users
@@ -35,7 +34,7 @@ func (identityStrategy) GenerateName(base string) string {
 	return base
 }
 
-func (identityStrategy) ResetBeforeCreate(obj runtime.Object) {
+func (identityStrategy) PrepareForCreate(obj runtime.Object) {
 	identity := obj.(*api.Identity)
 	identity.Name = identityName(identity.ProviderName, identity.ProviderUserName)
 }

--- a/pkg/user/registry/user/rest.go
+++ b/pkg/user/registry/user/rest.go
@@ -23,7 +23,6 @@ type userStrategy struct {
 // objects via the REST API.
 var Strategy = userStrategy{kapi.Scheme}
 
-func (userStrategy) PrepareForCreate(obj runtime.Object)      {}
 func (userStrategy) PrepareForUpdate(obj, old runtime.Object) {}
 
 // NamespaceScoped is false for users
@@ -35,7 +34,7 @@ func (userStrategy) GenerateName(base string) string {
 	return base
 }
 
-func (userStrategy) ResetBeforeCreate(obj runtime.Object) {
+func (userStrategy) PrepareForCreate(obj runtime.Object) {
 }
 
 // Validate validates a new user

--- a/pkg/user/registry/useridentitymapping/rest.go
+++ b/pkg/user/registry/useridentitymapping/rest.go
@@ -40,9 +40,6 @@ type userIdentityMappingStrategy struct {
 // objects via the REST API.
 var Strategy = userIdentityMappingStrategy{kapi.Scheme}
 
-func (userIdentityMappingStrategy) PrepareForCreate(obj runtime.Object)      {}
-func (userIdentityMappingStrategy) PrepareForUpdate(obj, old runtime.Object) {}
-
 // New returns a new UserIdentityMapping for use with Create.
 func (r *REST) New() runtime.Object {
 	return &api.UserIdentityMapping{}
@@ -61,8 +58,8 @@ func (userIdentityMappingStrategy) AllowCreateOnUpdate() bool {
 	return true
 }
 
-// ResetBeforeCreate clears fields that are not allowed to be set by end users on creation.
-func (s userIdentityMappingStrategy) ResetBeforeCreate(obj runtime.Object) {
+// PrepareForCreate clears fields that are not allowed to be set by end users on creation.
+func (s userIdentityMappingStrategy) PrepareForCreate(obj runtime.Object) {
 	mapping := obj.(*api.UserIdentityMapping)
 
 	if len(mapping.Name) == 0 {
@@ -80,8 +77,8 @@ func (s userIdentityMappingStrategy) ResetBeforeCreate(obj runtime.Object) {
 	mapping.User.UID = ""
 }
 
-// ResetBeforeUpdate clears fields that are not allowed to be set by end users on update
-func (s userIdentityMappingStrategy) ResetBeforeUpdate(obj runtime.Object) {
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update
+func (s userIdentityMappingStrategy) PrepareForUpdate(obj, old runtime.Object) {
 	mapping := obj.(*api.UserIdentityMapping)
 
 	if len(mapping.Name) == 0 {
@@ -123,7 +120,7 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	if !ok {
 		return nil, errors.New("Invalid type")
 	}
-	Strategy.ResetBeforeCreate(mapping)
+	Strategy.PrepareForCreate(mapping)
 	createdMapping, _, err := s.createOrUpdate(ctx, obj, true)
 	return createdMapping, err
 }
@@ -136,7 +133,7 @@ func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, boo
 	if !ok {
 		return nil, false, errors.New("Invalid type")
 	}
-	Strategy.ResetBeforeUpdate(mapping)
+	Strategy.PrepareForUpdate(mapping, nil)
 	return s.createOrUpdate(ctx, mapping, false)
 }
 


### PR DESCRIPTION
Andy pointed out that one of the refactorings for the new registry was incorrect.  I left the ResetBefore* methods instead of renaming them into the PrepareFor* method.  This does the proper rename.

Only useridentitymapping was using a ResetBeforeUpdate, all others are left with an empty implementation placeholder.  

@ncdc PTAL

/cc @smarterclayton 