### PR TITLE
osc new-app shouldn't pull when image is chained

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -337,7 +337,7 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 				if err != nil {
 					return nil, fmt.Errorf("can't build %q: %v", ref.Input(), err)
 				}
-				strategy, source, err := app.StrategyAndSourceForRepository(ref.Input().Uses)
+				strategy, source, err := app.StrategyAndSourceForRepository(ref.Input().Uses, input)
 				if err != nil {
 					return nil, fmt.Errorf("can't build %q: %v", ref.Input(), err)
 				}

--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -235,7 +235,26 @@ func (e SourceRepositoryEnumerator) Detect(dir string) (*SourceRepositoryInfo, e
 
 // StrategyAndSourceForRepository returns the build strategy and source code reference
 // of the provided source repository
-func StrategyAndSourceForRepository(repo *SourceRepository) (*BuildStrategyRef, *SourceRef, error) {
+// TODO: user should be able to choose whether to download a remote source ref for
+// more info
+func StrategyAndSourceForRepository(repo *SourceRepository, image *ImageRef) (*BuildStrategyRef, *SourceRef, error) {
+	if image != nil {
+		remoteUrl, err := repo.RemoteURL()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot obtain remote URL for repository at %s", repo.location)
+		}
+		strategy := &BuildStrategyRef{
+			Base:          image,
+			IsDockerBuild: repo.IsDockerBuild(),
+		}
+		source := &SourceRef{
+			URL:        remoteUrl,
+			Ref:        remoteUrl.Fragment,
+			ContextDir: "",
+		}
+		return strategy, source, nil
+	}
+
 	srcRef, err := NewSourceRefGenerator().FromGitURL(repo.location)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot obtain remote URL for repository at %s: %v", repo.location, err)


### PR DESCRIPTION
When a user specifies `osc new-app image~source` the default behavior
is not to clone the source - the user has told us to use the image
with that source.

@kargakis this undoes one of the changes you made with new-app - we
should talk about how to reintroduce this (letting user optionally
clone the repo for more checking).

[merge]