### PR TITLE
Added support for project node selector

### DIFF
--- a/pkg/cmd/admin/project/new_project.go
+++ b/pkg/cmd/admin/project/new_project.go
@@ -20,9 +20,10 @@ import (
 const NewProjectRecommendedName = "new-project"
 
 type NewProjectOptions struct {
-	ProjectName string
-	DisplayName string
-	Description string
+	ProjectName  string
+	DisplayName  string
+	Description  string
+	NodeSelector string
 
 	Client client.Interface
 
@@ -56,6 +57,7 @@ func NewCmdNewProject(name, fullName string, f *clientcmd.Factory, out io.Writer
 	cmd.Flags().StringVar(&options.AdminUser, "admin", "", "project admin username")
 	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
 	cmd.Flags().StringVar(&options.Description, "description", "", "project description")
+	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "Restrict pods onto nodes matching given label selector. Format: '<key1>=<value1>, <key2>=<value2>...'")
 
 	return cmd
 }
@@ -83,6 +85,7 @@ func (o *NewProjectOptions) Run() error {
 	project.Annotations = make(map[string]string)
 	project.Annotations["description"] = o.Description
 	project.Annotations["displayName"] = o.DisplayName
+	project.Annotations["openshift.io/node-selector"] = o.NodeSelector
 	project, err := o.Client.Projects().Create(project)
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -18,9 +18,10 @@ import (
 )
 
 type NewProjectOptions struct {
-	ProjectName string
-	DisplayName string
-	Description string
+	ProjectName  string
+	DisplayName  string
+	Description  string
+	NodeSelector string
 
 	Client client.Interface
 
@@ -40,8 +41,8 @@ After your project is created you can switch to it using %[2]s <project name>.`
 	requestProject_example = `  // Create a new project with minimal information
   $ %[1]s web-team-dev
 
-  // Create a new project with a description
-  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."`
+  // Create a new project with a description and node selector
+  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team." --node-selector="env=dev"`
 )
 
 func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -49,7 +50,7 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 	options.Out = out
 
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
+		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION] [--node-selector=<label selector>]", name),
 		Short:   "Request a new project",
 		Long:    fmt.Sprintf(requestProject_long, oscLoginName, oscProjectName),
 		Example: fmt.Sprintf(requestProject_example, fullName),
@@ -71,6 +72,7 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 
 	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
 	cmd.Flags().StringVar(&options.Description, "description", "", "project description")
+	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "Restrict pods onto nodes matching given label selector. Format: '<key1>=<value1>, <key2>=<value2>...'")
 
 	return cmd
 }
@@ -105,6 +107,7 @@ func (o *NewProjectOptions) Run() error {
 	projectRequest.DisplayName = o.DisplayName
 	projectRequest.Annotations = make(map[string]string)
 	projectRequest.Annotations["description"] = o.Description
+	projectRequest.Annotations["openshift.io/node-selector"] = o.NodeSelector
 
 	project, err := o.Client.ProjectRequests().Create(projectRequest)
 	if err != nil {

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -454,11 +454,18 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	nodeSelector := ""
+	if len(project.ObjectMeta.Annotations) > 0 {
+		if ns, ok := project.ObjectMeta.Annotations["openshift.io/node-selector"]; ok {
+			nodeSelector = ns
+		}
+	}
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, project.ObjectMeta)
 		formatString(out, "Display Name", project.Annotations["displayName"])
 		formatString(out, "Status", project.Status.Phase)
+		formatString(out, "Node Selector", nodeSelector)
 		return nil
 	})
 }

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -105,6 +105,8 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 
 	refs = append(refs, &config.PolicyConfig.BootstrapPolicyFile)
 
+	refs = append(refs, &config.ProjectNodeSelector)
+
 	return refs
 }
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -85,6 +85,8 @@ type MasterConfig struct {
 	// PolicyConfig holds information about where to locate critical pieces of bootstrapping policy
 	PolicyConfig PolicyConfig
 
+	// ProjectNodeSelector holds default project node label selector
+	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
 	// ProjectRequestConfig holds information about how to handle new project requests
 	ProjectRequestConfig ProjectRequestConfig
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -81,6 +81,8 @@ type MasterConfig struct {
 
 	PolicyConfig PolicyConfig `json:"policyConfig"`
 
+	// ProjectNodeSelector holds default project node label selector
+	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
 	// ProjectRequestConfig holds information about how to handle new project requests
 	ProjectRequestConfig ProjectRequestConfig `json:"projectRequestConfig"`
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -58,7 +58,8 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	portalNet := net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 
 	// in-order list of plug-ins that should intercept admission decisions
-	admissionControlPluginNames := []string{"NamespaceExists", "NamespaceLifecycle", "LimitRanger", "ResourceQuota"}
+	// TODO: Push node environment support to upstream in future
+	admissionControlPluginNames := []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ResourceQuota"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
 
 	_, portString, err := net.SplitHostPort(options.ServingInfo.BindAddress)

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -74,6 +74,7 @@ import (
 	clientetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclient/etcd"
 	clientauthetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization/etcd"
 	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
 	projectcontroller "github.com/openshift/origin/pkg/project/controller"
 	projectproxy "github.com/openshift/origin/pkg/project/registry/project/proxy"
 	projectrequeststorage "github.com/openshift/origin/pkg/project/registry/projectrequest/delegated"
@@ -766,6 +767,12 @@ func (c *MasterConfig) RunDNSServer() {
 	cmdutil.WaitForSuccessfulDial(false, "tcp", c.Options.DNSConfig.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
 
 	glog.Infof("OpenShift DNS listening at %s", c.Options.DNSConfig.BindAddress)
+}
+
+// RunProjectCache populates project cache, used by scheduler and project admission controller.
+func (c *MasterConfig) RunProjectCache() {
+	glog.Infof("Using default project node label selector: %s", c.Options.ProjectNodeSelector)
+	projectcache.RunProjectCache(c.PrivilegedLoopbackKubernetesClient, c.Options.ProjectNodeSelector)
 }
 
 // RunBuildController starts the build sync loop for builds and buildConfig processing.

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -47,6 +47,7 @@ type MasterArgs struct {
 	KubeConnectionArgs *KubeConnectionArgs
 
 	SchedulerConfigFile string
+	ProjectNodeSelector string
 }
 
 // BindMasterArgs binds the options to the flags with prefix + default flag names
@@ -60,6 +61,7 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 
 	flags.Var(&args.NodeList, prefix+"nodes", "The hostnames of each node. This currently must be specified up front. Comma delimited list")
 	flags.Var(&args.CORSAllowedOrigins, prefix+"cors-allowed-origins", "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  CORS is enabled for localhost, 127.0.0.1, and the asset server by default.")
+	flags.StringVar(&args.ProjectNodeSelector, prefix+"project-node-selector", "", "Default node label selector for the project if not explicitly specified. Format: '<key1>=<value1>, <key2>=<value2...'")
 }
 
 // NewDefaultMasterArgs creates MasterArgs with sub-objects created and default values set.
@@ -195,6 +197,10 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		ProjectRequestConfig: configapi.ProjectRequestConfig{
 			ProjectRequestTemplate: bootstrappolicy.DefaultOpenShiftSharedResourcesNamespace + "/project-request",
 		},
+	}
+
+	if len(args.ProjectNodeSelector) > 0 {
+		config.ProjectNodeSelector = args.ProjectNodeSelector
 	}
 
 	if args.ListenArg.UseTLS() {

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
-	_ "github.com/openshift/origin/pkg/project/admission"
+	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
+	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 )

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -311,8 +311,9 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	if err != nil {
 		return err
 	}
-	//	 must start policy caching immediately
+	// Must start policy caching immediately
 	openshiftConfig.RunPolicyCache()
+	openshiftConfig.RunProjectCache()
 
 	unprotectedInstallers := []origin.APIInstaller{}
 

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -10,18 +10,16 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
 )
 
 // TestAdmissionExists verifies you cannot create Origin content if namespace is not known
 func TestAdmissionExists(t *testing.T) {
-	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	mockClient := &testclient.Fake{
 		Err: fmt.Errorf("DOES NOT EXIST"),
 	}
-	handler := &lifecycle{
-		client: mockClient,
-		store:  store,
-	}
+	projectcache.FakeProjectCache(mockClient, cache.NewStore(cache.MetaNamespaceKeyFunc), "")
+	handler := &lifecycle{}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Parameters: buildapi.BuildParameters{
@@ -62,10 +60,8 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store := cache.NewStore(cache.MetaNamespaceIndexFunc)
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
-	handler := &lifecycle{
-		client: mockClient,
-		store:  store,
-	}
+	projectcache.FakeProjectCache(mockClient, store, "")
+	handler := &lifecycle{}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Parameters: buildapi.BuildParameters{

--- a/pkg/project/admission/nodeenv/admission.go
+++ b/pkg/project/admission/nodeenv/admission.go
@@ -1,0 +1,74 @@
+package admission
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/util/labelselector"
+)
+
+func init() {
+	admission.RegisterPlugin("OriginPodNodeEnvironment", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		return NewPodNodeEnvironment(client)
+	})
+}
+
+// podNodeEnvironment is an implementation of admission.Interface.
+type podNodeEnvironment struct {
+	client client.Interface
+}
+
+// Admit enforces that pod and its project node label selectors matches at least a node in the cluster.
+func (p *podNodeEnvironment) Admit(a admission.Attributes) (err error) {
+	// ignore deletes
+	if a.GetOperation() == "DELETE" {
+		return nil
+	}
+
+	resource := a.GetResource()
+	if resource != "pods" {
+		return nil
+	}
+
+	obj := a.GetObject()
+	name := "Unknown"
+	if obj != nil {
+		name, _ = meta.NewAccessor().Name(obj)
+	}
+	pod := obj.(*kapi.Pod)
+
+	projects, err := projectcache.GetProjectCache()
+	if err != nil {
+		return err
+	}
+	namespace, err := projects.GetNamespaceObject(a.GetNamespace())
+	if err != nil {
+		return apierrors.NewForbidden(resource, name, err)
+	}
+	projectNodeSelector, err := projects.GetNodeSelectorMap(namespace)
+	if err != nil {
+		return err
+	}
+
+	if labelselector.Conflicts(projectNodeSelector, pod.Spec.NodeSelector) {
+		return apierrors.NewForbidden(resource, name, fmt.Errorf("Pod node label selector conflicts with its project node label selector"))
+	}
+
+	// modify pod node selector = project node selector + current pod node selector
+	pod.Spec.NodeSelector = labelselector.Merge(projectNodeSelector, pod.Spec.NodeSelector)
+
+	return nil
+}
+
+func NewPodNodeEnvironment(client client.Interface) (admission.Interface, error) {
+	return &podNodeEnvironment{
+		client: client,
+	}, nil
+}

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -1,0 +1,113 @@
+package admission
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+	"github.com/openshift/origin/pkg/util/labelselector"
+)
+
+// TestPodAdmission verifies various scenarios involving pod/project/global node label selectors
+func TestPodAdmission(t *testing.T) {
+	mockClient := &testclient.Fake{}
+	project := &kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "testProject",
+			Namespace: "",
+		},
+	}
+	projectStore := cache.NewStore(cache.MetaNamespaceIndexFunc)
+	projectStore.Add(project)
+
+	handler := &podNodeEnvironment{client: mockClient}
+	pod := &kapi.Pod{
+		ObjectMeta: kapi.ObjectMeta{Name: "testPod"},
+	}
+
+	tests := []struct {
+		defaultNodeSelector string
+		projectNodeSelector string
+		podNodeSelector     map[string]string
+		mergedNodeSelector  map[string]string
+		admit               bool
+		testName            string
+	}{
+		{
+			defaultNodeSelector: "",
+			projectNodeSelector: "",
+			podNodeSelector:     map[string]string{},
+			mergedNodeSelector:  map[string]string{},
+			admit:               true,
+			testName:            "No node selectors",
+		},
+		{
+			defaultNodeSelector: "infra = false",
+			projectNodeSelector: "",
+			podNodeSelector:     map[string]string{},
+			mergedNodeSelector:  map[string]string{"infra": "false"},
+			admit:               true,
+			testName:            "Default node selector and no conflicts",
+		},
+		{
+			defaultNodeSelector: "",
+			projectNodeSelector: "infra = false",
+			podNodeSelector:     map[string]string{},
+			mergedNodeSelector:  map[string]string{"infra": "false"},
+			admit:               true,
+			testName:            "Project node selector and no conflicts",
+		},
+		{
+			defaultNodeSelector: "infra = false",
+			projectNodeSelector: "infra=true",
+			podNodeSelector:     map[string]string{},
+			mergedNodeSelector:  map[string]string{"infra": "true"},
+			admit:               true,
+			testName:            "Default and project node selector, no conflicts",
+		},
+		{
+			defaultNodeSelector: "infra = false",
+			projectNodeSelector: "infra=true",
+			podNodeSelector:     map[string]string{"env": "test"},
+			mergedNodeSelector:  map[string]string{"infra": "true", "env": "test"},
+			admit:               true,
+			testName:            "Project and pod node selector, no conflicts",
+		},
+		{
+			defaultNodeSelector: "env = test",
+			projectNodeSelector: "infra=true",
+			podNodeSelector:     map[string]string{"infra": "false"},
+			mergedNodeSelector:  map[string]string{"infra": "false"},
+			admit:               false,
+			testName:            "Conflicting pod and project node selector, one label",
+		},
+		{
+			defaultNodeSelector: "env=dev",
+			projectNodeSelector: "infra=false, env = test",
+			podNodeSelector:     map[string]string{"env": "dev", "color": "blue"},
+			mergedNodeSelector:  map[string]string{"env": "dev", "color": "blue"},
+			admit:               false,
+			testName:            "Conflicting pod and project node selector, multiple labels",
+		},
+	}
+	for _, test := range tests {
+		projectcache.FakeProjectCache(mockClient, projectStore, test.defaultNodeSelector)
+		project.ObjectMeta.Annotations = map[string]string{"openshift.io/node-selector": test.projectNodeSelector}
+		pod.Spec = kapi.PodSpec{NodeSelector: test.podNodeSelector}
+
+		err := handler.Admit(admission.NewAttributesRecord(pod, "Pod", project.ObjectMeta.Name, "pods", "CREATE"))
+		if test.admit && err != nil {
+			t.Errorf("Test: %s, expected no error but got: %s", test.testName, err)
+		} else if !test.admit && err == nil {
+			t.Errorf("Test: %s, expected an error", test.testName)
+		}
+
+		if !labelselector.Equals(test.mergedNodeSelector, pod.Spec.NodeSelector) {
+			t.Errorf("Test: %s, expected: %s but got: %s", test.testName, test.mergedNodeSelector, pod.Spec.NodeSelector)
+		}
+	}
+}

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -97,6 +97,33 @@ func TestValidateProject(t *testing.T) {
 			// Should fail because the display name has \t \n
 			numErrs: 1,
 		},
+		{
+			name: "valid node selector",
+			project: api.Project{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "foo",
+					Namespace: "",
+					Annotations: map[string]string{
+						"openshift.io/node-selector": "infra=true, env = test",
+					},
+				},
+			},
+			numErrs: 0,
+		},
+		{
+			name: "invalid node selector",
+			project: api.Project{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "foo",
+					Namespace: "",
+					Annotations: map[string]string{
+						"openshift.io/node-selector": "infra, env = $test",
+					},
+				},
+			},
+			// Should fail because infra and $test doesn't satisfy the format
+			numErrs: 1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/project/cache/cache.go
+++ b/pkg/project/cache/cache.go
@@ -1,0 +1,115 @@
+package cache
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	"github.com/openshift/origin/pkg/util/labelselector"
+)
+
+type ProjectCache struct {
+	Client              client.Interface
+	Store               cache.Store
+	DefaultNodeSelector string
+}
+
+var pcache *ProjectCache
+
+func (p *ProjectCache) GetNamespaceObject(name string) (*kapi.Namespace, error) {
+	// check for namespace in the cache
+	namespaceObj, exists, err := p.Store.Get(&kapi.Namespace{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      name,
+			Namespace: "",
+		},
+		Status: kapi.NamespaceStatus{},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var namespace *kapi.Namespace
+	if exists {
+		namespace = namespaceObj.(*kapi.Namespace)
+	} else {
+		// Our watch maybe latent, so we make a best effort to get the object, and only fail if not found
+		namespace, err = p.Client.Namespaces().Get(name)
+		// the namespace does not exist, so prevent create and update in that namespace
+		if err != nil {
+			return nil, fmt.Errorf("Namespace %s does not exist", name)
+		}
+	}
+	return namespace, nil
+}
+
+func (p *ProjectCache) GetNodeSelector(namespace *kapi.Namespace) string {
+	selector := ""
+	if len(namespace.ObjectMeta.Annotations) > 0 {
+		if ns, ok := namespace.ObjectMeta.Annotations["openshift.io/node-selector"]; ok {
+			selector = ns
+		}
+	}
+	if len(selector) == 0 {
+		selector = p.DefaultNodeSelector
+	}
+	return selector
+}
+
+func (p *ProjectCache) GetNodeSelectorMap(namespace *kapi.Namespace) (map[string]string, error) {
+	selector := p.GetNodeSelector(namespace)
+	labelsMap, err := labelselector.Parse(selector)
+	if err != nil {
+		return map[string]string{}, err
+	}
+	return labelsMap, nil
+}
+
+func GetProjectCache() (*ProjectCache, error) {
+	if pcache == nil {
+		return nil, fmt.Errorf("project cache not initialized")
+	}
+	return pcache, nil
+}
+
+func RunProjectCache(c client.Interface, defaultNodeSelector string) {
+	if pcache != nil {
+		return
+	}
+
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return c.Namespaces().List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return c.Namespaces().Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&kapi.Namespace{},
+		store,
+		0,
+	)
+	reflector.Run()
+	pcache = &ProjectCache{
+		Client:              c,
+		Store:               store,
+		DefaultNodeSelector: defaultNodeSelector,
+	}
+}
+
+// Used for testing purpose only
+func FakeProjectCache(c client.Interface, store cache.Store, defaultNodeSelector string) {
+	pcache = &ProjectCache{
+		Client:              c,
+		Store:               store,
+		DefaultNodeSelector: defaultNodeSelector,
+	}
+}

--- a/pkg/util/labelselector/labelselector.go
+++ b/pkg/util/labelselector/labelselector.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// labelselector is trim down version of k8s/pkg/labels/selector.go
+// It only accepts exact label matches
+// Example: "k1=v1, k2 = v2"
+
+package labelselector
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+)
+
+// constants definition for lexer token
+type Token int
+
+const (
+	ErrorToken Token = iota
+	EndOfStringToken
+	CommaToken
+	EqualsToken
+	IdentifierToken // to represent keys and values
+)
+
+// string2token contains the mapping between lexer Token and token literal
+// (except IdentifierToken, EndOfStringToken and ErrorToken since it makes no sense)
+var string2token = map[string]Token{
+	",": CommaToken,
+	"=": EqualsToken,
+}
+
+// The item produced by the lexer. It contains the Token and the literal.
+type ScannedItem struct {
+	tok     Token
+	literal string
+}
+
+// isWhitespace returns true if the rune is a space, tab, or newline.
+func isWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'
+}
+
+// isSpecialSymbol detect if the character ch can be an operator
+func isSpecialSymbol(ch byte) bool {
+	switch ch {
+	case '=', ',':
+		return true
+	}
+	return false
+}
+
+// Lexer represents the Lexer struct for label selector.
+// It contains necessary informationt to tokenize the input string
+type Lexer struct {
+	// s stores the string to be tokenized
+	s string
+	// pos is the position currently tokenized
+	pos int
+}
+
+// read return the character currently lexed
+// increment the position and check the buffer overflow
+func (l *Lexer) read() (b byte) {
+	b = 0
+	if l.pos < len(l.s) {
+		b = l.s[l.pos]
+		l.pos++
+	}
+	return b
+}
+
+// unread 'undoes' the last read character
+func (l *Lexer) unread() {
+	l.pos--
+}
+
+// scanIdOrKeyword scans string to recognize literal token or an identifier.
+func (l *Lexer) scanIdOrKeyword() (tok Token, lit string) {
+	var buffer []byte
+IdentifierLoop:
+	for {
+		switch ch := l.read(); {
+		case ch == 0:
+			break IdentifierLoop
+		case isSpecialSymbol(ch) || isWhitespace(ch):
+			l.unread()
+			break IdentifierLoop
+		default:
+			buffer = append(buffer, ch)
+		}
+	}
+	s := string(buffer)
+	if val, ok := string2token[s]; ok { // is a literal token
+		return val, s
+	}
+	return IdentifierToken, s // otherwise is an identifier
+}
+
+// scanSpecialSymbol scans string starting with special symbol.
+// special symbol identify non literal operators: "="
+func (l *Lexer) scanSpecialSymbol() (Token, string) {
+	lastScannedItem := ScannedItem{}
+	var buffer []byte
+SpecialSymbolLoop:
+	for {
+		switch ch := l.read(); {
+		case ch == 0:
+			break SpecialSymbolLoop
+		case isSpecialSymbol(ch):
+			buffer = append(buffer, ch)
+			if token, ok := string2token[string(buffer)]; ok {
+				lastScannedItem = ScannedItem{tok: token, literal: string(buffer)}
+			} else if lastScannedItem.tok != 0 {
+				l.unread()
+				break SpecialSymbolLoop
+			}
+		default:
+			l.unread()
+			break SpecialSymbolLoop
+		}
+	}
+	if lastScannedItem.tok == 0 {
+		return ErrorToken, fmt.Sprintf("error expected: keyword found '%s'", buffer)
+	}
+	return lastScannedItem.tok, lastScannedItem.literal
+}
+
+// skipWhiteSpaces consumes all blank characters
+// returning the first non blank character
+func (l *Lexer) skipWhiteSpaces(ch byte) byte {
+	for {
+		if !isWhitespace(ch) {
+			return ch
+		}
+		ch = l.read()
+	}
+}
+
+// Lex returns a pair of Token and the literal
+// literal is meaningfull only for IdentifierToken token
+func (l *Lexer) Lex() (tok Token, lit string) {
+	switch ch := l.skipWhiteSpaces(l.read()); {
+	case ch == 0:
+		return EndOfStringToken, ""
+	case isSpecialSymbol(ch):
+		l.unread()
+		return l.scanSpecialSymbol()
+	default:
+		l.unread()
+		return l.scanIdOrKeyword()
+	}
+}
+
+// Parser data structure contains the label selector parser data strucutre
+type Parser struct {
+	l            *Lexer
+	scannedItems []ScannedItem
+	position     int
+}
+
+// lookahead func returns the current token and string. No increment of current position
+func (p *Parser) lookahead() (Token, string) {
+	tok, lit := p.scannedItems[p.position].tok, p.scannedItems[p.position].literal
+	return tok, lit
+}
+
+// consume returns current token and string. Increments the the position
+func (p *Parser) consume() (Token, string) {
+	p.position++
+	tok, lit := p.scannedItems[p.position-1].tok, p.scannedItems[p.position-1].literal
+	return tok, lit
+}
+
+// scan runs through the input string and stores the ScannedItem in an array
+// Parser can now lookahead and consume the tokens
+func (p *Parser) scan() {
+	for {
+		token, literal := p.l.Lex()
+		p.scannedItems = append(p.scannedItems, ScannedItem{token, literal})
+		if token == EndOfStringToken {
+			break
+		}
+	}
+}
+
+// parse runs the left recursive descending algorithm
+// on input string. It returns a list of map[key]value.
+func (p *Parser) parse() (map[string]string, error) {
+	p.scan() // init scannedItems
+
+	labelsMap := map[string]string{}
+	for {
+		tok, lit := p.lookahead()
+		switch tok {
+		case IdentifierToken:
+			key, value, err := p.parseLabel()
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse requiremnt: %v", err)
+			}
+			labelsMap[key] = value
+			t, l := p.consume()
+			switch t {
+			case EndOfStringToken:
+				return labelsMap, nil
+			case CommaToken:
+				t2, l2 := p.lookahead()
+				if t2 != IdentifierToken {
+					return nil, fmt.Errorf("found '%s', expected: identifier after ','", l2)
+				}
+			default:
+				return nil, fmt.Errorf("found '%s', expected: ',' or 'end of string'", l)
+			}
+		case EndOfStringToken:
+			return labelsMap, nil
+		default:
+			return nil, fmt.Errorf("found '%s', expected: identifier or 'end of string'", lit)
+		}
+	}
+	return labelsMap, nil
+}
+
+func (p *Parser) parseLabel() (string, string, error) {
+	key, err := p.parseKey()
+	if err != nil {
+		return "", "", err
+	}
+	op, err := p.parseOperator()
+	if err != nil {
+		return "", "", err
+	}
+	if op != "=" {
+		return "", "", fmt.Errorf("Invalid operator: %s, expected: '='", op)
+	}
+	value, err := p.parseExactValue()
+	if err != nil {
+		return "", "", err
+	}
+	return key, value, nil
+}
+
+// parseKey parse literals.
+func (p *Parser) parseKey() (string, error) {
+	tok, literal := p.consume()
+	if tok != IdentifierToken {
+		err := fmt.Errorf("found '%s', expected: identifier", literal)
+		return "", err
+	}
+	if err := validateLabelKey(literal); err != nil {
+		return "", err
+	}
+	return literal, nil
+}
+
+// parseOperator returns operator
+func (p *Parser) parseOperator() (op string, err error) {
+	tok, lit := p.consume()
+	switch tok {
+	case EqualsToken:
+		op = "="
+	default:
+		return "", fmt.Errorf("found '%s', expected: '='", lit)
+	}
+	return op, nil
+}
+
+// parseExactValue parses the only value for exact match style
+func (p *Parser) parseExactValue() (string, error) {
+	tok, lit := p.consume()
+	if tok != IdentifierToken {
+		return "", fmt.Errorf("found '%s', expected: identifier", lit)
+	}
+	if err := validateLabelValue(lit); err != nil {
+		return "", err
+	}
+	return lit, nil
+}
+
+// Parse takes a string representing a selector and returns
+// map[key]value, or an error.
+// The input will cause an error if it does not follow this form:
+//
+// <selector-syntax> ::= [ <requirement> | <requirement> "," <selector-syntax> ]
+// <requirement> ::= KEY "=" VALUE
+// KEY is a sequence of one or more characters following [ DNS_SUBDOMAIN "/" ] DNS_LABEL
+// VALUE is a sequence of zero or more characters "([A-Za-z0-9_-\.])". Max length is 64 character.
+// Delimiter is white space: (' ', '\t')
+//
+//
+func Parse(selector string) (map[string]string, error) {
+	p := &Parser{l: &Lexer{s: selector, pos: 0}}
+	labels, error := p.parse()
+	if error != nil {
+		return map[string]string{}, error
+	}
+	return labels, nil
+}
+
+// Conflicts takes 2 maps
+// returns true if there a key match between the maps but the value doesn't match
+// returns false in other cases
+func Conflicts(labels1, labels2 map[string]string) bool {
+	for k, v := range labels1 {
+		if val, match := labels2[k]; match {
+			if val != v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Merge combines given maps
+// Note: It doesn't not check for any conflicts between the maps
+func Merge(labels1, labels2 map[string]string) map[string]string {
+	mergedMap := map[string]string{}
+
+	for k, v := range labels1 {
+		mergedMap[k] = v
+	}
+	for k, v := range labels2 {
+		mergedMap[k] = v
+	}
+	return mergedMap
+}
+
+// Equals returns true if the given maps are equal
+func Equals(labels1, labels2 map[string]string) bool {
+	if len(labels1) != len(labels2) {
+		return false
+	}
+
+	for k, v := range labels1 {
+		value, ok := labels2[k]
+		if !ok {
+			return false
+		}
+		if value != v {
+			return false
+		}
+	}
+	return true
+}
+
+const qualifiedNameErrorMsg string = "must match regex [" + util.DNS1123SubdomainFmt + " / ] " + util.DNS1123LabelFmt
+
+func validateLabelKey(k string) error {
+	if !util.IsQualifiedName(k) {
+		return fielderrors.NewFieldInvalid("label key", k, qualifiedNameErrorMsg)
+	}
+	return nil
+}
+
+func validateLabelValue(v string) error {
+	if !util.IsValidLabelValue(v) {
+		return fielderrors.NewFieldInvalid("label value", v, qualifiedNameErrorMsg)
+	}
+	return nil
+}

--- a/pkg/util/labelselector/labelselector_test.go
+++ b/pkg/util/labelselector/labelselector_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labelselector
+
+import (
+	"testing"
+)
+
+func TestLabelSelectorParse(t *testing.T) {
+	tests := []struct {
+		selector string
+		labels   map[string]string
+		valid    bool
+	}{
+		{
+			selector: "",
+			labels:   map[string]string{},
+			valid:    true,
+		},
+		{
+			selector: "   ",
+			labels:   map[string]string{},
+			valid:    true,
+		},
+		{
+			selector: "x=a",
+			labels:   map[string]string{"x": "a"},
+			valid:    true,
+		},
+		{
+			selector: "x=a,y=b,z=c",
+			labels:   map[string]string{"x": "a", "y": "b", "z": "c"},
+			valid:    true,
+		},
+		{
+			selector: "x = a, y=b ,z  = c  ",
+			labels:   map[string]string{"x": "a", "y": "b", "z": "c"},
+			valid:    true,
+		},
+		{
+			selector: "color=green, env = test ,service= front ",
+			labels:   map[string]string{"color": "green", "env": "test", "service": "front"},
+			valid:    true,
+		},
+		{
+			selector: ",",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x,y",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x=$y",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x!=y",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x==y",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x=a||y=b",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x in (y)",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x notin (y)",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+		{
+			selector: "x y",
+			labels:   map[string]string{},
+			valid:    false,
+		},
+	}
+	for _, test := range tests {
+		labels, err := Parse(test.selector)
+		if test.valid && err != nil {
+			t.Errorf("selector: %s, expected no error but got: %s", test.selector, err)
+		} else if !test.valid && err == nil {
+			t.Errorf("selector: %s, expected an error", test.selector)
+		}
+
+		if !Equals(labels, test.labels) {
+			t.Errorf("expected: %s but got: %s", test.labels, labels)
+		}
+	}
+}
+
+func TestLabelConflict(t *testing.T) {
+	tests := []struct {
+		labels1  map[string]string
+		labels2  map[string]string
+		conflict bool
+	}{
+		{
+			labels1:  map[string]string{},
+			labels2:  map[string]string{},
+			conflict: false,
+		},
+		{
+			labels1:  map[string]string{"env": "test"},
+			labels2:  map[string]string{"infra": "true"},
+			conflict: false,
+		},
+		{
+			labels1:  map[string]string{"env": "test"},
+			labels2:  map[string]string{"infra": "true", "env": "test"},
+			conflict: false,
+		},
+		{
+			labels1:  map[string]string{"env": "test"},
+			labels2:  map[string]string{"env": "dev"},
+			conflict: true,
+		},
+		{
+			labels1:  map[string]string{"env": "test", "infra": "false"},
+			labels2:  map[string]string{"infra": "true", "color": "blue"},
+			conflict: true,
+		},
+	}
+	for _, test := range tests {
+		conflict := Conflicts(test.labels1, test.labels2)
+		if conflict != test.conflict {
+			t.Errorf("expected: %v but got: %v", test.conflict, conflict)
+		}
+	}
+}
+
+func TestLabelMerge(t *testing.T) {
+	tests := []struct {
+		labels1      map[string]string
+		labels2      map[string]string
+		mergedLabels map[string]string
+	}{
+		{
+			labels1:      map[string]string{},
+			labels2:      map[string]string{},
+			mergedLabels: map[string]string{},
+		},
+		{
+			labels1:      map[string]string{"infra": "true"},
+			labels2:      map[string]string{},
+			mergedLabels: map[string]string{"infra": "true"},
+		},
+		{
+			labels1:      map[string]string{"infra": "true"},
+			labels2:      map[string]string{"env": "test", "color": "blue"},
+			mergedLabels: map[string]string{"infra": "true", "env": "test", "color": "blue"},
+		},
+	}
+	for _, test := range tests {
+		mergedLabels := Merge(test.labels1, test.labels2)
+		if !Equals(mergedLabels, test.mergedLabels) {
+			t.Errorf("expected: %v but got: %v", test.mergedLabels, mergedLabels)
+		}
+	}
+}

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -132,7 +132,8 @@ func TestProjectIsNamespace(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "new-project",
 			Annotations: map[string]string{
-				"displayName": "Hello World",
+				"displayName":                "Hello World",
+				"openshift.io/node-selector": "env=test",
 			},
 		},
 	}
@@ -152,7 +153,9 @@ func TestProjectIsNamespace(t *testing.T) {
 	if project.Annotations["displayName"] != namespace.Annotations["displayName"] {
 		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations["displayName"], namespace.Annotations["displayName"])
 	}
-
+	if project.Annotations["openshift.io/node-selector"] != namespace.Annotations["openshift.io/node-selector"] {
+		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations["openshift.io/node-selector"], namespace.Annotations["openshift.io/node-selector"])
+	}
 }
 
 // TestProjectMustExist verifies that content cannot be added in a project that does not exist
@@ -211,5 +214,4 @@ func TestProjectMustExist(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error on creation of a Origin resource because namespace does not exist")
 	}
-
 }


### PR DESCRIPTION
Project node selector will constrain all pods within a project
to a pool of nodes that satisfies given label selector.

 - Cluster admin can optionally specify global default project node selector.
   Either pass '--project-node-selector=<label_selector>' flag as command line argument
   to openshift start or pass 'projectNodeSelector: <label_selector>' entry in the master config.
 - User can optionally specify node selector for the project.
   REST API: Pass node selector as annotation to the project.
   Example:
	{
	  kind: 'Project',
          Annotations: map[string]string{
            'nodeSelector': <label_selector>
          }
          ...
	}
   CLI: osadm new-project <name> --node-selector=<label_selector>
 - Any project with no node selector will use global node selector if present.

Note: Current project node selector is limited to match exact labels. E.g.: "k1=v1, k2=v2"
      we will support full selector(exists, in, notin operators) later.