### PR TITLE
sample template messed up with v1beta3

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -183,7 +183,7 @@ This section covers how to perform all the steps of building, deploying, and upd
 
 8. Confirm the registry is accessible (you may need to run this more than once):
 
-        $ curl `osc get service docker-registry --template="{{ .portalIP }}:{{ .port }}"`
+        $ curl `osc get service docker-registry --template="{{ .spec.portalIP }}:{{ with index .spec.ports 0 }}{{ .port }}{{ end }}"`
 
     You should see:
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -271,7 +271,7 @@ echo "[INFO] Waiting for Docker registry pod to start"
 wait_for_command '[[ "$(osc get endpoints docker-registry --output-version=v1beta1 -t "{{ if .endpoints }}{{ len .endpoints }}{{ else }}0{{ end }}" || echo "0")" != "0" ]]' $((5*TIME_MIN))
 
 # services can end up on any IP.	Make sure we get the IP we need for the docker registry
-DOCKER_REGISTRY=$(osc get --output-version=v1beta1 --template="{{ .portalIP }}:{{ .port }}" service docker-registry)
+DOCKER_REGISTRY=$(osc get --output-version=v1beta3 --template="{{ .spec.portalIP }}:{{ with index .spec.ports 0 }}{{ .port }}{{ end }}" service docker-registry)
 
 echo "[INFO] Verifying the docker-registry is up at ${DOCKER_REGISTRY}"
 wait_for_url_timed "http://${DOCKER_REGISTRY}" "[INFO] Docker registry says: " $((2*TIME_MIN))


### PR DESCRIPTION
This got messed up with the change to v1beta3.  Other places "fixed" it by pinning the api version to v1beta1, but it seems like we'd want our sample to be demonstrating the latest levels working.

@bparees ptal