### PR TITLE
Avoid warning icon flicker for deployment configs

### DIFF
--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -17,7 +17,8 @@ angular.module('openshiftConsole')
     $scope.displayRouteByService = {};
     $scope.unfilteredServices = {};
     $scope.deployments = {};
-    $scope.deploymentConfigs = {};
+    // Initialize to undefined so we know when deployment configs are actually loaded.
+    $scope.deploymentConfigs = undefined;
     $scope.builds = {};
     $scope.imageStreams = {};
     $scope.imagesByDockerReference = {};

--- a/assets/app/scripts/directives/resources.js
+++ b/assets/app/scripts/directives/resources.js
@@ -7,9 +7,9 @@ angular.module('openshiftConsole')
       scope: {
       	// Replication controller / deployment fields
         rc: '=',
-        deploymentConfig: '=',
         deploymentConfigId: '=',
-        differentService: '=',
+        deploymentConfigMissing: '=',
+        deploymentConfigDifferentService: '=',
 
         // Nested podTemplate fields
         imagesByDockerReference: '=',

--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -5,7 +5,7 @@
   pods - [Pod]. Required.
 
   deploymentConfigId               - String. Optional. If present, indicates this replication controller came from a deployment.
-  deploymentConfig                 - DeploymentConfig. Optional.
+  deploymentConfigMissing          - Boolean. Optional.
   deploymentConfigDifferentService - Boolean. Optional.
 
   imagesByDockerReference - map[dockerReference][]Image. Optional.
@@ -29,11 +29,13 @@
       <div class="component-label">Deployment</div>
       <h3 class="h4">
         {{deploymentConfigId}}, #{{rc | annotation:'deploymentVersion'}}
-        <span class="pficon-layered" ng-if="deploymentConfig == null" data-toggle="tooltip" data-placement="right" title="Deployment config {{deploymentConfigId}} no longer exists" style="cursor: help;">
+        <span class="pficon-layered" ng-if="deploymentConfigMissing" data-toggle="tooltip" data-placement="right"
+            title="The deployment config this deployment was created from no longer exists." style="cursor: help;">
           <span class="pficon pficon-warning-triangle"></span>
           <span class="pficon pficon-warning-exclamation"></span>
         </span>
-        <span class="pficon-layered" ng-if="deploymentConfig != null && deploymentConfigDifferentService" data-toggle="tooltip" data-placement="right" title="The deployment config this deployment was created from has changed. New deployments will not be included in this list." style="cursor: help;">
+        <span class="pficon-layered" ng-if="deploymentConfigDifferentService" data-toggle="tooltip" data-placement="right"
+            title="The deployment config this deployment was created from has changed. New deployments will not be included in this list." style="cursor: help;">
           <span class="pficon pficon-warning-triangle"></span>
           <span class="pficon pficon-warning-exclamation"></span>
         </span>

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -131,11 +131,12 @@
           <div ng-repeat="deployment in deployments | orderObjectsByDate : true track by (deployment | uid)" 
                ng-if="(podsByDeployment[deployment.metadata.name] | hashSize) > 0">
 
+            <!-- Make sure deploymentConfigs are loaded before testing if the deployment config is missing. -->
             <overview-deployment
               rc="deployment"
               deployment-config-id="deploymentConfigId"
-              deployment-config="deploymentConfigs[deploymentConfigId]"
-              deployment-config-different-service="!deploymentConfigsByService[serviceId][deploymentConfigId]"
+              deployment-config-missing="deploymentConfigs && !deploymentConfigs[deploymentConfigId]"
+              deployment-config-different-service="deploymentConfigs[deploymentConfigId] && !deploymentConfigsByService[serviceId][deploymentConfigId]"
               images-by-docker-reference="imagesByDockerReference"
               builds="builds"
               pods="podsByDeployment[deployment.metadata.name]">
@@ -182,11 +183,12 @@
             <triggers triggers="deploymentConfigs[deploymentConfigId].triggers"></triggers>
           </div>                
 
+          <!-- Make sure deploymentConfigs are loaded before testing if the deployment config is missing. -->
           <overview-deployment
             rc="deployment"
             deployment-config-id="deploymentConfigId"
-            deployment-config="deploymentConfigs[deploymentConfigId]"
-            deployment-config-different-service="!deploymentConfigsByService[''][deploymentConfigId]"
+            deployment-config-missing="deploymentConfigs && !deploymentConfigs[deploymentConfigId]"
+            deployment-config-different-service="deploymentConfigs[deploymentConfigId] && !deploymentConfigsByService[''][deploymentConfigId]"
             images-by-docker-reference="imagesByDockerReference"
             builds="builds"
             pods="podsByDeployment[deployment.metadata.name]">


### PR DESCRIPTION
Don't show the missing deployment config warning until the deployment
configs have finished loading to avoid flicker.

Fixes #2411