### PR TITLE
Fix formatting in sample-app/README.md

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -137,6 +137,7 @@ This section covers how to perform all the steps of building, deploying, and upd
 
         $ osadm policy add-role-to-user view test-admin --config=openshift.local.config/master/admin.kubeconfig
 
+
 5. Login as `test-admin` using any password
 
         $ osc login --certificate-authority=openshift.local.config/master/ca.crt


### PR DESCRIPTION
We're using two empty lines between list items, and we need an empty
line preceding the command line to be properly formatted.