### PR TITLE
Add SyslogIdentifier=openshift-{master,node} respectively

### DIFF
--- a/rel-eng/openshift-master.service
+++ b/rel-eng/openshift-master.service
@@ -13,6 +13,7 @@ Type=notify
 EnvironmentFile=-/etc/sysconfig/openshift-master
 ExecStart=/usr/bin/openshift start $ROLE --images=${IMAGES} $OPTIONS
 WorkingDirectory=/var/lib/openshift/
+SyslogIdentifier=openshift-master
 
 [Install]
 WantedBy=multi-user.target

--- a/rel-eng/openshift-node.service
+++ b/rel-eng/openshift-node.service
@@ -12,6 +12,7 @@ Type=notify
 EnvironmentFile=-/etc/sysconfig/openshift-node
 ExecStart=/usr/bin/openshift start $ROLE --images=${IMAGES} --kubeconfig=${KUBECONFIG} $OPTIONS
 WorkingDirectory=/var/lib/openshift/
+SyslogIdentifier=openshift-node
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This will allow rsyslog users to split master and node logs if they
wish to do so using rsyslog.conf entries like the following

```
:programname, contains, "openshift"			/var/log/openshift
:programname, isequal, "openshift-master"		/var/log/openshift-master
:programname, isequal, "openshift-node"		/var/log/openshift-node
```
