### PR TITLE
Persist a master count config variable to enable multi-master

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -413,6 +413,8 @@ type EtcdConfig struct {
 type KubernetesMasterConfig struct {
 	// MasterIP is the public IP address of kubernetes stuff.  If empty, the first result from net.InterfaceAddrs will be used.
 	MasterIP string
+	// MasterCount is the number of expected masters that should be running. This value defaults to 1 and may be set to a positive integer.
+	MasterCount int
 	// ServicesSubnet is the subnet to use for assigning service IPs
 	ServicesSubnet string
 	// StaticNodeNames is the list of nodes that are statically known

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -8,6 +8,11 @@ import (
 
 func init() {
 	err := newer.Scheme.AddDefaultingFuncs(
+		func(obj *KubernetesMasterConfig) {
+			if obj.MasterCount == 0 {
+				obj.MasterCount = 1
+			}
+		},
 		func(obj *EtcdStorageConfig) {
 			if len(obj.KubernetesStorageVersion) == 0 {
 				obj.KubernetesStorageVersion = "v1beta3"

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -399,7 +399,9 @@ type EtcdConfig struct {
 }
 
 type KubernetesMasterConfig struct {
-	MasterIP            string   `json:"masterIP"`
+	MasterIP string `json:"masterIP"`
+	// MasterCount is the number of expected masters that should be running. This value defaults to 1 and may be set to a positive integer.
+	MasterCount         int      `json:"masterCount"`
 	ServicesSubnet      string   `json:"servicesSubnet"`
 	StaticNodeNames     []string `json:"staticNodeNames"`
 	SchedulerConfigFile string   `json:"schedulerConfigFile"`

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -191,6 +191,10 @@ func ValidateKubernetesMasterConfig(config *api.KubernetesMasterConfig) fielderr
 		allErrs = append(allErrs, ValidateSpecifiedIP(config.MasterIP, "masterIP")...)
 	}
 
+	if config.MasterCount < 1 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("masterCount", config.MasterCount, "must be a positive integer"))
+	}
+
 	if len(config.ServicesSubnet) > 0 {
 		if _, _, err := net.ParseCIDR(strings.TrimSpace(config.ServicesSubnet)); err != nil {
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("servicesSubnet", config.ServicesSubnet, "must be a valid CIDR notation IP range (e.g. 172.30.0.0/16)"))

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -74,6 +74,8 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 
 		EnableCoreControllers: true,
 
+		MasterCount: c.MasterCount,
+
 		Authorizer:       c.Authorizer,
 		AdmissionControl: c.AdmissionControl,
 	}

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -21,10 +21,12 @@ import (
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {
-	MasterIP   net.IP
-	MasterPort int
-	NodeHosts  []string
-	PortalNet  *net.IPNet
+	MasterIP    net.IP
+	MasterPort  int
+	MasterCount int
+
+	NodeHosts []string
+	PortalNet *net.IPNet
 
 	RequestContextMapper kapi.RequestContextMapper
 
@@ -74,6 +76,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	kmaster := &MasterConfig{
 		MasterIP:             net.ParseIP(options.KubernetesMasterConfig.MasterIP),
 		MasterPort:           port,
+		MasterCount:          options.KubernetesMasterConfig.MasterCount,
 		NodeHosts:            options.KubernetesMasterConfig.StaticNodeNames,
 		PortalNet:            &portalNet,
 		RequestContextMapper: requestContextMapper,


### PR DESCRIPTION
MasterCount is used by the master to determine the appropriate number
of masters in use so that the endpoints list can converge. Eventually,
we will have a better algorithm for master membership convergence.

The value will default to 1 and fail validation if < 1.  Admins must
set this to the same value on all masters.

@brenton @deads2k review