### PR TITLE
Ensure OpenShift content creation results in namespace finalizer

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -618,7 +618,7 @@ func (c *MasterConfig) ensureOpenShiftSharedResourcesNamespace() {
 		namespace = &kapi.Namespace{
 			ObjectMeta: kapi.ObjectMeta{Name: c.Options.PolicyConfig.OpenShiftSharedResourcesNamespace},
 			Spec: kapi.NamespaceSpec{
-				Finalizers: []kapi.FinalizerName{projectapi.FinalizerProject},
+				Finalizers: []kapi.FinalizerName{projectapi.FinalizerOrigin},
 			},
 		}
 		kapi.FillObjectMetaSystemFields(api.NewContext(), &namespace.ObjectMeta)

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -33,7 +33,7 @@ func TestAdmissionExists(t *testing.T) {
 		Err: fmt.Errorf("DOES NOT EXIST"),
 	}
 	projectcache.FakeProjectCache(mockClient, cache.NewStore(cache.MetaNamespaceKeyFunc), "")
-	handler := &lifecycle{}
+	handler := &lifecycle{client: mockClient}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Parameters: buildapi.BuildParameters{
@@ -75,7 +75,7 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
 	projectcache.FakeProjectCache(mockClient, store, "")
-	handler := &lifecycle{}
+	handler := &lifecycle{client: mockClient}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "other"},
 		Parameters: buildapi.BuildParameters{

--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -13,7 +13,7 @@ type ProjectList struct {
 
 // These are internal finalizer values to Origin
 const (
-	FinalizerProject kapi.FinalizerName = "openshift.com/project"
+	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/v1/types.go
+++ b/pkg/project/api/v1/types.go
@@ -13,7 +13,7 @@ type ProjectList struct {
 
 // These are internal finalizer values to Origin
 const (
-	FinalizerProject kapi.FinalizerName = "openshift.com/project"
+	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/v1beta1/types.go
+++ b/pkg/project/api/v1beta1/types.go
@@ -13,7 +13,7 @@ type ProjectList struct {
 
 // These are internal finalizer values to Origin
 const (
-	FinalizerProject kapi.FinalizerName = "openshift.com/project"
+	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/api/v1beta3/types.go
+++ b/pkg/project/api/v1beta3/types.go
@@ -13,7 +13,7 @@ type ProjectList struct {
 
 // These are internal finalizer values to Origin
 const (
-	FinalizerProject kapi.FinalizerName = "openshift.com/project"
+	FinalizerOrigin kapi.FinalizerName = "openshift.io/origin"
 )
 
 // ProjectSpec describes the attributes on a Project

--- a/pkg/project/controller/controller_test.go
+++ b/pkg/project/controller/controller_test.go
@@ -25,7 +25,7 @@ func TestSyncNamespaceThatIsTerminating(t *testing.T) {
 			DeletionTimestamp: &now,
 		},
 		Spec: kapi.NamespaceSpec{
-			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerProject},
+			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerOrigin},
 		},
 		Status: kapi.NamespaceStatus{
 			Phase: kapi.NamespaceTerminating,
@@ -75,7 +75,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Spec: kapi.NamespaceSpec{
-			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerProject},
+			Finalizers: []kapi.FinalizerName{kapi.FinalizerKubernetes, api.FinalizerOrigin},
 		},
 		Status: kapi.NamespaceStatus{
 			Phase: kapi.NamespaceActive,

--- a/pkg/project/registry/project/rest.go
+++ b/pkg/project/registry/project/rest.go
@@ -29,16 +29,16 @@ func (projectStrategy) PrepareForCreate(obj runtime.Object) {
 	project := obj.(*api.Project)
 	hasProjectFinalizer := false
 	for i := range project.Spec.Finalizers {
-		if project.Spec.Finalizers[i] == api.FinalizerProject {
+		if project.Spec.Finalizers[i] == api.FinalizerOrigin {
 			hasProjectFinalizer = true
 			break
 		}
 	}
 	if !hasProjectFinalizer {
 		if len(project.Spec.Finalizers) == 0 {
-			project.Spec.Finalizers = []kapi.FinalizerName{api.FinalizerProject}
+			project.Spec.Finalizers = []kapi.FinalizerName{api.FinalizerOrigin}
 		} else {
-			project.Spec.Finalizers = append(project.Spec.Finalizers, api.FinalizerProject)
+			project.Spec.Finalizers = append(project.Spec.Finalizers, api.FinalizerOrigin)
 		}
 	}
 }

--- a/pkg/project/registry/project/rest_test.go
+++ b/pkg/project/registry/project/rest_test.go
@@ -36,7 +36,7 @@ func TestProjectStrategy(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "foo", ResourceVersion: "10"},
 	}
 	Strategy.PrepareForCreate(project)
-	if len(project.Spec.Finalizers) != 1 || project.Spec.Finalizers[0] != api.FinalizerProject {
+	if len(project.Spec.Finalizers) != 1 || project.Spec.Finalizers[0] != api.FinalizerOrigin {
 		t.Errorf("Prepare For Create should have added project finalizer")
 	}
 	errs := Strategy.Validate(ctx, project)
@@ -48,7 +48,7 @@ func TestProjectStrategy(t *testing.T) {
 	}
 	// ensure we copy spec.finalizers from old to new
 	Strategy.PrepareForUpdate(invalidProject, project)
-	if len(invalidProject.Spec.Finalizers) != 1 || invalidProject.Spec.Finalizers[0] != api.FinalizerProject {
+	if len(invalidProject.Spec.Finalizers) != 1 || invalidProject.Spec.Finalizers[0] != api.FinalizerOrigin {
 		t.Errorf("PrepareForUpdate should have preserved old.spec.finalizers")
 	}
 	errs = Strategy.ValidateUpdate(ctx, invalidProject, project)

--- a/pkg/project/util/util.go
+++ b/pkg/project/util/util.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/openshift/origin/pkg/project/api"
+)
+
+// Associated returns true if the spec.finalizers contains the origin finalizer
+func Associated(namespace *kapi.Namespace) bool {
+	for i := range namespace.Spec.Finalizers {
+		if api.FinalizerOrigin == namespace.Spec.Finalizers[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// Associate adds the origin finalizer to spec.finalizers if its not there already
+func Associate(kubeClient kclient.Interface, namespace *kapi.Namespace) (*kapi.Namespace, error) {
+	if Associated(namespace) {
+		return namespace, nil
+	}
+	return finalizeInternal(kubeClient, namespace, true)
+}
+
+// Finalized returns true if the spec.finalizers does not contain the origin finalizer
+func Finalized(namespace *kapi.Namespace) bool {
+	for i := range namespace.Spec.Finalizers {
+		if api.FinalizerOrigin == namespace.Spec.Finalizers[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Finalize will remove the origin finalizer from the namespace
+func Finalize(kubeClient kclient.Interface, namespace *kapi.Namespace) (*kapi.Namespace, error) {
+	if Finalized(namespace) {
+		return namespace, nil
+	}
+	return finalizeInternal(kubeClient, namespace, false)
+}
+
+// finalizeInternal will update the namespace finalizer list to either have or not have origin finalizer
+func finalizeInternal(kubeClient kclient.Interface, namespace *kapi.Namespace, withOrigin bool) (*kapi.Namespace, error) {
+	namespaceFinalize := kapi.Namespace{}
+	namespaceFinalize.ObjectMeta = namespace.ObjectMeta
+	namespaceFinalize.Spec = namespace.Spec
+
+	finalizerSet := util.NewStringSet()
+	for i := range namespace.Spec.Finalizers {
+		finalizerSet.Insert(string(namespace.Spec.Finalizers[i]))
+	}
+
+	if withOrigin {
+		finalizerSet.Insert(string(api.FinalizerOrigin))
+	} else {
+		finalizerSet.Delete(string(api.FinalizerOrigin))
+	}
+
+	namespaceFinalize.Spec.Finalizers = make([]kapi.FinalizerName, 0, len(finalizerSet))
+	for _, value := range finalizerSet.List() {
+		namespaceFinalize.Spec.Finalizers = append(namespaceFinalize.Spec.Finalizers, kapi.FinalizerName(value))
+	}
+	return kubeClient.Namespaces().Finalize(&namespaceFinalize)
+}


### PR DESCRIPTION
Fixes #2499 

Also updates the name of the origin finalizer to align with openshift.io naming convention.

The core issue was that end-users were creating content in a default namespace, which was not created by openshift, and therefore, openshift did not tag that namespace with its finalizer token.

This fix ensures that if you are creating content in a namespace for any reason that is OpenShift specific that the namespace will always be updated with the OpenShift finalizer token in the spec.

As a result, things are cleaned-up when deleted.