### PR TITLE
in new-app flow: Fix where to get the port for the service

### DIFF
--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -172,7 +172,7 @@ angular.module("openshiftConsole")
         }
       });
 
-      ifResourcesDontExist(resources, $scope.namespace, $scope).then(
+      ifResourcesDontExist(resources, $scope.projectName, $scope).then(
           createResources,
           elseShowWarning
         );


### PR DESCRIPTION
@bparees @csrwng @smarterclayton Please review.  Updated to skip service generation if no exposed port and the location of where to find the port to use for the service.  Also found a bug in the logic where it was checking the wrong namespace to see if the resources already existed.

/cc @sspeiche 