### PR TITLE
update sdn types to work nicely in v1beta3 and osc

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -144,6 +144,9 @@ func init() {
 		"ClusterRoleBinding":   true,
 		"ClusterPolicy":        true,
 		"ClusterPolicyBinding": true,
+
+		"ClusterNetwork": true,
+		"HostSubnet":     true,
 	}
 
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address our resources

--- a/pkg/client/clusternetwork.go
+++ b/pkg/client/clusternetwork.go
@@ -32,13 +32,13 @@ func newClusterNetwork(c *Client) *clusterNetwork {
 // Get returns information about a particular network
 func (c *clusterNetwork) Get(networkName string) (result *sdnapi.ClusterNetwork, err error) {
 	result = &sdnapi.ClusterNetwork{}
-	err = c.r.Get().Resource("clusterNetwork").Name(networkName).Do().Into(result)
+	err = c.r.Get().Resource("clusterNetworks").Name(networkName).Do().Into(result)
 	return
 }
 
 // Create creates a new ClusterNetwork. Returns the server's representation of ClusterNetwork and error if one occurs.
 func (c *clusterNetwork) Create(cn *sdnapi.ClusterNetwork) (result *sdnapi.ClusterNetwork, err error) {
 	result = &sdnapi.ClusterNetwork{}
-	err = c.r.Post().Resource("clusterNetwork").Body(cn).Do().Into(result)
+	err = c.r.Post().Resource("clusterNetworks").Body(cn).Do().Into(result)
 	return
 }

--- a/pkg/client/hostsubnets.go
+++ b/pkg/client/hostsubnets.go
@@ -38,7 +38,7 @@ func newHostSubnet(c *Client) *hostSubnet {
 func (c *hostSubnet) List() (result *sdnapi.HostSubnetList, err error) {
 	result = &sdnapi.HostSubnetList{}
 	err = c.r.Get().
-		Resource("hostSubnet").
+		Resource("hostSubnets").
 		Do().
 		Into(result)
 	return
@@ -47,27 +47,27 @@ func (c *hostSubnet) List() (result *sdnapi.HostSubnetList, err error) {
 // Get returns information about a particular user or an error
 func (c *hostSubnet) Get(hostName string) (result *sdnapi.HostSubnet, err error) {
 	result = &sdnapi.HostSubnet{}
-	err = c.r.Get().Resource("hostSubnet").Name(hostName).Do().Into(result)
+	err = c.r.Get().Resource("hostSubnets").Name(hostName).Do().Into(result)
 	return
 }
 
 // Create creates a new user. Returns the server's representation of the user and error if one occurs.
 func (c *hostSubnet) Create(hostSubnet *sdnapi.HostSubnet) (result *sdnapi.HostSubnet, err error) {
 	result = &sdnapi.HostSubnet{}
-	err = c.r.Post().Resource("hostSubnet").Body(hostSubnet).Do().Into(result)
+	err = c.r.Post().Resource("hostSubnets").Body(hostSubnet).Do().Into(result)
 	return
 }
 
 // Delete takes the name of the host, and returns an error if one occurs during deletion of the subnet
 func (c *hostSubnet) Delete(name string) error {
-	return c.r.Delete().Resource("hostSubnet").Name(name).Do().Error()
+	return c.r.Delete().Resource("hostSubnets").Name(name).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested subnets
 func (c *hostSubnet) Watch(resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
-		Resource("hostSubnet").
+		Resource("hostSubnets").
 		Param("resourceVersion", resourceVersion).
 		Watch()
 }

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -20,6 +20,7 @@ import (
 	oauthapi "github.com/openshift/origin/pkg/oauth/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	routeapi "github.com/openshift/origin/pkg/route/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
@@ -50,6 +51,9 @@ var (
 
 	// known custom role extensions
 	IsPersonalSubjectAccessReviewColumns = []string{"NAME"}
+
+	hostSubnetColumns     = []string{"NAME", "HOST", "HOST IP", "SUBNET"}
+	clusterNetworkColumns = []string{"NAME", "NETWORK", "HOST SUBNET LENGTH"}
 )
 
 // NewHumanReadablePrinter returns a new HumanReadablePrinter
@@ -113,6 +117,12 @@ func NewHumanReadablePrinter(noHeaders bool) *kctl.HumanReadablePrinter {
 	p.Handler(userIdentityMappingColumns, printUserIdentityMapping)
 
 	p.Handler(IsPersonalSubjectAccessReviewColumns, printIsPersonalSubjectAccessReview)
+
+	p.Handler(hostSubnetColumns, printHostSubnet)
+	p.Handler(hostSubnetColumns, printHostSubnetList)
+	p.Handler(clusterNetworkColumns, printClusterNetwork)
+	p.Handler(clusterNetworkColumns, printClusterNetworkList)
+
 	return p
 }
 
@@ -560,4 +570,31 @@ func printIdentityList(list *userapi.IdentityList, w io.Writer) error {
 func printUserIdentityMapping(mapping *userapi.UserIdentityMapping, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", mapping.Name, mapping.Identity.Name, mapping.User.Name, mapping.User.UID)
 	return err
+}
+
+func printHostSubnet(h *sdnapi.HostSubnet, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", h.Name, h.Host, h.HostIP, h.Subnet)
+	return err
+}
+func printHostSubnetList(list *sdnapi.HostSubnetList, w io.Writer) error {
+	for _, item := range list.Items {
+		if err := printHostSubnet(&item, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printClusterNetwork(n *sdnapi.ClusterNetwork, w io.Writer) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%d\n", n.Name, n.Network, n.HostSubnetLength)
+	return err
+}
+
+func printClusterNetworkList(list *sdnapi.ClusterNetworkList, w io.Writer) error {
+	for _, item := range list.Items {
+		if err := printClusterNetwork(&item, w); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -293,8 +293,8 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		"projects":        projectStorage,
 		"projectRequests": projectRequestStorage,
 
-		"hostSubnet":     hostSubnetStorage,
-		"clusterNetwork": clusterNetworkStorage,
+		"hostSubnets":     hostSubnetStorage,
+		"clusterNetworks": clusterNetworkStorage,
 
 		"users":                userStorage,
 		"identities":           identityStorage,

--- a/pkg/sdn/api/register.go
+++ b/pkg/sdn/api/register.go
@@ -7,11 +7,13 @@ import (
 func init() {
 	api.Scheme.AddKnownTypes("",
 		&ClusterNetwork{},
+		&ClusterNetworkList{},
 		&HostSubnet{},
 		&HostSubnetList{},
 	)
 }
 
-func (*ClusterNetwork) IsAnAPIObject() {}
-func (*HostSubnet) IsAnAPIObject()     {}
-func (*HostSubnetList) IsAnAPIObject() {}
+func (*ClusterNetwork) IsAnAPIObject()     {}
+func (*ClusterNetworkList) IsAnAPIObject() {}
+func (*HostSubnet) IsAnAPIObject()         {}
+func (*HostSubnetList) IsAnAPIObject()     {}

--- a/pkg/sdn/api/types.go
+++ b/pkg/sdn/api/types.go
@@ -12,6 +12,12 @@ type ClusterNetwork struct {
 	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
 }
 
+type ClusterNetworkList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterNetwork `json:"items"`
+}
+
 // HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
 type HostSubnet struct {
 	kapi.TypeMeta   `json:",inline"`

--- a/pkg/sdn/api/v1beta1/register.go
+++ b/pkg/sdn/api/v1beta1/register.go
@@ -7,11 +7,13 @@ import (
 func init() {
 	api.Scheme.AddKnownTypes("v1beta1",
 		&ClusterNetwork{},
+		&ClusterNetworkList{},
 		&HostSubnet{},
 		&HostSubnetList{},
 	)
 }
 
-func (*ClusterNetwork) IsAnAPIObject() {}
-func (*HostSubnet) IsAnAPIObject()     {}
-func (*HostSubnetList) IsAnAPIObject() {}
+func (*ClusterNetwork) IsAnAPIObject()     {}
+func (*ClusterNetworkList) IsAnAPIObject() {}
+func (*HostSubnet) IsAnAPIObject()         {}
+func (*HostSubnetList) IsAnAPIObject()     {}

--- a/pkg/sdn/api/v1beta1/types.go
+++ b/pkg/sdn/api/v1beta1/types.go
@@ -12,6 +12,12 @@ type ClusterNetwork struct {
 	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
 }
 
+type ClusterNetworkList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterNetwork `json:"items"`
+}
+
 // HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
 type HostSubnet struct {
 	kapi.TypeMeta   `json:",inline"`

--- a/pkg/sdn/api/v1beta3/register.go
+++ b/pkg/sdn/api/v1beta3/register.go
@@ -7,11 +7,13 @@ import (
 func init() {
 	api.Scheme.AddKnownTypes("v1beta3",
 		&ClusterNetwork{},
+		&ClusterNetworkList{},
 		&HostSubnet{},
 		&HostSubnetList{},
 	)
 }
 
-func (*ClusterNetwork) IsAnAPIObject() {}
-func (*HostSubnet) IsAnAPIObject()     {}
-func (*HostSubnetList) IsAnAPIObject() {}
+func (*ClusterNetwork) IsAnAPIObject()     {}
+func (*ClusterNetworkList) IsAnAPIObject() {}
+func (*HostSubnet) IsAnAPIObject()         {}
+func (*HostSubnetList) IsAnAPIObject()     {}

--- a/pkg/sdn/api/v1beta3/types.go
+++ b/pkg/sdn/api/v1beta3/types.go
@@ -12,6 +12,12 @@ type ClusterNetwork struct {
 	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
 }
 
+type ClusterNetworkList struct {
+	kapi.TypeMeta `json:",inline"`
+	kapi.ListMeta `json:"metadata,omitempty"`
+	Items         []ClusterNetwork `json:"items"`
+}
+
 // HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
 type HostSubnet struct {
 	kapi.TypeMeta   `json:",inline"`

--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -24,7 +24,7 @@ const etcdPrefix = "/registry/sdnnetworks"
 func NewREST(h tools.EtcdHelper) *REST {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.ClusterNetwork{} },
-		NewListFunc: func() runtime.Object { return &api.ClusterNetwork{} },
+		NewListFunc: func() runtime.Object { return &api.ClusterNetworkList{} },
 		KeyRootFunc: func(ctx kapi.Context) string {
 			return etcdPrefix
 		},


### PR DESCRIPTION
Updates to make curl for sdn types work on v1beta3, make names consistent, play nice in osc get, allow for printing by existing tooling, work with the generic etcd registry.

@rajatchopra ptal
