### PR TITLE
remove dead parameters

### DIFF
--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -123,6 +123,7 @@ type WebConsoleConfig struct {
 	MasterAddr string
 	// MasterPrefix is the OpenShift API context root
 	MasterPrefix string
+	// TODO this is probably unneeded since everything goes through the openshift master's proxy
 	// KubernetesAddr is the host:port the UI should call the kubernetes API on. Scheme is derived from the scheme the UI is served on, so they must be the same.
 	KubernetesAddr string
 	// KubernetesPrefix is the Kubernetes API context root

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -152,10 +152,6 @@ type AssetConfig struct {
 
 	// MasterPublicURL is how the web console can access the OpenShift api server
 	MasterPublicURL string
-
-	// TODO: we probably don't need this since we have a proxy
-	// KubernetesPublicURL is how the web console can access the Kubernetes api server
-	KubernetesPublicURL string
 }
 
 type OAuthConfig struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -151,10 +151,6 @@ type AssetConfig struct {
 
 	// MasterPublicURL is how the web console can access the OpenShift v1beta3 server
 	MasterPublicURL string `json:"masterPublicURL"`
-
-	// TODO: we probably don't need this since we have a proxy
-	// KubernetesPublicURL is how the web console can access the Kubernetes v1beta3 server
-	KubernetesPublicURL string `json:"kubernetesPublicURL"`
 }
 
 type OAuthConfig struct {

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -96,11 +96,6 @@ func (c *AssetConfig) buildHandler() (http.Handler, error) {
 		return nil, err
 	}
 
-	k8sURL, err := url.Parse(c.Options.KubernetesPublicURL)
-	if err != nil {
-		return nil, err
-	}
-
 	publicURL, err := url.Parse(c.Options.PublicURL)
 	if err != nil {
 		glog.Fatal(err)
@@ -109,7 +104,7 @@ func (c *AssetConfig) buildHandler() (http.Handler, error) {
 	config := assets.WebConsoleConfig{
 		MasterAddr:        masterURL.Host,
 		MasterPrefix:      OpenShiftAPIPrefix,
-		KubernetesAddr:    k8sURL.Host,
+		KubernetesAddr:    masterURL.Host,
 		KubernetesPrefix:  KubernetesAPIPrefix,
 		OAuthAuthorizeURI: OpenShiftOAuthAuthorizeURL(masterURL.String()),
 		OAuthRedirectBase: c.Options.PublicURL,

--- a/pkg/cmd/server/start/command_test.go
+++ b/pkg/cmd/server/start/command_test.go
@@ -109,30 +109,6 @@ func TestCommandBindingEtcd(t *testing.T) {
 	}
 }
 
-func TestCommandBindingKubernetes(t *testing.T) {
-	valueToSet := "http://example.org:9123"
-	actualCfg := executeMasterCommand([]string{"--kubernetes=" + valueToSet})
-
-	expectedArgs := NewDefaultMasterArgs()
-	expectedArgs.KubeConnectionArgs.KubernetesAddr.Set(valueToSet)
-
-	if expectedArgs.KubeConnectionArgs.KubernetesAddr.String() != actualCfg.KubeConnectionArgs.KubernetesAddr.String() {
-		t.Errorf("expected %v, got %v", expectedArgs.KubeConnectionArgs.KubernetesAddr.String(), actualCfg.KubeConnectionArgs.KubernetesAddr.String())
-	}
-}
-
-func TestCommandBindingKubernetesPublic(t *testing.T) {
-	valueToSet := "http://example.org:9123"
-	actualCfg := executeMasterCommand([]string{"--public-kubernetes=" + valueToSet})
-
-	expectedArgs := NewDefaultMasterArgs()
-	expectedArgs.KubernetesPublicAddr.Set(valueToSet)
-
-	if expectedArgs.KubernetesPublicAddr.String() != actualCfg.KubernetesPublicAddr.String() {
-		t.Errorf("expected %v, got %v", expectedArgs.KubernetesPublicAddr.String(), actualCfg.KubernetesPublicAddr.String())
-	}
-}
-
 func TestCommandBindingPortalNet(t *testing.T) {
 	valueToSet := "192.168.0.0/16"
 	actualCfg := executeMasterCommand([]string{"--portal-net=" + valueToSet})

--- a/pkg/cmd/server/start/config_test.go
+++ b/pkg/cmd/server/start/config_test.go
@@ -29,26 +29,6 @@ func TestMasterPublicURLNoPathAllowed(t *testing.T) {
 	}
 }
 
-func TestKubePublicURLNoPathAllowed(t *testing.T) {
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.KubernetesPublicAddr.Set("http://example.com:9012/")
-	err := masterArgs.Validate()
-
-	if err == nil || !strings.Contains(err.Error(), "may not include a path") {
-		t.Errorf("expected %v, got %v", "may not include a path", err)
-	}
-}
-
-func TestKubeURLNoPathAllowed(t *testing.T) {
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.KubeConnectionArgs.KubernetesAddr.Set("http://example.com:9012/")
-	err := masterArgs.Validate()
-
-	if err == nil || !strings.Contains(err.Error(), "may not include a path") {
-		t.Errorf("expected %v, got %v", "may not include a path", err)
-	}
-}
-
 func TestMasterPublicAddressDefaulting(t *testing.T) {
 	expected := "http://example.com:9012"
 
@@ -109,94 +89,11 @@ func TestAssetBindAddressDefaulting(t *testing.T) {
 	}
 }
 
-func TestKubernetesPublicAddressDefaultToKubernetesAddress(t *testing.T) {
-	expected := "http://example.com:9012"
-
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.KubeConnectionArgs.KubernetesAddr.Set(expected)
-	masterArgs.MasterPublicAddr.Set("unexpectedpublicmaster")
-	masterArgs.MasterAddr.Set("unexpectedmaster")
-
-	actual, err := masterArgs.GetKubernetesPublicAddress()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expected != actual.String() {
-		t.Fatalf("expected %v, got %v", expected, actual)
-	}
-}
-
-func TestKubernetesPublicAddressDefaultToPublicMasterAddress(t *testing.T) {
-	expected := "http://example.com:9012"
-
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.MasterPublicAddr.Set(expected)
-	masterArgs.MasterAddr.Set("unexpectedmaster")
-
-	actual, err := masterArgs.GetKubernetesPublicAddress()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expected != actual.String() {
-		t.Fatalf("expected %v, got %v", expected, actual)
-	}
-}
-
-func TestKubernetesPublicAddressDefaultToMasterAddress(t *testing.T) {
-	expected := "http://example.com:9012"
-
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.MasterAddr.Set(expected)
-
-	actual, err := masterArgs.GetKubernetesPublicAddress()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expected != actual.String() {
-		t.Fatalf("expected %v, got %v", expected, actual)
-	}
-}
-
-func TestKubernetesPublicAddressExplicit(t *testing.T) {
-	expected := "http://external.com:12445"
-
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.MasterAddr.Set("http://internal.com:9012")
-	masterArgs.KubeConnectionArgs.KubernetesAddr.Set("http://internal.com:9013")
-	masterArgs.MasterPublicAddr.Set("http://internal.com:9014")
-	masterArgs.KubernetesPublicAddr.Set(expected)
-
-	actual, err := masterArgs.GetKubernetesPublicAddress()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expected != actual.String() {
-		t.Fatalf("expected %v, got %v", expected, actual)
-	}
-}
-
 func TestKubernetesAddressDefaulting(t *testing.T) {
 	expected := "http://example.com:9012"
 
 	masterArgs := NewDefaultMasterArgs()
 	masterArgs.MasterAddr.Set(expected)
-	masterAddr, _ := masterArgs.GetMasterAddress()
-
-	actual, err := masterArgs.KubeConnectionArgs.GetKubernetesAddress(masterAddr)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expected != actual.String() {
-		t.Fatalf("expected %v, got %v", expected, actual)
-	}
-}
-
-func TestKubernetesAddressExplicit(t *testing.T) {
-	expected := "http://external.com:12445"
-
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.MasterAddr.Set("http://internal.com:9012")
-	masterArgs.KubeConnectionArgs.KubernetesAddr.Set(expected)
 	masterAddr, _ := masterArgs.GetMasterAddress()
 
 	actual, err := masterArgs.KubeConnectionArgs.GetKubernetesAddress(masterAddr)
@@ -364,14 +261,6 @@ func TestKubeClientForExternalKubernetesMasterWithConfig(t *testing.T) {
 	masterArgs := NewDefaultMasterArgs()
 	masterArgs.KubeConnectionArgs.ClientConfigLoadingRules, masterArgs.KubeConnectionArgs.ClientConfig = makeKubeconfig(expectedServer, expectedUser)
 
-	actualPublic, err := masterArgs.GetKubernetesPublicAddress()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expectedServer != actualPublic.String() {
-		t.Fatalf("expected %v, got %v", expectedServer, actualPublic)
-	}
-
 	masterAddr, _ := masterArgs.GetMasterAddress()
 
 	actual, err := masterArgs.KubeConnectionArgs.GetKubernetesAddress(masterAddr)
@@ -403,55 +292,11 @@ func TestKubeClientForExternalKubernetesMasterWithErrorKubeconfig(t *testing.T) 
 	masterArgs := NewDefaultMasterArgs()
 	masterArgs.KubeConnectionArgs.ClientConfigLoadingRules, masterArgs.KubeConnectionArgs.ClientConfig = makeErrorKubeconfig()
 
-	// GetKubernetesPublicAddress hits the invalid kubeconfig in the fallback chain
-	_, err := masterArgs.GetKubernetesPublicAddress()
-	if err == nil {
-		t.Fatalf("expected error, got none")
-	}
-
 	// GetKubernetesAddress hits the invalid kubeconfig in the fallback chain
 	masterAddr, _ := masterArgs.GetMasterAddress()
-	_, err = masterArgs.KubeConnectionArgs.GetKubernetesAddress(masterAddr)
+	_, err := masterArgs.KubeConnectionArgs.GetKubernetesAddress(masterAddr)
 	if err == nil {
 		t.Fatalf("expected error, got none")
-	}
-}
-
-func TestKubeClientForExternalKubernetesMasterWithConflictingKubernetesAddress(t *testing.T) {
-	expectedServer := "https://some-other-server:1234"
-	expectedUser := "myuser"
-
-	masterArgs := NewDefaultMasterArgs()
-	// Explicitly set --kubernetes must match --kubeconfig or return an error
-	masterArgs.KubeConnectionArgs.KubernetesAddr.Set(expectedServer)
-	masterArgs.KubeConnectionArgs.ClientConfigLoadingRules, masterArgs.KubeConnectionArgs.ClientConfig = makeKubeconfig("https://another-server:2345", expectedUser)
-
-	// GetKubernetesAddress returns the explicitly set address
-	masterAddr, _ := masterArgs.GetMasterAddress()
-	actual, err := masterArgs.KubeConnectionArgs.GetKubernetesAddress(masterAddr)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expectedServer != actual.String() {
-		t.Fatalf("expected %v, got %v", expectedServer, actual)
-	}
-}
-
-func TestKubeClientForNodeWithConflictingKubernetesAddress(t *testing.T) {
-	expectedServer := "https://some-other-server:1234"
-	expectedUser := "myuser"
-
-	nodeArgs := NewDefaultNodeArgs()
-	nodeArgs.KubeConnectionArgs.KubernetesAddr.Set(expectedServer)
-	nodeArgs.KubeConnectionArgs.ClientConfigLoadingRules, nodeArgs.KubeConnectionArgs.ClientConfig = makeKubeconfig("https://another-server:2345", expectedUser)
-
-	// GetKubernetesAddress returns the explicitly set address
-	actualServer, err := nodeArgs.KubeConnectionArgs.GetKubernetesAddress(nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if expectedServer != actualServer.String() {
-		t.Fatalf("expected %v, got %v", expectedServer, actualServer)
 	}
 }
 

--- a/pkg/cmd/server/start/kube_connection_args.go
+++ b/pkg/cmd/server/start/kube_connection_args.go
@@ -27,7 +27,8 @@ type KubeConnectionArgs struct {
 }
 
 func BindKubeConnectionArgs(args *KubeConnectionArgs, flags *pflag.FlagSet, prefix string) {
-	flags.Var(&args.KubernetesAddr, prefix+"kubernetes", "The address of the Kubernetes server (host, host:port, or URL). If specified, no Kubernetes components will be started.")
+	// TODO remove entirely
+	flags.Var(&args.KubernetesAddr, prefix+"kubernetes", "removed in favor of --"+prefix+"kubeconfig")
 	flags.StringVar(&args.ClientConfigLoadingRules.ExplicitPath, prefix+"kubeconfig", "", "Path to the kubeconfig file to use for requests to the Kubernetes API.")
 }
 
@@ -39,6 +40,14 @@ func NewDefaultKubeConnectionArgs() *KubeConnectionArgs {
 	config.CertArgs = NewDefaultCertArgs()
 
 	return config
+}
+
+func (args KubeConnectionArgs) Validate() error {
+	if args.KubernetesAddr.Provided {
+		return errors.New("--kubernetes is no longer allowed, try using --kubeconfig")
+	}
+
+	return nil
 }
 
 func (args KubeConnectionArgs) GetExternalKubernetesClientConfig() (*client.Config, bool, error) {
@@ -53,10 +62,6 @@ func (args KubeConnectionArgs) GetExternalKubernetesClientConfig() (*client.Conf
 }
 
 func (args KubeConnectionArgs) GetKubernetesAddress(defaultAddress *url.URL) (*url.URL, error) {
-	if args.KubernetesAddr.Provided {
-		return args.KubernetesAddr.URL, nil
-	}
-
 	config, ok, err := args.GetExternalKubernetesClientConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -1,6 +1,7 @@
 package start
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -27,7 +28,7 @@ type NodeArgs struct {
 	AllowDisabledDocker bool
 	VolumeDir           string
 
-	DefaultKubernetesURL url.URL
+	DefaultKubernetesURL *url.URL
 	ClusterDomain        string
 	ClusterDNS           net.IP
 
@@ -68,6 +69,17 @@ func NewDefaultNodeArgs() *NodeArgs {
 		KubeConnectionArgs: NewDefaultKubeConnectionArgs(),
 		CertArgs:           NewDefaultCertArgs(),
 	}
+}
+
+func (args NodeArgs) Validate() error {
+	if err := args.KubeConnectionArgs.Validate(); err != nil {
+		return err
+	}
+	if _, err := args.KubeConnectionArgs.GetKubernetesAddress(args.DefaultKubernetesURL); err != nil {
+		return errors.New("--kubeconfig must be set to provide API server connection information")
+	}
+
+	return nil
 }
 
 // BuildSerializeableNodeConfig takes the NodeArgs (partially complete config) and uses them along with defaulting behavior to create the fully specified

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -98,6 +98,10 @@ func (o NodeOptions) Validate(args []string) error {
 		}
 	}
 
+	if err := o.NodeArgs.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -133,7 +137,7 @@ func (o NodeOptions) RunNode() error {
 
 	if mintCerts {
 		if err := o.CreateCerts(); err != nil {
-			return nil
+			return err
 		}
 	}
 
@@ -219,7 +223,7 @@ func (o NodeOptions) CreateCerts() error {
 		dnsIP = o.NodeArgs.ClusterDNS.String()
 	}
 
-	masterAddr, err := o.NodeArgs.KubeConnectionArgs.GetKubernetesAddress(&o.NodeArgs.DefaultKubernetesURL)
+	masterAddr, err := o.NodeArgs.KubeConnectionArgs.GetKubernetesAddress(o.NodeArgs.DefaultKubernetesURL)
 	if err != nil {
 		return err
 	}

--- a/pod.json
+++ b/pod.json
@@ -12,7 +12,7 @@
           "ports": [{
               "containerPort": 8443,
           }],
-          "command": ["start", "master", "--kubernetes=:8443"],
+          "command": ["start", "master"],
           "imagePullPolicy": "PullIfNotPresent"
         }
       ],


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1545.

This eliminates unused and conflicting parameters.  In particular, it removes `--public-kubernetes` and `--kubernetes`.  `--public-kuberenetes` isn't needed because we run our own proxy and want to manage our own access control.  `--kubernetes` isn't needed and can conflict with `--kubeconfig`.

@liggitt review
@sdodson @detiber This might affect you, though I doubt you were using those flags.
@brenton I'm not sure if you were trying to accomplish something when you hit #1545, but you probably want to see whether you were using these.