### PR TITLE
Tighten up config

### DIFF
--- a/pkg/cmd/server/api/register.go
+++ b/pkg/cmd/server/api/register.go
@@ -11,7 +11,6 @@ func init() {
 		&MasterConfig{},
 		&NodeConfig{},
 
-		&IdentityProviderUsage{},
 		&IdentityProvider{},
 		&BasicAuthPasswordIdentityProvider{},
 		&AllowAllPasswordIdentityProvider{},
@@ -25,7 +24,6 @@ func init() {
 	)
 }
 
-func (*IdentityProviderUsage) IsAnAPIObject()             {}
 func (*IdentityProvider) IsAnAPIObject()                  {}
 func (*BasicAuthPasswordIdentityProvider) IsAnAPIObject() {}
 func (*AllowAllPasswordIdentityProvider) IsAnAPIObject()  {}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -146,9 +146,9 @@ type AssetConfig struct {
 	// PublicURL is where you can find the asset server (TODO do we really need this?)
 	PublicURL string
 
-	// LogoutURI is an optional, absolute URI to redirect web browsers to after logging out of the web console.
+	// LogoutURL is an optional, absolute URL to redirect web browsers to after logging out of the web console.
 	// If not specified, the built-in logout page is shown.
-	LogoutURI string
+	LogoutURL string
 
 	// MasterPublicURL is how the web console can access the OpenShift api server
 	MasterPublicURL string
@@ -159,7 +159,7 @@ type AssetConfig struct {
 }
 
 type OAuthConfig struct {
-	// MasterURL is used for building valid client redirect URLs for external access
+	// MasterURL is used for building valid client redirect URLs for internal access
 	MasterURL string
 
 	// MasterPublicURL is used for building valid client redirect URLs for external access
@@ -196,20 +196,13 @@ type SessionConfig struct {
 	SessionName string
 }
 
-type IdentityProviderUsage struct {
-	// ProviderName is used to qualify the identities returned by this provider
-	ProviderName string
-
+type IdentityProvider struct {
+	// Name is used to qualify the identities returned by this provider
+	Name string
 	// UseAsChallenger indicates whether to issue WWW-Authenticate challenges for this provider
 	UseAsChallenger bool
 	// UseAsLogin indicates whether to use this identity provider for unauthenticated browsers to login against
 	UseAsLogin bool
-}
-
-type IdentityProvider struct {
-	// Usage contains metadata about how to use this provider
-	Usage IdentityProviderUsage
-
 	// Provider contains the information about how to set up a specific identity provider
 	Provider runtime.EmbeddedObject
 }
@@ -242,7 +235,7 @@ type RequestHeaderIdentityProvider struct {
 	// ClientCA is a file with the trusted signer certs.  If empty, no request verification is done, and any direct request to the OAuth server can impersonate any identity from this provider, merely by setting a request header.
 	ClientCA string
 	// Headers is the set of headers to check for identity information
-	Headers util.StringSet
+	Headers []string
 }
 
 type OAuthRedirectingIdentityProvider struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	newer "github.com/openshift/origin/pkg/cmd/server/api"
 )
 
@@ -20,6 +19,20 @@ func init() {
 			out.ClientCA = in.ClientCA
 			out.CertFile = in.ServerCert.CertFile
 			out.KeyFile = in.ServerCert.KeyFile
+			return nil
+		},
+		func(in *RemoteConnectionInfo, out *newer.RemoteConnectionInfo, s conversion.Scope) error {
+			out.URL = in.URL
+			out.CA = in.CA
+			out.ClientCert.CertFile = in.CertFile
+			out.ClientCert.KeyFile = in.KeyFile
+			return nil
+		},
+		func(in *newer.RemoteConnectionInfo, out *RemoteConnectionInfo, s conversion.Scope) error {
+			out.URL = in.URL
+			out.CA = in.CA
+			out.CertFile = in.ClientCert.CertFile
+			out.KeyFile = in.ClientCert.KeyFile
 			return nil
 		},
 		func(in *EtcdConnectionInfo, out *newer.EtcdConnectionInfo, s conversion.Scope) error {
@@ -48,20 +61,6 @@ func init() {
 			out.CA = in.CA
 			out.CertFile = in.ClientCert.CertFile
 			out.KeyFile = in.ClientCert.KeyFile
-			return nil
-		},
-		func(in *RequestHeaderIdentityProvider, out *newer.RequestHeaderIdentityProvider, s conversion.Scope) error {
-			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-				return err
-			}
-			out.Headers = util.NewStringSet(in.HeadersSlice...)
-			return nil
-		},
-		func(in *newer.RequestHeaderIdentityProvider, out *RequestHeaderIdentityProvider, s conversion.Scope) error {
-			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-				return err
-			}
-			out.HeadersSlice = in.Headers.List()
 			return nil
 		},
 	)

--- a/pkg/cmd/server/api/v1/register.go
+++ b/pkg/cmd/server/api/v1/register.go
@@ -12,7 +12,6 @@ func init() {
 		&MasterConfig{},
 		&NodeConfig{},
 
-		&IdentityProviderUsage{},
 		&IdentityProvider{},
 		&BasicAuthPasswordIdentityProvider{},
 		&AllowAllPasswordIdentityProvider{},
@@ -26,7 +25,6 @@ func init() {
 	)
 }
 
-func (*IdentityProviderUsage) IsAnAPIObject()             {}
 func (*IdentityProvider) IsAnAPIObject()                  {}
 func (*BasicAuthPasswordIdentityProvider) IsAnAPIObject() {}
 func (*AllowAllPasswordIdentityProvider) IsAnAPIObject()  {}

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -145,9 +145,9 @@ type AssetConfig struct {
 	// PublicURL is where you can find the asset server (TODO do we really need this?)
 	PublicURL string `json:"publicURL"`
 
-	// LogoutURI is an optional, absolute URI to redirect web browsers to after logging out of the web console.
+	// LogoutURL is an optional, absolute URL to redirect web browsers to after logging out of the web console.
 	// If not specified, the built-in logout page is shown.
-	LogoutURI string `json:"logoutURI"`
+	LogoutURL string `json:"logoutURL"`
 
 	// MasterPublicURL is how the web console can access the OpenShift v1beta3 server
 	MasterPublicURL string `json:"masterPublicURL"`
@@ -192,16 +192,14 @@ type SessionConfig struct {
 	SessionName string `json:"sessionName"`
 }
 
-type IdentityProviderUsage struct {
-	ProviderName string `json:"providerName"`
-
-	UseAsChallenger bool `json:"challenge"`
-	UseAsLogin      bool `json:"login"`
-}
-
 type IdentityProvider struct {
-	Usage IdentityProviderUsage `json:"usage"`
-
+	// Name is used to qualify the identities returned by this provider
+	Name string `json:"name"`
+	// UseAsChallenger indicates whether to issue WWW-Authenticate challenges for this provider
+	UseAsChallenger bool `json:"challenge"`
+	// UseAsLogin indicates whether to use this identity provider for unauthenticated browsers to login against
+	UseAsLogin bool `json:"login"`
+	// Provider contains the information about how to set up a specific identity provider
 	Provider runtime.RawExtension `json:"provider"`
 }
 
@@ -228,8 +226,8 @@ type HTPasswdPasswordIdentityProvider struct {
 type RequestHeaderIdentityProvider struct {
 	v1beta3.TypeMeta `json:",inline"`
 
-	ClientCA     string   `json:"clientCA"`
-	HeadersSlice []string `json:"headers"`
+	ClientCA string   `json:"clientCA"`
+	Headers  []string `json:"headers"`
 }
 
 type OAuthRedirectingIdentityProvider struct {

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -83,6 +83,13 @@ func ValidateAssetConfig(config *api.AssetConfig) fielderrors.ValidationErrorLis
 
 	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
 
+	if len(config.LogoutURL) > 0 {
+		_, urlErrs := ValidateURL(config.LogoutURL, "logoutURL")
+		if len(urlErrs) > 0 {
+			allErrs = append(allErrs, urlErrs...)
+		}
+	}
+
 	urlObj, urlErrs := ValidateURL(config.PublicURL, "publicURL")
 	if len(urlErrs) > 0 {
 		allErrs = append(allErrs, urlErrs...)

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -79,6 +79,9 @@ func ValidateRemoteConnectionInfo(remoteConnectionInfo api.RemoteConnectionInfo)
 
 	if len(remoteConnectionInfo.URL) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("url"))
+	} else {
+		_, urlErrs := ValidateURL(remoteConnectionInfo.URL, "url")
+		allErrs = append(allErrs, urlErrs...)
 	}
 
 	if len(remoteConnectionInfo.CA) > 0 {

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -114,7 +114,7 @@ func (c *AssetConfig) buildHandler() (http.Handler, error) {
 		OAuthAuthorizeURI: OpenShiftOAuthAuthorizeURL(masterURL.String()),
 		OAuthRedirectBase: c.Options.PublicURL,
 		OAuthClientID:     OpenShiftWebConsoleClientID,
-		LogoutURI:         c.Options.LogoutURI,
+		LogoutURI:         c.Options.LogoutURL,
 	}
 
 	handler := http.FileServer(

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -164,7 +164,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 				BindAddress: args.GetAssetBindAddress(),
 			},
 
-			LogoutURI:           "",
+			LogoutURL:           "",
 			MasterPublicURL:     masterPublicAddr.String(),
 			PublicURL:           assetPublicAddr.String(),
 			KubernetesPublicURL: kubePublicAddr.String(),
@@ -287,11 +287,9 @@ func (args MasterArgs) BuildSerializeableOAuthConfig() (*configapi.OAuthConfig, 
 
 	config.IdentityProviders = append(config.IdentityProviders,
 		configapi.IdentityProvider{
-			Usage: configapi.IdentityProviderUsage{
-				ProviderName:    "anypassword",
-				UseAsChallenger: true,
-				UseAsLogin:      true,
-			},
+			Name:            "anypassword",
+			UseAsChallenger: true,
+			UseAsLogin:      true,
 			Provider: runtime.EmbeddedObject{
 				&configapi.AllowAllPasswordIdentityProvider{},
 			},

--- a/test/integration/oauth_htpasswd_test.go
+++ b/test/integration/oauth_htpasswd_test.go
@@ -29,11 +29,9 @@ func TestHTPasswd(t *testing.T) {
 	}
 
 	masterOptions.OAuthConfig.IdentityProviders[0] = configapi.IdentityProvider{
-		Usage: configapi.IdentityProviderUsage{
-			ProviderName:    "htpasswd",
-			UseAsChallenger: true,
-			UseAsLogin:      true,
-		},
+		Name:            "htpasswd",
+		UseAsChallenger: true,
+		UseAsLogin:      true,
 		Provider: runtime.EmbeddedObject{
 			&configapi.HTPasswdPasswordIdentityProvider{
 				File: htpasswdFile.Name(),

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -11,7 +11,6 @@ import (
 
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -106,15 +105,13 @@ func TestOAuthRequestHeader(t *testing.T) {
 	}
 
 	masterOptions.OAuthConfig.IdentityProviders[0] = configapi.IdentityProvider{
-		Usage: configapi.IdentityProviderUsage{
-			ProviderName:    "requestheader",
-			UseAsChallenger: false,
-			UseAsLogin:      false,
-		},
+		Name:            "requestheader",
+		UseAsChallenger: false,
+		UseAsLogin:      false,
 		Provider: runtime.EmbeddedObject{
 			&configapi.RequestHeaderIdentityProvider{
 				ClientCA: caFile.Name(),
-				Headers:  util.NewStringSet("My-Remote-User", "SSO-User"),
+				Headers:  []string{"My-Remote-User", "SSO-User"},
 			},
 		},
 	}


### PR DESCRIPTION
@deads2k review

- [x] unnest usage object
- [x] restore stomped remoteconnection conversion
- [x] shorten providerName to name
- [x] rename logoutURI to logoutURL for consistency, and validate url
- [x] give the names of conflicting providers when more than one claims login ability
- [x] change RequestHeaderIdentityProvider to use a string slice for headers, since we need to check headers in specified order
- [x] Validate no provider name duplicates

Follow-ups:

- [ ] Add conversion tests
- [ ] Secret config - moved session secret changes to separate PR to work on externalization


Before:
```
oauthConfig:
  ...
  identityProviders:
  - provider:
      apiVersion: v1
      kind: AllowAllPasswordIdentityProvider
    usage:
      challenge: true
      login: true
      providerName: anypassword
```

After:
```
oauthConfig:
  ...
  identityProviders:
  - challenge: true
    login: true
    name: anypassword
    provider:
      apiVersion: v1
      kind: AllowAllPasswordIdentityProvider
```