### PR TITLE
fix e2e public master

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -102,7 +102,7 @@ openshift admin create-master-certs \
   --cert-dir="${MASTER_CONFIG_DIR}" \
   --hostnames="${SERVER_HOSTNAME_LIST}" \
   --master="${MASTER_ADDR}" \
-  --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}"
+  --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}"
 
 openshift admin create-node-config \
   --listen="${KUBELET_SCHEME}://0.0.0.0:${KUBELET_PORT}" \

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -199,7 +199,7 @@ openshift admin create-master-certs \
 	--cert-dir="${MASTER_CONFIG_DIR}" \
 	--hostnames="${SERVER_HOSTNAME_LIST}" \
 	--master="${MASTER_ADDR}" \
-	--public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}"
+	--public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}"
 
 openshift admin create-node-config \
 	--listen="${KUBELET_SCHEME}://0.0.0.0:${KUBELET_PORT}" \
@@ -221,7 +221,7 @@ openshift start \
 	--create-certs=false \
     --listen="${API_SCHEME}://0.0.0.0:${API_PORT}" \
     --master="${MASTER_ADDR}" \
-    --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}" \
+    --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}" \
     --hostname="${KUBELET_HOST}" \
     --volume-dir="${VOLUME_DIR}" \
     --etcd-dir="${ETCD_DATA_DIR}" \


### PR DESCRIPTION
e2e sets the public master incorrectly and that means you can't hit the web-console during the test.

@liggitt easy one.