### PR TITLE
make remove-user predictable

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/set.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/set.go
@@ -75,6 +75,16 @@ func (s StringSet) HasAll(items ...string) bool {
 	return true
 }
 
+// HasAll returns true if any items are contained in the set.
+func (s StringSet) HasAny(items ...string) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
 // Difference returns a set of objects that are not in s2
 // For example:
 // s1 = {1, 2, 3}

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -34,4 +35,47 @@ func ExpandResources(rawResources kutil.StringSet) kutil.StringSet {
 
 func (r PolicyRule) String() string {
 	return fmt.Sprintf("PolicyRule{Verbs:%v, Resources:%v, ResourceNames:%v, Restrictions:%v}", r.Verbs.List(), r.Resources.List(), r.ResourceNames.List(), r.AttributeRestrictions)
+}
+
+func getRoleBindingValues(roleBindingMap map[string]RoleBinding) []RoleBinding {
+	ret := []RoleBinding{}
+	for _, currBinding := range roleBindingMap {
+		ret = append(ret, currBinding)
+	}
+
+	return ret
+}
+func SortRoleBindings(roleBindingMap map[string]RoleBinding, reverse bool) []RoleBinding {
+	roleBindings := getRoleBindingValues(roleBindingMap)
+	if reverse {
+		sort.Sort(sort.Reverse(RoleBindingSorter(roleBindings)))
+	} else {
+		sort.Sort(RoleBindingSorter(roleBindings))
+	}
+
+	return roleBindings
+}
+
+type PolicyBindingSorter []PolicyBinding
+
+func (s PolicyBindingSorter) Len() int {
+	return len(s)
+}
+func (s PolicyBindingSorter) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+func (s PolicyBindingSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type RoleBindingSorter []RoleBinding
+
+func (s RoleBindingSorter) Len() int {
+	return len(s)
+}
+func (s RoleBindingSorter) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+func (s RoleBindingSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
 }


### PR DESCRIPTION
This partially addresses bug https://bugzilla.redhat.com/show_bug.cgi?id=1215969 .
Upstream: https://github.com/GoogleCloudPlatform/kubernetes/pull/7509

The ordering is now predictable and with default role names, the command will succeed, but not because of correct cover calculation logic.  Consistent behavior was easy achieve, so I wanted to be sure to add it.

@fabianofranz review?