### PR TITLE
Implement deployment hooks

### DIFF
--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -154,7 +154,39 @@
           "replicas": 1
         },
         "strategy": {
-          "type": "Recreate"
+          "type": "Recreate",
+          "recreateParams": {
+            "pre": {
+              "failurePolicy": "Abort",
+              "execNewPod": {
+                "containerName": "ruby-helloworld",
+                "command": [
+                  "/bin/true"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR1",
+                    "value": "custom_value1"
+                  }
+                ]
+              }
+            },
+            "post": {
+              "failurePolicy": "Ignore",
+              "execNewPod": {
+                "containerName": "ruby-helloworld",
+                "command": [
+                  "/bin/false"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR2",
+                    "value": "custom_value2"
+                  }
+                ]
+              }
+            }
+          }
         }
       },
       "triggers": [

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -107,6 +107,37 @@ func TestDeploymentConfigDescriber(t *testing.T) {
 	config.Triggers[0].ImageChangeParams.RepositoryName = ""
 	config.Triggers[0].ImageChangeParams.From = kapi.ObjectReference{Name: "imageRepo"}
 	describe()
+
+	config.Template.Strategy = deployapitest.OkStrategy()
+	config.Template.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{
+		Pre: &deployapi.LifecycleHook{
+			FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+			ExecNewPod: &deployapi.ExecNewPodHook{
+				ContainerName: "container",
+				Command:       []string{"/command1", "args"},
+				Env: []kapi.EnvVar{
+					{
+						Name:  "KEY1",
+						Value: "value1",
+					},
+				},
+			},
+		},
+		Post: &deployapi.LifecycleHook{
+			FailurePolicy: deployapi.LifecycleHookFailurePolicyIgnore,
+			ExecNewPod: &deployapi.ExecNewPodHook{
+				ContainerName: "container",
+				Command:       []string{"/command2", "args"},
+				Env: []kapi.EnvVar{
+					{
+						Name:  "KEY2",
+						Value: "value2",
+					},
+				},
+			},
+		},
+	}
+	describe()
 }
 
 func mkPod(status kapi.PodPhase, exitCode int) *kapi.Pod {

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -52,6 +52,8 @@ type DeploymentStrategy struct {
 	Type DeploymentStrategyType `json:"type,omitempty"`
 	// CustomParams are the input to the Custom deployment strategy.
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
+	// RecreateParams are the input to the Recreate deployment strategy.
+	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
@@ -72,6 +74,51 @@ type CustomDeploymentStrategyParams struct {
 	Environment []kapi.EnvVar `json:"environment,omitempty"`
 	// Command is optional and overrides CMD in the container Image.
 	Command []string `json:"command,omitempty"`
+}
+
+// RecreateDeploymentStrategyParams are the input to the Recreate deployment
+// strategy.
+type RecreateDeploymentStrategyParams struct {
+	// Pre is a lifecycle hook which is executed before the strategy manipulates
+	// the deployment. All LifecycleHookFailurePolicy values are supported.
+	Pre *LifecycleHook `json:"pre"`
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
+	// is NOT supported.
+	Post *LifecycleHook `json:"post"`
+}
+
+// Handler defines a specific deployment lifecycle action.
+type LifecycleHook struct {
+	// FailurePolicy specifies what action to take if the hook fails.
+	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy"`
+	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
+	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty"`
+}
+
+// HandlerFailurePolicy describes possibles actions to take if a hook fails.
+type LifecycleHookFailurePolicy string
+
+const (
+	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
+	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
+	// LifecycleHookFailurePolicyAbort means abort the deployment (if possible).
+	LifecycleHookFailurePolicyAbort LifecycleHookFailurePolicy = "Abort"
+	// LifecycleHookFailurePolicyIgnore means ignore failure and continue the deployment.
+	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
+)
+
+// ExecNewPodHook is a hook implementation which runs a command in a new pod
+// based on the specified container which is assumed to be part of the
+// deployment template.
+type ExecNewPodHook struct {
+	// Command is the action command and its arguments.
+	Command []string `json:"command"`
+	// Env is a set of environment variables to supply to the hook pod's container.
+	Env []kapi.EnvVar `json:"env,omitempty"`
+	// ContainerName is the name of a container in the deployment pod template
+	// whose Docker image will be used for the hook pod's container.
+	ContainerName string `json:"containerName"`
 }
 
 // A DeploymentList is a collection of deployments.

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -81,11 +81,11 @@ type CustomDeploymentStrategyParams struct {
 type RecreateDeploymentStrategyParams struct {
 	// Pre is a lifecycle hook which is executed before the strategy manipulates
 	// the deployment. All LifecycleHookFailurePolicy values are supported.
-	Pre *LifecycleHook `json:"pre"`
+	Pre *LifecycleHook `json:"pre,omitempty"`
 	// Post is a lifecycle hook which is executed after the strategy has
 	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
 	// is NOT supported.
-	Post *LifecycleHook `json:"post"`
+	Post *LifecycleHook `json:"post,omitempty"`
 }
 
 // Handler defines a specific deployment lifecycle action.

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -53,6 +53,8 @@ type DeploymentStrategy struct {
 	Type DeploymentStrategyType `json:"type,omitempty"`
 	// CustomParams are the input to the Custom deployment strategy.
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
+	// RecreateParams are the input to the Recreate deployment strategy.
+	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
@@ -73,6 +75,51 @@ type CustomDeploymentStrategyParams struct {
 	Environment []kapi.EnvVar `json:"environment,omitempty"`
 	// Command is optional and overrides CMD in the container Image.
 	Command []string `json:"command,omitempty"`
+}
+
+// RecreateDeploymentStrategyParams are the input to the Recreate deployment
+// strategy.
+type RecreateDeploymentStrategyParams struct {
+	// Pre is a lifecycle hook which is executed before the strategy manipulates
+	// the deployment. All LifecycleHookFailurePolicy values are supported.
+	Pre *LifecycleHook `json:"pre"`
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
+	// is NOT supported.
+	Post *LifecycleHook `json:"post"`
+}
+
+// Handler defines a specific deployment lifecycle action.
+type LifecycleHook struct {
+	// FailurePolicy specifies what action to take if the hook fails.
+	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy"`
+	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
+	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty"`
+}
+
+// HandlerFailurePolicy describes possibles actions to take if a hook fails.
+type LifecycleHookFailurePolicy string
+
+const (
+	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
+	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
+	// LifecycleHookFailurePolicyAbort means abort the deployment (if possible).
+	LifecycleHookFailurePolicyAbort LifecycleHookFailurePolicy = "Abort"
+	// LifecycleHookFailurePolicyIgnore means ignore failure and continue the deployment.
+	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
+)
+
+// ExecNewPodHook is a hook implementation which runs a command in a new pod
+// based on the specified container which is assumed to be part of the
+// deployment template.
+type ExecNewPodHook struct {
+	// Command is the action command and its arguments.
+	Command []string `json:"command"`
+	// Env is a set of environment variables to supply to the hook pod's container.
+	Env []kapi.EnvVar `json:"env,omitempty"`
+	// ContainerName is the name of a container in the deployment pod template
+	// whose Docker image will be used for the hook pod's container.
+	ContainerName string `json:"containerName"`
 }
 
 // A DeploymentList is a collection of deployments.

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -82,11 +82,11 @@ type CustomDeploymentStrategyParams struct {
 type RecreateDeploymentStrategyParams struct {
 	// Pre is a lifecycle hook which is executed before the strategy manipulates
 	// the deployment. All LifecycleHookFailurePolicy values are supported.
-	Pre *LifecycleHook `json:"pre"`
+	Pre *LifecycleHook `json:"pre,omitempty"`
 	// Post is a lifecycle hook which is executed after the strategy has
 	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
 	// is NOT supported.
-	Post *LifecycleHook `json:"post"`
+	Post *LifecycleHook `json:"post,omitempty"`
 }
 
 // Handler defines a specific deployment lifecycle action.

--- a/pkg/deploy/api/validation/validation_test.go
+++ b/pkg/deploy/api/validation/validation_test.go
@@ -227,6 +227,87 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			fielderrors.ValidationErrorTypeRequired,
 			"template.strategy.customParams.image",
 		},
+		"missing template.strategy.recreateParams.pre.failurePolicy": {
+			api.DeploymentConfig{
+				ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "bar"},
+				Template: api.DeploymentTemplate{
+					Strategy: api.DeploymentStrategy{
+						Type: api.DeploymentStrategyTypeRecreate,
+						RecreateParams: &api.RecreateDeploymentStrategyParams{
+							Pre: &api.LifecycleHook{
+								ExecNewPod: &api.ExecNewPodHook{
+									Command:       []string{"cmd"},
+									ContainerName: "container",
+								},
+							},
+						},
+					},
+					ControllerTemplate: test.OkControllerTemplate(),
+				},
+			},
+			fielderrors.ValidationErrorTypeRequired,
+			"template.strategy.recreateParams.pre.failurePolicy",
+		},
+		"missing template.strategy.recreateParams.pre.execNewPod": {
+			api.DeploymentConfig{
+				ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "bar"},
+				Template: api.DeploymentTemplate{
+					Strategy: api.DeploymentStrategy{
+						Type: api.DeploymentStrategyTypeRecreate,
+						RecreateParams: &api.RecreateDeploymentStrategyParams{
+							Pre: &api.LifecycleHook{
+								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+							},
+						},
+					},
+					ControllerTemplate: test.OkControllerTemplate(),
+				},
+			},
+			fielderrors.ValidationErrorTypeRequired,
+			"template.strategy.recreateParams.pre.execNewPod",
+		},
+		"missing template.strategy.recreateParams.pre.execNewPod.command": {
+			api.DeploymentConfig{
+				ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "bar"},
+				Template: api.DeploymentTemplate{
+					Strategy: api.DeploymentStrategy{
+						Type: api.DeploymentStrategyTypeRecreate,
+						RecreateParams: &api.RecreateDeploymentStrategyParams{
+							Pre: &api.LifecycleHook{
+								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+								ExecNewPod: &api.ExecNewPodHook{
+									ContainerName: "container",
+								},
+							},
+						},
+					},
+					ControllerTemplate: test.OkControllerTemplate(),
+				},
+			},
+			fielderrors.ValidationErrorTypeRequired,
+			"template.strategy.recreateParams.pre.execNewPod.command",
+		},
+		"missing template.strategy.recreateParams.pre.execNewPod.containerName": {
+			api.DeploymentConfig{
+				ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "bar"},
+				Template: api.DeploymentTemplate{
+					Strategy: api.DeploymentStrategy{
+						Type: api.DeploymentStrategyTypeRecreate,
+						RecreateParams: &api.RecreateDeploymentStrategyParams{
+							Pre: &api.LifecycleHook{
+								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+								ExecNewPod: &api.ExecNewPodHook{
+									Command: []string{"cmd"},
+								},
+							},
+						},
+					},
+					ControllerTemplate: test.OkControllerTemplate(),
+				},
+			},
+			fielderrors.ValidationErrorTypeRequired,
+			"template.strategy.recreateParams.pre.execNewPod.containerName",
+		},
 	}
 
 	for k, v := range errorCases {

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -10,30 +10,47 @@ import (
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	stratsupport "github.com/openshift/origin/pkg/deploy/strategy/support"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
-// RecreateDeploymentStrategy is a simple strategy appropriate as a default. Its behavior is to increase the
-// replica count of the new deployment to 1, and to decrease the replica count of previous deployments
-// to zero.
+// RecreateDeploymentStrategy is a simple strategy appropriate as a default.
+// Its behavior is to increase the replica count of the new deployment to 1,
+// and to decrease the replica count of previous deployments to zero.
 //
-// A failure to disable any existing deployments will be considered a deployment failure.
+// A failure to disable any existing deployments will be considered a
+// deployment failure.
 type RecreateDeploymentStrategy struct {
 	// client is used to interact with ReplicatonControllers.
 	client replicationControllerClient
 	// codec is used to decode DeploymentConfigs contained in deployments.
 	codec runtime.Codec
+	// hookExecutor can execute a lifecycle hook.
+	hookExecutor hookExecutor
 
 	retryTimeout time.Duration
 	retryPeriod  time.Duration
 }
 
+// NewRecreateDeploymentStrategy makes a RecreateDeploymentStrategy backed by
+// a real HookExecutor and client.
 func NewRecreateDeploymentStrategy(client kclient.Interface, codec runtime.Codec) *RecreateDeploymentStrategy {
 	return &RecreateDeploymentStrategy{
-		client:       &realReplicationController{client},
-		codec:        codec,
+		client: &realReplicationControllerClient{client},
+		codec:  codec,
+		hookExecutor: &stratsupport.HookExecutor{
+			PodClient: &stratsupport.HookExecutorPodClientImpl{
+				CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+					return client.Pods(namespace).Create(pod)
+				},
+				WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
+					return newPodWatch(client, namespace, name, 5*time.Second), nil
+				},
+			},
+		},
 		retryTimeout: 10 * time.Second,
 		retryPeriod:  1 * time.Second,
 	}
@@ -48,17 +65,67 @@ func (s *RecreateDeploymentStrategy) Deploy(deployment *kapi.ReplicationControll
 		return fmt.Errorf("Couldn't decode DeploymentConfig from deployment %s: %v", deployment.Name, err)
 	}
 
+	// Execute any pre-hook.
+	if deploymentConfig.Template.Strategy.RecreateParams != nil {
+		preHook := deploymentConfig.Template.Strategy.RecreateParams.Pre
+		if preHook != nil {
+		preHookLoop:
+			for {
+				err := s.hookExecutor.Execute(preHook, deployment)
+				if err == nil {
+					glog.Info("Pre hook finished successfully")
+					break
+				}
+				switch preHook.FailurePolicy {
+				case deployapi.LifecycleHookFailurePolicyAbort:
+					return fmt.Errorf("Pre hook failed, aborting: %s", err)
+				case deployapi.LifecycleHookFailurePolicyIgnore:
+					glog.Infof("Pre hook failed, ignoring: %s", err)
+					break preHookLoop
+				case deployapi.LifecycleHookFailurePolicyRetry:
+					glog.Infof("Pre hook failed, retrying: %s", err)
+					time.Sleep(s.retryPeriod)
+				}
+			}
+		}
+	}
+
+	// Scale up the new deployment.
 	if err = s.updateReplicas(deployment.Namespace, deployment.Name, deploymentConfig.Template.ControllerTemplate.Replicas); err != nil {
 		return err
 	}
 
-	// For this simple deploy, disable previous replication controllers.
+	// Disable any old deployments.
 	glog.Infof("Found %d prior deployments to disable", len(oldDeployments))
 	allProcessed := true
 	for _, oldDeployment := range oldDeployments {
 		if err = s.updateReplicas(oldDeployment.Namespace, oldDeployment.Name, 0); err != nil {
 			glog.Errorf("%v", err)
 			allProcessed = false
+		}
+	}
+
+	// Execute any post-hook.
+	if deploymentConfig.Template.Strategy.RecreateParams != nil {
+		postHook := deploymentConfig.Template.Strategy.RecreateParams.Post
+		if postHook != nil {
+		postHookLoop:
+			for {
+				err := s.hookExecutor.Execute(postHook, deployment)
+				if err == nil {
+					glog.Info("Post hook finished successfully")
+					break
+				}
+				switch postHook.FailurePolicy {
+				case deployapi.LifecycleHookFailurePolicyIgnore, deployapi.LifecycleHookFailurePolicyAbort:
+					// Abort isn't supported here, so treat it like ignore.
+					glog.Infof("Post hook failed, ignoring: %s", err)
+					break postHookLoop
+				case deployapi.LifecycleHookFailurePolicyRetry:
+					glog.Infof("Post hook failed, retrying: %s", err)
+					time.Sleep(s.retryPeriod)
+				}
+			}
 		}
 	}
 
@@ -101,19 +168,87 @@ func (s *RecreateDeploymentStrategy) updateReplicas(namespace, name string, repl
 	}
 }
 
+// replicationControllerClient provides access to ReplicationControllers.
 type replicationControllerClient interface {
 	getReplicationController(namespace, name string) (*kapi.ReplicationController, error)
 	updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error)
 }
 
-type realReplicationController struct {
+// realReplicationControllerClient is a replicationControllerClient which uses
+// a Kube client.
+type realReplicationControllerClient struct {
 	client kclient.Interface
 }
 
-func (r realReplicationController) getReplicationController(namespace string, name string) (*kapi.ReplicationController, error) {
+func (r *realReplicationControllerClient) getReplicationController(namespace string, name string) (*kapi.ReplicationController, error) {
 	return r.client.ReplicationControllers(namespace).Get(name)
 }
 
-func (r realReplicationController) updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+func (r *realReplicationControllerClient) updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 	return r.client.ReplicationControllers(namespace).Update(ctrl)
+}
+
+// hookExecutor knows how to execute a deployment lifecycle hook.
+type hookExecutor interface {
+	Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController) error
+}
+
+// hookExecutorImpl is a pluggable hookExecutor.
+type hookExecutorImpl struct {
+	executeFunc func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController) error
+}
+
+func (i *hookExecutorImpl) Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController) error {
+	return i.executeFunc(hook, deployment)
+}
+
+// podWatch provides watch semantics for a pod backed by a poller, since
+// events aren't generated for pod status updates.
+type podWatch struct {
+	result chan watch.Event
+	stop   chan bool
+}
+
+// newPodWatch makes a new podWatch.
+func newPodWatch(client kclient.Interface, namespace, name string, period time.Duration) *podWatch {
+	pods := make(chan watch.Event)
+	stop := make(chan bool)
+	tick := time.NewTicker(period)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				pod, err := client.Pods(namespace).Get(name)
+				if err != nil {
+					pods <- watch.Event{
+						Type: watch.Error,
+						Object: &kapi.Status{
+							Status:  "Failure",
+							Message: fmt.Sprintf("couldn't get pod %s/%s: %s", namespace, name, err),
+						},
+					}
+					continue
+				}
+				pods <- watch.Event{
+					Type:   watch.Modified,
+					Object: pod,
+				}
+			}
+		}
+	}()
+
+	return &podWatch{
+		result: pods,
+		stop:   stop,
+	}
+}
+
+func (w *podWatch) Stop() {
+	w.stop <- true
+}
+
+func (w *podWatch) ResultChan() <-chan watch.Event {
+	return w.result
 }

--- a/pkg/deploy/strategy/support/doc.go
+++ b/pkg/deploy/strategy/support/doc.go
@@ -1,0 +1,2 @@
+// Package support is a library of code useful to any strategy.
+package support

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -1,0 +1,135 @@
+package support
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/glog"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+// HookExecutor executes a deployment lifecycle hook.
+type HookExecutor struct {
+	// PodClient provides access to pods.
+	PodClient HookExecutorPodClient
+}
+
+// Execute executes hook in the context of deployment.
+func (e *HookExecutor) Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController) error {
+	if hook.ExecNewPod != nil {
+		return e.executeExecNewPod(hook.ExecNewPod, deployment)
+	}
+	return nil
+}
+
+// executeExecNewPod executes a ExecNewPod hook by creating a new pod based on
+// the hook parameters and deployment. The pod is then synchronously watched
+// until the pod completes, and if the pod failed, an error is returned.
+func (e *HookExecutor) executeExecNewPod(hook *deployapi.ExecNewPodHook, deployment *kapi.ReplicationController) error {
+	// Build a pod spec from the hook config and deployment
+	var image string
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != hook.ContainerName {
+			continue
+		}
+		image = container.Image
+	}
+	if len(image) == 0 {
+		return fmt.Errorf("no container named '%s' found in deployment template", hook.ContainerName)
+	}
+
+	podName := kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("deployment-%s-hook-", deployment.Name))
+	podSpec := &kapi.Pod{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: podName,
+			Annotations: map[string]string{
+				deployapi.DeploymentAnnotation: deployment.Name,
+			},
+		},
+		Spec: kapi.PodSpec{
+			Containers: []kapi.Container{
+				{
+					Name:    "lifecycle",
+					Image:   image,
+					Command: hook.Command,
+					Env:     hook.Env,
+				},
+			},
+			RestartPolicy: kapi.RestartPolicyNever,
+		},
+	}
+
+	// Set up a watch for the pod
+	podWatch, err := e.PodClient.WatchPod(deployment.Namespace, podName)
+	if err != nil {
+		return fmt.Errorf("couldn't create watch for pod %s/%s: %s", deployment.Namespace, podName, err)
+	}
+	defer podWatch.Stop()
+
+	// Try to create the pod
+	pod, err := e.PodClient.CreatePod(deployment.Namespace, podSpec)
+	if err != nil {
+		if !kerrors.IsAlreadyExists(err) {
+			return fmt.Errorf("couldn't create lifecycle pod for %s: %v", labelForDeployment(deployment), err)
+		}
+	} else {
+		glog.V(0).Infof("Created lifecycle pod %s for deployment %s", pod.Name, labelForDeployment(deployment))
+	}
+
+	// Wait for the pod to finish.
+	// TODO: Delete pod before returning?
+	glog.V(0).Infof("Waiting for hook pod %s/%s to complete", pod.Namespace, pod.Name)
+	for {
+		select {
+		case event, ok := <-podWatch.ResultChan():
+			if !ok {
+				return fmt.Errorf("couldn't watch pod %s/%s", pod.Namespace, pod.Name)
+			}
+			if event.Type == watch.Error {
+				return kerrors.FromObject(event.Object)
+			}
+			pod, podOk := event.Object.(*kapi.Pod)
+			if !podOk {
+				return fmt.Errorf("expected a pod event, got a %s", reflect.TypeOf(event.Object))
+			}
+			glog.V(0).Infof("Lifecycle pod %s/%s in phase %s", pod.Namespace, pod.Name, pod.Status.Phase)
+			switch pod.Status.Phase {
+			case kapi.PodSucceeded:
+				return nil
+			case kapi.PodFailed:
+				// TODO: Add context
+				return fmt.Errorf("pod failed")
+			}
+		}
+	}
+}
+
+// labelForDeployment builds a string identifier for a deployment.
+func labelForDeployment(deployment *kapi.ReplicationController) string {
+	return fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name)
+}
+
+// HookExecutorPodClient abstracts access to pods.
+type HookExecutorPodClient interface {
+	CreatePod(namespace string, pod *kapi.Pod) (*kapi.Pod, error)
+	WatchPod(namespace, name string) (watch.Interface, error)
+}
+
+// HookExecutorPodClientImpl is a pluggable HookExecutorPodClient.
+type HookExecutorPodClientImpl struct {
+	CreatePodFunc func(namespace string, pod *kapi.Pod) (*kapi.Pod, error)
+	WatchPodFunc  func(namespace, name string) (watch.Interface, error)
+}
+
+func (i *HookExecutorPodClientImpl) CreatePod(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+	return i.CreatePodFunc(namespace, pod)
+}
+
+func (i *HookExecutorPodClientImpl) WatchPod(namespace, name string) (watch.Interface, error) {
+	return i.WatchPodFunc(namespace, name)
+}

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -1,0 +1,223 @@
+package support
+
+import (
+	"fmt"
+	"testing"
+	//"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	//api "github.com/openshift/origin/pkg/api/latest"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+func TestHookExecutor_executeExecNewPodInvalidContainerRef(t *testing.T) {
+	hook := &deployapi.LifecycleHook{
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "undefined",
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	executor := &HookExecutor{
+		PodClient: &HookExecutorPodClientImpl{
+			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				t.Fatalf("unexpected call to CreatePod")
+				return nil, nil
+			},
+			WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
+				t.Fatalf("unexpected call to WatchPod")
+				return nil, nil
+			},
+		},
+	}
+
+	err := executor.Execute(hook, deployment)
+
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	t.Logf("got expected error: %s", err)
+}
+
+func TestHookExecutor_executeExecNewWatchFailure(t *testing.T) {
+	hook := &deployapi.LifecycleHook{
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "undefined",
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	executor := &HookExecutor{
+		PodClient: &HookExecutorPodClientImpl{
+			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				t.Fatalf("unexpected call to CreatePod")
+				return nil, nil
+			},
+			WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
+				return nil, fmt.Errorf("couldn't make watch")
+			},
+		},
+	}
+
+	err := executor.Execute(hook, deployment)
+
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	t.Logf("got expected error: %s", err)
+}
+
+func TestHookExecutor_executeExecNewCreatePodFailure(t *testing.T) {
+	hook := &deployapi.LifecycleHook{
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	podWatch := newTestWatch()
+
+	executor := &HookExecutor{
+		PodClient: &HookExecutorPodClientImpl{
+			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				return nil, fmt.Errorf("couldn't create pod")
+			},
+			WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
+				return podWatch, nil
+			},
+		},
+	}
+
+	err := executor.Execute(hook, deployment)
+
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	t.Logf("got expected error: %s", err)
+}
+
+func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
+	hook := &deployapi.LifecycleHook{
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+			Command:       []string{"overridden"},
+			Env: []kapi.EnvVar{
+				{
+					Name:  "name",
+					Value: "value",
+				},
+			},
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	podWatch := newTestWatch()
+
+	var createdPod *kapi.Pod
+	executor := &HookExecutor{
+		PodClient: &HookExecutorPodClientImpl{
+			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				go func() {
+					obj, _ := kapi.Scheme.Copy(pod)
+					cp := obj.(*kapi.Pod)
+					cp.Status.Phase = kapi.PodSucceeded
+					podWatch.events <- watch.Event{
+						Type:   watch.Modified,
+						Object: cp,
+					}
+				}()
+				createdPod = pod
+				return createdPod, nil
+			},
+			WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
+				return podWatch, nil
+			},
+		},
+	}
+
+	err := executor.Execute(hook, deployment)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if e, a := deployment.Spec.Template.Spec.Containers[0].Image, createdPod.Spec.Containers[0].Image; e != a {
+		t.Fatalf("expected container image %s, got %s", e, a)
+	}
+
+	if e, a := "overridden", createdPod.Spec.Containers[0].Command[0]; e != a {
+		t.Fatalf("expected container command %s, got %s", e, a)
+	}
+
+	if e, a := "value", createdPod.Spec.Containers[0].Env[0].Value; e != a {
+		t.Fatalf("expected env value %s, got %s", e, a)
+	}
+
+	if e, a := kapi.RestartPolicyNever, createdPod.Spec.RestartPolicy; e != a {
+		t.Fatalf("expected restart policy %s, got %s", e, a)
+	}
+}
+
+func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
+	hook := &deployapi.LifecycleHook{
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	podWatch := newTestWatch()
+
+	var createdPod *kapi.Pod
+	executor := &HookExecutor{
+		PodClient: &HookExecutorPodClientImpl{
+			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				go func() {
+					obj, _ := kapi.Scheme.Copy(pod)
+					cp := obj.(*kapi.Pod)
+					cp.Status.Phase = kapi.PodFailed
+					podWatch.events <- watch.Event{
+						Type:   watch.Modified,
+						Object: cp,
+					}
+				}()
+				createdPod = pod
+				return createdPod, nil
+			},
+			WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
+				return podWatch, nil
+			},
+		},
+	}
+
+	err := executor.Execute(hook, deployment)
+
+	if err == nil {
+		t.Fatalf("expected an error", err)
+	}
+	t.Logf("got expected error: %s", err)
+}
+
+type testWatch struct {
+	events chan watch.Event
+}
+
+func newTestWatch() *testWatch {
+	return &testWatch{make(chan watch.Event)}
+}
+
+func (w *testWatch) Stop() {
+}
+
+func (w *testWatch) ResultChan() <-chan watch.Event {
+	return w.events
+}


### PR DESCRIPTION
This PR implements [deployment hooks](https://github.com/openshift/origin/blob/master/docs/proposals/post-deployment-hooks.md), and replaces the now defunct #1456.