### PR TITLE
BZ 1214243 - Do not admit routes with the same scheme/host/path

### DIFF
--- a/pkg/route/admission/admission.go
+++ b/pkg/route/admission/admission.go
@@ -1,0 +1,130 @@
+package admission
+
+import (
+	"errors"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
+	"fmt"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+	osclient "github.com/openshift/origin/pkg/client"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+// This plugin must be manually initialized, it requires an openshift client which is not
+// available via the factory interface normally used in NewFromPlugins.
+
+// NewRouteAdmissionPlugin creates a new route admission plugin to enforce uniqueness.
+func NewRouteAdmissionPlugin(kClient kclient.Interface, osClient osclient.Interface) (admission.Interface, error) {
+	if kClient == nil || osClient == nil {
+		return nil, errors.New("kube client and openshift client are required")
+	}
+
+	store := cache.NewStore(StoreKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return osClient.Routes(api.NamespaceAll).List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return osClient.Routes(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&routeapi.Route{},
+		store,
+		0,
+	)
+	reflector.Run()
+
+	return &routeUniqueness{
+		Handler:    routeAdmissionHandler(),
+		kClient:    kClient,
+		osClient:   osClient,
+		routeStore: store,
+	}, nil
+}
+
+// routeAdmissionHandler is separated out so that tests can use it in the test plugin.
+func routeAdmissionHandler() *admission.Handler {
+	return admission.NewHandler(admission.Create, admission.Update)
+}
+
+// routeUniqueness implements the plugin that validates route uniqueness.
+type routeUniqueness struct {
+	*admission.Handler
+	kClient    kclient.Interface
+	osClient   osclient.Interface
+	routeStore cache.Store
+}
+
+// Admit ensures that the route in the form of scheme://host/path does not already exist in the
+// system.  Rules for admission:
+// 1.  If you're adding a route it must have a unique scheme, host, path combination
+// 2.  If you're updating a route you may not update it to a scheme, host, path combination that
+//     already exists (used by checking the namespace and name of the route)
+func (p *routeUniqueness) Admit(a admission.Attributes) error {
+	if a.GetResource() != "routes" {
+		return nil
+	}
+
+	route, ok := a.GetObject().(*routeapi.Route)
+	if !ok {
+		return admission.NewForbidden(a, fmt.Errorf("Resource was marked with kind Route but was unable to be converted"))
+	}
+	routeKey := MakeRouteKey(route)
+
+	// see if we can find a route that matches the scheme, host, path combination
+	foundObj, exists, err := p.routeStore.GetByKey(routeKey)
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+	// if no existing route is found this is ok to create
+	if !exists {
+		return nil
+	}
+	// if updating then the namespace and name must match in order to accept the update
+	found, ok := foundObj.(*routeapi.Route)
+	if !ok {
+		return admission.NewForbidden(a, fmt.Errorf("Invalid object found in store, unable to convert to route %v", foundObj))
+	}
+
+	// if adding and the route already exists then deny
+	if a.GetOperation() == admission.Create && exists {
+		return admission.NewForbidden(a, fmt.Errorf("Route %s already exists.  If you are the owner of this domain please contact support.", routeKey))
+	}
+
+	if found.Namespace != route.Namespace || found.Name != route.Name {
+		return admission.NewForbidden(a, fmt.Errorf("Route %s already exists.  If you are the owner of this domain please contact support.", routeKey))
+	}
+
+	// found a route, uids match, ok to update
+	return nil
+}
+
+// StoreKeyFunc provides the store a key function that produces keys in the format of MakeRouteKey
+// below.
+func StoreKeyFunc(obj interface{}) (string, error) {
+	route, ok := obj.(*routeapi.Route)
+	if !ok {
+		return "", fmt.Errorf("Unable to convert object to route: %v", obj)
+	}
+	return MakeRouteKey(route), nil
+}
+
+// MakeRouteKey produces keys in the format of {scheme}{host}{path}.
+func MakeRouteKey(route *routeapi.Route) string {
+	if route == nil {
+		return ""
+	}
+	scheme := "http://"
+	if route.TLS != nil && route.TLS.Termination != "" {
+		scheme = "https://"
+	}
+	return scheme + route.Host + route.Path
+}

--- a/pkg/route/admission/admission_test.go
+++ b/pkg/route/admission/admission_test.go
@@ -1,0 +1,202 @@
+package admission
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+// NewTestPlugin creates a new plugin with an injected store for testing.
+func NewTestPlugin(store cache.Store) admission.Interface {
+	return &routeUniqueness{
+		Handler:    routeAdmissionHandler(),
+		routeStore: store,
+	}
+}
+
+func TestHandler(t *testing.T) {
+	plugin := NewTestPlugin(nil)
+	if plugin.Handles(admission.Connect) {
+		t.Errorf("plugin should not handle connect")
+	}
+	if plugin.Handles(admission.Delete) {
+		t.Errorf("plugin should not handle delete")
+	}
+	if !plugin.Handles(admission.Create) {
+		t.Errorf("plugin should handle create")
+	}
+	if !plugin.Handles(admission.Update) {
+		t.Errorf("plugin should handle update")
+	}
+}
+
+func TestAdmission(t *testing.T) {
+	newValidRoute := func(routeType string) *routeapi.Route {
+		route := &routeapi.Route{
+			ObjectMeta: api.ObjectMeta{
+				Namespace: "namespace",
+				Name:      "name",
+			},
+			Host: "www.example.com",
+		}
+		if strings.Contains(routeType, "path") {
+			route.Path = "/foo"
+		}
+
+		switch routeType {
+		case "secure_edge", "secure_edge_path":
+			route.TLS = &routeapi.TLSConfig{
+				Termination: routeapi.TLSTerminationEdge,
+			}
+		case "secure_reencrypt", "secure_reencrypt_path":
+			route.TLS = &routeapi.TLSConfig{
+				Termination: routeapi.TLSTerminationReencrypt,
+			}
+
+		case "secure_passthrough", "secure_passthrough_path":
+			route.TLS = &routeapi.TLSConfig{
+				Termination: routeapi.TLSTerminationPassthrough,
+			}
+		}
+		return route
+	}
+
+	testCases := map[string]struct {
+		attributes   admission.Attributes
+		shouldPass   bool
+		storeObjects []runtime.Object
+	}{
+		"bad object": {
+			attributes: admission.NewAttributesRecord(nil, "Route", "", "routes", admission.Create, nil),
+			shouldPass: false,
+		},
+		"add unsecure, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("unsecure"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("secure_edge"), newValidRoute("secure_edge_path")},
+		},
+		"add unsecure path, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("unsecure_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure"), newValidRoute("secure_edge"), newValidRoute("secure_edge_path")},
+		},
+		"add unsecure, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("unsecure"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("unsecure")},
+		},
+		"add unsecure path, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("unsecure_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path")},
+		},
+		"add edge, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_edge"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("unsecure"), newValidRoute("secure_edge_path")},
+		},
+		"add edge path, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_edge_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("unsecure"), newValidRoute("secure_edge")},
+		},
+		"add edge, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_edge"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("secure_edge")},
+		},
+		"add edge path, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_edge_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("secure_edge_path")},
+		},
+		"add reencrypt, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_reencrypt"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("unsecure"), newValidRoute("secure_reencrypt_path")},
+		},
+		"add reencrypt path, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_reencrypt_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("unsecure"), newValidRoute("secure_reencrypt")},
+		},
+		"add reencrypt, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_reencrypt"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("secure_reencrypt")},
+		},
+		"add reencrypt path, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_reencrypt_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("secure_reencrypt_path")},
+		},
+		"add passthrough, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_passthrough"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("unsecure"), newValidRoute("secure_passthrough_path")},
+		},
+		"add passthrough path, no match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_passthrough_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure_path"), newValidRoute("unsecure"), newValidRoute("secure_passthrough")},
+		},
+		"add passthrough, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_passthrough"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("secure_passthrough")},
+		},
+		"add passthrough path, match": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("secure_passthrough_path"), "Route", "", "routes", admission.Create, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("secure_passthrough_path")},
+		},
+		"update, namespace doesn't match": {
+			attributes: admission.NewAttributesRecord(&routeapi.Route{
+				ObjectMeta: api.ObjectMeta{
+					Namespace: "namespace2",
+					Name:      "name",
+				},
+				Host: "www.example.com",
+			}, "Route", "", "routes", admission.Update, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("unsecure")},
+		},
+		"update, name doesn't match": {
+			attributes: admission.NewAttributesRecord(&routeapi.Route{
+				ObjectMeta: api.ObjectMeta{
+					Namespace: "namespace",
+					Name:      "name2",
+				},
+				Host: "www.example.com",
+			}, "Route", "", "routes", admission.Update, nil),
+			shouldPass:   false,
+			storeObjects: []runtime.Object{newValidRoute("unsecure")},
+		},
+		"update, name/namespace matches": {
+			attributes:   admission.NewAttributesRecord(newValidRoute("unsecure"), "Route", "", "routes", admission.Update, nil),
+			shouldPass:   true,
+			storeObjects: []runtime.Object{newValidRoute("unsecure")},
+		},
+	}
+
+	for k, v := range testCases {
+		store := cache.NewStore(StoreKeyFunc)
+		for _, obj := range v.storeObjects {
+			store.Add(obj)
+		}
+		plugin := NewTestPlugin(store)
+		err := plugin.Admit(v.attributes)
+		if v.shouldPass && err != nil {
+			t.Errorf("unexpected error in %s, should have passed but received %v", k, err)
+		}
+		if !v.shouldPass && err == nil {
+			t.Errorf("%s expected an error but received none", k)
+		}
+	}
+}


### PR DESCRIPTION
As discussed with @danmcp and @liggitt.  We will not admit duplicate routes.  

Rules:

1.  Routes will be considered unique by the scheme/host/path combination.  A route will any type of TLS will be considered as using the https scheme for admission purposes.
1.  When adding, if the unique key already exists then deny
1.  When updating, if the unique key already exists only admit if it is the same namespace/name

Of note:  Admission controllers do not have access to an openshift client which is required to maintain the route store.  To work around this I used the `admission.NewChainHandler` function to add a pre-initialized plugin to the chain of plugins created by `admission.NewFromPlugins`.  This method is currently marked as "for test use".  @derekwaynecarr PTAL at that section.

@liggitt @smarterclayton PTAL
