### PR TITLE
Update labels and styles for create flow

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -143,6 +143,10 @@ html, body {
 // Create App
 // --------------------------------------------------
 
+ label.checkbox {
+  font-weight: normal;
+}
+
 .create-from-template,
 .create-from-image {
   .template-name {
@@ -162,7 +166,7 @@ html, body {
   .flow {
     border-top: 1px solid rgba(0, 0, 0, 0.15);
     display: table;
-    margin-top: @grid-gutter-width * 1.5;
+    margin-top: @grid-gutter-width;
     width: 100%;
     > .flow-block {
       display: inline-block;
@@ -183,6 +187,10 @@ html, body {
         }
       }
     }
+  }
+  .first-section .flow {
+    margin-top: (@grid-gutter-width / 2);
+    border-top: 0;
   }
 }
 

--- a/assets/app/views/_templateopt.html
+++ b/assets/app/views/_templateopt.html
@@ -1,4 +1,4 @@
-<div class="template-options gutter-bottom" ng-show="hasParameters">
+<div class="template-options" ng-show="hasParameters">
   <div class="flow">
     <div class="flow-block">
       <h2>Parameters</h2>

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -3,16 +3,17 @@
     <div class="container">
       <div class="row">
         <div class="col-md-12">
-          <h1>Create from ...</h1>
+          <h1>Create</h1>
           <form name="from_source_form" class="form-inline gutter-bottom">
-            <h2>Source repository</h2>
+            <h2>Using Your Code</h2>
+            <p>Create your application from a Git source code repository.</p>
             <div class="row">
               <div class="col-md-8">
                 <div class="input-group">
                   <span ng-class="{'has-error': from_source_form.$invalid && from_source_form.from_source_url.$touched}">
                     <input class="form-control input-lg"
                       name="from_source_url"
-                      placeholder="URL for source repository"
+                      placeholder="Repository URL"
                       ng-pattern="sourceURLPattern"
                       type="text"
                       required
@@ -30,13 +31,15 @@
 
           <div class="row">
             <div class="col-md-12">
-              <h2>Instant apps</h2>
+              <h2>Using a Template</h2>
+              <p>Templates have predefined resources for quickly creating components. You can customize some options in the next step.</p>
+              <h3>Instant Apps</h3>
               <div class="row">
                 <catalog-template template="template" project="projectName" ng-repeat="template in templatesByTag['instant-app'] | orderBy : 'metadata.name'"></catalog-template>
                 <div class="col-md-4">
                   <div ng-if="!templatesByTag['instant-app'].length">
                     <em>There are no instant apps available to create.</em>
-                  </div>        
+                  </div>
                   <a class="btn btn-lg btn-primary btn-block" href="project/{{projectName}}/catalog/templates">Browse all templates...</a>
                 </div>
               </div>

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -9,7 +9,7 @@
           <div class="col-md-8">
             <osc-image-summary resource="image" name="imageName"></osc-image-summary>
             <form class="" ng-show="imageRepo" novalidate name="form">
-              <div>
+              <div class="gutter-bottom">
                   <h2>
                     Name
                   </h2>
@@ -28,10 +28,16 @@
                 </div>
               </div>
 
+              <div class="alert alert-info">
+                <span class="pficon pficon-info"></span>
+                <label>Note:</label> After creation, these settings can only be modified through the osc command.
+              </div>
+
               <osc-form-section
                 header="Routing" 
                 about-title="Routing"
                 about="Routing is a way to make your application publicly visible. Otherwise you may only be able to access your application by it's IP address, if allowed by the system administrator."
+                class="first-section"
                 >
                 <div ng-hide="$parent.expand">
                   <div>
@@ -198,10 +204,6 @@
 
               <labels labels="labels"></labels>
               <div class="buttons gutter-top-bottom gutter-top-bottom-2x">
-              <div class="alert alert-info">
-                <span class="pficon pficon-info"></span>
-                <label>Note:</label> After creation, these settings can only be modified through the osc command.
-              </div>
                 <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
                 <button class="btn btn-primary btn-lg" 
                     ng-click="createApp()" 

--- a/assets/app/views/newfromtemplate.html
+++ b/assets/app/views/newfromtemplate.html
@@ -8,7 +8,7 @@
           </div>
           <div class="col-md-9">
             <osc-image-summary resource="template"></osc-image-summary>
-            <div ng-if="templateImages.length" class="images gutter-bottom">
+            <div ng-if="templateImages.length" class="images">
               <h2>Images</h2>
               <ul class="list-unstyled" ng-repeat="image in templateImages">
                 <li>
@@ -17,8 +17,8 @@
                 </li>
               </ul>
             </div>
+            <template-options class="first-section"></template-options>
             <labels labels="template.labels"></labels>
-            <template-options></template-options>
             <div class="project gutter-bottom">
             Items will be created in the <b>{{ projectDisplayName() }}</b> project.
             </div>


### PR DESCRIPTION
* Add additional help text to first create page
* Tighten up spacing between editable sections
* Remove top border from first section
* Don't use bold text for checkbox labels
* Move warning to top of "create from image" page
* Put parameters before labels when creating from templates

Initial Page:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/7838933/b8a34ad4-045d-11e5-9b42-b216cb503ee6.png)

From Image:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/7838953/d53fd018-045d-11e5-9fa2-f47b6d302a9e.png)

From Template:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/7838976/e8a0dd82-045d-11e5-8e01-274f4b587ce5.png)
