### PR TITLE
UPSTREAM Fix nil pointer in limit ranger

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger/admission.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/limitranger/admission.go
@@ -153,6 +153,12 @@ func defaultContainerResourceRequirements(limitRange *api.LimitRange) api.Resour
 func mergePodResourceRequirements(pod *api.Pod, defaultRequirements *api.ResourceRequirements) {
 	for i := range pod.Spec.Containers {
 		container := pod.Spec.Containers[i]
+		if container.Resources.Limits == nil {
+			container.Resources.Limits = api.ResourceList{}
+		}
+		if container.Resources.Requests == nil {
+			container.Resources.Requests = api.ResourceList{}
+		}
 		for k, v := range defaultRequirements.Limits {
 			_, found := container.Resources.Limits[k]
 			if !found {


### PR DESCRIPTION
Fixes a nil pointer error in upstream admission.go file when applying default resources to a container in a pod.

/cc @liggitt @deads2k please review (this already merged upstream)