### PR TITLE
Describe project should show quota and resource limits

### DIFF
--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -54,7 +54,7 @@ func TestDescribers(t *testing.T) {
 		&ImageStreamTagDescriber{c},
 		&ImageStreamImageDescriber{c},
 		&RouteDescriber{c},
-		&ProjectDescriber{c},
+		&ProjectDescriber{c, fakeKube},
 		&PolicyDescriber{c},
 		&PolicyBindingDescriber{c},
 		&TemplateDescriber{c, nil, nil, nil},


### PR DESCRIPTION
Update describe project to show quota and resource limits to better align with project settings page in console.

**NOTE**: alignment is not preserved when i copy into github, but things are aligned in terminal.

```shell
openshift cli describe project derek
Name:		derek
Created:	3 hours ago
Labels:		<none>
Annotations:	displayName=,openshift.io/node-selector=
Display Name:	<none>
Description:	<none>
Status:		Active
Node Selector:	<none>
Quota
	Name:			quota
	Resource		Used	Hard
	--------		----	----
	cpu			0m	10
	memory			0m	1Gi
	pods			1	5
	replicationcontrollers	1	10
	resourcequotas		1	1
	services		2	1
Resource limits:
	Name:		limits
	Type		Resource	Min	Max	Default
	----		--------	---	---	---
	Pod		cpu		250m	2	-
	Pod		memory		5Mi	1Gi	-
	Container	cpu		250m	2	250m
	Container	memory		5Mi	1Gi	5Mi
```