### PR TITLE
Correct kind, name, selfLink for ISTag, ISImage

### DIFF
--- a/pkg/client/fake_imagerepositorytags.go
+++ b/pkg/client/fake_imagerepositorytags.go
@@ -16,9 +16,9 @@ type FakeImageRepositoryTags struct {
 
 var _ ImageRepositoryTagInterface = &FakeImageRepositoryTags{}
 
-func (c *FakeImageRepositoryTags) Get(name, tag string) (result *imageapi.Image, err error) {
+func (c *FakeImageRepositoryTags) Get(name, tag string) (result *imageapi.ImageRepositoryTag, err error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-imagerepository-tag", Value: fmt.Sprintf("%s:%s", name, tag)})
-	return &imageapi.Image{}, nil
+	return &imageapi.ImageRepositoryTag{}, nil
 }
 
 func (c *FakeImageRepositoryTags) Delete(name, tag string) error {

--- a/pkg/client/fake_imagestreamimages.go
+++ b/pkg/client/fake_imagestreamimages.go
@@ -16,7 +16,7 @@ type FakeImageStreamImages struct {
 
 var _ ImageStreamImageInterface = &FakeImageStreamImages{}
 
-func (c *FakeImageStreamImages) Get(name, id string) (result *imageapi.Image, err error) {
+func (c *FakeImageStreamImages) Get(name, id string) (result *imageapi.ImageStreamImage, err error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-imagestream-image", Value: fmt.Sprintf("%s@%s", name, id)})
-	return &imageapi.Image{}, nil
+	return &imageapi.ImageStreamImage{}, nil
 }

--- a/pkg/client/fake_imagestreamtags.go
+++ b/pkg/client/fake_imagestreamtags.go
@@ -16,9 +16,9 @@ type FakeImageStreamTags struct {
 
 var _ ImageStreamTagInterface = &FakeImageStreamTags{}
 
-func (c *FakeImageStreamTags) Get(name, tag string) (result *imageapi.Image, err error) {
+func (c *FakeImageStreamTags) Get(name, tag string) (result *imageapi.ImageStreamTag, err error) {
 	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-imagestream-tag", Value: fmt.Sprintf("%s:%s", name, tag)})
-	return &imageapi.Image{}, nil
+	return &imageapi.ImageStreamTag{}, nil
 }
 
 func (c *FakeImageStreamTags) Delete(name, tag string) error {

--- a/pkg/client/imagerepositorytags.go
+++ b/pkg/client/imagerepositorytags.go
@@ -13,7 +13,7 @@ type ImageRepositoryTagsNamespacer interface {
 
 // ImageRepositoryTagInterface exposes methods on ImageRepositoryTag resources.
 type ImageRepositoryTagInterface interface {
-	Get(name, tag string) (*api.Image, error)
+	Get(name, tag string) (*api.ImageRepositoryTag, error)
 	Delete(name, tag string) error
 }
 
@@ -32,8 +32,8 @@ func newImageRepositoryTags(c *Client, namespace string) *imageRepositoryTags {
 }
 
 // Get finds the specified image by name of an image repository and tag.
-func (c *imageRepositoryTags) Get(name, tag string) (result *api.Image, err error) {
-	result = &api.Image{}
+func (c *imageRepositoryTags) Get(name, tag string) (result *api.ImageRepositoryTag, err error) {
+	result = &api.ImageRepositoryTag{}
 	err = c.r.Get().Namespace(c.ns).Resource("imageRepositoryTags").Name(fmt.Sprintf("%s:%s", name, tag)).Do().Into(result)
 	return
 }

--- a/pkg/client/imagestreamimages.go
+++ b/pkg/client/imagestreamimages.go
@@ -13,7 +13,7 @@ type ImageStreamImagesNamespacer interface {
 
 // ImageStreamImageInterface exposes methods on ImageStreamImage resources.
 type ImageStreamImageInterface interface {
-	Get(name, id string) (*api.Image, error)
+	Get(name, id string) (*api.ImageStreamImage, error)
 }
 
 // imageStreamImages implements ImageStreamImagesNamespacer interface
@@ -31,8 +31,8 @@ func newImageStreamImages(c *Client, namespace string) *imageStreamImages {
 }
 
 // Get finds the specified image by name of an image repository and id.
-func (c *imageStreamImages) Get(name, id string) (result *api.Image, err error) {
-	result = &api.Image{}
+func (c *imageStreamImages) Get(name, id string) (result *api.ImageStreamImage, err error) {
+	result = &api.ImageStreamImage{}
 	err = c.r.Get().Namespace(c.ns).Resource("imageStreamImages").Name(fmt.Sprintf("%s@%s", name, id)).Do().Into(result)
 	return
 }

--- a/pkg/client/imagestreamtags.go
+++ b/pkg/client/imagestreamtags.go
@@ -13,7 +13,7 @@ type ImageStreamTagsNamespacer interface {
 
 // ImageStreamTagInterface exposes methods on ImageStreamTag resources.
 type ImageStreamTagInterface interface {
-	Get(name, tag string) (*api.Image, error)
+	Get(name, tag string) (*api.ImageStreamTag, error)
 	Delete(name, tag string) error
 }
 
@@ -32,8 +32,8 @@ func newImageStreamTags(c *Client, namespace string) *imageStreamTags {
 }
 
 // Get finds the specified image by name of an image stream and tag.
-func (c *imageStreamTags) Get(name, tag string) (result *api.Image, err error) {
-	result = &api.Image{}
+func (c *imageStreamTags) Get(name, tag string) (result *api.ImageStreamTag, err error) {
+	result = &api.ImageStreamTag{}
 	err = c.r.Get().Namespace(c.ns).Resource("imageStreamTags").Name(fmt.Sprintf("%s:%s", name, tag)).Do().Into(result)
 	return
 }

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -343,12 +343,12 @@ func (d *ImageStreamTagDescriber) Describe(namespace, name string) (string, erro
 		// TODO use repo's preferred default, when that's coded
 		tag = "latest"
 	}
-	image, err := c.Get(repo, tag)
+	imageStreamTag, err := c.Get(repo, tag)
 	if err != nil {
 		return "", err
 	}
 
-	return describeImage(image)
+	return describeImage(&imageStreamTag.Image)
 }
 
 // ImageStreamImageDescriber generates information about a ImageStreamImage (Image).
@@ -359,12 +359,12 @@ type ImageStreamImageDescriber struct {
 func (d *ImageStreamImageDescriber) Describe(namespace, name string) (string, error) {
 	c := d.ImageStreamImages(namespace)
 	repo, id := parsers.ParseRepositoryTag(name)
-	image, err := c.Get(repo, id)
+	imageStreamImage, err := c.Get(repo, id)
 	if err != nil {
 		return "", err
 	}
 
-	return describeImage(image)
+	return describeImage(&imageStreamImage.Image)
 }
 
 // ImageStreamDescriber generates information about a ImageStream

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -57,6 +57,9 @@ func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p.Handler(buildConfigColumns, printBuildConfig)
 	p.Handler(buildConfigColumns, printBuildConfigList)
 	p.Handler(imageColumns, printImage)
+	p.Handler(imageColumns, printImageStreamTag)
+	p.Handler(imageColumns, printImageRepositoryTag)
+	p.Handler(imageColumns, printImageStreamImage)
 	p.Handler(imageColumns, printImageList)
 	p.Handler(imageStreamColumns, printImageRepository)
 	p.Handler(imageStreamColumns, printImageRepositoryList)
@@ -197,6 +200,18 @@ func printBuildConfigList(buildList *buildapi.BuildConfigList, w io.Writer) erro
 func printImage(image *imageapi.Image, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "%s\t%s\n", image.Name, image.DockerImageReference)
 	return err
+}
+
+func printImageStreamTag(ist *imageapi.ImageStreamTag, w io.Writer) error {
+	return printImage(&ist.Image, w)
+}
+
+func printImageRepositoryTag(irt *imageapi.ImageRepositoryTag, w io.Writer) error {
+	return printImage(&irt.Image, w)
+}
+
+func printImageStreamImage(isi *imageapi.ImageStreamImage, w io.Writer) error {
+	return printImage(&isi.Image, w)
 }
 
 func printImageList(images *imageapi.ImageList, w io.Writer) error {

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -163,17 +163,17 @@ type ImageStreamMapping struct {
 //
 // ImageRepositoryTag is DEPRECATED; use ImageStreamTag instead.
 type ImageRepositoryTag struct {
-	Image
+	Image `json:",inline"`
 }
 
 // ImageStreamTag exists to allow calls to `osc get imageStreamTag ...` to function.
 type ImageStreamTag struct {
-	Image
+	Image `json:",inline"`
 }
 
 // ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
 type ImageStreamImage struct {
-	Image
+	Image `json:",inline"`
 }
 
 // DockerImageReference points to a Docker image.

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -166,17 +166,17 @@ type ImageStreamMapping struct {
 //
 // ImageRepositoryTag is DEPRECATED; use ImageStreamTag instead.
 type ImageRepositoryTag struct {
-	Image
+	Image `json:",inline"`
 }
 
 // ImageStreamTag exists to allow calls to `osc get imageStreamTag ...` to function.
 type ImageStreamTag struct {
-	Image
+	Image `json:",inline"`
 }
 
 // ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
 type ImageStreamImage struct {
-	Image
+	Image `json:",inline"`
 }
 
 // DockerImageReference points to a Docker image.

--- a/pkg/image/registry/imagerepositorytag/rest.go
+++ b/pkg/image/registry/imagerepositorytag/rest.go
@@ -26,7 +26,15 @@ func (r *REST) New() runtime.Object {
 // Get retrieves an image that has been tagged by repo and tag. `id` is of the format
 // <repo name>:<tag>.
 func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
-	return r.imageStreamTagRegistry.GetImageStreamTag(ctx, id)
+	ist, err := r.imageStreamTagRegistry.GetImageStreamTag(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	irt := api.ImageRepositoryTag{}
+	if err := kapi.Scheme.Convert(ist, &irt); err != nil {
+		return nil, err
+	}
+	return &irt, nil
 }
 
 // Delete removes a tag from a repo. `id` is of the format <repo name>:<tag>.

--- a/pkg/image/registry/imagerepositorytag/rest_test.go
+++ b/pkg/image/registry/imagerepositorytag/rest_test.go
@@ -177,12 +177,15 @@ func TestGetImageRepositoryTag(t *testing.T) {
 				t.Errorf("%s: unexpected status: %#v", name, status)
 			}
 		} else {
-			actual := obj.(*api.Image)
-			if e, a := testCase.image.Name, actual.Name; e != a {
-				t.Errorf("%s: image name: expected %v, got %v", name, e, a)
+			actual := obj.(*api.ImageRepositoryTag)
+			if e, a := "default", actual.Namespace; e != a {
+				t.Errorf("%s: name: expected %v, got %v", name, e, a)
+			}
+			if e, a := "test:latest", actual.Name; e != a {
+				t.Errorf("%s: name: expected %v, got %v", name, e, a)
 			}
 			if e, a := map[string]string{"size": "large", "color": "blue"}, actual.Annotations; !reflect.DeepEqual(e, a) {
-				t.Errorf("%s: image annotations: expected %v, got %v", name, e, a)
+				t.Errorf("%s: annotations: expected %v, got %v", name, e, a)
 			}
 		}
 	}

--- a/pkg/image/registry/imagestreamimage/rest.go
+++ b/pkg/image/registry/imagestreamimage/rest.go
@@ -27,7 +27,7 @@ func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Regis
 
 // New is only implemented to make REST implement RESTStorage
 func (r *REST) New() runtime.Object {
-	return &api.Image{}
+	return &api.ImageStreamImage{}
 }
 
 // nameAndID splits a string into its name component and ID component, and returns an error
@@ -71,7 +71,14 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 				if err != nil {
 					return nil, err
 				}
-				return api.ImageWithMetadata(*image)
+				imageWithMetadata, err := api.ImageWithMetadata(*image)
+				if err != nil {
+					return nil, err
+				}
+				isi := api.ImageStreamImage{Image: *imageWithMetadata}
+				isi.Namespace = kapi.NamespaceValue(ctx)
+				isi.Name = id
+				return &isi, nil
 			}
 		}
 	}

--- a/pkg/image/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/registry/imagestreamimage/rest_test.go
@@ -147,6 +147,10 @@ func TestGet(t *testing.T) {
 		"happy path": {
 			input: "repo@id",
 			repo: &api.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "ns",
+					Name:      "repo",
+				},
 				Status: api.ImageStreamStatus{
 					Tags: map[string]api.TagEventList{
 						"latest": {
@@ -269,15 +273,18 @@ func TestGet(t *testing.T) {
 			continue
 		}
 
-		image := obj.(*api.Image)
+		imageStreamImage := obj.(*api.ImageStreamImage)
 		// validate a couple of the fields
-		if e, a := test.image.Name, image.Name; e != a {
+		if e, a := test.repo.Namespace, "ns"; e != a {
+			t.Errorf("%s: namespace: expected %q, got %q", name, e, a)
+		}
+		if e, a := test.input, imageStreamImage.Name; e != a {
 			t.Errorf("%s: name: expected %q, got %q", name, e, a)
 		}
-		if e, a := "2d24f826cb16146e2016ff349a8a33ed5830f3b938d45c0f82943f4ab8c097e7", image.DockerImageMetadata.ID; e != a {
+		if e, a := "2d24f826cb16146e2016ff349a8a33ed5830f3b938d45c0f82943f4ab8c097e7", imageStreamImage.DockerImageMetadata.ID; e != a {
 			t.Errorf("%s: id: expected %q, got %q", name, e, a)
 		}
-		if e, a := "43bd710ec89a", image.DockerImageMetadata.ContainerConfig.Hostname; e != a {
+		if e, a := "43bd710ec89a", imageStreamImage.DockerImageMetadata.ContainerConfig.Hostname; e != a {
 			t.Errorf("%s: container config hostname: expected %q, got %q", name, e, a)
 		}
 	}

--- a/pkg/image/registry/imagestreamtag/registry.go
+++ b/pkg/image/registry/imagestreamtag/registry.go
@@ -8,7 +8,7 @@ import (
 
 // Registry is an interface for things that know how to store ImageStreamTag objects.
 type Registry interface {
-	GetImageStreamTag(ctx kapi.Context, nameAndTag string) (*api.Image, error)
+	GetImageStreamTag(ctx kapi.Context, nameAndTag string) (*api.ImageStreamTag, error)
 	DeleteImageStreamTag(ctx kapi.Context, nameAndTag string) (*kapi.Status, error)
 }
 
@@ -29,12 +29,12 @@ func NewRegistry(s Storage) Registry {
 	return &storage{s}
 }
 
-func (s *storage) GetImageStreamTag(ctx kapi.Context, nameAndTag string) (*api.Image, error) {
+func (s *storage) GetImageStreamTag(ctx kapi.Context, nameAndTag string) (*api.ImageStreamTag, error) {
 	obj, err := s.Get(ctx, nameAndTag)
 	if err != nil {
 		return nil, err
 	}
-	return obj.(*api.Image), nil
+	return obj.(*api.ImageStreamTag), nil
 }
 
 func (s *storage) DeleteImageStreamTag(ctx kapi.Context, nameAndTag string) (*kapi.Status, error) {

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -27,7 +27,7 @@ func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Regis
 
 // New is only implemented to make REST implement RESTStorage
 func (r *REST) New() runtime.Object {
-	return &api.Image{}
+	return &api.ImageStreamTag{}
 }
 
 // nameAndTag splits a string into its name component and tag component, and returns an error
@@ -82,7 +82,17 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 		}
 	}
 
-	return api.ImageWithMetadata(*image)
+	imageWithMetadata, err := api.ImageWithMetadata(*image)
+	if err != nil {
+		return nil, err
+	}
+
+	ist := api.ImageStreamTag{
+		Image: *imageWithMetadata,
+	}
+	ist.Namespace = kapi.NamespaceValue(ctx)
+	ist.Name = id
+	return &ist, nil
 }
 
 // Delete removes a tag from a stream. `id` is of the format <stream name>:<tag>.

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -129,6 +129,10 @@ func TestGetImageStreamTag(t *testing.T) {
 		"happy path": {
 			image: &api.Image{ObjectMeta: kapi.ObjectMeta{Name: "10"}, DockerImageReference: "foo/bar/baz"},
 			repo: &api.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
 				Spec: api.ImageStreamSpec{
 					Tags: map[string]api.TagReference{
 						"latest": {
@@ -227,12 +231,15 @@ func TestGetImageStreamTag(t *testing.T) {
 				t.Errorf("%s: unexpected status: %#v", name, status)
 			}
 		} else {
-			actual := obj.(*api.Image)
-			if e, a := testCase.image.Name, actual.Name; e != a {
-				t.Errorf("%s: image name: expected %v, got %v", name, e, a)
+			actual := obj.(*api.ImageStreamTag)
+			if e, a := "default", actual.Namespace; e != a {
+				t.Errorf("%s: namespace: expected %v, got %v", name, e, a)
+			}
+			if e, a := "test:latest", actual.Name; e != a {
+				t.Errorf("%s: name: expected %v, got %v", name, e, a)
 			}
 			if e, a := map[string]string{"size": "large", "color": "blue"}, actual.Annotations; !reflect.DeepEqual(e, a) {
-				t.Errorf("%s: image annotations: expected %v, got %v", name, e, a)
+				t.Errorf("%s: annotations: expected %v, got %v", name, e, a)
 			}
 		}
 	}

--- a/test/integration/imagerepository_test.go
+++ b/test/integration/imagerepository_test.go
@@ -194,7 +194,7 @@ func TestImageRepositoryMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image1" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newer" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -202,7 +202,7 @@ func TestImageRepositoryMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image2" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newest" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -229,7 +229,7 @@ func TestImageRepositoryMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image1" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newer" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -237,14 +237,14 @@ func TestImageRepositoryMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image2" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newest" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 	fromTag, err = clusterAdminClient.ImageRepositoryTags(testutil.Namespace()).Get(repo.Name, "anothertag")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image2" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:anothertag" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -191,7 +191,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image1" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newer" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -199,7 +199,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image2" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newest" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -226,7 +226,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image1" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newer" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -234,14 +234,14 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image2" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newest" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 	fromTag, err = clusterAdminClient.ImageStreamTags(testutil.Namespace()).Get(stream.Name, "anothertag")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "image2" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:anothertag" || fromTag.UID == "" || fromTag.DockerImageReference != "some/other/name" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -181,7 +181,7 @@ middleware:
 	if err != nil {
 		t.Fatalf("error getting imageStreamImage: %s", err)
 	}
-	if e, a := dgst.String(), image.Name; e != a {
+	if e, a := fmt.Sprintf("test@%s", dgst.String()), image.Name; e != a {
 		t.Errorf("image name: expected %q, got %q", e, a)
 	}
 	if e, a := fmt.Sprintf("127.0.0.1:5000/%s/%s@%s", testutil.Namespace(), stream.Name, dgst.String()), image.DockerImageReference; e != a {


### PR DESCRIPTION
Return ImageStreamTag (or ImageRepositoryTag) and ImageStreamImage
instead of Image. This ensures the correct kind, name, and selfLink
values are set.

Fixes #1701