### PR TITLE
Fix name collisions between build and deployment pods

### DIFF
--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -155,7 +155,12 @@ func mockBuildPodController(build *buildapi.Build) *BuildPodController {
 
 func mockPod(status kapi.PodPhase, exitCode int) *kapi.Pod {
 	return &kapi.Pod{
-		ObjectMeta: kapi.ObjectMeta{Name: "name"},
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "data-build-build",
+			Annotations: map[string]string{
+				buildapi.BuildAnnotation: "data-build",
+			},
+		},
 		Status: kapi.PodStatus{
 			Phase: status,
 			ContainerStatuses: []kapi.ContainerStatus{

--- a/pkg/build/registry/buildlog/rest_test.go
+++ b/pkg/build/registry/buildlog/rest_test.go
@@ -25,15 +25,15 @@ type testPodGetter struct{}
 func (p *testPodGetter) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 	pod := &kapi.Pod{}
 	switch name {
-	case "pending":
+	case "pending-build":
 		pod = mockPod(kapi.PodPending)
-	case "running":
+	case "running-build":
 		pod = mockPod(kapi.PodRunning)
-	case "succeeded":
+	case "succeeded-build":
 		pod = mockPod(kapi.PodSucceeded)
-	case "failed":
+	case "failed-build":
 		pod = mockPod(kapi.PodFailed)
-	case "unknown":
+	case "unknown-build":
 		pod = mockPod(kapi.PodUnknown)
 	}
 	return pod, nil
@@ -45,9 +45,9 @@ func (p *testPodGetter) Get(ctx kapi.Context, name string) (runtime.Object, erro
 // is evaluating the outcome based only on build state.
 func TestRegistryResourceLocation(t *testing.T) {
 	expectedLocations := map[api.BuildStatus]string{
-		api.BuildStatusComplete:  fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running/foo-container", kapi.NamespaceDefault),
-		api.BuildStatusFailed:    fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running/foo-container", kapi.NamespaceDefault),
-		api.BuildStatusRunning:   fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running/foo-container", kapi.NamespaceDefault),
+		api.BuildStatusComplete:  fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running-build/foo-container", kapi.NamespaceDefault),
+		api.BuildStatusFailed:    fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running-build/foo-container", kapi.NamespaceDefault),
+		api.BuildStatusRunning:   fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running-build/foo-container", kapi.NamespaceDefault),
 		api.BuildStatusNew:       "",
 		api.BuildStatusPending:   "",
 		api.BuildStatusError:     "",

--- a/pkg/build/registry/etcd/etcd_test.go
+++ b/pkg/build/registry/etcd/etcd_test.go
@@ -326,7 +326,7 @@ func TestEtcdListBuilds(t *testing.T) {
 func TestEtcdWatchBuilds(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	registry := NewTestEtcd(fakeClient)
-	filterFields := fields.SelectorFromSet(fields.Set{"metadata.name": "foo", "status": string(api.BuildStatusRunning), "podName": "foo"})
+	filterFields := fields.SelectorFromSet(fields.Set{"metadata.name": "foo", "status": string(api.BuildStatusRunning), "podName": "foo-build"})
 
 	watching, err := registry.WatchBuilds(kapi.NewContext(), labels.Everything(), filterFields, "1")
 	if err != nil {

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -6,16 +6,23 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/util/podname"
 )
+
+// BuildPodSuffix is the suffix used to append to a build pod name given a build name
+const BuildPodSuffix = "build"
 
 // GetBuildPodName returns name of the build pod.
 func GetBuildPodName(build *buildapi.Build) string {
-	return build.Name
+	return podname.GetName(build.Name, BuildPodSuffix)
 }
 
 // GetBuildName returns name of the build pod.
 func GetBuildName(pod *kapi.Pod) string {
-	return pod.Name
+	if pod.Annotations == nil {
+		return ""
+	}
+	return pod.Annotations[buildapi.BuildAnnotation]
 }
 
 // GetImageStreamForStrategy returns the ImageStream[Tag/Image] ObjectReference associated

--- a/pkg/build/util/util_test.go
+++ b/pkg/build/util/util_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetBuildPodName(t *testing.T) {
-	if expected, actual := "mybuild", GetBuildPodName(&buildapi.Build{ObjectMeta: kapi.ObjectMeta{Name: "mybuild"}}); expected != actual {
+	if expected, actual := "mybuild-build", GetBuildPodName(&buildapi.Build{ObjectMeta: kapi.ObjectMeta{Name: "mybuild"}}); expected != actual {
 		t.Errorf("Expected %s, got %s", expected, actual)
 	}
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -17,6 +17,7 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployv1 "github.com/openshift/origin/pkg/deploy/api/v1beta1"
 	deployv3 "github.com/openshift/origin/pkg/deploy/api/v1beta3"
+	"github.com/openshift/origin/pkg/util/podname"
 )
 
 // Maps the latest annotation keys to all known previous key names. Keys not represented here
@@ -57,8 +58,12 @@ func LatestDeploymentNameForConfig(config *deployapi.DeploymentConfig) string {
 	return config.Name + "-" + strconv.Itoa(config.LatestVersion)
 }
 
+// DeployerPodSuffix is the suffix added to pods created from a deployment
+const DeployerPodSuffix = "deploy"
+
+// DeployerPodNameForDeployment returns the name of a pod for a given deployment
 func DeployerPodNameForDeployment(deployment *api.ReplicationController) string {
-	return deployment.Name
+	return podname.GetName(deployment.Name, DeployerPodSuffix)
 }
 
 // LabelForDeployment builds a string identifier for a Deployment.

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -44,6 +44,19 @@ func podTemplateD() *kapi.PodTemplateSpec {
 	return t
 }
 
+func TestPodName(t *testing.T) {
+	deployment := &kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "testName",
+		},
+	}
+	expected := "testName-deploy"
+	actual := DeployerPodNameForDeployment(deployment)
+	if expected != actual {
+		t.Errorf("Unexpected pod name for deployment. Expected: %s Got: %s", expected, actual)
+	}
+}
+
 func TestPodSpecsEqualTrue(t *testing.T) {
 	result := PodSpecsEqual(podTemplateA().Spec, podTemplateA().Spec)
 

--- a/pkg/util/podname/doc.go
+++ b/pkg/util/podname/doc.go
@@ -1,0 +1,2 @@
+// Package podname contains a name generator for unique build pod and deployment pod names
+package podname

--- a/pkg/util/podname/namer.go
+++ b/pkg/util/podname/namer.go
@@ -1,0 +1,40 @@
+package podname
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+// GetName returns a pod name given a base ("deployment-5") and a suffix ("deploy")
+// It will first attempt to join them with a dash. If the resulting name is longer
+// than a valid pod name, it will truncate the base name and add an 8-character hash
+// of the [base]-[suffix] string.
+func GetName(base, suffix string) string {
+	name := fmt.Sprintf("%s-%s", base, suffix)
+	if len(name) > util.DNS1123SubdomainMaxLength {
+		prefix := base[0:min(len(base), util.DNS1123SubdomainMaxLength-9)]
+		// Calculate hash on initial base-suffix string
+		name = fmt.Sprintf("%s-%s", prefix, hash(name))
+	}
+	return name
+}
+
+// min returns the lesser of its 2 inputs
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// hash calculates the hexadecimal representation (8-chars)
+// of the hash of the passed in string using the FNV-a algorithm
+func hash(s string) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(s))
+	intHash := hash.Sum32()
+	result := fmt.Sprintf("%08x", intHash)
+	return result
+}

--- a/pkg/util/podname/namer_test.go
+++ b/pkg/util/podname/namer_test.go
@@ -1,0 +1,89 @@
+package podname
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func TestGetName(t *testing.T) {
+
+	for i := 0; i < 10; i++ {
+		shortName := randSeq(rand.Intn(util.DNS1123SubdomainMaxLength-1) + 1)
+		longName := randSeq(util.DNS1123SubdomainMaxLength + rand.Intn(100))
+
+		tests := []struct {
+			base, suffix, expected string
+		}{
+			{
+				base:     shortName,
+				suffix:   "deploy",
+				expected: shortName + "-deploy",
+			},
+			{
+				base:     longName,
+				suffix:   "deploy",
+				expected: longName[:244] + "-" + hash(longName+"-deploy"),
+			},
+			{
+				base:     shortName,
+				suffix:   longName,
+				expected: shortName + "-" + hash(shortName+"-"+longName),
+			},
+			{
+				base:     "",
+				suffix:   shortName,
+				expected: "-" + shortName,
+			},
+			{
+				base:     "",
+				suffix:   longName,
+				expected: "-" + hash("-"+longName),
+			},
+			{
+				base:     shortName,
+				suffix:   "",
+				expected: shortName + "-",
+			},
+			{
+				base:     longName,
+				suffix:   "",
+				expected: longName[:244] + "-" + hash(longName+"-"),
+			},
+		}
+
+		for _, test := range tests {
+			result := GetName(test.base, test.suffix)
+			if result != test.expected {
+				t.Errorf("Got unexpected result. Expected: %s Got: %s", test.expected, result)
+			}
+		}
+	}
+}
+
+func TestGetNameIsDifferent(t *testing.T) {
+	shortName := randSeq(32)
+	deployerName := GetName(shortName, "deploy")
+	builderName := GetName(shortName, "build")
+	if deployerName == builderName {
+		t.Errorf("Expecting names to be different: %s\n", deployerName)
+	}
+	longName := randSeq(util.DNS1123SubdomainMaxLength + 10)
+	deployerName = GetName(longName, "deploy")
+	builderName = GetName(longName, "build")
+	if deployerName == builderName {
+		t.Errorf("Expecting names to be different: %s\n", deployerName)
+	}
+}
+
+// From github.com/GoogleCloudPlatform/kubernetes/pkg/api/generator.go
+var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -562,8 +562,8 @@ func runBuildDeleteTest(t *testing.T, clusterAdminClient *client.Client, cluster
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	pod := event.Object.(*kapi.Pod)
-	if pod.Name != newBuild.Name {
-		t.Fatalf("Expected pod %s to be deleted, but pod %s was deleted", newBuild.Name, pod.Name)
+	if expected := buildutil.GetBuildPodName(newBuild); pod.Name != expected {
+		t.Fatalf("Expected pod %s to be deleted, but pod %s was deleted", expected, pod.Name)
 	}
 
 }
@@ -609,7 +609,7 @@ func runBuildRunningPodDeleteTest(t *testing.T, clusterAdminClient *client.Clien
 		t.Fatalf("expected build status to be marked pending, but was marked %s", newBuild.Status)
 	}
 
-	clusterAdminKubeClient.Pods(testutil.Namespace()).Delete(newBuild.Name, kapi.NewDeleteOptions(0))
+	clusterAdminKubeClient.Pods(testutil.Namespace()).Delete(buildutil.GetBuildPodName(newBuild), kapi.NewDeleteOptions(0))
 	event = waitForWatch(t, "build updated to error", buildWatch)
 	if e, a := watchapi.Modified, event.Type; e != a {
 		t.Fatalf("expected watch event type %s, got %s", e, a)
@@ -673,7 +673,7 @@ func runBuildCompletePodDeleteTest(t *testing.T, clusterAdminClient *client.Clie
 		t.Fatalf("expected build status to be marked complete, but was marked %s", newBuild.Status)
 	}
 
-	clusterAdminKubeClient.Pods(testutil.Namespace()).Delete(newBuild.Name, kapi.NewDeleteOptions(0))
+	clusterAdminKubeClient.Pods(testutil.Namespace()).Delete(buildutil.GetBuildPodName(newBuild), kapi.NewDeleteOptions(0))
 	time.Sleep(10 * time.Second)
 	newBuild, err = clusterAdminClient.Builds(testutil.Namespace()).Get(newBuild.Name)
 	if err != nil {


### PR DESCRIPTION
To avoid conflicts between builds and deployments, pods will now be named with a suffix ("-build" or "-deploy"). If the name exceeds a valid pod name length, then the name will be truncated and a hash of the entire name will be appended at the end.