### PR TITLE
allow everyone get,list access on the image group in openshift

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -27,7 +27,7 @@ func GetBootstrapOpenshiftRoles(openshiftNamespace string) []authorizationapi.Ro
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get", "list"),
-					Resources: util.NewStringSet("templates", "imagerepositories", "imagerepositorytags"),
+					Resources: util.NewStringSet("templates", authorizationapi.ImageGroupName),
 				},
 			},
 		},


### PR DESCRIPTION
The images group is:

```
"images", "imagerepositories", "imagerepositorymappings", "imagerepositorytags", "imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages"
```

@ncdc @jwforres @jcantrill 