### PR TITLE
Enable namespace exists and namespace lifecycle admission controllers

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -59,8 +59,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	portalNet := net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 
 	// in-order list of plug-ins that should intercept admission decisions
-	// TODO: add NamespaceExists
-	admissionControlPluginNames := []string{"LimitRanger", "ResourceQuota"}
+	admissionControlPluginNames := []string{"NamespaceExists", "NamespaceLifecycle", "LimitRanger", "ResourceQuota"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
 
 	_, portString, err := net.SplitHostPort(options.ServingInfo.BindAddress)

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -30,6 +30,14 @@ func TestSimpleImageChangeBuildTrigger(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient.Namespaces().Create(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{Name: testutil.Namespace()},
+	})
+
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: kapi.ObjectMeta{Name: "test-image-trigger-repo"},
 		Spec: imageapi.ImageStreamSpec{
@@ -158,6 +166,14 @@ func TestSimpleImageChangeBuildTriggerFromRef(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient.Namespaces().Create(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{Name: testutil.Namespace()},
+	})
 
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: kapi.ObjectMeta{Name: "test-image-trigger-repo"},


### PR DESCRIPTION
Added following upstream handlers:

1. NamespaceExists - a user must create a project before it can be used to hold content
2. NamespaceLifecycle - a user cannot create content in a project that is being terminated

@jwforres @smarterclayton 
