### PR TITLE
Show correct error details on browse builds page

### DIFF
--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -108,7 +108,7 @@ angular.module('openshiftConsole')
             {
               type: "error",
               message: "An error occurred while starting the build.",
-              details: "Status: " + result.status + ". " + result.data,
+              details: getErrorDetails(result)
             }
           ];
         }
@@ -132,7 +132,7 @@ angular.module('openshiftConsole')
             {
               type: "error",
               message: "An error occurred while rerunning the build.",
-              details: "Status: " + result.status + ". " + result.data,
+              details: getErrorDetails(result)
             }
           ];
         }
@@ -146,6 +146,20 @@ angular.module('openshiftConsole')
         updateFilterWarning();
       });
     });
+
+    function getErrorDetails(result) {
+      var error = result.data || {};
+      if (error.message) {
+        return error.message;
+      }
+
+      var status = result.status || error.status;
+      if (status) {
+        return "Status: " + status;
+      }
+
+      return "";
+    }
 
     $scope.$on('$destroy', function(){
       DataService.unwatchAll(watches);


### PR DESCRIPTION
Fixes #2571

Example error message:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/7888250/19c41bb0-0605-11e5-8a5b-d5073d7aa79c.png)

I left off the status code when an error message is there because I'm not sure it's useful.