### PR TITLE
Fix new-app build config image reference

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -187,12 +187,12 @@ func (r *ImageRef) ObjectReference() *kapi.ObjectReference {
 	if r.Stream != nil {
 		return &kapi.ObjectReference{
 			Kind: "ImageStreamTag",
-			Name: r.Name + ":" + r.Tag,
+			Name: r.Stream.Name + ":" + r.Tag,
 		}
 	}
 	return &kapi.ObjectReference{
-		Kind: "ImageStreamTag",
-		Name: r.Name + ":" + imageapi.DefaultImageTag,
+		Kind: "DockerImage",
+		Name: r.String(),
 	}
 }
 


### PR DESCRIPTION
Switch to using the stream name for image reference if an image stream is available. Otherwise, use a reference of type 'DockerImage'