### PR TITLE
fix vagrant paths to openshift.local.config

### DIFF
--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -35,7 +35,6 @@ echo "Generating certs"
 pushd /vagrant
   SERVER_CONFIG_DIR="`pwd`/openshift.local.config"
   MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
-  NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-${minion}"
   CERT_DIR="${MASTER_CONFIG_DIR}"
 
   # Master certs
@@ -51,7 +50,7 @@ pushd /vagrant
     ip=${minion_ip_array[$i]}
 
     /usr/bin/openshift admin create-node-config \
-      --node-dir="${NODE_CONFIG_DIR}" \
+      --node-dir="${SERVER_CONFIG_DIR}/node-${minion}" \
       --node="${minion}" \
       --hostnames="${minion},${ip}" \
       --master="https://${MASTER_IP}:8443" \


### PR DESCRIPTION
Starting origin with vagrant and OPENSHIFT_DEV_CLUSTER=1 fails due to wrong paths for config files.

Fixes: 40be29beaabd097788200d8dadbf0a9e35374df7