### PR TITLE
Osc login respect api version

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -146,9 +146,13 @@ func messageForError(err error) string {
 }
 
 // fatal prints the message and then exits. If V(2) or greater, glog.Fatal
-// is invoked for extended information. The provided msg should end in a
-// newline.
+// is invoked for extended information.
 func fatal(msg string) {
+	// add newline if needed
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+
 	if glog.V(2) {
 		glog.FatalDepth(2, msg)
 	}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -176,7 +176,8 @@ fi
 # must only accept one arg (server)
 [ "$(osc login https://server1 https://server2.com 2>&1 | grep 'Only the server URL may be specified')" ]
 # logs in with a valid certificate authority
-osc login ${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
+osc login ${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything --api-version=v1beta3
+grep -q "v1beta3" ${HOME}/.config/openshift/config
 osc logout
 # logs in skipping certificate check
 osc login ${KUBERNETES_MASTER} --insecure-skip-tls-verify -u test-user -p anything

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -130,11 +130,18 @@ func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args
 		}
 	}
 
-	if certFile := kcmdutil.GetFlagString(cmd, "client-certificate"); len(certFile) > 0 {
-		o.CertFile = certFile
-	}
-	if keyFile := kcmdutil.GetFlagString(cmd, "client-key"); len(keyFile) > 0 {
-		o.KeyFile = keyFile
+	o.CertFile = kcmdutil.GetFlagString(cmd, "client-certificate")
+	o.KeyFile = kcmdutil.GetFlagString(cmd, "client-key")
+	o.APIVersion = kcmdutil.GetFlagString(cmd, "api-version")
+
+	// if the API version isn't explicitly passed, use the API version from the default context (same rules as the server above)
+	if len(o.APIVersion) == 0 {
+		if defaultContext, defaultContextExists := o.StartingKubeConfig.Contexts[o.StartingKubeConfig.CurrentContext]; defaultContextExists {
+			if cluster, exists := o.StartingKubeConfig.Clusters[defaultContext.Cluster]; exists {
+				o.APIVersion = cluster.APIVersion
+			}
+		}
+
 	}
 
 	o.CAFile = kcmdutil.GetFlagString(cmd, "certificate-authority")

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -36,7 +36,10 @@ const defaultClusterURL = "https://localhost:8443"
 // Notice that some methods mutate this object so it should not be reused. The Config
 // provided as a pointer will also mutate (handle new auth tokens, etc).
 type LoginOptions struct {
-	Server string
+	Server      string
+	CAFile      string
+	InsecureTLS bool
+	APIVersion  string
 
 	// flags and printing helpers
 	Username string
@@ -51,10 +54,8 @@ type LoginOptions struct {
 	Out                io.Writer
 
 	// cert data to be used when authenticating
-	CAFile      string
-	CertFile    string
-	KeyFile     string
-	InsecureTLS bool
+	CertFile string
+	KeyFile  string
 
 	Token string
 
@@ -157,6 +158,11 @@ func (o *LoginOptions) getClientConfig() (*kclient.Config, error) {
 		default:
 			return nil, result.Error()
 		}
+	}
+
+	// check for matching api version
+	if len(o.APIVersion) > 0 {
+		clientConfig.Version = o.APIVersion
 	}
 
 	o.Config = clientConfig

--- a/pkg/cmd/cli/config/smart_merge.go
+++ b/pkg/cmd/cli/config/smart_merge.go
@@ -103,6 +103,7 @@ func CreateConfig(namespace string, clientCfg *client.Config) (*clientcmdapi.Con
 		cluster.CertificateAuthorityData = clientCfg.CAData
 	}
 	cluster.InsecureSkipTLSVerify = clientCfg.Insecure
+	cluster.APIVersion = clientCfg.Version
 	config.Clusters[clusterNick] = *cluster
 
 	context := clientcmdapi.NewContext()


### PR DESCRIPTION
Fixes #2119

makes osc login respect api version to work with skewed versions.

@fabianofranz ptal
@smarterclayton can you review the "auto-negotiate version" commit?