### PR TITLE
Show project name and overview link in create flow

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -169,6 +169,7 @@
         <script src="scripts/directives/tasks.js"></script>
         <script src="scripts/directives/catalog.js"></script>
         <script src="scripts/directives/oscObjectDescriber.js"></script>
+        <script src="scripts/directives/returnToOverview.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>

--- a/assets/app/scripts/directives/returnToOverview.js
+++ b/assets/app/scripts/directives/returnToOverview.js
@@ -1,0 +1,11 @@
+angular.module('openshiftConsole')
+  .directive('returnToOverview', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        project: '='
+      },
+      templateUrl: 'views/directives/_return-to-overview.html'
+    };
+  });
+

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -282,4 +282,13 @@ angular.module('openshiftConsole')
 
       return itemsArray;
     };
+  })
+  .filter('projectOverviewURL', function(Navigate) {
+    return function(project) {
+      if (!project || !project.metadata || !project.metadata.name) {
+        return null;
+      }
+
+      return Navigate.projectOverviewURL(project.metadata.name);
+    };
   });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -123,6 +123,19 @@ html, body {
   }
 }
 
+.return-project-name {
+  .h2;
+  /* Stack things at phone resolutions. */
+  display: block;
+  /* Align with return to overview link. */
+  margin-top: 0;
+  @media (min-width: @screen-sm-min) {
+    /* Side-by-side at larger resolutions. */
+    display: inline-block;
+    margin-right: 30px;
+  }
+}
+
 .empty-state-msg {
   background-color: #ffffff;
   border-radius: @border-radius-sm;

--- a/assets/app/views/catalog/images.html
+++ b/assets/app/views/catalog/images.html
@@ -1,6 +1,7 @@
 <div ng-controller="ProjectController">
   <div ng-controller="CatalogImagesController">
     <div class="container">
+      <return-to-overview project="project"></return-to-overview>
       <div class="row">
         <div class="col-md-12">
           <!-- TODO we don't need a breadcrumb yet

--- a/assets/app/views/catalog/templates.html
+++ b/assets/app/views/catalog/templates.html
@@ -1,6 +1,7 @@
 <div ng-controller="ProjectController">
   <div ng-controller="CatalogTemplatesController">
     <div class="container">
+      <return-to-overview project="project"></return-to-overview>
       <div class="row">
         <div class="col-md-12">
           <!-- TODO we don't need a breadcrumb yet

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -1,6 +1,7 @@
 <div ng-controller="ProjectController">
   <div ng-controller="CreateController">
     <div class="container">
+      <return-to-overview project="project"></return-to-overview>
       <div class="row">
         <div class="col-md-12">
           <h1>Create from ...</h1>

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -1,222 +1,225 @@
-<div class="container">
-  <div class="row">
-    <div class="col-md-12" ng-controller="ProjectController">
-      <div ng-controller="CreateFromImageController" class="create-from-image">
-        <div class="row">
-          <div class="col-md-2 template-name">
-            <span class="fa fa-cubes hidden-xs hidden-sm"></span>
-          </div>
-          <div class="col-md-8">
-            <osc-image-summary resource="image" name="imageName"></osc-image-summary>
-            <form class="" ng-show="imageRepo" novalidate name="form">
-              <div>
-                  <h2>
-                    Name
-                  </h2>
-                <div class="form-group" ng-class="{'has-error': form.appname.$error.oscResourceNameValidator}">
-                 <input class="form-control"
-                        type="text" ng-model="name" name="appname" required="true" osc-resource-name-validator>
+<div ng-controller="ProjectController">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <div ng-controller="CreateFromImageController" class="create-from-image">
+          <div class="row">
+            <div class="col-md-2 template-name">
+              <span class="fa fa-cubes hidden-xs hidden-sm gutter-top"></span>
+            </div>
+            <div class="col-md-8">
+              <return-to-overview project="project"></return-to-overview>
+              <osc-image-summary resource="image" name="imageName"></osc-image-summary>
+              <form class="" ng-show="imageRepo" novalidate name="form">
+                <div>
+                    <h2>
+                      Name
+                    </h2>
+                  <div class="form-group" ng-class="{'has-error': form.appname.$error.oscResourceNameValidator}">
+                   <input class="form-control"
+                          type="text" ng-model="name" name="appname" required="true" osc-resource-name-validator>
+                  </div>
+                  <p class="help-block">Used to uniquely identify within this project all the resources created to support the application.</p>
+                  <div class="has-error" ng-show="form.appname.$error.oscResourceNameValidator">
+                    <span class="help-block"><strong>Please enter a valid name.</strong>
+                    <p>A valid name is applied to all generated resources and is an alphanumeric (a-z, and 0-9) string, with a maximum length of 24 characters, with the '-' character allowed anywhere except the first or last character.</p>
+                    </span>
+                  </div>
+                  <div class="has-error" ng-show="nameTaken">
+                    <span class="help-block">This name is already in use within the project. Please choose a different name.</span>
+                  </div>
                 </div>
-                <p class="help-block">Used to uniquely identify within this project all the resources created to support the application.</p>
-                <div class="has-error" ng-show="form.appname.$error.oscResourceNameValidator">
-                  <span class="help-block"><strong>Please enter a valid name.</strong>
-                  <p>A valid name is applied to all generated resources and is an alphanumeric (a-z, and 0-9) string, with a maximum length of 24 characters, with the '-' character allowed anywhere except the first or last character.</p>
-                  </span>
-                </div>
-                <div class="has-error" ng-show="nameTaken">
-                  <span class="help-block">This name is already in use within the project. Please choose a different name.</span>
-                </div>
-              </div>
 
-              <osc-form-section
-                header="Routing" 
-                about-title="Routing"
-                about="Routing is a way to make your application publicly visible. Otherwise you may only be able to access your application by it's IP address, if allowed by the system administrator."
-                >
-                <div ng-hide="$parent.expand">
-                  <div>
-                    <label>Create a route to the application: </label>
-                    <span>{{routing | yesNo}}</span>
+                <osc-form-section
+                  header="Routing" 
+                  about-title="Routing"
+                  about="Routing is a way to make your application publicly visible. Otherwise you may only be able to access your application by it's IP address, if allowed by the system administrator."
+                  >
+                  <div ng-hide="$parent.expand">
+                    <div>
+                      <label>Create a route to the application: </label>
+                      <span>{{routing | yesNo}}</span>
+                    </div>
                   </div>
-                </div>
-                <div ng-show="$parent.expand">
-                  <div class="form-group">
-                    <label class="checkbox-inline">
-                      <input type="checkbox" ng-model="routing.include">
-                        Create a route to the application
-                        <span class="help action-inline">
-                          <i class="pficon pficon-help" data-toggle="tooltip" data-placement="right" data-original-title="Additional routes with alternative configuration options (security, TLS termination, etc) can be added using the osc command."></i>
-                        </span>
-                    </label>
+                  <div ng-show="$parent.expand">
+                    <div class="form-group">
+                      <label class="checkbox-inline">
+                        <input type="checkbox" ng-model="routing.include">
+                          Create a route to the application
+                          <span class="help action-inline">
+                            <i class="pficon pficon-help" data-toggle="tooltip" data-placement="right" data-original-title="Additional routes with alternative configuration options (security, TLS termination, etc) can be added using the osc command."></i>
+                          </span>
+                      </label>
+                    </div>
                   </div>
-                </div>
-              </osc-form-section> 
+                </osc-form-section> 
 
-              <!-- /routing -->
+                <!-- /routing -->
 
-              <osc-form-section 
-                header="Deployment Configuration" 
-                about-title="Deployment Configuration"
-                about="Deployment configurations describe how your application is configured
-                  by the cluster and under what conditions it should be recreated (e.g. when the image changes)."
-                >
-                <div ng-hide="$parent.expand">
-                  <h3>Autodeploy when</h3>
-                  <div>
-                    <label>New image is available: </label>
-                    <span>{{deploymentConfig.deployOnNewImage | yesNo}}</span>
-                  </div>
-                  <div>
-                    <label>Deployment configuration changes: </label>
-                    <span>{{deploymentConfig.deployOnConfigChange | yesNo}}</span>
-                  </div>
-                  <h3>Environment Variables <span class="help action-inline">
-                    <a href data-toggle="tooltip" data-placement="right" 
-                       data-original-title="Environment variables are used to configure and pass information to running containers.">
-                      <i class="pficon pficon-help"></i> 
-                    </a>
-                  </span></h3>
-                  
-                  <osc-key-values
-                    entries="deploymentConfig.envVars"
-                    delimiter="="
-                    key-validator="env"
-                    delete-policy="added"
-                    editable="false"
-                   />
-                </div>
-                <div class="animate-drawer" ng-show="$parent.expand">
-                  <h3>Autodeploy when</h3>
-                  <div>
-                    <label class="checkbox">
-                      <input type="checkbox" ng-model="deploymentConfig.deployOnNewImage">
-                      New image is available
-                    </label>
-                  </div>
-                  <div>
-                  <label class="checkbox">
-                    <input type="checkbox" ng-model="deploymentConfig.deployOnConfigChange">
-                    Deployment configuration changes
-                  </label>
-                  </div>
-                  <div>
+                <osc-form-section 
+                  header="Deployment Configuration" 
+                  about-title="Deployment Configuration"
+                  about="Deployment configurations describe how your application is configured
+                    by the cluster and under what conditions it should be recreated (e.g. when the image changes)."
+                  >
+                  <div ng-hide="$parent.expand">
+                    <h3>Autodeploy when</h3>
+                    <div>
+                      <label>New image is available: </label>
+                      <span>{{deploymentConfig.deployOnNewImage | yesNo}}</span>
+                    </div>
+                    <div>
+                      <label>Deployment configuration changes: </label>
+                      <span>{{deploymentConfig.deployOnConfigChange | yesNo}}</span>
+                    </div>
                     <h3>Environment Variables <span class="help action-inline">
                       <a href data-toggle="tooltip" data-placement="right" 
-                         data-original-title="Environment variables are used to configure and pass information to images.">
+                         data-original-title="Environment variables are used to configure and pass information to running containers.">
                         <i class="pficon pficon-help"></i> 
                       </a>
                     </span></h3>
+                    
                     <osc-key-values
                       entries="deploymentConfig.envVars"
                       delimiter="="
                       key-validator="env"
                       delete-policy="added"
-                      key-validation-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
-                    />
+                      editable="false"
+                     />
                   </div>
-                </div>
-              </osc-form-section>
-
-              <!-- /deployment config -->
-
-              <osc-form-section 
-                header="Build Configuration"
-                about-title="Build Configuration"
-                about="A build configuration describes how to build your deployable image.  This includes
-                  your source, the base builder image, and when to launch new builds."
-                >
-                <div class="animate-drawer" ng-hide="$parent.expand">
-                  <div>
-                    <label>Source Code: </label>
-                    <span>{{buildConfig.sourceUrl | defaultIfBlank: "Not Specified"}}</span>
-                  </div>
-                  <div>
-                    <label>Automatically build new image when code changes: </label>
-                    <span>{{buildConfig.buildOnSourceChange | yesNo}}</span>
-                  </div>
-                  <div>
-                    <label>Automatically build new image when builder image changes: </label>
-                    <span>{{buildConfig.buildOnImageChange | yesNo}}</span>
-                  </div>
-                </div>
-                <div class="animate-drawer" ng-show="$parent.expand">
-                  <div>
-                    <label>Source Code: </label>
-                    <span>{{buildConfig.sourceUrl}}</span>
-                  </div>
-                  <div>
+                  <div class="animate-drawer" ng-show="$parent.expand">
+                    <h3>Autodeploy when</h3>
+                    <div>
+                      <label class="checkbox">
+                        <input type="checkbox" ng-model="deploymentConfig.deployOnNewImage">
+                        New image is available
+                      </label>
+                    </div>
+                    <div>
                     <label class="checkbox">
-                      <input type="checkbox" ng-model="buildConfig.buildOnSourceChange"/>
-                      Configure webhook build trigger 
-                      <span class="help action-inline">
+                      <input type="checkbox" ng-model="deploymentConfig.deployOnConfigChange">
+                      Deployment configuration changes
+                    </label>
+                    </div>
+                    <div>
+                      <h3>Environment Variables <span class="help action-inline">
                         <a href data-toggle="tooltip" data-placement="right" 
-                           data-original-title="The source repository must be configured to use the webhook to trigger a build when source is committed">
+                           data-original-title="Environment variables are used to configure and pass information to images.">
                           <i class="pficon pficon-help"></i> 
                         </a>
-                      </span>
+                      </span></h3>
+                      <osc-key-values
+                        entries="deploymentConfig.envVars"
+                        delimiter="="
+                        key-validator="env"
+                        delete-policy="added"
+                        key-validation-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
+                      />
+                    </div>
+                  </div>
+                </osc-form-section>
+
+                <!-- /deployment config -->
+
+                <osc-form-section 
+                  header="Build Configuration"
+                  about-title="Build Configuration"
+                  about="A build configuration describes how to build your deployable image.  This includes
+                    your source, the base builder image, and when to launch new builds."
+                  >
+                  <div class="animate-drawer" ng-hide="$parent.expand">
+                    <div>
+                      <label>Source Code: </label>
+                      <span>{{buildConfig.sourceUrl | defaultIfBlank: "Not Specified"}}</span>
+                    </div>
+                    <div>
+                      <label>Automatically build new image when code changes: </label>
+                      <span>{{buildConfig.buildOnSourceChange | yesNo}}</span>
+                    </div>
+                    <div>
+                      <label>Automatically build new image when builder image changes: </label>
+                      <span>{{buildConfig.buildOnImageChange | yesNo}}</span>
+                    </div>
+                  </div>
+                  <div class="animate-drawer" ng-show="$parent.expand">
+                    <div>
+                      <label>Source Code: </label>
+                      <span>{{buildConfig.sourceUrl}}</span>
+                    </div>
+                    <div>
+                      <label class="checkbox">
+                        <input type="checkbox" ng-model="buildConfig.buildOnSourceChange"/>
+                        Configure webhook build trigger 
+                        <span class="help action-inline">
+                          <a href data-toggle="tooltip" data-placement="right" 
+                             data-original-title="The source repository must be configured to use the webhook to trigger a build when source is committed">
+                            <i class="pficon pficon-help"></i> 
+                          </a>
+                        </span>
+                      </label>
+                    </div>
+                    <div>
+                      <label class="checkbox">
+                        <input type="checkbox" ng-model="buildConfig.buildOnImageChange"/>
+                        Automatically build new image when the builder image changes
+                        <span class="help action-inline">
+                          <a href data-toggle="tooltip" data-placement="right" data-original-title="Automatically building a new image when the builder image changes allows your code to always run on the latest updates.">
+                          <i class="pficon pficon-help"></i> 
+                          </a>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </osc-form-section>
+
+                <!-- /build config -->
+
+                <osc-form-section 
+                  header="Scaling"
+                  about-title="Scaling"
+                  about="Scaling defines the number of running instances of your built image."
+                  >
+                  <div ng-hide="$parent.expand">
+                    <div>
+                      <label>Replicas: </label>
+                      <span>{{scaling.replicas}}</span>
+                    </div>
+                  </div>
+                  <div ng-show="$parent.expand">
+                    <label class="number">
+                      Replicas: 
+                      <input type="number" class="input-number" min="0" name="replicas" ng-model="scaling.replicas" required ng-pattern="/^\-?\d+$/">
                     </label>
+                    <div class="has-error" ng-show="form.replicas.$invalid">
+                      <span class="help-block">Replicas must be an integer value greater than or equal to 0</span>
+                    </div>
                   </div>
-                  <div>
-                    <label class="checkbox">
-                      <input type="checkbox" ng-model="buildConfig.buildOnImageChange"/>
-                      Automatically build new image when the builder image changes
-                      <span class="help action-inline">
-                        <a href data-toggle="tooltip" data-placement="right" data-original-title="Automatically building a new image when the builder image changes allows your code to always run on the latest updates.">
-                        <i class="pficon pficon-help"></i> 
-                        </a>
-                      </span>
-                    </label>
-                  </div>
+                </osc-form-section>
+
+                <!-- /scaling -->
+
+                <labels labels="labels"></labels>
+                <div class="buttons gutter-top-bottom gutter-top-bottom-2x">
+                <div class="alert alert-info">
+                  <span class="pficon pficon-info"></span>
+                  <label>Note:</label> After creation, these settings can only be modified through the osc command.
                 </div>
-              </osc-form-section>
-
-              <!-- /build config -->
-
-              <osc-form-section 
-                header="Scaling"
-                about-title="Scaling"
-                about="Scaling defines the number of running instances of your built image."
-                >
-                <div ng-hide="$parent.expand">
-                  <div>
-                    <label>Replicas: </label>
-                    <span>{{scaling.replicas}}</span>
-                  </div>
+                  <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
+                  <button class="btn btn-primary btn-lg" 
+                      ng-click="createApp()" 
+                      ng-disabled="form.appname.$invalid || 
+                          form.replicas.$invalid"
+                      >Create</button>
+                  <a class="btn btn-default btn-lg" href="javascript:;" back>Cancel</a>
                 </div>
-                <div ng-show="$parent.expand">
-                  <label class="number">
-                    Replicas: 
-                    <input type="number" class="input-number" min="0" name="replicas" ng-model="scaling.replicas" required ng-pattern="/^\-?\d+$/">
-                  </label>
-                  <div class="has-error" ng-show="form.replicas.$invalid">
-                    <span class="help-block">Replicas must be an integer value greater than or equal to 0</span>
-                  </div>
-                </div>
-              </osc-form-section>
-
-              <!-- /scaling -->
-
-              <labels labels="labels"></labels>
-              <div class="buttons gutter-top-bottom gutter-top-bottom-2x">
-              <div class="alert alert-info">
-                <span class="pficon pficon-info"></span>
-                <label>Note:</label> After creation, these settings can only be modified through the osc command.
+              </form>
+              <div ng-hide="imageRepo">
+                {{ emptyMessage }}
               </div>
-                <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
-                <button class="btn btn-primary btn-lg" 
-                    ng-click="createApp()" 
-                    ng-disabled="form.appname.$invalid || 
-                        form.replicas.$invalid"
-                    >Create</button>
-                <a class="btn btn-default btn-lg" href="javascript:;" back>Cancel</a>
-              </div>
-            </form>
-            <div ng-hide="imageRepo">
-              {{ emptyMessage }}
             </div>
-          </div>
-        </div><!-- /row -->
-      </div><!-- /create-from-template -->
-    </div><!-- /col-* -->
-  </div><!-- /row -->
-</div><!-- /container -->
+          </div><!-- /row -->
+        </div><!-- /create-from-template -->
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/app/views/directives/_return-to-overview.html
+++ b/assets/app/views/directives/_return-to-overview.html
@@ -1,0 +1,4 @@
+<div class="gutter-top">
+  <div class="h2 return-project-name">Project {{project | displayName}}</div>
+  <a ng-attr-href="{{project | projectOverviewURL}}">Return to Project Overview</a>
+</div>

--- a/assets/app/views/newfromtemplate.html
+++ b/assets/app/views/newfromtemplate.html
@@ -1,37 +1,40 @@
-<div class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <div ng-controller="NewFromTemplateController" class="create-from-template">
-        <div class="row">
-          <div class="col-md-2 template-name">
-            <span class="fa fa-cubes hidden-xs hidden-sm"></span>
+<div ng-controller="ProjectController">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <div ng-controller="NewFromTemplateController" class="create-from-template">
+          <div class="row">
+            <div class="col-md-2 template-name">
+              <span class="fa fa-cubes hidden-xs hidden-sm gutter-top"></span>
+            </div>
+            <div class="col-md-9">
+              <return-to-overview project="project"></return-to-overview>
+              <osc-image-summary resource="template"></osc-image-summary>
+              <div ng-if="templateImages.length" class="images gutter-bottom">
+                <h2>Images</h2>
+                <ul class="list-unstyled" ng-repeat="image in templateImages">
+                  <li>
+                    <i class="fa fa-cube"></i>
+                    <span class="name">{{ image.name }}</span>
+                  </li>
+                </ul>
+              </div>
+              <labels labels="template.labels"></labels>
+              <template-options></template-options>
+              <div class="project gutter-bottom">
+              Items will be created in the <b>{{ projectDisplayName() }}</b> project.
+              </div>
+              <div class="buttons gutter-top-bottom">
+                <button class="btn btn-primary btn-lg" ng-click="createFromTemplate()">Create</button>
+                <a class="btn btn-default btn-lg" href="javascript:;" back>Cancel</a>
+              </div>
+            </div>
           </div>
-          <div class="col-md-9">
-            <osc-image-summary resource="template"></osc-image-summary>
-            <div ng-if="templateImages.length" class="images gutter-bottom">
-              <h2>Images</h2>
-              <ul class="list-unstyled" ng-repeat="image in templateImages">
-                <li>
-                  <i class="fa fa-cube"></i>
-                  <span class="name">{{ image.name }}</span>
-                </li>
-              </ul>
-            </div>
-            <labels labels="template.labels"></labels>
-            <template-options></template-options>
-            <div class="project gutter-bottom">
-            Items will be created in the <b>{{ projectDisplayName() }}</b> project.
-            </div>
-            <div class="buttons gutter-top-bottom">
-              <button class="btn btn-primary btn-lg" ng-click="createFromTemplate()">Create</button>
-              <a class="btn btn-default btn-lg" href="javascript:;" back>Cancel</a>
-            </div>
+          <div ng-hide="template">
+            {{ emptyMessage }}
           </div>
-        </div>
-        <div ng-hide="template">
-          {{ emptyMessage }}
-        </div>
-      </div><!-- /create-from-template -->
+        </div><!-- /create-from-template -->
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Display the current project and a link back to the project overview at
the top of every page when creating from a source repository or template
in the web console.

Fixes #1852

Side-by-side at normal resolutions:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7734550/b0bc3a5a-ff04-11e4-8500-a7e88f437f0f.png)

Stacked at phone resolutions:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7734559/c668dcaa-ff04-11e4-84d2-af9d35004cc8.png)
