### PR TITLE
Invert the default behavior for osadm registry/router

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -458,14 +458,14 @@ osc describe policybinding master -n recreated-project | grep createuser2
 echo "ex new-project: ok"
 
 # Test running a router
-[ ! "$(osadm router | grep 'does not exist')" ]
+[ ! "$(osadm router --dry-run | grep 'does not exist')" ]
 [ "$(osadm router -o yaml --credentials="${OPENSHIFTCONFIG}" | grep 'openshift/origin-haproxy-')" ]
 osadm router --create --credentials="${OPENSHIFTCONFIG}"
 [ "$(osadm router | grep 'service exists')" ]
 echo "ex router: ok"
 
 # Test running a registry
-[ ! "$(osadm registry | grep 'does not exist')"]
+[ ! "$(osadm registry --dry-run | grep 'does not exist')"]
 [ "$(osadm registry -o yaml --credentials="${OPENSHIFTCONFIG}" | grep 'openshift/origin-docker-registry')" ]
 osadm registry --create --credentials="${OPENSHIFTCONFIG}"
 [ "$(osadm registry | grep 'service exists')" ]

--- a/pkg/cmd/experimental/registry/registry.go
+++ b/pkg/cmd/experimental/registry/registry.go
@@ -12,7 +12,6 @@ import (
 	kclientcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -27,11 +26,9 @@ Install or configure a Docker registry for OpenShift
 
 This command sets up a Docker registry integrated with OpenShift to provide notifications when
 images are pushed. With no arguments, the command will check for the existing registry service
-called 'docker-registry' and perform some diagnostics to ensure the registry is properly
-configured and functioning.
-
-If a registry service does not exist, the --create flag can be passed to
-create a deployment configuration and service that will run the registry.
+called 'docker-registry' and try to create it. If you want to test whether the registry has
+been created add the --dry-run flag and the command will exit with 1 if the registry does not
+exist.
 
 To run a highly available registry, you should be using a remote storage mechanism like an
 object store (several are supported by the Docker registry). The default Docker registry image
@@ -41,9 +38,9 @@ pass --replicas=2 or higher to ensure you have failover protection. The default 
 uses a local volume and the data will be lost if you delete the running pod.
 
 Examples:
-  Check the default Docker registry ("docker-registry"):
+  Check if default Docker registry ("docker-registry") has been created:
 
-  $ %[1]s %[2]s
+  $ %[1]s %[2]s --dry-run
 
   See what the registry would look like if created:
 
@@ -51,18 +48,18 @@ Examples:
 
   Create a registry if it does not exist with two replicas:
 
-  $ %[1]s %[2]s --create --replicas=2
+  $ %[1]s %[2]s --replicas=2 --credentials=registry-user.kubeconfig
 
   Use a different registry image and see the registry configuration:
 
   $ %[1]s %[2]s -o yaml --images=myrepo/docker-registry:mytag
 
-ALPHA: This command is currently being actively developed. It is intended to simplify
-  the tasks of setting up a Docker registry in a new installation. Some configuration
-  beyond this command is still required to make your registry permanent.
+NOTE: This command is intended to simplify the tasks of setting up a Docker registry in a new
+  installation. Some configuration beyond this command is still required to make
+  your registry persist data.
 `
 
-type config struct {
+type RegistryConfig struct {
 	Type          string
 	ImageTemplate variable.ImageTemplate
 	Ports         string
@@ -70,16 +67,18 @@ type config struct {
 	Labels        string
 	Volume        string
 	HostMount     string
-	Create        bool
+	DryRun        bool
 	Credentials   string
 
 	// TODO: accept environment values.
 }
 
+var errExit = fmt.Errorf("exit")
+
 const defaultLabel = "docker-registry=default"
 
 func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
-	cfg := &config{
+	cfg := &RegistryConfig{
 		ImageTemplate: variable.NewDefaultImageTemplate(),
 
 		Labels:   defaultLabel,
@@ -92,184 +91,11 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 		Use:   name,
 		Short: "Install and check OpenShift Docker registry",
 		Long:  fmt.Sprintf(longDesc, parentName, name),
-
 		Run: func(cmd *cobra.Command, args []string) {
-			var name string
-			switch len(args) {
-			case 0:
-				name = "docker-registry"
-			default:
-				glog.Fatalf("No arguments are allowed to this command")
+			err := RunCmdRegistry(f, cmd, out, cfg, args)
+			if err != errExit {
+				cmdutil.CheckErr(err)
 			}
-
-			ports, err := app.ContainerPortsFromString(cfg.Ports)
-			if err != nil {
-				glog.Fatal(err)
-			}
-
-			label := map[string]string{
-				"docker-registry": "default",
-			}
-			if cfg.Labels != defaultLabel {
-				valid, remove, err := app.LabelsFromSpec(strings.Split(cfg.Labels, ","))
-				if err != nil {
-					glog.Fatal(err)
-				}
-				if len(remove) > 0 {
-					glog.Fatalf("You may not pass negative labels in %q", cfg.Labels)
-				}
-				label = valid
-			}
-
-			image := cfg.ImageTemplate.ExpandOrDie(cfg.Type)
-
-			namespace, err := f.OpenShiftClientConfig.Namespace()
-			if err != nil {
-				glog.Fatalf("Error getting client: %v", err)
-			}
-			_, kClient, err := f.Clients()
-			if err != nil {
-				glog.Fatalf("Error getting client: %v", err)
-			}
-
-			p, output, err := cmdutil.PrinterForCommand(cmd)
-			if err != nil {
-				glog.Fatalf("Unable to configure printer: %v", err)
-			}
-
-			generate := output
-			if !generate {
-				_, err = kClient.Services(namespace).Get(name)
-				if err != nil {
-					if !errors.IsNotFound(err) {
-						glog.Fatalf("Can't check for existing docker-registry %q: %v", name, err)
-					}
-					generate = true
-				}
-			}
-
-			if generate {
-				if !cfg.Create && !output {
-					glog.Fatalf("Docker-registry %q does not exist (no service). Pass --create to install.", name)
-				}
-
-				// create new registry
-				if len(cfg.Credentials) == 0 {
-					glog.Fatalf("You must specify a .kubeconfig file path containing credentials for connecting the registry to the master with --credentials")
-				}
-				clientConfigLoadingRules := &kclientcmd.ClientConfigLoadingRules{ExplicitPath: cfg.Credentials}
-				credentials, err := clientConfigLoadingRules.Load()
-				if err != nil {
-					glog.Fatalf("The provided credentials %q could not be loaded: %v", cfg.Credentials, err)
-				}
-				config, err := kclientcmd.NewDefaultClientConfig(*credentials, &kclientcmd.ConfigOverrides{}).ClientConfig()
-				if err != nil {
-					glog.Fatalf("The provided credentials %q could not be used: %v", cfg.Credentials, err)
-				}
-				if err := kclient.LoadTLSFiles(config); err != nil {
-					glog.Fatalf("The provided credentials %q could not load certificate info: %v", cfg.Credentials, err)
-				}
-				insecure := "false"
-				if config.Insecure {
-					insecure = "true"
-				}
-				env := app.Environment{
-					"OPENSHIFT_MASTER":    config.Host,
-					"OPENSHIFT_CA_DATA":   string(config.CAData),
-					"OPENSHIFT_KEY_DATA":  string(config.KeyData),
-					"OPENSHIFT_CERT_DATA": string(config.CertData),
-					"OPENSHIFT_INSECURE":  insecure,
-				}
-
-				mountHost := len(cfg.HostMount) > 0
-				podTemplate := &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{Labels: label},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:  "registry",
-								Image: image,
-								Ports: ports,
-								Env:   env.List(),
-								VolumeMounts: []kapi.VolumeMount{
-									{
-										Name:      "registry-storage",
-										MountPath: cfg.Volume,
-									},
-								},
-								Privileged: mountHost,
-								// TODO reenable the liveness probe when we no longer support the v1 registry.
-								/*
-									LivenessProbe: &kapi.Probe{
-										InitialDelaySeconds: 3,
-										TimeoutSeconds:      5,
-										Handler: kapi.Handler{
-											HTTPGet: &kapi.HTTPGetAction{
-												Path: "/healthz",
-												Port: util.NewIntOrStringFromInt(5000),
-											},
-										},
-									},
-								*/
-							},
-						},
-						Volumes: []kapi.Volume{
-							{
-								Name:         "registry-storage",
-								VolumeSource: kapi.VolumeSource{},
-							},
-						},
-					},
-				}
-				if mountHost {
-					podTemplate.Spec.Volumes[0].HostPath = &kapi.HostPathVolumeSource{Path: cfg.HostMount}
-				} else {
-					podTemplate.Spec.Volumes[0].EmptyDir = &kapi.EmptyDirVolumeSource{}
-				}
-
-				objects := []runtime.Object{
-					&dapi.DeploymentConfig{
-						ObjectMeta: kapi.ObjectMeta{
-							Name:   name,
-							Labels: label,
-						},
-						Triggers: []dapi.DeploymentTriggerPolicy{
-							{Type: dapi.DeploymentTriggerOnConfigChange},
-						},
-						Template: dapi.DeploymentTemplate{
-							Strategy: dapi.DeploymentStrategy{
-								Type: dapi.DeploymentStrategyTypeRecreate,
-							},
-							ControllerTemplate: kapi.ReplicationControllerSpec{
-								Replicas: cfg.Replicas,
-								Selector: label,
-								Template: podTemplate,
-							},
-						},
-					},
-				}
-				objects = app.AddServices(objects)
-				// TODO: label all created objects with the same label
-				list := &kapi.List{Items: objects}
-
-				if output {
-					if err := p.PrintObj(list, out); err != nil {
-						glog.Fatalf("Unable to print object: %v", err)
-					}
-					return
-				}
-
-				bulk := configcmd.Bulk{
-					Factory: f.Factory,
-					After:   configcmd.NewPrintNameOrErrorAfter(out, os.Stderr),
-				}
-				if errs := bulk.Create(list, namespace); len(errs) != 0 {
-					os.Exit(1)
-				}
-				return
-			}
-
-			fmt.Fprintf(out, "Docker registry %q service exists\n", name)
 		},
 	}
 
@@ -281,10 +107,191 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 	cmd.Flags().StringVar(&cfg.Labels, "labels", cfg.Labels, "A set of labels to uniquely identify the registry and its components.")
 	cmd.Flags().StringVar(&cfg.Volume, "volume", cfg.Volume, "The volume path to use for registry storage; defaults to /registry which is the default for origin-docker-registry.")
 	cmd.Flags().StringVar(&cfg.HostMount, "mount-host", cfg.HostMount, "If set, the registry volume will be created as a host-mount at this path.")
-	cmd.Flags().BoolVar(&cfg.Create, "create", cfg.Create, "Create the registry if it does not exist.")
+	cmd.Flags().BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "Check if the registry exists instead of creating.")
+	cmd.Flags().Bool("create", false, "deprecated; this is now the default behavior")
 	cmd.Flags().StringVar(&cfg.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the registry should use to contact the master.")
 
 	cmdutil.AddPrinterFlags(cmd)
 
 	return cmd
+}
+
+func RunCmdRegistry(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *RegistryConfig, args []string) error {
+	var name string
+	switch len(args) {
+	case 0:
+		name = "docker-registry"
+	default:
+		return cmdutil.UsageError(cmd, "No arguments are allowed to this command")
+	}
+
+	ports, err := app.ContainerPortsFromString(cfg.Ports)
+	if err != nil {
+		return err
+	}
+
+	label := map[string]string{
+		"docker-registry": "default",
+	}
+	if cfg.Labels != defaultLabel {
+		valid, remove, err := app.LabelsFromSpec(strings.Split(cfg.Labels, ","))
+		if err != nil {
+			return err
+		}
+		if len(remove) > 0 {
+			return cmdutil.UsageError(cmd, "You may not pass negative labels in %q", cfg.Labels)
+		}
+		label = valid
+	}
+
+	image := cfg.ImageTemplate.ExpandOrDie(cfg.Type)
+
+	namespace, err := f.OpenShiftClientConfig.Namespace()
+	if err != nil {
+		return fmt.Errorf("error getting client: %v", err)
+	}
+	_, kClient, err := f.Clients()
+	if err != nil {
+		return fmt.Errorf("error getting client: %v", err)
+	}
+
+	p, output, err := cmdutil.PrinterForCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("unable to configure printer: %v", err)
+	}
+
+	generate := output
+	if !generate {
+		_, err = kClient.Services(namespace).Get(name)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("can't check for existing docker-registry %q: %v", name, err)
+			}
+			generate = true
+		}
+	}
+
+	if generate {
+		if cfg.DryRun && !output {
+			return fmt.Errorf("docker-registry %q does not exist (no service).", name)
+		}
+
+		// create new registry
+		if len(cfg.Credentials) == 0 {
+			return fmt.Errorf("registry does not exist; you must specify a .kubeconfig file path containing credentials for connecting the registry to the master with --credentials")
+		}
+		clientConfigLoadingRules := &kclientcmd.ClientConfigLoadingRules{ExplicitPath: cfg.Credentials}
+		credentials, err := clientConfigLoadingRules.Load()
+		if err != nil {
+			return fmt.Errorf("registry does not exist; the provided credentials %q could not be loaded: %v", cfg.Credentials, err)
+		}
+		config, err := kclientcmd.NewDefaultClientConfig(*credentials, &kclientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return fmt.Errorf("registry does not exist; the provided credentials %q could not be used: %v", cfg.Credentials, err)
+		}
+		if err := kclient.LoadTLSFiles(config); err != nil {
+			return fmt.Errorf("registry does not exist; the provided credentials %q could not load certificate info: %v", cfg.Credentials, err)
+		}
+		insecure := "false"
+		if config.Insecure {
+			insecure = "true"
+		}
+		env := app.Environment{
+			"OPENSHIFT_MASTER":    config.Host,
+			"OPENSHIFT_CA_DATA":   string(config.CAData),
+			"OPENSHIFT_KEY_DATA":  string(config.KeyData),
+			"OPENSHIFT_CERT_DATA": string(config.CertData),
+			"OPENSHIFT_INSECURE":  insecure,
+		}
+
+		mountHost := len(cfg.HostMount) > 0
+		podTemplate := &kapi.PodTemplateSpec{
+			ObjectMeta: kapi.ObjectMeta{Labels: label},
+			Spec: kapi.PodSpec{
+				Containers: []kapi.Container{
+					{
+						Name:  "registry",
+						Image: image,
+						Ports: ports,
+						Env:   env.List(),
+						VolumeMounts: []kapi.VolumeMount{
+							{
+								Name:      "registry-storage",
+								MountPath: cfg.Volume,
+							},
+						},
+						Privileged: mountHost,
+						// TODO reenable the liveness probe when we no longer support the v1 registry.
+						/*
+							LivenessProbe: &kapi.Probe{
+								InitialDelaySeconds: 3,
+								TimeoutSeconds:      5,
+								Handler: kapi.Handler{
+									HTTPGet: &kapi.HTTPGetAction{
+										Path: "/healthz",
+										Port: util.NewIntOrStringFromInt(5000),
+									},
+								},
+							},
+						*/
+					},
+				},
+				Volumes: []kapi.Volume{
+					{
+						Name:         "registry-storage",
+						VolumeSource: kapi.VolumeSource{},
+					},
+				},
+			},
+		}
+		if mountHost {
+			podTemplate.Spec.Volumes[0].HostPath = &kapi.HostPathVolumeSource{Path: cfg.HostMount}
+		} else {
+			podTemplate.Spec.Volumes[0].EmptyDir = &kapi.EmptyDirVolumeSource{}
+		}
+
+		objects := []runtime.Object{
+			&dapi.DeploymentConfig{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:   name,
+					Labels: label,
+				},
+				Triggers: []dapi.DeploymentTriggerPolicy{
+					{Type: dapi.DeploymentTriggerOnConfigChange},
+				},
+				Template: dapi.DeploymentTemplate{
+					Strategy: dapi.DeploymentStrategy{
+						Type: dapi.DeploymentStrategyTypeRecreate,
+					},
+					ControllerTemplate: kapi.ReplicationControllerSpec{
+						Replicas: cfg.Replicas,
+						Selector: label,
+						Template: podTemplate,
+					},
+				},
+			},
+		}
+		objects = app.AddServices(objects)
+		// TODO: label all created objects with the same label
+		list := &kapi.List{Items: objects}
+
+		if output {
+			if err := p.PrintObj(list, out); err != nil {
+				return fmt.Errorf("unable to print object: %v", err)
+			}
+			return nil
+		}
+
+		bulk := configcmd.Bulk{
+			Factory: f.Factory,
+			After:   configcmd.NewPrintNameOrErrorAfter(out, os.Stderr),
+		}
+		if errs := bulk.Create(list, namespace); len(errs) != 0 {
+			return errExit
+		}
+		return nil
+	}
+
+	fmt.Fprintf(out, "Docker registry %q service exists\n", name)
+	return nil
 }


### PR DESCRIPTION
Instead of --create, create by default, and add --dry-run
for not doing anything.  Change the errors to be correct,
and continue to support --create (it does nothing).

@pweil- review please