### PR TITLE
Project node selector fixes

### DIFF
--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -18,10 +18,9 @@ import (
 )
 
 type NewProjectOptions struct {
-	ProjectName  string
-	DisplayName  string
-	Description  string
-	NodeSelector string
+	ProjectName string
+	DisplayName string
+	Description string
 
 	Client client.Interface
 
@@ -106,7 +105,6 @@ func (o *NewProjectOptions) Run() error {
 	projectRequest.DisplayName = o.DisplayName
 	projectRequest.Annotations = make(map[string]string)
 	projectRequest.Annotations["description"] = o.Description
-	projectRequest.Annotations["openshift.io/node-selector"] = o.NodeSelector
 
 	project, err := o.Client.ProjectRequests().Create(projectRequest)
 	if err != nil {

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -27,6 +27,7 @@ import (
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
@@ -552,7 +553,7 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 
 	nodeSelector := ""
 	if len(project.ObjectMeta.Annotations) > 0 {
-		if ns, ok := project.ObjectMeta.Annotations["openshift.io/node-selector"]; ok {
+		if ns, ok := project.ObjectMeta.Annotations[projectapi.ProjectNodeSelectorParam]; ok {
 			nodeSelector = ns
 		}
 	}

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/util/labelselector"
 )
@@ -30,28 +31,29 @@ func TestPodAdmission(t *testing.T) {
 	}
 
 	tests := []struct {
-		defaultNodeSelector string
-		projectNodeSelector string
-		podNodeSelector     map[string]string
-		mergedNodeSelector  map[string]string
-		admit               bool
-		testName            string
+		defaultNodeSelector       string
+		projectNodeSelector       string
+		podNodeSelector           map[string]string
+		mergedNodeSelector        map[string]string
+		ignoreProjectNodeSelector bool
+		admit                     bool
+		testName                  string
 	}{
 		{
-			defaultNodeSelector: "",
-			projectNodeSelector: "",
-			podNodeSelector:     map[string]string{},
-			mergedNodeSelector:  map[string]string{},
-			admit:               true,
-			testName:            "No node selectors",
+			defaultNodeSelector:       "",
+			podNodeSelector:           map[string]string{},
+			mergedNodeSelector:        map[string]string{},
+			ignoreProjectNodeSelector: true,
+			admit:    true,
+			testName: "No node selectors",
 		},
 		{
-			defaultNodeSelector: "infra = false",
-			projectNodeSelector: "",
-			podNodeSelector:     map[string]string{},
-			mergedNodeSelector:  map[string]string{"infra": "false"},
-			admit:               true,
-			testName:            "Default node selector and no conflicts",
+			defaultNodeSelector:       "infra = false",
+			podNodeSelector:           map[string]string{},
+			mergedNodeSelector:        map[string]string{"infra": "false"},
+			ignoreProjectNodeSelector: true,
+			admit:    true,
+			testName: "Default node selector and no conflicts",
 		},
 		{
 			defaultNodeSelector: "",
@@ -60,6 +62,14 @@ func TestPodAdmission(t *testing.T) {
 			mergedNodeSelector:  map[string]string{"infra": "false"},
 			admit:               true,
 			testName:            "Project node selector and no conflicts",
+		},
+		{
+			defaultNodeSelector: "infra = false",
+			projectNodeSelector: "",
+			podNodeSelector:     map[string]string{},
+			mergedNodeSelector:  map[string]string{},
+			admit:               true,
+			testName:            "Empty project node selector and no conflicts",
 		},
 		{
 			defaultNodeSelector: "infra = false",
@@ -96,7 +106,9 @@ func TestPodAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		projectcache.FakeProjectCache(mockClient, projectStore, test.defaultNodeSelector)
-		project.ObjectMeta.Annotations = map[string]string{"openshift.io/node-selector": test.projectNodeSelector}
+		if !test.ignoreProjectNodeSelector {
+			project.ObjectMeta.Annotations = map[string]string{projectapi.ProjectNodeSelectorParam: test.projectNodeSelector}
+		}
 		pod.Spec = kapi.PodSpec{NodeSelector: test.podNodeSelector}
 
 		err := handler.Admit(admission.NewAttributesRecord(pod, "Pod", project.ObjectMeta.Name, "pods", admission.Create, nil))

--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -11,9 +11,11 @@ type ProjectList struct {
 	Items []Project
 }
 
-// These are internal finalizer values to Origin
 const (
+	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
+
+	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/v1/types.go
+++ b/pkg/project/api/v1/types.go
@@ -11,9 +11,11 @@ type ProjectList struct {
 	Items         []Project `json:"items"`
 }
 
-// These are internal finalizer values to Origin
 const (
+	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
+
+	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/v1beta1/types.go
+++ b/pkg/project/api/v1beta1/types.go
@@ -11,9 +11,11 @@ type ProjectList struct {
 	Items         []Project `json:"items"`
 }
 
-// These are internal finalizer values to Origin
 const (
+	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
+
+	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/v1beta3/types.go
+++ b/pkg/project/api/v1beta3/types.go
@@ -11,9 +11,11 @@ type ProjectList struct {
 	Items         []Project `json:"items"`
 }
 
-// These are internal finalizer values to Origin
 const (
+	// These are internal finalizer values to Origin
 	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
+
+	ProjectNodeSelectorParam string = "openshift.io/node-selector"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/validation/validation.go
+++ b/pkg/project/api/validation/validation.go
@@ -59,9 +59,9 @@ func validateNodeSelector(p *api.Project) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
 	if len(p.Annotations) > 0 {
-		if selector, ok := p.Annotations["openshift.io/node-selector"]; ok {
+		if selector, ok := p.Annotations[api.ProjectNodeSelectorParam]; ok {
 			if _, err := labelselector.Parse(selector); err != nil {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("nodeSelector", p.Annotations["openshift.io/node-selector"], "must be a valid label selector"))
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("nodeSelector", p.Annotations[api.ProjectNodeSelectorParam], "must be a valid label selector"))
 			}
 		}
 	}

--- a/pkg/project/api/validation/validation_test.go
+++ b/pkg/project/api/validation/validation_test.go
@@ -122,7 +122,7 @@ func TestValidateProject(t *testing.T) {
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						"openshift.io/node-selector": "infra=true, env = test",
+						api.ProjectNodeSelectorParam: "infra=true, env = test",
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func TestValidateProject(t *testing.T) {
 					Name:      "foo",
 					Namespace: "",
 					Annotations: map[string]string{
-						"openshift.io/node-selector": "infra, env = $test",
+						api.ProjectNodeSelectorParam: "infra, env = $test",
 					},
 				},
 			},

--- a/pkg/project/cache/cache.go
+++ b/pkg/project/cache/cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
+	projectapi "github.com/openshift/origin/pkg/project/api"
 	"github.com/openshift/origin/pkg/util/labelselector"
 )
 
@@ -51,12 +52,14 @@ func (p *ProjectCache) GetNamespaceObject(name string) (*kapi.Namespace, error) 
 
 func (p *ProjectCache) GetNodeSelector(namespace *kapi.Namespace) string {
 	selector := ""
+	found := false
 	if len(namespace.ObjectMeta.Annotations) > 0 {
-		if ns, ok := namespace.ObjectMeta.Annotations["openshift.io/node-selector"]; ok {
+		if ns, ok := namespace.ObjectMeta.Annotations[projectapi.ProjectNodeSelectorParam]; ok {
 			selector = ns
+			found = true
 		}
 	}
-	if len(selector) == 0 {
+	if !found {
 		selector = p.DefaultNodeSelector
 	}
 	return selector

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -66,7 +66,7 @@ func TestLogin(t *testing.T) {
 		AdminRole:   bootstrappolicy.AdminRoleName,
 		AdminUser:   username,
 	}
-	if err := newProjectOptions.Run(); err != nil {
+	if err := newProjectOptions.Run(false); err != nil {
 		t.Fatalf("unexpected error, a project is required to continue: %v", err)
 	}
 

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -131,8 +131,8 @@ func TestProjectIsNamespace(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "new-project",
 			Annotations: map[string]string{
-				"displayName":                "Hello World",
-				"openshift.io/node-selector": "env=test",
+				"displayName":                       "Hello World",
+				projectapi.ProjectNodeSelectorParam: "env=test",
 			},
 		},
 	}
@@ -152,8 +152,8 @@ func TestProjectIsNamespace(t *testing.T) {
 	if project.Annotations["displayName"] != namespace.Annotations["displayName"] {
 		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations["displayName"], namespace.Annotations["displayName"])
 	}
-	if project.Annotations["openshift.io/node-selector"] != namespace.Annotations["openshift.io/node-selector"] {
-		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations["openshift.io/node-selector"], namespace.Annotations["openshift.io/node-selector"])
+	if project.Annotations[projectapi.ProjectNodeSelectorParam] != namespace.Annotations[projectapi.ProjectNodeSelectorParam] {
+		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations[projectapi.ProjectNodeSelectorParam], namespace.Annotations[projectapi.ProjectNodeSelectorParam])
 	}
 }
 

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -341,7 +341,7 @@ func CreateNewProject(clusterAdminClient *client.Client, clientConfig kclient.Co
 		AdminUser:   adminUser,
 	}
 
-	if err := newProjectOptions.Run(); err != nil {
+	if err := newProjectOptions.Run(false); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- Allow empty project node selector
- Changed "openshift.io/node-selector" annotation as constant