### PR TITLE
Add admin prune builds and deployments command

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/node"
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/admin/project"
+	"github.com/openshift/origin/pkg/cmd/admin/prune"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/experimental/buildchain"
 	exipfailover "github.com/openshift/origin/pkg/cmd/experimental/ipfailover"
@@ -49,6 +50,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 	cmds.AddCommand(buildchain.NewCmdBuildChain(f, fullName, "build-chain"))
 	cmds.AddCommand(node.NewCommandManageNode(f, node.ManageNodeCommandName, fullName+" "+node.ManageNodeCommandName, out))
 	cmds.AddCommand(cmd.NewCmdConfig(fullName, "config"))
+	cmds.AddCommand(prune.NewCommandPrune(prune.PruneRecommendedName, fullName+" "+prune.PruneRecommendedName, f, out))
 
 	// TODO: these probably belong in a sub command
 	cmds.AddCommand(admin.NewCommandCreateKubeConfig(admin.CreateKubeConfigCommandName, fullName+" "+admin.CreateKubeConfigCommandName, out))

--- a/pkg/cmd/admin/prune/builds.go
+++ b/pkg/cmd/admin/prune/builds.go
@@ -1,0 +1,121 @@
+package prune
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/build/prune"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const buildsLongDesc = `
+`
+
+const PruneBuildsRecommendedName = "builds"
+
+type pruneBuildsConfig struct {
+	DryRun          bool
+	KeepYoungerThan time.Duration
+	Orphans         bool
+	KeepComplete    int
+	KeepFailed      int
+}
+
+func NewCmdPruneBuilds(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+	cfg := &pruneBuildsConfig{
+		DryRun:          true,
+		KeepYoungerThan: 60 * time.Minute,
+		Orphans:         false,
+		KeepComplete:    5,
+		KeepFailed:      1,
+	}
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Prune builds",
+		Long:  fmt.Sprintf(buildsLongDesc, parentName, name),
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				glog.Fatalf("No arguments are allowed to this command")
+			}
+
+			osClient, _, err := f.Clients()
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			buildConfigList, err := osClient.BuildConfigs(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			buildList, err := osClient.Builds(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			buildConfigs := []*buildapi.BuildConfig{}
+			for i := range buildConfigList.Items {
+				buildConfigs = append(buildConfigs, &buildConfigList.Items[i])
+			}
+
+			builds := []*buildapi.Build{}
+			for i := range buildList.Items {
+				builds = append(builds, &buildList.Items[i])
+			}
+
+			var buildPruneFunc prune.PruneFunc
+
+			w := tabwriter.NewWriter(out, 10, 4, 3, ' ', 0)
+			defer w.Flush()
+
+			describingPruneBuildFunc := func(build *buildapi.Build) error {
+				fmt.Fprintf(w, "%s\t%s\n", build.Namespace, build.Name)
+				return nil
+			}
+
+			switch cfg.DryRun {
+			case false:
+				buildPruneFunc = func(build *buildapi.Build) error {
+					describingPruneBuildFunc(build)
+					err := osClient.Builds(build.Namespace).Delete(build.Name)
+					if err != nil {
+						return err
+					}
+					return nil
+				}
+			default:
+				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made.")
+				buildPruneFunc = describingPruneBuildFunc
+			}
+
+			fmt.Fprintln(w, "NAMESPACE\tNAME")
+			pruneTask := prune.NewPruneTasker(buildConfigs, builds, cfg.KeepYoungerThan, cfg.Orphans, cfg.KeepComplete, cfg.KeepFailed, buildPruneFunc)
+			err = pruneTask.PruneTask()
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "Perform a build pruning dry-run, displaying what would be deleted but not actually deleting anything.")
+	cmd.Flags().BoolVar(&cfg.Orphans, "orphans", cfg.Orphans, "Prune all builds whose associated build config no longer exists and whose status is complete, failed, error, or canceled.")
+	cmd.Flags().DurationVar(&cfg.KeepYoungerThan, "keep-younger-than", cfg.KeepYoungerThan, "Specify the minimum age of a build for it to be considered a candidate for pruning.")
+	cmd.Flags().IntVar(&cfg.KeepComplete, "keep-complete", cfg.KeepComplete, "Per build configuration, specify the number of builds whose status is complete that will be preserved.")
+	cmd.Flags().IntVar(&cfg.KeepFailed, "keep-failed", cfg.KeepFailed, "Per build configuration, specify the number of builds whose status is failed, error, or canceled that will be preserved.")
+
+	return cmd
+}

--- a/pkg/cmd/admin/prune/deployments.go
+++ b/pkg/cmd/admin/prune/deployments.go
@@ -1,0 +1,120 @@
+package prune
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	"github.com/openshift/origin/pkg/deploy/prune"
+)
+
+const deploymentsLongDesc = `
+`
+
+const PruneDeploymentsRecommendedName = "deployments"
+
+type pruneDeploymentConfig struct {
+	DryRun          bool
+	KeepYoungerThan time.Duration
+	Orphans         bool
+	KeepComplete    int
+	KeepFailed      int
+}
+
+func NewCmdPruneDeployments(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+	cfg := &pruneDeploymentConfig{
+		DryRun:          true,
+		KeepYoungerThan: 60 * time.Minute,
+		KeepComplete:    5,
+		KeepFailed:      1,
+	}
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Prune deployments",
+		Long:  fmt.Sprintf(deploymentsLongDesc, parentName, name),
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				glog.Fatalf("No arguments are allowed to this command")
+			}
+
+			osClient, kclient, err := f.Clients()
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			deploymentConfigList, err := osClient.DeploymentConfigs(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			deploymentList, err := kclient.ReplicationControllers(kapi.NamespaceAll).List(labels.Everything())
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			deploymentConfigs := []*deployapi.DeploymentConfig{}
+			for i := range deploymentConfigList.Items {
+				deploymentConfigs = append(deploymentConfigs, &deploymentConfigList.Items[i])
+			}
+
+			deployments := []*kapi.ReplicationController{}
+			for i := range deploymentList.Items {
+				deployments = append(deployments, &deploymentList.Items[i])
+			}
+
+			var deploymentPruneFunc prune.PruneFunc
+
+			w := tabwriter.NewWriter(out, 10, 4, 3, ' ', 0)
+			defer w.Flush()
+
+			describingPruneDeploymentFunc := func(deployment *kapi.ReplicationController) error {
+				fmt.Fprintf(w, "%s\t%s\n", deployment.Namespace, deployment.Name)
+				return nil
+			}
+
+			switch cfg.DryRun {
+			case false:
+				deploymentPruneFunc = func(deployment *kapi.ReplicationController) error {
+					describingPruneDeploymentFunc(deployment)
+					err := kclient.ReplicationControllers(deployment.Namespace).Delete(deployment.Name)
+					if err != nil {
+						return err
+					}
+					return nil
+				}
+			default:
+				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made.")
+				deploymentPruneFunc = describingPruneDeploymentFunc
+			}
+
+			fmt.Fprintln(w, "NAMESPACE\tNAME")
+			pruneTask := prune.NewPruneTasker(deploymentConfigs, deployments, cfg.KeepYoungerThan, cfg.Orphans, cfg.KeepComplete, cfg.KeepFailed, deploymentPruneFunc)
+			err = pruneTask.PruneTask()
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "Perform a deployment pruning dry-run, displaying what would be deleted but not actually deleting anything.")
+	cmd.Flags().BoolVar(&cfg.Orphans, "orphans", cfg.Orphans, "Prune all deployments where the associated deployment config no longer exists, the status is complete or failed, and the replica size is 0.")
+	cmd.Flags().DurationVar(&cfg.KeepYoungerThan, "keep-younger-than", cfg.KeepYoungerThan, "Specify the minimum age of a deployment for it to be considered a candidate for pruning.")
+	cmd.Flags().IntVar(&cfg.KeepComplete, "keep-complete", cfg.KeepComplete, "Per deployment config, specify the number of deployments whose status is complete that will be preserved whose replica size is 0.")
+	cmd.Flags().IntVar(&cfg.KeepFailed, "keep-failed", cfg.KeepFailed, "Per deployment config, specify the number of deployments whose status is failed that will be preserved whose replica size is 0.")
+
+	return cmd
+}

--- a/pkg/cmd/admin/prune/prune.go
+++ b/pkg/cmd/admin/prune/prune.go
@@ -1,0 +1,29 @@
+package prune
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const PruneRecommendedName = "prune"
+
+func NewCommandPrune(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   name,
+		Short: "Prune resources",
+		Long:  `Prune resources`,
+		Run:   runHelp,
+	}
+
+	cmds.AddCommand(NewCmdPruneBuilds(f, fullName, PruneBuildsRecommendedName, out))
+	cmds.AddCommand(NewCmdPruneDeployments(f, fullName, PruneDeploymentsRecommendedName, out))
+	return cmds
+}
+
+func runHelp(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}


### PR DESCRIPTION
Adds the following:

```shell
[root@openshiftdev vagrant]# openshift admin prune builds --keep-younger-than=1m
Dry run enabled - no modifications will be made.
Namespace: test, Name: ruby-sample-build-5
Namespace: test, Name: ruby-sample-build-4
Namespace: test, Name: ruby-sample-build-3
Namespace: test, Name: ruby-sample-build-2
Namespace: test, Name: ruby-sample-build-1
```

or if you really purge:

```shell
[root@openshiftdev vagrant]# openshift admin prune builds --keep-younger-than=1m --keep-failed=3 --dry-run=false
Dry run **disabled* - builds will be pruned and data will be deleted!
Namespace: test, Name: ruby-sample-build-3
Namespace: test, Name: ruby-sample-build-2
Namespace: test, Name: ruby-sample-build-1
```

/cc @ncdc @smarterclayton 

So this is functional for builds, let me know if you want to provide different output.