### PR TITLE
Add `osc env` command for setting and reading env

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -399,6 +399,19 @@ osc get deploymentConfigs
 osc get dc
 osc create -f test/integration/fixtures/test-deployment-config.json
 osc describe deploymentConfigs test-deployment-config
+[ "$(osc env dc/test-deployment-config --list | grep TEST=value)" ]
+[ ! "$(osc env dc/test-deployment-config TEST- --list | grep TEST=value)" ]
+[ "$(osc env dc/test-deployment-config TEST=foo --list | grep TEST=foo)" ]
+[ "$(osc env dc/test-deployment-config OTHER=foo --list | grep TEST=value)" ]
+[ ! "$(osc env dc/test-deployment-config OTHER=foo -c 'ruby' --list | grep OTHER=foo)" ]
+[ "$(osc env dc/test-deployment-config OTHER=foo -c 'ruby*'   --list | grep OTHER=foo)" ]
+[ "$(osc env dc/test-deployment-config OTHER=foo -c '*hello*' --list | grep OTHER=foo)" ]
+[ "$(osc env dc/test-deployment-config OTHER=foo -c '*world'  --list | grep OTHER=foo)" ]
+[ "$(osc env dc/test-deployment-config OTHER=foo --list | grep OTHER=foo)" ]
+[ "$(osc env dc/test-deployment-config OTHER=foo -o yaml | grep "name: OTHER")" ]
+[ "$(echo "OTHER=foo" | osc env dc/test-deployment-config -e - --list | grep OTHER=foo)" ]
+[ ! "$(echo "#OTHER=foo" | osc env dc/test-deployment-config -e - --list | grep OTHER=foo)" ]
+[ "$(osc env dc/test-deployment-config TEST=bar OTHER=baz BAR-)" ]
 osc deploy test-deployment-config
 osc delete deploymentConfigs test-deployment-config
 echo "deploymentConfigs: ok"

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -71,6 +71,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	cmds.AddCommand(cmd.NewCmdBuildLogs(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdDeploy(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdRollback(fullName, f, out))
+	cmds.AddCommand(cmd.NewCmdEnv(fullName, f, os.Stdin, out))
 	cmds.AddCommand(cmd.NewCmdGet(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdDescribe(fullName, f, out))
 	// Deprecate 'osc apply' with 'osc create' command.

--- a/pkg/cmd/cli/cmd/env.go
+++ b/pkg/cmd/cli/cmd/env.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/spf13/cobra"
+
+	//ocutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	envLong = `Update the environment on a pod
+
+Each container in a pod may have its own environment variable definitions. This command can
+add, update, or remove environment variables from containers in pods or any object that has
+a pod template (replication controllers or deployment configurations). You can specify a
+single object or multiple, and alter environment on all containers or just those that match
+a wildcard.
+
+If "--env -" is passed, environment variables can be read from STDIN using the standard env
+syntax.`
+
+	envExample = `  // Update deployment 'registry' with a new environment variable
+  $ %[1]s env dc/registry STORAGE_DIR=/local
+
+  // List the environment variables defined on a deployment 'registry'
+  $ %[1]s env dc/registry --list
+
+  // List the environment variables defined on all pods
+  $ %[1]s env pods --all --list
+
+  // Output a YAML object with updated enviroment for deployment 'registry'
+  // Does not alter the object on the server
+  $ %[1]s env dc/registry STORAGE_DIR=/local -o yaml
+
+  // Update all replication controllers in the project to have ENV=prod
+  $ %[1]s env replicationControllers --all ENV=prod
+
+  // Remove the enviroment variable ENV from a pod definition on disk and update the pod on the server
+  $ %[1]s env -f pod.json ENV-
+
+  // Set some of the local shell environment into a deployment on the server
+  $ env | grep RAILS_ | %[1]s env -e - dc/registry`
+)
+
+func NewCmdEnv(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
+	var filenames util.StringList
+	var env util.StringList
+	cmd := &cobra.Command{
+		Use:     "env RESOURCE/NAME KEY_1=VAL_1 ... KEY_N=VAL_N [options]",
+		Short:   "Update the environment on a resource with a pod template",
+		Long:    envLong,
+		Example: fmt.Sprintf(envExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := RunEnv(f, in, out, cmd, args, env, filenames)
+			if err == errExit {
+				os.Exit(1)
+			}
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringP("containers", "c", "*", "The names of containers in the selected pod templates to change - may use wildcards")
+	cmd.Flags().VarP(&env, "env", "e", "Specify key value pairs of environment variables to set into each container.")
+	cmd.Flags().Bool("list", false, "Display the environment and any changes in the standard format")
+	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
+	cmd.Flags().Bool("all", false, "select all resources in the namespace of the specified resource types")
+	cmd.Flags().VarP(&filenames, "filename", "f", "Filename, directory, or URL to file to use to edit the resource.")
+	cmd.Flags().Bool("overwrite", true, "If true, allow environment to be overwritten, otherwise reject updates that overwrite existing environment.")
+	cmd.Flags().String("resource-version", "", "If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.")
+	cmd.Flags().StringP("output", "o", "", "Display the changed objects instead of updating them. One of: json|yaml.")
+	cmd.Flags().String("output-version", "", "Output the changed objects with the given version (default api-version).")
+	return cmd
+}
+
+func updateObject(info *resource.Info, updateFn func(runtime.Object) (runtime.Object, error)) (runtime.Object, error) {
+	helper := resource.NewHelper(info.Client, info.Mapping)
+
+	obj, err := updateFn(info.Object)
+	if err != nil {
+		return nil, err
+	}
+	data, err := helper.Codec.Encode(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = helper.Update(info.Namespace, info.Name, true, data)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func validateNoOverwrites(meta *kapi.ObjectMeta, labels map[string]string) error {
+	for key := range labels {
+		if value, found := meta.Labels[key]; found {
+			return fmt.Errorf("'%s' already has a value (%s), and --overwrite is false", key, value)
+		}
+	}
+	return nil
+}
+
+func parseEnv(spec []string, defaultReader io.Reader) ([]kapi.EnvVar, []string, error) {
+	env := []kapi.EnvVar{}
+	exists := util.NewStringSet()
+	var remove []string
+	for _, envSpec := range spec {
+		switch {
+		case envSpec == "-":
+			if defaultReader == nil {
+				return nil, nil, fmt.Errorf("when '-' is used, STDIN must be open")
+			}
+			fileEnv, err := readEnv(defaultReader)
+			if err != nil {
+				return nil, nil, err
+			}
+			env = append(env, fileEnv...)
+		case strings.Index(envSpec, "=") != -1:
+			parts := strings.SplitN(envSpec, "=", 2)
+			if len(parts) != 2 {
+				return nil, nil, fmt.Errorf("invalid environment variable: %v", envSpec)
+			}
+			exists.Insert(parts[0])
+			env = append(env, kapi.EnvVar{
+				Name:  parts[0],
+				Value: parts[1],
+			})
+		case strings.HasSuffix(envSpec, "-"):
+			remove = append(remove, envSpec[:len(envSpec)-1])
+		default:
+			return nil, nil, fmt.Errorf("unknown environment variable: %v", envSpec)
+		}
+	}
+	for _, removeLabel := range remove {
+		if _, found := exists[removeLabel]; found {
+			return nil, nil, fmt.Errorf("can not both modify and remove an environment variable in the same command")
+		}
+	}
+	return env, remove, nil
+}
+
+func readEnv(r io.Reader) ([]kapi.EnvVar, error) {
+	env := []kapi.EnvVar{}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		envSpec := scanner.Text()
+		if pos := strings.Index(envSpec, "#"); pos != -1 {
+			envSpec = envSpec[:pos]
+		}
+		if strings.Index(envSpec, "=") != -1 {
+			parts := strings.SplitN(envSpec, "=", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid environment variable: %v", envSpec)
+			}
+			env = append(env, kapi.EnvVar{
+				Name:  parts[0],
+				Value: parts[1],
+			})
+		}
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return nil, err
+	}
+	return env, nil
+}
+
+func RunEnv(f *clientcmd.Factory, in io.Reader, out io.Writer, cmd *cobra.Command, args []string, envParams, filenames util.StringList) error {
+	resources, envArgs := []string{}, []string{}
+	first := true
+	for _, s := range args {
+		isEnv := strings.Contains(s, "=") || strings.HasSuffix(s, "-")
+		switch {
+		case first && isEnv:
+			first = false
+			fallthrough
+		case !first && isEnv:
+			envArgs = append(envArgs, s)
+		case first && !isEnv:
+			resources = append(resources, s)
+		case !first && !isEnv:
+			return cmdutil.UsageError(cmd, "all resources must be specified before environment changes: %s", s)
+		}
+	}
+	if len(resources) < 1 {
+		return cmdutil.UsageError(cmd, "one or more resources must be specified as <resource> <name> or <resource>/<name>")
+	}
+
+	containerMatch := cmdutil.GetFlagString(cmd, "containers")
+	list := cmdutil.GetFlagBool(cmd, "list")
+	selector := cmdutil.GetFlagString(cmd, "selector")
+	all := cmdutil.GetFlagBool(cmd, "all")
+	//overwrite := cmdutil.GetFlagBool(cmd, "overwrite")
+	resourceVersion := cmdutil.GetFlagString(cmd, "resource-version")
+	outputFormat := cmdutil.GetFlagString(cmd, "output")
+
+	if list && len(outputFormat) > 0 {
+		return cmdutil.UsageError(cmd, "--list and --output may not be specified together")
+	}
+
+	clientConfig, err := f.ClientConfig()
+	if err != nil {
+		return err
+	}
+	outputVersion := cmdutil.OutputVersion(cmd, clientConfig.Version)
+
+	cmdNamespace, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	env, remove, err := parseEnv(append(envParams, envArgs...), in)
+	if err != nil {
+		return err
+	}
+
+	mapper, typer := f.Object()
+	b := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
+		ContinueOnError().
+		NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilenameParam(filenames...).
+		SelectorParam(selector).
+		ResourceTypeOrNameArgs(all, resources...).
+		Flatten()
+
+	one := false
+	infos, err := b.Do().IntoSingular(&one).Infos()
+	if err != nil {
+		return err
+	}
+	// only apply resource version locking on a single resource
+	if !one && len(resourceVersion) > 0 {
+		return cmdutil.UsageError(cmd, "--resource-version may only be used with a single resource")
+	}
+
+	skipped := 0
+	for _, info := range infos {
+		ok, err := f.UpdatePodSpecForObject(info.Object, func(spec *kapi.PodSpec) error {
+			containers := selectContainers(spec.Containers, containerMatch)
+			if len(containers) == 0 {
+				fmt.Fprintf(cmd.Out(), "warning: %s/%s does not have any containers matching %q\n", info.Mapping.Resource, info.Name, containerMatch)
+				return nil
+			}
+			for _, c := range containers {
+				c.Env = updateEnv(c.Env, env, remove)
+
+				if list {
+					fmt.Fprintf(out, "# %s %s, container %s\n", info.Mapping.Resource, info.Name, c.Name)
+					for _, env := range c.Env {
+						// if env.ValueFrom != nil && env.ValueFrom.FieldRef != nil {
+						// 	fmt.Fprintf(cmd.Out(), "%s= # calculated from pod %s %s\n", env.Name, env.ValueFrom.FieldRef.FieldPath, env.ValueFrom.FieldRef.APIVersion)
+						// 	continue
+						// }
+						fmt.Fprintf(out, "%s=%s\n", env.Name, env.Value)
+
+					}
+				}
+			}
+			return nil
+		})
+		if !ok {
+			skipped++
+			continue
+		}
+		if err != nil {
+			fmt.Fprintf(cmd.Out(), "error: %s/%s %v\n", info.Mapping.Resource, info.Name, err)
+			continue
+		}
+	}
+	if one && skipped == len(infos) {
+		return fmt.Errorf("the %s %s is not a pod or does not have a pod template", infos[0].Mapping.Resource, infos[0].Name)
+	}
+
+	if list {
+		return nil
+	}
+
+	objects, err := resource.AsVersionedObject(infos, false, outputVersion)
+	if err != nil {
+		return err
+	}
+
+	if len(outputFormat) != 0 {
+		p, _, err := kubectl.GetPrinter(outputFormat, "")
+		if err != nil {
+			return err
+		}
+		return p.PrintObj(objects, out)
+	}
+
+	failed := false
+	for _, info := range infos {
+		data, err := info.Mapping.Codec.Encode(info.Object)
+		if err != nil {
+			fmt.Fprintf(cmd.Out(), "Error: %v\n", err)
+			failed = true
+			continue
+		}
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Update(info.Namespace, info.Name, true, data)
+		if err != nil {
+			fmt.Fprintf(cmd.Out(), "Error: %v\n", err)
+			failed = true
+			continue
+		}
+		info.Refresh(obj, true)
+		fmt.Fprintf(out, "%s/%s\n", info.Mapping.Resource, info.Name)
+	}
+	if failed {
+		return errExit
+	}
+	return nil
+}
+
+func updateEnv(existing []kapi.EnvVar, env []kapi.EnvVar, remove []string) []kapi.EnvVar {
+	out := []kapi.EnvVar{}
+	covered := util.NewStringSet(remove...)
+	for _, e := range existing {
+		if covered.Has(e.Name) {
+			continue
+		}
+		newer, ok := findEnv(env, e.Name)
+		if ok {
+			covered.Insert(e.Name)
+			out = append(out, newer)
+			continue
+		}
+		out = append(out, e)
+	}
+	for _, e := range env {
+		if covered.Has(e.Name) {
+			continue
+		}
+		covered.Insert(e.Name)
+		out = append(out, e)
+	}
+	return out
+}
+
+func findEnv(env []kapi.EnvVar, name string) (kapi.EnvVar, bool) {
+	for _, e := range env {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return kapi.EnvVar{}, false
+}
+
+func selectContainers(containers []kapi.Container, spec string) []*kapi.Container {
+	out := []*kapi.Container{}
+	for i, c := range containers {
+		if selectString(c.Name, spec) {
+			out = append(out, &containers[i])
+		}
+	}
+	return out
+}
+
+// selectString returns true if the provided string matches spec, where spec is a string with
+// a non-greedy '*' wildcard operator.
+// TODO: turn into a regex and handle greedy matches and backtracking.
+func selectString(s, spec string) bool {
+	if spec == "*" {
+		return true
+	}
+	if !strings.Contains(spec, "*") {
+		return s == spec
+	}
+
+	pos := 0
+	match := true
+	parts := strings.Split(spec, "*")
+	for i, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		next := strings.Index(s[pos:], part)
+		switch {
+		// next part not in string
+		case next < pos:
+			fallthrough
+		// first part does not match start of string
+		case i == 0 && pos != 0:
+			fallthrough
+		// last part does not exactly match remaining part of string
+		case i == (len(parts)-1) && len(s) != (len(part)+next):
+			match = false
+			break
+		default:
+			pos = next
+		}
+	}
+	return match
+}

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -52,24 +52,24 @@ type LoginOptions struct {
 }
 
 const (
-	login_long = `Logs in to the OpenShift server and saves a config file that will be used by 
-subsequent commands.
+	loginLong = `Log in to an OpenShift server and save config for future use
 
-First-time users of the OpenShift client must run this command to configure the server,
-establish a session against it, and save it to a configuration file. The default
-configuration will be in your home directory under ".config/openshift/config".
+First-time users of the OpenShift client should run this command to connect to a server,
+establish an authenticated session, and save connection to the configuration file. The
+default configuration will be saved to your home directory under
+".config/openshift/config".
 
-The information required to login, like username and password, a session token, or
-the server details, can be provided through flags. If not provided, the command will
+The information required to login -- like username and password, a session token, or
+the server details -- can be provided through flags. If not provided, the command will
 prompt for user input as needed.`
 
-	login_example = `  // Logs in interactively
+	loginExample = `  // Log in interactively
   $ %[1]s login
 
-  // Logs in to the given server with the given certificate authority file
+  // Log in to the given server with the given certificate authority file
   $ %[1]s login localhost:8443 --certificate-authority=/path/to/cert.crt
 
-  // Logs in to the given server with the given credentials (will not prompt interactively)
+  // Log in to the given server with the given credentials (will not prompt interactively)
   $ %[1]s login localhost:8443 --username=myuser --password=mypass`
 )
 
@@ -82,9 +82,9 @@ func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out 
 
 	cmds := &cobra.Command{
 		Use:     "login [URL]",
-		Short:   "Logs in and save the configuration",
-		Long:    login_long,
-		Example: fmt.Sprintf(login_example, fullName),
+		Short:   "Log in to an OpenShift server",
+		Long:    loginLong,
+		Example: fmt.Sprintf(loginExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, cmd, args); err != nil {
 				kcmdutil.CheckErr(err)

--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -26,11 +26,19 @@ type LogoutOptions struct {
 }
 
 const (
-	logout_long = `Logs out the current user by deleting the token and removing the token from the kubeconfig file.
+	logoutLong = `Log out of the active session out by clearing saved tokens
+
+An authentication token is stored in the config file after login - this command will delete
+that token on the server, and then remove the token from the configuration file.
+
+If you are using an alternative authentication method like Kerberos or client certificates,
+your ticket or client certificate will not be removed from the current system since these
+are typically managed by other programs. Instead, you can delete your config file to remove
+the local copy of that certificate or the record of your server login.
 
 After logging out, if you want to log back into the OpenShift server, try '%[1]s'.`
 
-	logout_example = `  // Logout
+	logoutExample = `  // Logout
   $ %[1]s`
 )
 
@@ -42,9 +50,9 @@ func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Fac
 
 	cmds := &cobra.Command{
 		Use:     name,
-		Short:   "Logs out the current user.",
-		Long:    fmt.Sprintf(logout_long, oscLoginFullCommand),
-		Example: fmt.Sprintf(logout_example, fullName),
+		Short:   "End the current server session",
+		Long:    fmt.Sprintf(logoutLong, oscLoginFullCommand),
+		Example: fmt.Sprintf(logoutExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, cmd, args); err != nil {
 				kcmdutil.CheckErr(err)
@@ -60,6 +68,8 @@ func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Fac
 
 		},
 	}
+
+	// TODO: support --all which performs the same logic on all users in your config file.
 
 	return cmds
 }

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -29,21 +29,19 @@ type usage interface {
 var errExit = fmt.Errorf("exit directly")
 
 const (
-	newApp_long = `Create a new application in OpenShift by specifying source code, templates, and/or images.
+	newAppLong = `Create a new application in OpenShift by specifying source code, templates, and/or images.
 
-This command will try to build up the components of an application using images, templates, 
-or code located on your system. It will lookup the images on the local Docker installation 
+This command will try to build up the components of an application using images, templates,
+or code located on your system. It will lookup the images on the local Docker installation
 (if available), a Docker registry, or an OpenShift image stream. If you specify a source
 code URL, it will set up a build that takes your source code and converts it into an
 image that can run inside of a pod. The images will be deployed via a deployment
 configuration, and a service will be hooked up to the first public port of the app.
 
 If you specify source code, you may need to run a build with 'start-build' after the
-application is created.
+application is created.`
 
-ALPHA: This command is under active development - feedback is appreciated.`
-
-	newApp_example = `  // Try to create an application based on the source code in the current directory
+	newAppExample = `  // Try to create an application based on the source code in the current directory
   $ %[1]s new-app .
 
   // Use the public Docker Hub MySQL image to create an app
@@ -67,8 +65,8 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 	cmd := &cobra.Command{
 		Use:     "new-app (IMAGE | IMAGESTREAM | TEMPLATE | PATH | URL ...)",
 		Short:   "Create a new application",
-		Long:    newApp_long,
-		Example: fmt.Sprintf(newApp_example, fullName),
+		Long:    newAppLong,
+		Example: fmt.Sprintf(newAppExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			err := RunNewApplication(f, out, c, args, config)
 			if err == errExit {

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -35,10 +35,19 @@ type ProjectOptions struct {
 }
 
 const (
-	project_long = `Switch to another project and make it the default in your configuration. If no project were 
-specified, display information about the default.`
+	projectLong = `Switch to another project and make it the default in your configuration
 
-	project_example = `  // Switch to 'myapp' project
+If no project was specified on the command line, display information about the current active
+project. Since you can use this command to connect to projects on different servers, you will
+occasionally encounter projects of the same name on different servers. When switching to that
+project, a new local context will be created that will have a unique name - for instance,
+'myapp-2'. If you have previously created a context with a different name than the project
+name, this command will accept that context name instead.
+
+For advanced configuration, or to manage the contents of your config file, use the 'config'
+command.`
+
+	projectExample = `  // Switch to 'myapp' project
   $ %[1]s myapp
 
   // Display the project currently in use
@@ -52,8 +61,8 @@ func NewCmdProject(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.
 	cmd := &cobra.Command{
 		Use:     "project [NAME]",
 		Short:   "Switch to another project",
-		Long:    project_long,
-		Example: fmt.Sprintf(project_example, fullName),
+		Long:    projectLong,
+		Example: fmt.Sprintf(projectExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			options.PathOptions = cliconfig.NewPathOptions(cmd)
 
@@ -75,7 +84,7 @@ func (o *ProjectOptions) Complete(f *clientcmd.Factory, args []string, out io.Wr
 	argsLength := len(args)
 	switch {
 	case argsLength > 1:
-		return errors.New("Only one argument is supported (project name).")
+		return errors.New("Only one argument is supported (project name or context name).")
 	case argsLength == 1:
 		o.ProjectName = args[0]
 	}

--- a/pkg/cmd/util/env.go
+++ b/pkg/cmd/util/env.go
@@ -35,7 +35,7 @@ func GetEnv(key string) (string, bool) {
 
 type Environment map[string]string
 
-var argumentEnvironment = regexp.MustCompile("^([\\w\\-]+)\\=(.*)$")
+var argumentEnvironment = regexp.MustCompile("^([\\w\\-_]+)\\=(.*)$")
 
 func IsEnvironmentArgument(s string) bool {
 	return argumentEnvironment.MatchString(s)

--- a/test/integration/fixtures/test-deployment-config.json
+++ b/test/integration/fixtures/test-deployment-config.json
@@ -29,6 +29,9 @@
                   {
                     "containerPort": 8080
                   }
+                ],
+                "env": [
+                  {"name":"TEST","value":"value"}
                 ]
               }
             ]


### PR DESCRIPTION
Allows osc users to easily add and remove environment variables
from pods, replication controllers, and deployment controllers.

Environment can be read from args, params, or STDIN. Environment
can be listed, modified in place and output, or modified in place
and sent to the server for update.

Adopts the initial "generation" pattern, which allows the input
to be decorated and then passed to a subsequent program for
further decoration.