### PR TITLE
Implement cert delete functionality

### DIFF
--- a/plugins/router/template/certmanager.go
+++ b/plugins/router/template/certmanager.go
@@ -2,21 +2,62 @@ package templaterouter
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/golang/glog"
 	"io/ioutil"
+	"os"
 
 	routeapi "github.com/openshift/origin/pkg/route/api"
 )
 
-// certManager is responsible for writing out certificates to the disk for the template router plugin.
-type certManager struct{}
+// simpleCertificateManager is the default implementation of a certificateManager
+type simpleCertificateManager struct {
+	cfg *certificateManagerConfig
+	w   certificateWriter
+}
 
-// writeCertificatesForConfig write certificates for edge and reencrypt termination by appending the key, cert, and ca cert
-// into a single <host>.pem file.  Also write <host>_pod.pem file if it is reencrypt termination
-func (cm *certManager) writeCertificatesForConfig(config *ServiceAliasConfig) error {
+// newSimpleCertificateManager should be used to create a new cert manager.  It will return an error
+// if the config is not valid
+func newSimpleCertificateManager(cfg *certificateManagerConfig, w certificateWriter) (certificateManager, error) {
+	if err := validateCertManagerConfig(cfg); err != nil {
+		return nil, err
+	}
+	if w == nil {
+		return nil, fmt.Errorf("certificate manager requires a certificate writer")
+	}
+	return &simpleCertificateManager{cfg, w}, nil
+}
+
+// validateCertManagerConfig ensures that the key functions and directories are set as well as
+// ensuring that the two configured directories are set to different values
+func validateCertManagerConfig(cfg *certificateManagerConfig) error {
+	if cfg.certKeyFunc == nil || cfg.caCertKeyFunc == nil ||
+		cfg.destCertKeyFunc == nil || len(cfg.certDir) == 0 ||
+		len(cfg.caCertDir) == 0 {
+		return fmt.Errorf("certificate manager requires all config items to be set")
+	}
+	if cfg.certDir == cfg.caCertDir {
+		return fmt.Errorf("certificate manager requires different directories for certDir and caCertDir")
+	}
+	return nil
+}
+
+// CertificateWriter provides direct access to the underlying writer if required
+func (cm *simpleCertificateManager) CertificateWriter() certificateWriter {
+	return cm.w
+}
+
+// WriteCertificatesForConfig write certificates for edge and reencrypt termination by appending the
+// key, cert, and ca cert into a single <host>.pem file.  Also write <host>_pod.pem file if it is
+// reencrypt termination
+func (cm *simpleCertificateManager) WriteCertificatesForConfig(config *ServiceAliasConfig) error {
+	if config == nil {
+		return nil
+	}
 	if len(config.Certificates) > 0 {
 		if config.TLSTermination == routeapi.TLSTerminationEdge || config.TLSTermination == routeapi.TLSTerminationReencrypt {
-			certObj, ok := config.Certificates[config.Host]
+			certKey := cm.cfg.certKeyFunc(config)
+			certObj, ok := config.Certificates[certKey]
 
 			if ok {
 				newLine := []byte("\n")
@@ -26,33 +67,80 @@ func (cm *certManager) writeCertificatesForConfig(config *ServiceAliasConfig) er
 				buffer.Write(newLine)
 				buffer.Write([]byte(certObj.Contents))
 
-				caCertObj, caOk := config.Certificates[config.Host+caCertPostfix]
+				caCertKey := cm.cfg.caCertKeyFunc(config)
+				caCertObj, caOk := config.Certificates[caCertKey]
 
 				if caOk {
 					buffer.Write(newLine)
 					buffer.Write([]byte(caCertObj.Contents))
 				}
 
-				cm.writeCertificate(certDir, config.Host, buffer.Bytes())
+				err := cm.w.WriteCertificate(cm.cfg.certDir, certObj.ID, buffer.Bytes())
+				if err != nil {
+					return err
+				}
 			}
 		}
 
 		if config.TLSTermination == routeapi.TLSTerminationReencrypt {
-			destCertKey := config.Host + destCertPostfix
+			destCertKey := cm.cfg.destCertKeyFunc(config)
 			destCert, ok := config.Certificates[destCertKey]
 
 			if ok {
-				cm.writeCertificate(caCertDir, destCertKey, []byte(destCert.Contents))
+				err := cm.w.WriteCertificate(cm.cfg.caCertDir, destCert.ID, []byte(destCert.Contents))
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
-
 	return nil
 }
 
-// writeCertificate creates and writes the file identified by <id> in <directory>.  The file extension
+// deleteCertificatesForConfig will delete all certificates for the ServiceAliasConfig
+func (cm *simpleCertificateManager) DeleteCertificatesForConfig(config *ServiceAliasConfig) error {
+	if config == nil {
+		return nil
+	}
+	if len(config.Certificates) > 0 {
+		if config.TLSTermination == routeapi.TLSTerminationEdge || config.TLSTermination == routeapi.TLSTerminationReencrypt {
+			certKey := cm.cfg.certKeyFunc(config)
+			certObj, ok := config.Certificates[certKey]
+
+			if ok {
+				err := cm.w.DeleteCertificate(cm.cfg.certDir, certObj.ID)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if config.TLSTermination == routeapi.TLSTerminationReencrypt {
+			destCertKey := cm.cfg.destCertKeyFunc(config)
+			destCert, ok := config.Certificates[destCertKey]
+
+			if ok {
+				err := cm.w.DeleteCertificate(cm.cfg.caCertDir, destCert.ID)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// simpleCertificateWriter is the default implementation of a certificateWriter
+type simpleCertificateWriter struct{}
+
+// NewSimpleCertificateWriter provides a new instance of simpleCertificateWriter
+func newSimpleCertificateWriter() certificateWriter {
+	return &simpleCertificateWriter{}
+}
+
+// WriteCertificate creates and writes the file identified by <id> in <directory>.  The file extension
 // .pem will be added to id.
-func (cm *certManager) writeCertificate(directory string, id string, cert []byte) error {
+func (cm *simpleCertificateWriter) WriteCertificate(directory string, id string, cert []byte) error {
 	fileName := directory + id + ".pem"
 	err := ioutil.WriteFile(fileName, cert, 0644)
 
@@ -60,12 +148,22 @@ func (cm *certManager) writeCertificate(directory string, id string, cert []byte
 		glog.Errorf("Error writing certificate file %v: %v", fileName, err)
 		return err
 	}
-
 	return nil
 }
 
-// deleteCertificatesForConfig will delete all certificates for the ServiceAliasConfig
-func (cm *certManager) deleteCertificatesForConfig(config *ServiceAliasConfig) error {
-	//TODO
-	return nil
+// DeleteCertificate deletes certificates identified by <id> in <directory> with the .pem extension added.
+// this will not return an error if the file does not exist
+func (cm *simpleCertificateWriter) DeleteCertificate(directory, id string) error {
+	fileName := directory + id + ".pem"
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		glog.V(4).Infof("attempted to delete file %s but it does not exist", fileName)
+		return nil
+	}
+
+	err := os.Remove(fileName)
+	if os.IsNotExist(err) {
+		glog.V(4).Infof("%s passed the existence check but it was gone when os.Remove was called", fileName)
+		return nil
+	}
+	return err
 }

--- a/plugins/router/template/certmanager.go
+++ b/plugins/router/template/certmanager.go
@@ -54,6 +54,10 @@ func (cm *simpleCertificateManager) WriteCertificatesForConfig(config *ServiceAl
 	if config == nil {
 		return nil
 	}
+	if config.Status == ServiceAliasConfigStatusSaved {
+		glog.V(4).Infof("skipping certificate write for %s%s since it's status is already %s", config.Host, config.Path, ServiceAliasConfigStatusSaved)
+		return nil
+	}
 	if len(config.Certificates) > 0 {
 		if config.TLSTermination == routeapi.TLSTerminationEdge || config.TLSTermination == routeapi.TLSTerminationReencrypt {
 			certKey := cm.cfg.certKeyFunc(config)
@@ -75,8 +79,7 @@ func (cm *simpleCertificateManager) WriteCertificatesForConfig(config *ServiceAl
 					buffer.Write([]byte(caCertObj.Contents))
 				}
 
-				err := cm.w.WriteCertificate(cm.cfg.certDir, certObj.ID, buffer.Bytes())
-				if err != nil {
+				if err := cm.w.WriteCertificate(cm.cfg.certDir, certObj.ID, buffer.Bytes()); err != nil {
 					return err
 				}
 			}
@@ -87,8 +90,7 @@ func (cm *simpleCertificateManager) WriteCertificatesForConfig(config *ServiceAl
 			destCert, ok := config.Certificates[destCertKey]
 
 			if ok {
-				err := cm.w.WriteCertificate(cm.cfg.caCertDir, destCert.ID, []byte(destCert.Contents))
-				if err != nil {
+				if err := cm.w.WriteCertificate(cm.cfg.caCertDir, destCert.ID, []byte(destCert.Contents)); err != nil {
 					return err
 				}
 			}

--- a/plugins/router/template/certmanager_test.go
+++ b/plugins/router/template/certmanager_test.go
@@ -1,0 +1,194 @@
+package templaterouter
+
+import (
+	"reflect"
+	"testing"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+func TestCertManager(t *testing.T) {
+	cfg := newFakeCertificateManagerConfig()
+	fakeCertWriter := &fakeCertWriter{}
+	certManager, _ := newSimpleCertificateManager(cfg, fakeCertWriter)
+
+	testCases := map[string]struct {
+		cfg             *ServiceAliasConfig
+		expectedAdds    []string
+		expectedDeletes []string
+	}{
+		"add cert nil config": {
+			expectedAdds:    []string{},
+			expectedDeletes: []string{},
+		},
+		"add cert edge": {
+			//expect that the ca cert will be concatenated to the regular cert so we only come out with a single add/delete
+			cfg: &ServiceAliasConfig{
+				Host:           "www.example.com",
+				TLSTermination: routeapi.TLSTerminationEdge,
+				Certificates: map[string]Certificate{
+					"www.example.com": {
+						ID: "testCert",
+					},
+					"www.example.com" + caCertPostfix: {
+						ID: "testCert",
+					},
+				},
+			},
+			expectedAdds:    []string{cfg.certDir + "testCert"},
+			expectedDeletes: []string{cfg.certDir + "testCert"},
+		},
+		"add cert passthrough": {
+			//passthrough should not define certs (enforced by the api) Certmanager shouldn't attempt to write anything for it
+			//even if it has certs since it is unsupported
+			cfg: &ServiceAliasConfig{
+				Host:           "www.example.com",
+				TLSTermination: routeapi.TLSTerminationPassthrough,
+				Certificates: map[string]Certificate{
+					"www.example.com": {
+						ID: "testCert",
+					},
+					"www.example.com" + caCertPostfix: {
+						ID: "testCert",
+					},
+				},
+			},
+			expectedAdds:    []string{},
+			expectedDeletes: []string{},
+		},
+		"add cert reencrypt": {
+			//expect that we have 2 adds/deletes.  1 for the regular cert/ca and 1 for the destination cert
+			cfg: &ServiceAliasConfig{
+				Host:           "www.example.com",
+				TLSTermination: routeapi.TLSTerminationReencrypt,
+				Certificates: map[string]Certificate{
+					"www.example.com": {
+						ID: "testCert",
+					},
+					"www.example.com" + caCertPostfix: {
+						ID: "testCert",
+					},
+					"www.example.com" + destCertPostfix: {
+						ID: "testCert",
+					},
+				},
+			},
+			expectedAdds:    []string{cfg.certDir + "testCert", cfg.caCertDir + "testCert"},
+			expectedDeletes: []string{cfg.certDir + "testCert", cfg.caCertDir + "testCert"},
+		},
+		"add cert no certs": {
+			cfg: &ServiceAliasConfig{
+				Host:           "www.example.com",
+				TLSTermination: routeapi.TLSTerminationEdge,
+				Certificates:   map[string]Certificate{},
+			},
+			expectedAdds:    []string{},
+			expectedDeletes: []string{},
+		},
+		"add cert no tls termination type": {
+			cfg: &ServiceAliasConfig{
+				Host: "www.example.com",
+				Certificates: map[string]Certificate{
+					"www.example.com": {
+						ID: "testCert",
+					},
+					"www.example.com" + caCertPostfix: {
+						ID: "testCert",
+					},
+				},
+			},
+			expectedAdds:    []string{},
+			expectedDeletes: []string{},
+		},
+		"add cert invalid tls termination type": {
+			cfg: &ServiceAliasConfig{
+				Host:           "www.example.com",
+				TLSTermination: "invalid",
+				Certificates: map[string]Certificate{
+					"www.example.com": {
+						ID: "testCert",
+					},
+					"www.example.com" + caCertPostfix: {
+						ID: "testCert",
+					},
+				},
+			},
+			expectedAdds:    []string{},
+			expectedDeletes: []string{},
+		},
+	}
+
+	for k, tc := range testCases {
+		fakeCertWriter.clear()
+		err := certManager.WriteCertificatesForConfig(tc.cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error writing certs for service alias config for %s.  Config: %v, err: %v", k, tc.cfg, err)
+		}
+		err = certManager.DeleteCertificatesForConfig(tc.cfg)
+		if err != nil {
+			t.Fatalf("Unexpected error deleting certs for service alias config for %s.  Config: %v, err: %v", k, tc.cfg, err)
+		}
+
+		if len(tc.expectedAdds) != len(fakeCertWriter.addedCerts) {
+			t.Errorf("Unexpected number of adds for %s occurred. Expected: %d Got: %d", k, len(tc.expectedAdds), len(fakeCertWriter.addedCerts))
+		}
+
+		if len(tc.expectedDeletes) != len(fakeCertWriter.deletedCerts) {
+			t.Errorf("Unexpected number of deletes for %s occurred. Expected: %d Got: %d", k, len(tc.expectedDeletes), len(fakeCertWriter.deletedCerts))
+		}
+
+		if !reflect.DeepEqual(tc.expectedAdds, fakeCertWriter.addedCerts) {
+			t.Errorf("Unexpected adds for %s, wanted: %v, got %v", k, tc.expectedAdds, fakeCertWriter.addedCerts)
+		}
+
+		if !reflect.DeepEqual(tc.expectedDeletes, fakeCertWriter.deletedCerts) {
+			t.Errorf("Unexpected deletes for %s, wanted: %v, got %v", k, tc.expectedDeletes, fakeCertWriter.deletedCerts)
+		}
+	}
+}
+
+func TestCertManagerConfig(t *testing.T) {
+	validCfg := newFakeCertificateManagerConfig()
+
+	missingCertKeyCfg := newFakeCertificateManagerConfig()
+	missingCertKeyCfg.certKeyFunc = nil
+
+	missingCACertKeyCfg := newFakeCertificateManagerConfig()
+	missingCACertKeyCfg.caCertKeyFunc = nil
+
+	missingDestCertKeyCfg := newFakeCertificateManagerConfig()
+	missingDestCertKeyCfg.destCertKeyFunc = nil
+
+	missingCertDirCfg := newFakeCertificateManagerConfig()
+	missingCertDirCfg.certDir = ""
+
+	missingCACertDirCfg := newFakeCertificateManagerConfig()
+	missingCACertDirCfg.caCertDir = ""
+
+	matchingCertDirCfg := newFakeCertificateManagerConfig()
+	matchingCertDirCfg.caCertDir = matchingCertDirCfg.certDir
+
+	testCases := map[string]struct {
+		config     *certificateManagerConfig
+		shouldPass bool
+	}{
+		"valid": {shouldPass: true, config: validCfg},
+		"missing certificateKeyFunc": {shouldPass: false, config: missingCertKeyCfg},
+		"missing caCertificateKeyFunc": {shouldPass: false, config: missingCACertKeyCfg},
+		"missing destCertificateKeyFunc": {shouldPass: false, config: missingDestCertKeyCfg},
+		"missing 	certificateDir": {shouldPass: false, config: missingCertDirCfg},
+		"missing caCertificateDir": {shouldPass: false, config: missingCACertDirCfg},
+		"matching certificateDir/caCertificateDir": {shouldPass: false, config: matchingCertDirCfg},
+	}
+
+	fakeCertWriter := &fakeCertWriter{}
+	for k, tc := range testCases {
+		_, err := newSimpleCertificateManager(tc.config, fakeCertWriter)
+		if tc.shouldPass && err != nil {
+			t.Errorf("%s expected config to pass validation but failed with err: %v", k, err)
+		}
+		if !tc.shouldPass && err == nil {
+			t.Errorf("%s expected config to fail validation but passed", k)
+		}
+	}
+}

--- a/plugins/router/template/fake.go
+++ b/plugins/router/template/fake.go
@@ -1,0 +1,43 @@
+package templaterouter
+
+// newFakeTemplateRouter provides an empty template router with a simple certificate manager
+// backed by a fake cert writer for testing
+func newFakeTemplateRouter() templateRouter{
+	fakeCertManager, _ := newSimpleCertificateManager(newFakeCertificateManagerConfig(), &fakeCertWriter{})
+	return templateRouter{
+		state: map[string]ServiceUnit{},
+		certManager: fakeCertManager,
+	}
+}
+
+// fakeCertWriter is a certificate writer that records actions but is a no-op
+type fakeCertWriter struct {
+	addedCerts   []string
+	deletedCerts []string
+}
+
+// clear clears the fake cert writer for test case resets
+func (fcw *fakeCertWriter) clear() {
+	fcw.addedCerts = make([]string, 0)
+	fcw.deletedCerts = make([]string, 0)
+}
+
+func (fcw *fakeCertWriter) WriteCertificate(directory string, id string, cert []byte) error {
+	fcw.addedCerts = append(fcw.addedCerts, directory+id)
+	return nil
+}
+
+func (fcw *fakeCertWriter) DeleteCertificate(directory, id string) error {
+	fcw.deletedCerts = append(fcw.deletedCerts, directory+id)
+	return nil
+}
+
+func newFakeCertificateManagerConfig() *certificateManagerConfig {
+	return &certificateManagerConfig{
+		certKeyFunc:     generateCertKey,
+		caCertKeyFunc:   generateCACertKey,
+		destCertKeyFunc: generateDestCertKey,
+		certDir:         certDir,
+		caCertDir:       caCertDir,
+	}
+}

--- a/plugins/router/template/fake.go
+++ b/plugins/router/template/fake.go
@@ -2,10 +2,10 @@ package templaterouter
 
 // newFakeTemplateRouter provides an empty template router with a simple certificate manager
 // backed by a fake cert writer for testing
-func newFakeTemplateRouter() templateRouter{
+func newFakeTemplateRouter() templateRouter {
 	fakeCertManager, _ := newSimpleCertificateManager(newFakeCertificateManagerConfig(), &fakeCertWriter{})
 	return templateRouter{
-		state: map[string]ServiceUnit{},
+		state:       map[string]ServiceUnit{},
 		certManager: fakeCertManager,
 	}
 }

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -57,7 +57,7 @@ type templateData struct {
 
 func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath, defaultCertificate string) (*templateRouter, error) {
 	glog.Infof("Creating a new template router")
-	certManagerConfig := &certificateManagerConfig {
+	certManagerConfig := &certificateManagerConfig{
 		certKeyFunc:     generateCertKey,
 		caCertKeyFunc:   generateCACertKey,
 		destCertKeyFunc: generateDestCertKey,
@@ -68,7 +68,7 @@ func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath
 	if err != nil {
 		return nil, err
 	}
-	
+
 	router := &templateRouter{
 		templates:              templates,
 		reloadScriptPath:       reloadScriptPath,
@@ -154,12 +154,14 @@ func (r *templateRouter) writeState() error {
 func (r *templateRouter) writeConfig() error {
 	//write out any certificate files that don't exist
 	for _, serviceUnit := range r.state {
-		for _, cfg := range serviceUnit.ServiceAliasConfigs {
+		for k, cfg := range serviceUnit.ServiceAliasConfigs {
 			err := r.certManager.WriteCertificatesForConfig(&cfg)
 			if err != nil {
 				glog.Errorf("Error writing certificates for %s: %v", serviceUnit.Name, err)
 				return err
 			}
+			cfg.Status = ServiceAliasConfigStatusSaved
+			serviceUnit.ServiceAliasConfigs[k] = cfg
 		}
 	}
 

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -36,7 +36,7 @@ type templateRouter struct {
 	templates        map[string]*template.Template
 	reloadScriptPath string
 	state            map[string]ServiceUnit
-	certManager      certManager
+	certManager      certificateManager
 	// defaultCertificate is a concatenated certificate(s), their keys, and their CAs that should be used by the underlying
 	// implementation as the default certificate if no certificate is resolved by the normal matching mechanisms.  This is
 	// usually a wildcard certificate for a cloud domain such as *.mypaas.com to allow applications to create app.mypaas.com
@@ -57,11 +57,23 @@ type templateData struct {
 
 func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath, defaultCertificate string) (*templateRouter, error) {
 	glog.Infof("Creating a new template router")
+	certManagerConfig := &certificateManagerConfig {
+		certKeyFunc:     generateCertKey,
+		caCertKeyFunc:   generateCACertKey,
+		destCertKeyFunc: generateDestCertKey,
+		certDir:         certDir,
+		caCertDir:       caCertDir,
+	}
+	certManager, err := newSimpleCertificateManager(certManagerConfig, newSimpleCertificateWriter())
+	if err != nil {
+		return nil, err
+	}
+	
 	router := &templateRouter{
 		templates:              templates,
 		reloadScriptPath:       reloadScriptPath,
 		state:                  map[string]ServiceUnit{},
-		certManager:            certManager{},
+		certManager:            certManager,
 		defaultCertificate:     defaultCertificate,
 		defaultCertificatePath: "",
 	}
@@ -83,7 +95,7 @@ func newTemplateRouter(templates map[string]*template.Template, reloadScriptPath
 func (r *templateRouter) writeDefaultCert() error {
 	if len(r.defaultCertificate) > 0 {
 		glog.Infof("Writing default certificate to %s", certDir)
-		err := r.certManager.writeCertificate(certDir, defaultCertName, []byte(r.defaultCertificate))
+		err := r.certManager.CertificateWriter().WriteCertificate(certDir, defaultCertName, []byte(r.defaultCertificate))
 		if err == nil {
 			r.defaultCertificatePath = fmt.Sprintf("%s%s.pem", certDir, defaultCertName)
 		}
@@ -143,7 +155,7 @@ func (r *templateRouter) writeConfig() error {
 	//write out any certificate files that don't exist
 	for _, serviceUnit := range r.state {
 		for _, cfg := range serviceUnit.ServiceAliasConfigs {
-			err := r.writeCertificates(&cfg)
+			err := r.certManager.WriteCertificatesForConfig(&cfg)
 			if err != nil {
 				glog.Errorf("Error writing certificates for %s: %v", serviceUnit.Name, err)
 				return err
@@ -175,7 +187,7 @@ func (r *templateRouter) writeConfig() error {
 func (r *templateRouter) writeCertificates(cfg *ServiceAliasConfig) error {
 	if r.shouldWriteCerts(cfg) {
 		//TODO: better way so this doesn't need to create lots of files every time state is written, probably too expensive
-		return r.certManager.writeCertificatesForConfig(cfg)
+		return r.certManager.WriteCertificatesForConfig(cfg)
 	}
 	return nil
 }
@@ -209,6 +221,14 @@ func (r *templateRouter) FindServiceUnit(id string) (v ServiceUnit, ok bool) {
 
 // DeleteServiceUnit deletes the service with the given id.
 func (r *templateRouter) DeleteServiceUnit(id string) {
+	svcUnit, ok := r.FindServiceUnit(id)
+	if !ok {
+		return
+	}
+
+	for _, cfg := range svcUnit.ServiceAliasConfigs {
+		r.cleanUpServiceAliasConfig(&cfg)
+	}
 	delete(r.state, id)
 }
 
@@ -249,30 +269,33 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route) {
 				config.Certificates = make(map[string]Certificate)
 			}
 
+			certKey := generateCertKey(&config)
 			cert := Certificate{
-				ID:         route.Host,
+				ID:         backendKey,
 				Contents:   route.TLS.Certificate,
 				PrivateKey: route.TLS.Key,
 			}
 
-			config.Certificates[cert.ID] = cert
+			config.Certificates[certKey] = cert
 
 			if len(route.TLS.CACertificate) > 0 {
+				caCertKey := generateCACertKey(&config)
 				caCert := Certificate{
-					ID:       route.Host + caCertPostfix,
+					ID:       backendKey,
 					Contents: route.TLS.CACertificate,
 				}
 
-				config.Certificates[caCert.ID] = caCert
+				config.Certificates[caCertKey] = caCert
 			}
 
 			if len(route.TLS.DestinationCACertificate) > 0 {
+				destCertKey := generateDestCertKey(&config)
 				destCert := Certificate{
-					ID:       route.Host + destCertPostfix,
+					ID:       backendKey,
 					Contents: route.TLS.DestinationCACertificate,
 				}
 
-				config.Certificates[destCert.ID] = destCert
+				config.Certificates[destCertKey] = destCert
 			}
 		}
 	}
@@ -284,13 +307,18 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route) {
 
 // RemoveRoute removes the given route for the given id.
 func (r *templateRouter) RemoveRoute(id string, route *routeapi.Route) {
-	_, ok := r.state[id]
-
+	serviceUnit, ok := r.state[id]
 	if !ok {
 		return
 	}
 
-	delete(r.state[id].ServiceAliasConfigs, r.routeKey(route))
+	routeKey := r.routeKey(route)
+	serviceAliasConfig, ok := serviceUnit.ServiceAliasConfigs[routeKey]
+	if !ok {
+		return
+	}
+	r.cleanUpServiceAliasConfig(&serviceAliasConfig)
+	delete(r.state[id].ServiceAliasConfigs, routeKey)
 }
 
 // AddEndpoints adds new Endpoints for the given id.
@@ -306,6 +334,15 @@ func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) {
 	}
 
 	r.state[id] = frontend
+}
+
+// cleanUpServiceAliasConfig performs any necessary steps to clean up a service alias config before deleting it from
+// the router.  Right now the only clean up step is to remove any of the certificates on disk.
+func (r *templateRouter) cleanUpServiceAliasConfig(cfg *ServiceAliasConfig) {
+	err := r.certManager.DeleteCertificatesForConfig(cfg)
+	if err != nil {
+		glog.Errorf("Error deleting certificates for route %s, the route will still be deleted but files may remain in the container: %v", cfg.Host, err)
+	}
 }
 
 func cmpStrSlices(first []string, second []string) bool {
@@ -365,4 +402,16 @@ func hasRequiredEdgeCerts(cfg *ServiceAliasConfig) bool {
 		return true
 	}
 	return false
+}
+
+func generateCertKey(config *ServiceAliasConfig) string {
+	return config.Host
+}
+
+func generateCACertKey(config *ServiceAliasConfig) string {
+	return config.Host + caCertPostfix
+}
+
+func generateDestCertKey(config *ServiceAliasConfig) string {
+	return config.Host + destCertPostfix
 }

--- a/plugins/router/template/router_test.go
+++ b/plugins/router/template/router_test.go
@@ -6,14 +6,9 @@ import (
 	"testing"
 )
 
-// emptyRouter creates a new, empty template router
-func emptyRouter() templateRouter {
-	return templateRouter{state: map[string]ServiceUnit{}}
-}
-
 // TestCreateServiceUnit tests creating a service unit and finding it in router state
 func TestCreateServiceUnit(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit("test")
 
@@ -24,7 +19,7 @@ func TestCreateServiceUnit(t *testing.T) {
 
 // TestDeleteServiceUnit tests that deleted service units no longer exist in state
 func TestDeleteServiceUnit(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
@@ -41,7 +36,7 @@ func TestDeleteServiceUnit(t *testing.T) {
 
 // TestAddEndpoints test adding endpoints to service units
 func TestAddEndpoints(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
@@ -80,7 +75,7 @@ func TestAddEndpoints(t *testing.T) {
 
 // TestDeleteEndpoints tests removing endpoints from service units
 func TestDeleteEndpoints(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	suKey := "test"
 	router.CreateServiceUnit(suKey)
 
@@ -121,7 +116,7 @@ func TestDeleteEndpoints(t *testing.T) {
 
 // TestRouteKey tests that route keys are created as expected
 func TestRouteKey(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: "foo",
@@ -138,7 +133,7 @@ func TestRouteKey(t *testing.T) {
 
 // TestAddRoute tests adding a service alias config to a service unit
 func TestAddRoute(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: "foo",
@@ -212,7 +207,7 @@ func findCert(cert string, certs map[string]Certificate, isPrivateKey bool, t *t
 
 // TestRemoveRoute tests removing a ServiceAliasConfig from a ServiceUnit
 func TestRemoveRoute(t *testing.T) {
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	route := &routeapi.Route{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: "foo",
@@ -315,7 +310,7 @@ func TestShouldWriteCertificates(t *testing.T) {
 		},
 	}
 
-	router := emptyRouter()
+	router := newFakeTemplateRouter()
 	for _, tc := range testCases {
 		result := router.shouldWriteCerts(tc.cfg)
 		if result != tc.shouldWriteCerts {

--- a/plugins/router/template/types.go
+++ b/plugins/router/template/types.go
@@ -27,7 +27,19 @@ type ServiceAliasConfig struct {
 	TLSTermination routeapi.TLSTerminationType
 	// Certificates used for securing this backend.  Keyed by the cert id
 	Certificates map[string]Certificate
+	// Indicates the status of configuration that needs to be persisted.  Right now this only
+	// includes the certificates and is not an indicator of being written to the underlying
+	// router implementation
+	Status ServiceAliasConfigStatus
 }
+
+type ServiceAliasConfigStatus string
+
+const (
+	// ServiceAliasConfigStatusSaved indicates that the necessary files for this config have
+	// been persisted to disk.
+	ServiceAliasConfigStatusSaved ServiceAliasConfigStatus = "saved"
+)
 
 // Certificate represents a pub/private key pair.  It is identified by ID which will become the file name.
 // A CA certificate will not have a PrivateKey set.


### PR DESCRIPTION
Cert deletes were marked as TODO, this makes them TODONE

In order to make the cert manager testable before implementing the delete I refactored it so that you can inject how it writes (and the other config items that were previously hard coded).  Commits are:
1. the refactor of the cert manager
1. the unit tests for the cert manager with a fake cert writer - tests both adds and deletes as well as valid configurations
1. implement the real delete and call the clean up code from deleting service units (services) and individual routes

@pmorie @abhgupta @smarterclayton @rajatchopra PTAL