### PR TITLE
Add initial events for deployment failures

### DIFF
--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -76,6 +76,7 @@ func TestDeploymentConfigDescriber(t *testing.T) {
 	config := deployapitest.OkDeploymentConfig(1)
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	podList := &kapi.PodList{}
+	eventList := &kapi.EventList{}
 
 	d := &DeploymentConfigDescriber{
 		client: &genericDeploymentDescriberClient{
@@ -87,6 +88,9 @@ func TestDeploymentConfigDescriber(t *testing.T) {
 			},
 			listPodsFunc: func(namespace string, selector labels.Selector) (*kapi.PodList, error) {
 				return podList, nil
+			},
+			listEventsFunc: func(deploymentConfig *deployapi.DeploymentConfig) (*kapi.EventList, error) {
+				return eventList, nil
 			},
 		},
 	}

--- a/pkg/deploy/controller/deployment/controller_test.go
+++ b/pkg/deploy/controller/deployment/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 
 	api "github.com/openshift/origin/pkg/api/latest"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -41,6 +42,7 @@ func TestHandle_createPodOk(t *testing.T) {
 		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
 			return expectedContainer, nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	// Verify new -> pending
@@ -124,6 +126,7 @@ func TestHandle_makeContainerFail(t *testing.T) {
 		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
 			return nil, fmt.Errorf("couldn't make container")
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	config := deploytest.OkDeploymentConfig(1)
@@ -163,6 +166,7 @@ func TestHandle_createPodFail(t *testing.T) {
 		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
 			return okContainer(), nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	config := deploytest.OkDeploymentConfig(1)
@@ -201,6 +205,7 @@ func TestHandle_createPodAlreadyExists(t *testing.T) {
 		makeContainer: func(strategy *deployapi.DeploymentStrategy) (*kapi.Container, error) {
 			return okContainer(), nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	// Verify no-op
@@ -238,6 +243,7 @@ func TestHandle_noop(t *testing.T) {
 			t.Fatalf("unexpected call to make container")
 			return nil, nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	// Verify no-op
@@ -291,6 +297,7 @@ func TestHandle_cleanupPodOk(t *testing.T) {
 			t.Fatalf("unexpected call to make container")
 			return nil, nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	// Verify successful cleanup
@@ -339,6 +346,7 @@ func TestHandle_cleanupPodNoop(t *testing.T) {
 			t.Fatalf("unexpected call to make container")
 			return nil, nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	// Verify no-op
@@ -379,6 +387,7 @@ func TestHandle_cleanupPodFail(t *testing.T) {
 			t.Fatalf("unexpected call to make container")
 			return nil, nil
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	// Verify error

--- a/pkg/deploy/controller/deploymentconfig/controller_test.go
+++ b/pkg/deploy/controller/deploymentconfig/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 
 	api "github.com/openshift/origin/pkg/api/latest"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -30,6 +31,7 @@ func TestHandle_initialOk(t *testing.T) {
 				return nil, nil
 			},
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	err := controller.Handle(deploytest.OkDeploymentConfig(0))
@@ -58,6 +60,7 @@ func TestHandle_updateOk(t *testing.T) {
 				return deployment, nil
 			},
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	err := controller.Handle(deploymentConfig)
@@ -142,6 +145,7 @@ func TestHandle_nonfatalCreateError(t *testing.T) {
 				return nil, kerrors.NewInternalError(fmt.Errorf("test error"))
 			},
 		},
+		recorder: &record.FakeRecorder{},
 	}
 
 	err := configController.Handle(deploytest.OkDeploymentConfig(1))


### PR DESCRIPTION
This PR introduces new events around deployments to let a user of the system get a sense of what is going wrong when things fail.  The most immediate failure I am protecting against is when there is lack of resources in the users project to support the activity due to insufficient quota.

A follow-on PR will let resource requirements for the deployer pod itself be set.

/cc @ironcladlou 