### PR TITLE
Fix OAuthAccessToken policy

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/delete.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/delete.go
@@ -85,7 +85,7 @@ func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		FilenameParam(filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(cmdutil.GetFlagBool(cmd, "all")).
-		ResourceTypeOrNameArgs(false, args...).
+		ResourceTypeOrNameArgs(false, args...).RequireObject(false).
 		Flatten().
 		Do()
 	err = r.Err()

--- a/pkg/cmd/experimental/policy/who_can.go
+++ b/pkg/cmd/experimental/policy/who_can.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -69,8 +70,17 @@ func (o *whoCanOptions) run() error {
 		return err
 	}
 
-	fmt.Printf("Users: %v\n", resourceAccessReviewResponse.Users)
-	fmt.Printf("Groups: %v\n", resourceAccessReviewResponse.Groups)
+	if len(resourceAccessReviewResponse.Users) == 0 {
+		fmt.Printf("Users:  none\n\n")
+	} else {
+		fmt.Printf("Users:  %s\n\n", strings.Join(resourceAccessReviewResponse.Users.List(), "\n        "))
+	}
+
+	if len(resourceAccessReviewResponse.Groups) == 0 {
+		fmt.Printf("Groups: none\n\n")
+	} else {
+		fmt.Printf("Groups: %s\n\n", strings.Join(resourceAccessReviewResponse.Groups.List(), "\n        "))
+	}
 
 	return nil
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -150,7 +150,7 @@ func GetBootstrapMasterRoles(masterNamespace string) []authorizationapi.Role {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("delete"),
-					Resources: util.NewStringSet("oauthaccesstoken", "oauthauthorizetoken"),
+					Resources: util.NewStringSet("oauthaccesstokens", "oauthauthorizetokens"),
 				},
 			},
 		},


### PR DESCRIPTION
- [x] Allows OAuthAccessTokens to be deleted without GET access (upstream fix)
- [x] Fixes policy to allow anyone to delete their access/authorize tokens
- [x] Improved display of `who-can` command