### PR TITLE
Prune deployment utilities

### DIFF
--- a/pkg/deploy/prune/data.go
+++ b/pkg/deploy/prune/data.go
@@ -1,0 +1,155 @@
+package prune
+
+import (
+	"fmt"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+// DeploymentByDeploymentConfigIndexFunc indexes Deployment items by their associated DeploymentConfig, if none, index with key "orphan"
+func DeploymentByDeploymentConfigIndexFunc(obj interface{}) (string, error) {
+	controller, ok := obj.(*kapi.ReplicationController)
+	if !ok {
+		return "", fmt.Errorf("not a replication controller: %v", obj)
+	}
+	name := deployutil.DeploymentConfigNameFor(controller)
+	if len(name) == 0 {
+		return "orphan", nil
+	}
+	return controller.Namespace + "/" + name, nil
+}
+
+// Filter filters the set of objects
+type Filter interface {
+	Filter(items []*kapi.ReplicationController) []*kapi.ReplicationController
+}
+
+// andFilter ands a set of predicate functions to know if it should be included in the return set
+type andFilter struct {
+	filterPredicates []FilterPredicate
+}
+
+// Filter ands the set of predicates evaluated against each item to make a filtered set
+func (a *andFilter) Filter(items []*kapi.ReplicationController) []*kapi.ReplicationController {
+	results := []*kapi.ReplicationController{}
+	for _, item := range items {
+		include := true
+		for _, filterPredicate := range a.filterPredicates {
+			include = include && filterPredicate(item)
+		}
+		if include {
+			results = append(results, item)
+		}
+	}
+	return results
+}
+
+// FilterPredicate is a function that returns true if the object should be included in the filtered set
+type FilterPredicate func(item *kapi.ReplicationController) bool
+
+// NewFilterBeforePredicate is a function that returns true if the build was created before the current time minus specified duration
+func NewFilterBeforePredicate(d time.Duration) FilterPredicate {
+	now := util.Now()
+	before := util.NewTime(now.Time.Add(-1 * d))
+	return func(item *kapi.ReplicationController) bool {
+		return item.CreationTimestamp.Before(before)
+	}
+}
+
+// FilterDeploymentsPredicate is a function that returns true if the replication controller is associated with a DeploymentConfig
+func FilterDeploymentsPredicate(item *kapi.ReplicationController) bool {
+	return len(deployutil.DeploymentConfigNameFor(item)) > 0
+}
+
+// FilterZeroReplicaSize is a function that returns true if the replication controller size is 0
+func FilterZeroReplicaSize(item *kapi.ReplicationController) bool {
+	return item.Spec.Replicas == 0 && item.Status.Replicas == 0
+}
+
+// DataSet provides functions for working with deployment data
+type DataSet interface {
+	GetDeploymentConfig(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, bool, error)
+	ListDeploymentConfigs() ([]*deployapi.DeploymentConfig, error)
+	ListDeployments() ([]*kapi.ReplicationController, error)
+	ListDeploymentsByDeploymentConfig(config *deployapi.DeploymentConfig) ([]*kapi.ReplicationController, error)
+}
+
+type dataSet struct {
+	deploymentConfigStore cache.Store
+	deploymentIndexer     cache.Indexer
+}
+
+// NewDataSet returns a DataSet over the specified items
+func NewDataSet(deploymentConfigs []*deployapi.DeploymentConfig, deployments []*kapi.ReplicationController) DataSet {
+	deploymentConfigStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, deploymentConfig := range deploymentConfigs {
+		deploymentConfigStore.Add(deploymentConfig)
+	}
+
+	deploymentIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		"deploymentConfig": DeploymentByDeploymentConfigIndexFunc,
+	})
+	for _, deployment := range deployments {
+		deploymentIndexer.Add(deployment)
+	}
+
+	return &dataSet{
+		deploymentConfigStore: deploymentConfigStore,
+		deploymentIndexer:     deploymentIndexer,
+	}
+}
+
+func (d *dataSet) GetDeploymentConfig(controller *kapi.ReplicationController) (*deployapi.DeploymentConfig, bool, error) {
+	name := deployutil.DeploymentConfigNameFor(controller)
+	if len(name) == 0 {
+		return nil, false, nil
+	}
+
+	var deploymentConfig *deployapi.DeploymentConfig
+	key := &deployapi.DeploymentConfig{ObjectMeta: kapi.ObjectMeta{Name: name, Namespace: controller.Namespace}}
+	item, exists, err := d.deploymentConfigStore.Get(key)
+	if exists {
+		deploymentConfig = item.(*deployapi.DeploymentConfig)
+	}
+	return deploymentConfig, exists, err
+}
+
+func (d *dataSet) ListDeploymentConfigs() ([]*deployapi.DeploymentConfig, error) {
+	results := []*deployapi.DeploymentConfig{}
+	for _, item := range d.deploymentConfigStore.List() {
+		results = append(results, item.(*deployapi.DeploymentConfig))
+	}
+	return results, nil
+}
+
+func (d *dataSet) ListDeployments() ([]*kapi.ReplicationController, error) {
+	results := []*kapi.ReplicationController{}
+	for _, item := range d.deploymentIndexer.List() {
+		results = append(results, item.(*kapi.ReplicationController))
+	}
+	return results, nil
+}
+
+func (d *dataSet) ListDeploymentsByDeploymentConfig(deploymentConfig *deployapi.DeploymentConfig) ([]*kapi.ReplicationController, error) {
+	results := []*kapi.ReplicationController{}
+	key := &kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace:   deploymentConfig.Namespace,
+			Annotations: map[string]string{deployapi.DeploymentConfigAnnotation: deploymentConfig.Name},
+		},
+	}
+	items, err := d.deploymentIndexer.Index("deploymentConfig", key)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		results = append(results, item.(*kapi.ReplicationController))
+	}
+	return results, nil
+}

--- a/pkg/deploy/prune/data_test.go
+++ b/pkg/deploy/prune/data_test.go
@@ -1,0 +1,164 @@
+package prune
+
+import (
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+func mockDeploymentConfig(namespace, name string) *deployapi.DeploymentConfig {
+	return &deployapi.DeploymentConfig{ObjectMeta: kapi.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+func withSize(item *kapi.ReplicationController, replicas int) *kapi.ReplicationController {
+	item.Spec.Replicas = replicas
+	item.Status.Replicas = replicas
+	return item
+}
+
+func withCreated(item *kapi.ReplicationController, creationTimestamp util.Time) *kapi.ReplicationController {
+	item.CreationTimestamp = creationTimestamp
+	return item
+}
+
+func withStatus(item *kapi.ReplicationController, status deployapi.DeploymentStatus) *kapi.ReplicationController {
+	item.Annotations[deployapi.DeploymentStatusAnnotation] = string(status)
+	return item
+}
+
+func mockDeployment(namespace, name string, deploymentConfig *deployapi.DeploymentConfig) *kapi.ReplicationController {
+	item := &kapi.ReplicationController{ObjectMeta: kapi.ObjectMeta{Namespace: namespace, Name: name, Annotations: map[string]string{}}}
+	if deploymentConfig != nil {
+		item.Annotations[deployapi.DeploymentConfigAnnotation] = deploymentConfig.Name
+	}
+	item.Annotations[deployapi.DeploymentStatusAnnotation] = string(deployapi.DeploymentStatusNew)
+	return item
+}
+
+func TestDeploymentByDeploymentConfigIndexFunc(t *testing.T) {
+	config := mockDeploymentConfig("a", "b")
+	deployment := mockDeployment("a", "c", config)
+	actualKey, err := DeploymentByDeploymentConfigIndexFunc(deployment)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	expectedKey := "a/b"
+	if actualKey != expectedKey {
+		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
+	}
+	deploymentWithNoConfig := &kapi.ReplicationController{}
+	actualKey, err = DeploymentByDeploymentConfigIndexFunc(deploymentWithNoConfig)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	expectedKey = "orphan"
+	if actualKey != expectedKey {
+		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
+	}
+}
+
+func TestFilterBeforePredicate(t *testing.T) {
+	youngerThan := time.Hour
+	now := util.Now()
+	old := util.NewTime(now.Time.Add(-1 * youngerThan))
+	items := []*kapi.ReplicationController{}
+	items = append(items, withCreated(mockDeployment("a", "old", nil), old))
+	items = append(items, withCreated(mockDeployment("a", "new", nil), now))
+	filter := &andFilter{
+		filterPredicates: []FilterPredicate{NewFilterBeforePredicate(youngerThan)},
+	}
+	result := filter.Filter(items)
+	if len(result) != 1 {
+		t.Errorf("Unexpected number of results")
+	}
+	if expected, actual := "old", result[0].Name; expected != actual {
+		t.Errorf("expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestEmptyDataSet(t *testing.T) {
+	deployments := []*kapi.ReplicationController{}
+	deploymentConfigs := []*deployapi.DeploymentConfig{}
+	dataSet := NewDataSet(deploymentConfigs, deployments)
+	_, exists, err := dataSet.GetDeploymentConfig(&kapi.ReplicationController{})
+	if exists || err != nil {
+		t.Errorf("Unexpected result %v, %v", exists, err)
+	}
+	deploymentConfigResults, err := dataSet.ListDeploymentConfigs()
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(deploymentConfigResults) != 0 {
+		t.Errorf("Unexpected result %v", deploymentConfigResults)
+	}
+	deploymentResults, err := dataSet.ListDeployments()
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(deploymentResults) != 0 {
+		t.Errorf("Unexpected result %v", deploymentResults)
+	}
+	deploymentResults, err = dataSet.ListDeploymentsByDeploymentConfig(&deployapi.DeploymentConfig{})
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(deploymentResults) != 0 {
+		t.Errorf("Unexpected result %v", deploymentResults)
+	}
+}
+
+func TestPopulatedDataSet(t *testing.T) {
+	deploymentConfigs := []*deployapi.DeploymentConfig{
+		mockDeploymentConfig("a", "deployment-config-1"),
+		mockDeploymentConfig("b", "deployment-config-2"),
+	}
+	deployments := []*kapi.ReplicationController{
+		mockDeployment("a", "deployment-1", deploymentConfigs[0]),
+		mockDeployment("a", "deployment-2", deploymentConfigs[0]),
+		mockDeployment("b", "deployment-3", deploymentConfigs[1]),
+		mockDeployment("c", "deployment-4", nil),
+	}
+	dataSet := NewDataSet(deploymentConfigs, deployments)
+	for _, deployment := range deployments {
+		deploymentConfig, exists, err := dataSet.GetDeploymentConfig(deployment)
+		config, hasConfig := deployment.Annotations[deployapi.DeploymentConfigAnnotation]
+		if hasConfig {
+			if err != nil {
+				t.Errorf("Item %v, unexpected error: %v", deployment, err)
+			}
+			if !exists {
+				t.Errorf("Item %v, unexpected result: %v", deployment, exists)
+			}
+			if expected, actual := config, deploymentConfig.Name; expected != actual {
+				t.Errorf("expected %v, actual %v", expected, actual)
+			}
+			if expected, actual := deployment.Namespace, deploymentConfig.Namespace; expected != actual {
+				t.Errorf("expected %v, actual %v", expected, actual)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Item %v, unexpected error: %v", deployment, err)
+			}
+			if exists {
+				t.Errorf("Item %v, unexpected result: %v", deployment, exists)
+			}
+		}
+	}
+	expectedNames := util.NewStringSet("deployment-1", "deployment-2")
+	deploymentResults, err := dataSet.ListDeploymentsByDeploymentConfig(deploymentConfigs[0])
+	if err != nil {
+		t.Errorf("Unexpected result %v", err)
+	}
+	if len(deploymentResults) != len(expectedNames) {
+		t.Errorf("Unexpected result %v", deploymentResults)
+	}
+	for _, deployment := range deploymentResults {
+		if !expectedNames.Has(deployment.Name) {
+			t.Errorf("Unexpected name: %v", deployment.Name)
+		}
+	}
+}

--- a/pkg/deploy/prune/prune.go
+++ b/pkg/deploy/prune/prune.go
@@ -1,0 +1,69 @@
+package prune
+
+import (
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+// PruneFunc is a function that is invoked for each item during Prune
+type PruneFunc func(item *kapi.ReplicationController) error
+
+// PruneTask is an object that knows how to execute a single iteration of a Prune
+type PruneTasker interface {
+	PruneTask() error
+}
+
+// pruneTask is an object that knows how to prune a data set
+type pruneTask struct {
+	resolver Resolver
+	handler  PruneFunc
+}
+
+// NewPruneTasker returns a PruneTasker over specified data using specified flags
+// keepYoungerThan will filter out all objects from prune data set that are younger than the specified time duration
+// orphans if true will include inactive orphan deployments in candidate prune set
+// keepComplete is per DeploymentConfig how many of the most recent deployments should be preserved
+// keepFailed is per DeploymentConfig how many of the most recent failed deployments should be preserved
+func NewPruneTasker(deploymentConfigs []*deployapi.DeploymentConfig, deployments []*kapi.ReplicationController, keepYoungerThan time.Duration, orphans bool, keepComplete int, keepFailed int, handler PruneFunc) PruneTasker {
+	filter := &andFilter{
+		filterPredicates: []FilterPredicate{
+			FilterDeploymentsPredicate,
+			FilterZeroReplicaSize,
+			NewFilterBeforePredicate(keepYoungerThan),
+		},
+	}
+	deployments = filter.Filter(deployments)
+	dataSet := NewDataSet(deploymentConfigs, deployments)
+
+	resolvers := []Resolver{}
+	if orphans {
+		inactiveDeploymentStatus := []deployapi.DeploymentStatus{
+			deployapi.DeploymentStatusComplete,
+			deployapi.DeploymentStatusFailed,
+		}
+		resolvers = append(resolvers, NewOrphanDeploymentResolver(dataSet, inactiveDeploymentStatus))
+	}
+	resolvers = append(resolvers, NewPerDeploymentConfigResolver(dataSet, keepComplete, keepFailed))
+	return &pruneTask{
+		resolver: &mergeResolver{resolvers: resolvers},
+		handler:  handler,
+	}
+}
+
+// PruneTask will visit each item in the prunable set and invoke the associated handler
+func (t *pruneTask) PruneTask() error {
+	deployments, err := t.resolver.Resolve()
+	if err != nil {
+		return err
+	}
+	for _, deployment := range deployments {
+		err = t.handler(deployment)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/deploy/prune/prune_test.go
+++ b/pkg/deploy/prune/prune_test.go
@@ -1,0 +1,103 @@
+package prune
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+type mockPruneRecorder struct {
+	set util.StringSet
+	err error
+}
+
+func (m *mockPruneRecorder) Handler(deployment *kapi.ReplicationController) error {
+	m.set.Insert(deployment.Name)
+	return m.err
+}
+
+func (m *mockPruneRecorder) Verify(t *testing.T, expected util.StringSet) {
+	if len(m.set) != len(expected) || !m.set.HasAll(expected.List()...) {
+		expectedValues := expected.List()
+		actualValues := m.set.List()
+		sort.Strings(expectedValues)
+		sort.Strings(actualValues)
+		t.Errorf("expected \n\t%v\n, actual \n\t%v\n", expectedValues, actualValues)
+	}
+}
+
+func TestPruneTask(t *testing.T) {
+	deploymentStatusOptions := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusComplete,
+		deployapi.DeploymentStatusFailed,
+		deployapi.DeploymentStatusNew,
+		deployapi.DeploymentStatusPending,
+		deployapi.DeploymentStatusRunning,
+	}
+	deploymentStatusFilter := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusComplete,
+		deployapi.DeploymentStatusFailed,
+	}
+	deploymentStatusFilterSet := util.StringSet{}
+	for _, deploymentStatus := range deploymentStatusFilter {
+		deploymentStatusFilterSet.Insert(string(deploymentStatus))
+	}
+
+	for _, orphans := range []bool{true, false} {
+		for _, deploymentStatusOption := range deploymentStatusOptions {
+			keepYoungerThan := time.Hour
+
+			now := util.Now()
+			old := util.NewTime(now.Time.Add(-1 * keepYoungerThan))
+
+			deploymentConfigs := []*deployapi.DeploymentConfig{}
+			deployments := []*kapi.ReplicationController{}
+
+			deploymentConfig := mockDeploymentConfig("a", "deployment-config")
+			deploymentConfigs = append(deploymentConfigs, deploymentConfig)
+
+			deployments = append(deployments, withCreated(withStatus(mockDeployment("a", "build-1", deploymentConfig), deploymentStatusOption), now))
+			deployments = append(deployments, withCreated(withStatus(mockDeployment("a", "build-2", deploymentConfig), deploymentStatusOption), old))
+			deployments = append(deployments, withSize(withCreated(withStatus(mockDeployment("a", "build-3-with-replicas", deploymentConfig), deploymentStatusOption), old), 4))
+			deployments = append(deployments, withCreated(withStatus(mockDeployment("a", "orphan-build-1", nil), deploymentStatusOption), now))
+			deployments = append(deployments, withCreated(withStatus(mockDeployment("a", "orphan-build-2", nil), deploymentStatusOption), old))
+			deployments = append(deployments, withSize(withCreated(withStatus(mockDeployment("a", "orphan-build-3-with-replicas", nil), deploymentStatusOption), old), 4))
+
+			keepComplete := 1
+			keepFailed := 1
+			expectedValues := util.StringSet{}
+			filter := &andFilter{
+				filterPredicates: []FilterPredicate{
+					FilterDeploymentsPredicate,
+					FilterZeroReplicaSize,
+					NewFilterBeforePredicate(keepYoungerThan),
+				},
+			}
+			dataSet := NewDataSet(deploymentConfigs, filter.Filter(deployments))
+			resolver := NewPerDeploymentConfigResolver(dataSet, keepComplete, keepFailed)
+			if orphans {
+				resolver = &mergeResolver{
+					resolvers: []Resolver{resolver, NewOrphanDeploymentResolver(dataSet, deploymentStatusFilter)},
+				}
+			}
+			expectedDeployments, err := resolver.Resolve()
+			for _, item := range expectedDeployments {
+				expectedValues.Insert(item.Name)
+			}
+
+			recorder := &mockPruneRecorder{set: util.StringSet{}}
+			task := NewPruneTasker(deploymentConfigs, deployments, keepYoungerThan, orphans, keepComplete, keepFailed, recorder.Handler)
+			err = task.PruneTask()
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			recorder.Verify(t, expectedValues)
+		}
+	}
+
+}

--- a/pkg/deploy/prune/resolvers.go
+++ b/pkg/deploy/prune/resolvers.go
@@ -1,0 +1,125 @@
+package prune
+
+import (
+	"sort"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+// Resolver knows how to resolve the set of candidate objects to prune
+type Resolver interface {
+	Resolve() ([]*kapi.ReplicationController, error)
+}
+
+// mergeResolver merges the set of results from multiple resolvers
+type mergeResolver struct {
+	resolvers []Resolver
+}
+
+func (m *mergeResolver) Resolve() ([]*kapi.ReplicationController, error) {
+	results := []*kapi.ReplicationController{}
+	for _, resolver := range m.resolvers {
+		items, err := resolver.Resolve()
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, items...)
+	}
+	return results, nil
+}
+
+// NewOrphanDeploymentResolver returns a Resolver that matches objects with no associated DeploymentConfig and has a DeploymentStatus in filter
+func NewOrphanDeploymentResolver(dataSet DataSet, deploymentStatusFilter []deployapi.DeploymentStatus) Resolver {
+	filter := util.NewStringSet()
+	for _, deploymentStatus := range deploymentStatusFilter {
+		filter.Insert(string(deploymentStatus))
+	}
+	return &orphanDeploymentResolver{
+		dataSet:                dataSet,
+		deploymentStatusFilter: filter,
+	}
+}
+
+// orphanDeploymentResolver resolves orphan deployments that match the specified filter
+type orphanDeploymentResolver struct {
+	dataSet                DataSet
+	deploymentStatusFilter util.StringSet
+}
+
+// Resolve the matching set of objects
+func (o *orphanDeploymentResolver) Resolve() ([]*kapi.ReplicationController, error) {
+	deployments, err := o.dataSet.ListDeployments()
+	if err != nil {
+		return nil, err
+	}
+
+	results := []*kapi.ReplicationController{}
+	for _, deployment := range deployments {
+		deploymentStatus := deployutil.DeploymentStatusFor(deployment)
+		if !o.deploymentStatusFilter.Has(string(deploymentStatus)) {
+			continue
+		}
+		_, exists, _ := o.dataSet.GetDeploymentConfig(deployment)
+		if !exists {
+			results = append(results, deployment)
+		}
+	}
+	return results, nil
+}
+
+type perDeploymentConfigResolver struct {
+	dataSet      DataSet
+	keepComplete int
+	keepFailed   int
+}
+
+// NewPerDeploymentConfigResolver returns a Resolver that selects items to prune per config
+func NewPerDeploymentConfigResolver(dataSet DataSet, keepComplete int, keepFailed int) Resolver {
+	return &perDeploymentConfigResolver{
+		dataSet:      dataSet,
+		keepComplete: keepComplete,
+		keepFailed:   keepFailed,
+	}
+}
+
+func (o *perDeploymentConfigResolver) Resolve() ([]*kapi.ReplicationController, error) {
+	deploymentConfigs, err := o.dataSet.ListDeploymentConfigs()
+	if err != nil {
+		return nil, err
+	}
+
+	completeStates := util.NewStringSet(string(deployapi.DeploymentStatusComplete))
+	failedStates := util.NewStringSet(string(deployapi.DeploymentStatusFailed))
+
+	results := []*kapi.ReplicationController{}
+	for _, deploymentConfig := range deploymentConfigs {
+		deployments, err := o.dataSet.ListDeploymentsByDeploymentConfig(deploymentConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		completeDeployments, failedDeployments := []*kapi.ReplicationController{}, []*kapi.ReplicationController{}
+		for _, deployment := range deployments {
+			status := deployutil.DeploymentStatusFor(deployment)
+			if completeStates.Has(string(status)) {
+				completeDeployments = append(completeDeployments, deployment)
+			} else if failedStates.Has(string(status)) {
+				failedDeployments = append(failedDeployments, deployment)
+			}
+		}
+		sort.Sort(sortableReplicationControllers(completeDeployments))
+		sort.Sort(sortableReplicationControllers(failedDeployments))
+
+		if o.keepComplete >= 0 && o.keepComplete < len(completeDeployments) {
+			results = append(results, completeDeployments[o.keepComplete:]...)
+		}
+		if o.keepFailed >= 0 && o.keepFailed < len(failedDeployments) {
+			results = append(results, failedDeployments[o.keepFailed:]...)
+		}
+	}
+	return results, nil
+}

--- a/pkg/deploy/prune/resolvers_test.go
+++ b/pkg/deploy/prune/resolvers_test.go
@@ -1,0 +1,187 @@
+package prune
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+)
+
+type mockResolver struct {
+	items []*kapi.ReplicationController
+	err   error
+}
+
+func (m *mockResolver) Resolve() ([]*kapi.ReplicationController, error) {
+	return m.items, m.err
+}
+
+func TestMergeResolver(t *testing.T) {
+	resolverA := &mockResolver{
+		items: []*kapi.ReplicationController{
+			mockDeployment("a", "b", nil),
+		},
+	}
+	resolverB := &mockResolver{
+		items: []*kapi.ReplicationController{
+			mockDeployment("c", "d", nil),
+		},
+	}
+	resolver := &mergeResolver{resolvers: []Resolver{resolverA, resolverB}}
+	results, err := resolver.Resolve()
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Unexpected results %v", results)
+	}
+	expectedNames := util.NewStringSet("b", "d")
+	for _, item := range results {
+		if !expectedNames.Has(item.Name) {
+			t.Errorf("Unexpected name %v", item.Name)
+		}
+	}
+}
+
+func TestOrphanDeploymentResolver(t *testing.T) {
+	activeDeploymentConfig := mockDeploymentConfig("a", "active-deployment-config")
+	inactiveDeploymentConfig := mockDeploymentConfig("a", "inactive-deployment-config")
+
+	deploymentConfigs := []*deployapi.DeploymentConfig{activeDeploymentConfig}
+	deployments := []*kapi.ReplicationController{}
+
+	expectedNames := util.StringSet{}
+	deploymentStatusOptions := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusComplete,
+		deployapi.DeploymentStatusFailed,
+		deployapi.DeploymentStatusNew,
+		deployapi.DeploymentStatusPending,
+		deployapi.DeploymentStatusRunning,
+	}
+
+	deploymentStatusFilter := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusComplete,
+		deployapi.DeploymentStatusFailed,
+	}
+	deploymentStatusFilterSet := util.StringSet{}
+	for _, deploymentStatus := range deploymentStatusFilter {
+		deploymentStatusFilterSet.Insert(string(deploymentStatus))
+	}
+
+	for _, deploymentStatusOption := range deploymentStatusOptions {
+		deployments = append(deployments, withStatus(mockDeployment("a", string(deploymentStatusOption)+"-active", activeDeploymentConfig), deploymentStatusOption))
+		deployments = append(deployments, withStatus(mockDeployment("a", string(deploymentStatusOption)+"-inactive", inactiveDeploymentConfig), deploymentStatusOption))
+		deployments = append(deployments, withStatus(mockDeployment("a", string(deploymentStatusOption)+"-orphan", nil), deploymentStatusOption))
+		if deploymentStatusFilterSet.Has(string(deploymentStatusOption)) {
+			expectedNames.Insert(string(deploymentStatusOption) + "-inactive")
+			expectedNames.Insert(string(deploymentStatusOption) + "-orphan")
+		}
+	}
+
+	dataSet := NewDataSet(deploymentConfigs, deployments)
+	resolver := NewOrphanDeploymentResolver(dataSet, deploymentStatusFilter)
+	results, err := resolver.Resolve()
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	foundNames := util.StringSet{}
+	for _, result := range results {
+		foundNames.Insert(result.Name)
+	}
+	if len(foundNames) != len(expectedNames) || !expectedNames.HasAll(foundNames.List()...) {
+		t.Errorf("expected %v, actual %v", expectedNames, foundNames)
+	}
+}
+
+func TestPerDeploymentConfigResolver(t *testing.T) {
+	deploymentStatusOptions := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusComplete,
+		deployapi.DeploymentStatusFailed,
+		deployapi.DeploymentStatusNew,
+		deployapi.DeploymentStatusPending,
+		deployapi.DeploymentStatusRunning,
+	}
+	deploymentConfigs := []*deployapi.DeploymentConfig{
+		mockDeploymentConfig("a", "deployment-config-1"),
+		mockDeploymentConfig("b", "deployment-config-2"),
+	}
+	deploymentsPerStatus := 100
+	deployments := []*kapi.ReplicationController{}
+	for _, deploymentConfig := range deploymentConfigs {
+		for _, deploymentStatusOption := range deploymentStatusOptions {
+			for i := 0; i < deploymentsPerStatus; i++ {
+				deployment := withStatus(mockDeployment(deploymentConfig.Namespace, fmt.Sprintf("%v-%v-%v", deploymentConfig.Name, deploymentStatusOption, i), deploymentConfig), deploymentStatusOption)
+				deployments = append(deployments, deployment)
+			}
+		}
+	}
+
+	now := util.Now()
+	for i := range deployments {
+		creationTimestamp := util.NewTime(now.Time.Add(-1 * time.Duration(i) * time.Hour))
+		deployments[i].CreationTimestamp = creationTimestamp
+	}
+
+	// test number to keep at varying ranges
+	for keep := 0; keep < deploymentsPerStatus*2; keep++ {
+		dataSet := NewDataSet(deploymentConfigs, deployments)
+
+		expectedNames := util.StringSet{}
+		deploymentCompleteStatusFilterSet := util.NewStringSet(string(deployapi.DeploymentStatusComplete))
+		deploymentFailedStatusFilterSet := util.NewStringSet(string(deployapi.DeploymentStatusFailed))
+
+		for _, deploymentConfig := range deploymentConfigs {
+			deploymentItems, err := dataSet.ListDeploymentsByDeploymentConfig(deploymentConfig)
+			if err != nil {
+				t.Errorf("Unexpected err %v", err)
+			}
+			completedDeployments, failedDeployments := []*kapi.ReplicationController{}, []*kapi.ReplicationController{}
+			for _, deployment := range deploymentItems {
+				status := deployment.Annotations[deployapi.DeploymentStatusAnnotation]
+				if deploymentCompleteStatusFilterSet.Has(status) {
+					completedDeployments = append(completedDeployments, deployment)
+				} else if deploymentFailedStatusFilterSet.Has(status) {
+					failedDeployments = append(failedDeployments, deployment)
+				}
+			}
+			sort.Sort(sortableReplicationControllers(completedDeployments))
+			sort.Sort(sortableReplicationControllers(failedDeployments))
+			purgeCompleted := []*kapi.ReplicationController{}
+			purgeFailed := []*kapi.ReplicationController{}
+			if keep >= 0 && keep < len(completedDeployments) {
+				purgeCompleted = completedDeployments[keep:]
+			}
+			if keep >= 0 && keep < len(failedDeployments) {
+				purgeFailed = failedDeployments[keep:]
+			}
+			for _, deployment := range purgeCompleted {
+				expectedNames.Insert(deployment.Name)
+			}
+			for _, deployment := range purgeFailed {
+				expectedNames.Insert(deployment.Name)
+			}
+		}
+
+		resolver := NewPerDeploymentConfigResolver(dataSet, keep, keep)
+		results, err := resolver.Resolve()
+		if err != nil {
+			t.Errorf("Unexpected error %v", err)
+		}
+		foundNames := util.StringSet{}
+		for _, result := range results {
+			foundNames.Insert(result.Name)
+		}
+		if len(foundNames) != len(expectedNames) || !expectedNames.HasAll(foundNames.List()...) {
+			expectedValues := expectedNames.List()
+			actualValues := foundNames.List()
+			sort.Strings(expectedValues)
+			sort.Strings(actualValues)
+			t.Errorf("keep %v\n, expected \n\t%v\n, actual \n\t%v\n", keep, expectedValues, actualValues)
+		}
+	}
+}

--- a/pkg/deploy/prune/sort.go
+++ b/pkg/deploy/prune/sort.go
@@ -1,0 +1,22 @@
+package prune
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+// sortableReplicationControllers supports sorting ReplicationController items by most recently created
+type sortableReplicationControllers []*kapi.ReplicationController
+
+func (s sortableReplicationControllers) Len() int {
+	return len(s)
+}
+
+func (s sortableReplicationControllers) Less(i, j int) bool {
+	return !s[i].CreationTimestamp.Before(s[j].CreationTimestamp)
+}
+
+func (s sortableReplicationControllers) Swap(i, j int) {
+	t := s[i]
+	s[i] = s[j]
+	s[j] = t
+}

--- a/pkg/deploy/prune/sort_test.go
+++ b/pkg/deploy/prune/sort_test.go
@@ -1,0 +1,37 @@
+package prune
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// TestSort verifies that builds are sorted by most recently created
+func TestSort(t *testing.T) {
+	present := util.Now()
+	past := util.NewTime(present.Time.Add(-1 * time.Minute))
+	controllers := []*kapi.ReplicationController{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:              "past",
+				CreationTimestamp: past,
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:              "present",
+				CreationTimestamp: present,
+			},
+		},
+	}
+	sort.Sort(sortableReplicationControllers(controllers))
+	if controllers[0].Name != "present" {
+		t.Errorf("Unexpected sort order")
+	}
+	if controllers[1].Name != "past" {
+		t.Errorf("Unexpected sort order")
+	}
+}


### PR DESCRIPTION
Follows pattern set forth here: https://github.com/openshift/origin/pull/2260

Now for deployments.

Follow up PR will tie build and deployment prune utilities into ```osadm``` command.

/cc @abhgupta @smarterclayton @ironcladlou 