### PR TITLE
Bug 1218592 Fix pod ca cert name in haproxy template

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -175,7 +175,7 @@ backend be_secure_{{$cfgIdx}}
   balance leastconn
   timeout check 5000ms
                 {{ range $endpointID, $endpoint := $serviceUnit.EndpointTable }}
-  server {{$serviceUnit.TemplateSafeName}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file /var/lib/containers/router/cacerts/{{$cfg.Host}}_pod.pem
+  server {{$serviceUnit.TemplateSafeName}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file /var/lib/containers/router/cacerts/{{$cfgIdx}}.pem
                 {{ end }}
             {{ end  }}
         {{ end  }}{{/* $serviceUnit.ServiceAliasConfigs*/}}


### PR DESCRIPTION
Missed name when switching config keys.  Affects reencrypt routes, they are the only route that references a certificate by name (all others use a CN match).