### PR TITLE
Fix structure of webhooks URL markup in web console

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -339,7 +339,7 @@ module.exports = function (grunt) {
           collapseBooleanAttributes: true,
           removeComments: true,
           removeCommentsFromCDATA: true,
-          removeOptionalTags: true,
+          removeOptionalTags: false,
           keepClosingSlash: true
         },
         files: [{

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -93,9 +93,8 @@
             <dl class="dl-horizontal left indent">
 
               <div ng-repeat="trigger in buildConfig.triggers">
-                <span ng-switch="trigger.type">
-                  <span ng-switch-when="github">
-                    
+                <div ng-switch="trigger.type">
+                  <div ng-switch-when="github">
                       <dt>GitHub webhook URL
                       <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more 
                       <i class="fa fa-external-link"></i></span></a>
@@ -104,19 +103,17 @@
                         <span click-to-reveal link-text='Show URL...' style="margin-right: 5px;">{{buildConfigName | webhookURL : trigger.type : trigger.github.secret : project.metadata.name}}</span>
                         <copy-to-clipboard-button clipboard-text="buildConfigName | webhookURL : trigger.type : trigger.github.secret : project.metadata.name"></copy-to-clipboard-button>
                       </dd>
-
-                  </span>
-                  <span ng-switch-when="generic">
-
+                  </div>
+                  <div ng-switch-when="generic">
                       <dt>Generic webhook URL
                         <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more <i class="fa fa-external-link"></i></span></a>
+                      </dt>
                       <dd>
                         <span click-to-reveal link-text='Show URL...' style="margin-right: 5px;">{{buildConfigName | webhookURL : trigger.type : trigger.generic.secret : project.metadata.name}}</span>
                         <copy-to-clipboard-button clipboard-text="buildConfigName | webhookURL : trigger.type : trigger.generic.secret : project.metadata.name"></copy-to-clipboard-button>
                       </dd>
-
-                  </span>
-                  <span ng-switch-when="imageChange">                    
+                  </div>
+                  <div ng-switch-when="imageChange">
                     <div ng-switch="buildConfig.parameters.strategy.type">
                       <div ng-switch-when="STI">
                         <dl class="dl-horizontal" ng-if="buildConfig.parameters.strategy.stiStrategy.from&& buildConfig.parameters.strategy.stiStrategy.from.kind!='ImageStreamImage'">
@@ -151,9 +148,9 @@
                         </dl>
                       </div>                  
                     </div>
-                  </span>
-                  <span ng-switch-default>{{trigger.type}}</span>
-                </span>
+                  </div>
+                  <div ng-switch-default>{{trigger.type}}</div>
+                </div>
               </div>
             </dl>
 


### PR DESCRIPTION
When minimized, the structure of the resulting markup is not the same as in source. The minimizer is removing &lt;/dt&gt; and &lt;/dd&gt; and the browser doesn't interpret the span's as block-level elements, so they all become part of the same ng-switch block.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1220678