### PR TITLE
UPSTREAM: json marshalling error must manifest earlier in resource visitors

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/schema.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/schema.go
@@ -50,6 +50,21 @@ type NullSchema struct{}
 
 func (NullSchema) ValidateBytes(data []byte) error { return nil }
 
+type FilenameInputSchema struct{}
+
+func (FilenameInputSchema) ValidateBytes(data []byte) error {
+	var obj interface{}
+	out, err := yaml.ToJSON(data)
+	if err != nil {
+		return err
+	}
+	data = out
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	return nil
+}
+
 type SwaggerSchema struct {
 	api swagger.ApiDeclaration
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/schema.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/schema.go
@@ -50,21 +50,6 @@ type NullSchema struct{}
 
 func (NullSchema) ValidateBytes(data []byte) error { return nil }
 
-type FilenameInputSchema struct{}
-
-func (FilenameInputSchema) ValidateBytes(data []byte) error {
-	var obj interface{}
-	out, err := yaml.ToJSON(data)
-	if err != nil {
-		return err
-	}
-	data = out
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return err
-	}
-	return nil
-}
-
 type SwaggerSchema struct {
 	api swagger.ApiDeclaration
 }
@@ -80,7 +65,7 @@ func NewSwaggerSchemaFromBytes(data []byte) (Schema, error) {
 
 func (s *SwaggerSchema) ValidateBytes(data []byte) error {
 	var obj interface{}
-	out, err := yaml.ToJSON(data)
+	out, err := yaml.ToJSON(data, false)
 	if err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient/fixture.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient/fixture.go
@@ -86,7 +86,7 @@ func AddObjectsFromPath(path string, o ObjectRetriever, decoder runtime.Decoder)
 	if err != nil {
 		return err
 	}
-	data, err = yaml.ToJSON(data)
+	data, err = yaml.ToJSON(data, false)
 	if err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -209,6 +209,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				}
 				return &clientSwaggerSchema{client, api.Scheme}, nil
 			}
+			if filenameFlag := flags.Lookup("filename"); filenameFlag != nil && filenameFlag.Changed {
+				return validation.FilenameInputSchema{}, nil
+			}
 			return validation.NullSchema{}, nil
 		},
 		DefaultNamespace: func() (string, error) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -209,9 +209,6 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				}
 				return &clientSwaggerSchema{client, api.Scheme}, nil
 			}
-			if filenameFlag := flags.Lookup("filename"); filenameFlag != nil && filenameFlag.Changed {
-				return validation.FilenameInputSchema{}, nil
-			}
 			return validation.NullSchema{}, nil
 		},
 		DefaultNamespace: func() (string, error) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/mapper.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/mapper.go
@@ -37,7 +37,7 @@ type Mapper struct {
 // if any of the decoding or client lookup steps fail. Name and namespace will be
 // set into Info if the mapping's MetadataAccessor can retrieve them.
 func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
-	json, err := yaml.ToJSON(data)
+	json, err := yaml.ToJSON(data, true)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse %q: %v", source, err)
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
@@ -185,7 +185,7 @@ func ValidateSchema(data []byte, schema validation.Schema) error {
 	if schema == nil {
 		return nil
 	}
-	data, err := yaml.ToJSON(data)
+	data, err := yaml.ToJSON(data, false)
 	if err != nil {
 		return fmt.Errorf("error converting to JSON: %v", err)
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/resource/visitor.go
@@ -187,7 +187,7 @@ func ValidateSchema(data []byte, schema validation.Schema) error {
 	}
 	data, err := yaml.ToJSON(data)
 	if err != nil {
-		return fmt.Errorf("error converting to YAML: %v", err)
+		return fmt.Errorf("error converting to JSON: %v", err)
 	}
 	if err := schema.ValidateBytes(data); err != nil {
 		return fmt.Errorf("error validating data: %v", err)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config/common.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config/common.go
@@ -91,7 +91,7 @@ type defaultFunc func(pod *api.Pod) error
 
 func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *api.Pod, err error) {
 	// JSON is valid YAML, so this should work for everything.
-	json, err := utilyaml.ToJSON(data)
+	json, err := utilyaml.ToJSON(data, false)
 	if err != nil {
 		return false, nil, err
 	}
@@ -117,7 +117,7 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *a
 }
 
 func tryDecodePodList(data []byte, defaultFn defaultFunc) (parsed bool, pods api.PodList, err error) {
-	json, err := utilyaml.ToJSON(data)
+	json, err := utilyaml.ToJSON(data, false)
 	if err != nil {
 		return false, api.PodList{}, err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/codec.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/runtime/codec.go
@@ -40,7 +40,7 @@ func YAMLDecoder(codec Codec) Codec {
 }
 
 func (c yamlCodec) Decode(data []byte) (Object, error) {
-	out, err := yaml.ToJSON(data)
+	out, err := yaml.ToJSON(data, false)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c yamlCodec) Decode(data []byte) (Object, error) {
 }
 
 func (c yamlCodec) DecodeInto(data []byte, obj Object) error {
-	out, err := yaml.ToJSON(data)
+	out, err := yaml.ToJSON(data, false)
 	if err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/yaml/decoder.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/yaml/decoder.go
@@ -31,8 +31,14 @@ import (
 // or returns an error. If the document appears to be JSON the
 // YAML decoding path is not used (so that error messages are)
 // JSON specific.
-func ToJSON(data []byte) ([]byte, error) {
+func ToJSON(data []byte, checkValid bool) ([]byte, error) {
 	if hasJSONPrefix(data) {
+		if checkValid {
+			var obj interface{}
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, err
+			}
+		}
 		return data, nil
 	}
 	return yaml.YAMLToJSON(data)

--- a/pkg/cmd/server/api/latest/helpers.go
+++ b/pkg/cmd/server/api/latest/helpers.go
@@ -79,7 +79,7 @@ func ReadYAMLFile(filename string, obj runtime.Object) error {
 	if err != nil {
 		return err
 	}
-	data, err = kyaml.ToJSON(data)
+	data, err = kyaml.ToJSON(data, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/jsonmerge/jsonmerge.go
+++ b/pkg/util/jsonmerge/jsonmerge.go
@@ -53,11 +53,11 @@ func RequireKeyUnchanged(key string) PreconditionFunc {
 // if either document is in error.
 func NewDelta(from, to []byte) (*Delta, error) {
 	d := &Delta{}
-	before, err := yaml.ToJSON(from)
+	before, err := yaml.ToJSON(from, false)
 	if err != nil {
 		return nil, err
 	}
-	after, err := yaml.ToJSON(to)
+	after, err := yaml.ToJSON(to, false)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func NewDelta(from, to []byte) (*Delta, error) {
 // IsConflicting will be true if the changes overlap, otherwise a
 // generic error will be returned.
 func (d *Delta) Apply(latest []byte) ([]byte, error) {
-	base, err := yaml.ToJSON(latest)
+	base, err := yaml.ToJSON(latest, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/2412
Also related to https://github.com/openshift/origin/issues/2366

The resource builder in `osc create` is marked as `ContinueOnError` so that the creation of elements can succeed even when other elements fail. However, there is no previous validation for lower-level errors like JSON marshalling problems. This needs to happen *before* `InfoForData`, otherwise malformed JSON issues will not error right away and will only appear in logs. `yaml.ToJSON` does not perform actual JSON validation, it only checks for an open brace as prefix.

This PR adds actual JSON validation to `ValidateSchema` in visitors in a similar manner done in the [schema validation here](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/validation/schema.go#L66).