### PR TITLE
Don't show undefined in error messages when error details incomplete

### DIFF
--- a/assets/app/scripts/controllers/newfromtemplate.js
+++ b/assets/app/scripts/controllers/newfromtemplate.js
@@ -110,12 +110,7 @@ angular.module('openshiftConsole')
                 if (result.failure.length > 0) {
                   result.failure.forEach(
                     function(failure) {
-                      var objectName = "";
-                      if (failure.data && failure.data.details) {
-                        objectName = failure.data.details.kind + " " + failure.data.details.id;
-                      } else {
-                        objectName = "object";
-                      }
+                      var objectName = getFailureObjectName(failure) || "object";
                       alerts.push({
                         type: "error",
                         message: "Cannot create " + objectName + ". ",
@@ -181,4 +176,17 @@ angular.module('openshiftConsole')
         Navigate.toErrorPage("Cannot create from template: the specified template could not be retrieved.");
       }
     );
+
+    function getFailureObjectName(failure) {
+      if (!failure.data || !failure.data.details) {
+        return null;
+      }
+
+      var details = failure.data.details;
+      if (details.kind) {
+        return (details.id) ? details.kind + " " + details.id : details.kind;
+      }
+
+      return details.id;
+    }
   });


### PR DESCRIPTION
![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7682243/af7e6e0e-fd44-11e4-843a-563a6215b3ec.png)

Fixes #2130