### PR TITLE
stronger validation for tls termination type

### DIFF
--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -228,3 +228,13 @@ func TestValidateReencryptTermInvalid(t *testing.T) {
 		t.Errorf("Unexpected error list encountered: %#v.  Expected 4 errors, got %v", errs, len(errs))
 	}
 }
+
+func TestValidateTLSInvalidTermination(t *testing.T) {
+	errs := validateTLS(&api.TLSConfig{
+		Termination: "invalid",
+	})
+
+	if len(errs) != 1 {
+		t.Errorf("Unexpected error list encountered: %#v.  Expected 1 errors, got %v", errs, len(errs))
+	}
+}


### PR DESCRIPTION
This strengthens the validation on the api server side for routes to protect against a bad tls termination type string.  The router correctly ignored it but you could still create it and it was unclear why the router didn't work.

/cc @jcantrill 

```
[vagrant@openshiftdev origin]$ cat ~/test_route.json 
{
    "apiVersion": "v1beta1",
    "kind": "Route",
    "metadata": {
        "labels": {
            "generatedby": "OpenShiftWebConsole",
            "name": "ruby-hello-world"
        },
        "name": "ruby-hello-world"
    },
    "serviceName": "ruby-hello-world",
    "tls": {
        "termination": "unsecure"
    }
}
[vagrant@openshiftdev origin]$ osc create -f ~/test_route.json 
Error: route "ruby-hello-world" is invalid: tls.termination: invalid value 'unsecure': invalid value for termination, acceptable values are edge, passthrough, reencrypt, or emtpy (no tls specified)
```