### PR TITLE
only validate start args when NOT using config

### DIFF
--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -160,12 +160,16 @@ func (o AllInOneOptions) Validate(args []string) error {
 		}
 	}
 
-	if err := o.MasterArgs.Validate(); err != nil {
-		return err
-	}
+	// if we are not starting up using a config file, run the argument validation
+	if o.WriteConfigOnly || ((len(o.MasterConfigFile) == 0) && (len(o.NodeConfigFile) == 0)) {
+		if err := o.MasterArgs.Validate(); err != nil {
+			return err
+		}
 
-	if err := o.NodeArgs.Validate(); err != nil {
-		return err
+		if err := o.NodeArgs.Validate(); err != nil {
+			return err
+		}
+
 	}
 
 	if len(o.MasterArgs.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath) != 0 {

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -130,8 +130,12 @@ func (o MasterOptions) Validate(args []string) error {
 		}
 	}
 
-	if err := o.MasterArgs.Validate(); err != nil {
-		return err
+	// if we are not starting up using a config file, run the argument validation
+	if o.WriteConfigOnly || len(o.ConfigFile) == 0 {
+		if err := o.MasterArgs.Validate(); err != nil {
+			return err
+		}
+
 	}
 
 	return nil

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -107,8 +107,11 @@ func (o NodeOptions) Validate(args []string) error {
 		}
 	}
 
-	if err := o.NodeArgs.Validate(); err != nil {
-		return err
+	// if we are not starting up using a config file, run the argument validation
+	if o.WriteConfigOnly || len(o.ConfigFile) == 0 {
+		if err := o.NodeArgs.Validate(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When we're starting up from a config file, there's no reason to validate other arguments.  In fact, it's downright confusing since you'll be told you need to specify required flags that could conflict with your config file.

@sdodson this is what bit you.
@liggitt bug to review.