### PR TITLE
Added support for project node selector

### DIFF
--- a/pkg/cmd/admin/project/new_project.go
+++ b/pkg/cmd/admin/project/new_project.go
@@ -20,9 +20,10 @@ import (
 const NewProjectRecommendedName = "new-project"
 
 type NewProjectOptions struct {
-	ProjectName string
-	DisplayName string
-	Description string
+	ProjectName  string
+	DisplayName  string
+	Description  string
+	NodeSelector string
 
 	Client client.Interface
 
@@ -59,6 +60,7 @@ func NewCmdNewProject(name, fullName string, f *clientcmd.Factory, out io.Writer
 	cmd.Flags().StringVar(&options.AdminUser, "admin", "", "project admin username")
 	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
 	cmd.Flags().StringVar(&options.Description, "description", "", "project description")
+	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "Restrict pods onto nodes matching given label selector")
 
 	return cmd
 }
@@ -86,6 +88,7 @@ func (o *NewProjectOptions) Run() error {
 	project.Annotations = make(map[string]string)
 	project.Annotations["description"] = o.Description
 	project.Annotations["displayName"] = o.DisplayName
+	project.Annotations["nodeSelector"] = o.NodeSelector
 	project, err := o.Client.Projects().Create(project)
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -18,9 +18,10 @@ import (
 )
 
 type NewProjectOptions struct {
-	ProjectName string
-	DisplayName string
-	Description string
+	ProjectName  string
+	DisplayName  string
+	Description  string
+	NodeSelector string
 
 	Client client.Interface
 
@@ -40,8 +41,8 @@ After your project is created you can switch to it using %[2]s <project name>.`
 	requestProject_example = `  // Create a new project with minimal information
   $ %[1]s web-team-dev
 
-  // Create a new project with a description
-  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."`
+  // Create a new project with a description and node selector
+  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team." --node-selector="env=dev"`
 )
 
 func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -49,7 +50,7 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 	options.Out = out
 
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
+		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION] [--node-selector=<label selector>]", name),
 		Short:   "Request a new project",
 		Long:    fmt.Sprintf(requestProject_long, oscLoginName, oscProjectName),
 		Example: fmt.Sprintf(requestProject_example, fullName),
@@ -71,6 +72,7 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 
 	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
 	cmd.Flags().StringVar(&options.Description, "description", "", "project description")
+	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "Restrict pods onto nodes matching given label selector")
 
 	return cmd
 }
@@ -105,6 +107,7 @@ func (o *NewProjectOptions) Run() error {
 	projectRequest.DisplayName = o.DisplayName
 	projectRequest.Annotations = make(map[string]string)
 	projectRequest.Annotations["description"] = o.Description
+	projectRequest.Annotations["nodeSelector"] = o.NodeSelector
 
 	project, err := o.Client.ProjectRequests().Create(projectRequest)
 	if err != nil {

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -451,11 +451,18 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	nodeSelector := ""
+	if len(project.ObjectMeta.Annotations) > 0 {
+		if ns, ok := project.ObjectMeta.Annotations["nodeSelector"]; ok {
+			nodeSelector = ns
+		}
+	}
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, project.ObjectMeta)
 		formatString(out, "Display Name", project.Annotations["displayName"])
 		formatString(out, "Status", project.Status.Phase)
+		formatString(out, "Node Selector", nodeSelector)
 		return nil
 	})
 }

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -89,6 +89,8 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 
 	refs = append(refs, &config.PolicyConfig.BootstrapPolicyFile)
 
+	refs = append(refs, &config.ProjectNodeSelector)
+
 	return refs
 }
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -85,6 +85,8 @@ type MasterConfig struct {
 	// PolicyConfig holds information about where to locate critical pieces of bootstrapping policy
 	PolicyConfig PolicyConfig
 
+	// ProjectNodeSelector holds default project node label selector
+	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
 	// ProjectRequestConfig holds information about how to handle new project requests
 	ProjectRequestConfig ProjectRequestConfig
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -81,6 +81,8 @@ type MasterConfig struct {
 
 	PolicyConfig PolicyConfig `json:"policyConfig"`
 
+	// ProjectNodeSelector holds default project node label selector
+	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
 	// ProjectRequestConfig holds information about how to handle new project requests
 	ProjectRequestConfig ProjectRequestConfig `json:"projectRequestConfig"`
 }

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 
 	"github.com/openshift/origin/pkg/cmd/server/api"
@@ -88,6 +89,8 @@ func ValidateMasterConfig(config *api.MasterConfig) fielderrors.ValidationErrorL
 		allErrs = append(allErrs, ValidateOAuthConfig(config.OAuthConfig).Prefix("oauthConfig")...)
 	}
 
+	allErrs = append(allErrs, ValidateProjectNodeSelector(config.ProjectNodeSelector)...)
+
 	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
 
 	allErrs = append(allErrs, ValidateProjectRequestConfig(config.ProjectRequestConfig).Prefix("projectRequestConfig")...)
@@ -103,6 +106,19 @@ func ValidateEtcdStorageConfig(config api.EtcdStorageConfig) fielderrors.Validat
 	}
 	if len(config.OpenShiftStorageVersion) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("openShiftStorageVersion"))
+	}
+
+	return allErrs
+}
+
+func ValidateProjectNodeSelector(nodeSelector string) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(nodeSelector) > 0 {
+		_, err := labels.Parse(nodeSelector)
+		if err != nil {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("projectNodeSelector", nodeSelector, "must be a valid label selector"))
+		}
 	}
 
 	return allErrs

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/namespace"
+	originscheduler "github.com/openshift/origin/pkg/scheduler"
 )
 
 const (
@@ -171,5 +172,5 @@ func (c *MasterConfig) createSchedulerConfig() (*scheduler.Config, error) {
 	}
 
 	// if the config file isn't provided, use the default provider
-	return configFactory.CreateFromProvider(factory.DefaultProvider)
+	return configFactory.CreateFromProvider(originscheduler.DefaultProvider)
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -74,6 +74,7 @@ import (
 	clientetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclient/etcd"
 	clientauthetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization/etcd"
 	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
 	projectcontroller "github.com/openshift/origin/pkg/project/controller"
 	projectproxy "github.com/openshift/origin/pkg/project/registry/project/proxy"
 	projectrequeststorage "github.com/openshift/origin/pkg/project/registry/projectrequest/delegated"
@@ -753,6 +754,12 @@ func (c *MasterConfig) RunDNSServer() {
 	cmdutil.WaitForSuccessfulDial(false, "tcp", c.Options.DNSConfig.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
 
 	glog.Infof("OpenShift DNS listening at %s", c.Options.DNSConfig.BindAddress)
+}
+
+// RunProjectCache populates project cache, used by scheduler and project admission controller.
+func (c *MasterConfig) RunProjectCache() {
+	glog.Infof("Using default project node label selector: %s", c.Options.ProjectNodeSelector)
+	projectcache.RunProjectCache(c.PrivilegedLoopbackKubernetesClient, c.Options.ProjectNodeSelector)
 }
 
 // RunBuildController starts the build sync loop for builds and buildConfig processing.

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -47,6 +47,7 @@ type MasterArgs struct {
 	KubeConnectionArgs *KubeConnectionArgs
 
 	SchedulerConfigFile string
+	ProjectNodeSelector string
 }
 
 // BindMasterArgs binds the options to the flags with prefix + default flag names
@@ -60,6 +61,7 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 
 	flags.Var(&args.NodeList, prefix+"nodes", "The hostnames of each node. This currently must be specified up front. Comma delimited list")
 	flags.Var(&args.CORSAllowedOrigins, prefix+"cors-allowed-origins", "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  CORS is enabled for localhost, 127.0.0.1, and the asset server by default.")
+	flags.StringVar(&args.ProjectNodeSelector, prefix+"project-node-selector", "", "Default node label selector for the project if not explicitly specified.")
 }
 
 // NewDefaultMasterArgs creates MasterArgs with sub-objects created and default values set.
@@ -196,6 +198,10 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		ProjectRequestConfig: configapi.ProjectRequestConfig{
 			ProjectRequestTemplate: bootstrappolicy.DefaultOpenShiftSharedResourcesNamespace + "/project-request",
 		},
+	}
+
+	if len(args.ProjectNodeSelector) > 0 {
+		config.ProjectNodeSelector = args.ProjectNodeSelector
 	}
 
 	if args.ListenArg.UseTLS() {

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -8,5 +8,8 @@ import (
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
-	_ "github.com/openshift/origin/pkg/project/admission"
+	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
+
+	// Scheduler plugins used by OpenShift
+	_ "github.com/openshift/origin/pkg/scheduler/algorithmprovider/defaults"
 )

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -308,8 +308,9 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	if err != nil {
 		return err
 	}
-	//	 must start policy caching immediately
+	// Must start policy caching immediately
 	openshiftConfig.RunPolicyCache()
+	openshiftConfig.RunProjectCache()
 
 	unprotectedInstallers := []origin.APIInstaller{}
 

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -10,18 +10,16 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
 )
 
 // TestAdmissionExists verifies you cannot create Origin content if namespace is not known
 func TestAdmissionExists(t *testing.T) {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	mockClient := &testclient.Fake{
 		Err: fmt.Errorf("DOES NOT EXIST"),
 	}
-	handler := &lifecycle{
-		client: mockClient,
-		store:  store,
-	}
+	projectcache.FakeProjectCache(mockClient, cache.NewStore(cache.MetaNamespaceKeyFunc), "")
+	handler := &lifecycle{}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Parameters: buildapi.BuildParameters{
@@ -62,10 +60,8 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store := cache.NewStore(cache.MetaNamespaceIndexFunc)
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
-	handler := &lifecycle{
-		client: mockClient,
-		store:  store,
-	}
+	projectcache.FakeProjectCache(mockClient, store, "")
+	handler := &lifecycle{}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Parameters: buildapi.BuildParameters{

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	kvalidation "github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 	"github.com/openshift/origin/pkg/project/api"
@@ -23,6 +24,7 @@ func ValidateProject(project *api.Project) fielderrors.ValidationErrorList {
 	if !validateNoNewLineOrTab(project.Annotations["displayName"]) {
 		result = append(result, fielderrors.NewFieldInvalid("displayName", project.Annotations["displayName"], "may not contain a new line or tab"))
 	}
+	result = append(result, validateNodeSelector(project)...)
 	return result
 }
 
@@ -35,6 +37,7 @@ func validateNoNewLineOrTab(s string) bool {
 func ValidateProjectUpdate(newProject *api.Project, oldProject *api.Project) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 	allErrs = append(allErrs, kvalidation.ValidateObjectMetaUpdate(&oldProject.ObjectMeta, &newProject.ObjectMeta).Prefix("metadata")...)
+	allErrs = append(allErrs, validateNodeSelector(newProject)...)
 	newProject.Spec.Finalizers = oldProject.Spec.Finalizers
 	newProject.Status = oldProject.Status
 	return allErrs
@@ -45,4 +48,17 @@ func ValidateProjectRequest(request *api.ProjectRequest) fielderrors.ValidationE
 	project.ObjectMeta = request.ObjectMeta
 
 	return ValidateProject(project)
+}
+
+func validateNodeSelector(p *api.Project) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(p.Annotations) > 0 {
+		if selector, ok := p.Annotations["nodeSelector"]; ok {
+			if _, err := labels.Parse(selector); err != nil {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("nodeSelector", p.Annotations["nodeSelector"], "must be a valid label selector"))
+			}
+		}
+	}
+	return allErrs
 }

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -97,6 +97,33 @@ func TestValidateProject(t *testing.T) {
 			// Should fail because the display name has \t \n
 			numErrs: 1,
 		},
+		{
+			name: "valid node selector",
+			project: api.Project{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "foo",
+					Namespace: "",
+					Annotations: map[string]string{
+						"nodeSelector": "infra=true, env in (prod, qa)",
+					},
+				},
+			},
+			numErrs: 0,
+		},
+		{
+			name: "invalid node selector",
+			project: api.Project{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "foo",
+					Namespace: "",
+					Annotations: map[string]string{
+						"nodeSelector": "infra:true,env",
+					},
+				},
+			},
+			// Should fail because infra:true is invalid format
+			numErrs: 1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/project/cache/cache.go
+++ b/pkg/project/cache/cache.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+)
+
+type ProjectCache struct {
+	Client              client.Interface
+	Store               cache.Store
+	DefaultNodeSelector string
+}
+
+var pcache *ProjectCache
+
+func (p *ProjectCache) GetNamespaceObject(name string) (*kapi.Namespace, error) {
+	// check for namespace in the cache
+	namespaceObj, exists, err := p.Store.Get(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      name,
+			Namespace: "",
+		},
+		Status: kapi.NamespaceStatus{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var namespace *kapi.Namespace
+	if exists {
+		namespace = namespaceObj.(*kapi.Namespace)
+	} else {
+		// Our watch maybe latent, so we make a best effort to get the object, and only fail if not found
+		namespace, err = p.Client.Namespaces().Get(name)
+		// the namespace does not exist, so prevent create and update in that namespace
+		if err != nil {
+			return nil, fmt.Errorf("Namespace %s does not exist", name)
+		}
+	}
+	return namespace, nil
+}
+
+func (p *ProjectCache) GetNodeSelector(namespace *kapi.Namespace) string {
+	selector := ""
+	if len(namespace.ObjectMeta.Annotations) > 0 {
+		if ns, ok := namespace.ObjectMeta.Annotations["nodeSelector"]; ok {
+			selector = ns
+		}
+	}
+	if len(selector) == 0 {
+		selector = p.DefaultNodeSelector
+	}
+	return selector
+}
+
+func (p *ProjectCache) GetNodeSelectorObject(namespace *kapi.Namespace) (labels.Selector, error) {
+	selector := p.GetNodeSelector(namespace)
+	if len(selector) == 0 {
+		return labels.Everything(), nil
+	} else {
+		selectorObj, err := labels.Parse(selector)
+		if err != nil {
+			return nil, err
+		}
+		return selectorObj, nil
+	}
+}
+
+func GetProjectCache() (*ProjectCache, error) {
+	if pcache == nil {
+		return nil, fmt.Errorf("project cache not initialized")
+	}
+	return pcache, nil
+}
+
+func RunProjectCache(c client.Interface, defaultNodeSelector string) {
+	if pcache != nil {
+		return
+	}
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return c.Namespaces().List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&kapi.Namespace{},
+		store,
+		0,
+	)
+	reflector.Run()
+	pcache = &ProjectCache{
+		Client:              c,
+		Store:               store,
+		DefaultNodeSelector: defaultNodeSelector,
+	}
+}
+
+// Used for testing purpose only
+func FakeProjectCache(c client.Interface, store cache.Store, defaultNodeSelector string) {
+	pcache = &ProjectCache{
+		Client:              c,
+		Store:               store,
+		DefaultNodeSelector: defaultNodeSelector,
+	}
+}

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -1,0 +1,68 @@
+// This is the default algorithm provider for the Origin scheduler.
+package defaults
+
+import (
+	kscheduler "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
+
+	"github.com/openshift/origin/pkg/scheduler"
+)
+
+func init() {
+	defaultPredicates, err := defaultPredicates()
+	if err != nil {
+		panic(err)
+	}
+	defaultPriorities, err := defaultPriorities()
+	if err != nil {
+		panic(err)
+	}
+	factory.RegisterAlgorithmProvider(scheduler.DefaultProvider, defaultPredicates, defaultPriorities)
+
+	// Register non-default origin predicates/priorities here
+	// factory.RegisterFitPredicateFactory(...)
+	// factory.RegisterPriorityConfigFactory(...)
+}
+
+func defaultPredicates() (util.StringSet, error) {
+	// Fit is determined by project node label selector query.
+	matchProjectNodeSelector := "MatchProjectNodeSelector"
+	factory.RegisterFitPredicateFactory(
+		matchProjectNodeSelector,
+		func(args factory.PluginFactoryArgs) kscheduler.FitPredicate {
+			return scheduler.NewProjectSelectorMatchPredicate(args.NodeInfo)
+		},
+	)
+
+	// Get predicates from k8s default provider.
+	// If we decide not to use all the predicates from k8s default provider,
+	// chery-pick individual predicates from <k8s>/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+	kprovider, err := factory.GetAlgorithmProvider(factory.DefaultProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	originDefaultPredicates := kprovider.FitPredicateKeys
+	// Add default origin predicates
+	originDefaultPredicates.Insert(matchProjectNodeSelector)
+
+	return originDefaultPredicates, nil
+}
+
+func defaultPriorities() (util.StringSet, error) {
+	// Get priority functions from k8s default provider.
+	// If we decide not to use all the priority functions from k8s default provider,
+	// chery-pick individual priority function from <k8s>/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+	kprovider, err := factory.GetAlgorithmProvider(factory.DefaultProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	OriginDefaultPriorities := kprovider.PriorityFunctionKeys
+	// Add default origin priority function keys
+	// OriginDefaultPriorities.Insert(...)
+
+	return OriginDefaultPriorities, nil
+}

--- a/pkg/scheduler/algorithmprovider/plugins.go
+++ b/pkg/scheduler/algorithmprovider/plugins.go
@@ -1,0 +1,6 @@
+// This package is used to register algorithm provider plugins.
+package algorithmprovider
+
+import (
+	_ "github.com/openshift/origin/pkg/scheduler/algorithmprovider/defaults"
+)

--- a/pkg/scheduler/algorithmprovider/plugins_test.go
+++ b/pkg/scheduler/algorithmprovider/plugins_test.go
@@ -1,0 +1,51 @@
+package algorithmprovider
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
+
+	"github.com/openshift/origin/pkg/scheduler"
+)
+
+var (
+	algorithmProviderNames = []string{
+		scheduler.DefaultProvider,
+	}
+)
+
+func TestDefaultConfigExists(t *testing.T) {
+	p, err := factory.GetAlgorithmProvider(scheduler.DefaultProvider)
+	if err != nil {
+		t.Errorf("error retrieving default provider: %v", err)
+	}
+	if p == nil {
+		t.Error("algorithm provider config should not be nil")
+	}
+	if len(p.FitPredicateKeys) == 0 {
+		t.Error("default algorithm provider shouldn't have 0 fit predicates")
+	}
+}
+
+func TestAlgorithmProviders(t *testing.T) {
+	for _, pn := range algorithmProviderNames {
+		p, err := factory.GetAlgorithmProvider(pn)
+		if err != nil {
+			t.Errorf("error retrieving '%s' provider: %v", pn, err)
+			break
+		}
+		if len(p.PriorityFunctionKeys) == 0 {
+			t.Errorf("%s algorithm provider shouldn't have 0 priority functions", pn)
+		}
+		for _, pf := range p.PriorityFunctionKeys.List() {
+			if !factory.IsPriorityFunctionRegistered(pf) {
+				t.Errorf("priority function %s is not registered but is used in the %s algorithm provider", pf, pn)
+			}
+		}
+		for _, fp := range p.FitPredicateKeys.List() {
+			if !factory.IsFitPredicateRegistered(fp) {
+				t.Errorf("fit predicate %s is not registered but is used in the %s algorithm provider", fp, pn)
+			}
+		}
+	}
+}

--- a/pkg/scheduler/predicates.go
+++ b/pkg/scheduler/predicates.go
@@ -1,0 +1,48 @@
+package scheduler
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	kscheduler "github.com/GoogleCloudPlatform/kubernetes/pkg/scheduler"
+
+	"github.com/openshift/origin/pkg/project/cache"
+)
+
+const (
+	DefaultProvider = "OriginDefaultProvider"
+)
+
+func NewProjectSelectorMatchPredicate(info kscheduler.NodeInfo) kscheduler.FitPredicate {
+	selector := &projectNodeSelector{
+		info: info,
+	}
+	return selector.ProjectSelectorMatches
+}
+
+type projectNodeSelector struct {
+	info kscheduler.NodeInfo
+}
+
+func (p *projectNodeSelector) ProjectSelectorMatches(pod kapi.Pod, existingPods []kapi.Pod, node string) (bool, error) {
+	minion, err := p.info.GetNodeInfo(node)
+	if err != nil {
+		return false, err
+	}
+	return ProjectMatchesNodeLabels(&pod, minion)
+}
+
+func ProjectMatchesNodeLabels(pod *kapi.Pod, node *kapi.Node) (bool, error) {
+	projects, err := cache.GetProjectCache()
+	if err != nil {
+		return false, err
+	}
+	namespace, err := projects.GetNamespaceObject(pod.ObjectMeta.Namespace)
+	if err != nil {
+		return false, err
+	}
+	selector, err := projects.GetNodeSelectorObject(namespace)
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(labels.Set(node.Labels)), nil
+}

--- a/pkg/scheduler/predicates_test.go
+++ b/pkg/scheduler/predicates_test.go
@@ -1,0 +1,90 @@
+package scheduler
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+)
+
+type FakeNodeInfo kapi.Node
+
+func (n FakeNodeInfo) GetNodeInfo(nodeName string) (*kapi.Node, error) {
+	node := kapi.Node(n)
+	return &node, nil
+}
+
+func TestPodFitsProjectSelector(t *testing.T) {
+	mockClient := &testclient.Fake{}
+	project := &kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "testProject",
+			Namespace: "",
+		},
+	}
+	projectStore := cache.NewStore(cache.MetaNamespaceIndexFunc)
+	projectStore.Add(project)
+
+	pod := kapi.Pod{ObjectMeta: kapi.ObjectMeta{Name: "testPod"}}
+	node := kapi.Node{ObjectMeta: kapi.ObjectMeta{Name: "testNode"}}
+
+	tests := []struct {
+		defaultNodeSelector string
+		projectNodeSelector string
+		nodeLabels          map[string]string
+		fits                bool
+		testName            string
+	}{
+		{
+			defaultNodeSelector: "",
+			projectNodeSelector: "",
+			nodeLabels:          map[string]string{"infra": "false"},
+			fits:                true,
+			testName:            "No node selectors",
+		},
+		{
+			defaultNodeSelector: "infra=false",
+			projectNodeSelector: "",
+			nodeLabels:          map[string]string{"infra": "false"},
+			fits:                true,
+			testName:            "Matches default node selector",
+		},
+		{
+			defaultNodeSelector: "env=test",
+			projectNodeSelector: "",
+			nodeLabels:          map[string]string{"infra": "false"},
+			fits:                false,
+			testName:            "Doesn't match default node selector",
+		},
+		{
+			defaultNodeSelector: "",
+			projectNodeSelector: "infra=false",
+			nodeLabels:          map[string]string{"infra": "false"},
+			fits:                true,
+			testName:            "Matches project node selector",
+		},
+		{
+			defaultNodeSelector: "infra=false",
+			projectNodeSelector: "env=test",
+			nodeLabels:          map[string]string{"infra": "false"},
+			fits:                false,
+			testName:            "Doesn't match project node selector",
+		},
+	}
+	for _, test := range tests {
+		node.ObjectMeta.Labels = test.nodeLabels
+		projectcache.FakeProjectCache(mockClient, projectStore, test.defaultNodeSelector)
+		project.ObjectMeta.Annotations = map[string]string{"nodeSelector": test.projectNodeSelector}
+		predicate := projectNodeSelector{FakeNodeInfo(node)}
+		fits, err := predicate.ProjectSelectorMatches(pod, []kapi.Pod{}, "machine")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if fits != test.fits {
+			t.Errorf("%s: expected: %v got %v", test.testName, test.fits, fits)
+		}
+	}
+}

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -131,7 +131,8 @@ func TestProjectIsNamespace(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "new-project",
 			Annotations: map[string]string{
-				"displayName": "Hello World",
+				"displayName":  "Hello World",
+				"nodeSelector": "env=test",
 			},
 		},
 	}
@@ -151,7 +152,9 @@ func TestProjectIsNamespace(t *testing.T) {
 	if project.Annotations["displayName"] != namespace.Annotations["displayName"] {
 		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations["displayName"], namespace.Annotations["displayName"])
 	}
-
+	if project.Annotations["nodeSelector"] != namespace.Annotations["nodeSelector"] {
+		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations["nodeSelector"], namespace.Annotations["displayname"])
+	}
 }
 
 // TestProjectMustExist verifies that content cannot be added in a project that does not exist
@@ -210,5 +213,4 @@ func TestProjectMustExist(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error on creation of a Origin resource because namespace does not exist")
 	}
-
 }


### PR DESCRIPTION
Project node selector will constrain all pods within a project
to a pool of nodes that satisfies given label selector.

 - Cluster admin can optionally specify global default project node selector.
   Either pass '--project-node-selector=[selector]' flag as command line argument 
   to openshift start or pass 'projectNodeSelector: [selector]' entry in the master config.

 - User can optionally specify node selector for the project.

   REST API: Pass node selector as annotation to the project.
   Example:
	{
	  kind: 'Project',
          Annotations: map[string]string{
            'nodeSelector': [node_label_selector]
          }
          ...
	}

   CLI: osadm new-project <name> --node-selector=[node_label_selector]
 - Any project with no node selector will use global node selector if present.