### PR TITLE
make api levels configuratable

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -11,6 +11,7 @@ import (
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/client"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -333,4 +334,14 @@ func IsOAuthIdentityProvider(provider IdentityProvider) bool {
 	}
 
 	return false
+}
+
+func HasOpenShiftAPILevel(config MasterConfig, apiLevel string) bool {
+	apiLevelSet := util.NewStringSet(config.APILevels...)
+	return apiLevelSet.Has(apiLevel)
+}
+
+func HasKubernetesAPILevel(config KubernetesMasterConfig, apiLevel string) bool {
+	apiLevelSet := util.NewStringSet(config.APILevels...)
+	return apiLevelSet.Has(apiLevel)
 }

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -6,6 +6,15 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
+var (
+	KnownKubernetesAPILevels   = []string{"v1beta1", "v1beta2", "v1beta3", "v1"}
+	KnownOpenShiftAPILevels    = []string{"v1beta1", "v1beta3", "v1"}
+	DefaultKubernetesAPILevels = []string{"v1beta1", "v1beta2", "v1beta3", "v1"}
+	DefaultOpenShiftAPILevels  = []string{"v1beta1", "v1beta3", "v1"}
+	DeadKubernetesAPILevels    = []string{}
+	DeadOpenShiftAPILevels     = []string{}
+)
+
 // NodeConfig is the fully specified config starting an OpenShift node
 type NodeConfig struct {
 	api.TypeMeta
@@ -50,6 +59,9 @@ type MasterConfig struct {
 
 	// CORSAllowedOrigins
 	CORSAllowedOrigins []string
+
+	// APILevels is a list of API levels that should be enabled on startup: v1beta1, v1beta3, v1 as examples
+	APILevels []string
 
 	// MasterPublicURL is how clients can access the OpenShift API server
 	MasterPublicURL string
@@ -432,6 +444,8 @@ type EtcdConfig struct {
 }
 
 type KubernetesMasterConfig struct {
+	// APILevels is a list of API levels that should be enabled on startup: v1beta1, v1beta2, v1beta3, v1 as examples
+	APILevels []string
 	// MasterIP is the public IP address of kubernetes stuff.  If empty, the first result from net.InterfaceAddrs will be used.
 	MasterIP string
 	// MasterCount is the number of expected masters that should be running. This value defaults to 1 and may be set to a positive integer.

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -8,9 +8,17 @@ import (
 
 func init() {
 	err := newer.Scheme.AddDefaultingFuncs(
+		func(obj *MasterConfig) {
+			if len(obj.APILevels) == 0 {
+				obj.APILevels = newer.DefaultOpenShiftAPILevels
+			}
+		},
 		func(obj *KubernetesMasterConfig) {
 			if obj.MasterCount == 0 {
 				obj.MasterCount = 1
+			}
+			if len(obj.APILevels) == 0 {
+				obj.APILevels = newer.DefaultKubernetesAPILevels
 			}
 		},
 		func(obj *EtcdStorageConfig) {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -50,6 +50,9 @@ type MasterConfig struct {
 	// CORSAllowedOrigins
 	CORSAllowedOrigins []string `json:"corsAllowedOrigins"`
 
+	// APILevels is a list of API levels that should be enabled on startup: v1beta1, v1beta3, v1 as examples
+	APILevels []string `json:"apiLevels"`
+
 	// MasterPublicURL is how clients can access the OpenShift API server
 	MasterPublicURL string `json:"masterPublicURL"`
 
@@ -421,7 +424,9 @@ type EtcdConfig struct {
 }
 
 type KubernetesMasterConfig struct {
-	MasterIP string `json:"masterIP"`
+	// APILevels is a list of API levels that should be enabled on startup: v1beta1, v1beta2, v1beta3, v1 as examples
+	APILevels []string `json:"apiLevels"`
+	MasterIP  string   `json:"masterIP"`
 	// MasterCount is the number of expected masters that should be running. This value defaults to 1 and may be set to a positive integer.
 	MasterCount         int      `json:"masterCount"`
 	ServicesSubnet      string   `json:"servicesSubnet"`

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -42,7 +42,8 @@ volumeDirectory: ""
 	// Before modifying this constant, ensure any changes have corresponding issues filed for:
 	// - documentation: https://github.com/openshift/openshift-docs/
 	// - install: https://github.com/openshift/openshift-ansible/
-	expectedSerializedMasterConfig = `apiVersion: v1
+	expectedSerializedMasterConfig = `apiLevels: null
+apiVersion: v1
 assetConfig:
   logoutURL: ""
   masterPublicURL: ""
@@ -89,6 +90,7 @@ kubeletClientInfo:
   keyFile: ""
   port: 0
 kubernetesMasterConfig:
+  apiLevels: null
   masterCount: 0
   masterIP: ""
   schedulerConfigFile: ""

--- a/pkg/cmd/server/api/validation/allinone.go
+++ b/pkg/cmd/server/api/validation/allinone.go
@@ -1,19 +1,17 @@
 package validation
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
-
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-func ValidateAllInOneConfig(master *api.MasterConfig, node *api.NodeConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
+func ValidateAllInOneConfig(master *api.MasterConfig, node *api.NodeConfig) ValidationResults {
+	validationResults := ValidationResults{}
 
-	allErrs = append(allErrs, ValidateMasterConfig(master).Prefix("masterConfig")...)
+	validationResults.Append(ValidateMasterConfig(master).Prefix("masterConfig"))
 
-	allErrs = append(allErrs, ValidateNodeConfig(node).Prefix("nodeConfig")...)
+	validationResults.AddErrors(ValidateNodeConfig(node).Prefix("nodeConfig")...)
 
 	// Validation between the configs
 
-	return allErrs
+	return validationResults
 }

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/scheduler/factory"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/namespace"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 )
 
 const (
@@ -54,7 +56,7 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 	}
 
 	masterConfig := &master.Config{
-		PublicAddress: c.MasterIP,
+		PublicAddress: net.ParseIP(c.Options.MasterIP),
 		ReadWritePort: c.MasterPort,
 		ReadOnlyPort:  c.MasterPort,
 
@@ -70,14 +72,17 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 		KubeletClient:    kubeletClient,
 		APIPrefix:        KubeAPIPrefix,
 
-		EnableV1: true,
-
 		EnableCoreControllers: true,
 
-		MasterCount: c.MasterCount,
+		MasterCount: c.Options.MasterCount,
 
 		Authorizer:       c.Authorizer,
 		AdmissionControl: c.AdmissionControl,
+
+		DisableV1Beta1: !configapi.HasKubernetesAPILevel(c.Options, "v1beta1"),
+		DisableV1Beta2: !configapi.HasKubernetesAPILevel(c.Options, "v1beta2"),
+		DisableV1Beta3: !configapi.HasKubernetesAPILevel(c.Options, "v1beta3"),
+		EnableV1:       configapi.HasKubernetesAPILevel(c.Options, "v1"),
 	}
 	_ = master.New(masterConfig)
 
@@ -162,8 +167,8 @@ func (c *MasterConfig) createSchedulerConfig() (*scheduler.Config, error) {
 	var configData []byte
 
 	configFactory := factory.NewConfigFactory(c.KubeClient)
-	if _, err := os.Stat(c.SchedulerConfigFile); err == nil {
-		configData, err = ioutil.ReadFile(c.SchedulerConfigFile)
+	if _, err := os.Stat(c.Options.SchedulerConfigFile); err == nil {
+		configData, err = ioutil.ReadFile(c.Options.SchedulerConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to read scheduler config: %v", err)
 		}

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -21,12 +21,11 @@ import (
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {
-	MasterIP    net.IP
-	MasterPort  int
-	MasterCount int
+	Options configapi.KubernetesMasterConfig
+
+	MasterPort int
 
 	// TODO: remove, not used
-	NodeHosts []string
 	PortalNet *net.IPNet
 
 	RequestContextMapper kapi.RequestContextMapper
@@ -37,8 +36,6 @@ type MasterConfig struct {
 
 	Authorizer       authorizer.Authorizer
 	AdmissionControl admission.Interface
-
-	SchedulerConfigFile string
 }
 
 func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextMapper kapi.RequestContextMapper, kubeClient *kclient.Client) (*MasterConfig, error) {
@@ -76,10 +73,9 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	}
 
 	kmaster := &MasterConfig{
-		MasterIP:             net.ParseIP(options.KubernetesMasterConfig.MasterIP),
+		Options: *options.KubernetesMasterConfig,
+
 		MasterPort:           port,
-		MasterCount:          options.KubernetesMasterConfig.MasterCount,
-		NodeHosts:            options.KubernetesMasterConfig.StaticNodeNames,
 		PortalNet:            &portalNet,
 		RequestContextMapper: requestContextMapper,
 		EtcdHelper:           ketcdHelper,
@@ -87,7 +83,6 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 		KubeletClientConfig:  kubeletClientConfig,
 		Authorizer:           apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:     admissionController,
-		SchedulerConfigFile:  options.KubernetesMasterConfig.SchedulerConfigFile,
 	}
 
 	return kmaster, nil

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -239,9 +239,14 @@ func (o MasterOptions) RunMaster() error {
 		return nil
 	}
 
-	errs := validation.ValidateMasterConfig(masterConfig)
-	if len(errs) != 0 {
-		return kerrors.NewInvalid("MasterConfig", o.ConfigFile, errs)
+	validationResults := validation.ValidateMasterConfig(masterConfig)
+	if len(validationResults.Warnings) != 0 {
+		for _, warning := range validationResults.Warnings {
+			glog.Warningf("%v", warning)
+		}
+	}
+	if len(validationResults.Errors) != 0 {
+		return kerrors.NewInvalid("MasterConfig", o.ConfigFile, validationResults.Errors)
 	}
 
 	if err := StartMaster(masterConfig); err != nil {


### PR DESCRIPTION
Adds options for choosing API levels to start.  This is the first step in disabling "v1beta1".  It also adds warnings to some of our validation methods.

@liggitt 