### PR TITLE
UPSTREAM: Fix a small regression on api server proxy after switch to v1beta3

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/log.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/log.go
@@ -115,7 +115,7 @@ func RunLog(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 	readCloser, err := client.RESTClient.Get().
 		Prefix("proxy").
-		Resource("minions").
+		Resource("nodes").
 		Name(pod.Spec.Host).
 		Suffix("containerLogs", namespace, podID, container).
 		Param("follow", strconv.FormatBool(follow)).


### PR DESCRIPTION
Pulls in fix https://github.com/GoogleCloudPlatform/kubernetes/pull/6701 from upstream