### PR TITLE
Making the deployer pod name deterministic

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -191,6 +191,15 @@ const (
 	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
 )
 
+// These constants represent the various reasons for cancelling a deployment
+// or for a deployment being placed in a failed state
+const (
+	DeploymentCancelledByUser                 = "The deployment was cancelled by the user"
+	DeploymentCancelledNewerDeploymentExists  = "The deployment was cancelled as a newer deployment was found running"
+	DeploymentFailedUnrelatedDeploymentExists = "The deployment failed as an unrelated pod with the same name as this deployment is already running"
+	DeploymentFailedDeployerPodNoLongerExists = "The deployment failed as the deployer pod no longer exists"
+)
+
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -188,6 +188,15 @@ const (
 	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
 )
 
+// These constants represent the various reasons for cancelling a deployment
+// or for a deployment being placed in a failed state
+const (
+	DeploymentCancelledByUser                 = "The deployment was cancelled by the user"
+	DeploymentCancelledNewerDeploymentExists  = "The deployment was cancelled as a newer deployment was found running"
+	DeploymentFailedUnrelatedDeploymentExists = "The deployment failed as an unrelated pod with the same name as this deployment is already running"
+	DeploymentFailedDeployerPodNoLongerExists = "The deployment failed as the deployer pod no longer exists"
+)
+
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -155,6 +155,15 @@ const (
 	DeploymentCancelledAnnotation = "openshift.io/deployment.cancelled"
 )
 
+// These constants represent the various reasons for cancelling a deployment
+// or for a deployment being placed in a failed state
+const (
+	DeploymentCancelledByUser                 = "The deployment was cancelled by the user"
+	DeploymentCancelledNewerDeploymentExists  = "The deployment was cancelled as a newer deployment was found running"
+	DeploymentFailedUnrelatedDeploymentExists = "The deployment failed as an unrelated pod with the same name as this deployment is already running"
+	DeploymentFailedDeployerPodNoLongerExists = "The deployment failed as the deployer pod no longer exists"
+)
+
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -58,6 +58,9 @@ func (factory *DeploymentControllerFactory) Create() controller.RunnableControll
 			},
 		},
 		podClient: &podClientImpl{
+			getPodFunc: func(namespace, name string) (*kapi.Pod, error) {
+				return factory.KubeClient.Pods(namespace).Get(name)
+			},
 			createPodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
 				return factory.KubeClient.Pods(namespace).Create(pod)
 			},

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -52,7 +52,7 @@ func LatestDeploymentNameForConfig(config *deployapi.DeploymentConfig) string {
 }
 
 func DeployerPodNameForDeployment(deployment *api.ReplicationController) string {
-	return fmt.Sprintf("deploy-%s", deployment.Name)
+	return deployment.Name
 }
 
 // LabelForDeployment builds a string identifier for a Deployment.


### PR DESCRIPTION
The deployer pod name will be of the format: 
```
deploy-<config-name>-<config-latest-version>
```

As of now, when a deployer pod fails, the deployment status is set to Failed as well and the deployment is not retried. If such a deployment needs to be retried (at a later point), we will need to clear off the failed pod before the retry.