### PR TITLE
Improve handling of challenging OAuth clients

### DIFF
--- a/pkg/auth/authenticator/challenger/passwordchallenger/password_auth_handler.go
+++ b/pkg/auth/authenticator/challenger/passwordchallenger/password_auth_handler.go
@@ -1,6 +1,7 @@
 package passwordchallenger
 
 import (
+	"fmt"
 	"net/http"
 
 	oauthhandlers "github.com/openshift/origin/pkg/auth/oauth/handlers"
@@ -10,6 +11,12 @@ type basicPasswordAuthHandler struct {
 	realm string
 }
 
+// CSRFTokenHeader must be passed when requesting a WWW-Authenticate Basic challenge to prevent CSRF attacks on browsers.
+// The presence of this header indicates that a user agent intended to make a basic auth request (as opposed to a browser
+// being tricked into requesting /oauth/authorize?response_type=token&client_id=openshift-challenging-client).
+// Because multiple clients (osc, Java client, etc) are required to set this header, it probably should not be changed.
+const CSRFTokenHeader = "X-CSRF-Token"
+
 // NewBasicAuthChallenger returns a AuthenticationChallenger that responds with a basic auth challenge for the supplied realm
 func NewBasicAuthChallenger(realm string) oauthhandlers.AuthenticationChallenger {
 	return &basicPasswordAuthHandler{realm}
@@ -18,7 +25,19 @@ func NewBasicAuthChallenger(realm string) oauthhandlers.AuthenticationChallenger
 // AuthenticationChallenge returns a header that indicates a basic auth challenge for the supplied realm
 func (h *basicPasswordAuthHandler) AuthenticationChallenge(req *http.Request) (http.Header, error) {
 	headers := http.Header{}
-	headers.Add("WWW-Authenticate", "Basic realm=\""+h.realm+"\"")
+
+	if len(req.Header.Get(CSRFTokenHeader)) == 0 {
+		headers.Add("Warning",
+			fmt.Sprintf(
+				`%s %s "A non-empty %s header is required to receive basic-auth challenges"`,
+				oauthhandlers.WarningHeaderMiscCode,
+				oauthhandlers.WarningHeaderOpenShiftSource,
+				CSRFTokenHeader,
+			),
+		)
+	} else {
+		headers.Add("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, h.realm))
+	}
 
 	return headers, nil
 }

--- a/pkg/auth/authenticator/challenger/passwordchallenger/password_auth_handler_test.go
+++ b/pkg/auth/authenticator/challenger/passwordchallenger/password_auth_handler_test.go
@@ -1,27 +1,49 @@
 package passwordchallenger
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 )
 
 func TestAuthChallengeNeeded(t *testing.T) {
-	handler := NewBasicAuthChallenger("testing-realm")
-	req := &http.Request{}
-	header, err := handler.AuthenticationChallenge(req)
+	realm := "testing-realm"
+	expectedChallenge := fmt.Sprintf(`Basic realm="%s"`, realm)
 
+	handler := NewBasicAuthChallenger(realm)
+
+	req, _ := http.NewRequest("GET", "", nil)
+	req.Header.Set(CSRFTokenHeader, "1")
+	header, err := handler.AuthenticationChallenge(req)
 	if err != nil {
-		t.Errorf("Unexepcted error: %v", err)
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if warning := header.Get("Warning"); warning != "" {
+		t.Errorf("Unexpected warning %v", warning)
+	}
+	if challenge := header.Get("WWW-Authenticate"); challenge != expectedChallenge {
+		t.Errorf("Expected %v, got %v", expectedChallenge, challenge)
 	}
 
-	if value, ok := header["Www-Authenticate"]; ok {
-		expectedValue := "Basic realm=\"testing-realm\""
-		if value[0] != expectedValue {
-			t.Errorf("Expected %v, got %v", expectedValue, value)
-		}
-	} else {
-		t.Error("Did not get back header")
+}
 
+func TestAuthChallengeWithoutCSRF(t *testing.T) {
+	realm := "testing-realm"
+	expectedWarning := CSRFTokenHeader
+
+	handler := NewBasicAuthChallenger(realm)
+
+	req, _ := http.NewRequest("GET", "", nil)
+	header, err := handler.AuthenticationChallenge(req)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if warning := header.Get("Warning"); !strings.Contains(warning, expectedWarning) {
+		t.Errorf("Expected warning containing %s, got %s", expectedWarning, warning)
+	}
+	if challenge := header.Get("WWW-Authenticate"); challenge != "" {
+		t.Errorf("Unexpected challenge %v", challenge)
 	}
 
 }

--- a/pkg/auth/authenticator/challenger/placeholderchallenger/placeholder_challenger.go
+++ b/pkg/auth/authenticator/challenger/placeholderchallenger/placeholder_challenger.go
@@ -1,0 +1,33 @@
+package placeholderchallenger
+
+import (
+	"fmt"
+	"net/http"
+
+	oauthhandlers "github.com/openshift/origin/pkg/auth/oauth/handlers"
+)
+
+type placeholderChallenger struct {
+	tokenRequestURL string
+}
+
+// New returns an AuthenticationChallenger that responds with a warning and link to the web UI for requesting a token
+func New(url string) oauthhandlers.AuthenticationChallenger {
+	return placeholderChallenger{url}
+}
+
+// AuthenticationChallenge returns a header that indicates a basic auth challenge for the supplied realm
+func (c placeholderChallenger) AuthenticationChallenge(req *http.Request) (http.Header, error) {
+	headers := http.Header{}
+	headers.Add("Warning",
+		fmt.Sprintf(
+			`%s %s "You must obtain an API token by visiting %s"`,
+			oauthhandlers.WarningHeaderMiscCode,
+			oauthhandlers.WarningHeaderOpenShiftSource,
+			c.tokenRequestURL,
+		),
+	)
+	headers.Add("Link", fmt.Sprintf(`<%s>; rel="related"`, c.tokenRequestURL))
+
+	return headers, nil
+}

--- a/pkg/cmd/experimental/tokens/request.go
+++ b/pkg/cmd/experimental/tokens/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -17,14 +18,10 @@ func NewCmdRequestToken(f *clientcmd.Factory) *cobra.Command {
 		Long:  `request an access token`,
 		Run: func(cmd *cobra.Command, args []string) {
 			clientCfg, err := f.OpenShiftClientConfig.ClientConfig()
-			if err != nil {
-				fmt.Errorf("%v\n", err)
-			}
+			util.CheckErr(err)
 
 			accessToken, err := tokencmd.RequestToken(clientCfg, os.Stdin, "", "")
-			if err != nil {
-				fmt.Errorf("%v\n", err)
-			}
+			util.CheckErr(err)
 
 			fmt.Printf("%v\n", string(accessToken))
 		},

--- a/pkg/cmd/experimental/tokens/tokens.go
+++ b/pkg/cmd/experimental/tokens/tokens.go
@@ -2,6 +2,7 @@ package tokens
 
 import (
 	"os"
+	"path"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/golang/glog"
@@ -44,5 +45,5 @@ func getFlagString(cmd *cobra.Command, flag string) string {
 }
 
 func getRequestTokenURL(clientCfg *client.Config) string {
-	return clientCfg.Host + origin.OpenShiftLoginPrefix + tokenrequest.RequestTokenEndpoint
+	return clientCfg.Host + path.Join(origin.OpenShiftOAuthAPIPrefix, tokenrequest.RequestTokenEndpoint)
 }

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -149,7 +149,7 @@ func (c *AuthConfig) InstallAPI(container *restful.Container) []string {
 		osOAuthClient.Transport = &transport
 	}
 
-	tokenRequestEndpoints := tokenrequest.NewEndpoints(osOAuthClient)
+	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.Options.MasterPublicURL, osOAuthClient)
 	tokenRequestEndpoints.Install(mux, OpenShiftOAuthAPIPrefix)
 
 	// glog.Infof("oauth server configured as: %#v", server)

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/authenticator/challenger/passwordchallenger"
+	"github.com/openshift/origin/pkg/auth/authenticator/challenger/placeholderchallenger"
 	"github.com/openshift/origin/pkg/auth/authenticator/password/allowanypassword"
 	"github.com/openshift/origin/pkg/auth/authenticator/password/basicauthpassword"
 	"github.com/openshift/origin/pkg/auth/authenticator/password/denypassword"
@@ -183,6 +184,9 @@ func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
 func OpenShiftOAuthTokenURL(masterAddr string) string {
 	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, osinserver.TokenPath)
 }
+func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
+	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, tokenrequest.RequestTokenEndpoint)
+}
 
 func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddresses []string, clientRegistry oauthclient.Registry) {
 	clientsToEnsure := []*oauthapi.OAuthClient{
@@ -328,6 +332,11 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 				return nil, errors.New("oauth identity providers cannot issue challenges")
 			}
 		}
+	}
+
+	if len(redirectors) > 0 && len(challengers) == 0 {
+		// Add a default challenger that will warn and give a link to the web browser token-granting location
+		challengers["placeholder"] = placeholderchallenger.New(OpenShiftOAuthTokenRequestURL(c.Options.MasterPublicURL))
 	}
 
 	authHandler := handlers.NewUnionAuthenticationHandler(challengers, redirectors, errorHandler)


### PR DESCRIPTION
- [x] Protect browsers from basic-auth CSRF attacks by requiring a custom header ("X-CSRF-Token")
- [x] Make `osc` send the custom header
- [x] Provide a more helpful warning when authenticating via WWW-Authenticate challenge is not supported by the current OAuth config
- [x] Surface warnings in `osc` when login fails (because of bad credentials or because cli login isn't supported)
- [x] Tweak the browser request token page to show using the token to log in