### PR TITLE
make test-integration.sh allow single test

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -82,5 +82,5 @@ export childargs
 
 # run each test as its own process
 pushd "./${package}" 2>&1 >/dev/null
-time go run "${OS_ROOT}/hack/listtests.go" -prefix="${OS_GO_PACKAGE}/${package}.Test" "${testdir}" | xargs -I {} -n 1 bash -c "exectest {} ${@:1}" # "${testexec}" -test.run="^{}$" "${@:1}"
+time go run "${OS_ROOT}/hack/listtests.go" -prefix="${OS_GO_PACKAGE}/${package}.Test" "${testdir}" | grep -E "${1-Test}" | xargs -I {} -n 1 bash -c "exectest {} ${@:2}" # "${testexec}" -test.run="^{}$" "${@:2}"
 popd 2>&1 >/dev/null

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -234,6 +234,7 @@ function start_etcd {
 
   wait_for_url "http://${host}:${port}/version" "etcd: " 0.25 80
   curl -X PUT  "http://${host}:${port}/v2/keys/_test"
+  echo
 }
 
 # stop_openshift_server utility function to terminate an


### PR DESCRIPTION
Allows 
```
hack/test-integration.sh "TestAuthenticatedUsersAgainstOpenshiftNamespace TestBuildConfigClient TestCreateBuild"
```
To run just those three tests.

@bparees you made it annoy  me more.