### PR TITLE
Enforce admission control of Origin resources in terminating namespaces

### DIFF
--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -245,6 +245,8 @@ openshift admin policy add-role-to-user view e2e-user --namespace=default
 
 # create test project so that this shows up in the console
 openshift admin new-project test --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
+openshift admin new-project docker --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
+openshift admin new-project custom --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
 
 echo "The console should be available at ${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}/console."
 echo "Log in as 'e2e-user' to see the 'test' project."

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -129,7 +129,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
 	// in-order list of plug-ins that should intercept admission decisions (origin only intercepts)
-	admissionControlPluginNames := []string{"AlwaysAdmit"}
+	admissionControlPluginNames := []string{"OriginNamespaceLifecycle"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
 
 	config := &MasterConfig{

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -1,0 +1,12 @@
+package start
+
+import (
+
+	// Admission control plug-ins used by OpenShift
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
+	_ "github.com/openshift/origin/pkg/project/admission"
+)

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -18,12 +18,6 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/server/admin"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/admit"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle"
-	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
 )
 
 type AllInOneOptions struct {

--- a/pkg/project/admission/admission.go
+++ b/pkg/project/admission/admission.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	"github.com/openshift/origin/pkg/api/latest"
+)
+
+// TODO: modify the upstream plug-in so this can be collapsed
+// need ability to specify a RESTMapper on upstream version
+func init() {
+	admission.RegisterPlugin("OriginNamespaceLifecycle", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		return NewLifecycle(client), nil
+	})
+}
+
+type lifecycle struct {
+	client client.Interface
+	store  cache.Store
+}
+
+// Admit enforces that a namespace must exist in order to associate content with it.
+// Admit enforces that a namespace that is terminating cannot accept new content being associated with it.
+func (e *lifecycle) Admit(a admission.Attributes) (err error) {
+	defaultVersion, kind, err := latest.RESTMapper.VersionAndKindForResource(a.GetResource())
+	if err != nil {
+		return err
+	}
+	mapping, err := latest.RESTMapper.RESTMapping(kind, defaultVersion)
+	if err != nil {
+		return err
+	}
+	if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+		return nil
+	}
+
+	// we want to allow someone to delete something in case it was phantom created somehow
+	if a.GetOperation() == "DELETE" {
+		return nil
+	}
+
+	// check for namespace in the cache
+	namespaceObj, exists, err := e.store.Get(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      a.GetNamespace(),
+			Namespace: "",
+		},
+		Status: kapi.NamespaceStatus{},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	name := "Unknown"
+	obj := a.GetObject()
+	if obj != nil {
+		name, _ = meta.NewAccessor().Name(obj)
+	}
+
+	var namespace *kapi.Namespace
+	if exists {
+		namespace = namespaceObj.(*kapi.Namespace)
+	} else {
+		// Our watch maybe latent, so we make a best effort to get the object, and only fail if not found
+		namespace, err = e.client.Namespaces().Get(a.GetNamespace())
+		// the namespace does not exit, so prevent create and update in that namespace
+		if err != nil {
+			return apierrors.NewForbidden(kind, name, fmt.Errorf("Namespace %s does not exist", a.GetNamespace()))
+		}
+	}
+
+	if a.GetOperation() != "CREATE" {
+		return nil
+	}
+
+	if namespace.Status.Phase != kapi.NamespaceTerminating {
+		return nil
+	}
+
+	return apierrors.NewForbidden(kind, name, fmt.Errorf("Namespace %s is terminating", a.GetNamespace()))
+}
+
+func NewLifecycle(c client.Interface) admission.Interface {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return c.Namespaces().List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&kapi.Namespace{},
+		store,
+		0,
+	)
+	reflector.Run()
+	return &lifecycle{
+		client: c,
+		store:  store,
+	}
+}

--- a/pkg/project/admission/admission_test.go
+++ b/pkg/project/admission/admission_test.go
@@ -1,0 +1,116 @@
+package admission
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// TestAdmissionExists verifies you cannot create Origin content if namespace is not known
+func TestAdmissionExists(t *testing.T) {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	mockClient := &testclient.Fake{
+		Err: fmt.Errorf("DOES NOT EXIST"),
+	}
+	handler := &lifecycle{
+		client: mockClient,
+		store:  store,
+	}
+	build := &buildapi.Build{
+		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
+		Parameters: buildapi.BuildParameters{
+			Source: buildapi.BuildSource{
+				Type: buildapi.BuildSourceGit,
+				Git: &buildapi.GitBuildSource{
+					URI: "http://github.com/my/repository",
+				},
+				ContextDir: "context",
+			},
+			Strategy: buildapi.BuildStrategy{
+				Type:           buildapi.DockerBuildStrategyType,
+				DockerStrategy: &buildapi.DockerBuildStrategy{},
+			},
+			Output: buildapi.BuildOutput{
+				DockerImageReference: "repository/data",
+			},
+		},
+		Status: buildapi.BuildStatusNew,
+	}
+	err := handler.Admit(admission.NewAttributesRecord(build, "bogus-ns", "builds", "CREATE"))
+	if err == nil {
+		t.Errorf("Expected an error because namespace does not exist")
+	}
+}
+
+// TestAdmissionLifecycle verifies you cannot create Origin content if namespace is terminating
+func TestAdmissionLifecycle(t *testing.T) {
+	namespaceObj := &kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "test",
+			Namespace: "",
+		},
+		Status: kapi.NamespaceStatus{
+			Phase: kapi.NamespaceActive,
+		},
+	}
+	store := cache.NewStore(cache.MetaNamespaceIndexFunc)
+	store.Add(namespaceObj)
+	mockClient := &testclient.Fake{}
+	handler := &lifecycle{
+		client: mockClient,
+		store:  store,
+	}
+	build := &buildapi.Build{
+		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
+		Parameters: buildapi.BuildParameters{
+			Source: buildapi.BuildSource{
+				Type: buildapi.BuildSourceGit,
+				Git: &buildapi.GitBuildSource{
+					URI: "http://github.com/my/repository",
+				},
+				ContextDir: "context",
+			},
+			Strategy: buildapi.BuildStrategy{
+				Type:           buildapi.DockerBuildStrategyType,
+				DockerStrategy: &buildapi.DockerBuildStrategy{},
+			},
+			Output: buildapi.BuildOutput{
+				DockerImageReference: "repository/data",
+			},
+		},
+		Status: buildapi.BuildStatusNew,
+	}
+	err := handler.Admit(admission.NewAttributesRecord(build, namespaceObj.Namespace, "builds", "CREATE"))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+
+	// change namespace state to terminating
+	namespaceObj.Status.Phase = kapi.NamespaceTerminating
+	store.Add(namespaceObj)
+
+	// verify create operations in the namespace cause an error
+	err = handler.Admit(admission.NewAttributesRecord(build, namespaceObj.Namespace, "builds", "CREATE"))
+	if err == nil {
+		t.Errorf("Expected error rejecting creates in a namespace when it is terminating")
+	}
+
+	// verify update operations in the namespace can proceed
+	err = handler.Admit(admission.NewAttributesRecord(build, namespaceObj.Namespace, "builds", "UPDATE"))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+
+	// verify delete operations in the namespace can proceed
+	err = handler.Admit(admission.NewAttributesRecord(nil, namespaceObj.Namespace, "builds", "DELETE"))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler: %v", err)
+	}
+
+}

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -158,11 +158,12 @@ func mockBuild() *buildapi.Build {
 }
 
 type testBuildOpenshift struct {
-	Client   *osclient.Client
-	server   *httptest.Server
-	whPrefix string
-	stop     chan struct{}
-	lock     sync.Mutex
+	KubeClient *kclient.Client
+	Client     *osclient.Client
+	server     *httptest.Server
+	whPrefix   string
+	stop       chan struct{}
+	lock       sync.Mutex
 }
 
 func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
@@ -182,6 +183,7 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 	osClient := osclient.NewOrDie(&client.Config{Host: openshift.server.URL, Version: latest.Version})
 
 	openshift.Client = osClient
+	openshift.KubeClient = kubeClient
 
 	kubeletClient, err := kclient.NewKubeletClient(&kclient.KubeletConfig{Port: 10250})
 	if err != nil {

--- a/test/integration/imagerepository_test.go
+++ b/test/integration/imagerepository_test.go
@@ -31,6 +31,11 @@ func TestImageRepositoryList(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	builds, err := clusterAdminClient.ImageRepositories(testutil.Namespace()).List(labels.Everything(), fields.Everything())
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
@@ -51,6 +56,11 @@ func TestImageRepositoryCreate(t *testing.T) {
 	}
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -93,6 +103,11 @@ func TestImageRepositoryMappingCreate(t *testing.T) {
 	}
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -242,6 +257,10 @@ func TestImageRepositoryDelete(t *testing.T) {
 	}
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -30,6 +30,10 @@ func TestImageStreamList(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	builds, err := clusterAdminClient.ImageStreams(testutil.Namespace()).List(labels.Everything(), fields.Everything())
 	if err != nil {
@@ -51,6 +55,10 @@ func TestImageStreamCreate(t *testing.T) {
 	}
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -93,6 +101,10 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	}
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -242,6 +254,10 @@ func TestImageStreamDelete(t *testing.T) {
 	}
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -70,6 +70,11 @@ func TestWebhookGithubPushWithImageTag(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	// create imagerepo
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: kapi.ObjectMeta{Name: "imageStream"},
@@ -126,6 +131,11 @@ func TestWebhookGithubPushWithImageTagRef(t *testing.T) {
 	}
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -190,6 +200,11 @@ func TestWebhookGithubPushWithImageTagUnmatched(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	// create imagerepo
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: kapi.ObjectMeta{Name: "imageStream"},
@@ -249,6 +264,15 @@ func TestWebhookGithubPushWithNamespaceUnmatched(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, testutil.Namespace())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	err = testutil.CreateNamespace(clusterAdminKubeConfig, "unmatched")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	// create imagerepo
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: kapi.ObjectMeta{Namespace: "unmatched", Name: "imageStream"},
@@ -297,6 +321,10 @@ func TestWebhookGithubPing(t *testing.T) {
 	testutil.DeleteAllEtcdKeys()
 	openshift := NewTestBuildOpenshift(t)
 	defer openshift.Close()
+
+	openshift.KubeClient.Namespaces().Create(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{Name: testutil.Namespace()},
+	})
 
 	// create buildconfig
 	buildConfig := mockBuildConfigParms("originalImage", "imageStream", "validTag")

--- a/test/util/namespace.go
+++ b/test/util/namespace.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/openshift/origin/pkg/cmd/util"
 )
 
@@ -18,4 +19,17 @@ func Namespace() string {
 // timestamp. Optionally you can set the prefix.
 func RandomNamespace(prefix string) string {
 	return prefix + string([]byte(fmt.Sprintf("%d", time.Now().UnixNano()))[3:12])
+}
+
+// CreateNamespace creates a namespace with the specified name using the provided kubeconfig
+// DO NOT USE, use create project instead
+func CreateNamespace(clusterAdminKubeConfig, name string) (err error) {
+	clusterAdminKubeClient, err := GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		return err
+	}
+	_, err = clusterAdminKubeClient.Namespaces().Create(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{Name: name},
+	})
+	return err
 }


### PR DESCRIPTION
We had been blocking the creation of Kubernetes resources in a non-existent or terminating namespace when running OpenShift, but we were not blocking the creation of OpenShift resources.

This required an admission control plug-in that worked against the Origin latest resource types.

It also exposed that we were not ensuring the shared resources namespace always existed.
