### PR TITLE
Use the Fake cAdvisor interface on Macs

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -115,8 +115,13 @@ func (c *NodeConfig) RunKubelet() {
 	}
 
 	cadvisorInterface, err := cadvisor.New(4194)
+	if err == nil {
+		// TODO: use VersionInfo after the next rebase
+		_, err = cadvisorInterface.MachineInfo()
+	}
 	if err != nil {
 		glog.Errorf("WARNING: cAdvisor cannot be started: %v", err)
+		cadvisorInterface = &cadvisor.Fake{}
 	}
 
 	// initialize Kubelet


### PR DESCRIPTION
In the future we should also allow cAdvisor to be deliberately disabled

[merge]