### PR TITLE
Add resource requirements to build parameters

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -55,6 +55,9 @@ type BuildParameters struct {
 
 	// Output describes the Docker image the Strategy should produce.
 	Output BuildOutput `json:"output,omitempty"`
+
+	// Compute resource requirements to execute the build
+	Resources kapi.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // BuildStatus represents the status of a build at a point in time.

--- a/pkg/build/api/v1beta1/conversion.go
+++ b/pkg/build/api/v1beta1/conversion.go
@@ -28,6 +28,9 @@ func init() {
 			if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 				return err
 			}
+			if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+				return err
+			}
 			return nil
 		},
 		func(in *BuildParameters, out *newer.BuildParameters, s conversion.Scope) error {
@@ -45,6 +48,9 @@ func init() {
 				return err
 			}
 			if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
 				return err
 			}
 			return nil

--- a/pkg/build/api/v1beta1/types.go
+++ b/pkg/build/api/v1beta1/types.go
@@ -55,6 +55,9 @@ type BuildParameters struct {
 
 	// Output describes the Docker image the Strategy should produce.
 	Output BuildOutput `json:"output,omitempty"`
+
+	// Compute resource requirements to execute the build
+	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"the desired compute resources the build should have"`
 }
 
 // BuildStatus represents the status of a build at a point in time.

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -78,6 +78,7 @@ func validateBuildParameters(params *buildapi.BuildParameters) fielderrors.Valid
 	allErrs = append(allErrs, validateOutput(&params.Output).Prefix("output")...)
 	allErrs = append(allErrs, validateStrategy(&params.Strategy).Prefix("strategy")...)
 
+	// TODO: validate resource requirements (prereq: https://github.com/GoogleCloudPlatform/kubernetes/pull/7059)
 	return allErrs
 }
 

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -73,6 +73,8 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
+	pod.Spec.Containers[0].Resources = build.Parameters.Resources
+
 	if strategy.ExposeDockerSocket {
 		setupDockerSocket(pod)
 		setupDockerSecrets(pod, build.Parameters.Output.PushSecretName)

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -51,6 +51,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 		},
 	}
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
+	pod.Spec.Containers[0].Resources = build.Parameters.Resources
 
 	setupDockerSocket(pod)
 	setupDockerSecrets(pod, build.Parameters.Output.PushSecretName)

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 
 	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -62,6 +63,9 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if len(container.Env) != 3 {
 		t.Fatalf("Expected 3 elements in Env table, got %d", len(container.Env))
 	}
+	if !kapi.Semantic.DeepEqual(container.Resources, expected.Parameters.Resources) {
+		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, expected.Parameters.Resources)
+	}
 	buildJSON, _ := v1beta1.Codec.Encode(expected)
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
@@ -98,6 +102,12 @@ func mockDockerBuild() *buildapi.Build {
 			Output: buildapi.BuildOutput{
 				DockerImageReference: "docker-registry/repository/dockerBuild",
 				PushSecretName:       "foo",
+			},
+			Resources: kapi.ResourceRequirements{
+				Limits: kapi.ResourceList{
+					kapi.ResourceName(kapi.ResourceCPU):    resource.MustParse("10"),
+					kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
+				},
 			},
 		},
 		Status: buildapi.BuildStatusNew,

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -74,6 +74,7 @@ func (bs *STIBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, er
 		},
 	}
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
+	pod.Spec.Containers[0].Resources = build.Parameters.Resources
 
 	setupDockerSocket(pod)
 	setupDockerSecrets(pod, build.Parameters.Output.PushSecretName)

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 
 	"github.com/openshift/origin/pkg/api/v1beta1"
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -69,6 +70,9 @@ func TestSTICreateBuildPod(t *testing.T) {
 	if len(actual.Spec.Volumes) != 2 {
 		t.Fatalf("Expected 2 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
+	if !kapi.Semantic.DeepEqual(container.Resources, expected.Parameters.Resources) {
+		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, expected.Parameters.Resources)
+	}
 	found := false
 	for _, v := range container.Env {
 		if v.Name == "FOO" && v.Value == "bar" {
@@ -119,6 +123,12 @@ func mockSTIBuild() *buildapi.Build {
 			Output: buildapi.BuildOutput{
 				DockerImageReference: "docker-registry/repository/stiBuild",
 				PushSecretName:       "foo",
+			},
+			Resources: kapi.ResourceRequirements{
+				Limits: kapi.ResourceList{
+					kapi.ResourceName(kapi.ResourceCPU):    resource.MustParse("10"),
+					kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
+				},
 			},
 		},
 		Status: buildapi.BuildStatusNew,


### PR DESCRIPTION
@bparees this is the change to expose resources as a parameter to a build

in the absence of resources, pods created by a build will get the default resources applied that are defined in the project limits.  in the absence of a default, the pod will run with unbounded resources on the node like it does today.

right now, we will be able to limit cpu and memory usage of a build derived pod.  soon we will be able to limit duration if i get what is required for that merged in upstream kubernetes next sprint.