### PR TITLE
add cluster-reader role

### DIFF
--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -37,7 +37,7 @@ func TestSubjects(t *testing.T) {
 			Resource: "pods",
 		},
 		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:kube-client", "system:openshift-client", "system:openshift-deployer"),
-		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:nodes"),
+		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:nodes"),
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = newAdzePolicies()

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -24,6 +24,7 @@ const (
 	AuthenticatedGroup   = "system:authenticated"
 	UnauthenticatedGroup = "system:unauthenticated"
 	ClusterAdminGroup    = "system:cluster-admins"
+	ClusterReaderGroup   = "system:cluster-readers"
 	NodesGroup           = "system:nodes"
 	RouterGroup          = "system:routers"
 	RegistryGroup        = "system:registries"
@@ -32,6 +33,7 @@ const (
 // Roles
 const (
 	ClusterAdminRoleName      = "cluster-admin"
+	ClusterReaderRoleName     = "cluster-reader"
 	AdminRoleName             = "admin"
 	EditRoleName              = "edit"
 	ViewRoleName              = "view"
@@ -54,6 +56,7 @@ const (
 	InternalComponentRoleBindingName = InternalComponentRoleName + "s"
 	DeployerRoleBindingName          = DeployerRoleName + "s"
 	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "s"
+	ClusterReaderRoleBindingName     = ClusterReaderRoleName + "s"
 	BasicUserRoleBindingName         = BasicUserRoleName + "s"
 	DeleteTokensRoleBindingName      = DeleteTokensRoleName + "-binding"
 	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -43,6 +43,21 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: ClusterReaderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get", "list", "watch"),
+					Resources: util.NewStringSet(authorizationapi.ResourceAll),
+				},
+				{
+					Verbs:           util.NewStringSet("get"),
+					NonResourceURLs: util.NewStringSet(authorizationapi.NonResourceAll),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: AdminRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
@@ -239,6 +254,15 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 				Name: ClusterAdminRoleName,
 			},
 			Groups: util.NewStringSet(ClusterAdminGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ClusterReaderRoleBindingName,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: ClusterReaderRoleName,
+			},
+			Groups: util.NewStringSet(ClusterReaderGroup),
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{


### PR DESCRIPTION
This adds a `cluster-reader` role that has read-only rights to * in the cluster.  This is useful for setting up a cluster-root kubeconfig file with one user as reader and another context (sudo) as a cluster-admin user.  Most of the time the admin won't be risking mutation, but when they need it they can run `osc delete pods/foo --context=sudo` and be able to delete.

This is also useful for monitoring all resources in a cluster.

@jimmidyson We talked about this last week.
@liggitt thoughts?