### PR TITLE
Allow 1 ImageStream tag to track another

### DIFF
--- a/pkg/build/controller/image_change_controller.go
+++ b/pkg/build/controller/image_change_controller.go
@@ -80,9 +80,9 @@ func (c *ImageChangeController) HandleImageRepo(repo *imageapi.ImageStream) erro
 			// This split is safe because ImageStreamTag names always have the form
 			// name:tag.
 			tag := strings.Split(from.Name, ":")[1]
-			latest, err := imageapi.LatestTaggedImage(repo, tag)
-			if err != nil {
-				util.HandleError(fmt.Errorf("unable to find tagged image: %v", err))
+			latest := imageapi.LatestTaggedImage(repo, tag)
+			if latest == nil {
+				util.HandleError(fmt.Errorf("unable to find tagged image: no image recorded for %s/%s:%s", repo.Namespace, repo.Name, tag))
 				continue
 			}
 

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -48,9 +48,9 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 			}
 
 			// Find the latest tag event for the trigger tag
-			latestEvent, err := imageapi.LatestTaggedImage(imageRepo, params.Tag)
-			if err != nil {
-				glog.V(4).Infof("Couldn't find latest tag event for tag %s in imageRepo %s: %s", params.Tag, labelForRepo(imageRepo), err)
+			latestEvent := imageapi.LatestTaggedImage(imageRepo, params.Tag)
+			if latestEvent == nil {
+				glog.V(4).Infof("Couldn't find latest tag event for tag %s in imageRepo %s", params.Tag, labelForRepo(imageRepo))
 				continue
 			}
 

--- a/pkg/deploy/generator/config_generator.go
+++ b/pkg/deploy/generator/config_generator.go
@@ -54,10 +54,10 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 		}
 
 		// Find the latest tag event for the trigger tag
-		latestEvent, err := imageapi.LatestTaggedImage(imageStream, params.Tag)
-		if err != nil {
+		latestEvent := imageapi.LatestTaggedImage(imageStream, params.Tag)
+		if latestEvent == nil {
 			f := fmt.Sprintf("triggers[%d].imageChange.tag", i)
-			errs = append(errs, fielderrors.NewFieldInvalid(f, params.Tag, err.Error()))
+			errs = append(errs, fielderrors.NewFieldInvalid(f, params.Tag, fmt.Sprintf("no image recorded for %s/%s:%s", imageStream.Namespace, imageStream.Name, params.Tag)))
 			continue
 		}
 

--- a/pkg/generate/app/imagelookup.go
+++ b/pkg/generate/app/imagelookup.go
@@ -276,9 +276,9 @@ func (r ImageStreamResolver) Resolve(value string) (*ComponentMatch, error) {
 		if len(searchTag) == 0 {
 			searchTag = imageapi.DefaultImageTag
 		}
-		latest, err := imageapi.LatestTaggedImage(repo, searchTag)
-		if err != nil {
-			return nil, ErrNoMatch{value: value, qualifier: err.Error()}
+		latest := imageapi.LatestTaggedImage(repo, searchTag)
+		if latest == nil {
+			return nil, ErrNoMatch{value: value, qualifier: fmt.Sprintf("no image recorded for %s/%s:%s", repo.Namespace, repo.Name, searchTag)}
 		}
 		imageData, err := r.ImageStreamImages.ImageStreamImages(namespace).Get(ref.Name, latest.Image)
 		if err != nil {

--- a/pkg/image/registry/imagerepositorymapping/rest_test.go
+++ b/pkg/image/registry/imagerepositorymapping/rest_test.go
@@ -450,9 +450,9 @@ func TestAddExistingImageWithNewTag(t *testing.T) {
 		t.Errorf("Expected %s, got %s", e, a)
 	}
 
-	event, err := api.LatestTaggedImage(repo, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	event := api.LatestTaggedImage(repo, "")
+	if event == nil {
+		t.Fatalf("unexpected nil event")
 	}
 	if event.DockerImageReference != "localhost:5000/someproject/somerepo:"+imageID || event.Image != imageID {
 		t.Errorf("unexpected latest tagged image: %#v", event)

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -164,12 +164,12 @@ func TestTagVerifier(t *testing.T) {
 					From: &kapi.ObjectReference{
 						Kind:      "ImageStreamTag",
 						Namespace: "otherns",
-						Name:      "abc",
+						Name:      "a:b:c",
 					},
 				},
 			},
 			expected: fielderrors.ValidationErrorList{
-				fielderrors.NewFieldInvalid("spec.tags[latest].from.name", "abc", "must be of the form <repo>:<tag> or <repo>@<id>"),
+				fielderrors.NewFieldInvalid("spec.tags[latest].from.name", "a:b:c", "must be of the form <tag>, <repo>:<tag>, <id>, or <repo>@<id>"),
 			},
 		},
 		"sar error": {

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -60,8 +60,8 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 		return nil, err
 	}
 
-	event, err := api.LatestTaggedImage(stream, tag)
-	if err != nil {
+	event := api.LatestTaggedImage(stream, tag)
+	if event == nil {
 		return nil, errors.NewNotFound("imageStreamTag", tag)
 	}
 


### PR DESCRIPTION
If you set spec.tags[latest].from to kind=ImageStreamTag, name=`<tag>`,
whenever `<tag>` is updated, status.tags[latest].items[0] will be updated
to match the new image pushed for `<tag>`.

For example, you could have a spec.tags setting for "latest" that tracks
the tag "2.0". Any time a new image is pushed for "2.0", the "latest"
tag is updated as well.

This currently only supports intra-stream tag tracking. Support for
tracking tags in other streams may be added later.