### PR TITLE
we need to create 'docker' group on fedora 21

### DIFF
--- a/hack/vm-provision-full.sh
+++ b/hack/vm-provision-full.sh
@@ -29,6 +29,9 @@ function set_env {
 set_env /home/$USERNAME
 set_env /root
 
+# fedora removed docker group, see https://bugzilla.redhat.com/show_bug.cgi?id=1195525
+groupadd docker || echo group \"docker\" already exists
+
 systemctl enable docker
 systemctl start docker
 


### PR DESCRIPTION
for the script to work properly on fedora 21 we need to manually create `docker` group before docker service is started. See https://bugzilla.redhat.com/show_bug.cgi?id=1195525