### PR TITLE
eliminate basic auth flags

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -323,8 +323,8 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	overrides := &clientcmd.ConfigOverrides{}
 	flagNames := clientcmd.RecommendedConfigOverrideFlags("")
 	// short flagnames are disabled by default.  These are here for compatibility with existing scripts
-	flagNames.AuthOverrideFlags.AuthPathShort = "a"
-	flagNames.ClusterOverrideFlags.APIServerShort = "s"
+	flagNames.AuthOverrideFlags.AuthPath.ShortName = "a"
+	flagNames.ClusterOverrideFlags.APIServer.ShortName = "s"
 
 	clientcmd.BindOverrideFlags(overrides, flags, flagNames)
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, os.Stdin)

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -60,8 +60,7 @@ func NewCmdLogin(f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra
 		},
 	}
 
-	// TODO flags below should be DE-REGISTERED from the persistent flags and kept only here.
-	// Login is the only command that can negotiate a session token against the auth server.
+	// Login is the only command that can negotiate a session token against the auth server using basic auth
 	cmds.Flags().StringVarP(&options.Username, "username", "u", "", "Username, will prompt if not provided")
 	cmds.Flags().StringVarP(&options.Password, "password", "p", "", "Password, will prompt if not provided")
 

--- a/pkg/cmd/util/clientconfig.go
+++ b/pkg/cmd/util/clientconfig.go
@@ -13,7 +13,9 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 
 	overrides := &clientcmd.ConfigOverrides{}
 	overrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
-	overrideFlags.ContextOverrideFlags.NamespaceShort = "n"
+	overrideFlags.ContextOverrideFlags.Namespace.ShortName = "n"
+	overrideFlags.AuthOverrideFlags.Username.LongName = ""
+	overrideFlags.AuthOverrideFlags.Password.LongName = ""
 	clientcmd.BindOverrideFlags(overrides, flags, overrideFlags)
 
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -157,7 +157,7 @@ func defaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 
 	overrides := &clientcmd.ConfigOverrides{}
 	overrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
-	overrideFlags.ContextOverrideFlags.NamespaceShort = "n"
+	overrideFlags.ContextOverrideFlags.Namespace.ShortName = "n"
 	clientcmd.BindOverrideFlags(overrides, flags, overrideFlags)
 
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1704.
Upstream: https://github.com/GoogleCloudPlatform/kubernetes/pull/6768

This eliminates the username and password flags from all the commands except `osc login`