### PR TITLE
Restores usage to cli templates and other improvements

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -18,22 +18,20 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
-const longDesc = `
-OpenShift Administrative Commands
+const admin_long = `OpenShift Administrative Commands
 
 Commands for managing an OpenShift cluster are exposed here. Many administrative
 actions involve interaction with the OpenShift client as well.
 
 Note: This is a beta release of OpenShift and may change significantly.  See
-    https://github.com/openshift/origin for the latest information on OpenShift.
-`
+    https://github.com/openshift/origin for the latest information on OpenShift.`
 
 func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 	// Main command
 	cmds := &cobra.Command{
 		Use:   name,
-		Short: "tools for managing an OpenShift cluster",
-		Long:  fmt.Sprintf(longDesc),
+		Short: "Tools for managing an OpenShift cluster",
+		Long:  fmt.Sprintf(admin_long),
 		Run: func(c *cobra.Command, args []string) {
 			c.SetOutput(out)
 			c.Help()

--- a/pkg/cmd/admin/policy/modify_roles.go
+++ b/pkg/cmd/admin/policy/modify_roles.go
@@ -36,9 +36,9 @@ func NewCmdAddRoleToGroup(name, fullName string, f *clientcmd.Factory, out io.Wr
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <role> <group> [group]...",
-		Short: "add groups to a role in the current project",
-		Long:  `add groups to a role in the current project`,
+		Use:   name + " ROLE GROUP [GROUP ...]",
+		Short: "Add groups to a role in the current project",
+		Long:  `Add groups to a role in the current project`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, &options.Groups, "group"); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
@@ -59,9 +59,9 @@ func NewCmdAddRoleToUser(name, fullName string, f *clientcmd.Factory, out io.Wri
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <role> <user> [user]...",
-		Short: "add users to a role in the current project",
-		Long:  `add users to a role in the current project`,
+		Use:   name + " ROLE USER [USER ...]",
+		Short: "Add users to a role in the current project",
+		Long:  `Add users to a role in the current project`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, &options.Users, "user"); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
@@ -82,9 +82,9 @@ func NewCmdRemoveRoleFromGroup(name, fullName string, f *clientcmd.Factory, out 
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <role> <group> [group]...",
-		Short: "remove group from role in the current project",
-		Long:  `remove group from role in the current project`,
+		Use:   name + " ROLE GROUP [GROUP ...]",
+		Short: "Remove group from role in the current project",
+		Long:  `Remove group from role in the current project`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, &options.Groups, "group"); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
@@ -105,9 +105,9 @@ func NewCmdRemoveRoleFromUser(name, fullName string, f *clientcmd.Factory, out i
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <role> <user> [user]...",
-		Short: "remove user from role in the current project",
-		Long:  `remove user from role in the current project`,
+		Use:   name + " ROLE USER [USER ...]",
+		Short: "Remove user from role in the current project",
+		Long:  `Remove user from role in the current project`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, &options.Users, "user"); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))

--- a/pkg/cmd/admin/policy/remove_from_project.go
+++ b/pkg/cmd/admin/policy/remove_from_project.go
@@ -33,9 +33,9 @@ func NewCmdRemoveGroupFromProject(name, fullName string, f *clientcmd.Factory, o
 	options := &RemoveFromProjectOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <group> [group]...",
-		Short: "remove group from the current project",
-		Long:  `remove group from the current project`,
+		Use:   name + " GROUP [GROUP ...]",
+		Short: "Remove group from the current project",
+		Long:  `Remove group from the current project`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, &options.Groups, "group"); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
@@ -54,9 +54,9 @@ func NewCmdRemoveUserFromProject(name, fullName string, f *clientcmd.Factory, ou
 	options := &RemoveFromProjectOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <user> [user]...",
-		Short: "remove user from the current project",
-		Long:  `remove user from the current project`,
+		Use:   name + " USER [USER ...]",
+		Short: "Remove user from the current project",
+		Long:  `Remove user from the current project`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, &options.Users, "user"); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -29,7 +29,7 @@ func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	options := &whoCanOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <verb> <resource>",
+		Use:   "who-can VERB RESOURCE",
 		Short: "Indicates which users can perform the action on the resource.",
 		Long:  `Indicates which users can perform the action on the resource.`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -55,7 +55,7 @@ func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 
 func (o *whoCanOptions) complete(args []string) error {
 	if len(args) != 2 {
-		return errors.New("You must specify two arguments: <verb> <resource>")
+		return errors.New("You must specify two arguments: verb and resource")
 	}
 
 	o.verb = args[0]

--- a/pkg/cmd/admin/project/new_project.go
+++ b/pkg/cmd/admin/project/new_project.go
@@ -35,7 +35,7 @@ func NewCmdNewProject(name, fullName string, f *clientcmd.Factory, out io.Writer
 	options := &NewProjectOptions{}
 
 	cmd := &cobra.Command{
-		Use:   name + " <project-name>",
+		Use:   name + " NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]",
 		Short: "create a new project",
 		Long:  `create a new project`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -65,7 +65,7 @@ func NewCmdNewProject(name, fullName string, f *clientcmd.Factory, out io.Writer
 
 func (o *NewProjectOptions) complete(args []string) error {
 	if len(args) != 1 {
-		return errors.New("You must specify one argument: <project-name>")
+		return errors.New("You must specify one argument: project name")
 	}
 
 	o.ProjectName = args[0]

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -15,8 +15,7 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
-const longDesc = `
-OpenShift Client
+const cli_long = `OpenShift Client.
 
 The OpenShift client exposes commands for managing your applications, as well as lower level
 tools to interact with each component of your system.
@@ -43,15 +42,14 @@ created for you.
 You can easily switch between multiple projects using '%[1]s project <projectname>'.
 
 Note: This is a beta release of OpenShift and may change significantly.  See
-    https://github.com/openshift/origin for the latest information on OpenShift.
-`
+    https://github.com/openshift/origin for the latest information on OpenShift.`
 
 func NewCommandCLI(name, fullName string) *cobra.Command {
 	// Main command
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Client tools for OpenShift",
-		Long:  fmt.Sprintf(longDesc, fullName),
+		Long:  fmt.Sprintf(cli_long, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			c.SetOutput(os.Stdout)
 			c.Help()
@@ -62,7 +60,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	in := os.Stdin
 	out := os.Stdout
 
-	cmds.AddCommand(cmd.NewCmdLogin(f, in, out))
+	cmds.AddCommand(cmd.NewCmdLogin(fullName, f, in, out))
 	cmds.AddCommand(cmd.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out))
 	cmds.AddCommand(cmd.NewCmdProject(fullName+" project", f, out))
 	cmds.AddCommand(cmd.NewCmdRequestProject("new-project", fullName+" new-project", fullName+" login", fullName+" project", f, out))

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -24,18 +24,18 @@ tools to interact with each component of your system.
 To create a new application, you can use the example app source. Login to your server and then
 run new-app:
 
-    $ %[1]s login
-    $ %[1]s new-app openshift/ruby-20-centos7~git@github.com/mfojtik/sinatra-app-example
+  $ %[1]s login
+  $ %[1]s new-app openshift/ruby-20-centos7~git@github.com/mfojtik/sinatra-app-example
 
 This will create an application based on the Docker image 'openshift/ruby-20-centos7' that builds
 the source code at 'github.com/mfojtik/sinatra-app-example'. To start the build, run
 
-    $ %[1]s start-build sinatra-app-example
+  $ %[1]s start-build sinatra-app-example
 
 and watch the build logs and build status with:
 
-    $ %[1]s get builds
-    $ %[1]s build-logs <name_of_build>
+  $ %[1]s get builds
+  $ %[1]s build-logs <name_of_build>
 
 You'll be able to view the deployed application on the IP and port of the service that new-app
 created for you.

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -26,7 +26,7 @@ Examples:
 func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	opts := api.BuildLogOptions{}
 	cmd := &cobra.Command{
-		Use:   "build-logs <build>",
+		Use:   "build-logs BUILD",
 		Short: "Show container logs from the build container",
 		Long:  fmt.Sprintf(buildLogsLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -42,7 +42,7 @@ func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobr
 // RunBuildLogs contains all the necessary functionality for the OpenShift cli build-logs command
 func RunBuildLogs(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, opts api.BuildLogOptions, args []string) error {
 	if len(args) != 1 {
-		return cmdutil.UsageError(cmd, "<build> is a required argument")
+		return cmdutil.UsageError(cmd, "A build name is required")
 	}
 
 	namespace, err := f.DefaultNamespace()

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -18,8 +18,8 @@ NOTE: This command may be moved in the future.
 
 Examples:
 
-	# Stream logs from container to stdout
-	$ %[1]s build-logs 566bed879d2d
+  # Stream logs from container to stdout
+  $ %[1]s build-logs 566bed879d2d
 `
 
 // NewCmdBuildLogs implements the OpenShift cli build-logs command

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -12,23 +12,23 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const buildLogsLongDesc = `Retrieve logs from the containers where the build occured
+const (
+	buildLogs_long = `Retrieve logs from the containers where the build occured.
 
-NOTE: This command may be moved in the future.
+NOTE: This command may be moved in the future.`
 
-Examples:
-
-  # Stream logs from container to stdout
-  $ %[1]s build-logs 566bed879d2d
-`
+	buildLogs_example = `  // Stream logs from container to stdout
+  $ %[1]s build-logs 566bed879d2d`
+)
 
 // NewCmdBuildLogs implements the OpenShift cli build-logs command
 func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	opts := api.BuildLogOptions{}
 	cmd := &cobra.Command{
-		Use:   "build-logs BUILD",
-		Short: "Show container logs from the build container",
-		Long:  fmt.Sprintf(buildLogsLongDesc, fullName),
+		Use:     "build-logs BUILD",
+		Short:   "Show container logs from the build container",
+		Long:    buildLogs_long,
+		Example: fmt.Sprintf(buildLogs_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunBuildLogs(f, out, cmd, opts, args)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -32,7 +32,7 @@ Examples:
 // NewCmdCancelBuild implements the OpenShift cli cancel-build command
 func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cancel-build <build>",
+		Use:   "cancel-build BUILD",
 		Short: "Cancel a pending or running build.",
 		Long:  fmt.Sprintf(cancelBuildLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -14,27 +14,26 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const cancelBuildLongDesc = `
-Cancels a pending or running build.
+const (
+	cancelBuild_long = `Cancels a pending or running build.`
 
-Examples:
-
-  # Cancel the build with the given name
+	cancelBuild_example = `  // Cancel the build with the given name
   $ %[1]s cancel-build 1da32cvq
 
-  # Cancel the named build and print the build logs
+  // Cancel the named build and print the build logs
   $ %[1]s cancel-build 1da32cvq --dump-logs
 
-  # Cancel the named build and create a new one with the same parameters
-  $ %[1]s cancel-build 1da32cvq --restart
-`
+  // Cancel the named build and create a new one with the same parameters
+  $ %[1]s cancel-build 1da32cvq --restart`
+)
 
 // NewCmdCancelBuild implements the OpenShift cli cancel-build command
 func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cancel-build BUILD",
-		Short: "Cancel a pending or running build.",
-		Long:  fmt.Sprintf(cancelBuildLongDesc, fullName),
+		Use:     "cancel-build BUILD",
+		Short:   "Cancel a pending or running build.",
+		Long:    cancelBuild_long,
+		Example: fmt.Sprintf(cancelBuild_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunCancelBuild(f, out, cmd, args)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -19,14 +19,14 @@ Cancels a pending or running build.
 
 Examples:
 
-	# Cancel the build with the given name
-	$ %[1]s cancel-build 1da32cvq
+  # Cancel the build with the given name
+  $ %[1]s cancel-build 1da32cvq
 
-	# Cancel the named build and print the build logs
-	$ %[1]s cancel-build 1da32cvq --dump-logs
+  # Cancel the named build and print the build logs
+  $ %[1]s cancel-build 1da32cvq --dump-logs
 
-	# Cancel the named build and create a new one with the same parameters
-	$ %[1]s cancel-build 1da32cvq --restart
+  # Cancel the named build and create a new one with the same parameters
+  $ %[1]s cancel-build 1da32cvq --restart
 `
 
 // NewCmdCancelBuild implements the OpenShift cli cancel-build command

--- a/pkg/cmd/cli/cmd/config.go
+++ b/pkg/cmd/cli/cmd/config.go
@@ -11,6 +11,18 @@ import (
 	cmdconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 )
 
+const (
+	config_long = `Manages the OpenShift config files.
+
+Reference: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubeconfig-file.md`
+
+	config_example = `  // Change the config context to use
+  %[1]s %[2]s use-context my-context
+
+  // Set the value of a config preference
+  %[1]s %[2]s set preferences.some true`
+)
+
 func NewCmdConfig(parentName, name string) *cobra.Command {
 	pathOptions := &config.PathOptions{
 		GlobalFile:       cmdconfig.RecommendedHomeFile,
@@ -25,14 +37,8 @@ func NewCmdConfig(parentName, name string) *cobra.Command {
 
 	cmd := config.NewCmdConfig(pathOptions, os.Stdout)
 	cmd.Short = "Change configuration files for the client"
-	cmd.Long = fmt.Sprintf(`Manages the OpenShift config files.
-
-Examples:
-
-  %[1]s %[2]s use-context my-context
-  %[1]s %[2]s set preferences.some true
-
-Reference: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubeconfig-file.md`, parentName, name)
+	cmd.Long = config_long
+	cmd.Example = fmt.Sprintf(config_example, parentName, name)
 
 	return cmd
 }

--- a/pkg/cmd/cli/cmd/config.go
+++ b/pkg/cmd/cli/cmd/config.go
@@ -25,10 +25,12 @@ func NewCmdConfig(parentName, name string) *cobra.Command {
 
 	cmd := config.NewCmdConfig(pathOptions, os.Stdout)
 	cmd.Short = "Change configuration files for the client"
-	cmd.Long = fmt.Sprintf(`Manages the OpenShift config files using subcommands like:
+	cmd.Long = fmt.Sprintf(`Manages the OpenShift config files.
 
-%[1]s %[2]s use-context my-context
-%[1]s %[2]s set preferences.some true
+Examples:
+
+  %[1]s %[2]s use-context my-context
+  %[1]s %[2]s set preferences.some true
 
 Reference: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubeconfig-file.md`, parentName, name)
 

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -30,7 +30,7 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 	var retryDeploy bool
 
 	cmd := &cobra.Command{
-		Use:   "deploy <deploymentConfig>",
+		Use:   "deploy DEPLOYMENTCONFIG",
 		Short: "View, start and restart deployments.",
 		Long:  newCmdDeployDescription,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -16,13 +16,19 @@ import (
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
-const newCmdDeployDescription = `
-View, start and restart deployments.
+const (
+	deploy_long = `View, start and restart deployments.
 
 If no options are given, view the latest deployment.
 
-NOTE: This command is still under active development and is subject to change.
-`
+NOTE: This command is still under active development and is subject to change.`
+
+	deploy_example = `  // Display the latest deployment for the 'database' deployment config
+  $ %[1]s deploy database
+
+  // Start a new deployment based on the 'frontend' deployment config
+  $ %[1]s deploy frontend --latest`
+)
 
 // NewCmdDeploy creates a new `deploy` command.
 func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -30,9 +36,10 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 	var retryDeploy bool
 
 	cmd := &cobra.Command{
-		Use:   "deploy DEPLOYMENTCONFIG",
-		Short: "View, start and restart deployments.",
-		Long:  newCmdDeployDescription,
+		Use:     "deploy DEPLOYMENTCONFIG",
+		Short:   "View, start and restart deployments.",
+		Long:    deploy_long,
+		Example: fmt.Sprintf(deploy_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 || len(args[0]) == 0 {
 				fmt.Println(cmdutil.UsageError(cmd, "A deploymentConfig name is required."))

--- a/pkg/cmd/cli/cmd/edit.go
+++ b/pkg/cmd/cli/cmd/edit.go
@@ -40,30 +40,28 @@ In the event an error occurs while updating, a temporary file will be created on
 that contains your unapplied changes. The most common error when updating a resource
 is another editor changing the resource on the server. When this occurs, you will have
 to apply your changes to the newer version of the resource, or update your temporary
-saved copy to include the latest resource version.
+saved copy to include the latest resource version.`
 
-Examples:
-
-  # Edit the service named 'docker-registry':
+	edit_example = `  // Edit the service named 'docker-registry':
   $ %[1]s edit svc/docker-registry
 
-  # Edit the deployment config named 'my-deployment':
+  // Edit the deployment config named 'my-deployment':
   $ %[1]s edit dc/my-deployment
 
-  # Use an alternative editor
+  // Use an alternative editor
   $ OSC_EDITOR="nano" %[1]s edit dc/my-deployment
 
-  # Edit the service 'docker-registry' in JSON using the v1beta3 API format:
-  $ %[1]s edit svc/docker-registry --output-version=v1beta3 -o json
-`
+  // Edit the service 'docker-registry' in JSON using the v1beta3 API format:
+  $ %[1]s edit svc/docker-registry --output-version=v1beta3 -o json`
 )
 
 func NewCmdEdit(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	var filenames util.StringList
 	cmd := &cobra.Command{
-		Use:   "edit (RESOURCE/NAME | -f FILENAME)",
-		Short: "Edit a resource on the server and apply the update.",
-		Long:  fmt.Sprintf(edit_long, fullName),
+		Use:     "edit (RESOURCE/NAME | -f FILENAME)",
+		Short:   "Edit a resource on the server and apply the update.",
+		Long:    edit_long,
+		Example: fmt.Sprintf(edit_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunEdit(fullName, f, out, cmd, args, filenames)
 			if err == errExit {

--- a/pkg/cmd/cli/cmd/edit.go
+++ b/pkg/cmd/cli/cmd/edit.go
@@ -61,7 +61,7 @@ Examples:
 func NewCmdEdit(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	var filenames util.StringList
 	cmd := &cobra.Command{
-		Use:   "edit -f FILENAME",
+		Use:   "edit (RESOURCE/NAME | -f FILENAME)",
 		Short: "Edit a resource on the server and apply the update.",
 		Long:  fmt.Sprintf(edit_long, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/edit.go
+++ b/pkg/cmd/cli/cmd/edit.go
@@ -44,17 +44,17 @@ saved copy to include the latest resource version.
 
 Examples:
 
-	# Edit the service named 'docker-registry':
-	$ %[1]s edit svc/docker-registry
+  # Edit the service named 'docker-registry':
+  $ %[1]s edit svc/docker-registry
 
-	# Edit the deployment config named 'my-deployment':
-	$ %[1]s edit dc/my-deployment
+  # Edit the deployment config named 'my-deployment':
+  $ %[1]s edit dc/my-deployment
 
-	# Use an alternative editor
-	$ OSC_EDITOR="nano" %[1]s edit dc/my-deployment
+  # Use an alternative editor
+  $ OSC_EDITOR="nano" %[1]s edit dc/my-deployment
 
-	# Edit the service 'docker-registry' in JSON using the v1beta3 API format:
-	$ %[1]s edit svc/docker-registry --output-version=v1beta3 -o json
+  # Edit the service 'docker-registry' in JSON using the v1beta3 API format:
+  $ %[1]s edit svc/docker-registry --output-version=v1beta3 -o json
 `
 )
 

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -71,7 +71,7 @@ func NewCmdLogin(f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra
 	}
 
 	cmds := &cobra.Command{
-		Use:   "login [server URL] [--username=<username>] [--password=<password>] [--certificate-authority=<path>]",
+		Use:   "login [URL]",
 		Short: "Logs in and save the configuration",
 		Long:  longDescription,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -51,7 +51,8 @@ type LoginOptions struct {
 	PathOptions *kcmdconfig.PathOptions
 }
 
-const longDescription = `Logs in to the OpenShift server and saves a config file that will be used by 
+const (
+	login_long = `Logs in to the OpenShift server and saves a config file that will be used by 
 subsequent commands.
 
 First-time users of the OpenShift client must run this command to configure the server,
@@ -60,20 +61,30 @@ configuration will be in your home directory under ".config/openshift/config".
 
 The information required to login, like username and password, a session token, or
 the server details, can be provided through flags. If not provided, the command will
-prompt for user input as needed.
-`
+prompt for user input as needed.`
+
+	login_example = `  // Logs in interactively
+  $ %[1]s login
+
+  // Logs in to the given server with the given certificate authority file
+  $ %[1]s login localhost:8443 --certificate-authority=/path/to/cert.crt
+
+  // Logs in to the given server with the given credentials (will not prompt interactively)
+  $ %[1]s login localhost:8443 --username=myuser --password=mypass`
+)
 
 // NewCmdLogin implements the OpenShift cli login command
-func NewCmdLogin(f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
+func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
 	options := &LoginOptions{
 		Reader: reader,
 		Out:    out,
 	}
 
 	cmds := &cobra.Command{
-		Use:   "login [URL]",
-		Short: "Logs in and save the configuration",
-		Long:  longDescription,
+		Use:     "login [URL]",
+		Short:   "Logs in and save the configuration",
+		Long:    login_long,
+		Example: fmt.Sprintf(login_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, cmd, args); err != nil {
 				kcmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -51,8 +51,8 @@ type LoginOptions struct {
 	PathOptions *kcmdconfig.PathOptions
 }
 
-const longDescription = `Logs in to the OpenShift server and saves a config file that
-will be used by subsequent commands.
+const longDescription = `Logs in to the OpenShift server and saves a config file that will be used by 
+subsequent commands.
 
 First-time users of the OpenShift client must run this command to configure the server,
 establish a session against it, and save it to a configuration file. The default

--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -29,8 +29,8 @@ const logoutLongDescription = `Logs out the current user by deleting the token a
 
 Examples:
 
-	# Logout:
-	$ %[1]s
+  # Logout:
+  $ %[1]s
 
 If you want to log back into the OpenShift server, try '%[2]s'.
 `

--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -25,15 +25,14 @@ type LogoutOptions struct {
 	PathOptions *kcmdconfig.PathOptions
 }
 
-const logoutLongDescription = `Logs out the current user by deleting the token and removing the token from the kubeconfig file.
+const (
+	logout_long = `Logs out the current user by deleting the token and removing the token from the kubeconfig file.
 
-Examples:
+After logging out, if you want to log back into the OpenShift server, try '%[1]s'.`
 
-  # Logout:
-  $ %[1]s
-
-If you want to log back into the OpenShift server, try '%[2]s'.
-`
+	logout_example = `  // Logout
+  $ %[1]s`
+)
 
 // NewCmdLogout implements the OpenShift cli logout command
 func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
@@ -42,9 +41,10 @@ func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Fac
 	}
 
 	cmds := &cobra.Command{
-		Use:   name,
-		Short: "Logs out the current user.",
-		Long:  fmt.Sprintf(logoutLongDescription, fullName, oscLoginFullCommand),
+		Use:     name,
+		Short:   "Logs out the current user.",
+		Long:    fmt.Sprintf(logout_long, oscLoginFullCommand),
+		Example: fmt.Sprintf(logout_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, cmd, args); err != nil {
 				kcmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -40,17 +40,17 @@ configuration, and a service will be hooked up to the first public port of the a
 
 Examples:
 
-	# Try to create an application based on the source code in the current directory
-	$ %[1]s new-app .
+  # Try to create an application based on the source code in the current directory
+  $ %[1]s new-app .
 
-	$ Use the public Docker Hub MySQL image to create an app
-	$ %[1]s new-app mysql
+  # Use the public Docker Hub MySQL image to create an app
+  $ %[1]s new-app mysql
 
-	# Use a MySQL image in a private registry to create an app
-	$ %[1]s new-app myregistry.com/mycompany/mysql
+  # Use a MySQL image in a private registry to create an app
+  $ %[1]s new-app myregistry.com/mycompany/mysql
 
-	# Create an application from the remote repository using the specified label
-	$ %[1]s new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
+  # Create an application from the remote repository using the specified label
+  $ %[1]s new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
 
   # Create an application based on a stored template, explicitly setting a parameter value
   $ %[1]s new-app ruby-helloworld-sample --param=MYSQL_USER=admin

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -52,8 +52,8 @@ Examples:
 	# Create an application from the remote repository using the specified label
 	$ %[1]s new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
 
-	# Create an application based on a stored template, explicitly setting a parameter value
-	$ %[1]s new-app ruby-helloworld-sample --env=MYSQL_USER=admin
+  # Create an application based on a stored template, explicitly setting a parameter value
+  $ %[1]s new-app ruby-helloworld-sample --param=MYSQL_USER=admin
 
 If you specify source code, you may need to run a build with 'start-build' after the
 application is created.
@@ -67,7 +67,7 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 	config := newcmd.NewAppConfig(typer)
 
 	cmd := &cobra.Command{
-		Use:   "new-app <components> [--code=<path|url>]",
+		Use:   "new-app (IMAGE | IMAGESTREAM | TEMPLATE | PATH | URL ...)",
 		Short: "Create a new application",
 		Long:  fmt.Sprintf(newAppLongDesc, fullName),
 

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -28,8 +28,8 @@ type usage interface {
 
 var errExit = fmt.Errorf("exit directly")
 
-const newAppLongDesc = `
-Create a new application in OpenShift by specifying source code, templates, and/or images.
+const (
+	newApp_long = `Create a new application in OpenShift by specifying source code, templates, and/or images.
 
 This command will try to build up the components of an application using images, templates, 
 or code located on your system. It will lookup the images on the local Docker installation 
@@ -38,28 +38,26 @@ code URL, it will set up a build that takes your source code and converts it int
 image that can run inside of a pod. The images will be deployed via a deployment
 configuration, and a service will be hooked up to the first public port of the app.
 
-Examples:
-
-  # Try to create an application based on the source code in the current directory
-  $ %[1]s new-app .
-
-  # Use the public Docker Hub MySQL image to create an app
-  $ %[1]s new-app mysql
-
-  # Use a MySQL image in a private registry to create an app
-  $ %[1]s new-app myregistry.com/mycompany/mysql
-
-  # Create an application from the remote repository using the specified label
-  $ %[1]s new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
-
-  # Create an application based on a stored template, explicitly setting a parameter value
-  $ %[1]s new-app ruby-helloworld-sample --param=MYSQL_USER=admin
-
 If you specify source code, you may need to run a build with 'start-build' after the
 application is created.
 
-ALPHA: This command is under active development - feedback is appreciated.
-`
+ALPHA: This command is under active development - feedback is appreciated.`
+
+	newApp_example = `  // Try to create an application based on the source code in the current directory
+  $ %[1]s new-app .
+
+  // Use the public Docker Hub MySQL image to create an app
+  $ %[1]s new-app mysql
+
+  // Use a MySQL image in a private registry to create an app
+  $ %[1]s new-app myregistry.com/mycompany/mysql
+
+  // Create an application from the remote repository using the specified label
+  $ %[1]s new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
+
+  // Create an application based on a stored template, explicitly setting a parameter value
+  $ %[1]s new-app ruby-helloworld-sample --param=MYSQL_USER=admin`
+)
 
 // NewCmdNewApplication implements the OpenShift cli new-app command
 func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -67,10 +65,10 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 	config := newcmd.NewAppConfig(typer)
 
 	cmd := &cobra.Command{
-		Use:   "new-app (IMAGE | IMAGESTREAM | TEMPLATE | PATH | URL ...)",
-		Short: "Create a new application",
-		Long:  fmt.Sprintf(newAppLongDesc, fullName),
-
+		Use:     "new-app (IMAGE | IMAGESTREAM | TEMPLATE | PATH | URL ...)",
+		Short:   "Create a new application",
+		Long:    newApp_long,
+		Example: fmt.Sprintf(newApp_example, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			err := RunNewApplication(f, out, c, args, config)
 			if err == errExit {

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -50,17 +50,17 @@ JSON and YAML formats are accepted.
 
 Examples:
 
-	# Convert template.json file into resource list
-	$ %[1]s process -f template.json
+  # Convert template.json file into resource list
+  $ %[1]s process -f template.json
 
-	# Process template while passing a user-defined label
-	$ %[1]s process -f template.json -l name=mytemplate
+  # Process template while passing a user-defined label
+  $ %[1]s process -f template.json -l name=mytemplate
 
-	# Convert stored template into resource list
-	$ %[1]s process foo
+  # Convert stored template into resource list
+  $ %[1]s process foo
 
-	# Convert template.json into resource list
-	$ cat template.json | %[1]s process -f -
+  # Convert template.json into resource list
+  $ cat template.json | %[1]s process -f -
 `
 
 // NewCmdProcess implements the OpenShift cli process command

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -66,7 +66,7 @@ Examples:
 // NewCmdProcess implements the OpenShift cli process command
 func NewCmdProcess(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "process -f filename",
+		Use:   "process (TEMPLATE | -f FILENAME) [-v=KEY=VALUE]",
 		Short: "Process template into list of resources",
 		Long:  fmt.Sprintf(processLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -44,31 +44,31 @@ func injectUserVars(cmd *cobra.Command, t *api.Template) {
 	}
 }
 
-const processLongDesc = `Process template into a list of resources specified in filename or stdin
+const (
+	process_long = `Process template into a list of resources specified in filename or stdin
 
-JSON and YAML formats are accepted.
+JSON and YAML formats are accepted.`
 
-Examples:
-
-  # Convert template.json file into resource list
+	process_example = `  // Convert template.json file into resource list
   $ %[1]s process -f template.json
 
-  # Process template while passing a user-defined label
+  // Process template while passing a user-defined label
   $ %[1]s process -f template.json -l name=mytemplate
 
-  # Convert stored template into resource list
+  // Convert stored template into resource list
   $ %[1]s process foo
 
-  # Convert template.json into resource list
-  $ cat template.json | %[1]s process -f -
-`
+  // Convert template.json into resource list
+  $ cat template.json | %[1]s process -f -`
+)
 
 // NewCmdProcess implements the OpenShift cli process command
 func NewCmdProcess(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "process (TEMPLATE | -f FILENAME) [-v=KEY=VALUE]",
-		Short: "Process template into list of resources",
-		Long:  fmt.Sprintf(processLongDesc, fullName),
+		Use:     "process (TEMPLATE | -f FILENAME) [-v=KEY=VALUE]",
+		Short:   "Process template into list of resources",
+		Long:    process_long,
+		Example: fmt.Sprintf(process_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunProcess(f, out, cmd, args)
 			kcmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -35,15 +35,15 @@ type ProjectOptions struct {
 }
 
 const projectLongDesc = `
-Switch to another project and make it the default in your configuration.
+Switch to another project and make it the default in your configuration. If no project were specified, display information about the default.
 
 Examples:
 
-        # Switch to my-app project
-        $ %[1]s myapp
+  # Switch to my-app project
+  $ %[1]s myapp
 
-        # Display the project currently in use
-        $ %[1]s
+  # Display the project currently in use
+  $ %[1]s
 `
 
 // NewCmdProject implements the OpenShift cli rollback command
@@ -51,7 +51,7 @@ func NewCmdProject(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.
 	options := &ProjectOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "project <project-name>",
+		Use:   "project [NAME]",
 		Short: "Switch to another project",
 		Long:  fmt.Sprintf(projectLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -34,26 +34,26 @@ type ProjectOptions struct {
 	ProjectOnly bool
 }
 
-const projectLongDesc = `
-Switch to another project and make it the default in your configuration. If no project were specified, display information about the default.
+const (
+	project_long = `Switch to another project and make it the default in your configuration. If no project were 
+specified, display information about the default.`
 
-Examples:
-
-  # Switch to my-app project
+	project_example = `  // Switch to 'myapp' project
   $ %[1]s myapp
 
-  # Display the project currently in use
-  $ %[1]s
-`
+  // Display the project currently in use
+  $ %[1]s`
+)
 
 // NewCmdProject implements the OpenShift cli rollback command
 func NewCmdProject(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	options := &ProjectOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "project [NAME]",
-		Short: "Switch to another project",
-		Long:  fmt.Sprintf(projectLongDesc, fullName),
+		Use:     "project [NAME]",
+		Short:   "Switch to another project",
+		Long:    project_long,
+		Example: fmt.Sprintf(project_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			options.PathOptions = cliconfig.NewPathOptions(cmd)
 

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -37,11 +37,11 @@ be logged in, so you might have to run %[2]s first.
 
 Examples:
 
-	$ Create a new project with minimal information
-	$ %[1]s web-team-dev
+  # Create a new project with minimal information
+  $ %[1]s web-team-dev
 
-	# Create a new project with a description
-	$ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."
+  # Create a new project with a description
+  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."
 
 After your project is created you can switch to it using %[3]s <project name>.
 `

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -51,7 +51,7 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 	options.Out = out
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s <project-name> [--display-name=<your display name> --description=<your description]", name),
+		Use:   fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
 		Short: "request a new project",
 		Long:  fmt.Sprintf(requestProjectLongDesc, fullName, oscLoginName, oscProjectName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -28,32 +28,31 @@ type NewProjectOptions struct {
 	Out            io.Writer
 }
 
-const requestProjectLongDesc = `
-Create a new project for yourself in OpenShift with you as the project admin.
+const (
+	requestProject_long = `Create a new project for yourself in OpenShift with you as the project admin.
 
 Assuming your cluster admin has granted you permission, this command will 
 create a new project for you and assign you as the project admin.  You must 
-be logged in, so you might have to run %[2]s first.
+be logged in, so you might have to run %[1]s first.
 
-Examples:
+After your project is created you can switch to it using %[2]s <project name>.`
 
-  # Create a new project with minimal information
+	requestProject_example = `  // Create a new project with minimal information
   $ %[1]s web-team-dev
 
-  # Create a new project with a description
-  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."
-
-After your project is created you can switch to it using %[3]s <project name>.
-`
+  // Create a new project with a description
+  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."`
+)
 
 func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	options := &NewProjectOptions{}
 	options.Out = out
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
-		Short: "request a new project",
-		Long:  fmt.Sprintf(requestProjectLongDesc, fullName, oscLoginName, oscProjectName),
+		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
+		Short:   "Request a new project",
+		Long:    fmt.Sprintf(requestProject_long, oscLoginName, oscProjectName),
+		Example: fmt.Sprintf(requestProject_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.complete(cmd, f); err != nil {
 				kcmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -51,7 +51,7 @@ func NewCmdRollback(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	}
 
 	cmd := &cobra.Command{
-		Use:   "rollback <from-deployment>",
+		Use:   "rollback DEPLOYMENT",
 		Short: "Revert part of an application back to a previous deployment.",
 		Long:  fmt.Sprintf(rollbackLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -15,8 +15,8 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
 
-const rollbackLongDesc = `
-Revert part of an application back to a previous deployment.
+const (
+	rollback_long = `Revert part of an application back to a previous deployment.
 
 When you run this command your deployment configuration will be updated to match
 the provided deployment. By default only the pod and container configuration
@@ -28,19 +28,17 @@ deployment may not have the correct values.
 If you would like to review the outcome of the rollback, pass '--dry-run' to print
 a human-readable representation of the updated deployment configuration instead of
 executing the rollback. This is useful if you're not quite sure what the outcome
-will be.
+will be.`
 
-Examples:
-
-  # Perform a rollback
+	rollback_example = `  // Perform a rollback
   $ %[1]s rollback deployment-1
 
-  # See what the rollback will look like, but don't perform the rollback
+  // See what the rollback will look like, but don't perform the rollback
   $ %[1]s rollback deployment-1 --dry-run
 
-  # Perform the rollback manually by piping the JSON of the new config back to %[1]s
-  $ %[1]s rollback deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -
-`
+  // Perform the rollback manually by piping the JSON of the new config back to %[1]s
+  $ %[1]s rollback deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -`
+)
 
 // NewCmdRollback implements the OpenShift cli rollback command
 func NewCmdRollback(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -51,9 +49,10 @@ func NewCmdRollback(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	}
 
 	cmd := &cobra.Command{
-		Use:   "rollback DEPLOYMENT",
-		Short: "Revert part of an application back to a previous deployment.",
-		Long:  fmt.Sprintf(rollbackLongDesc, fullName),
+		Use:     "rollback DEPLOYMENT",
+		Short:   "Revert part of an application back to a previous deployment.",
+		Long:    rollback_long,
+		Example: fmt.Sprintf(rollback_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunRollback(f, out, cmd, args, rollback)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -32,14 +32,14 @@ will be.
 
 Examples:
 
-	# Perform a rollback
-	$ %[1]s rollback deployment-1
+  # Perform a rollback
+  $ %[1]s rollback deployment-1
 
-	# See what the rollback will look like, but don't perform the rollback
-	$ %[1]s rollback deployment-1 --dry-run
+  # See what the rollback will look like, but don't perform the rollback
+  $ %[1]s rollback deployment-1 --dry-run
 
-	# Perform the rollback manually by piping the JSON of the new config back to %[1]s
-	$ %[1]s rollback deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -
+  # Perform the rollback manually by piping the JSON of the new config back to %[1]s
+  $ %[1]s rollback deployment-1 --output=json | %[1]s update deploymentConfigs deployment -f -
 `
 
 // NewCmdRollback implements the OpenShift cli rollback command

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -26,15 +26,15 @@ This command starts a build for the provided build configuration or re-runs an e
 
 Examples:
 
-	# Starts build from build configuration matching the name "3bd2ug53b"
-	$ %[1]s start-build 3bd2ug53b
+  # Starts build from build configuration matching the name "3bd2ug53b"
+  $ %[1]s start-build 3bd2ug53b
 
-	# Starts build from build matching the name "3bd2ug53b"
-	$ %[1]s start-build --from-build=3bd2ug53b
+  # Starts build from build matching the name "3bd2ug53b"
+  $ %[1]s start-build --from-build=3bd2ug53b
 
-	# Starts build from build configuration matching the name "3bd2ug53b" and watches the logs until the build
-	# completes or fails
-	$ %[1]s start-build 3bd2ug53b --follow
+  # Starts build from build configuration matching the name "3bd2ug53b" and watches the logs until the build
+  # completes or fails
+  $ %[1]s start-build 3bd2ug53b --follow
 `
 
 // NewCmdStartBuild implements the OpenShift cli start-build command

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -43,8 +43,8 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 	webhooks.Default("none")
 
 	cmd := &cobra.Command{
-		Use:   "start-build (<build_config>|--from-build=<build>)",
-		Short: "Starts a new build from existing build or build config",
+		Use:   "start-build (BUILDCONFIG | --from-build=BUILD)",
+		Short: "Starts a new build from existing build or buildConfig",
 		Long:  fmt.Sprintf(startBuildLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunStartBuild(f, out, cmd, args, webhooks)

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -19,23 +19,22 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const startBuildLongDesc = `Start a build
+const (
+	startBuild_long = `Start a build.
 
 This command starts a build for the provided build configuration or re-runs an existing build using
---from-build=<name>. You may pass the --follow flag to see output from the build.
+--from-build=<name>. You may pass the --follow flag to see output from the build.`
 
-Examples:
-
-  # Starts build from build configuration matching the name "3bd2ug53b"
+	startBuild_example = `  // Starts build from build configuration matching the name "3bd2ug53b"
   $ %[1]s start-build 3bd2ug53b
 
-  # Starts build from build matching the name "3bd2ug53b"
+  // Starts build from build matching the name "3bd2ug53b"
   $ %[1]s start-build --from-build=3bd2ug53b
 
-  # Starts build from build configuration matching the name "3bd2ug53b" and watches the logs until the build
-  # completes or fails
-  $ %[1]s start-build 3bd2ug53b --follow
-`
+  // Starts build from build configuration matching the name "3bd2ug53b" and watches the logs until the build
+  // completes or fails
+  $ %[1]s start-build 3bd2ug53b --follow`
+)
 
 // NewCmdStartBuild implements the OpenShift cli start-build command
 func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -43,9 +42,10 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 	webhooks.Default("none")
 
 	cmd := &cobra.Command{
-		Use:   "start-build (BUILDCONFIG | --from-build=BUILD)",
-		Short: "Starts a new build from existing build or buildConfig",
-		Long:  fmt.Sprintf(startBuildLongDesc, fullName),
+		Use:     "start-build (BUILDCONFIG | --from-build=BUILD)",
+		Short:   "Starts a new build from existing build or buildConfig",
+		Long:    startBuild_long,
+		Example: fmt.Sprintf(startBuild_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunStartBuild(f, out, cmd, args, webhooks)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -18,8 +18,9 @@ For more information about individual items, use the describe command (e.g. osc 
 osc describe deploymentConfig, osc describe service).
 
 Examples:
-        # Show an overview of the current project
-        $ %[1]s status
+
+  # Show an overview of the current project
+  $ %[1]s status
 `
 
 // NewCmdStatus implements the OpenShift cli status command

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -12,23 +12,22 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const statusLongDesc = `
-Show a high level overview of the current project. Links components by their relationships.
+const (
+	status_long = `Show a high level overview of the current project. Links components by their relationships.
 For more information about individual items, use the describe command (e.g. osc describe buildConfig,
-osc describe deploymentConfig, osc describe service).
+osc describe deploymentConfig, osc describe service).`
 
-Examples:
-
-  # Show an overview of the current project
-  $ %[1]s status
-`
+	status_example = `  // Show an overview of the current project
+  $ %[1]s status`
+)
 
 // NewCmdStatus implements the OpenShift cli status command
 func NewCmdStatus(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "Show an overview of the current project",
-		Long:  fmt.Sprintf(statusLongDesc, fullName),
+		Use:     "status",
+		Short:   "Show an overview of the current project",
+		Long:    status_long,
+		Example: fmt.Sprintf(status_example, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunStatus(f, out)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -20,17 +20,17 @@ Possible resources include builds, buildConfigs, services, pods, etc.
 
 Examples:
 
-	# List all pods in ps output format.
-	$ %[1]s get pods
+  # List all pods in ps output format.
+  $ %[1]s get pods
 
-	# List a single replication controller with specified ID in ps output format.
-	$ %[1]s get replicationController 1234-56-7890-234234-456456
+  # List a single replication controller with specified ID in ps output format.
+  $ %[1]s get replicationController 1234-56-7890-234234-456456
 
-	# List a single pod in JSON output format.
-	$ %[1]s get -o json pod 1234-56-7890-234234-456456
+  # List a single pod in JSON output format.
+  $ %[1]s get -o json pod 1234-56-7890-234234-456456
 
-	# Return only the status value of the specified pod.
-	$ %[1]s get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
+  # Return only the status value of the specified pod.
+  $ %[1]s get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -45,14 +45,14 @@ JSON and YAML formats are accepted.
 
 Examples:
 
-	# Update a pod using the data in pod.json.
-	$ %[1]s update -f pod.json
+  # Update a pod using the data in pod.json.
+  $ %[1]s update -f pod.json
 
-	# Update a pod based on the JSON passed into stdin.
-	$ cat pod.json | %[1]s update -f -
+  # Update a pod based on the JSON passed into stdin.
+  $ cat pod.json | %[1]s update -f -
 
-	# Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
-	$ %[1]s update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'
+  # Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
+  $ %[1]s update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -74,20 +74,20 @@ will be lost along with the rest of the resource.
 
 Examples:
 
-	# Delete a pod using the type and ID specified in pod.json.
-	$ %[1]s delete -f pod.json
+  # Delete a pod using the type and ID specified in pod.json.
+  $ %[1]s delete -f pod.json
 
-	# Delete a pod based on the type and ID in the JSON passed into stdin.
-	$ cat pod.json | %[1]s delete -f -
+  # Delete a pod based on the type and ID in the JSON passed into stdin.
+  $ cat pod.json | %[1]s delete -f -
 
-	# Delete pods and services with label name=myLabel.
-	$ %[1]s delete pods,services -l name=myLabel
+  # Delete pods and services with label name=myLabel.
+  $ %[1]s delete pods,services -l name=myLabel
 
-	# Delete a pod with ID 1234-56-7890-234234-456456.
-	$ %[1]s delete pod 1234-56-7890-234234-456456
+  # Delete a pod with ID 1234-56-7890-234234-456456.
+  $ %[1]s delete pod 1234-56-7890-234234-456456
 
-	# Delete all pods
-	$ %[1]s delete pods --all
+  # Delete all pods
+  $ %[1]s delete pods --all
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -100,11 +100,11 @@ func NewCmdLog(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Comm
 
 Examples:
 
-	# Returns snapshot of ruby-container logs from pod 123456-7890.
-	$ %[1]s log 123456-7890 ruby-container
+  # Returns snapshot of ruby-container logs from pod 123456-7890.
+  $ %[1]s log 123456-7890 ruby-container
 
-	# Starts streaming of ruby-container logs from pod 123456-7890.
-	$ %[1]s log -f 123456-7890 ruby-container
+  # Starts streaming of ruby-container logs from pod 123456-7890.
+  $ %[1]s log -f 123456-7890 ruby-container
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -119,11 +119,11 @@ JSON and YAML formats are accepted.
 
 Examples:
 
-	# Create a pod using the data in pod.json.
-	$ %[1]s create -f pod.json
+  # Create a pod using the data in pod.json.
+  $ %[1]s create -f pod.json
 
-	# Create a pod based on the JSON passed into stdin.
-	$ cat pod.json | %[1]s create -f -
+  # Create a pod based on the JSON passed into stdin.
+  $ cat pod.json | %[1]s create -f -
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -136,11 +136,11 @@ func NewCmdExec(fullName string, f *clientcmd.Factory, cmdIn io.Reader, cmdOut, 
 
 Examples:
 
-	# get output from running 'date' in ruby-container from pod 123456-7890
-	$ %[1]s exec -p 123456-7890 -c ruby-container date
+  # get output from running 'date' in ruby-container from pod 123456-7890
+  $ %[1]s exec -p 123456-7890 -c ruby-container date
 
-	# switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780 and sends stdout/stderr from 'bash' back to the client
-	$ %[1]s exec -p 123456-7890 -c ruby-container -i -t -- bash -il
+  # switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780 and sends stdout/stderr from 'bash' back to the client
+  $ %[1]s exec -p 123456-7890 -c ruby-container -i -t -- bash -il
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -153,17 +153,17 @@ func NewCmdPortForward(fullName string, f *clientcmd.Factory) *cobra.Command {
 
 Examples:
 
-	# listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
-	$ %[1]s port-forward -p mypod 5000 6000
+  # listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
+  $ %[1]s port-forward -p mypod 5000 6000
 
-	# listens on port 8888 locally, forwarding to 5000 in the pod
-	$ %[1]s port-forward -p mypod 8888:5000
+  # listens on port 8888 locally, forwarding to 5000 in the pod
+  $ %[1]s port-forward -p mypod 8888:5000
 
-	# listens on a random port locally, forwarding to 5000 in the pod
-	$ %[1]s port-forward -p mypod :5000
+  # listens on a random port locally, forwarding to 5000 in the pod
+  $ %[1]s port-forward -p mypod :5000
 
-	# listens on a random port locally, forwarding to 5000 in the pod
-	$ %[1]s port-forward -p mypod 0:5000
+  # listens on a random port locally, forwarding to 5000 in the pod
+  $ %[1]s port-forward -p mypod 0:5000
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -179,11 +179,11 @@ given resource.
 
 Examples:
 
-	# Provide details about the ruby-20-centos7 image repository
-	$ %[1]s describe imageRepository ruby-20-centos7
+  # Provide details about the ruby-20-centos7 image repository
+  $ %[1]s describe imageRepository ruby-20-centos7
 
-	# Provide details about the ruby-sample-build build configuration
-	$ %[1]s describe bc ruby-sample-build
+  # Provide details about the ruby-sample-build build configuration
+  $ %[1]s describe bc ruby-sample-build
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd
@@ -196,12 +196,12 @@ func NewCmdProxy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Co
 
 Examples:
 
-	# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
-	$ %[1]s proxy --port=8011 --www=./local/www/
+  # Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
+  $ %[1]s proxy --port=8011 --www=./local/www/
 
-	# Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
-	# This makes e.g. the pods api available at localhost:8011/k8s-api/v1beta1/pods/
-	$ %[1]s proxy --api-prefix=k8s-api
+  # Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
+  # This makes e.g. the pods api available at localhost:8011/k8s-api/v1beta1/pods/
+  $ %[1]s proxy --api-prefix=k8s-api
 `
 	cmd.Long = fmt.Sprintf(longDesc, fullName)
 	return cmd

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -11,57 +13,57 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
+const (
+	get_long = `Display one or many resources.
+
+Possible resources include builds, buildConfigs, services, pods, etc.`
+
+	get_example = `  // List all pods in ps output format.
+  $ %[1]s get pods
+
+  // List a single replication controller with specified ID in ps output format.
+  $ %[1]s get replicationController 1234-56-7890-234234-456456
+
+  // List a single pod in JSON output format.
+  $ %[1]s get -o json pod 1234-56-7890-234234-456456
+
+  // Return only the status value of the specified pod.
+  $ %[1]s get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}`
+)
+
 // NewCmdGet is a wrapper for the Kubernetes cli get command
 func NewCmdGet(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdGet(f.Factory, out)
-	longDesc := `Display one or many resources.
-
-Possible resources include builds, buildConfigs, services, pods, etc.
-
-Examples:
-
-  # List all pods in ps output format.
-  $ %[1]s get pods
-
-  # List a single replication controller with specified ID in ps output format.
-  $ %[1]s get replicationController 1234-56-7890-234234-456456
-
-  # List a single pod in JSON output format.
-  $ %[1]s get -o json pod 1234-56-7890-234234-456456
-
-  # Return only the status value of the specified pod.
-  $ %[1]s get -o template pod 1234-56-7890-234234-456456 --template={{.currentState.status}}
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = get_long
+	cmd.Example = fmt.Sprintf(get_example, fullName)
 	return cmd
 }
+
+const (
+	update_long = `Update a resource by filename or stdin.
+
+JSON and YAML formats are accepted.`
+
+	update_example = `  // Update a pod using the data in pod.json.
+  $ %[1]s update -f pod.json
+
+  // Update a pod based on the JSON passed into stdin.
+  $ cat pod.json | %[1]s update -f -
+
+  // Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
+  $ %[1]s update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'`
+)
 
 // NewCmdUpdate is a wrapper for the Kubernetes cli update command
 func NewCmdUpdate(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdUpdate(f.Factory, out)
-	longDesc := `Update a resource by filename or stdin.
-
-JSON and YAML formats are accepted.
-
-Examples:
-
-  # Update a pod using the data in pod.json.
-  $ %[1]s update -f pod.json
-
-  # Update a pod based on the JSON passed into stdin.
-  $ cat pod.json | %[1]s update -f -
-
-  # Update a pod by downloading it, applying the patch, then updating. Requires apiVersion be specified.
-  $ %[1]s update pods my-pod --patch='{ "apiVersion": "v1beta1", "desiredState": { "manifest": [{ "cpu": 100 }]}}'
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = update_long
+	cmd.Example = fmt.Sprintf(update_example, fullName)
 	return cmd
 }
 
-// NewCmdDelete is a wrapper for the Kubernetes cli delete command
-func NewCmdDelete(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	cmd := cmd.NewCmdDelete(f.Factory, out)
-	longDesc := `Delete a resource by filename, stdin, resource and ID, or by resources and label selector.
+const (
+	delete_long = `Delete a resource by filename, stdin, resource and ID, or by resources and label selector.
 
 JSON and YAML formats are accepted.
 
@@ -70,139 +72,157 @@ arguments are used and the filename is ignored.
 
 Note that the delete command does NOT do resource version checks, so if someone
 submits an update to a resource right when you submit a delete, their update
-will be lost along with the rest of the resource.
+will be lost along with the rest of the resource.`
 
-Examples:
-
-  # Delete a pod using the type and ID specified in pod.json.
+	delete_example = `  // Delete a pod using the type and ID specified in pod.json.
   $ %[1]s delete -f pod.json
 
-  # Delete a pod based on the type and ID in the JSON passed into stdin.
+  // Delete a pod based on the type and ID in the JSON passed into stdin.
   $ cat pod.json | %[1]s delete -f -
 
-  # Delete pods and services with label name=myLabel.
+  // Delete pods and services with label name=myLabel.
   $ %[1]s delete pods,services -l name=myLabel
 
-  # Delete a pod with ID 1234-56-7890-234234-456456.
+  // Delete a pod with ID 1234-56-7890-234234-456456.
   $ %[1]s delete pod 1234-56-7890-234234-456456
 
-  # Delete all pods
-  $ %[1]s delete pods --all
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+  // Delete all pods
+  $ %[1]s delete pods --all`
+)
+
+// NewCmdDelete is a wrapper for the Kubernetes cli delete command
+func NewCmdDelete(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	cmd := cmd.NewCmdDelete(f.Factory, out)
+	cmd.Long = delete_long
+	cmd.Example = fmt.Sprintf(delete_example, fullName)
 	return cmd
 }
+
+const (
+	log_long = `Print the logs for a container in a pod. If the pod has only one container, the container name is optional.`
+
+	log_example = `  // Returns snapshot of ruby-container logs from pod 123456-7890.
+  $ %[1]s log 123456-7890 ruby-container
+
+  // Starts streaming of ruby-container logs from pod 123456-7890.
+  $ %[1]s log -f 123456-7890 ruby-container`
+)
 
 // NewCmdLog is a wrapper for the Kubernetes cli log command
 func NewCmdLog(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdLog(f.Factory, out)
-	longDesc := `Print the logs for a container in a pod. If the pod has only one container, the container name is optional.
-
-Examples:
-
-  # Returns snapshot of ruby-container logs from pod 123456-7890.
-  $ %[1]s log 123456-7890 ruby-container
-
-  # Starts streaming of ruby-container logs from pod 123456-7890.
-  $ %[1]s log -f 123456-7890 ruby-container
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = log_long
+	cmd.Example = fmt.Sprintf(log_example, fullName)
 	return cmd
 }
+
+const (
+	create_long = `Create a resource by filename or stdin.
+
+JSON and YAML formats are accepted.`
+
+	create_example = `  // Create a pod using the data in pod.json.
+  $ %[1]s create -f pod.json
+
+  // Create a pod based on the JSON passed into stdin.
+  $ cat pod.json | %[1]s create -f -`
+)
 
 // NewCmdCreate is a wrapper for the Kubernetes cli create command
 func NewCmdCreate(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdCreate(f.Factory, out)
-	longDesc := `Create a resource by filename or stdin.
-
-JSON and YAML formats are accepted.
-
-Examples:
-
-  # Create a pod using the data in pod.json.
-  $ %[1]s create -f pod.json
-
-  # Create a pod based on the JSON passed into stdin.
-  $ cat pod.json | %[1]s create -f -
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = create_long
+	cmd.Example = fmt.Sprintf(create_example, fullName)
 	return cmd
 }
+
+const (
+	exec_long = `Execute a command in a container.`
+
+	exec_example = `  // Get output from running 'date' in ruby-container from pod 123456-7890
+  $ %[1]s exec -p 123456-7890 -c ruby-container date
+
+  // Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780 and sends stdout/stderr from 'bash' back to the client
+  $ %[1]s exec -p 123456-7890 -c ruby-container -i -t -- bash -il`
+)
 
 // NewCmdExec is a wrapper for the Kubernetes cli exec command
 func NewCmdExec(fullName string, f *clientcmd.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdExec(f.Factory, cmdIn, cmdOut, cmdErr)
-	longDesc := `Execute a command in a container.
-
-Examples:
-
-  # get output from running 'date' in ruby-container from pod 123456-7890
-  $ %[1]s exec -p 123456-7890 -c ruby-container date
-
-  # switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780 and sends stdout/stderr from 'bash' back to the client
-  $ %[1]s exec -p 123456-7890 -c ruby-container -i -t -- bash -il
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = exec_long
+	cmd.Example = fmt.Sprintf(exec_example, fullName)
 	return cmd
 }
+
+const (
+	portForward_long = `Forward 1 or more local ports to a pod.`
+
+	portForward_example = `  // Listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
+  $ %[1]s port-forward -p mypod 5000 6000
+
+  // Listens on port 8888 locally, forwarding to 5000 in the pod
+  $ %[1]s port-forward -p mypod 8888:5000
+
+  // Listens on a random port locally, forwarding to 5000 in the pod
+  $ %[1]s port-forward -p mypod :5000
+
+  // Listens on a random port locally, forwarding to 5000 in the pod
+  $ %[1]s port-forward -p mypod 0:5000`
+)
 
 // NewCmdPortForward is a wrapper for the Kubernetes cli port-forward command
 func NewCmdPortForward(fullName string, f *clientcmd.Factory) *cobra.Command {
 	cmd := cmd.NewCmdPortForward(f.Factory)
-	longDesc := `Forward 1 or more local ports to a pod.
-
-Examples:
-
-  # listens on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
-  $ %[1]s port-forward -p mypod 5000 6000
-
-  # listens on port 8888 locally, forwarding to 5000 in the pod
-  $ %[1]s port-forward -p mypod 8888:5000
-
-  # listens on a random port locally, forwarding to 5000 in the pod
-  $ %[1]s port-forward -p mypod :5000
-
-  # listens on a random port locally, forwarding to 5000 in the pod
-  $ %[1]s port-forward -p mypod 0:5000
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = portForward_long
+	cmd.Example = fmt.Sprintf(portForward_example, fullName)
 	return cmd
 }
+
+const (
+	describe_long = `Show details of a specific resource.
+
+This command joins many API calls together to form a detailed description of a
+given resource.`
+
+	describe_example = `  // Provide details about the ruby-20-centos7 image repository
+  $ %[1]s describe imageRepository ruby-20-centos7
+
+  // Provide details about the ruby-sample-build build configuration
+  $ %[1]s describe bc ruby-sample-build`
+)
 
 // NewCmdDescribe is a wrapper for the Kubernetes cli describe command
 func NewCmdDescribe(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdDescribe(f.Factory, out)
-	longDesc := `Show details of a specific resource.
-
-This command joins many API calls together to form a detailed description of a
-given resource.
-
-Examples:
-
-  # Provide details about the ruby-20-centos7 image repository
-  $ %[1]s describe imageRepository ruby-20-centos7
-
-  # Provide details about the ruby-sample-build build configuration
-  $ %[1]s describe bc ruby-sample-build
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = describe_long
+	cmd.Example = fmt.Sprintf(describe_example, fullName)
 	return cmd
 }
+
+const (
+	proxy_long = `Run a proxy to the Kubernetes API server.`
+
+	proxy_example = `  // Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
+  $ %[1]s proxy --port=8011 --www=./local/www/
+
+  // Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
+  // This makes e.g. the pods api available at localhost:8011/k8s-api/v1beta1/pods/
+  $ %[1]s proxy --api-prefix=k8s-api`
+)
 
 // NewCmdProxy is a wrapper for the Kubernetes cli proxy command
 func NewCmdProxy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := cmd.NewCmdProxy(f.Factory, out)
-	longDesc := `Run a proxy to the Kubernetes API server.
-
-Examples:
-
-  # Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
-  $ %[1]s proxy --port=8011 --www=./local/www/
-
-  # Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
-  # This makes e.g. the pods api available at localhost:8011/k8s-api/v1beta1/pods/
-  $ %[1]s proxy --api-prefix=k8s-api
-`
-	cmd.Long = fmt.Sprintf(longDesc, fullName)
+	cmd.Long = proxy_long
+	cmd.Example = fmt.Sprintf(proxy_example, fullName)
 	return cmd
+}
+
+func tab(original string) string {
+	lines := []string{}
+	scanner := bufio.NewScanner(strings.NewReader(original))
+	for scanner.Scan() {
+		lines = append(lines, "  "+scanner.Text())
+	}
+	return strings.Join(lines, "\n")
 }

--- a/pkg/cmd/experimental/buildchain/buildchain.go
+++ b/pkg/cmd/experimental/buildchain/buildchain.go
@@ -26,23 +26,23 @@ default namespace will be used respectively.
 
 Examples:
 
-    # Build dependency tree for the specified image repository and tag
-    $ openshift ex build-chain [image-repository]:[tag]
+  # Build dependency tree for the specified image repository and tag
+  $ openshift ex build-chain [image-repository]:[tag]
 
-    # Build dependency trees for all tags in the specified image repository
-    $ openshift ex build-chain [image-repository] --all-tags
+  # Build dependency trees for all tags in the specified image repository
+  $ openshift ex build-chain [image-repository] --all-tags
 
-    # Build the dependency tree using tag 'latest' in 'testing' namespace
-    $ openshift ex build-chain [image-repository] -n testing
+  # Build the dependency tree using tag 'latest' in 'testing' namespace
+  $ openshift ex build-chain [image-repository] -n testing
 
-    # Build the dependency tree and output it in DOT syntax
-    $ openshift ex build-chain [image-repository] -o dot
+  # Build the dependency tree and output it in DOT syntax
+  $ openshift ex build-chain [image-repository] -o dot
 
-    # Build dependency trees for all image repositories in the current namespace
-    $ openshift ex build-chain
+  # Build dependency trees for all image repositories in the current namespace
+  $ openshift ex build-chain
 
-    # Build dependency trees for all image repositories across all namespaces
-    $ openshift ex build-chain --all
+  # Build dependency trees for all image repositories across all namespaces
+  $ openshift ex build-chain --all
 `
 
 // ImageRepo is a representation of a node inside a tree
@@ -89,7 +89,7 @@ func NewEdge(fullname, to string) *Edge {
 // NewCmdBuildChain implements the OpenShift experimental build-chain command
 func NewCmdBuildChain(f *clientcmd.Factory, parentName, name string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s [image-repository]:[tag]", name),
+		Use:   fmt.Sprintf("%s [IMAGEREPOSITORY:TAG | --all]", name),
 		Short: "Output build dependencies of a specific image repository",
 		Long:  longDescription,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/experimental/buildchain/buildchain.go
+++ b/pkg/cmd/experimental/buildchain/buildchain.go
@@ -19,31 +19,30 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-const longDescription = `Output build dependencies of a specific image repository.
+const (
+	buildChain_long = `Output build dependencies of a specific image repository.
 Supported output formats are json, dot, and ast. The default is set to json.
 Tag and namespace are optional and if they are not specified, 'latest' and the 
-default namespace will be used respectively.
+default namespace will be used respectively.`
 
-Examples:
-
-  # Build dependency tree for the specified image repository and tag
+	buildChain_example = `  // Build dependency tree for the specified image repository and tag
   $ openshift ex build-chain [image-repository]:[tag]
 
-  # Build dependency trees for all tags in the specified image repository
+  // Build dependency trees for all tags in the specified image repository
   $ openshift ex build-chain [image-repository] --all-tags
 
-  # Build the dependency tree using tag 'latest' in 'testing' namespace
+  // Build the dependency tree using tag 'latest' in 'testing' namespace
   $ openshift ex build-chain [image-repository] -n testing
 
-  # Build the dependency tree and output it in DOT syntax
+  // Build the dependency tree and output it in DOT syntax
   $ openshift ex build-chain [image-repository] -o dot
 
-  # Build dependency trees for all image repositories in the current namespace
+  // Build dependency trees for all image repositories in the current namespace
   $ openshift ex build-chain
 
-  # Build dependency trees for all image repositories across all namespaces
-  $ openshift ex build-chain --all
-`
+  // Build dependency trees for all image repositories across all namespaces
+  $ openshift ex build-chain --all`
+)
 
 // ImageRepo is a representation of a node inside a tree
 type ImageRepo struct {
@@ -89,9 +88,10 @@ func NewEdge(fullname, to string) *Edge {
 // NewCmdBuildChain implements the OpenShift experimental build-chain command
 func NewCmdBuildChain(f *clientcmd.Factory, parentName, name string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s [IMAGEREPOSITORY:TAG | --all]", name),
-		Short: "Output build dependencies of a specific image repository",
-		Long:  longDescription,
+		Use:     fmt.Sprintf("%s [IMAGEREPOSITORY:TAG | --all]", name),
+		Short:   "Output build dependencies of a specific image repository",
+		Long:    buildChain_long,
+		Example: buildChain_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunBuildChain(f, cmd, args)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/experimental/bundlesecret/bundle-secret.go
+++ b/pkg/cmd/experimental/bundlesecret/bundle-secret.go
@@ -33,11 +33,11 @@ func NewCmdBundleSecret(f *clientcmd.Factory, parentName, name string, out io.Wr
 	options := NewDefaultOptions()
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s <secret-name> <source> [<source>...]", name),
+		Use:   fmt.Sprintf("%s NAME SOURCE [SOURCE ...]", name),
 		Short: "Bundle files (or files within directories) into a Kubernetes secret",
 		Long: fmt.Sprintf(`Bundle files (or files within directories) into a Kubernetes secret.
 
-    $ %s %s <secret-name> <source> [<source>...]
+  $ %s %s <secret-name> <source> [<source>...]
 		`, parentName, name),
 		Run: func(c *cobra.Command, args []string) {
 			options.Complete(args)

--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -13,9 +13,8 @@ import (
 	"github.com/openshift/origin/pkg/ipfailover/keepalived"
 )
 
-const shortDesc = "Configure or view IP Failover configuration"
-const description = `
-Configure or view IP Failover configuration
+const (
+	ipFailover_long = `Configure or view IP Failover configuration
 
 This command helps to setup IP Failover configuration for an OpenShift
 environment. An administrator can configure IP failover on an entire
@@ -29,30 +28,27 @@ recommended that the labelled selector for the nodes matches atleast 2 nodes
 to ensure you have failover protection and that you provide a --replicas=<n>
 value that matches the number of nodes for the given labelled selector.
 
-
-Examples:
-
-  # Check the default IP failover configuration ("ipfailover"):
-  $ %[1]s %[2]s
-
-  # See what the IP failover configuration would look like if it is created:
-  $ %[1]s %[2]s -o json
-
-  # Create an IP failover configuration if it does not already exist:
-  $ %[1]s %[2]s ipf --virtual-ips="10.1.1.1-4" --create
-
-  # Create an IP failover configuration on a selection of nodes labelled
-  # "router=us-west-ha" (on 4 nodes with 7 virtual IPs monitoring a service
-  # listening on port 80 (aka the OpenShift router process).
-  $ %[1]s %[2]s ipfailover --selector="router=us-west-ha" --virtual-ips="1.2.3.4,10.1.1.100-104,5.6.7.8" --watch-port=80 --replicas=4 --create
-
-  # Use a different IP failover config image and see the configuration:
-  $ %[1]s %[2]s ipf-alt --selector="jack=the-vipper" --virtual-ips="1.2.3.4" -o yaml --images=myrepo/myipfailover:mytag
-
 ALPHA: This command is currently being actively developed. It is intended
        to simplify the administrative tasks of setting up a highly
-       available failover configuration.
-`
+       available failover configuration.`
+
+	ipFailover_example = `  // Check the default IP failover configuration ("ipfailover"):
+  $ %[1]s %[2]s
+
+  // See what the IP failover configuration would look like if it is created:
+  $ %[1]s %[2]s -o json
+
+  // Create an IP failover configuration if it does not already exist:
+  $ %[1]s %[2]s ipf --virtual-ips="10.1.1.1-4" --create
+
+  // Create an IP failover configuration on a selection of nodes labelled
+  // "router=us-west-ha" (on 4 nodes with 7 virtual IPs monitoring a service
+  // listening on port 80 (aka the OpenShift router process).
+  $ %[1]s %[2]s ipfailover --selector="router=us-west-ha" --virtual-ips="1.2.3.4,10.1.1.100-104,5.6.7.8" --watch-port=80 --replicas=4 --create
+
+  // Use a different IP failover config image and see the configuration:
+  $ %[1]s %[2]s ipf-alt --selector="jack=the-vipper" --virtual-ips="1.2.3.4" -o yaml --images=myrepo/myipfailover:mytag`
+)
 
 func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
 	options := &ipfailover.IPFailoverConfigCmdOptions{
@@ -65,9 +61,10 @@ func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out i
 	}
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s [NAME]", name),
-		Short: shortDesc,
-		Long:  fmt.Sprintf(description, parentName, name),
+		Use:     fmt.Sprintf("%s [NAME]", name),
+		Short:   "Configure or view IP Failover configuration",
+		Long:    ipFailover_long,
+		Example: fmt.Sprintf(ipFailover_example, parentName, name),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := processCommand(f, options, cmd, args, out)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -31,26 +31,22 @@ value that matches the number of nodes for the given labelled selector.
 
 
 Examples:
-  Check the default IP failover configuration ("ipfailover"):
 
+  # Check the default IP failover configuration ("ipfailover"):
   $ %[1]s %[2]s
 
-  See what the IP failover configuration would look like if it is created:
-
+  # See what the IP failover configuration would look like if it is created:
   $ %[1]s %[2]s -o json
 
-  Create an IP failover configuration if it does not already exist:
-
+  # Create an IP failover configuration if it does not already exist:
   $ %[1]s %[2]s ipf --virtual-ips="10.1.1.1-4" --create
 
-  Create an IP failover configuration on a selection of nodes labelled
-  "router=us-west-ha" (on 4 nodes with 7 virtual IPs monitoring a service
-  listening on port 80 (aka the OpenShift router process).
-
+  # Create an IP failover configuration on a selection of nodes labelled
+  # "router=us-west-ha" (on 4 nodes with 7 virtual IPs monitoring a service
+  # listening on port 80 (aka the OpenShift router process).
   $ %[1]s %[2]s ipfailover --selector="router=us-west-ha" --virtual-ips="1.2.3.4,10.1.1.100-104,5.6.7.8" --watch-port=80 --replicas=4 --create
 
-  Use a different IP failover config image and see the configuration:
-
+  # Use a different IP failover config image and see the configuration:
   $ %[1]s %[2]s ipf-alt --selector="jack=the-vipper" --virtual-ips="1.2.3.4" -o yaml --images=myrepo/myipfailover:mytag
 
 ALPHA: This command is currently being actively developed. It is intended
@@ -69,7 +65,7 @@ func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out i
 	}
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s [<name>]", name),
+		Use:   fmt.Sprintf("%s [NAME]", name),
 		Short: shortDesc,
 		Long:  fmt.Sprintf(description, parentName, name),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/experimental/registry/registry.go
+++ b/pkg/cmd/experimental/registry/registry.go
@@ -38,20 +38,16 @@ pass --replicas=2 or higher to ensure you have failover protection. The default 
 uses a local volume and the data will be lost if you delete the running pod.
 
 Examples:
-  Check if default Docker registry ("docker-registry") has been created:
-
+  # Check if default Docker registry ("docker-registry") has been created:
   $ %[1]s %[2]s --dry-run
 
-  See what the registry would look like if created:
-
+  # See what the registry would look like if created:
   $ %[1]s %[2]s -o json
 
-  Create a registry if it does not exist with two replicas:
-
+  # Create a registry if it does not exist with two replicas:
   $ %[1]s %[2]s --replicas=2 --credentials=registry-user.kubeconfig
 
-  Use a different registry image and see the registry configuration:
-
+  # Use a different registry image and see the registry configuration:
   $ %[1]s %[2]s -o yaml --images=myrepo/docker-registry:mytag
 
 NOTE: This command is intended to simplify the tasks of setting up a Docker registry in a new

--- a/pkg/cmd/experimental/registry/registry.go
+++ b/pkg/cmd/experimental/registry/registry.go
@@ -21,8 +21,8 @@ import (
 	"github.com/openshift/origin/pkg/generate/app"
 )
 
-const longDesc = `
-Install or configure a Docker registry for OpenShift
+const (
+	registry_long = `Install or configure a Docker registry for OpenShift
 
 This command sets up a Docker registry integrated with OpenShift to provide notifications when
 images are pushed. With no arguments, the command will check for the existing registry service
@@ -37,23 +37,22 @@ that image for more on setting up alternative storage. Once you've made those ch
 pass --replicas=2 or higher to ensure you have failover protection. The default registry setup
 uses a local volume and the data will be lost if you delete the running pod.
 
-Examples:
-  # Check if default Docker registry ("docker-registry") has been created:
-  $ %[1]s %[2]s --dry-run
-
-  # See what the registry would look like if created:
-  $ %[1]s %[2]s -o json
-
-  # Create a registry if it does not exist with two replicas:
-  $ %[1]s %[2]s --replicas=2 --credentials=registry-user.kubeconfig
-
-  # Use a different registry image and see the registry configuration:
-  $ %[1]s %[2]s -o yaml --images=myrepo/docker-registry:mytag
-
 NOTE: This command is intended to simplify the tasks of setting up a Docker registry in a new
   installation. Some configuration beyond this command is still required to make
-  your registry persist data.
-`
+  your registry persist data.`
+
+	registry_example = `  // Check if default Docker registry ("docker-registry") has been created
+  $ %[1]s %[2]s --dry-run
+
+  // See what the registry would look like if created
+  $ %[1]s %[2]s -o json
+
+  // Create a registry if it does not exist with two replicas
+  $ %[1]s %[2]s --replicas=2 --credentials=registry-user.kubeconfig
+
+  // Use a different registry image and see the registry configuration
+  $ %[1]s %[2]s -o yaml --images=myrepo/docker-registry:mytag`
+)
 
 type RegistryConfig struct {
 	Type          string
@@ -84,9 +83,10 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 	}
 
 	cmd := &cobra.Command{
-		Use:   name,
-		Short: "Install and check OpenShift Docker registry",
-		Long:  fmt.Sprintf(longDesc, parentName, name),
+		Use:     name,
+		Short:   "Install and check OpenShift Docker registry",
+		Long:    registry_long,
+		Example: fmt.Sprintf(registry_example, parentName, name),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunCmdRegistry(f, cmd, out, cfg, args)
 			if err != errExit {

--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -39,20 +39,16 @@ running your router in production, you should pass --replicas=2 or higher to ens
 you have failover protection.
 
 Examples:
-  Check the default router ("router"):
 
   $ %[1]s %[2]s --dry-run
 
-  See what the router would look like if created:
-
+  # See what the router would look like if created:
   $ %[1]s %[2]s -o json
 
-  Create a router if it does not exist:
-
+  # Create a router if it does not exist:
   $ %[1]s %[2]s router-west --create --replicas=2
 
-  Use a different router image and see the router configuration:
-
+  # Use a different router image and see the router configuration:
   $ %[1]s %[2]s region-west -o yaml --images=myrepo/somerouter:mytag
 
 ALPHA: This command is currently being actively developed. It is intended to simplify

--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -24,8 +24,8 @@ import (
 	"github.com/openshift/origin/pkg/generate/app"
 )
 
-const longDesc = `
-Install or configure an OpenShift router
+const (
+	router_long = `Install or configure an OpenShift router
 
 This command helps to setup an OpenShift router to take edge traffic and balance it to
 your application. With no arguments, the command will check for an existing router
@@ -38,22 +38,21 @@ create a deployment configuration and service that will run the router. If you a
 running your router in production, you should pass --replicas=2 or higher to ensure
 you have failover protection.
 
-Examples:
+ALPHA: This command is currently being actively developed. It is intended to simplify
+  the tasks of setting up routers in a new installation. `
 
+	router_example = `  // Check the default router ("router")
   $ %[1]s %[2]s --dry-run
 
-  # See what the router would look like if created:
+  // See what the router would look like if created
   $ %[1]s %[2]s -o json
 
-  # Create a router if it does not exist:
+  // Create a router if it does not exist
   $ %[1]s %[2]s router-west --create --replicas=2
 
-  # Use a different router image and see the router configuration:
-  $ %[1]s %[2]s region-west -o yaml --images=myrepo/somerouter:mytag
-
-ALPHA: This command is currently being actively developed. It is intended to simplify
-  the tasks of setting up routers in a new installation.
-`
+  // Use a different router image and see the router configuration
+  $ %[1]s %[2]s region-west -o yaml --images=myrepo/somerouter:mytag`
+)
 
 type RouterConfig struct {
 	Type               string
@@ -80,9 +79,10 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 	}
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s [<name>]", name),
-		Short: "Install and check OpenShift routers",
-		Long:  fmt.Sprintf(longDesc, parentName, name),
+		Use:     fmt.Sprintf("%s [NAME]", name),
+		Short:   "Install and check OpenShift routers",
+		Long:    router_long,
+		Example: fmt.Sprintf(router_example, parentName, name),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunCmdRouter(f, cmd, out, cfg, args)
 			if err != errExit {

--- a/pkg/cmd/infra/builder/builder.go
+++ b/pkg/cmd/infra/builder/builder.go
@@ -7,19 +7,24 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
-const longCommandSTIDesc = `
-Perform a Source-to-Image Build
+const (
+	stiBuilder_long = `Perform a Source-to-Image Build.
 
 This command executes a Source-to-Image build using arguments passed via the environment.
-It expects to be run inside of a container.
-`
+It expects to be run inside of a container.`
+
+	dockerBuilder_long = `Perform a Docker Build.
+
+This command executes a Docker build using arguments passed via the environment.
+It expects to be run inside of a container.`
+)
 
 // NewCommandSTIBuilder provides a CLI handler for STI build type
 func NewCommandSTIBuilder(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   name,
 		Short: "Run an OpenShift Source-to-Images build",
-		Long:  longCommandSTIDesc,
+		Long:  stiBuilder_long,
 		Run: func(c *cobra.Command, args []string) {
 			cmd.RunSTIBuild()
 		},
@@ -29,19 +34,12 @@ func NewCommandSTIBuilder(name string) *cobra.Command {
 	return cmd
 }
 
-const longCommandDockerDesc = `
-Perform a Docker Build
-
-This command executes a Docker build using arguments passed via the environment.
-It expects to be run inside of a container.
-`
-
 // NewCommandDockerBuilder provides a CLI handler for Docker build type
 func NewCommandDockerBuilder(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   name,
 		Short: "Run an OpenShift Docker build",
-		Long:  longCommandDockerDesc,
+		Long:  dockerBuilder_long,
 		Run: func(c *cobra.Command, args []string) {
 			cmd.RunDockerBuild()
 		},

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -19,11 +19,11 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
-const longCommandDesc = `
-Perform a Deployment
+const (
+	deployer_long = `Perform a Deployment.
 
-This command makes calls to OpenShift to perform a deployment as described by a deployment config.
-`
+This command makes calls to OpenShift to perform a deployment as described by a deployment config.`
+)
 
 type config struct {
 	Config         *clientcmd.Config
@@ -45,7 +45,7 @@ func NewCommandDeployer(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s%s", name, clientcmd.ConfigSyntax),
 		Short: "Run the OpenShift deployer",
-		Long:  longCommandDesc,
+		Long:  deployer_long,
 		Run: func(c *cobra.Command, args []string) {
 			_, kClient, err := cfg.Config.Clients()
 			if err != nil {

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -16,12 +16,12 @@ import (
 	templateplugin "github.com/openshift/origin/plugins/router/template"
 )
 
-const longCommandDesc = `
-Start an OpenShift router
+const (
+	router_long = `Start an OpenShift router.
 
 This command launches a router connected to your OpenShift master. The router listens for routes and endpoints
-created by users and keeps a local router configuration up to date with those changes.
-`
+created by users and keeps a local router configuration up to date with those changes.`
+)
 
 type templateRouterConfig struct {
 	Config             *clientcmd.Config
@@ -39,7 +39,7 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s%s", name, clientcmd.ConfigSyntax),
 		Short: "Start an OpenShift router",
-		Long:  longCommandDesc,
+		Long:  router_long,
 		Run: func(c *cobra.Command, args []string) {
 			defaultCert := util.Env("DEFAULT_CERTIFICATE", "")
 			if len(defaultCert) > 0 {

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -27,8 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
-const longDescription = `
-OpenShift Application Platform
+const openshift_long = `OpenShift Application Platform.
 
 OpenShift helps you build, deploy, and manage your applications. To start an all-in-one server, run:
 
@@ -38,8 +37,7 @@ OpenShift is built around Docker and the Kubernetes cluster container manager.  
 Docker installed on this machine to start your server.
 
 Note: This is a beta release of OpenShift and may change significantly.  See
-    https://github.com/openshift/origin for the latest information on OpenShift.
-`
+    https://github.com/openshift/origin for the latest information on OpenShift.`
 
 // CommandFor returns the appropriate command for this base name,
 // or the global OpenShift command
@@ -80,7 +78,7 @@ func NewCommandOpenShift() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "openshift",
 		Short: "OpenShift helps you build, deploy, and manage your cloud applications",
-		Long:  longDescription,
+		Long:  openshift_long,
 		Run: func(c *cobra.Command, args []string) {
 			c.SetOutput(os.Stdout)
 			c.Help()

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -32,7 +32,7 @@ OpenShift Application Platform
 
 OpenShift helps you build, deploy, and manage your applications. To start an all-in-one server, run:
 
-    $ openshift start &
+  $ openshift start &
 
 OpenShift is built around Docker and the Kubernetes cluster container manager.  You must have
 Docker installed on this machine to start your server.

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -31,19 +31,17 @@ type AllInOneOptions struct {
 	NodeConfigFile   string
 }
 
-const longAllInOneCommandDesc = `
-Start an OpenShift all-in-one server
+const allInOne_long = `Start an OpenShift all-in-one server
 
 This command helps you launch an OpenShift all-in-one server, which allows
 you to run all of the components of an OpenShift system on a server with Docker. Running
 
-    $ openshift start
+  $ openshift start
 
 will start OpenShift listening on all interfaces, launch an etcd server to store persistent
 data, and launch the Kubernetes system components. The server will run in the foreground until
 you terminate the process.  This command delegates to "openshift start master" and 
 "openshift start node".
-
 
 Note: starting OpenShift without passing the --master address will attempt to find the IP
 address that will be visible inside running Docker containers. This is not always successful,
@@ -51,8 +49,7 @@ so if you have problems tell OpenShift what public address it will be via --mast
 
 You may also pass --etcd=<address> to connect to an external etcd server.
 
-You may also pass --kubeconfig=<path> to connect to an external Kubernetes cluster.
-`
+You may also pass --kubeconfig=<path> to connect to an external Kubernetes cluster.`
 
 // NewCommandStartMaster provides a CLI handler for 'start' command
 func NewCommandStartAllInOne() (*cobra.Command, *AllInOneOptions) {
@@ -61,7 +58,7 @@ func NewCommandStartAllInOne() (*cobra.Command, *AllInOneOptions) {
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Launch OpenShift All-In-One",
-		Long:  longAllInOneCommandDesc,
+		Long:  allInOne_long,
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Complete(); err != nil {
 				fmt.Println(err.Error())

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -36,12 +36,11 @@ type MasterOptions struct {
 	ConfigFile         string
 }
 
-const longMasterCommandDesc = `
-Start an OpenShift master
+const master_long = `Start an OpenShift master.
 
 This command helps you launch an OpenShift master.  Running
 
-    $ openshift start master
+  $ openshift start master
 
 will start an OpenShift master listening on all interfaces, launch an etcd server to store 
 persistent data, and launch the Kubernetes system components. The server will run in the 
@@ -54,15 +53,13 @@ so if you have problems tell OpenShift what public address it will be via --mast
 You may also pass an optional argument to the start command to start OpenShift in one of the
 following roles:
 
-    $ openshift start master --nodes=<host1,host2,host3,...>
-
-      Launches the server and control plane for OpenShift. You may pass a list of the node
-      hostnames you want to use, or create nodes via the REST API or 'openshift kube'.
+  // Launches the server and control plane for OpenShift. You may pass a list of the node
+  // hostnames you want to use, or create nodes via the REST API or 'openshift kube'.
+  $ openshift start master --nodes=<host1,host2,host3,...>
 
 You may also pass --etcd=<address> to connect to an external etcd server.
 
-You may also pass --kubeconfig=<path> to connect to an external Kubernetes cluster.
-`
+You may also pass --kubeconfig=<path> to connect to an external Kubernetes cluster.`
 
 // NewCommandStartMaster provides a CLI handler for 'start' command
 func NewCommandStartMaster() (*cobra.Command, *MasterOptions) {
@@ -71,7 +68,7 @@ func NewCommandStartMaster() (*cobra.Command, *MasterOptions) {
 	cmd := &cobra.Command{
 		Use:   "master",
 		Short: "Launch OpenShift master",
-		Long:  longMasterCommandDesc,
+		Long:  master_long,
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Complete(); err != nil {
 				fmt.Println(err.Error())

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -26,15 +26,13 @@ type NodeOptions struct {
 	ConfigFile string
 }
 
-const longNodeCommandDesc = `
-Start an OpenShift node
+const node_long = `Start an OpenShift node.
 This command helps you launch an OpenShift node.  Running
 
-    $ openshift start node --master=<masterIP>
+  $ openshift start node --master=<masterIP>
 
 will start an OpenShift node that attempts to connect to the master on the provided IP. The 
-node will run in the foreground until you terminate the process.
-`
+node will run in the foreground until you terminate the process.`
 
 // NewCommandStartMaster provides a CLI handler for 'start' command
 func NewCommandStartNode() (*cobra.Command, *NodeOptions) {
@@ -43,7 +41,7 @@ func NewCommandStartNode() (*cobra.Command, *NodeOptions) {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Launch OpenShift node",
-		Long:  longNodeCommandDesc,
+		Long:  node_long,
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Complete(); err != nil {
 				fmt.Println(err.Error())

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -36,7 +36,10 @@ const (
 
 	mainUsageTemplate = vars + `{{ $cmd := . }}{{if and .Runnable (ne .UseLine "") (ne .UseLine $rootCmd)}}
 Usage: 
-  {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{ if .HasRunnableSubCommands}}
+  {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasRunnableSubCommands}}
 {{end}}{{end}}{{ if .HasRunnableSubCommands}}
 Available Commands: {{range .Commands}}{{if and .Runnable (ne .Name "options")}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}

--- a/pkg/cmd/templates/templates.go
+++ b/pkg/cmd/templates/templates.go
@@ -7,7 +7,7 @@ func MainHelpTemplate() string {
 }
 
 func MainUsageTemplate() string {
-	return decorate(mainUsageTemplate, true)
+	return decorate(mainUsageTemplate, true) + "\n"
 }
 
 func OptionsHelpTemplate() string {
@@ -34,16 +34,18 @@ const (
 	mainHelpTemplate = `{{.Long | trim}}
 {{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
 
-	mainUsageTemplate = vars + `{{ $cmd := . }}{{ if .HasRunnableSubCommands}}
+	mainUsageTemplate = vars + `{{ $cmd := . }}{{if and .Runnable (ne .UseLine "") (ne .UseLine $rootCmd)}}
+Usage: 
+  {{.UseLine}}{{if .HasFlags}} [options]{{end}}{{ if .HasRunnableSubCommands}}
+{{end}}{{end}}{{ if .HasRunnableSubCommands}}
 Available Commands: {{range .Commands}}{{if and .Runnable (ne .Name "options")}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
-{{end}}
-{{ if or $localNotPersistentFlags.HasFlags $explicitlyExposedFlags.HasFlags}}Options:
-{{ if $localNotPersistentFlags.HasFlags}}{{flagsUsages $localNotPersistentFlags}}{{end}}{{ if $explicitlyExposedFlags.HasFlags}}{{flagsUsages $explicitlyExposedFlags}}{{end}}
-{{end}}{{ if not $isRootCmd}}Use "{{$rootCmd}} --help" for a list of all commands available in {{$rootCmd}}.
-{{end}}{{ if .HasSubCommands }}Use "{{$rootCmd}} <command> --help" for more information about a given command.
-{{end}}{{ if and .HasInheritedFlags (not $isRootCmd)}}Use "{{$rootCmd}} options" for a list of global command-line options (applies to all commands).
-{{end}}`
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
+{{ if or $localNotPersistentFlags.HasFlags $explicitlyExposedFlags.HasFlags}}
+Options:
+{{ if $localNotPersistentFlags.HasFlags}}{{flagsUsages $localNotPersistentFlags}}{{end}}{{ if $explicitlyExposedFlags.HasFlags}}{{flagsUsages $explicitlyExposedFlags}}{{end}}{{end}}{{ if not $isRootCmd}}
+Use "{{$rootCmd}} --help" for a list of all commands available in {{$rootCmd}}.{{end}}{{ if .HasSubCommands }}
+Use "{{$rootCmd}} <command> --help" for more information about a given command.{{end}}{{ if and .HasInheritedFlags (not $isRootCmd)}}
+Use "{{$rootCmd}} options" for a list of global command-line options (applies to all commands).{{end}}`
 
 	optionsHelpTemplate = ``
 


### PR DESCRIPTION
Related to https://github.com/openshift/origin/issues/1677.

Usage will only be displayed if it has actual content (skips if it's only the command name for example).

Good practice in usage lines is to make *only* arguments explicit, except for options strictly important for the command. The template will automatically add the `[options]` suffix if the command has any flag declared, and flags have their own section in help.