### PR TITLE
make registry and router exit non-zero for failures

### DIFF
--- a/pkg/cmd/experimental/registry/registry.go
+++ b/pkg/cmd/experimental/registry/registry.go
@@ -92,6 +92,8 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 			err := RunCmdRegistry(f, cmd, out, cfg, args)
 			if err != errExit {
 				cmdutil.CheckErr(err)
+			} else {
+				os.Exit(1)
 			}
 		},
 	}

--- a/pkg/cmd/experimental/router/router.go
+++ b/pkg/cmd/experimental/router/router.go
@@ -88,6 +88,8 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 			err := RunCmdRouter(f, cmd, out, cfg, args)
 			if err != errExit {
 				cmdutil.CheckErr(err)
+			} else {
+				os.Exit(1)
 			}
 		},
 	}


### PR DESCRIPTION
registry and router could fail in their bulk creates, but they still reported zero exit codes.  This fixes that problem to make errors stand out.

@fabianofranz or  @liggitt  ptal