### PR TITLE
change openshiftconfig loading rules and files

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/loader.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/loader.go
@@ -18,8 +18,10 @@ package clientcmd
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -33,21 +35,23 @@ import (
 const (
 	RecommendedConfigPathFlag   = "kubeconfig"
 	RecommendedConfigPathEnvVar = "KUBECONFIG"
-
-	DefaultEnvVarIndex     = 0
-	DefaultCurrentDirIndex = 1
-	DefaultHomeDirIndex    = 2
+	RecommendedHomeFileName     = "/.kube/config"
 )
+
+var OldRecommendedHomeFile = path.Join(os.Getenv("HOME"), "/.kube/.kubeconfig")
+var RecommendedHomeFile = path.Join(os.Getenv("HOME"), RecommendedHomeFileName)
 
 // ClientConfigLoadingRules is an ExplicitPath and string slice of specific locations that are used for merging together a Config
 // Callers can put the chain together however they want, but we'd recommend:
-// [0] = EnvVarPath
-// [1] = CurrentDirectoryPath
-// [2] = HomeDirectoryPath
+// EnvVarPathFiles if set (a list of files if set) OR the HomeDirectoryPath
 // ExplicitPath is special, because if a user specifically requests a certain file be used and error is reported if thie file is not present
 type ClientConfigLoadingRules struct {
 	ExplicitPath string
 	Precedence   []string
+
+	// MigrationRules is a map of destination files to source files.  If a destination file is not present, then the source file is checked.
+	// If the source file is present, then it is copied to the destination file BEFORE any further loading happens.
+	MigrationRules map[string]string
 
 	// DoNotResolvePaths indicates whether or not to resolve paths with respect to the originating files.  This is phrased as a negative so
 	// that a default object that doesn't set this will usually get the behavior it wants.
@@ -57,14 +61,29 @@ type ClientConfigLoadingRules struct {
 // NewDefaultClientConfigLoadingRules returns a ClientConfigLoadingRules object with default fields filled in.  You are not required to
 // use this constructor
 func NewDefaultClientConfigLoadingRules() *ClientConfigLoadingRules {
+	chain := []string{}
+	migrationRules := map[string]string{}
+
+	envVarFiles := os.Getenv(RecommendedConfigPathEnvVar)
+	if len(envVarFiles) != 0 {
+		chain = append(chain, filepath.SplitList(envVarFiles)...)
+
+	} else {
+		chain = append(chain, RecommendedHomeFile)
+		migrationRules[RecommendedHomeFile] = OldRecommendedHomeFile
+
+	}
+
 	return &ClientConfigLoadingRules{
-		Precedence: []string{os.Getenv(RecommendedConfigPathEnvVar), ".kubeconfig", os.Getenv("HOME") + "/.kube/.kubeconfig"},
+		Precedence:     chain,
+		MigrationRules: migrationRules,
 	}
 }
 
-// Load takes the loading rules and merges together a Config object based on following order.
-//   1.  ExplicitPath
-//   2.  Precedence slice
+// Load starts by running the MigrationRules and then
+// takes the loading rules and returns a Config object based on following rules.
+//   if the ExplicitPath, return the unmerged explicit file
+//   Otherwise, return a merged config based on the Precedence slice
 // A missing ExplicitPath file produces an error. Empty filenames or other missing files are ignored.
 // Read errors or files with non-deserializable content produce errors.
 // The first file to set a particular map key wins and map key's value is never changed.
@@ -75,17 +94,25 @@ func NewDefaultClientConfigLoadingRules() *ClientConfigLoadingRules {
 // Relative paths inside of the .kubeconfig files are resolved against the .kubeconfig file's parent folder
 // and only absolute file paths are returned.
 func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
+	if err := rules.Migrate(); err != nil {
+		return nil, err
+	}
+
 	errlist := []error{}
+
+	kubeConfigFiles := []string{}
 
 	// Make sure a file we were explicitly told to use exists
 	if len(rules.ExplicitPath) > 0 {
 		if _, err := os.Stat(rules.ExplicitPath); os.IsNotExist(err) {
-			errlist = append(errlist, fmt.Errorf("The config file %v does not exist", rules.ExplicitPath))
+			return nil, err
 		}
-	}
+		kubeConfigFiles = append(kubeConfigFiles, rules.ExplicitPath)
 
-	kubeConfigFiles := []string{rules.ExplicitPath}
-	kubeConfigFiles = append(kubeConfigFiles, rules.Precedence...)
+	} else {
+		kubeConfigFiles = append(kubeConfigFiles, rules.Precedence...)
+
+	}
 
 	// first merge all of our maps
 	mapConfig := clientcmdapi.NewConfig()
@@ -93,7 +120,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 		if err := mergeConfigWithFile(mapConfig, file); err != nil {
 			errlist = append(errlist, err)
 		}
-		if !rules.DoNotResolvePaths {
+		if rules.ResolvePaths() {
 			if err := ResolveLocalPaths(file, mapConfig); err != nil {
 				errlist = append(errlist, err)
 			}
@@ -106,7 +133,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 	for i := len(kubeConfigFiles) - 1; i >= 0; i-- {
 		file := kubeConfigFiles[i]
 		mergeConfigWithFile(nonMapConfig, file)
-		if !rules.DoNotResolvePaths {
+		if rules.ResolvePaths() {
 			ResolveLocalPaths(file, nonMapConfig)
 		}
 	}
@@ -118,6 +145,53 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 	mergo.Merge(config, nonMapConfig)
 
 	return config, errors.NewAggregate(errlist)
+}
+
+// Migrate uses the MigrationRules map.  If a destination file is not present, then the source file is checked.
+// If the source file is present, then it is copied to the destination file BEFORE any further loading happens.
+func (rules *ClientConfigLoadingRules) Migrate() error {
+	if rules.MigrationRules == nil {
+		return nil
+	}
+
+	for destination, source := range rules.MigrationRules {
+		if _, err := os.Stat(destination); err == nil {
+			// if the destination already exists, do nothing
+			continue
+		} else if !os.IsNotExist(err) {
+			// if we had an error other than non-existence, fail
+			return err
+		}
+
+		if sourceInfo, err := os.Stat(source); err != nil {
+			if os.IsNotExist(err) {
+				// if the source file doesn't exist, there's no work to do.
+				continue
+			}
+
+			// if we had an error other than non-existence, fail
+			return err
+		} else if sourceInfo.IsDir() {
+			return fmt.Errorf("cannot migrate %v to %v because it is a directory", source, destination)
+		}
+
+		in, err := os.Open(source)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(destination)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		if _, err = io.Copy(out, in); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func mergeConfigWithFile(startingConfig *clientcmdapi.Config, filename string) error {
@@ -257,4 +331,8 @@ func Write(config clientcmdapi.Config) ([]byte, error) {
 		return nil, err
 	}
 	return content, nil
+}
+
+func (rules ClientConfigLoadingRules) ResolvePaths() bool {
+	return !rules.DoNotResolvePaths
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/merged_client_builder_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/merged_client_builder_test.go
@@ -78,10 +78,7 @@ func testWriteAuthInfoFile(auth clientauth.Info, filename string) error {
 }
 
 func testBindClientConfig(cmd *cobra.Command) ClientConfig {
-	loadingRules := NewDefaultClientConfigLoadingRules()
-	loadingRules.Precedence[DefaultEnvVarIndex] = ""
-	loadingRules.Precedence[DefaultCurrentDirIndex] = ""
-	loadingRules.Precedence[DefaultHomeDirIndex] = ""
+	loadingRules := &ClientConfigLoadingRules{}
 	cmd.PersistentFlags().StringVar(&loadingRules.ExplicitPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 
 	overrides := &ConfigOverrides{}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/config.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/config.go
@@ -18,10 +18,10 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strconv"
 
@@ -33,41 +33,54 @@ import (
 )
 
 type PathOptions struct {
-	Local     bool
-	Global    bool
-	UseEnvVar bool
-
-	LocalFile  string
+	// GlobalFile is the full path to the file to load as the global (final) option
 	GlobalFile string
-	EnvVarFile string
-
-	EnvVar           string
+	// EnvVar is the env var name that points to the list of kubeconfig files to load
+	EnvVar string
+	// ExplicitFileFlag is the name of the flag to use for prompting for the kubeconfig file
 	ExplicitFileFlag string
 
+	// GlobalFileSubpath is an optional value used for displaying help
+	GlobalFileSubpath string
+
 	LoadingRules *clientcmd.ClientConfigLoadingRules
+}
+
+// ConfigAccess is used by subcommands and methods in this package to load and modify the appropriate config files
+type ConfigAccess interface {
+	// GetLoadingPrecedence returns the slice of files that should be used for loading and inspecting the config
+	GetLoadingPrecedence() []string
+	// GetStartingConfig returns the config that subcommands should being operating against.  It may or may not be merged depending on loading rules
+	GetStartingConfig() (*clientcmdapi.Config, error)
+	// GetDefaultFilename returns the name of the file you should write into (create if necessary), if you're trying to create a new stanza as opposed to updating an existing one.
+	GetDefaultFilename() string
+	// IsExplicitFile indicates whether or not this command is interested in exactly one file.  This implementation only ever does that  via a flag, but implementations that handle local, global, and flags may have more
+	IsExplicitFile() bool
+	// GetExplicitFile returns the particular file this command is operating against.  This implementation only ever has one, but implementations that handle local, global, and flags may have more
+	GetExplicitFile() string
 }
 
 func NewCmdConfig(pathOptions *PathOptions, out io.Writer) *cobra.Command {
 	if len(pathOptions.ExplicitFileFlag) == 0 {
 		pathOptions.ExplicitFileFlag = clientcmd.RecommendedConfigPathFlag
 	}
-	if len(pathOptions.EnvVar) > 0 {
-		pathOptions.EnvVarFile = os.Getenv(pathOptions.EnvVar)
-	}
 
 	cmd := &cobra.Command{
 		Use:   "config SUBCOMMAND",
 		Short: "config modifies kubeconfig files",
-		Long:  `config modifies kubeconfig files using subcommands like "kubectl config set current-context my-context"`,
+		Long: `config modifies kubeconfig files using subcommands like "kubectl config set current-context my-context"
+
+The loading order follows these rules:
+    1. If the --` + pathOptions.ExplicitFileFlag + ` flag is set, then only that file is loaded.  The flag may only be set once and no merging takes place.
+    2. If $` + pathOptions.EnvVar + ` environment variable is set, then it is used a list of paths (normal path delimitting rules for your system).  These paths are merged together.  When a value is modified, it is modified in the file that defines the stanza.  When a value is created, it is created in the first file that exists.  If no files in the chain exist, then it creates the last file in the list.
+    3. Otherwise, ` + path.Join("${HOME}", pathOptions.GlobalFileSubpath) + ` is used and no merging takes place.
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},
 	}
 
 	// file paths are common to all sub commands
-	cmd.PersistentFlags().BoolVar(&pathOptions.Local, "local", pathOptions.Local, "use the kubeconfig in the current directory")
-	cmd.PersistentFlags().BoolVar(&pathOptions.Global, "global", pathOptions.Global, "use the kubeconfig from "+pathOptions.GlobalFile)
-	cmd.PersistentFlags().BoolVar(&pathOptions.UseEnvVar, "envvar", pathOptions.UseEnvVar, "use the kubeconfig from $"+pathOptions.EnvVar)
 	cmd.PersistentFlags().StringVar(&pathOptions.LoadingRules.ExplicitPath, pathOptions.ExplicitFileFlag, pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
 	cmd.AddCommand(NewCmdConfigView(out, pathOptions))
@@ -83,12 +96,11 @@ func NewCmdConfig(pathOptions *PathOptions, out io.Writer) *cobra.Command {
 
 func NewDefaultPathOptions() *PathOptions {
 	ret := &PathOptions{
-		LocalFile:  ".kubeconfig",
-		GlobalFile: path.Join(os.Getenv("HOME"), "/.kube/.kubeconfig"),
-		EnvVar:     clientcmd.RecommendedConfigPathEnvVar,
-		EnvVarFile: os.Getenv(clientcmd.RecommendedConfigPathEnvVar),
-
+		GlobalFile:       clientcmd.RecommendedHomeFile,
+		EnvVar:           clientcmd.RecommendedConfigPathEnvVar,
 		ExplicitFileFlag: clientcmd.RecommendedConfigPathFlag,
+
+		GlobalFileSubpath: clientcmd.RecommendedHomeFileName,
 
 		LoadingRules: clientcmd.NewDefaultClientConfigLoadingRules(),
 	}
@@ -97,125 +109,78 @@ func NewDefaultPathOptions() *PathOptions {
 	return ret
 }
 
-func (o PathOptions) Validate() error {
-	if len(o.LoadingRules.ExplicitPath) > 0 {
-		if o.Global {
-			return errors.New("cannot specify both --" + o.ExplicitFileFlag + " and --global")
-		}
-		if o.Local {
-			return errors.New("cannot specify both --" + o.ExplicitFileFlag + " and --local")
-		}
-		if o.UseEnvVar {
-			return errors.New("cannot specify both --" + o.ExplicitFileFlag + " and --envvar")
-		}
+func (o *PathOptions) GetEnvVarFiles() []string {
+	if len(o.EnvVar) == 0 {
+		return []string{}
 	}
 
-	if o.Global {
-		if o.Local {
-			return errors.New("cannot specify both --global and --local")
-		}
-		if o.UseEnvVar {
-			return errors.New("cannot specify both --global and --envvar")
-		}
+	envVarValue := os.Getenv(o.EnvVar)
+	if len(envVarValue) == 0 {
+		return []string{}
 	}
 
-	if o.Local {
-		if o.UseEnvVar {
-			return errors.New("cannot specify both --local and --envvar")
-		}
-	}
-
-	if o.UseEnvVar {
-		if len(o.EnvVarFile) == 0 {
-			return fmt.Errorf("environment variable %v does not have a value", o.EnvVar)
-		}
-
-	}
-
-	return nil
+	return filepath.SplitList(envVarValue)
 }
 
-func (o *PathOptions) getStartingConfig() (*clientcmdapi.Config, error) {
-	if err := o.Validate(); err != nil {
+func (o *PathOptions) GetLoadingPrecedence() []string {
+	if envVarFiles := o.GetEnvVarFiles(); len(envVarFiles) > 0 {
+		return envVarFiles
+	}
+
+	return []string{o.GlobalFile}
+}
+
+func (o *PathOptions) GetStartingConfig() (*clientcmdapi.Config, error) {
+	// don't mutate the original
+	loadingRules := *o.LoadingRules
+	loadingRules.Precedence = o.GetLoadingPrecedence()
+
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, &clientcmd.ConfigOverrides{})
+	rawConfig, err := clientConfig.RawConfig()
+	if os.IsNotExist(err) {
+		return clientcmdapi.NewConfig(), nil
+	}
+	if err != nil {
 		return nil, err
 	}
 
-	config := clientcmdapi.NewConfig()
-
-	switch {
-	case o.Global:
-		config = getConfigFromFileOrDie(o.GlobalFile)
-
-	case o.UseEnvVar:
-		config = getConfigFromFileOrDie(o.EnvVarFile)
-
-	case o.Local:
-		config = getConfigFromFileOrDie(o.LocalFile)
-
-		// no specific flag was set, load according to the loading rules
-	default:
-		clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(o.LoadingRules, &clientcmd.ConfigOverrides{})
-		rawConfig, err := clientConfig.RawConfig()
-		if err != nil {
-			return nil, err
-		}
-		config = &rawConfig
-
-	}
-
-	return config, nil
+	return &rawConfig, nil
 }
 
-// GetDefaultFilename returns the name of the file you should write into (create if necessary), if you're trying to create
-// a new stanza as opposed to updating an existing one.
 func (o *PathOptions) GetDefaultFilename() string {
 	if o.IsExplicitFile() {
 		return o.GetExplicitFile()
 	}
 
-	if len(o.EnvVarFile) > 0 {
-		return o.EnvVarFile
-	}
+	if envVarFiles := o.GetEnvVarFiles(); len(envVarFiles) > 0 {
+		if len(envVarFiles) == 1 {
+			return envVarFiles[0]
+		}
 
-	if _, err := os.Stat(o.LocalFile); err == nil {
-		return o.LocalFile
+		// if any of the envvar files already exists, return it
+		for _, envVarFile := range envVarFiles {
+			if _, err := os.Stat(envVarFile); err == nil {
+				return envVarFile
+			}
+		}
+
+		// otherwise, return the last one in the list
+		return envVarFiles[len(envVarFiles)-1]
 	}
 
 	return o.GlobalFile
-
 }
 
 func (o *PathOptions) IsExplicitFile() bool {
-	switch {
-	case len(o.LoadingRules.ExplicitPath) > 0 ||
-		o.Global ||
-		o.UseEnvVar ||
-		o.Local:
+	if len(o.LoadingRules.ExplicitPath) > 0 {
 		return true
 	}
+
 	return false
 }
 
 func (o *PathOptions) GetExplicitFile() string {
-	if !o.IsExplicitFile() {
-		return ""
-	}
-
-	switch {
-	case len(o.LoadingRules.ExplicitPath) > 0:
-		return o.LoadingRules.ExplicitPath
-
-	case o.Global:
-		return o.GlobalFile
-
-	case o.UseEnvVar:
-		return o.EnvVarFile
-
-	case o.Local:
-		return o.LocalFile
-	}
-
-	return ""
+	return o.LoadingRules.ExplicitPath
 }
 
 // ModifyConfig takes a Config object, iterates through Clusters, AuthInfos, and Contexts, uses the LocationOfOrigin if specified or
@@ -223,8 +188,8 @@ func (o *PathOptions) GetExplicitFile() string {
 // Preferences and CurrentContext should always be set in the default destination file.  Since we can't distinguish between empty and missing values
 // (no nil strings), we're forced have separate handling for them.  In all the currently known cases, newConfig should have, at most, one difference,
 // that means that this code will only write into a single file.
-func (o *PathOptions) ModifyConfig(newConfig clientcmdapi.Config) error {
-	startingConfig, err := o.getStartingConfig()
+func ModifyConfig(configAccess ConfigAccess, newConfig clientcmdapi.Config) error {
+	startingConfig, err := configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -232,121 +197,121 @@ func (o *PathOptions) ModifyConfig(newConfig clientcmdapi.Config) error {
 	// at this point, config and startingConfig should have, at most, one difference.  We need to chase the difference until we find it
 	// then we'll build a partial config object to call write upon.  Special case the test for current context and preferences since those
 	// always write to the default file.
-	if reflect.DeepEqual(*startingConfig, newConfig) {
+	switch {
+	case reflect.DeepEqual(*startingConfig, newConfig):
 		// nothing to do
-		return nil
-	}
 
-	if startingConfig.CurrentContext != newConfig.CurrentContext {
-		if err := o.writeCurrentContext(newConfig.CurrentContext); err != nil {
+	case startingConfig.CurrentContext != newConfig.CurrentContext:
+		if err := writeCurrentContext(configAccess, newConfig.CurrentContext); err != nil {
 			return err
 		}
-	}
 
-	if !reflect.DeepEqual(startingConfig.Preferences, newConfig.Preferences) {
-		if err := o.writePreferences(newConfig.Preferences); err != nil {
+	case !reflect.DeepEqual(startingConfig.Preferences, newConfig.Preferences):
+		if err := writePreferences(configAccess, newConfig.Preferences); err != nil {
 			return err
 		}
-	}
 
-	// Search every cluster, authInfo, and context.  First from new to old for differences, then from old to new for deletions
-	for key, cluster := range newConfig.Clusters {
-		startingCluster, exists := startingConfig.Clusters[key]
-		if !reflect.DeepEqual(cluster, startingCluster) || !exists {
-			destinationFile := cluster.LocationOfOrigin
-			if len(destinationFile) == 0 {
-				destinationFile = o.GetDefaultFilename()
-			}
+	default:
+		// something is different. Search every cluster, authInfo, and context.  First from new to old for differences, then from old to new for deletions
+		for key, cluster := range newConfig.Clusters {
+			startingCluster, exists := startingConfig.Clusters[key]
+			if !reflect.DeepEqual(cluster, startingCluster) || !exists {
+				destinationFile := cluster.LocationOfOrigin
+				if len(destinationFile) == 0 {
+					destinationFile = configAccess.GetDefaultFilename()
+				}
 
-			configToWrite := getConfigFromFileOrDie(destinationFile)
-			configToWrite.Clusters[key] = cluster
+				configToWrite := getConfigFromFileOrDie(destinationFile)
+				configToWrite.Clusters[key] = cluster
 
-			if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
-				return err
-			}
-		}
-	}
-
-	for key, context := range newConfig.Contexts {
-		startingContext, exists := startingConfig.Contexts[key]
-		if !reflect.DeepEqual(context, startingContext) || !exists {
-			destinationFile := context.LocationOfOrigin
-			if len(destinationFile) == 0 {
-				destinationFile = o.GetDefaultFilename()
-			}
-
-			configToWrite := getConfigFromFileOrDie(destinationFile)
-			configToWrite.Contexts[key] = context
-
-			if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
-				return err
+				if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
+					return err
+				}
 			}
 		}
-	}
 
-	for key, authInfo := range newConfig.AuthInfos {
-		startingAuthInfo, exists := startingConfig.AuthInfos[key]
-		if !reflect.DeepEqual(authInfo, startingAuthInfo) || !exists {
-			destinationFile := authInfo.LocationOfOrigin
-			if len(destinationFile) == 0 {
-				destinationFile = o.GetDefaultFilename()
-			}
+		for key, context := range newConfig.Contexts {
+			startingContext, exists := startingConfig.Contexts[key]
+			if !reflect.DeepEqual(context, startingContext) || !exists {
+				destinationFile := context.LocationOfOrigin
+				if len(destinationFile) == 0 {
+					destinationFile = configAccess.GetDefaultFilename()
+				}
 
-			configToWrite := getConfigFromFileOrDie(destinationFile)
-			configToWrite.AuthInfos[key] = authInfo
+				configToWrite := getConfigFromFileOrDie(destinationFile)
+				configToWrite.Contexts[key] = context
 
-			if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
-				return err
-			}
-		}
-	}
-
-	for key, cluster := range startingConfig.Clusters {
-		if _, exists := newConfig.Clusters[key]; !exists {
-			destinationFile := cluster.LocationOfOrigin
-			if len(destinationFile) == 0 {
-				destinationFile = o.GetDefaultFilename()
-			}
-
-			configToWrite := getConfigFromFileOrDie(destinationFile)
-			delete(configToWrite.Clusters, key)
-
-			if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
-				return err
+				if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
+					return err
+				}
 			}
 		}
-	}
 
-	for key, context := range startingConfig.Contexts {
-		if _, exists := newConfig.Contexts[key]; !exists {
-			destinationFile := context.LocationOfOrigin
-			if len(destinationFile) == 0 {
-				destinationFile = o.GetDefaultFilename()
-			}
+		for key, authInfo := range newConfig.AuthInfos {
+			startingAuthInfo, exists := startingConfig.AuthInfos[key]
+			if !reflect.DeepEqual(authInfo, startingAuthInfo) || !exists {
+				destinationFile := authInfo.LocationOfOrigin
+				if len(destinationFile) == 0 {
+					destinationFile = configAccess.GetDefaultFilename()
+				}
 
-			configToWrite := getConfigFromFileOrDie(destinationFile)
-			delete(configToWrite.Contexts, key)
+				configToWrite := getConfigFromFileOrDie(destinationFile)
+				configToWrite.AuthInfos[key] = authInfo
 
-			if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
-				return err
-			}
-		}
-	}
-
-	for key, authInfo := range startingConfig.AuthInfos {
-		if _, exists := newConfig.AuthInfos[key]; !exists {
-			destinationFile := authInfo.LocationOfOrigin
-			if len(destinationFile) == 0 {
-				destinationFile = o.GetDefaultFilename()
-			}
-
-			configToWrite := getConfigFromFileOrDie(destinationFile)
-			delete(configToWrite.AuthInfos, key)
-
-			if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
-				return err
+				if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
+					return err
+				}
 			}
 		}
+
+		for key, cluster := range startingConfig.Clusters {
+			if _, exists := newConfig.Clusters[key]; !exists {
+				destinationFile := cluster.LocationOfOrigin
+				if len(destinationFile) == 0 {
+					destinationFile = configAccess.GetDefaultFilename()
+				}
+
+				configToWrite := getConfigFromFileOrDie(destinationFile)
+				delete(configToWrite.Clusters, key)
+
+				if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
+					return err
+				}
+			}
+		}
+
+		for key, context := range startingConfig.Contexts {
+			if _, exists := newConfig.Contexts[key]; !exists {
+				destinationFile := context.LocationOfOrigin
+				if len(destinationFile) == 0 {
+					destinationFile = configAccess.GetDefaultFilename()
+				}
+
+				configToWrite := getConfigFromFileOrDie(destinationFile)
+				delete(configToWrite.Contexts, key)
+
+				if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
+					return err
+				}
+			}
+		}
+
+		for key, authInfo := range startingConfig.AuthInfos {
+			if _, exists := newConfig.AuthInfos[key]; !exists {
+				destinationFile := authInfo.LocationOfOrigin
+				if len(destinationFile) == 0 {
+					destinationFile = configAccess.GetDefaultFilename()
+				}
+
+				configToWrite := getConfigFromFileOrDie(destinationFile)
+				delete(configToWrite.AuthInfos, key)
+
+				if err := clientcmd.WriteToFile(*configToWrite, destinationFile); err != nil {
+					return err
+				}
+			}
+		}
+
 	}
 
 	return nil
@@ -356,15 +321,26 @@ func (o *PathOptions) ModifyConfig(newConfig clientcmdapi.Config) error {
 // If newCurrentContext is the same as the startingConfig's current context, then we exit.
 // If newCurrentContext has a value, then that value is written into the default destination file.
 // If newCurrentContext is empty, then we find the config file that is setting the CurrentContext and clear the value from that file
-func (o *PathOptions) writeCurrentContext(newCurrentContext string) error {
-	if startingConfig, err := o.getStartingConfig(); err != nil {
+func writeCurrentContext(configAccess ConfigAccess, newCurrentContext string) error {
+	if startingConfig, err := configAccess.GetStartingConfig(); err != nil {
 		return err
 	} else if startingConfig.CurrentContext == newCurrentContext {
 		return nil
 	}
 
+	if configAccess.IsExplicitFile() {
+		file := configAccess.GetExplicitFile()
+		currConfig := getConfigFromFileOrDie(file)
+		currConfig.CurrentContext = newCurrentContext
+		if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	if len(newCurrentContext) > 0 {
-		destinationFile := o.GetDefaultFilename()
+		destinationFile := configAccess.GetDefaultFilename()
 		config := getConfigFromFileOrDie(destinationFile)
 		config.CurrentContext = newCurrentContext
 
@@ -375,46 +351,34 @@ func (o *PathOptions) writeCurrentContext(newCurrentContext string) error {
 		return nil
 	}
 
-	if o.IsExplicitFile() {
-		file := o.GetExplicitFile()
-		currConfig := getConfigFromFileOrDie(file)
-		currConfig.CurrentContext = newCurrentContext
-		if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
-			return err
-		}
+	// we're supposed to be clearing the current context.  We need to find the first spot in the chain that is setting it and clear it
+	for _, file := range configAccess.GetLoadingPrecedence() {
+		if _, err := os.Stat(file); err == nil {
+			currConfig := getConfigFromFileOrDie(file)
 
-		return nil
-	}
+			if len(currConfig.CurrentContext) > 0 {
+				currConfig.CurrentContext = newCurrentContext
+				if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
+					return err
+				}
 
-	filesToCheck := make([]string, 0, len(o.LoadingRules.Precedence)+1)
-	filesToCheck = append(filesToCheck, o.LoadingRules.ExplicitPath)
-	filesToCheck = append(filesToCheck, o.LoadingRules.Precedence...)
-
-	for _, file := range filesToCheck {
-		currConfig := getConfigFromFileOrDie(file)
-
-		if len(currConfig.CurrentContext) > 0 {
-			currConfig.CurrentContext = newCurrentContext
-			if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
-				return err
+				return nil
 			}
-
-			return nil
 		}
 	}
 
-	return nil
+	return errors.New("no config found to write context")
 }
 
-func (o *PathOptions) writePreferences(newPrefs clientcmdapi.Preferences) error {
-	if startingConfig, err := o.getStartingConfig(); err != nil {
+func writePreferences(configAccess ConfigAccess, newPrefs clientcmdapi.Preferences) error {
+	if startingConfig, err := configAccess.GetStartingConfig(); err != nil {
 		return err
 	} else if reflect.DeepEqual(startingConfig.Preferences, newPrefs) {
 		return nil
 	}
 
-	if o.IsExplicitFile() {
-		file := o.GetExplicitFile()
+	if configAccess.IsExplicitFile() {
+		file := configAccess.GetExplicitFile()
 		currConfig := getConfigFromFileOrDie(file)
 		currConfig.Preferences = newPrefs
 		if err := clientcmd.WriteToFile(*currConfig, file); err != nil {
@@ -424,11 +388,7 @@ func (o *PathOptions) writePreferences(newPrefs clientcmdapi.Preferences) error 
 		return nil
 	}
 
-	filesToCheck := make([]string, 0, len(o.LoadingRules.Precedence)+1)
-	filesToCheck = append(filesToCheck, o.LoadingRules.ExplicitPath)
-	filesToCheck = append(filesToCheck, o.LoadingRules.Precedence...)
-
-	for _, file := range filesToCheck {
+	for _, file := range configAccess.GetLoadingPrecedence() {
 		currConfig := getConfigFromFileOrDie(file)
 
 		if !reflect.DeepEqual(currConfig.Preferences, newPrefs) {
@@ -441,7 +401,7 @@ func (o *PathOptions) writePreferences(newPrefs clientcmdapi.Preferences) error 
 		}
 	}
 
-	return nil
+	return errors.New("no config found to write preferences")
 }
 
 // getConfigFromFileOrDie tries to read a kubeconfig file and if it can't, it calls exit.  One exception, missing files result in empty configs, not an exit

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/create_authinfo.go
@@ -31,7 +31,7 @@ import (
 )
 
 type createAuthInfoOptions struct {
-	pathOptions       *PathOptions
+	configAccess      ConfigAccess
 	name              string
 	authPath          util.StringFlag
 	clientCertificate util.StringFlag
@@ -67,8 +67,8 @@ $ kubectl set-credentials cluster-admin --username=admin --password=uXFGweU9l35q
 // Embed client certificate data in the "cluster-admin" entry
 $ kubectl set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true`
 
-func NewCmdConfigSetAuthInfo(out io.Writer, pathOptions *PathOptions) *cobra.Command {
-	options := &createAuthInfoOptions{pathOptions: pathOptions}
+func NewCmdConfigSetAuthInfo(out io.Writer, configAccess ConfigAccess) *cobra.Command {
+	options := &createAuthInfoOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("set-credentials NAME [--%v=/path/to/authfile] [--%v=path/to/certfile] [--%v=path/to/keyfile] [--%v=bearer_token] [--%v=basic_user] [--%v=basic_password]", clientcmd.FlagAuthPath, clientcmd.FlagCertFile, clientcmd.FlagKeyFile, clientcmd.FlagBearerToken, clientcmd.FlagUsername, clientcmd.FlagPassword),
@@ -104,7 +104,7 @@ func (o createAuthInfoOptions) run() error {
 		return err
 	}
 
-	config, err := o.pathOptions.getStartingConfig()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func (o createAuthInfoOptions) run() error {
 	authInfo := o.modifyAuthInfo(config.AuthInfos[o.name])
 	config.AuthInfos[o.name] = authInfo
 
-	if err := o.pathOptions.ModifyConfig(*config); err != nil {
+	if err := ModifyConfig(o.configAccess, *config); err != nil {
 		return err
 	}
 
@@ -225,5 +225,5 @@ func (o createAuthInfoOptions) validate() error {
 		}
 	}
 
-	return o.pathOptions.Validate()
+	return nil
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/create_cluster.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/create_cluster.go
@@ -30,7 +30,7 @@ import (
 )
 
 type createClusterOptions struct {
-	pathOptions           *PathOptions
+	configAccess          ConfigAccess
 	name                  string
 	server                util.StringFlag
 	apiVersion            util.StringFlag
@@ -52,8 +52,8 @@ $ kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.
 $ kubectl config set-cluster e2e --insecure-skip-tls-verify=true`
 )
 
-func NewCmdConfigSetCluster(out io.Writer, pathOptions *PathOptions) *cobra.Command {
-	options := &createClusterOptions{pathOptions: pathOptions}
+func NewCmdConfigSetCluster(out io.Writer, configAccess ConfigAccess) *cobra.Command {
+	options := &createClusterOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("set-cluster NAME [--%v=server] [--%v=path/to/certficate/authority] [--%v=apiversion] [--%v=true]", clientcmd.FlagAPIServer, clientcmd.FlagCAFile, clientcmd.FlagAPIVersion, clientcmd.FlagInsecure),
@@ -89,7 +89,7 @@ func (o createClusterOptions) run() error {
 		return err
 	}
 
-	config, err := o.pathOptions.getStartingConfig()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (o createClusterOptions) run() error {
 	cluster := o.modifyCluster(config.Clusters[o.name])
 	config.Clusters[o.name] = cluster
 
-	if err := o.pathOptions.ModifyConfig(*config); err != nil {
+	if err := ModifyConfig(o.configAccess, *config); err != nil {
 		return err
 	}
 
@@ -169,5 +169,5 @@ func (o createClusterOptions) validate() error {
 		}
 	}
 
-	return o.pathOptions.Validate()
+	return nil
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/create_context.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/create_context.go
@@ -29,11 +29,11 @@ import (
 )
 
 type createContextOptions struct {
-	pathOptions *PathOptions
-	name        string
-	cluster     util.StringFlag
-	authInfo    util.StringFlag
-	namespace   util.StringFlag
+	configAccess ConfigAccess
+	name         string
+	cluster      util.StringFlag
+	authInfo     util.StringFlag
+	namespace    util.StringFlag
 }
 
 const (
@@ -43,8 +43,8 @@ Specifying a name that already exists will merge new fields on top of existing v
 $ kubectl config set-context gce --user=cluster-admin`
 )
 
-func NewCmdConfigSetContext(out io.Writer, pathOptions *PathOptions) *cobra.Command {
-	options := &createContextOptions{pathOptions: pathOptions}
+func NewCmdConfigSetContext(out io.Writer, configAccess ConfigAccess) *cobra.Command {
+	options := &createContextOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("set-context NAME [--%v=cluster_nickname] [--%v=user_nickname] [--%v=namespace]", clientcmd.FlagClusterName, clientcmd.FlagAuthInfoName, clientcmd.FlagNamespace),
@@ -76,7 +76,7 @@ func (o createContextOptions) run() error {
 		return err
 	}
 
-	config, err := o.pathOptions.getStartingConfig()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (o createContextOptions) run() error {
 	context := o.modifyContext(config.Contexts[o.name])
 	config.Contexts[o.name] = context
 
-	if err := o.pathOptions.ModifyConfig(*config); err != nil {
+	if err := ModifyConfig(o.configAccess, *config); err != nil {
 		return err
 	}
 
@@ -123,5 +123,5 @@ func (o createContextOptions) validate() error {
 		return errors.New("You must specify a non-empty context name")
 	}
 
-	return o.pathOptions.Validate()
+	return nil
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/set.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/set.go
@@ -32,7 +32,7 @@ const (
 )
 
 type setOptions struct {
-	pathOptions   *PathOptions
+	configAccess  ConfigAccess
 	propertyName  string
 	propertyValue string
 }
@@ -41,8 +41,8 @@ const set_long = `Sets an individual value in a kubeconfig file
 PROPERTY_NAME is a dot delimited name where each token represents either a attribute name or a map key.  Map keys may not contain dots.
 PROPERTY_VALUE is the new value you wish to set.`
 
-func NewCmdConfigSet(out io.Writer, pathOptions *PathOptions) *cobra.Command {
-	options := &setOptions{pathOptions: pathOptions}
+func NewCmdConfigSet(out io.Writer, configAccess ConfigAccess) *cobra.Command {
+	options := &setOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:   "set PROPERTY_NAME PROPERTY_VALUE",
@@ -69,7 +69,7 @@ func (o setOptions) run() error {
 		return err
 	}
 
-	config, err := o.pathOptions.getStartingConfig()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (o setOptions) run() error {
 		return err
 	}
 
-	if err := o.pathOptions.ModifyConfig(*config); err != nil {
+	if err := ModifyConfig(o.configAccess, *config); err != nil {
 		return err
 	}
 
@@ -110,7 +110,7 @@ func (o setOptions) validate() error {
 		return errors.New("You must specify a property")
 	}
 
-	return o.pathOptions.Validate()
+	return nil
 }
 
 func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue string, unset bool) error {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/unset.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/unset.go
@@ -26,15 +26,15 @@ import (
 )
 
 type unsetOptions struct {
-	pathOptions  *PathOptions
+	configAccess ConfigAccess
 	propertyName string
 }
 
 const unset_long = `Unsets an individual value in a kubeconfig file
 PROPERTY_NAME is a dot delimited name where each token represents either a attribute name or a map key.  Map keys may not contain dots.`
 
-func NewCmdConfigUnset(out io.Writer, pathOptions *PathOptions) *cobra.Command {
-	options := &unsetOptions{pathOptions: pathOptions}
+func NewCmdConfigUnset(out io.Writer, configAccess ConfigAccess) *cobra.Command {
+	options := &unsetOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:   "unset PROPERTY_NAME",
@@ -61,7 +61,7 @@ func (o unsetOptions) run() error {
 		return err
 	}
 
-	config, err := o.pathOptions.getStartingConfig()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (o unsetOptions) run() error {
 		return err
 	}
 
-	if err := o.pathOptions.ModifyConfig(*config); err != nil {
+	if err := ModifyConfig(o.configAccess, *config); err != nil {
 		return err
 	}
 
@@ -98,5 +98,5 @@ func (o unsetOptions) validate() error {
 		return errors.New("You must specify a property")
 	}
 
-	return o.pathOptions.Validate()
+	return nil
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/use_context.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config/use_context.go
@@ -25,12 +25,12 @@ import (
 )
 
 type useContextOptions struct {
-	pathOptions *PathOptions
-	contextName string
+	configAccess ConfigAccess
+	contextName  string
 }
 
-func NewCmdConfigUseContext(out io.Writer, pathOptions *PathOptions) *cobra.Command {
-	options := &useContextOptions{pathOptions: pathOptions}
+func NewCmdConfigUseContext(out io.Writer, configAccess ConfigAccess) *cobra.Command {
+	options := &useContextOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:   "use-context CONTEXT_NAME",
@@ -57,14 +57,14 @@ func (o useContextOptions) run() error {
 		return err
 	}
 
-	config, err := o.pathOptions.getStartingConfig()
+	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
 
 	config.CurrentContext = o.contextName
 
-	if err := o.pathOptions.ModifyConfig(*config); err != nil {
+	if err := ModifyConfig(o.configAccess, *config); err != nil {
 		return err
 	}
 
@@ -87,5 +87,5 @@ func (o useContextOptions) validate() error {
 		return errors.New("You must specify a current-context")
 	}
 
-	return o.pathOptions.Validate()
+	return nil
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -286,11 +286,11 @@ func (c *clientSwaggerSchema) ValidateBytes(data []byte) error {
 
 // DefaultClientConfig creates a clientcmd.ClientConfig with the following hierarchy:
 //   1.  Use the kubeconfig builder.  The number of merges and overrides here gets a little crazy.  Stay with me.
-//       1.  Merge together the kubeconfig itself.  This is done with the following hierarchy and merge rules:
-//           1.  CommandLineLocation - this parsed from the command line, so it must be late bound
-//           2.  EnvVarLocation
-//           3.  CurrentDirectoryLocation
-//           4.  HomeDirectoryLocation
+//       1.  Merge together the kubeconfig itself.  This is done with the following hierarchy rules:
+//           1.  CommandLineLocation - this parsed from the command line, so it must be late bound.  If you specify this,
+//               then no other kubeconfig files are merged.  This file must exist.
+//           2.  If $KUBECONFIG is set, then it is treated as a list of files that should be merged.
+//			 3.  HomeDirectoryLocation
 //           Empty filenames are ignored.  Files with non-deserializable content produced errors.
 //           The first file to set a particular value or map key wins and the value or map key is never changed.
 //           This means that the first file to set CurrentContext will have its context preserved.  It also means

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -166,10 +166,11 @@ popd
 
 # test config files in the home directory
 mkdir -p ${HOME}/.config/openshift
-mv ${CONFIG_DIR}/.openshiftconfig ${HOME}/.config/openshift/.config
+mv ${CONFIG_DIR}/.openshiftconfig ${HOME}/.config/openshift/config
 osc get services
+mv ${HOME}/.config/openshift/config ${HOME}/.config/openshift/non-default-config
 echo "config files: ok"
-export OPENSHIFTCONFIG="${HOME}/.config/openshift/.config"
+export OPENSHIFTCONFIG="${HOME}/.config/openshift/non-default-config"
 
 # from this point every command will use config from the OPENSHIFTCONFIG env var
 

--- a/pkg/cmd/cli/cmd/config.go
+++ b/pkg/cmd/cli/cmd/config.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/spf13/cobra"
 
@@ -14,12 +13,11 @@ import (
 
 func NewCmdConfig(parentName, name string) *cobra.Command {
 	pathOptions := &config.PathOptions{
-		LocalFile:  cmdconfig.OpenShiftConfigFileName,
-		GlobalFile: path.Join(os.Getenv("HOME"), cmdconfig.OpenShiftConfigHomeDirFileName),
-		EnvVar:     cmdconfig.OpenShiftConfigPathEnvVar,
-		EnvVarFile: os.Getenv(cmdconfig.OpenShiftConfigPathEnvVar),
-
+		GlobalFile:       cmdconfig.RecommendedHomeFile,
+		EnvVar:           cmdconfig.OpenShiftConfigPathEnvVar,
 		ExplicitFileFlag: cmdconfig.OpenShiftConfigFlagName,
+
+		GlobalFileSubpath: cmdconfig.OpenShiftConfigHomeDirFileName,
 
 		LoadingRules: cmdconfig.NewOpenShiftClientConfigLoadingRules(),
 	}

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -20,7 +20,7 @@ will be used by subsequent commands.
 
 First-time users of the OpenShift client must run this command to configure the server,
 establish a session against it, and save it to a configuration file. The default
-configuration will be in your home directory under ".config/openshift/.config".
+configuration will be in your home directory under ".config/openshift/config".
 
 The information required to login, like username and password, a session token, or
 the server details, can be provided through flags. If not provided, the command will

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -185,19 +184,18 @@ func RunProject(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 	}
 
 	pathOptions := &kubecmdconfig.PathOptions{
-		LocalFile:  cliconfig.OpenShiftConfigFileName,
-		GlobalFile: path.Join(os.Getenv("HOME"), cliconfig.OpenShiftConfigHomeDirFileName),
-		EnvVarFile: os.Getenv(cliconfig.OpenShiftConfigPathEnvVar),
-
+		GlobalFile:       cliconfig.RecommendedHomeFile,
 		EnvVar:           cliconfig.OpenShiftConfigPathEnvVar,
 		ExplicitFileFlag: cliconfig.OpenShiftConfigFlagName,
+
+		GlobalFileSubpath: cliconfig.OpenShiftConfigHomeDirFileName,
 
 		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
 			ExplicitPath: cmdutil.GetFlagString(cmd, cliconfig.OpenShiftConfigFlagName),
 		},
 	}
 
-	if err := pathOptions.ModifyConfig(config); err != nil {
+	if err := kubecmdconfig.ModifyConfig(pathOptions, config); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/experimental/registry/registry.go
+++ b/pkg/cmd/experimental/registry/registry.go
@@ -157,7 +157,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 				if len(cfg.Credentials) == 0 {
 					glog.Fatalf("You must specify a .kubeconfig file path containing credentials for connecting the registry to the master with --credentials")
 				}
-				clientConfigLoadingRules := &kclientcmd.ClientConfigLoadingRules{cfg.Credentials, []string{}, false}
+				clientConfigLoadingRules := &kclientcmd.ClientConfigLoadingRules{ExplicitPath: cfg.Credentials}
 				credentials, err := clientConfigLoadingRules.Load()
 				if err != nil {
 					glog.Fatalf("The provided credentials %q could not be loaded: %v", cfg.Credentials, err)


### PR DESCRIPTION
This changes the osc kubeconfig chain to: 
 1. --config - use the file directly no merging
 1. merge local `.openshiftconfig` with **either** `$OPENSHIFT` if it has a value or `.config/openshift/config` (note the lack of '.').

Upstream has migration methods being added in https://github.com/GoogleCloudPlatform/kubernetes/pull/6680.  Since we collapsed onto the same chain before, this should bring everything into line.

@fabianofranz ptal