### PR TITLE
Remove misleading comment from docs

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -72,7 +72,7 @@ To facilitate rapid development we've put together a Vagrantfile you can use to 
 
         $ vagrant ssh
 
-6.  Run a build (ssh puts you into the correct origin directory):
+6.  Run a build:
 
         $ cd /data/src/github.com/openshift/origin
         $ hack/build-go.sh


### PR DESCRIPTION
I believe either the parenthesized info is incorrect or the `cd ...` step shouldn't be needed.