### PR TITLE
Remove deletion of registry pod from test-cmd

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -298,8 +298,6 @@ osadm registry --create --credentials="${OPENSHIFTCONFIG}"
 osc delete dc docker-registry
 osc delete se docker-registry
 osc delete rc docker-registry-1
-registrypod=$(osc get pod | grep docker-registry-1 | awk '{print $1}')
-[ -n "${registrypod}" ] && osc delete pod $registrypod
 # done deleting registry resources
 osc delete imageStreams test
 [ -z "$(osc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]


### PR DESCRIPTION
Remove the deletion of the registry pod from test-cmd, as the deletion
of the replication controller cascades and deletes the associated pod.