### PR TITLE
Enable service accounts

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/reflector.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/reflector.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"sync"
 	"time"
 
 	apierrs "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
@@ -53,8 +54,10 @@ type Reflector struct {
 	resyncPeriod time.Duration
 	// lastSyncResourceVersion is the resource version token last
 	// observed when doing a sync with the underlying store
-	// it is not thread safe as it is not synchronized with access to the store
+	// it is thread safe, but not synchronized with the underlying store
 	lastSyncResourceVersion string
+	// lastSyncResourceVersionMutex guards read/write access to lastSyncResourceVersion
+	lastSyncResourceVersionMutex sync.RWMutex
 }
 
 // NewNamespaceKeyedIndexerAndReflector creates an Indexer and a Reflector
@@ -145,7 +148,7 @@ func (r *Reflector) listAndWatch(stopCh <-chan struct{}) {
 		glog.Errorf("Unable to sync list result: %v", err)
 		return
 	}
-	r.lastSyncResourceVersion = resourceVersion
+	r.setLastSyncResourceVersion(resourceVersion)
 
 	for {
 		w, err := r.listerWatcher.Watch(resourceVersion)
@@ -225,7 +228,7 @@ loop:
 				glog.Errorf("unable to understand watch event %#v", event)
 			}
 			*resourceVersion = meta.ResourceVersion()
-			r.lastSyncResourceVersion = *resourceVersion
+			r.setLastSyncResourceVersion(*resourceVersion)
 			eventCount++
 		}
 	}
@@ -242,5 +245,13 @@ loop:
 // LastSyncResourceVersion is the resource version observed when last sync with the underlying store
 // The value returned is not synchronized with access to the underlying store and is not thread-safe
 func (r *Reflector) LastSyncResourceVersion() string {
+	r.lastSyncResourceVersionMutex.RLock()
+	defer r.lastSyncResourceVersionMutex.RUnlock()
 	return r.lastSyncResourceVersion
+}
+
+func (r *Reflector) setLastSyncResourceVersion(v string) {
+	r.lastSyncResourceVersionMutex.Lock()
+	defer r.lastSyncResourceVersionMutex.Unlock()
+	r.lastSyncResourceVersion = v
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/jwt.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/jwt.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	jwt "github.com/dgrijalva/jwt-go"
 
@@ -32,9 +31,6 @@ import (
 )
 
 const (
-	ServiceAccountUsernamePrefix    = "serviceaccount"
-	ServiceAccountUsernameSeparator = ":"
-
 	Issuer = "kubernetes/serviceaccount"
 
 	SubjectClaim            = "sub"
@@ -75,22 +71,6 @@ func ReadPublicKey(file string) (*rsa.PublicKey, error) {
 	return jwt.ParseRSAPublicKeyFromPEM(data)
 }
 
-// MakeUsername generates a username from the given namespace and ServiceAccount name.
-// The resulting username can be passed to SplitUsername to extract the original namespace and ServiceAccount name.
-func MakeUsername(namespace, name string) string {
-	return strings.Join([]string{ServiceAccountUsernamePrefix, namespace, name}, ServiceAccountUsernameSeparator)
-}
-
-// SplitUsername returns the namespace and ServiceAccount name embedded in the given username,
-// or an error if the username is not a valid name produced by MakeUsername
-func SplitUsername(username string) (string, string, error) {
-	parts := strings.Split(username, ServiceAccountUsernameSeparator)
-	if len(parts) != 3 || parts[0] != ServiceAccountUsernamePrefix || len(parts[1]) == 0 || len(parts[2]) == 0 {
-		return "", "", fmt.Errorf("Username must be in the form %s", MakeUsername("namespace", "name"))
-	}
-	return parts[1], parts[2], nil
-}
-
 // JWTTokenGenerator returns a TokenGenerator that generates signed JWT tokens, using the given privateKey.
 // privateKey is a PEM-encoded byte array of a private RSA key.
 // JWTTokenAuthenticator()
@@ -108,7 +88,7 @@ func (j *jwtTokenGenerator) GenerateToken(serviceAccount api.ServiceAccount, sec
 	// Identify the issuer
 	token.Claims[IssuerClaim] = Issuer
 
-	// Username: `serviceaccount:<namespace>:<serviceaccount>`
+	// Username
 	token.Claims[SubjectClaim] = MakeUsername(serviceAccount.Namespace, serviceAccount.Name)
 
 	// Persist enough structured info for the authenticator to be able to look up the service account and secret
@@ -196,6 +176,11 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(token string) (user.Info, bool
 			return nil, false, errors.New("serviceAccountUID claim is missing")
 		}
 
+		subjectNamespace, subjectName, err := SplitUsername(sub)
+		if err != nil || subjectNamespace != namespace || subjectName != serviceAccountName {
+			return nil, false, errors.New("sub claim is invalid")
+		}
+
 		if j.lookup {
 			// Make sure token hasn't been invalidated by deletion of the secret
 			secret, err := j.getter.GetSecret(namespace, secretName)
@@ -216,11 +201,7 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(token string) (user.Info, bool
 			}
 		}
 
-		return &user.DefaultInfo{
-			Name:   sub,
-			UID:    serviceAccountUID,
-			Groups: []string{},
-		}, true, nil
+		return UserInfo(namespace, serviceAccountName, serviceAccountUID), true, nil
 	}
 
 	return nil, false, validationError

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller.go
@@ -96,6 +96,9 @@ func NewTokensController(cl client.Interface, options TokensControllerOptions) *
 		cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc},
 	)
 
+	e.serviceAccountsSynced = e.serviceAccountController.HasSynced
+	e.secretsSynced = e.secretController.HasSynced
+
 	return e
 }
 
@@ -112,6 +115,9 @@ type TokensController struct {
 	// Since we join two objects, we'll watch both of them with controllers.
 	serviceAccountController *framework.Controller
 	secretController         *framework.Controller
+
+	serviceAccountsSynced func() bool
+	secretsSynced         func() bool
 }
 
 // Runs controller loops and returns immediately
@@ -133,6 +139,9 @@ func (e *TokensController) Stop() {
 
 // serviceAccountAdded reacts to a ServiceAccount creation by creating a corresponding ServiceAccountToken Secret
 func (e *TokensController) serviceAccountAdded(obj interface{}) {
+	if !e.secretsSynced() {
+		return
+	}
 	serviceAccount := obj.(*api.ServiceAccount)
 	err := e.createSecretIfNeeded(serviceAccount)
 	if err != nil {
@@ -142,6 +151,9 @@ func (e *TokensController) serviceAccountAdded(obj interface{}) {
 
 // serviceAccountUpdated reacts to a ServiceAccount update (or re-list) by ensuring a corresponding ServiceAccountToken Secret exists
 func (e *TokensController) serviceAccountUpdated(oldObj interface{}, newObj interface{}) {
+	if !e.secretsSynced() {
+		return
+	}
 	newServiceAccount := newObj.(*api.ServiceAccount)
 	err := e.createSecretIfNeeded(newServiceAccount)
 	if err != nil {
@@ -171,6 +183,9 @@ func (e *TokensController) serviceAccountDeleted(obj interface{}) {
 
 // secretAdded reacts to a Secret create by ensuring the referenced ServiceAccount exists, and by adding a token to the secret if needed
 func (e *TokensController) secretAdded(obj interface{}) {
+	if !e.serviceAccountsSynced() {
+		return
+	}
 	secret := obj.(*api.Secret)
 	serviceAccount, err := e.getServiceAccount(secret)
 	if err != nil {
@@ -188,6 +203,9 @@ func (e *TokensController) secretAdded(obj interface{}) {
 
 // secretUpdated reacts to a Secret update (or re-list) by deleting the secret (if the referenced ServiceAccount does not exist)
 func (e *TokensController) secretUpdated(oldObj interface{}, newObj interface{}) {
+	if !e.serviceAccountsSynced() {
+		return
+	}
 	newSecret := newObj.(*api.Secret)
 	newServiceAccount, err := e.getServiceAccount(newSecret)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/util.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/util.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+)
+
+const (
+	ServiceAccountUsernamePrefix    = "system:serviceaccount:"
+	ServiceAccountUsernameSeparator = ":"
+	ServiceAccountGroupPrefix       = "system:serviceaccounts:"
+	AllServiceAccountsGroup         = "system:serviceaccounts"
+)
+
+// MakeUsername generates a username from the given namespace and ServiceAccount name.
+// The resulting username can be passed to SplitUsername to extract the original namespace and ServiceAccount name.
+func MakeUsername(namespace, name string) string {
+	return ServiceAccountUsernamePrefix + namespace + ServiceAccountUsernameSeparator + name
+}
+
+var invalidUsernameErr = fmt.Errorf("Username must be in the form %s", MakeUsername("namespace", "name"))
+
+// SplitUsername returns the namespace and ServiceAccount name embedded in the given username,
+// or an error if the username is not a valid name produced by MakeUsername
+func SplitUsername(username string) (string, string, error) {
+	if !strings.HasPrefix(username, ServiceAccountUsernamePrefix) {
+		return "", "", invalidUsernameErr
+	}
+	trimmed := strings.TrimPrefix(username, ServiceAccountUsernamePrefix)
+	parts := strings.Split(trimmed, ServiceAccountUsernameSeparator)
+	if len(parts) != 2 {
+		return "", "", invalidUsernameErr
+	}
+	namespace, name := parts[0], parts[1]
+	if ok, _ := validation.ValidateNamespaceName(namespace, false); !ok {
+		return "", "", invalidUsernameErr
+	}
+	if ok, _ := validation.ValidateServiceAccountName(name, false); !ok {
+		return "", "", invalidUsernameErr
+	}
+	return namespace, name, nil
+}
+
+// MakeGroupNames generates service account group names for the given namespace and ServiceAccount name
+func MakeGroupNames(namespace, name string) []string {
+	return []string{
+		AllServiceAccountsGroup,
+		MakeNamespaceGroupName(namespace),
+	}
+}
+
+// MakeNamespaceGroupName returns the name of the group all service accounts in the namespace are included in
+func MakeNamespaceGroupName(namespace string) string {
+	return ServiceAccountGroupPrefix + namespace
+}
+
+// UserInfo returns a user.Info interface for the given namespace, service account name and UID
+func UserInfo(namespace, name, uid string) user.Info {
+	return &user.DefaultInfo{
+		Name:   MakeUsername(namespace, name),
+		UID:    uid,
+		Groups: MakeGroupNames(namespace, name),
+	}
+}

--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -55,11 +55,13 @@ func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 	// TODO: these probably belong in a sub command
 	cmds.AddCommand(admin.NewCommandCreateKubeConfig(admin.CreateKubeConfigCommandName, fullName+" "+admin.CreateKubeConfigCommandName, out))
 	cmds.AddCommand(admin.NewCommandCreateBootstrapPolicyFile(admin.CreateBootstrapPolicyFileCommand, fullName+" "+admin.CreateBootstrapPolicyFileCommand, out))
+	cmds.AddCommand(admin.NewCommandCreateBootstrapProjectTemplate(f, admin.CreateBootstrapProjectTemplateCommand, fullName+" "+admin.CreateBootstrapProjectTemplateCommand, out))
 	cmds.AddCommand(admin.NewCommandOverwriteBootstrapPolicy(admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.CreateBootstrapPolicyFileCommand, out))
 	cmds.AddCommand(admin.NewCommandNodeConfig(admin.NodeConfigCommandName, fullName+" "+admin.NodeConfigCommandName, out))
 	// TODO: these should be rolled up together
 	cmds.AddCommand(admin.NewCommandCreateMasterCerts(admin.CreateMasterCertsCommandName, fullName+" "+admin.CreateMasterCertsCommandName, out))
 	cmds.AddCommand(admin.NewCommandCreateClient(admin.CreateClientCommandName, fullName+" "+admin.CreateClientCommandName, out))
+	cmds.AddCommand(admin.NewCommandCreateKeyPair(admin.CreateKeyPairCommandName, fullName+" "+admin.CreateKeyPairCommandName, out))
 	cmds.AddCommand(admin.NewCommandCreateServerCert(admin.CreateServerCertCommandName, fullName+" "+admin.CreateServerCertCommandName, out))
 	cmds.AddCommand(admin.NewCommandCreateSignerCert(admin.CreateSignerCertCommandName, fullName+" "+admin.CreateSignerCertCommandName, out))
 

--- a/pkg/cmd/server/admin/create_bootstrap_project_template.go
+++ b/pkg/cmd/server/admin/create_bootstrap_project_template.go
@@ -1,0 +1,72 @@
+package admin
+
+import (
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/project/registry/projectrequest/delegated"
+	templateapi "github.com/openshift/origin/pkg/template/api"
+)
+
+const CreateBootstrapProjectTemplateCommand = "create-bootstrap-project-template"
+
+type CreateBootstrapProjectTemplateOptions struct {
+	Name string
+}
+
+func NewCommandCreateBootstrapProjectTemplate(f *clientcmd.Factory, commandName string, fullName string, out io.Writer) *cobra.Command {
+	options := &CreateBootstrapProjectTemplateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   commandName,
+		Short: "Create bootstrap project template for OpenShift",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Validate(args); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
+			}
+
+			template, err := options.CreateBootstrapProjectTemplate()
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			err = f.Factory.PrintObject(cmd, template, out)
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+		},
+	}
+	cmd.SetOutput(out)
+
+	cmd.Flags().StringVar(&options.Name, "name", delegated.DefaultTemplateName, "The name of the template to output.")
+	cmdutil.AddPrinterFlags(cmd)
+
+	// Default to JSON
+	if flag := cmd.Flags().Lookup("output"); flag != nil {
+		flag.Value.Set("json")
+	}
+
+	return cmd
+}
+
+func (o CreateBootstrapProjectTemplateOptions) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+	if len(o.Name) == 0 {
+		return errors.New("--name must be provided")
+	}
+
+	return nil
+}
+
+func (o CreateBootstrapProjectTemplateOptions) CreateBootstrapProjectTemplate() (*templateapi.Template, error) {
+	template := delegated.DefaultTemplate()
+	template.Name = o.Name
+	return template, nil
+}

--- a/pkg/cmd/server/admin/create_keypair.go
+++ b/pkg/cmd/server/admin/create_keypair.go
@@ -1,0 +1,151 @@
+package admin
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+)
+
+const CreateKeyPairCommandName = "create-key-pair"
+
+type CreateKeyPairOptions struct {
+	PublicKeyFile  string
+	PrivateKeyFile string
+
+	Overwrite bool
+	Output    cmdutil.Output
+}
+
+const create_key_pair_long = `
+Create a 2048-bit RSA key pair, and generate PEM-encoded public/private key files.
+
+Example: Creating service account signing and authenticating key files:
+
+    $ CONFIG=openshift.local.config/master
+    $ %[1]s --public-key=$CONFIG/serviceaccounts.public.key --private-key=$CONFIG/serviceaccounts.private.key
+`
+
+func NewCommandCreateKeyPair(commandName string, fullName string, out io.Writer) *cobra.Command {
+	options := &CreateKeyPairOptions{Output: cmdutil.Output{out}}
+
+	cmd := &cobra.Command{
+		Use:   commandName,
+		Short: "Create a public/private key pair",
+		Long:  fmt.Sprintf(create_key_pair_long, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Validate(args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			err := options.CreateKeyPair()
+			kcmdutil.CheckErr(err)
+		},
+	}
+	cmd.SetOutput(out)
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&options.PublicKeyFile, "public-key", "", "The public key file.")
+	flags.StringVar(&options.PrivateKeyFile, "private-key", "", "The private key file.")
+
+	flags.BoolVar(&options.Overwrite, "overwrite", false, "Overwrite existing key files if found. If false, either file existing will prevent creation.")
+
+	return cmd
+}
+
+func (o CreateKeyPairOptions) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+	if len(o.PublicKeyFile) == 0 {
+		return errors.New("--public-key must be provided")
+	}
+	if len(o.PrivateKeyFile) == 0 {
+		return errors.New("--private-key must be provided")
+	}
+	if o.PublicKeyFile == o.PrivateKeyFile {
+		return errors.New("--public-key and --private-key must be different")
+	}
+
+	return nil
+}
+
+func (o CreateKeyPairOptions) CreateKeyPair() error {
+	glog.V(2).Infof("Creating a key pair with: %#v", o)
+
+	if !o.Overwrite {
+		if _, err := os.Stat(o.PrivateKeyFile); err == nil {
+			fmt.Fprintf(o.Output.Get(), "Keeping existing private key file %s\n", o.PrivateKeyFile)
+			return nil
+		}
+		if _, err := os.Stat(o.PublicKeyFile); err == nil {
+			fmt.Fprintf(o.Output.Get(), "Keeping existing public key file %s\n", o.PublicKeyFile)
+			return nil
+		}
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	if err := writePrivateKeyFile(o.PrivateKeyFile, privateKey); err != nil {
+		return err
+	}
+
+	if err := writePublicKeyFile(o.PublicKeyFile, &privateKey.PublicKey); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Output.Get(), "Generated new key pair as %s and %s\n", o.PublicKeyFile, o.PrivateKeyFile)
+
+	return nil
+}
+
+func writePublicKeyFile(path string, key *rsa.PublicKey) error {
+	// ensure parent dir
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+		return err
+	}
+
+	derBytes, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return err
+	}
+
+	b := bytes.Buffer{}
+	if err := pem.Encode(&b, &pem.Block{Type: "RSA PUBLIC KEY", Bytes: derBytes}); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b.Bytes(), os.FileMode(0600))
+}
+
+func writePrivateKeyFile(path string, key *rsa.PrivateKey) error {
+	// ensure parent dir
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+		return err
+	}
+
+	b := bytes.Buffer{}
+	err := pem.Encode(&b, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b.Bytes(), os.FileMode(0600))
+}

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -47,7 +47,7 @@ server cert and run the command to fill it in:
 
     $ mv openshift.local.config/master/master.server.crt{,.old}
     $ %[1]s --cert-dir=... \
-	        --master=https://internal.master.fqdn:8443 \
+            --master=https://internal.master.fqdn:8443 \
             --public-master=https://external.master.fqdn:8443 \
             --hostnames=external.master.fqdn,internal.master.fqdn,localhost,127.0.0.1,172.17.42.1,kubernetes.default.local
 
@@ -167,6 +167,10 @@ func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 		return err
 	}
 
+	if err := o.createServiceAccountKeys(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -255,6 +259,23 @@ func (o CreateMasterCertsOptions) createServerCerts(getSignerCertOptions *GetSig
 		if _, err := serverCertOptions.CreateServerCert(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (o CreateMasterCertsOptions) createServiceAccountKeys() error {
+	keypairOptions := CreateKeyPairOptions{
+		PublicKeyFile:  DefaultServiceAccountPublicKeyFile(o.CertDir),
+		PrivateKeyFile: DefaultServiceAccountPrivateKeyFile(o.CertDir),
+
+		Overwrite: o.Overwrite,
+		Output:    o.Output,
+	}
+	if err := keypairOptions.Validate(nil); err != nil {
+		return err
+	}
+	if err := keypairOptions.CreateKeyPair(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -171,6 +171,13 @@ func DefaultEtcdServingCertInfo(certDir string) configapi.CertInfo {
 	}
 }
 
+func DefaultServiceAccountPrivateKeyFile(certDir string) string {
+	return path.Join(certDir, "serviceaccounts.private.key")
+}
+func DefaultServiceAccountPublicKeyFile(certDir string) string {
+	return path.Join(certDir, "serviceaccounts.public.key")
+}
+
 func DefaultNodeDir(nodeName string) string {
 	return "node-" + nodeName
 }

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -102,6 +102,11 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.KubernetesMasterConfig.SchedulerConfigFile)
 	}
 
+	refs = append(refs, &config.ServiceAccountConfig.PrivateKeyFile)
+	for i := range config.ServiceAccountConfig.PublicKeyFiles {
+		refs = append(refs, &config.ServiceAccountConfig.PublicKeyFiles[i])
+	}
+
 	refs = append(refs, &config.MasterClients.DeployerKubeConfig)
 	refs = append(refs, &config.MasterClients.OpenShiftLoopbackKubeConfig)
 	refs = append(refs, &config.MasterClients.ExternalKubernetesKubeConfig)

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -76,6 +76,9 @@ type MasterConfig struct {
 	// DNSConfig, if present start the DNS server in this process
 	DNSConfig *DNSConfig
 
+	// ServiceAccountConfig holds options related to service accounts
+	ServiceAccountConfig ServiceAccountConfig
+
 	// MasterClients holds all the client connection information for controllers and other system components
 	MasterClients MasterClients
 
@@ -229,6 +232,23 @@ type OAuthConfig struct {
 	SessionConfig *SessionConfig
 
 	TokenConfig TokenConfig
+}
+
+type ServiceAccountConfig struct {
+	// ManagedNames is a list of service account names that will be auto-created in every namespace.
+	// If no names are specified, the ServiceAccountsController will not be started.
+	ManagedNames []string
+
+	// PrivateKeyFile is a file containing a PEM-encoded private RSA key, used to sign service account tokens.
+	// If no private key is specified, the service account TokensController will not be started.
+	PrivateKeyFile string
+
+	// PublicKeyFiles is a list of files, each containing a PEM-encoded public RSA key.
+	// (If any file contains a private key, the public portion of the key is used)
+	// The list of public keys is used to verify presented service account tokens.
+	// Each key is tried in order until the list is exhausted or verification succeeds.
+	// If no keys are specified, no service account authentication will be available.
+	PublicKeyFiles []string
 }
 
 type TokenConfig struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -74,6 +74,9 @@ type MasterConfig struct {
 	// DNSConfig, if present start the DNS server in this process
 	DNSConfig *DNSConfig `json:"dnsConfig"`
 
+	// ServiceAccountConfig holds options related to service accounts
+	ServiceAccountConfig ServiceAccountConfig `json:"serviceAccountConfig"`
+
 	// MasterClients holds all the client connection information for controllers and other system components
 	MasterClients MasterClients `json:"masterClients"`
 
@@ -223,6 +226,23 @@ type OAuthConfig struct {
 	SessionConfig *SessionConfig `json:"sessionConfig"`
 
 	TokenConfig TokenConfig `json:"tokenConfig"`
+}
+
+type ServiceAccountConfig struct {
+	// ManagedNames is a list of service account names that will be auto-created in every namespace.
+	// If no names are specified, the ServiceAccountsController will not be started.
+	ManagedNames []string `json:"managedNames"`
+
+	// PrivateKeyFile is a file containing a PEM-encoded private RSA key, used to sign service account tokens.
+	// If no private key is specified, the service account TokensController will not be started.
+	PrivateKeyFile string `json:"privateKeyFile"`
+
+	// PublicKeyFiles is a list of files, each containing a PEM-encoded public RSA key.
+	// (If any file contains a private key, the public portion of the key is used)
+	// The list of public keys is used to verify presented service account tokens.
+	// Each key is tried in order until the list is exhausted or verification succeeds.
+	// If no keys are specified, no service account authentication will be available.
+	PublicKeyFiles []string `json:"publicKeyFiles"`
 }
 
 type TokenConfig struct {

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -7,6 +7,9 @@ const (
 
 // users
 const (
+	DefaultServiceAccountName = "default"
+	BuilderServiceAccountName = "builder"
+
 	RouterUnqualifiedUsername   = "openshift-router"
 	RegistryUnqualifiedUsername = "openshift-registry"
 
@@ -40,6 +43,8 @@ const (
 	SelfProvisionerRoleName   = "self-provisioner"
 	BasicUserRoleName         = "basic-user"
 	StatusCheckerRoleName     = "cluster-status"
+	ImagePullerRoleName       = "system:image-puller"
+	ImageBuilderRoleName      = "system:image-builder"
 	DeployerRoleName          = "system:deployer"
 	RouterRoleName            = "system:router"
 	RegistryRoleName          = "system:registry"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -130,6 +130,28 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: ImagePullerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get"),
+					Resources: util.NewStringSet("imagestreams"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ImageBuilderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get", "update"),
+					Resources: util.NewStringSet("imagestreams"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: DeployerRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -61,7 +61,8 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 
 	// in-order list of plug-ins that should intercept admission decisions
 	// TODO: Push node environment support to upstream in future
-	admissionControlPluginNames := []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ResourceQuota"}
+	// TODO: JTL: update serviceaccount admission plugin to limit secrets to the ones held by the serviceaccount
+	admissionControlPluginNames := []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ServiceAccount", "ResourceQuota"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
 
 	_, portString, err := net.SplitHostPort(options.ServingInfo.BindAddress)

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/exists"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
+	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/serviceaccount"
 	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 )

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -359,7 +359,6 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 		kubeConfig.RunResourceQuotaManager()
 		kubeConfig.RunNamespaceController()
 		kubeConfig.RunPersistentVolumeClaimBinder()
-
 	} else {
 		_, kubeConfig, err := configapi.GetKubeClient(openshiftMasterConfig.MasterClients.ExternalKubernetesKubeConfig)
 		if err != nil {
@@ -395,6 +394,8 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	openshiftConfig.RunImageImportController()
 	openshiftConfig.RunOriginNamespaceController()
 	openshiftConfig.RunProjectAuthorizationCache()
+	openshiftConfig.RunServiceAccountsController()
+	openshiftConfig.RunServiceAccountTokensController()
 
 	openshiftConfig.RunSDNController()
 

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -1,9 +1,9 @@
 package delegated
 
 import (
-	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
+	"github.com/openshift/origin/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	projectapi "github.com/openshift/origin/pkg/project/api"
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	DefaultTemplateName = "project-request"
+
 	ProjectNameParam        = "PROJECT_NAME"
 	ProjectDisplayNameParam = "PROJECT_DISPLAYNAME"
 	ProjectDescriptionParam = "PROJECT_DESCRIPTION"
@@ -23,11 +25,12 @@ var (
 
 func DefaultTemplate() *templateapi.Template {
 	ret := &templateapi.Template{}
-	ret.Name = "project-request"
-	ret.Namespace = kapi.NamespaceDefault
+	ret.Name = DefaultTemplateName
+
+	ns := "${" + ProjectNameParam + "}"
 
 	project := &projectapi.Project{}
-	project.Name = "${" + ProjectNameParam + "}"
+	project.Name = ns
 	project.Annotations = map[string]string{
 		"description": "${" + ProjectDescriptionParam + "}",
 		"displayName": "${" + ProjectDisplayNameParam + "}",
@@ -36,10 +39,24 @@ func DefaultTemplate() *templateapi.Template {
 
 	binding := &authorizationapi.RoleBinding{}
 	binding.Name = "admins"
-	binding.Namespace = "${" + ProjectNameParam + "}"
+	binding.Namespace = ns
 	binding.Users = util.NewStringSet("${" + ProjectAdminUserParam + "}")
 	binding.RoleRef.Name = bootstrappolicy.AdminRoleName
 	ret.Objects = append(ret.Objects, binding)
+
+	serviceAccountsBinding := &authorizationapi.RoleBinding{}
+	serviceAccountsBinding.Name = "image-pullers"
+	serviceAccountsBinding.Namespace = ns
+	serviceAccountsBinding.Groups = util.NewStringSet(serviceaccount.MakeNamespaceGroupName(ns))
+	serviceAccountsBinding.RoleRef.Name = bootstrappolicy.ImagePullerRoleName
+	ret.Objects = append(ret.Objects, serviceAccountsBinding)
+
+	serviceAccountBuilderBinding := &authorizationapi.RoleBinding{}
+	serviceAccountBuilderBinding.Name = "image-builders"
+	serviceAccountBuilderBinding.Namespace = ns
+	serviceAccountBuilderBinding.Users = util.NewStringSet(serviceaccount.MakeUsername(ns, bootstrappolicy.BuilderServiceAccountName))
+	serviceAccountBuilderBinding.RoleRef.Name = bootstrappolicy.ImageBuilderRoleName
+	ret.Objects = append(ret.Objects, serviceAccountBuilderBinding)
 
 	for _, parameterName := range parameters {
 		parameter := templateapi.Parameter{}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -27,15 +27,15 @@ var (
 
 	// ConcurrentBuildControllersTestWait is the time that TestConcurrentBuildControllers waits
 	// for any other changes to happen when testing whether only a single build got processed
-	ConcurrentBuildControllersTestWait = 5 * time.Second
+	ConcurrentBuildControllersTestWait = 15 * time.Second
 
 	// ConcurrentBuildPodControllersTestWait is the time that TestConcurrentBuildPodControllers waits
 	// after a state transition to make sure other state transitions don't occur unexpectedly
-	ConcurrentBuildPodControllersTestWait = 10 * time.Second
+	ConcurrentBuildPodControllersTestWait = 15 * time.Second
 
 	// BuildControllersWatchTimeout is used by all tests to wait for watch events. In case where only
 	// a single watch event is expected, the test will fail after the timeout.
-	BuildControllersWatchTimeout = 5 * time.Second
+	BuildControllersWatchTimeout = 15 * time.Second
 )
 
 func init() {
@@ -280,9 +280,10 @@ func setupBuildControllerTest(additionalBuildControllers, additionalBuildPodCont
 
 	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	checkErr(t, err)
-	clusterAdminKubeClient.Namespaces().Create(&kapi.Namespace{
+	_, err = clusterAdminKubeClient.Namespaces().Create(&kapi.Namespace{
 		ObjectMeta: kapi.ObjectMeta{Name: testutil.Namespace()},
 	})
+	checkErr(t, err)
 	openshiftConfig, err := origin.BuildMasterConfig(*master)
 	checkErr(t, err)
 	for i := 0; i < additionalBuildControllers; i++ {

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -1,0 +1,223 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount"
+	serviceaccountadmission "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/serviceaccount"
+
+	"github.com/openshift/origin/pkg/cmd/admin/policy"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+func TestServiceAccountAuthorization(t *testing.T) {
+	saNamespace := api.NamespaceDefault
+	saName := serviceaccountadmission.DefaultServiceAccountName
+	saUsername := serviceaccount.MakeUsername(saNamespace, saName)
+
+	// Start one OpenShift master as "cluster1" to play the external kube server
+	cluster1MasterConfig, cluster1AdminConfigFile, err := testutil.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cluster1AdminConfig, err := testutil.GetClusterAdminClientConfig(cluster1AdminConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cluster1AdminKubeClient, err := testutil.GetClusterAdminKubeClient(cluster1AdminConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cluster1AdminOSClient, err := testutil.GetClusterAdminClient(cluster1AdminConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Get a service account token and build a client
+	saToken, err := waitForServiceAccountToken(cluster1AdminKubeClient, saNamespace, saName, 20, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(saToken) == 0 {
+		t.Fatalf("token was not created")
+	}
+	cluster1SAClientConfig := kclient.Config{
+		Host:        cluster1AdminConfig.Host,
+		Prefix:      cluster1AdminConfig.Prefix,
+		BearerToken: saToken,
+		TLSClientConfig: kclient.TLSClientConfig{
+			CAFile: cluster1AdminConfig.CAFile,
+			CAData: cluster1AdminConfig.CAData,
+		},
+	}
+	cluster1SAKubeClient, err := kclient.New(&cluster1SAClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Make sure the service account doesn't have access
+	failNS := &api.Namespace{ObjectMeta: api.ObjectMeta{Name: "test-fail"}}
+	if _, err := cluster1SAKubeClient.Namespaces().Create(failNS); !errors.IsForbidden(err) {
+		t.Fatalf("expected forbidden error, got %v", err)
+	}
+
+	// Make the service account a cluster admin on cluster1
+	addRoleOptions := &policy.RoleModificationOptions{
+		RoleName:            bootstrappolicy.ClusterAdminRoleName,
+		RoleBindingAccessor: policy.NewClusterRoleBindingAccessor(cluster1AdminOSClient),
+		Users:               []string{saUsername},
+	}
+	if err := addRoleOptions.AddRole(); err != nil {
+		t.Fatalf("could not add role to service account")
+	}
+
+	// Make sure the service account now has access
+	// This tests authentication using the etcd-based token getter
+	passNS := &api.Namespace{ObjectMeta: api.ObjectMeta{Name: "test-pass"}}
+	if _, err := cluster1SAKubeClient.Namespaces().Create(passNS); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Create a kubeconfig from the serviceaccount config
+	cluster1SAKubeConfigFile, err := ioutil.TempFile(testutil.GetBaseDir(), "cluster1-service-account.kubeconfig")
+	if err != nil {
+		t.Fatalf("error creating tmpfile: %v", err)
+	}
+	defer os.Remove(cluster1SAKubeConfigFile.Name())
+	if err := writeClientConfigToKubeConfig(cluster1SAClientConfig, cluster1SAKubeConfigFile.Name()); err != nil {
+		t.Fatalf("error creating kubeconfig: %v", err)
+	}
+
+	// Set up cluster 2 to run against cluster 1 as external kubernetes
+	cluster2MasterConfig, err := testutil.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Don't start kubernetes in process
+	cluster2MasterConfig.KubernetesMasterConfig = nil
+	// Connect to cluster1 using the service account credentials
+	cluster2MasterConfig.MasterClients.ExternalKubernetesKubeConfig = cluster1SAKubeConfigFile.Name()
+	// Don't start etcd
+	cluster2MasterConfig.EtcdConfig = nil
+	// Use the same credentials as cluster1 to connect to existing etcd
+	cluster2MasterConfig.EtcdClientInfo = cluster1MasterConfig.EtcdClientInfo
+	// Set a custom etcd prefix to make sure data is getting sent to cluster1
+	cluster2MasterConfig.EtcdStorageConfig.KubernetesStoragePrefix += "2"
+	cluster2MasterConfig.EtcdStorageConfig.OpenShiftStoragePrefix += "2"
+	// Don't manage any names in cluster2
+	cluster2MasterConfig.ServiceAccountConfig.ManagedNames = []string{}
+	// Don't create any service account tokens in cluster2
+	cluster2MasterConfig.ServiceAccountConfig.PrivateKeyFile = ""
+	// Use the same public keys to validate tokens as cluster1
+	cluster2MasterConfig.ServiceAccountConfig.PublicKeyFiles = cluster1MasterConfig.ServiceAccountConfig.PublicKeyFiles
+
+	// Start cluster 2 (without clearing etcd) and get admin client configs and clients
+	cluster2Options := testutil.TestOptions{DeleteAllEtcdKeys: false}
+	cluster2AdminConfigFile, err := testutil.StartConfiguredMasterWithOptions(cluster2MasterConfig, cluster2Options)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cluster2AdminConfig, err := testutil.GetClusterAdminClientConfig(cluster2AdminConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cluster2AdminOSClient, err := testutil.GetClusterAdminClient(cluster2AdminConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Build a client to use the same service account token against cluster2
+	cluster2SAClientConfig := cluster1SAClientConfig
+	cluster2SAClientConfig.Host = cluster2AdminConfig.Host
+	cluster2SAKubeClient, err := kclient.New(&cluster2SAClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Make sure the service account doesn't have access
+	// A forbidden error makes sure the token was recognized, and policy denied us
+	// This exercises the client-based token getter
+	// It also makes sure we don't loop back through the cluster2 kube proxy which would cause an auth loop
+	failNS2 := &api.Namespace{ObjectMeta: api.ObjectMeta{Name: "test-fail2"}}
+	if _, err := cluster2SAKubeClient.Namespaces().Create(failNS2); !errors.IsForbidden(err) {
+		t.Fatalf("expected forbidden error, got %v", err)
+	}
+
+	// Make the service account a cluster admin on cluster2
+	addRoleOptions2 := &policy.RoleModificationOptions{
+		RoleName:            bootstrappolicy.ClusterAdminRoleName,
+		RoleBindingAccessor: policy.NewClusterRoleBindingAccessor(cluster2AdminOSClient),
+		Users:               []string{saUsername},
+	}
+	if err := addRoleOptions2.AddRole(); err != nil {
+		t.Fatalf("could not add role to service account")
+	}
+
+	// Make sure the service account now has access to cluster2
+	passNS2 := &api.Namespace{ObjectMeta: api.ObjectMeta{Name: "test-pass2"}}
+	if _, err := cluster2SAKubeClient.Namespaces().Create(passNS2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Make sure the ns actually got created in cluster1
+	if _, err := cluster1SAKubeClient.Namespaces().Get(passNS2.Name); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writeClientConfigToKubeConfig(config kclient.Config, path string) error {
+	kubeConfig := &clientcmdapi.Config{
+		Clusters:       map[string]clientcmdapi.Cluster{"myserver": {Server: config.Host, CertificateAuthority: config.CAFile, CertificateAuthorityData: config.CAData}},
+		AuthInfos:      map[string]clientcmdapi.AuthInfo{"myuser": {Token: config.BearerToken}},
+		Contexts:       map[string]clientcmdapi.Context{"mycontext": {Cluster: "myserver", AuthInfo: "myuser"}},
+		CurrentContext: "mycontext",
+	}
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+		return err
+	}
+	if err := clientcmd.WriteToFile(*kubeConfig, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForServiceAccountToken(client *kclient.Client, ns, name string, attempts int, interval time.Duration) (string, error) {
+	for i := 0; i <= attempts; i++ {
+		time.Sleep(interval)
+		token, err := getServiceAccountToken(client, ns, name)
+		if err != nil {
+			return "", err
+		}
+		if len(token) > 0 {
+			return token, nil
+		}
+	}
+	return "", nil
+}
+
+func getServiceAccountToken(client *kclient.Client, ns, name string) (string, error) {
+	secrets, err := client.Secrets(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return "", err
+	}
+	for _, secret := range secrets.Items {
+		if secret.Type == api.SecretTypeServiceAccountToken && secret.Annotations[api.ServiceAccountNameKey] == name {
+			return string(secret.Data[api.ServiceAccountTokenKey]), nil
+		}
+	}
+	return "", nil
+}

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -253,8 +253,22 @@ func StartTestAllInOne() (*configapi.MasterConfig, string, error) {
 	return master, adminKubeConfigFile, err
 }
 
+type TestOptions struct {
+	DeleteAllEtcdKeys bool
+}
+
+func DefaultTestOptions() TestOptions {
+	return TestOptions{true}
+}
+
 func StartConfiguredMaster(masterConfig *configapi.MasterConfig) (string, error) {
-	DeleteAllEtcdKeys()
+	return StartConfiguredMasterWithOptions(masterConfig, DefaultTestOptions())
+}
+
+func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig, testOptions TestOptions) (string, error) {
+	if testOptions.DeleteAllEtcdKeys {
+		DeleteAllEtcdKeys()
+	}
 
 	if err := start.StartMaster(masterConfig); err != nil {
 		return "", err


### PR DESCRIPTION
- [x] Start service account controller
- [x] Start service account token controller
- [x] Add service account admission plugin
- [x] Add serviceaccount token authenticator
- [x] Generate public/private keypair for service accounts
- [x] Add groups to service accounts
- [x] Add config for managed service account names, signing key, authenticating key
- [x] Add bootstrap policy for image-puller and image-builder roles
- [x] Add role bindings to default project template
  - Bind all service accounts in a namespace to the `image-puller` role
  - Bind the `builder` service account in a namespace to the `image-builder` role
- [x] Add a `osadm create-bootstrap-project-template` command to dump the default project template to a file

Follow-ups:
- Nest `osadm` cert commands - #2461
- Turn TODOs in validate methods into surfaced warnings - #2462
- test-cmd tests for `create-key-pair`, `create-bootstrap-project-template`
- Make `osadm new-project` use the default new project template, or take a template - #2464

Added a stanza to master-config.yaml
```
serviceAccountConfig:
  managedNames:
  - default
  - builder
  privateKeyFile: ...
  publicKeyFiles:
  - ...
  - ...
```

`managedNames` is a list of service account names that will be auto-created in every namespace. If no names are specified, the ServiceAccountsController will not be started.

`privateKeyFile` is a file containing a PEM-encoded private RSA key, used to sign service account tokens. If no private key is specified, no API tokens will be generated for service accounts.

`publicKeyFiles` is a list of files, each containing a PEM-encoded public RSA key (If any file contains a private key, the public portion of the key is used). The list of public keys is used to verify service account tokens presented to the API as bearer tokens. Each key is tried in order until the list is exhausted or verification succeeds. If no keys are specified, no service account API authentication will be available.

`osadm create-master-certs` and `openshift start --write-config=...` generate a public/private keypair:
```
$CONFIG_DIR/serviceaccounts.private.key
$CONFIG_DIR/serviceaccounts.public.key
```

When running Kubernetes in-process, the default config generated by `--write-config` is:
```
serviceAccountConfig:
  managedNames:
  - default
  - builder
  privateKeyFile: serviceaccounts.private.key
  publicKeyFiles:
  - serviceaccounts.public.key
```

When running against an external Kubernetes (indicated by specifying `--kubeconfig`), the default config generated by `--write-config` is:
```
serviceAccountConfig:
  managedNames:
  - builder
  privateKeyFile: ""
  publicKeyFiles: []
```
In this case, we expect Kubernetes to manage the `default` service account, and to have it's own private key it uses to create the service account tokens. The user would need to obtain the public key file from their kubernetes cluster (used to validate service account tokens) and add it to the config in order to enable service account usage within OpenShift.