### PR TITLE
Add text-overflow: ellipsis style to project select

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -77,6 +77,9 @@ html, body {
     .caret {
       font-size: @font-size-large + 5;
     }
+    .filter-option {
+      text-overflow: ellipsis;
+    }
   }
   .dropdown-menu.open {
     .dropdown-menu.inner.selectpicker {


### PR DESCRIPTION
Fixes #2324

Hovering the mouse over the elided text shows the full name in a tooltip.

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7688446/6dc91c88-fd72-11e4-949b-3e04e9f326c0.png)

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7688438/633ee702-fd72-11e4-8fc5-1847fa915887.png)