### PR TITLE
Sort projects by display name

### DIFF
--- a/assets/app/scripts/directives/nav.js
+++ b/assets/app/scripts/directives/nav.js
@@ -20,7 +20,7 @@ angular.module('openshiftConsole')
       templateUrl: "views/_sidebar-main-nav-item.html"
     };
   })
-  .directive('projectNav', function($timeout, $location, LabelFilter) {
+  .directive('projectNav', function($timeout, $location, $filter, LabelFilter) {
     return {
       restrict: 'E',
       templateUrl: 'views/_project-nav.html',
@@ -28,11 +28,13 @@ angular.module('openshiftConsole')
         var select = $('.selectpicker', element);
 
         var updateOptions = function(projects) {
-          angular.forEach(projects, function(project) {
+          var sortedProjects = $filter('orderByDisplayName')(projects);
+          // Create options from the sorted array.
+          angular.forEach(sortedProjects, function(project) {
             $('<option>')
               .attr("value", project.metadata.name)
               .attr("selected", project.metadata.name == $scope.projectName)
-              .text((project.metadata.annotations && project.metadata.annotations.displayName)|| project.metadata.name)
+              .text($filter('displayName')(project))
               .appendTo(select);
           });
           // TODO add back in when we support create project

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -39,8 +39,19 @@ angular.module('openshiftConsole')
     };
   })
   .filter('displayName', function(annotationFilter) {
-    return function(resource) {
-      return annotationFilter(resource, "displayName");
+    // annotationOnly - if true, don't fall back to using metadata.name when
+    //                  there's no displayName annotation
+    return function(resource, annotationOnly) {
+      var displayName = annotationFilter(resource, "displayName");
+      if (displayName || annotationOnly) {
+        return displayName;
+      }
+
+      if (resource && resource.metadata) {
+        return resource.metadata.name;
+      }
+
+      return null;
     };
   })
   .filter('tags', function(annotationFilter) {
@@ -235,5 +246,15 @@ angular.module('openshiftConsole')
         ref += " [" + tag + "]";
       }
       return ref;
+    };
+  })
+  .filter('orderByDisplayName', function(displayNameFilter, toArrayFilter) {
+    return function(items) {
+      var itemsArray = toArrayFilter(items);
+      itemsArray.sort(function(left, right) {
+        return displayNameFilter(left).localeCompare(displayNameFilter(right));
+      });
+
+      return itemsArray;
     };
   });

--- a/assets/app/views/projects.html
+++ b/assets/app/views/projects.html
@@ -1,6 +1,6 @@
 <div class="container">
   <h1>Projects</h1>
-  <div class="tile tile-project tile-click" style="margin-bottom: 10px;" ng-repeat="project in projects">
+  <div class="tile tile-project tile-click" style="margin-bottom: 10px;" ng-repeat="project in projects | orderByDisplayName">
     <h2 class="project">
       <a class="tile-target" href="project/{{project.metadata.name}}">{{(project | displayName) || project.metadata.name}}</a>
       <span  ng-if="project.status.phase != 'Active'" class="pficon-layered" data-toggle="tooltip" data-placement="right" title="This project has been marked for deletion." style="cursor: help; vertical-align: top; margin-left: 5px;">

--- a/assets/app/views/settings.html
+++ b/assets/app/views/settings.html
@@ -9,8 +9,8 @@
       <!-- TODO make these fields editable - probably with a cog icon that flips into inline-editing -->
       <dl class="dl-horizontal left">
         <dt>Display name:</dt>
-        <dd ng-if="project | displayName">{{project | displayName}}</dd>
-        <dd ng-if="!project | displayName"><em>No display name</em></dd>
+        <dd ng-if="project | displayName: true">{{project | displayName: true}}</dd>
+        <dd ng-if="!project | displayName: true"><em>No display name</em></dd>
         <dt>Description:</dt>
         <dd ng-if="project | description">{{project | description}}</dd>
         <dd ng-if="!(project | description)"><em>No description</em></dd>


### PR DESCRIPTION
Sort both the projects dropdown and the projects page by display name,
falling back to project name if no display name is set.

Fixes #2201

Projects dropdown:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7614197/4eee17fe-f963-11e4-90db-3c007b7c5d73.png)

Projects page:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7614215/672290a2-f963-11e4-89e9-65faff04f028.png)
