### PR TITLE
Fix not-a-function errors navigating between pages

### DIFF
--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -64,7 +64,7 @@ angular.module('openshiftConsole')
       Logger.log("buildConfigs (subscribe)", $scope.buildConfigs);
     }));
 
-    var associateRunningBuildToBuildConfig = function(buildsByBuildConfig) {
+    function associateRunningBuildToBuildConfig(buildsByBuildConfig) {
       var buildConfigBuildsInProgress = {};
       angular.forEach(buildsByBuildConfig, function(buildConfigBuilds, buildConfigName) {
         buildConfigBuildsInProgress[buildConfigName] = {};
@@ -78,7 +78,7 @@ angular.module('openshiftConsole')
       return buildConfigBuildsInProgress;
     };
 
-    var updateFilterWarning = function() {
+    function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.builds) && !$.isEmptyObject($scope.unfilteredBuilds)) {
         $scope.alerts["builds"] = {
           type: "warning",

--- a/assets/app/scripts/controllers/deployments.js
+++ b/assets/app/scripts/controllers/deployments.js
@@ -21,7 +21,7 @@ angular.module('openshiftConsole')
     $scope.emptyMessage = "Loading...";
     var watches = [];
 
-    var extractPodTemplates = function() {
+    function extractPodTemplates() {
       angular.forEach($scope.deployments, function(deployment, deploymentId){
         $scope.podTemplates[deploymentId] = deployment.spec.template;
       });
@@ -52,7 +52,7 @@ angular.module('openshiftConsole')
       Logger.log("builds (subscribe)", $scope.builds);
     }));
 
-    var updateFilterWarning = function() {
+    function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.deployments) && !$.isEmptyObject($scope.unfilteredDeployments)) {
         $scope.alerts["deployments"] = {
           type: "warning",

--- a/assets/app/scripts/controllers/images.js
+++ b/assets/app/scripts/controllers/images.js
@@ -27,7 +27,7 @@ angular.module('openshiftConsole')
       Logger.log("image streams (subscribe)", $scope.imageStreams);
     })); 
 
-    var updateFilterWarning = function() {
+    function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.imageStreams) && !$.isEmptyObject($scope.unfilteredImageStreams)) {
         $scope.alerts["imageStreams"] = {
           type: "warning",

--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -70,7 +70,7 @@ angular.module('openshiftConsole')
     }));
 
     // Expects deploymentsByServiceByDeploymentConfig to be up to date
-    var podRelationships = function() {
+    function podRelationships() {
       $scope.monopodsByService = {"": {}};
       $scope.podsByService = {};
       $scope.podsByDeployment = {};
@@ -126,7 +126,7 @@ angular.module('openshiftConsole')
     };
 
     // Filter out monopods we know we don't want to see
-    var showMonopod = function(pod) {
+    function showMonopod(pod) {
       // Hide pods in the Succeeded or Terminated phase since these are run once pods
       // that are done
       if (pod.status.phase == 'Succeeded' || pod.status.phase == 'Terminated') {
@@ -149,7 +149,7 @@ angular.module('openshiftConsole')
       return true;
     };
 
-    var deploymentConfigsByService = function() {
+    function deploymentConfigsByService() {
       $scope.deploymentConfigsByService = {"": {}};
       angular.forEach($scope.deploymentConfigs, function(deploymentConfig, depName){
         var foundMatch = false;
@@ -170,7 +170,7 @@ angular.module('openshiftConsole')
       });
     };
 
-    var deploymentsByService = function() {
+    function deploymentsByService() {
       var bySvc = $scope.deploymentsByService = {"": {}};
       var bySvcByDepCfg = $scope.deploymentsByServiceByDeploymentConfig = {"": {}};
 
@@ -244,7 +244,7 @@ angular.module('openshiftConsole')
       Logger.log("imageStreams (subscribe)", $scope.imageStreams);
     }));
 
-    var associateDeploymentConfigTriggersToBuild = function(deploymentConfig, build) {
+    function associateDeploymentConfigTriggersToBuild(deploymentConfig, build) {
       // Make sure we have both a deploymentConfig and a build
       if (!deploymentConfig || !build) {
         return;
@@ -322,7 +322,7 @@ angular.module('openshiftConsole')
       Logger.log("builds (subscribe)", $scope.builds);
     }));
 
-    var updateFilterWarning = function() {
+    function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.services) && !$.isEmptyObject($scope.unfilteredServices)) {
         $scope.alerts["services"] = {
           type: "warning",

--- a/assets/app/scripts/controllers/pods.js
+++ b/assets/app/scripts/controllers/pods.js
@@ -44,7 +44,7 @@ angular.module('openshiftConsole')
       Logger.log("builds (subscribe)", $scope.builds);
     }));
 
-    var updateFilterWarning = function() {
+    function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.pods) && !$.isEmptyObject($scope.unfilteredPods)) {
         $scope.alerts["pods"] = {
           type: "warning",

--- a/assets/app/scripts/controllers/services.js
+++ b/assets/app/scripts/controllers/services.js
@@ -32,7 +32,7 @@ angular.module('openshiftConsole')
         Logger.log("routes (subscribe)", $scope.routesByService);
     }));
 
-    var routesByService = function(routes) {
+    function routesByService(routes) {
         var routeMap = {};
         angular.forEach(routes, function(route, routeName){
             routeMap[route.serviceName] = routeMap[route.serviceName] || {};
@@ -41,7 +41,7 @@ angular.module('openshiftConsole')
         return routeMap;
     };
 
-    var updateFilterWarning = function() {
+    function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.services)  && !$.isEmptyObject($scope.unfilteredServices)) {
         $scope.alerts["services"] = {
           type: "warning",

--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -241,7 +241,7 @@ angular.module('openshiftConsole')
 
     // If this is a cached type (immutable types only), ignore the force parameter
     if (this._isTypeCached(type) && existingData && existingData.by('metadata.name')[name]) {
-      return existingData.by('metadata.name')[name];
+      deferred.resolve(existingData.by('metadata.name')[name]);
     }
     else if (!force && this._watchInFlight(type, context) && this._resourceVersion(type, context)) {
       var obj = existingData.by('metadata.name')[name];


### PR DESCRIPTION
In some cases, watch listeners inside controllers are called immediately
upon registration with DataService. This leads to not-a-function errors
when function expressions below haven't been evaluated. Use function
statements rather than function expressions to avoid the errors.

Fixes #1855