### PR TITLE
proxy global policy objects

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -460,8 +460,8 @@ osadm policy add-role-to-user admin adduser -n ui-test-project
 # Make sure project can be listed by osc (after auth cache syncs)
 sleep 2 && [ "$(osc get projects | grep 'ui-test-project')" ]
 # Make sure users got added
-[ "$(osc describe policybinding master -n ui-test-project | grep createuser)" ]
-[ "$(osc describe policybinding master -n ui-test-project | grep adduser)" ]
+[ "$(osc describe policybinding master:default -n ui-test-project | grep createuser)" ]
+[ "$(osc describe policybinding master:default -n ui-test-project | grep adduser)" ]
 echo "ui-project-commands: ok"
 
 # Test deleting and recreating a project
@@ -469,7 +469,7 @@ osadm new-project recreated-project --admin="createuser1"
 osc delete project recreated-project
 osc delete project recreated-project
 osadm new-project recreated-project --admin="createuser2"
-osc describe policybinding master -n recreated-project | grep createuser2
+osc describe policybinding master:default -n recreated-project | grep createuser2
 echo "ex new-project: ok"
 
 # Test running a router

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -83,7 +83,9 @@ var originTypes = []string{
 	"Project", "ProjectRequest",
 	"User", "Identity", "UserIdentityMapping",
 	"OAuthClient", "OAuthClientAuthorization", "OAuthAccessToken", "OAuthAuthorizeToken",
-	"Role", "RoleBinding", "Policy", "PolicyBinding", "ResourceAccessReview", "SubjectAccessReview",
+	"Role", "RoleBinding", "Policy", "PolicyBinding",
+	"ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding",
+	"ResourceAccessReview", "SubjectAccessReview",
 }
 
 // UserResources are the resource names that apply to the primary, user facing resources used by
@@ -148,6 +150,11 @@ func init() {
 		"OAuthAuthorizeToken":      true,
 		"OAuthClient":              true,
 		"OAuthClientAuthorization": true,
+
+		"ClusterRole":          true,
+		"ClusterRoleBinding":   true,
+		"ClusterPolicy":        true,
+		"ClusterPolicyBinding": true,
 	}
 
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address our resources

--- a/pkg/authorization/api/casts.go
+++ b/pkg/authorization/api/casts.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+type TypeConverter struct {
+	MasterNamespace string
+}
+
+// policies
+
+func (t TypeConverter) ToPolicyList(in *ClusterPolicyList) *PolicyList {
+	ret := &PolicyList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToPolicy(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToPolicy(in *ClusterPolicy) *Policy {
+	if in == nil {
+		return nil
+	}
+
+	ret := &Policy{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = t.MasterNamespace
+	ret.LastModified = in.LastModified
+	ret.Roles = t.ToRoleMap(in.Roles)
+
+	return ret
+}
+
+func (t TypeConverter) ToRoleMap(in map[string]ClusterRole) map[string]Role {
+	ret := map[string]Role{}
+	for key, role := range in {
+		ret[key] = *t.ToRole(&role)
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToRoleList(in *ClusterRoleList) *RoleList {
+	ret := &RoleList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToRole(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToRole(in *ClusterRole) *Role {
+	if in == nil {
+		return nil
+	}
+
+	ret := &Role{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = t.MasterNamespace
+	ret.Rules = in.Rules
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterPolicyList(in *PolicyList) *ClusterPolicyList {
+	ret := &ClusterPolicyList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToClusterPolicy(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterPolicy(in *Policy) *ClusterPolicy {
+	if in == nil {
+		return nil
+	}
+
+	ret := &ClusterPolicy{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = ""
+	ret.LastModified = in.LastModified
+	ret.Roles = t.ToClusterRoleMap(in.Roles)
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterRoleMap(in map[string]Role) map[string]ClusterRole {
+	ret := map[string]ClusterRole{}
+	for key, role := range in {
+		ret[key] = *t.ToClusterRole(&role)
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterRoleList(in *RoleList) *ClusterRoleList {
+	ret := &ClusterRoleList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToClusterRole(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterRole(in *Role) *ClusterRole {
+	if in == nil {
+		return nil
+	}
+
+	ret := &ClusterRole{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = ""
+	ret.Rules = in.Rules
+
+	return ret
+}
+
+// policy bindings
+
+func (t TypeConverter) ToPolicyBindingList(in *ClusterPolicyBindingList) *PolicyBindingList {
+	ret := &PolicyBindingList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToPolicyBinding(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToPolicyBinding(in *ClusterPolicyBinding) *PolicyBinding {
+	if in == nil {
+		return nil
+	}
+
+	ret := &PolicyBinding{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = t.MasterNamespace
+	ret.LastModified = in.LastModified
+	ret.PolicyRef = t.ToPolicyRef(in.PolicyRef)
+	ret.RoleBindings = t.ToRoleBindingMap(in.RoleBindings)
+
+	return ret
+}
+
+func (t TypeConverter) ToPolicyRef(in kapi.ObjectReference) kapi.ObjectReference {
+	ret := kapi.ObjectReference{}
+	ret.Namespace = t.MasterNamespace
+	ret.Name = in.Name
+	return ret
+}
+
+func (t TypeConverter) ToRoleBindingMap(in map[string]ClusterRoleBinding) map[string]RoleBinding {
+	ret := map[string]RoleBinding{}
+	for key, RoleBinding := range in {
+		ret[key] = *t.ToRoleBinding(&RoleBinding)
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToRoleBindingList(in *ClusterRoleBindingList) *RoleBindingList {
+	ret := &RoleBindingList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToRoleBinding(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToRoleBinding(in *ClusterRoleBinding) *RoleBinding {
+	if in == nil {
+		return nil
+	}
+
+	ret := &RoleBinding{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = t.MasterNamespace
+	ret.Users = in.Users
+	ret.Groups = in.Groups
+	ret.RoleRef = t.ToRoleRef(in.RoleRef)
+	return ret
+}
+
+func (t TypeConverter) ToRoleRef(in kapi.ObjectReference) kapi.ObjectReference {
+	ret := kapi.ObjectReference{}
+	ret.Namespace = t.MasterNamespace
+	ret.Name = in.Name
+	return ret
+}
+
+func (t TypeConverter) ToClusterPolicyBindingList(in *PolicyBindingList) *ClusterPolicyBindingList {
+	ret := &ClusterPolicyBindingList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToClusterPolicyBinding(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterPolicyBinding(in *PolicyBinding) *ClusterPolicyBinding {
+	if in == nil {
+		return nil
+	}
+
+	ret := &ClusterPolicyBinding{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = ""
+	ret.LastModified = in.LastModified
+	ret.PolicyRef = t.ToClusterPolicyRef(in.PolicyRef)
+	ret.RoleBindings = t.ToClusterRoleBindingMap(in.RoleBindings)
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterPolicyRef(in kapi.ObjectReference) kapi.ObjectReference {
+	ret := kapi.ObjectReference{}
+	ret.Namespace = ""
+	ret.Name = in.Name
+	return ret
+}
+
+func (t TypeConverter) ToClusterRoleBindingMap(in map[string]RoleBinding) map[string]ClusterRoleBinding {
+	ret := map[string]ClusterRoleBinding{}
+	for key, RoleBinding := range in {
+		ret[key] = *t.ToClusterRoleBinding(&RoleBinding)
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterRoleBindingList(in *RoleBindingList) *ClusterRoleBindingList {
+	ret := &ClusterRoleBindingList{}
+	for _, curr := range in.Items {
+		ret.Items = append(ret.Items, *t.ToClusterRoleBinding(&curr))
+	}
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterRoleBinding(in *RoleBinding) *ClusterRoleBinding {
+	if in == nil {
+		return nil
+	}
+
+	ret := &ClusterRoleBinding{}
+	ret.ObjectMeta = in.ObjectMeta
+	ret.Namespace = ""
+	ret.Users = in.Users
+	ret.Groups = in.Groups
+	ret.RoleRef = t.ToClusterRoleRef(in.RoleRef)
+
+	return ret
+}
+
+func (t TypeConverter) ToClusterRoleRef(in kapi.ObjectReference) kapi.ObjectReference {
+	ret := kapi.ObjectReference{}
+	ret.Namespace = ""
+	ret.Name = in.Name
+	return ret
+}

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -79,3 +79,7 @@ func (s RoleBindingSorter) Less(i, j int) bool {
 func (s RoleBindingSorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
+
+func GetPolicyBindingName(policyRefNamespace string) string {
+	return fmt.Sprintf("%s:%s", policyRefNamespace, PolicyName)
+}

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -20,8 +20,26 @@ func init() {
 		&RoleList{},
 
 		&IsPersonalSubjectAccessReview{},
+
+		&ClusterRole{},
+		&ClusterRoleBinding{},
+		&ClusterPolicy{},
+		&ClusterPolicyBinding{},
+		&ClusterPolicyList{},
+		&ClusterPolicyBindingList{},
+		&ClusterRoleBindingList{},
+		&ClusterRoleList{},
 	)
 }
+
+func (*ClusterRole) IsAnAPIObject()              {}
+func (*ClusterPolicy) IsAnAPIObject()            {}
+func (*ClusterPolicyBinding) IsAnAPIObject()     {}
+func (*ClusterRoleBinding) IsAnAPIObject()       {}
+func (*ClusterPolicyList) IsAnAPIObject()        {}
+func (*ClusterPolicyBindingList) IsAnAPIObject() {}
+func (*ClusterRoleBindingList) IsAnAPIObject()   {}
+func (*ClusterRoleList) IsAnAPIObject()          {}
 
 func (*Role) IsAnAPIObject()                         {}
 func (*Policy) IsAnAPIObject()                       {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -231,3 +231,86 @@ type RoleList struct {
 	kapi.ListMeta
 	Items []Role
 }
+
+// ClusterRole is a logical grouping of PolicyRules that can be referenced as a unit by ClusterRoleBindings.
+type ClusterRole struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	// Rules holds all the PolicyRules for this ClusterRole
+	Rules []PolicyRule
+}
+
+// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace.
+// It adds who information via Users and Groups and namespace information by which namespace it exists in.  ClusterRoleBindings in a given
+// namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces).
+type ClusterRoleBinding struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	// UserNames holds all the usernames directly bound to the role
+	Users kutil.StringSet
+	// GroupNames holds all the groups directly bound to the role
+	Groups kutil.StringSet
+
+	// Since Policy is a singleton, this is sufficient knowledge to locate a role
+	// ClusterRoleRefs can only reference the current namespace and the global namespace
+	// If the ClusterRoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef kapi.ObjectReference
+}
+
+// ClusterPolicy is a object that holds all the ClusterRoles for a particular namespace.  There is at most
+// one ClusterPolicy document per namespace.
+type ClusterPolicy struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	// LastModified is the last time that any part of the ClusterPolicy was created, updated, or deleted
+	LastModified kutil.Time
+
+	// Roles holds all the ClusterRoles held by this ClusterPolicy, mapped by Role.Name
+	Roles map[string]ClusterRole
+}
+
+// ClusterPolicyBinding is a object that holds all the ClusterRoleBindings for a particular namespace.  There is
+// one ClusterPolicyBinding document per referenced ClusterPolicy namespace
+type ClusterPolicyBinding struct {
+	kapi.TypeMeta
+	kapi.ObjectMeta
+
+	// LastModified is the last time that any part of the ClusterPolicyBinding was created, updated, or deleted
+	LastModified kutil.Time
+
+	// ClusterPolicyRef is a reference to the ClusterPolicy that contains all the ClusterRoles that this ClusterPolicyBinding's RoleBindings may reference
+	PolicyRef kapi.ObjectReference
+	// RoleBindings holds all the RoleBindings held by this ClusterPolicyBinding, mapped by RoleBinding.Name
+	RoleBindings map[string]ClusterRoleBinding
+}
+
+// ClusterPolicyList is a collection of ClusterPolicies
+type ClusterPolicyList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []ClusterPolicy
+}
+
+// ClusterPolicyBindingList is a collection of ClusterPolicyBindings
+type ClusterPolicyBindingList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []ClusterPolicyBinding
+}
+
+// ClusterRoleBindingList is a collection of ClusterRoleBindings
+type ClusterRoleBindingList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []ClusterRoleBinding
+}
+
+// ClusterRoleList is a collection of ClusterRoles
+type ClusterRoleList struct {
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []ClusterRole
+}

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -20,8 +20,26 @@ func init() {
 		&RoleList{},
 
 		&IsPersonalSubjectAccessReview{},
+
+		&ClusterRole{},
+		&ClusterRoleBinding{},
+		&ClusterPolicy{},
+		&ClusterPolicyBinding{},
+		&ClusterPolicyList{},
+		&ClusterPolicyBindingList{},
+		&ClusterRoleBindingList{},
+		&ClusterRoleList{},
 	)
 }
+
+func (*ClusterRole) IsAnAPIObject()              {}
+func (*ClusterPolicy) IsAnAPIObject()            {}
+func (*ClusterPolicyBinding) IsAnAPIObject()     {}
+func (*ClusterRoleBinding) IsAnAPIObject()       {}
+func (*ClusterPolicyList) IsAnAPIObject()        {}
+func (*ClusterPolicyBindingList) IsAnAPIObject() {}
+func (*ClusterRoleBindingList) IsAnAPIObject()   {}
+func (*ClusterRoleList) IsAnAPIObject()          {}
 
 func (*Role) IsAnAPIObject()                         {}
 func (*Policy) IsAnAPIObject()                       {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -187,3 +187,96 @@ type RoleList struct {
 	kapi.ListMeta `json:"metadata,omitempty"`
 	Items         []Role `json:"items"`
 }
+
+// ClusterRole is a logical grouping of PolicyRules that can be referenced as a unit by ClusterRoleBindings.
+type ClusterRole struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// Rules holds all the PolicyRules for this ClusterRole
+	Rules []PolicyRule `json:"rules"`
+}
+
+// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace.
+// It adds who information via Users and Groups and namespace information by which namespace it exists in.  ClusterRoleBindings in a given
+// namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces).
+type ClusterRoleBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// UserNames holds all the usernames directly bound to the role
+	UserNames []string `json:"userNames"`
+	// GroupNames holds all the groups directly bound to the role
+	GroupNames []string `json:"groupNames"`
+
+	// Since Policy is a singleton, this is sufficient knowledge to locate a role
+	// ClusterRoleRefs can only reference the current namespace and the global namespace
+	// If the ClusterRoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef kapi.ObjectReference `json:"roleRef"`
+}
+
+// ClusterPolicy is a object that holds all the ClusterRoles for a particular namespace.  There is at most
+// one ClusterPolicy document per namespace.
+type ClusterPolicy struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// LastModified is the last time that any part of the ClusterPolicy was created, updated, or deleted
+	LastModified kutil.Time `json:"lastModified"`
+
+	// ClusterRoles holds all the ClusterRoles held by this ClusterPolicy, mapped by ClusterRole.Name
+	Roles []NamedClusterRole `json:"roles"`
+}
+
+// ClusterPolicyBinding is a object that holds all the ClusterRoleBindings for a particular namespace.  There is
+// one ClusterPolicyBinding document per referenced ClusterPolicy namespace
+type ClusterPolicyBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// LastModified is the last time that any part of the ClusterPolicyBinding was created, updated, or deleted
+	LastModified kutil.Time `json:"lastModified"`
+
+	// PolicyRef is a reference to the ClusterPolicy that contains all the ClusterRoles that this ClusterPolicyBinding's RoleBindings may reference
+	PolicyRef kapi.ObjectReference `json:"policyRef"`
+	// RoleBindings holds all the ClusterRoleBindings held by this ClusterPolicyBinding, mapped by ClusterRoleBinding.Name
+	RoleBindings []NamedClusterRoleBinding `json:"roleBindings"`
+}
+
+type NamedClusterRole struct {
+	Name string      `json:"name"`
+	Role ClusterRole `json:"role"`
+}
+
+type NamedClusterRoleBinding struct {
+	Name        string             `json:"name"`
+	RoleBinding ClusterRoleBinding `json:"roleBinding"`
+}
+
+// ClusterPolicyList is a collection of ClusterPolicies
+type ClusterPolicyList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterPolicy `json:"items"`
+}
+
+// ClusterPolicyBindingList is a collection of ClusterPolicyBindings
+type ClusterPolicyBindingList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterPolicyBinding `json:"items"`
+}
+
+// ClusterRoleBindingList is a collection of ClusterRoleBindings
+type ClusterRoleBindingList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterRoleBinding `json:"items"`
+}
+
+// ClusterRoleList is a collection of ClusterRoles
+type ClusterRoleList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterRole `json:"items"`
+}

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -20,8 +20,26 @@ func init() {
 		&RoleList{},
 
 		&IsPersonalSubjectAccessReview{},
+
+		&ClusterRole{},
+		&ClusterRoleBinding{},
+		&ClusterPolicy{},
+		&ClusterPolicyBinding{},
+		&ClusterPolicyList{},
+		&ClusterPolicyBindingList{},
+		&ClusterRoleBindingList{},
+		&ClusterRoleList{},
 	)
 }
+
+func (*ClusterRole) IsAnAPIObject()              {}
+func (*ClusterPolicy) IsAnAPIObject()            {}
+func (*ClusterPolicyBinding) IsAnAPIObject()     {}
+func (*ClusterRoleBinding) IsAnAPIObject()       {}
+func (*ClusterPolicyList) IsAnAPIObject()        {}
+func (*ClusterPolicyBindingList) IsAnAPIObject() {}
+func (*ClusterRoleBindingList) IsAnAPIObject()   {}
+func (*ClusterRoleList) IsAnAPIObject()          {}
 
 func (*Role) IsAnAPIObject()                         {}
 func (*Policy) IsAnAPIObject()                       {}

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -187,3 +187,96 @@ type RoleList struct {
 	kapi.ListMeta `json:"metadata,omitempty"`
 	Items         []Role `json:"items"`
 }
+
+// ClusterRole is a logical grouping of PolicyRules that can be referenced as a unit by ClusterRoleBindings.
+type ClusterRole struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// Rules holds all the PolicyRules for this ClusterRole
+	Rules []PolicyRule `json:"rules"`
+}
+
+// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace.
+// It adds who information via Users and Groups and namespace information by which namespace it exists in.  ClusterRoleBindings in a given
+// namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces).
+type ClusterRoleBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// UserNames holds all the usernames directly bound to the role
+	UserNames []string `json:"userNames"`
+	// GroupNames holds all the groups directly bound to the role
+	GroupNames []string `json:"groupNames"`
+
+	// Since Policy is a singleton, this is sufficient knowledge to locate a role
+	// ClusterRoleRefs can only reference the current namespace and the global namespace
+	// If the ClusterRoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef kapi.ObjectReference `json:"roleRef"`
+}
+
+// ClusterPolicy is a object that holds all the ClusterRoles for a particular namespace.  There is at most
+// one ClusterPolicy document per namespace.
+type ClusterPolicy struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// LastModified is the last time that any part of the ClusterPolicy was created, updated, or deleted
+	LastModified kutil.Time `json:"lastModified"`
+
+	// ClusterRoles holds all the ClusterRoles held by this ClusterPolicy, mapped by ClusterRole.Name
+	Roles []NamedClusterRole `json:"roles"`
+}
+
+// ClusterPolicyBinding is a object that holds all the ClusterRoleBindings for a particular namespace.  There is
+// one ClusterPolicyBinding document per referenced ClusterPolicy namespace
+type ClusterPolicyBinding struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// LastModified is the last time that any part of the ClusterPolicyBinding was created, updated, or deleted
+	LastModified kutil.Time `json:"lastModified"`
+
+	// PolicyRef is a reference to the ClusterPolicy that contains all the ClusterRoles that this ClusterPolicyBinding's RoleBindings may reference
+	PolicyRef kapi.ObjectReference `json:"policyRef"`
+	// RoleBindings holds all the ClusterRoleBindings held by this ClusterPolicyBinding, mapped by ClusterRoleBinding.Name
+	RoleBindings []NamedClusterRoleBinding `json:"roleBindings"`
+}
+
+type NamedClusterRole struct {
+	Name string      `json:"name"`
+	Role ClusterRole `json:"role"`
+}
+
+type NamedClusterRoleBinding struct {
+	Name        string             `json:"name"`
+	RoleBinding ClusterRoleBinding `json:"roleBinding"`
+}
+
+// ClusterPolicyList is a collection of ClusterPolicies
+type ClusterPolicyList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterPolicy `json:"items"`
+}
+
+// ClusterPolicyBindingList is a collection of ClusterPolicyBindings
+type ClusterPolicyBindingList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterPolicyBinding `json:"items"`
+}
+
+// ClusterRoleBindingList is a collection of ClusterRoleBindings
+type ClusterRoleBindingList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterRoleBinding `json:"items"`
+}
+
+// ClusterRoleList is a collection of ClusterRoles
+type ClusterRoleList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterRole `json:"items"`
+}

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -42,8 +42,8 @@ func ValidatePolicyUpdate(policy *authorizationapi.Policy, oldPolicy *authorizat
 
 func PolicyBindingNameValidator(policyRefNamespace string) validation.ValidateNameFunc {
 	return func(name string, prefix bool) (bool, string) {
-		if name != policyRefNamespace {
-			return false, "name must be " + policyRefNamespace
+		if name != authorizationapi.GetPolicyBindingName(policyRefNamespace) {
+			return false, "name must be " + authorizationapi.GetPolicyBindingName(policyRefNamespace)
 		}
 
 		return true, ""

--- a/pkg/authorization/api/validation/validation_test.go
+++ b/pkg/authorization/api/validation/validation_test.go
@@ -75,7 +75,7 @@ func TestValidatePolicy(t *testing.T) {
 
 func TestValidatePolicyBinding(t *testing.T) {
 	errs := ValidatePolicyBinding(&authorizationapi.PolicyBinding{
-		ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: "master"},
+		ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.GetPolicyBindingName("master")},
 		PolicyRef:  kapi.ObjectReference{Namespace: "master"},
 	})
 	if len(errs) != 0 {
@@ -89,7 +89,7 @@ func TestValidatePolicyBinding(t *testing.T) {
 	}{
 		"zero-length namespace": {
 			A: authorizationapi.PolicyBinding{
-				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName},
+				ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.GetPolicyBindingName(authorizationapi.PolicyName)},
 				PolicyRef:  kapi.ObjectReference{Namespace: authorizationapi.PolicyName},
 			},
 			T: fielderrors.ValidationErrorTypeRequired,
@@ -113,7 +113,7 @@ func TestValidatePolicyBinding(t *testing.T) {
 		},
 		"bad role": {
 			A: authorizationapi.PolicyBinding{
-				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.PolicyName},
+				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.GetPolicyBindingName(authorizationapi.PolicyName)},
 				PolicyRef:  kapi.ObjectReference{Namespace: authorizationapi.PolicyName},
 				RoleBindings: map[string]authorizationapi.RoleBinding{
 					"any": {
@@ -127,7 +127,7 @@ func TestValidatePolicyBinding(t *testing.T) {
 		},
 		"mismatched name": {
 			A: authorizationapi.PolicyBinding{
-				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.PolicyName},
+				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.GetPolicyBindingName(authorizationapi.PolicyName)},
 				PolicyRef:  kapi.ObjectReference{Namespace: authorizationapi.PolicyName},
 				RoleBindings: map[string]authorizationapi.RoleBinding{
 					"any1": {

--- a/pkg/authorization/registry/clusterpolicy/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterpolicy/proxy/proxy.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+)
+
+type ClusterPolicyStorage struct {
+	masterNamespace string
+	typeConverter   authorizationapi.TypeConverter
+	policyStorage   policyregistry.Storage
+}
+
+func NewClusterPolicyStorage(masterNamespace string, policyStorage policyregistry.Storage) *ClusterPolicyStorage {
+	return &ClusterPolicyStorage{masterNamespace, authorizationapi.TypeConverter{masterNamespace}, policyStorage}
+}
+
+func (s *ClusterPolicyStorage) New() runtime.Object {
+	return &authorizationapi.ClusterPolicy{}
+}
+func (s *ClusterPolicyStorage) NewList() runtime.Object {
+	return &authorizationapi.ClusterPolicyList{}
+}
+
+func (s *ClusterPolicyStorage) List(ctx kapi.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	ret, err := s.policyStorage.List(kapi.WithNamespace(ctx, s.masterNamespace), label, field)
+	if ret == nil {
+		return nil, err
+	}
+	return s.typeConverter.ToClusterPolicyList(ret.(*authorizationapi.PolicyList)), err
+}
+
+func (s *ClusterPolicyStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	ret, err := s.policyStorage.Get(kapi.WithNamespace(ctx, s.masterNamespace), name)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterPolicy(ret.(*authorizationapi.Policy)), err
+}
+func (s *ClusterPolicyStorage) Delete(ctx kapi.Context, name string, options *kapi.DeleteOptions) (runtime.Object, error) {
+	ret, err := s.policyStorage.Delete(kapi.WithNamespace(ctx, s.masterNamespace), name, options)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterPolicy(ret.(*authorizationapi.Policy)), err
+}
+
+func (s *ClusterPolicyStorage) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	clusterObj := obj.(*authorizationapi.ClusterPolicy)
+	convertedObj := s.typeConverter.ToPolicy(clusterObj)
+
+	ret, err := s.policyStorage.Create(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterPolicy(ret.(*authorizationapi.Policy)), err
+}
+
+func (s *ClusterPolicyStorage) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	clusterObj := obj.(*authorizationapi.ClusterPolicy)
+	convertedObj := s.typeConverter.ToPolicy(clusterObj)
+
+	ret, created, err := s.policyStorage.Update(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, created, err
+	}
+
+	return s.typeConverter.ToClusterPolicy(ret.(*authorizationapi.Policy)), created, err
+}

--- a/pkg/authorization/registry/clusterpolicybinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterpolicybinding/proxy/proxy.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+)
+
+type ClusterPolicyBindingStorage struct {
+	masterNamespace      string
+	typeConverter        authorizationapi.TypeConverter
+	policyBindingStorage policybindingregistry.Storage
+}
+
+func NewClusterPolicyBindingStorage(masterNamespace string, policyBindingStorage policybindingregistry.Storage) *ClusterPolicyBindingStorage {
+	return &ClusterPolicyBindingStorage{masterNamespace, authorizationapi.TypeConverter{masterNamespace}, policyBindingStorage}
+}
+
+func (s *ClusterPolicyBindingStorage) New() runtime.Object {
+	return &authorizationapi.ClusterPolicyBinding{}
+}
+func (s *ClusterPolicyBindingStorage) NewList() runtime.Object {
+	return &authorizationapi.ClusterPolicyBindingList{}
+}
+
+func (s *ClusterPolicyBindingStorage) List(ctx kapi.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	ret, err := s.policyBindingStorage.List(kapi.WithNamespace(ctx, s.masterNamespace), label, field)
+	if ret == nil {
+		return nil, err
+	}
+	return s.typeConverter.ToClusterPolicyBindingList(ret.(*authorizationapi.PolicyBindingList)), err
+}
+
+func (s *ClusterPolicyBindingStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	ret, err := s.policyBindingStorage.Get(kapi.WithNamespace(ctx, s.masterNamespace), name)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterPolicyBinding(ret.(*authorizationapi.PolicyBinding)), err
+}
+func (s *ClusterPolicyBindingStorage) Delete(ctx kapi.Context, name string, options *kapi.DeleteOptions) (runtime.Object, error) {
+	ret, err := s.policyBindingStorage.Delete(kapi.WithNamespace(ctx, s.masterNamespace), name, options)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterPolicyBinding(ret.(*authorizationapi.PolicyBinding)), err
+}
+
+func (s *ClusterPolicyBindingStorage) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	clusterObj := obj.(*authorizationapi.ClusterPolicyBinding)
+	convertedObj := s.typeConverter.ToPolicyBinding(clusterObj)
+
+	ret, err := s.policyBindingStorage.Create(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterPolicyBinding(ret.(*authorizationapi.PolicyBinding)), err
+}
+
+func (s *ClusterPolicyBindingStorage) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	clusterObj := obj.(*authorizationapi.ClusterPolicyBinding)
+	convertedObj := s.typeConverter.ToPolicyBinding(clusterObj)
+
+	ret, created, err := s.policyBindingStorage.Update(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, created, err
+	}
+
+	return s.typeConverter.ToClusterPolicyBinding(ret.(*authorizationapi.PolicyBinding)), created, err
+}

--- a/pkg/authorization/registry/clusterrole/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy/proxy.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
+)
+
+type ClusterRoleStorage struct {
+	masterNamespace string
+	typeConverter   authorizationapi.TypeConverter
+	roleStorage     roleregistry.Storage
+}
+
+func NewClusterRoleStorage(masterNamespace string, roleStorage roleregistry.Storage) *ClusterRoleStorage {
+	return &ClusterRoleStorage{masterNamespace, authorizationapi.TypeConverter{masterNamespace}, roleStorage}
+}
+
+func (s *ClusterRoleStorage) New() runtime.Object {
+	return &authorizationapi.ClusterRole{}
+}
+func (s *ClusterRoleStorage) NewList() runtime.Object {
+	return &authorizationapi.ClusterRoleList{}
+}
+
+func (s *ClusterRoleStorage) List(ctx kapi.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	ret, err := s.roleStorage.List(kapi.WithNamespace(ctx, s.masterNamespace), label, field)
+	if ret == nil {
+		return nil, err
+	}
+	return s.typeConverter.ToClusterRoleList(ret.(*authorizationapi.RoleList)), err
+}
+
+func (s *ClusterRoleStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	ret, err := s.roleStorage.Get(kapi.WithNamespace(ctx, s.masterNamespace), name)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterRole(ret.(*authorizationapi.Role)), err
+}
+func (s *ClusterRoleStorage) Delete(ctx kapi.Context, name string, options *kapi.DeleteOptions) (runtime.Object, error) {
+	ret, err := s.roleStorage.Delete(kapi.WithNamespace(ctx, s.masterNamespace), name, options)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterRole(ret.(*authorizationapi.Role)), err
+}
+
+func (s *ClusterRoleStorage) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	clusterObj := obj.(*authorizationapi.ClusterRole)
+	convertedObj := s.typeConverter.ToRole(clusterObj)
+
+	ret, err := s.roleStorage.Create(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterRole(ret.(*authorizationapi.Role)), err
+}
+
+func (s *ClusterRoleStorage) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	clusterObj := obj.(*authorizationapi.ClusterRole)
+	convertedObj := s.typeConverter.ToRole(clusterObj)
+
+	ret, created, err := s.roleStorage.Update(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, created, err
+	}
+
+	return s.typeConverter.ToClusterRole(ret.(*authorizationapi.Role)), created, err
+}

--- a/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
+)
+
+type ClusterRoleBindingStorage struct {
+	masterNamespace    string
+	typeConverter      authorizationapi.TypeConverter
+	roleBindingStorage rolebindingregistry.Storage
+}
+
+func NewClusterRoleBindingStorage(masterNamespace string, roleBindingStorage rolebindingregistry.Storage) *ClusterRoleBindingStorage {
+	return &ClusterRoleBindingStorage{masterNamespace, authorizationapi.TypeConverter{masterNamespace}, roleBindingStorage}
+}
+
+func (s *ClusterRoleBindingStorage) New() runtime.Object {
+	return &authorizationapi.ClusterRoleBinding{}
+}
+func (s *ClusterRoleBindingStorage) NewList() runtime.Object {
+	return &authorizationapi.ClusterRoleBindingList{}
+}
+
+func (s *ClusterRoleBindingStorage) List(ctx kapi.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {
+	ret, err := s.roleBindingStorage.List(kapi.WithNamespace(ctx, s.masterNamespace), label, field)
+	if ret == nil {
+		return nil, err
+	}
+	return s.typeConverter.ToClusterRoleBindingList(ret.(*authorizationapi.RoleBindingList)), err
+}
+
+func (s *ClusterRoleBindingStorage) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	ret, err := s.roleBindingStorage.Get(kapi.WithNamespace(ctx, s.masterNamespace), name)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterRoleBinding(ret.(*authorizationapi.RoleBinding)), err
+}
+func (s *ClusterRoleBindingStorage) Delete(ctx kapi.Context, name string, options *kapi.DeleteOptions) (runtime.Object, error) {
+	ret, err := s.roleBindingStorage.Delete(kapi.WithNamespace(ctx, s.masterNamespace), name, options)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterRoleBinding(ret.(*authorizationapi.RoleBinding)), err
+}
+
+func (s *ClusterRoleBindingStorage) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	clusterObj := obj.(*authorizationapi.ClusterRoleBinding)
+	convertedObj := s.typeConverter.ToRoleBinding(clusterObj)
+
+	ret, err := s.roleBindingStorage.Create(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, err
+	}
+
+	return s.typeConverter.ToClusterRoleBinding(ret.(*authorizationapi.RoleBinding)), err
+}
+
+func (s *ClusterRoleBindingStorage) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	clusterObj := obj.(*authorizationapi.ClusterRoleBinding)
+	convertedObj := s.typeConverter.ToRoleBinding(clusterObj)
+
+	ret, created, err := s.roleBindingStorage.Update(kapi.WithNamespace(ctx, s.masterNamespace), convertedObj)
+	if ret == nil {
+		return nil, created, err
+	}
+
+	return s.typeConverter.ToClusterRoleBinding(ret.(*authorizationapi.RoleBinding)), created, err
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,10 +34,6 @@ type Interface interface {
 	UserIdentityMappingsInterface
 	ProjectsInterface
 	ProjectRequestsInterface
-	PoliciesNamespacer
-	RolesNamespacer
-	RoleBindingsNamespacer
-	PolicyBindingsNamespacer
 	ResourceAccessReviewsNamespacer
 	ClusterResourceAccessReviews
 	SubjectAccessReviewsNamespacer
@@ -45,6 +41,14 @@ type Interface interface {
 	TemplatesNamespacer
 	TemplateConfigsNamespacer
 	OAuthAccessTokensInterface
+	PoliciesNamespacer
+	PolicyBindingsNamespacer
+	RolesNamespacer
+	RoleBindingsNamespacer
+	ClusterPoliciesInterface
+	ClusterPolicyBindingsInterface
+	ClusterRolesInterface
+	ClusterRoleBindingsInterface
 }
 
 // Builds provides a REST client for Builds
@@ -195,6 +199,22 @@ func (c *Client) ClusterSubjectAccessReviews() SubjectAccessReviewInterface {
 // OAuthAccessTokens provides a REST client for OAuthAccessTokens
 func (c *Client) OAuthAccessTokens() OAuthAccessTokenInterface {
 	return newOAuthAccessTokens(c)
+}
+
+func (c *Client) ClusterPolicies() ClusterPolicyInterface {
+	return newClusterPolicies(c)
+}
+
+func (c *Client) ClusterPolicyBindings() ClusterPolicyBindingInterface {
+	return newClusterPolicyBindings(c)
+}
+
+func (c *Client) ClusterRoles() ClusterRoleInterface {
+	return newClusterRoles(c)
+}
+
+func (c *Client) ClusterRoleBindings() ClusterRoleBindingInterface {
+	return newClusterRoleBindings(c)
 }
 
 // Client is an OpenShift client object

--- a/pkg/client/clusterpolicies.go
+++ b/pkg/client/clusterpolicies.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type ClusterPoliciesInterface interface {
+	ClusterPolicies() ClusterPolicyInterface
+}
+
+type ClusterPolicyInterface interface {
+	List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyList, error)
+	Get(name string) (*authorizationapi.ClusterPolicy, error)
+	Delete(name string) error
+}
+
+type clusterPolicies struct {
+	r *Client
+}
+
+func newClusterPolicies(c *Client) *clusterPolicies {
+	return &clusterPolicies{
+		r: c,
+	}
+}
+
+// List returns a list of policies that match the label and field selectors.
+func (c *clusterPolicies) List(label labels.Selector, field fields.Selector) (result *authorizationapi.ClusterPolicyList, err error) {
+	result = &authorizationapi.ClusterPolicyList{}
+	err = c.r.Get().Resource("clusterPolicies").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular policy and error if one occurs.
+func (c *clusterPolicies) Get(name string) (result *authorizationapi.ClusterPolicy, err error) {
+	result = &authorizationapi.ClusterPolicy{}
+	err = c.r.Get().Resource("clusterPolicies").Name(name).Do().Into(result)
+	return
+}
+
+// Delete deletes a policy, returns error if one occurs.
+func (c *clusterPolicies) Delete(name string) (err error) {
+	err = c.r.Delete().Resource("clusterPolicies").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/clusterpolicybindings.go
+++ b/pkg/client/clusterpolicybindings.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type ClusterPolicyBindingsInterface interface {
+	ClusterPolicyBindings() ClusterPolicyBindingInterface
+}
+
+type ClusterPolicyBindingInterface interface {
+	List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyBindingList, error)
+	Get(name string) (*authorizationapi.ClusterPolicyBinding, error)
+	Create(policyBinding *authorizationapi.ClusterPolicyBinding) (*authorizationapi.ClusterPolicyBinding, error)
+	Delete(name string) error
+}
+
+type clusterPolicyBindings struct {
+	r *Client
+}
+
+// newClusterPolicyBindings returns a clusterPolicyBindings
+func newClusterPolicyBindings(c *Client) *clusterPolicyBindings {
+	return &clusterPolicyBindings{
+		r: c,
+	}
+}
+
+// List returns a list of clusterPolicyBindings that match the label and field selectors.
+func (c *clusterPolicyBindings) List(label labels.Selector, field fields.Selector) (result *authorizationapi.ClusterPolicyBindingList, err error) {
+	result = &authorizationapi.ClusterPolicyBindingList{}
+	err = c.r.Get().Resource("clusterPolicyBindings").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular policyBinding and error if one occurs.
+func (c *clusterPolicyBindings) Get(name string) (result *authorizationapi.ClusterPolicyBinding, err error) {
+	result = &authorizationapi.ClusterPolicyBinding{}
+	err = c.r.Get().Resource("clusterPolicyBindings").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates new policyBinding. Returns the server's representation of the policyBinding and error if one occurs.
+func (c *clusterPolicyBindings) Create(policyBinding *authorizationapi.ClusterPolicyBinding) (result *authorizationapi.ClusterPolicyBinding, err error) {
+	result = &authorizationapi.ClusterPolicyBinding{}
+	err = c.r.Post().Resource("clusterPolicyBindings").Body(policyBinding).Do().Into(result)
+	return
+}
+
+// Delete deletes a policyBinding, returns error if one occurs.
+func (c *clusterPolicyBindings) Delete(name string) (err error) {
+	err = c.r.Delete().Resource("clusterPolicyBindings").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/clusterrolebindings.go
+++ b/pkg/client/clusterrolebindings.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type ClusterRoleBindingsInterface interface {
+	ClusterRoleBindings() ClusterRoleBindingInterface
+}
+
+type ClusterRoleBindingInterface interface {
+	List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterRoleBindingList, error)
+	Get(name string) (*authorizationapi.ClusterRoleBinding, error)
+	Create(roleBinding *authorizationapi.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error)
+	Delete(name string) error
+}
+
+type clusterRoleBindings struct {
+	r *Client
+}
+
+// newClusterRoleBindings returns a clusterRoleBindings
+func newClusterRoleBindings(c *Client) *clusterRoleBindings {
+	return &clusterRoleBindings{
+		r: c,
+	}
+}
+
+// List returns a list of clusterRoleBindings that match the label and field selectors.
+func (c *clusterRoleBindings) List(label labels.Selector, field fields.Selector) (result *authorizationapi.ClusterRoleBindingList, err error) {
+	result = &authorizationapi.ClusterRoleBindingList{}
+	err = c.r.Get().Resource("clusterRoleBindings").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular roleBinding and error if one occurs.
+func (c *clusterRoleBindings) Get(name string) (result *authorizationapi.ClusterRoleBinding, err error) {
+	result = &authorizationapi.ClusterRoleBinding{}
+	err = c.r.Get().Resource("clusterRoleBindings").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates new roleBinding. Returns the server's representation of the roleBinding and error if one occurs.
+func (c *clusterRoleBindings) Create(roleBinding *authorizationapi.ClusterRoleBinding) (result *authorizationapi.ClusterRoleBinding, err error) {
+	result = &authorizationapi.ClusterRoleBinding{}
+	err = c.r.Post().Resource("clusterRoleBindings").Body(roleBinding).Do().Into(result)
+	return
+}
+
+// Delete deletes a roleBinding, returns error if one occurs.
+func (c *clusterRoleBindings) Delete(name string) (err error) {
+	err = c.r.Delete().Resource("clusterRoleBindings").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/clusterroles.go
+++ b/pkg/client/clusterroles.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type ClusterRolesInterface interface {
+	ClusterRoles() ClusterRoleInterface
+}
+
+type ClusterRoleInterface interface {
+	List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterRoleList, error)
+	Get(name string) (*authorizationapi.ClusterRole, error)
+	Create(role *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error)
+	Delete(name string) error
+}
+
+type clusterRoles struct {
+	r *Client
+}
+
+// newClusterRoles returns a clusterRoles
+func newClusterRoles(c *Client) *clusterRoles {
+	return &clusterRoles{
+		r: c,
+	}
+}
+
+// List returns a list of clusterRoles that match the label and field selectors.
+func (c *clusterRoles) List(label labels.Selector, field fields.Selector) (result *authorizationapi.ClusterRoleList, err error) {
+	result = &authorizationapi.ClusterRoleList{}
+	err = c.r.Get().Resource("clusterRoles").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular role and error if one occurs.
+func (c *clusterRoles) Get(name string) (result *authorizationapi.ClusterRole, err error) {
+	result = &authorizationapi.ClusterRole{}
+	err = c.r.Get().Resource("clusterRoles").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates new role. Returns the server's representation of the role and error if one occurs.
+func (c *clusterRoles) Create(role *authorizationapi.ClusterRole) (result *authorizationapi.ClusterRole, err error) {
+	result = &authorizationapi.ClusterRole{}
+	err = c.r.Post().Resource("clusterRoles").Body(role).Do().Into(result)
+	return
+}
+
+// Delete deletes a role, returns error if one occurs.
+func (c *clusterRoles) Delete(name string) (err error) {
+	err = c.r.Delete().Resource("clusterRoles").Name(name).Do().Error()
+	return
+}

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -146,4 +146,21 @@ func (c *Fake) OAuthAccessTokens() OAuthAccessTokenInterface {
 }
 func (c *Fake) ClusterSubjectAccessReviews() SubjectAccessReviewInterface {
 	return &FakeClusterSubjectAccessReviews{Fake: c}
+
+}
+
+func (c *Fake) ClusterPolicies() ClusterPolicyInterface {
+	return &FakeClusterPolicies{Fake: c}
+}
+
+func (c *Fake) ClusterPolicyBindings() ClusterPolicyBindingInterface {
+	return &FakeClusterPolicyBindings{Fake: c}
+}
+
+func (c *Fake) ClusterRoles() ClusterRoleInterface {
+	return &FakeClusterRoles{Fake: c}
+}
+
+func (c *Fake) ClusterRoleBindings() ClusterRoleBindingInterface {
+	return &FakeClusterRoleBindings{Fake: c}
 }

--- a/pkg/client/fake_clusterpolicies.go
+++ b/pkg/client/fake_clusterpolicies.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeClusterPolicies struct {
+	Fake *Fake
+}
+
+func (c *FakeClusterPolicies) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyList, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterPolicies"}, &authorizationapi.ClusterPolicyList{})
+	return obj.(*authorizationapi.ClusterPolicyList), err
+}
+
+func (c *FakeClusterPolicies) Get(name string) (*authorizationapi.ClusterPolicy, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterPolicy"}, &authorizationapi.ClusterPolicy{})
+	return obj.(*authorizationapi.ClusterPolicy), err
+}
+
+func (c *FakeClusterPolicies) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterPolicy", Value: name})
+	return nil
+}

--- a/pkg/client/fake_clusterpolicybindings.go
+++ b/pkg/client/fake_clusterpolicybindings.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeClusterPolicyBindings struct {
+	Fake *Fake
+}
+
+func (c *FakeClusterPolicyBindings) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyBindingList, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterPolicyBindings"}, &authorizationapi.ClusterPolicyBindingList{})
+	return obj.(*authorizationapi.ClusterPolicyBindingList), err
+}
+
+func (c *FakeClusterPolicyBindings) Get(name string) (*authorizationapi.ClusterPolicyBinding, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterPolicyBinding"}, &authorizationapi.ClusterPolicyBinding{})
+	return obj.(*authorizationapi.ClusterPolicyBinding), err
+}
+
+func (c *FakeClusterPolicyBindings) Create(policyBinding *authorizationapi.ClusterPolicyBinding) (*authorizationapi.ClusterPolicyBinding, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-clusterPolicyBinding", Value: policyBinding}, &authorizationapi.ClusterPolicyBinding{})
+	return obj.(*authorizationapi.ClusterPolicyBinding), err
+}
+
+func (c *FakeClusterPolicyBindings) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterPolicyBinding", Value: name})
+	return nil
+}

--- a/pkg/client/fake_clusterrolebindings.go
+++ b/pkg/client/fake_clusterrolebindings.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeClusterRoleBindings struct {
+	Fake *Fake
+}
+
+func (c *FakeClusterRoleBindings) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterRoleBindingList, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterRoleBindings"}, &authorizationapi.ClusterRoleBindingList{})
+	return obj.(*authorizationapi.ClusterRoleBindingList), err
+}
+
+func (c *FakeClusterRoleBindings) Get(name string) (*authorizationapi.ClusterRoleBinding, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterRoleBinding"}, &authorizationapi.ClusterRoleBinding{})
+	return obj.(*authorizationapi.ClusterRoleBinding), err
+}
+
+func (c *FakeClusterRoleBindings) Create(roleBinding *authorizationapi.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-clusterRoleBinding", Value: roleBinding}, &authorizationapi.ClusterRoleBinding{})
+	return obj.(*authorizationapi.ClusterRoleBinding), err
+}
+
+func (c *FakeClusterRoleBindings) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterRoleBinding", Value: name})
+	return nil
+}

--- a/pkg/client/fake_clusterroles.go
+++ b/pkg/client/fake_clusterroles.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeClusterRoles struct {
+	Fake *Fake
+}
+
+func (c *FakeClusterRoles) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterRoleList, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterRoles"}, &authorizationapi.ClusterRoleList{})
+	return obj.(*authorizationapi.ClusterRoleList), err
+}
+
+func (c *FakeClusterRoles) Get(name string) (*authorizationapi.ClusterRole, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterRole"}, &authorizationapi.ClusterRole{})
+	return obj.(*authorizationapi.ClusterRole), err
+}
+
+func (c *FakeClusterRoles) Create(role *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-clusterRole", Value: role}, &authorizationapi.ClusterRole{})
+	return obj.(*authorizationapi.ClusterRole), err
+}
+
+func (c *FakeClusterRoles) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterRole", Value: name})
+	return nil
+}

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -52,6 +52,10 @@ var (
 	IsPersonalSubjectAccessReviewColumns = []string{"NAME"}
 )
 
+var (
+	authorizationTypeConverter = authorizationapi.TypeConverter{""}
+)
+
 // NewHumanReadablePrinter returns a new HumanReadablePrinter
 func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p := kctl.NewHumanReadablePrinter(noHeaders)
@@ -78,6 +82,7 @@ func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p.Handler(deploymentConfigColumns, printDeploymentConfigList)
 	p.Handler(templateColumns, printTemplate)
 	p.Handler(templateColumns, printTemplateList)
+
 	p.Handler(policyColumns, printPolicy)
 	p.Handler(policyColumns, printPolicyList)
 	p.Handler(policyBindingColumns, printPolicyBinding)
@@ -86,6 +91,15 @@ func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p.Handler(roleBindingColumns, printRoleBindingList)
 	p.Handler(roleColumns, printRole)
 	p.Handler(roleColumns, printRoleList)
+
+	p.Handler(policyColumns, printClusterPolicy)
+	p.Handler(policyColumns, printClusterPolicyList)
+	p.Handler(policyBindingColumns, printClusterPolicyBinding)
+	p.Handler(policyBindingColumns, printClusterPolicyBindingList)
+	p.Handler(roleColumns, printClusterRole)
+	p.Handler(roleColumns, printClusterRoleList)
+	p.Handler(roleBindingColumns, printClusterRoleBinding)
+	p.Handler(roleBindingColumns, printClusterRoleBindingList)
 
 	p.Handler(oauthClientColumns, printOAuthClient)
 	p.Handler(oauthClientColumns, printOAuthClientList)
@@ -392,6 +406,38 @@ func printPolicyBindingList(list *authorizationapi.PolicyBindingList, w io.Write
 	}
 
 	return nil
+}
+
+func printClusterPolicy(policy *authorizationapi.ClusterPolicy, w io.Writer) error {
+	return printPolicy(authorizationTypeConverter.ToPolicy(policy), w)
+}
+
+func printClusterPolicyList(list *authorizationapi.ClusterPolicyList, w io.Writer) error {
+	return printPolicyList(authorizationTypeConverter.ToPolicyList(list), w)
+}
+
+func printClusterPolicyBinding(policyBinding *authorizationapi.ClusterPolicyBinding, w io.Writer) error {
+	return printPolicyBinding(authorizationTypeConverter.ToPolicyBinding(policyBinding), w)
+}
+
+func printClusterPolicyBindingList(list *authorizationapi.ClusterPolicyBindingList, w io.Writer) error {
+	return printPolicyBindingList(authorizationTypeConverter.ToPolicyBindingList(list), w)
+}
+
+func printClusterRole(role *authorizationapi.ClusterRole, w io.Writer) error {
+	return printRole(authorizationTypeConverter.ToRole(role), w)
+}
+
+func printClusterRoleList(list *authorizationapi.ClusterRoleList, w io.Writer) error {
+	return printRoleList(authorizationTypeConverter.ToRoleList(list), w)
+}
+
+func printClusterRoleBinding(roleBinding *authorizationapi.ClusterRoleBinding, w io.Writer) error {
+	return printRoleBinding(authorizationTypeConverter.ToRoleBinding(roleBinding), w)
+}
+
+func printClusterRoleBindingList(list *authorizationapi.ClusterRoleBindingList, w io.Writer) error {
+	return printRoleBindingList(authorizationTypeConverter.ToRoleBindingList(list), w)
 }
 
 func printIsPersonalSubjectAccessReview(a *authorizationapi.IsPersonalSubjectAccessReview, w io.Writer) error {

--- a/pkg/cmd/experimental/policy/policy.go
+++ b/pkg/cmd/experimental/policy/policy.go
@@ -64,7 +64,7 @@ func getUniqueName(basename string, existingNames *util.StringSet) string {
 }
 
 func getExistingRoleBindingsForRole(roleNamespace, role string, bindingInterface client.PolicyBindingInterface) ([]*authorizationapi.RoleBinding, error) {
-	existingBindings, err := bindingInterface.Get(roleNamespace)
+	existingBindings, err := bindingInterface.Get(authorizationapi.GetPolicyBindingName(roleNamespace))
 	if err != nil && !strings.Contains(err.Error(), " not found") {
 		return nil, err
 	}


### PR DESCRIPTION
Moving the internals of authorization away from a single unifying type that can read, write, and round-trip is very painful because of the logic contained and referenced by the virtual registries for roles and rolebindings that enforce referential integrity and re-entrance.

We can get most of the gains by exposing the master namespace via a virtual resources: clusterpolicy, clusterpolicybinding, clusterrole, and clusterrolebinding.  This will allow them to be authorized separately and eliminate the need to know the master namespace itself when using our built in commands.  We could even build in logic to allow references to roles without namespaces and have them point to the master namespace, since that is unambiguous.

At any rate, here's the start.

@derekwaynecarr  please review.