### PR TITLE
Implement webhooks in v1beta3

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/rest/webhook.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/rest/webhook.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+)
+
+// HookHandler is a Kubernetes API compatible webhook that is able to get access to the raw request
+// and response. Used when adapting existing webhook code to the Kubernetes patterns.
+type HookHandler interface {
+	ServeHTTP(w http.ResponseWriter, r *http.Request, ctx api.Context, name, subpath string) error
+}
+
+type httpHookHandler struct {
+	http.Handler
+}
+
+func (h httpHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, ctx api.Context, name, subpath string) error {
+	h.Handler.ServeHTTP(w, r)
+	return nil
+}
+
+// WebHook provides a reusable rest.Storage implementation for linking a generic WebHook handler
+// into the Kube API pattern. It is intended to be used with GET or POST against a resource's
+// named path, possibly as a subresource. The handler has access to the extracted information
+// from the Kube apiserver including the context, the name, and the subpath.
+type WebHook struct {
+	h        HookHandler
+	allowGet bool
+}
+
+var _ rest.Connecter = &WebHook{}
+
+func NewWebHook(handler HookHandler, allowGet bool) *WebHook {
+	return &WebHook{
+		h:        handler,
+		allowGet: allowGet,
+	}
+}
+
+func NewHTTPWebHook(handler http.Handler, allowGet bool) *WebHook {
+	return &WebHook{
+		h:        httpHookHandler{handler},
+		allowGet: allowGet,
+	}
+}
+
+func (h *WebHook) New() runtime.Object {
+	return &api.Status{}
+}
+
+func (h *WebHook) Connect(ctx api.Context, name string, options runtime.Object) (rest.ConnectHandler, error) {
+	return &WebHookHandler{
+		handler: h.h,
+		ctx:     ctx,
+		name:    name,
+		options: options.(*api.PodProxyOptions),
+	}, nil
+}
+
+func (h *WebHook) NewConnectOptions() (runtime.Object, bool, string) {
+	return &api.PodProxyOptions{}, true, "path"
+}
+
+func (h *WebHook) ConnectMethods() []string {
+	if h.allowGet {
+		return []string{"GET", "POST"}
+	}
+	return []string{"POST"}
+}
+
+type WebHookHandler struct {
+	handler HookHandler
+	ctx     api.Context
+	name    string
+	options *api.PodProxyOptions
+	err     error
+}
+
+var _ rest.ConnectHandler = &WebHookHandler{}
+
+func (h *WebHookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.err = h.handler.ServeHTTP(w, r, h.ctx, h.name, h.options.Path)
+	if h.err == nil {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func (h *WebHookHandler) RequestError() error {
+	return h.err
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -431,6 +431,12 @@ osc start-build --list-webhooks='all' ruby-sample-build
 [[ $(osc start-build --list-webhooks='all' ruby-sample-build | grep --text "github") ]]
 [[ $(osc start-build --list-webhooks='github' ruby-sample-build | grep --text "secret101") ]]
 [ ! "$(osc start-build --list-webhooks='blah')" ]
+
+webhook=$(osc start-build --list-webhooks='generic' ruby-sample-build --api-version=v1beta1 | head -n 1)
+osc start-build --from-webhook="${webhook}"
+webhook=$(osc start-build --list-webhooks='generic' ruby-sample-build --api-version=v1beta3 | head -n 1)
+osc start-build --from-webhook="${webhook}"
+osc get builds
 echo "buildConfig: ok"
 
 osc create -f test/integration/fixtures/test-buildcli.json

--- a/pkg/build/registry/buildconfig/webhook.go
+++ b/pkg/build/registry/buildconfig/webhook.go
@@ -1,0 +1,73 @@
+package buildconfig
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/rest"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/client"
+	"github.com/openshift/origin/pkg/build/webhook"
+)
+
+func NewWebHookREST(registry Registry, instantiator client.BuildConfigInstantiator, plugins map[string]webhook.Plugin) *rest.WebHook {
+	controller := &controller{
+		registry:     registry,
+		instantiator: instantiator,
+		plugins:      plugins,
+	}
+	return rest.NewWebHook(controller, false)
+}
+
+type controller struct {
+	registry     Registry
+	instantiator client.BuildConfigInstantiator
+	plugins      map[string]webhook.Plugin
+}
+
+// ServeHTTP implements rest.HookHandler
+func (c *controller) ServeHTTP(w http.ResponseWriter, req *http.Request, ctx kapi.Context, name, subpath string) error {
+	parts := strings.Split(subpath, "/")
+	if len(parts) < 2 {
+		return errors.NewBadRequest(fmt.Sprintf("unexpected hook subpath %s", subpath))
+	}
+	secret, hookType := parts[0], parts[1]
+
+	plugin, ok := c.plugins[hookType]
+	if !ok {
+		return errors.NewNotFound("BuildConfigHook", hookType)
+	}
+
+	config, err := c.registry.GetBuildConfig(ctx, name)
+	if err != nil {
+		// clients should not be able to find information about build configs in the system unless the config exists
+		// and the secret matches
+		return errors.NewUnauthorized(fmt.Sprintf("the webhook %q for %q did not accept your secret", hookType, name))
+	}
+
+	revision, proceed, err := plugin.Extract(config, secret, "", req)
+	switch err {
+	case webhook.ErrSecretMismatch, webhook.ErrHookNotEnabled:
+		return errors.NewUnauthorized(fmt.Sprintf("the webhook %q for %q did not accept your secret", plugin, name))
+	case nil:
+	default:
+		return errors.NewInternalError(fmt.Errorf("hook failed: %v", err))
+	}
+
+	if !proceed {
+		return nil
+	}
+
+	request := &buildapi.BuildRequest{
+		ObjectMeta: kapi.ObjectMeta{Name: name},
+		Revision:   revision,
+	}
+	if _, err := c.instantiator.Instantiate(config.Namespace, request); err != nil {
+		return errors.NewInternalError(fmt.Errorf("could not generate a build: %v", err))
+	}
+	return nil
+}

--- a/pkg/build/registry/buildconfig/webhook_test.go
+++ b/pkg/build/registry/buildconfig/webhook_test.go
@@ -1,0 +1,142 @@
+package buildconfig
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	_ "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/rest"
+
+	//"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/registry/test"
+	"github.com/openshift/origin/pkg/build/webhook"
+)
+
+type buildConfigInstantiator struct {
+	Build   *api.Build
+	Err     error
+	Request *api.BuildRequest
+}
+
+func (i *buildConfigInstantiator) Instantiate(namespace string, request *api.BuildRequest) (*api.Build, error) {
+	i.Request = request
+	return i.Build, i.Err
+}
+
+type plugin struct {
+	Secret, Path string
+	Err          error
+}
+
+func (p *plugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (*api.SourceRevision, bool, error) {
+	p.Secret, p.Path = secret, path
+	return nil, true, p.Err
+}
+
+func newStorage() (*rest.WebHook, *buildConfigInstantiator, *test.BuildConfigRegistry) {
+	mockRegistry := &test.BuildConfigRegistry{}
+	bci := &buildConfigInstantiator{}
+	hook := NewWebHookREST(mockRegistry, bci, map[string]webhook.Plugin{
+		"ok":        &plugin{},
+		"errsecret": &plugin{Err: webhook.ErrSecretMismatch},
+		"errhook":   &plugin{Err: webhook.ErrHookNotEnabled},
+		"err":       &plugin{Err: fmt.Errorf("test error")},
+	})
+	return hook, bci, mockRegistry
+}
+
+func TestNewWebHook(t *testing.T) {
+	hook, _, _ := newStorage()
+	if out, ok := hook.New().(*kapi.Status); !ok {
+		t.Errorf("unexpected new: %#v", out)
+	}
+}
+
+func TestConnectWebHook(t *testing.T) {
+	testCases := map[string]struct {
+		Name   string
+		Path   string
+		Obj    *api.BuildConfig
+		RegErr error
+		ErrFn  func(error) bool
+		WFn    func(*httptest.ResponseRecorder) bool
+	}{
+		"hook returns generic error": {
+			Name: "test",
+			Path: "secret/err/extra",
+			ErrFn: func(err error) bool {
+				return strings.Contains(err.Error(), "Internal error occurred: hook failed: test error")
+			},
+		},
+		"hook returns unauthorized for bad secret": {
+			Name:  "test",
+			Path:  "secret/errsecret/extra",
+			ErrFn: errors.IsUnauthorized,
+		},
+		"hook returns unauthorized for bad hook": {
+			Name:  "test",
+			Path:  "secret/errhook/extra",
+			ErrFn: errors.IsUnauthorized,
+		},
+		"hook returns unauthorized for missing build config": {
+			Name:   "test",
+			Path:   "secret/errhook/extra",
+			RegErr: fmt.Errorf("any old error"),
+			ErrFn:  errors.IsUnauthorized,
+		},
+		"hook returns 200 for ok hook": {
+			Name:  "test",
+			Path:  "secret/ok/extra",
+			Obj:   &api.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: "test", Namespace: "default"}},
+			ErrFn: func(err error) bool { return err == nil },
+			WFn: func(w *httptest.ResponseRecorder) bool {
+				return w.Code == http.StatusOK
+			},
+		},
+	}
+	for k, testCase := range testCases {
+		hook, bci, registry := newStorage()
+		if testCase.Obj != nil {
+			registry.BuildConfig = testCase.Obj
+		}
+		if testCase.RegErr != nil {
+			registry.Err = testCase.RegErr
+		}
+		handler, err := hook.Connect(kapi.NewDefaultContext(), testCase.Name, &kapi.PodProxyOptions{Path: testCase.Path})
+		if err != nil {
+			t.Errorf("%s: %v", k, err)
+			continue
+		}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, &http.Request{})
+		if err := handler.RequestError(); !testCase.ErrFn(err) {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		if testCase.WFn != nil && !testCase.WFn(w) {
+			t.Errorf("%s: unexpected response: %#v", k, w)
+			continue
+		}
+		if testCase.Obj != nil {
+			if bci.Request == nil {
+				t.Errorf("%s: instantiator not invoked", k)
+				continue
+			}
+			if bci.Request.Name != testCase.Obj.Name {
+				t.Errorf("%s: instantiator incorrect: %#v", k, bci)
+				continue
+			}
+		} else {
+			if bci.Request != nil {
+				t.Errorf("%s: instantiator should not be invoked: %#v", k, bci)
+				continue
+			}
+		}
+	}
+}

--- a/pkg/build/webhook/generic/fixtures/post-receive-git.json
+++ b/pkg/build/webhook/generic/fixtures/post-receive-git.json
@@ -8,12 +8,12 @@
         "ref": "refs/heads/master",
         "commit": "2602ace61490de0513dfbd7c7de949356cf9bd17",
         "author": {
-          "name": "Martin Nagy",
-          "email": "nagy.martin@gmail.com"
+          "name": "Joe Smith",
+          "email": "joe.smith@gmail.com"
         },
         "committer": {
-          "name": "Martin Nagy",
-          "email": "nagy.martin@gmail.com"
+          "name": "Joe Smith",
+          "email": "joe.smith@gmail.com"
         },
         "message": "Merge pull request #31 from mnagy/prepare_for_new_mysql_image\n\nPrepare for new openshift/mysql-55-centos7 image"
       }

--- a/pkg/build/webhook/generic/generic.go
+++ b/pkg/build/webhook/generic/generic.go
@@ -24,11 +24,11 @@ func New() *WebHookPlugin {
 func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (revision *api.SourceRevision, proceed bool, err error) {
 	trigger, ok := webhook.FindTriggerPolicy(api.GenericWebHookBuildTriggerType, buildCfg)
 	if !ok {
-		err = fmt.Errorf("BuildConfig %s does not support the Generic webhook trigger type", buildCfg.Name)
+		err = webhook.ErrHookNotEnabled
 		return
 	}
 	if trigger.GenericWebHook.Secret != secret {
-		err = fmt.Errorf("Secret does not match for BuildConfig %s", buildCfg.Name)
+		err = webhook.ErrSecretMismatch
 		return
 	}
 	if err = verifyRequest(req); err != nil {

--- a/pkg/build/webhook/github/github.go
+++ b/pkg/build/webhook/github/github.go
@@ -38,11 +38,11 @@ type pushEvent struct {
 func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *http.Request) (revision *api.SourceRevision, proceed bool, err error) {
 	trigger, ok := webhook.FindTriggerPolicy(api.GithubWebHookBuildTriggerType, buildCfg)
 	if !ok {
-		err = fmt.Errorf("BuildConfig %s does not support the Github webhook trigger type", buildCfg.Name)
+		err = webhook.ErrHookNotEnabled
 		return
 	}
 	if trigger.GithubWebHook.Secret != secret {
-		err = fmt.Errorf("Secret does not match for BuildConfig %s", buildCfg.Name)
+		err = webhook.ErrSecretMismatch
 		return
 	}
 	if err = verifyRequest(req); err != nil {

--- a/pkg/build/webhook/webhook.go
+++ b/pkg/build/webhook/webhook.go
@@ -1,9 +1,15 @@
 package webhook
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openshift/origin/pkg/build/api"
+)
+
+var (
+	ErrSecretMismatch = fmt.Errorf("the provided secret does not match")
+	ErrHookNotEnabled = fmt.Errorf("the specified hook is not enabled")
 )
 
 // GitRefMatches determines if the ref from a webhook event matches a build configuration

--- a/pkg/client/buildconfigs.go
+++ b/pkg/client/buildconfigs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -69,11 +70,21 @@ func (c *buildConfigs) Get(name string) (result *buildapi.BuildConfig, err error
 // WebHookURL returns the URL for the provided build config name and trigger policy, or ErrTriggerIsNotAWebHook
 // if the trigger is not a webhook type.
 func (c *buildConfigs) WebHookURL(name string, trigger *buildapi.BuildTriggerPolicy) (*url.URL, error) {
+	if kapi.PreV1Beta3(c.r.APIVersion()) {
+		switch {
+		case trigger.GenericWebHook != nil:
+			return c.r.Get().Namespace(c.ns).Resource("buildConfigHooks").Name(name).Suffix(trigger.GenericWebHook.Secret, "generic").URL(), nil
+		case trigger.GithubWebHook != nil:
+			return c.r.Get().Namespace(c.ns).Resource("buildConfigHooks").Name(name).Suffix(trigger.GithubWebHook.Secret, "github").URL(), nil
+		default:
+			return nil, ErrTriggerIsNotAWebHook
+		}
+	}
 	switch {
 	case trigger.GenericWebHook != nil:
-		return c.r.Get().Namespace(c.ns).Resource("buildConfigHooks").Name(name).Suffix(trigger.GenericWebHook.Secret, "generic").URL(), nil
+		return c.r.Get().Namespace(c.ns).Resource("buildConfigs").Name(name).SubResource("webhooks").Suffix(trigger.GenericWebHook.Secret, "generic").URL(), nil
 	case trigger.GithubWebHook != nil:
-		return c.r.Get().Namespace(c.ns).Resource("buildConfigHooks").Name(name).Suffix(trigger.GithubWebHook.Secret, "github").URL(), nil
+		return c.r.Get().Namespace(c.ns).Resource("buildConfigs").Name(name).SubResource("webhooks").Suffix(trigger.GithubWebHook.Secret, "github").URL(), nil
 	default:
 		return nil, ErrTriggerIsNotAWebHook
 	}

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -43,6 +43,7 @@ const (
 	RegistryRoleName          = "system:registry"
 	InternalComponentRoleName = "system:component"
 	DeleteTokensRoleName      = "system:delete-tokens"
+	WebHooksRoleName          = "system:webhook"
 
 	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
 )
@@ -58,6 +59,7 @@ const (
 	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"
 	RouterRoleBindingName            = RouterRoleName + "s"
 	RegistryRoleBindingName          = RegistryRoleName + "s"
+	WebHooksRoleBindingName          = WebHooksRoleName + "s"
 
 	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "s"
 )

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -180,6 +180,17 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				},
 			},
 		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: WebHooksRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get", "create"),
+					Resources: util.NewStringSet("buildconfigs/webhooks"),
+				},
+			},
+		},
 	}
 }
 
@@ -282,6 +293,15 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 				Name: RegistryRoleName,
 			},
 			Groups: util.NewStringSet(RegistryGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: WebHooksRoleBindingName,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: WebHooksRoleName,
+			},
+			Groups: util.NewStringSet(AuthenticatedGroup, UnauthenticatedGroup),
 		},
 	}
 }

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -89,18 +89,24 @@ func TestWebhookGithubPushWithImage(t *testing.T) {
 	}
 	defer watch.Stop()
 
-	// trigger build event sending push notification
-	postFile(clusterAdminClient.RESTClient.Client, "push", "pushevent.json", clusterAdminClientConfig.Host+whPrefix+"pushbuild/secret101/github?namespace="+testutil.Namespace(), http.StatusOK, t)
+	for _, s := range []string{
+		whPrefix + "pushbuild/secret101/github?namespace=" + testutil.Namespace(),
+		"/osapi/v1beta1/buildConfigs/pushbuild/webhooks/secret101/github?namespace=" + testutil.Namespace(),
+	} {
 
-	event := <-watch.ResultChan()
-	actual := event.Object.(*buildapi.Build)
+		// trigger build event sending push notification
+		postFile(clusterAdminClient.RESTClient.Client, "push", "pushevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t)
 
-	if actual.Status != buildapi.BuildStatusNew {
-		t.Errorf("Expected %s, got %s", buildapi.BuildStatusNew, actual.Status)
-	}
+		event := <-watch.ResultChan()
+		actual := event.Object.(*buildapi.Build)
 
-	if actual.Parameters.Strategy.DockerStrategy.From.Name != "originalImage" {
-		t.Errorf("Expected %s, got %s", "originalImage", actual.Parameters.Strategy.DockerStrategy.From.Name)
+		if actual.Status != buildapi.BuildStatusNew {
+			t.Errorf("Expected %s, got %s", buildapi.BuildStatusNew, actual.Status)
+		}
+
+		if actual.Parameters.Strategy.DockerStrategy.From.Name != "originalImage" {
+			t.Errorf("Expected %s, got %s", "originalImage", actual.Parameters.Strategy.DockerStrategy.From.Name)
+		}
 	}
 }
 
@@ -168,18 +174,24 @@ func TestWebhookGithubPushWithImageStream(t *testing.T) {
 	}
 	defer watch.Stop()
 
-	// trigger build event sending push notification
-	postFile(clusterAdminClient.RESTClient.Client, "push", "pushevent.json", clusterAdminClientConfig.Host+whPrefix+"pushbuild/secret101/github?namespace="+testutil.Namespace(), http.StatusOK, t)
+	for _, s := range []string{
+		whPrefix + "pushbuild/secret101/github?namespace=" + testutil.Namespace(),
+		"/osapi/v1beta1/buildConfigs/pushbuild/webhooks/secret101/github?namespace=" + testutil.Namespace(),
+	} {
 
-	event := <-watch.ResultChan()
-	actual := event.Object.(*buildapi.Build)
+		// trigger build event sending push notification
+		postFile(clusterAdminClient.RESTClient.Client, "push", "pushevent.json", clusterAdminClientConfig.Host+s, http.StatusOK, t)
 
-	if actual.Status != buildapi.BuildStatusNew {
-		t.Errorf("Expected %s, got %s", buildapi.BuildStatusNew, actual.Status)
-	}
+		event := <-watch.ResultChan()
+		actual := event.Object.(*buildapi.Build)
 
-	if actual.Parameters.Strategy.STIStrategy.From.Name != "registry:3000/integration/imageStream:success" {
-		t.Errorf("Expected %s, got %s", "registry:3000/integration-test/imageStream:success", actual.Parameters.Strategy.STIStrategy.From.Name)
+		if actual.Status != buildapi.BuildStatusNew {
+			t.Errorf("Expected %s, got %s", buildapi.BuildStatusNew, actual.Status)
+		}
+
+		if actual.Parameters.Strategy.STIStrategy.From.Name != "registry:3000/integration/imageStream:success" {
+			t.Errorf("Expected %s, got %s", "registry:3000/integration-test/imageStream:success", actual.Parameters.Strategy.STIStrategy.From.Name)
+		}
 	}
 }
 
@@ -204,17 +216,22 @@ func TestWebhookGithubPing(t *testing.T) {
 	}
 	defer watch.Stop()
 
-	// trigger build event sending push notification
-	postFile(&http.Client{}, "ping", "pingevent.json", openshift.server.URL+openshift.whPrefix+"pushbuild/secret101/github?namespace="+testutil.Namespace(), http.StatusOK, t)
+	for _, s := range []string{
+		openshift.whPrefix + "pushbuild/secret101/github?namespace=" + testutil.Namespace(),
+		"/osapi/v1beta1/buildConfigs/pushbuild/webhooks/secret101/github?namespace=" + testutil.Namespace(),
+	} {
+		// trigger build event sending push notification
+		postFile(&http.Client{}, "ping", "pingevent.json", openshift.server.URL+s, http.StatusOK, t)
 
-	// TODO: improve negative testing
-	timer := time.NewTimer(time.Second / 2)
-	select {
-	case <-timer.C:
-		// nothing should happen
-	case event := <-watch.ResultChan():
-		build := event.Object.(*buildapi.Build)
-		t.Fatalf("Unexpected build created: %#v", build)
+		// TODO: improve negative testing
+		timer := time.NewTimer(time.Second / 2)
+		select {
+		case <-timer.C:
+			// nothing should happen
+		case event := <-watch.ResultChan():
+			build := event.Object.(*buildapi.Build)
+			t.Fatalf("Unexpected build created: %#v", build)
+		}
 	}
 }
 


### PR DESCRIPTION
Moving webhooks to a new subresource under build configs.

Security policy still needs to be set to allow system:unauthenticated
to access them.

@bparees assign a reviewer please

Gitserver commits are to update the webhook behavior, will be merged separate