### PR TITLE
enable stats listener for haproxy

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -23,6 +23,14 @@ defaults
   # Long timeout for WebSocket connections.
   timeout tunnel 1h
 
+listen stats :1936
+    mode http
+    stats enable
+    stats hide-version
+    stats realm Haproxy\ Statistics
+    stats uri /
+    stats auth admin:cEVu2hUb
+
 frontend public
   bind :80
   mode http

--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -74,7 +74,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 		ImageTemplate: variable.NewDefaultImageTemplate(),
 
 		Labels:   defaultLabel,
-		Ports:    "80:80,443:443",
+		Ports:    "80:80,443:443,1936:1936",
 		Replicas: 1,
 	}
 


### PR DESCRIPTION
@rajatchopra @smarterclayton - this exposes the haproxy stats on :1936 with basic auth of admin:password.  When https://github.com/openshift/origin/pull/1779 goes in I can refactor to allow you to pass a password through the `openshift ex router` command since I'll have the wrapper object required to pass additional config to the template.  Good/bad?


/cc @thoraxe - Erik if this is something you needed for a demo (and this isn't merged) you can mod the template as shown below and create the router like this: https://gist.github.com/pweil-/c8bb245a0b4126e7b348