### PR TITLE
Add 'is' shortcut for imageStreams

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -141,6 +141,7 @@ func expandResourceShortcut(resource string) string {
 	shortForms := map[string]string{
 		"dc": "deploymentConfigs",
 		"bc": "buildConfigs",
+		"is": "imageStreams",
 	}
 	if expanded, ok := shortForms[resource]; ok {
 		return expanded


### PR DESCRIPTION
Just tired of typing 'osc get imageStream xyz' ;-)