### PR TITLE
Removing unnecessary namespace prefix for deployment/deploymentConfig/Repo

### DIFF
--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -42,7 +42,7 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 	}
 
 	if !hasChangeTrigger {
-		glog.V(4).Infof("Ignoring DeploymentConfig %s/%s; no change triggers detected", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("Ignoring DeploymentConfig %s; no change triggers detected", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -50,11 +50,11 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 		_, _, err := c.generateDeployment(config)
 		if err != nil {
 			if kerrors.IsConflict(err) {
-				return fatalError(fmt.Sprintf("DeploymentConfig %s/%s updated since retrieval; aborting trigger: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err))
+				return fatalError(fmt.Sprintf("DeploymentConfig %s updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
 			}
-			return fmt.Errorf("couldn't create initial Deployment for DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+			return fmt.Errorf("couldn't create initial Deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 		}
-		glog.V(4).Infof("Created initial Deployment for DeploymentConfig %s/%s", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("Created initial Deployment for DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -62,15 +62,15 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 	deployment, err := c.changeStrategy.getDeployment(config.Namespace, latestDeploymentName)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			glog.V(2).Infof("Ignoring change for DeploymentConfig %s/%s; no existing Deployment found", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+			glog.V(2).Infof("Ignoring change for DeploymentConfig %s; no existing Deployment found", deployutil.LabelForDeploymentConfig(config))
 			return nil
 		}
-		return fmt.Errorf("couldn't retrieve Deployment for DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("couldn't retrieve Deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 
 	deployedConfig, err := c.decodeConfig(deployment)
 	if err != nil {
-		return fatalError(fmt.Sprintf("error decoding DeploymentConfig from Deployment %s for DeploymentConfig %s/%s: %v", deployutil.LabelForDeployment(deployment), config.Namespace, deployutil.LabelForDeploymentConfig(config), err))
+		return fatalError(fmt.Sprintf("error decoding DeploymentConfig from Deployment %s for DeploymentConfig %s: %v", deployutil.LabelForDeployment(deployment), deployutil.LabelForDeploymentConfig(config), err))
 	}
 
 	if deployutil.PodSpecsEqual(config.Template.ControllerTemplate.Template.Spec, deployedConfig.Template.ControllerTemplate.Template.Spec) {
@@ -81,11 +81,11 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 	fromVersion, toVersion, err := c.generateDeployment(config)
 	if err != nil {
 		if kerrors.IsConflict(err) {
-			return fatalError(fmt.Sprintf("DeploymentConfig %s/%s updated since retrieval; aborting trigger: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err))
+			return fatalError(fmt.Sprintf("DeploymentConfig %s updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
 		}
-		return fmt.Errorf("couldn't generate deployment for DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("couldn't generate deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
-	glog.V(4).Infof("Updated DeploymentConfig %s/%s from version %d to %d for existing deployment %s", config.Namespace, deployutil.LabelForDeploymentConfig(config), fromVersion, toVersion, deployutil.LabelForDeployment(deployment))
+	glog.V(4).Infof("Updated DeploymentConfig %s from version %d to %d for existing deployment %s", deployutil.LabelForDeploymentConfig(config), fromVersion, toVersion, deployutil.LabelForDeployment(deployment))
 	return nil
 }
 

--- a/pkg/deploy/controller/deployerpod/controller.go
+++ b/pkg/deploy/controller/deployerpod/controller.go
@@ -53,9 +53,9 @@ func (c *DeployerPodController) Handle(pod *kapi.Pod) error {
 	if currentStatus != nextStatus {
 		deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(nextStatus)
 		if _, err := c.deploymentClient.updateDeployment(deployment.Namespace, deployment); err != nil {
-			return fmt.Errorf("couldn't update Deployment %s/%s to status %s: %v", deployment.Namespace, deployutil.LabelForDeployment(deployment), nextStatus, err)
+			return fmt.Errorf("couldn't update Deployment %s to status %s: %v", deployutil.LabelForDeployment(deployment), nextStatus, err)
 		}
-		glog.V(4).Infof("Updated Deployment %s/%s status from %s to %s", deployment.Namespace, deployutil.LabelForDeployment(deployment), currentStatus, nextStatus)
+		glog.V(4).Infof("Updated Deployment %s status from %s to %s", deployutil.LabelForDeployment(deployment), currentStatus, nextStatus)
 	}
 
 	return nil

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -58,7 +58,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 	// Check if any existing inflight deployments (any non-terminal state).
 	existingDeployments, err := c.deploymentClient.listDeploymentsForConfig(config.Namespace, config.Name)
 	if err != nil {
-		return fmt.Errorf("couldn't list Deployments for DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("couldn't list Deployments for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 	var inflightDeployment *kapi.ReplicationController
 	for _, deployment := range existingDeployments.Items {
@@ -84,9 +84,9 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 			deploymentForCancellation.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
 			deploymentForCancellation.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledNewerDeploymentExists
 			if _, err := c.deploymentClient.updateDeployment(deploymentForCancellation.Namespace, deploymentForCancellation); err != nil {
-				glog.Errorf("couldn't cancel Deployment %s/%s: %v", deploymentForCancellation.Namespace, deployutil.LabelForDeployment(deploymentForCancellation), err)
+				glog.Errorf("couldn't cancel Deployment %s: %v", deployutil.LabelForDeployment(deploymentForCancellation), err)
 			}
-			glog.V(4).Infof("Cancelled Deployment %s for DeploymentConfig %s/%s", deployutil.LabelForDeployment(deploymentForCancellation), config.Namespace, deployutil.LabelForDeploymentConfig(config))
+			glog.V(4).Infof("Cancelled Deployment %s for DeploymentConfig %s", deployutil.LabelForDeployment(deploymentForCancellation), deployutil.LabelForDeploymentConfig(config))
 		}
 	}
 
@@ -98,14 +98,14 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 			return nil
 		}
 		// if this is an earlier deployment, raise a transientError so that the deployment config can be re-queued
-		glog.V(4).Infof("Found previous inflight Deployment for %s/%s - will requeue", config.Namespace, deployutil.LabelForDeploymentConfig(config))
-		return transientError(fmt.Sprintf("found previous inflight Deployment for %s/%s - requeuing", config.Namespace, deployutil.LabelForDeploymentConfig(config)))
+		glog.V(4).Infof("Found previous inflight Deployment for %s - will requeue", deployutil.LabelForDeploymentConfig(config))
+		return transientError(fmt.Sprintf("found previous inflight Deployment for %s - requeuing", deployutil.LabelForDeploymentConfig(config)))
 	}
 
 	// Try and build a deployment for the config.
 	deployment, err := c.makeDeployment(config)
 	if err != nil {
-		return fatalError(fmt.Sprintf("couldn't make Deployment from (potentially invalid) DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err))
+		return fatalError(fmt.Sprintf("couldn't make Deployment from (potentially invalid) DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err))
 	}
 
 	// Compute the desired replicas for the deployment. The count should match
@@ -127,20 +127,20 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 
 	// Create the deployment.
 	if _, err := c.deploymentClient.createDeployment(config.Namespace, deployment); err == nil {
-		glog.V(4).Infof("Created Deployment for DeploymentConfig %s/%s", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("Created Deployment for DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	} else {
 		// If the deployment was already created, just move on. The cache could be stale, or another
 		// process could have already handled this update.
 		if errors.IsAlreadyExists(err) {
-			c.recorder.Eventf(config, "alreadyExists", "Deployment already exists for DeploymentConfig: %s/%s", config.Namespace, deployutil.LabelForDeploymentConfig(config))
-			glog.V(4).Infof("Deployment already exists for DeploymentConfig %s/%s", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+			c.recorder.Eventf(config, "alreadyExists", "Deployment already exists for DeploymentConfig: %s", deployutil.LabelForDeploymentConfig(config))
+			glog.V(4).Infof("Deployment already exists for DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
 			return nil
 		}
 
 		// log an event if the deployment could not be created that the user can discover
 		c.recorder.Eventf(config, "failedCreate", "Error creating: %v", err)
-		return fmt.Errorf("couldn't create Deployment for DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("couldn't create Deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 }
 

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -29,13 +29,13 @@ func (e fatalError) Error() string {
 func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 	configs, err := c.deploymentConfigClient.listDeploymentConfigs()
 	if err != nil {
-		return fmt.Errorf("couldn't get list of DeploymentConfig while handling ImageStream %s/%s: %v", imageRepo.Namespace, labelForRepo(imageRepo), err)
+		return fmt.Errorf("couldn't get list of DeploymentConfig while handling ImageStream %s: %v", labelForRepo(imageRepo), err)
 	}
 
 	// Find any configs which should be updated based on the new image state
 	configsToUpdate := map[string]*deployapi.DeploymentConfig{}
 	for _, config := range configs {
-		glog.V(4).Infof("Detecting changed images for DeploymentConfig %s/%s", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("Detecting changed images for DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
 
 		for _, trigger := range config.Triggers {
 			params := trigger.ImageChangeParams
@@ -53,7 +53,7 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 			// Find the latest tag event for the trigger tag
 			latestEvent := imageapi.LatestTaggedImage(imageRepo, params.Tag)
 			if latestEvent == nil {
-				glog.V(2).Infof("Couldn't find latest tag event for tag %s in ImageStream %s/%s", params.Tag, imageRepo.Namespace, labelForRepo(imageRepo))
+				glog.V(2).Infof("Couldn't find latest tag event for tag %s in ImageStream %s", params.Tag, labelForRepo(imageRepo))
 				continue
 			}
 
@@ -72,18 +72,18 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 		err := c.regenerate(config)
 		if err != nil {
 			anyFailed = true
-			glog.V(2).Infof("Couldn't regenerate DeploymentConfig %s/%s: %s", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+			glog.V(2).Infof("Couldn't regenerate DeploymentConfig %s: %s", deployutil.LabelForDeploymentConfig(config), err)
 			continue
 		}
 
-		glog.V(4).Infof("Regenerated DeploymentConfig %s/%s in response to image change trigger", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("Regenerated DeploymentConfig %s in response to image change trigger", deployutil.LabelForDeploymentConfig(config))
 	}
 
 	if anyFailed {
-		return fatalError(fmt.Sprintf("couldn't update some DeploymentConfig for trigger on ImageStream %s/%s", imageRepo.Namespace, labelForRepo(imageRepo)))
+		return fatalError(fmt.Sprintf("couldn't update some DeploymentConfig for trigger on ImageStream %s", labelForRepo(imageRepo)))
 	}
 
-	glog.V(4).Infof("Updated all DeploymentConfigs for trigger on ImageStream %s/%s", imageRepo.Namespace, labelForRepo(imageRepo))
+	glog.V(4).Infof("Updated all DeploymentConfigs for trigger on ImageStream %s", labelForRepo(imageRepo))
 	return nil
 }
 
@@ -119,12 +119,12 @@ func (c *ImageChangeController) regenerate(config *deployapi.DeploymentConfig) e
 	// Get a regenerated config which includes the new image repo references
 	newConfig, err := c.deploymentConfigClient.generateDeploymentConfig(config.Namespace, config.Name)
 	if err != nil {
-		return fmt.Errorf("error generating new version of DeploymentConfig %s/%s: %v", config.Namespace, deployutil.LabelForDeploymentConfig(config), err)
+		return fmt.Errorf("error generating new version of DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
 	}
 
 	// No update occured
 	if config.LatestVersion == newConfig.LatestVersion {
-		glog.V(4).Infof("No version difference for generated DeploymentConfig %s/%s", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+		glog.V(4).Infof("No version difference for generated DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -134,7 +134,7 @@ func (c *ImageChangeController) regenerate(config *deployapi.DeploymentConfig) e
 		return err
 	}
 
-	glog.Infof("Regenerated DeploymentConfig %s/%s for image updates", config.Namespace, deployutil.LabelForDeploymentConfig(config))
+	glog.Infof("Regenerated DeploymentConfig %s for image updates", deployutil.LabelForDeploymentConfig(config))
 	return nil
 }
 


### PR DESCRIPTION
Noticed that the:
- LabelForDeploymentConfig
- LabelForDeployment
- labelForRepo

functions already contain namespace prefix, so removing it.
@ironcladlou fyi