### PR TITLE
Transition to Kube 1.0 DNS schema

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -51,8 +51,8 @@ function exectest() {
   echo "Running $1..."
 
   result=1
-  if [ ! -z "${VERBOSE-}" ]; then
-    out=$("${testexec}" -test.v=true -v ${VERBOSE-} -test.run="^$1$" "${@:2}" 2>&1)
+  if [ -n "${VERBOSE-}" ]; then
+    "${testexec}" -test.v -test.run="^$1$" "${@:2}" 2>&1
     result=$?
   else
     out=$("${testexec}" -test.run="^$1$" "${@:2}" 2>&1)

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -569,7 +569,6 @@ func authenticationHandlerFilter(handler http.Handler, authenticator authenticat
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		glog.V(5).Infof("user %v -> %v", user, req.URL)
 
 		ctx, ok := contextMapper.Get(req)
 		if !ok {

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -59,6 +59,7 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 	flags.Var(&args.MasterPublicAddr, prefix+"public-master", "The master address for use by public clients, if different (host, host:port, or URL). Defaults to same as --master.")
 	flags.Var(&args.EtcdAddr, prefix+"etcd", "The address of the etcd server (host, host:port, or URL). If specified, no built-in etcd will be started.")
 	flags.Var(&args.PortalNet, prefix+"portal-net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
+	flags.Var(&args.DNSBindAddr, prefix+"dns", "The address to listen for DNS requests on.")
 
 	flags.StringVar(&args.EtcdDir, prefix+"etcd-dir", "openshift.local.etcd", "The etcd data directory.")
 
@@ -74,7 +75,7 @@ func NewDefaultMasterArgs() *MasterArgs {
 		EtcdAddr:         flagtypes.Addr{Value: "0.0.0.0:4001", DefaultScheme: "https", DefaultPort: 4001}.Default(),
 		PortalNet:        flagtypes.DefaultIPNet("172.30.0.0/16"),
 		MasterPublicAddr: flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
-		DNSBindAddr:      flagtypes.Addr{Value: "0.0.0.0:53", DefaultScheme: "http", DefaultPort: 53, AllowPrefix: true}.Default(),
+		DNSBindAddr:      flagtypes.Addr{Value: "0.0.0.0:53", DefaultScheme: "tcp", DefaultPort: 53, AllowPrefix: true}.Default(),
 
 		ConfigDir: &util.StringFlag{},
 

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -68,7 +68,7 @@ func NewDefaultNodeArgs() *NodeArgs {
 
 		MasterCertDir: "openshift.local.config/master/certificates",
 
-		ClusterDomain: cmdutil.Env("OPENSHIFT_DNS_DOMAIN", "local"),
+		ClusterDomain: cmdutil.Env("OPENSHIFT_DNS_DOMAIN", "cluster.local"),
 		ClusterDNS:    dnsIP,
 
 		NetworkPluginName: "",

--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -12,8 +12,8 @@ import (
 // NewServerDefaults returns the default SkyDNS server configuration for a DNS server.
 func NewServerDefaults() (*server.Config, error) {
 	config := &server.Config{
-		Domain: "local.",
-		Local:  "openshift.default.local.",
+		Domain: "cluster.local.",
+		Local:  "openshift.default.svc.cluster.local.",
 	}
 	return config, server.SetDefaults(config)
 }
@@ -39,8 +39,11 @@ func ListenAndServe(config *server.Config, client *client.Client, etcdclient *et
 }
 
 func openshiftFallback(name string, exact bool) (string, bool) {
-	if name == "openshift.default" {
-		return "kubernetes.default.", true
+	if name == "openshift.default.svc" {
+		return "kubernetes.default.svc.", true
+	}
+	if name == "openshift.default.endpoints" {
+		return "kubernetes.default.endpoints.", true
 	}
 	return "", false
 }


### PR DESCRIPTION
Our schema will be:

    # A records for each svc (portalIP or headless)
    <service>.<namespace>.svc.cluster.local
    # A records for each endpoint (same as headless)
    <service>.<namespace>.endpoints.cluster.local

SRV records are returned correctly for unique port/name combinations.

@mfojtik be aware, this will break existing examples.