### PR TITLE
add verb allowed on base policy restriction

### DIFF
--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -19,8 +19,6 @@ func init() {
 		&RoleBindingList{},
 		&RoleList{},
 
-		&IsPersonalSubjectAccessReview{},
-
 		&ClusterRole{},
 		&ClusterRoleBinding{},
 		&ClusterPolicy{},
@@ -29,8 +27,13 @@ func init() {
 		&ClusterPolicyBindingList{},
 		&ClusterRoleBindingList{},
 		&ClusterRoleList{},
+
+		&IsPersonalSubjectAccessReview{},
+		&IsVerbAllowedOnBaseResource{},
 	)
 }
+
+func (*IsVerbAllowedOnBaseResource) IsAnAPIObject() {}
 
 func (*ClusterRole) IsAnAPIObject()              {}
 func (*ClusterPolicy) IsAnAPIObject()            {}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -49,6 +49,12 @@ const (
 	KubeStatusGroupName  = ResourceGroupPrefix + ":allkube-status"
 )
 
+/*
+Other resources:
+ 1.  pods/exec - this allows command execution on a given pod/container.  This is not included directly in any list, because it implies the power to destroy a pod.  You'll note that the bootstrap policy
+     places additional restrictions on this resource
+*/
+
 var (
 	GroupsToResources = map[string][]string{
 		BuildGroupName:              {"builds", "buildconfigs", "buildlogs", "buildconfigs/instantiate", "builds/log", "builds/clone"},
@@ -90,6 +96,14 @@ type PolicyRule struct {
 // IsPersonalSubjectAccessReview is a marker for PolicyRule.AttributeRestrictions that denotes that subjectaccessreviews on self should be allowed
 type IsPersonalSubjectAccessReview struct {
 	kapi.TypeMeta
+}
+
+// IsVerbAllowedOnBaseResource checks to see if the user can perform the specified verb on the base resource with the current name (if provided).
+type IsVerbAllowedOnBaseResource struct {
+	kapi.TypeMeta
+
+	// Verb is the verb to check
+	Verb string
 }
 
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.

--- a/pkg/authorization/api/v1beta1/register.go
+++ b/pkg/authorization/api/v1beta1/register.go
@@ -29,8 +29,11 @@ func init() {
 		&ClusterPolicyBindingList{},
 		&ClusterRoleBindingList{},
 		&ClusterRoleList{},
+		&IsVerbAllowedOnBaseResource{},
 	)
 }
+
+func (*IsVerbAllowedOnBaseResource) IsAnAPIObject() {}
 
 func (*ClusterRole) IsAnAPIObject()              {}
 func (*ClusterPolicy) IsAnAPIObject()            {}

--- a/pkg/authorization/api/v1beta1/types.go
+++ b/pkg/authorization/api/v1beta1/types.go
@@ -38,6 +38,14 @@ type IsPersonalSubjectAccessReview struct {
 	kapi.TypeMeta `json:",inline"`
 }
 
+// IsVerbAllowedOnBaseResource checks to see if the user can perform the specified verb on the base resource with the current name (if provided).
+type IsVerbAllowedOnBaseResource struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// Verb is the verb to check
+	Verb string `json:"verb"`
+}
+
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
 type Role struct {
 	kapi.TypeMeta   `json:",inline"`

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -29,8 +29,11 @@ func init() {
 		&ClusterPolicyBindingList{},
 		&ClusterRoleBindingList{},
 		&ClusterRoleList{},
+		&IsVerbAllowedOnBaseResource{},
 	)
 }
+
+func (*IsVerbAllowedOnBaseResource) IsAnAPIObject() {}
 
 func (*ClusterRole) IsAnAPIObject()              {}
 func (*ClusterPolicy) IsAnAPIObject()            {}

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -38,6 +38,14 @@ type IsPersonalSubjectAccessReview struct {
 	kapi.TypeMeta `json:",inline"`
 }
 
+// IsVerbAllowedOnBaseResource checks to see if the user can perform the specified verb on the base resource with the current name (if provided).
+type IsVerbAllowedOnBaseResource struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// Verb is the verb to check
+	Verb string `json:"verb"`
+}
+
 // Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings.
 type Role struct {
 	kapi.TypeMeta   `json:",inline"`

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -110,7 +110,7 @@ func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.C
 		}
 
 		for _, rule := range role.Rules {
-			matches, err := attributes.RuleMatches(rule)
+			matches, err := attributes.RuleMatches(ctx, a, rule)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -134,7 +134,7 @@ func (a *openshiftAuthorizer) authorizeWithNamespaceRules(ctx kapi.Context, pass
 	allRules, ruleRetrievalError := a.ruleResolver.GetEffectivePolicyRules(ctx)
 
 	for _, rule := range allRules {
-		matches, err := attributes.RuleMatches(rule)
+		matches, err := attributes.RuleMatches(ctx, a, rule)
 		if err != nil {
 			return false, "", err
 		}

--- a/pkg/authorization/authorizer/verb_allowed.go
+++ b/pkg/authorization/authorizer/verb_allowed.go
@@ -1,0 +1,25 @@
+package authorizer
+
+import (
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func IsVerbAllowedOnBaseResource(ctx kapi.Context, authorizer Authorizer, restriction *authorizationapi.IsVerbAllowedOnBaseResource, a AuthorizationAttributes) (bool, error) {
+
+	attributes := DefaultAuthorizationAttributes{
+		Verb:              restriction.Verb,
+		APIVersion:        a.GetAPIVersion(),
+		Resource:          strings.Split(a.GetResource(), "/")[0], // get to the base resource (eliminate any subresources)
+		ResourceName:      a.GetResourceName(),
+		RequestAttributes: a.GetRequestAttributes(),
+		NonResourceURL:    a.IsNonResourceURL(),
+		URL:               a.GetURL(),
+	}
+
+	allowed, _, err := authorizer.Authorize(ctx, attributes)
+	return allowed, err
+}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -54,6 +54,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     util.NewStringSet("get", "list", "watch"),
 					Resources: util.NewStringSet(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName),
 				},
+				{
+					Verbs:     util.NewStringSet("get"),
+					Resources: util.NewStringSet("pods/exec"),
+				},
 			},
 		},
 		{
@@ -68,6 +72,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch"),
 					Resources: util.NewStringSet(authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects"),
+				},
+				{
+					Verbs:                 util.NewStringSet("get"),
+					Resources:             util.NewStringSet("pods/exec"),
+					AttributeRestrictions: runtime.EmbeddedObject{&authorizationapi.IsVerbAllowedOnBaseResource{Verb: "update"}},
 				},
 			},
 		},


### PR DESCRIPTION
This adds a attribute restriction type to `PolicyRules` that checks to see if the user also has access to perform a verbs on the base resource before allowing access.  This allows project admins to exec into any pod, but only allows editors to exec into pods that they have update privileges on.  By default, this is a distinction without a difference, but if a project is ever subdivided, then exec can function as expected.

@csrwng review?
@smarterclayton an example of needing a full object, not a boolean.