### PR TITLE
UPSTREAM: Continue on errors in kubectl

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -46,62 +46,116 @@ type debugError interface {
 	DebugError() (msg string, args []interface{})
 }
 
+// CheckErr prints a user friendly error to STDERR and exits with a non-zero
+// exit code. Unrecognized errors will be printed with an "error: " prefix.
+//
+// This method is generic to the command in use and may be used by non-Kubectl
+// commands.
 func CheckErr(err error) {
-	if err != nil {
-		if debugErr, ok := err.(debugError); ok {
-			glog.V(4).Infof(debugErr.DebugError())
-		}
-		_, isStatus := err.(client.APIStatus)
-		switch {
-		case clientcmd.IsConfigurationInvalid(err):
-			fatal(MultilineError("Error in configuration: ", err))
-		case isStatus:
-			fatal(fmt.Sprintf("Error from server: %s", err.Error()))
-		case errors.IsUnexpectedObjectError(err):
-			fatal(fmt.Sprintf("Server returned an unexpected response: %s", err.Error()))
-		}
-		switch t := err.(type) {
-		case *url.Error:
-			glog.V(4).Infof("Connection error: %s %s: %v", t.Op, t.URL, t.Err)
-			switch {
-			case strings.Contains(t.Err.Error(), "connection refused"):
-				host := t.URL
-				if server, err := url.Parse(t.URL); err == nil {
-					host = server.Host
-				}
-				fatal(fmt.Sprintf("The connection to the server %s was refused - did you specify the right host or port?", host))
-			}
-			fatal(fmt.Sprintf("Unable to connect to the server: %v", t.Err))
-		}
-		fatal(fmt.Sprintf("Error: %s", err.Error()))
+	if err == nil {
+		return
 	}
+
+	// handle multiline errors
+	if clientcmd.IsConfigurationInvalid(err) {
+		fatal(MultilineError("Error in configuration: ", err))
+	}
+	if agg, ok := err.(utilerrors.Aggregate); ok && len(agg.Errors()) > 0 {
+		fatal(MultipleErrors("", agg.Errors()))
+	}
+
+	msg, ok := StandardErrorMessage(err)
+	if !ok {
+		msg = fmt.Sprintf("error: %s\n", err.Error())
+	}
+	fatal(msg)
 }
 
+// StandardErrorMessage translates common errors into a human readable message, or returns
+// false if the error is not one of the recognized types. It may also log extended
+// information to glog.
+//
+// This method is generic to the command in use and may be used by non-Kubectl
+// commands.
+func StandardErrorMessage(err error) (string, bool) {
+	if debugErr, ok := err.(debugError); ok {
+		glog.V(4).Infof(debugErr.DebugError())
+	}
+	_, isStatus := err.(client.APIStatus)
+	switch {
+	case isStatus:
+		return fmt.Sprintf("Error from server: %s", err.Error()), true
+	case errors.IsUnexpectedObjectError(err):
+		return fmt.Sprintf("Server returned an unexpected response: %s", err.Error()), true
+	}
+	switch t := err.(type) {
+	case *url.Error:
+		glog.V(4).Infof("Connection error: %s %s: %v", t.Op, t.URL, t.Err)
+		switch {
+		case strings.Contains(t.Err.Error(), "connection refused"):
+			host := t.URL
+			if server, err := url.Parse(t.URL); err == nil {
+				host = server.Host
+			}
+			return fmt.Sprintf("The connection to the server %s was refused - did you specify the right host or port?", host), true
+		}
+		return fmt.Sprintf("Unable to connect to the server: %v", t.Err), true
+	}
+	return "", false
+}
+
+// MultilineError returns a string representing an error that splits sub errors into their own
+// lines. The returned string will end with a newline.
 func MultilineError(prefix string, err error) string {
 	if agg, ok := err.(utilerrors.Aggregate); ok {
-		errs := agg.Errors()
+		errs := utilerrors.Flatten(agg).Errors()
 		buf := &bytes.Buffer{}
 		switch len(errs) {
 		case 0:
-			return fmt.Sprintf("%s%v", prefix, err)
+			return fmt.Sprintf("%s%v\n", prefix, err)
 		case 1:
-			return fmt.Sprintf("%s%v", prefix, errs[0])
+			msg, ok := StandardErrorMessage(errs[0])
+			if !ok {
+				msg = errs[0].Error()
+			}
+			return fmt.Sprintf("%s%v\n", prefix, msg)
 		default:
 			fmt.Fprintln(buf, prefix)
 			for _, err := range errs {
-				fmt.Fprintf(buf, "* %v\n", err)
+				msg, ok := StandardErrorMessage(err)
+				if !ok {
+					msg = err.Error()
+				}
+				fmt.Fprintf(buf, "* %v\n", msg)
 			}
 			return buf.String()
 		}
 	}
-	return fmt.Sprintf("%s%s", prefix, err)
+	return fmt.Sprintf("%s%s\n", prefix, err)
 }
 
+// MultipleErrors returns a newline delimited string containing
+// the prefix and referenced errors in standard form.
+func MultipleErrors(prefix string, errs []error) string {
+	buf := &bytes.Buffer{}
+	for _, err := range errs {
+		msg, ok := StandardErrorMessage(err)
+		if !ok {
+			msg = err.Error()
+		}
+		fmt.Fprintf(buf, "%s%v\n", prefix, msg)
+	}
+	return buf.String()
+}
+
+// fatal prints the message and then exits. If V(2) or greater, glog.Fatal
+// is invoked for extended information. The provided msg should end in a
+// newline.
 func fatal(msg string) {
 	if glog.V(2) {
 		glog.FatalDepth(2, msg)
 	}
-	fmt.Fprintln(os.Stderr, msg)
+	fmt.Fprint(os.Stderr, msg)
 	os.Exit(1)
 }
 

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/builder.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/builder.go
@@ -614,6 +614,9 @@ func (b *Builder) Do() *Result {
 		helpers = append(helpers, RetrieveLazy)
 	}
 	r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
+	if b.continueOnError {
+		r.visitor = ContinueOnErrorVisitor{r.visitor}
+	}
 	return r
 }
 

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
@@ -350,6 +350,22 @@ func (v DecoratedVisitor) Visit(fn VisitorFunc) error {
 	})
 }
 
+type ContinueOnErrorVisitor struct {
+	Visitor
+}
+
+func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
+	errs := []error{}
+	err := v.Visitor.Visit(func(info *Info) error {
+		if err := fn(info); err != nil {
+			errs = append(errs, err)
+		}
+		return nil
+	})
+	errs = append(errs, err)
+	return errors.NewAggregate(errs)
+}
+
 // FlattenListVisitor flattens any objects that runtime.ExtractList recognizes as a list
 // - has an "Items" public field that is a slice of runtime.Objects or objects satisfying
 // that interface - into multiple Infos. An error on any sub item (for instance, if a List


### PR DESCRIPTION
When ContinueOnError() is present on resource.Builder,
we should *actually* continue on error in all cases.

Also improves generic errors and makes the cmd/util.CheckErr
function more reusable.