### PR TITLE
system:node, system:node-proxy, system:sdn-reader, system:sdn-manager roles

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -29,6 +29,8 @@ const (
 	ImageGroupName      = ResourceGroupPrefix + ":images"
 	OAuthGroupName      = ResourceGroupPrefix + ":oauth"
 	UserGroupName       = ResourceGroupPrefix + ":users"
+	TemplateGroupName   = ResourceGroupPrefix + ":templates"
+	SDNGroupName        = ResourceGroupPrefix + ":sdn"
 	// PolicyOwnerGroupName includes the physical resources behind the PermissionGrantingGroupName.  Unless these physical objects are created first, users with privileges to PermissionGrantingGroupName will
 	// only be able to bind to global roles
 	PolicyOwnerGroupName = ResourceGroupPrefix + ":policy"
@@ -54,12 +56,14 @@ var (
 		BuildGroupName:              {"builds", "buildconfigs", "buildlogs", "buildconfigs/instantiate", "builds/log", "builds/clone"},
 		ImageGroupName:              {"images", "imagerepositories", "imagerepositorymappings", "imagerepositorytags", "imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages"},
 		DeploymentGroupName:         {"deployments", "deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks"},
+		SDNGroupName:                {"clusternetworks", "hostsubnets"},
+		TemplateGroupName:           {"templates", "templateconfigs", "processedtemplates"},
 		UserGroupName:               {"identities", "users", "useridentitymappings"},
 		OAuthGroupName:              {"oauthauthorizetokens", "oauthaccesstokens", "oauthclients", "oauthclientauthorizations"},
 		PolicyOwnerGroupName:        {"policies", "policybindings"},
 		PermissionGrantingGroupName: {"roles", "rolebindings", "resourceaccessreviews", "subjectaccessreviews"},
-		OpenshiftExposedGroupName:   {BuildGroupName, ImageGroupName, DeploymentGroupName, "templates", "templateconfigs", "processedtemplates", "routes"},
-		OpenshiftAllGroupName:       {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects"},
+		OpenshiftExposedGroupName:   {BuildGroupName, ImageGroupName, DeploymentGroupName, TemplateGroupName, "routes"},
+		OpenshiftAllGroupName:       {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, SDNGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects"},
 		OpenshiftStatusGroupName:    {"imagerepositories/status"},
 
 		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -36,7 +36,7 @@ func TestSubjects(t *testing.T) {
 			Verb:     "get",
 			Resource: "pods",
 		},
-		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:kube-client", "system:openshift-client", "system:openshift-deployer"),
+		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:openshift-client", "system:openshift-deployer"),
 		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:nodes"),
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -19,10 +19,9 @@ const (
 
 // groups
 const (
-	UnauthenticatedUsername       = "system:anonymous"
-	InternalComponentUsername     = "system:openshift-client"
-	InternalComponentKubeUsername = "system:kube-client"
-	DeployerUsername              = "system:openshift-deployer"
+	UnauthenticatedUsername   = "system:anonymous"
+	InternalComponentUsername = "system:openshift-client"
+	DeployerUsername          = "system:openshift-deployer"
 
 	AuthenticatedGroup   = "system:authenticated"
 	UnauthenticatedGroup = "system:unauthenticated"
@@ -48,8 +47,12 @@ const (
 	DeployerRoleName          = "system:deployer"
 	RouterRoleName            = "system:router"
 	RegistryRoleName          = "system:registry"
+	NodeRoleName              = "system:node"
+	NodeProxierRoleName       = "system:node-proxier"
+	SDNReaderRoleName         = "system:sdn-reader"
+	SDNManagerRoleName        = "system:sdn-manager"
 	InternalComponentRoleName = "system:component"
-	DeleteTokensRoleName      = "system:delete-tokens"
+	OAuthTokenDeleterRoleName = "system:oauth-token-deleter"
 	WebHooksRoleName          = "system:webhook"
 
 	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
@@ -63,10 +66,14 @@ const (
 	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "s"
 	ClusterReaderRoleBindingName     = ClusterReaderRoleName + "s"
 	BasicUserRoleBindingName         = BasicUserRoleName + "s"
-	DeleteTokensRoleBindingName      = DeleteTokensRoleName + "-binding"
+	OAuthTokenDeleterRoleBindingName = OAuthTokenDeleterRoleName + "s"
 	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"
 	RouterRoleBindingName            = RouterRoleName + "s"
 	RegistryRoleBindingName          = RegistryRoleName + "s"
+	NodeRoleBindingName              = NodeRoleName + "s"
+	NodeProxierRoleBindingName       = NodeProxierRoleName + "s"
+	SDNReaderRoleBindingName         = SDNReaderRoleName + "s"
+	SDNManagerRoleBindingName        = SDNManagerRoleName + "s"
 	WebHooksRoleBindingName          = WebHooksRoleName + "s"
 
 	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "s"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -156,8 +156,21 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     util.NewStringSet(authorizationapi.VerbAll),
-					Resources: util.NewStringSet(authorizationapi.ResourceAll),
+					// replicationControllerGetter
+					Verbs:     util.NewStringSet("get", "list"),
+					Resources: util.NewStringSet("replicationcontrollers"),
+				},
+				{
+					// RecreateDeploymentStrategy.replicationControllerClient
+					// RollingDeploymentStrategy.updaterClient
+					Verbs:     util.NewStringSet("get", "update"),
+					Resources: util.NewStringSet("replicationcontrollers"),
+				},
+				{
+					// RecreateDeploymentStrategy.hookExecutor
+					// RollingDeploymentStrategy.hookExecutor
+					Verbs:     util.NewStringSet("get", "list", "watch", "create"),
+					Resources: util.NewStringSet("pods"),
 				},
 			},
 		},
@@ -174,7 +187,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: DeleteTokensRoleName,
+				Name: OAuthTokenDeleterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
@@ -220,6 +233,119 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: NodeProxierRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					// Used to build serviceLister
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("services", "endpoints"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: NodeRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					// Needed to build serviceLister, to populate env vars for services
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("services"),
+				},
+
+				{
+					Verbs:     util.NewStringSet("get", "list", "watch"),
+					Resources: util.NewStringSet("nodes"),
+				},
+				{
+					// TODO: restrict to the bound node once supported
+					Verbs:     util.NewStringSet("update"),
+					Resources: util.NewStringSet("nodes/status"),
+				},
+
+				{
+					// TODO: restrict to the bound node as creator once supported
+					Verbs:     util.NewStringSet("create", "update"),
+					Resources: util.NewStringSet("events"),
+				},
+
+				{
+					// TODO: restrict to pods scheduled on the bound node once supported
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("pods"),
+				},
+				{
+					// TODO: remove once mirror pods are removed
+					// TODO: restrict deletion to mirror pods created by the bound node once supported
+					// Needed for the node to create/delete mirror pods
+					Verbs:     util.NewStringSet("get", "create", "delete"),
+					Resources: util.NewStringSet("pods"),
+				},
+				{
+					// TODO: restrict to pods scheduled on the bound node once supported
+					Verbs:     util.NewStringSet("update"),
+					Resources: util.NewStringSet("pods/status"),
+				},
+
+				{
+					// TODO: restrict to secrets used by pods scheduled on bound node once supported
+					// Needed for imagepullsecrets and secret volumes
+					Verbs:     util.NewStringSet("get"),
+					Resources: util.NewStringSet("secrets"),
+				},
+
+				{
+					// TODO: restrict to claims/volumes used by pods scheduled on bound node once supported
+					// Needed for persistent volumes
+					Verbs:     util.NewStringSet("get"),
+					Resources: util.NewStringSet("persistentvolumeclaims", "persistentvolumes"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: SDNReaderRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get", "list", "watch"),
+					Resources: util.NewStringSet("hostsubnets"),
+				},
+				{
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("nodes"),
+				},
+				{
+					Verbs:     util.NewStringSet("get"),
+					Resources: util.NewStringSet("clusternetworks"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: SDNManagerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("get", "list", "watch", "create", "delete"),
+					Resources: util.NewStringSet("hostsubnets"),
+				},
+				{
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("nodes"),
+				},
+				{
+					Verbs:     util.NewStringSet("get", "create"),
+					Resources: util.NewStringSet("clusternetworks"),
+				},
+			},
+		},
+
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: WebHooksRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
@@ -257,8 +383,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: InternalComponentRoleName,
 			},
-			Users:  util.NewStringSet(InternalComponentUsername, InternalComponentKubeUsername),
-			Groups: util.NewStringSet(NodesGroup),
+			Users: util.NewStringSet(InternalComponentUsername),
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -307,10 +432,10 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: DeleteTokensRoleBindingName,
+				Name: OAuthTokenDeleterRoleBindingName,
 			},
 			RoleRef: kapi.ObjectReference{
-				Name: DeleteTokensRoleName,
+				Name: OAuthTokenDeleterRoleName,
 			},
 			Groups: util.NewStringSet(AuthenticatedGroup, UnauthenticatedGroup),
 		},
@@ -340,6 +465,35 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 				Name: RegistryRoleName,
 			},
 			Groups: util.NewStringSet(RegistryGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: NodeRoleBindingName,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: NodeRoleName,
+			},
+			Groups: util.NewStringSet(NodesGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: NodeProxierRoleBindingName,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: NodeProxierRoleName,
+			},
+			// Allow node identities to run node proxies
+			Groups: util.NewStringSet(NodesGroup),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: SDNReaderRoleBindingName,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: SDNReaderRoleName,
+			},
+			// Allow node identities to run SDN plugins
+			Groups: util.NewStringSet(NodesGroup),
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -134,8 +134,8 @@ func TestAuthorizationOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 }
 
 // TODO this list should start collapsing as we continue to tighten access on generated system ids
-var globalClusterAdminUsers = util.NewStringSet("system:kube-client", "system:openshift-client", "system:openshift-deployer")
-var globalClusterAdminGroups = util.NewStringSet("system:cluster-admins", "system:nodes")
+var globalClusterAdminUsers = util.NewStringSet("system:openshift-client")
+var globalClusterAdminGroups = util.NewStringSet("system:cluster-admins")
 
 type resourceAccessReviewTest struct {
 	clientInterface client.ResourceAccessReviewInterface


### PR DESCRIPTION
- [x] Add `system:node` role with tightened permissions for nodes
- [x] Add `system:sdn-reader` role for accessing SDN resources
- [x] Add `system:node-proxy` role for listing services/endpoints for node proxy
- [x] Bound `system:nodes` group to the three new roles by default, and removed binding to internal components group
- [x] Tightened `system:deployer` permissions
- [x] Removed unused `system:kube-client` user constants and bindings