### PR TITLE
Perform template processing on external values

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient/testclient.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient/testclient.go
@@ -27,7 +27,7 @@ import (
 
 // NewSimpleFake returns a client that will respond with the provided objects
 func NewSimpleFake(objects ...runtime.Object) *Fake {
-	o := NewObjects(api.Scheme)
+	o := NewObjects(api.Scheme, api.Scheme)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient/testclient_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient/testclient_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	o := NewObjects(api.Scheme)
-	if err := AddObjectsFromPath("../../../examples/guestbook/frontend-service.json", o); err != nil {
+	o := NewObjects(api.Scheme, api.Scheme)
+	if err := AddObjectsFromPath("../../../examples/guestbook/frontend-service.json", o, api.Scheme); err != nil {
 		t.Fatal(err)
 	}
 	client := &Fake{ReactFn: ObjectReaction(o, latest.RESTMapper)}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/conversion/error.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/conversion/error.go
@@ -54,6 +54,10 @@ type missingKindErr struct {
 	data string
 }
 
+func NewMissingKindErr(data string) error {
+	return &missingKindErr{data}
+}
+
 func (k *missingKindErr) Error() string {
 	return fmt.Sprintf("Object 'Kind' is missing in '%s'", k.data)
 }
@@ -68,6 +72,10 @@ func IsMissingKind(err error) bool {
 
 type missingVersionErr struct {
 	data string
+}
+
+func NewMissingVersionErr(data string) error {
+	return &missingVersionErr{data}
 }
 
 func (k *missingVersionErr) Error() string {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/conversion/scheme.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/conversion/scheme.go
@@ -232,6 +232,17 @@ func (s *Scheme) AddDefaultingFuncs(defaultingFuncs ...interface{}) error {
 	return nil
 }
 
+// Recognizes returns true if the scheme is able to handle the provided version and kind
+// of an object.
+func (s *Scheme) Recognizes(version, kind string) bool {
+	m, ok := s.versionMap[version]
+	if !ok {
+		return false
+	}
+	_, ok = m[kind]
+	return ok
+}
+
 // RegisterInputDefaults sets the provided field mapping function and field matching
 // as the defaults for the provided input type.  The fn may be nil, in which case no
 // mapping will happen by default. Use this method to register a mechanism for handling

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
@@ -347,6 +347,12 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 		if err != nil {
 			return fn(info)
 		}
+		if errs := runtime.DecodeList(items, struct {
+			runtime.ObjectTyper
+			runtime.Decoder
+		}{v.Mapper, info.Mapping.Codec}); len(errs) > 0 {
+			return errors.NewAggregate(errs)
+		}
 		for i := range items {
 			item, err := v.InfoForObject(items[i])
 			if err != nil {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/codec.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/codec.go
@@ -21,8 +21,8 @@ import (
 )
 
 // CodecFor returns a Codec that invokes Encode with the provided version.
-func CodecFor(scheme *Scheme, version string) Codec {
-	return &codecWrapper{scheme, version}
+func CodecFor(codec ObjectCodec, version string) Codec {
+	return &codecWrapper{codec, version}
 }
 
 // yamlCodec converts YAML passed to the Decoder methods to JSON.
@@ -69,11 +69,11 @@ func EncodeOrDie(codec Codec, obj Object) string {
 // codecWrapper implements encoding to an alternative
 // default version for a scheme.
 type codecWrapper struct {
-	*Scheme
+	ObjectCodec
 	version string
 }
 
 // Encode implements Codec
 func (c *codecWrapper) Encode(obj Object) ([]byte, error) {
-	return c.Scheme.EncodeToVersion(obj, c.version)
+	return c.EncodeToVersion(obj, c.version)
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/interfaces.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/interfaces.go
@@ -16,6 +16,24 @@ limitations under the License.
 
 package runtime
 
+// ObjectScheme represents common conversions between formal external API versions
+// and the internal Go structs. ObjectScheme is typically used with ObjectCodec to
+// transform internal Go structs into serialized versions. There may be many valid
+// ObjectCodecs for each ObjectScheme.
+type ObjectScheme interface {
+	ObjectConvertor
+	ObjectTyper
+	ObjectCreater
+	ObjectCopier
+}
+
+// ObjectCodec represents the common mechanisms for converting to and from a particular
+// binary representation of an object.
+type ObjectCodec interface {
+	ObjectEncoder
+	Decoder
+}
+
 // Decoder defines methods for deserializing API objects into a given type
 type Decoder interface {
 	Decode(data []byte) (Object, error)
@@ -33,6 +51,22 @@ type Codec interface {
 	Encoder
 }
 
+// ObjectCopier duplicates an object.
+type ObjectCopier interface {
+	// Copy returns an exact copy of the provided Object, or an error if the
+	// copy could not be completed.
+	Copy(Object) (Object, error)
+}
+
+// ObjectEncoder turns an object into a byte array. This interface is a
+// general form of the Encoder interface
+type ObjectEncoder interface {
+	// EncodeToVersion convert and serializes an object in the internal format
+	// to a specified output version. An error is returned if the object
+	// cannot be converted for any reason.
+	EncodeToVersion(obj Object, outVersion string) ([]byte, error)
+}
+
 // ObjectConvertor converts an object to a different version.
 type ObjectConvertor interface {
 	Convert(in, out interface{}) error
@@ -43,13 +77,36 @@ type ObjectConvertor interface {
 // ObjectTyper contains methods for extracting the APIVersion and Kind
 // of objects.
 type ObjectTyper interface {
+	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// if another problem is detected. In many cases this method can be as expensive to
+	// invoke as the Decode method.
 	DataVersionAndKind([]byte) (version, kind string, err error)
+	// ObjectVersionAndKind returns the version and kind of the provided object, or an
+	// error if the object is not recognized (IsNotRegisteredError will return true).
 	ObjectVersionAndKind(Object) (version, kind string, err error)
+	// Recognizes returns true if the scheme is able to handle the provided version and kind,
+	// or more precisely that the provided version is a possible conversion or decoding
+	// target.
+	Recognizes(version, kind string) bool
 }
 
 // ObjectCreater contains methods for instantiating an object by kind and version.
 type ObjectCreater interface {
 	New(version, kind string) (out Object, err error)
+}
+
+// ObjectDecoder is a convenience interface for identifying serialized versions of objects
+// and transforming them into Objects. It intentionally overlaps with ObjectTyper and
+// Decoder for use in decode only paths.
+type ObjectDecoder interface {
+	Decoder
+	// DataVersionAndKind returns the version and kind of the provided data, or an error
+	// if another problem is detected. In many cases this method can be as expensive to
+	// invoke as the Decode method.
+	DataVersionAndKind([]byte) (version, kind string, err error)
+	// Recognizes returns true if the scheme is able to handle the provided version and kind
+	// of an object.
+	Recognizes(version, kind string) bool
 }
 
 // ResourceVersioner provides methods for setting and retrieving

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/types.go
@@ -116,3 +116,17 @@ type Unknown struct {
 }
 
 func (*Unknown) IsAnAPIObject() {}
+
+// Unstructured allows objects that do not have Golang structs registered to be manipulated
+// generically. This can be used to deal with the API objects from a plug-in. Unstructured
+// objects still have functioning TypeMeta features-- kind, version, etc.
+// TODO: Make this object have easy access to field based accessors and settors for
+// metadata and field mutatation.
+type Unstructured struct {
+	TypeMeta `json:",inline"`
+	// Object is a JSON compatible map with string, float, int, []interface{}, or map[string]interface{}
+	// children.
+	Object map[string]interface{}
+}
+
+func (*Unstructured) IsAnAPIObject() {}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/unstructured.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/unstructured.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+)
+
+// UnstructuredJSONScheme is capable of converting JSON data into the Unstructured
+// type, which can be used for generic access to objects without a predefined scheme.
+var UnstructuredJSONScheme ObjectDecoder = unstructuredJSONScheme{}
+
+type unstructuredJSONScheme struct{}
+
+// Recognizes returns true for any version or kind that is specified (internal
+// versions are specifically excluded).
+func (unstructuredJSONScheme) Recognizes(version, kind string) bool {
+	return len(version) > 0 && len(kind) > 0
+}
+
+func (s unstructuredJSONScheme) Decode(data []byte) (Object, error) {
+	unstruct := &Unstructured{}
+	if err := s.DecodeInto(data, unstruct); err != nil {
+		return nil, err
+	}
+	return unstruct, nil
+}
+
+func (unstructuredJSONScheme) DecodeInto(data []byte, obj Object) error {
+	unstruct, ok := obj.(*Unstructured)
+	if !ok {
+		return fmt.Errorf("the unstructured JSON scheme does not recognize %v", reflect.TypeOf(obj))
+	}
+
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	if v, ok := m["kind"]; ok {
+		if s, ok := v.(string); ok {
+			unstruct.Kind = s
+		}
+	}
+	if v, ok := m["apiVersion"]; ok {
+		if s, ok := v.(string); ok {
+			unstruct.APIVersion = s
+		}
+	}
+	if len(unstruct.APIVersion) == 0 {
+		return conversion.NewMissingVersionErr(string(data))
+	}
+	if len(unstruct.Kind) == 0 {
+		return conversion.NewMissingKindErr(string(data))
+	}
+	unstruct.Object = m
+	return nil
+}
+
+func (unstructuredJSONScheme) DataVersionAndKind(data []byte) (version, kind string, err error) {
+	obj := TypeMeta{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", "", err
+	}
+	if len(obj.APIVersion) == 0 {
+		return "", "", conversion.NewMissingVersionErr(string(data))
+	}
+	if len(obj.Kind) == 0 {
+		return "", "", conversion.NewMissingKindErr(string(data))
+	}
+	return obj.APIVersion, obj.Kind, nil
+}

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -79,6 +79,7 @@ func ValidateObject(obj runtime.Object) (errors []error) {
 		errors = templatev.ValidateTemplate(t)
 	default:
 		if list, err := runtime.ExtractList(obj); err == nil {
+			runtime.DecodeList(list, kapi.Scheme)
 			for i := range list {
 				errs := ValidateObject(list[i])
 				errors = append(errors, errs...)

--- a/pkg/client/testclient/testclient_test.go
+++ b/pkg/client/testclient/testclient_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	o := testclient.NewObjects(kapi.Scheme)
-	if err := testclient.AddObjectsFromPath("../../../test/integration/fixtures/test-deployment-config.json", o); err != nil {
+	o := testclient.NewObjects(kapi.Scheme, kapi.Scheme)
+	if err := testclient.AddObjectsFromPath("../../../test/integration/fixtures/test-deployment-config.json", o, kapi.Scheme); err != nil {
 		t.Fatal(err)
 	}
 	osc, _ := NewFixtureClients(o)
@@ -37,7 +37,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
-	o := testclient.NewObjects(kapi.Scheme)
+	o := testclient.NewObjects(kapi.Scheme, kapi.Scheme)
 	o.Add(&kapi.List{
 		Items: []runtime.Object{
 			&(errors.NewNotFound("DeploymentConfigList", "").(*errors.StatusError).ErrStatus),

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -148,9 +148,9 @@ func TestProjectStatus(t *testing.T) {
 			}
 			return time.Now()
 		}
-		o := ktestclient.NewObjects(kapi.Scheme)
+		o := ktestclient.NewObjects(kapi.Scheme, kapi.Scheme)
 		if len(test.Path) > 0 {
-			if err := ktestclient.AddObjectsFromPath(test.Path, o); err != nil {
+			if err := ktestclient.AddObjectsFromPath(test.Path, o, kapi.Scheme); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	utilerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
@@ -138,6 +139,7 @@ func OverwriteBootstrapPolicy(etcdHelper tools.EtcdHelper, masterNamespace, poli
 		if !ok {
 			return errors.New("policy must be contained in a template.  One can be created with '" + createBootstrapPolicyCommand + "'.")
 		}
+		runtime.DecodeList(template.Objects, kapi.Scheme)
 
 		for _, item := range template.Objects {
 			switch t := item.(type) {

--- a/pkg/util/stringreplace/object.go
+++ b/pkg/util/stringreplace/object.go
@@ -10,44 +10,55 @@ import (
 // visitor function on them. The visitor function can be used to modify the
 // value of the string fields.
 func VisitObjectStrings(obj interface{}, visitor func(string) string) {
-	v := reflect.ValueOf(obj).Elem()
+	visitValue(reflect.ValueOf(obj), visitor)
+}
 
-	visitField := func(val reflect.Value) {
-		switch val.Kind() {
-		case reflect.Ptr, reflect.Interface:
-			if val.CanInterface() {
-				VisitObjectStrings(val.Interface(), visitor)
-			}
-		case reflect.Struct, reflect.Map, reflect.Slice, reflect.Array:
-			if val.CanInterface() {
-				VisitObjectStrings(val.Addr().Interface(), visitor)
-			}
-		case reflect.String:
-			if !val.CanSet() {
-				glog.V(5).Infof("Unable to set String value '%v'", v)
-			}
-			val.SetString(visitor(val.String()))
-		}
-	}
-
+func visitValue(v reflect.Value, visitor func(string) string) {
 	switch v.Kind() {
+
+	case reflect.Ptr:
+		visitValue(v.Elem(), visitor)
+	case reflect.Interface:
+		visitValue(reflect.ValueOf(v.Interface()), visitor)
+
 	case reflect.Slice, reflect.Array:
-		for c := 0; c < v.Len(); c++ {
-			visitField(v.Index(c))
+		for i := 0; i < v.Len(); i++ {
+			visitValue(v.Index(i), visitor)
 		}
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
-			visitField(v.Field(i))
+			visitValue(v.Field(i), visitor)
 		}
+
 	case reflect.Map:
+		vt := v.Type().Elem()
 		for _, k := range v.MapKeys() {
-			c := reflect.New(v.MapIndex(k).Type()).Elem()
-			c.Set(v.MapIndex(k))
-			visitField(c)
-			v.SetMapIndex(k, c)
+			val := reflect.New(vt).Elem()
+			existing := v.MapIndex(k)
+			// if the map value type is interface, we must resolve it to a concrete
+			// value prior to setting it back.
+			if existing.CanInterface() {
+				existing = reflect.ValueOf(existing.Interface())
+			}
+			switch existing.Kind() {
+			case reflect.String:
+				s := visitor(existing.String())
+				val.Set(reflect.ValueOf(s))
+			default:
+				val.Set(existing)
+				visitValue(val, visitor)
+			}
+			v.SetMapIndex(k, val)
 		}
+
+	case reflect.String:
+		if !v.CanSet() {
+			glog.V(5).Infof("Unable to set String value '%v'", v)
+			return
+		}
+		v.SetString(visitor(v.String()))
+
 	default:
 		glog.V(5).Infof("Unknown field type '%s': %v", v.Kind(), v)
-		visitField(v)
 	}
 }


### PR DESCRIPTION
Templates currently perform a conversion, which populates default
values and also runs afoul of rules in conversion which may delete/alter/validate
the values we want to templatize.

This change alters the behavior of api.List to deserialize objects into
runtime.Unknown rather than performing the full conversion. It also adds
a new runtime.Unstructured type that can be manipulated directly.