### PR TITLE
Bug 1218971: Persist existing imageStream name in buildCofig

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -187,7 +187,7 @@ func (r *ImageRef) ObjectReference() *kapi.ObjectReference {
 	if r.Stream != nil {
 		return &kapi.ObjectReference{
 			Kind: "ImageStreamTag",
-			Name: r.Name + ":" + r.Tag,
+			Name: r.Stream.Name + ":" + r.Tag,
 		}
 	}
 	return &kapi.ObjectReference{


### PR DESCRIPTION
When new-app re-uses imageStreams it should persist their names in the generated buildConfig.

Before:
```
[vagrant@openshiftdev sample-app]$ osc create  -f  ../image-streams/image-streams-centos7.json
imageStreams/ruby
imageStreams/nodejs
imageStreams/perl
imageStreams/php
imageStreams/python
imageStreams/wildfly
imageStreams/mysql
imageStreams/postgresql
imageStreams/mongodb

[vagrant@openshiftdev sample-app]$ osc new-app --image=ruby git://github.com/openshift/ruby-hello-world -l app=testapp --loglevel=4
I0514 09:40:10.647225   12969 imagelookup.go:265] checking image stream test/ruby with ref ""
I0514 09:40:10.684900   12969 newapp.go:187] Image "test/ruby" is a builder, so a repository will be expected unless you also specify --build=docker
I0514 09:40:10.685142   12969 newapp.go:230] Using "git://github.com/openshift/ruby-hello-world" as the source for build
I0514 09:40:10.685283   12969 newapp.go:441] Code [git://github.com/openshift/ruby-hello-world]
I0514 09:40:10.685312   12969 newapp.go:442] Components test/ruby
I0514 09:40:10.685868   12969 newapp.go:327] found group: app.ComponentReferences{(*app.ComponentInput)(0xc20843c720)}
I0514 09:40:10.686206   12969 newapp.go:335] will use "test/ruby" as the base image for a source build of "git://github.com/openshift/ruby-hello-world"
imageStreams/ruby-hello-world
buildConfigs/ruby-hello-world
I0514 09:40:10.775436   12969 defaults.go:202] creating security context for container ruby-hello-world
I0514 09:40:10.775466   12969 defaults.go:207] downward merge of container.Capabilities for container ruby-hello-world
I0514 09:40:10.775475   12969 defaults.go:226] downward merge of container.Privileged for container ruby-hello-world
deploymentConfigs/ruby-hello-world
services/ruby-hello-world
A build was created - you can run `osc start-build ruby-hello-world` to start it.
Service "ruby-hello-world" created at 172.30.20.221 with port mappings 8080.

[vagrant@openshiftdev sample-app]$ osc start-build ruby-hello-world --loglevel=5
I0514 09:52:30.499491   13018 helpers.go:52] server response object: [{
  "metadata": {},
  "status": "Failure",
  "message": "imageStream \"ruby-20-centos7\" not found",
  "reason": "NotFound",
  "details": {
    "id": "ruby-20-centos7",
    "kind": "imageStream"
  },
  "code": 404
}]
F0514 09:52:30.500855   13018 startbuild.go:57] Error from server: imageStream "ruby-20-centos7" not found

[vagrant@openshiftdev sample-app]$ osc get is ruby -o json
{
    "kind": "ImageStream",
    "apiVersion": "v1beta3",
    "metadata": {
        "name": "ruby",
        "namespace": "test",
        "selfLink": "/osapi/v1beta3/namespaces/test/imagestreams/ruby",
        "uid": "2f26c60b-fa1d-11e4-ba32-080027c5bfa9",
        "resourceVersion": "1405",
        "creationTimestamp": "2015-05-14T09:39:58Z",
        "annotations": {
            "openshift.io/image.dockerRepositoryCheck": "2015-05-14T09:40:18Z"
        }
    },
    "spec": {
        "dockerImageRepository": "openshift/ruby-20-centos7",
        "tags": [
            {
                "name": "latest",
                "annotations": {
                    "description": "Build and run Ruby 2.0 applications",
                    "iconClass": "icon-ruby",
                    "tags": "builder,ruby",
                    "version": "2.0"
                }
            }
        ]
    },
    "status": {
        "dockerImageRepository": "openshift/ruby-20-centos7",
        "tags": [
            {
                "tag": "latest",
                "items": [
                    {
                        "created": "2015-05-14T09:39:59Z",
                        "dockerImageReference": "openshift/ruby-20-centos7:latest",
                        "image": "36d4b5fa0a14210bcea66cc9f100482c2e4589ceaa60fedb03e680e3b47ca4a6"
                    }
                ]
            },
            {
                "tag": "v0.4",
                "items": [
                    {
                        "created": "2015-05-14T09:40:00Z",
                        "dockerImageReference": "openshift/ruby-20-centos7:v0.4",
                        "image": "c7dbf059225847a7bfb4f40bc335ad7e70defc913de1a28aabea3a2072844a3f"
                    }
                ]
            }
        ]
    }
}

[vagrant@openshiftdev sample-app]$ osc describe bc ruby-hello-world
Name:			ruby-hello-world
Created:		14 minutes ago
Labels:			app=testapp
Latest Version:		2
Strategy:		STI
Image Reference:	ImageStreamTag ruby-20-centos7:latest
Source Type:		Git
URL:			git://github.com/openshift/ruby-hello-world
Output to:		ruby-hello-world:latest
Output Spec:		<none>
Webhook Generic:	https://localhost:8443/osapi/v1beta3/namespaces/test/buildconfigs/ruby-hello-world/webhooks/H06rQ-e2McVqrRM1V-Xi/generic
Webhook Github:		https://localhost:8443/osapi/v1beta3/namespaces/test/buildconfigs/ruby-hello-world/webhooks/YzEJJ_S-dxxGnQq3rN0j/github
```

Now:
```
[vagrant@openshiftdev sample-app]$ osc describe bc ruby-hello-world
Name:			ruby-hello-world
Created:		18 seconds ago
Labels:			app=testapp
Latest Version:		Never built
Strategy:		STI
Image Reference:	ImageStreamTag ruby:latest
Source Type:		Git
URL:			git://github.com/openshift/ruby-hello-world
Output to:		ruby-hello-world:latest
Output Spec:		<none>
Webhook Github:		https://localhost:8443/osapi/v1beta3/namespaces/test/buildconfigs/ruby-hello-world/webhooks/ApZdXSR4DhUHAksQEQMC/github
Webhook Generic:	https://localhost:8443/osapi/v1beta3/namespaces/test/buildconfigs/ruby-hello-world/webhooks/tlI6YOkW8O3R-1AVn-AV/generic

[vagrant@openshiftdev sample-app]$ osc start-build ruby-hello-world
ruby-hello-world-1
```

cc: @smarterclayton 