### PR TITLE
Fail build after several unsuccessfull retries

### DIFF
--- a/pkg/build/controller/factory/factory_test.go
+++ b/pkg/build/controller/factory/factory_test.go
@@ -1,0 +1,58 @@
+package factory
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	controller "github.com/openshift/origin/pkg/controller"
+)
+
+type buildUpdater struct {
+	Build *buildapi.Build
+}
+
+func (b *buildUpdater) Update(namespace string, build *buildapi.Build) error {
+	b.Build = build
+	return nil
+}
+
+func TestLimitedLogAndRetryFinish(t *testing.T) {
+	updater := &buildUpdater{}
+	err := errors.New("funky error")
+
+	now := kutil.Now()
+	retry := controller.Retry{0, kutil.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute()-31, now.Second(), now.Nanosecond(), now.Location())}
+	if limitedLogAndRetry(updater, 30*time.Minute)(&buildapi.Build{Status: buildapi.BuildStatusNew}, err, retry) {
+		t.Error("Expected no more retries after reaching timeout!")
+	}
+	if updater.Build == nil {
+		t.Fatal("BuildUpdater wasn't called!")
+	}
+	if updater.Build.Status != buildapi.BuildStatusFailed {
+		t.Errorf("Expected status %s, got %s!", buildapi.BuildStatusFailed, updater.Build.Status)
+	}
+	if !strings.Contains(updater.Build.Message, err.Error()) {
+		t.Errorf("Expected message to contain %v, got %s!", err, updater.Build.Status)
+	}
+	if updater.Build.CompletionTimestamp == nil {
+		t.Error("Expected CompletionTimestamp to be set!")
+	}
+}
+
+func TestLimitedLogAndRetryProcessing(t *testing.T) {
+	updater := &buildUpdater{}
+	err := errors.New("funky error")
+
+	now := kutil.Now()
+	retry := controller.Retry{0, kutil.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute()-10, now.Second(), now.Nanosecond(), now.Location())}
+	if !limitedLogAndRetry(updater, 30*time.Minute)(&buildapi.Build{Status: buildapi.BuildStatusNew}, err, retry) {
+		t.Error("Expected more retries!")
+	}
+	if updater.Build != nil {
+		t.Fatal("BuildUpdater shouldn't be called!")
+	}
+}

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -222,7 +222,7 @@ func TestDescribeBuildDuration(t *testing.T) {
 			},
 			"1m0s",
 		},
-		{ // 5 - build cancelled before running, start time wasn't set yet
+		{ // 6 - build cancelled before running, start time wasn't set yet
 			&buildapi.Build{
 				ObjectMeta:          kapi.ObjectMeta{CreationTimestamp: creation},
 				CompletionTimestamp: &completion,
@@ -231,7 +231,7 @@ func TestDescribeBuildDuration(t *testing.T) {
 			},
 			"waited for 2m0s",
 		},
-		{ // 5 - build cancelled while running, start time is set already
+		{ // 7 - build cancelled while running, start time is set already
 			&buildapi.Build{
 				ObjectMeta:          kapi.ObjectMeta{CreationTimestamp: creation},
 				StartTimestamp:      &start,
@@ -240,6 +240,24 @@ func TestDescribeBuildDuration(t *testing.T) {
 				Duration:            duration,
 			},
 			"1m0s",
+		},
+		{ // 8 - build failed before running, start time wasn't set yet
+			&buildapi.Build{
+				ObjectMeta:          kapi.ObjectMeta{CreationTimestamp: creation},
+				CompletionTimestamp: &completion,
+				Status:              buildapi.BuildStatusFailed,
+				Duration:            duration,
+			},
+			"waited for 2m0s",
+		},
+		{ // 9 - build error before running, start time wasn't set yet
+			&buildapi.Build{
+				ObjectMeta:          kapi.ObjectMeta{CreationTimestamp: creation},
+				CompletionTimestamp: &completion,
+				Status:              buildapi.BuildStatusError,
+				Duration:            duration,
+			},
+			"waited for 2m0s",
 		},
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -80,13 +80,10 @@ func TestQueueRetryManager_retries(t *testing.T) {
 		keyFunc: func(obj interface{}) (string, error) {
 			return obj.(testObj).id, nil
 		},
-		retryFunc: func(obj interface{}, err error, count int) bool {
-			if count > 4 {
-				return false
-			}
-			return true
+		retryFunc: func(obj interface{}, err error, r Retry) bool {
+			return r.Count < 5 && !r.StartTimestamp.IsZero()
 		},
-		retries: make(map[string]int),
+		retries: make(map[string]Retry),
 		limiter: kutil.NewTokenBucketRateLimiter(1000, 1000),
 	}
 
@@ -131,7 +128,7 @@ func TestRetryController_realFifoEventOrdering(t *testing.T) {
 
 	controller := &RetryController{
 		Queue:        fifo,
-		RetryManager: NewQueueRetryManager(fifo, keyFunc, func(_ interface{}, _ error, _ int) bool { return true }, kutil.NewTokenBucketRateLimiter(1000, 10)),
+		RetryManager: NewQueueRetryManager(fifo, keyFunc, func(_ interface{}, _ error, _ Retry) bool { return true }, kutil.NewTokenBucketRateLimiter(1000, 10)),
 		Handle: func(obj interface{}) error {
 			if e, a := 1, obj.(testObj).value; e != a {
 				t.Fatalf("expected to handle test value %d, got %d", e, a)
@@ -170,11 +167,8 @@ func TestRetryController_ratelimit(t *testing.T) {
 	limiter := &mockLimiter{}
 	retryManager := NewQueueRetryManager(fifo,
 		keyFunc,
-		func(_ interface{}, _ error, c int) bool {
-			if c < 15 {
-				return true
-			}
-			return false
+		func(_ interface{}, _ error, r Retry) bool {
+			return r.Count < 15
 		},
 		limiter,
 	)

--- a/pkg/deploy/controller/configchange/factory.go
+++ b/pkg/deploy/controller/configchange/factory.go
@@ -64,12 +64,12 @@ func (factory *DeploymentConfigChangeControllerFactory) Create() controller.Runn
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool {
+			func(obj interface{}, err error, retries controller.Retry) bool {
 				kutil.HandleError(err)
 				if _, isFatal := err.(fatalError); isFatal {
 					return false
 				}
-				if count > 0 {
+				if retries.Count > 0 {
 					return false
 				}
 				return true

--- a/pkg/deploy/controller/deployerpod/factory.go
+++ b/pkg/deploy/controller/deployerpod/factory.go
@@ -72,7 +72,7 @@ func (factory *DeployerPodControllerFactory) Create() controller.RunnableControl
 		RetryManager: controller.NewQueueRetryManager(
 			podQueue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool { return count < 1 },
+			func(obj interface{}, err error, retries controller.Retry) bool { return retries.Count < 1 },
 			kutil.NewTokenBucketRateLimiter(1, 10),
 		),
 		Handle: func(obj interface{}) error {

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -84,12 +84,12 @@ func (factory *DeploymentControllerFactory) Create() controller.RunnableControll
 		RetryManager: controller.NewQueueRetryManager(
 			deploymentQueue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool {
+			func(obj interface{}, err error, retries controller.Retry) bool {
 				if _, isFatal := err.(fatalError); isFatal {
 					kutil.HandleError(err)
 					return false
 				}
-				if count > 1 {
+				if retries.Count > 1 {
 					return false
 				}
 				return true

--- a/pkg/deploy/controller/deploymentcancellation/factory.go
+++ b/pkg/deploy/controller/deploymentcancellation/factory.go
@@ -61,7 +61,7 @@ func (factory *DeploymentCancellationControllerFactory) Create() controller.Runn
 		RetryManager: controller.NewQueueRetryManager(
 			deploymentQueue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool { return count < 1 },
+			func(obj interface{}, err error, retries controller.Retry) bool { return retries.Count < 1 },
 			kutil.NewTokenBucketRateLimiter(1, 10),
 		),
 		Handle: func(obj interface{}) error {

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -74,7 +74,7 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool {
+			func(obj interface{}, err error, retries controller.Retry) bool {
 				kutil.HandleError(err)
 				// no retries for a fatal error
 				if _, isFatal := err.(fatalError); isFatal {
@@ -85,7 +85,7 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 					return true
 				}
 				// no retries for anything else
-				if count > 0 {
+				if retries.Count > 0 {
 					return false
 				}
 				return true

--- a/pkg/deploy/controller/imagechange/factory.go
+++ b/pkg/deploy/controller/imagechange/factory.go
@@ -73,12 +73,12 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool {
+			func(obj interface{}, err error, retries controller.Retry) bool {
 				kutil.HandleError(err)
 				if _, isFatal := err.(fatalError); isFatal {
 					return false
 				}
-				if count > 0 {
+				if retries.Count > 0 {
 					return false
 				}
 				return true

--- a/pkg/image/controller/factory.go
+++ b/pkg/image/controller/factory.go
@@ -47,9 +47,9 @@ func (f *ImportControllerFactory) Create() controller.RunnableController {
 		RetryManager: controller.NewQueueRetryManager(
 			q,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool {
+			func(obj interface{}, err error, retries controller.Retry) bool {
 				util.HandleError(err)
-				return count < 5
+				return retries.Count < 5
 			},
 			kutil.NewTokenBucketRateLimiter(1, 10),
 		),

--- a/pkg/project/controller/factory.go
+++ b/pkg/project/controller/factory.go
@@ -46,12 +46,12 @@ func (factory *NamespaceControllerFactory) Create() controller.RunnableControlle
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			func(obj interface{}, err error, count int) bool {
+			func(obj interface{}, err error, retries controller.Retry) bool {
 				kutil.HandleError(err)
 				if _, isFatal := err.(fatalError); isFatal {
 					return false
 				}
-				if count > 0 {
+				if retries.Count > 0 {
 					return false
 				}
 				return true


### PR DESCRIPTION
@smarterclayton after talking to @bparees we've decided we cannot loose the requirement for output image, because we use that information for [pushing](https://github.com/openshift/origin/blob/master/pkg/build/controller/controller.go#L96-L100). Without it we'd be guessing what user actually meant. In the end we've decided to go back to initial idea where we will fail a build upon X retires (where X is 60 currently, which is ~1 minute).