### PR TITLE
Wrap navbar controls naturally for small screens

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -56,16 +56,9 @@ html, body {
 
 .console-os .navbar-project {
   border-bottom: 1px solid @navbar-os-project-border-color; 
-  padding-bottom: 5px;
+  padding-bottom: 20px;
   position: relative;
   background: @navbar-os-project-bg;
-  min-height: 85px;
-  .navbar-project-menu {
-    position: relative;
-    display: block;
-    top: 0;
-    margin: 0 20px;
-  }
   label.control-label {
     color: @navbar-project-label-color;
     font-size: 11px;
@@ -104,36 +97,25 @@ html, body {
       margin-bottom: 0;
     }
   }
+  .active-filters {
+    /* If line-height is set, the active-filters div takes up space even
+       when no filters are active. */
+    line-height: 0;
+  }
+  .create-button-container {
+    margin-top: 15px;
+  }
 }
 @media (min-width: @screen-sm-min) {
   .console-os .navbar-project {
-    .navbar-project-menu {
-      display: inline-block;
-      float: left;
-      width: @navbar-project-menu-sm;
+    .navbar-filter-widget {
+      /* Prevent the filter button from wrapping at wide screen sizes. */
+      min-width: 340px;
     }
-    .navbar-search {
-      margin-left: @sidebar-left-width-open-sm;
-    }
-  }
-}
-@media (min-width: @screen-lg-min) { 
-  .console-os .navbar-project {
-    .navbar-project-menu {
-      width: @navbar-project-menu-md;
-    }
-    .navbar-search {
-      margin-left: @sidebar-left-width-open-md;
-    }
-  }
-}
-@media (min-width: @screen-xlg-min)  {
-  .console-os .navbar-project {
-    .navbar-project-menu {
-      width: @navbar-project-menu-lg;
-    }
-    .navbar-search {
-      margin-left: @sidebar-left-width-open-lg;
+    .create-button-container {
+      text-align: right;
+      /* Align button with other navbar controls that have a label above. */
+      margin-top: 30px;
     }
   }
 }

--- a/assets/app/styles/_variables.less
+++ b/assets/app/styles/_variables.less
@@ -27,9 +27,6 @@
 @navbar-os-project-menu-border: 1px solid @btn-default-border;
 @navbar-os-project-menu-color: #333;
 @navbar-project-input-height: 41px;
-@navbar-project-menu-lg: (@sidebar-left-width-open-lg - 40);
-@navbar-project-menu-md: (@sidebar-left-width-open-md - 40);
-@navbar-project-menu-sm: (@sidebar-left-width-open-sm - 40);
 @osc-object-box-shadow: 0 0 0 1px @connector-color;
 @sidebar-os-bg: @sidebar-os-drawer;
 @sidebar-os-drawer: #fff;

--- a/assets/app/views/_project-nav.html
+++ b/assets/app/views/_project-nav.html
@@ -1,42 +1,36 @@
-<div class="navbar-project">
-  <div class="navbar-project-menu">
-    <div class="form-group">
-      <label class="control-label" for="boostrapSelect">Projects</label>
-      <!-- TODO add multiple attribute back to the select tag when we support selecting multiple -->
-      <select class="selectpicker form-control" data-selected-text-format="count>3" id="boostrapSelect"></select>
+<div class="navbar-project container-fluid">
+  <div class="row">
+    <div class="col-sm-4">
+      <div class="form-group">
+        <label class="control-label" for="boostrapSelect">Projects</label>
+        <!-- TODO add multiple attribute back to the select tag when we support selecting multiple -->
+        <select class="selectpicker form-control" data-selected-text-format="count>3" id="boostrapSelect"></select>
+      </div>
     </div>
-  </div>
-  <div class="navbar-search filter">
-    <div class="container-fluid">
-        <div class="row">
-          <div class="col-md-6">
-            <div class="form-group">
-              <label ng-if="!renderOptions || !renderOptions.hideFilterWidget" class="control-label">Filter by labels</label>
-              <div class="navbar-filter-widget">
-              </div>
-            </div>
-          </div>
-          <div class="col-md-4 active-filters">
-          </div>
-          <div class="col-md-2" style="margin-top: 30px;">
-            <span ng-if="project.status.phase == 'Active'">
-              <a href="project/{{projectName}}/create" class="btn btn-lg btn-primary">
-                <span>Create</span>
-                <i class="fa fa-plus" />
-              </a>
-            </span>
-            <span ng-if="project.status.phase != 'Active'">
-              <a href="project/{{projectName}}/create" class="btn btn-lg btn-primary" disabled="disabled">
-                <span>Create</span>
-                <i class="fa fa-plus" />
-              </a>
-              <span ng-if="project.status.phase == 'Terminating'" class="pficon-layered" data-toggle="tooltip" data-placement="left" title="This project has been marked for deletion. No content may be created in this project." style="cursor: help; font-size: 32px; vertical-align: top; margin-left: 5px;">
-                <span class="pficon pficon-warning-triangle"></span>
-                <span class="pficon pficon-warning-exclamation"></span>
-              </span>              
-            </span>
-          </div>
-        </div>
+    <div class="col-sm-5 filter">
+      <div class="form-group">
+        <label ng-if="!renderOptions || !renderOptions.hideFilterWidget" class="control-label">Filter by labels</label>
+        <div class="navbar-filter-widget"></div>
+      </div>
+      <div class="active-filters"></div>
+    </div>
+    <div class="col-sm-3 create-button-container">
+      <span ng-if="project.status.phase == 'Active'">
+        <a href="project/{{projectName}}/create" class="btn btn-lg btn-primary">
+          <span>Create</span>
+          <i class="fa fa-plus" />
+        </a>
+      </span>
+      <span ng-if="project.status.phase != 'Active'">
+        <a href="project/{{projectName}}/create" class="btn btn-lg btn-primary" disabled="disabled">
+          <span>Create</span>
+          <i class="fa fa-plus" />
+        </a>
+        <span ng-if="project.status.phase == 'Terminating'" class="pficon-layered" data-toggle="tooltip" data-placement="left" title="This project has been marked for deletion. No content may be created in this project." style="cursor: help; font-size: 32px; vertical-align: top; margin-left: 5px;">
+          <span class="pficon pficon-warning-triangle"></span>
+          <span class="pficon pficon-warning-exclamation"></span>
+        </span>
+      </span>
     </div>
   </div>
 </div>

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -25,7 +25,7 @@
     "selectize": "0.11.2",
     "zeroclipboard": "2.2.0",
     "messenger": "1.4.1",
-    "kubernetes-label-selector": "0.0.1",
+    "kubernetes-label-selector": "0.0.3",
     "openshift-object-describer": "0.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Place the entire navbar in one fluid container row. Wrap the filter
widget and create button together at small screen sizes. Keep the Filter
button from wrapping below the filter text field unless screen is very
small.

Fixes #2066

Medium and large screens:

![navbar-large](https://cloud.githubusercontent.com/assets/1167259/7496478/5bb914ec-f3e2-11e4-90db-b600d95c4c13.png)

Small and extra small screens:

![navbar-small](https://cloud.githubusercontent.com/assets/1167259/7496487/627acc94-f3e2-11e4-929f-4c2cde74b8ef.png)
