### PR TITLE
Replace custom/flaky pod comparison with DeepEqual

### DIFF
--- a/pkg/deploy/rollback/rollback_generator_test.go
+++ b/pkg/deploy/rollback/rollback_generator_test.go
@@ -7,7 +7,6 @@ import (
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
-	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
 func TestGeneration(t *testing.T) {
@@ -110,5 +109,6 @@ func hasReplicationMetaDiff(a, b *deployapi.DeploymentConfig) bool {
 }
 
 func hasPodTemplateDiff(a, b *deployapi.DeploymentConfig) bool {
-	return !deployutil.PodSpecsEqual(a.Template.ControllerTemplate.Template.Spec, b.Template.ControllerTemplate.Template.Spec)
+	specA, specB := a.Template.ControllerTemplate.Template.Spec, b.Template.ControllerTemplate.Template.Spec
+	return !kapi.Semantic.DeepEqual(specA, specB)
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -1,13 +1,9 @@
 package util
 
 import (
-	"encoding/json"
 	"fmt"
-	"hash/adler32"
 	"strconv"
 	"strings"
-
-	"github.com/golang/glog"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
@@ -74,30 +70,6 @@ func LabelForDeployment(deployment *api.ReplicationController) string {
 // LabelForDeploymentConfig builds a string identifier for a DeploymentConfig.
 func LabelForDeploymentConfig(config *deployapi.DeploymentConfig) string {
 	return fmt.Sprintf("%s/%s:%d", config.Namespace, config.Name, config.LatestVersion)
-}
-
-// HashPodSpec hashes a PodSpec into a uint64.
-// TODO: Resources are currently ignored due to the formats not surviving encoding/decoding
-// in a consistent manner (e.g. 0 is represented sometimes as 0.000)
-func HashPodSpec(t api.PodSpec) uint64 {
-	// Ignore resources by making them uniformly empty
-	for i := range t.Containers {
-		t.Containers[i].Resources = api.ResourceRequirements{}
-	}
-
-	jsonString, err := json.Marshal(t)
-	if err != nil {
-		glog.Errorf("An error occurred marshalling pod state: %v", err)
-		return 0
-	}
-	hash := adler32.New()
-	fmt.Fprintf(hash, "%s", jsonString)
-	return uint64(hash.Sum32())
-}
-
-// PodSpecsEqual returns true if the given PodSpecs are the same.
-func PodSpecsEqual(a, b api.PodSpec) bool {
-	return HashPodSpec(a) == HashPodSpec(b)
 }
 
 // DecodeDeploymentConfig decodes a DeploymentConfig from controller using codec. An error is returned

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -57,38 +57,6 @@ func TestPodName(t *testing.T) {
 	}
 }
 
-func TestPodSpecsEqualTrue(t *testing.T) {
-	result := PodSpecsEqual(podTemplateA().Spec, podTemplateA().Spec)
-
-	if !result {
-		t.Fatalf("Unexpected false result for PodSpecsEqual")
-	}
-}
-
-func TestPodSpecsJustLabelDiff(t *testing.T) {
-	result := PodSpecsEqual(podTemplateA().Spec, podTemplateB().Spec)
-
-	if !result {
-		t.Fatalf("Unexpected false result for PodSpecsEqual")
-	}
-}
-
-func TestPodSpecsEqualContainerImageChange(t *testing.T) {
-	result := PodSpecsEqual(podTemplateA().Spec, podTemplateC().Spec)
-
-	if result {
-		t.Fatalf("Unexpected true result for PodSpecsEqual")
-	}
-}
-
-func TestPodSpecsEqualAdditionalContainerInManifest(t *testing.T) {
-	result := PodSpecsEqual(podTemplateA().Spec, podTemplateD().Spec)
-
-	if result {
-		t.Fatalf("Unexpected true result for PodSpecsEqual")
-	}
-}
-
 func TestMakeDeploymentOk(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
 	deployment, err := MakeDeployment(config, kapi.Codec)


### PR DESCRIPTION
Replace the old custom flaky hash based pod comparison in the deployment
code with Semantic.DeepEqual. This is far more reliable, and fixes a long
standing bug where Pod resource changes don't trigger deployments. It also
ensures future Pod API revisions will be correctly handled when detecting
changes.

Closes https://github.com/openshift/origin/issues/2510