### PR TITLE
OAuth secret config

### DIFF
--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -380,7 +380,7 @@ func (o CreateNodeConfigOptions) MakeNodeConfig(serverCertFile, serverKeyFile, n
 		return err
 	}
 
-	content, err := latestconfigapi.WriteNode(config)
+	content, err := latestconfigapi.WriteYAML(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -48,6 +48,11 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 	}
 
 	if config.OAuthConfig != nil {
+
+		if config.OAuthConfig.SessionConfig != nil {
+			refs = append(refs, &config.OAuthConfig.SessionConfig.SessionSecretsFile)
+		}
+
 		for _, identityProvider := range config.OAuthConfig.IdentityProviders {
 			switch provider := identityProvider.Provider.Object.(type) {
 			case (*RequestHeaderIdentityProvider):

--- a/pkg/cmd/server/api/register.go
+++ b/pkg/cmd/server/api/register.go
@@ -10,6 +10,7 @@ func init() {
 	Scheme.AddKnownTypes("",
 		&MasterConfig{},
 		&NodeConfig{},
+		&SessionSecrets{},
 
 		&IdentityProvider{},
 		&BasicAuthPasswordIdentityProvider{},
@@ -35,5 +36,6 @@ func (*GrantConfig) IsAnAPIObject()                       {}
 func (*GoogleOAuthProvider) IsAnAPIObject()               {}
 func (*GitHubOAuthProvider) IsAnAPIObject()               {}
 
-func (*MasterConfig) IsAnAPIObject() {}
-func (*NodeConfig) IsAnAPIObject()   {}
+func (*MasterConfig) IsAnAPIObject()   {}
+func (*NodeConfig) IsAnAPIObject()     {}
+func (*SessionSecrets) IsAnAPIObject() {}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -183,13 +183,31 @@ type TokenConfig struct {
 	AccessTokenMaxAgeSeconds int32
 }
 
+// SessionConfig specifies options for cookie-based sessions. Used by AuthRequestHandlerSession
 type SessionConfig struct {
-	// SessionSecrets list the secret(s) to use to encrypt created sessions. Used by AuthRequestHandlerSession
-	SessionSecrets []string
+	// SessionSecretsFile is a reference to a file containing a serialized SessionSecrets object
+	// If no file is specified, a random signing and encryption key are generated at each server start
+	SessionSecretsFile string
 	// SessionMaxAgeSeconds specifies how long created sessions last. Used by AuthRequestHandlerSession
 	SessionMaxAgeSeconds int32
 	// SessionName is the cookie name used to store the session
 	SessionName string
+}
+
+// SessionSecrets list the secrets to use to sign/encrypt and authenticate/decrypt created sessions.
+type SessionSecrets struct {
+	api.TypeMeta
+
+	// New sessions are signed and encrypted using the first secret.
+	// Existing sessions are decrypted/authenticated by each secret until one succeeds. This allows rotating secrets.
+	Secrets []SessionSecret
+}
+
+type SessionSecret struct {
+	// Signing secret, used to authenticate sessions using HMAC. Recommended to use a secret with 32 or 64 bytes.
+	Authentication string
+	// Encrypting secret, used to encrypt sessions. Must be 16, 24, or 32 characters long, to select AES-128, AES-192, or AES-256.
+	Encryption string
 }
 
 type IdentityProvider struct {

--- a/pkg/cmd/server/api/v1/register.go
+++ b/pkg/cmd/server/api/v1/register.go
@@ -11,6 +11,7 @@ func init() {
 	api.Scheme.AddKnownTypes("v1",
 		&MasterConfig{},
 		&NodeConfig{},
+		&SessionSecrets{},
 
 		&IdentityProvider{},
 		&BasicAuthPasswordIdentityProvider{},
@@ -36,5 +37,6 @@ func (*GrantConfig) IsAnAPIObject()                       {}
 func (*GoogleOAuthProvider) IsAnAPIObject()               {}
 func (*GitHubOAuthProvider) IsAnAPIObject()               {}
 
-func (*MasterConfig) IsAnAPIObject() {}
-func (*NodeConfig) IsAnAPIObject()   {}
+func (*MasterConfig) IsAnAPIObject()   {}
+func (*NodeConfig) IsAnAPIObject()     {}
+func (*SessionSecrets) IsAnAPIObject() {}

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -179,13 +179,31 @@ type TokenConfig struct {
 	AccessTokenMaxAgeSeconds int32 `json:"accessTokenMaxAgeSeconds"`
 }
 
+// SessionConfig specifies options for cookie-based sessions. Used by AuthRequestHandlerSession
 type SessionConfig struct {
-	// SessionSecrets list the secret(s) to use to encrypt created sessions. Used by AuthRequestHandlerSession
-	SessionSecrets []string `json:"sessionSecrets"`
+	// SessionSecretsFile is a reference to a file containing a serialized SessionSecrets object
+	// If no file is specified, a random signing and encryption key are generated at each server start
+	SessionSecretsFile string `json:"sessionSecretsFile"`
 	// SessionMaxAgeSeconds specifies how long created sessions last. Used by AuthRequestHandlerSession
 	SessionMaxAgeSeconds int32 `json:"sessionMaxAgeSeconds"`
 	// SessionName is the cookie name used to store the session
 	SessionName string `json:"sessionName"`
+}
+
+// SessionSecrets list the secrets to use to sign/encrypt and authenticate/decrypt created sessions.
+type SessionSecrets struct {
+	v1beta3.TypeMeta `json:",inline"`
+
+	// New sessions are signed and encrypted using the first secret.
+	// Existing sessions are decrypted/authenticated by each secret until one succeeds. This allows rotating secrets.
+	Secrets []SessionSecret `json:"secrets"`
+}
+
+type SessionSecret struct {
+	// Signing secret, used to authenticate sessions using HMAC. Recommended to use a secret with 32 or 64 bytes.
+	Authentication string `json:"authentication"`
+	// Encrypting secret, used to encrypt sessions. Must be 16, 24, or 32 characters long, to select AES-128, AES-
+	Encryption string `json:"encryption"`
 }
 
 type IdentityProvider struct {

--- a/pkg/cmd/server/origin/auth_config_test.go
+++ b/pkg/cmd/server/origin/auth_config_test.go
@@ -1,0 +1,96 @@
+package origin
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/api/latest"
+)
+
+func TestGetDefaultSessionSecrets(t *testing.T) {
+	secrets, err := getSessionSecrets("")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(secrets) != 2 {
+		t.Errorf("Unexpected 2 secrets, got: %#v", secrets)
+	}
+}
+
+func TestGetMissingSessionSecretsFile(t *testing.T) {
+	_, err := getSessionSecrets("missing")
+	if err == nil {
+		t.Errorf("Expected error, got none")
+	}
+}
+
+func TestGetInvalidSessionSecretsFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "invalid.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	ioutil.WriteFile(tmpfile.Name(), []byte("invalid content"), os.FileMode(0600))
+
+	_, err = getSessionSecrets(tmpfile.Name())
+	if err == nil {
+		t.Errorf("Expected error, got none")
+	}
+}
+
+func TestGetEmptySessionSecretsFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "empty.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	secrets := &api.SessionSecrets{
+		Secrets: []api.SessionSecret{},
+	}
+
+	yaml, err := latest.WriteYAML(secrets)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	ioutil.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600))
+
+	_, err = getSessionSecrets(tmpfile.Name())
+	if err == nil {
+		t.Errorf("Expected error, got none")
+	}
+}
+
+func TestGetValidSessionSecretsFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "valid.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	secrets := &api.SessionSecrets{
+		Secrets: []api.SessionSecret{
+			{Authentication: "a1", Encryption: "e1"},
+			{Authentication: "a2", Encryption: "e2"},
+		},
+	}
+	expectedSecrets := []string{"a1", "e1", "a2", "e2"}
+
+	yaml, err := latest.WriteYAML(secrets)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	ioutil.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600))
+
+	readSecrets, err := getSessionSecrets(tmpfile.Name())
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(readSecrets, expectedSecrets) {
+		t.Errorf("Unexpected %v, got %v", expectedSecrets, readSecrets)
+	}
+}

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"strconv"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
@@ -234,7 +233,7 @@ func (args MasterArgs) BuildSerializeableOAuthConfig() (*configapi.OAuthConfig, 
 		},
 
 		SessionConfig: &configapi.SessionConfig{
-			SessionSecrets:       []string{uuid.NewUUID().String()},
+			SessionSecretsFile:   "",
 			SessionMaxAgeSeconds: 300,
 			SessionName:          "ssn",
 		},

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -219,7 +219,7 @@ func (o MasterOptions) RunMaster() error {
 			return err
 		}
 
-		content, err := configapilatest.WriteMaster(masterConfig)
+		content, err := configapilatest.WriteYAML(masterConfig)
 		if err != nil {
 			return err
 		}
@@ -306,11 +306,13 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 
 	unprotectedInstallers := []origin.APIInstaller{}
 
-	authConfig, err := origin.BuildAuthConfig(*openshiftMasterConfig)
-	if err != nil {
-		return err
+	if openshiftMasterConfig.OAuthConfig != nil {
+		authConfig, err := origin.BuildAuthConfig(*openshiftMasterConfig)
+		if err != nil {
+			return err
+		}
+		unprotectedInstallers = append(unprotectedInstallers, authConfig)
 	}
-	unprotectedInstallers = append(unprotectedInstallers, authConfig)
 
 	var standaloneAssetConfig *origin.AssetConfig
 	if openshiftMasterConfig.AssetConfig != nil {

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -183,7 +183,7 @@ func (o NodeOptions) RunNode() error {
 			return err
 		}
 
-		content, err := configapilatest.WriteNode(nodeConfig)
+		content, err := configapilatest.WriteYAML(nodeConfig)
 		if err != nil {
 			return err
 		}

--- a/test/integration/oauth_disabled_test.go
+++ b/test/integration/oauth_disabled_test.go
@@ -1,0 +1,62 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"testing"
+
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+func TestOAuthDisabled(t *testing.T) {
+	// Build master config
+	masterOptions, err := testutil.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Disable OAuth
+	masterOptions.OAuthConfig = nil
+
+	// Start server
+	clusterAdminKubeConfig, err := testutil.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	client, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Make sure cert auth still works
+	namespaces, err := client.Namespaces().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if len(namespaces.Items) == 0 {
+		t.Errorf("Expected namespaces, got none")
+	}
+
+	// Use the server and CA info
+	anonConfig := kclient.Config{}
+	anonConfig.Host = clientConfig.Host
+	anonConfig.CAFile = clientConfig.CAFile
+	anonConfig.CAData = clientConfig.CAData
+
+	// Make sure we can't authenticate using OAuth
+	if _, err := tokencmd.RequestToken(&anonConfig, nil, "username", "password"); err == nil {
+		t.Error("Expected error, got none")
+	}
+
+}


### PR DESCRIPTION
- [x] Add structure and validation around session secrets
- [x] Switch session secret from time-based uuid to hash of random uuid
- [x] Generate default signing and encrypting secrets
- [x] Optionally externalize secrets using a file ref to a serialized SessionSecrets object
- [x] Update OAuth config documentation