### PR TITLE
Allow registry to auto-provision image streams

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -191,7 +191,8 @@ func GetBootstrapMasterRoles(masterNamespace string) []authorizationapi.Role {
 					Resources: util.NewStringSet("imagestreamimages", "imagestreamtags", "imagestreams"),
 				},
 				{
-					Verbs:     util.NewStringSet("update"),
+					// TODO: remove "create" once we re-enable user authentication in the registry
+					Verbs:     util.NewStringSet("create", "update"),
 					Resources: util.NewStringSet("imagestreams"),
 				},
 				{


### PR DESCRIPTION
Adjust the registry's role so it can create image streams on the fly.

NOTE: this must be removed when we re-enable user authentication in the
registry (currently awaiting service accounts).