### PR TITLE
Update openshift-object-describer dependency to 0.0.9

### DIFF
--- a/assets/bower.json
+++ b/assets/bower.json
@@ -26,7 +26,7 @@
     "zeroclipboard": "2.2.0",
     "messenger": "1.4.1",
     "kubernetes-label-selector": "0.0.3",
-    "openshift-object-describer": "0.0.7"
+    "openshift-object-describer": "0.0.9"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",


### PR DESCRIPTION
* Add route describer
* Add container statuses for pods (see #1805)
* Don't show 'None' when env vars are set
* Format date strings

Fixes #2249