### PR TITLE
Handle portalIP 'None' and empty service.spec.ports

### DIFF
--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -10,19 +10,26 @@
         <div>
           <em>{{emptyMessage}}</em>
         </div>
-      </div>      
+      </div>
       <!-- TODO handle multiple services mapping to the same deploymentConfig/deployment/pod -->
       <section ng-repeat="(serviceId, service) in services">
         <div class="row">
           <div class="col-md-12">
             <div class="tile">
               <h2 class="service" ng-init="numPorts = service.spec.ports.length">{{serviceId}}
-                <span class="small"> - routing traffic on {{service.spec.portalIP}} -</span>
-                <span class="small" ng-repeat="portMapping in service.spec.ports | orderBy:port | limitTo:2">
-                  port {{portMapping.port}} &#8594; {{portMapping.targetPort}} ({{portMapping.protocol}})<span ng-if="$index < (numPorts - 1)">, </span>
+                <span class="small" ng-if="service.spec.portalIP != 'None'">
+                  - routing traffic on {{service.spec.portalIP}}
                 </span>
-                <span class="small" ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
-                  and {{numRemaining}} {{numRemaining == 1 ? "other" : "others"}}
+                <span class="small" ng-if="numPorts"> -
+                  <!-- Show only the first two ports if there are many since we don't have much space here.
+                       The full list is visible elsewhere. -->
+                  <span ng-repeat="portMapping in service.spec.ports | orderBy:port | limitTo:2">
+                    port {{portMapping.port}} &#8594; {{portMapping.targetPort}}
+                      ({{portMapping.protocol}})<span ng-if="$index < (numPorts - 1)">, </span>
+                  </span>
+                  <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
+                    and {{numRemaining}} {{numRemaining == 1 ? "other" : "others"}}
+                  </span>
                 </span>
                 <span class="connector connector-vertical" style="left: 50%; top: 31px; height: 21px;">
                   <span class="connector-endpoint connector-endpoint-top"></span>

--- a/assets/app/views/services.html
+++ b/assets/app/views/services.html
@@ -11,13 +11,18 @@
       <div style="margin-bottom: 10px;" ng-repeat="service in services">
         <h3>{{service.metadata.name}}</h3>
         <div>Created: <relative-timestamp timestamp="service.metadata.creationTimestamp"></relative-timestamp></div>
-        <div>IP: {{service.spec.portalIP}}</div>
-        <div>Ports:</div>
-        <ul>
-          <li ng-repeat="portMapping in service.spec.ports | orderBy:port">
-            {{portMapping.port}} &#8594; {{portMapping.targetPort}} ({{portMapping.protocol}})
-          </li>
-        </ul>
+        <div>IP:
+          <span ng-if="service.spec.portalIP == 'None'"><em>none</em></span>
+          <span ng-if="service.spec.portalIP != 'None'">{{service.spec.portalIP}}</span>
+        </div>
+        <div>Ports:
+          <span ng-if="!service.spec.ports.length"><em>none</em></span>
+          <ul ng-if="service.spec.ports.length">
+            <li ng-repeat="portMapping in service.spec.ports | orderBy:port">
+              {{portMapping.port}} &#8594; {{portMapping.targetPort}} ({{portMapping.protocol}})
+            </li>
+          </ul>
+        </div>
         <div>Selectors: <span ng-if="!service.spec.selector"><em>none</em></span>
             <span ng-repeat="(selectorLabel, selectorValue) in service.spec.selector"> {{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></span>
         </div>


### PR DESCRIPTION
Update the Project and Browse -> Services pages to handle portalIP value
'None' and an empty ports array in service.spec.

See also 8a2ba7058aeaa89b92f8d668a76f225c51257bc4