### PR TITLE
default certificate support

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -81,7 +81,7 @@ backend be_sni
 
 frontend fe_sni
   # terminate ssl on edge
-  bind 127.0.0.1:10444 ssl crt /var/lib/containers/router/certs accept-proxy
+  bind 127.0.0.1:10444 ssl {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt /var/lib/containers/router/certs accept-proxy
   mode http
 
   # re-ssl?
@@ -113,7 +113,7 @@ backend be_no_sni
 
 frontend fe_no_sni
   # terminate ssl on edge
-  bind 127.0.0.1:10443 ssl crt /var/lib/haproxy/conf/default_pub_keys.pem accept-proxy
+  bind 127.0.0.1:10443 ssl {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
 
   # re-ssl?
   acl reencrypt hdr(host),map(/var/lib/haproxy/conf/os_reencrypt.map) -m found
@@ -144,7 +144,7 @@ backend openshift_default
             where to send the traffic but should run the be in tcp mode
         3. if the config is terminated at the
 */}}
-{{ range $id, $serviceUnit := . }}
+{{ range $id, $serviceUnit := .State }}
         {{ range $cfgIdx, $cfg := $serviceUnit.ServiceAliasConfigs }}
             {{ if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
                 {{ if (eq $cfg.TLSTermination "") }}
@@ -189,7 +189,7 @@ backend be_secure_{{$cfgIdx}}
                         by attaching a prefix (be_http_) by use_backend statements if acls are matched.
 */}}
 {{ define "/var/lib/haproxy/conf/os_http_be.map" }}
-{{   range $id, $serviceUnit := . }}
+{{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "")}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
@@ -203,7 +203,7 @@ backend be_secure_{{$cfgIdx}}
                             a tls only route on the unsecure port
 */}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_be.map" }}
-{{   range $id, $serviceUnit := . }}
+{{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "edge")}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
@@ -218,7 +218,7 @@ backend be_secure_{{$cfgIdx}}
                         by attaching a prefix (be_tcp_ or be_secure_) by use_backend statements if acls are matched.
 */}}
 {{ define "/var/lib/haproxy/conf/os_tcp_be.map" }}
-{{   range $id, $serviceUnit := . }}
+{{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (eq $cfg.Path "") (and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "passthrough") (eq $cfg.TLSTermination "reencrypt"))) }}
 {{$cfg.Host}} {{$idx}}
@@ -232,7 +232,7 @@ backend be_secure_{{$cfgIdx}}
     					through to the host_be.  Driven by the termination type of the ServiceAliasConfigs
 */}}
 {{ define "/var/lib/haproxy/conf/os_sni_passthrough.map" }}
-{{   range $id, $serviceUnit := . }}
+{{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "passthrough") }}
 {{$cfg.Host}} 1
@@ -247,7 +247,7 @@ backend be_secure_{{$cfgIdx}}
                     that does specific checks that avoid mitm attacks: http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#5.2-ssl
 */}}
 {{ define "/var/lib/haproxy/conf/os_reencrypt.map" }}
-{{   range $id, $serviceUnit := . }}
+{{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "reencrypt") }}
 {{$cfg.Host}} 1

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -24,9 +24,10 @@ created by users and keeps a local router configuration up to date with those ch
 `
 
 type templateRouterConfig struct {
-	Config       *clientcmd.Config
-	TemplateFile string
-	ReloadScript string
+	Config             *clientcmd.Config
+	TemplateFile       string
+	ReloadScript       string
+	DefaultCertificate string
 }
 
 // NewCommndTemplateRouter provides CLI handler for the template router backend
@@ -40,6 +41,11 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 		Short: "Start an OpenShift router",
 		Long:  longCommandDesc,
 		Run: func(c *cobra.Command, args []string) {
+			defaultCert := util.Env("DEFAULT_CERTIFICATE", "")
+			if len(defaultCert) > 0 {
+				cfg.DefaultCertificate = defaultCert
+			}
+
 			plugin, err := makeTemplatePlugin(cfg)
 			if err != nil {
 				glog.Fatal(err)
@@ -70,7 +76,7 @@ func makeTemplatePlugin(cfg *templateRouterConfig) (*templateplugin.TemplatePlug
 		return nil, errors.New("Reload script must be specified")
 	}
 
-	return templateplugin.NewTemplatePlugin(cfg.TemplateFile, cfg.ReloadScript)
+	return templateplugin.NewTemplatePlugin(cfg.TemplateFile, cfg.ReloadScript, cfg.DefaultCertificate)
 }
 
 // start launches the load balancer.

--- a/plugins/router/template/plugin.go
+++ b/plugins/router/template/plugin.go
@@ -45,7 +45,7 @@ type router interface {
 }
 
 // NewTemplatePlugin creates a new TemplatePlugin.
-func NewTemplatePlugin(templatePath, reloadScriptPath string) (*TemplatePlugin, error) {
+func NewTemplatePlugin(templatePath, reloadScriptPath, defaultCertificate string) (*TemplatePlugin, error) {
 	masterTemplate := template.Must(template.New("config").ParseFiles(templatePath))
 	templates := map[string]*template.Template{}
 
@@ -57,7 +57,7 @@ func NewTemplatePlugin(templatePath, reloadScriptPath string) (*TemplatePlugin, 
 		templates[template.Name()] = template
 	}
 
-	router, err := newTemplateRouter(templates, reloadScriptPath)
+	router, err := newTemplateRouter(templates, reloadScriptPath, defaultCertificate)
 	return &TemplatePlugin{router}, err
 }
 

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -20,9 +20,10 @@ const (
 )
 
 const (
-	routeFile = "/var/lib/containers/router/routes.json"
-	certDir   = "/var/lib/containers/router/certs/"
-	caCertDir = "/var/lib/containers/router/cacerts/"
+	routeFile       = "/var/lib/containers/router/routes.json"
+	certDir         = "/var/lib/containers/router/certs/"
+	caCertDir       = "/var/lib/containers/router/cacerts/"
+	defaultCertName = "default"
 
 	caCertPostfix   = "_ca"
 	destCertPostfix = "_pod"
@@ -36,17 +37,59 @@ type templateRouter struct {
 	reloadScriptPath string
 	state            map[string]ServiceUnit
 	certManager      certManager
+	// defaultCertificate is a concatenated certificate(s), their keys, and their CAs that should be used by the underlying
+	// implementation as the default certificate if no certificate is resolved by the normal matching mechanisms.  This is
+	// usually a wildcard certificate for a cloud domain such as *.mypaas.com to allow applications to create app.mypaas.com
+	// as secure routes without having to provide their own certificates
+	defaultCertificate string
+	// if the default certificate is populated then this will be filled in so it can be passed to the templates
+	defaultCertificatePath string
 }
 
-func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath string) (*templateRouter, error) {
-	router := &templateRouter{templates, reloadScriptPath, map[string]ServiceUnit{}, certManager{}}
+// templateConfig is a subset of the templateRouter information that should be passed to the template for generating
+// the correct configuration.
+type templateData struct {
+	//the routes
+	State map[string]ServiceUnit
+	//full path and file name to the default certificate
+	DefaultCertificate string
+}
+
+func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath, defaultCertificate string) (*templateRouter, error) {
+	glog.Infof("Creating a new template router")
+	router := &templateRouter{
+		templates:              templates,
+		reloadScriptPath:       reloadScriptPath,
+		state:                  map[string]ServiceUnit{},
+		certManager:            certManager{},
+		defaultCertificate:     defaultCertificate,
+		defaultCertificatePath: "",
+	}
+	if err := router.writeDefaultCert(); err != nil {
+		return nil, err
+	}
+	glog.Infof("Reading any persisted state")
 	if err := router.readState(); err != nil {
 		return nil, err
 	}
+	glog.Infof("Performing initial commit")
 	if err := router.Commit(); err != nil {
 		return nil, err
 	}
 	return router, nil
+}
+
+// writeDefaultCert is called a single time during init to write out the default certificate
+func (r *templateRouter) writeDefaultCert() error {
+	if len(r.defaultCertificate) > 0 {
+		glog.Infof("Writing default certificate to %s", certDir)
+		err := r.certManager.writeCertificate(certDir, defaultCertName, []byte(r.defaultCertificate))
+		if err == nil {
+			r.defaultCertificatePath = fmt.Sprintf("%s%s.pem", certDir, defaultCertName)
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *templateRouter) readState() error {
@@ -98,10 +141,13 @@ func (r *templateRouter) writeState() error {
 // writeConfig writes the config to disk
 func (r *templateRouter) writeConfig() error {
 	//write out any certificate files that don't exist
-	//TODO: better way so this doesn't need to create lots of files every time state is written, probably too expensive
 	for _, serviceUnit := range r.state {
 		for _, cfg := range serviceUnit.ServiceAliasConfigs {
-			r.certManager.writeCertificatesForConfig(&cfg)
+			err := r.writeCertificates(&cfg)
+			if err != nil {
+				glog.Errorf("Error writing certificates for %s: %v", serviceUnit.Name, err)
+				return err
+			}
 		}
 	}
 
@@ -112,7 +158,7 @@ func (r *templateRouter) writeConfig() error {
 			return err
 		}
 
-		err = template.Execute(file, r.state)
+		err = template.Execute(file, templateData{r.state, r.defaultCertificatePath})
 		if err != nil {
 			glog.Errorf("Error executing template for file %v: %v", path, err)
 			return err
@@ -121,6 +167,16 @@ func (r *templateRouter) writeConfig() error {
 		file.Close()
 	}
 
+	return nil
+}
+
+// writeCertificates attempts to write certificates only if the cfg requires it see shouldWriteCerts
+// for details
+func (r *templateRouter) writeCertificates(cfg *ServiceAliasConfig) error {
+	if r.shouldWriteCerts(cfg) {
+		//TODO: better way so this doesn't need to create lots of files every time state is written, probably too expensive
+		return r.certManager.writeCertificatesForConfig(cfg)
+	}
 	return nil
 }
 
@@ -269,4 +325,44 @@ func cmpStrSlices(first []string, second []string) bool {
 		}
 	}
 	return true
+}
+
+// shouldWriteCerts determines if the router should ask the cert manager to write out certificates
+// it will return true if a route is edge or reencrypt and it has all the required (host/key) certificates
+// defined.  If the route does not have the certificates defined it will log an info message if the
+// router is configured with a default certificate and assume the route is meant to be a wildcard.  Otherwise
+// it will log a warning.  The route will still be written but users may receive browser errors
+// for a host/cert mismatch
+func (r *templateRouter) shouldWriteCerts(cfg *ServiceAliasConfig) bool {
+	if cfg.Certificates == nil {
+		return false
+	}
+
+	if cfg.TLSTermination == routeapi.TLSTerminationEdge || cfg.TLSTermination == routeapi.TLSTerminationReencrypt {
+		if hasRequiredEdgeCerts(cfg) {
+			return true
+		} else {
+			msg := fmt.Sprintf("a %s terminated route with host %s does not have the required certificates.  The route will still be created but no certificates will be written",
+				cfg.TLSTermination, cfg.Host)
+			// if a default cert is configured we'll assume it is meant to be a wildcard and only log info
+			// otherwise we'll consider this a warning
+			if len(r.defaultCertificate) > 0 {
+				glog.V(4).Info(msg)
+			} else {
+				glog.Warning(msg)
+			}
+			return false
+		}
+	}
+	return false
+}
+
+// hasRequiredEdgeCerts ensures that at least a host certificate and key are provided.
+// a ca cert is not required because it may be something that is in the root cert chain
+func hasRequiredEdgeCerts(cfg *ServiceAliasConfig) bool {
+	hostCert, ok := cfg.Certificates[cfg.Host]
+	if ok && len(hostCert.Contents) > 0 && len(hostCert.PrivateKey) > 0 {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This pr contains the ability to specify a default certificate for a router in order to support wild card certificates.

Included:

1.  new command flag for the router `--default-cert=/path/to/file`
1.  haproxy template update that uses the `crt` directive to add the default cert if available.  It will still use the dummy pem file in the non-sni backend if no default cert is found.  In the SNI end it will resort to the configured directory
1.  refactor of the template since we are passing more than just routes as the data.  There is now a wrapper object with `DefaultCertificate` and `State`
1.  the shard is now passed to validation.  If validation sees that there are no certificates set for edge/reencrypt termination it will see if the host ends in the DNS shard configuration

Issue: for updates we don't allocate the shard.   Right now I short circuit for a nil shard so an error condition exists for an update where tls is removed, term is still set to edge/reencrypt.  I assume at some point we'll want to store the shard configuration somewhere and be able to retrieve it via an annotation on the route.

If this looks good I'll wrap up the unit tests tomorrow.

@ramr @rajatchopra @smarterclayton PTAL