### PR TITLE
Fix ProjectNodeSelector config

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -113,8 +113,6 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 
 	refs = append(refs, &config.PolicyConfig.BootstrapPolicyFile)
 
-	refs = append(refs, &config.ProjectNodeSelector)
-
 	return refs
 }
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -88,22 +88,23 @@ type MasterConfig struct {
 	// PolicyConfig holds information about where to locate critical pieces of bootstrapping policy
 	PolicyConfig PolicyConfig
 
-	// ProjectNodeSelector holds default project node label selector
-	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
-	// ProjectRequestConfig holds information about how to handle new project requests
-	ProjectRequestConfig ProjectRequestConfig
+	// ProjectConfig holds information about project creation and defaults
+	ProjectConfig ProjectConfig
 
 	// NetworkConfig to be passed to the compiled in network plugin
 	NetworkConfig NetworkConfig
 }
 
-// ProjectRequestConfig holds information about how to handle new project requests
-type ProjectRequestConfig struct {
+type ProjectConfig struct {
+	// DefaultNodeSelector holds default project node label selector
+	DefaultNodeSelector string
+
 	// ProjectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint
 	ProjectRequestMessage string
 
-	// ProjectRequestTemplate is the template to use for creating projects in response to projectrequest.  It is in the format namespace/template and it is optional.
-	// If it is not specified, then projectrequest will not work.  If the template does not exist, then a default will be created.
+	// ProjectRequestTemplate is the template to use for creating projects in response to projectrequest.
+	// It is in the format namespace/template and it is optional.
+	// If it is not specified, a default template is used.
 	ProjectRequestTemplate string
 }
 

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -84,21 +84,23 @@ type MasterConfig struct {
 
 	PolicyConfig PolicyConfig `json:"policyConfig"`
 
-	// ProjectNodeSelector holds default project node label selector
-	ProjectNodeSelector string `json:"projectNodeSelector,omitempty"`
-	// ProjectRequestConfig holds information about how to handle new project requests
-	ProjectRequestConfig ProjectRequestConfig `json:"projectRequestConfig"`
+	// ProjectConfig holds information about project creation and defaults
+	ProjectConfig ProjectConfig `json:"projectConfig"`
 
 	// NetworkConfig to be passed to the compiled in network plugin
 	NetworkConfig NetworkConfig `json:"networkConfig"`
 }
 
-type ProjectRequestConfig struct {
+type ProjectConfig struct {
+	// DefaultNodeSelector holds default project node label selector
+	DefaultNodeSelector string `json:"defaultNodeSelector"`
+
 	// ProjectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint
 	ProjectRequestMessage string `json:"projectRequestMessage"`
 
-	// ProjectRequestTemplate is the template to use for creating projects in response to projectrequest.  It is in the format namespace/template and it is optional.
-	// If it is not specified, then projectrequest will not work.  If the template does not exist, then a default will be created.
+	// ProjectRequestTemplate is the template to use for creating projects in response to projectrequest.
+	// It is in the format namespace/template and it is optional.
+	// If it is not specified, a default template is used.
 	ProjectRequestTemplate string `json:"projectRequestTemplate"`
 }
 

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -96,11 +96,9 @@ func ValidateMasterConfig(config *api.MasterConfig) fielderrors.ValidationErrorL
 
 	allErrs = append(allErrs, ValidateServiceAccountConfig(config.ServiceAccountConfig, builtInKubernetes).Prefix("serviceAccountConfig")...)
 
-	allErrs = append(allErrs, ValidateProjectNodeSelector(config.ProjectNodeSelector)...)
-
 	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
 
-	allErrs = append(allErrs, ValidateProjectRequestConfig(config.ProjectRequestConfig).Prefix("projectRequestConfig")...)
+	allErrs = append(allErrs, ValidateProjectConfig(config.ProjectConfig).Prefix("projectConfig")...)
 
 	return allErrs
 }
@@ -120,19 +118,6 @@ func ValidateEtcdStorageConfig(config api.EtcdStorageConfig) fielderrors.Validat
 	}
 	if strings.ContainsRune(config.OpenShiftStoragePrefix, '%') {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("openShiftStoragePrefix", config.OpenShiftStoragePrefix, "the '%' character may not be used in etcd path prefixes"))
-	}
-
-	return allErrs
-}
-
-func ValidateProjectNodeSelector(nodeSelector string) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
-
-	if len(nodeSelector) > 0 {
-		_, err := labelselector.Parse(nodeSelector)
-		if err != nil {
-			allErrs = append(allErrs, fielderrors.NewFieldInvalid("projectNodeSelector", nodeSelector, "must be a valid label selector"))
-		}
 	}
 
 	return allErrs
@@ -273,12 +258,18 @@ func ValidatePolicyConfig(config api.PolicyConfig) fielderrors.ValidationErrorLi
 	return allErrs
 }
 
-// ValidateProjectRequestConfig is stub for now.  no validation is required.
-func ValidateProjectRequestConfig(config api.ProjectRequestConfig) fielderrors.ValidationErrorList {
+func ValidateProjectConfig(config api.ProjectConfig) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
 	if _, _, err := api.ParseNamespaceAndName(config.ProjectRequestTemplate); err != nil {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("projectRequestTemplate", config.ProjectRequestTemplate, "must be in the form: namespace/templateName"))
+	}
+
+	if len(config.DefaultNodeSelector) > 0 {
+		_, err := labelselector.Parse(config.DefaultNodeSelector)
+		if err != nil {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("defaultNodeSelector", config.DefaultNodeSelector, "must be a valid label selector"))
+		}
 	}
 
 	return allErrs

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -251,12 +251,12 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 
 	projectStorage := projectproxy.NewREST(kclient.Namespaces(), c.ProjectAuthorizationCache)
 
-	namespace, templateName, err := configapi.ParseNamespaceAndName(c.Options.ProjectRequestConfig.ProjectRequestTemplate)
+	namespace, templateName, err := configapi.ParseNamespaceAndName(c.Options.ProjectConfig.ProjectRequestTemplate)
 	if err != nil {
 		glog.Errorf("Error parsing project request template value: %v", err)
 		// we can continue on, the storage that gets created will be valid, it simply won't work properly.  There's no reason to kill the master
 	}
-	projectRequestStorage := projectrequeststorage.NewREST(c.Options.ProjectRequestConfig.ProjectRequestMessage, namespace, templateName, c.PrivilegedLoopbackOpenShiftClient)
+	projectRequestStorage := projectrequeststorage.NewREST(c.Options.ProjectConfig.ProjectRequestMessage, namespace, templateName, c.PrivilegedLoopbackOpenShiftClient)
 
 	bcClient, _ := c.BuildControllerClients()
 	buildConfigWebHooks := buildconfigregistry.NewWebHookREST(
@@ -806,8 +806,8 @@ func (c *MasterConfig) RunDNSServer() {
 
 // RunProjectCache populates project cache, used by scheduler and project admission controller.
 func (c *MasterConfig) RunProjectCache() {
-	glog.Infof("Using default project node label selector: %s", c.Options.ProjectNodeSelector)
-	projectcache.RunProjectCache(c.PrivilegedLoopbackKubernetesClient, c.Options.ProjectNodeSelector)
+	glog.Infof("Using default project node label selector: %s", c.Options.ProjectConfig.DefaultNodeSelector)
+	projectcache.RunProjectCache(c.PrivilegedLoopbackKubernetesClient, c.Options.ProjectConfig.DefaultNodeSelector)
 }
 
 // RunBuildController starts the build sync loop for builds and buildConfig processing.

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -154,7 +154,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		Options: options,
 
 		Authenticator:                 newAuthenticator(options, etcdHelper, serviceAccountTokenGetter, apiClientCAs),
-		Authorizer:                    newAuthorizer(policyCache, options.ProjectRequestConfig.ProjectRequestMessage),
+		Authorizer:                    newAuthorizer(policyCache, options.ProjectConfig.ProjectRequestMessage),
 		AuthorizationAttributeBuilder: newAuthorizationAttributeBuilder(requestContextMapper),
 
 		PolicyCache:               policyCache,

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -48,8 +48,6 @@ type MasterArgs struct {
 
 	SchedulerConfigFile string
 
-	ProjectNodeSelector string
-
 	NetworkArgs *NetworkArgs
 }
 
@@ -65,7 +63,6 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 
 	flags.Var(&args.NodeList, prefix+"nodes", "The hostnames of each node. This currently must be specified up front. Comma delimited list")
 	flags.Var(&args.CORSAllowedOrigins, prefix+"cors-allowed-origins", "List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching.  CORS is enabled for localhost, 127.0.0.1, and the asset server by default.")
-	flags.StringVar(&args.ProjectNodeSelector, prefix+"project-node-selector", "", "Default node label selector for the project if not explicitly specified. Format: '<key1>=<value1>, <key2>=<value2...'")
 }
 
 // NewDefaultMasterArgs creates MasterArgs with sub-objects created and default values set.
@@ -199,17 +196,17 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 			Latest: args.ImageFormatArgs.ImageTemplate.Latest,
 		},
 
-		ProjectRequestConfig: configapi.ProjectRequestConfig{},
+		ProjectConfig: configapi.ProjectConfig{
+			DefaultNodeSelector:    "",
+			ProjectRequestMessage:  "",
+			ProjectRequestTemplate: "",
+		},
 
 		NetworkConfig: configapi.NetworkConfig{
 			NetworkPluginName:  args.NetworkArgs.NetworkPluginName,
 			ClusterNetworkCIDR: args.NetworkArgs.ClusterNetworkCIDR,
 			HostSubnetLength:   args.NetworkArgs.HostSubnetLength,
 		},
-	}
-
-	if len(args.ProjectNodeSelector) > 0 {
-		config.ProjectNodeSelector = args.ProjectNodeSelector
 	}
 
 	if args.ListenArg.UseTLS() {

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -90,7 +90,7 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	masterOptions.ProjectRequestConfig.ProjectRequestTemplate = namespace + "/" + templateName
+	masterOptions.ProjectConfig.ProjectRequestTemplate = namespace + "/" + templateName
 
 	clusterAdminKubeConfig, err := testutil.StartConfiguredMaster(masterOptions)
 	if err != nil {


### PR DESCRIPTION
Removes json serialization tags from internal config
Removes `omitempty` from serialized config, so the key is always output
Stops trying to validate the node selector string as a file
Removed command line flag for default node selector (config only)

Fixes #2399