### PR TITLE
bad file references due to moved config

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -58,7 +58,7 @@ In order to run the router in a deployed environment the following conditions mu
 
 To install the router pod you use the `openshift ex router` command line, passing the flags `--create` and `--credentials=<kubeconfig_file>`.
 The credentials flag controls the identity that the router will use to talk to the master (and the address of the master) so in most
-environments you can use the `${CERTS_DIR}/openshift-client/.kubeconfig` file. Once you run this command you can check the configuration
+environments you can use the `${CONFIG_DIR}/master/openshift-client.kubeconfig` file. Once you run this command you can check the configuration
 of the router by running `osc get dc router` to check the deployment status.
 
 `openshift ex router` offers other options for deploying routers - run `openshift help ex router` for more details.

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -138,7 +138,7 @@ This section covers how to perform all the steps of building, deploying, and upd
         $ osadm policy add-role-to-user view test-admin --config=openshift.local.config/master/admin.kubeconfig
 
 5. Login as `test-admin` using any password
-        $ osc login --certificate-authority=`pwd`/openshift.local.certificates/ca/cert.crt
+        $ osc login --certificate-authority=`pwd`/openshift.local.config/master/ca.crt
 
 
 6. *Optional:* View the OpenShift web console in your browser by browsing to `https://<host>:8443/console`.  Login using the user `test-admin` and any password.

--- a/hack/export-certs.sh
+++ b/hack/export-certs.sh
@@ -22,8 +22,8 @@ if [[ -z "${CERT_DIR}" ]]; then
     exit 1
 fi
 
-export CURL_CERT="${CERT_DIR}/cert.crt"
-export CURL_KEY="${CERT_DIR}/key.key"
-export CURL_CA_BUNDLE="${CERT_DIR}/../ca/cert.crt"
+export CURL_CERT="${CERT_DIR}/admin.crt"
+export CURL_KEY="${CERT_DIR}/admin.key"
+export CURL_CA_BUNDLE="${CERT_DIR}/ca.crt"
 
 set_curl_args

--- a/images/ipfailover/keepalived/README.md
+++ b/images/ipfailover/keepalived/README.md
@@ -27,12 +27,12 @@ Pre-requisites/Prep Time
    with two (_2_) replicas.
 
         $ vagrant ssh minion-1  # (or master or minion-2).
-        #  Ensure KUBECONFIG is set or else set it.
-        [ -n "$KUBECONFIG" ] ||  \
-           export KUBECONFIG=/openshift.local.certificates/admin/.kubeconfig
+        #  Ensure OPENSHIFTCONFIG is set or else set it.
+        [ -n "$OPENSHIFTCONFIG" ] ||  \
+           export OPENSHIFTCONFIG=/openshift.local.config/master/admin.kubeconfig
         #  openshift kube get dc,rc,pods,se,mi,routes
         openshift ex router arparp --create --replicas=2  \
-                                   --credentials="${KUBECONFIG}"
+                                   --credentials="${OPENSHIFTCONFIG}"
 
 
 3. Wait for the Router pods to get into running state (I'm just sitting

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -55,11 +55,11 @@ pushd /vagrant
       --node="${minion}" \
       --hostnames="${minion},${ip}" \
       --master="https://${MASTER_IP}:8443" \
-      --node-client-certificate-authority="${CERT_DIR}/ca/cert.crt" \
-      --certificate-authority="${CERT_DIR}/ca/cert.crt" \
-      --signer-cert="${CERT_DIR}/ca/cert.crt" \
-      --signer-key="${CERT_DIR}/ca/key.key" \
-      --signer-serial="${CERT_DIR}/ca/serial.txt"
+      --node-client-certificate-authority="${CERT_DIR}/ca.crt" \
+      --certificate-authority="${CERT_DIR}/ca.crt" \
+      --signer-cert="${CERT_DIR}/ca.crt" \
+      --signer-key="${CERT_DIR}/ca.key" \
+      --signer-serial="${CERT_DIR}/ca.serial.txt"
   done
 
 popd


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1215932

Some references were added and I missed them while rebasing.

@liggitt do you know how to actually run the vagrant environment locally?  I just get a big stack on `vagrant up`.

```
/home/deads/.vagrant.d/gems/gems/excon-0.42.1/lib/excon/middlewares/expects.rb:6:in `response_call': The image id '[ami-826b2eea]' does not exist (Fog::Compute::AWS::NotFound)
	from /home/deads/.vagrant.d/gems/gems/excon-0.42.1/lib/excon/middlewares/response_parser.rb:8:in `response_call'
	from /home/deads/.vagrant.d/gems/gems/excon-0.42.1/lib/excon/connection.rb:365:in `response'
	from /home/deads/.vagrant.d/gems/gems/excon-0.42.1/lib/excon/connection.rb:235:in `request'
	from /home/deads/.vagrant.d/gems/gems/fog-xml-0.1.1/lib/fog/xml/sax_parser_connection.rb:37:in `request'
	from /home/deads/.vagrant.d/gems/gems/fog-xml-0.1.1/lib/fog/xml/connection.rb:7:in `request'
	from /home/deads/.vagrant.d/gems/gems/fog-1.25.0/lib/fog/aws/compute.rb:522:in `_request'
	from /home/deads/.vagrant.d/gems/gems/fog-1.25.0/lib/fog/aws/compute.rb:517:in `request'
```