### PR TITLE
Adding deployment cancellation controller

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -903,6 +903,16 @@ func (c *MasterConfig) RunDeploymentImageChangeTriggerController() {
 	controller.Run()
 }
 
+func (c *MasterConfig) RunDeploymentCancellationController() {
+	kclient := c.DeploymentCancellationControllerClient()
+	factory := deployconfigcontroller.DeploymentConfigControllerFactory{
+		KubeClient: kclient,
+		Codec:      latest.Codec,
+	}
+	controller := factory.Create()
+	controller.Run()
+}
+
 // SDN controller runs openshift-sdn if the said network plugin is provided
 func (c *MasterConfig) RunSDNController() {
 	if c.Options.NetworkConfig.NetworkPluginName == osdn.NetworkPluginName() {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -325,6 +325,9 @@ func (c *MasterConfig) DeploymentConfigChangeControllerClients() (*osclient.Clie
 func (c *MasterConfig) DeploymentImageChangeControllerClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
+func (c *MasterConfig) DeploymentCancellationControllerClient() *kclient.Client {
+	return c.PrivilegedLoopbackKubernetesClient
+}
 
 // OriginNamespaceControllerClients returns a client for openshift and kubernetes.
 // The openshift client object must have authority to delete openshift content in any namespace

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -205,6 +205,10 @@ const (
 // Currently set to 6 hours
 const MaxDeploymentDurationSeconds int64 = 21600
 
+// This constant represents the value for the DeploymentCancelledAnnotation annotation
+// that signifies that the deployment should be cancelled
+const DeploymentCancelledAnnotationValue = "true"
+
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -202,6 +202,10 @@ const (
 // Currently set to 6 hours
 const MaxDeploymentDurationSeconds int64 = 21600
 
+// This constant represents the value for the DeploymentCancelledAnnotation annotation
+// that signifies that the deployment should be cancelled
+const DeploymentCancelledAnnotationValue = "true"
+
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -169,6 +169,10 @@ const (
 // Currently set to 6 hours
 const MaxDeploymentDurationSeconds int64 = 21600
 
+// This constant represents the value for the DeploymentCancelledAnnotation annotation
+// that signifies that the deployment should be cancelled
+const DeploymentCancelledAnnotationValue = "true"
+
 // DeploymentConfig represents a configuration for a single deployment (represented as a
 // ReplicationController). It also contains details about changes which resulted in the current
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -35,6 +35,8 @@ type DeploymentControllerFactory struct {
 // Create creates a DeploymentController.
 func (factory *DeploymentControllerFactory) Create() controller.RunnableController {
 	deploymentLW := &deployutil.ListWatcherImpl{
+		// TODO: Investigate specifying annotation field selectors to fetch only 'deployments'
+		// Currently field selectors are not supported for replication controllers
 		ListFunc: func() (runtime.Object, error) {
 			return factory.KubeClient.ReplicationControllers(kapi.NamespaceAll).List(labels.Everything())
 		},

--- a/pkg/deploy/controller/deploymentcancellation/controller.go
+++ b/pkg/deploy/controller/deploymentcancellation/controller.go
@@ -1,0 +1,78 @@
+package deploymentcancellation
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+// DeploymentCancellationController monitors for deployments that have been
+// cancelled by the user and sets the ActiveDeadlineSeconds to 0 on the
+// corresponding deployer pods.
+//
+// Use the DeploymentCancellationControllerFactory to create this controller.
+type DeploymentCancellationController struct {
+	// podClient provides access to pods.
+	podClient podClient
+	recorder  record.EventRecorder
+}
+
+// Handle processes deployment and either creates a deployer pod or responds
+// to a terminal deployment status.
+func (c *DeploymentCancellationController) Handle(deployment *kapi.ReplicationController) error {
+	currentStatus := deployutil.DeploymentStatusFor(deployment)
+
+	switch currentStatus {
+	case deployapi.DeploymentStatusNew,
+		deployapi.DeploymentStatusPending,
+		deployapi.DeploymentStatusRunning:
+
+		if !deployutil.IsDeploymentCancelled(deployment) {
+			return nil
+		}
+
+		deployerPod, err := c.podClient.getPod(deployment.Namespace, deployutil.DeployerPodNameFor(deployment))
+		if err != nil {
+			return fmt.Errorf("couldn't fetch deployer pod for %s: %v", deployutil.LabelForDeployment(deployment), err)
+		}
+
+		// set the ActiveDeadlineSeconds on the deployer pod to 0, if not already set
+		zeroDelay := int64(0)
+		if deployerPod.Spec.ActiveDeadlineSeconds == nil || *deployerPod.Spec.ActiveDeadlineSeconds != zeroDelay {
+			deployerPod.Spec.ActiveDeadlineSeconds = &zeroDelay
+			if _, err := c.podClient.updatePod(deployerPod.Namespace, deployerPod); err != nil {
+				c.recorder.Eventf(deployment, "failedCancellation", "Error updating ActiveDeadlineSeconds to 0 on deployer pod for deployment %s: %v", deployutil.LabelForDeployment(deployment), err)
+				return fmt.Errorf("couldn't update ActiveDeadlineSeconds to 0 on deployer pod for deployment %s: %v", deployutil.LabelForDeployment(deployment), err)
+			}
+			glog.V(2).Infof("Updated ActiveDeadlineSeconds to 0 on deployer pod for deployment %s", deployutil.LabelForDeployment(deployment))
+		}
+	}
+
+	return nil
+}
+
+// podClient abstracts access to pods.
+type podClient interface {
+	getPod(namespace, name string) (*kapi.Pod, error)
+	updatePod(namespace string, pod *kapi.Pod) (*kapi.Pod, error)
+}
+
+// podClientImpl is a pluggable podClient.
+type podClientImpl struct {
+	getPodFunc    func(namespace, name string) (*kapi.Pod, error)
+	updatePodFunc func(namespace string, pod *kapi.Pod) (*kapi.Pod, error)
+}
+
+func (i *podClientImpl) getPod(namespace, name string) (*kapi.Pod, error) {
+	return i.getPodFunc(namespace, name)
+}
+
+func (i *podClientImpl) updatePod(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+	return i.updatePodFunc(namespace, pod)
+}

--- a/pkg/deploy/controller/deploymentcancellation/controller_test.go
+++ b/pkg/deploy/controller/deploymentcancellation/controller_test.go
@@ -1,0 +1,166 @@
+package deploymentcancellation
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+// TestHandle_cancelInflightDeployment ensures that a deployment in the
+// new/pending/running state can be cancelled
+// and a deployment in failed/complete state cannot be cancelled
+func TestHandle_cancelInflightDeployment(t *testing.T) {
+	var updatedPod *kapi.Pod
+	deployment := cancelledDeployment()
+
+	controller := &DeploymentCancellationController{
+		podClient: &podClientImpl{
+			getPodFunc: func(namespace, name string) (*kapi.Pod, error) {
+				return okPod(), nil
+			},
+			updatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				updatedPod = pod
+				return updatedPod, nil
+			},
+		},
+		recorder: &record.FakeRecorder{},
+	}
+
+	// test inflight statuses
+	inflightStatus := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusNew,
+		deployapi.DeploymentStatusPending,
+		deployapi.DeploymentStatusRunning,
+	}
+	for _, status := range inflightStatus {
+		updatedPod = nil
+		deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(status)
+
+		err := controller.Handle(deployment)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if updatedPod == nil {
+			t.Fatalf("expected an updated deployer pod")
+		}
+
+		if *updatedPod.Spec.ActiveDeadlineSeconds != int64(0) {
+			t.Fatalf("ActiveDeadlineSeconds not set to 0")
+		}
+	}
+
+	// test terminal statuses
+	terminalStatus := []deployapi.DeploymentStatus{
+		deployapi.DeploymentStatusComplete,
+		deployapi.DeploymentStatusFailed,
+	}
+	for _, status := range terminalStatus {
+		updatedPod = nil
+		deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(status)
+		err := controller.Handle(deployment)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if updatedPod != nil {
+			t.Fatalf("unexpected deployer pod update")
+		}
+	}
+}
+
+// TestHandle_podActiveDeadlineNonZero ensures that a deployer pod
+// that can be cancelled and has an ActiveDeadlineSeconds value
+// of non-zero is updated correctly
+func TestHandle_podActiveDeadlineNonZero(t *testing.T) {
+	var updatedPod *kapi.Pod
+	deployment := cancelledDeployment()
+
+	controller := &DeploymentCancellationController{
+		podClient: &podClientImpl{
+			getPodFunc: func(namespace, name string) (*kapi.Pod, error) {
+				return ttlNonZeroPod(), nil
+			},
+			updatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				updatedPod = pod
+				return updatedPod, nil
+			},
+		},
+		recorder: &record.FakeRecorder{},
+	}
+
+	err := controller.Handle(deployment)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if updatedPod == nil {
+		t.Fatalf("expected an updated deployer pod")
+	}
+
+	if *updatedPod.Spec.ActiveDeadlineSeconds != int64(0) {
+		t.Fatalf("ActiveDeadlineSeconds not set to 0")
+	}
+}
+
+// TestHandle_podActiveDeadlineZero ensures that a deployer pod
+// that can be cancelled and has an ActiveDeadlineSeconds value
+// already set to zero is not updated again
+func TestHandle_podActiveDeadlineZero(t *testing.T) {
+	controller := &DeploymentCancellationController{
+		podClient: &podClientImpl{
+			getPodFunc: func(namespace, name string) (*kapi.Pod, error) {
+				return ttlZeroPod(), nil
+			},
+			updatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				t.Fatalf("unexpected pod update")
+				return nil, nil
+			},
+		},
+		recorder: &record.FakeRecorder{},
+	}
+
+	deployment := cancelledDeployment()
+	err := controller.Handle(deployment)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func cancelledDeployment() *kapi.ReplicationController {
+	config := deploytest.OkDeploymentConfig(1)
+	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
+	deployment.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
+	return deployment
+}
+
+func okPod() *kapi.Pod {
+	return &kapi.Pod{}
+}
+
+func ttlNonZeroPod() *kapi.Pod {
+	ttl := int64(10)
+	return &kapi.Pod{
+		Spec: kapi.PodSpec{
+			ActiveDeadlineSeconds: &ttl,
+		},
+	}
+}
+
+func ttlZeroPod() *kapi.Pod {
+	ttl := int64(0)
+	return &kapi.Pod{
+		Spec: kapi.PodSpec{
+			ActiveDeadlineSeconds: &ttl,
+		},
+	}
+}

--- a/pkg/deploy/controller/deploymentcancellation/factory.go
+++ b/pkg/deploy/controller/deploymentcancellation/factory.go
@@ -1,0 +1,72 @@
+package deploymentcancellation
+
+import (
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	controller "github.com/openshift/origin/pkg/controller"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+)
+
+// DeploymentCancellationControllerFactory can create a DeploymentCancellationController
+// that cancels deployments that have the cancellation annotation set.
+type DeploymentCancellationControllerFactory struct {
+	// KubeClient is a Kubernetes client.
+	KubeClient kclient.Interface
+	// Codec is used for encoding/decoding.
+	Codec runtime.Codec
+}
+
+// Create creates a DeploymentCancellationController.
+func (factory *DeploymentCancellationControllerFactory) Create() controller.RunnableController {
+	deploymentLW := &deployutil.ListWatcherImpl{
+		// TODO: Investigate specifying annotation field selectors to fetch only 'deployments'
+		// Currently field selectors are not supported for replication controllers
+		ListFunc: func() (runtime.Object, error) {
+			return factory.KubeClient.ReplicationControllers(kapi.NamespaceAll).List(labels.Everything())
+		},
+		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			return factory.KubeClient.ReplicationControllers(kapi.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
+		},
+	}
+	deploymentQueue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+	cache.NewReflector(deploymentLW, &kapi.ReplicationController{}, deploymentQueue, 2*time.Minute).Run()
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(factory.KubeClient.Events(""))
+
+	deployController := &DeploymentCancellationController{
+		podClient: &podClientImpl{
+			getPodFunc: func(namespace, name string) (*kapi.Pod, error) {
+				return factory.KubeClient.Pods(namespace).Get(name)
+			},
+			updatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
+				return factory.KubeClient.Pods(namespace).Update(pod)
+			},
+		},
+		recorder: eventBroadcaster.NewRecorder(kapi.EventSource{Component: "deployer"}),
+	}
+
+	return &controller.RetryController{
+		Queue: deploymentQueue,
+		RetryManager: controller.NewQueueRetryManager(
+			deploymentQueue,
+			cache.MetaNamespaceKeyFunc,
+			func(obj interface{}, err error, count int) bool { return count < 1 },
+			kutil.NewTokenBucketRateLimiter(1, 10),
+		),
+		Handle: func(obj interface{}) error {
+			deployment := obj.(*kapi.ReplicationController)
+			return deployController.Handle(deployment)
+		},
+	}
+}

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -79,7 +79,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 				deploymentForCancellation = &deployment
 			}
 
-			deploymentForCancellation.Annotations[deployapi.DeploymentCancelledAnnotation] = "true"
+			deploymentForCancellation.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
 			if _, err := c.deploymentClient.updateDeployment(deploymentForCancellation.Namespace, deploymentForCancellation); err != nil {
 				glog.Errorf("couldn't cancel deployment %s: %v", deployutil.LabelForDeployment(deploymentForCancellation), err)
 			}

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/adler32"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -44,6 +45,10 @@ var annotationMap = map[string][]string{
 	deployapi.DeploymentVersionAnnotation: {
 		deployv1.DeploymentVersionAnnotation,
 		deployv3.DeploymentVersionAnnotation,
+	},
+	deployapi.DeploymentCancelledAnnotation: {
+		deployv1.DeploymentCancelledAnnotation,
+		deployv3.DeploymentCancelledAnnotation,
 	},
 }
 
@@ -246,6 +251,11 @@ func DeploymentVersionFor(obj runtime.Object) int {
 		return -1
 	}
 	return v
+}
+
+func IsDeploymentCancelled(deployment *api.ReplicationController) bool {
+	value := mappedAnnotationFor(deployment, deployapi.DeploymentCancelledAnnotation)
+	return strings.EqualFold(value, deployapi.DeploymentCancelledAnnotationValue)
 }
 
 // mappedAnnotationFor finds the given annotation in obj using the annotation


### PR DESCRIPTION
 - watches updates to deployments
 - checks inflight (new/pending/running) deployments for the cancellation annotation 
 - if cancellation annotation is set, it sets the ActiveDeadlineSeconds on the deployer pod to 0

