### PR TITLE
Considering existing deployments for deployment configs

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -183,6 +183,12 @@ const (
 	// new deployment.
 	// TODO: This should be made public upstream.
 	DesiredReplicasAnnotation = "kubectl.kubernetes.io/desired-replicas"
+	// DeploymentStatusReasonAnnotation represents the reason for deployment being in a given state
+	// Used for specifying the reason for cancellation or failure of a deployment
+	DeploymentStatusReasonAnnotation = "openshift.io/deployment.status-reason"
+	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
+	// The annotation value does not matter and its mere presence indicates cancellation
+	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
 )
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -180,6 +180,12 @@ const (
 	// DeploymentConfigLabel is the name of a label used to correlate a deployment with the
 	// DeploymentConfigs on which the deployment is based.
 	DeploymentConfigLabel = "deploymentconfig"
+	// DeploymentStatusReasonAnnotation represents the reason for deployment being in a given state
+	// Used for specifying the reason for cancellation or failure of a deployment
+	DeploymentStatusReasonAnnotation = "openshift.io/deployment.status-reason"
+	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
+	// The annotation value does not matter and its mere presence indicates cancellation
+	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
 )
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -147,6 +147,12 @@ const (
 	// DeploymentConfigLabel is the name of a label used to correlate a deployment with the
 	// DeploymentConfigs on which the deployment is based.
 	DeploymentConfigLabel = "deploymentconfig"
+	// DeploymentStatusReasonAnnotation represents the reason for deployment being in a given state
+	// Used for specifying the reason for cancellation or failure of a deployment
+	DeploymentStatusReasonAnnotation = "openshift.io/deployment.status-reason"
+	// DeploymentCancelledAnnotation indicates that the deployment has been cancelled
+	// The annotation value does not matter and its mere presence indicates cancellation
+	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
 )
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -49,9 +49,6 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 
 	configController := &DeploymentConfigController{
 		deploymentClient: &deploymentClientImpl{
-			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				return factory.KubeClient.ReplicationControllers(namespace).Get(name)
-			},
 			createDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 				return factory.KubeClient.ReplicationControllers(namespace).Create(deployment)
 			},
@@ -61,6 +58,9 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 					return nil, err
 				}
 				return factory.KubeClient.ReplicationControllers(namespace).List(selector)
+			},
+			updateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+				return factory.KubeClient.ReplicationControllers(namespace).Update(deployment)
 			},
 		},
 		makeDeployment: func(config *deployapi.DeploymentConfig) (*kapi.ReplicationController, error) {


### PR DESCRIPTION
 - If a running/pending/new deployment exists, the config is requeued
 - If multiple running/previous/new deployments exists, older ones are cancelled