### PR TITLE
Fix gofmt error for go1.4

### DIFF
--- a/pkg/cmd/cli/cmd/edit_test.go
+++ b/pkg/cmd/cli/cmd/edit_test.go
@@ -1,3 +1,1 @@
 package cmd
-
-import ()


### PR DESCRIPTION
THe empty `import()` hits gofmt error in go 1.4. I know `hack/verify-gofmt.sh` has not supported go 1.4, but it will do soon on [pull/2006](https://github.com/openshift/origin/pull/2006)