### PR TITLE
Considering existing deployments for deployment configs

### DIFF
--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -49,9 +49,6 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 
 	configController := &DeploymentConfigController{
 		deploymentClient: &deploymentClientImpl{
-			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return factory.KubeClient.ReplicationControllers(namespace).Get(name)
-			},
 			createDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 				return factory.KubeClient.ReplicationControllers(namespace).Create(deployment)
 			},


### PR DESCRIPTION
This PR considers the existing deployments and paves the way to cancel older deployments if multiple deployments are found running for the same deployment config version.

@ironcladlou PTAL