### PR TITLE
Add support to list deployment history

### DIFF
--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -76,6 +76,7 @@ func TestDeploymentConfigDescriber(t *testing.T) {
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	podList := &kapi.PodList{}
 	eventList := &kapi.EventList{}
+	deploymentList := &kapi.ReplicationControllerList{}
 
 	d := &DeploymentConfigDescriber{
 		client: &genericDeploymentDescriberClient{
@@ -84,6 +85,9 @@ func TestDeploymentConfigDescriber(t *testing.T) {
 			},
 			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
 				return deployment, nil
+			},
+			listDeploymentsFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
+				return deploymentList, nil
 			},
 			listPodsFunc: func(namespace string, selector labels.Selector) (*kapi.PodList, error) {
 				return podList, nil


### PR DESCRIPTION
Makes use of the existing `osc deploy` command to list the deployments history through the `-L` flag. Loosely inspired by `git log` and some ideas from `git diff --stat`.

Already available in `master`:

```
osc deploy database       // display the latest deployment for the "database" dc
```

Added by this PR:

```
osc deploy database -L    // list all deployments for the "database" dc
osc deploy database -L 3  // list the latest 3 deployments for the "database" dc
```

Other features and flags remain the same.

The UPSTREAM commit is under discussion here: https://github.com/spf13/pflag/pull/18.
