### PR TITLE
Add an initial delay to the router liveness probe

### DIFF
--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -205,6 +205,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 															},
 														},
 													},
+													InitialDelaySeconds: 10,
 												},
 											},
 										},


### PR DESCRIPTION
The router is experiences issues with the liveness probe where it is probing the socket before the plugin has a chance to write out the initial configs and start the router.  

There were two issues to address:

1.  The router never started until a watch event was received, fixed by https://github.com/openshift/origin/pull/1603
1.  The probe occurred before haproxy was started

The combination of writing the initial config plus the initial delay should help reduce the chance the probe fires before HAProxy is started.  However we still have a case where, if the router is writing a large file, we can probe before the router is ready. 

We discussed in IRC the possibility of having the kubelet backoff on probe failure based on configuration which would ultimately be the right solution.  As @jimmidyson pointed out in https://github.com/openshift/origin/pull/1603#issuecomment-91040985 it's very likely that a lot of containers may need to perform X amount of variable size work before they are considered ready and a static delay would not cover it.

@sdodson could you give this a test manually (the combination of https://github.com/openshift/origin/pull/1603 plus the delay) in your environment?  I was unable to reproduce the loop after at least 10 e2e runs with this combination.

Reference issues: 
https://github.com/openshift/origin/issues/1504
https://github.com/openshift/origin/pull/1575

@sdodson @jimmidyson @smarterclayton