### PR TITLE
Hide ugly output from osc status --help

### DIFF
--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -16,6 +16,10 @@ const statusLongDesc = `
 Show a high level overview of the current project. Links components by their relationships.
 For more information about individual items, use the describe command (e.g. osc describe buildConfig,
 osc describe deploymentConfig, osc describe service).
+
+Examples:
+        # Show an overview of the current project
+        $ %[1]s status
 `
 
 // NewCmdStatus implements the OpenShift cli status command


### PR DESCRIPTION
The commands will output `%!(EXTRA string=osc)`, in case it deosn't have `Example:` in LongDesc. This patch will change to not show the ugly output.