### PR TITLE
Omit internal field when empty

### DIFF
--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -237,7 +237,7 @@ type DeploymentTriggerImageChangeParams struct {
 	// trigger will be used.
 	From kapi.ObjectReference `json:"from" description:"a reference to an ImageRepository, ImageStream, or ImageStreamTag to watch for changes`
 	// LastTriggeredImage is the last image to be triggered.
-	LastTriggeredImage string `json:"lastTriggeredImage" description:"the last image to be triggered"`
+	LastTriggeredImage string `json:"lastTriggeredImage,omitempty" description:"the last image to be triggered"`
 }
 
 // DeploymentDetails captures information about the causes of a deployment.


### PR DESCRIPTION
Apparently we do omit other internal / optional fields, this one is apparently missing the "omitempty" flag.

@mfojtik PTAL