### PR TITLE
Fix build-images.sh: ENV requires two params

### DIFF
--- a/images/dockerregistry/Dockerfile
+++ b/images/dockerregistry/Dockerfile
@@ -3,7 +3,7 @@ FROM openshift/origin-base
 ADD config.yml /config.yml
 ADD bin/dockerregistry /dockerregistry
 
-ENV REGISTRY_CONFIGURATION_PATH=/config.yml
+ENV REGISTRY_CONFIGURATION_PATH /config.yml
 
 EXPOSE 5000
 VOLUME /registry


### PR DESCRIPTION
Build fails with the following error, this is due to the = sign between en ENV variable and its value

--- openshift/origin-docker-registry ---
Sending build context to Docker daemon 17.33 MB
Sending build context to Docker daemon
2015/04/15 09:41:26 Error: ENV must have two arguments