### PR TITLE
perform an initial commit and add a probe delay

### DIFF
--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -39,8 +39,13 @@ type templateRouter struct {
 
 func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath string) (*templateRouter, error) {
 	router := &templateRouter{templates, reloadScriptPath, map[string]ServiceUnit{}, certManager{}}
-	err := router.readState()
-	return router, err
+	if err := router.readState(); err != nil {
+		return nil, err
+	}
+	if err := router.Commit(); err != nil {
+		return nil, err
+	}
+	return router, nil
 }
 
 func (r *templateRouter) readState() error {


### PR DESCRIPTION
These changes address the following:

1.  The router does not start automatically.  A commit was only happen when a watch event was processed.  If the watch configuration was wrong then a config is never written and haproxy is never started.  A new commit is added to the plugin to write an empty state config file after creating a new router
2.  Delay probes for 60 seconds to allow the router time to write the config file (with the new initial commit) and be started before failing containers.  

@pmorie PTAL at the plugin changes
@deads2k - this is the PR that I was mentioning in IRC that should help with e2e transient failures
@jimmidyson @sdodson - as discussed on https://github.com/openshift/origin/pull/1575 and https://github.com/openshift/origin/issues/1504#issuecomment-88945808