### PR TITLE
Fix conversion of output.DockerImageReference on v1beta3 builds

### DIFF
--- a/pkg/build/api/v1beta3/conversion.go
+++ b/pkg/build/api/v1beta3/conversion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kapi_v1beta3 "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 
 	newer "github.com/openshift/origin/pkg/build/api"
@@ -201,6 +202,13 @@ func init() {
 			if in.To != nil && (len(in.To.Kind) == 0 || in.To.Kind == "ImageStream") {
 				out.To.Kind = "ImageStreamTag"
 				out.To.Name = imageapi.JoinImageStreamTag(in.To.Name, in.Tag)
+				return nil
+			}
+			if len(in.DockerImageReference) != 0 {
+				out.To = &kapi_v1beta3.ObjectReference{
+					Kind: "DockerImage",
+					Name: in.DockerImageReference,
+				}
 			}
 			return nil
 		},
@@ -216,6 +224,11 @@ func init() {
 				out.To.Kind = "ImageStream"
 				out.To.Name = name
 				out.Tag = tag
+				return nil
+			}
+			if in.To != nil && in.To.Kind == "DockerImage" {
+				out.To = nil
+				out.DockerImageReference = in.To.Name
 			}
 			return nil
 		},

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -242,8 +242,8 @@ type STIBuildStrategy struct {
 type BuildOutput struct {
 	// To defines an optional ImageStream to push the output of this build to. The namespace
 	// may be empty, in which case the ImageStream will be looked for in the namespace of
-	// the build. Kind must be set to 'ImageStream' and is the only supported value. This
-	// value will be used to look up a Docker image repository to push to.
+	// the build. Kind must be one of 'ImageStreamImage', 'ImageStreamTag' or 'DockerImage'.
+	// This value will be used to look up a Docker image repository to push to.
 	To *kapi.ObjectReference `json:"to,omitempty"`
 
 	// pushSecretName is the name of a Secret that would be used for setting


### PR DESCRIPTION
Converts an output.DockerImageReference in the internal API to an object reference with Kind of "DockerImage" in the v1beta3 API.