### PR TITLE
Utilities to prune Builds

### DIFF
--- a/pkg/build/prune/data.go
+++ b/pkg/build/prune/data.go
@@ -1,0 +1,139 @@
+package prune
+
+import (
+	"fmt"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// BuildByBuildConfigIndexFunc indexes Build items by their associated BuildConfig, if none, index with key "orphan"
+func BuildByBuildConfigIndexFunc(obj interface{}) (string, error) {
+	build, ok := obj.(*buildapi.Build)
+	if !ok {
+		return "", fmt.Errorf("not a build: %v", build)
+	}
+	config := build.Config
+	if config == nil {
+		return "orphan", nil
+	}
+	return config.Namespace + "/" + config.Name, nil
+}
+
+// Filter filters the set of objects
+type Filter interface {
+	Filter(builds []*buildapi.Build) []*buildapi.Build
+}
+
+// andFilter ands a set of predicate functions to know if it should be included in the return set
+type andFilter struct {
+	filterPredicates []FilterPredicate
+}
+
+// Filter ands the set of predicates evaluated against each Build to make a filtered set
+func (a *andFilter) Filter(builds []*buildapi.Build) []*buildapi.Build {
+	results := []*buildapi.Build{}
+	for _, build := range builds {
+		include := true
+		for _, filterPredicate := range a.filterPredicates {
+			include = include && filterPredicate(build)
+		}
+		if include {
+			results = append(results, build)
+		}
+	}
+	return results
+}
+
+// FilterPredicate is a function that returns true if the object should be included in the filtered set
+type FilterPredicate func(build *buildapi.Build) bool
+
+// NewFilterBeforePredicate is a function that returns true if the build was created before the current time minus specified duration
+func NewFilterBeforePredicate(d time.Duration) FilterPredicate {
+	now := util.Now()
+	before := util.NewTime(now.Time.Add(-1 * d))
+	return func(build *buildapi.Build) bool {
+		return build.CreationTimestamp.Before(before)
+	}
+}
+
+// DataSet provides functions for working with build data
+type DataSet interface {
+	GetBuildConfig(build *buildapi.Build) (*buildapi.BuildConfig, bool, error)
+	ListBuildConfigs() ([]*buildapi.BuildConfig, error)
+	ListBuilds() ([]*buildapi.Build, error)
+	ListBuildsByBuildConfig(buildConfig *buildapi.BuildConfig) ([]*buildapi.Build, error)
+}
+
+type dataSet struct {
+	buildConfigStore cache.Store
+	buildIndexer     cache.Indexer
+}
+
+// NewDataSet returns a DataSet over the specified items
+func NewDataSet(buildConfigs []*buildapi.BuildConfig, builds []*buildapi.Build) DataSet {
+	buildConfigStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, buildConfig := range buildConfigs {
+		buildConfigStore.Add(buildConfig)
+	}
+
+	buildIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		"buildConfig": BuildByBuildConfigIndexFunc,
+	})
+	for _, build := range builds {
+		buildIndexer.Add(build)
+	}
+
+	return &dataSet{
+		buildConfigStore: buildConfigStore,
+		buildIndexer:     buildIndexer,
+	}
+}
+
+func (d *dataSet) GetBuildConfig(build *buildapi.Build) (*buildapi.BuildConfig, bool, error) {
+	config := build.Config
+	if config == nil {
+		return nil, false, nil
+	}
+
+	var buildConfig *buildapi.BuildConfig
+	key := &buildapi.BuildConfig{ObjectMeta: kapi.ObjectMeta{Name: config.Name, Namespace: config.Namespace}}
+	item, exists, err := d.buildConfigStore.Get(key)
+	if exists {
+		buildConfig = item.(*buildapi.BuildConfig)
+	}
+	return buildConfig, exists, err
+}
+
+func (d *dataSet) ListBuildConfigs() ([]*buildapi.BuildConfig, error) {
+	results := []*buildapi.BuildConfig{}
+	for _, item := range d.buildConfigStore.List() {
+		results = append(results, item.(*buildapi.BuildConfig))
+	}
+	return results, nil
+}
+
+func (d *dataSet) ListBuilds() ([]*buildapi.Build, error) {
+	results := []*buildapi.Build{}
+	for _, item := range d.buildIndexer.List() {
+		results = append(results, item.(*buildapi.Build))
+	}
+	return results, nil
+}
+
+func (d *dataSet) ListBuildsByBuildConfig(buildConfig *buildapi.BuildConfig) ([]*buildapi.Build, error) {
+	results := []*buildapi.Build{}
+	key := &buildapi.Build{Config: &kapi.ObjectReference{Name: buildConfig.Name, Namespace: buildConfig.Namespace}}
+	items, err := d.buildIndexer.Index("buildConfig", key)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		results = append(results, item.(*buildapi.Build))
+	}
+	return results, nil
+}

--- a/pkg/build/prune/data_test.go
+++ b/pkg/build/prune/data_test.go
@@ -1,0 +1,175 @@
+package prune
+
+import (
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+func mockBuildConfig(namespace, name string) *buildapi.BuildConfig {
+	return &buildapi.BuildConfig{ObjectMeta: kapi.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+func withCreated(build *buildapi.Build, creationTimestamp util.Time) *buildapi.Build {
+	build.CreationTimestamp = creationTimestamp
+	return build
+}
+
+func withStatus(build *buildapi.Build, status buildapi.BuildStatus) *buildapi.Build {
+	build.Status = status
+	return build
+}
+
+func mockBuild(namespace, name string, buildConfig *buildapi.BuildConfig) *buildapi.Build {
+	build := &buildapi.Build{ObjectMeta: kapi.ObjectMeta{Namespace: namespace, Name: name}}
+	if buildConfig != nil {
+		build.Config = &kapi.ObjectReference{
+			Name:      buildConfig.Name,
+			Namespace: buildConfig.Namespace,
+		}
+	}
+	build.Status = buildapi.BuildStatusNew
+	return build
+}
+
+func TestBuildByBuildConfigIndexFunc(t *testing.T) {
+	buildWithConfig := &buildapi.Build{
+		Config: &kapi.ObjectReference{
+			Name:      "buildConfigName",
+			Namespace: "buildConfigNamespace",
+		},
+	}
+	actualKey, err := BuildByBuildConfigIndexFunc(buildWithConfig)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	expectedKey := buildWithConfig.Config.Namespace + "/" + buildWithConfig.Config.Name
+	if actualKey != expectedKey {
+		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
+	}
+	buildWithNoConfig := &buildapi.Build{}
+	actualKey, err = BuildByBuildConfigIndexFunc(buildWithNoConfig)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	expectedKey = "orphan"
+	if actualKey != expectedKey {
+		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
+	}
+}
+
+func TestFilterBeforePredicate(t *testing.T) {
+	youngerThan := time.Hour
+	now := util.Now()
+	old := util.NewTime(now.Time.Add(-1 * youngerThan))
+	builds := []*buildapi.Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:              "old",
+				CreationTimestamp: old,
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:              "new",
+				CreationTimestamp: now,
+			},
+		},
+	}
+	filter := &andFilter{
+		filterPredicates: []FilterPredicate{NewFilterBeforePredicate(youngerThan)},
+	}
+	result := filter.Filter(builds)
+	if len(result) != 1 {
+		t.Errorf("Unexpected number of results")
+	}
+	if expected, actual := "old", result[0].Name; expected != actual {
+		t.Errorf("expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestEmptyDataSet(t *testing.T) {
+	builds := []*buildapi.Build{}
+	buildConfigs := []*buildapi.BuildConfig{}
+	dataSet := NewDataSet(buildConfigs, builds)
+	_, exists, err := dataSet.GetBuildConfig(&buildapi.Build{})
+	if exists || err != nil {
+		t.Errorf("Unexpected result %v, %v", exists, err)
+	}
+	buildConfigResults, err := dataSet.ListBuildConfigs()
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(buildConfigResults) != 0 {
+		t.Errorf("Unexpected result %v", buildConfigResults)
+	}
+	buildResults, err := dataSet.ListBuilds()
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(buildResults) != 0 {
+		t.Errorf("Unexpected result %v", buildResults)
+	}
+	buildResults, err = dataSet.ListBuildsByBuildConfig(&buildapi.BuildConfig{})
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(buildResults) != 0 {
+		t.Errorf("Unexpected result %v", buildResults)
+	}
+}
+
+func TestPopuldatedDataSet(t *testing.T) {
+	buildConfigs := []*buildapi.BuildConfig{
+		mockBuildConfig("a", "build-config-1"),
+		mockBuildConfig("b", "build-config-2"),
+	}
+	builds := []*buildapi.Build{
+		mockBuild("a", "build-1", buildConfigs[0]),
+		mockBuild("a", "build-2", buildConfigs[0]),
+		mockBuild("b", "build-3", buildConfigs[1]),
+		mockBuild("c", "build-4", nil),
+	}
+	dataSet := NewDataSet(buildConfigs, builds)
+	for _, build := range builds {
+		buildConfig, exists, err := dataSet.GetBuildConfig(build)
+		if build.Config != nil {
+			if err != nil {
+				t.Errorf("Item %v, unexpected error: %v", build, err)
+			}
+			if !exists {
+				t.Errorf("Item %v, unexpected result: %v", build, exists)
+			}
+			if expected, actual := build.Config.Name, buildConfig.Name; expected != actual {
+				t.Errorf("expected %v, actual %v", expected, actual)
+			}
+			if expected, actual := build.Config.Namespace, buildConfig.Namespace; expected != actual {
+				t.Errorf("expected %v, actual %v", expected, actual)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Item %v, unexpected error: %v", build, err)
+			}
+			if exists {
+				t.Errorf("Item %v, unexpected result: %v", build, exists)
+			}
+		}
+	}
+	expectedNames := util.NewStringSet("build-1", "build-2")
+	buildResults, err := dataSet.ListBuildsByBuildConfig(buildConfigs[0])
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(buildResults) != len(expectedNames) {
+		t.Errorf("Unexpected result %v", buildResults)
+	}
+	for _, build := range buildResults {
+		if !expectedNames.Has(build.Name) {
+			t.Errorf("Unexpected name: %v", build.Name)
+		}
+	}
+}

--- a/pkg/build/prune/prune.go
+++ b/pkg/build/prune/prune.go
@@ -1,0 +1,65 @@
+package prune
+
+import (
+	"time"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// PruneFunc is a function that is invoked for each item during Prune
+type PruneFunc func(build *buildapi.Build) error
+
+// PruneTask is an object that knows how to execute a single iteration of a Prune
+type PruneTasker interface {
+	PruneTask() error
+}
+
+// pruneTask is an object that knows how to prune a data set
+type pruneTask struct {
+	resolver Resolver
+	handler  PruneFunc
+}
+
+// NewPruneTasker returns a PruneTasker over specified data using specified flags
+// keepYoungerThan will filter out all objects from prune data set that are younger than the specified time duration
+// orphans if true will include inactive orphan builds in candidate prune set
+// keepComplete is per BuildConfig how many of the most recent builds should be preserved
+// keepFailed is per BuildConfig how many of the most recent failed builds should be preserved
+func NewPruneTasker(buildConfigs []*buildapi.BuildConfig, builds []*buildapi.Build, keepYoungerThan time.Duration, orphans bool, keepComplete int, keepFailed int, handler PruneFunc) PruneTasker {
+	filter := &andFilter{
+		filterPredicates: []FilterPredicate{NewFilterBeforePredicate(keepYoungerThan)},
+	}
+	builds = filter.Filter(builds)
+	dataSet := NewDataSet(buildConfigs, builds)
+
+	resolvers := []Resolver{}
+	if orphans {
+		inactiveBuildStatus := []buildapi.BuildStatus{
+			buildapi.BuildStatusCancelled,
+			buildapi.BuildStatusComplete,
+			buildapi.BuildStatusError,
+			buildapi.BuildStatusFailed,
+		}
+		resolvers = append(resolvers, NewOrphanBuildResolver(dataSet, inactiveBuildStatus))
+	}
+	resolvers = append(resolvers, NewPerBuildConfigResolver(dataSet, keepComplete, keepFailed))
+	return &pruneTask{
+		resolver: &mergeResolver{resolvers: resolvers},
+		handler:  handler,
+	}
+}
+
+// PruneTask will visit each item in the prunable set and invoke the associated handler
+func (t *pruneTask) PruneTask() error {
+	builds, err := t.resolver.Resolve()
+	if err != nil {
+		return err
+	}
+	for _, build := range builds {
+		err = t.handler(build)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/build/prune/prune_test.go
+++ b/pkg/build/prune/prune_test.go
@@ -1,0 +1,100 @@
+package prune
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+type mockPruneRecorder struct {
+	set util.StringSet
+	err error
+}
+
+func (m *mockPruneRecorder) Handler(build *buildapi.Build) error {
+	m.set.Insert(build.Name)
+	return m.err
+}
+
+func (m *mockPruneRecorder) Verify(t *testing.T, expected util.StringSet) {
+	if len(m.set) != len(expected) || !m.set.HasAll(expected.List()...) {
+		expectedValues := expected.List()
+		actualValues := m.set.List()
+		sort.Strings(expectedValues)
+		sort.Strings(actualValues)
+		t.Errorf("expected \n\t%v\n, actual \n\t%v\n", expectedValues, actualValues)
+	}
+}
+
+func TestPruneTask(t *testing.T) {
+	buildStatusOptions := []buildapi.BuildStatus{
+		buildapi.BuildStatusCancelled,
+		buildapi.BuildStatusComplete,
+		buildapi.BuildStatusError,
+		buildapi.BuildStatusFailed,
+		buildapi.BuildStatusNew,
+		buildapi.BuildStatusPending,
+		buildapi.BuildStatusRunning,
+	}
+	buildStatusFilter := []buildapi.BuildStatus{
+		buildapi.BuildStatusCancelled,
+		buildapi.BuildStatusComplete,
+		buildapi.BuildStatusError,
+		buildapi.BuildStatusFailed,
+	}
+	buildStatusFilterSet := util.StringSet{}
+	for _, buildStatus := range buildStatusFilter {
+		buildStatusFilterSet.Insert(string(buildStatus))
+	}
+
+	for _, orphans := range []bool{true, false} {
+		for _, buildStatusOption := range buildStatusOptions {
+			keepYoungerThan := time.Hour
+
+			now := util.Now()
+			old := util.NewTime(now.Time.Add(-1 * keepYoungerThan))
+
+			buildConfigs := []*buildapi.BuildConfig{}
+			builds := []*buildapi.Build{}
+
+			buildConfig := mockBuildConfig("a", "build-config")
+			buildConfigs = append(buildConfigs, buildConfig)
+
+			builds = append(builds, withCreated(withStatus(mockBuild("a", "build-1", buildConfig), buildStatusOption), now))
+			builds = append(builds, withCreated(withStatus(mockBuild("a", "build-2", buildConfig), buildStatusOption), old))
+			builds = append(builds, withCreated(withStatus(mockBuild("a", "orphan-build-1", nil), buildStatusOption), now))
+			builds = append(builds, withCreated(withStatus(mockBuild("a", "orphan-build-2", nil), buildStatusOption), old))
+
+			keepComplete := 1
+			keepFailed := 1
+			expectedValues := util.StringSet{}
+			filter := &andFilter{
+				filterPredicates: []FilterPredicate{NewFilterBeforePredicate(keepYoungerThan)},
+			}
+			dataSet := NewDataSet(buildConfigs, filter.Filter(builds))
+			resolver := NewPerBuildConfigResolver(dataSet, keepComplete, keepFailed)
+			if orphans {
+				resolver = &mergeResolver{
+					resolvers: []Resolver{resolver, NewOrphanBuildResolver(dataSet, buildStatusFilter)},
+				}
+			}
+			expectedBuilds, err := resolver.Resolve()
+			for _, build := range expectedBuilds {
+				expectedValues.Insert(build.Name)
+			}
+
+			recorder := &mockPruneRecorder{set: util.StringSet{}}
+			task := NewPruneTasker(buildConfigs, builds, keepYoungerThan, orphans, keepComplete, keepFailed, recorder.Handler)
+			err = task.PruneTask()
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			recorder.Verify(t, expectedValues)
+		}
+	}
+
+}

--- a/pkg/build/prune/resolvers.go
+++ b/pkg/build/prune/resolvers.go
@@ -1,0 +1,127 @@
+package prune
+
+import (
+	"sort"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// Resolver knows how to resolve the set of candidate objects to prune
+type Resolver interface {
+	Resolve() ([]*buildapi.Build, error)
+}
+
+// mergeResolver merges the set of results from multiple resolvers
+type mergeResolver struct {
+	resolvers []Resolver
+}
+
+func (m *mergeResolver) Resolve() ([]*buildapi.Build, error) {
+	results := []*buildapi.Build{}
+	for _, resolver := range m.resolvers {
+		builds, err := resolver.Resolve()
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, builds...)
+	}
+	return results, nil
+}
+
+// NewOrphanBuildResolver returns a Resolver that matches Build objects with no associated BuildConfig and has a BuildStatus in filter
+func NewOrphanBuildResolver(dataSet DataSet, buildStatusFilter []buildapi.BuildStatus) Resolver {
+	filter := util.NewStringSet()
+	for _, buildStatus := range buildStatusFilter {
+		filter.Insert(string(buildStatus))
+	}
+	return &orphanBuildResolver{
+		dataSet:           dataSet,
+		buildStatusFilter: filter,
+	}
+}
+
+// orphanBuildResolver resolves orphan builds that match the specified filter
+type orphanBuildResolver struct {
+	dataSet           DataSet
+	buildStatusFilter util.StringSet
+}
+
+// Resolve the matching set of Build objects
+func (o *orphanBuildResolver) Resolve() ([]*buildapi.Build, error) {
+	builds, err := o.dataSet.ListBuilds()
+	if err != nil {
+		return nil, err
+	}
+
+	results := []*buildapi.Build{}
+	for _, build := range builds {
+		if !o.buildStatusFilter.Has(string(build.Status)) {
+			continue
+		}
+		isOrphan := false
+		if build.Config == nil {
+			isOrphan = true
+		} else {
+			_, exists, _ := o.dataSet.GetBuildConfig(build)
+			isOrphan = !exists
+		}
+		if isOrphan {
+			results = append(results, build)
+		}
+	}
+	return results, nil
+}
+
+type perBuildConfigResolver struct {
+	dataSet      DataSet
+	keepComplete int
+	keepFailed   int
+}
+
+// NewPerBuildConfigResolver returns a Resolver that selects Builds to prune per BuildConfig
+func NewPerBuildConfigResolver(dataSet DataSet, keepComplete int, keepFailed int) Resolver {
+	return &perBuildConfigResolver{
+		dataSet:      dataSet,
+		keepComplete: keepComplete,
+		keepFailed:   keepFailed,
+	}
+}
+
+func (o *perBuildConfigResolver) Resolve() ([]*buildapi.Build, error) {
+	buildConfigs, err := o.dataSet.ListBuildConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	completeStates := util.NewStringSet(string(buildapi.BuildStatusComplete))
+	failedStates := util.NewStringSet(string(buildapi.BuildStatusFailed), string(buildapi.BuildStatusError), string(buildapi.BuildStatusCancelled))
+
+	results := []*buildapi.Build{}
+	for _, buildConfig := range buildConfigs {
+		builds, err := o.dataSet.ListBuildsByBuildConfig(buildConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		completeBuilds, failedBuilds := []*buildapi.Build{}, []*buildapi.Build{}
+		for _, build := range builds {
+			if completeStates.Has(string(build.Status)) {
+				completeBuilds = append(completeBuilds, build)
+			} else if failedStates.Has(string(build.Status)) {
+				failedBuilds = append(failedBuilds, build)
+			}
+		}
+		sort.Sort(sortableBuilds(completeBuilds))
+		sort.Sort(sortableBuilds(failedBuilds))
+
+		if o.keepComplete >= 0 && o.keepComplete < len(completeBuilds) {
+			results = append(results, completeBuilds[o.keepComplete:]...)
+		}
+		if o.keepFailed >= 0 && o.keepFailed < len(failedBuilds) {
+			results = append(results, failedBuilds[o.keepFailed:]...)
+		}
+	}
+	return results, nil
+}

--- a/pkg/build/prune/resolvers_test.go
+++ b/pkg/build/prune/resolvers_test.go
@@ -1,0 +1,190 @@
+package prune
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+type mockResolver struct {
+	builds []*buildapi.Build
+	err    error
+}
+
+func (m *mockResolver) Resolve() ([]*buildapi.Build, error) {
+	return m.builds, m.err
+}
+
+func TestMergeResolver(t *testing.T) {
+	resolverA := &mockResolver{
+		builds: []*buildapi.Build{
+			mockBuild("a", "b", nil),
+		},
+	}
+	resolverB := &mockResolver{
+		builds: []*buildapi.Build{
+			mockBuild("c", "d", nil),
+		},
+	}
+	resolver := &mergeResolver{resolvers: []Resolver{resolverA, resolverB}}
+	results, err := resolver.Resolve()
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Unexpected results %v", results)
+	}
+	expectedNames := util.NewStringSet("b", "d")
+	for _, build := range results {
+		if !expectedNames.Has(build.Name) {
+			t.Errorf("Unexpected name %v", build.Name)
+		}
+	}
+}
+
+func TestOrphanBuildResolver(t *testing.T) {
+	activeBuildConfig := mockBuildConfig("a", "active-build-config")
+	inactiveBuildConfig := mockBuildConfig("a", "inactive-build-config")
+
+	buildConfigs := []*buildapi.BuildConfig{activeBuildConfig}
+	builds := []*buildapi.Build{}
+
+	expectedNames := util.StringSet{}
+	buildStatusOptions := []buildapi.BuildStatus{
+		buildapi.BuildStatusCancelled,
+		buildapi.BuildStatusComplete,
+		buildapi.BuildStatusError,
+		buildapi.BuildStatusFailed,
+		buildapi.BuildStatusNew,
+		buildapi.BuildStatusPending,
+		buildapi.BuildStatusRunning,
+	}
+	buildStatusFilter := []buildapi.BuildStatus{
+		buildapi.BuildStatusCancelled,
+		buildapi.BuildStatusComplete,
+		buildapi.BuildStatusError,
+		buildapi.BuildStatusFailed,
+	}
+	buildStatusFilterSet := util.StringSet{}
+	for _, buildStatus := range buildStatusFilter {
+		buildStatusFilterSet.Insert(string(buildStatus))
+	}
+
+	for _, buildStatusOption := range buildStatusOptions {
+		builds = append(builds, withStatus(mockBuild("a", string(buildStatusOption)+"-active", activeBuildConfig), buildStatusOption))
+		builds = append(builds, withStatus(mockBuild("a", string(buildStatusOption)+"-inactive", inactiveBuildConfig), buildStatusOption))
+		builds = append(builds, withStatus(mockBuild("a", string(buildStatusOption)+"-orphan", nil), buildStatusOption))
+		if buildStatusFilterSet.Has(string(buildStatusOption)) {
+			expectedNames.Insert(string(buildStatusOption) + "-inactive")
+			expectedNames.Insert(string(buildStatusOption) + "-orphan")
+		}
+	}
+
+	dataSet := NewDataSet(buildConfigs, builds)
+	resolver := NewOrphanBuildResolver(dataSet, buildStatusFilter)
+	results, err := resolver.Resolve()
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	foundNames := util.StringSet{}
+	for _, result := range results {
+		foundNames.Insert(result.Name)
+	}
+	if len(foundNames) != len(expectedNames) || !expectedNames.HasAll(foundNames.List()...) {
+		t.Errorf("expected %v, actual %v", expectedNames, foundNames)
+	}
+}
+
+func TestPerBuildConfigResolver(t *testing.T) {
+	buildStatusOptions := []buildapi.BuildStatus{
+		buildapi.BuildStatusCancelled,
+		buildapi.BuildStatusComplete,
+		buildapi.BuildStatusError,
+		buildapi.BuildStatusFailed,
+		buildapi.BuildStatusNew,
+		buildapi.BuildStatusPending,
+		buildapi.BuildStatusRunning,
+	}
+	buildConfigs := []*buildapi.BuildConfig{
+		mockBuildConfig("a", "build-config-1"),
+		mockBuildConfig("b", "build-config-2"),
+	}
+	buildsPerStatus := 100
+	builds := []*buildapi.Build{}
+	for _, buildConfig := range buildConfigs {
+		for _, buildStatusOption := range buildStatusOptions {
+			for i := 0; i < buildsPerStatus; i++ {
+				build := withStatus(mockBuild(buildConfig.Namespace, fmt.Sprintf("%v-%v-%v", buildConfig.Name, buildStatusOption, i), buildConfig), buildStatusOption)
+				builds = append(builds, build)
+			}
+		}
+	}
+
+	now := util.Now()
+	for i := range builds {
+		creationTimestamp := util.NewTime(now.Time.Add(-1 * time.Duration(i) * time.Hour))
+		builds[i].CreationTimestamp = creationTimestamp
+	}
+
+	// test number to keep at varying ranges
+	for keep := 0; keep < buildsPerStatus*2; keep++ {
+		dataSet := NewDataSet(buildConfigs, builds)
+
+		expectedNames := util.StringSet{}
+		buildCompleteStatusFilterSet := util.NewStringSet(string(buildapi.BuildStatusComplete))
+		buildFailedStatusFilterSet := util.NewStringSet(string(buildapi.BuildStatusCancelled), string(buildapi.BuildStatusError), string(buildapi.BuildStatusFailed))
+
+		for _, buildConfig := range buildConfigs {
+			buildItems, err := dataSet.ListBuildsByBuildConfig(buildConfig)
+			if err != nil {
+				t.Errorf("Unexpected err %v", err)
+			}
+			completedBuilds, failedBuilds := []*buildapi.Build{}, []*buildapi.Build{}
+			for _, build := range buildItems {
+				if buildCompleteStatusFilterSet.Has(string(build.Status)) {
+					completedBuilds = append(completedBuilds, build)
+				} else if buildFailedStatusFilterSet.Has(string(build.Status)) {
+					failedBuilds = append(failedBuilds, build)
+				}
+			}
+			sort.Sort(sortableBuilds(completedBuilds))
+			sort.Sort(sortableBuilds(failedBuilds))
+			purgeCompleted := []*buildapi.Build{}
+			purgeFailed := []*buildapi.Build{}
+			if keep >= 0 && keep < len(completedBuilds) {
+				purgeCompleted = completedBuilds[keep:]
+			}
+			if keep >= 0 && keep < len(failedBuilds) {
+				purgeFailed = failedBuilds[keep:]
+			}
+			for _, build := range purgeCompleted {
+				expectedNames.Insert(build.Name)
+			}
+			for _, build := range purgeFailed {
+				expectedNames.Insert(build.Name)
+			}
+		}
+
+		resolver := NewPerBuildConfigResolver(dataSet, keep, keep)
+		results, err := resolver.Resolve()
+		if err != nil {
+			t.Errorf("Unexpected error %v", err)
+		}
+		foundNames := util.StringSet{}
+		for _, result := range results {
+			foundNames.Insert(result.Name)
+		}
+		if len(foundNames) != len(expectedNames) || !expectedNames.HasAll(foundNames.List()...) {
+			expectedValues := expectedNames.List()
+			actualValues := foundNames.List()
+			sort.Strings(expectedValues)
+			sort.Strings(actualValues)
+			t.Errorf("keep %v\n, expected \n\t%v\n, actual \n\t%v\n", keep, expectedValues, actualValues)
+		}
+	}
+}

--- a/pkg/build/prune/sort.go
+++ b/pkg/build/prune/sort.go
@@ -1,0 +1,22 @@
+package prune
+
+import (
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// sortableBuilds supports sorting Build items by most recently created Build
+type sortableBuilds []*buildapi.Build
+
+func (s sortableBuilds) Len() int {
+	return len(s)
+}
+
+func (s sortableBuilds) Less(i, j int) bool {
+	return !s[i].CreationTimestamp.Before(s[j].CreationTimestamp)
+}
+
+func (s sortableBuilds) Swap(i, j int) {
+	t := s[i]
+	s[i] = s[j]
+	s[j] = t
+}

--- a/pkg/build/prune/sort_test.go
+++ b/pkg/build/prune/sort_test.go
@@ -1,0 +1,39 @@
+package prune
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+// TestSort verifies that builds are sorted by most recently created
+func TestSort(t *testing.T) {
+	present := util.Now()
+	past := util.NewTime(present.Time.Add(-1 * time.Minute))
+	builds := []*buildapi.Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:              "past",
+				CreationTimestamp: past,
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:              "present",
+				CreationTimestamp: present,
+			},
+		},
+	}
+	sort.Sort(sortableBuilds(builds))
+	if builds[0].Name != "present" {
+		t.Errorf("Unexpected sort order")
+	}
+	if builds[1].Name != "past" {
+		t.Errorf("Unexpected sort order")
+	}
+}


### PR DESCRIPTION
The following adds utility code to support prune build operations.

A follow-on PR will tie it into an ```osadm``` command.

@csrwng @bparees @smarterclayton - this was tedious, I imagine reviewing it will be tedious as well.