### PR TITLE
Fix error handling of osc project

### DIFF
--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	kapierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
@@ -45,13 +44,14 @@ func NewCmdProject(f *clientcmd.Factory, out io.Writer) *cobra.Command {
 		Long:  `Switch to another project and make it the default in your configuration.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.PathOptions = cliconfig.NewPathOptions(cmd)
-			options.Complete(f, args, out)
 
-			err := options.RunProject()
-			if err == errExit {
-				os.Exit(1)
+			if err := options.Complete(f, args, out); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
 			}
-			cmdutil.CheckErr(err)
+
+			if err := options.RunProject(); err != nil {
+				cmdutil.CheckErr(err)
+			}
 		},
 	}
 	return cmd


### PR DESCRIPTION
If you have never created project, I will see stacktrace with osc project. This patch will fix it.

You can reproduce this issue with following steps.
~~~
$ make clean ; make cmd=osc;
$ _output/local/go/bin/osc project
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x493816]

goroutine 1 [running]:
fmt.Fprintf(0x0, 0x0, 0x1b0a010, 0x47, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/lib/golang/src/fmt/print.go:189 +0xa6
github.com/openshift/origin/pkg/cmd/cli/cmd.ProjectOptions.RunProject(0x0, 0x0, 0x0, 0x0, 0x0, 0xc20811f5f0, 0xc20811f620, 0xc20811f650, 0xc20811f680, 0x0, ...)
	/ssd/patch/origin/_output/local/go/src/github.com/openshift/origin/pkg/cmd/cli/cmd/project.go:153 +0xd7d
github.com/openshift/origin/pkg/cmd/cli/cmd.func·009(0xc2080bd340, 0x2eeeca8, 0x0, 0x0)
	/ssd/patch/origin/_output/local/go/src/github.com/openshift/origin/pkg/cmd/cli/cmd/project.go:61 +0x117
github.com/spf13/cobra.(*Command).execute(0xc2080bd340, 0x2eeeca8, 0x0, 0x0, 0x0, 0x0)
	/ssd/patch/origin/Godeps/_workspace/src/github.com/spf13/cobra/command.go:447 +0x410
github.com/spf13/cobra.(*Command).Execute(0xc2080bcdc0, 0x0, 0x0)
	/ssd/patch/origin/Godeps/_workspace/src/github.com/spf13/cobra/command.go:512 +0x51b
main.main()
	/ssd/patch/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift/openshift.go:17 +0x137

goroutine 5 [syscall]:
os/signal.loop()
	/usr/lib/golang/src/os/signal/signal_unix.go:21 +0x1f
created by os/signal.init·1
	/usr/lib/golang/src/os/signal/signal_unix.go:27 +0x35

goroutine 6 [chan receive]:
github.com/golang/glog.(*loggingT).flushDaemon(0x2ee1780)
	/ssd/patch/origin/Godeps/_workspace/src/github.com/golang/glog/glog.go:879 +0x78
created by github.com/golang/glog.init·1
	/ssd/patch/origin/Godeps/_workspace/src/github.com/golang/glog/glog.go:410 +0x2a7

goroutine 33 [syscall, locked to thread]:
runtime.goexit()
	/usr/lib/golang/src/runtime/asm_amd64.s:2232 +0x1
~~~