### PR TITLE
doc: export OPENSHIFTCONFIG for convenience

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -130,12 +130,12 @@ This section covers how to perform all the steps of building, deploying, and upd
     to the system keys.)
 
         $ export CURL_CA_BUNDLE=`pwd`/openshift.local.config/master/ca.crt
-        $ sudo chmod a+rwX `pwd`/openshift.local.config/master/admin.kubeconfig
-
+        $ export OPENSHIFTCONFIG=`pwd`/openshift.local.config/master/admin.kubeconfig
+        $ sudo chmod a+rwX "$OPENSHIFTCONFIG"
 
 4. Bind a user names `test-admin` to the `view` role in the default namespace so you can observe progress in the web console
 
-        $ osadm policy add-role-to-user view test-admin --config=openshift.local.config/master/admin.kubeconfig
+        $ osadm policy add-role-to-user view test-admin
 
 5. Login as `test-admin` using any password
         $ osc login --certificate-authority=`pwd`/openshift.local.certificates/ca/cert.crt
@@ -155,7 +155,7 @@ This section covers how to perform all the steps of building, deploying, and upd
 7. Deploy a private docker registry within OpenShift with the certs necessary for access to master:
 
         $ sudo chmod +r ./openshift.local.config/master/openshift-registry.kubeconfig
-        $ openshift ex registry --create --credentials=./openshift.local.config/master/openshift-registry.kubeconfig --config=openshift.local.config/master/admin.kubeconfig
+        $ openshift ex registry --create --credentials=./openshift.local.config/master/openshift-registry.kubeconfig
           docker-registry # the service
           docker-registry # the deployment config
 
@@ -373,7 +373,7 @@ the ip address shown below with the correct one for your environment.
             $ docker pull openshift/origin-haproxy-router
 
             $ sudo chmod +r `pwd`/openshift.local.config/master/openshift-router.kubeconfig
-            $ openshift ex router --create --credentials="`pwd`/openshift.local.config/master/openshift-router.kubeconfig" --config=openshift.local.config/master/admin.kubeconfig
+            $ openshift ex router --create --credentials="`pwd`/openshift.local.config/master/openshift-router.kubeconfig"
               router # the service
               router # the deployment config
 


### PR DESCRIPTION
Have '--config=' param for every commands is inconvenient, and
there are several places in sample-app/README.md that missing
the '--config=' params.