### PR TITLE
Validate project and image stream namespaces and names

### DIFF
--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -29,7 +29,7 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	expected := mockCustomBuild()
 	actual, err := strategy.CreateBuildPod(expected)
 	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v", err)
 	}
 
 	if expected, actual := buildutil.GetBuildPodName(expected), actual.ObjectMeta.Name; expected != actual {

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -44,14 +44,15 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 		if strings.Contains(repoParts[0], ":") {
 			// registry/name
 			ref.Registry = repoParts[0]
-			ref.Namespace = "library"
+			// TODO: default this in all cases where Namespace ends up as ""?
+			ref.Namespace = DockerDefaultNamespace
 			if len(repoParts[1]) == 0 {
 				return ref, fmt.Errorf("the docker pull spec %q must be two or three segments separated by slashes", spec)
 			}
 			ref.Name = repoParts[1]
 			ref.Tag = tag
 			ref.ID = id
-			return ref, nil
+			break
 		}
 		// namespace/name
 		ref.Namespace = repoParts[0]
@@ -61,7 +62,7 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 		ref.Name = repoParts[1]
 		ref.Tag = tag
 		ref.ID = id
-		return ref, nil
+		break
 	case 3:
 		// registry/namespace/name
 		ref.Registry = repoParts[0]
@@ -72,7 +73,7 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 		ref.Name = repoParts[2]
 		ref.Tag = tag
 		ref.ID = id
-		return ref, nil
+		break
 	case 1:
 		// name
 		if len(repoParts[0]) == 0 {
@@ -81,10 +82,23 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 		ref.Name = repoParts[0]
 		ref.Tag = tag
 		ref.ID = id
-		return ref, nil
+		break
 	default:
 		return ref, fmt.Errorf("the docker pull spec %q must be two or three segments separated by slashes", spec)
 	}
+
+	// TODO: validate repository name here?
+	//
+	// repo := ref.Name
+	// if len(ref.Namespace) > 0 {
+	// 	repo = ref.Namespace + "/" + ref.Name
+	// }
+
+	// if err := v2.ValidateRepositoryName(repo); err != nil {
+	// 	return DockerImageReference{}, err
+	// }
+
+	return ref, nil
 }
 
 // DockerClientDefaults sets the default values used by the Docker client.

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -93,6 +93,39 @@ func TestParseDockerImageReference(t *testing.T) {
 			Name:      "baz",
 			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
+		// TODO: test cases if ParseDockerImageReference validates segment length and allowed chars
+		//
+		// {
+		// 	// namespace/name == 255 chars
+		// 	From:      fmt.Sprintf("bar:5000/%s/%s:tag", strings.Repeat("a", 63), strings.Repeat("b", 191)),
+		// 	Registry:  "bar:5000",
+		// 	Namespace: strings.Repeat("a", 63),
+		// 	Name:      strings.Repeat("b", 191),
+		// 	Tag:       "tag",
+		// },
+		// {
+		// 	// namespace/name == 255 chars with implicit namespace
+		// 	From:      fmt.Sprintf("bar:5000/%s:tag", strings.Repeat("b", 247)),
+		// 	Registry:  "bar:5000",
+		// 	Namespace: "library",
+		// 	Name:      strings.Repeat("b", 247),
+		// 	Tag:       "tag",
+		// },
+		// {
+		// 	// namespace/name > 255 chars
+		// 	From: fmt.Sprintf("bar:5000/%s/%s:tag", strings.Repeat("a", 63), strings.Repeat("b", 192)),
+		// 	Err:  true,
+		// },
+		// {
+		// 	// namespace/name > 255 chars with implicit namespace
+		// 	From: fmt.Sprintf("bar:5000/%s:tag", strings.Repeat("b", 248)),
+		// 	Err:  true,
+		// },
+		// {
+		// 	// namespace < 2 chars
+		// 	From: "bar:5000/a/b:tag",
+		// 	Err:  true,
+		// },
 		{
 			From: "https://bar:5000/foo/baz",
 			Err:  true,

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -44,7 +44,7 @@ func TestValidateProject(t *testing.T) {
 			name: "invalid id uppercase",
 			project: api.Project{
 				ObjectMeta: kapi.ObjectMeta{
-					Name: "A",
+					Name: "AA",
 				},
 			},
 			numErrs: 1,
@@ -53,7 +53,25 @@ func TestValidateProject(t *testing.T) {
 			name: "valid id leading number",
 			project: api.Project{
 				ObjectMeta: kapi.ObjectMeta{
-					Name: "1",
+					Name: "11",
+				},
+			},
+			numErrs: 0,
+		},
+		{
+			name: "invalid id for create (< 2 characters)",
+			project: api.Project{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "h",
+				},
+			},
+			numErrs: 1,
+		},
+		{
+			name: "valid id for create (2+ characters)",
+			project: api.Project{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "hi",
 				},
 			},
 			numErrs: 0,
@@ -146,4 +164,22 @@ func TestValidateProject(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Unexpected non-zero error list: %#v", errs)
 	}
+}
+
+func TestValidateProjectUpdate(t *testing.T) {
+	// Ensure we can update projects with short names, to make sure we can
+	// proxy updates to namespaces created outside project validation
+	project := &api.Project{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:            "a",
+			UID:             "123",
+			ResourceVersion: "1",
+		},
+	}
+
+	errs := ValidateProjectUpdate(project, project)
+	if len(errs) > 0 {
+		t.Fatalf("Expected no errors, got %v", errs)
+	}
+
 }

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -48,7 +48,7 @@ func TestWebhookGithubPushWithImage(t *testing.T) {
 
 	// create imagerepo
 	imageStream := &imageapi.ImageStream{
-		ObjectMeta: kapi.ObjectMeta{Name: "imageStream"},
+		ObjectMeta: kapi.ObjectMeta{Name: "image-stream"},
 		Spec: imageapi.ImageStreamSpec{
 			DockerImageRepository: "registry:3000/integration/imageStream",
 			Tags: map[string]imageapi.TagReference{
@@ -63,7 +63,7 @@ func TestWebhookGithubPushWithImage(t *testing.T) {
 	}
 
 	ism := &imageapi.ImageStreamMapping{
-		ObjectMeta: kapi.ObjectMeta{Name: "imageStream"},
+		ObjectMeta: kapi.ObjectMeta{Name: "image-stream"},
 		Tag:        "validTag",
 		Image: imageapi.Image{
 			ObjectMeta: kapi.ObjectMeta{
@@ -133,7 +133,7 @@ func TestWebhookGithubPushWithImageStream(t *testing.T) {
 
 	// create imagerepo
 	imageStream := &imageapi.ImageStream{
-		ObjectMeta: kapi.ObjectMeta{Name: "imageStream"},
+		ObjectMeta: kapi.ObjectMeta{Name: "image-stream"},
 		Spec: imageapi.ImageStreamSpec{
 			DockerImageRepository: "registry:3000/integration/imageStream",
 			Tags: map[string]imageapi.TagReference{
@@ -148,7 +148,7 @@ func TestWebhookGithubPushWithImageStream(t *testing.T) {
 	}
 
 	ism := &imageapi.ImageStreamMapping{
-		ObjectMeta: kapi.ObjectMeta{Name: "imageStream"},
+		ObjectMeta: kapi.ObjectMeta{Name: "image-stream"},
 		Tag:        "validTag",
 		Image: imageapi.Image{
 			ObjectMeta: kapi.ObjectMeta{
@@ -162,7 +162,7 @@ func TestWebhookGithubPushWithImageStream(t *testing.T) {
 	}
 
 	// create buildconfig
-	buildConfig := mockBuildConfigImageStreamParms("originalImage", "imageStream", "validTag")
+	buildConfig := mockBuildConfigImageStreamParms("originalImage", "image-stream", "validTag")
 
 	if _, err := clusterAdminClient.BuildConfigs(testutil.Namespace()).Create(buildConfig); err != nil {
 		t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
To ensure we end up with valid image repository paths derived from ImageStreams, add the following validation:
- [x] Require Project names to be >= 2 characters on creation
- [x] Require ImageStream namespaces to be >= 2 characters
- [x] Require ImageStream namespace+'/'+name to be <= 255 characters
- [x] Require ImageStream names to be valid docker image repository names

To ensure we don't break updating an existing project/namespace that was created with a single character name:
- [x] Allow updating projects with names < 2 characters

Fixes #1232