### PR TITLE
Allow process to output a template

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -200,6 +200,7 @@ osc get templates
 osc get templates ruby-helloworld-sample
 osc process ruby-helloworld-sample
 osc describe templates ruby-helloworld-sample
+[ "$(osc describe templates ruby-helloworld-sample | grep -E "BuildConfig.*ruby-sample-build")" ]
 osc delete templates ruby-helloworld-sample
 osc get templates
 # TODO: create directly from template

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -191,9 +191,8 @@ func GetParameterByName(t *api.Template, name string) *api.Parameter {
 	return nil
 }
 
-// SubstituteParameters loops over all Environment variables defined for
-// all ReplicationController and Pod containers and substitutes all
-// Parameter expression occurrences with their corresponding values.
+// SubstituteParameters loops over all values defined in structured
+// and unstructured types that are children of item.
 //
 // Example of Parameter expression:
 //   - ${PARAMETER_NAME}


### PR DESCRIPTION
Support `--raw` and `--output=describe` on process which describe
the template as returned by the server (includes values rendered
by the template).

Fix a bug introduced by runtime.Unstructured where templates were
not properly displaying their nested Objects, and add a test to
ensure it does not break again.

@mfojtik