### PR TITLE
explicitly set the project to avoid depending on project cache refresh

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -167,7 +167,8 @@ osc new-project project-foo --display-name="my project" --description="boring pr
 osc logout
 [ -z "$(osc get pods | grep 'system:anonymous')" ]
 osc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
-[ "$(osc project | grep 'Using project "project-foo"')" ]
+osc get projects
+osc project project-foo
  
 
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1993

`osc login` relies on the project cache to locate the available projects.  Instead of relying on that, explicitly set the project.  If we don't have rights, that will fail and that means that our login after logout failed.

Also added a listing of project just so we can see if the project cache is up to date if something fails along the way.