### PR TITLE
Fix URL for build webhooks docs in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Management Console
 
 The OpenShift API server also hosts the web-based management console. You can try out the management console at [http://localhost:8443/console](http://localhost:8443/console).
 
-For more information on the console [checkout the README](assets/README.md) and the [docs](http://docs.openshift.org/latest/using_openshift/console.html).
+For more information on the console [checkout the README](assets/README.md) and the [docs](http://docs.openshift.org/latest/dev_guide/console.html).
 
 ![Management console overview](docs/screenshots/console_overview.png?raw=true)
 

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -123,7 +123,7 @@ angular.module('openshiftConsole')
     return function(type) {
       switch(type) {
         case "webhooks":
-          return "http://docs.openshift.org/latest/using_openshift/builds.html#webhook-triggers";
+          return "http://docs.openshift.org/latest/dev_guide/builds.html#webhook-triggers";
         default:
           return "http://docs.openshift.org/latest/welcome/index.html";
       }


### PR DESCRIPTION
Just a small fix of docs link in console