### PR TITLE
Only show 'None' when labels is empty

### DIFF
--- a/assets/app/views/directives/labels.html
+++ b/assets/app/views/directives/labels.html
@@ -19,7 +19,7 @@
     </osc-key-values>
   </div>
   <div ng-hide="$parent.expand">
-    <div>
+    <div ng-if="(labels | hashSize) == 0">
       <strong>None</strong>
     </div>
     <osc-key-values


### PR DESCRIPTION
Fixes #2025 

With labels defined:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7571023/c07bf6ca-f7e2-11e4-9401-4f8c543e9bd4.png)

With no labels:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7571040/d4e092c4-f7e2-11e4-9dae-9daa1787d2ce.png)