### PR TITLE
Fix tests to be ifconfig 1.4.X compatible

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -80,7 +80,7 @@ export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
 # Specify the scheme and port for the listen address, but let the IP auto-discover. Set --public-master to localhost, for a stable link to the console.
 echo "[INFO] Create certificates for the OpenShift server to ${CERT_DIR}"
 # find the same IP that openshift start will bind to.  This allows access from pods that have to talk back to master
-ALL_IP_ADDRESSES=`ifconfig | grep "inet " | awk '{print $2}'`
+ALL_IP_ADDRESSES=`ifconfig | grep "inet " | sed 's/adr://' | awk '{print $2}'`
 SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},localhost"
 while read -r IP_ADDRESS
 do

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -51,7 +51,7 @@ ARTIFACT_DIR="${ARTIFACT_DIR:-${BASETMPDIR}/artifacts}"
 mkdir -p $LOG_DIR
 mkdir -p $ARTIFACT_DIR
 
-DEFAULT_SERVER_IP=`ifconfig | grep -Ev "(127.0.0.1|172.17.42.1)" | grep "inet " | head -n 1 | awk '{print $2}'`
+DEFAULT_SERVER_IP=`ifconfig | grep -Ev "(127.0.0.1|172.17.42.1)" | grep "inet " | head -n 1 | sed 's/adr://' | awk '{print $2}'`
 API_HOST="${API_HOST:-${DEFAULT_SERVER_IP}}"
 API_PORT="${API_PORT:-8443}"
 API_SCHEME="${API_SCHEME:-https}"
@@ -183,7 +183,7 @@ echo "[INFO] Using images:              ${USE_IMAGES}"
 # Start All-in-one server and wait for health
 echo "[INFO] Create certificates for the OpenShift server"
 # find the same IP that openshift start will bind to.  This allows access from pods that have to talk back to master
-ALL_IP_ADDRESSES=`ifconfig | grep "inet " | awk '{print $2}'`
+ALL_IP_ADDRESSES=`ifconfig | grep "inet " | sed 's/adr://' | awk '{print $2}'`
 SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},localhost"
 while read -r IP_ADDRESS
 do

--- a/hack/test-extended.sh
+++ b/hack/test-extended.sh
@@ -16,7 +16,7 @@ export OS_MASTER_PORT=$(go run ${OS_ROOT}/test/util/random_port/generate.go)
 export OS_DNS_PORT=$(go run ${OS_ROOT}/test/util/random_port/generate.go)
 export ETCD_PORT=$(go run ${OS_ROOT}/test/util/random_port/generate.go)
 
-DEFAULT_SERVER_IP=$(ifconfig | grep -Ev "(127.0.0.1|172.17.42.1)" | grep "inet " | head -n 1 | awk '{print $2}')
+DEFAULT_SERVER_IP=$(ifconfig | grep -Ev "(127.0.0.1|172.17.42.1)" | grep "inet " | head -n 1 | sed 's/adr://' | awk '{print $2}')
 
 export OS_MASTER_ADDR=${DEFAULT_SERVER_IP}:${OS_MASTER_PORT}
 export OS_DNS_ADDR=${DEFAULT_SERVER_IP}:${OS_DNS_PORT}
@@ -51,7 +51,7 @@ cleanup() {
 #       launcher.
 start_server() {
   mkdir -p ${BASETMPDIR}/volumes
-  ALL_IP_ADDRESSES=`ifconfig | grep "inet " | awk '{print $2}'`
+  ALL_IP_ADDRESSES=`ifconfig | grep "inet " | sed 's/adr://' | awk '{print $2}'`
   SERVER_HOSTNAME_LIST="${DEFAULT_SERVER_IP},localhost"
   while read -r IP_ADDRESS; do
     SERVER_HOSTNAME_LIST="${SERVER_HOSTNAME_LIST},${IP_ADDRESS}"


### PR DESCRIPTION
ifconfig in its version 1.4.X is prepending "adr:" before
the ip address. For instance:

wlan0     Link encap:Ethernet  HWaddr 0c:d2:92:d9:60:98
          inet adr:192.168.100.37  Bcast:192.168.100.255  ..

The fix just removes the adr: with a sed everywhere ifconfig
is called in tests.