### PR TITLE
UPSTREAM: Add URL parameters to proxy redirect Location header

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/proxy.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/proxy.go
@@ -195,7 +195,11 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// This is essentially a hack for https://github.com/GoogleCloudPlatform/kubernetes/issues/4958.
 	// Note: Keep this code after tryUpgrade to not break that flow.
 	if len(parts) == 2 && !strings.HasSuffix(req.URL.Path, "/") {
-		w.Header().Set("Location", req.URL.Path+"/")
+		var queryPart string
+		if len(req.URL.RawQuery) > 0 {
+			queryPart = "?" + req.URL.RawQuery
+		}
+		w.Header().Set("Location", req.URL.Path+"/"+queryPart)
 		w.WriteHeader(http.StatusMovedPermanently)
 		return
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/proxy_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/proxy_test.go
@@ -374,19 +374,24 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		path string
 		// The path requested on the proxy server.
 		proxyServerPath string
+		// query string
+		query string
 	}{
-		{"/trailing/slash/", "/trailing/slash/"},
-		{"/", "/"},
+		{"/trailing/slash/", "/trailing/slash/", ""},
+		{"/", "/", "test1=value1&test2=value2"},
 		// "/" should be added at the end.
-		{"", "/"},
+		{"", "/", "test1=value1&test2=value2"},
 		// "/" should not be added at a non-root path.
-		{"/some/path", "/some/path"},
+		{"/some/path", "/some/path", ""},
 	}
 
 	for _, item := range table {
 		proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if req.URL.Path != item.proxyServerPath {
 				t.Errorf("Unexpected request on path: %s, expected path: %s, item: %v", req.URL.Path, item.proxyServerPath, item)
+			}
+			if req.URL.RawQuery != item.query {
+				t.Errorf("Unexpected query on url: %s, expected: %s", req.URL.RawQuery, item.query)
 			}
 		}))
 		defer proxyServer.Close()


### PR DESCRIPTION
Includes upstream fix: https://github.com/GoogleCloudPlatform/kubernetes/pull/6932