### PR TITLE
Disable registry liveness probe to support v1 & v2

### DIFF
--- a/pkg/cmd/experimental/registry/registry.go
+++ b/pkg/cmd/experimental/registry/registry.go
@@ -12,7 +12,6 @@ import (
 	kclientcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
@@ -199,16 +198,19 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 									},
 								},
 								Privileged: mountHost,
-								LivenessProbe: &kapi.Probe{
-									InitialDelaySeconds: 3,
-									TimeoutSeconds:      5,
-									Handler: kapi.Handler{
-										HTTPGet: &kapi.HTTPGetAction{
-											Path: "/healthz",
-											Port: util.NewIntOrStringFromInt(5000),
+								// TODO reenable the liveness probe when we no longer support the v1 registry.
+								/*
+									LivenessProbe: &kapi.Probe{
+										InitialDelaySeconds: 3,
+										TimeoutSeconds:      5,
+										Handler: kapi.Handler{
+											HTTPGet: &kapi.HTTPGetAction{
+												Path: "/healthz",
+												Port: util.NewIntOrStringFromInt(5000),
+											},
 										},
 									},
-								},
+								*/
 							},
 						},
 						Volumes: []kapi.Volume{


### PR DESCRIPTION
Disable the liveness probe created by 'osadm registry --create' as it
isn't compatible with the old v1 registry.

Fixes bug 1216288