### PR TITLE
Add resource requirements to deployment strategy

### DIFF
--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -10,6 +11,12 @@ import (
 func OkStrategy() deployapi.DeploymentStrategy {
 	return deployapi.DeploymentStrategy{
 		Type: deployapi.DeploymentStrategyTypeRecreate,
+		Resources: kapi.ResourceRequirements{
+			Limits: kapi.ResourceList{
+				kapi.ResourceName(kapi.ResourceCPU):    resource.MustParse("10"),
+				kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
+			},
+		},
 	}
 }
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -54,6 +54,8 @@ type DeploymentStrategy struct {
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty"`
+	// Compute resource requirements to execute the deployment
+	Resources kapi.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.

--- a/pkg/deploy/api/v1beta1/conversion.go
+++ b/pkg/deploy/api/v1beta1/conversion.go
@@ -1,0 +1,46 @@
+package v1beta1
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+
+	newer "github.com/openshift/origin/pkg/deploy/api"
+)
+
+func init() {
+	err := api.Scheme.AddConversionFuncs(
+		func(in *DeploymentStrategy, out *newer.DeploymentStrategy, s conversion.Scope) error {
+			if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
+			if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/deploy/api/v1beta1/conversion_test.go
+++ b/pkg/deploy/api/v1beta1/conversion_test.go
@@ -1,0 +1,21 @@
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+
+	newer "github.com/openshift/origin/pkg/deploy/api"
+)
+
+func TestStrategyRoundTrip(t *testing.T) {
+	p := DeploymentStrategy{
+		Type:      DeploymentStrategyTypeRecreate,
+		Resources: kapi.ResourceRequirements{},
+	}
+	out := &newer.DeploymentStrategy{}
+	if err := api.Scheme.Convert(&p, out); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -55,6 +55,8 @@ type DeploymentStrategy struct {
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty"`
+	// Compute resource requirements to execute the deployment
+	Resources kapi.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.

--- a/pkg/deploy/api/v1beta3/conversion.go
+++ b/pkg/deploy/api/v1beta3/conversion.go
@@ -83,6 +83,36 @@ func init() {
 			}
 			return nil
 		},
+		func(in *DeploymentStrategy, out *newer.DeploymentStrategy, s conversion.Scope) error {
+			if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *newer.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
+			if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
+				return err
+			}
+			if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+				return err
+			}
+			return nil
+		},
 		func(in *newer.DeploymentTemplate, out *DeploymentConfigSpec, s conversion.Scope) error {
 			out.Replicas = in.ControllerTemplate.Replicas
 			if in.ControllerTemplate.Selector != nil {

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -30,6 +30,8 @@ type DeploymentStrategy struct {
 	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
 	// RecreateParams are the input to the Recreate deployment strategy.
 	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty"`
+	// Compute resource requirements to execute the deployment
+	Resources kapi.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -90,6 +90,8 @@ func validateDeploymentStrategy(strategy *deployapi.DeploymentStrategy) fielderr
 		}
 	}
 
+	// TODO: validate resource requirements (prereq: https://github.com/GoogleCloudPlatform/kubernetes/pull/7059)
+
 	return errs
 }
 

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -129,11 +129,12 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 		Spec: kapi.PodSpec{
 			Containers: []kapi.Container{
 				{
-					Name:    "deployment",
-					Command: container.Command,
-					Args:    container.Args,
-					Image:   container.Image,
-					Env:     envVars,
+					Name:      "deployment",
+					Command:   container.Command,
+					Args:      container.Args,
+					Image:     container.Image,
+					Env:       envVars,
+					Resources: deploymentConfig.Template.Strategy.Resources,
 				},
 			},
 			RestartPolicy: kapi.RestartPolicyNever,

--- a/pkg/deploy/controller/deployment/controller_test.go
+++ b/pkg/deploy/controller/deployment/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 
 	api "github.com/openshift/origin/pkg/api/latest"
@@ -99,6 +100,10 @@ func TestHandle_createPodOk(t *testing.T) {
 
 	if e, a := expectedContainer.Env[0].Value, actualContainer.Env[0].Value; e != a {
 		t.Fatalf("expected container env value %s, got %s", expectedContainer.Env[0].Value, actualContainer.Env[0].Value)
+	}
+
+	if e, a := expectedContainer.Resources, actualContainer.Resources; !kapi.Semantic.DeepEqual(e, a) {
+		t.Fatalf("expected container resources %v, got %v", expectedContainer.Resources, actualContainer.Resources)
 	}
 }
 
@@ -410,6 +415,12 @@ func okContainer() *kapi.Container {
 			{
 				Name:  "env1",
 				Value: "val1",
+			},
+		},
+		Resources: kapi.ResourceRequirements{
+			Limits: kapi.ResourceList{
+				kapi.ResourceName(kapi.ResourceCPU):    resource.MustParse("10"),
+				kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
 			},
 		},
 	}


### PR DESCRIPTION
Allow user to specify resource requirements as part of deployment strategy.

In the absence of specified resource requirements, then deployment pods will get the project default resource requirements if specified.  If no project default resource requirements are enumerated, then the deployment pods will continue to get unbounded resources as they currently get prior to this change.  

If no project default resource requirements are enumerated, but a project quota is limiting cpu or memory, then the deployment will fail because it attempts to use unbounded resources.  That failure is logged as an event per an earlier PR.

/cc @ironcladlou - please take a look