### PR TITLE
update user/~ to return a user, even without an backing etcd entry

### DIFF
--- a/pkg/cmd/experimental/tokens/tokens.go
+++ b/pkg/cmd/experimental/tokens/tokens.go
@@ -1,6 +1,7 @@
 package tokens
 
 import (
+	"io"
 	"os"
 	"path"
 
@@ -13,11 +14,13 @@ import (
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
+const TokenRecommendedCommandName = "tokens"
+
 const (
 	TOKEN_FILE_PARAM = "token-file"
 )
 
-func NewCmdTokens(f *osclientcmd.Factory, parentName, name string) *cobra.Command {
+func NewCmdTokens(name, fullName string, f *osclientcmd.Factory, out io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
@@ -31,7 +34,7 @@ func NewCmdTokens(f *osclientcmd.Factory, parentName, name string) *cobra.Comman
 
 	cmds.AddCommand(NewCmdValidateToken(f))
 	cmds.AddCommand(NewCmdRequestToken(f))
-	cmds.AddCommand(NewCmdWhoAmI(f))
+	cmds.AddCommand(NewCmdWhoAmI(WhoAmIRecommendedCommandName, fullName+" "+WhoAmIRecommendedCommandName, f, out))
 
 	return cmds
 }

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -1,7 +1,6 @@
 package openshift
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -93,7 +92,7 @@ func NewCommandOpenShift() *cobra.Command {
 	root.AddCommand(admin.NewCommandAdmin("admin", "openshift admin", os.Stdout))
 	root.AddCommand(cli.NewCommandCLI("cli", "openshift cli"))
 	root.AddCommand(cli.NewCmdKubectl("kube"))
-	root.AddCommand(newExperimentalCommand("openshift", "ex"))
+	root.AddCommand(newExperimentalCommand("ex", "openshift ex"))
 	root.AddCommand(version.NewVersionCommand("openshift"))
 
 	// infra commands are those that are bundled with the binary but not displayed to end users
@@ -114,7 +113,7 @@ func NewCommandOpenShift() *cobra.Command {
 	return root
 }
 
-func newExperimentalCommand(parentName, name string) *cobra.Command {
+func newExperimentalCommand(name, fullName string) *cobra.Command {
 	experimental := &cobra.Command{
 		Use:   name,
 		Short: "Experimental commands under active development",
@@ -128,13 +127,12 @@ func newExperimentalCommand(parentName, name string) *cobra.Command {
 	f := clientcmd.New(experimental.PersistentFlags())
 	out := os.Stdout
 
-	subName := fmt.Sprintf("%s %s", parentName, name)
-	experimental.AddCommand(tokens.NewCmdTokens(f, subName, "tokens"))
-	experimental.AddCommand(exipfailover.NewCmdIPFailoverConfig(f, subName, "ipfailover", os.Stdout))
-	experimental.AddCommand(exrouter.NewCmdRouter(f, subName, "router", os.Stdout))
-	experimental.AddCommand(exregistry.NewCmdRegistry(f, subName, "registry", os.Stdout))
-	experimental.AddCommand(buildchain.NewCmdBuildChain(f, subName, "build-chain"))
-	experimental.AddCommand(bundlesecret.NewCmdBundleSecret(f, subName, "bundle-secret", os.Stdout))
+	experimental.AddCommand(tokens.NewCmdTokens(tokens.TokenRecommendedCommandName, fullName+" "+tokens.TokenRecommendedCommandName, f, out))
+	experimental.AddCommand(exipfailover.NewCmdIPFailoverConfig(f, fullName, "ipfailover", os.Stdout))
+	experimental.AddCommand(exrouter.NewCmdRouter(f, fullName, "router", os.Stdout))
+	experimental.AddCommand(exregistry.NewCmdRegistry(f, fullName, "registry", os.Stdout))
+	experimental.AddCommand(buildchain.NewCmdBuildChain(f, fullName, "build-chain"))
+	experimental.AddCommand(bundlesecret.NewCmdBundleSecret(f, fullName, "bundle-secret", os.Stdout))
 	experimental.AddCommand(cmd.NewCmdOptions(f, out))
 	return experimental
 }

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -16,6 +16,7 @@ import (
 	newproject "github.com/openshift/origin/pkg/cmd/admin/project"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
+	"github.com/openshift/origin/pkg/cmd/experimental/tokens"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/user/api"
 	testutil "github.com/openshift/origin/test/util"
@@ -43,12 +44,6 @@ func TestLogin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	// empty config, should display message
-	// loginOptions := newLoginOptions("", "", "", false)
-	// if err := loginOptions.GatherInfo(); err == nil {
-	// 	t.Errorf("Raw login should error out")
-	// }
 
 	username := "joe"
 	password := "pass"
@@ -106,6 +101,25 @@ func TestLogin(t *testing.T) {
 	// if _, err = loginOptions.SaveConfig(configFile.Name()); err != nil {
 	// 	t.Fatalf("unexpected error: %v", err)
 	// }
+
+	userWhoamiOptions := tokens.WhoAmIOptions{oClient.Users(), ioutil.Discard}
+	retrievedUser, err := userWhoamiOptions.WhoAmI()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if retrievedUser.Name != username {
+		t.Errorf("expected %v, got %v", retrievedUser.Name, username)
+	}
+
+	adminWhoamiOptions := tokens.WhoAmIOptions{clusterAdminClient.Users(), ioutil.Discard}
+	retrievedAdmin, err := adminWhoamiOptions.WhoAmI()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if retrievedAdmin.Name != "system:admin" {
+		t.Errorf("expected %v, got %v", retrievedAdmin.Name, "system:admin")
+	}
+
 }
 
 func newLoginOptions(server string, username string, password string, insecure bool) *cmd.LoginOptions {


### PR DESCRIPTION
This allows access to user/~ by users like "system:admin".

@liggitt ptal