### PR TITLE
ImageStream fixes

### DIFF
--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -46,6 +46,11 @@ func ValidateImageStream(stream *api.ImageStream) fielderrors.ValidationErrorLis
 			result = append(result, fielderrors.NewFieldInvalid("spec.dockerImageRepository", stream.Spec.DockerImageRepository, err.Error()))
 		}
 	}
+	for tag, tagRef := range stream.Spec.Tags {
+		if len(tagRef.DockerImageReference) > 0 && tagRef.From != nil {
+			result = append(result, fielderrors.NewFieldInvalid(fmt.Sprintf("spec.tags[%s]", tag), "", "only 1 of dockerImageReference or from may be set"))
+		}
+	}
 	for tag, history := range stream.Status.Tags {
 		for i, tagEvent := range history.Items {
 			if len(tagEvent.DockerImageReference) == 0 {

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -42,6 +42,8 @@ func NewREST(h tools.EtcdHelper, defaultRegistry imagestream.DefaultRegistry, su
 	}
 
 	strategy := imagestream.NewStrategy(defaultRegistry, subjectAccessReviewRegistry)
+	rest := &REST{subjectAccessReviewRegistry: subjectAccessReviewRegistry}
+	strategy.ImageStreamGetter = rest
 
 	statusStore := store
 	statusStore.UpdateStrategy = imagestream.NewStatusStrategy(strategy)
@@ -50,8 +52,8 @@ func NewREST(h tools.EtcdHelper, defaultRegistry imagestream.DefaultRegistry, su
 	store.UpdateStrategy = strategy
 	store.Decorator = strategy.Decorate
 
-	rest := &REST{store: &store, subjectAccessReviewRegistry: subjectAccessReviewRegistry}
-	strategy.ImageStreamGetter = rest
+	rest.store = &store
+
 	return rest, &StatusREST{store: &statusStore}
 }
 


### PR DESCRIPTION
Image stream validations - ensure only 1 of spec.tags.from and spec.tags.dockerImageReference can
be set.

Fix nil ImageStreamGetter - reorder ImageStream REST and Strategy creation so the Strategy's
ImageStreamGetter can be set appropriately.