### PR TITLE
Require Go 1.4 for OpenShift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 language: go
 
 go:
-  - 1.3
   - 1.4
 
 env:
  - TEST_ASSETS=true
  - TEST_ASSETS=false
-
-matrix:
-  exclude:
-    - go: 1.3
-      env: TEST_ASSETS=true
 
 install:
   - ./hack/verify-jsonformat.sh

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -33,7 +33,7 @@ You can develop OpenShift 3 on Windows, Mac, or Linux, but you'll need Docker in
 Here's how to get set up:
 
 1. For Go, Git and optionally also Docker, follow the links below to get to installation information for these tools: +
-** http://golang.org/doc/install[Installing Go]
+** http://golang.org/doc/install[Installing Go]. You must install Go 1.4.
 ** http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Installing Git]
 ** https://docs.docker.com/installation/#installation[Installing Docker]. NOTE: OpenShift now requires at least Docker 1.6. RPMs for CentOS 7 are not yet available in the default yum repositories. If you're running CentOS, please see the link:README.md#docker-16[README] for information on where to get Docker 1.6 RPMs for your platform.
 2. Next, create a Go workspace directory: +

--- a/README.md
+++ b/README.md
@@ -206,37 +206,7 @@ FAQ
     iterate through the next few months, you'll see this repository focus more on integration and
     plugins, with more and more features becoming part of Kubernetes.
 
-2. What about [geard](https://github.com/openshift/geard)?
-
-    Geard started as a prototype vehicle for the next generation of the OpenShift node - as an
-    orchestration endpoint, to offer integration with systemd, and to prototype network abstraction,
-    routing, SSH access to containers, and Git hosting.  Its intended goal is to provide a simple
-    way of reliably managing containers at scale, and to offer administrators tools for easily
-    composing those applications (gear deploy).
-
-    With the introduction of Kubernetes, the Kubelet, and the pull model it leverages from etcd, we
-    believe we can implement the pull-orchestration model described in
-    [orchestrating geard](https://github.com/openshift/geard/blob/master/docs/orchestrating_geard.md),
-    especially now that we have a path to properly
-    [limit host compromises from affecting the cluster](https://github.com/GoogleCloudPlatform/kubernetes/pull/860).  
-    The pull-model has many advantages for end clients, not least of which that they are guaranteed
-    to eventually converge to the correct state of the server. We expect that the use cases the geard
-    endpoint offered will be merged into the Kubelet for consumption by admins.
-
-    systemd and Docker integration offers efficient and clean process management and secure logging
-    aggregation with the system.  We plan on introducing those capabilities into Kubernetes over
-    time, especially as we work with the Docker upstream to limit the impact of the Docker daemon's
-    parent child process relationship with containers, where death of the Docker daemon terminates
-    the containers under it
-
-    Network links and their ability to simplify how software connects to other containers is planned
-    for Docker links v2 and is a capability we believe will be important in Kubernetes as well ([see issue 494 for more details](https://github.com/GoogleCloudPlatform/kubernetes/issues/494)).
-
-    The geard deployment descriptor describes containers and their relationships and will be mapped
-    to deployment on top of Kubernetes.  The geard commandline itself will likely be merged directly
-    into the `openshift` command for all-in-one management of a cluster.
-
-3. What can I run on OpenShift?
+2. What can I run on OpenShift?
 
     OpenShift is designed to run any existing Docker images.  In addition you can define builds that will produce new Docker images from a Dockerfile.  However the real magic of OpenShift can be seen when using [Source-To-Image](https://github.com/openshift/source-to-image)(STI) builds which allow you to simply supply an application source repository which will be combined with an existing STI-enabled Docker image to produce a new runnable image that runs your application.  We are continuing to grow the ecosystem of STI-enabled images and documenting them [here](https://ci.openshift.redhat.com/openshift-docs-master-testing/latest/openshift_sti_images/overview.html).  We also have a few more experimental images available:
 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -208,12 +208,12 @@ EOF
   if [[ "${TRAVIS:-}" != "true" ]]; then
     local go_version
     go_version=($(go version))
-    if [[ "${go_version[2]}" < "go1.2" ]]; then
+    if [[ "${go_version[2]}" < "go1.4" ]]; then
       echo <<EOF
 
 Detected go version: ${go_version[*]}.
-Kubernetes requires go version 1.2 or greater.
-Please install Go version 1.2 or later.
+OpenShift and Kubernetes requires go version 1.4 or greater.
+Please install Go version 1.4 or later.
 
 EOF
       exit 2
@@ -299,7 +299,7 @@ os::build::place_bins() {
       if [[ "${OS_RELEASE_ARCHIVE-}" == "" ]]; then
         continue
       fi
-      
+
       # Create a temporary bin directory containing only the binaries marked for release.
       local release_binpath=$(mktemp -d openshift.release.${OS_RELEASE_ARCHIVE}.XXX)
       find "${full_binpath_src}" -maxdepth 1 -type f -exec \

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -10,7 +10,7 @@ GO_VERSION=($(go version))
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
   echo "Unknown go version '${GO_VERSION}', skipping gofmt."
   exit 0
 fi

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -11,7 +11,7 @@ fi
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
   echo "Unknown go version '${GO_VERSION}', skipping golint."
   exit 0
 fi

--- a/openshift.spec
+++ b/openshift.spec
@@ -25,7 +25,7 @@ ExclusiveArch:  x86_64
 Source0:        https://%{import_path}/archive/%{commit}/%{name}-%{version}.tar.gz
 
 BuildRequires:  systemd
-BuildRequires:  golang >= 1.2-7
+BuildRequires:  golang >= 1.4
 
 
 %description


### PR DESCRIPTION
Cannot be merged until centos7 has Go 1.4 available as RPMs.