### PR TITLE
Sdn integration

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -988,6 +988,14 @@
 		{
 			"ImportPath": "speter.net/go/exp/math/dec/inf",
 			"Rev": "42ca6cd68aa922bc3f32f1e056e61b65945d9ad7"
+		},
+		{
+			"ImportPath": "github.com/openshift/openshift-sdn/ovssubnet",
+			"Rev": "83026250e430a37f9a2c17a0bdecd6e36383c753"
+		},
+		{
+			"ImportPath": "github.com/openshift/openshift-sdn/pkg/api",
+			"Rev": "83026250e430a37f9a2c17a0bdecd6e36383c753"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-ovs-subnet
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-ovs-subnet
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -ex
+
+action=$1
+pod_namespace=$2
+pod_name=$3
+net_container=$4
+
+source /etc/openshift-sdn/config.env
+cluster_subnet=${OPENSHIFT_CLUSTER_SUBNET}
+tap_ip=${OPENSHIFT_SDN_TAP1_ADDR}
+
+Init() {
+    true
+}
+
+Setup() {
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
+    new_ip=$ipaddr
+    ipaddr_sub=$(docker inspect --format "{{.NetworkSettings.IPPrefixLen}}" ${net_container})
+    docker_gateway=$(docker inspect --format "{{.NetworkSettings.Gateway}}" ${net_container})
+    veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
+    veth_host=$(ip link show | sed -ne "s/^$veth_ifindex: \([^:]*\).*/\1/p")
+
+    brctl delif lbr0 $veth_host
+    ovs-vsctl add-port br0 ${veth_host} 
+    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,cookie=0x${ovs_port},priority=100,ip,nw_dst=${new_ip},actions=output:${ovs_port}"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,cookie=0x${ovs_port},priority=100,arp,nw_dst=${new_ip},actions=output:${ovs_port}"
+
+    add_subnet_route="ip route add ${cluster_subnet} dev eth0 proto kernel scope link src $ipaddr"
+    nsenter -n -t $pid -- $add_subnet_route
+}
+
+Teardown() {
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
+    veth_host=$(ip link show | sed -ne "s/^$veth_ifindex: \([^:]*\).*/\1/p")
+    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+    ovs-vsctl del-port $veth_host
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=0,cookie=0x${ovs_port}/0xffffffff"
+}
+
+case "$action" in
+    init)
+	Init
+	;;
+    setup)
+	Setup
+	;;
+    teardown)
+	Teardown
+	;;
+    *)
+        echo "Bad input: $@"
+        exit 1
+esac
+

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -ex
+
+subnet_gateway=$1
+subnet=$2
+cluster_subnet=$3
+subnet_mask_len=$4
+tun_gateway=$5
+printf 'Container network is "%s"; local host has subnet "%s" and gateway "%s".\n' "${cluster_subnet}" "${subnet}" "${subnet_gateway}"
+TUN=tun0
+
+## openvswitch
+ovs-vsctl del-br br0 || true
+ovs-vsctl add-br br0 -- set Bridge br0 fail-mode=secure
+ovs-vsctl set bridge br0 protocols=OpenFlow13
+ovs-vsctl del-port br0 vxlan0 || true
+ovs-vsctl add-port br0 vxlan0 -- set Interface vxlan0 type=vxlan options:remote_ip="flow" options:key="flow" ofport_request=1
+ovs-vsctl add-port br0 ${TUN} -- set Interface ${TUN} type=internal ofport_request=2
+
+## linux bridge
+ip link set lbr0 down || true
+brctl delbr lbr0 || true
+brctl addbr lbr0
+ip addr add ${subnet_gateway}/${subnet_mask_len} dev lbr0
+ip link set lbr0 up
+
+# setup tun address
+ip addr add ${tun_gateway}/${subnet_mask_len} dev ${TUN}
+ip link set ${TUN} up
+ip route add ${cluster_subnet} dev ${TUN} proto kernel scope link
+
+## iptables
+iptables -t nat -D POSTROUTING -s ${cluster_subnet} ! -d ${cluster_subnet} -j MASQUERADE || true
+iptables -t nat -A POSTROUTING -s ${cluster_subnet} ! -d ${cluster_subnet} -j MASQUERADE
+iptables -D INPUT -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT || true
+iptables -D INPUT -i ${TUN} -m comment --comment "traffic from docker for internet" -j ACCEPT || true
+lineno=$(iptables -nvL INPUT --line-numbers | grep "state RELATED,ESTABLISHED" | awk '{print $1}')
+iptables -I INPUT $lineno -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT
+iptables -I INPUT $((lineno+1)) -i ${TUN} -m comment --comment "traffic from docker for internet" -j ACCEPT
+
+## docker
+if [[ -z "${DOCKER_OPTIONS}" ]]
+then
+    DOCKER_OPTIONS='-b=lbr0 --mtu=1450 --selinux-enabled'
+fi
+
+if ! grep -q "^OPTIONS='${DOCKER_OPTIONS}'" /etc/sysconfig/docker
+then
+    cat <<EOF > /etc/sysconfig/docker
+# This file has been modified by openshift-sdn. Please modify the
+# DOCKER_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
+# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
+# files (depending on your setup).
+
+OPTIONS='${DOCKER_OPTIONS}'
+EOF
+fi
+systemctl daemon-reload
+systemctl restart docker.service
+
+# delete the subnet routing entry created because of lbr0
+ip route del ${subnet} dev lbr0 proto kernel scope link src ${subnet_gateway} || true
+
+mkdir -p /etc/openshift-sdn
+echo "export OPENSHIFT_SDN_TAP1_ADDR=${tun_gateway}" >& "/etc/openshift-sdn/config.env"
+echo "export OPENSHIFT_CLUSTER_SUBNET=${cluster_subnet}" >> "/etc/openshift-sdn/config.env"

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -ex
+
+subnet_gateway=$1
+subnet=$2
+container_network=$3
+subnet_mask_len=$4
+printf 'Container network is "%s"; local host has subnet "%s" and gateway "%s".\n' "${container_network}" "${subnet}" "${subnet_gateway}"
+
+## openvswitch
+ovs-vsctl del-br br0 || true
+ovs-vsctl add-br br0 -- set Bridge br0 fail-mode=secure
+ovs-vsctl set bridge br0 protocols=OpenFlow13
+ovs-vsctl del-port br0 vxlan0 || true
+ovs-vsctl add-port br0 vxlan0 -- set Interface vxlan0 type=vxlan options:remote_ip="flow" options:key="flow" ofport_request=10
+ip link del vlinuxbr || true
+ip link add vlinuxbr type veth peer name vovsbr
+ip link set vlinuxbr up
+ip link set vovsbr up
+ip link set vlinuxbr txqueuelen 0
+ip link set vovsbr txqueuelen 0
+
+ovs-vsctl del-port br0 vovsbr || true
+ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=9
+
+## linux bridge
+ip link set lbr0 down || true
+brctl delbr lbr0 || true
+brctl addbr lbr0
+ip addr add ${subnet_gateway}/${subnet_mask_len} dev lbr0
+ip link set lbr0 up
+brctl addif lbr0 vlinuxbr
+ip route del ${subnet} dev lbr0 proto kernel scope link src ${subnet_gateway} || true
+ip route add ${container_network} dev lbr0 proto kernel scope link src ${subnet_gateway}
+
+
+## iptables
+iptables -t nat -D POSTROUTING -s ${container_network} ! -d ${container_network} -j MASQUERADE || true
+iptables -t nat -A POSTROUTING -s ${container_network} ! -d ${container_network} -j MASQUERADE
+iptables -D INPUT -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT || true
+iptables -D INPUT -i lbr0 -m comment --comment "traffic from docker" -j ACCEPT || true
+lineno=$(iptables -nvL INPUT --line-numbers | grep "state RELATED,ESTABLISHED" | awk '{print $1}')
+iptables -I INPUT $lineno -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT
+iptables -I INPUT $((lineno+1)) -i lbr0 -m comment --comment "traffic from docker" -j ACCEPT
+
+
+## docker
+if [[ -z "${DOCKER_NETWORK_OPTIONS}" ]]
+then
+    DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
+fi
+
+if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfig/docker-network
+then
+    cat <<EOF > /etc/sysconfig/docker-network
+# This file has been modified by openshift-sdn. Please modify the
+# DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
+# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
+# files (depending on your setup).
+
+DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
+EOF
+fi
+systemctl daemon-reload
+systemctl restart docker.service

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/common.go
@@ -1,0 +1,291 @@
+package ovssubnet
+
+import (
+	"errors"
+	"fmt"
+	log "github.com/golang/glog"
+	"net"
+	"time"
+
+	"github.com/openshift/openshift-sdn/ovssubnet/controller/kube"
+	"github.com/openshift/openshift-sdn/ovssubnet/controller/lbr"
+	"github.com/openshift/openshift-sdn/pkg/api"
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+)
+
+type OvsController struct {
+	subnetRegistry  api.SubnetRegistry
+	localIP         string
+	localSubnet     *api.Subnet
+	hostName        string
+	subnetAllocator *netutils.SubnetAllocator
+	sig             chan struct{}
+	flowController  FlowController
+}
+
+type FlowController interface {
+	Setup(localSubnet, globalSubnet string) error
+	AddOFRules(minionIP, localSubnet, localIP string) error
+	DelOFRules(minionIP, localIP string) error
+}
+
+func NewKubeController(sub api.SubnetRegistry, hostname string, selfIP string) (*OvsController, error) {
+	kubeController, err := NewController(sub, hostname, selfIP)
+	if err == nil {
+		kubeController.flowController = kube.NewFlowController()
+	}
+	return kubeController, err
+}
+
+func NewDefaultController(sub api.SubnetRegistry, hostname string, selfIP string) (*OvsController, error) {
+	defaultController, err := NewController(sub, hostname, selfIP)
+	if err == nil {
+		defaultController.flowController = lbr.NewFlowController()
+	}
+	return defaultController, err
+}
+
+func NewController(sub api.SubnetRegistry, hostname string, selfIP string) (*OvsController, error) {
+	if selfIP == "" {
+		addrs, err := net.LookupIP(hostname)
+		if err != nil {
+			log.Errorf("Failed to lookup IP Address for %s", hostname)
+			return nil, err
+		}
+		selfIP = addrs[0].String()
+	}
+	log.Infof("Self IP: %s.", selfIP)
+	return &OvsController{
+		subnetRegistry:  sub,
+		localIP:         selfIP,
+		hostName:        hostname,
+		localSubnet:     nil,
+		subnetAllocator: nil,
+		sig:             make(chan struct{}),
+	}, nil
+}
+
+func (oc *OvsController) StartMaster(sync bool, containerNetwork string, containerSubnetLength uint) error {
+	// wait a minute for etcd to come alive
+	status := oc.subnetRegistry.CheckEtcdIsAlive(60)
+	if !status {
+		log.Errorf("Etcd not running?")
+		return errors.New("Etcd not reachable. Sync cluster check failed.")
+	}
+	// initialize the minion key
+	if sync {
+		err := oc.subnetRegistry.InitMinions()
+		if err != nil {
+			log.Infof("Minion path already initialized.")
+		}
+	}
+
+	// initialize the subnet key?
+	err := oc.subnetRegistry.InitSubnets()
+	subrange := make([]string, 0)
+	if err != nil {
+		subnets, err := oc.subnetRegistry.GetSubnets()
+		if err != nil {
+			log.Errorf("Error in initializing/fetching subnets: %v", err)
+			return err
+		}
+		for _, sub := range *subnets {
+			subrange = append(subrange, sub.Sub)
+		}
+	}
+
+	err = oc.subnetRegistry.WriteNetworkConfig(containerNetwork, containerSubnetLength)
+	if err != nil {
+		return err
+	}
+
+	oc.subnetAllocator, err = netutils.NewSubnetAllocator(containerNetwork, containerSubnetLength, subrange)
+	if err != nil {
+		return err
+	}
+	err = oc.ServeExistingMinions()
+	if err != nil {
+		log.Warningf("Error initializing existing minions: %v", err)
+		// no worry, we can still keep watching it.
+	}
+	go oc.watchMinions()
+	return nil
+}
+
+func (oc *OvsController) ServeExistingMinions() error {
+	minions, err := oc.subnetRegistry.GetMinions()
+	if err != nil {
+		return err
+	}
+
+	for _, minion := range *minions {
+		_, err := oc.subnetRegistry.GetSubnet(minion)
+		if err == nil {
+			// subnet already exists, continue
+			continue
+		}
+		err = oc.AddNode(minion)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (oc *OvsController) AddNode(minion string) error {
+	sn, err := oc.subnetAllocator.GetNetwork()
+	if err != nil {
+		log.Errorf("Error creating network for minion %s.", minion)
+		return err
+	}
+	var minionIP string
+	ip := net.ParseIP(minion)
+	if ip == nil {
+		addrs, err := net.LookupIP(minion)
+		if err != nil {
+			log.Errorf("Failed to lookup IP address for minion %s: %v", minion, err)
+			return err
+		}
+		minionIP = addrs[0].String()
+		if minionIP == "" {
+			return fmt.Errorf("Failed to obtain IP address from minion label: %s", minion)
+		}
+	} else {
+		minionIP = ip.String()
+	}
+	sub := &api.Subnet{
+		Minion: minionIP,
+		Sub:    sn.String(),
+	}
+	oc.subnetRegistry.CreateSubnet(minion, sub)
+	if err != nil {
+		log.Errorf("Error writing subnet to etcd for minion %s: %v", minion, sn)
+		return err
+	}
+	return nil
+}
+
+func (oc *OvsController) DeleteNode(minion string) error {
+	sub, err := oc.subnetRegistry.GetSubnet(minion)
+	if err != nil {
+		log.Errorf("Error fetching subnet for minion %s for delete operation.", minion)
+		return err
+	}
+	_, ipnet, err := net.ParseCIDR(sub.Sub)
+	if err != nil {
+		log.Errorf("Error parsing subnet for minion %s for deletion: %s", minion, sub.Sub)
+		return err
+	}
+	oc.subnetAllocator.ReleaseNetwork(ipnet)
+	return oc.subnetRegistry.DeleteSubnet(minion)
+}
+
+func (oc *OvsController) syncWithMaster() error {
+	return oc.subnetRegistry.CreateMinion(oc.hostName, oc.localIP)
+}
+
+func (oc *OvsController) StartNode(sync, skipsetup bool) error {
+	if sync {
+		err := oc.syncWithMaster()
+		if err != nil {
+			log.Errorf("Failed to register with master: %v", err)
+			return err
+		}
+	}
+	err := oc.initSelfSubnet()
+	if err != nil {
+		log.Errorf("Failed to get subnet for this host: %v", err)
+		return err
+	}
+	// call flow controller's setup
+	if err == nil {
+		if !skipsetup {
+			// Assume we are working with IPv4
+			containerNetwork, err := oc.subnetRegistry.GetContainerNetwork()
+			if err != nil {
+				log.Errorf("Failed to obtain ContainerNetwork: %v", err)
+				return err
+			}
+			err = oc.flowController.Setup(oc.localSubnet.Sub, containerNetwork)
+			if err != nil {
+				return err
+			}
+		}
+		subnets, err := oc.subnetRegistry.GetSubnets()
+		if err != nil {
+			log.Errorf("Could not fetch existing subnets: %v", err)
+		}
+		for _, s := range *subnets {
+			oc.flowController.AddOFRules(s.Minion, s.Sub, oc.localIP)
+		}
+		go oc.watchCluster()
+	}
+	return err
+}
+
+func (oc *OvsController) initSelfSubnet() error {
+	// get subnet for self
+	for {
+		sub, err := oc.subnetRegistry.GetSubnet(oc.hostName)
+		if err != nil {
+			log.Errorf("Could not find an allocated subnet for minion %s: %s. Waiting...", oc.hostName, err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		oc.localSubnet = sub
+		return nil
+	}
+}
+
+func (oc *OvsController) watchMinions() {
+	// watch latest?
+	stop := make(chan bool)
+	minevent := make(chan *api.MinionEvent)
+	go oc.subnetRegistry.WatchMinions(minevent, stop)
+	for {
+		select {
+		case ev := <-minevent:
+			switch ev.Type {
+			case api.Added:
+				_, err := oc.subnetRegistry.GetSubnet(ev.Minion)
+				if err != nil {
+					// subnet does not exist already
+					oc.AddNode(ev.Minion)
+				}
+			case api.Deleted:
+				oc.DeleteNode(ev.Minion)
+			}
+		case <-oc.sig:
+			log.Error("Signal received. Stopping watching of minions.")
+			stop <- true
+			return
+		}
+	}
+}
+
+func (oc *OvsController) watchCluster() {
+	stop := make(chan bool)
+	clusterEvent := make(chan *api.SubnetEvent)
+	go oc.subnetRegistry.WatchSubnets(clusterEvent, stop)
+	for {
+		select {
+		case ev := <-clusterEvent:
+			switch ev.Type {
+			case api.Added:
+				// add openflow rules
+				oc.flowController.AddOFRules(ev.Sub.Minion, ev.Sub.Sub, oc.localIP)
+			case api.Deleted:
+				// delete openflow rules meant for the minion
+				oc.flowController.DelOFRules(ev.Sub.Minion, oc.localIP)
+			}
+		case <-oc.sig:
+			stop <- true
+			return
+		}
+	}
+}
+
+func (oc *OvsController) Stop() {
+	close(oc.sig)
+	//oc.sig <- struct{}{}
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/controller/doc.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/controller/doc.go
@@ -1,0 +1,1 @@
+package controller

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/controller/kube/kube.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/controller/kube/kube.go
@@ -1,0 +1,111 @@
+package kube
+
+import (
+	"crypto/md5"
+	"fmt"
+	log "github.com/golang/glog"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+	netutils_server "github.com/openshift/openshift-sdn/pkg/netutils/server"
+)
+
+type FlowController struct {
+}
+
+func NewFlowController() *FlowController {
+	return &FlowController{}
+}
+
+func (c *FlowController) Setup(localSubnet, containerNetwork string) error {
+	_, ipnet, err := net.ParseCIDR(localSubnet)
+	subnetMaskLength, _ := ipnet.Mask.Size()
+	gateway := netutils.GenerateDefaultGateway(ipnet).String()
+	out, err := exec.Command("openshift-sdn-kube-subnet-setup.sh", gateway, ipnet.String(), containerNetwork, strconv.Itoa(subnetMaskLength), gateway).CombinedOutput()
+	log.Infof("Output of setup script:\n%s", out)
+	if err != nil {
+		log.Errorf("Error executing setup script. \n\tOutput: %s\n\tError: %v\n", out, err)
+		return err
+	}
+	//go c.manageLocalIpam(ipnet)
+	_, err = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0").CombinedOutput()
+	if err != nil {
+		return err
+	}
+	_, err = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", "cookie=0x0,table=0,priority=50,actions=output:2").CombinedOutput()
+	return err
+}
+
+func (c *FlowController) manageLocalIpam(ipnet *net.IPNet) error {
+	ipamHost := "127.0.0.1"
+	ipamPort := uint(9080)
+	inuse := make([]string, 0)
+	ipam, _ := netutils.NewIPAllocator(ipnet.String(), inuse)
+	f, err := os.Create("/etc/openshift-sdn/config.env")
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(fmt.Sprintf("OPENSHIFT_SDN_TAP1_ADDR=%s\nOPENSHIFT_SDN_IPAM_SERVER=http://%s:%s", netutils.GenerateDefaultGateway(ipnet), ipamHost, ipamPort))
+	if err != nil {
+		return err
+	}
+	f.Close()
+	// listen and serve does not return the control
+	netutils_server.ListenAndServeNetutilServer(ipam, net.ParseIP(ipamHost), ipamPort, nil)
+	return nil
+}
+
+func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
+	cookie := generateCookie(minionIP)
+	if minionIP == localIP {
+		// return nil as the actions=NORMAL does not behave well, needs work
+		// for the input rules to containers, see the kube-hook
+		return nil
+		// self, so add the input rules
+		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=200,ip,in_port=1,nw_dst=%s,actions=NORMAL", cookie, subnet)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s,priority=200,arp,in_port=1,nw_dst=%s,actions=NORMAL", cookie, subnet)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", arprule, o, e)
+	} else {
+		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, subnet, minionIP)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, subnet, minionIP)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", arprule, o, e)
+		return e
+	}
+	return nil
+}
+
+func (c *FlowController) DelOFRules(minion, localIP string) error {
+	log.Infof("Calling del rules for %s", minion)
+	cookie := generateCookie(minion)
+	if minion == localIP {
+		iprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,ip,in_port=10", cookie)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,arp,in_port=10", cookie)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()
+		log.Infof("Output of deleting local ip rules %s (%v)", o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", arprule).CombinedOutput()
+		log.Infof("Output of deleting local arp rules %s (%v)", o, e)
+		return e
+	} else {
+		iprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,ip", cookie)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,arp", cookie)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()
+		log.Infof("Output of deleting %s: %s (%v)", iprule, o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", arprule).CombinedOutput()
+		log.Infof("Output of deleting %s: %s (%v)", arprule, o, e)
+		return e
+	}
+	return nil
+}
+
+func generateCookie(ip string) string {
+	return strconv.FormatInt(int64(md5.Sum([]byte(ip))[0]), 16)
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/controller/lbr/lbr.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/controller/lbr/lbr.go
@@ -1,0 +1,81 @@
+package lbr
+
+import (
+	"crypto/md5"
+	"fmt"
+	log "github.com/golang/glog"
+	"net"
+	"os/exec"
+	"strconv"
+
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+)
+
+type FlowController struct {
+}
+
+func NewFlowController() *FlowController {
+	return &FlowController{}
+}
+
+func (c *FlowController) Setup(localSubnet, containerNetwork string) error {
+	_, ipnet, err := net.ParseCIDR(localSubnet)
+	subnetMaskLength, _ := ipnet.Mask.Size()
+	out, err := exec.Command("openshift-sdn-simple-setup-node.sh", netutils.GenerateDefaultGateway(ipnet).String(), ipnet.String(), containerNetwork, strconv.Itoa(subnetMaskLength)).CombinedOutput()
+	log.Infof("Output of setup script:\n%s", out)
+	if err != nil {
+		log.Errorf("Error executing setup script. \n\tOutput: %s\n\tError: %v\n", out, err)
+	}
+	_, err = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0").CombinedOutput()
+	return err
+}
+
+func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
+	cookie := generateCookie(minionIP)
+	if minionIP == localIP {
+		// self, so add the input rules
+		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=200,ip,in_port=10,nw_dst=%s,actions=output:9", cookie, subnet)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s,priority=200,arp,in_port=10,nw_dst=%s,actions=output:9", cookie, subnet)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", arprule, o, e)
+		return e
+	} else {
+		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=200,ip,in_port=9,nw_dst=%s,actions=set_field:%s->tun_dst,output:10", cookie, subnet, minionIP)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s,priority=200,arp,in_port=9,nw_dst=%s,actions=set_field:%s->tun_dst,output:10", cookie, subnet, minionIP)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
+		log.Infof("Output of adding %s: %s (%v)", arprule, o, e)
+		return e
+	}
+	return nil
+}
+
+func (c *FlowController) DelOFRules(minion, localIP string) error {
+	log.Infof("Calling del rules for %s.", minion)
+	cookie := generateCookie(minion)
+	if minion == localIP {
+		iprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,ip,in_port=10", cookie)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,arp,in_port=10", cookie)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()
+		log.Infof("Output of deleting local ip rules: %s (%v)", o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", arprule).CombinedOutput()
+		log.Infof("Output of deleting local arp rules: %s (%v)", o, e)
+		return e
+	} else {
+		iprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,ip,in_port=9", cookie)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,arp,in_port=9", cookie)
+		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()
+		log.Infof("Output of deleting %s: %s (%v)", iprule, o, e)
+		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", arprule).CombinedOutput()
+		log.Infof("Output of deleting %s: %s (%v)", arprule, o, e)
+		return e
+	}
+	return nil
+}
+
+func generateCookie(ip string) string {
+	return strconv.FormatInt(int64(md5.Sum([]byte(ip))[0]), 16)
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/api/types.go
@@ -1,0 +1,43 @@
+package api
+
+type EventType string
+
+const (
+	Added   EventType = "ADDED"
+	Deleted EventType = "DELETED"
+)
+
+type SubnetRegistry interface {
+	InitSubnets() error
+	GetSubnets() (*[]Subnet, error)
+	GetSubnet(minion string) (*Subnet, error)
+	DeleteSubnet(minion string) error
+	CreateSubnet(sn string, sub *Subnet) error
+	WatchSubnets(receiver chan *SubnetEvent, stop chan bool) error
+
+	InitMinions() error
+	GetMinions() (*[]string, error)
+	CreateMinion(minion string, data string) error
+	WatchMinions(receiver chan *MinionEvent, stop chan bool) error
+
+	WriteNetworkConfig(network string, subnetLength uint) error
+	GetContainerNetwork() (string, error)
+	GetSubnetLength() (uint64, error)
+	CheckEtcdIsAlive(seconds uint64) bool
+}
+
+type SubnetEvent struct {
+	Type   EventType
+	Minion string
+	Sub    Subnet
+}
+
+type MinionEvent struct {
+	Type   EventType
+	Minion string
+}
+
+type Subnet struct {
+	Minion string
+	Sub    string
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/README.md
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/README.md
@@ -1,0 +1,2 @@
+# netutils
+Miscellaneous network utilities

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common.go
@@ -1,0 +1,22 @@
+package netutils
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+func IPToUint32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip.To4())
+}
+
+func Uint32ToIP(u uint32) net.IP {
+	ip := make([]byte, 4)
+	binary.BigEndian.PutUint32(ip, u)
+	return net.IPv4(ip[0], ip[1], ip[2], ip[3])
+}
+
+// Generate the default gateway IP Address for a subnet
+func GenerateDefaultGateway(sna *net.IPNet) net.IP {
+	ip := sna.IP.To4()
+	return net.IPv4(ip[0], ip[1], ip[2], ip[3]|0x1)
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common_test.go
@@ -1,0 +1,22 @@
+package netutils
+
+import (
+	"net"
+	"testing"
+)
+
+func TestConversion(t *testing.T) {
+	ip := net.ParseIP("10.1.2.3")
+	if ip == nil {
+		t.Fatal("Failed to parse IP")
+	}
+
+	u := IPToUint32(ip)
+	t.Log(u)
+	ip2 := Uint32ToIP(u)
+	t.Log(ip2)
+
+	if !ip2.Equal(ip) {
+		t.Fatal("Conversion back and forth failed")
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/ip_allocator.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/ip_allocator.go
@@ -1,0 +1,75 @@
+package netutils
+
+import (
+	"fmt"
+	"net"
+)
+
+type IPAllocator struct {
+	network  *net.IPNet
+	allocMap map[string]bool
+}
+
+func NewIPAllocator(network string, inUse []string) (*IPAllocator, error) {
+	_, netIP, err := net.ParseCIDR(network)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse network address: %q", network)
+	}
+
+	amap := make(map[string]bool)
+	for _, netStr := range inUse {
+		_, nIp, err := net.ParseCIDR(netStr)
+		if err != nil {
+			fmt.Println("Failed to parse network address: ", netStr)
+			continue
+		}
+		if !netIP.Contains(nIp.IP) {
+			fmt.Println("Provided subnet doesn't belong to network: ", nIp)
+			continue
+		}
+		amap[netStr] = true
+	}
+
+	// Add the network address to the map
+	amap[netIP.String()] = true
+	return &IPAllocator{network: netIP, allocMap: amap}, nil
+}
+
+func (ipa *IPAllocator) GetIP() (*net.IPNet, error) {
+	var (
+		numIPs    uint32
+		numIPBits uint
+	)
+	baseipu := IPToUint32(ipa.network.IP)
+	netMaskSize, _ := ipa.network.Mask.Size()
+	numIPBits = 32 - uint(netMaskSize)
+	numIPs = 1 << numIPBits
+
+	var i uint32
+	// We exclude the last address as it is reserved for broadcast
+	for i = 0; i < numIPs-1; i++ {
+		ipu := baseipu | i
+		genIP := &net.IPNet{IP: Uint32ToIP(ipu), Mask: net.CIDRMask(netMaskSize, 32)}
+		if !ipa.allocMap[genIP.String()] {
+			ipa.allocMap[genIP.String()] = true
+			return genIP, nil
+		}
+	}
+
+	return nil, fmt.Errorf("No IPs available.")
+}
+
+func (ipa *IPAllocator) ReleaseIP(ip *net.IPNet) error {
+	if !ipa.network.Contains(ip.IP) {
+		return fmt.Errorf("Provided IP %v doesn't belong to the network %v.", ip, ipa.network)
+	}
+
+	ipStr := ip.String()
+	if !ipa.allocMap[ipStr] {
+		return fmt.Errorf("Provided IP %v is already available.", ip)
+	}
+
+	ipa.allocMap[ipStr] = false
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/ip_allocator_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/ip_allocator_test.go
@@ -1,0 +1,83 @@
+package netutils
+
+import (
+	"testing"
+)
+
+func TestAllocateIP(t *testing.T) {
+	ipa, err := NewIPAllocator("10.1.2.0/24", nil)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: %v", err)
+	}
+
+	ip, err := ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.1/24" {
+		t.Fatal("Did not get expected IP")
+	}
+	ip, err = ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.2/24" {
+		t.Fatal("Did not get expected IP")
+	}
+	ip, err = ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.3/24" {
+		t.Fatal("Did not get expected IP")
+	}
+}
+
+func TestAllocateIPInUse(t *testing.T) {
+	inUse := []string{"10.1.2.1/24", "10.1.2.2/24", "10.2.2.3/24", "Invalid"}
+	ipa, err := NewIPAllocator("10.1.2.0/24", inUse)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: %v", err)
+	}
+
+	ip, err := ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.3/24" {
+		t.Fatal("Did not get expected IP", ip)
+	}
+	ip, err = ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.4/24" {
+		t.Fatal("Did not get expected IP", ip)
+	}
+}
+
+func TestAllocateReleaseIP(t *testing.T) {
+	ipa, err := NewIPAllocator("10.1.2.0/24", nil)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: %v", err)
+	}
+
+	ip, err := ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.1/24" {
+		t.Fatal("Did not get expected IP")
+	}
+
+	if err := ipa.ReleaseIP(ip); err != nil {
+		t.Fatal("Failed to release the IP")
+	}
+	ip, err = ipa.GetIP()
+	if err != nil {
+		t.Fatal("Failed to get IP: ", err)
+	}
+	if ip.String() != "10.1.2.1/24" {
+		t.Fatal("Did not get expected IP")
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/server/server.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/server/server.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Server is a http.Handler which exposes netutils functionality over HTTP.
+type Server struct {
+	ipam IpamInterface
+	mux  *http.ServeMux
+}
+
+type TLSOptions struct {
+	Config   *tls.Config
+	CertFile string
+	KeyFile  string
+}
+
+// IpamInterface contains all the methods required by the server.
+type IpamInterface interface {
+	GetIP() (*net.IPNet, error)
+	ReleaseIP(ip *net.IPNet) error
+	//GetStats() string
+}
+
+// ListenAndServeNetutilServer initializes a server to respond to HTTP network requests on the ipam interface
+func ListenAndServeNetutilServer(ipam IpamInterface, address net.IP, port uint, tlsOptions *TLSOptions) {
+	handler := NewServer(ipam)
+	s := &http.Server{
+		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
+		Handler:        handler,
+		ReadTimeout:    5 * time.Minute,
+		WriteTimeout:   5 * time.Minute,
+		MaxHeaderBytes: 1 << 20,
+	}
+	if tlsOptions != nil {
+		s.TLSConfig = tlsOptions.Config
+		s.ListenAndServeTLS(tlsOptions.CertFile, tlsOptions.KeyFile)
+	} else {
+		s.ListenAndServe()
+	}
+}
+
+// NewServer initializes and configures the netutils_server.Server object to handle HTTP requests.
+func NewServer(ipam IpamInterface) *Server {
+	server := Server{
+		ipam: ipam,
+		mux:  http.NewServeMux(),
+	}
+	server.InstallDefaultHandlers()
+	return &server
+}
+
+// InstallDefaultHandlers registers the default set of supported HTTP request patterns with the mux.
+func (s *Server) InstallDefaultHandlers() {
+	s.mux.HandleFunc("/netutils/subnet", s.handleSubnet)
+	s.mux.HandleFunc("/netutils/ip/", s.handleIP)
+	s.mux.HandleFunc("/netutils/gateway", s.handleGateway)
+	s.mux.HandleFunc("/stats", s.handleStats)
+}
+
+// error serializes an error object into an HTTP response.
+func (s *Server) error(w http.ResponseWriter, err error) {
+	msg := fmt.Sprintf("Internal Error: %v", err)
+	http.Error(w, msg, http.StatusInternalServerError)
+}
+
+// handleSubnet handles gateway requests
+func (s *Server) handleSubnet(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-type", "application/json")
+	w.Write([]byte("Not implemented"))
+	return
+}
+
+// handleGateway handles gateway requests
+func (s *Server) handleGateway(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-type", "application/json")
+	w.Write([]byte("Not implemented"))
+	return
+}
+
+// handleIP handles IP requests
+func (s *Server) handleIP(w http.ResponseWriter, req *http.Request) {
+	if req.Method == "GET" {
+		w.Header().Add("Content-type", "application/json")
+		ipnet, err := s.ipam.GetIP()
+		if err != nil {
+			s.error(w, err)
+		} else {
+			w.Write([]byte(ipnet.String()))
+		}
+	} else if req.Method == "DELETE" {
+		ip, ipNet, err := net.ParseCIDR(req.URL.Path[len("/netutils/ip/"):])
+		if err != nil {
+			s.error(w, err)
+		}
+		delIP := &net.IPNet{IP: ip, Mask: ipNet.Mask}
+		err = s.ipam.ReleaseIP(delIP)
+		if err != nil {
+			s.error(w, err)
+		}
+	} else {
+		http.Error(w, "Method can only be GET/DELETE", http.StatusNotFound)
+	}
+	return
+}
+
+// handleStats handles stats requests
+func (s *Server) handleStats(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-type", "application/json")
+	w.Write([]byte("Not implemented"))
+	return
+}
+
+// ServeHTTP responds to HTTP requests
+func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	s.mux.ServeHTTP(w, req)
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/server/server_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/server/server_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+)
+
+func delIP(t *testing.T, delip string) error {
+	url := fmt.Sprintf("http://127.0.0.1:9080/netutils/ip/%s", delip)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		t.Fatal("Error in forming request to IPAM server")
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("Error in connecting to IPAM server")
+	}
+	if res.StatusCode > 400 {
+		return fmt.Errorf("Bad response from server: %d", res.StatusCode)
+	}
+	return err
+}
+
+func getIP(t *testing.T) string {
+	res, err := http.Get("http://127.0.0.1:9080/netutils/ip")
+	if err != nil {
+		t.Fatal("Error in connecting to IPAM server")
+	}
+	ip, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal("Error in obtaining IP address through server")
+	}
+	res.Body.Close()
+	return string(ip)
+}
+
+func TestIPServe(t *testing.T) {
+	inuse := make([]string, 0)
+	ipam, err := netutils.NewIPAllocator("10.20.30.40/24", inuse)
+	if err != nil {
+		t.Fatalf("Error while initializing IPAM: %v", err)
+	}
+	go ListenAndServeNetutilServer(ipam, net.ParseIP("127.0.0.1"), 9080, nil)
+
+	// get, get, delete, get
+	ip := getIP(t)
+	if ip != "10.20.30.1/24" {
+		t.Fatalf("Wrong IP. Expected 10.20.30.1/24, got %s", ip)
+	}
+	ip = getIP(t)
+	if ip != "10.20.30.2/24" {
+		t.Fatalf("Wrong IP. Expected 10.20.30.2/24, got %s", ip)
+	}
+	err = delIP(t, ip)
+	if err != nil {
+		t.Fatalf("Error while deleting IP address %s: %v", ip, err)
+	}
+	// get it again
+	ip = getIP(t)
+	if ip != "10.20.30.2/24" {
+		t.Fatalf("Wrong IP. Expected 10.20.30.2/24, got %s", ip)
+	}
+	// delete the wrong one and fail if there is no error
+	err = delIP(t, "10.10.10.10/23")
+	if err == nil {
+		t.Fatalf("Error while deleting IP address %s: %v", ip, err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/subnet_allocator.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/subnet_allocator.go
@@ -1,0 +1,79 @@
+package netutils
+
+import (
+	"fmt"
+	"net"
+)
+
+type SubnetAllocator struct {
+	network  *net.IPNet
+	capacity uint
+	allocMap map[string]bool
+}
+
+func NewSubnetAllocator(network string, capacity uint, inUse []string) (*SubnetAllocator, error) {
+	_, netIP, err := net.ParseCIDR(network)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse network address: %q", network)
+	}
+
+	netMaskSize, _ := netIP.Mask.Size()
+	if capacity > (32 - uint(netMaskSize)) {
+		return nil, fmt.Errorf("Subnet capacity cannot be larger than number of networks available.")
+	}
+
+	amap := make(map[string]bool)
+	for _, netStr := range inUse {
+		_, nIp, err := net.ParseCIDR(netStr)
+		if err != nil {
+			fmt.Println("Failed to parse network address: ", netStr)
+			continue
+		}
+		if !netIP.Contains(nIp.IP) {
+			fmt.Println("Provided subnet doesn't belong to network: ", nIp)
+			continue
+		}
+		amap[nIp.String()] = true
+	}
+	return &SubnetAllocator{network: netIP, capacity: capacity, allocMap: amap}, nil
+}
+
+func (sna *SubnetAllocator) GetNetwork() (*net.IPNet, error) {
+	var (
+		numSubnets    uint32
+		numSubnetBits uint
+	)
+	baseipu := IPToUint32(sna.network.IP)
+	netMaskSize, _ := sna.network.Mask.Size()
+	numSubnetBits = 32 - uint(netMaskSize) - sna.capacity
+	numSubnets = 1 << numSubnetBits
+
+	var i uint32
+	for i = 0; i < numSubnets; i++ {
+		shifted := i << sna.capacity
+		ipu := baseipu | shifted
+		genIp := Uint32ToIP(ipu)
+		genSubnet := &net.IPNet{IP: genIp, Mask: net.CIDRMask(int(numSubnetBits)+netMaskSize, 32)}
+		if !sna.allocMap[genSubnet.String()] {
+			sna.allocMap[genSubnet.String()] = true
+			return genSubnet, nil
+		}
+	}
+
+	return nil, fmt.Errorf("No subnets available.")
+}
+
+func (sna *SubnetAllocator) ReleaseNetwork(ipnet *net.IPNet) error {
+	if !sna.network.Contains(ipnet.IP) {
+		return fmt.Errorf("Provided subnet %v doesn't belong to the network %v.", ipnet, sna.network)
+	}
+
+	ipnetStr := ipnet.String()
+	if !sna.allocMap[ipnetStr] {
+		return fmt.Errorf("Provided subnet %v is already available.", ipnet)
+	}
+
+	sna.allocMap[ipnetStr] = false
+
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/subnet_allocator_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/subnet_allocator_test.go
@@ -1,0 +1,105 @@
+package netutils
+
+import (
+	"testing"
+)
+
+func TestAllocateSubnet(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.1.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.2.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+}
+
+func TestAllocateSubnetInUse(t *testing.T) {
+	inUse := []string{"10.1.0.0/24", "10.1.2.0/24", "10.2.2.2/24", "Invalid"}
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, inUse)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.1.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.3.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+}
+
+func TestAllocateReleaseSubnet(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+
+	if err := sna.ReleaseNetwork(sn); err != nil {
+		t.Fatal("Failed to release the subnet")
+	}
+
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+}
+
+func TestGenerateGateway(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/24" {
+		t.Fatal("Did not get expected subnet")
+	}
+
+	gatewayIP := GenerateDefaultGateway(sn)
+	t.Log(gatewayIP)
+	if gatewayIP.String() != "10.1.0.1" {
+		t.Fatal("Did not get expected gateway IP Address")
+	}
+}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -130,7 +130,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.vm.provision "shell", inline: "/vagrant/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{ENV['OPENSHIFT_SDN']}"
       config.vm.network "private_network", ip: "#{master_ip}"
       config.vm.hostname = "openshift-master"
-      config.vm.provision "shell", inline: "systemctl start openshift-master-sdn", run: "always"
     end
 
     # OpenShift minion

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/openshift/origin/pkg/oauth/api"
 	_ "github.com/openshift/origin/pkg/project/api"
 	_ "github.com/openshift/origin/pkg/route/api"
+	_ "github.com/openshift/origin/pkg/sdn/api"
 	_ "github.com/openshift/origin/pkg/template/api"
 	_ "github.com/openshift/origin/pkg/user/api"
 )

--- a/pkg/api/v1beta1/register.go
+++ b/pkg/api/v1beta1/register.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/openshift/origin/pkg/oauth/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/project/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/route/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/sdn/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/template/api/v1beta1"
 	_ "github.com/openshift/origin/pkg/user/api/v1beta1"
 )

--- a/pkg/api/v1beta3/register.go
+++ b/pkg/api/v1beta3/register.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/openshift/origin/pkg/oauth/api/v1beta3"
 	_ "github.com/openshift/origin/pkg/project/api/v1beta3"
 	_ "github.com/openshift/origin/pkg/route/api/v1beta3"
+	_ "github.com/openshift/origin/pkg/sdn/api/v1beta3"
 	_ "github.com/openshift/origin/pkg/template/api/v1beta3"
 	_ "github.com/openshift/origin/pkg/user/api/v1beta3"
 )

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,6 +29,8 @@ type Interface interface {
 	DeploymentsNamespacer
 	DeploymentConfigsNamespacer
 	RoutesNamespacer
+	HostSubnetsInterface
+	ClusterNetworkingInterface
 	IdentitiesInterface
 	UsersInterface
 	UserIdentityMappingsInterface
@@ -119,6 +121,16 @@ func (c *Client) DeploymentConfigs(namespace string) DeploymentConfigInterface {
 // Routes provides a REST client for Route
 func (c *Client) Routes(namespace string) RouteInterface {
 	return newRoutes(c, namespace)
+}
+
+// HostSubnet provides a REST client for HostSubnet
+func (c *Client) HostSubnets() HostSubnetInterface {
+	return newHostSubnet(c)
+}
+
+// ClusterNetwork provides a REST client for ClusterNetworking
+func (c *Client) ClusterNetwork() ClusterNetworkInterface {
+	return newClusterNetwork(c)
 }
 
 // Users provides a REST client for User

--- a/pkg/client/clusternetwork.go
+++ b/pkg/client/clusternetwork.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+	_ "github.com/openshift/origin/pkg/sdn/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/sdn/api/v1beta3"
+)
+
+// ClusterNetworkingInterface has methods to work with ClusterNetwork resources
+type ClusterNetworkingInterface interface {
+	ClusterNetwork() ClusterNetworkInterface
+}
+
+// ClusterNetworkInterface exposes methods on clusterNetwork resources.
+type ClusterNetworkInterface interface {
+	Get(name string) (*sdnapi.ClusterNetwork, error)
+	Create(sub *sdnapi.ClusterNetwork) (*sdnapi.ClusterNetwork, error)
+}
+
+// clusterNetwork implements ClusterNetworkInterface interface
+type clusterNetwork struct {
+	r *Client
+}
+
+// newClusterNetwork returns a clusterNetwork
+func newClusterNetwork(c *Client) *clusterNetwork {
+	return &clusterNetwork{
+		r: c,
+	}
+}
+
+// Get returns information about a particular network
+func (c *clusterNetwork) Get(networkName string) (result *sdnapi.ClusterNetwork, err error) {
+	result = &sdnapi.ClusterNetwork{}
+	err = c.r.Get().Resource("clusterNetwork").Name(networkName).Do().Into(result)
+	return
+}
+
+// Create creates a new ClusterNetwork. Returns the server's representation of ClusterNetwork and error if one occurs.
+func (c *clusterNetwork) Create(cn *sdnapi.ClusterNetwork) (result *sdnapi.ClusterNetwork, err error) {
+	result = &sdnapi.ClusterNetwork{}
+	err = c.r.Post().Resource("clusterNetwork").Body(cn).Do().Into(result)
+	return
+}

--- a/pkg/client/fake.go
+++ b/pkg/client/fake.go
@@ -84,6 +84,14 @@ func (c *Fake) Routes(namespace string) RouteInterface {
 	return &FakeRoutes{Fake: c, Namespace: namespace}
 }
 
+func (c *Fake) HostSubnets() HostSubnetInterface {
+	return &FakeHostSubnet{Fake: c}
+}
+
+func (c *Fake) ClusterNetwork() ClusterNetworkInterface {
+	return &FakeClusterNetwork{Fake: c}
+}
+
 func (c *Fake) Templates(namespace string) TemplateInterface {
 	return &FakeTemplates{Fake: c}
 }

--- a/pkg/client/fake_clusternetwork.go
+++ b/pkg/client/fake_clusternetwork.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+// FakeClusterNetwork implements ClusterNetworkInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeClusterNetwork struct {
+	Fake *Fake
+}
+
+func (c *FakeClusterNetwork) Get(name string) (*sdnapi.ClusterNetwork, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-network"}, &sdnapi.ClusterNetwork{})
+	return obj.(*sdnapi.ClusterNetwork), err
+}
+
+func (c *FakeClusterNetwork) Create(sdn *sdnapi.ClusterNetwork) (*sdnapi.ClusterNetwork, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-network"}, &sdnapi.ClusterNetwork{})
+	return obj.(*sdnapi.ClusterNetwork), err
+}

--- a/pkg/client/fake_hostsubnets.go
+++ b/pkg/client/fake_hostsubnets.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+// FakeHostSubnet implements HostSubnetInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeHostSubnet struct {
+	Fake *Fake
+}
+
+func (c *FakeHostSubnet) List() (*sdnapi.HostSubnetList, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "list-subnets"}, &sdnapi.HostSubnetList{})
+	return obj.(*sdnapi.HostSubnetList), err
+}
+
+func (c *FakeHostSubnet) Get(name string) (*sdnapi.HostSubnet, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "get-subnets"}, &sdnapi.HostSubnet{})
+	return obj.(*sdnapi.HostSubnet), err
+}
+
+func (c *FakeHostSubnet) Create(sdn *sdnapi.HostSubnet) (*sdnapi.HostSubnet, error) {
+	obj, err := c.Fake.Invokes(FakeAction{Action: "create-subnet"}, &sdnapi.HostSubnet{})
+	return obj.(*sdnapi.HostSubnet), err
+}
+
+func (c *FakeHostSubnet) Delete(name string) error {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-subnet"})
+	return nil
+}
+
+func (c *FakeHostSubnet) Watch(resourceVersion string) (watch.Interface, error) {
+	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-subnets"})
+	return nil, nil
+}

--- a/pkg/client/hostsubnets.go
+++ b/pkg/client/hostsubnets.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+	_ "github.com/openshift/origin/pkg/sdn/api/v1beta1"
+	_ "github.com/openshift/origin/pkg/sdn/api/v1beta3"
+)
+
+// HostSubnetInterface has methods to work with HostSubnet resources
+type HostSubnetsInterface interface {
+	HostSubnets() HostSubnetInterface
+}
+
+// HostSubnetInterface exposes methods on HostSubnet resources.
+type HostSubnetInterface interface {
+	List() (*sdnapi.HostSubnetList, error)
+	Get(name string) (*sdnapi.HostSubnet, error)
+	Create(sub *sdnapi.HostSubnet) (*sdnapi.HostSubnet, error)
+	Delete(name string) error
+	Watch(resourceVersion string) (watch.Interface, error)
+}
+
+// hostSubnet implements HostSubnetInterface interface
+type hostSubnet struct {
+	r *Client
+}
+
+// newHostSubnet returns a hostsubnet
+func newHostSubnet(c *Client) *hostSubnet {
+	return &hostSubnet{
+		r: c,
+	}
+}
+
+// List returns a list of hostsubnets that match the label and field selectors.
+func (c *hostSubnet) List() (result *sdnapi.HostSubnetList, err error) {
+	result = &sdnapi.HostSubnetList{}
+	err = c.r.Get().
+		Resource("hostSubnet").
+		Do().
+		Into(result)
+	return
+}
+
+// Get returns information about a particular user or an error
+func (c *hostSubnet) Get(hostName string) (result *sdnapi.HostSubnet, err error) {
+	result = &sdnapi.HostSubnet{}
+	err = c.r.Get().Resource("hostSubnet").Name(hostName).Do().Into(result)
+	return
+}
+
+// Create creates a new user. Returns the server's representation of the user and error if one occurs.
+func (c *hostSubnet) Create(hostSubnet *sdnapi.HostSubnet) (result *sdnapi.HostSubnet, err error) {
+	result = &sdnapi.HostSubnet{}
+	err = c.r.Post().Resource("hostSubnet").Body(hostSubnet).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the host, and returns an error if one occurs during deletion of the subnet
+func (c *hostSubnet) Delete(name string) error {
+	return c.r.Delete().Resource("hostSubnet").Name(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested subnets
+func (c *hostSubnet) Watch(resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Resource("hostSubnet").
+		Param("resourceVersion", resourceVersion).
+		Watch()
+}

--- a/pkg/cmd/cli/cmd/edit_test.go
+++ b/pkg/cmd/cli/cmd/edit_test.go
@@ -1,3 +1,1 @@
 package cmd
-
-import ()

--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -42,14 +42,15 @@ type CreateNodeConfigOptions struct {
 	DNSIP               string
 	ListenAddr          flagtypes.Addr
 
-	ClientCertFile   string
-	ClientKeyFile    string
-	ServerCertFile   string
-	ServerKeyFile    string
-	NodeClientCAFile string
-	APIServerCAFile  string
-	APIServerURL     string
-	Output           cmdutil.Output
+	ClientCertFile    string
+	ClientKeyFile     string
+	ServerCertFile    string
+	ServerKeyFile     string
+	NodeClientCAFile  string
+	APIServerCAFile   string
+	APIServerURL      string
+	Output            cmdutil.Output
+	NetworkPluginName string
 }
 
 func NewCommandNodeConfig(commandName string, fullName string, out io.Writer) *cobra.Command {
@@ -94,6 +95,7 @@ func NewCommandNodeConfig(commandName string, fullName string, out io.Writer) *c
 	flags.StringVar(&options.NodeClientCAFile, "node-client-certificate-authority", options.NodeClientCAFile, "The file containing signing authorities to use to verify requests to the node. If empty, all requests will be allowed.")
 	flags.StringVar(&options.APIServerURL, "master", options.APIServerURL, "The API server's URL.")
 	flags.StringVar(&options.APIServerCAFile, "certificate-authority", options.APIServerCAFile, "Path to the API server's CA file.")
+	flags.StringVar(&options.NetworkPluginName, "network-plugin", options.NetworkPluginName, "Name of the network plugin to hook to for pod networking.")
 
 	return cmd
 }
@@ -109,6 +111,7 @@ func NewDefaultCreateNodeConfigOptions() *CreateNodeConfigOptions {
 	options.ImageTemplate = variable.NewDefaultImageTemplate()
 
 	options.ListenAddr = flagtypes.Addr{Value: "0.0.0.0:10250", DefaultScheme: "https", DefaultPort: 10250, AllowPrefix: true}.Default()
+	options.NetworkPluginName = ""
 
 	return options
 }
@@ -360,6 +363,8 @@ func (o CreateNodeConfigOptions) MakeNodeConfig(serverCertFile, serverKeyFile, n
 		DNSIP:     o.DNSIP,
 
 		MasterKubeConfig: kubeConfigFile,
+
+		NetworkPluginName: o.NetworkPluginName,
 	}
 
 	if o.UseTLS() {

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -89,6 +89,9 @@ type MasterConfig struct {
 	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
 	// ProjectRequestConfig holds information about how to handle new project requests
 	ProjectRequestConfig ProjectRequestConfig
+
+	// NetworkConfig to be passed to the compiled in network plugin
+	NetworkConfig NetworkConfig
 }
 
 // ProjectRequestConfig holds information about how to handle new project requests
@@ -107,6 +110,13 @@ type PolicyConfig struct {
 
 	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)
 	OpenShiftSharedResourcesNamespace string
+}
+
+// NetworkConfig to be passed to the compiled in network plugin
+type NetworkConfig struct {
+	NetworkPluginName  string `json:"networkPluginName"`
+	ClusterNetworkCIDR string `json:"clusterNetworkCIDR"`
+	HostSubnetLength   uint   `json:"hostSubnetLength"`
 }
 
 type ImageConfig struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -85,6 +85,9 @@ type MasterConfig struct {
 	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
 	// ProjectRequestConfig holds information about how to handle new project requests
 	ProjectRequestConfig ProjectRequestConfig `json:"projectRequestConfig"`
+
+	// NetworkConfig to be passed to the compiled in network plugin
+	NetworkConfig NetworkConfig
 }
 
 type ProjectRequestConfig struct {
@@ -102,6 +105,13 @@ type PolicyConfig struct {
 
 	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)
 	OpenShiftSharedResourcesNamespace string `json:"openshiftSharedResourcesNamespace"`
+}
+
+// NetworkConfig to be passed to the compiled in network plugin
+type NetworkConfig struct {
+	NetworkPluginName  string `json:"networkPluginName"`
+	ClusterNetworkCIDR string `json:"clusterNetworkCIDR"`
+	HostSubnetLength   uint   `json:"hostSubnetLength"`
 }
 
 type ImageConfig struct {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -81,6 +81,8 @@ import (
 	routeallocationcontroller "github.com/openshift/origin/pkg/route/controller/allocation"
 	routeetcd "github.com/openshift/origin/pkg/route/registry/etcd"
 	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
+	clusternetworketcd "github.com/openshift/origin/pkg/sdn/registry/clusternetwork/etcd"
+	hostsubnetetcd "github.com/openshift/origin/pkg/sdn/registry/hostsubnet/etcd"
 	"github.com/openshift/origin/pkg/service"
 	templateregistry "github.com/openshift/origin/pkg/template/registry"
 	templateetcd "github.com/openshift/origin/pkg/template/registry/etcd"
@@ -107,6 +109,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
 	"github.com/openshift/origin/pkg/cmd/server/admin"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/plugins/osdn"
 	routeplugin "github.com/openshift/origin/plugins/route/allocation/simple"
 )
 
@@ -153,6 +156,8 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 	buildEtcd := buildetcd.New(c.EtcdHelper)
 	deployEtcd := deployetcd.New(c.EtcdHelper)
 	routeEtcd := routeetcd.New(c.EtcdHelper)
+	hostSubnetStorage := hostsubnetetcd.NewREST(c.EtcdHelper)
+	clusterNetworkStorage := clusternetworketcd.NewREST(c.EtcdHelper)
 
 	userStorage := useretcd.NewREST(c.EtcdHelper)
 	userRegistry := userregistry.NewRegistry(userStorage)
@@ -278,6 +283,9 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 
 		"projects":        projectStorage,
 		"projectRequests": projectRequestStorage,
+
+		"hostSubnet":     hostSubnetStorage,
+		"clusterNetwork": clusterNetworkStorage,
 
 		"users":                userStorage,
 		"identities":           identityStorage,
@@ -894,6 +902,13 @@ func (c *MasterConfig) RunDeploymentImageChangeTriggerController() {
 	factory := imagechangecontroller.ImageChangeControllerFactory{Client: osclient}
 	controller := factory.Create()
 	controller.Run()
+}
+
+// SDN controller runs openshift-sdn if the said network plugin is provided
+func (c *MasterConfig) RunSDNController() {
+	if c.Options.NetworkConfig.NetworkPluginName == osdn.NetworkPluginName() {
+		osdn.Master(*c.SdnClient(), *c.KubeClient(), c.Options.NetworkConfig.ClusterNetworkCIDR, c.Options.NetworkConfig.HostSubnetLength)
+	}
 }
 
 // RouteAllocator returns a route allocation controller.

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -257,6 +257,13 @@ func (c *MasterConfig) PolicyClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
+// SdnClient returns the sdn client object
+// It must have the capability to get/list/watch/create/delete
+// HostSubnets. And have the capability to get ClusterNetwork.
+func (c *MasterConfig) SdnClient() *osclient.Client {
+	return c.PrivilegedLoopbackOpenShiftClient
+}
+
 // DeploymentClient returns the deployment client object
 func (c *MasterConfig) DeploymentClient() *kclient.Client {
 	return c.PrivilegedLoopbackKubernetesClient

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -47,7 +47,10 @@ type MasterArgs struct {
 	KubeConnectionArgs *KubeConnectionArgs
 
 	SchedulerConfigFile string
+
 	ProjectNodeSelector string
+
+	NetworkArgs *NetworkArgs
 }
 
 // BindMasterArgs binds the options to the flags with prefix + default flag names
@@ -78,6 +81,7 @@ func NewDefaultMasterArgs() *MasterArgs {
 		ListenArg:          NewDefaultListenArg(),
 		ImageFormatArgs:    NewDefaultImageFormatArgs(),
 		KubeConnectionArgs: NewDefaultKubeConnectionArgs(),
+		NetworkArgs:        NewDefaultNetworkArgs(),
 	}
 
 	return config
@@ -196,6 +200,12 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 
 		ProjectRequestConfig: configapi.ProjectRequestConfig{
 			ProjectRequestTemplate: bootstrappolicy.DefaultOpenShiftSharedResourcesNamespace + "/project-request",
+		},
+
+		NetworkConfig: configapi.NetworkConfig{
+			NetworkPluginName:  args.NetworkArgs.NetworkPluginName,
+			ClusterNetworkCIDR: args.NetworkArgs.ClusterNetworkCIDR,
+			HostSubnetLength:   args.NetworkArgs.HostSubnetLength,
 		},
 	}
 

--- a/pkg/cmd/server/start/network_args.go
+++ b/pkg/cmd/server/start/network_args.go
@@ -1,0 +1,28 @@
+package start
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// NetworkArgs is a struct that the command stores flag values into.
+type NetworkArgs struct {
+	NetworkPluginName  string
+	ClusterNetworkCIDR string
+	HostSubnetLength   uint
+}
+
+func BindNetworkArgs(args *NetworkArgs, flags *pflag.FlagSet, prefix string) {
+	flags.StringVar(&args.NetworkPluginName, prefix+"network-plugin", args.NetworkPluginName, "The name of the networking plugin to be used for networking.")
+	flags.StringVar(&args.ClusterNetworkCIDR, prefix+"network-cidr", args.ClusterNetworkCIDR, "The CIDR string representing the network that all containers should belong to.")
+	flags.UintVar(&args.HostSubnetLength, prefix+"host-subnet-length", args.HostSubnetLength, "The length of subnet each host is given from the network-cidr.")
+}
+
+func NewDefaultNetworkArgs() *NetworkArgs {
+	config := &NetworkArgs{
+		NetworkPluginName:  "",
+		ClusterNetworkCIDR: "10.1.0.0/16",
+		HostSubnetLength:   8,
+	}
+
+	return config
+}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -114,6 +114,7 @@ func NewCommandStartMaster(out io.Writer) (*cobra.Command, *MasterOptions) {
 	BindListenArg(options.MasterArgs.ListenArg, flags, "")
 	BindImageFormatArgs(options.MasterArgs.ImageFormatArgs, flags, "")
 	BindKubeConnectionArgs(options.MasterArgs.KubeConnectionArgs, flags, "")
+	BindNetworkArgs(options.MasterArgs.NetworkArgs, flags, "")
 
 	return cmd, options
 }
@@ -393,6 +394,8 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	openshiftConfig.RunImageImportController()
 	openshiftConfig.RunOriginNamespaceController()
 	openshiftConfig.RunProjectAuthorizationCache()
+
+	openshiftConfig.RunSDNController()
 
 	return nil
 }

--- a/pkg/sdn/api/register.go
+++ b/pkg/sdn/api/register.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("",
+		&ClusterNetwork{},
+		&HostSubnet{},
+		&HostSubnetList{},
+	)
+}
+
+func (*ClusterNetwork) IsAnAPIObject() {}
+func (*HostSubnet) IsAnAPIObject()     {}
+func (*HostSubnetList) IsAnAPIObject() {}

--- a/pkg/sdn/api/types.go
+++ b/pkg/sdn/api/types.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+type ClusterNetwork struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	Network          string `json:"network" description:"CIDR string to specify the global overlay network's L3 space"`
+	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
+}
+
+// HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
+type HostSubnet struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// host may just be an IP address, resolvable hostname or a complete DNS
+	Host   string `json:"host" description:"Name of the host that is registered at the master. A lease will be sought after this name."`
+	HostIP string `json:"hostIP" description:"IP address to be used as vtep by other hosts in the overlay network"`
+	Subnet string `json:"subnet" description:"Actual subnet CIDR lease assigned to the host"`
+}
+
+// HostSubnetList is a collection of HostSubnets
+type HostSubnetList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []HostSubnet `json:"items"`
+}

--- a/pkg/sdn/api/v1beta1/register.go
+++ b/pkg/sdn/api/v1beta1/register.go
@@ -1,0 +1,17 @@
+package v1beta1
+
+import (
+	api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("v1beta1",
+		&ClusterNetwork{},
+		&HostSubnet{},
+		&HostSubnetList{},
+	)
+}
+
+func (*ClusterNetwork) IsAnAPIObject() {}
+func (*HostSubnet) IsAnAPIObject()     {}
+func (*HostSubnetList) IsAnAPIObject() {}

--- a/pkg/sdn/api/v1beta1/types.go
+++ b/pkg/sdn/api/v1beta1/types.go
@@ -1,0 +1,31 @@
+package v1beta1
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+)
+
+type ClusterNetwork struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	Network          string `json:"network" description:"CIDR string to specify the global overlay network's L3 space"`
+	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
+}
+
+// HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
+type HostSubnet struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// host may just be an IP address, resolvable hostname or a complete DNS
+	Host   string `json:"host" description:"Name of the host that is registered at the master. A lease will be sought after this name."`
+	HostIP string `json:"hostIP" description:"IP address to be used as vtep by other hosts in the overlay network"`
+	Subnet string `json:"subnet" description:"Actual subnet CIDR lease assigned to the host"`
+}
+
+// HostSubnetList is a collection of HostSubnets
+type HostSubnetList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []HostSubnet `json:"items"`
+}

--- a/pkg/sdn/api/v1beta3/register.go
+++ b/pkg/sdn/api/v1beta3/register.go
@@ -1,0 +1,17 @@
+package v1beta3
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+func init() {
+	api.Scheme.AddKnownTypes("v1beta3",
+		&ClusterNetwork{},
+		&HostSubnet{},
+		&HostSubnetList{},
+	)
+}
+
+func (*ClusterNetwork) IsAnAPIObject() {}
+func (*HostSubnet) IsAnAPIObject()     {}
+func (*HostSubnetList) IsAnAPIObject() {}

--- a/pkg/sdn/api/v1beta3/types.go
+++ b/pkg/sdn/api/v1beta3/types.go
@@ -1,0 +1,31 @@
+package v1beta3
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
+)
+
+type ClusterNetwork struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	Network          string `json:"network" description:"CIDR string to specify the global overlay network's L3 space"`
+	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
+}
+
+// HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
+type HostSubnet struct {
+	kapi.TypeMeta   `json:",inline"`
+	kapi.ObjectMeta `json:"metadata,omitempty"`
+
+	// host may just be an IP address, resolvable hostname or a complete DNS
+	Host   string `json:"host" description:"Name of the host that is registered at the master. A lease will be sought after this name."`
+	HostIP string `json:"hostIP" description:"IP address to be used as vtep by other hosts in the overlay network"`
+	Subnet string `json:"subnet" description:"Actual subnet CIDR lease assigned to the host"`
+}
+
+// HostSubnetList is a collection of HostSubnets
+type HostSubnetList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []HostSubnet `json:"items"`
+}

--- a/pkg/sdn/api/validation/validation.go
+++ b/pkg/sdn/api/validation/validation.go
@@ -1,0 +1,43 @@
+package validation
+
+import (
+	"net"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+// ValidateClusterNetwork tests if required fields in the ClusterNetwork are set.
+func ValidateClusterNetwork(clusterNet *sdnapi.ClusterNetwork) fielderrors.ValidationErrorList {
+	result := fielderrors.ValidationErrorList{}
+
+	_, ipnet, err := net.ParseCIDR(clusterNet.Network)
+	if err != nil {
+		result = append(result, fielderrors.NewFieldInvalid("network", clusterNet.Network, err.Error()))
+	} else {
+		ones, bitSize := ipnet.Mask.Size()
+		if (bitSize - ones) <= clusterNet.HostSubnetLength {
+			result = append(result, fielderrors.NewFieldInvalid("hostSubnetLength", clusterNet.HostSubnetLength, "Subnet length is greater than cluster Mask"))
+		}
+	}
+
+	return result
+}
+
+// ValidateHostSubnet tests fields for the host subnet, the host should be a network resolvable string,
+//  and subnet should be a valid CIDR
+func ValidateHostSubnet(hs *sdnapi.HostSubnet) fielderrors.ValidationErrorList {
+	result := fielderrors.ValidationErrorList{}
+	if hs.Name == "" {
+		result = append(result, fielderrors.NewFieldInvalid("name", hs.Name, "Name missing in object metadata"))
+	}
+	_, _, err := net.ParseCIDR(hs.Subnet)
+	if err != nil {
+		result = append(result, fielderrors.NewFieldInvalid("subnet", hs.Subnet, err.Error()))
+	}
+	if net.ParseIP(hs.HostIP) == nil {
+		result = append(result, fielderrors.NewFieldInvalid("hostIP", hs.HostIP, "Invalid IP address"))
+	}
+	return result
+}

--- a/pkg/sdn/api/validation/validation_test.go
+++ b/pkg/sdn/api/validation/validation_test.go
@@ -1,0 +1,117 @@
+package validation
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+)
+
+// TestValidateClusterNetwork ensures not specifying a required field results in error and a fully specified
+// sdn passes successfully
+func TestValidateClusterNetwork(t *testing.T) {
+	tests := []struct {
+		name           string
+		cn             *api.ClusterNetwork
+		expectedErrors int
+	}{
+		{
+			name: "Good one",
+			cn: &api.ClusterNetwork{
+				Network:          "10.20.0.0/16",
+				HostSubnetLength: 8,
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Bad network",
+			cn: &api.ClusterNetwork{
+				Network:          "10.20.0.0.0/16",
+				HostSubnetLength: 8,
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Invalid subnet length",
+			cn: &api.ClusterNetwork{
+				Network:          "10.20.30.0/24",
+				HostSubnetLength: 16,
+			},
+			expectedErrors: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		errs := ValidateClusterNetwork(tc.cn)
+
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("Test case %s expected %d error(s), got %d. %v", tc.name, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}
+
+func TestValidateHostSubnet(t *testing.T) {
+	tests := []struct {
+		name           string
+		hs             *api.HostSubnet
+		expectedErrors int
+	}{
+		{
+			name: "Good one",
+			hs: &api.HostSubnet{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "abc.def.com",
+				},
+				Host:   "abc.def.com",
+				HostIP: "10.20.30.40",
+				Subnet: "8.8.8.0/24",
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "No Name",
+			hs: &api.HostSubnet{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "foo",
+				},
+				Host:   "abc.def.com",
+				HostIP: "10.20.30.40",
+				Subnet: "8.8.8.0/24",
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Malformed HostIP",
+			hs: &api.HostSubnet{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "abc.def.com",
+				},
+				Host:   "abc.def.com",
+				HostIP: "10.20.300.40",
+				Subnet: "8.8.0.0/24",
+			},
+			expectedErrors: 1,
+		},
+		{
+			name: "Malformed subnet",
+			hs: &api.HostSubnet{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "abc.def.com",
+				},
+				Host:   "abc.def.com",
+				HostIP: "10.20.30.40",
+				Subnet: "8.8.0/24",
+			},
+			expectedErrors: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		errs := ValidateHostSubnet(tc.hs)
+
+		if len(errs) != tc.expectedErrors {
+			t.Errorf("Test case %s expected %d error(s), got %d. %v", tc.name, tc.expectedErrors, len(errs), errs)
+		}
+	}
+}

--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -1,0 +1,49 @@
+package etcd
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+	"github.com/openshift/origin/pkg/sdn/registry/clusternetwork"
+)
+
+// rest implements a RESTStorage for sdn against etcd
+type REST struct {
+	etcdgeneric.Etcd
+}
+
+const etcdPrefix = "/registry/sdnnetworks"
+
+// NewREST returns a RESTStorage object that will work against subnets
+func NewREST(h tools.EtcdHelper) *REST {
+	store := &etcdgeneric.Etcd{
+		NewFunc:     func() runtime.Object { return &api.ClusterNetwork{} },
+		NewListFunc: func() runtime.Object { return &api.ClusterNetwork{} },
+		KeyRootFunc: func(ctx kapi.Context) string {
+			return etcdPrefix
+		},
+		KeyFunc: func(ctx kapi.Context, name string) (string, error) {
+			return (etcdPrefix + "/" + name), nil
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*api.ClusterNetwork).Name, nil
+		},
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return clusternetwork.MatchClusterNetwork(label, field)
+		},
+		EndpointName: "clusternetwork",
+
+		Helper: h,
+	}
+
+	store.CreateStrategy = clusternetwork.Strategy
+	store.UpdateStrategy = clusternetwork.Strategy
+
+	return &REST{*store}
+}

--- a/pkg/sdn/registry/clusternetwork/registry.go
+++ b/pkg/sdn/registry/clusternetwork/registry.go
@@ -1,0 +1,52 @@
+package clusternetwork
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+)
+
+// Registry is an interface implemented by things that know how to store sdn's ClusterNetwork objects.
+type Registry interface {
+	// GetClusterNetwork returns a specific network
+	GetClusterNetwork(ctx kapi.Context, name string) (*api.ClusterNetwork, error)
+	// CreateClusterNetwork creates a cluster network
+	CreateClusterNetwork(ctx kapi.Context, hs *api.ClusterNetwork) (*api.ClusterNetwork, error)
+}
+
+// Storage is an interface for a standard REST Storage backend
+// TODO: move me somewhere common
+type Storage interface {
+	rest.Getter
+
+	Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error)
+}
+
+// storage puts strong typing around storage calls
+type storage struct {
+	Storage
+}
+
+// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
+// types will panic.
+func NewRegistry(s Storage) Registry {
+	return &storage{s}
+}
+
+func (s *storage) GetClusterNetwork(ctx kapi.Context, name string) (*api.ClusterNetwork, error) {
+	obj, err := s.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.ClusterNetwork), nil
+}
+
+func (s *storage) CreateClusterNetwork(ctx kapi.Context, hs *api.ClusterNetwork) (*api.ClusterNetwork, error) {
+	obj, err := s.Create(ctx, hs)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.ClusterNetwork), nil
+}

--- a/pkg/sdn/registry/clusternetwork/rest.go
+++ b/pkg/sdn/registry/clusternetwork/rest.go
@@ -1,0 +1,69 @@
+package clusternetwork
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+	"github.com/openshift/origin/pkg/sdn/api/validation"
+)
+
+// sdnStrategy implements behavior for ClusterNetworks
+type sdnStrategy struct {
+	runtime.ObjectTyper
+}
+
+// Strategy is the default logic that applies when creating and updating ClusterNetwork
+// objects via the REST API.
+var Strategy = sdnStrategy{kapi.Scheme}
+
+func (sdnStrategy) PrepareForUpdate(obj, old runtime.Object) {}
+
+// NamespaceScoped is false for sdns
+func (sdnStrategy) NamespaceScoped() bool {
+	return false
+}
+
+func (sdnStrategy) GenerateName(base string) string {
+	return base
+}
+
+func (sdnStrategy) PrepareForCreate(obj runtime.Object) {
+}
+
+// Validate validates a new sdn
+func (sdnStrategy) Validate(ctx kapi.Context, obj runtime.Object) fielderrors.ValidationErrorList {
+	hs, _ := obj.(*api.ClusterNetwork)
+	return validation.ValidateClusterNetwork(hs)
+}
+
+// AllowCreateOnUpdate is false for sdns
+func (sdnStrategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+// ValidateUpdate is the default update validation for a ClusterNetwork
+func (sdnStrategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
+	result := fielderrors.ValidationErrorList{}
+	if obj.(*api.ClusterNetwork).Network != old.(*api.ClusterNetwork).Network {
+		result = append(result, fielderrors.NewFieldInvalid("Network", obj.(*api.ClusterNetwork), "cannot change the cluster's network CIDR midflight."))
+	}
+	return result
+}
+
+// MatchClusterNetwork returns a generic matcher for a given label and field selector.
+func MatchClusterNetwork(label labels.Selector, field fields.Selector) generic.Matcher {
+	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {
+		_, ok := obj.(*api.ClusterNetwork)
+		if !ok {
+			return false, fmt.Errorf("not a ClusterNetwork")
+		}
+		return true, nil
+	})
+}

--- a/pkg/sdn/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/sdn/registry/hostsubnet/etcd/etcd.go
@@ -1,0 +1,49 @@
+package etcd
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	etcdgeneric "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic/etcd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+	"github.com/openshift/origin/pkg/sdn/registry/hostsubnet"
+)
+
+// rest implements a RESTStorage for sdn against etcd
+type REST struct {
+	etcdgeneric.Etcd
+}
+
+const etcdPrefix = "/registry/sdnsubnets"
+
+// NewREST returns a RESTStorage object that will work against subnets
+func NewREST(h tools.EtcdHelper) *REST {
+	store := &etcdgeneric.Etcd{
+		NewFunc:     func() runtime.Object { return &api.HostSubnet{} },
+		NewListFunc: func() runtime.Object { return &api.HostSubnetList{} },
+		KeyRootFunc: func(ctx kapi.Context) string {
+			return etcdPrefix
+		},
+		KeyFunc: func(ctx kapi.Context, name string) (string, error) {
+			return (etcdPrefix + "/" + name), nil
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) {
+			return obj.(*api.HostSubnet).Host, nil
+		},
+		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
+			return hostsubnet.MatchHostSubnet(label, field)
+		},
+		EndpointName: "hostsubnet",
+
+		Helper: h,
+	}
+
+	store.CreateStrategy = hostsubnet.Strategy
+	store.UpdateStrategy = hostsubnet.Strategy
+
+	return &REST{*store}
+}

--- a/pkg/sdn/registry/hostsubnet/registry.go
+++ b/pkg/sdn/registry/hostsubnet/registry.go
@@ -1,0 +1,77 @@
+package hostsubnet
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+)
+
+// Registry is an interface implemented by things that know how to store sdn objects.
+type Registry interface {
+	// ListSubnets obtains a list of subnets
+	ListSubnets(ctx kapi.Context) (*api.HostSubnetList, error)
+	// GetSubnet returns a specific subnet
+	GetSubnet(ctx kapi.Context, name string) (*api.HostSubnet, error)
+	// CreateSubnet creates a HostSubnet
+	CreateSubnet(ctx kapi.Context, hs *api.HostSubnet) (*api.HostSubnet, error)
+	// DeleteSubnet deletes a hostsubnet
+	DeleteSubnet(ctx kapi.Context, name string) error
+}
+
+// Storage is an interface for a standard REST Storage backend
+// TODO: move me somewhere common
+type Storage interface {
+	rest.Lister
+	rest.Getter
+
+	Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error)
+	Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error)
+	Delete(ctx kapi.Context, name string, opts *kapi.DeleteOptions) (runtime.Object, error)
+}
+
+// storage puts strong typing around storage calls
+type storage struct {
+	Storage
+}
+
+// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
+// types will panic.
+func NewRegistry(s Storage) Registry {
+	return &storage{s}
+}
+
+func (s *storage) ListSubnets(ctx kapi.Context) (*api.HostSubnetList, error) {
+	obj, err := s.List(ctx, labels.Everything(), fields.Everything())
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.HostSubnetList), nil
+}
+
+func (s *storage) GetSubnet(ctx kapi.Context, name string) (*api.HostSubnet, error) {
+	obj, err := s.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.HostSubnet), nil
+}
+
+func (s *storage) CreateSubnet(ctx kapi.Context, hs *api.HostSubnet) (*api.HostSubnet, error) {
+	obj, err := s.Create(ctx, hs)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.HostSubnet), nil
+}
+
+func (s *storage) DeleteSubnet(ctx kapi.Context, name string) error {
+	_, err := s.Delete(ctx, name, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/sdn/registry/hostsubnet/rest.go
+++ b/pkg/sdn/registry/hostsubnet/rest.go
@@ -1,0 +1,69 @@
+package hostsubnet
+
+import (
+	"fmt"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/generic"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+
+	"github.com/openshift/origin/pkg/sdn/api"
+	"github.com/openshift/origin/pkg/sdn/api/validation"
+)
+
+// sdnStrategy implements behavior for HostSubnets
+type sdnStrategy struct {
+	runtime.ObjectTyper
+}
+
+// Strategy is the default logic that applies when creating and updating HostSubnet
+// objects via the REST API.
+var Strategy = sdnStrategy{kapi.Scheme}
+
+func (sdnStrategy) PrepareForUpdate(obj, old runtime.Object) {}
+
+// NamespaceScoped is false for sdns
+func (sdnStrategy) NamespaceScoped() bool {
+	return false
+}
+
+func (sdnStrategy) GenerateName(base string) string {
+	return base
+}
+
+func (sdnStrategy) PrepareForCreate(obj runtime.Object) {
+}
+
+// Validate validates a new sdn
+func (sdnStrategy) Validate(ctx kapi.Context, obj runtime.Object) fielderrors.ValidationErrorList {
+	hs := obj.(*api.HostSubnet)
+	return validation.ValidateHostSubnet(hs)
+}
+
+// AllowCreateOnUpdate is false for sdns
+func (sdnStrategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+// ValidateUpdate is the default update validation for a HostSubnet
+func (sdnStrategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
+	result := fielderrors.ValidationErrorList{}
+	if obj.(*api.HostSubnet).Subnet != old.(*api.HostSubnet).Subnet {
+		result = append(result, fielderrors.NewFieldInvalid("Subnet", obj.(*api.HostSubnet), "cannot change the subnet lease midflight."))
+	}
+	return result
+}
+
+// MatchHostSubnet returns a generic matcher for a given label and field selector.
+func MatchHostSubnet(label labels.Selector, field fields.Selector) generic.Matcher {
+	return generic.MatcherFunc(func(obj runtime.Object) (bool, error) {
+		_, ok := obj.(*api.HostSubnet)
+		if !ok {
+			return false, fmt.Errorf("not a HostSubnet")
+		}
+		return true, nil
+	})
+}

--- a/plugins/osdn/osdn.go
+++ b/plugins/osdn/osdn.go
@@ -1,0 +1,206 @@
+package osdn
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/exec"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	"github.com/openshift/openshift-sdn/ovssubnet"
+	osdnapi "github.com/openshift/openshift-sdn/pkg/api"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/sdn/api"
+)
+
+type OsdnRegistryInterface struct {
+	oClient osclient.Interface
+	kClient kclient.Interface
+}
+
+func NetworkPluginName() string {
+	return "redhat/openshift-ovs-subnet"
+}
+
+func Master(osClient osclient.Client, kClient kclient.Client, clusterNetwork string, clusterNetworkLength uint) {
+	osdnInterface := newOsdnRegistryInterface(osClient, kClient)
+
+	// get hostname
+	output, err := exec.New().Command("hostname", "-f").CombinedOutput()
+	if err != nil {
+		glog.Fatalf("SDN initialization failed: %v", err)
+	}
+	host := strings.TrimSpace(string(output))
+
+	kc, err := ovssubnet.NewKubeController(&osdnInterface, host, "")
+	if err != nil {
+		glog.Fatalf("SDN initialization failed: %v", err)
+	}
+	kc.StartMaster(false, clusterNetwork, clusterNetworkLength)
+}
+
+func Node(osClient osclient.Client, kClient kclient.Client, hostname string, publicIP string) {
+	osdnInterface := newOsdnRegistryInterface(osClient, kClient)
+	kc, err := ovssubnet.NewKubeController(&osdnInterface, hostname, publicIP)
+	if err != nil {
+		glog.Fatalf("SDN initialization failed: %v", err)
+	}
+	kc.StartNode(false, false)
+}
+
+func newOsdnRegistryInterface(osClient osclient.Client, kClient kclient.Client) OsdnRegistryInterface {
+	return OsdnRegistryInterface{&osClient, &kClient}
+}
+
+func (oi *OsdnRegistryInterface) InitSubnets() error {
+	return nil
+}
+
+func (oi *OsdnRegistryInterface) GetSubnets() (*[]osdnapi.Subnet, error) {
+	hostSubnetList, err := oi.oClient.HostSubnets().List()
+	if err != nil {
+		return nil, err
+	}
+	// convert HostSubnet to osdnapi.Subnet
+	subList := make([]osdnapi.Subnet, 0)
+	for _, subnet := range hostSubnetList.Items {
+		subList = append(subList, osdnapi.Subnet{Minion: subnet.HostIP, Sub: subnet.Subnet})
+	}
+	return &subList, nil
+}
+
+func (oi *OsdnRegistryInterface) GetSubnet(minion string) (*osdnapi.Subnet, error) {
+	hs, err := oi.oClient.HostSubnets().Get(minion)
+	if err != nil {
+		return nil, err
+	}
+	return &osdnapi.Subnet{Minion: hs.Host, Sub: hs.Subnet}, nil
+}
+
+func (oi *OsdnRegistryInterface) DeleteSubnet(minion string) error {
+	return oi.oClient.HostSubnets().Delete(minion)
+}
+
+func (oi *OsdnRegistryInterface) CreateSubnet(minion string, sub *osdnapi.Subnet) error {
+	hs := &api.HostSubnet{
+		TypeMeta:   kapi.TypeMeta{Kind: "HostSubnet"},
+		ObjectMeta: kapi.ObjectMeta{Name: minion},
+		Host:       minion,
+		HostIP:     sub.Minion,
+		Subnet:     sub.Sub,
+	}
+	_, err := oi.oClient.HostSubnets().Create(hs)
+	return err
+}
+
+func (oi *OsdnRegistryInterface) WatchSubnets(receiver chan *osdnapi.SubnetEvent, stop chan bool) error {
+	// double go :(
+	revision := ""
+	wi, err := oi.oClient.HostSubnets().Watch(revision)
+	if err != nil {
+		return err
+	}
+	go func() {
+		for {
+			ev := <-wi.ResultChan()
+			switch ev.Type {
+			case watch.Added:
+				// create SubnetEvent
+				hs := ev.Object.(*api.HostSubnet)
+				receiver <- &osdnapi.SubnetEvent{Type: osdnapi.Added, Minion: hs.Host, Sub: osdnapi.Subnet{Minion: hs.HostIP, Sub: hs.Subnet}}
+			case watch.Deleted:
+				hs := ev.Object.(*api.HostSubnet)
+				receiver <- &osdnapi.SubnetEvent{Type: osdnapi.Deleted, Minion: hs.Host, Sub: osdnapi.Subnet{Minion: hs.HostIP, Sub: hs.Subnet}}
+			case watch.Modified:
+				hs := ev.Object.(*api.HostSubnet)
+				receiver <- &osdnapi.SubnetEvent{Type: osdnapi.Added, Minion: hs.Host, Sub: osdnapi.Subnet{Minion: hs.HostIP, Sub: hs.Subnet}}
+			case watch.Error:
+				fmt.Errorf("Error in watching subnets")
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (oi *OsdnRegistryInterface) InitMinions() error {
+	// return no error, as this gets initialized by apiserver
+	return nil
+}
+
+func (oi *OsdnRegistryInterface) GetMinions() (*[]string, error) {
+	nodes, err := oi.kClient.Nodes().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return nil, err
+	}
+	// convert kapi.NodeList to []string
+	minionList := make([]string, 0)
+	for _, minion := range nodes.Items {
+		minionList = append(minionList, minion.Name)
+	}
+	return &minionList, nil
+}
+
+func (oi *OsdnRegistryInterface) CreateMinion(minion string, data string) error {
+	return fmt.Errorf("Feature not supported in native mode. SDN cannot create/register minions.")
+}
+
+func (oi *OsdnRegistryInterface) WatchMinions(receiver chan *osdnapi.MinionEvent, stop chan bool) error {
+	wi, err := oi.kClient.Nodes().Watch(labels.Everything(), fields.Everything(), "0")
+	if err != nil {
+		return err
+	}
+	go func() {
+		for {
+			ev := <-wi.ResultChan()
+			switch ev.Type {
+			case watch.Added:
+				// create minionEvent
+				node := ev.Object.(*kapi.Node)
+				receiver <- &osdnapi.MinionEvent{Type: osdnapi.Added, Minion: node.ObjectMeta.Name}
+			case watch.Deleted:
+				node := ev.Object.(*kapi.Node)
+				receiver <- &osdnapi.MinionEvent{Type: osdnapi.Deleted, Minion: node.ObjectMeta.Name}
+			case watch.Modified:
+				node := ev.Object.(*kapi.Node)
+				receiver <- &osdnapi.MinionEvent{Type: osdnapi.Added, Minion: node.ObjectMeta.Name}
+			case watch.Error:
+				fmt.Errorf("Error in watching subnets")
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (oi *OsdnRegistryInterface) WriteNetworkConfig(network string, subnetLength uint) error {
+	cn := &api.ClusterNetwork{
+		TypeMeta:         kapi.TypeMeta{Kind: "ClusterNetwork"},
+		ObjectMeta:       kapi.ObjectMeta{Name: "default"},
+		Network:          network,
+		HostSubnetLength: int(subnetLength),
+	}
+	_, err := oi.oClient.ClusterNetwork().Create(cn)
+	return err
+}
+
+func (oi *OsdnRegistryInterface) GetContainerNetwork() (string, error) {
+	cn, err := oi.oClient.ClusterNetwork().Get("default")
+	return cn.Network, err
+}
+
+func (oi *OsdnRegistryInterface) GetSubnetLength() (uint64, error) {
+	cn, err := oi.oClient.ClusterNetwork().Get("default")
+	return uint64(cn.HostSubnetLength), err
+}
+
+func (oi *OsdnRegistryInterface) CheckEtcdIsAlive(seconds uint64) bool {
+	// always assumed to be true as we run through the apiserver
+	return true
+}

--- a/vagrant/provision-master-sdn.sh
+++ b/vagrant/provision-master-sdn.sh
@@ -18,20 +18,4 @@ make
 make install
 popd
 
-# Create systemd service
-cat <<EOF > /usr/lib/systemd/system/openshift-master-sdn.service
-[Unit]
-Description=OpenShift SDN Master
-Requires=openshift-master.service
-After=openshift-master.service
-
-[Service]
-ExecStart=/usr/bin/openshift-sdn -etcd-endpoints=https://${MASTER_IP}:4001 -etcd-keyfile=${ETCD_KEYFILE} -etcd-certfile=${ETCD_CERTFILE} -etcd-cafile=${ETCD_CAFILE}
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-# Start the service
-systemctl daemon-reload
-systemctl start openshift-master-sdn.service
+# no need to start openshift-sdn, as it is integrated with openshift binary

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -57,6 +57,7 @@ pushd /vagrant
       --node="${minion}" \
       --hostnames="${minion},${ip}" \
       --master="https://${MASTER_IP}:8443" \
+      --network-plugin="redhat/openshift-ovs-subnet" \
       --node-client-certificate-authority="${CERT_DIR}/ca.crt" \
       --certificate-authority="${CERT_DIR}/ca.crt" \
       --signer-cert="${CERT_DIR}/ca.crt" \
@@ -78,7 +79,7 @@ Requires=docker.service network.service
 After=network.service
 
 [Service]
-ExecStart=/usr/bin/openshift start master --master=https://${MASTER_IP}:8443 --nodes=${node_list}
+ExecStart=/usr/bin/openshift start master --master=https://${MASTER_IP}:8443 --nodes=${node_list} --network-plugin=redhat/openshift-ovs-subnet
 WorkingDirectory=/vagrant/
 
 [Install]

--- a/vagrant/provision-node-sdn.sh
+++ b/vagrant/provision-node-sdn.sh
@@ -19,24 +19,7 @@ make
 make install
 popd
 
-# Create systemd service
-cat <<EOF > /usr/lib/systemd/system/openshift-node-sdn.service
-[Unit]
-Description=openshift SDN node
-Requires=openvswitch.service
-After=openvswitch.service
-Before=openshift-node.service
-
-[Service]
-ExecStart=/usr/bin/openshift-sdn -minion -etcd-endpoints=https://${MASTER_IP}:4001 -public-ip=${MINION_IP} -etcd-keyfile=${ETCD_KEYFILE} -etcd-certfile=${ETCD_CERTFILE} -etcd-cafile=${ETCD_CAFILE}
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-# Start the service
-systemctl daemon-reload
 systemctl enable openvswitch
 systemctl start openvswitch
-systemctl enable openshift-node-sdn.service
-systemctl start openshift-node-sdn.service
+
+# no need to start openshift-sdn, as it is integrated with openshift binary


### PR DESCRIPTION
Fat PR. 
 - Integrates openshift-sdn within openshift. When one runs openshift start master, it starts the openshift-sdn in master mode. Same thing on the node side. All necessary config options are exposed alongwith default settings.
 - Primary change is that both the sdn-master and sdn-node use apiserver apis as read/write/watch interface to persistent store (etcd).
 - Minor conflict in openshift-node systemd unit file: it cannot depend on docker.service because sdn code restarts docker (change has been reflected in vagrant already, need to propagate elsewhere).
 - openshift-sdn packages are Godep'ed, but the rpm still needs to be installed because the shell-scripts that are part of rpm need to be present on the node for callouts.