### PR TITLE
Run deployer pods with service account credentials

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller.go
@@ -144,9 +144,6 @@ func (e *TokensController) Stop() {
 
 // serviceAccountAdded reacts to a ServiceAccount creation by creating a corresponding ServiceAccountToken Secret
 func (e *TokensController) serviceAccountAdded(obj interface{}) {
-	if !e.secretsSynced() {
-		return
-	}
 	serviceAccount := obj.(*api.ServiceAccount)
 	err := e.createSecretIfNeeded(serviceAccount)
 	if err != nil {
@@ -156,9 +153,6 @@ func (e *TokensController) serviceAccountAdded(obj interface{}) {
 
 // serviceAccountUpdated reacts to a ServiceAccount update (or re-list) by ensuring a corresponding ServiceAccountToken Secret exists
 func (e *TokensController) serviceAccountUpdated(oldObj interface{}, newObj interface{}) {
-	if !e.secretsSynced() {
-		return
-	}
 	newServiceAccount := newObj.(*api.ServiceAccount)
 	err := e.createSecretIfNeeded(newServiceAccount)
 	if err != nil {
@@ -188,9 +182,6 @@ func (e *TokensController) serviceAccountDeleted(obj interface{}) {
 
 // secretAdded reacts to a Secret create by ensuring the referenced ServiceAccount exists, and by adding a token to the secret if needed
 func (e *TokensController) secretAdded(obj interface{}) {
-	if !e.serviceAccountsSynced() {
-		return
-	}
 	secret := obj.(*api.Secret)
 	serviceAccount, err := e.getServiceAccount(secret)
 	if err != nil {
@@ -198,6 +189,9 @@ func (e *TokensController) secretAdded(obj interface{}) {
 		return
 	}
 	if serviceAccount == nil {
+		if !e.serviceAccountsSynced() {
+			return
+		}
 		if err := e.deleteSecret(secret); err != nil {
 			glog.Errorf("Error deleting secret %s/%s: %v", secret.Namespace, secret.Name, err)
 		}
@@ -208,9 +202,6 @@ func (e *TokensController) secretAdded(obj interface{}) {
 
 // secretUpdated reacts to a Secret update (or re-list) by deleting the secret (if the referenced ServiceAccount does not exist)
 func (e *TokensController) secretUpdated(oldObj interface{}, newObj interface{}) {
-	if !e.serviceAccountsSynced() {
-		return
-	}
 	newSecret := newObj.(*api.Secret)
 	newServiceAccount, err := e.getServiceAccount(newSecret)
 	if err != nil {
@@ -218,6 +209,9 @@ func (e *TokensController) secretUpdated(oldObj interface{}, newObj interface{})
 		return
 	}
 	if newServiceAccount == nil {
+		if !e.serviceAccountsSynced() {
+			return
+		}
 		if err := e.deleteSecret(newSecret); err != nil {
 			glog.Errorf("Error deleting secret %s/%s: %v", newSecret.Namespace, newSecret.Name, err)
 		}
@@ -262,6 +256,11 @@ func (e *TokensController) createSecretIfNeeded(serviceAccount *api.ServiceAccou
 	// If the service account references no secrets, short-circuit and create a new one
 	if len(serviceAccount.Secrets) == 0 {
 		return e.createSecret(serviceAccount)
+	}
+
+	// We can't check live secret references until the secrets store is synced
+	if !e.secretsSynced() {
+		return nil
 	}
 
 	// If any existing token secrets are referenced by the service account, return

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -318,7 +318,7 @@ docker tag -f openshift/ruby-20-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-20-
 docker push ${DOCKER_REGISTRY}/cache/ruby-20-centos7:latest
 echo "[INFO] Pushed ruby-20-centos7"
 
-echo "[INFO] Back to 'master' context with 'admin' user..."
+echo "[INFO] Back to 'default' project with 'admin' user..."
 osc project ${CLUSTER_ADMIN_CONTEXT}
 
 # The build requires a dockercfg secret in the builder service account in order
@@ -338,12 +338,7 @@ osc project test
 echo "[INFO] Applying STI application config"
 osc create -f "${STI_CONFIG_FILE}"
 
-
-# this needs to be done before waiting for the build because right now only cluster-admins can see build logs, because that uses proxy
-echo "[INFO] Back to 'master' context with 'admin' user..."
-osc project default
-
-# Trigger build
+# Wait for build which should have triggered automatically
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} and streaming its logs..."
 #osc start-build -n test ruby-sample-build --follow
 wait_for_build "test"
@@ -362,6 +357,9 @@ wait_for_app "test"
 #curl -k -X POST $API_SCHEME://$API_HOST:$API_PORT/osapi/v1beta3/namespaces/custom/buildconfigs/ruby-sample-build/webhooks/secret101/generic && sleep 3
 #wait_for_build "custom"
 #wait_for_app "custom"
+
+echo "[INFO] Back to 'default' project with 'admin' user..."
+osc project ${CLUSTER_ADMIN_CONTEXT}
 
 # ensure the router is started
 # TODO: simplify when #4702 is fixed upstream

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -36,7 +36,7 @@ func TestSubjects(t *testing.T) {
 			Verb:     "get",
 			Resource: "pods",
 		},
-		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:openshift-client", "system:openshift-deployer"),
+		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:openshift-client"),
 		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:nodes"),
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -77,7 +77,6 @@ func DefaultAPIClientCAFile(certDir string) string {
 
 func DefaultAPIClientCerts(certDir string) []ClientCertInfo {
 	return []ClientCertInfo{
-		DefaultDeployerClientCertInfo(certDir),
 		DefaultOpenshiftLoopbackClientCertInfo(certDir),
 		DefaultClusterAdminClientCertInfo(certDir),
 		DefaultRouterClientCertInfo(certDir),
@@ -106,18 +105,6 @@ func DefaultRegistryClientCertInfo(certDir string) ClientCertInfo {
 		UnqualifiedUser: bootstrappolicy.RegistryUnqualifiedUsername,
 		User:            bootstrappolicy.RegistryUsername,
 		Groups:          util.NewStringSet(bootstrappolicy.RegistryGroup),
-	}
-}
-
-func DefaultDeployerClientCertInfo(certDir string) ClientCertInfo {
-	return ClientCertInfo{
-		CertLocation: configapi.CertInfo{
-			CertFile: DefaultCertFilename(certDir, "openshift-deployer"),
-			KeyFile:  DefaultKeyFilename(certDir, "openshift-deployer"),
-		},
-		UnqualifiedUser: "openshift-deployer",
-		User:            "system:openshift-deployer",
-		Groups:          util.NewStringSet("system:deployers"),
 	}
 }
 

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -108,7 +108,6 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.ServiceAccountConfig.PublicKeyFiles[i])
 	}
 
-	refs = append(refs, &config.MasterClients.DeployerKubeConfig)
 	refs = append(refs, &config.MasterClients.OpenShiftLoopbackKubeConfig)
 	refs = append(refs, &config.MasterClients.ExternalKubernetesKubeConfig)
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -224,8 +224,6 @@ type ServingInfo struct {
 }
 
 type MasterClients struct {
-	// DeployerKubeConfig is a .kubeconfig filename for depoyment pods to use
-	DeployerKubeConfig string
 	// OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master
 	OpenShiftLoopbackKubeConfig string
 	// ExternalKubernetesKubeConfig is a .kubeconfig filename for proxying to kubernetes

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -213,8 +213,6 @@ type ServingInfo struct {
 }
 
 type MasterClients struct {
-	// DeployerKubeConfig is a .kubeconfig filename for depoyment pods to use
-	DeployerKubeConfig string `json:"deployerKubeConfig"`
 	// OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master
 	OpenShiftLoopbackKubeConfig string `json:"openshiftLoopbackKubeConfig"`
 	// ExternalKubernetesKubeConfig is a .kubeconfig filename for proxying to kubernetes

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -100,7 +100,6 @@ kubernetesMasterConfig:
   servicesSubnet: ""
   staticNodeNames: null
 masterClients:
-  deployerKubeConfig: ""
   externalKubernetesKubeConfig: ""
   openshiftLoopbackKubeConfig: ""
 masterPublicURL: ""

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -7,8 +7,9 @@ const (
 
 // users
 const (
-	DefaultServiceAccountName = "default"
-	BuilderServiceAccountName = "builder"
+	DefaultServiceAccountName  = "default"
+	BuilderServiceAccountName  = "builder"
+	DeployerServiceAccountName = "deployer"
 
 	RouterUnqualifiedUsername   = "openshift-router"
 	RegistryUnqualifiedUsername = "openshift-registry"
@@ -21,7 +22,6 @@ const (
 const (
 	UnauthenticatedUsername   = "system:anonymous"
 	InternalComponentUsername = "system:openshift-client"
-	DeployerUsername          = "system:openshift-deployer"
 
 	AuthenticatedGroup   = "system:authenticated"
 	UnauthenticatedGroup = "system:unauthenticated"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -413,15 +413,6 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: DeployerRoleBindingName,
-			},
-			RoleRef: kapi.ObjectReference{
-				Name: DeployerRoleName,
-			},
-			Users: util.NewStringSet(DeployerUsername),
-		},
-		{
-			ObjectMeta: kapi.ObjectMeta{
 				Name: ClusterAdminRoleBindingName,
 			},
 			RoleRef: kapi.ObjectReference{

--- a/pkg/cmd/server/bootstrappolicy/project_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/project_policy.go
@@ -30,5 +30,15 @@ func GetBootstrapServiceAccountProjectRoleBindings(namespace string) []authoriza
 			},
 			Users: util.NewStringSet(serviceaccount.MakeUsername(namespace, BuilderServiceAccountName)),
 		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      DeployerRoleBindingName,
+				Namespace: namespace,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: DeployerRoleName,
+			},
+			Users: util.NewStringSet(serviceaccount.MakeUsername(namespace, DeployerServiceAccountName)),
+		},
 	}
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -59,7 +59,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 
 	// in-order list of plug-ins that should intercept admission decisions
 	// TODO: Push node environment support to upstream in future
-	// TODO: JTL: update serviceaccount admission plugin to limit secrets to the ones held by the serviceaccount
 	admissionControlPluginNames := []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ServiceAccount", "ResourceQuota"}
 	admissionController := admission.NewFromPlugins(kubeClient, admissionControlPluginNames, "")
 

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -87,8 +87,6 @@ type MasterConfig struct {
 	// PrivilegedLoopbackClientConfig is the client configuration used to call OpenShift APIs from system components
 	// To apply different access control to a system component, create a client config specifically for that component.
 	PrivilegedLoopbackClientConfig kclient.Config
-	// DeployerPrivilegedLoopbackClientConfig is the client configuration used to call OpenShift APIs from launched deployer pods
-	DeployerOSClientConfig kclient.Config
 
 	// kubeClient is the client used to call Kubernetes APIs from system components, built from KubeClientConfig.
 	// It should only be accessed via the *Client() helper methods.
@@ -124,10 +122,6 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		return nil, err
 	}
 	privilegedLoopbackOpenShiftClient, privilegedLoopbackClientConfig, err := configapi.GetOpenShiftClient(options.MasterClients.OpenShiftLoopbackKubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	_, deployerOSClientConfig, err := configapi.GetOpenShiftClient(options.MasterClients.DeployerKubeConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +167,6 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		ClientCAs:    clientCAs,
 		APIClientCAs: apiClientCAs,
 
-		DeployerOSClientConfig:             *deployerOSClientConfig,
 		PrivilegedLoopbackClientConfig:     *privilegedLoopbackClientConfig,
 		PrivilegedLoopbackOpenShiftClient:  privilegedLoopbackOpenShiftClient,
 		PrivilegedLoopbackKubernetesClient: privilegedLoopbackKubeClient,
@@ -360,12 +353,6 @@ func (c *MasterConfig) ImageImportControllerClient() *osclient.Client {
 // DeploymentControllerClients returns the deployment controller client object
 func (c *MasterConfig) DeploymentControllerClients() (*osclient.Client, *kclient.Client) {
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
-}
-
-// DeployerClientConfig returns the client configuration a Deployer instance launched in a pod
-// should use when making API calls.
-func (c *MasterConfig) DeployerClientConfig() *kclient.Config {
-	return &c.DeployerOSClientConfig
 }
 
 func (c *MasterConfig) DeploymentConfigControllerClients() (*osclient.Client, *kclient.Client) {

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -173,7 +173,6 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		},
 
 		MasterClients: configapi.MasterClients{
-			DeployerKubeConfig:           admin.DefaultKubeConfigFilename(args.ConfigDir.Value(), "openshift-deployer"),
 			OpenShiftLoopbackKubeConfig:  admin.DefaultKubeConfigFilename(args.ConfigDir.Value(), "openshift-client"),
 			ExternalKubernetesKubeConfig: args.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath,
 		},
@@ -229,10 +228,11 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 	}
 
 	if builtInKubernetes {
-		// When we start Kubernetes, we're responsible for generating the default account
+		// When we start Kubernetes, we're responsible for generating all the managed service accounts
 		config.ServiceAccountConfig.ManagedNames = []string{
 			bootstrappolicy.DefaultServiceAccountName,
 			bootstrappolicy.BuilderServiceAccountName,
+			bootstrappolicy.DeployerServiceAccountName,
 		}
 		// We also need the private key file to give to the token generator
 		config.ServiceAccountConfig.PrivateKeyFile = admin.DefaultServiceAccountPrivateKeyFile(args.ConfigDir.Value())
@@ -241,11 +241,12 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 			admin.DefaultServiceAccountPublicKeyFile(args.ConfigDir.Value()),
 		}
 	} else {
-		// When running against an external Kubernetes, we're only responsible for the builder account.
+		// When running against an external Kubernetes, we're only responsible for the builder and deployer accounts.
 		// We don't have the private key, but we need to get the public key to authenticate signed tokens.
 		// TODO: JTL: take arg for public key(s)?
 		config.ServiceAccountConfig.ManagedNames = []string{
 			bootstrappolicy.BuilderServiceAccountName,
+			bootstrappolicy.DeployerServiceAccountName,
 		}
 		config.ServiceAccountConfig.PublicKeyFiles = []string{}
 	}

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -25,6 +25,8 @@ import (
 //
 // Use the DeploymentControllerFactory to create this controller.
 type DeploymentController struct {
+	// serviceAccount to create deployment pods with
+	serviceAccount string
 	// deploymentClient provides access to deployments.
 	deploymentClient deploymentClient
 	// podClient provides access to pods.
@@ -210,6 +212,7 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 			},
 			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
 			RestartPolicy:         kapi.RestartPolicyNever,
+			ServiceAccount:        c.serviceAccount,
 		},
 	}
 

--- a/pkg/deploy/controller/deployment/factory.go
+++ b/pkg/deploy/controller/deployment/factory.go
@@ -26,6 +26,8 @@ type DeploymentControllerFactory struct {
 	KubeClient kclient.Interface
 	// Codec is used for encoding/decoding.
 	Codec runtime.Codec
+	// ServiceAccount is the service account name to run deployer pods as
+	ServiceAccount string
 	// Environment is a set of environment which should be injected into all deployer pod containers.
 	Environment []kapi.EnvVar
 	// DeployerImage specifies which Docker image can support the default strategies.
@@ -51,6 +53,7 @@ func (factory *DeploymentControllerFactory) Create() controller.RunnableControll
 	eventBroadcaster.StartRecordingToSink(factory.KubeClient.Events(""))
 
 	deployController := &DeploymentController{
+		serviceAccount: factory.ServiceAccount,
 		deploymentClient: &deploymentClientImpl{
 			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
 				return factory.KubeClient.ReplicationControllers(namespace).Get(name)


### PR DESCRIPTION
Fixes #2506

- [x] Removes the cluster-wide deployer user (cert generation, config, etc)
- [x] Adds "deployer" as a managed service account name in each namespace
- [x] Stops injecting credentials as envvars to deployer pods
- [x] Uses mounted service account token as credential for deployer pod
- [x] Add check on startup to add default rolebindings to the default namespace
- [x] Make `osadm new-project` add bootstrap serviceaccount rolebindings by default
- [x] Coordinate tagging new deployer image to pick up service account token
- [x] Open issue for doc to remove `masterClients.deployerKubeConfig` https://github.com/openshift/openshift-docs/issues/451
- [x] Open issue for ansible to remove `masterClients.deployerKubeConfig` and references to `openshift-deployer.{crt,key,kubeconfig}` https://github.com/detiber/openshift-ansible/issues/37