### PR TITLE
display pretty strings for policy rule extensions

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -1,6 +1,7 @@
 package describe
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"reflect"
@@ -618,7 +619,13 @@ const policyRuleHeadings = "Verbs\tResources\tResource Names\tExtension"
 func describePolicyRule(out *tabwriter.Writer, rule authorizationapi.PolicyRule, indent string) {
 	extensionString := ""
 	if rule.AttributeRestrictions != (runtime.EmbeddedObject{}) {
-		extensionString = fmt.Sprintf("%v", rule.AttributeRestrictions)
+		extensionString = fmt.Sprintf("%#v", rule.AttributeRestrictions.Object)
+
+		buffer := new(bytes.Buffer)
+		printer := NewHumanReadablePrinter(true)
+		if err := printer.PrintObj(rule.AttributeRestrictions.Object, buffer); err == nil {
+			extensionString = strings.TrimSpace(buffer.String())
+		}
 	}
 
 	fmt.Fprintf(out, indent+"%v\t%v\t%v\t%v\n",

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -45,6 +45,9 @@ var (
 	userColumns                = []string{"NAME", "UID", "FULL NAME", "IDENTITIES"}
 	identityColumns            = []string{"NAME", "IDP NAME", "IDP USER NAME", "USER NAME", "USER UID"}
 	userIdentityMappingColumns = []string{"NAME", "IDENTITY", "USER NAME", "USER UID"}
+
+	// known custom role extensions
+	IsPersonalSubjectAccessReviewColumns = []string{"NAME"}
 )
 
 func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
@@ -92,6 +95,8 @@ func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p.Handler(identityColumns, printIdentity)
 	p.Handler(identityColumns, printIdentityList)
 	p.Handler(userIdentityMappingColumns, printUserIdentityMapping)
+
+	p.Handler(IsPersonalSubjectAccessReviewColumns, printIsPersonalSubjectAccessReview)
 	return p
 }
 
@@ -354,6 +359,11 @@ func printPolicyBindingList(list *authorizationapi.PolicyBindingList, w io.Write
 	}
 
 	return nil
+}
+
+func printIsPersonalSubjectAccessReview(a *authorizationapi.IsPersonalSubjectAccessReview, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "IsPersonalSubjectAccessReview\n")
+	return err
 }
 
 func printRole(role *authorizationapi.Role, w io.Writer) error {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1205028

Displays policy rule extensions by looking up their printer if it is available.  If not, displays the object using `%#v` which is ugly, but more useful that a pointer or `%v`.

@liggitt 