### PR TITLE
UPSTREAM: Allowing ActiveDeadlineSeconds to be updated for a pod

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
@@ -979,6 +979,15 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) errs.ValidationErrorList {
 		allErrs = append(allErrs, errs.NewFieldInvalid("spec.containers", newPod.Spec.Containers, "may not add or remove containers"))
 		return allErrs
 	}
+
+	// for updates, we are allowing ActiveDeadlineSeconds to be 0
+	// since a user may just want to terminate the containers without deleting the pod
+	if newPod.Spec.ActiveDeadlineSeconds != nil {
+		if *newPod.Spec.ActiveDeadlineSeconds <= 0 {
+			allErrs = append(allErrs, errs.NewFieldInvalid("activeDeadlineSeconds", newPod.Spec.ActiveDeadlineSeconds, "activeDeadlineSeconds must be a positive integer greater than 0"))
+		}
+	}
+
 	pod := *newPod
 	// Tricky, we need to copy the container list so that we don't overwrite the update
 	var newContainers []api.Container
@@ -987,6 +996,14 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) errs.ValidationErrorList {
 		newContainers = append(newContainers, container)
 	}
 	pod.Spec.Containers = newContainers
+
+	// allow ActiveDeadlineSeconds to be updated as well
+	pod.Spec.ActiveDeadlineSeconds = nil
+	if oldPod.Spec.ActiveDeadlineSeconds != nil {
+		activeDeadlineSeconds := *oldPod.Spec.ActiveDeadlineSeconds
+		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
+	}
+
 	if !api.Semantic.DeepEqual(pod.Spec, oldPod.Spec) {
 		allErrs = append(allErrs, errs.NewFieldInvalid("spec", newPod.Spec, "may not update fields other than container.image"))
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation_test.go
@@ -1207,6 +1207,9 @@ func TestValidatePod(t *testing.T) {
 }
 
 func TestValidatePodUpdate(t *testing.T) {
+	activeDeadlineSecondsZero := int64(0)
+	activeDeadlineSecondsNegative := int64(-30)
+	activeDeadlineSecondsPositive := int64(30)
 	tests := []struct {
 		a       api.Pod
 		b       api.Pod
@@ -1316,6 +1319,46 @@ func TestValidatePodUpdate(t *testing.T) {
 			},
 			true,
 			"image change",
+		},
+		{
+			api.Pod{
+				Spec: api.PodSpec{
+					ActiveDeadlineSeconds: &activeDeadlineSecondsZero,
+				},
+			},
+			api.Pod{},
+			false,
+			"activedeadlineseconds change to 0",
+		},
+		{
+			api.Pod{
+				Spec: api.PodSpec{
+					ActiveDeadlineSeconds: &activeDeadlineSecondsPositive,
+				},
+			},
+			api.Pod{},
+			true,
+			"activedeadlineseconds change to positive",
+		},
+		{
+			api.Pod{
+				Spec: api.PodSpec{
+					ActiveDeadlineSeconds: &activeDeadlineSecondsNegative,
+				},
+			},
+			api.Pod{},
+			false,
+			"activedeadlineseconds change to negative",
+		},
+		{
+			api.Pod{
+				Spec: api.PodSpec{
+					ActiveDeadlineSeconds: &activeDeadlineSecondsPositive,
+				},
+			},
+			api.Pod{},
+			true,
+			"activedeadlineseconds change back to nil",
 		},
 		{
 			api.Pod{


### PR DESCRIPTION
@derekwaynecarr if the upstream PR is good, then please merge this as well.