### PR TITLE
osc expose: Expose routes from services

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/expose.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/expose.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
@@ -39,15 +38,15 @@ re-use the labels from the resource it exposes.`
 $ kubectl expose rc nginx --port=80 --target-port=8000
 
 // Creates a second service based on the above service, exposing the container port 8443 as port 443 with the name "nginx-https"
-$ kubectl expose service nginx --port=443 --target-port=8443 --service-name=nginx-https
+$ kubectl expose service nginx --port=443 --target-port=8443 --name=nginx-https
 
 // Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
-$ kubectl expose rc streamer --port=4100 --protocol=udp --service-name=video-stream`
+$ kubectl expose rc streamer --port=4100 --protocol=udp --name=video-stream`
 )
 
 func NewCmdExposeService(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "expose RESOURCE NAME --port=port [--protocol=TCP|UDP] [--target-port=number-or-name] [--service-name=name] [--public-ip=ip] [--create-external-load-balancer=bool]",
+		Use:     "expose RESOURCE NAME --port=port [--protocol=TCP|UDP] [--target-port=number-or-name] [--name=name] [--public-ip=ip] [--create-external-load-balancer=bool]",
 		Short:   "Take a replicated application and expose it as Kubernetes Service",
 		Long:    expose_long,
 		Example: expose_example,
@@ -69,40 +68,43 @@ func NewCmdExposeService(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("target-port", "", "Name or number for the port on the container that the service should direct traffic to. Optional.")
 	cmd.Flags().String("public-ip", "", "Name of a public IP address to set for the service. The service will be assigned this IP in addition to its generated service IP.")
 	cmd.Flags().String("overrides", "", "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.")
-	cmd.Flags().String("service-name", "", "The name for the newly created service.")
+	cmd.Flags().String("name", "", "The name for the newly created service.")
 	return cmd
 }
 
 func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
-	var name, res string
-	switch l := len(args); {
-	case l == 2:
-		res, name = args[0], args[1]
-	default:
-		return cmdutil.UsageError(cmd, "the type and name of a resource to expose are required arguments")
-	}
-
 	namespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	// Get the input object
-	var mapping *meta.RESTMapping
 	mapper, typer := f.Object()
-	v, k, err := mapper.VersionAndKindForResource(res)
+	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
+		ContinueOnError().
+		NamespaceParam(namespace).DefaultNamespace().
+		ResourceTypeOrNameArgs(false, args...).
+		Flatten().
+		Do()
+	err = r.Err()
 	if err != nil {
 		return err
 	}
-	mapping, err = mapper.RESTMapping(k, v)
+	mapping, err := r.ResourceMapping()
 	if err != nil {
 		return err
 	}
+	infos, err := r.Infos()
+	if err != nil {
+		return err
+	}
+	info := infos[0]
+
+	// Get the input object
 	client, err := f.RESTClient(mapping)
 	if err != nil {
 		return err
 	}
-	inputObject, err := resource.NewHelper(client, mapping).Get(namespace, name)
+	inputObject, err := resource.NewHelper(client, mapping).Get(info.Namespace, info.Name)
 	if err != nil {
 		return err
 	}
@@ -115,10 +117,9 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 	names := generator.ParamNames()
 	params := kubectl.MakeParams(cmd, names)
-	if len(cmdutil.GetFlagString(cmd, "service-name")) == 0 {
-		params["name"] = name
-	} else {
-		params["name"] = cmdutil.GetFlagString(cmd, "service-name")
+	params["name"] = cmdutil.GetFlagString(cmd, "name")
+	if len(params["name"]) == 0 {
+		params["name"] = info.Name
 	}
 	if s, found := params["selector"]; !found || len(s) == 0 || cmdutil.GetFlagInt(cmd, "port") < 1 {
 		if len(s) == 0 {
@@ -140,13 +141,14 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 			if err != nil {
 				return err
 			}
-			if len(ports) == 0 {
+			switch len(ports) {
+			case 0:
 				return cmdutil.UsageError(cmd, "couldn't find a suitable port via --port flag or introspection")
-			}
-			if len(ports) > 1 {
+			case 1:
+				params["port"] = ports[0]
+			default:
 				return cmdutil.UsageError(cmd, "more than one port to choose from, please explicitly specify a port using the --port flag.")
 			}
-			params["port"] = ports[0]
 		}
 	}
 	if cmdutil.GetFlagBool(cmd, "create-external-load-balancer") {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/expose_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/expose_test.go
@@ -46,7 +46,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"app": "go"},
 				},
 			},
-			flags: map[string]string{"selector": "func=stream", "protocol": "UDP", "port": "14", "service-name": "foo", "labels": "svc=test"},
+			flags: map[string]string{"selector": "func=stream", "protocol": "UDP", "port": "14", "name": "foo", "labels": "svc=test"},
 			output: &api.Service{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "12", Labels: map[string]string{"svc": "test"}},
 				TypeMeta:   api.TypeMeta{Kind: "Service", APIVersion: "v1beta3"},

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,6 +184,24 @@ $ osc get -o yaml pod POD_ID
 $ osc log frontend-pod mysql-container
 ```
 
+osc expose
+------------
+
+This command looks up a service and exposes it as a route. There is also
+the ability to expose a deployment config, replication controller, service, 
+or pod as a new service on a specified port. If no labels are specified, 
+the new object will re-use the labels from the object it exposes.
+
+
+#### Examples
+
+```bash
+# Expose a service as a route
+$ osc expose service frontend
+# Expose a deployment config as a service and use the specified port and name
+$ osc expose dc ruby-heloo-world --port=8080 --name=myservice --generator=services/v1
+```
+
 osc process
 ---------------
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -512,6 +512,14 @@ sleep 2 && [ "$(osc get projects | grep 'ui-test-project')" ]
 [ "$(osc describe policybinding ':default' -n ui-test-project | grep adduser)" ]
 echo "ui-project-commands: ok"
 
+# Expose service as a route
+osc delete svc/frontend
+osc create -f test/integration/fixtures/test-service.json
+osc expose service frontend
+[ "$(osc get route frontend | grep 'name=frontend')" ]
+osc delete svc,route -l name=frontend
+echo "expose: ok"
+
 # Test deleting and recreating a project
 osadm new-project recreated-project --admin="createuser1"
 osc delete project recreated-project

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -74,6 +74,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	cmds.AddCommand(cmd.NewCmdDeploy(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdRollback(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdEnv(fullName, f, os.Stdin, out))
+	cmds.AddCommand(cmd.NewCmdExpose(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdGet(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdDescribe(fullName, f, out))
 	// Deprecate 'osc apply' with 'osc create' command.

--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	kcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	expose_long = `Take a replicated application and expose it as a route.
+
+Looks up a service by name and derives a route from it.`
+
+	expose_example = `// Create a route based on service nginx. The new route will re-use nginx's labels.
+$ %[1]s expose service nginx
+
+// Create a route and specify your own label.
+$ %[1]s expose service nginx --labels name=myroute`
+)
+
+// NewCmdExpose is a wrapper for the Kubernetes cli expose command
+func NewCmdExpose(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	cmd := kcmd.NewCmdExposeService(f.Factory, out)
+	cmd.Long = expose_long
+	cmd.Example = fmt.Sprintf(expose_example, fullName)
+	cmd.Flags().Set("generator", "route/v1")
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		err := validate(cmd, f, args)
+		cmdutil.CheckErr(err)
+		err = kcmd.RunExpose(f.Factory, out, cmd, args)
+		cmdutil.CheckErr(err)
+	}
+	return cmd
+}
+
+// validate adds one layer of validation prior to calling the upstream
+// expose command. Used only for validating services that are about
+// to be exposed as routes.
+func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+	if cmdutil.GetFlagString(cmd, "generator") != "route/v1" {
+		return nil
+	}
+	namespace, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	_, kc, err := f.Clients()
+	if err != nil {
+		return err
+	}
+
+	mapper, typer := f.Object()
+	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
+		ContinueOnError().
+		NamespaceParam(namespace).DefaultNamespace().
+		ResourceTypeOrNameArgs(false, args...).
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+	mapping, err := r.ResourceMapping()
+	if err != nil {
+		return err
+	}
+	infos, err := r.Infos()
+	if err != nil {
+		return err
+	}
+	if len(infos) > 1 {
+		return fmt.Errorf("multiple resources provided: %v", args)
+	}
+	info := infos[0]
+
+	switch mapping.Kind {
+	case "Service":
+		svc, err := kc.Services(info.Namespace).Get(info.Name)
+		if err != nil {
+			return err
+		}
+
+		supportsTCP := false
+		for _, port := range svc.Spec.Ports {
+			if port.Protocol == "TCP" {
+				supportsTCP = true
+				break
+			}
+		}
+		if !supportsTCP {
+			return fmt.Errorf("service %s doesn't support TCP", info.Name)
+		}
+	default:
+		return fmt.Errorf("cannot expose a %s as a route", mapping.Kind)
+	}
+
+	return nil
+}

--- a/pkg/route/generator/doc.go
+++ b/pkg/route/generator/doc.go
@@ -1,0 +1,2 @@
+// Package generator implements the Generator interface for routes
+package generator

--- a/pkg/route/generator/generate.go
+++ b/pkg/route/generator/generate.go
@@ -1,0 +1,40 @@
+package generator
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/route/api"
+)
+
+// RouteGenerator implements the kubectl.Generator interface for routes
+type RouteGenerator struct{}
+
+// ParamNames returns the parameters required for generating a route
+func (RouteGenerator) ParamNames() []kubectl.GeneratorParam {
+	return []kubectl.GeneratorParam{
+		{"labels", false},
+		{"name", true},
+	}
+}
+
+// Generate accepts a set of parameters and maps them into a new route
+func (RouteGenerator) Generate(params map[string]string) (runtime.Object, error) {
+	labels, err := kubectl.ParseLabels(params["labels"])
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:   params["name"],
+			Labels: labels,
+		},
+		ServiceName: params["name"],
+	}, nil
+}
+
+// Useful pattern for validating that RouteGenerator implements
+// the Generator interface
+var _ kubectl.Generator = RouteGenerator{}

--- a/test/integration/fixtures/test-service.json
+++ b/test/integration/fixtures/test-service.json
@@ -5,5 +5,8 @@
   "port": 9998,
   "selector": {
     "name": "frontend"
+  },
+  "labels": {
+    "name": "frontend"
   }
 }


### PR DESCRIPTION
This commit adds the expose command from Kubernetes with a couple of additions. `osc expose` like `kubectl expose` exposes services, pods, or replication controllers as services and then it goes on exposing deployment configs as services and services as routes.

In order for `osc expose` to generate routes from services, routes had to implement the kubectl.Generator interface.

cc: @smarterclayton 