### PR TITLE
Add support for no port watch for the f5 router use case

### DIFF
--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -55,7 +55,13 @@ function generate_script_config() {
 
   echo ""
   echo "vrrp_script $CHECK_SCRIPT_NAME {"
-  echo "   script \"</dev/tcp/${serviceip}/${port}\""
+
+  if [ "$port" = "0" ]; then
+    echo "   script \"true\""
+  else
+    echo "   script \"</dev/tcp/${serviceip}/${port}\""
+  fi
+
   echo "   interval $CHECK_INTERVAL_SECS"
   echo "}"
 }

--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -250,6 +250,7 @@ $(generate_vrrp_sync_groups "$HA_CONFIG_NAME" "$vips")
   idx=$((idx + 1))
 
   local counter=1
+  local previous="none"
 
   for vip in ${vips}; do
     local offset=$((RANDOM % 32))
@@ -259,7 +260,14 @@ $(generate_vrrp_sync_groups "$HA_CONFIG_NAME" "$vips")
 
     if [ $n -eq 0 ]; then
       instancetype="master"
-      priority=$((255 - $ipslot))
+      if [ "$previous" = "master" ]; then
+        #  Inverse priority + reset, so that we can flip-flop priorities.
+        priority=$((ipslot + 1))
+        previous="flip-flop"
+      else
+        priority=$((255 - $ipslot))
+        previous=$instancetype
+      fi
     fi
 
     generate_vrrpd_instance_config "$HA_CONFIG_NAME" "$counter" "$vip"  \

--- a/images/ipfailover/keepalived/lib/utils.sh
+++ b/images/ipfailover/keepalived/lib/utils.sh
@@ -3,7 +3,7 @@
 
 #  Constants.
 LIB_DIR=$(dirname "${BASH_SOURCE[0]}")
-VBOX_INTERFACES="enp0s3 enp0s8"
+VBOX_INTERFACES="enp0s3 enp0s8 eth1"
 
 
 #


### PR DESCRIPTION
Fix network interface for recent networking changes to the vagrant env + support to not watch/monitor port for the f5 ipfailover use case.

@rajatchopra   PTAL 
