### PR TITLE
Bug 1223188 - Can't delete the template resource when delete a project 

### DIFF
--- a/pkg/project/controller/controller.go
+++ b/pkg/project/controller/controller.go
@@ -119,6 +119,24 @@ func deleteAllContent(client osclient.Interface, namespace string) (err error) {
 	if err != nil {
 		return err
 	}
+	err = deleteTemplates(client, namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteTemplates(client osclient.Interface, ns string) error {
+	items, err := client.Templates(ns).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return err
+	}
+	for i := range items.Items {
+		err := client.Templates(ns).Delete(items.Items[i].Name)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/project/controller/controller_test.go
+++ b/pkg/project/controller/controller_test.go
@@ -45,6 +45,7 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 		"list-roleBinding",
 		"list-role",
 		"list-routes",
+		"list-templates",
 		"list-builds",
 		"finalize-namespace",
 		"list-deploymentconfig",
@@ -56,7 +57,7 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 	for i := range mockOriginClient.Actions {
 		actionSet.Insert(mockOriginClient.Actions[i].Action)
 	}
-	if !actionSet.HasAll(expectedActionSet.List()...) {
+	if !(actionSet.HasAll(expectedActionSet.List()...) && (len(actionSet) == len(expectedActionSet))) {
 		t.Errorf("Expected actions: %v, but got: %v", expectedActionSet, actionSet)
 	}
 }


### PR DESCRIPTION
Previously deleting a project that had templates would not delete templates from the namespace. Now it does. 

https://bugzilla.redhat.com/show_bug.cgi?id=1223188
/cc @derekwaynecarr 