### PR TITLE
Setting deployment/cancellation reason based on constants

### DIFF
--- a/pkg/deploy/controller/deployerpod/factory.go
+++ b/pkg/deploy/controller/deployerpod/factory.go
@@ -1,7 +1,6 @@
 package deployerpod
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -110,7 +109,7 @@ func pollPods(deploymentStore cache.Store, kClient kclient.Interface) (cache.Enu
 				if kerrors.IsNotFound(err) {
 					nextStatus := deployapi.DeploymentStatusFailed
 					deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(nextStatus)
-					deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = fmt.Sprintf("deployment process pod %q was deleted before completion", podID)
+					deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentFailedDeployerPodNoLongerExists
 
 					if _, err := kClient.ReplicationControllers(deployment.Namespace).Update(deployment); err != nil {
 						glog.Errorf("couldn't update deployment %s to status %s: %v", deployutil.LabelForDeployment(deployment), nextStatus, err)

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -80,6 +80,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 			}
 
 			deploymentForCancellation.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
+			deploymentForCancellation.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledNewerDeploymentExists
 			if _, err := c.deploymentClient.updateDeployment(deploymentForCancellation.Namespace, deploymentForCancellation); err != nil {
 				glog.Errorf("couldn't cancel deployment %s: %v", deployutil.LabelForDeployment(deploymentForCancellation), err)
 			}


### PR DESCRIPTION
@ironcladlou PTAL
In all there are 4 scenaiors when we are setting the deployment status reason annotation. The other two were already using the constant. These two were implemented before the constants were created.