### PR TITLE
auto-negotiate version

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -237,8 +238,39 @@ func SetOpenShiftDefaults(config *kclient.Config) error {
 	}
 	if config.Version == "" {
 		// Clients default to the preferred code API version
-		// TODO: implement version negotiation (highest version supported by server)
-		config.Version = latest.Version
+		// attempt auto-negotiation first
+
+		tempClient, err := kclient.New(config)
+		if err == nil {
+			bytes, err := tempClient.Get().AbsPath("osapi").DoRaw()
+
+			if err == nil {
+
+				availableVersions := map[string][]string{}
+				if err := json.Unmarshal(bytes, &availableVersions); err == nil {
+
+					if possibleVersions, exists := availableVersions["versions"]; exists {
+
+					foundVersion:
+						for i := len(latest.Versions) - 1; i >= 0; i-- {
+							knownVersion := latest.Versions[i]
+							for _, possibleVersion := range possibleVersions {
+								if knownVersion == possibleVersion {
+									config.Version = possibleVersion
+									break foundVersion
+								}
+							}
+						}
+
+					}
+				}
+			}
+		}
+
+		if len(config.Version) == 0 {
+			// we had an error, just take a guess at the version
+			config.Version = latest.Version
+		}
 	}
 	version := config.Version
 	versionInterfaces, err := latest.InterfacesFor(version)


### PR DESCRIPTION
When creating a new `Client` without a specifed version, attempt to auto-negotiate with server.   This allows automatic handling of version skews.

@smarterclayton 