### PR TITLE
Display error when processing a template fails.

### DIFF
--- a/assets/app/scripts/controllers/newfromtemplate.js
+++ b/assets/app/scripts/controllers/newfromtemplate.js
@@ -131,11 +131,15 @@ angular.module('openshiftConsole')
           Navigate.toProjectOverview($scope.projectName);
         },
         function(result) { // failure
+          var details;
+          if (result.data && result.data.message) {
+            details = result.data.message;
+          }
           $scope.alerts = [
             {
               type: "error",
               message: "An error occurred processing the template.",
-              details: "Status: " + result.status + ". " + result.data,
+              details: details
             }
           ];
         }

--- a/assets/app/views/newfromtemplate.html
+++ b/assets/app/views/newfromtemplate.html
@@ -22,6 +22,7 @@
             <div class="project gutter-bottom">
             Items will be created in the <b>{{ projectDisplayName() }}</b> project.
             </div>
+            <alerts alerts="alerts"></alerts>
             <div class="buttons gutter-top-bottom">
               <button class="btn btn-primary btn-lg" ng-click="createFromTemplate()">Create</button>
               <a class="btn btn-default btn-lg" href="javascript:;" back>Cancel</a>


### PR DESCRIPTION
Fixes message displayed when an error occurs and adds an alerts tag to the newfromtemplate page so it can actually display an error.