### PR TITLE
default node names always lowercase

### DIFF
--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -146,12 +146,11 @@ func (args NodeArgs) BuildSerializeableNodeConfig() (*configapi.NodeConfig, erro
 
 // defaultHostname returns the default hostname for this system.
 func defaultHostname() (string, error) {
-
 	// Note: We use exec here instead of os.Hostname() because we
 	// want the FQDN, and this is the easiest way to get it.
 	fqdn, err := exec.Command("hostname", "-f").Output()
 	if err != nil {
 		return "", fmt.Errorf("Couldn't determine hostname: %v", err)
 	}
-	return strings.TrimSpace(string(fqdn)), nil
+	return strings.ToLower(strings.TrimSpace(string(fqdn))), nil
 }


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1962.

@smarterclayton I wasn't entirely certain of your intent.  I made sure that the default is always lowercase, but I did not force the node name to lower case if the user explicitly chooses a name.  Do you want us to always enforce lower case node names?