### PR TITLE
Add resource definitions to details sidebar when nothing selected

### DIFF
--- a/assets/app/styles/_sidebar.less
+++ b/assets/app/styles/_sidebar.less
@@ -115,6 +115,9 @@
             .word-break();
           }
         }
+        .sidebar-help {
+          color: @gray-light;
+        }
       }
     }
   }

--- a/assets/app/views/directives/osc-object-describer.html
+++ b/assets/app/views/directives/osc-object-describer.html
@@ -1,6 +1,18 @@
 <div>
   <div ng-if="!resource">
-    Select an object to see more details.
+    <p>Select an object to see more details.</p>
+
+    <span class="sidebar-help">
+      <p>A <strong>pod</strong> contains one or more Docker containers that
+        run together on a node, containing your application code.</p>
+
+      <p>A <strong>service</strong> groups pods and provides a common DNS name and
+        an optional, load-balanced IP address to access them.</p>
+
+      <p>A <strong>deployment</strong> is an update to your application, triggered by
+        a changed image or configuration.</p>
+    </span>
   </div>
+
   <kubernetes-object-describer kind="{{kind}}" resource="resource" ng-if="resource"></kubernetes-object-describer>
 </div>


### PR DESCRIPTION
The definitions show only when nothing is selected.

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7502615/330977fc-f40b-11e4-96b1-c4c4c00ed12c.png)