### PR TITLE
Print more info on image tags and images

### DIFF
--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -307,7 +307,7 @@ func TestGenerateBuildWithImageTagForSourceStrategyImageRepository(t *testing.T)
 		},
 		GetImageStreamImageFunc: func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error) {
 			return &imageapi.ImageStreamImage{
-				imageapi.Image{
+				Image: imageapi.Image{
 					ObjectMeta:           kapi.ObjectMeta{Name: imageRepoName + ":@id"},
 					DockerImageReference: originalImage + ":" + newTag,
 				},
@@ -378,7 +378,7 @@ func TestGenerateBuildWithImageTagForDockerStrategyImageRepository(t *testing.T)
 		},
 		GetImageStreamImageFunc: func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error) {
 			return &imageapi.ImageStreamImage{
-				imageapi.Image{
+				Image: imageapi.Image{
 					ObjectMeta:           kapi.ObjectMeta{Name: imageRepoName + ":@id"},
 					DockerImageReference: originalImage + ":" + newTag,
 				},
@@ -448,7 +448,7 @@ func TestGenerateBuildWithImageTagForCustomStrategyImageRepository(t *testing.T)
 		},
 		GetImageStreamImageFunc: func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error) {
 			return &imageapi.ImageStreamImage{
-				imageapi.Image{
+				Image: imageapi.Image{
 					ObjectMeta:           kapi.ObjectMeta{Name: imageRepoName + ":@id"},
 					DockerImageReference: originalImage + ":" + newTag,
 				},
@@ -894,7 +894,7 @@ func mockBuildGenerator() *BuildGenerator {
 		},
 		GetImageStreamImageFunc: func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error) {
 			return &imageapi.ImageStreamImage{
-				imageapi.Image{
+				Image: imageapi.Image{
 					ObjectMeta:           kapi.ObjectMeta{Name: imageRepoName + ":@id"},
 					DockerImageReference: latestDockerReference,
 				},

--- a/pkg/build/generator/rest_test.go
+++ b/pkg/build/generator/rest_test.go
@@ -98,7 +98,7 @@ func TestCreateInstantiate(t *testing.T) {
 			return &imageapi.ImageStreamTag{*image, name}, nil
 		},
 		GetImageStreamImageFunc: func(ctx kapi.Context, name string) (*imageapi.ImageStreamImage, error) {
-			return &imageapi.ImageStreamImage{*image}, nil
+			return &imageapi.ImageStreamImage{Image: *image}, nil
 		},
 	}}}
 

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -104,7 +104,7 @@ func (r *repository) Get(ctx context.Context, dgst digest.Digest) (*manifest.Sig
 	if err != nil {
 		return nil, err
 	}
-
+	// TODO: we already fetched it above
 	image, err := r.getImage(dgst)
 	if err != nil {
 		return nil, err

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -178,7 +178,8 @@ const DefaultImageTag = "latest"
 
 // ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
 type ImageStreamImage struct {
-	Image `json:",inline"`
+	Image     `json:",inline"`
+	ImageName string
 }
 
 // DockerImageReference points to a Docker image.

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -177,7 +177,8 @@ type ImageStreamTag struct {
 
 // ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
 type ImageStreamImage struct {
-	Image `json:",inline"`
+	Image     `json:",inline"`
+	ImageName string `json:"imageName"`
 }
 
 // DockerImageReference points to a Docker image.

--- a/pkg/image/api/v1beta3/types.go
+++ b/pkg/image/api/v1beta3/types.go
@@ -112,13 +112,14 @@ type ImageRepositoryTag struct {
 
 // ImageStreamTag exists to allow calls to `osc get imageStreamTag ...` to function.
 type ImageStreamTag struct {
-	Image
+	Image     `json:",inline"`
 	ImageName string `json:"imageName"`
 }
 
 // ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
 type ImageStreamImage struct {
-	Image
+	Image     `json:",inline"`
+	ImageName string `json:"imageName"`
 }
 
 // DockerImageReference points to a Docker image.

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -208,7 +208,10 @@ middleware:
 	if err != nil {
 		t.Fatalf("error getting imageStreamImage: %s", err)
 	}
-	if e, a := fmt.Sprintf("test@%s", dgst.String()), image.Name; e != a {
+	if e, a := fmt.Sprintf("test@%s", dgst.Hex()[:7]), image.Name; e != a {
+		t.Errorf("image name: expected %q, got %q", e, a)
+	}
+	if e, a := dgst.String(), image.ImageName; e != a {
 		t.Errorf("image name: expected %q, got %q", e, a)
 	}
 	if e, a := fmt.Sprintf("127.0.0.1:5000/%s/%s@%s", testutil.Namespace(), stream.Name, dgst.String()), image.DockerImageReference; e != a {


### PR DESCRIPTION
Support partial retrieval of image stream images by the prefix
of their image name. Allow trimming of the digest as well for
simpler output

Add imageName field to imageStreamImage.

@ncdc