### PR TITLE
OpenShift admin command to manage node operations

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -431,6 +431,19 @@ osc delete is/ruby-20-centos7-buildcli
 osc delete bc/ruby-sample-build-validtag
 osc delete bc/ruby-sample-build-invalidtag
 
+# Test admin manage-node operations
+[ "$(openshift admin manage-node --help 2>&1 | grep 'Manage node operations')" ]
+[ "$(osadm manage-node --schedulable=true | grep --text 'Ready' | grep -v 'Sched')" ]
+osc create -f examples/hello-openshift/hello-pod.json
+[ "$(osadm manage-node --list-pods | grep 'hello-openshift' | grep -v 'unassigned')" ]
+[ "$(osadm manage-node --evacuate --dry-run | grep 'hello-openshift')" ]
+[ "$(osadm manage-node --schedulable=false | grep 'SchedulingDisabled')" ]
+[ "$(osadm manage-node --evacuate 2>&1 | grep 'Unable to evacuate')" ]
+[ "$(osadm manage-node --evacuate --force | grep 'hello-openshift')" ]
+[ ! "$(osadm manage-node --list-pods | grep 'hello-openshift')" ]
+osc delete pods hello-openshift
+echo "manage-node: ok"
+
 openshift admin policy add-role-to-group cluster-admin system:unauthenticated
 openshift admin policy remove-role-from-group cluster-admin system:unauthenticated
 openshift admin policy remove-role-from-group-from-project system:unauthenticated

--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/origin/pkg/cmd/admin/node"
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/admin/project"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
@@ -46,6 +47,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 	cmds.AddCommand(exrouter.NewCmdRouter(f, fullName, "router", out))
 	cmds.AddCommand(exregistry.NewCmdRegistry(f, fullName, "registry", out))
 	cmds.AddCommand(buildchain.NewCmdBuildChain(f, fullName, "build-chain"))
+	cmds.AddCommand(node.NewCommandManageNode(f, node.ManageNodeCommandName, fullName+" "+node.ManageNodeCommandName, out))
 	cmds.AddCommand(cmd.NewCmdConfig(fullName, "config"))
 
 	// TODO: these probably belong in a sub command

--- a/pkg/cmd/admin/node/evacuate.go
+++ b/pkg/cmd/admin/node/evacuate.go
@@ -1,0 +1,134 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+)
+
+type EvacuateOptions struct {
+	Options *NodeOptions
+
+	// Optional params
+	DryRun bool
+	Force  bool
+}
+
+func (e *EvacuateOptions) AddFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.BoolVar(&e.DryRun, "dry-run", false, "Show pods that will be migrated. Optional param for --evacuate")
+	flags.BoolVar(&e.Force, "force", false, "Delete pods not backed by replication controller. Optional param for --evacuate")
+}
+
+func (e *EvacuateOptions) Run() error {
+	nodes, err := e.Options.GetNodes()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	for _, node := range nodes {
+		err := e.RunEvacuate(node)
+		if err != nil {
+			// Don't bail out if one node fails
+			errList = append(errList, err)
+		}
+	}
+	if len(errList) != 0 {
+		return kerrors.NewAggregate(errList)
+	}
+	return nil
+}
+
+func (e *EvacuateOptions) RunEvacuate(node *kapi.Node) error {
+	if e.DryRun {
+		listpodsOp := ListPodsOptions{Options: e.Options}
+		return listpodsOp.Run()
+	}
+
+	// We do *not* automatically mark the node unschedulable to perform evacuation.
+	// Rationale: If we unschedule the node and later the operation is unsuccessful (stopped by user, network error, etc.),
+	// we may not be able to recover in some cases to mark the node back to schedulable. To avoid these cases, we recommend
+	// user to explicitly set the node to schedulable/unschedulable.
+	if !node.Spec.Unschedulable {
+		return fmt.Errorf("Node '%s' must be unschedulable to perform evacuation.\nYou can mark the node unschedulable with 'openshift admin manage-node %s --schedulable=false'", node.ObjectMeta.Name, node.ObjectMeta.Name)
+	}
+
+	labelSelector, err := labels.Parse(e.Options.PodSelector)
+	if err != nil {
+		return err
+	}
+	fieldSelector := fields.Set{GetPodHostFieldLabel(node.TypeMeta.APIVersion): node.ObjectMeta.Name}.AsSelector()
+
+	// Filter all pods that satisfies pod label selector and belongs to the given node
+	pods, err := e.Options.Kclient.Pods(kapi.NamespaceAll).List(labelSelector, fieldSelector)
+	if err != nil {
+		return err
+	}
+	rcs, err := e.Options.Kclient.ReplicationControllers(kapi.NamespaceAll).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	printerWithHeaders, printerNoHeaders, err := e.Options.GetPrintersByResource("pod")
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	firstPod := true
+	numPodsWithNoRC := 0
+	// grace = 0 implies delete the pod immediately
+	grace := int64(0)
+	deleteOptions := &kapi.DeleteOptions{GracePeriodSeconds: &grace}
+
+	for _, pod := range pods.Items {
+		foundrc := false
+		for _, rc := range rcs.Items {
+			selector := labels.SelectorFromSet(rc.Spec.Selector)
+			if selector.Matches(labels.Set(pod.Labels)) {
+				foundrc = true
+				break
+			}
+		}
+
+		if firstPod {
+			fmt.Fprintln(e.Options.Writer, "\nMigrating these pods on node: ", node.ObjectMeta.Name, "\n")
+			firstPod = false
+			printerWithHeaders.PrintObj(&pod, e.Options.Writer)
+		} else {
+			printerNoHeaders.PrintObj(&pod, e.Options.Writer)
+		}
+
+		if foundrc || e.Force {
+			if err := e.Options.Kclient.Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err != nil {
+				glog.Errorf("Unable to delete a pod: %+v, error: %v", pod, err)
+				errList = append(errList, err)
+				continue
+			}
+		} else { // Pods without replication controller and no --force option
+			numPodsWithNoRC++
+		}
+	}
+	if numPodsWithNoRC > 0 {
+		err := fmt.Errorf(`Unable to evacuate some pods because they are not backed by replication controller.
+Suggested options:
+- You can list bare pods in json/yaml format using '--list-pods -o json|yaml'
+- Force deletion of bare pods with --force option to --evacuate
+- Optionally recreate these bare pods by massaging the json/yaml output from above list pods
+`)
+		errList = append(errList, err)
+	}
+
+	if len(errList) != 0 {
+		return kerrors.NewAggregate(errList)
+	}
+	return nil
+}

--- a/pkg/cmd/admin/node/listpods.go
+++ b/pkg/cmd/admin/node/listpods.go
@@ -1,0 +1,79 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+)
+
+type ListPodsOptions struct {
+	Options *NodeOptions
+}
+
+func (l *ListPodsOptions) AddFlags(cmd *cobra.Command) {
+	kcmdutil.AddPrinterFlags(cmd)
+}
+
+func (l *ListPodsOptions) Run() error {
+	nodes, err := l.Options.GetNodes()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	for _, node := range nodes {
+		err := l.RunListPods(node)
+		if err != nil {
+			// Don't bail out if one node fails
+			errList = append(errList, err)
+		}
+	}
+	if len(errList) != 0 {
+		return kerrors.NewAggregate(errList)
+	}
+	return nil
+}
+
+func (l *ListPodsOptions) RunListPods(node *kapi.Node) error {
+	labelSelector, err := labels.Parse(l.Options.PodSelector)
+	if err != nil {
+		return err
+	}
+	fieldSelector := fields.Set{GetPodHostFieldLabel(node.TypeMeta.APIVersion): node.ObjectMeta.Name}.AsSelector()
+
+	// Filter all pods that satisfies pod label selector and belongs to the given node
+	pods, err := l.Options.Kclient.Pods(kapi.NamespaceAll).List(labelSelector, fieldSelector)
+	if err != nil {
+		return err
+	}
+
+	var printerWithHeaders, printerNoHeaders kubectl.ResourcePrinter
+	if l.Options.CmdPrinterOutput {
+		printerWithHeaders = l.Options.CmdPrinter
+		printerNoHeaders = l.Options.CmdPrinter
+	} else {
+		printerWithHeaders, printerNoHeaders, err = l.Options.GetPrintersByResource("pod")
+		if err != nil {
+			return err
+		}
+	}
+	firstPod := true
+
+	for _, pod := range pods.Items {
+		if firstPod {
+			fmt.Fprintln(l.Options.Writer, "\nListing matched pods on node: ", node.ObjectMeta.Name, "\n")
+			printerWithHeaders.PrintObj(&pod, l.Options.Writer)
+			firstPod = false
+		} else {
+			printerNoHeaders.PrintObj(&pod, l.Options.Writer)
+		}
+	}
+	return err
+}

--- a/pkg/cmd/admin/node/node.go
+++ b/pkg/cmd/admin/node/node.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	ManageNodeCommandName = "manage-node"
+
+	manageNodeLong = `Manage node operations
+
+schedulable: Marking node schedulable will allow pods to be schedulable on the node and
+	     marking node unschedulable will block pods to be scheduled on the node.
+
+evacuate: Migrate all/selected pods. There is an option to delete the bare pods.
+          It can list all pods that will be migrated before performing evacuation.
+
+list-pods: List all/selected pods on given/selected nodes. It can list the output in json/yaml format.`
+
+	manageNodeExample = `	// Block accepting any pods on given nodes
+	$ %[1]s <mynode> --schedulable=false
+
+	// Mark selected nodes as schedulable
+	$ %[1]s --selector="<env=dev>" --schedulable=true
+
+	// Migrate selected pods
+	$ %[1]s <mynode> --evacuate --pod-selector="<service=myapp>"
+
+	// Show pods that will be migrated
+	$ %[1]s <mynode> --evacuate --dry-run --pod-selector="<service=myapp>"
+
+	// List all pods on given nodes
+	$ %[1]s <mynode1> <mynode2> --list-pods`
+)
+
+var schedulable, evacuate, listpods bool
+
+func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, out io.Writer) *cobra.Command {
+	opts := &NodeOptions{}
+	schedulableOp := &SchedulableOptions{Options: opts}
+	evacuateOp := &EvacuateOptions{Options: opts}
+	listpodsOp := &ListPodsOptions{Options: opts}
+
+	cmd := &cobra.Command{
+		Use:     commandName,
+		Short:   "Manage node operations: schedulable, evacuate, list-pods",
+		Long:    manageNodeLong,
+		Example: fmt.Sprintf(manageNodeExample, fullName),
+		Run: func(c *cobra.Command, args []string) {
+
+			if err := ValidOperation(c); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
+			}
+
+			if err := opts.Complete(f, c, args, out); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+
+			if err := opts.Validate(); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
+			}
+
+			// Cross op validations
+			if evacuateOp.DryRun && !evacuate {
+				err := errors.New("--dry-run is only applicable for --evacuate")
+				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
+			}
+
+			var err error
+			if c.Flag("schedulable").Changed {
+				schedulableOp.Schedulable = schedulable
+				err = schedulableOp.Run()
+			} else if evacuate {
+				err = evacuateOp.Run()
+			} else if listpods {
+				err = listpodsOp.Run()
+			}
+			kcmdutil.CheckErr(err)
+		},
+	}
+	flags := cmd.Flags()
+
+	// Supported operations
+	flags.BoolVar(&schedulable, "schedulable", false, "Control pod schedulability on the node.")
+	flags.BoolVar(&evacuate, "evacuate", false, "Migrate all/selected pods on the node.")
+	flags.BoolVar(&listpods, "list-pods", false, "List all/selected pods on the node. Printer flags --output, etc. are only valid for this option.")
+
+	// Common optional params
+	flags.StringVar(&opts.PodSelector, "pod-selector", "", "Label selector to filter pods on the node. Optional param for --evacuate or --list-pods")
+	flags.StringVar(&opts.Selector, "selector", "", "Label selector to filter nodes. Either pass one/more nodes as arguments or use this node selector")
+
+	// Operation specific params
+	evacuateOp.AddFlags(cmd)
+	listpodsOp.AddFlags(cmd)
+
+	return cmd
+}
+
+func ValidOperation(c *cobra.Command) error {
+	numOps := 0
+	if c.Flag("schedulable").Changed {
+		numOps++
+	}
+	if evacuate {
+		numOps++
+	}
+	if listpods {
+		numOps++
+	}
+
+	if numOps == 0 {
+		return errors.New("must provide a node operation. Supported operations: --schedulable, --evacuate and --list-pods")
+	} else if numOps != 1 {
+		return errors.New("must provide only one node operation at a time")
+	}
+	return nil
+}

--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -1,0 +1,190 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+type NodeOptions struct {
+	DefaultNamespace string
+	Kclient          *client.Client
+	Writer           io.Writer
+
+	Mapper            meta.RESTMapper
+	Typer             runtime.ObjectTyper
+	RESTClientFactory func(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	Printer           func(mapping *meta.RESTMapping, noHeaders bool) (kubectl.ResourcePrinter, error)
+
+	CmdPrinter       kubectl.ResourcePrinter
+	CmdPrinterOutput bool
+
+	NodeNames []string
+
+	// Common optional params
+	Selector    string
+	PodSelector string
+}
+
+func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string, out io.Writer) error {
+	defaultNamespace, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	_, kc, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	cmdPrinter, output, err := kcmdutil.PrinterForCommand(c)
+	if err != nil {
+		return err
+	}
+	mapper, typer := f.Object()
+
+	n.DefaultNamespace = defaultNamespace
+	n.Kclient = kc
+	n.Writer = out
+	n.Mapper = mapper
+	n.Typer = typer
+	n.RESTClientFactory = f.Factory.RESTClient
+	n.Printer = f.Printer
+	n.NodeNames = []string{}
+	n.CmdPrinter = cmdPrinter
+	n.CmdPrinterOutput = false
+
+	if output {
+		n.CmdPrinterOutput = true
+	}
+	if len(args) != 0 {
+		n.NodeNames = append(n.NodeNames, args...)
+	}
+	return nil
+}
+
+func (n *NodeOptions) Validate() error {
+	errList := []error{}
+	if len(n.Selector) > 0 {
+		if _, err := labels.Parse(n.Selector); err != nil {
+			errList = append(errList, errors.New("--selector=<node_selector> must be a valid label selector"))
+		}
+		if len(n.NodeNames) != 0 {
+			errList = append(errList, errors.New("either specify --selector=<node_selector> or nodes but not both"))
+		}
+	}
+
+	if len(n.PodSelector) > 0 {
+		if _, err := labels.Parse(n.PodSelector); err != nil {
+			errList = append(errList, errors.New("--pod-selector=<pod_selector> must be a valid label selector"))
+		}
+	}
+	return kerrors.NewAggregate(errList)
+}
+
+func (n *NodeOptions) GetNodes() ([]*kapi.Node, error) {
+	nameArgs := []string{"nodes"}
+	if len(n.NodeNames) != 0 {
+		nameArgs = append(nameArgs, n.NodeNames...)
+	}
+
+	r := resource.NewBuilder(n.Mapper, n.Typer, resource.ClientMapperFunc(n.RESTClientFactory)).
+		ContinueOnError().
+		NamespaceParam(n.DefaultNamespace).
+		SelectorParam(n.Selector).
+		ResourceTypeOrNameArgs(true, nameArgs...).
+		Flatten().
+		Do()
+	if r.Err() != nil {
+		return nil, r.Err()
+	}
+
+	errList := []error{}
+	nodeList := []*kapi.Node{}
+	_ = r.Visit(func(info *resource.Info) error {
+		node, ok := info.Object.(*kapi.Node)
+		if !ok {
+			err := fmt.Errorf("cannot convert input to Node: ", reflect.TypeOf(info.Object))
+			errList = append(errList, err)
+			// Don't bail out if one node fails
+			return nil
+		}
+		nodeList = append(nodeList, node)
+		return nil
+	})
+	if len(errList) != 0 {
+		return nodeList, kerrors.NewAggregate(errList)
+	}
+
+	if len(nodeList) == 0 {
+		return nodeList, fmt.Errorf("No nodes found")
+	} else {
+		givenNodeNames := util.NewStringSet(n.NodeNames...)
+		foundNodeNames := util.StringSet{}
+		for _, node := range nodeList {
+			foundNodeNames.Insert(node.ObjectMeta.Name)
+		}
+		skippedNodeNames := givenNodeNames.Difference(foundNodeNames)
+		if skippedNodeNames.Len() > 0 {
+			return nodeList, fmt.Errorf("Nodes %v not found", strings.Join(skippedNodeNames.List(), ", "))
+		}
+	}
+	return nodeList, nil
+}
+
+func (n *NodeOptions) GetPrintersByObject(obj runtime.Object) (kubectl.ResourcePrinter, kubectl.ResourcePrinter, error) {
+	version, kind, err := kapi.Scheme.ObjectVersionAndKind(obj)
+	if err != nil {
+		return nil, nil, err
+	}
+	return n.GetPrinters(kind, version)
+}
+
+func (n *NodeOptions) GetPrintersByResource(resource string) (kubectl.ResourcePrinter, kubectl.ResourcePrinter, error) {
+	version, kind, err := n.Mapper.VersionAndKindForResource(resource)
+	if err != nil {
+		return nil, nil, err
+	}
+	return n.GetPrinters(kind, version)
+}
+
+func (n *NodeOptions) GetPrinters(kind, version string) (kubectl.ResourcePrinter, kubectl.ResourcePrinter, error) {
+	mapping, err := n.Mapper.RESTMapping(kind, version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	printerWithHeaders, err := n.Printer(mapping, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	printerNoHeaders, err := n.Printer(mapping, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	return printerWithHeaders, printerNoHeaders, nil
+}
+
+func GetPodHostFieldLabel(apiVersion string) string {
+	switch apiVersion {
+	case "v1beta1", "v1beta2":
+		return "DesiredState.Host"
+	default:
+		return "spec.host"
+	}
+}

--- a/pkg/cmd/admin/node/schedulable.go
+++ b/pkg/cmd/admin/node/schedulable.go
@@ -1,0 +1,60 @@
+package node
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+)
+
+type SchedulableOptions struct {
+	Options *NodeOptions
+
+	Schedulable bool
+}
+
+func (s *SchedulableOptions) Run() error {
+	nodes, err := s.Options.GetNodes()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	ignoreHeaders := false
+	for _, node := range nodes {
+		err := s.RunSchedulable(node, &ignoreHeaders)
+		if err != nil {
+			// Don't bail out if one node fails
+			errList = append(errList, err)
+		}
+	}
+	if len(errList) != 0 {
+		return kerrors.NewAggregate(errList)
+	}
+	return nil
+}
+
+func (s *SchedulableOptions) RunSchedulable(node *kapi.Node, ignoreHeaders *bool) error {
+	var updatedNode *kapi.Node
+	var err error
+
+	if node.Spec.Unschedulable != !s.Schedulable {
+		node.Spec.Unschedulable = !s.Schedulable
+		updatedNode, err = s.Options.Kclient.Nodes().Update(node)
+		if err != nil {
+			return err
+		}
+	} else {
+		updatedNode = node
+	}
+
+	printerWithHeaders, printerNoHeaders, err := s.Options.GetPrintersByObject(updatedNode)
+	if err != nil {
+		return err
+	}
+	if *ignoreHeaders {
+		printerNoHeaders.PrintObj(updatedNode, s.Options.Writer)
+	} else {
+		printerWithHeaders.PrintObj(updatedNode, s.Options.Writer)
+		*ignoreHeaders = true
+	}
+	return nil
+}

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -127,9 +127,7 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 
 		version, kind, err := mapper.VersionAndKindForResource("template")
 		if mapping, err = mapper.RESTMapping(kind, version); err != nil {
-			if err != nil {
-				return err
-			}
+			return err
 		}
 	} else {
 		obj, err := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
@@ -154,9 +152,7 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 			return err
 		}
 		if mapping, err = mapper.RESTMapping(kind, version); err != nil {
-			if err != nil {
-				return err
-			}
+			return err
 		}
 	}
 


### PR DESCRIPTION
Supported node operations:
  openshift admin manage-node <nodes>|--selector=<node-selector> --schedulable=<true|false>
  openshift admin manage-node <nodes>|--selector=<node-selector> --list-pods [--pod-selector=<selector>]
  openshift admin manage-node <nodes>|--selector=<node-selector> --evacuate [--dry-run] [--force] [--pod-selector=<selector>]