### PR TITLE
Make webhooks usable by scripters and admins

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -426,8 +426,13 @@ osc get buildConfigs
 osc get bc
 osc get builds
 
-[[ $(osc describe buildConfigs ruby-sample-build | grep --text "Webhook Github") =~ "${API_SCHEME}://${API_HOST}:${API_PORT}/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/github" ]]
-[[ $(osc describe buildConfigs ruby-sample-build | grep --text "Webhook Generic") =~ "${API_SCHEME}://${API_HOST}:${API_PORT}/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic" ]]
+[[ $(osc describe buildConfigs ruby-sample-build | grep --text "Webhook Github"  | grep -F "${API_SCHEME}://${API_HOST}:${API_PORT}/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/github") ]]
+[[ $(osc describe buildConfigs ruby-sample-build | grep --text "Webhook Generic" | grep -F "${API_SCHEME}://${API_HOST}:${API_PORT}/osapi/v1beta1/buildConfigHooks/ruby-sample-build/secret101/generic") ]]
+osc start-build --list-webhooks='all' ruby-sample-build
+[[ $(osc start-build --list-webhooks='all' ruby-sample-build | grep --text "generic") ]]
+[[ $(osc start-build --list-webhooks='all' ruby-sample-build | grep --text "github") ]]
+[[ $(osc start-build --list-webhooks='github' ruby-sample-build | grep --text "secret101") ]]
+[ ! "$(osc start-build --list-webhooks='blah')" ]
 echo "buildConfig: ok"
 
 osc create -f test/integration/fixtures/test-buildcli.json

--- a/pkg/build/webhook/controller.go
+++ b/pkg/build/webhook/controller.go
@@ -10,7 +10,6 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildclient "github.com/openshift/origin/pkg/build/client"
-	osclient "github.com/openshift/origin/pkg/client"
 )
 
 // Plugin for Webhook verification is dependent on the sending side, it can be
@@ -28,7 +27,6 @@ type Plugin interface {
 type controller struct {
 	buildConfigInstantiator buildclient.BuildConfigInstantiator
 	buildConfigGetter       buildclient.BuildConfigGetter
-	imageRepoGetter         osclient.ImageStreamNamespaceGetter
 	plugins                 map[string]Plugin
 }
 
@@ -42,12 +40,11 @@ type urlVars struct {
 }
 
 // NewController creates new webhook controller and feed it with provided plugins.
-func NewController(buildConfigGetter buildclient.BuildConfigGetter, buildConfigInstantiator buildclient.BuildConfigInstantiator,
-	imageRepoGetter osclient.ImageStreamNamespaceGetter, plugins map[string]Plugin) http.Handler {
+func NewController(bcg buildclient.BuildConfigGetter,
+	bci buildclient.BuildConfigInstantiator, plugins map[string]Plugin) http.Handler {
 	return &controller{
-		buildConfigGetter:       buildConfigGetter,
-		buildConfigInstantiator: buildConfigInstantiator,
-		imageRepoGetter:         imageRepoGetter,
+		buildConfigGetter:       bcg,
+		buildConfigInstantiator: bci,
 		plugins:                 plugins,
 	}
 }

--- a/pkg/build/webhook/controller_test.go
+++ b/pkg/build/webhook/controller_test.go
@@ -11,18 +11,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/build/api"
-	imageapi "github.com/openshift/origin/pkg/image/api"
 )
-
-type okImageRepositoryNamespaceGetter struct{}
-
-func (m *okImageRepositoryNamespaceGetter) GetByNamespace(namespace, name string) (*imageapi.ImageStream, error) {
-	return &imageapi.ImageStream{
-		Status: imageapi.ImageStreamStatus{
-			DockerImageRepository: "repository/image",
-		},
-	}, nil
-}
 
 type okBuildConfigGetter struct{}
 
@@ -91,7 +80,7 @@ func (*errPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *h
 
 func TestParseUrlError(t *testing.T) {
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, nil))
+		nil))
 	defer server.Close()
 
 	resp, err := http.Post(server.URL, "application/json", nil)
@@ -107,7 +96,7 @@ func TestParseUrlError(t *testing.T) {
 
 func TestParseUrlOK(t *testing.T) {
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]Plugin{
+		map[string]Plugin{
 			"pathplugin": &pathPlugin{},
 		}))
 	defer server.Close()
@@ -127,7 +116,7 @@ func TestParseUrlOK(t *testing.T) {
 func TestParseUrlLong(t *testing.T) {
 	plugin := &pathPlugin{}
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]Plugin{
+		map[string]Plugin{
 			"pathplugin": plugin,
 		}))
 	defer server.Close()
@@ -149,7 +138,7 @@ func TestParseUrlLong(t *testing.T) {
 
 func TestInvokeWebhookErrorSecret(t *testing.T) {
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, nil))
+		nil))
 	defer server.Close()
 
 	resp, err := http.Post(server.URL+"/build100/wrongsecret/somePlugin",
@@ -166,7 +155,7 @@ func TestInvokeWebhookErrorSecret(t *testing.T) {
 
 func TestInvokeWebhookMissingPlugin(t *testing.T) {
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, nil))
+		nil))
 	defer server.Close()
 
 	resp, err := http.Post(server.URL+"/build100/secret101/missingplugin",
@@ -184,7 +173,7 @@ func TestInvokeWebhookMissingPlugin(t *testing.T) {
 
 func TestInvokeWebhookErrorBuildConfig(t *testing.T) {
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &errorBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]Plugin{
+		map[string]Plugin{
 			"okPlugin": &pathPlugin{},
 		}))
 	defer server.Close()
@@ -204,7 +193,7 @@ func TestInvokeWebhookErrorBuildConfig(t *testing.T) {
 
 func TestInvokeWebhookErrorGetConfig(t *testing.T) {
 	server := httptest.NewServer(NewController(&errorBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, nil))
+		nil))
 	defer server.Close()
 
 	resp, err := http.Post(server.URL+"/build100/secret101/errPlugin",
@@ -222,7 +211,7 @@ func TestInvokeWebhookErrorGetConfig(t *testing.T) {
 
 func TestInvokeWebhookErrorCreateBuild(t *testing.T) {
 	server := httptest.NewServer(NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]Plugin{
+		map[string]Plugin{
 			"errPlugin": &errPlugin{},
 		}))
 	defer server.Close()
@@ -295,7 +284,7 @@ func TestInvokeWebhookOK(t *testing.T) {
 				},
 			},
 		},
-		&okImageRepositoryNamespaceGetter{},
+
 		map[string]Plugin{
 			"okPlugin": &pathPlugin{},
 		}))

--- a/pkg/build/webhook/generic/generic.go
+++ b/pkg/build/webhook/generic/generic.go
@@ -48,6 +48,9 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 			glog.V(4).Infof("Error unmarshaling json %v, but continuing", err)
 			return nil, true, nil
 		}
+		if data.Git == nil {
+			return nil, true, nil
+		}
 		if !webhook.GitRefMatches(data.Git.Ref, buildCfg.Parameters.Source.Git.Ref) {
 			glog.V(2).Infof("Skipping build for '%s'.  Branch reference from '%s' does not match configuration", buildCfg, data)
 			return nil, false, nil

--- a/pkg/build/webhook/github/github_test.go
+++ b/pkg/build/webhook/github/github_test.go
@@ -12,18 +12,7 @@ import (
 
 	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/webhook"
-	imageapi "github.com/openshift/origin/pkg/image/api"
 )
-
-type okImageRepositoryNamespaceGetter struct{}
-
-func (m *okImageRepositoryNamespaceGetter) GetByNamespace(namespace, name string) (*imageapi.ImageStream, error) {
-	return &imageapi.ImageStream{
-		Status: imageapi.ImageStreamStatus{
-			DockerImageRepository: "repository/image",
-		},
-	}, nil
-}
 
 type okBuildConfigGetter struct{}
 
@@ -67,7 +56,7 @@ func (*okBuildConfigInstantiator) Instantiate(namespace string, requet *api.Buil
 
 func TestWrongMethod(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	resp, _ := http.Get(server.URL + "/build100/secret101/github")
@@ -80,7 +69,7 @@ func TestWrongMethod(t *testing.T) {
 
 func TestWrongContentType(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	client := &http.Client{}
@@ -98,7 +87,7 @@ func TestWrongContentType(t *testing.T) {
 
 func TestWrongUserAgent(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	client := &http.Client{}
@@ -116,7 +105,7 @@ func TestWrongUserAgent(t *testing.T) {
 
 func TestMissingGithubEvent(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	client := &http.Client{}
@@ -133,7 +122,7 @@ func TestMissingGithubEvent(t *testing.T) {
 
 func TestWrongGithubEvent(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	client := &http.Client{}
@@ -151,7 +140,7 @@ func TestWrongGithubEvent(t *testing.T) {
 
 func TestJsonPingEvent(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	postFile("ping", "pingevent.json", server.URL+"/build100/secret101/github",
@@ -160,7 +149,7 @@ func TestJsonPingEvent(t *testing.T) {
 
 func TestJsonPushEventError(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	post("push", []byte{}, server.URL+"/build100/secret101/github", http.StatusBadRequest, t)
@@ -168,7 +157,7 @@ func TestJsonPushEventError(t *testing.T) {
 
 func TestJsonPushEvent(t *testing.T) {
 	server := httptest.NewServer(webhook.NewController(&okBuildConfigGetter{}, &okBuildConfigInstantiator{},
-		&okImageRepositoryNamespaceGetter{}, map[string]webhook.Plugin{"github": New()}))
+		map[string]webhook.Plugin{"github": New()}))
 	defer server.Close()
 
 	postFile("push", "pushevent.json", server.URL+"/build100/secret101/github",

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -1,21 +1,28 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
-const startBuildLongDesc = `
-Manually starts build from existing build or buildConfig
+const startBuildLongDesc = `Start a build
 
-NOTE: This command is experimental and is subject to change in the future.
+This command starts a build for the provided build configuration or re-runs an existing build using
+--from-build=<name>. You may pass the --follow flag to see output from the build.
 
 Examples:
 
@@ -25,15 +32,16 @@ Examples:
 	# Starts build from build matching the name "3bd2ug53b"
 	$ %[1]s start-build --from-build=3bd2ug53b
 
-	# Starts build from build configuration matching the name "3bd2ug53b" and watches the logs until the build completes or fails
+	# Starts build from build configuration matching the name "3bd2ug53b" and watches the logs until the build
+	# completes or fails
 	$ %[1]s start-build 3bd2ug53b --follow
 `
 
 // NewCmdStartBuild implements the OpenShift cli start-build command
 func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start-build (<buildConfig>|--from-build=<build>)",
-		Short: "Starts a new build from existing build or buildConfig",
+		Use:   "start-build (<build_config>|--from-build=<build>)",
+		Short: "Starts a new build from existing build or build config",
 		Long:  fmt.Sprintf(startBuildLongDesc, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunStartBuild(f, out, cmd, args)
@@ -42,15 +50,22 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 	}
 	cmd.Flags().String("from-build", "", "Specify the name of a build which should be re-run")
 	cmd.Flags().Bool("follow", false, "Start a build and watch its logs until it completes or fails")
+	cmd.Flags().String("from-webhook", "", "Specify a webhook URL for an existing build config to trigger")
+	cmd.Flags().String("git-post-receive", "", "The contents of the post-receive hook to trigger a build")
 	return cmd
 }
 
 // RunStartBuild contains all the necessary functionality for the OpenShift cli start-build command
 func RunStartBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	webhook := cmdutil.GetFlagString(cmd, "from-webhook")
+	if len(webhook) > 0 {
+		return RunStartBuildWebHook(f, out, webhook, cmdutil.GetFlagString(cmd, "git-post-receive"))
+	}
+
 	buildName := cmdutil.GetFlagString(cmd, "from-build")
 	follow := cmdutil.GetFlagBool(cmd, "follow")
 	if len(args) != 1 && len(buildName) == 0 {
-		return cmdutil.UsageError(cmd, "Must pass a name of buildConfig or specify build name with '--from-build' flag")
+		return cmdutil.UsageError(cmd, "Must pass a name of build config or specify build name with '--from-build' flag")
 	}
 
 	client, _, err := f.Clients()
@@ -97,6 +112,58 @@ func RunStartBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args
 		if err != nil {
 			return fmt.Errorf("error streaming logs: %v", err)
 		}
+	}
+	return nil
+}
+
+// RunStartBuildWebHook tries to trigger the provided webhook. It will attempt to utilize the current client
+// configuration if the webhook has the same URL.
+func RunStartBuildWebHook(f *clientcmd.Factory, out io.Writer, webhook string, postReceivePath string) error {
+	// attempt to extract a post receive body
+	// TODO: implement in follow on
+	/*refs := []git.ChangedRef{}
+	switch receive := postReceivePath; {
+	case receive == "-":
+		r, err := git.ParsePostReceive(os.Stdin)
+		if err != nil {
+			return err
+		}
+		refs = r
+	case len(receive) > 0:
+		file, err := os.Open(receive)
+		if err != nil {
+			return fmt.Errorf("unable to open --git-post-receive argument as a file: %v", err)
+		}
+		defer file.Close()
+		r, err := git.ParsePostReceive(file)
+		if err != nil {
+			return err
+		}
+		refs = r
+	}
+	_ = refs*/
+
+	hook, err := url.Parse(webhook)
+	if err != nil {
+		return err
+	}
+	httpClient := http.DefaultClient
+	// when using HTTPS, try to reuse the local config transport if possible to get a client cert
+	// TODO: search all configs
+	if hook.Scheme == "https" {
+		config, err := f.OpenShiftClientConfig.ClientConfig()
+		if err == nil {
+			if url, err := client.DefaultServerURL(config.Host, "", "test", true); err == nil {
+				if url.Host == hook.Host && url.Scheme == hook.Scheme {
+					if rt, err := client.TransportFor(config); err == nil {
+						httpClient = &http.Client{Transport: rt}
+					}
+				}
+			}
+		}
+	}
+	if _, err := httpClient.Post(hook.String(), "application/json", bytes.NewBufferString("{}")); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/cmd/cli/cmd/startbuild_test.go
+++ b/pkg/cmd/cli/cmd/startbuild_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+type FakeClientConfig struct {
+	Raw    clientcmdapi.Config
+	Client *client.Config
+	NS     string
+	Err    error
+}
+
+// RawConfig returns the merged result of all overrides
+func (c *FakeClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return c.Raw, c.Err
+}
+
+// ClientConfig returns a complete client config
+func (c *FakeClientConfig) ClientConfig() (*client.Config, error) {
+	return c.Client, c.Err
+}
+
+// Namespace returns the namespace resulting from the merged result of all overrides
+func (c *FakeClientConfig) Namespace() (string, error) {
+	return c.NS, c.Err
+}
+
+func TestStartBuildWebHook(t *testing.T) {
+	invoked := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		invoked <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &FakeClientConfig{}
+	f := clientcmd.NewFactory(cfg)
+	buf := &bytes.Buffer{}
+	if err := RunStartBuildWebHook(f, buf, server.URL+"/webhook", ""); err != nil {
+		t.Fatalf("unable to start hook: %v", err)
+	}
+	<-invoked
+
+	if err := RunStartBuildWebHook(f, buf, server.URL+"/webhook", "unknownpath"); err != nil {
+		t.Fatalf("unexpected non-error: %v", err)
+	}
+}
+
+func TestStartBuildWebHookHTTPS(t *testing.T) {
+	invoked := make(chan struct{}, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		invoked <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	testErr := errors.New("not enabled")
+	cfg := &FakeClientConfig{
+		Err: testErr,
+	}
+	f := clientcmd.NewFactory(cfg)
+	buf := &bytes.Buffer{}
+	if err := RunStartBuildWebHook(f, buf, server.URL+"/webhook", ""); err == nil || !strings.Contains(err.Error(), "certificate signed by unknown authority") {
+		t.Fatalf("unexpected non-error: %v", err)
+	}
+}

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -241,8 +241,8 @@ func describeCustomStrategy(s *buildapi.CustomBuildStrategy, out *tabwriter.Writ
 }
 
 // DescribeTriggers generates information about the triggers associated with a buildconfig
-func (d *BuildConfigDescriber) DescribeTriggers(bc *buildapi.BuildConfig, host string, out *tabwriter.Writer) {
-	webhooks := webhookURL(bc, host)
+func (d *BuildConfigDescriber) DescribeTriggers(bc *buildapi.BuildConfig, out *tabwriter.Writer) {
+	webhooks := webhookURL(bc, d.Interface)
 	for whType, whURL := range webhooks {
 		t := strings.Title(whType)
 		formatString(out, "Webhook "+t, whURL)
@@ -292,7 +292,7 @@ func (d *BuildConfigDescriber) Describe(namespace, name string) (string, error) 
 			formatString(out, "Latest Version", strconv.Itoa(buildConfig.LastVersion))
 		}
 		describeBuildParameters(buildConfig.Parameters, out)
-		d.DescribeTriggers(buildConfig, d.host, out)
+		d.DescribeTriggers(buildConfig, out)
 		if len(builds.Items) == 0 {
 			return nil
 		}

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -275,7 +275,7 @@ func NewTestBuildOpenshift(t *testing.T) *testBuildOpenshift {
 	bcClient := buildclient.NewOSClientBuildConfigClient(osClient)
 	osMux.Handle(openshift.whPrefix, http.StripPrefix(openshift.whPrefix,
 		webhook.NewController(bcClient, buildclient.NewOSClientBuildConfigInstantiatorClient(osClient),
-			osClient.ImageStreams(kapi.NamespaceAll).(osclient.ImageStreamNamespaceGetter), map[string]webhook.Plugin{
+			map[string]webhook.Plugin{
 				"github": github.New(),
 			})))
 


### PR DESCRIPTION
Prerequisite for building sane git receive hooks.  Has a few stubs
for processing post-receive hooks which can come later.

Upstream issue is https://github.com/GoogleCloudPlatform/kubernetes/pull/7546

Fixed a bug in generic.go which panicked when an empty {} JSON object
was sent.

@mfojtik / @csrwng