### PR TITLE
Do not require "imageChange" key in build trigger spec

### DIFF
--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -28,6 +28,11 @@ func init() {
 				obj.From.Kind = "ImageStreamTag"
 			}
 		},
+		func(obj *BuildTriggerPolicy) {
+			if obj.Type == ImageChangeBuildTriggerType && obj.ImageChange == nil {
+				obj.ImageChange = &ImageChangeTrigger{}
+			}
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/build/api/v1/conversion_test.go
+++ b/pkg/build/api/v1/conversion_test.go
@@ -1,11 +1,28 @@
 package v1_test
 
 import (
-/*	"testing"
+	"testing"
 
 	knewer "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	kolder "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"
+	/*kolder "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1"*/
 
 	newer "github.com/openshift/origin/pkg/build/api"
-	older "github.com/openshift/origin/pkg/build/api/v1"*/
+	older "github.com/openshift/origin/pkg/build/api/v1"
 )
+
+var Convert = knewer.Scheme.Convert
+
+func TestImageChangeTriggerDefaultValueConversion(t *testing.T) {
+	var actual newer.BuildTriggerPolicy
+
+	oldVersion := older.BuildTriggerPolicy{
+		Type: older.ImageChangeBuildTriggerType,
+	}
+	err := Convert(&oldVersion, &actual)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if actual.ImageChange == nil {
+		t.Errorf("expected %v, actual %v", &newer.ImageChangeTrigger{}, nil)
+	}
+}

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -529,6 +529,12 @@ func TestValidateTrigger(t *testing.T) {
 			},
 			expected: []*fielderrors.ValidationError{fielderrors.NewFieldInvalid("github", "", "long github description")},
 		},
+		"imageChange trigger without params": {
+			trigger: buildapi.BuildTriggerPolicy{
+				Type: buildapi.ImageChangeBuildTriggerType,
+			},
+			expected: []*fielderrors.ValidationError{fielderrors.NewFieldRequired("imageChange")},
+		},
 		"valid github trigger": {
 			trigger: buildapi.BuildTriggerPolicy{
 				Type: buildapi.GithubWebHookBuildTriggerType,
@@ -543,6 +549,20 @@ func TestValidateTrigger(t *testing.T) {
 				GenericWebHook: &buildapi.WebHookTrigger{
 					Secret: "secret101",
 				},
+			},
+		},
+		"valid imageChange trigger": {
+			trigger: buildapi.BuildTriggerPolicy{
+				Type: buildapi.ImageChangeBuildTriggerType,
+				ImageChange: &buildapi.ImageChangeTrigger{
+					LastTriggeredImageID: "asdf1234",
+				},
+			},
+		},
+		"valid imageChange trigger with empty fields": {
+			trigger: buildapi.BuildTriggerPolicy{
+				Type:        buildapi.ImageChangeBuildTriggerType,
+				ImageChange: &buildapi.ImageChangeTrigger{},
 			},
 		},
 	}


### PR DESCRIPTION
It used to be required when it had more keys inside, now it has only the
internal `LastTriggeredImageID` which is not required.
Our application templates are starting to look like:
```
{
  "kind": "BuildConfig",
  "apiVersion": "v1",
  ...
  "spec": {
    ...
    "triggers": [
      {
        "type": "imageChange",
        "imageChange": {}        <---- not needed
      },
      ...
    ]
  }
}
```