### PR TITLE
remove local .openshiftconfig

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -157,16 +157,9 @@ osc get services --config="${CERT_DIR}/admin/.kubeconfig"
 # test config files from env vars
 OPENSHIFTCONFIG="${CERT_DIR}/admin/.kubeconfig" osc get services
 
-# test config files in the current directory
-TEMP_PWD=`pwd` 
-pushd ${CONFIG_DIR} >/dev/null
-    cp ${CERT_DIR}/admin/.kubeconfig .openshiftconfig
-    ${TEMP_PWD}/${GO_OUT}/osc get services
-popd 
-
 # test config files in the home directory
 mkdir -p ${HOME}/.config/openshift
-mv ${CONFIG_DIR}/.openshiftconfig ${HOME}/.config/openshift/config
+mv ${CERT_DIR}/admin/.kubeconfig ${HOME}/.config/openshift/config
 osc get services
 mv ${HOME}/.config/openshift/config ${HOME}/.config/openshift/non-default-config
 echo "config files: ok"

--- a/pkg/cmd/cli/config/loader.go
+++ b/pkg/cmd/cli/config/loader.go
@@ -11,7 +11,6 @@ import (
 const (
 	OpenShiftConfigPathEnvVar      = "OPENSHIFTCONFIG"
 	OpenShiftConfigFlagName        = "config"
-	OpenShiftConfigFileName        = ".openshiftconfig"
 	OpenShiftConfigHomeDir         = ".config/openshift"
 	OpenShiftConfigHomeFileName    = "config"
 	OpenShiftConfigHomeDirFileName = OpenShiftConfigHomeDir + "/" + OpenShiftConfigHomeFileName
@@ -24,7 +23,7 @@ var RecommendedHomeFile = path.Join(os.Getenv("HOME"), OpenShiftConfigHomeDirFil
 // 1. --config value
 // 2. if OPENSHIFTCONFIG env var has a value, use it. Otherwise, ~/.config/openshift/config file
 func NewOpenShiftClientConfigLoadingRules() *clientcmd.ClientConfigLoadingRules {
-	chain := []string{OpenShiftConfigFileName}
+	chain := []string{}
 	migrationRules := map[string]string{}
 
 	envVarFile := os.Getenv(OpenShiftConfigPathEnvVar)


### PR DESCRIPTION
Removes local `.openshiftconfig` from the chain.  This should have happened before.