### PR TITLE
Refactor deploy retry to create a new deployment

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -240,10 +240,11 @@ func (c *retryDeploymentCommand) retry(config *deployapi.DeploymentConfig, out i
 		return fmt.Errorf("#%d is %s; only failed deployments can be retried", config.LatestVersion, status)
 	}
 
-	deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(deployapi.DeploymentStatusNew)
-	_, err = c.client.UpdateDeployment(deployment)
+	previousVersion := config.LatestVersion
+	config.LatestVersion++
+	_, err = c.client.UpdateDeploymentConfig(config)
 	if err == nil {
-		fmt.Fprintf(out, "retried #%d\n", config.LatestVersion)
+		fmt.Fprintf(out, "deployed #%d (retry of #%d)\n", config.LatestVersion, previousVersion)
 	}
 	return err
 }


### PR DESCRIPTION
Now that deployer names are deterministic, the retry function can't
simply reset the status of a deployment, as the infra will attempt
to recreate a deployer with the same name as the reset deployment.

Instead, just create a new deployment upon retry.

Closes #2558