### PR TITLE
properly relativize paths

### DIFF
--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -304,7 +304,15 @@ func (o *LoginOptions) SaveConfig() (bool, error) {
 	}
 
 	newConfig := config.CreateConfig(o.Username, o.Project, o.Config)
-	baseDir := filepath.Dir(o.PathOptions.GetDefaultFilename())
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, err
+	}
+	baseDir, err := cmdutil.MakeAbs(filepath.Dir(o.PathOptions.GetDefaultFilename()), cwd)
+	if err != nil {
+		return false, err
+	}
 	if err := config.RelativizeClientConfigPaths(&newConfig, baseDir); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
@jcantrill This will make the `osc login` you were running succeed.  The path being used before was not absolutized before relativizing.  Moving relativization upstream is on my todo list.

@fabianofranz ptal.