### PR TITLE
Fix port ordering for a service

### DIFF
--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -80,7 +80,7 @@
                 Show only the first two ports if there are many since we don't have much space here.
                 The full list is visible elsewhere.
                 -->
-                <span ng-repeat="portMapping in service.spec.ports | orderBy:port | limitTo:2" class="nowrap">
+                <span ng-repeat="portMapping in service.spec.ports | orderBy:'port' | limitTo:2" class="nowrap">
                   port {{portMapping.port}}&#8201;&#8594;&#8201;{{portMapping.targetPort}}
                     ({{portMapping.protocol}})<span ng-if="$index < (numPorts - 1)">, </span>
                 </span>

--- a/assets/app/views/services.html
+++ b/assets/app/views/services.html
@@ -20,7 +20,7 @@
         <div>Ports:
           <span ng-if="!service.spec.ports.length"><em>none</em></span>
           <ul ng-if="service.spec.ports.length">
-            <li ng-repeat="portMapping in service.spec.ports | orderBy:port">
+            <li ng-repeat="portMapping in service.spec.ports | orderBy:'port'">
               {{portMapping.port}} &#8594; {{portMapping.targetPort}} ({{portMapping.protocol}})
             </li>
           </ul>


### PR DESCRIPTION
Quote the argument to the `orderBy` filter to properly order the port
mappings for services on the Overview and Browse -> Services pages.

Before:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7758502/28aa56e0-ffd8-11e4-9870-859788552c2f.png)

After:

![openshift_management_console](https://cloud.githubusercontent.com/assets/1167259/7758516/393a97ae-ffd8-11e4-8733-aac91d9bf369.png)
