### PR TITLE
prevent slashes in object names

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -43,6 +43,7 @@ func ValidateObject(obj runtime.Object) (errors []error) {
 		errors = validation.ValidateMinion(t)
 
 	case *imageapi.Image:
+		t.Namespace = ""
 		errors = imagev.ValidateImage(t)
 	case *imageapi.ImageRepository:
 		s := &imageapi.ImageStream{}

--- a/pkg/image/api/validation/validation_test.go
+++ b/pkg/image/api/validation/validation_test.go
@@ -36,6 +36,11 @@ func TestValidateImageMissingFields(t *testing.T) {
 			fielderrors.ValidationErrorTypeInvalid,
 			"metadata.name",
 		},
+		"no percent in Name": {
+			api.Image{ObjectMeta: kapi.ObjectMeta{Name: "foo%%bar"}},
+			fielderrors.ValidationErrorTypeInvalid,
+			"metadata.name",
+		},
 		"missing DockerImageReference": {
 			api.Image{ObjectMeta: kapi.ObjectMeta{Name: "foo"}},
 			fielderrors.ValidationErrorTypeRequired,
@@ -186,6 +191,20 @@ func TestValidateImageStream(t *testing.T) {
 			name:      "",
 			expected: fielderrors.ValidationErrorList{
 				fielderrors.NewFieldRequired("metadata.name"),
+			},
+		},
+		"no slash in Name": {
+			namespace: "foo",
+			name:      "foo/bar",
+			expected: fielderrors.ValidationErrorList{
+				fielderrors.NewFieldInvalid("metadata.name", "foo/bar", `may not contain "/"`),
+			},
+		},
+		"no percent in Name": {
+			namespace: "foo",
+			name:      "foo%%bar",
+			expected: fielderrors.ValidationErrorList{
+				fielderrors.NewFieldInvalid("metadata.name", "foo%%bar", `may not contain "%"`),
 			},
 		},
 		"missing namespace": {

--- a/pkg/image/api/validation/validation_test.go
+++ b/pkg/image/api/validation/validation_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestValidateImageOK(t *testing.T) {
 	errs := ValidateImage(&api.Image{
-		ObjectMeta:           kapi.ObjectMeta{Name: "foo", Namespace: "default"},
+		ObjectMeta:           kapi.ObjectMeta{Name: "foo"},
 		DockerImageReference: "openshift/ruby-19-centos",
 	})
 	if len(errs) > 0 {
@@ -29,7 +29,12 @@ func TestValidateImageMissingFields(t *testing.T) {
 		"missing Name": {
 			api.Image{DockerImageReference: "ref"},
 			fielderrors.ValidationErrorTypeRequired,
-			"name",
+			"metadata.name",
+		},
+		"no slash in Name": {
+			api.Image{ObjectMeta: kapi.ObjectMeta{Name: "foo/bar"}},
+			fielderrors.ValidationErrorTypeInvalid,
+			"metadata.name",
 		},
 		"missing DockerImageReference": {
 			api.Image{ObjectMeta: kapi.ObjectMeta{Name: "foo"}},
@@ -122,14 +127,11 @@ func TestValidateImageStreamMappingNotOK(t *testing.T) {
 				DockerImageRepository: "openshift/ruby-19-centos",
 				Tag: "latest",
 				Image: api.Image{
-					ObjectMeta: kapi.ObjectMeta{
-						Namespace: "default",
-					},
 					DockerImageReference: "openshift/ruby-19-centos",
 				},
 			},
 			fielderrors.ValidationErrorTypeRequired,
-			"image.name",
+			"image.metadata.name",
 		},
 		"invalid repository pull spec": {
 			api.ImageStreamMapping{
@@ -183,21 +185,21 @@ func TestValidateImageStream(t *testing.T) {
 			namespace: "foo",
 			name:      "",
 			expected: fielderrors.ValidationErrorList{
-				fielderrors.NewFieldRequired("name"),
+				fielderrors.NewFieldRequired("metadata.name"),
 			},
 		},
 		"missing namespace": {
 			namespace: "",
 			name:      "foo",
 			expected: fielderrors.ValidationErrorList{
-				fielderrors.NewFieldInvalid("namespace", "", ""),
+				fielderrors.NewFieldRequired("metadata.namespace"),
 			},
 		},
 		"invalid namespace": {
 			namespace: "!$",
 			name:      "foo",
 			expected: fielderrors.ValidationErrorList{
-				fielderrors.NewFieldInvalid("namespace", "!$", ""),
+				fielderrors.NewFieldInvalid("metadata.namespace", "!$", `must have at most 253 characters and match regex [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`),
 			},
 		},
 		"invalid dockerImageRepository": {

--- a/pkg/image/registry/imagerepositorymapping/rest_test.go
+++ b/pkg/image/registry/imagerepositorymapping/rest_test.go
@@ -356,8 +356,7 @@ func TestAddExistingImageWithNewTag(t *testing.T) {
 
 	existingImage := &api.Image{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      imageID,
-			Namespace: "default",
+			Name: imageID,
 		},
 		DockerImageReference: "localhost:5000/someproject/somerepo:" + imageID,
 		DockerImageMetadata: api.DockerImage{
@@ -483,8 +482,7 @@ func TestAddExistingImageAndTag(t *testing.T) {
 
 	existingImage := &api.Image{
 		ObjectMeta: kapi.ObjectMeta{
-			Name:      "existingImage",
-			Namespace: "default",
+			Name: "existingImage",
 		},
 		DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
 		DockerImageMetadata: api.DockerImage{


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/1844
Upstream: https://github.com/GoogleCloudPlatform/kubernetes/pull/7129

Added code in kube to prevent bad API object names.  Updated lots of image validation code to validate object meta fields and properly validate namespaced versus non-namespaced resources.

@ncdc review please?
@sosiouxme fyi