### PR TITLE
UPSTREAM: cobra loses arguments with same value as subcommand

### DIFF
--- a/Godeps/_workspace/src/github.com/spf13/cobra/command.go
+++ b/Godeps/_workspace/src/github.com/spf13/cobra/command.go
@@ -328,12 +328,17 @@ func stripFlags(args []string, c *Command) []string {
 	return commands
 }
 
-func argsMinusX(args []string, x string) []string {
+// argsMinusFirstX removes only the first x from args.  Otherwise, commands that look like
+// openshift admin policy add-role-to-user admin my-user, lose the admin argument (arg[4]).
+func argsMinusFirstX(args []string, x string) []string {
+	removedFirstX := false
 	newargs := []string{}
 
 	for _, y := range args {
-		if x != y {
+		if removedFirstX || (x != y) {
 			newargs = append(newargs, y)
+		} else {
+			removedFirstX = true
 		}
 	}
 	return newargs
@@ -359,7 +364,7 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 				matches := make([]*Command, 0)
 				for _, cmd := range c.commands {
 					if cmd.Name() == argsWOflags[0] || cmd.HasAlias(argsWOflags[0]) { // exact name or alias match
-						return innerfind(cmd, argsMinusX(args, argsWOflags[0]))
+						return innerfind(cmd, argsMinusFirstX(args, argsWOflags[0]))
 					} else if EnablePrefixMatching {
 						if strings.HasPrefix(cmd.Name(), argsWOflags[0]) { // prefix match
 							matches = append(matches, cmd)
@@ -374,7 +379,7 @@ func (c *Command) Find(arrs []string) (*Command, []string, error) {
 
 				// only accept a single prefix match - multiple matches would be ambiguous
 				if len(matches) == 1 {
-					return innerfind(matches[0], argsMinusX(args, argsWOflags[0]))
+					return innerfind(matches[0], argsMinusFirstX(args, argsWOflags[0]))
 				}
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/1894
Fixes: #1447
Upstream: https://github.com/spf13/cobra/pull/95

running a command like: 
```
openshift admin policy add-role-to-user admin my-user
```
where `admin` and `my-user` are arguments to the `openshift admin policy add-role-to-user` command, removes the `admin` argument (`args[4]`).

This pull stops removing more than one token from the `args` for command matches.


@fabianofranz ptal