### PR TITLE
Adds kube resize end-to-end test

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -61,8 +61,10 @@ func TestExampleObjectSchemas(t *testing.T) {
 	capabilities.Setup(true, nil)
 	cases := map[string]map[string]runtime.Object{
 		"../examples/hello-openshift": {
-			"hello-pod":     &kapi.Pod{},
-			"hello-project": &projectapi.Project{},
+			"hello-pod":                    &kapi.Pod{},
+			"hello-project":                &projectapi.Project{},
+			"hello-replication-controller": nil, // Skip.
+			"hello-template":               &templateapi.Template{},
 		},
 		"../examples/sample-app": {
 			"github-webhook-example":           nil, // Skip.

--- a/examples/hello-openshift/hello-replication-controller.json
+++ b/examples/hello-openshift/hello-replication-controller.json
@@ -1,0 +1,66 @@
+{
+    "kind": "Config",
+    "apiVersion": "v1beta1",
+    "metadata": {
+        "creationTimestamp": null
+    },
+    "items": [
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1beta1",
+            "metadata": {
+                "name": "replication-controller-test",
+                "creationTimestamp": null
+            },
+            "triggers": [
+                {
+                    "type": "ConfigChange"
+                }
+            ],
+            "template": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "controllerTemplate": {
+                    "replicas": 3,
+                    "replicaSelector": {
+                        "name": "registrypod"
+                    },
+                    "podTemplate": {
+                        "desiredState": {
+                            "manifest": {
+                                "version": "v1beta2",
+                                "id": "",
+                                "volumes": null,
+                                "containers": [
+                                    {
+                                        "name": "replication-controller-test",
+                                        "image": "openshift/hello-openshift",
+                                        "ports": [
+                                            {
+                                                "containerPort": 5000,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "resources": {},
+                                        "terminationMessagePath": "/dev/termination-log",
+                                        "privileged": true,
+                                        "imagePullPolicy": "PullIfNotPresent",
+                                        "capabilities": {}
+                                    }
+                                ],
+                                "restartPolicy": {
+                                    "always": {}
+                                },
+                                "dnsPolicy": "ClusterFirst"
+                            }
+                        },
+                        "labels": {
+                            "name": "registrypod"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/examples/hello-openshift/hello-template.json
+++ b/examples/hello-openshift/hello-template.json
@@ -1,0 +1,61 @@
+{
+  "apiVersion": "v1beta1",
+  "creationTimestamp": "2014-09-18T18:28:38-04:00",
+  "items": [
+    {
+      "apiVersion": "v1beta1",
+      "kind": "DeploymentConfig",
+      "metadata": {
+        "name": "replication-controller-test"
+      },
+      "template": {
+        "controllerTemplate": {
+          "podTemplate": {
+            "desiredState": {
+              "manifest": {
+                "containers": [
+                  {                    
+                    "image": "openshift/hello-openshift",
+                    "imagePullPolicy": "PullIfNotPresent",
+                    "name": "replication-controller-test",
+                    "ports": [
+                      {
+                        "containerPort": 5000,
+                        "protocol": "TCP"
+                      }
+                    ],
+                    "privileged": true 
+                  }
+                ],
+                "version": "v1beta1"
+              },
+              "restartpolicy": {}
+            },
+            "labels": {
+              "name": "registrypod"
+            }
+          },
+          "replicaSelector": {
+            "name": "registrypod"
+          },
+          "replicas": 3
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "triggers": [
+        {
+          "type": "ConfigChange"
+        }
+      ]
+    }
+  ],
+  "kind": "Template",
+  "metadata": {
+    "annotations": {
+      "description": "Template for launching a "
+    },
+    "name": "replication-controller-test-template"
+  }
+}

--- a/hack/more-end-to-end-tests/test-kube-resize-command.sh
+++ b/hack/more-end-to-end-tests/test-kube-resize-command.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Tests the openshift kube resize command
+# This scripts needs to be called and sourced by the test-end-to-end.sh script to initialize the correct
+# required variables
+
+# Wait for replication controller to spawn pods and then wait for upscale and then downscale
+# $1 namespace
+function wait_for_replication_controller_resize() {
+    namespace=$1
+    
+    REPLICATION_CONTROLLER_CONFIG_FILE=examples/hello-openshift/hello-replication-controller.json
+
+    echo "[INFO] Creating project $1 "
+    openshift ex new-project $namespace
+
+    echo "[INFO] Waiting for replication controller to start in $1 namespace"
+    osc create -f ${REPLICATION_CONTROLLER_CONFIG_FILE} -n $namespace
+    replicas=3
+    replication_controller_name=replication-controller-test-1
+
+    sleep 10
+    # the replication-controller-test spawns three replicas
+    wait_for_command "osc get pods -n $namespace | grep Running | grep -i ${replication_controller_name} | wc -l | grep -x $replicas" $((120*TIME_SEC))
+    echo "[INFO] Replication controller ${replication_controller_name} spwanned the number or requested pods : ${replicas}"
+
+
+    replicas=2
+    openshift kube resize --replicas=$replicas rc ${replication_controller_name} -n $namespace
+    wait_for_command "osc get pods -n $namespace | grep Running | grep -i ${replication_controller_name} | wc -l | grep -x $replicas" $((120*TIME_SEC))
+    echo "[INFO] Replication controller ${replication_controller_name} spwanned the number or requested pods : ${replicas}"
+ 
+    replicas=4
+    openshift kube resize --replicas=$replicas rc ${replication_controller_name} -n $namespace
+    wait_for_command "osc get pods -n $namespace | grep Running | grep -i ${replication_controller_name} | wc -l | grep -x $replicas" $((120*TIME_SEC))
+    echo "[INFO] Replication controller ${replication_controller_name} spwanned the number or requested pods : ${replicas}"
+ 
+
+    replicas=0
+    # Because of set +e on wait_for_command, doing a grep on counts will fail, so we have to check that pods are destroyed in another manner
+    openshift kube resize --replicas=$replicas rc ${replication_controller_name} -n $namespace
+    wait_for_command "osc get pods -n $namespace | wc -l | grep -x 1" $((120*TIME_SEC))
+    echo "[INFO] Replication controller ${replication_controller_name} spwanned the number or requested pods : ${replicas}"
+
+}
+
+
+# Start here the different methods
+
+wait_for_replication_controller_resize "testrc"

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -36,6 +36,7 @@ fi
 
 ROUTER_TESTS_ENABLED="${ROUTER_TESTS_ENABLED:-true}"
 TEST_ASSETS="${TEST_ASSETS:-false}"
+TEST_MORE="${TEST_MORE:-true}"
 
 if [[ -z "${BASETMPDIR-}" ]]; then
 	TMPDIR="${TMPDIR:-"/tmp"}"
@@ -362,6 +363,16 @@ osc exec -p ${registry_pod} whoami | grep root
 echo "[INFO] Validating port-forward"
 osc port-forward -p ${registry_pod} 5001:5000  &> "${LOG_DIR}/port-forward.log" &
 wait_for_url_timed "http://localhost:5001/healthz" "[INFO] Docker registry says: " $((10*TIME_SEC))
+
+# Additional e2e tests can be found in hack/more-end-to-end-tests
+if [[ "$TEST_MORE" == "true" ]]; then
+    echo "[INFO] Running more e2e tests..."
+    for i in ${OS_ROOT}/hack/more-end-to-end-tests/*
+    do
+        source $i
+    done
+fi
+
 
 # UI e2e tests can be found in assets/test/e2e
 if [[ "$TEST_ASSETS" == "true" ]]; then


### PR DESCRIPTION
- Uses an TEST_MORE environment variable to run addition tests
- additional tests are expected to be found under hack/more-end-to-end-tests/ directory
- spawn a replication controller in testrc namespace using hello-openshift image
- increase the number of replicas
- check that the number of pods are increased
- decrease the number of replicas
- check that the number of pods are decreased