### PR TITLE
add logout command

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -164,6 +164,11 @@ fi
 osc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
 osc new-project project-foo --display-name="my project" --description="boring project description"
 [ "$(osc project | grep 'Using project "project-foo"')" ]
+osc logout
+[ -z "$(osc get pods | grep 'system:anonymous')" ]
+osc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
+[ "$(osc project | grep 'Using project "project-foo"')" ]
+ 
 
 
 # test config files from the --config flag

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -43,6 +43,7 @@ type Interface interface {
 	SubjectAccessReviewsNamespacer
 	TemplatesNamespacer
 	TemplateConfigsNamespacer
+	OAuthAccessTokensInterface
 }
 
 // Builds provides a REST client for Builds
@@ -190,6 +191,11 @@ func (c *Client) RootSubjectAccessReviews() SubjectAccessReviewInterface {
 	return newRootSubjectAccessReviews(c)
 }
 
+// OAuthAccessTokens provides a REST client for OAuthAccessTokens
+func (c *Client) OAuthAccessTokens() OAuthAccessTokenInterface {
+	return newOAuthAccessTokens(c)
+}
+
 // Client is an OpenShift client object
 type Client struct {
 	*kclient.RESTClient
@@ -207,6 +213,7 @@ func New(c *kclient.Config) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &Client{client}, nil
 }
 

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -139,3 +139,7 @@ func (c *Fake) RootResourceAccessReviews() ResourceAccessReviewInterface {
 func (c *Fake) SubjectAccessReviews(namespace string) SubjectAccessReviewInterface {
 	return &FakeSubjectAccessReviews{Fake: c}
 }
+
+func (c *Fake) OAuthAccessTokens() OAuthAccessTokenInterface {
+	return &FakeOAuthAccessTokens{Fake: c}
+}

--- a/pkg/client/fake_oauthaccesstoken.go
+++ b/pkg/client/fake_oauthaccesstoken.go
@@ -1,0 +1,12 @@
+package client
+
+import ()
+
+type FakeOAuthAccessTokens struct {
+	Fake *Fake
+}
+
+func (c *FakeOAuthAccessTokens) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-oauthaccesstoken", Value: name})
+	return nil
+}

--- a/pkg/client/oauthaccesstoken.go
+++ b/pkg/client/oauthaccesstoken.go
@@ -1,0 +1,27 @@
+package client
+
+import ()
+
+type OAuthAccessTokensInterface interface {
+	OAuthAccessTokens() OAuthAccessTokenInterface
+}
+
+type OAuthAccessTokenInterface interface {
+	Delete(name string) error
+}
+
+type oauthAccessTokenInterface struct {
+	r *Client
+}
+
+func newOAuthAccessTokens(c *Client) *oauthAccessTokenInterface {
+	return &oauthAccessTokenInterface{
+		r: c,
+	}
+}
+
+// Delete removes the OAuthAccessToken on server
+func (c *oauthAccessTokenInterface) Delete(name string) (err error) {
+	err = c.r.Delete().Resource("oAuthAccessTokens").Name(name).Do().Error()
+	return
+}

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -63,6 +63,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	out := os.Stdout
 
 	cmds.AddCommand(cmd.NewCmdLogin(f, in, out))
+	cmds.AddCommand(cmd.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out))
 	cmds.AddCommand(cmd.NewCmdProject(f, out))
 	cmds.AddCommand(cmd.NewCmdRequestProject("new-project", fullName+" new-project", fullName+" login", fullName+" project", f, out))
 	cmds.AddCommand(cmd.NewCmdNewApplication(fullName, f, out))

--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	kclientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+	kcmdconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/config"
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/cli/config"
+	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+type LogoutOptions struct {
+	StartingKubeConfig *kclientcmdapi.Config
+	Config             *kclient.Config
+	Out                io.Writer
+
+	PathOptions *kcmdconfig.PathOptions
+}
+
+const logoutLongDescription = `Logs out the current user by deleting the token and removing the token from the kubeconfig file.
+
+Examples:
+
+	# Logout:
+	$ %[1]s
+
+If you want to log back into the OpenShift server, try '%[2]s'.
+`
+
+// NewCmdLogout implements the OpenShift cli logout command
+func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
+	options := &LogoutOptions{
+		Out: out,
+	}
+
+	cmds := &cobra.Command{
+		Use:   name,
+		Short: "Logs out the current user.",
+		Long:  fmt.Sprintf(logoutLongDescription, fullName, oscLoginFullCommand),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Complete(f, cmd, args); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+
+			if err := options.Validate(args); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+
+			if err := options.RunLogout(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+
+		},
+	}
+
+	return cmds
+}
+
+func (o *LogoutOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string) error {
+	kubeconfig, err := f.OpenShiftClientConfig.RawConfig()
+	o.StartingKubeConfig = &kubeconfig
+	if err != nil {
+		return err
+	}
+
+	o.Config, err = f.OpenShiftClientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	o.PathOptions = config.NewPathOptions(cmd)
+
+	return nil
+}
+
+func (o LogoutOptions) Validate(args []string) error {
+	if len(args) > 0 {
+		return errors.New("No arguments are allowed")
+	}
+
+	if o.StartingKubeConfig == nil {
+		return errors.New("Must have a config file already created")
+	}
+
+	if len(o.Config.BearerToken) == 0 {
+		return errors.New("You must have a token in order to logout.")
+	}
+
+	return nil
+}
+
+func (o LogoutOptions) RunLogout() error {
+	token := o.Config.BearerToken
+
+	client, err := client.New(o.Config)
+	if err != nil {
+		return err
+	}
+
+	userInfo, err := whoAmI(client)
+	if err != nil {
+		return err
+	}
+
+	if err := client.OAuthAccessTokens().Delete(token); err != nil {
+		return err
+	}
+
+	newConfig := *o.StartingKubeConfig
+
+	for key, value := range newConfig.AuthInfos {
+		if value.Token == token {
+			value.Token = ""
+			newConfig.AuthInfos[key] = value
+			// don't break, its possible that more than one user stanza has the same token.
+		}
+	}
+
+	if err := kcmdconfig.ModifyConfig(o.PathOptions, newConfig); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "User, %v, logged out of %v\n", userInfo.Name, o.Config.Host)
+
+	return nil
+}


### PR DESCRIPTION
This adds `osc logout` to delete a token and remove the token from the kubeconfig file.  I'll make a separate pull to update `osc login` to re-use the user stanza if it finds one with the username=nick-name and no contents.

@fabianofranz review?
@smarterclayton per request