### PR TITLE
Upgrade osin, increase entropy in tokens

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -406,7 +406,7 @@
 		},
 		{
 			"ImportPath": "github.com/RangelReale/osin",
-			"Rev": "1f4e9754a8931fbd9834ab11592f358418efc9ff"
+			"Rev": "a9958a122a90a3b069389d394284283c19d58913"
 		},
 		{
 			"ImportPath": "github.com/RangelReale/osincli",

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/access_test.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/access_test.go
@@ -189,7 +189,7 @@ func TestAccessClientCredentials(t *testing.T) {
 		t.Fatalf("Unexpected access token: %s", d)
 	}
 
-	if d := resp.Output["refresh_token"]; d != "r1" {
-		t.Fatalf("Unexpected refresh token: %s", d)
+	if d, dok := resp.Output["refresh_token"]; dok {
+		t.Fatalf("Refresh token should not be generated: %s", d)
 	}
 }

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/example/complete/complete.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/example/complete/complete.go
@@ -106,60 +106,59 @@ func main() {
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
+		defer w.Write([]byte("</body></html>"))
 
-		if code != "" {
-			jr := make(map[string]interface{})
-
-			// build access code url
-			aurl := fmt.Sprintf("/token?grant_type=authorization_code&client_id=1234&state=xyz&redirect_uri=%s&code=%s",
-				url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
-
-			// if parse, download and parse json
-			if r.Form.Get("doparse") == "1" {
-				err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
-					&osin.BasicAuth{"1234", "aabbccdd"}, jr)
-				if err != nil {
-					w.Write([]byte(err.Error()))
-					w.Write([]byte("<br/>"))
-				}
-			}
-
-			// show json error
-			if erd, ok := jr["error"]; ok {
-				w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
-			}
-
-			// show json access token
-			if at, ok := jr["access_token"]; ok {
-				w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
-			}
-
-			w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
-
-			// output links
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Goto Token URL</a><br/>", aurl)))
-
-			cururl := *r.URL
-			curq := cururl.Query()
-			curq.Add("doparse", "1")
-			cururl.RawQuery = curq.Encode()
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
-
-			if rt, ok := jr["refresh_token"]; ok {
-				rurl := fmt.Sprintf("/appauth/refresh?code=%s", rt)
-				w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Refresh Token</a><br/>", rurl)))
-			}
-
-			if at, ok := jr["access_token"]; ok {
-				rurl := fmt.Sprintf("/appauth/info?code=%s", at)
-				w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Info</a><br/>", rurl)))
-			}
-
-		} else {
+		if code == "" {
 			w.Write([]byte("Nothing to do"))
+			return
 		}
 
-		w.Write([]byte("</body></html>"))
+		jr := make(map[string]interface{})
+
+		// build access code url
+		aurl := fmt.Sprintf("/token?grant_type=authorization_code&client_id=1234&state=xyz&redirect_uri=%s&code=%s",
+			url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
+
+		// if parse, download and parse json
+		if r.Form.Get("doparse") == "1" {
+			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
+				&osin.BasicAuth{"1234", "aabbccdd"}, jr)
+			if err != nil {
+				w.Write([]byte(err.Error()))
+				w.Write([]byte("<br/>"))
+			}
+		}
+
+		// show json error
+		if erd, ok := jr["error"]; ok {
+			w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
+		}
+
+		// show json access token
+		if at, ok := jr["access_token"]; ok {
+			w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
+		}
+
+		w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
+
+		// output links
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Goto Token URL</a><br/>", aurl)))
+
+		cururl := *r.URL
+		curq := cururl.Query()
+		curq.Add("doparse", "1")
+		cururl.RawQuery = curq.Encode()
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
+
+		if rt, ok := jr["refresh_token"]; ok {
+			rurl := fmt.Sprintf("/appauth/refresh?code=%s", rt)
+			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Refresh Token</a><br/>", rurl)))
+		}
+
+		if at, ok := jr["access_token"]; ok {
+			rurl := fmt.Sprintf("/appauth/info?code=%s", at)
+			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Info</a><br/>", rurl)))
+		}
 	})
 
 	// Application destination - TOKEN
@@ -187,7 +186,7 @@ func main() {
 		aurl := fmt.Sprintf("/token?grant_type=password&scope=everything&username=%s&password=%s",
 			"test", "test")
 
-		// doownload token
+		// download token
 		err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
 			&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
 		if err != nil {
@@ -232,7 +231,7 @@ func main() {
 		// build access code url
 		aurl := fmt.Sprintf("/token?grant_type=client_credentials")
 
-		// doownload token
+		// download token
 		err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
 			&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
 		if err != nil {
@@ -277,7 +276,7 @@ func main() {
 		// build access code url
 		aurl := fmt.Sprintf("/token?grant_type=assertion&assertion_type=urn:osin.example.complete&assertion=osin.data")
 
-		// doownload token
+		// download token
 		err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
 			&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
 		if err != nil {
@@ -316,49 +315,49 @@ func main() {
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - REFRESH<br/>"))
+		defer w.Write([]byte("</body></html>"))
 
 		code := r.Form.Get("code")
 
-		if code != "" {
-			jr := make(map[string]interface{})
-
-			// build access code url
-			aurl := fmt.Sprintf("/token?grant_type=refresh_token&refresh_token=%s", url.QueryEscape(code))
-
-			// doownload token
-			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
-				&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
-			if err != nil {
-				w.Write([]byte(err.Error()))
-				w.Write([]byte("<br/>"))
-			}
-
-			// show json error
-			if erd, ok := jr["error"]; ok {
-				w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
-			}
-
-			// show json access token
-			if at, ok := jr["access_token"]; ok {
-				w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
-			}
-
-			w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
-
-			if rt, ok := jr["refresh_token"]; ok {
-				rurl := fmt.Sprintf("/appauth/refresh?code=%s", rt)
-				w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Refresh Token</a><br/>", rurl)))
-			}
-
-			if at, ok := jr["access_token"]; ok {
-				rurl := fmt.Sprintf("/appauth/info?code=%s", at)
-				w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Info</a><br/>", rurl)))
-			}
-		} else {
+		if code == "" {
 			w.Write([]byte("Nothing to do"))
+			return
 		}
 
-		w.Write([]byte("</body></html>"))
+		jr := make(map[string]interface{})
+
+		// build access code url
+		aurl := fmt.Sprintf("/token?grant_type=refresh_token&refresh_token=%s", url.QueryEscape(code))
+
+		// download token
+		err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
+			&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
+		if err != nil {
+			w.Write([]byte(err.Error()))
+			w.Write([]byte("<br/>"))
+		}
+
+		// show json error
+		if erd, ok := jr["error"]; ok {
+			w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
+		}
+
+		// show json access token
+		if at, ok := jr["access_token"]; ok {
+			w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
+		}
+
+		w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
+
+		if rt, ok := jr["refresh_token"]; ok {
+			rurl := fmt.Sprintf("/appauth/refresh?code=%s", rt)
+			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Refresh Token</a><br/>", rurl)))
+		}
+
+		if at, ok := jr["access_token"]; ok {
+			rurl := fmt.Sprintf("/appauth/info?code=%s", at)
+			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Info</a><br/>", rurl)))
+		}
 	})
 
 	// Application destination - INFO
@@ -367,44 +366,44 @@ func main() {
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - INFO<br/>"))
+		defer w.Write([]byte("</body></html>"))
 
 		code := r.Form.Get("code")
 
-		if code != "" {
-			jr := make(map[string]interface{})
-
-			// build access code url
-			aurl := fmt.Sprintf("/info?code=%s", url.QueryEscape(code))
-
-			// doownload token
-			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
-				&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
-			if err != nil {
-				w.Write([]byte(err.Error()))
-				w.Write([]byte("<br/>"))
-			}
-
-			// show json error
-			if erd, ok := jr["error"]; ok {
-				w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
-			}
-
-			// show json access token
-			if at, ok := jr["access_token"]; ok {
-				w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
-			}
-
-			w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
-
-			if rt, ok := jr["refresh_token"]; ok {
-				rurl := fmt.Sprintf("/appauth/refresh?code=%s", rt)
-				w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Refresh Token</a><br/>", rurl)))
-			}
-		} else {
+		if code == "" {
 			w.Write([]byte("Nothing to do"))
+			return
 		}
 
-		w.Write([]byte("</body></html>"))
+		jr := make(map[string]interface{})
+
+		// build access code url
+		aurl := fmt.Sprintf("/info?code=%s", url.QueryEscape(code))
+
+		// download token
+		err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
+			&osin.BasicAuth{Username: "1234", Password: "aabbccdd"}, jr)
+		if err != nil {
+			w.Write([]byte(err.Error()))
+			w.Write([]byte("<br/>"))
+		}
+
+		// show json error
+		if erd, ok := jr["error"]; ok {
+			w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
+		}
+
+		// show json access token
+		if at, ok := jr["access_token"]; ok {
+			w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
+		}
+
+		w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
+
+		if rt, ok := jr["refresh_token"]; ok {
+			rurl := fmt.Sprintf("/appauth/refresh?code=%s", rt)
+			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Refresh Token</a><br/>", rurl)))
+		}
 	})
 
 	http.ListenAndServe(":14000", nil)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/example/goauth2client/goauth2client.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/example/goauth2client/goauth2client.go
@@ -88,41 +88,40 @@ func main() {
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
+		defer w.Write([]byte("</body></html>"))
 
-		if code != "" {
-
-			var jr *oauth.Token
-			var err error
-
-			// if parse, download and parse json
-			if r.Form.Get("doparse") == "1" {
-				jr, err = ctransport.Exchange(code)
-				if err != nil {
-					jr = nil
-					w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", err)))
-				}
-			}
-
-			// show json access token
-			if jr != nil {
-				w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", jr.AccessToken)))
-				if jr.RefreshToken != "" {
-					w.Write([]byte(fmt.Sprintf("REFRESH TOKEN: %s<br/>\n", jr.RefreshToken)))
-				}
-			}
-
-			w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
-
-			cururl := *r.URL
-			curq := cururl.Query()
-			curq.Add("doparse", "1")
-			cururl.RawQuery = curq.Encode()
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
-		} else {
+		if code == "" {
 			w.Write([]byte("Nothing to do"))
+			return
 		}
 
-		w.Write([]byte("</body></html>"))
+		var jr *oauth.Token
+		var err error
+
+		// if parse, download and parse json
+		if r.Form.Get("doparse") == "1" {
+			jr, err = ctransport.Exchange(code)
+			if err != nil {
+				jr = nil
+				w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", err)))
+			}
+		}
+
+		// show json access token
+		if jr != nil {
+			w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", jr.AccessToken)))
+			if jr.RefreshToken != "" {
+				w.Write([]byte(fmt.Sprintf("REFRESH TOKEN: %s<br/>\n", jr.RefreshToken)))
+			}
+		}
+
+		w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
+
+		cururl := *r.URL
+		curq := cururl.Query()
+		curq.Add("doparse", "1")
+		cururl.RawQuery = curq.Encode()
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
 	})
 
 	http.ListenAndServe(":14000", nil)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/example/jwttoken/jwttoken.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/example/jwttoken/jwttoken.go
@@ -29,18 +29,19 @@ func (c *AccessTokenGenJWT) GenerateAccessToken(data *osin.AccessData, generater
 		return "", "", err
 	}
 
-	if generaterefresh {
+	if !generaterefresh {
+		return
+	}
 
-		// generate JWT access token
-		token = jwt.New(jwt.GetSigningMethod("RS256"))
-		token.Claims["cid"] = data.Client.GetId()
-		token.Claims["at"] = accesstoken
-		token.Claims["exp"] = data.ExpireAt().Unix()
+	// generate JWT access token
+	token = jwt.New(jwt.GetSigningMethod("RS256"))
+	token.Claims["cid"] = data.Client.GetId()
+	token.Claims["at"] = accesstoken
+	token.Claims["exp"] = data.ExpireAt().Unix()
 
-		refreshtoken, err = token.SignedString(c.PrivateKey)
-		if err != nil {
-			return "", "", err
-		}
+	refreshtoken, err = token.SignedString(c.PrivateKey)
+	if err != nil {
+		return "", "", err
 	}
 	return
 }
@@ -108,49 +109,49 @@ func main() {
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
+		defer w.Write([]byte("</body></html>"))
 
-		if code != "" {
-			jr := make(map[string]interface{})
-
-			// build access code url
-			aurl := fmt.Sprintf("/token?grant_type=authorization_code&client_id=1234&state=xyz&redirect_uri=%s&code=%s",
-				url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
-
-			// if parse, download and parse json
-			if r.Form.Get("doparse") == "1" {
-				err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
-					&osin.BasicAuth{"1234", "aabbccdd"}, jr)
-				if err != nil {
-					w.Write([]byte(err.Error()))
-					w.Write([]byte("<br/>"))
-				}
-			}
-
-			// show json error
-			if erd, ok := jr["error"]; ok {
-				w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
-			}
-
-			// show json access token
-			if at, ok := jr["access_token"]; ok {
-				w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
-			}
-
-			w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
-
-			// output links
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Goto Token URL</a><br/>", aurl)))
-
-			cururl := *r.URL
-			curq := cururl.Query()
-			curq.Add("doparse", "1")
-			cururl.RawQuery = curq.Encode()
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
-		} else {
+		if code == "" {
 			w.Write([]byte("Nothing to do"))
+			return
 		}
 
-		w.Write([]byte("</body></html>"))
+		jr := make(map[string]interface{})
+
+		// build access code url
+		aurl := fmt.Sprintf("/token?grant_type=authorization_code&client_id=1234&state=xyz&redirect_uri=%s&code=%s",
+			url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
+
+		// if parse, download and parse json
+		if r.Form.Get("doparse") == "1" {
+			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
+				&osin.BasicAuth{"1234", "aabbccdd"}, jr)
+			if err != nil {
+				w.Write([]byte(err.Error()))
+				w.Write([]byte("<br/>"))
+			}
+		}
+
+		// show json error
+		if erd, ok := jr["error"]; ok {
+			w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
+		}
+
+		// show json access token
+		if at, ok := jr["access_token"]; ok {
+			w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
+		}
+
+		w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
+
+		// output links
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Goto Token URL</a><br/>", aurl)))
+
+		cururl := *r.URL
+		curq := cururl.Query()
+		curq.Add("doparse", "1")
+		cururl.RawQuery = curq.Encode()
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
 	})
 
 	http.ListenAndServe(":14000", nil)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/example/osincliclient/osincliclient.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/example/osincliclient/osincliclient.go
@@ -101,23 +101,25 @@ func main() {
 	// Auth endpoint
 	clienthttp.HandleFunc("/appauth", func(w http.ResponseWriter, r *http.Request) {
 		// parse a token request
-		if areqdata, err := areq.HandleRequest(r); err == nil {
-			treq := client.NewAccessRequest(osincli.AUTHORIZATION_CODE, areqdata)
-
-			// show access request url (for debugging only)
-			u2 := treq.GetTokenUrl()
-			w.Write([]byte(fmt.Sprintf("Access token URL: %s\n", u2.String())))
-
-			// exchange the authorize token for the access token
-			ad, err := treq.GetToken()
-			if err == nil {
-				w.Write([]byte(fmt.Sprintf("Access token: %+v\n", ad)))
-			} else {
-				w.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
-			}
-		} else {
+		areqdata, err := areq.HandleRequest(r)
+		if err != nil {
 			w.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
+			return
 		}
+
+		treq := client.NewAccessRequest(osincli.AUTHORIZATION_CODE, areqdata)
+
+		// show access request url (for debugging only)
+		u2 := treq.GetTokenUrl()
+		w.Write([]byte(fmt.Sprintf("Access token URL: %s\n", u2.String())))
+
+		// exchange the authorize token for the access token
+		ad, err := treq.GetToken()
+		if err != nil {
+			w.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
+			return
+		}
+		w.Write([]byte(fmt.Sprintf("Access token: %+v\n", ad)))
 	})
 
 	go http.ListenAndServe(":14001", clienthttp)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/example/simple/simple.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/example/simple/simple.go
@@ -77,49 +77,49 @@ func main() {
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
+		defer w.Write([]byte("</body></html>"))
 
-		if code != "" {
-			jr := make(map[string]interface{})
-
-			// build access code url
-			aurl := fmt.Sprintf("/token?grant_type=authorization_code&client_id=1234&client_secret=aabbccdd&state=xyz&redirect_uri=%s&code=%s",
-				url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
-
-			// if parse, download and parse json
-			if r.Form.Get("doparse") == "1" {
-				err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
-					&osin.BasicAuth{"1234", "aabbccdd"}, jr)
-				if err != nil {
-					w.Write([]byte(err.Error()))
-					w.Write([]byte("<br/>"))
-				}
-			}
-
-			// show json error
-			if erd, ok := jr["error"]; ok {
-				w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
-			}
-
-			// show json access token
-			if at, ok := jr["access_token"]; ok {
-				w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
-			}
-
-			w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
-
-			// output links
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Goto Token URL</a><br/>", aurl)))
-
-			cururl := *r.URL
-			curq := cururl.Query()
-			curq.Add("doparse", "1")
-			cururl.RawQuery = curq.Encode()
-			w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
-		} else {
+		if code == "" {
 			w.Write([]byte("Nothing to do"))
+			return
 		}
 
-		w.Write([]byte("</body></html>"))
+		jr := make(map[string]interface{})
+
+		// build access code url
+		aurl := fmt.Sprintf("/token?grant_type=authorization_code&client_id=1234&client_secret=aabbccdd&state=xyz&redirect_uri=%s&code=%s",
+			url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
+
+		// if parse, download and parse json
+		if r.Form.Get("doparse") == "1" {
+			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
+				&osin.BasicAuth{"1234", "aabbccdd"}, jr)
+			if err != nil {
+				w.Write([]byte(err.Error()))
+				w.Write([]byte("<br/>"))
+			}
+		}
+
+		// show json error
+		if erd, ok := jr["error"]; ok {
+			w.Write([]byte(fmt.Sprintf("ERROR: %s<br/>\n", erd)))
+		}
+
+		// show json access token
+		if at, ok := jr["access_token"]; ok {
+			w.Write([]byte(fmt.Sprintf("ACCESS TOKEN: %s<br/>\n", at)))
+		}
+
+		w.Write([]byte(fmt.Sprintf("FULL RESULT: %+v<br/>\n", jr)))
+
+		// output links
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Goto Token URL</a><br/>", aurl)))
+
+		cururl := *r.URL
+		curq := cururl.Query()
+		curq.Add("doparse", "1")
+		cururl.RawQuery = curq.Encode()
+		w.Write([]byte(fmt.Sprintf("<a href=\"%s\">Download Token</a><br/>", cururl.String())))
 	})
 
 	http.ListenAndServe(":14000", nil)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/info.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/info.go
@@ -15,10 +15,15 @@ type InfoRequest struct {
 // NOT an RFC specification.
 func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
 	r.ParseForm()
+	bearer := CheckBearerAuth(r)
+	if bearer == nil {
+		w.SetError(E_INVALID_REQUEST, "")
+		return nil
+	}
 
 	// generate info request
 	ret := &InfoRequest{
-		Code: r.Form.Get("code"),
+		Code: bearer.Code,
 	}
 
 	if ret.Code == "" {
@@ -47,7 +52,7 @@ func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}
-	if ret.AccessData.IsExpired() {
+	if ret.AccessData.IsExpiredAt(s.Now()) {
 		w.SetError(E_INVALID_GRANT, "")
 		return nil
 	}
@@ -66,7 +71,7 @@ func (s *Server) FinishInfoRequest(w *Response, r *http.Request, ir *InfoRequest
 	w.Output["client_id"] = ir.AccessData.Client.GetId()
 	w.Output["access_token"] = ir.AccessData.AccessToken
 	w.Output["token_type"] = s.Config.TokenType
-	w.Output["expires_in"] = ir.AccessData.CreatedAt.Add(time.Duration(ir.AccessData.ExpiresIn)*time.Second).Sub(time.Now()) / time.Second
+	w.Output["expires_in"] = ir.AccessData.CreatedAt.Add(time.Duration(ir.AccessData.ExpiresIn)*time.Second).Sub(s.Now()) / time.Second
 	if ir.AccessData.RefreshToken != "" {
 		w.Output["refresh_token"] = ir.AccessData.RefreshToken
 	}

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/info_test.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/info_test.go
@@ -22,7 +22,37 @@ func TestInfo(t *testing.T) {
 		server.FinishInfoRequest(resp, req, ar)
 	}
 
-	//fmt.Printf("%+v", resp)
+	if resp.IsError && resp.InternalError != nil {
+		t.Fatalf("Error in response: %s", resp.InternalError)
+	}
+
+	if resp.IsError {
+		t.Fatalf("Should not be an error")
+	}
+
+	if resp.Type != DATA {
+		t.Fatalf("Response should be data")
+	}
+
+	if d := resp.Output["access_token"]; d != "9999" {
+		t.Fatalf("Unexpected authorization code: %s", d)
+	}
+}
+
+func TestInfoWhenCodeIsOnHeader(t *testing.T) {
+	sconfig := NewServerConfig()
+	server := NewServer(sconfig, NewTestingStorage())
+	resp := server.NewResponse()
+
+	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer 9999")
+
+	if ar := server.HandleInfoRequest(resp, req); ar != nil {
+		server.FinishInfoRequest(resp, req, ar)
+	}
 
 	if resp.IsError && resp.InternalError != nil {
 		t.Fatalf("Error in response: %s", resp.InternalError)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/response.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/response.go
@@ -45,7 +45,12 @@ func NewResponse(storage Storage) *Response {
 		IsError:         false,
 		Storage:         storage.Clone(),
 	}
-	r.Headers.Add("Cache-Control", "no-store")
+	r.Headers.Add(
+		"Cache-Control",
+		"no-cache, no-store, max-age=0, must-revalidate",
+	)
+	r.Headers.Add("Pragma", "no-cache")
+	r.Headers.Add("Expires", "Fri, 01 Jan 1990 00:00:00 GMT")
 	return r
 }
 
@@ -117,7 +122,10 @@ func (r *Response) GetRedirectUrl() (string, error) {
 	}
 	if r.RedirectInFragment {
 		u.RawQuery = ""
-		u.Fragment = q.Encode()
+		u.Fragment, err = url.QueryUnescape(q.Encode())
+		if err != nil {
+			return "", err
+		}
 	} else {
 		u.RawQuery = q.Encode()
 	}

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/server.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/server.go
@@ -1,7 +1,7 @@
 package osin
 
 import (
-	"net/http"
+	"time"
 )
 
 // Server is an OAuth2 implementation
@@ -10,6 +10,7 @@ type Server struct {
 	Storage           Storage
 	AuthorizeTokenGen AuthorizeTokenGen
 	AccessTokenGen    AccessTokenGen
+	Now               func() time.Time
 }
 
 // NewServer creates a new server instance
@@ -19,21 +20,13 @@ func NewServer(config *ServerConfig, storage Storage) *Server {
 		Storage:           storage,
 		AuthorizeTokenGen: &AuthorizeTokenGenDefault{},
 		AccessTokenGen:    &AccessTokenGenDefault{},
+		Now:               time.Now,
 	}
 }
 
 // NewResponse creates a new response for the server
 func (s *Server) NewResponse() *Response {
-	r := &Response{
-		Type:            DATA,
-		StatusCode:      200,
-		ErrorStatusCode: 200,
-		Output:          make(ResponseData),
-		Headers:         make(http.Header),
-		IsError:         false,
-		Storage:         s.Storage.Clone(),
-	}
-	r.Headers.Add("Cache-Control", "no-store")
+	r := NewResponse(s.Storage)
 	r.ErrorStatusCode = s.Config.ErrorStatusCode
 	return r
 }

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/storage.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/storage.go
@@ -10,7 +10,7 @@ type Storage interface {
 	// Can return itself if not a problem.
 	Clone() Storage
 
-	// Close the resources the Storate potentially holds (using Clone for example)
+	// Close the resources the Storage potentially holds (using Clone for example)
 	Close()
 
 	// GetClient loads the client by id (client_id)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/tokengen.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/tokengen.go
@@ -1,18 +1,24 @@
 package osin
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"encoding/base64"
+	"strings"
+
+	"code.google.com/p/go-uuid/uuid"
 )
 
 // AuthorizeTokenGenDefault is the default authorization token generator
 type AuthorizeTokenGenDefault struct {
 }
 
+func removePadding(token string) string {
+	return strings.TrimRight(token, "=")
+}
+
 // GenerateAuthorizeToken generates a base64-encoded UUID code
 func (a *AuthorizeTokenGenDefault) GenerateAuthorizeToken(data *AuthorizeData) (ret string, err error) {
-	token := uuid.New()
-	return base64.StdEncoding.EncodeToString([]byte(token)), nil
+	token := uuid.NewRandom()
+	return removePadding(base64.URLEncoding.EncodeToString([]byte(token))), nil
 }
 
 // AccessTokenGenDefault is the default authorization token generator
@@ -21,12 +27,12 @@ type AccessTokenGenDefault struct {
 
 // GenerateAccessToken generates base64-encoded UUID access and refresh tokens
 func (a *AccessTokenGenDefault) GenerateAccessToken(data *AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
-	accesstoken = uuid.New()
-	accesstoken = base64.StdEncoding.EncodeToString([]byte(accesstoken))
+	token := uuid.NewRandom()
+	accesstoken = removePadding(base64.URLEncoding.EncodeToString([]byte(token)))
 
 	if generaterefresh {
-		refreshtoken = uuid.New()
-		refreshtoken = base64.StdEncoding.EncodeToString([]byte(refreshtoken))
+		rtoken := uuid.NewRandom()
+		refreshtoken = removePadding(base64.URLEncoding.EncodeToString([]byte(rtoken)))
 	}
 	return
 }

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/util.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/util.go
@@ -13,6 +13,11 @@ type BasicAuth struct {
 	Password string
 }
 
+// Parse bearer authentication header
+type BearerAuth struct {
+	Code string
+}
+
 // Return authorization header data
 func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 	if r.Header.Get("Authorization") == "" {
@@ -34,6 +39,24 @@ func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 	}
 
 	return &BasicAuth{Username: pair[0], Password: pair[1]}, nil
+}
+
+// Return "Bearer" token from request. The header has precedence over query string.
+func CheckBearerAuth(r *http.Request) *BearerAuth {
+	authHeader := r.Header.Get("Authorization")
+	authForm := r.Form.Get("code")
+	if authHeader == "" && authForm == "" {
+		return nil
+	}
+	token := authForm
+	if authHeader != "" {
+		s := strings.SplitN(authHeader, " ", 2)
+		if (len(s) != 2 || s[0] != "Bearer") && token == "" {
+			return nil
+		}
+		token = s[1]
+	}
+	return &BearerAuth{Code: token}
 }
 
 // getClientAuth checks client basic authentication in params if allowed,

--- a/pkg/oauth/server/osinserver/osinserver.go
+++ b/pkg/oauth/server/osinserver/osinserver.go
@@ -23,9 +23,15 @@ type Server struct {
 }
 
 func New(config *osin.ServerConfig, storage osin.Storage, authorize AuthorizeHandler, access AccessHandler, errorHandler ErrorHandler) *Server {
+	server := osin.NewServer(config, storage)
+
+	// Override tokengen to ensure we get valid length tokens
+	server.AuthorizeTokenGen = &AuthorizeTokenGen{}
+	server.AccessTokenGen = &AccessTokenGen{}
+
 	return &Server{
 		config:       config,
-		server:       osin.NewServer(config, storage),
+		server:       server,
 		authorize:    authorize,
 		access:       access,
 		errorHandler: errorHandler,

--- a/pkg/oauth/server/osinserver/tokengen.go
+++ b/pkg/oauth/server/osinserver/tokengen.go
@@ -1,0 +1,45 @@
+package osinserver
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"code.google.com/p/go-uuid/uuid"
+
+	"github.com/RangelReale/osin"
+)
+
+func randomToken() string {
+	// Two random uuids to get the length we want (> 32 chars when base-64 encoded)
+	b := []byte{}
+	b = append(b, []byte(uuid.NewRandom())...)
+	b = append(b, []byte(uuid.NewRandom())...)
+	// Use URLEncoding to ensure we don't get / characters
+	s := base64.URLEncoding.EncodeToString(b)
+	// Strip trailing ='s... they're ugly
+	return strings.TrimRight(s, "=")
+}
+
+// AuthorizeTokenGen is an authorization token generator
+type AuthorizeTokenGen struct {
+}
+
+// GenerateAuthorizeToken generates a random UUID code
+func (a *AuthorizeTokenGen) GenerateAuthorizeToken(data *osin.AuthorizeData) (ret string, err error) {
+	return randomToken(), nil
+}
+
+// AccessTokenGen is an access token generator
+type AccessTokenGen struct {
+}
+
+// GenerateAccessToken generates random UUID access and refresh tokens
+func (a *AccessTokenGen) GenerateAccessToken(data *osin.AccessData, generaterefresh bool) (string, string, error) {
+	accesstoken := randomToken()
+
+	refreshtoken := ""
+	if generaterefresh {
+		refreshtoken = randomToken()
+	}
+	return accesstoken, refreshtoken, nil
+}


### PR DESCRIPTION
- [x] Fixes #1342 by pulling in upstream patch (RangelReale/osin#32) to round-trip the `state` param for the implicit oauth flow (https://github.com/openshift/origin/pull/2288/files#diff-6979cfdf6b487f5f3be424a1d4496b9cR227)
- [x] Switch to base64 URLEncoding tokens to avoid `/` characters in token names
- [x] Increase entropy in access/authorize tokens while shrinking token length

We were previously doing:
```
random uuid bytes -> hex encoding -> base64 encoding
```
This made 122 random bits take about 49 characters to represent. If we skip the hex encoding step, we can get 244 random bits in about 44 characters.