### PR TITLE
Add support for NodeSelector - placement of router and ipfailover pods

### DIFF
--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -236,7 +236,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 							ObjectMeta: kapi.ObjectMeta{Labels: label},
 							Spec: kapi.PodSpec{
 								NodeSelector: nodeSelector,
-								Containers:   []kapi.Container{
+								Containers: []kapi.Container{
 									{
 										Name:  "router",
 										Image: image,

--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -134,6 +134,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 		glog.Fatal(err)
 	}
 
+	nodeSelector := map[string]string{}
 	label := map[string]string{"router": name}
 	if cfg.Labels != defaultLabel {
 		valid, remove, err := app.LabelsFromSpec(strings.Split(cfg.Labels, ","))
@@ -144,6 +145,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			return cmdutil.UsageError(cmd, "You may not pass negative labels in %q", cfg.Labels)
 		}
 		label = valid
+		nodeSelector = label
 	}
 
 	image := cfg.ImageTemplate.ExpandOrDie(cfg.Type)
@@ -233,7 +235,8 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 						Template: &kapi.PodTemplateSpec{
 							ObjectMeta: kapi.ObjectMeta{Labels: label},
 							Spec: kapi.PodSpec{
-								Containers: []kapi.Container{
+								NodeSelector: nodeSelector,
+								Containers:   []kapi.Container{
 									{
 										Name:  "router",
 										Image: image,

--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -63,6 +63,7 @@ type RouterConfig struct {
 	DryRun             bool
 	Credentials        string
 	DefaultCertificate string
+	Selector           string
 }
 
 var errExit = fmt.Errorf("exit")
@@ -101,6 +102,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 	cmd.Flags().Bool("create", false, "deprecated; this is now the default behavior")
 	cmd.Flags().StringVar(&cfg.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.")
 	cmd.Flags().StringVar(&cfg.DefaultCertificate, "default-cert", cfg.DefaultCertificate, "Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.")
+	cmd.Flags().StringVar(&cfg.Selector, "selector", cfg.Selector, "Selector used to filter nodes on deployment. Used to run routers on a specific set of nodes.")
 
 	cmdutil.AddPrinterFlags(cmd)
 
@@ -134,7 +136,6 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 		glog.Fatal(err)
 	}
 
-	nodeSelector := map[string]string{}
 	label := map[string]string{"router": name}
 	if cfg.Labels != defaultLabel {
 		valid, remove, err := app.LabelsFromSpec(strings.Split(cfg.Labels, ","))
@@ -145,7 +146,18 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			return cmdutil.UsageError(cmd, "You may not pass negative labels in %q", cfg.Labels)
 		}
 		label = valid
-		nodeSelector = label
+	}
+
+	nodeSelector := map[string]string{}
+	if len(cfg.Selector) > 0 {
+		valid, remove, err := app.LabelsFromSpec(strings.Split(cfg.Selector, ","))
+		if err != nil {
+			glog.Fatal(err)
+		}
+		if len(remove) > 0 {
+			return cmdutil.UsageError(cmd, "You may not pass negative labels in selector %q", cfg.Selector)
+		}
+		nodeSelector = valid
 	}
 
 	image := cfg.ImageTemplate.ExpandOrDie(cfg.Type)

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -134,6 +134,17 @@ func generateVolumeConfig() []kapi.Volume {
 	return []kapi.Volume{vol}
 }
 
+//  Generates the node selector (if any) to use.
+func generateNodeSelector(name string, selector map[string]string) map[string]string {
+	// Check if the selector is default.
+	selectorValue, ok := selector[ipfailover.DefaultName]
+	if ok && len(selector) == 1 && selectorValue == name {
+		return map[string]string{}
+	}
+
+	return selector
+}
+
 //  Generate the IP Failover deployment configuration.
 func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigCmdOptions, selector map[string]string) (*dapi.DeploymentConfig, error) {
 	containers, err := generateContainerConfig(name, options)
@@ -144,9 +155,10 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 	podTemplate := &kapi.PodTemplateSpec{
 		ObjectMeta: kapi.ObjectMeta{Labels: selector},
 		Spec: kapi.PodSpec{
-			HostNetwork: true,
-			Containers:  containers,
-			Volumes:     generateVolumeConfig(),
+			HostNetwork:  true,
+			NodeSelector: generateNodeSelector(name, selector),
+			Containers:   containers,
+			Volumes:      generateVolumeConfig(),
 		},
 	}
 

--- a/pkg/ipfailover/keepalived/generator_test.go
+++ b/pkg/ipfailover/keepalived/generator_test.go
@@ -75,7 +75,6 @@ func TestGenerateDeploymentConfig(t *testing.T) {
 		},
 	}
 
-
 	for _, tc := range tests {
 		options := makeIPFailoverConfigOptions(tc.Selector, tc.Replicas)
 		selector := makeSelector(options)

--- a/pkg/ipfailover/keepalived/generator_test.go
+++ b/pkg/ipfailover/keepalived/generator_test.go
@@ -1,0 +1,111 @@
+package keepalived
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/util/variable"
+	"github.com/openshift/origin/pkg/generate/app"
+	"github.com/openshift/origin/pkg/ipfailover"
+)
+
+func makeIPFailoverConfigOptions(selector string, replicas int) *ipfailover.IPFailoverConfigCmdOptions {
+	return &ipfailover.IPFailoverConfigCmdOptions{
+		ImageTemplate:    variable.NewDefaultImageTemplate(),
+		Selector:         selector,
+		VirtualIPs:       "",
+		WatchPort:        80,
+		NetworkInterface: "eth0",
+		Replicas:         replicas,
+	}
+
+}
+
+func makeSelector(options *ipfailover.IPFailoverConfigCmdOptions) map[string]string {
+	labels, _, err := app.LabelsFromSpec(strings.Split(options.Selector, ","))
+	if err == nil {
+		return labels
+	}
+
+	return map[string]string{}
+}
+
+func TestGenerateDeploymentConfig(t *testing.T) {
+	tests := []struct {
+		Name              string
+		Selector          string
+		Replicas          int
+		PodSelectorLength int
+	}{
+		{
+			Name:              "config-test-no-selector",
+			Selector:          "",
+			Replicas:          1,
+			PodSelectorLength: 0,
+		},
+		{
+			Name:              "config-test-default-selector",
+			Selector:          "ipfailover=config-test-default-selector",
+			Replicas:          2,
+			PodSelectorLength: 0,
+		},
+		{
+			Name:              "config-test-non-default-selector",
+			Selector:          "ipfailover=test-nodes",
+			Replicas:          3,
+			PodSelectorLength: 1,
+		},
+		{
+			Name:              "config-test-selector",
+			Selector:          "router=geo-us-west",
+			Replicas:          3,
+			PodSelectorLength: 1,
+		},
+		{
+			Name:              "config-test-ha-router-selector",
+			Selector:          "router=geo-us-west,az=us-west-1",
+			Replicas:          4,
+			PodSelectorLength: 2,
+		},
+		{
+			Name:              "config-test-multi-selector",
+			Selector:          "foo=bar,baz=none,open=sesame,ha=ha",
+			Replicas:          42,
+			PodSelectorLength: 4,
+		},
+	}
+
+
+	for _, tc := range tests {
+		options := makeIPFailoverConfigOptions(tc.Selector, tc.Replicas)
+		selector := makeSelector(options)
+		dc, err := GenerateDeploymentConfig(tc.Name, options, selector)
+		if err != nil {
+			t.Errorf("Test case for %s got an error %v where none was expected", tc.Name, err)
+		}
+		if tc.Name != dc.Name {
+			t.Errorf("Test case for %s got deployment config name %v where %v was expected", tc.Name, dc.Name, tc.Name)
+		}
+
+		controller := dc.Template.ControllerTemplate
+		if controller.Replicas != tc.Replicas {
+			t.Errorf("Test case for %s got controller replicas %v where %v was expected", tc.Name, controller.Replicas, tc.Replicas)
+		}
+
+		podSpec := controller.Template.Spec
+		if !podSpec.HostNetwork {
+			t.Errorf("Test case for %s got HostNetwork disabled where HostNetwork was expected to be enabled", tc.Name)
+		}
+
+		psLength := len(podSpec.NodeSelector)
+		if tc.PodSelectorLength != psLength {
+			t.Errorf("Test case for %s got pod spec NodeSelector length %v where %v was expected",
+				tc.Name, psLength, tc.PodSelectorLength)
+		}
+
+		volumeCount := len(podSpec.Volumes)
+		if volumeCount < 1 {
+			t.Errorf("Test case for %s got pod spec Volumes count %v where at least 1 was expected", tc.Name, volumeCount)
+		}
+	}
+}


### PR DESCRIPTION
@pweil-  PTAL   As per the comments/discussion in https://trello.com/c/Veam0Owo/680-5-router-failover-routing-beta3 this PR adds support for placement of router and ipfailover pods based on the NodeSelector.

@bmeng  FYI