### PR TITLE
Deployer pod failure detection improvements

### DIFF
--- a/pkg/deploy/controller/deployerpod/controller.go
+++ b/pkg/deploy/controller/deployerpod/controller.go
@@ -40,14 +40,16 @@ func (c *DeployerPodController) Handle(pod *kapi.Pod) error {
 	switch pod.Status.Phase {
 	case kapi.PodRunning:
 		nextStatus = deployapi.DeploymentStatusRunning
-	case kapi.PodSucceeded, kapi.PodFailed:
-		nextStatus = deployapi.DeploymentStatusComplete
+	case kapi.PodSucceeded:
 		// Detect failure based on the container state
+		nextStatus = deployapi.DeploymentStatusComplete
 		for _, info := range pod.Status.ContainerStatuses {
 			if info.State.Termination != nil && info.State.Termination.ExitCode != 0 {
 				nextStatus = deployapi.DeploymentStatusFailed
 			}
 		}
+	case kapi.PodFailed:
+		nextStatus = deployapi.DeploymentStatusFailed
 	}
 
 	if currentStatus != nextStatus {

--- a/pkg/deploy/controller/deployerpod/controller_test.go
+++ b/pkg/deploy/controller/deployerpod/controller_test.go
@@ -160,6 +160,42 @@ func TestHandle_podTerminatedFail(t *testing.T) {
 	}
 }
 
+// TestHandle_podTerminatedFailNoContainerStatus ensures that a failed
+// deployer pod with no container status results in a transition of the
+// deployment's status to failed.
+func TestHandle_podTerminatedFailNoContainerStatus(t *testing.T) {
+	var updatedDeployment *kapi.ReplicationController
+
+	controller := &DeployerPodController{
+		deploymentClient: &deploymentClientImpl{
+			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				config := deploytest.OkDeploymentConfig(1)
+				deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
+				deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(deployapi.DeploymentStatusRunning)
+				return deployment, nil
+			},
+			updateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
+				updatedDeployment = deployment
+				return deployment, nil
+			},
+		},
+	}
+
+	err := controller.Handle(terminatedPod())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if updatedDeployment == nil {
+		t.Fatalf("expected deployment update")
+	}
+
+	if e, a := deployapi.DeploymentStatusFailed, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
+		t.Fatalf("expected updated deployment status %s, got %s", e, a)
+	}
+}
+
 func okPod() *kapi.Pod {
 	return &kapi.Pod{
 		ObjectMeta: kapi.ObjectMeta{
@@ -194,6 +230,12 @@ func failedPod() *kapi.Pod {
 			},
 		},
 	}
+	return p
+}
+
+func terminatedPod() *kapi.Pod {
+	p := okPod()
+	p.Status.Phase = kapi.PodFailed
 	return p
 }
 


### PR DESCRIPTION
When a pod is terminated by the kubelet in response to the deadline
being exceeded, there is no container status present to inspect on
the pod. The pod status will still be PodFailed.

Adjust the deployer pod failure detection to account for this. When
the pod status is PodSucceeded, use container status to decide if the
deployment failed. When the pod status is PodFailed, consider the
deployment a failure regardless of whether container status is available.