### PR TITLE
Fix broken '--node-selector' for osc new-project

### DIFF
--- a/pkg/project/cache/cache.go
+++ b/pkg/project/cache/cache.go
@@ -51,12 +51,14 @@ func (p *ProjectCache) GetNamespaceObject(name string) (*kapi.Namespace, error) 
 
 func (p *ProjectCache) GetNodeSelector(namespace *kapi.Namespace) string {
 	selector := ""
+	found := false
 	if len(namespace.ObjectMeta.Annotations) > 0 {
 		if ns, ok := namespace.ObjectMeta.Annotations["openshift.io/node-selector"]; ok {
 			selector = ns
+			found = true
 		}
 	}
-	if len(selector) == 0 {
+	if !found {
 		selector = p.DefaultNodeSelector
 	}
 	return selector


### PR DESCRIPTION
Handle osc new-project <name> --node-selector=""(empty selector)