### PR TITLE
Work around 64MB tmpfs limit

### DIFF
--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -10,8 +10,12 @@ RUN yum install -y hg golang golang-pkg-darwin golang-pkg-windows && yum clean a
 
 ENV GOPATH /go
 
+# work around 64MB tmpfs size
+ENV TMPDIR /openshifttmp
+
 # Get the code coverage tool and godep
-RUN go get code.google.com/p/go.tools/cmd/cover github.com/tools/godep github.com/golang/lint/golint
+RUN mkdir $TMPDIR && \
+    go get code.google.com/p/go.tools/cmd/cover github.com/tools/godep github.com/golang/lint/golint
 
 # Mark this as a os-build container
 RUN touch /os-build-image


### PR DESCRIPTION
Specify a different temporary directory besides /tmp because /tmp in
containers in Docker 1.6 on Fedora and RHEL 7 is only 64MB, and that's
not enough to build OpenShift.