### PR TITLE
Added Kube PVC to OS whitelist

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -64,7 +64,7 @@ var (
 
 		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
 		KubeInternalsGroupName: {"minions", "nodes", "bindings", "events", "namespaces"},
-		KubeExposedGroupName:   {"pods", "replicationcontrollers", "services", "endpoints", "pods/log"},
+		KubeExposedGroupName:   {"pods", "replicationcontrollers", "services", "endpoints", "persistentvolumeclaims", "pods/log"},
 		KubeAllGroupName:       {KubeInternalsGroupName, KubeExposedGroupName, QuotaGroupName},
 		KubeStatusGroupName:    {"pods/status", "resourcequotas/status", "namespaces/status"},
 	}


### PR DESCRIPTION
Added PersistentVolumeClaim to list of exposed kube objects.

PersistentVolumes are admin objects and admins get */* rights by default.

@deads2k 