### PR TITLE
UPSTREAM: Disable 'Timestamps' in Docker logs to prevent double-timestamps

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools/manager.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools/manager.go
@@ -220,7 +220,7 @@ func (dm *DockerManager) GetContainerLogs(pod *api.Pod, containerID, tail string
 		Stderr:       true,
 		OutputStream: stdout,
 		ErrorStream:  stderr,
-		Timestamps:   true,
+		Timestamps:   false,
 		RawTerminal:  false,
 		Follow:       follow,
 	}


### PR DESCRIPTION
@smarterclayton @TomasTomecek PTAL.