### PR TITLE
added missing mysql root password to sample app

### DIFF
--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -205,6 +205,10 @@
                       {
                         "name": "MYSQL_DATABASE",
                         "value": "${MYSQL_DATABASE}"
+                      },
+                      {
+                       "name": "MYSQL_ROOT_PASSWORD",
+                       "value": "${MYSQL_ROOT_PASSWORD}"
                       }
                     ],
                     "image": "mysql",
@@ -270,6 +274,12 @@
       "from": "[a-zA-Z0-9]{8}",
       "generate": "expression",
       "name": "MYSQL_PASSWORD"
+    },
+    {
+      "description": "database root password",
+      "from": "[a-zA-Z0-9]{8}",
+      "generate": "expression",
+      "name": "MYSQL_ROOT_PASSWORD"
     },
     {
       "description": "database name",


### PR DESCRIPTION
MySQL docker image requires a setting env MSQL_ROOT_PASSWORD, it doesn't work without it.
As a result pf its failure/exit, there were a lot of mysql based container instances created, and the machine ended up with "out of space", and origin was stopped as well.