### PR TITLE
Bug 1218486: Ensure real DNS subjectAltNames precede IP DNS subjectAltNames in generated certs

### DIFF
--- a/pkg/cmd/server/crypto/crypto.go
+++ b/pkg/cmd/server/crypto/crypto.go
@@ -331,10 +331,18 @@ func IPAddressesDNSNames(hosts []string) ([]net.IP, []string) {
 	for _, host := range hosts {
 		if ip := net.ParseIP(host); ip != nil {
 			ips = append(ips, ip)
+		} else {
+			dns = append(dns, host)
 		}
-		// Include IP addresses as DNS names in the cert, for Python's sake
-		dns = append(dns, host)
 	}
+
+	// Include IP addresses as DNS subjectAltNames in the cert as well, for the sake of Python, Windows (< 10), and unnamed other libraries
+	// Ensure these technically invalid DNS subjectAltNames occur after the valid ones, to avoid triggering cert errors in Firefox
+	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1148766
+	for _, ip := range ips {
+		dns = append(dns, ip.String())
+	}
+
 	return ips, dns
 }
 


### PR DESCRIPTION
Works around https://bugzilla.mozilla.org/show_bug.cgi?id=1148766 by listing valid dns names first as DNS subjectAltNames, before IPs as DNS subjectAltNames.

Fixes #2235