### PR TITLE
separate tls and non-tls backend lookups

### DIFF
--- a/images/router/haproxy-base/Dockerfile
+++ b/images/router/haproxy-base/Dockerfile
@@ -9,7 +9,7 @@ FROM openshift/origin-base
 RUN yum -y install haproxy && \
     mkdir -p /var/lib/containers/router/{certs,cacerts} && \
     mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
-    touch /var/lib/haproxy/conf/{{os_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt}.map,haproxy.config} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt}.map,haproxy.config} && \
     yum clean all
 
 ADD conf/ /var/lib/haproxy/conf/

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -81,10 +81,10 @@ frontend fe_sni
   use_backend be_secure_%[hdr(host),map(/var/lib/haproxy/conf/os_tcp_be.map)] if reencrypt
 
   # map to http backend
-  use_backend be_http_%[base,map_beg(/var/lib/haproxy/conf/os_http_be.map)]
+  use_backend be_edge_http_%[base,map_beg(/var/lib/haproxy/conf/os_edge_http_be.map)]
 
   # if a specific path based lookup was not found then revert to a host header lookup
-  use_backend be_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
+  use_backend be_edge_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_edge_http_be.map)] if TRUE
 
   default_backend openshift_default
 
@@ -112,7 +112,7 @@ frontend fe_no_sni
   use_backend be_secure_%[hdr(host),map(/var/lib/haproxy/conf/os_tcp_be.map)] if reencrypt
 
   # regular http
-  use_backend be_http_%[hdr(host),map(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
+  use_backend be_edge_http_%[hdr(host),map(/var/lib/haproxy/conf/os_edge_http_be.map)] if TRUE
 
   default_backend openshift_default
 
@@ -139,10 +139,10 @@ backend openshift_default
 {{ range $id, $serviceUnit := . }}
         {{ range $cfgIdx, $cfg := $serviceUnit.ServiceAliasConfigs }}
             {{ if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
-                {{ if eq $cfg.Path "" }}
-backend be_http_{{$serviceUnit.TemplateSafeName}}
-                {{ else }}
+                {{ if (eq $cfg.TLSTermination "") }}
 backend be_http_{{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+                {{ else }}
+backend be_edge_http_{{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
                 {{ end }}
   mode http
   balance leastconn
@@ -183,12 +183,26 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{ define "/var/lib/haproxy/conf/os_http_be.map" }}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge"))}}
+{{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "")}}
 {{$cfg.Host}}{{$cfg.Path}} {{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
 {{       end }}
 {{     end }}
 {{   end }}
 {{ end }}{{/* end http host map template */}}
+
+{{/*
+    os_edge_http_be.map: same as os_http_be.map but allows us to separate tls from non-tls routes to ensure we don't expose
+                            a tls only route on the unsecure port
+*/}}
+{{ define "/var/lib/haproxy/conf/os_edge_http_be.map" }}
+{{   range $id, $serviceUnit := . }}
+{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "edge")}}
+{{$cfg.Host}}{{$cfg.Path}} {{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+{{       end }}
+{{     end }}
+{{   end }}
+{{ end }}{{/* end edge http host map template */}}
 
 
 {{/*

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -2,6 +2,7 @@ package templaterouter
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -166,9 +167,9 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 	r.state[id] = service
 }
 
-// routeKey generates route key in form of Host-Path
+// routeKey generates route key in form of Namespace/Name
 func (r *templateRouter) routeKey(route *routeapi.Route) string {
-	return route.Host + "-" + route.Path
+	return fmt.Sprintf("%s/%s", route.Namespace, route.Name)
 }
 
 // AddRoute adds a route for the given id


### PR DESCRIPTION
Issue: The template router uses the same lookup map for edge terminated routes and unsecure routes because they both resolved to an unsecured backend.  This means when you define an edge terminated tls route you were automatically able to access it via :80.  This is undesirable.

While testing I also found that there was a delete bug because of the internal route key that was missed when we switched to the namespaced keys.  I updated the key and the unit tests to catch the scenario along with some general clean up.

Fixes: https://github.com/openshift/origin/issues/1567#issuecomment-90922162

I also created a BZ bug for this so it will be included in QA: https://bugzilla.redhat.com/show_bug.cgi?id=1210487#add_comment