### PR TITLE
openstack vagrant improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,7 @@ OPENSTACK_CRED_FILE = "~/.openstackcred"
 OPENSTACK_BOX_URL   = "https://github.com/cloudbau/vagrant-openstack-plugin/raw/master/dummy.box"
 AWS_CRED_FILE       = "~/.awscred"
 AWS_BOX_URL         = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+VM_NAME_PREFIX      = ENV['OPENSHIFT_VM_NAME_PREFIX'] || ""
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -123,7 +124,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }
 
     # OpenShift master
-    config.vm.define "master" do |config|
+    config.vm.define "#{VM_NAME_PREFIX}master" do |config|
       config.vm.box = kube_box[kube_os]["name"]
       config.vm.box_url = kube_box[kube_os]["box_url"]
       config.vm.provision "shell", inline: "/vagrant/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{ENV['OPENSHIFT_SDN']}"
@@ -134,7 +135,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # OpenShift minion
     num_minion.times do |n|
-      config.vm.define "minion-#{n+1}" do |minion|
+      config.vm.define "#{VM_NAME_PREFIX}minion-#{n+1}" do |minion|
         minion_index = n+1
         minion_ip = minion_ips[n]
         minion.vm.box = kube_box[kube_os]["name"]
@@ -150,7 +151,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     ##########################
     # define settings for the single VM being created.
-    config.vm.define "openshiftdev", primary: true do |config|
+    config.vm.define "#{VM_NAME_PREFIX}openshiftdev", primary: true do |config|
       config.vm.hostname = "openshiftdev.local"
 
       if vagrant_openshift_config['rebuild_yum_cache']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -246,6 +246,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       os.ssh_username = user = voc['ssh_user']|| creds['OSSshUser']  || "root"           # login for the VM instance
       os.server_name  = ENV['OS_HOSTNAME']    || vagrant_openshift_config['instance_name'] # name for the instance created
       full_provision(override.vm, user)
+
+      # floating ip usually needed for accessing machines
+      floating_ip     = creds['OSFloatingIP'] || ENV['OS_FLOATING_IP']
+      os.floating_ip  = floating_ip == ":auto" ? :auto : floating_ip
+      floating_ip_pool = creds['OSFloatingIPPool'] || ENV['OS_FLOATING_IP_POOL']
+      os.floating_ip_pool = floating_ip_pool == "false" ? false : floating_ip_pool
     end if vagrant_openshift_config['openstack']
 
 

--- a/hack/vm-provision-full.sh
+++ b/hack/vm-provision-full.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 USERNAME="${1:-vagrant}"
 
 yum update -y
-yum install -y docker-io git vim golang e2fsprogs tmux httpie ctags hg bind-utils
+yum install -y docker-io git vim golang e2fsprogs tmux httpie ctags hg bind-utils which
 
 if [[ ! -d /data/src/github.com/openshift/origin ]]; then
   mkdir -p /data/src/github.com/openshift/origin

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -20,7 +20,7 @@ done
 node_list=${node_list:1}
 
 # Install the required packages
-yum install -y docker-io git golang e2fsprogs hg net-tools bridge-utils
+yum install -y docker-io git golang e2fsprogs hg net-tools bridge-utils which
 
 # Build openshift
 echo "Building openshift"

--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -24,7 +24,7 @@ for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
 done
 
 # Install the required packages
-yum install -y docker-io git golang e2fsprogs hg openvswitch net-tools bridge-utils
+yum install -y docker-io git golang e2fsprogs hg openvswitch net-tools bridge-utils which
 
 # Build openshift
 echo "Building openshift"


### PR DESCRIPTION
Without VM prefixes it's very hard to share a cloud account like openstack because you can hardly know which instance is yours and which not. 6384f3d allows to set a VM name prefix with an environment variable

Without floating IP it's imposisble to use openstack vagrant setup in most cases because you need a floating IP to access instances. 188fb06 makes it possible to specify floating IPs. The most usable values are `:auto` for floating ip and `false` for pool. if `:auto` is not used then I can only see single instance setup possible. `false` means auto for pools. Counter inthuitive but this is an openstack bug. See https://github.com/cloudbau/vagrant-openstack-plugin/pull/109

Install `which` utility missing from fedora cloud image.

Update: I rebased as I forgot two other places that need `which` installation.