### PR TITLE
allow stats user/port/password to be configured

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -23,13 +23,15 @@ defaults
   # Long timeout for WebSocket connections.
   timeout tunnel 1h
 
-listen stats :1936
+{{ if and (and (ne .StatsUser "") (ne .StatsPassword "")) (gt .StatsPort 0) }}
+listen stats :{{.StatsPort}}
     mode http
     stats enable
     stats hide-version
     stats realm Haproxy\ Statistics
     stats uri /
-    stats auth admin:cEVu2hUb
+    stats auth {{.StatsUser}}:{{.StatsPassword}}
+{{ end }}
 
 frontend public
   bind :80

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -64,6 +66,9 @@ type RouterConfig struct {
 	Credentials        string
 	DefaultCertificate string
 	Selector           string
+	StatsPort          int
+	StatsPassword      string
+	StatsUsername      string
 }
 
 var errExit = fmt.Errorf("exit")
@@ -77,6 +82,8 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 		Labels:   defaultLabel,
 		Ports:    "80:80,443:443,1936:1936",
 		Replicas: 1,
+
+		StatsUsername: "admin",
 	}
 
 	cmd := &cobra.Command{
@@ -105,6 +112,9 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 	cmd.Flags().StringVar(&cfg.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.")
 	cmd.Flags().StringVar(&cfg.DefaultCertificate, "default-cert", cfg.DefaultCertificate, "Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.")
 	cmd.Flags().StringVar(&cfg.Selector, "selector", cfg.Selector, "Selector used to filter nodes on deployment. Used to run routers on a specific set of nodes.")
+	cmd.Flags().IntVar(&cfg.StatsPort, "stats-port", 1936, "If the underlying router implementation can provide statistics this is a hint to expose it on this port.")
+	cmd.Flags().StringVar(&cfg.StatsPassword, "stats-password", cfg.StatsPassword, "If the underlying router implementation can provide statistics this is the requested password for auth.  If not set a password will be generated.")
+	cmd.Flags().StringVar(&cfg.StatsUsername, "stats-user", cfg.StatsUsername, "If the underlying router implementation can provide statistics this is the requested username for auth.")
 
 	cmdutil.AddPrinterFlags(cmd)
 
@@ -131,6 +141,12 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 		name = args[0]
 	default:
 		return cmdutil.UsageError(cmd, "You may pass zero or one arguments to provide a name for the router")
+	}
+
+	if len(cfg.StatsUsername) > 0 {
+		if strings.Contains(cfg.StatsUsername, ":") {
+			return cmdutil.UsageError(cmd, "username %s must not contain ':'", cfg.StatsUsername)
+		}
 	}
 
 	ports, err := app.ContainerPortsFromString(cfg.Ports)
@@ -221,6 +237,11 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			return fmt.Errorf("router could not be created; error reading default certificate file", err)
 		}
 
+		if len(cfg.StatsPassword) == 0 {
+			cfg.StatsPassword = generateStatsPassword()
+			fmt.Fprintf(out, "password for stats user %s has been set to %s\n", cfg.StatsUsername, cfg.StatsPassword)
+		}
+
 		env := app.Environment{
 			"OPENSHIFT_MASTER":         config.Host,
 			"OPENSHIFT_CA_DATA":        string(config.CAData),
@@ -230,6 +251,9 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			"DEFAULT_CERTIFICATE":      defaultCert,
 			"ROUTER_SERVICE_NAME":      name,
 			"ROUTER_SERVICE_NAMESPACE": namespace,
+			"STATS_PORT":               strconv.Itoa(cfg.StatsPort),
+			"STATS_USERNAME":           cfg.StatsUsername,
+			"STATS_PASSWORD":           cfg.StatsPassword,
 		}
 
 		objects := []runtime.Object{
@@ -304,4 +328,16 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 
 	fmt.Fprintf(out, "Router %q service exists\n", name)
 	return nil
+}
+
+// generateStatsPassword creates a random password
+func generateStatsPassword() string {
+	allowableChars := []rune("abcdefghijlkmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+	allowableCharLength := len(allowableChars)
+	password := []string{}
+	for i := 0; i < 10; i++ {
+		char := allowableChars[rand.Intn(allowableCharLength)]
+		password = append(password, string(char))
+	}
+	return strings.Join(password, "")
 }


### PR DESCRIPTION
In this PR

1.  Additions to the router and ex router command to allow passing of stats information via flags.  At least a password is required, port will default to '1936' and user will default to 'admin' in ex router
1.  Refactor to use config objects rather than extending the list of args passed into the create methods now that we've exceeded 3
1.  Update to haproxy template to only write stats directives if user/port/password is configured

@rajatchopra @ramr @smarterclayton ptal

cc @liggitt @brenton 

resolves https://github.com/openshift/origin/issues/2500