### PR TITLE
make subcommands return non-zero status on failures

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -311,6 +311,8 @@ echo "templates: ok"
 [ "$(openshift admin policy TYPO; echo $? | grep '1')" ]
 [ "$(openshift admin TYPO; echo $? | grep '1')" ]
 [ "$(openshift cli TYPO; echo $? | grep '1')" ]
+[ "$(osc policy TYPO; echo $? | grep '1')" ]
+
 osc get pods --match-server-version
 osc create -f examples/hello-openshift/hello-pod.json
 osc describe pod hello-openshift
@@ -525,6 +527,13 @@ openshift admin policy add-cluster-role-to-group cluster-admin system:unauthenti
 openshift admin policy remove-cluster-role-from-group cluster-admin system:unauthenticated
 openshift admin policy add-cluster-role-to-user cluster-admin system:no-user
 openshift admin policy remove-cluster-role-from-user cluster-admin system:no-user
+
+osc policy add-role-to-group cluster-admin system:unauthenticated
+osc policy add-role-to-user cluster-admin system:no-user
+osc policy remove-role-from-group cluster-admin system:unauthenticated
+osc policy remove-role-from-user cluster-admin system:no-user
+osc policy remove-group system:unauthenticated
+osc policy remove-user system:no-user
 echo "ex policy: ok"
 
 # Test the commands the UI projects page tells users to run

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -292,8 +292,8 @@ echo "templates: ok"
 
 # help for given command through help command must be consistent
 [ "$(osc help get 2>&1 | grep 'Display one or many resources')" ]
-[ "$(openshift cli help get 2>&1 | grep 'Display one or many resources')" ]
-[ "$(openshift kubectl help get 2>&1 | grep 'Display one or many resources')" ]
+[ "$(openshift help cli get 2>&1 | grep 'Display one or many resources')" ]
+[ "$(openshift help kubectl get 2>&1 | grep 'Display one or many resources')" ]
 [ "$(openshift help start 2>&1 | grep 'Start an OpenShift all-in-one server')" ]
 [ "$(openshift help start master 2>&1 | grep 'Start an OpenShift master')" ]
 [ "$(openshift help start node 2>&1 | grep 'Start an OpenShift node')" ]
@@ -307,6 +307,10 @@ echo "templates: ok"
 # commands that expect file paths must validate and error out correctly
 [ "$(osc login --certificate-authority=/path/to/invalid 2>&1 | grep 'no such file or directory')" ]
 
+# make sure that typoed commands come back with non-zero return codes
+[ "$(openshift admin policy TYPO; echo $? | grep '1')" ]
+[ "$(openshift admin TYPO; echo $? | grep '1')" ]
+[ "$(openshift cli TYPO; echo $? | grep '1')" ]
 osc get pods --match-server-version
 osc create -f examples/hello-openshift/hello-pod.json
 osc describe pod hello-openshift

--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -16,6 +16,7 @@ import (
 	exregistry "github.com/openshift/origin/pkg/cmd/experimental/registry"
 	exrouter "github.com/openshift/origin/pkg/cmd/experimental/router"
 	"github.com/openshift/origin/pkg/cmd/server/admin"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/version"
 )
@@ -34,10 +35,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 		Use:   name,
 		Short: "Tools for managing an OpenShift cluster",
 		Long:  fmt.Sprintf(adminLong),
-		Run: func(c *cobra.Command, args []string) {
-			c.SetOutput(out)
-			c.Help()
-		},
+		Run:   cmdutil.DefaultSubCommandRun(out),
 	}
 
 	f := clientcmd.New(cmds.PersistentFlags())

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -14,6 +14,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -25,7 +26,7 @@ func NewCommandPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer
 		Use:   name,
 		Short: "Manage authorization policy",
 		Long:  `Manage authorization policy`,
-		Run:   runHelp,
+		Run:   cmdutil.DefaultSubCommandRun(out),
 	}
 
 	cmds.AddCommand(NewCmdWhoCan(WhoCanRecommendedName, fullName+" "+WhoCanRecommendedName, f, out))
@@ -43,10 +44,6 @@ func NewCommandPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer
 	cmds.AddCommand(NewCmdRemoveClusterRoleFromGroup(RemoveClusterRoleFromGroupRecommendedName, fullName+" "+RemoveClusterRoleFromGroupRecommendedName, f, out))
 
 	return cmds
-}
-
-func runHelp(cmd *cobra.Command, args []string) {
-	cmd.Help()
 }
 
 func getFlagString(cmd *cobra.Command, flag string) string {

--- a/pkg/cmd/admin/prune/prune.go
+++ b/pkg/cmd/admin/prune/prune.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -21,15 +22,11 @@ func NewCommandPrune(name, fullName string, f *clientcmd.Factory, out io.Writer)
 		Use:   name,
 		Short: "Remove older versions of resources from the server",
 		Long:  pruneLong,
-		Run:   runHelp,
+		Run:   cmdutil.DefaultSubCommandRun(out),
 	}
 
 	cmds.AddCommand(NewCmdPruneBuilds(f, fullName, PruneBuildsRecommendedName, out))
 	cmds.AddCommand(NewCmdPruneDeployments(f, fullName, PruneDeploymentsRecommendedName, out))
 	cmds.AddCommand(NewCmdPruneImages(f, fullName, PruneImagesRecommendedName, out))
 	return cmds
-}
-
-func runHelp(cmd *cobra.Command, args []string) {
-	cmd.Help()
 }

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
 
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/policy"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/version"
@@ -94,6 +95,8 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	cmds.AddCommand(cmd.NewCmdResize(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdStop(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdLabel(fullName, f, out))
+
+	cmds.AddCommand(policy.NewCommandPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out))
 
 	return cmds
 }

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	kubecmd "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
 
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/version"
 )
@@ -46,21 +47,19 @@ Note: This is a beta release of OpenShift and may change significantly.  See
     https://github.com/openshift/origin for the latest information on OpenShift.`
 
 func NewCommandCLI(name, fullName string) *cobra.Command {
+	in := os.Stdin
+	out := os.Stdout
+
 	// Main command
 	cmds := &cobra.Command{
 		Use:   name,
 		Short: "Client tools for OpenShift",
 		Long:  fmt.Sprintf(cli_long, fullName),
-		Run: func(c *cobra.Command, args []string) {
-			c.SetOutput(os.Stdout)
-			c.Help()
-		},
+		Run:   cmdutil.DefaultSubCommandRun(out),
 		BashCompletionFunction: bashCompletionFunc,
 	}
 
 	f := clientcmd.New(cmds.PersistentFlags())
-	in := os.Stdin
-	out := os.Stdout
 
 	cmds.AddCommand(cmd.NewCmdLogin(fullName, f, in, out))
 	cmds.AddCommand(cmd.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out))

--- a/pkg/cmd/cli/policy/policy.go
+++ b/pkg/cmd/cli/policy/policy.go
@@ -1,0 +1,41 @@
+package policy
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	adminpolicy "github.com/openshift/origin/pkg/cmd/admin/policy"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const PolicyRecommendedName = "policy"
+
+func NewCommandPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   name,
+		Short: "Manage authorization policy",
+		Long:  `Manage authorization policy`,
+		Run:   runHelp,
+	}
+
+	cmds.AddCommand(adminpolicy.NewCmdWhoCan(adminpolicy.WhoCanRecommendedName, fullName+" "+adminpolicy.WhoCanRecommendedName, f, out))
+
+	cmds.AddCommand(adminpolicy.NewCmdAddRoleToUser(adminpolicy.AddRoleToUserRecommendedName, fullName+" "+adminpolicy.AddRoleToUserRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdRemoveRoleFromUser(adminpolicy.RemoveRoleFromUserRecommendedName, fullName+" "+adminpolicy.RemoveRoleFromUserRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdRemoveUserFromProject(adminpolicy.RemoveUserRecommendedName, fullName+" "+adminpolicy.RemoveUserRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdAddRoleToGroup(adminpolicy.AddRoleToGroupRecommendedName, fullName+" "+adminpolicy.AddRoleToGroupRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdRemoveRoleFromGroup(adminpolicy.RemoveRoleFromGroupRecommendedName, fullName+" "+adminpolicy.RemoveRoleFromGroupRecommendedName, f, out))
+	cmds.AddCommand(adminpolicy.NewCmdRemoveGroupFromProject(adminpolicy.RemoveGroupRecommendedName, fullName+" "+adminpolicy.RemoveGroupRecommendedName, f, out))
+
+	return cmds
+}
+
+func runHelp(cmd *cobra.Command, args []string) {
+	cmd.Help()
+
+	// make sure that we exit with non-zero status so that typoed commands don't look like they were successful
+	os.Exit(1)
+}

--- a/pkg/cmd/util/cmd.go
+++ b/pkg/cmd/util/cmd.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
+	return func(c *cobra.Command, args []string) {
+		c.SetOutput(out)
+
+		if len(args) > 0 {
+			kcmdutil.CheckErr(kcmdutil.UsageError(c, fmt.Sprintf(`unknown command "%s"`, strings.Join(args, " "))))
+		}
+
+		c.Help()
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/2518

Makes subcommands return non-zero status on failures.  Also creates `osc policy` for handling non-cluster admin policy commands.