### PR TITLE
have osc new-project switch projects

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -123,7 +123,7 @@ if [[ "${API_SCHEME}" == "https" ]]; then
 fi
 
 # set the home directory so we don't pick up the users .config
-export HOME="${CERT_DIR}/admin"
+export HOME="${TEMP_DIR}/home"
 
 wait_for_url "${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz" "kubelet: " 0.25 80
 wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
@@ -146,10 +146,13 @@ export KUBERNETES_MASTER="${API_SCHEME}://${API_HOST}:${API_PORT}"
 if [[ "${API_SCHEME}" == "https" ]]; then
     # test bad certificate
     [ "$(osc get services 2>&1 | grep 'certificate signed by unknown authority')" ]
-
-    # ignore anything in the running user's $HOME dir
-    export HOME="${CERT_DIR}/admin"
 fi
+
+
+osc login --server=${KUBERNETES_MASTER} --certificate-authority="${CERT_DIR}/ca/cert.crt" -u test-user -p anything
+osc new-project project-foo --display-name="my project" --description="boring project description"
+[ "$(osc project | grep 'Using project "project-foo"')" ]
+
 
 # test config files from the --config flag
 osc get services --config="${CERT_DIR}/admin/.kubeconfig"

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -11,6 +11,7 @@ import (
 	kapierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	kclientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+	kcmdconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config"
 	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/cli/config"
@@ -47,8 +48,7 @@ type LoginOptions struct {
 	KeyFile     string
 	InsecureTLS bool
 
-	// Optional, if provided will only try to save in it
-	PathToSaveConfig string
+	PathOptions *kcmdconfig.PathOptions
 }
 
 const longDescription = `Logs in to the OpenShift server and saves a config file that
@@ -148,12 +148,13 @@ func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args
 	if keyFile := kcmdutil.GetFlagString(cmd, "client-key"); len(keyFile) > 0 {
 		o.KeyFile = keyFile
 	}
-	o.PathToSaveConfig = kcmdutil.GetFlagString(cmd, config.OpenShiftConfigFlagName)
 
 	o.CAFile = kcmdutil.GetFlagString(cmd, "certificate-authority")
 	o.InsecureTLS = kcmdutil.GetFlagBool(cmd, "insecure-skip-tls-verify")
 
 	o.DefaultNamespace, _ = f.OpenShiftClientConfig.Namespace()
+
+	o.PathOptions = config.NewPathOptions(cmd)
 
 	return nil
 }

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -75,7 +75,9 @@ func NewCmdLogin(f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra
 		Short: "Logs in and save the configuration",
 		Long:  longDescription,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.Complete(f, cmd, args)
+			if err := options.Complete(f, cmd, args); err != nil {
+				kcmdutil.CheckErr(err)
+			}
 
 			if err := options.Validate(args, kcmdutil.GetFlagString(cmd, "server")); err != nil {
 				kcmdutil.CheckErr(err)
@@ -118,10 +120,14 @@ func NewCmdLogin(f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra
 
 func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string) error {
 	kubeconfig, err := f.OpenShiftClientConfig.RawConfig()
-	if err != nil {
-		return err
-	}
 	o.StartingKubeConfig = &kubeconfig
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// build a valid object to use if we failed on a non-existent file
+		o.StartingKubeConfig = kclientcmdapi.NewConfig()
+	}
 
 	if serverFlag := kcmdutil.GetFlagString(cmd, "server"); len(serverFlag) > 0 {
 		o.Server = serverFlag
@@ -170,6 +176,10 @@ func (o LoginOptions) Validate(args []string, serverFlag string) error {
 
 	if (len(o.Server) == 0) && !cmdutil.IsTerminal(o.Reader) {
 		return errors.New("A server URL must be specified")
+	}
+
+	if o.StartingKubeConfig == nil {
+		return errors.New("Must have a config file already created")
 	}
 
 	return nil

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -304,25 +304,13 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 		return false, fmt.Errorf("Insufficient data to merge configuration.")
 	}
 
-	pathOptions := &kubecmdconfig.PathOptions{
-		GlobalFile:       config.RecommendedHomeFile,
-		EnvVar:           config.OpenShiftConfigPathEnvVar,
-		ExplicitFileFlag: config.OpenShiftConfigFlagName,
-
-		GlobalFileSubpath: config.OpenShiftConfigHomeDirFileName,
-
-		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
-			ExplicitPath: o.PathToSaveConfig,
-		},
-	}
-
 	globalExistedBefore := true
-	if _, err := os.Stat(pathOptions.GlobalFile); os.IsNotExist(err) {
+	if _, err := os.Stat(o.PathOptions.GlobalFile); os.IsNotExist(err) {
 		globalExistedBefore = false
 	}
 
 	newConfig := config.CreateConfig(o.Username, o.Project, o.Config)
-	baseDir := filepath.Dir(pathOptions.GetDefaultFilename())
+	baseDir := filepath.Dir(o.PathOptions.GetDefaultFilename())
 	if err := config.RelativizeClientConfigPaths(&newConfig, baseDir); err != nil {
 		return false, err
 	}
@@ -332,12 +320,12 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 		return false, err
 	}
 
-	if err := kubecmdconfig.ModifyConfig(pathOptions, *configToWrite); err != nil {
+	if err := kubecmdconfig.ModifyConfig(o.PathOptions, *configToWrite); err != nil {
 		return false, err
 	}
 
 	created := false
-	if _, err := os.Stat(pathOptions.GlobalFile); err == nil {
+	if _, err := os.Stat(o.PathOptions.GlobalFile); err == nil {
 		created = created || !globalExistedBefore
 	}
 

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -243,17 +243,11 @@ func (o *LoginOptions) gatherProjectInfo() error {
 
 	switch len(projectsItems) {
 	case 0:
-		// TODO most users will not be allowed to run the suggested commands below, so we should check it and/or
-		// have a server endpoint that allows an admin to describe to users how to request projects
-		fmt.Fprintf(o.Out, `You don't have any projects. If you have access to create a new project, run
+		fmt.Fprintf(o.Out, `You don't have any projects. You can try to create a new project, by running
 
-    $ openshift ex new-project <projectname> --admin=%q
+    $ osc new-project <projectname>
 
-To be added as an admin to an existing project, run
-
-    $ openshift ex policy add-role-to-user admin %q -n <projectname>
-
-`, o.Username, o.Username)
+`)
 
 	case 1:
 		o.Project = projectsItems[0].Name

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+
 	"github.com/openshift/origin/pkg/client"
+	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 )
@@ -18,6 +21,9 @@ type NewProjectOptions struct {
 	Description string
 
 	Client client.Interface
+
+	ProjectOptions *ProjectOptions
+	Out            io.Writer
 }
 
 const requestProjectLongDesc = `
@@ -40,22 +46,23 @@ After your project is created you can switch to it using %[3]s <project name>.
 
 func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	options := &NewProjectOptions{}
+	options.Out = out
 
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s <project-name> [--display-name=<your display name> --description=<your description]", name),
 		Short: "request a new project",
 		Long:  fmt.Sprintf(requestProjectLongDesc, fullName, oscLoginName, oscProjectName),
 		Run: func(cmd *cobra.Command, args []string) {
-			if !options.complete(cmd) {
-				return
+			if err := options.complete(cmd, f); err != nil {
+				kcmdutil.CheckErr(err)
 			}
 
 			var err error
 			if options.Client, _, err = f.Clients(); err != nil {
-				glog.Fatalf("Error getting client: %v", err)
+				kcmdutil.CheckErr(err)
 			}
 			if err := options.Run(); err != nil {
-				glog.Fatal(err)
+				kcmdutil.CheckErr(err)
 			}
 		},
 	}
@@ -67,16 +74,22 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 	return cmd
 }
 
-func (o *NewProjectOptions) complete(cmd *cobra.Command) bool {
+func (o *NewProjectOptions) complete(cmd *cobra.Command, f *clientcmd.Factory) error {
 	args := cmd.Flags().Args()
 	if len(args) != 1 {
 		cmd.Help()
-		return false
+		return errors.New("must have exactly one argument")
 	}
 
 	o.ProjectName = args[0]
 
-	return true
+	o.ProjectOptions = &ProjectOptions{}
+	o.ProjectOptions.PathOptions = cliconfig.NewPathOptions(cmd)
+	if err := o.ProjectOptions.Complete(f, []string{""}, o.Out); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (o *NewProjectOptions) Run() error {
@@ -85,8 +98,19 @@ func (o *NewProjectOptions) Run() error {
 	projectRequest.DisplayName = o.DisplayName
 	projectRequest.Annotations = make(map[string]string)
 	projectRequest.Annotations["description"] = o.Description
-	if _, err := o.Client.ProjectRequests().Create(projectRequest); err != nil {
+
+	project, err := o.Client.ProjectRequests().Create(projectRequest)
+	if err != nil {
 		return err
+	}
+
+	if o.ProjectOptions != nil {
+		o.ProjectOptions.ProjectName = project.Name
+		o.ProjectOptions.ProjectOnly = true
+
+		if err := o.ProjectOptions.RunProject(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/cli/config/loader.go
+++ b/pkg/cmd/cli/config/loader.go
@@ -5,7 +5,12 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	kclientcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	kubecmdconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config"
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 )
 
 const (
@@ -37,5 +42,18 @@ func NewOpenShiftClientConfigLoadingRules() *clientcmd.ClientConfigLoadingRules 
 	return &clientcmd.ClientConfigLoadingRules{
 		Precedence:     chain,
 		MigrationRules: migrationRules,
+	}
+}
+
+func NewPathOptions(cmd *cobra.Command) *kubecmdconfig.PathOptions {
+	return &kubecmdconfig.PathOptions{
+		GlobalFile: path.Join(os.Getenv("HOME"), OpenShiftConfigHomeDirFileName),
+
+		EnvVar:           OpenShiftConfigPathEnvVar,
+		ExplicitFileFlag: OpenShiftConfigFlagName,
+
+		LoadingRules: &kclientcmd.ClientConfigLoadingRules{
+			ExplicitPath: cmdutil.GetFlagString(cmd, OpenShiftConfigFlagName),
+		},
 	}
 }

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -50,6 +51,7 @@ func TestUnprivilegedNewProject(t *testing.T) {
 		Description: "the special description",
 
 		Client: valerieOpenshiftClient,
+		Out:    ioutil.Discard,
 	}
 
 	if err := requestProject.Run(); err != nil {


### PR DESCRIPTION
When requesting a new project, it's natural to want that project added to your `openshiftconfig` and want have it selected.  This adds that functionality and fixes a message in `osc login` about requesting a project.

@smarterclayton functionality you requested.  @fabianofranz is out today, so I thought you might want to review.