### PR TITLE
add self-provisioned newproject

### DIFF
--- a/assets/app/views/projects.html
+++ b/assets/app/views/projects.html
@@ -12,9 +12,9 @@
   </div>
   <div ng-if="emptyMessage && (projects | hashSize) == 0">{{emptyMessage}}</div>
   <div style="margin-top: 10px;">
-    To create a new project, run <code>openshift ex new-project &lt;projectname&gt; --admin={{user.metadata.name || '&lt;YourUsername&gt;'}}</code>
+    To create a new project, run <code>osc new-project &lt;projectname&gt;</code>
   </div>
   <div style="margin-top: 10px;">
-    To be added as an admin to an existing project, run <code>openshift ex policy add-role-to-user admin {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>
+    To be added as an admin to an existing project, run <code>osadm policy add-role-to-user admin {{user.metadata.name || '&lt;YourUsername&gt;'}} -n &lt;projectname&gt;</code>
   </div>
 </div>

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -80,7 +80,7 @@ var originTypes = []string{
 	"Image", "ImageRepository", "ImageStream", "ImageRepositoryMapping", "ImageStreamMapping", "ImageRepositoryTag", "ImageStreamTag", "ImageStreamImage",
 	"Template", "TemplateConfig", "ProcessedTemplate",
 	"Route",
-	"Project",
+	"Project", "ProjectRequest",
 	"User", "Identity", "UserIdentityMapping",
 	"OAuthClient", "OAuthClientAuthorization", "OAuthAccessToken", "OAuthAuthorizeToken",
 	"Role", "RoleBinding", "Policy", "PolicyBinding", "ResourceAccessReview", "SubjectAccessReview",
@@ -130,7 +130,8 @@ func init() {
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
 	kindToRootScope := map[string]bool{
-		"Project": true,
+		"Project":        true,
+		"ProjectRequest": true,
 
 		"User":                true,
 		"Identity":            true,

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -440,7 +440,7 @@ func newDefaultGlobalBinding() []authorizationapi.PolicyBinding {
 			Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,
 		},
 		RoleBindings: map[string]authorizationapi.RoleBinding{
-			"cluster-admins": {
+			"extra-cluster-admins": {
 				ObjectMeta: kapi.ObjectMeta{
 					Name:      "cluster-admins",
 					Namespace: bootstrappolicy.DefaultMasterAuthorizationNamespace,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,6 +33,7 @@ type Interface interface {
 	UsersInterface
 	UserIdentityMappingsInterface
 	ProjectsInterface
+	ProjectRequestsInterface
 	PoliciesNamespacer
 	RolesNamespacer
 	RoleBindingsNamespacer
@@ -132,6 +133,11 @@ func (c *Client) UserIdentityMappings() UserIdentityMappingInterface {
 // Projects provides a REST client for Projects
 func (c *Client) Projects() ProjectInterface {
 	return newProjects(c)
+}
+
+// ProjectRequests provides a REST client for Projects
+func (c *Client) ProjectRequests() ProjectRequestInterface {
+	return newProjectRequests(c)
 }
 
 // TemplateConfigs provides a REST client for TemplateConfig

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -108,6 +108,10 @@ func (c *Fake) Projects() ProjectInterface {
 	return &FakeProjects{Fake: c}
 }
 
+func (c *Fake) ProjectRequests() ProjectRequestInterface {
+	return &FakeProjectRequests{Fake: c}
+}
+
 func (c *Fake) Policies(namespace string) PolicyInterface {
 	return &FakePolicies{Fake: c}
 }

--- a/pkg/client/fake_projectrequests.go
+++ b/pkg/client/fake_projectrequests.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	projectapi "github.com/openshift/origin/pkg/project/api"
+)
+
+type FakeProjectRequests struct {
+	Fake *Fake
+}
+
+func (c *FakeProjectRequests) Create(project *projectapi.ProjectRequest) (*projectapi.Project, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-newProject", Value: project}, &projectapi.ProjectRequest{})
+	return obj.(*projectapi.Project), err
+}

--- a/pkg/client/projectrequests.go
+++ b/pkg/client/projectrequests.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	_ "github.com/openshift/origin/pkg/user/api/v1beta1"
+)
+
+// UsersInterface has methods to work with User resources in a namespace
+type ProjectRequestsInterface interface {
+	ProjectRequests() ProjectRequestInterface
+}
+
+// UserInterface exposes methods on user resources.
+type ProjectRequestInterface interface {
+	Create(p *projectapi.ProjectRequest) (*projectapi.Project, error)
+}
+
+type newProjectRequestsStruct struct {
+	r *Client
+}
+
+// newUsers returns a users
+func newProjectRequests(c *Client) *newProjectRequestsStruct {
+	return &newProjectRequestsStruct{
+		r: c,
+	}
+}
+
+// Create creates a new ProjectRequest
+func (c *newProjectRequestsStruct) Create(p *projectapi.ProjectRequest) (result *projectapi.Project, err error) {
+	result = &projectapi.Project{}
+	err = c.r.Post().Resource("projectrequests").Body(p).Do().Into(result)
+	return
+}

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -64,6 +64,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 
 	cmds.AddCommand(cmd.NewCmdLogin(f, in, out))
 	cmds.AddCommand(cmd.NewCmdProject(f, out))
+	cmds.AddCommand(cmd.NewCmdRequestProject("new-project", fullName+" new-project", fullName+" login", fullName+" project", f, out))
 	cmds.AddCommand(cmd.NewCmdNewApplication(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdStatus(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdStartBuild(fullName, f, out))

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+)
+
+type NewProjectOptions struct {
+	ProjectName string
+	DisplayName string
+	Description string
+
+	Client client.Interface
+}
+
+const requestProjectLongDesc = `
+Create a new project for yourself in OpenShift with you as the project admin.
+
+Assuming your cluster admin has granted you permission, this command will 
+create a new project for you and assign you as the project admin.  You must 
+be logged in, so you might have to run %[2]s first.
+
+Examples:
+
+	$ Create a new project with minimal information
+	$ %[1]s web-team-dev
+
+	# Create a new project with a description
+	$ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."
+
+After your project is created you can switch to it using %[3]s <project name>.
+`
+
+func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &NewProjectOptions{}
+
+	cmd := &cobra.Command{
+		Use:   fmt.Sprintf("%s <project-name> [--display-name=<your display name> --description=<your description]", name),
+		Short: "request a new project",
+		Long:  fmt.Sprintf(requestProjectLongDesc, fullName, oscLoginName, oscProjectName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if !options.complete(cmd) {
+				return
+			}
+
+			var err error
+			if options.Client, _, err = f.Clients(); err != nil {
+				glog.Fatalf("Error getting client: %v", err)
+			}
+			if err := options.Run(); err != nil {
+				glog.Fatal(err)
+			}
+		},
+	}
+	cmd.SetOutput(out)
+
+	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
+	cmd.Flags().StringVar(&options.Description, "description", "", "project description")
+
+	return cmd
+}
+
+func (o *NewProjectOptions) complete(cmd *cobra.Command) bool {
+	args := cmd.Flags().Args()
+	if len(args) != 1 {
+		cmd.Help()
+		return false
+	}
+
+	o.ProjectName = args[0]
+
+	return true
+}
+
+func (o *NewProjectOptions) Run() error {
+	projectRequest := &projectapi.ProjectRequest{}
+	projectRequest.Name = o.ProjectName
+	projectRequest.DisplayName = o.DisplayName
+	projectRequest.Annotations = make(map[string]string)
+	projectRequest.Annotations["description"] = o.Description
+	if _, err := o.Client.ProjectRequests().Create(projectRequest); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -36,6 +36,7 @@ const (
 	AdminRoleName             = "admin"
 	EditRoleName              = "edit"
 	ViewRoleName              = "view"
+	SelfProvisionerRoleName   = "self-provisioner"
 	BasicUserRoleName         = "basic-user"
 	StatusCheckerRoleName     = "cluster-status"
 	DeployerRoleName          = "system:deployer"
@@ -49,14 +50,15 @@ const (
 
 // RoleBindings
 const (
-	InternalComponentRoleBindingName = InternalComponentRoleName + "-binding"
-	DeployerRoleBindingName          = DeployerRoleName + "-binding"
-	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "-binding"
-	BasicUserRoleBindingName         = BasicUserRoleName + "-binding"
+	SelfProvisionerRoleBindingName   = SelfProvisionerRoleName + "s"
+	InternalComponentRoleBindingName = InternalComponentRoleName + "s"
+	DeployerRoleBindingName          = DeployerRoleName + "s"
+	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "s"
+	BasicUserRoleBindingName         = BasicUserRoleName + "s"
 	DeleteTokensRoleBindingName      = DeleteTokensRoleName + "-binding"
 	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"
-	RouterRoleBindingName            = RouterRoleName + "-binding"
-	RegistryRoleBindingName          = RegistryRoleName + "-binding"
+	RouterRoleBindingName            = RouterRoleName + "s"
+	RegistryRoleBindingName          = RegistryRoleName + "s"
 
-	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "-binding"
+	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "s"
 )

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -102,8 +102,18 @@ func GetBootstrapMasterRoles(masterNamespace string) []authorizationapi.Role {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("users"), ResourceNames: util.NewStringSet("~")},
+				{Verbs: util.NewStringSet("get"), Resources: util.NewStringSet("projectrequests")},
 				{Verbs: util.NewStringSet("list"), Resources: util.NewStringSet("projects")},
 				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("subjectaccessreviews"), AttributeRestrictions: runtime.EmbeddedObject{&authorizationapi.IsPersonalSubjectAccessReview{}}},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      SelfProvisionerRoleName,
+				Namespace: masterNamespace,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("projectrequests")},
 			},
 		},
 		{
@@ -252,6 +262,17 @@ func GetBootstrapMasterRoleBindings(masterNamespace string) []authorizationapi.R
 			},
 			RoleRef: kapi.ObjectReference{
 				Name:      BasicUserRoleName,
+				Namespace: masterNamespace,
+			},
+			Groups: util.NewStringSet(AuthenticatedGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      SelfProvisionerRoleBindingName,
+				Namespace: masterNamespace,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name:      SelfProvisionerRoleName,
 				Namespace: masterNamespace,
 			},
 			Groups: util.NewStringSet(AuthenticatedGroup),

--- a/pkg/project/api/register.go
+++ b/pkg/project/api/register.go
@@ -8,8 +8,10 @@ func init() {
 	api.Scheme.AddKnownTypes("",
 		&Project{},
 		&ProjectList{},
+		&ProjectRequest{},
 	)
 }
 
-func (*Project) IsAnAPIObject()     {}
-func (*ProjectList) IsAnAPIObject() {}
+func (*ProjectRequest) IsAnAPIObject() {}
+func (*Project) IsAnAPIObject()        {}
+func (*ProjectList) IsAnAPIObject()    {}

--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -37,3 +37,10 @@ type Project struct {
 	Spec        ProjectSpec
 	Status      ProjectStatus
 }
+
+type ProjectRequest struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	DisplayName string
+}

--- a/pkg/project/api/v1beta1/register.go
+++ b/pkg/project/api/v1beta1/register.go
@@ -8,8 +8,10 @@ func init() {
 	api.Scheme.AddKnownTypes("v1beta1",
 		&Project{},
 		&ProjectList{},
+		&ProjectRequest{},
 	)
 }
 
-func (*Project) IsAnAPIObject()     {}
-func (*ProjectList) IsAnAPIObject() {}
+func (*ProjectRequest) IsAnAPIObject() {}
+func (*Project) IsAnAPIObject()        {}
+func (*ProjectList) IsAnAPIObject()    {}

--- a/pkg/project/api/v1beta1/types.go
+++ b/pkg/project/api/v1beta1/types.go
@@ -39,3 +39,9 @@ type Project struct {
 	// Status describes the current status of a Namespace
 	Status ProjectStatus `json:"status,omitempty" description:"status describes the current status of a Project; read-only"`
 }
+
+type ProjectRequest struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+	DisplayName     string `json:"displayName,omitempty"`
+}

--- a/pkg/project/api/v1beta3/register.go
+++ b/pkg/project/api/v1beta3/register.go
@@ -8,8 +8,10 @@ func init() {
 	api.Scheme.AddKnownTypes("v1beta3",
 		&Project{},
 		&ProjectList{},
+		&ProjectRequest{},
 	)
 }
 
-func (*Project) IsAnAPIObject()     {}
-func (*ProjectList) IsAnAPIObject() {}
+func (*ProjectRequest) IsAnAPIObject() {}
+func (*Project) IsAnAPIObject()        {}
+func (*ProjectList) IsAnAPIObject()    {}

--- a/pkg/project/api/v1beta3/types.go
+++ b/pkg/project/api/v1beta3/types.go
@@ -39,3 +39,9 @@ type Project struct {
 	// Status describes the current status of a Namespace
 	Status ProjectStatus `json:"status,omitempty" description:"status describes the current status of a Project; read-only"`
 }
+
+type ProjectRequest struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+	DisplayName     string `json:"displayName,omitempty"`
+}

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -39,3 +39,11 @@ func ValidateProjectUpdate(newProject *api.Project, oldProject *api.Project) fie
 	newProject.Status = oldProject.Status
 	return allErrs
 }
+
+func ValidateProjectRequest(request *api.ProjectRequest) fielderrors.ValidationErrorList {
+	project := &api.Project{}
+	project.ObjectMeta = request.ObjectMeta
+	project.DisplayName = request.DisplayName
+
+	return ValidateProject(project)
+}

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -1,0 +1,67 @@
+package delegated
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/registry/rolebinding"
+
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectstorage "github.com/openshift/origin/pkg/project/registry/project/proxy"
+	projectrequestregistry "github.com/openshift/origin/pkg/project/registry/projectrequest"
+)
+
+type REST struct {
+	masterNamespace     string
+	roleBindingRegistry rolebinding.Registry
+
+	projectStorage projectstorage.REST
+}
+
+func NewREST(masterNamespace string, roleBindingRegistry rolebinding.Registry, projectStorage projectstorage.REST) *REST {
+	return &REST{
+		masterNamespace:     masterNamespace,
+		roleBindingRegistry: roleBindingRegistry,
+		projectStorage:      projectStorage,
+	}
+}
+
+func (r *REST) New() runtime.Object {
+	return &projectapi.ProjectRequest{}
+}
+
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	if err := rest.BeforeCreate(projectrequestregistry.Strategy, ctx, obj); err != nil {
+		return nil, err
+	}
+
+	projectRequest := obj.(*projectapi.ProjectRequest)
+
+	project := &projectapi.Project{}
+	project.ObjectMeta = projectRequest.ObjectMeta
+	project.DisplayName = projectRequest.DisplayName
+
+	projectObj, err := r.projectStorage.Create(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	realizedProject := projectObj.(*projectapi.Project)
+
+	adminBinding := &authorizationapi.RoleBinding{}
+	adminBinding.Namespace = realizedProject.Name
+	adminBinding.Name = "admins"
+	adminBinding.RoleRef = kapi.ObjectReference{Namespace: r.masterNamespace, Name: "admin"}
+	if userInfo, exists := kapi.UserFrom(ctx); exists {
+		adminBinding.Users = util.NewStringSet(userInfo.GetName())
+	}
+
+	projectContext := kapi.WithNamespace(ctx, realizedProject.Name)
+	if err := r.roleBindingRegistry.CreateRoleBinding(projectContext, adminBinding, true); err != nil {
+		return nil, err
+	}
+
+	return realizedProject, nil
+}

--- a/pkg/project/registry/projectrequest/strategy.go
+++ b/pkg/project/registry/projectrequest/strategy.go
@@ -1,0 +1,47 @@
+package projectrequest
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectvalidation "github.com/openshift/origin/pkg/project/api/validation"
+)
+
+// strategy implements behavior for OAuthClient objects
+type strategy struct {
+	runtime.ObjectTyper
+}
+
+var Strategy = strategy{kapi.Scheme}
+
+func (strategy) PrepareForUpdate(obj, old runtime.Object) {}
+
+// NamespaceScoped is false for projectrequest objects
+func (strategy) NamespaceScoped() bool {
+	return false
+}
+
+func (strategy) GenerateName(base string) string {
+	return base
+}
+
+func (strategy) PrepareForCreate(obj runtime.Object) {
+}
+
+// Validate validates a new client
+func (strategy) Validate(ctx kapi.Context, obj runtime.Object) fielderrors.ValidationErrorList {
+	projectrequest := obj.(*projectapi.ProjectRequest)
+	return projectvalidation.ValidateProjectRequest(projectrequest)
+}
+
+// ValidateUpdate validates a client update
+func (strategy) ValidateUpdate(ctx kapi.Context, obj runtime.Object, old runtime.Object) fielderrors.ValidationErrorList {
+	return nil
+}
+
+// AllowCreateOnUpdate is false for OAuth objects
+func (strategy) AllowCreateOnUpdate() bool {
+	return false
+}

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -1,0 +1,60 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/client"
+
+	osc "github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+func TestUnprivilegedNewProject(t *testing.T) {
+	_, clusterAdminKubeConfig, err := testutil.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	valerieClientConfig := *clusterAdminClientConfig
+	valerieClientConfig.Username = ""
+	valerieClientConfig.Password = ""
+	valerieClientConfig.BearerToken = ""
+	valerieClientConfig.CertFile = ""
+	valerieClientConfig.KeyFile = ""
+	valerieClientConfig.CertData = nil
+	valerieClientConfig.KeyData = nil
+
+	accessToken, err := tokencmd.RequestToken(&valerieClientConfig, nil, "valerie", "security!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	valerieClientConfig.BearerToken = accessToken
+	valerieOpenshiftClient, err := client.New(&valerieClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	requestProject := osc.NewProjectOptions{
+		ProjectName: "new-project",
+		DisplayName: "display name here",
+		Description: "the special description",
+
+		Client: valerieOpenshiftClient,
+	}
+
+	if err := requestProject.Run(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	waitForProject(t, valerieOpenshiftClient, "new-project", 5*time.Second, 10)
+}


### PR DESCRIPTION
Adds `osc request-project <project-name>`.  This command POSTs to osapi/v1beta1/requestprojects and if the user is allowed to access that endpoint, an escalation is allowed to let the user create a project and create a role binding to `master:admin`.  Nothing in here is configurable, but the request command itself and its endpoint is unlikely change even if the underlying storage implementation does.

@smarterclayton This allows a startup flow to be:
 1. `osc login`
 1. `osc request-project my-project`
 1. `osc project my-project`
and avoids having anyone mess with the cluster admin cert.