### PR TITLE
Improve ISTag image not found error response

### DIFF
--- a/pkg/image/registry/imagerepositorytag/rest_test.go
+++ b/pkg/image/registry/imagerepositorytag/rest_test.go
@@ -96,6 +96,16 @@ func TestGetImageRepositoryTag(t *testing.T) {
 				},
 			},
 		},
+		"image = ''": {
+			repo: &api.ImageStream{Status: api.ImageStreamStatus{
+				Tags: map[string]api.TagEventList{
+					"latest": {Items: []api.TagEvent{{DockerImageReference: "test", Image: ""}}},
+				},
+			}},
+			expectError:     true,
+			errorTargetKind: "imageStreamTag",
+			errorTargetID:   "test:latest",
+		},
 		"missing image": {
 			repo: &api.ImageStream{Status: api.ImageStreamStatus{
 				Tags: map[string]api.TagEventList{
@@ -120,7 +130,7 @@ func TestGetImageRepositoryTag(t *testing.T) {
 			}},
 			expectError:     true,
 			errorTargetKind: "imageStreamTag",
-			errorTargetID:   "latest",
+			errorTargetID:   "test:latest",
 		},
 	}
 

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -61,8 +61,8 @@ func (r *REST) Get(ctx kapi.Context, id string) (runtime.Object, error) {
 	}
 
 	event := api.LatestTaggedImage(stream, tag)
-	if event == nil {
-		return nil, errors.NewNotFound("imageStreamTag", tag)
+	if event == nil || len(event.Image) == 0 {
+		return nil, errors.NewNotFound("imageStreamTag", id)
 	}
 
 	image, err := r.imageRegistry.GetImage(ctx, event.Image)

--- a/pkg/image/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/registry/imagestreamtag/rest_test.go
@@ -150,6 +150,16 @@ func TestGetImageStreamTag(t *testing.T) {
 				},
 			},
 		},
+		"image = ''": {
+			repo: &api.ImageStream{Status: api.ImageStreamStatus{
+				Tags: map[string]api.TagEventList{
+					"latest": {Items: []api.TagEvent{{DockerImageReference: "test", Image: ""}}},
+				},
+			}},
+			expectError:     true,
+			errorTargetKind: "imageStreamTag",
+			errorTargetID:   "test:latest",
+		},
 		"missing image": {
 			repo: &api.ImageStream{Status: api.ImageStreamStatus{
 				Tags: map[string]api.TagEventList{
@@ -174,7 +184,7 @@ func TestGetImageStreamTag(t *testing.T) {
 			}},
 			expectError:     true,
 			errorTargetKind: "imageStreamTag",
-			errorTargetID:   "latest",
+			errorTargetID:   "test:latest",
 		},
 	}
 


### PR DESCRIPTION
When trying to retrieve an ImageStreamTag, if it's not found, make the
not-found name be <stream>:<tag> instead of just <tag>.

If the status.tags[tag].Items[0] exists, but Items[0].Image is "",
return a not-found error instead of a cryptic etcd error message.