### PR TITLE
allow templates substitution into string map keys

### DIFF
--- a/pkg/util/stringreplace/object.go
+++ b/pkg/util/stringreplace/object.go
@@ -44,7 +44,18 @@ func VisitObjectStrings(obj interface{}, visitor func(string) string) {
 			c := reflect.New(v.MapIndex(k).Type()).Elem()
 			c.Set(v.MapIndex(k))
 			visitField(c)
-			v.SetMapIndex(k, c)
+
+			// we only want to substitute key when they are string keys
+			if k.Kind() == reflect.String {
+				s := k.String()
+				VisitObjectStrings(&s, visitor)
+				newKey := reflect.ValueOf(s)
+				v.SetMapIndex(newKey, c)
+				v.SetMapIndex(k, reflect.Value{})
+
+			} else {
+				v.SetMapIndex(k, c)
+			}
 		}
 	default:
 		glog.V(5).Infof("Unknown field type '%s': %v", v.Kind(), v)

--- a/pkg/util/stringreplace/object_test.go
+++ b/pkg/util/stringreplace/object_test.go
@@ -38,7 +38,7 @@ func TestVisitObjectStringsOnStruct(t *testing.T) {
 			},
 			{
 				MapInMap: map[string]map[string]string{
-					"foo": {"bar": "sample-test"},
+					"sample-foo": {"sample-bar": "sample-test"},
 				},
 			},
 		},
@@ -64,15 +64,15 @@ func TestVisitObjectStringsOnMap(t *testing.T) {
 	samples := [][]map[string]string{
 		{
 			{"foo": "bar"},
-			{"foo": "sample-bar"},
+			{"sample-foo": "sample-bar"},
 		},
 		{
 			{"empty": ""},
-			{"empty": "sample-"},
+			{"sample-empty": "sample-"},
 		},
 		{
 			{"": "invalid"},
-			{"": "sample-invalid"},
+			{"sample-": "sample-invalid"},
 		},
 	}
 


### PR DESCRIPTION
Template processing is being done against the internal representation of the objects.  `util.StringSet` (`map[string]util.Empty`) is a common type that is used.  In order to handle that type, we need to allow substitution on map keys that are strings.

We need this capability so that we can use a template to fulfill `projectrequest` creation via a template.

@mfojtik ptal
@smarterclayton  @bparees cc