### PR TITLE
Deployment hooks inherit resources and working dir

### DIFF
--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -30,60 +30,23 @@ func (e *HookExecutor) Execute(hook *deployapi.LifecycleHook, deployment *kapi.R
 // executeExecNewPod executes a ExecNewPod hook by creating a new pod based on
 // the hook parameters and deployment. The pod is then synchronously watched
 // until the pod completes, and if the pod failed, an error is returned.
+//
+// The hook pod inherits the following from the container the hook refers to:
+//
+//   * Environment (hook keys take precedence)
+//   * Working directory
+//   * Resources
 func (e *HookExecutor) executeExecNewPod(hook *deployapi.ExecNewPodHook, deployment *kapi.ReplicationController) error {
 	// Build a pod spec from the hook config and deployment
-	var baseContainer *kapi.Container
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == hook.ContainerName {
-			baseContainer = &container
-			break
-		}
-	}
-	if baseContainer == nil {
-		return fmt.Errorf("no container named '%s' found in deployment template", hook.ContainerName)
-	}
-
-	// Generate a name for the pod
-	podName := kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("deployment-%s-hook-", deployment.Name))
-
-	// Build a merged environment; hook environment takes precedence over base
-	// container environment
-	envMap := map[string]string{}
-	mergedEnv := []kapi.EnvVar{}
-	for _, env := range baseContainer.Env {
-		envMap[env.Name] = env.Value
-	}
-	for _, env := range hook.Env {
-		envMap[env.Name] = env.Value
-	}
-	for k, v := range envMap {
-		mergedEnv = append(mergedEnv, kapi.EnvVar{Name: k, Value: v})
-	}
-
-	podSpec := &kapi.Pod{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: podName,
-			Annotations: map[string]string{
-				deployapi.DeploymentAnnotation: deployment.Name,
-			},
-		},
-		Spec: kapi.PodSpec{
-			Containers: []kapi.Container{
-				{
-					Name:    "lifecycle",
-					Image:   baseContainer.Image,
-					Command: hook.Command,
-					Env:     mergedEnv,
-				},
-			},
-			RestartPolicy: kapi.RestartPolicyNever,
-		},
+	podSpec, err := buildContainer(hook, deployment)
+	if err != nil {
+		return err
 	}
 
 	// Set up a watch for the pod
-	podWatch, err := e.PodClient.WatchPod(deployment.Namespace, podName)
+	podWatch, err := e.PodClient.WatchPod(deployment.Namespace, podSpec.Name)
 	if err != nil {
-		return fmt.Errorf("couldn't create watch for pod %s/%s: %s", deployment.Namespace, podName, err)
+		return fmt.Errorf("couldn't create watch for pod %s/%s: %s", deployment.Namespace, podSpec.Name, err)
 	}
 	defer podWatch.Stop()
 
@@ -123,6 +86,67 @@ func (e *HookExecutor) executeExecNewPod(hook *deployapi.ExecNewPodHook, deploym
 			}
 		}
 	}
+}
+
+// buildContainer makes a pod spec from a hook and deployment.
+func buildContainer(hook *deployapi.ExecNewPodHook, deployment *kapi.ReplicationController) (*kapi.Pod, error) {
+	var baseContainer *kapi.Container
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == hook.ContainerName {
+			baseContainer = &container
+			break
+		}
+	}
+	if baseContainer == nil {
+		return nil, fmt.Errorf("no container named '%s' found in deployment template", hook.ContainerName)
+	}
+
+	// Generate a name for the pod
+	podName := kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("deployment-%s-hook-", deployment.Name))
+
+	// Build a merged environment; hook environment takes precedence over base
+	// container environment
+	envMap := map[string]string{}
+	mergedEnv := []kapi.EnvVar{}
+	for _, env := range baseContainer.Env {
+		envMap[env.Name] = env.Value
+	}
+	for _, env := range hook.Env {
+		envMap[env.Name] = env.Value
+	}
+	for k, v := range envMap {
+		mergedEnv = append(mergedEnv, kapi.EnvVar{Name: k, Value: v})
+	}
+
+	// Inherit resources from the base container
+	resources := kapi.ResourceRequirements{}
+	if err := kapi.Scheme.Convert(&baseContainer.Resources, &resources); err != nil {
+		return nil, fmt.Errorf("couldn't clone ResourceRequirements: %v", err)
+	}
+
+	podSpec := &kapi.Pod{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: podName,
+			Annotations: map[string]string{
+				deployapi.DeploymentAnnotation: deployment.Name,
+			},
+		},
+		Spec: kapi.PodSpec{
+			Containers: []kapi.Container{
+				{
+					Name:       "lifecycle",
+					Image:      baseContainer.Image,
+					Command:    hook.Command,
+					WorkingDir: baseContainer.WorkingDir,
+					Env:        mergedEnv,
+					Resources:  resources,
+				},
+			},
+			RestartPolicy: kapi.RestartPolicyNever,
+		},
+	}
+
+	return podSpec, nil
 }
 
 // labelForDeployment builds a string identifier for a deployment.

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -3,46 +3,15 @@ package support
 import (
 	"fmt"
 	"testing"
-	//"time"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
-	//api "github.com/openshift/origin/pkg/api/latest"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
-
-func TestHookExecutor_executeExecNewPodInvalidContainerRef(t *testing.T) {
-	hook := &deployapi.LifecycleHook{
-		ExecNewPod: &deployapi.ExecNewPodHook{
-			ContainerName: "undefined",
-		},
-	}
-
-	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
-
-	executor := &HookExecutor{
-		PodClient: &HookExecutorPodClientImpl{
-			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
-				t.Fatalf("unexpected call to CreatePod")
-				return nil, nil
-			},
-			WatchPodFunc: func(namespace, name string) (watch.Interface, error) {
-				t.Fatalf("unexpected call to WatchPod")
-				return nil, nil
-			},
-		},
-	}
-
-	err := executor.Execute(hook, deployment)
-
-	if err == nil {
-		t.Fatalf("expected an error")
-	}
-	t.Logf("got expected error: %s", err)
-}
 
 func TestHookExecutor_executeExecNewWatchFailure(t *testing.T) {
 	hook := &deployapi.LifecycleHook{
@@ -107,21 +76,11 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 	hook := &deployapi.LifecycleHook{
 		ExecNewPod: &deployapi.ExecNewPodHook{
 			ContainerName: "container1",
-			Command:       []string{"overridden"},
-			Env: []kapi.EnvVar{
-				{
-					Name:  "name",
-					Value: "value",
-				},
-				{
-					Name:  "ENV1",
-					Value: "overridden",
-				},
-			},
 		},
 	}
 
-	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+	config := deploytest.OkDeploymentConfig(1)
+	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 
 	podWatch := newTestWatch()
 
@@ -151,44 +110,6 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if e, a := deployment.Spec.Template.Spec.Containers[0].Image, createdPod.Spec.Containers[0].Image; e != a {
-		t.Fatalf("expected container image %s, got %s", e, a)
-	}
-
-	if e, a := "overridden", createdPod.Spec.Containers[0].Command[0]; e != a {
-		t.Fatalf("expected container command %s, got %s", e, a)
-	}
-
-	// Verify environment merging
-	expectedEnv := map[string]string{
-		"name": "value",
-		"ENV1": "overridden",
-	}
-
-	for k, v := range expectedEnv {
-		found := false
-		for _, env := range createdPod.Spec.Containers[0].Env {
-			if env.Name == k && env.Value == v {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected to find %s=%s in pod environment", k, v)
-		}
-	}
-
-	for _, env := range createdPod.Spec.Containers[0].Env {
-		val, found := expectedEnv[env.Name]
-		if !found || val != env.Value {
-			t.Errorf("container has unexpected environment entry %s=%s", env.Name, env.Value)
-		}
-	}
-
-	if e, a := kapi.RestartPolicyNever, createdPod.Spec.RestartPolicy; e != a {
-		t.Fatalf("expected restart policy %s, got %s", e, a)
 	}
 }
 
@@ -231,6 +152,107 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 		t.Fatalf("expected an error", err)
 	}
 	t.Logf("got expected error: %s", err)
+}
+
+func TestHookExecutor_buildContainerInvalidContainerRef(t *testing.T) {
+	hook := &deployapi.ExecNewPodHook{
+		ContainerName: "undefined",
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	_, err := buildContainer(hook, deployment)
+
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	t.Logf("got expected error: %s", err)
+}
+
+func TestHookExecutor_buildContainerOk(t *testing.T) {
+	hook := &deployapi.ExecNewPodHook{
+		ContainerName: "container1",
+		Command:       []string{"overridden"},
+		Env: []kapi.EnvVar{
+			{
+				Name:  "name",
+				Value: "value",
+			},
+			{
+				Name:  "ENV1",
+				Value: "overridden",
+			},
+		},
+	}
+
+	config := deploytest.OkDeploymentConfig(1)
+
+	cpuLimit := resource.MustParse("10")
+	memoryLimit := resource.MustParse("10M")
+	config.Template.ControllerTemplate.Template.Spec.Containers[0].Resources = kapi.ResourceRequirements{
+		Limits: kapi.ResourceList{
+			kapi.ResourceCPU:    cpuLimit,
+			kapi.ResourceMemory: memoryLimit,
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
+
+	podSpec, err := buildContainer(hook, deployment)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	gotContainer := podSpec.Spec.Containers[0]
+
+	// Verify the correct image was selected
+	if e, a := deployment.Spec.Template.Spec.Containers[0].Image, gotContainer.Image; e != a {
+		t.Fatalf("expected container image %s, got %s", e, a)
+	}
+
+	// Verify command overriding
+	if e, a := "overridden", gotContainer.Command[0]; e != a {
+		t.Fatalf("expected container command %s, got %s", e, a)
+	}
+
+	// Verify environment merging
+	expectedEnv := map[string]string{
+		"name": "value",
+		"ENV1": "overridden",
+	}
+
+	for k, v := range expectedEnv {
+		found := false
+		for _, env := range gotContainer.Env {
+			if env.Name == k && env.Value == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected to find %s=%s in pod environment", k, v)
+		}
+	}
+
+	for _, env := range gotContainer.Env {
+		val, found := expectedEnv[env.Name]
+		if !found || val != env.Value {
+			t.Errorf("container has unexpected environment entry %s=%s", env.Name, env.Value)
+		}
+	}
+
+	// Verify resource limit inheritance
+	if cpu := gotContainer.Resources.Limits.Cpu(); cpu.Value() != cpuLimit.Value() {
+		t.Errorf("expected cpu %v, got: %v", cpuLimit, cpu)
+	}
+	if memory := gotContainer.Resources.Limits.Memory(); memory.Value() != memoryLimit.Value() {
+		t.Errorf("expected memory %v, got: %v", memoryLimit, memory)
+	}
+
+	// Verify restart policy
+	if e, a := kapi.RestartPolicyNever, podSpec.Spec.RestartPolicy; e != a {
+		t.Fatalf("expected restart policy %s, got %s", e, a)
+	}
 }
 
 type testWatch struct {


### PR DESCRIPTION
Make deployment hooks inherit resources and working dir from the
base container. Refactor the pod building code and improve the unit
tests.