### PR TITLE
Updating Project/Namespace annotations for displayName & description

### DIFF
--- a/assets/app/scripts/controllers/createProject.js
+++ b/assets/app/scripts/controllers/createProject.js
@@ -14,9 +14,7 @@ angular.module('openshiftConsole')
         DataService.create('projectrequests', null, {
           name: $scope.name,
           displayName: $scope.displayName,
-          annotations: {
-            description: $scope.description
-          }
+          description: $scope.description
         }, $scope).then(function(data) { // Success
           Navigate.toProjectOverview(data.metadata.name);
         }, function(result) { // Failure

--- a/assets/app/scripts/controllers/newfromtemplate.js
+++ b/assets/app/scripts/controllers/newfromtemplate.js
@@ -8,7 +8,9 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('NewFromTemplateController', function ($scope, $http, $routeParams, DataService, $q, $location, TaskList, $parse, Navigate, imageObjectRefFilter, failureObjectNameFilter) {
+  .controller('NewFromTemplateController', function ($scope, $http, $routeParams, DataService, $q, $location, TaskList, $parse, Navigate, $filter, imageObjectRefFilter, failureObjectNameFilter) {
+    var displayNameFilter = $filter('displayName');
+
 
     function errorPage(message) {
       var redirect = URI('error').query({
@@ -84,11 +86,11 @@ angular.module('openshiftConsole')
     }
 
     $scope.projectDisplayName = function() {
-      return (this.project && this.project.displayName) || this.projectName;
+      return displayNameFilter(this.project) || this.projectName;
     };
 
     $scope.templateDisplayName = function() {
-      return (this.template.annotations && this.template.annotations.displayName) || this.template.metadata.name;
+      return displayNameFilter(this.template);
     };
 
     $scope.createFromTemplate = function() {

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -22,7 +22,9 @@ angular.module('openshiftConsole')
       "pod": ["openshift.io/deployer-pod.name"],
       "deploymentStatus": ["openshift.io/deployment.phase"],
       "encodedDeploymentConfig": ["openshift.io/encoded-deployment-config"],
-      "deploymentVersion": ["openshift.io/deployment-config.latest-version"]
+      "deploymentVersion": ["openshift.io/deployment-config.latest-version"],
+      "displayName": ["openshift.io/display-name"],
+      "description": ["openshift.io/description"]
     };
     return function(resource, key) {
       if (resource && resource.spec && resource.spec.tags && key.indexOf(".") !== -1){
@@ -35,7 +37,7 @@ angular.module('openshiftConsole')
           if(tagName === tag.name && tag.annotations){
             return tag.annotations[tagKey];
           }
-        }
+        } 
       }
       if (resource && resource.metadata && resource.metadata.annotations) {
         // If the key's already in the annotation map, return it.
@@ -182,7 +184,8 @@ angular.module('openshiftConsole')
   })  
   .filter('buildForImage', function() {
     return function(image, builds) {
-      // TODO concerned that this gets called anytime any data is changed on the scope, whether its relevant changes or not
+      // TODO concerned that this gets called anytime any data is changed on the scope,
+      // whether its relevant changes or not
       var envVars = image.dockerImageMetadata.Config.Env;
       for (var i = 0; i < envVars.length; i++) {
         var keyValue = envVars[i].split("=");
@@ -206,7 +209,8 @@ angular.module('openshiftConsole')
   })
   .filter('isWebRoute', function(){
     return function(route){
-       //TODO: implement when we can tell if routes are http(s) or not web related which will drive links in view
+       //TODO: implement when we can tell if routes are http(s) or not web related which will drive
+       // links in view
        return true;
     };
   })

--- a/assets/app/views/createProject.html
+++ b/assets/app/views/createProject.html
@@ -47,7 +47,7 @@
         <div class="form-group">
           <label for="description">Description</label>
           <textarea class="form-control input-lg"
-              name="displayName"
+              name="description"
               id="description"
               placeholder="A short description."
               ng-model="description"></textarea>

--- a/examples/hello-openshift/hello-project.json
+++ b/examples/hello-openshift/hello-project.json
@@ -8,8 +8,8 @@
       "name": "hello-openshift-project"
     },
     "annotations": {
-      "description": "This is an example project to demonstrate OpenShift v3",
-      "displayName": "Hello OpenShift"
+      "openshift.io/description": "This is an example project to demonstrate OpenShift v3",
+      "openshift.io/display-name": "Hello OpenShift"
     }
   },
   "spec": {},

--- a/examples/hello-openshift/v1beta3/hello-project.json
+++ b/examples/hello-openshift/v1beta3/hello-project.json
@@ -8,8 +8,8 @@
       "name": "hello-openshift-project"
     },
     "annotations": {
-      "description": "This is an example project to demonstrate OpenShift v3",
-      "displayName": "Hello OpenShift"
+      "openshift.io/description": "This is an example project to demonstrate OpenShift v3",
+      "openshift.io/display-name": "Hello OpenShift"
     }
   },
   "spec": {},

--- a/pkg/cmd/admin/project/new_project.go
+++ b/pkg/cmd/admin/project/new_project.go
@@ -96,10 +96,10 @@ func (o *NewProjectOptions) Run(useNodeSelector bool) error {
 	project := &projectapi.Project{}
 	project.Name = o.ProjectName
 	project.Annotations = make(map[string]string)
-	project.Annotations["description"] = o.Description
-	project.Annotations["displayName"] = o.DisplayName
+	project.Annotations[projectapi.ProjectDescription] = o.Description
+	project.Annotations[projectapi.ProjectDisplayName] = o.DisplayName
 	if useNodeSelector {
-		project.Annotations[projectapi.ProjectNodeSelectorParam] = o.NodeSelector
+		project.Annotations[projectapi.ProjectNodeSelector] = o.NodeSelector
 	}
 	project, err := o.Client.Projects().Create(project)
 	if err != nil {

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -103,8 +103,8 @@ func (o *NewProjectOptions) Run() error {
 	projectRequest := &projectapi.ProjectRequest{}
 	projectRequest.Name = o.ProjectName
 	projectRequest.DisplayName = o.DisplayName
+	projectRequest.Description = o.Description
 	projectRequest.Annotations = make(map[string]string)
-	projectRequest.Annotations["description"] = o.Description
 
 	project, err := o.Client.ProjectRequests().Create(projectRequest)
 	if err != nil {

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -553,15 +553,15 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 
 	nodeSelector := ""
 	if len(project.ObjectMeta.Annotations) > 0 {
-		if ns, ok := project.ObjectMeta.Annotations[projectapi.ProjectNodeSelectorParam]; ok {
+		if ns, ok := project.ObjectMeta.Annotations[projectapi.ProjectNodeSelector]; ok {
 			nodeSelector = ns
 		}
 	}
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, project.ObjectMeta)
-		formatString(out, "Display Name", project.Annotations["displayName"])
-		formatString(out, "Description", project.Annotations["description"])
+		formatString(out, "Display Name", project.Annotations[projectapi.ProjectDisplayName])
+		formatString(out, "Description", project.Annotations[projectapi.ProjectDescription])
 		formatString(out, "Status", project.Status.Phase)
 		formatString(out, "Node Selector", nodeSelector)
 		fmt.Fprintf(out, "\n")

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -302,7 +302,7 @@ func printImageStreamList(streams *imageapi.ImageStreamList, w io.Writer, withNa
 }
 
 func printProject(project *projectapi.Project, w io.Writer, withNamespace bool) error {
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", project.Name, project.Annotations["displayName"], project.Status.Phase)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", project.Name, project.Annotations[projectapi.ProjectDisplayName], project.Status.Phase)
 	return err
 }
 

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 )
 
 // ProjectStatusDescriber generates extended information about a Project
@@ -75,8 +76,9 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		indent := "  "
-		if len(project.Annotations["displayName"]) > 0 && project.Annotations["displayName"] != namespace {
-			fmt.Fprintf(out, "In project %s (%s)\n", project.Annotations["displayName"], namespace)
+		if len(project.Annotations[projectapi.ProjectDisplayName]) > 0 &&
+			project.Annotations[projectapi.ProjectDisplayName] != namespace {
+			fmt.Fprintf(out, "In project %s (%s)\n", project.Annotations[projectapi.ProjectDisplayName], namespace)
 		} else {
 			fmt.Fprintf(out, "In project %s\n", namespace)
 		}

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -40,7 +40,7 @@ func TestProjectStatus(t *testing.T) {
 						Name:      "example",
 						Namespace: "",
 						Annotations: map[string]string{
-							"displayName": "Test",
+							"openshift.io/display-name": "Test",
 						},
 					},
 				},

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 
-	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/util/labelselector"
 )
@@ -107,7 +106,7 @@ func TestPodAdmission(t *testing.T) {
 	for _, test := range tests {
 		projectcache.FakeProjectCache(mockClient, projectStore, test.defaultNodeSelector)
 		if !test.ignoreProjectNodeSelector {
-			project.ObjectMeta.Annotations = map[string]string{projectapi.ProjectNodeSelectorParam: test.projectNodeSelector}
+			project.ObjectMeta.Annotations = map[string]string{"openshift.io/node-selector": test.projectNodeSelector}
 		}
 		pod.Spec = kapi.PodSpec{NodeSelector: test.podNodeSelector}
 

--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -14,8 +14,6 @@ type ProjectList struct {
 const (
 	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
-
-	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project
@@ -42,4 +40,16 @@ type ProjectRequest struct {
 	kapi.TypeMeta
 	kapi.ObjectMeta
 	DisplayName string
+	Description string
 }
+
+// These constants represent annotations keys affixed to projects
+const (
+	// ProjectDisplayName is an annotation that stores the name displayed when querying for projects
+	ProjectDisplayName = "openshift.io/display-name"
+	// ProjectDescription is an annotatoion that holds the description of the project
+	ProjectDescription = "openshift.io/description"
+	// ProjectNodeSelector is an annotation that holds the node selector;
+	// the node selector annotation determines which nodes will have pods from this project scheduled to them
+	ProjectNodeSelector = "openshift.io/node-selector"
+)

--- a/pkg/project/api/v1/types.go
+++ b/pkg/project/api/v1/types.go
@@ -14,8 +14,6 @@ type ProjectList struct {
 const (
 	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
-
-	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project
@@ -45,4 +43,5 @@ type ProjectRequest struct {
 	kapi.TypeMeta   `json:",inline"`
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 	DisplayName     string `json:"displayName,omitempty" description:"display name to apply to a project"`
+	Description     string `json:"description,omitempty" description:"description to apply to a proejct"`
 }

--- a/pkg/project/api/v1beta1/types.go
+++ b/pkg/project/api/v1beta1/types.go
@@ -14,8 +14,6 @@ type ProjectList struct {
 const (
 	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
-
-	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project
@@ -46,4 +44,5 @@ type ProjectRequest struct {
 	kapi.TypeMeta   `json:",inline"`
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 	DisplayName     string `json:"displayName,omitempty"`
+	Description     string `json:"description,omitempty"`
 }

--- a/pkg/project/api/v1beta3/conversion_test.go
+++ b/pkg/project/api/v1beta3/conversion_test.go
@@ -17,8 +17,8 @@ func TestProjectConversion(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "foo",
 			Annotations: map[string]string{
-				"description": "This is a description",
-				"displayName": "hi",
+				"openshift.io/description":  "This is a description",
+				"openshift.io/display-name": "hi",
 			},
 		},
 	}
@@ -27,8 +27,8 @@ func TestProjectConversion(t *testing.T) {
 		ObjectMeta: v1beta3.ObjectMeta{
 			Name: "foo",
 			Annotations: map[string]string{
-				"description": "This is a description",
-				"displayName": "hi",
+				"openshift.io/description":  "This is a description",
+				"openshift.io/display-name": "hi",
 			},
 		},
 	}

--- a/pkg/project/api/v1beta3/types.go
+++ b/pkg/project/api/v1beta3/types.go
@@ -14,8 +14,6 @@ type ProjectList struct {
 const (
 	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
-
-	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project
@@ -45,4 +43,16 @@ type ProjectRequest struct {
 	kapi.TypeMeta   `json:",inline"`
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 	DisplayName     string `json:"displayName,omitempty"`
+	Description     string `json:"description,omitempty"`
 }
+
+// These constants represent annotations keys affixed to projects
+const (
+	// ProjectDisplayName is an annotation that stores the name displayed when querying for projects
+	ProjectDisplayName = "openshift.io/display-name"
+	// ProjectDescription is an annotatoion that holds the description of the project
+	ProjectDescription = "openshift.io/description"
+	// ProjectNodeSelector is an annotation that holds the node selector;
+	// the node selector annotation determines which nodes will have pods from this project scheduled to them
+	ProjectNodeSelector = "openshift.io/node-selector"
+)

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
 
 	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	"github.com/openshift/origin/pkg/util/labelselector"
 )
 
@@ -26,8 +27,9 @@ func ValidateProject(project *api.Project) fielderrors.ValidationErrorList {
 	if len(project.Namespace) > 0 {
 		result = append(result, fielderrors.NewFieldInvalid("namespace", project.Namespace, "must be the empty-string"))
 	}
-	if !validateNoNewLineOrTab(project.Annotations["displayName"]) {
-		result = append(result, fielderrors.NewFieldInvalid("displayName", project.Annotations["displayName"], "may not contain a new line or tab"))
+	if !validateNoNewLineOrTab(project.Annotations[projectapi.ProjectDisplayName]) {
+		result = append(result, fielderrors.NewFieldInvalid(projectapi.ProjectDisplayName,
+			project.Annotations[projectapi.ProjectDisplayName], "may not contain a new line or tab"))
 	}
 	result = append(result, validateNodeSelector(project)...)
 	return result
@@ -59,9 +61,10 @@ func validateNodeSelector(p *api.Project) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
 	if len(p.Annotations) > 0 {
-		if selector, ok := p.Annotations[api.ProjectNodeSelectorParam]; ok {
+		if selector, ok := p.Annotations[projectapi.ProjectNodeSelector]; ok {
 			if _, err := labelselector.Parse(selector); err != nil {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("nodeSelector", p.Annotations[api.ProjectNodeSelectorParam], "must be a valid label selector"))
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("nodeSelector",
+					p.Annotations[projectapi.ProjectNodeSelector], "must be a valid label selector"))
 			}
 		}
 	}

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -18,8 +18,8 @@ func TestValidateProject(t *testing.T) {
 			project: api.Project{
 				ObjectMeta: kapi.ObjectMeta{
 					Annotations: map[string]string{
-						"description": "This is a description",
-						"displayName": "hi",
+						"openshift.io/description":  "This is a description",
+						"openshift.io/display-name": "hi",
 					},
 				},
 			},
@@ -32,8 +32,8 @@ func TestValidateProject(t *testing.T) {
 				ObjectMeta: kapi.ObjectMeta{
 					Name: "141-.124.$",
 					Annotations: map[string]string{
-						"description": "This is a description",
-						"displayName": "hi",
+						"openshift.io/description":  "This is a description",
+						"openshift.io/display-name": "hi",
 					},
 				},
 			},
@@ -92,8 +92,8 @@ func TestValidateProject(t *testing.T) {
 					Name:      "foo",
 					Namespace: "foo",
 					Annotations: map[string]string{
-						"description": "This is a description",
-						"displayName": "hi",
+						"openshift.io/description":  "This is a description",
+						"openshift.io/display-name": "hi",
 					},
 				},
 			},
@@ -107,8 +107,8 @@ func TestValidateProject(t *testing.T) {
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						"description": "This is a description",
-						"displayName": "h\t\ni",
+						"openshift.io/description":  "This is a description",
+						"openshift.io/display-name": "h\t\ni",
 					},
 				},
 			},
@@ -122,7 +122,7 @@ func TestValidateProject(t *testing.T) {
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						api.ProjectNodeSelectorParam: "infra=true, env = test",
+						"openshift.io/node-selector": "infra=true, env = test",
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func TestValidateProject(t *testing.T) {
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						api.ProjectNodeSelectorParam: "infra, env = $test",
+						"openshift.io/node-selector": "infra, env = $test",
 					},
 				},
 			},
@@ -155,8 +155,8 @@ func TestValidateProject(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "foo",
 			Annotations: map[string]string{
-				"description": "This is a description",
-				"displayName": "hi",
+				"openshift.io/description":  "This is a description",
+				"openshift.io/display-name": "hi",
 			},
 		},
 	}

--- a/pkg/project/cache/cache.go
+++ b/pkg/project/cache/cache.go
@@ -54,7 +54,7 @@ func (p *ProjectCache) GetNodeSelector(namespace *kapi.Namespace) string {
 	selector := ""
 	found := false
 	if len(namespace.ObjectMeta.Annotations) > 0 {
-		if ns, ok := namespace.ObjectMeta.Annotations[projectapi.ProjectNodeSelectorParam]; ok {
+		if ns, ok := namespace.ObjectMeta.Annotations[projectapi.ProjectNodeSelector]; ok {
 			selector = ns
 			found = true
 		}

--- a/pkg/project/registry/project/proxy/proxy.go
+++ b/pkg/project/registry/project/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/openshift/origin/pkg/project/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectregistry "github.com/openshift/origin/pkg/project/registry/project"
 )
@@ -74,7 +75,7 @@ func convertProject(project *api.Project) *kapi.Namespace {
 	if namespace.Annotations == nil {
 		namespace.Annotations = map[string]string{}
 	}
-	namespace.Annotations["displayName"] = project.Annotations["displayName"]
+	namespace.Annotations[projectapi.ProjectDisplayName] = project.Annotations[projectapi.ProjectDisplayName]
 	return namespace
 }
 

--- a/pkg/project/registry/project/proxy/proxy_test.go
+++ b/pkg/project/registry/project/proxy/proxy_test.go
@@ -74,7 +74,7 @@ func TestCreateInvalidProject(t *testing.T) {
 	storage := NewREST(mockClient.Namespaces(), &mockLister{})
 	_, err := storage.Create(nil, &api.Project{
 		ObjectMeta: kapi.ObjectMeta{
-			Annotations: map[string]string{"displayName": "h\t\ni"},
+			Annotations: map[string]string{"openshift.io/display-name": "h\t\ni"},
 		},
 	})
 	if !errors.IsInvalid(err) {

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -69,8 +69,8 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 		projectDisplayName = projectRequest.DisplayName
 	}
 
-	if len(projectRequest.Annotations["description"]) > 0 {
-		projectDescription = projectRequest.Annotations["description"]
+	if len(projectRequest.Description) > 0 {
+		projectDescription = projectRequest.Description
 	}
 	if userInfo, exists := kapi.UserFrom(ctx); exists {
 		projectAdmin = userInfo.GetName()

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -31,8 +31,8 @@ func DefaultTemplate() *templateapi.Template {
 	project := &projectapi.Project{}
 	project.Name = ns
 	project.Annotations = map[string]string{
-		"description": "${" + ProjectDescriptionParam + "}",
-		"displayName": "${" + ProjectDisplayNameParam + "}",
+		projectapi.ProjectDescription: "${" + ProjectDescriptionParam + "}",
+		projectapi.ProjectDisplayName: "${" + ProjectDisplayNameParam + "}",
 	}
 	ret.Objects = append(ret.Objects, project)
 

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -131,8 +131,8 @@ func TestProjectIsNamespace(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "new-project",
 			Annotations: map[string]string{
-				"displayName":                       "Hello World",
-				projectapi.ProjectNodeSelectorParam: "env=test",
+				"openshift.io/display-name":  "Hello World",
+				"openshift.io/node-selector": "env=test",
 			},
 		},
 	}
@@ -149,11 +149,11 @@ func TestProjectIsNamespace(t *testing.T) {
 	if project.Name != namespace.Name {
 		t.Fatalf("Project name did not match namespace name, project %v, namespace %v", project.Name, namespace.Name)
 	}
-	if project.Annotations["displayName"] != namespace.Annotations["displayName"] {
-		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations["displayName"], namespace.Annotations["displayName"])
+	if project.Annotations["openshift.io/display-name"] != namespace.Annotations["openshift.io/display-name"] {
+		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations["openshift.io/display-name"], namespace.Annotations["openshift.io/display-name"])
 	}
-	if project.Annotations[projectapi.ProjectNodeSelectorParam] != namespace.Annotations[projectapi.ProjectNodeSelectorParam] {
-		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations[projectapi.ProjectNodeSelectorParam], namespace.Annotations[projectapi.ProjectNodeSelectorParam])
+	if project.Annotations["openshift.io/node-selector"] != namespace.Annotations["openshift.io/node-selector"] {
+		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations["openshift.io/node-selector"], namespace.Annotations["openshift.io/node-selector"])
 	}
 }
 


### PR DESCRIPTION
Prepending 'openshift.io/' to 'display-name'  & ' description' annotation fields for namespacing. 

Changing the projectRequest struct to stop mirroring the project struct.

@derekwaynecarr 
#2169 