### PR TITLE
Add more description for --master option of openshift-master start

### DIFF
--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -53,7 +53,7 @@ type MasterArgs struct {
 
 // BindMasterArgs binds the options to the flags with prefix + default flag names
 func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
-	flags.Var(&args.MasterAddr, prefix+"master", "The master address for use by OpenShift components (host, host:port, or URL). Scheme and port default to the --listen scheme and port.")
+	flags.Var(&args.MasterAddr, prefix+"master", "The master address for use by OpenShift components (host, host:port, or URL). Scheme and port default to the --listen scheme and port. When unset, attempt to use the first public IPv4 non-loopback address registered on this host.")
 	flags.Var(&args.MasterPublicAddr, prefix+"public-master", "The master address for use by public clients, if different (host, host:port, or URL). Defaults to same as --master.")
 	flags.Var(&args.EtcdAddr, prefix+"etcd", "The address of the etcd server (host, host:port, or URL). If specified, no built-in etcd will be started.")
 	flags.Var(&args.KubernetesPublicAddr, prefix+"public-kubernetes", "The Kubernetes server address for use by public clients, if different. (host, host:port, or URL). Defaults to same as --kubernetes.")


### PR DESCRIPTION
In case we start openshift-master WITHOUT master option, openshift-master attempts to use the first public IPv4 non-loopback address registered on this host.
This will cause some trouble and it's difficult to debug the root cause.

It is better to add the description on the help.