### PR TITLE
Stop using ephemeral ports for integration tests

### DIFF
--- a/test/integration/oauth_basicauth_test.go
+++ b/test/integration/oauth_basicauth_test.go
@@ -202,7 +202,10 @@ func TestOAuthBasicAuthPassword(t *testing.T) {
 	})
 
 	// Start remote server
-	remoteAddr := testutil.FindAvailableBindAddress()
+	remoteAddr, err := testutil.FindAvailableBindAddress(9443, 9999)
+	if err != nil {
+		t.Fatalf("Couldn't get free address for test server: %v", err)
+	}
 	remoteServer := &http.Server{
 		Addr:           remoteAddr,
 		Handler:        remoteHandler,


### PR DESCRIPTION
We shouldn't use ephemeral ports for integration tests, because a free port can be taken by an outgoing request before we get a chance to start a listener on the port.

Also, we should indicate the range we want a port from so we can make sure the same port doesn't get chosen for master and dns, etc.

Fixes #1674 