### PR TITLE
Support cancelling deployment hooks and other related deployment pods

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -136,6 +136,12 @@ const (
 	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
 	// to implement the deployment behavior.
 	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
+	// DeployerPodForDeploymentLabel is a label which groups pods related to a
+	// deployment. The value is a deployment name. The deployer pod and hook pods
+	// created by the internal strategies will have this label. Custom
+	// strategies can apply this label to any pods they create, enabling
+	// platform-provided cancellation and garbage collection support.
+	DeployerPodForDeploymentLabel = "openshift.io/deployer-pod-for.name"
 	// DeploymentStatusAnnotation is an annotation name used to retrieve the DeploymentPhase of
 	// a deployment.
 	DeploymentStatusAnnotation = "openshift.io/deployment.phase"

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -136,6 +136,12 @@ const (
 	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
 	// to implement the deployment behavior.
 	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
+	// DeployerPodForDeploymentLabel is a label which groups pods related to a
+	// deployment. The value is a deployment name. The deployer pod and hook pods
+	// created by the internal strategies will have this label. Custom
+	// strategies can apply this label to any pods they create, enabling
+	// platform-provided cancellation and garbage collection support.
+	DeployerPodForDeploymentLabel = "openshift.io/deployer-pod-for.name"
 	// DeploymentPhaseAnnotation is an annotation name used to retrieve the DeploymentPhase of
 	// a deployment.
 	DeploymentPhaseAnnotation = "openshift.io/deployment.phase"

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -136,6 +136,12 @@ const (
 	// annotation value is the name of the deployer Pod which will act upon the ReplicationController
 	// to implement the deployment behavior.
 	DeploymentPodAnnotation = "openshift.io/deployer-pod.name"
+	// DeployerPodForDeploymentLabel is a label which groups pods related to a
+	// deployment. The value is a deployment name. The deployer pod and hook pods
+	// created by the internal strategies will have this label. Custom
+	// strategies can apply this label to any pods they create, enabling
+	// platform-provided cancellation and garbage collection support.
+	DeployerPodForDeploymentLabel = "openshift.io/deployer-pod-for.name"
 	// DeploymentPhaseAnnotation is an annotation name used to retrieve the DeploymentPhase of
 	// a deployment.
 	DeploymentPhaseAnnotation = "openshift.io/deployment.phase"


### PR DESCRIPTION
Group deployer and hook/related pods with a label. When cancelling deployments, use the label to cancel related pods as a group.

This accounts not only for hook pods created by the internal strategies, but also allows custom strategy users to integrate with platform-provided cancellation/garbage collection.

Closes #2556