### PR TITLE
[WIP, DO NOT MERGE] Add support for watching ImageStreamTags

### DIFF
--- a/pkg/image/registry/imagestreamtag/registry.go
+++ b/pkg/image/registry/imagestreamtag/registry.go
@@ -3,12 +3,16 @@ package imagestreamtag
 import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/openshift/origin/pkg/image/api"
 )
 
 // Registry is an interface for things that know how to store ImageStreamTag objects.
 type Registry interface {
 	GetImageStreamTag(ctx kapi.Context, nameAndTag string) (*api.ImageStreamTag, error)
+	WatchImageStreamTags(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 	DeleteImageStreamTag(ctx kapi.Context, nameAndTag string) (*kapi.Status, error)
 }
 
@@ -16,6 +20,7 @@ type Registry interface {
 type Storage interface {
 	rest.Deleter
 	rest.Getter
+	rest.Watcher
 }
 
 // storage puts strong typing around storage calls
@@ -35,6 +40,10 @@ func (s *storage) GetImageStreamTag(ctx kapi.Context, nameAndTag string) (*api.I
 		return nil, err
 	}
 	return obj.(*api.ImageStreamTag), nil
+}
+
+func (s *storage) WatchImageStreamTags(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return s.Watch(ctx, label, field, resourceVersion)
 }
 
 func (s *storage) DeleteImageStreamTag(ctx kapi.Context, nameAndTag string) (*kapi.Status, error) {

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -2,11 +2,15 @@ package imagestreamtag
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
@@ -93,6 +97,144 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 	ist.Namespace = kapi.NamespaceValue(ctx)
 	ist.Name = id
 	return &ist, nil
+}
+
+// watcher provides support for watching image stream tags.
+type watcher struct {
+	imageStreamWatcher watch.Interface
+	rest               *REST
+	tag                string
+	resultChan         chan watch.Event
+}
+
+// newWatcher returns a new watcher.
+func newWatcher(imageStreamWatcher watch.Interface, rest *REST, tag string) watch.Interface {
+	w := &watcher{imageStreamWatcher, rest, tag, make(chan watch.Event)}
+	go w.run()
+	return w
+}
+
+// Stop stops the watcher.
+func (w *watcher) Stop() {
+	w.imageStreamWatcher.Stop()
+}
+
+// run processes ImageStream events and emits ImageStreamTag events.
+func (w *watcher) run() {
+	for {
+		event, ok := <-w.imageStreamWatcher.ResultChan()
+		if !ok {
+			break
+		}
+
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			stream, ok := event.Object.(*api.ImageStream)
+			if !ok {
+				w.resultChan <- watch.Event{
+					Type: watch.Error,
+					Object: &kapi.Status{
+						Status:  "Failure",
+						Message: "event object was not an ImageStream",
+						Code:    http.StatusInternalServerError,
+					},
+				}
+				continue
+			}
+
+			if _, ok := stream.Status.Tags[w.tag]; !ok {
+				continue
+			}
+
+			ist, err := w.rest.Get(kapi.WithNamespace(kapi.NewContext(), stream.Namespace), fmt.Sprintf("%s:%s", stream.Name, w.tag))
+			if err != nil {
+				w.resultChan <- watch.Event{
+					Type: watch.Error,
+					Object: &kapi.Status{
+						Status:  "Failure",
+						Message: fmt.Sprintf("error retrieving image stream tag: %v", err),
+						Code:    http.StatusInternalServerError,
+					},
+				}
+				continue
+			}
+
+			w.resultChan <- watch.Event{
+				Type:   event.Type,
+				Object: ist,
+			}
+		case watch.Deleted:
+			stream, ok := event.Object.(*api.ImageStream)
+			if !ok {
+				w.resultChan <- watch.Event{
+					Type: watch.Error,
+					Object: &kapi.Status{
+						Status:  "Failure",
+						Message: "event object was not an ImageStream",
+						Code:    http.StatusInternalServerError,
+					},
+				}
+				continue
+			}
+
+			w.resultChan <- watch.Event{
+				Type: watch.Deleted,
+				Object: &api.ImageStreamTag{
+					Image: api.Image{
+						ObjectMeta: kapi.ObjectMeta{
+							Namespace: stream.Namespace,
+							Name:      fmt.Sprintf("%s:%s", stream.Name, w.tag),
+						},
+					},
+				},
+			}
+		}
+	}
+}
+
+// ResultChan returns the watcher's result channel.
+func (w *watcher) ResultChan() <-chan watch.Event {
+	return w.resultChan
+}
+
+func tagAndSelector(field fields.Selector) (tag string, selector fields.Selector, err error) {
+	var stream string
+	_, err = field.Transform(func(field, value string) (newField, newValue string, err error) {
+		if field == "name" {
+			parts := strings.Split(value, ":")
+			if len(parts) != 2 {
+				return "", "", fmt.Errorf("name must be of the form <stream>:<tag>")
+			}
+
+			stream = parts[0]
+			if len(stream) == 0 {
+				return "", "", fmt.Errorf("name must be of the form <stream>:<tag>")
+			}
+
+			tag = parts[1]
+			if len(tag) == 0 {
+				return "", "", fmt.Errorf("name must be of the form <stream>:<tag>")
+			}
+		}
+		return field, value, nil
+	})
+	if err != nil {
+		return
+	}
+	selector = fields.SelectorFromSet(fields.Set{"name": stream})
+	return
+}
+
+func (r *REST) Watch(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	tag, imageStreamField, err := tagAndSelector(field)
+	if err != nil {
+		return nil, err
+	}
+	w, err := r.imageStreamRegistry.WatchImageStreams(ctx, label, imageStreamField, resourceVersion)
+	if err != nil {
+		return nil, fmt.Errorf("Error watching image streams: %v", err)
+	}
+	return newWatcher(w, r, tag), nil
 }
 
 // Delete removes a tag from a stream. `id` is of the format <stream name>:<tag>.

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -7,9 +7,13 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/coreos/go-etcd/etcd"
+	"github.com/golang/glog"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -398,4 +402,156 @@ func TestDeleteImageStreamTag(t *testing.T) {
 			t.Errorf("%s: tags: expected %v, got %v", name, e, a)
 		}
 	}
+}
+
+func TestWatch(t *testing.T) {
+	fakeEtcdClient, helper, storage := setup(t)
+
+	myImage := api.Image{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "myimage",
+		},
+		DockerImageReference: "default/foo@myimage",
+	}
+
+	helper.SetObj("/images/myimage", &myImage, &myImage, 0)
+
+	myImage2 := api.Image{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "myimage2",
+		},
+		DockerImageReference: "default/foo@myimage2",
+	}
+
+	helper.SetObj("/images/myimage2", &myImage2, &myImage2, 0)
+
+	stream := api.ImageStream{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "default",
+			Name:      "foo",
+		},
+		Status: api.ImageStreamStatus{
+			Tags: map[string]api.TagEventList{
+				"latest": {
+					Items: []api.TagEvent{
+						{
+							DockerImageReference: "default/foo:latest",
+							Image:                "myimage",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	helper.SetObj("/imageRepositories/default/foo", &stream, &stream, 0)
+
+	watching, err := storage.Watch(kapi.NewDefaultContext(), labels.Everything(), fields.SelectorFromSet(fields.Set{"name": "foo:latest"}), "1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fakeEtcdClient.WaitForWatchCompletion()
+
+	// simulate watch event for default/foo
+	glog.Infof("Simulating watch event for default/foo")
+	fakeEtcdClient.WatchResponse <- &etcd.Response{
+		Action: "set",
+		Node: &etcd.Node{
+			Value: runtime.EncodeOrDie(latest.Codec, &stream),
+		},
+	}
+
+	expected := api.ImageStreamTag{
+		Image: api.Image{
+			ObjectMeta: kapi.ObjectMeta{
+				Namespace:       "default",
+				Name:            "foo:latest",
+				ResourceVersion: "1",
+			},
+			DockerImageReference:       "default/foo@myimage",
+			DockerImageMetadataVersion: "1.0",
+		},
+	}
+
+	// wait for watch event
+	glog.Infof("Waiting for watch event")
+	select {
+	case event, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+		if e, a := &expected, event.Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("unexpected watch object, diff=%s", util.ObjectDiff(e, a))
+		}
+	}
+
+	// simulate watch event for default/foo, but no change to :latest
+	glog.Infof("Simulating watch event for default/foo, no change to :latest")
+	stream.Status.Tags["other"] = api.TagEventList{
+		Items: []api.TagEvent{
+			{
+				DockerImageReference: "default/foo@someimage",
+				Image:                "someimage",
+			},
+		},
+	}
+	helper.SetObj("/imageRepositories/default/foo", &stream, &stream, 0)
+	fakeEtcdClient.WatchResponse <- &etcd.Response{
+		Action: "set",
+		Node: &etcd.Node{
+			Value: runtime.EncodeOrDie(latest.Codec, &stream),
+		},
+	}
+
+	// wait for watch event
+	glog.Infof("Waiting for watch event")
+	select {
+	case event, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+		if e, a := &expected, event.Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("unexpected watch object, diff=%s", util.ObjectDiff(e, a))
+		}
+	}
+
+	// simulate watch event for default/foo, but changing :latest
+	glog.Infof("Simulating watch event for default/foo, change :latest")
+	history := stream.Status.Tags["latest"]
+	event := &history.Items[0]
+	event.DockerImageReference = "default/foo@myimage2"
+	event.Image = "myimage2"
+	stream.Status.Tags["latest"] = history
+	helper.SetObj("/imageRepositories/default/foo", &stream, &stream, 0)
+	fakeEtcdClient.WatchResponse <- &etcd.Response{
+		Action: "set",
+		Node: &etcd.Node{
+			Value: runtime.EncodeOrDie(latest.Codec, &stream),
+		},
+	}
+
+	expected2 := api.ImageStreamTag{
+		Image: api.Image{
+			ObjectMeta: kapi.ObjectMeta{
+				Namespace:       "default",
+				Name:            "foo:latest",
+				ResourceVersion: "2",
+			},
+			DockerImageReference:       "default/foo@myimage2",
+			DockerImageMetadataVersion: "1.0",
+		},
+	}
+	// wait for watch event
+	glog.Infof("Waiting for watch event")
+	select {
+	case event, ok := <-watching.ResultChan():
+		if !ok {
+			t.Errorf("watching channel should be open")
+		}
+		if e, a := &expected2, event.Object; !reflect.DeepEqual(e, a) {
+			t.Errorf("unexpected watch object, diff=%s", util.ObjectDiff(e, a))
+		}
+	}
+
+	watching.Stop()
 }


### PR DESCRIPTION
Note: this is only available to internal clients running in the master.
External clients can't watch ImageStreamTags yet because it's not
possible to use the REST API to specify field selectors to watch a
single resource.