### PR TITLE
Preserve scaling factor of prior deployment

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -161,6 +161,10 @@ const (
 	// DeploymentConfigLabel is the name of a label used to correlate a deployment with the
 	// DeploymentConfigs on which the deployment is based.
 	DeploymentConfigLabel = "deploymentconfig"
+	// DesiredReplicasAnnotation represents the desired number of replicas for a
+	// new deployment.
+	// TODO: This should be made public upstream.
+	DesiredReplicasAnnotation = "kubectl.kubernetes.io/desired-replicas"
 )
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -1,6 +1,7 @@
 package deploymentconfig
 
 import (
+	"fmt"
 	"time"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -53,6 +54,13 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 			},
 			createDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 				return factory.KubeClient.ReplicationControllers(namespace).Create(deployment)
+			},
+			listDeploymentsForConfigFunc: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
+				selector, err := labels.Parse(fmt.Sprintf("%s=%s", deployapi.DeploymentConfigLabel, configName))
+				if err != nil {
+					return nil, err
+				}
+				return factory.KubeClient.ReplicationControllers(namespace).List(selector)
 			},
 		},
 		makeDeployment: func(config *deployapi.DeploymentConfig) (*kapi.ReplicationController, error) {


### PR DESCRIPTION
When scaling up a new deployment and a prior deployment exists,
preserve the replica count of the prior deployment. If no prior
deployment exists, use the template replica count.