### PR TITLE
fix vagrant-fedora21 networking issue; update openshift-sdn version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1058,11 +1058,11 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/ovssubnet",
-			"Rev": "83026250e430a37f9a2c17a0bdecd6e36383c753"
+			"Rev": "3ba813b579ee95a86599ba0896f2d470d7702a19"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/api",
-			"Rev": "83026250e430a37f9a2c17a0bdecd6e36383c753"
+			"Rev": "3ba813b579ee95a86599ba0896f2d470d7702a19"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/common.go
@@ -52,7 +52,16 @@ func NewController(sub api.SubnetRegistry, hostname string, selfIP string) (*Ovs
 			log.Errorf("Failed to lookup IP Address for %s", hostname)
 			return nil, err
 		}
-		selfIP = addrs[0].String()
+		for _, addr := range addrs {
+			if addr.String() != "127.0.0.1" {
+				selfIP = addr.String()
+				break
+			}
+		}
+		if selfIP == "" {
+			log.Errorf("Failed to lookup valid IP Address for %s (%v)", hostname, addrs)
+			return nil, err
+		}
 	}
 	log.Infof("Self IP: %s.", selfIP)
 	return &OvsController{

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -5,6 +5,11 @@ source $(dirname $0)/provision-config.sh
 
 OPENSHIFT_SDN=$4
 
+NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
+sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+
+systemctl restart network
+
 # Setup hosts file to support ping by hostname to each minion in the cluster from apiserver
 node_list=""
 minion_ip_array=(${MINION_IPS//,/ })


### PR DESCRIPTION
openshift-sdn Godep updated to reflect this fix:
https://github.com/openshift/openshift-sdn/pull/68

The above issue addresses the problem when /etc/hosts of a node has a 127.0.0.1 entry against the hostname also.