### PR TITLE
Namespace deployment annotations for v1beta3

### DIFF
--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -208,10 +208,7 @@ angular.module('openshiftConsole')
       angular.forEach($scope.deployments, function(deployment, depName){
         var foundMatch = false;
         var deploymentSelector = new LabelSelector(deployment.spec.selector);
-        var depConfigName = "";
-        if (deployment.metadata.annotations) {
-          depConfigName = deployment.metadata.annotations.deploymentConfig || "";
-        }
+        var depConfigName = $filter('annotation')(deployment, 'deploymentConfig') || "";
 
         angular.forEach($scope.unfilteredServices, function(service, name){
           bySvc[name] = bySvc[name] || {};
@@ -236,9 +233,10 @@ angular.module('openshiftConsole')
     };
 
     function parseEncodedDeploymentConfig(deployment) {
-      if (deployment.metadata.annotations && deployment.metadata.annotations.encodedDeploymentConfig) {
+      var configJson = $filter('annotation')(deployment, 'encodedDeploymentConfig')
+      if (configJson) {
         try {
-          var depConfig = $.parseJSON(deployment.metadata.annotations.encodedDeploymentConfig);
+          var depConfig = $.parseJSON(configJson);
           deployment.details = depConfig.details;
         }
         catch (e) {

--- a/assets/app/views/deployments.html
+++ b/assets/app/views/deployments.html
@@ -11,10 +11,10 @@
         </div>
       </div>      
       <div style="margin-bottom: 10px;" ng-repeat="deployment in deployments">
-        <h3>{{deployment.metadata.annotations.deploymentConfig}} <span class="small">({{deployment.metadata.name}})</span></h3>
+        <h3>{{deployment | annotation:'deploymentConfig'}} <span class="small">({{deployment.metadata.name}})</span></h3>
         <div>Created: <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></div>
-        <div>Status: {{deployment.metadata.annotations.deploymentStatus}}</div>
-        <div>Version: {{deployment.metadata.annotations.deploymentVersion}}</div>
+        <div>Status: {{deployment | annotation:'deploymentStatus'}}</div>
+        <div>Version: {{deployment | annotation:'deploymentVersion'}}</div>
         <div>Replicas: {{deployment.spec.replicas}}</div>
         <pod-template ng-init="podTemplate = deployment.spec.template"></pod-template>
       </div>      

--- a/pkg/api/graph/deployment.go
+++ b/pkg/api/graph/deployment.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"sort"
-	"strconv"
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/search"
@@ -11,6 +10,7 @@ import (
 
 	build "github.com/openshift/origin/pkg/build/api"
 	deploy "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	image "github.com/openshift/origin/pkg/image/api"
 )
 
@@ -348,15 +348,7 @@ type RecentDeploymentReferences []*kapi.ReplicationController
 func (m RecentDeploymentReferences) Len() int      { return len(m) }
 func (m RecentDeploymentReferences) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
 func (m RecentDeploymentReferences) Less(i, j int) bool {
-	a, err := strconv.Atoi(m[i].Annotations[deploy.DeploymentVersionAnnotation])
-	if err != nil {
-		return false
-	}
-	b, err := strconv.Atoi(m[j].Annotations[deploy.DeploymentVersionAnnotation])
-	if err != nil {
-		return true
-	}
-	return a > b
+	return deployutil.DeploymentVersionFor(m[i]) > deployutil.DeploymentVersionFor(m[j])
 }
 
 func CompareObjectMeta(a, b *kapi.ObjectMeta) bool {

--- a/pkg/api/graph/types.go
+++ b/pkg/api/graph/types.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -15,6 +14,7 @@ import (
 	build "github.com/openshift/origin/pkg/build/api"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	deploy "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	image "github.com/openshift/origin/pkg/image/api"
 )
 
@@ -402,7 +402,7 @@ func JoinDeployments(node *DeploymentConfigNode, deploys []kapi.ReplicationContr
 		return
 	}
 	sort.Sort(RecentDeploymentReferences(matches))
-	if strconv.Itoa(node.DeploymentConfig.LatestVersion) == matches[0].Annotations[deploy.DeploymentVersionAnnotation] {
+	if node.DeploymentConfig.LatestVersion == deployutil.DeploymentVersionFor(matches[0]) {
 		node.ActiveDeployment = matches[0]
 		node.Deployments = matches[1:]
 		return
@@ -422,7 +422,7 @@ func belongsToBuildConfig(config *build.BuildConfig, b *build.Build) bool {
 
 func belongsToDeploymentConfig(config *deploy.DeploymentConfig, b *kapi.ReplicationController) bool {
 	if b.Annotations != nil {
-		return config.Name == b.Annotations[deploy.DeploymentConfigAnnotation]
+		return config.Name == deployutil.DeploymentConfigNameFor(b)
 	}
 	return false
 }

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -174,7 +174,7 @@ func (c *deployLatestCommand) deploy(config *deployapi.DeploymentConfig, out io.
 		}
 	} else {
 		// Reject attempts to start a concurrent deployment.
-		status := statusFor(deployment)
+		status := deployutil.DeploymentStatusFor(deployment)
 		if status != deployapi.DeploymentStatusComplete && status != deployapi.DeploymentStatusFailed {
 			return fmt.Errorf("#%d is already in progress (%s)", config.LatestVersion, status)
 		}
@@ -206,9 +206,7 @@ func (c *retryDeploymentCommand) retry(config *deployapi.DeploymentConfig, out i
 		return err
 	}
 
-	status := statusFor(deployment)
-
-	if status != deployapi.DeploymentStatusFailed {
+	if status := deployutil.DeploymentStatusFor(deployment); status != deployapi.DeploymentStatusFailed {
 		return fmt.Errorf("#%d is %s; only failed deployments can be retried", config.LatestVersion, status)
 	}
 
@@ -218,10 +216,6 @@ func (c *retryDeploymentCommand) retry(config *deployapi.DeploymentConfig, out i
 		fmt.Fprintf(out, "retried #%d\n", config.LatestVersion)
 	}
 	return err
-}
-
-func statusFor(deployment *kapi.ReplicationController) deployapi.DeploymentStatus {
-	return deployapi.DeploymentStatus(deployment.Annotations[deployapi.DeploymentStatusAnnotation])
 }
 
 // deployCommandClientImpl is a pluggable deployCommandClient.

--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -157,7 +157,7 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 		t.Fatalf("expected updated config")
 	}
 
-	if e, a := deployapi.DeploymentStatusNew, statusFor(updatedDeployment); e != a {
+	if e, a := deployapi.DeploymentStatusNew, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
 		t.Fatalf("expected deployment status %s, got %s", e, a)
 	}
 }

--- a/pkg/cmd/cli/describe/deployments.go
+++ b/pkg/cmd/cli/describe/deployments.go
@@ -139,7 +139,7 @@ func (d *DeploymentConfigDescriber) Describe(namespace, name string) (string, er
 				formatString(out, "Latest Deployment", fmt.Sprintf("error: %v", err))
 			}
 		} else {
-			header := fmt.Sprintf("Deployment #%v (latest)", deployment.Annotations[deployapi.DeploymentVersionAnnotation])
+			header := fmt.Sprintf("Deployment #%d (latest)", deployutil.DeploymentVersionFor(deployment))
 			printDeploymentRc(deployment, d.client, out, header, true)
 		}
 		deploymentsHistory, err := d.client.listDeployments(namespace, labels.Everything())
@@ -148,8 +148,8 @@ func (d *DeploymentConfigDescriber) Describe(namespace, name string) (string, er
 			sorted = append(sorted, deploymentsHistory.Items...)
 			sort.Sort(sorted)
 			for _, item := range sorted {
-				if item.Name != deploymentName && deploymentConfig.Name == item.Annotations[deployapi.DeploymentConfigAnnotation] {
-					header := fmt.Sprintf("Deployment #%v", item.Annotations[deployapi.DeploymentVersionAnnotation])
+				if item.Name != deploymentName && deploymentConfig.Name == deployutil.DeploymentConfigNameFor(&item) {
+					header := fmt.Sprintf("Deployment #%d", deployutil.DeploymentVersionFor(&item))
 					printDeploymentRc(&item, d.client, out, header, false)
 				}
 			}
@@ -249,7 +249,7 @@ func printDeploymentRc(deployment *kapi.ReplicationController, client deployment
 	}
 	timeAt := strings.ToLower(formatRelativeTime(deployment.CreationTimestamp.Time))
 	fmt.Fprintf(w, "\tCreated:\t%s ago\n", timeAt)
-	fmt.Fprintf(w, "\tStatus:\t%s\n", deployment.Annotations[deployapi.DeploymentStatusAnnotation])
+	fmt.Fprintf(w, "\tStatus:\t%s\n", deployutil.DeploymentStatusFor(deployment))
 	fmt.Fprintf(w, "\tReplicas:\t%d current / %d desired\n", deployment.Status.Replicas, deployment.Spec.Replicas)
 
 	if verbose {

--- a/pkg/cmd/infra/deployer/deployer_test.go
+++ b/pkg/cmd/infra/deployer/deployer_test.go
@@ -158,44 +158,6 @@ func TestGetDeploymentContextWithPriorDeployments(t *testing.T) {
 	}
 }
 
-func TestGetDeploymentContextInvalidPriorDeployment(t *testing.T) {
-	getter := &testReplicationControllerGetter{
-		getFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-			deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
-			return deployment, nil
-		},
-		listFunc: func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error) {
-			return &kapi.ReplicationControllerList{
-				Items: []kapi.ReplicationController{
-					{
-						ObjectMeta: kapi.ObjectMeta{
-							Name: "corrupt-deployment",
-							Annotations: map[string]string{
-								deployapi.DeploymentConfigAnnotation:  "config",
-								deployapi.DeploymentVersionAnnotation: "junk",
-							},
-						},
-					},
-				},
-			}, nil
-		},
-	}
-
-	newDeployment, oldDeployments, err := getDeployerContext(getter, kapi.NamespaceDefault, "deployment")
-
-	if newDeployment != nil {
-		t.Fatalf("unexpected newDeployment: %#v", newDeployment)
-	}
-
-	if oldDeployments != nil {
-		t.Fatalf("unexpected oldDeployments: %#v", oldDeployments)
-	}
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
 type testReplicationControllerGetter struct {
 	getFunc  func(namespace, name string) (*kapi.ReplicationController, error)
 	listFunc func(namespace string, selector labels.Selector) (*kapi.ReplicationControllerList, error)

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -153,24 +153,24 @@ type DeploymentList struct {
 const (
 	// DeploymentConfigAnnotation is an annotation name used to correlate a deployment with the
 	// DeploymentConfig on which the deployment is based.
-	DeploymentConfigAnnotation = "deploymentConfig"
+	DeploymentConfigAnnotation = "openshift.io/deployment-config.name"
 	// DeploymentAnnotation is an annotation on a deployer Pod. The annotation value is the name
 	// of the deployment (a ReplicationController) on which the deployer Pod acts.
-	DeploymentAnnotation = "deployment"
+	DeploymentAnnotation = "openshift.io/deployment.name"
 	// DeploymentPodAnnotation is an annotation on a deployment (a ReplicationController). The
 	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
 	// to implement the deployment behavior.
-	DeploymentPodAnnotation = "pod"
-	// DeploymentStatusAnnotation is an annotation name used to retrieve the DeploymentStatus of
+	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
+	// DeploymentStatusAnnotation is an annotation name used to retrieve the DeploymentPhase of
 	// a deployment.
-	DeploymentStatusAnnotation = "deploymentStatus"
+	DeploymentStatusAnnotation = "openshift.io/deployment.phase"
 	// DeploymentEncodedConfigAnnotation is an annotation name used to retrieve specific encoded
 	// DeploymentConfig on which a given deployment is based.
-	DeploymentEncodedConfigAnnotation = "encodedDeploymentConfig"
+	DeploymentEncodedConfigAnnotation = "openshift.io/encoded-deployment-config"
 	// DeploymentVersionAnnotation is an annotation on a deployment (a ReplicationController). The
 	// annotation value is the LatestVersion value of the DeploymentConfig which was the basis for
 	// the deployment.
-	DeploymentVersionAnnotation = "deploymentVersion"
+	DeploymentVersionAnnotation = "openshift.io/deployment-config.latest-version"
 	// DeploymentLabel is the name of a label used to correlate a deployment with the Pod created
 	// to execute the deployment logic.
 	// TODO: This is a workaround for upstream's lack of annotation support on PodTemplate. Once

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -121,24 +121,24 @@ type RollingDeploymentStrategyParams struct {
 const (
 	// DeploymentConfigAnnotation is an annotation name used to correlate a deployment with the
 	// DeploymentConfig on which the deployment is based.
-	DeploymentConfigAnnotation = "deploymentConfig"
+	DeploymentConfigAnnotation = "openshift.io/deployment-config.name"
 	// DeploymentAnnotation is an annotation on a deployer Pod. The annotation value is the name
 	// of the deployment (a ReplicationController) on which the deployer Pod acts.
-	DeploymentAnnotation = "deployment"
+	DeploymentAnnotation = "openshift.io/deployment.name"
 	// DeploymentPodAnnotation is an annotation on a deployment (a ReplicationController). The
 	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
 	// to implement the deployment behavior.
-	DeploymentPodAnnotation = "pod"
+	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
 	// DeploymentPhaseAnnotation is an annotation name used to retrieve the DeploymentPhase of
 	// a deployment.
-	DeploymentPhaseAnnotation = "deploymentStatus"
+	DeploymentPhaseAnnotation = "openshift.io/deployment.phase"
 	// DeploymentEncodedConfigAnnotation is an annotation name used to retrieve specific encoded
 	// DeploymentConfig on which a given deployment is based.
-	DeploymentEncodedConfigAnnotation = "encodedDeploymentConfig"
+	DeploymentEncodedConfigAnnotation = "openshift.io/encoded-deployment-config"
 	// DeploymentVersionAnnotation is an annotation on a deployment (a ReplicationController). The
 	// annotation value is the LatestVersion value of the DeploymentConfig which was the basis for
 	// the deployment.
-	DeploymentVersionAnnotation = "deploymentVersion"
+	DeploymentVersionAnnotation = "openshift.io/deployment-config.latest-version"
 	// DeploymentLabel is the name of a label used to correlate a deployment with the Pod created
 	// to execute the deployment logic.
 	// TODO: This is a workaround for upstream's lack of annotation support on PodTemplate. Once

--- a/pkg/deploy/controller/deployerpod/controller.go
+++ b/pkg/deploy/controller/deployerpod/controller.go
@@ -23,8 +23,8 @@ type DeployerPodController struct {
 // Handle syncs pod's status with any associated deployment.
 func (c *DeployerPodController) Handle(pod *kapi.Pod) error {
 	// Verify the assumption that we'll be given only pods correlated to a deployment
-	deploymentName, hasDeploymentName := pod.Annotations[deployapi.DeploymentAnnotation]
-	if !hasDeploymentName {
+	deploymentName := deployutil.DeploymentNameFor(pod)
+	if len(deploymentName) == 0 {
 		glog.V(2).Infof("Ignoring pod %s; no deployment annotation found", pod.Name)
 		return nil
 	}
@@ -34,7 +34,7 @@ func (c *DeployerPodController) Handle(pod *kapi.Pod) error {
 		return fmt.Errorf("couldn't get deployment %s/%s associated with pod %s", pod.Namespace, deploymentName, pod.Name)
 	}
 
-	currentStatus := deployutil.StatusForDeployment(deployment)
+	currentStatus := deployutil.DeploymentStatusFor(deployment)
 	nextStatus := currentStatus
 
 	switch pod.Status.Phase {

--- a/pkg/deploy/controller/deployerpod/controller_test.go
+++ b/pkg/deploy/controller/deployerpod/controller_test.go
@@ -85,7 +85,7 @@ func TestHandle_runningPod(t *testing.T) {
 		t.Fatalf("expected deployment update")
 	}
 
-	if e, a := deployapi.DeploymentStatusRunning, deployutil.StatusForDeployment(updatedDeployment); e != a {
+	if e, a := deployapi.DeploymentStatusRunning, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
 		t.Fatalf("expected updated deployment status %s, got %s", e, a)
 	}
 }
@@ -120,7 +120,7 @@ func TestHandle_podTerminatedOk(t *testing.T) {
 		t.Fatalf("expected deployment update")
 	}
 
-	if e, a := deployapi.DeploymentStatusComplete, deployutil.StatusForDeployment(updatedDeployment); e != a {
+	if e, a := deployapi.DeploymentStatusComplete, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
 		t.Fatalf("expected updated deployment status %s, got %s", e, a)
 	}
 }
@@ -155,7 +155,7 @@ func TestHandle_podTerminatedFail(t *testing.T) {
 		t.Fatalf("expected deployment update")
 	}
 
-	if e, a := deployapi.DeploymentStatusFailed, deployutil.StatusForDeployment(updatedDeployment); e != a {
+	if e, a := deployapi.DeploymentStatusFailed, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
 		t.Fatalf("expected updated deployment status %s, got %s", e, a)
 	}
 }

--- a/pkg/deploy/controller/deployerpod/factory.go
+++ b/pkg/deploy/controller/deployerpod/factory.go
@@ -91,11 +91,11 @@ func pollPods(deploymentStore cache.Store, kClient kclient.PodsNamespacer) (cach
 	for _, obj := range deploymentStore.List() {
 		deployment := obj.(*kapi.ReplicationController)
 
-		switch deployapi.DeploymentStatus(deployment.Annotations[deployapi.DeploymentStatusAnnotation]) {
+		switch deployutil.DeploymentStatusFor(deployment) {
 		case deployapi.DeploymentStatusPending, deployapi.DeploymentStatusRunning:
 			// Validate the correlating pod annotation
-			podID, hasPodID := deployment.Annotations[deployapi.DeploymentPodAnnotation]
-			if !hasPodID {
+			podID := deployutil.DeployerPodNameFor(deployment)
+			if len(podID) == 0 {
 				glog.V(2).Infof("Unexpected state: deployment %s has no pod annotation; skipping pod polling", deployment.Name)
 				continue
 			}

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -44,7 +44,7 @@ func (e fatalError) Error() string { return "fatal error handling deployment: " 
 // Handle processes deployment and either creates a deployer pod or responds
 // to a terminal deployment status.
 func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) error {
-	currentStatus := deployutil.StatusForDeployment(deployment)
+	currentStatus := deployutil.DeploymentStatusFor(deployment)
 	nextStatus := currentStatus
 
 	switch currentStatus {
@@ -76,7 +76,7 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 		// Automatically clean up successful pods
 		// TODO: Could probably do a lookup here to skip the delete call, but it's not worth adding
 		// yet since (delete retries will only normally occur during full a re-sync).
-		podName := deployment.Annotations[deployapi.DeploymentPodAnnotation]
+		podName := deployutil.DeployerPodNameFor(deployment)
 		if err := c.podClient.deletePod(deployment.Namespace, podName); err != nil {
 			if !kerrors.IsNotFound(err) {
 				return fmt.Errorf("couldn't delete completed deployer pod %s/%s for deployment %s: %v", deployment.Namespace, podName, deployutil.LabelForDeployment(deployment), err)

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -71,7 +71,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 		return fmt.Errorf("couldn't list deployments for config %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 	for _, deployment := range existingDeployments.Items {
-		deploymentStatus := deployutil.StatusForDeployment(&deployment)
+		deploymentStatus := deployutil.DeploymentStatusFor(&deployment)
 		switch deploymentStatus {
 		case deployapi.DeploymentStatusFailed,
 			deployapi.DeploymentStatusComplete:

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -2,7 +2,6 @@ package rolling
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -14,7 +13,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 
-	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/strategy"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -158,17 +156,10 @@ func (s *RollingDeploymentStrategy) findLatestDeployment(oldDeployments []*kapi.
 	var latest *kapi.ReplicationController
 	latestVersion := 0
 	for _, deployment := range oldDeployments {
-		if val, hasVersion := deployment.Annotations[deployapi.DeploymentVersionAnnotation]; hasVersion {
-			version, err := strconv.Atoi(val)
-			if err != nil {
-				return nil, fmt.Errorf("deployment %s/%s has invalid version annotation value '%s': %v", deployment.Namespace, deployment.Name, val, err)
-			}
-			if version > latestVersion {
-				latest = deployment
-				latestVersion = version
-			}
-		} else {
-			glog.Infof("Ignoring deployment with missing version annotation: %s/%s", deployment.Namespace, deployment.Name)
+		version := deployutil.DeploymentVersionFor(deployment)
+		if version > latestVersion {
+			latest = deployment
+			latestVersion = version
 		}
 	}
 	if latest != nil {

--- a/pkg/deploy/strategy/rolling/rolling_test.go
+++ b/pkg/deploy/strategy/rolling/rolling_test.go
@@ -142,10 +142,6 @@ func TestRolling_findLatestDeployment(t *testing.T) {
 		deployments[deployment.Name] = deployment
 	}
 
-	ignoredDeployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(12), kapi.Codec)
-	delete(ignoredDeployment.Annotations, deployapi.DeploymentVersionAnnotation)
-	deployments[ignoredDeployment.Name] = ignoredDeployment
-
 	strategy := &RollingDeploymentStrategy{
 		codec: api.Codec,
 		client: &rollingUpdaterClient{
@@ -178,7 +174,6 @@ func TestRolling_findLatestDeployment(t *testing.T) {
 				"config-3",
 				"config-1",
 				"config-7",
-				ignoredDeployment.Name,
 			},
 			latest: "config-7",
 		},
@@ -203,24 +198,6 @@ func TestRolling_findLatestDeployment(t *testing.T) {
 		if e, a := scenario.latest, found.Name; e != a {
 			t.Errorf("expected latest %s, got %s for scenario: %v", e, a, scenario)
 		}
-	}
-}
-
-func TestRolling_findLatestDeploymentInvalidDeployment(t *testing.T) {
-	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
-	deployment.Annotations[deployapi.DeploymentVersionAnnotation] = ""
-
-	strategy := &RollingDeploymentStrategy{
-		codec: api.Codec,
-		client: &rollingUpdaterClient{
-			GetReplicationControllerFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return deployment, nil
-			},
-		},
-	}
-	_, err := strategy.findLatestDeployment([]*kapi.ReplicationController{deployment})
-	if err == nil {
-		t.Errorf("expected an error")
 	}
 }
 

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -108,7 +108,7 @@ func TestMakeDeploymentOk(t *testing.T) {
 		}
 	}
 
-	if len(deployment.Annotations[deployapi.DeploymentEncodedConfigAnnotation]) == 0 {
+	if len(EncodedDeploymentConfigFor(deployment)) == 0 {
 		t.Fatalf("expected deployment with DeploymentEncodedConfigAnnotation annotation")
 	}
 

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -35,6 +35,7 @@ import (
 	deployconfiggenerator "github.com/openshift/origin/pkg/deploy/generator"
 	deployconfigregistry "github.com/openshift/origin/pkg/deploy/registry/deployconfig"
 	deployetcd "github.com/openshift/origin/pkg/deploy/registry/etcd"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	imageetcd "github.com/openshift/origin/pkg/image/registry/image/etcd"
@@ -97,10 +98,10 @@ func TestTriggers_manual(t *testing.T) {
 	}
 	deployment := event.Object.(*kapi.ReplicationController)
 
-	if e, a := config.Name, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
+	if e, a := config.Name, deployutil.DeploymentConfigNameFor(deployment); e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
-	if e, a := "1", deployment.Annotations[deployapi.DeploymentVersionAnnotation]; e != a {
+	if e, a := 1, deployutil.DeploymentVersionFor(deployment); e != a {
 		t.Fatalf("Deployment annotation version does not match: %#v", deployment)
 	}
 }
@@ -201,7 +202,7 @@ waitForNewRC:
 		}
 	}
 
-	if e, a := config.Name, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
+	if e, a := config.Name, deployutil.DeploymentConfigNameFor(deployment); e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
 
@@ -217,7 +218,7 @@ waitForPendingStatus:
 			}
 		}
 	}
-	if e, a := string(deployapi.DeploymentStatusPending), deployment.Annotations[deployapi.DeploymentStatusAnnotation]; e != a {
+	if e, a := deployapi.DeploymentStatusPending, deployutil.DeploymentStatusFor(deployment); e != a {
 		t.Fatalf("expected deployment status %q, got %q", e, a)
 	}
 
@@ -287,7 +288,7 @@ func TestTriggers_configChange(t *testing.T) {
 
 	deployment := event.Object.(*kapi.ReplicationController)
 
-	if e, a := config.Name, deployment.Annotations[deployapi.DeploymentConfigAnnotation]; e != a {
+	if e, a := config.Name, deployutil.DeploymentConfigNameFor(deployment); e != a {
 		t.Fatalf("Expected deployment annotated with deploymentConfig '%s', got '%s'", e, a)
 	}
 


### PR DESCRIPTION
Refactor deployment annotations in v1beta3 to be namespaced. Normalize
all access to annotations through utility functions which support all
former key names.

This is part of https://github.com/openshift/origin/issues/2169.