### PR TITLE
Reparent etcd resources under a prefix

### DIFF
--- a/pkg/build/registry/etcd/etcd.go
+++ b/pkg/build/registry/etcd/etcd.go
@@ -23,7 +23,7 @@ const (
 	// BuildPath is the path to build resources in etcd
 	BuildPath string = "/builds"
 	// BuildConfigPath is the path to buildConfig resources in etcd
-	BuildConfigPath string = "/buildConfigs"
+	BuildConfigPath string = "/buildconfigs"
 )
 
 // Etcd implements build.Registry and buildconfig.Registry backed by etcd.

--- a/pkg/build/registry/etcd/etcd_test.go
+++ b/pkg/build/registry/etcd/etcd_test.go
@@ -46,12 +46,12 @@ func makeTestDefaultBuildListKey() string {
 }
 func makeTestBuildConfigListKey(namespace string) string {
 	if len(namespace) != 0 {
-		return "/buildConfigs/" + namespace
+		return "/buildconfigs/" + namespace
 	}
-	return "/buildConfigs"
+	return "/buildconfigs"
 }
 func makeTestBuildConfigKey(namespace, id string) string {
-	return "/buildConfigs/" + namespace + "/" + id
+	return "/buildconfigs/" + namespace + "/" + id
 }
 func makeTestDefaultBuildConfigKey(id string) string {
 	return makeTestBuildConfigKey(kapi.NamespaceDefault, id)
@@ -685,7 +685,7 @@ func TestEtcdListBuildConfigsInDifferentNamespaces(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	namespaceAlfa := kapi.WithNamespace(kapi.NewContext(), "alfa")
 	namespaceBravo := kapi.WithNamespace(kapi.NewContext(), "bravo")
-	fakeClient.Data["/buildConfigs/alfa"] = tools.EtcdResponseWithError{
+	fakeClient.Data["/buildconfigs/alfa"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
@@ -697,7 +697,7 @@ func TestEtcdListBuildConfigsInDifferentNamespaces(t *testing.T) {
 		},
 		E: nil,
 	}
-	fakeClient.Data["/buildConfigs/bravo"] = tools.EtcdResponseWithError{
+	fakeClient.Data["/buildconfigs/bravo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
@@ -735,8 +735,8 @@ func TestEtcdGetBuildConfigInDifferentNamespaces(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	namespaceAlfa := kapi.WithNamespace(kapi.NewContext(), "alfa")
 	namespaceBravo := kapi.WithNamespace(kapi.NewContext(), "bravo")
-	fakeClient.Set("/buildConfigs/alfa/foo", runtime.EncodeOrDie(latest.Codec, &api.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
-	fakeClient.Set("/buildConfigs/bravo/foo", runtime.EncodeOrDie(latest.Codec, &api.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
+	fakeClient.Set("/buildconfigs/alfa/foo", runtime.EncodeOrDie(latest.Codec, &api.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
+	fakeClient.Set("/buildconfigs/bravo/foo", runtime.EncodeOrDie(latest.Codec, &api.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
 	registry := NewTestEtcd(fakeClient)
 
 	alfaFoo, err := registry.GetBuildConfig(namespaceAlfa, "foo")

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -148,10 +148,18 @@ type EtcdStorageConfig struct {
 	// serialized to. This value should *not* be advanced until all clients in the
 	// cluster that read from etcd have code that allows them to read the new version.
 	KubernetesStorageVersion string
+	// KubernetesStoragePrefix is the path within etcd that the Kubernetes resources will
+	// be rooted under. This value, if changed, will mean existing objects in etcd will
+	// no longer be located.
+	KubernetesStoragePrefix string
 	// OpenShiftStorageVersion is the API version that OS resources in etcd should be
 	// serialized to. This value should *not* be advanced until all clients in the
 	// cluster that read from etcd have code that allows them to read the new version.
 	OpenShiftStorageVersion string
+	// OpenShiftStoragePrefix is the path within etcd that the OpenShift resources will
+	// be rooted under. This value, if changed, will mean existing objects in etcd will
+	// no longer be located.
+	OpenShiftStoragePrefix string
 }
 
 type ServingInfo struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -12,8 +12,14 @@ func init() {
 			if len(obj.KubernetesStorageVersion) == 0 {
 				obj.KubernetesStorageVersion = "v1beta3"
 			}
+			if len(obj.KubernetesStoragePrefix) == 0 {
+				obj.KubernetesStoragePrefix = "kubernetes.io"
+			}
 			if len(obj.OpenShiftStorageVersion) == 0 {
 				obj.OpenShiftStorageVersion = "v1beta1"
+			}
+			if len(obj.OpenShiftStoragePrefix) == 0 {
+				obj.OpenShiftStoragePrefix = "openshift.io"
 			}
 		},
 	)

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -144,10 +144,18 @@ type EtcdStorageConfig struct {
 	// serialized to. This value should *not* be advanced until all clients in the
 	// cluster that read from etcd have code that allows them to read the new version.
 	KubernetesStorageVersion string `json:"kubernetesStorageVersion"`
+	// KubernetesStoragePrefix is the path within etcd that the Kubernetes resources will
+	// be rooted under. This value, if changed, will mean existing objects in etcd will
+	// no longer be located. The default value is 'kubernetes.io'.
+	KubernetesStoragePrefix string `json:"kubernetesStoragePrefix"`
 	// OpenShiftStorageVersion is the API version that OS resources in etcd should be
 	// serialized to. This value should *not* be advanced until all clients in the
 	// cluster that read from etcd have code that allows them to read the new version.
 	OpenShiftStorageVersion string `json:"openShiftStorageVersion"`
+	// OpenShiftStoragePrefix is the path within etcd that the OpenShift resources will
+	// be rooted under. This value, if changed, will mean existing objects in etcd will
+	// no longer be located. The default value is 'openshift.io'.
+	OpenShiftStoragePrefix string `json:"openShiftStoragePrefix"`
 }
 
 type ServingInfo struct {

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -105,6 +105,13 @@ func ValidateEtcdStorageConfig(config api.EtcdStorageConfig) fielderrors.Validat
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("openShiftStorageVersion"))
 	}
 
+	if strings.ContainsRune(config.KubernetesStoragePrefix, '%') {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("kubernetesStoragePrefix", config.KubernetesStoragePrefix, "the '%' character may not be used in etcd path prefixes"))
+	}
+	if strings.ContainsRune(config.OpenShiftStoragePrefix, '%') {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("openShiftStoragePrefix", config.OpenShiftStoragePrefix, "the '%' character may not be used in etcd path prefixes"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -48,7 +48,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	if err != nil {
 		return nil, err
 	}
-	ketcdHelper, err := master.NewEtcdHelper(etcdClient, options.EtcdStorageConfig.KubernetesStorageVersion, "kubernetes.io")
+	ketcdHelper, err := master.NewEtcdHelper(etcdClient, options.EtcdStorageConfig.KubernetesStorageVersion, options.EtcdStorageConfig.KubernetesStoragePrefix)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up Kubernetes server storage: %v", err)
 	}

--- a/pkg/cmd/server/origin/auth_config.go
+++ b/pkg/cmd/server/origin/auth_config.go
@@ -38,7 +38,7 @@ func BuildAuthConfig(options configapi.MasterConfig) (*AuthConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
+	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion, options.EtcdStorageConfig.OpenShiftStoragePrefix)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up server storage: %v", err)
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -97,7 +97,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
+	etcdHelper, err := NewEtcdHelper(client, options.EtcdStorageConfig.OpenShiftStorageVersion, options.EtcdStorageConfig.OpenShiftStoragePrefix)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up server storage: %v", err)
 	}

--- a/pkg/deploy/registry/etcd/etcd.go
+++ b/pkg/deploy/registry/etcd/etcd.go
@@ -20,7 +20,7 @@ const (
 	// DeploymentPath is the path to deployment resources in etcd
 	DeploymentPath string = "/deployments"
 	// DeploymentConfigPath is the path to deploymentConfig resources in etcd
-	DeploymentConfigPath string = "/deploymentConfigs"
+	DeploymentConfigPath string = "/deploymentconfigs"
 )
 
 // Etcd implements deployment.Registry and deploymentconfig.Registry interfaces.

--- a/pkg/deploy/registry/etcd/etcd_test.go
+++ b/pkg/deploy/registry/etcd/etcd_test.go
@@ -40,12 +40,12 @@ func makeTestDefaultDeploymentListKey() string {
 }
 func makeTestDeploymentConfigListKey(namespace string) string {
 	if len(namespace) != 0 {
-		return "/deploymentConfigs/" + namespace
+		return "/deploymentconfigs/" + namespace
 	}
-	return "/deploymentConfigs"
+	return "/deploymentconfigs"
 }
 func makeTestDeploymentConfigKey(namespace, id string) string {
-	return "/deploymentConfigs/" + namespace + "/" + id
+	return "/deploymentconfigs/" + namespace + "/" + id
 }
 func makeTestDefaultDeploymentConfigKey(id string) string {
 	return makeTestDeploymentConfigKey(kapi.NamespaceDefault, id)
@@ -642,7 +642,7 @@ func TestEtcdListDeploymentConfigsInDifferentNamespaces(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	namespaceAlfa := kapi.WithNamespace(kapi.NewContext(), "alfa")
 	namespaceBravo := kapi.WithNamespace(kapi.NewContext(), "bravo")
-	fakeClient.Data["/deploymentConfigs/alfa"] = tools.EtcdResponseWithError{
+	fakeClient.Data["/deploymentconfigs/alfa"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
@@ -654,7 +654,7 @@ func TestEtcdListDeploymentConfigsInDifferentNamespaces(t *testing.T) {
 		},
 		E: nil,
 	}
-	fakeClient.Data["/deploymentConfigs/bravo"] = tools.EtcdResponseWithError{
+	fakeClient.Data["/deploymentconfigs/bravo"] = tools.EtcdResponseWithError{
 		R: &etcd.Response{
 			Node: &etcd.Node{
 				Nodes: []*etcd.Node{
@@ -692,8 +692,8 @@ func TestEtcdGetDeploymentConfigInDifferentNamespaces(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	namespaceAlfa := kapi.WithNamespace(kapi.NewContext(), "alfa")
 	namespaceBravo := kapi.WithNamespace(kapi.NewContext(), "bravo")
-	fakeClient.Set("/deploymentConfigs/alfa/foo", runtime.EncodeOrDie(latest.Codec, &api.DeploymentConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
-	fakeClient.Set("/deploymentConfigs/bravo/foo", runtime.EncodeOrDie(latest.Codec, &api.DeploymentConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
+	fakeClient.Set("/deploymentconfigs/alfa/foo", runtime.EncodeOrDie(latest.Codec, &api.DeploymentConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
+	fakeClient.Set("/deploymentconfigs/bravo/foo", runtime.EncodeOrDie(latest.Codec, &api.DeploymentConfig{ObjectMeta: kapi.ObjectMeta{Name: "foo"}}), 0)
 	registry := NewTestEtcd(fakeClient)
 
 	alfaFoo, err := registry.GetDeploymentConfig(namespaceAlfa, "foo")

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -100,7 +100,7 @@ func TestOverwritePolicyCommand(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
+	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, masterConfig.EtcdStorageConfig.OpenShiftStoragePrefix)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -84,7 +84,7 @@ func TestUserInitialization(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, "openshift")
+	etcdHelper, err := origin.NewEtcdHelper(etcdClient, masterConfig.EtcdStorageConfig.OpenShiftStorageVersion, masterConfig.EtcdStorageConfig.OpenShiftStoragePrefix)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Adds configuration for the resource prefix in etcd for both
Kube and OpenShift and uses that prefix consistently. Values
default to 'openshift.io' and 'kubernetes.io'.

This is a breaking change to existing data between 0.5.0 and 0.5.1.

@deads2k review please, only the last commit.