### PR TITLE
Merge non-conflicting changes during osc edit

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/api_installer.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/api_installer.go
@@ -128,6 +128,24 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		return err
 	}
 
+	if hasSubresource {
+		storage, ok := a.group.Storage[resource]
+		if !ok {
+			return fmt.Errorf("subresources can only be declared when the parent is also registered: %s needs %s", path, resource)
+		}
+		object := storage.New()
+		_, kind, err := a.group.Typer.ObjectVersionAndKind(object)
+		if err != nil {
+			return err
+		}
+		parentMapping, err := a.group.Mapper.RESTMapping(kind, a.group.Version)
+		if err != nil {
+			return err
+		}
+		// the sub resource uses the scope of its parent, in the case of sub resource kinds that may span namespaces
+		mapping.Scope = parentMapping.Scope
+	}
+
 	// what verbs are supported by the storage, used to know what verbs we support per path
 	creater, isCreater := storage.(rest.Creater)
 	lister, isLister := storage.(rest.Lister)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/api_installer.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver/api_installer.go
@@ -678,6 +678,9 @@ var _ ScopeNamer = legacyScopeNaming{}
 
 // Namespace returns the namespace from the query or the default.
 func (n legacyScopeNaming) Namespace(req *restful.Request) (namespace string, err error) {
+	if n.scope.Name() == meta.RESTScopeNameRoot {
+		return api.NamespaceNone, nil
+	}
 	values, ok := req.Request.URL.Query()[n.scope.ParamName()]
 	if !ok || len(values) == 0 {
 		// legacy behavior

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
@@ -441,7 +441,7 @@ func FilterNamespace(info *Info) error {
 // set. If info.Object is set, it will be mutated as well.
 func SetNamespace(namespace string) VisitorFunc {
 	return func(info *Info) error {
-		if len(info.Namespace) == 0 {
+		if len(info.Namespace) == 0 && info.Namespaced() {
 			info.Namespace = namespace
 			UpdateObjectNamespace(info)
 		}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/master/master.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/master/master.go
@@ -669,7 +669,7 @@ func (m *Master) api_v1beta2() *apiserver.APIGroupVersion {
 func (m *Master) api_v1beta3() *apiserver.APIGroupVersion {
 	storage := make(map[string]rest.Storage)
 	for k, v := range m.storage {
-		if k == "minions" {
+		if k == "minions" || k == "minions/status" {
 			continue
 		}
 		storage[strings.ToLower(k)] = v

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd/etcd.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd/etcd.go
@@ -118,7 +118,7 @@ func NamespaceKeyRootFunc(ctx api.Context, prefix string) string {
 func NoNamespaceKeyFunc(ctx api.Context, prefix string, name string) (string, error) {
 	ns, ok := api.NamespaceFrom(ctx)
 	if ok && len(ns) > 0 {
-		return "", kubeerr.NewBadRequest("Namespace parameter is not allowed.")
+		return "", kubeerr.NewBadRequest(fmt.Sprintf("Namespace parameter is not allowed on %s.", path.Base(prefix)))
 	}
 	if len(name) == 0 {
 		return "", kubeerr.NewBadRequest("Name parameter required.")

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -1,0 +1,34 @@
+package latest
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+)
+
+func TestRESTRootScope(t *testing.T) {
+	for _, v := range [][]string{{"v1beta1"}, {"v1beta2"}, {"v1beta3"}, {"v1"}, {"", "v1beta1"}} {
+		mapping, err := RESTMapper.RESTMapping("Node", v...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mapping.Scope.Name() != meta.RESTScopeNameRoot {
+			t.Errorf("Node should have a root scope: %#v", mapping.Scope)
+		}
+	}
+	mapping, err := RESTMapper.RESTMapping("User", "v1beta1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mapping.Scope.Name() != meta.RESTScopeNameRoot {
+		t.Errorf("User should have a root scope: %#v", mapping.Scope)
+	}
+
+	mapping, err = RESTMapper.RESTMapping("Status", "v1beta1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mapping.Scope.Name() != meta.RESTScopeNameRoot {
+		t.Errorf("Status should have a root scope: %#v", mapping.Scope)
+	}
+}

--- a/pkg/cmd/cli/cmd/edit.go
+++ b/pkg/cmd/cli/cmd/edit.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/editor"
+	"github.com/openshift/origin/pkg/util/jsonmerge"
 )
 
 const (
@@ -193,6 +194,15 @@ func RunEdit(fullName string, f *clientcmd.Factory, out io.Writer, cmd *cobra.Co
 			continue
 		}
 
+		// attempt to calculate a delta for merging conflicts
+		delta, err := jsonmerge.NewDelta(original, edited)
+		if err != nil {
+			glog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
+			delta = nil
+		}
+		results.delta = delta
+		results.version = defaultVersion
+
 		err = resource.NewFlattenListVisitor(updates, rmap).Visit(func(info *resource.Info) error {
 			data, err := info.Mapping.Codec.Encode(info.Object)
 			if err != nil {
@@ -216,7 +226,7 @@ func RunEdit(fullName string, f *clientcmd.Factory, out io.Writer, cmd *cobra.Co
 			return errExit
 		}
 		if results.conflict > 0 {
-			fmt.Fprintf(cmd.Out(), "You must update your resource version and run `%s update -f %s` to overwrite the remote changes.\n", fullName, file)
+			fmt.Fprintf(cmd.Out(), "You must update your local resource version and run `%s update -f %s` to overwrite the remote changes.\n", fullName, file)
 			return errExit
 		}
 		if len(results.edit) == 0 {
@@ -274,6 +284,9 @@ type editResults struct {
 	conflict  int
 	edit      []*resource.Info
 	file      string
+
+	delta   *jsonmerge.Delta
+	version string
 }
 
 func (r *editResults) AddError(err error, info *resource.Info) string {
@@ -295,15 +308,66 @@ func (r *editResults) AddError(err error, info *resource.Info) string {
 	case errors.IsNotFound(err):
 		r.notfound++
 		return fmt.Sprintf("Error: the %s %s has been deleted on the server", info.Mapping.Kind, info.Name)
+
 	case errors.IsConflict(err):
+		if r.delta != nil {
+			v1 := info.ResourceVersion
+			if perr := tryPatch(r.delta, info, r.version); perr != nil {
+				// the error was related to the patching process
+				if nerr, ok := perr.(patchError); ok {
+					r.conflict++
+					// the patch is in conflict, report to user and exit
+					if jsonmerge.IsConflicting(nerr.error) {
+						// TODO: read message
+						return fmt.Sprintf("Error: a conflicting change was made to the %s %s on the server", info.Mapping.Kind, info.Name)
+					}
+					glog.V(4).Infof("Attempted to patch the resource, but failed: %v", perr)
+					return fmt.Sprintf("Error: %v", err)
+				}
+				// try processing this server error and unset delta so we don't recurse
+				r.delta = nil
+				return r.AddError(err, info)
+			}
+			return fmt.Sprintf("Applied your changes to %s from version %s onto %s", info.Name, v1, info.ResourceVersion)
+		}
+		// no delta was available
 		r.conflict++
-		// TODO: make this better by extracting the resource version of the new version and allowing the user
-		// to know what command they need to run to update again (by rewriting the version?)
 		return fmt.Sprintf("Error: %v", err)
 	default:
 		r.retryable++
 		return fmt.Sprintf("Error: the %s %s could not be updated: %v", info.Mapping.Kind, info.Name, err)
 	}
+}
+
+type patchError struct {
+	error
+}
+
+// tryPatch reads the latest version of the object, writes it to version, then attempts to merge
+// the changes onto it without conflict. If a conflict occurs jsonmerge.IsConflicting(err) is
+// true. The info object is mutated
+func tryPatch(delta *jsonmerge.Delta, info *resource.Info, version string) error {
+	if err := info.Get(); err != nil {
+		return patchError{err}
+	}
+	obj, err := resource.AsVersionedObject([]*resource.Info{info}, false, version)
+	if err != nil {
+		return patchError{err}
+	}
+	data, err := info.Mapping.Codec.Encode(obj)
+	if err != nil {
+		return patchError{err}
+	}
+	merged, err := delta.Apply(data)
+	if err != nil {
+		return patchError{err}
+	}
+	updated, err := resource.NewHelper(info.Client, info.Mapping).Update(info.Namespace, info.Name, false, merged)
+	if err != nil {
+		return err
+	}
+	info.Refresh(updated, true)
+	return nil
 }
 
 // preservedFile writes out a message about the provided file if it exists to the
@@ -323,6 +387,7 @@ func preservedFile(err error, path string, out io.Writer) error {
 // any errors encountered reading the stream.
 func hasLines(r io.Reader) (bool, error) {
 	// TODO: if any files we read have > 64KB lines, we'll need to switch to bytes.ReadLine
+	// TODO: probably going to be secrets
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		if line := strings.TrimSpace(s.Text()); len(line) > 0 && line[0] != '#' {

--- a/pkg/cmd/cli/cmd/edit_test.go
+++ b/pkg/cmd/cli/cmd/edit_test.go
@@ -1,0 +1,3 @@
+package cmd
+
+import ()

--- a/pkg/util/jsonmerge/jsonmerge.go
+++ b/pkg/util/jsonmerge/jsonmerge.go
@@ -1,0 +1,115 @@
+package jsonmerge
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/evanphx/json-patch"
+	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/yaml"
+)
+
+// Delta represents a change between two JSON documents.
+type Delta struct {
+	original []byte
+	edit     []byte
+}
+
+// NewDelta accepts two JSON or YAML documents and calculates the difference
+// between them.  It returns a Delta object which can be used to resolve
+// conflicts against a third version with a common parent, or an error
+// if either document is in error.
+func NewDelta(from, to []byte) (*Delta, error) {
+	d := &Delta{}
+	before, err := yaml.ToJSON(from)
+	if err != nil {
+		return nil, err
+	}
+	after, err := yaml.ToJSON(to)
+	if err != nil {
+		return nil, err
+	}
+	diff, err := jsonpatch.CreateMergePatch(before, after)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(6).Infof("Patch created from:\n%s\n%s\n%s", string(before), string(after), string(diff))
+	d.original = before
+	d.edit = diff
+	return d, nil
+}
+
+// Apply attempts to apply the changes described by Delta onto latest,
+// returning an error if the changes cannot be applied cleanly.
+// IsConflicting will be true if the changes overlap, otherwise a
+// generic error will be returned.
+func (d *Delta) Apply(latest []byte) ([]byte, error) {
+	base, err := yaml.ToJSON(latest)
+	if err != nil {
+		return nil, err
+	}
+	changes, err := jsonpatch.CreateMergePatch(d.original, base)
+	if err != nil {
+		return nil, err
+	}
+	diff1 := make(map[string]interface{})
+	if err := json.Unmarshal(d.edit, &diff1); err != nil {
+		return nil, err
+	}
+	diff2 := make(map[string]interface{})
+	if err := json.Unmarshal(changes, &diff2); err != nil {
+		return nil, err
+	}
+	glog.V(6).Infof("Testing for conflict between:\n%s\n%s", string(d.edit), string(changes))
+	if overlap(diff1, diff2) {
+		return nil, ErrConflict
+	}
+	return jsonpatch.MergePatch(base, d.edit)
+}
+
+// IsConflicting returns true if the provided error indicates a
+// conflict exists between the original changes and the applied
+// changes.
+func IsConflicting(err error) bool {
+	return err == ErrConflict
+}
+
+var ErrConflict = fmt.Errorf("changes are in conflict")
+
+func overlap(a, b interface{}) bool {
+	switch u := a.(type) {
+	case map[string]interface{}:
+		switch v := b.(type) {
+		case map[string]interface{}:
+			for key, left := range u {
+				if right, ok := v[key]; ok && overlap(left, right) {
+					return true
+				}
+			}
+			return false
+		default:
+			return true
+		}
+	case []interface{}:
+		switch v := b.(type) {
+		case []interface{}:
+			if len(u) != len(v) {
+				return true
+			}
+			for i := range u {
+				if overlap(u[i], v[i]) {
+					return true
+				}
+			}
+			return false
+		default:
+			return true
+		}
+	case string, float64, bool, int, int64, nil:
+		return !reflect.DeepEqual(a, b)
+	default:
+		panic(fmt.Sprintf("unknown type: %v", reflect.TypeOf(u)))
+	}
+}

--- a/pkg/util/jsonmerge/jsonmerge.go
+++ b/pkg/util/jsonmerge/jsonmerge.go
@@ -15,6 +15,36 @@ import (
 type Delta struct {
 	original []byte
 	edit     []byte
+
+	preconditions []PreconditionFunc
+}
+
+// PreconditionFunc is a test to verify that an incompatible change
+// has occurred before an Apply can be successful.
+type PreconditionFunc func(interface{}) bool
+
+// AddPreconditions adds precondition checks to a change which must
+// be satisfied before an Apply is considered successful. If a
+// precondition returns false, the Apply is failed with
+// ErrPreconditionFailed.
+func (d *Delta) AddPreconditions(fns ...PreconditionFunc) {
+	d.preconditions = append(d.preconditions, fns...)
+}
+
+// RequireKeyUnchanged creates a precondition function that fails
+// if the provided key is present in the diff (indicating its value
+// has changed).
+func RequireKeyUnchanged(key string) PreconditionFunc {
+	return func(diff interface{}) bool {
+		m, ok := diff.(map[string]interface{})
+		if !ok {
+			return true
+		}
+		// the presence of key in a diff means that its value has been changed, therefore
+		// we should fail the precondition.
+		_, ok = m[key]
+		return !ok
+	}
 }
 
 // NewDelta accepts two JSON or YAML documents and calculates the difference
@@ -62,8 +92,14 @@ func (d *Delta) Apply(latest []byte) ([]byte, error) {
 	if err := json.Unmarshal(changes, &diff2); err != nil {
 		return nil, err
 	}
+	for _, fn := range d.preconditions {
+		if !fn(diff1) || !fn(diff2) {
+			return nil, ErrPreconditionFailed
+		}
+	}
+
 	glog.V(6).Infof("Testing for conflict between:\n%s\n%s", string(d.edit), string(changes))
-	if overlap(diff1, diff2) {
+	if hasConflicts(diff1, diff2) {
 		return nil, ErrConflict
 	}
 	return jsonpatch.MergePatch(base, d.edit)
@@ -76,15 +112,25 @@ func IsConflicting(err error) bool {
 	return err == ErrConflict
 }
 
+// IsPreconditionFailed returns true if the provided error indicates
+// a Delta precondition did not succeed.
+func IsPreconditionFailed(err error) bool {
+	return err == ErrPreconditionFailed
+}
+
+var ErrPreconditionFailed = fmt.Errorf("a precondition failed")
 var ErrConflict = fmt.Errorf("changes are in conflict")
 
-func overlap(a, b interface{}) bool {
-	switch u := a.(type) {
+// hasConflicts returns true if the left and right JSON interface objects overlap with
+// different values in any key.  The code will panic if an unrecognized type is passed
+// (anything not returned by a JSON decode).  All keys are required to be strings.
+func hasConflicts(left, right interface{}) bool {
+	switch typedLeft := left.(type) {
 	case map[string]interface{}:
-		switch v := b.(type) {
+		switch typedRight := right.(type) {
 		case map[string]interface{}:
-			for key, left := range u {
-				if right, ok := v[key]; ok && overlap(left, right) {
+			for key, leftValue := range typedLeft {
+				if rightValue, ok := typedRight[key]; ok && hasConflicts(leftValue, rightValue) {
 					return true
 				}
 			}
@@ -93,13 +139,13 @@ func overlap(a, b interface{}) bool {
 			return true
 		}
 	case []interface{}:
-		switch v := b.(type) {
+		switch typedRight := right.(type) {
 		case []interface{}:
-			if len(u) != len(v) {
+			if len(typedLeft) != len(typedRight) {
 				return true
 			}
-			for i := range u {
-				if overlap(u[i], v[i]) {
+			for i := range typedLeft {
+				if hasConflicts(typedLeft[i], typedRight[i]) {
 					return true
 				}
 			}
@@ -108,8 +154,8 @@ func overlap(a, b interface{}) bool {
 			return true
 		}
 	case string, float64, bool, int, int64, nil:
-		return !reflect.DeepEqual(a, b)
+		return !reflect.DeepEqual(left, right)
 	default:
-		panic(fmt.Sprintf("unknown type: %v", reflect.TypeOf(u)))
+		panic(fmt.Sprintf("unknown type: %v", reflect.TypeOf(left)))
 	}
 }

--- a/pkg/util/jsonmerge/jsonmerge_test.go
+++ b/pkg/util/jsonmerge/jsonmerge_test.go
@@ -1,0 +1,59 @@
+package jsonmerge
+
+import (
+	"testing"
+)
+
+func TestOverlap(t *testing.T) {
+	testCases := []struct {
+		A   interface{}
+		B   interface{}
+		Ret bool
+	}{
+		{A: "hello", B: "hello", Ret: false}, // 0
+		{A: "hello", B: "hell", Ret: true},
+		{A: "hello", B: nil, Ret: true},
+		{A: "hello", B: 1, Ret: true},
+		{A: "hello", B: float64(1.0), Ret: true},
+		{A: "hello", B: false, Ret: true},
+
+		{A: "hello", B: []interface{}{}, Ret: true}, // 6
+		{A: []interface{}{1}, B: []interface{}{}, Ret: true},
+		{A: []interface{}{}, B: []interface{}{}, Ret: false},
+		{A: []interface{}{1}, B: []interface{}{1}, Ret: false},
+		{A: map[string]interface{}{}, B: []interface{}{1}, Ret: true},
+
+		{A: map[string]interface{}{}, B: map[string]interface{}{"a": 1}, Ret: false}, // 11
+		{A: map[string]interface{}{"a": 1}, B: map[string]interface{}{"a": 1}, Ret: false},
+		{A: map[string]interface{}{"a": 1}, B: map[string]interface{}{"a": 2}, Ret: true},
+		{A: map[string]interface{}{"a": 1}, B: map[string]interface{}{"b": 2}, Ret: false},
+
+		{ // 15
+			A:   map[string]interface{}{"a": []interface{}{1}},
+			B:   map[string]interface{}{"a": []interface{}{1}},
+			Ret: false,
+		},
+		{
+			A:   map[string]interface{}{"a": []interface{}{1}},
+			B:   map[string]interface{}{"a": []interface{}{}},
+			Ret: true,
+		},
+		{
+			A:   map[string]interface{}{"a": []interface{}{1}},
+			B:   map[string]interface{}{"a": 1},
+			Ret: true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		out := overlap(testCase.A, testCase.B)
+		if out != testCase.Ret {
+			t.Errorf("%d: expected %t got %t", i, testCase.Ret, out)
+			continue
+		}
+		out = overlap(testCase.B, testCase.A)
+		if out != testCase.Ret {
+			t.Errorf("%d: expected reversed %t got %t", i, testCase.Ret, out)
+		}
+	}
+}

--- a/pkg/util/jsonmerge/jsonmerge_test.go
+++ b/pkg/util/jsonmerge/jsonmerge_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestOverlap(t *testing.T) {
+func TestHasConflicts(t *testing.T) {
 	testCases := []struct {
 		A   interface{}
 		B   interface{}
@@ -46,12 +46,12 @@ func TestOverlap(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		out := overlap(testCase.A, testCase.B)
+		out := hasConflicts(testCase.A, testCase.B)
 		if out != testCase.Ret {
 			t.Errorf("%d: expected %t got %t", i, testCase.Ret, out)
 			continue
 		}
-		out = overlap(testCase.B, testCase.A)
+		out = hasConflicts(testCase.B, testCase.A)
 		if out != testCase.Ret {
 			t.Errorf("%d: expected reversed %t got %t", i, testCase.Ret, out)
 		}


### PR DESCRIPTION
Automagically!  Except that jsonpatch can't handle maps :(

When a resource is changed on the server during an edit, the client
will try to calculate a diff and apply it to the changed resource,
scanning for conflicts in the two diffs.  If jsonpatch were better,
this would be flawless, as is, edits in the same map result in conflicts.

@deads2k you'll appreciate this.