### PR TITLE
Build controller logs events when failing to create pods

### DIFF
--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -128,6 +129,7 @@ func mockBuildController() *BuildController {
 		PodManager:        &okPodManager{},
 		BuildStrategy:     &okStrategy{},
 		ImageStreamClient: &okImageStreamClient{},
+		Recorder:          &record.FakeRecorder{},
 	}
 }
 

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -42,10 +42,11 @@ func TestDescribeFor(t *testing.T) {
 
 func TestDescribers(t *testing.T) {
 	fake := &client.Fake{}
+	fakeKube := &testclient.Fake{}
 	c := &describeClient{T: t, Namespace: "foo", Fake: fake}
 
 	testDescriberList := []kubectl.Describer{
-		&BuildDescriber{c},
+		&BuildDescriber{c, fakeKube},
 		&BuildConfigDescriber{c, ""},
 		&BuildLogDescriber{c},
 		&DeploymentDescriber{c},


### PR DESCRIPTION
Requires following upstream changes:
1. GetReference supports downstream objects https://github.com/GoogleCloudPlatform/kubernetes/pull/7093
2. kubectl.describeEvents become kubectl.DescribeEvents https://github.com/GoogleCloudPlatform/kubernetes/pull/7095

Goal here is to let an end-user observe a build, and know why it failed to create.  In particular, it is possible it failed to create if they exceeded their allowed quota.  In which case, they get a nice message making note of that when describing the build.

