### PR TITLE
[BZ-1212362] - routes using same service produce duplicate named backends

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -140,9 +140,9 @@ backend openshift_default
         {{ range $cfgIdx, $cfg := $serviceUnit.ServiceAliasConfigs }}
             {{ if or (eq $cfg.TLSTermination "") (eq $cfg.TLSTermination "edge") }}
                 {{ if (eq $cfg.TLSTermination "") }}
-backend be_http_{{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+backend be_http_{{$cfgIdx}}
                 {{ else }}
-backend be_edge_http_{{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+backend be_edge_http_{{$cfgIdx}}
                 {{ end }}
   mode http
   balance leastconn
@@ -153,7 +153,7 @@ backend be_edge_http_{{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
             {{ end }}
 
             {{ if eq $cfg.TLSTermination "passthrough" }}
-backend be_tcp_{{$serviceUnit.TemplateSafeName}}
+backend be_tcp_{{$cfgIdx}}
   balance leastconn
   timeout check 5000ms
                 {{ range $endpointID, $endpoint := $serviceUnit.EndpointTable }}
@@ -162,7 +162,7 @@ backend be_tcp_{{$serviceUnit.TemplateSafeName}}
             {{ end }}
 
             {{ if eq $cfg.TLSTermination "reencrypt" }}
-backend be_secure_{{$serviceUnit.TemplateSafeName}}
+backend be_secure_{{$cfgIdx}}
   mode http
   balance leastconn
   timeout check 5000ms
@@ -184,7 +184,7 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "")}}
-{{$cfg.Host}}{{$cfg.Path}} {{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+{{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
 {{   end }}
@@ -198,7 +198,7 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "edge")}}
-{{$cfg.Host}}{{$cfg.Path}} {{$serviceUnit.TemplateSafeName}}{{$cfg.TemplateSafePath}}
+{{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
 {{   end }}
@@ -213,7 +213,7 @@ backend be_secure_{{$serviceUnit.TemplateSafeName}}
 {{   range $id, $serviceUnit := . }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
 {{       if and (eq $cfg.Path "") (and (ne $cfg.Host "") (or (eq $cfg.TLSTermination "passthrough") (eq $cfg.TLSTermination "reencrypt"))) }}
-{{$cfg.Host}} {{$serviceUnit.TemplateSafeName}}
+{{$cfg.Host}} {{$idx}}
 {{       end }}
 {{     end }}
 {{   end }}

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -167,9 +167,11 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 	r.state[id] = service
 }
 
-// routeKey generates route key in form of Namespace/Name
+// routeKey generates route key in form of Namespace-Name.  This is NOT the normal key structure of ns/name because
+// it is not safe to use / in names of router config files.  This allows templates to use this key without having
+// to create (or provide) a separate method
 func (r *templateRouter) routeKey(route *routeapi.Route) string {
-	return fmt.Sprintf("%s/%s", route.Namespace, route.Name)
+	return fmt.Sprintf("%s-%s", route.Namespace, route.Name)
 }
 
 // AddRoute adds a route for the given id

--- a/plugins/router/template/router_test.go
+++ b/plugins/router/template/router_test.go
@@ -131,8 +131,8 @@ func TestRouteKey(t *testing.T) {
 
 	key := router.routeKey(route)
 
-	if key != "foo/bar" {
-		t.Errorf("Expected key 'foo/bar' but got: %s", key)
+	if key != "foo-bar" {
+		t.Errorf("Expected key 'foo-bar' but got: %s", key)
 	}
 }
 

--- a/plugins/router/template/types.go
+++ b/plugins/router/template/types.go
@@ -47,15 +47,5 @@ type Endpoint struct {
 //TemplateSafeName provides a name that can be used in the template that does not contain restricted
 //characters like / which is used to concat namespace and name in the service unit key
 func (s ServiceUnit) TemplateSafeName() string {
-	return templateSafeString(s.Name)
-}
-
-//TemplateSafePath provides a name that can be used in the template that does not contain restricted
-//characters like / which is used to concat namespace and name in the service unit key
-func (s ServiceAliasConfig) TemplateSafePath() string {
-	return templateSafeString(s.Path)
-}
-
-func templateSafeString(s string) string {
-	return strings.Replace(s, "/", "-", -1)
+	return strings.Replace(s.Name, "/", "-", -1)
 }


### PR DESCRIPTION
Fixes [BZ-1212362]

Changes:

1. Key the backend based on the route ns/name, not the service unit name/route path
1. Ensure the iteration key is template safe
1. Remove the no longer used TemplateSafePath
1. Since this was a template issue add an integration test that can be used to validate future implementations

Tests:
```
[vagrant@openshiftdev unsecure]$ osc get routes
NAME              HOST/PORT          PATH      SERVICE       LABELS
route-unsecure    www.example.com              hello-nginx   
route-unsecure2   www.example2.com             hello-nginx   
[vagrant@openshiftdev unsecure]$ curl -H Host:www.example.com 10.0.2.15
Hello World
[vagrant@openshiftdev unsecure]$ curl -H Host:www.example2.com 10.0.2.15
Hello World

.... int tests ....
ok      TestRouter
ok      TestRouterDuplications
ok      TestRouterPathSpecificity
```

A personal note to routes: We've laughed, we've cried.  You said you wanted some space and now you have your own backend.  I hope you're happy