### PR TITLE
[RPMs] move ovs scripts into openshift-sdn-ovs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -983,16 +983,16 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/ovssubnet",
-			"Rev": "3ba813b579ee95a86599ba0896f2d470d7702a19"
+			"Rev": "7752990d5095d92905752aa5165a3d65ba8195e6"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/api",
-			"Rev": "3ba813b579ee95a86599ba0896f2d470d7702a19"
+			"Rev": "7752990d5095d92905752aa5165a3d65ba8195e6"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/netutils",
-			"Comment": "v0.1-83-g3ba813b",
-			"Rev": "3ba813b579ee95a86599ba0896f2d470d7702a19"
+			"Comment": "v0.1-85-g7752990",
+			"Rev": "7752990d5095d92905752aa5165a3d65ba8195e6"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
@@ -40,20 +40,20 @@ iptables -I INPUT $lineno -p udp -m multiport --dports 4789 -m comment --comment
 iptables -I INPUT $((lineno+1)) -i ${TUN} -m comment --comment "traffic from docker for internet" -j ACCEPT
 
 ## docker
-if [[ -z "${DOCKER_OPTIONS}" ]]
+if [[ -z "${DOCKER_NETWORK_OPTIONS}" ]]
 then
-    DOCKER_OPTIONS='-b=lbr0 --mtu=1450 --selinux-enabled'
+    DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
 fi
 
-if ! grep -q "^OPTIONS='${DOCKER_OPTIONS}'" /etc/sysconfig/docker
+if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfig/docker-network
 then
-    cat <<EOF > /etc/sysconfig/docker
+    cat <<EOF > /etc/sysconfig/docker-network
 # This file has been modified by openshift-sdn. Please modify the
-# DOCKER_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
+# DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
 # /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
 # files (depending on your setup).
 
-OPTIONS='${DOCKER_OPTIONS}'
+DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
 fi
 systemctl daemon-reload

--- a/rel-eng/openshift-node.service
+++ b/rel-eng/openshift-node.service
@@ -4,7 +4,7 @@ After=docker.service
 After=openshift-master.service
 After=openshift-sdn-master.service
 After=openshift-sdn-node.service
-Requires=docker.service
+Wants=docker.service
 Documentation=https://github.com/openshift/origin
 
 [Service]

--- a/rel-eng/openshift-node.sysconfig
+++ b/rel-eng/openshift-node.sysconfig
@@ -6,3 +6,10 @@ OPTIONS="--loglevel=0"
 # If if your node is running on a separate host you can rsync the contents
 # rsync -a root@openshift-master:/var/lib/openshift/openshift.local.certificates/node-`hostname`/ /etc/openshift/node
 CONFIG_FILE=/etc/openshift/node/node-config.yaml
+
+# The $DOCKER_NETWORK_OPTIONS variable is used by sdn plugins to set
+# $DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/docker-network
+# Most plugins include their own defaults within the scripts
+# TODO: More elegant solution like this
+# https://github.com/coreos/flannel/blob/master/dist/mk-docker-opts.sh
+# DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'

--- a/rel-eng/openshift-sdn-ovs.conf
+++ b/rel-eng/openshift-sdn-ovs.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=openvswitch.service
+After=openvswitch.service


### PR DESCRIPTION
*This change does these things*
* Drop openshift-sdn-simple-setup-node.sh, it's not used
* Creates `openshift-sdn-ovs` subpackage
 * Pulls in openshift-sdn-simple-setup-node.sh from godep
 * Pulls in openshift-ovs-subnet from godep
 * Add openvswitch dependency on `openshift-sdn-ovs` subpackage
 * Add openvswitch service dependency to openshift-node to ensure it's started before the node
* Bump github.com/openshift/openshift-sdn to stop clobbering /etc/sysconfig/docker
* Changes openshift-node from Requires to Wants on docker because there's no longer an intermediate service between docker and openshift-node to provision the bridge

Ultimately this frees us from building and shipping components across two repos as everything from openshift-sdn is already godep'd into origin.

*Known issues*
* On reboot after having enabled `redhat/openshift-ovs-subnet` docker will fail to start via the services, however once openshift-node starts it will initialize the bridge and then restart docker
* If you have previously enabled `redhat/openshift-ovs-subnet` but disable it afterwards you must manually remove DOCKER_NETWORK_OPTIONS from /etc/sysconfig/docker-network as docker will fail without the sdn bridge

*How to enable integrated `openshift-sdn-ovs`*
* Ensure that all previous openshift-sdn packages are removed from master and nodes
* Set `networkPluginName: "redhat/openshift-ovs-subnet"` in your master's config, restart openshift-master
* Install `openshift-sdn-ovs` on all nodes
* Set `networkPluginName: "redhat/openshift-ovs-subnet"` in each node's config, restart openshift-node