### PR TITLE
Replace available loglevel by openshift

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -107,7 +107,7 @@ func NewCmdKubectl(name string) *cobra.Command {
 		if f := cmds.PersistentFlags().Lookup(flag.Name); f == nil {
 			cmds.PersistentFlags().AddFlag(flag)
 		} else {
-			glog.V(6).Infof("already registered flag %s", flag.Name)
+			glog.V(5).Infof("already registered flag %s", flag.Name)
 		}
 	})
 	cmds.AddCommand(cmd.NewCmdOptions(f, out))

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -569,7 +569,7 @@ func authenticationHandlerFilter(handler http.Handler, authenticator authenticat
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		glog.V(6).Infof("user %v -> %v", user, req.URL)
+		glog.V(5).Infof("user %v -> %v", user, req.URL)
 
 		ctx, ok := contextMapper.Get(req)
 		if !ok {


### PR DESCRIPTION
I know you set `glog.V(6)` at [pull/1310](https://github.com/openshift/origin/pull/1310/files), but it's confusing to us.

I believe we can set OpenShift's loglevel as 0-5 only.