### PR TITLE
don't write project request template

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -528,8 +528,6 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 	go util.Forever(func() {
 		c.ensureOpenShiftSharedResourcesNamespace()
 	}, 10*time.Second)
-
-	c.checkProjectRequestTemplate()
 }
 
 func (c *MasterConfig) defaultAPIGroupVersion() *apiserver.APIGroupVersion {
@@ -584,40 +582,6 @@ func (c *MasterConfig) getRequestContextMapper() kapi.RequestContextMapper {
 		c.RequestContextMapper = kapi.NewRequestContextMapper()
 	}
 	return c.RequestContextMapper
-}
-
-// checkProjectRequestTemplate looks to see if there should be a projectrequest template.  If there should be one and it's not present
-func (c *MasterConfig) checkProjectRequestTemplate() {
-	if len(c.Options.ProjectRequestConfig.ProjectRequestTemplate) == 0 {
-		return
-	}
-
-	const baseErrorFormat = "Error creating default project request template %v.  Unprivileged project requests will fail until a template is available."
-
-	namespace, templateName, err := configapi.ParseNamespaceAndName(c.Options.ProjectRequestConfig.ProjectRequestTemplate)
-	if err != nil {
-		glog.Errorf(baseErrorFormat+"  Caused by: %v", c.Options.ProjectRequestConfig.ProjectRequestTemplate, err)
-		return
-	}
-	if len(namespace) == 0 {
-		glog.Errorf(baseErrorFormat+"  The namespace for the project request template may not be empty.", c.Options.ProjectRequestConfig.ProjectRequestTemplate)
-		return
-	}
-	if len(templateName) == 0 {
-		glog.Errorf(baseErrorFormat+"  The name for the project request template may not be empty.", c.Options.ProjectRequestConfig.ProjectRequestTemplate)
-		return
-	}
-
-	// if the template already exists, no work to do
-	if _, err := c.PrivilegedLoopbackOpenShiftClient.Templates(namespace).Get(templateName); err == nil {
-		return
-	}
-
-	template := projectrequeststorage.NewSampleTemplate(namespace, templateName)
-	if _, err := c.PrivilegedLoopbackOpenShiftClient.Templates(namespace).Create(template); err != nil {
-		glog.Errorf(baseErrorFormat+"  Caused by: %v", c.Options.ProjectRequestConfig.ProjectRequestTemplate, err)
-		return
-	}
 }
 
 // ensureOpenShiftSharedResourcesNamespace is called as part of global policy initialization to ensure shared namespace exists

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -198,9 +198,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 			Latest: args.ImageFormatArgs.ImageTemplate.Latest,
 		},
 
-		ProjectRequestConfig: configapi.ProjectRequestConfig{
-			ProjectRequestTemplate: bootstrappolicy.DefaultOpenShiftSharedResourcesNamespace + "/project-request",
-		},
+		ProjectRequestConfig: configapi.ProjectRequestConfig{},
 
 		NetworkConfig: configapi.NetworkConfig{
 			NetworkPluginName:  args.NetworkArgs.NetworkPluginName,

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -20,6 +20,7 @@ import (
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectrequestregistry "github.com/openshift/origin/pkg/project/registry/projectrequest"
+	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
 type REST struct {
@@ -48,9 +49,6 @@ func (r *REST) NewList() runtime.Object {
 }
 
 func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
-	if len(r.openshiftNamespace) == 0 || len(r.templateName) == 0 {
-		return nil, errors.New("this endpoint is disabled")
-	}
 
 	if err := rest.BeforeCreate(projectrequestregistry.Strategy, ctx, obj); err != nil {
 		return nil, err
@@ -78,7 +76,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 		projectAdmin = userInfo.GetName()
 	}
 
-	template, err := r.openshiftClient.Templates(r.openshiftNamespace).Get(r.templateName)
+	template, err := r.getTemplate()
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +94,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 		}
 	}
 
-	list, err := r.openshiftClient.TemplateConfigs(r.openshiftNamespace).Create(template)
+	list, err := r.openshiftClient.TemplateConfigs(kapi.NamespaceDefault).Create(template)
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +114,14 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	}
 
 	return r.openshiftClient.Projects().Get(projectName)
+}
+
+func (r *REST) getTemplate() (*templateapi.Template, error) {
+	if len(r.openshiftNamespace) == 0 || len(r.templateName) == 0 {
+		return DefaultTemplate(), nil
+	}
+
+	return r.openshiftClient.Templates(r.openshiftNamespace).Get(r.templateName)
 }
 
 func (r *REST) List(ctx kapi.Context, label labels.Selector, field fields.Selector) (runtime.Object, error) {

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -1,10 +1,10 @@
 package delegated
 
 import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
-
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
@@ -21,10 +21,10 @@ var (
 	parameters = []string{ProjectNameParam, ProjectDisplayNameParam, ProjectDescriptionParam, ProjectAdminUserParam}
 )
 
-func NewSampleTemplate(openshiftNamespace, templateName string) *templateapi.Template {
+func DefaultTemplate() *templateapi.Template {
 	ret := &templateapi.Template{}
-	ret.Name = templateName
-	ret.Namespace = openshiftNamespace
+	ret.Name = "project-request"
+	ret.Namespace = kapi.NamespaceDefault
 
 	project := &projectapi.Project{}
 	project.Name = "${" + ProjectNameParam + "}"


### PR DESCRIPTION
As we discussed.  If no template is provided in the config, ProjectRequest now operates against a default template that is not persisted.  Setting the project request template field in the config overrides this default.

@liggitt 