### PR TITLE
Pass through remote OAuth errors

### DIFF
--- a/pkg/auth/oauth/external/handler.go
+++ b/pkg/auth/oauth/external/handler.go
@@ -92,6 +92,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	glog.V(4).Infof("Got auth data")
 
+	// Validate state before making any server-to-server calls
+	ok, err := h.state.Check(authData.State, req)
+	if !ok {
+		glog.V(4).Infof("State is invalid")
+		err := errors.New("State is invalid")
+		h.handleError(err, w, req)
+		return
+	}
+	if err != nil {
+		glog.V(4).Infof("Error verifying state: %v", err)
+		h.handleError(err, w, req)
+		return
+	}
+
 	// Exchange code for a token
 	accessReq := h.client.NewAccessRequest(osincli.AUTHORIZATION_CODE, authData)
 	accessData, err := accessReq.GetToken()
@@ -124,19 +138,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ok, err = h.state.Check(authData.State, w, req)
-	if !ok {
-		glog.V(4).Infof("State is invalid")
-		err := errors.New("State is invalid")
-		h.handleError(err, w, req)
-		return
-	}
-	if err != nil {
-		glog.V(4).Infof("Error verifying state: %v", err)
-		h.handleError(err, w, req)
-		return
-	}
-
 	_, err = h.success.AuthenticationSucceeded(user, authData.State, w, req)
 	if err != nil {
 		glog.V(4).Infof("Error calling success handler: %v", err)
@@ -159,11 +160,23 @@ type defaultState struct {
 	csrf csrf.CSRF
 }
 
-func DefaultState(csrf csrf.CSRF) State {
+// RedirectorState combines state generation/verification with redirections on authentication success and error
+type RedirectorState interface {
+	State
+	handlers.AuthenticationSuccessHandler
+	handlers.AuthenticationErrorHandler
+}
+
+func CSRFRedirectingState(csrf csrf.CSRF) RedirectorState {
 	return &defaultState{csrf}
 }
 
 func (d *defaultState) Generate(w http.ResponseWriter, req *http.Request) (string, error) {
+	then := req.URL.String()
+	if len(then) == 0 {
+		return "", errors.New("Cannot generate state: request has no URL")
+	}
+
 	csrfToken, err := d.csrf.Generate(w, req)
 	if err != nil {
 		return "", err
@@ -171,12 +184,12 @@ func (d *defaultState) Generate(w http.ResponseWriter, req *http.Request) (strin
 
 	state := url.Values{
 		"csrf": {csrfToken},
-		"then": {req.URL.String()},
+		"then": {then},
 	}
 	return encodeState(state)
 }
 
-func (d *defaultState) Check(state string, w http.ResponseWriter, req *http.Request) (bool, error) {
+func (d *defaultState) Check(state string, req *http.Request) (bool, error) {
 	values, err := decodeState(state)
 	if err != nil {
 		return false, err
@@ -199,7 +212,7 @@ func (d *defaultState) Check(state string, w http.ResponseWriter, req *http.Requ
 	return true, nil
 }
 
-func (defaultState) AuthenticationSucceeded(user user.Info, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
+func (d *defaultState) AuthenticationSucceeded(user user.Info, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
 	values, err := decodeState(state)
 	if err != nil {
 		return false, err
@@ -211,6 +224,61 @@ func (defaultState) AuthenticationSucceeded(user user.Info, state string, w http
 	}
 
 	http.Redirect(w, req, then, http.StatusFound)
+	return true, nil
+}
+
+// AuthenticationError handles the very specific case where the remote OAuth provider returned an error
+// In that case, attempt to redirect to the "then" URL with all error parameters echoed
+// In any other case, or if an error is encountered, returns false and the original error
+func (d *defaultState) AuthenticationError(err error, w http.ResponseWriter, req *http.Request) (bool, error) {
+	// only handle errors that came from the remote OAuth provider...
+	osinErr, ok := err.(*osincli.Error)
+	if !ok {
+		return false, err
+	}
+
+	// with an OAuth error...
+	if len(osinErr.Id) == 0 {
+		return false, err
+	}
+
+	// if they embedded valid state...
+	ok, stateErr := d.Check(osinErr.State, req)
+	if !ok || stateErr != nil {
+		return false, err
+	}
+
+	// if the state decodes...
+	values, err := decodeState(osinErr.State)
+	if err != nil {
+		return false, err
+	}
+
+	// if it contains a redirect...
+	then := values.Get("then")
+	if len(then) == 0 {
+		return false, err
+	}
+
+	// which parses...
+	thenURL, urlErr := url.Parse(then)
+	if urlErr != nil {
+		return false, err
+	}
+
+	// Add in the error, error_description, error_uri params to the "then" redirect
+	q := thenURL.Query()
+	q.Set("error", osinErr.Id)
+	if len(osinErr.Description) > 0 {
+		q.Set("error_description", osinErr.Description)
+	}
+	if len(osinErr.URI) > 0 {
+		q.Set("error_uri", osinErr.URI)
+	}
+	thenURL.RawQuery = q.Encode()
+
+	http.Redirect(w, req, thenURL.String(), http.StatusFound)
+
 	return true, nil
 }
 

--- a/pkg/auth/oauth/external/handler_test.go
+++ b/pkg/auth/oauth/external/handler_test.go
@@ -1,11 +1,140 @@
 package external
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/RangelReale/osincli"
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
+	"github.com/openshift/origin/pkg/auth/server/csrf"
 )
 
 func TestHandler(t *testing.T) {
 	_ = handlers.NewUnionAuthenticationHandler(nil, map[string]handlers.AuthenticationRedirector{"handler": &Handler{}}, nil)
+}
+
+func TestRedirectingStateValidCSRF(t *testing.T) {
+	fakeCSRF := &csrf.FakeCSRF{"xyz", nil}
+	redirectingState := CSRFRedirectingState(fakeCSRF)
+
+	req, _ := http.NewRequest("GET", "http://www.example.com", nil)
+	state, err := redirectingState.Generate(httptest.NewRecorder(), req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+
+	// Make sure the state verifies
+	req2, _ := http.NewRequest("GET", "http://www.example.com/callback", nil)
+	ok, err := redirectingState.Check(state, req2)
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+	if !ok {
+		t.Fatalf("Unexpected invalid state")
+	}
+}
+
+func TestRedirectingStateInvalidCSRF(t *testing.T) {
+	fakeCSRF := &csrf.FakeCSRF{"xyz", nil}
+	redirectingState := CSRFRedirectingState(fakeCSRF)
+
+	req, _ := http.NewRequest("GET", "http://www.example.com", nil)
+	state, err := redirectingState.Generate(httptest.NewRecorder(), req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+
+	req2, _ := http.NewRequest("GET", "http://www.example.com/callback", nil)
+
+	// Change the CSRF validator so it returns invalid (but no error)
+	fakeCSRF.Token = "abc"
+	if _, err := redirectingState.Check(state, req2); err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+
+	// Change the CSRF validator so it returns an error
+	fakeCSRF.Err = errors.New("CSRF error")
+	if _, err := redirectingState.Check(state, req2); err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+}
+
+func TestRedirectingStateSuccess(t *testing.T) {
+	originalURL := "http://www.example.com"
+
+	fakeCSRF := &csrf.FakeCSRF{"xyz", nil}
+	redirectingState := CSRFRedirectingState(fakeCSRF)
+
+	req, _ := http.NewRequest("GET", originalURL, nil)
+	state, err := redirectingState.Generate(httptest.NewRecorder(), req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+
+	req2, _ := http.NewRequest("GET", "http://www.example.com/callback", nil)
+	recorder := httptest.NewRecorder()
+	user := &user.DefaultInfo{}
+
+	handled, err := redirectingState.AuthenticationSucceeded(user, state, recorder, req2)
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
+	if !handled {
+		t.Errorf("Expected handled request")
+	}
+	if recorder.Header().Get("Location") != originalURL {
+		t.Errorf("Expected redirect to %s, got %#v", originalURL, recorder.Header())
+	}
+}
+
+func TestRedirectingStateOAuthError(t *testing.T) {
+	originalURL := "http://www.example.com"
+	expectedURL := "http://www.example.com?error=access_denied"
+
+	fakeCSRF := &csrf.FakeCSRF{"xyz", nil}
+	redirectingState := CSRFRedirectingState(fakeCSRF)
+
+	req, _ := http.NewRequest("GET", originalURL, nil)
+	state, err := redirectingState.Generate(httptest.NewRecorder(), req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %#v", err)
+	}
+
+	req2, _ := http.NewRequest("GET", "http://www.example.com/callback", nil)
+	recorder := httptest.NewRecorder()
+	osinErr := &osincli.Error{
+		Id:    "access_denied",
+		State: state,
+	}
+
+	handled, err := redirectingState.AuthenticationError(osinErr, recorder, req2)
+	if err != nil {
+		t.Errorf("Unexpected error: %#v", err)
+	}
+	if !handled {
+		t.Errorf("Expected handled request")
+	}
+	if recorder.Header().Get("Location") != expectedURL {
+		t.Errorf("Expected redirect to %s, got %#v", expectedURL, recorder.Header())
+	}
+}
+
+func TestRedirectingStateError(t *testing.T) {
+	fakeCSRF := &csrf.FakeCSRF{"xyz", nil}
+	redirectingState := CSRFRedirectingState(fakeCSRF)
+
+	req2, _ := http.NewRequest("GET", "http://www.example.com/callback", nil)
+	recorder := httptest.NewRecorder()
+	inErr := errors.New("test")
+
+	handled, err := redirectingState.AuthenticationError(inErr, recorder, req2)
+	if handled {
+		t.Errorf("Expected unhandled request")
+	}
+	if err != inErr {
+		t.Errorf("Expected original error back, got %#v", err)
+	}
 }

--- a/pkg/auth/oauth/external/interfaces.go
+++ b/pkg/auth/oauth/external/interfaces.go
@@ -25,5 +25,5 @@ type Provider interface {
 // Examples: CSRF protection, post authentication redirection
 type State interface {
 	Generate(w http.ResponseWriter, req *http.Request) (string, error)
-	Check(state string, w http.ResponseWriter, req *http.Request) (bool, error)
+	Check(state string, req *http.Request) (bool, error)
 }

--- a/pkg/auth/oauth/handlers/authenticator.go
+++ b/pkg/auth/oauth/handlers/authenticator.go
@@ -79,6 +79,8 @@ func (h *AccessAuthenticator) HandleAccess(ar *osin.AccessRequest, w http.Respon
 	}
 
 	if ok {
+		// Disable refresh_token generation
+		ar.GenerateRefresh = false
 		ar.Authorized = true
 		if info != nil {
 			ar.AccessData.UserData = info

--- a/pkg/auth/oauth/handlers/empties.go
+++ b/pkg/auth/oauth/handlers/empties.go
@@ -25,11 +25,11 @@ func (EmptySuccess) AuthenticationSucceeded(user user.Info, state string, w http
 type EmptyError struct{}
 
 func (EmptyError) AuthenticationError(err error, w http.ResponseWriter, req *http.Request) (bool, error) {
-	glog.V(4).Infof("AuthenticationError: %v", err)
+	glog.Errorf("AuthenticationError: %v", err)
 	return false, err
 }
 
 func (EmptyError) GrantError(err error, w http.ResponseWriter, req *http.Request) (bool, error) {
-	glog.V(4).Infof("GrantError: %v", err)
+	glog.Errorf("GrantError: %v", err)
 	return false, err
 }

--- a/pkg/auth/oauth/handlers/grant.go
+++ b/pkg/auth/oauth/handlers/grant.go
@@ -97,10 +97,6 @@ type redirectGrant struct {
 	url string
 }
 
-// If a user denies a grant, a grant handler can return control to the /authorize handler with an error=grant_denied parameter
-// and the denial will be returned to the client, rather than re-calling GrantNeeded
-const GrantDeniedError = "grant_denied"
-
 // NewRedirectGrant returns a grant handler that redirects to the given URL when a grant is needed.
 // The following query parameters are added to the URL:
 //   then - original request URL
@@ -113,11 +109,6 @@ func NewRedirectGrant(url string) GrantHandler {
 
 // GrantNeeded implements the GrantHandler interface
 func (g *redirectGrant) GrantNeeded(user user.Info, grant *api.Grant, w http.ResponseWriter, req *http.Request) (bool, bool, error) {
-	// If the current request has an error=grant_denied parameter, the user denied the grant
-	if err := req.FormValue("error"); err == GrantDeniedError {
-		return false, false, nil
-	}
-
 	redirectURL, err := url.Parse(g.url)
 	if err != nil {
 		return false, false, err

--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -9,7 +9,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/auth/authenticator"
-	ohandlers "github.com/openshift/origin/pkg/auth/oauth/handlers"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
 	oapi "github.com/openshift/origin/pkg/oauth/api"
 	clientregistry "github.com/openshift/origin/pkg/oauth/registry/client"
@@ -170,7 +169,7 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 			return
 		}
 		q := url.Query()
-		q["error"] = []string{ohandlers.GrantDeniedError}
+		q.Set("error", "access_denied")
 		url.RawQuery = q.Encode()
 		http.Redirect(w, req, url.String(), http.StatusFound)
 		return

--- a/pkg/auth/server/grant/grant_test.go
+++ b/pkg/auth/server/grant/grant_test.go
@@ -275,7 +275,7 @@ func TestGrant(t *testing.T) {
 			},
 
 			ExpectStatusCode: 302,
-			ExpectRedirect:   "/authorize?error=grant_denied",
+			ExpectRedirect:   "/authorize?error=access_denied",
 		},
 	}
 

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -284,8 +284,6 @@ func (c *AuthConfig) getAuthenticationFinalizer() osinserver.AuthorizeHandler {
 }
 
 func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler handlers.AuthenticationErrorHandler) (handlers.AuthenticationHandler, error) {
-	successHandler := c.getAuthenticationSuccessHandler()
-
 	challengers := map[string]handlers.AuthenticationChallenger{}
 	redirectors := map[string]handlers.AuthenticationRedirector{}
 
@@ -299,8 +297,16 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 			}
 
 			if identityProvider.UseAsLogin {
+				// Password auth requires:
+				// 1. a session success handler (to remember you logged in)
+				// 2. a redirectSuccessHandler (to go back to the "then" param)
+				if c.SessionAuth == nil {
+					return nil, errors.New("SessionAuth is required for password-based login")
+				}
+				passwordSuccessHandler := handlers.AuthenticationSuccessHandlers{c.SessionAuth, redirectSuccessHandler{}}
+
 				redirectors["login"] = &redirector{RedirectURL: OpenShiftLoginPrefix, ThenParam: "then"}
-				login := login.NewLogin(getCSRF(), &callbackPasswordAuthenticator{passwordAuth, successHandler}, login.DefaultLoginFormRenderer)
+				login := login.NewLogin(getCSRF(), &callbackPasswordAuthenticator{passwordAuth, passwordSuccessHandler}, login.DefaultLoginFormRenderer)
 				login.Install(mux, OpenShiftLoginPrefix)
 			}
 			if identityProvider.UseAsChallenger {
@@ -313,9 +319,22 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 				return nil, err
 			}
 
-			state := external.DefaultState(getCSRF())
+			// Default state builder, combining CSRF and return URL handling
+			state := external.CSRFRedirectingState(getCSRF())
+
+			// OAuth auth requires
+			// 1. a session success handler (to remember you logged in)
+			// 2. a state success handler (to go back to the URL encoded in the state)
+			if c.SessionAuth == nil {
+				return nil, errors.New("SessionAuth is required for OAuth-based login")
+			}
+			oauthSuccessHandler := handlers.AuthenticationSuccessHandlers{c.SessionAuth, state}
+
+			// If the specified errorHandler doesn't handle the login error, let the state error handler attempt to propagate specific errors back to the token requester
+			oauthErrorHandler := handlers.AuthenticationErrorHandlers{errorHandler, state}
+
 			callbackPath := path.Join(OpenShiftOAuthCallbackPrefix, identityProvider.Name)
-			oauthHandler, err := external.NewExternalOAuthRedirector(oauthProvider, state, c.Options.MasterPublicURL+callbackPath, successHandler, errorHandler, identityMapper)
+			oauthHandler, err := external.NewExternalOAuthRedirector(oauthProvider, state, c.Options.MasterPublicURL+callbackPath, oauthSuccessHandler, oauthErrorHandler, identityMapper)
 			if err != nil {
 				return nil, fmt.Errorf("unexpected error: %v", err)
 			}
@@ -413,32 +432,6 @@ func (c *AuthConfig) getPasswordAuthenticator(identityProvider configapi.Identit
 		return nil, fmt.Errorf("No password auth found that matches %v.  The OAuth server cannot start!", identityProvider)
 	}
 
-}
-
-func (c *AuthConfig) getAuthenticationSuccessHandler() handlers.AuthenticationSuccessHandler {
-	successHandlers := handlers.AuthenticationSuccessHandlers{}
-
-	if c.SessionAuth != nil {
-		successHandlers = append(successHandlers, c.SessionAuth)
-	}
-
-	addedRedirectSuccessHandler := false
-	for _, identityProvider := range c.Options.IdentityProviders {
-		if !identityProvider.UseAsLogin {
-			continue
-		}
-
-		if configapi.IsOAuthIdentityProvider(identityProvider) {
-			successHandlers = append(successHandlers, external.DefaultState(getCSRF()).(handlers.AuthenticationSuccessHandler))
-		}
-
-		if !addedRedirectSuccessHandler && configapi.IsPasswordAuthenticator(identityProvider) {
-			successHandlers = append(successHandlers, redirectSuccessHandler{})
-			addedRedirectSuccessHandler = true
-		}
-	}
-
-	return successHandlers
 }
 
 func (c *AuthConfig) getAuthenticationRequestHandler() (authenticator.Request, error) {


### PR DESCRIPTION
If a user denies a remote OAuth token request, we get error params sent back to `/oauth2callback/<providerName>?error=...&error_description=...`

This PR does the following:
- [x] Validates state parameter in the external OAuth handler prior to making server-to-server calls, rather than after
- [x] Makes the external OAuth handler echo those errors back to `/oauth/authorize`
- [x] Makes the `/oauth/authorize` endpoint respond to error parameters by echoing them back to the token requester.
- [x] Updates the case where a user denied a grant (with method=prompt) to use the same mechanism