### PR TITLE
handle secret types

### DIFF
--- a/pkg/cmd/experimental/bundlesecret/bundle_secret_test.go
+++ b/pkg/cmd/experimental/bundlesecret/bundle_secret_test.go
@@ -1,7 +1,11 @@
 package bundlesecret
 
 import (
+	"io/ioutil"
 	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 func TestValidate(t *testing.T) {
@@ -87,5 +91,37 @@ func TestCreateSecret(t *testing.T) {
 		if err != nil && !test.expErr {
 			t.Errorf("%s: unexpected error: %s", test.testName, err)
 		}
+	}
+}
+
+func TestSecretTypeSpecified(t *testing.T) {
+	options := CreateSecretOptions{
+		Name:           "any",
+		SecretTypeName: string(kapi.SecretTypeDockercfg),
+		Sources:        util.StringList([]string{"./bsFixtures/www.google.com"}),
+		Stderr:         ioutil.Discard,
+	}
+
+	secret, err := options.CreateSecret()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if secret.Type != kapi.SecretTypeDockercfg {
+		t.Errorf("expected %v, got %v", kapi.SecretTypeDockercfg, secret.Type)
+	}
+}
+func TestSecretTypeDiscovered(t *testing.T) {
+	options := CreateSecretOptions{
+		Name:    "any",
+		Sources: util.StringList([]string{"./bsFixtures/leadingdot/.dockercfg"}),
+		Stderr:  ioutil.Discard,
+	}
+
+	secret, err := options.CreateSecret()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if secret.Type != kapi.SecretTypeDockercfg {
+		t.Errorf("expected %v, got %v", kapi.SecretTypeDockercfg, secret.Type)
 	}
 }

--- a/pkg/cmd/experimental/bundlesecret/known_secret_types.go
+++ b/pkg/cmd/experimental/bundlesecret/known_secret_types.go
@@ -1,0 +1,28 @@
+package bundlesecret
+
+import (
+	"reflect"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+type KnownSecretType struct {
+	Type             kapi.SecretType
+	RequiredContents util.StringSet
+}
+
+func (ks KnownSecretType) Matches(secretContent map[string][]byte) bool {
+	if secretContent == nil {
+		return false
+	}
+
+	secretKeys := util.KeySet(reflect.ValueOf(secretContent))
+	return reflect.DeepEqual(ks.RequiredContents.List(), secretKeys.List())
+}
+
+var (
+	KnownSecretTypes = []KnownSecretType{
+		{kapi.SecretTypeDockercfg, util.NewStringSet(kapi.DockerConfigKey)},
+	}
+)


### PR DESCRIPTION
Adds support for specifying `Secret.Type` from the command line and automatic detection based on secret data content.

@derekwaynecarr ptal