### PR TITLE
Refactor deploy hook retry policy

### DIFF
--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -68,7 +68,7 @@ func (s *RecreateDeploymentStrategy) Deploy(deployment *kapi.ReplicationControll
 	params := deploymentConfig.Template.Strategy.RecreateParams
 	// Execute any pre-hook.
 	if params != nil && params.Pre != nil {
-		err := s.hookExecutor.Execute(params.Pre, deployment, s.retryPeriod)
+		err := s.hookExecutor.Execute(params.Pre, deployment, "prehook")
 		if err != nil {
 			return fmt.Errorf("Pre hook failed: %s", err)
 		}
@@ -106,13 +106,11 @@ func (s *RecreateDeploymentStrategy) Deploy(deployment *kapi.ReplicationControll
 
 	// Execute any post-hook. Errors are logged and ignored.
 	if params != nil && params.Post != nil {
-		// TODO: handle this in defaulting/conversion/validation?
-		if params.Post.FailurePolicy == deployapi.LifecycleHookFailurePolicyAbort {
-			params.Post.FailurePolicy = deployapi.LifecycleHookFailurePolicyIgnore
-		}
-		err := s.hookExecutor.Execute(params.Post, deployment, s.retryPeriod)
+		err := s.hookExecutor.Execute(params.Post, deployment, "posthook")
 		if err != nil {
-			glog.Infof("Post hook failed: %s", err)
+			glog.Errorf("Post hook failed: %s", err)
+		} else {
+			glog.Infof("Post hook finished")
 		}
 	}
 
@@ -177,14 +175,14 @@ func (r *realReplicationControllerClient) updateReplicationController(namespace 
 
 // hookExecutor knows how to execute a deployment lifecycle hook.
 type hookExecutor interface {
-	Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, retryPeriod time.Duration) error
+	Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error
 }
 
 // hookExecutorImpl is a pluggable hookExecutor.
 type hookExecutorImpl struct {
-	executeFunc func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, retryPeriod time.Duration) error
+	executeFunc func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error
 }
 
-func (i *hookExecutorImpl) Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, retryPeriod time.Duration) error {
-	return i.executeFunc(hook, deployment, retryPeriod)
+func (i *hookExecutorImpl) Execute(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
+	return i.executeFunc(hook, deployment, label)
 }

--- a/pkg/deploy/strategy/recreate/recreate_test.go
+++ b/pkg/deploy/strategy/recreate/recreate_test.go
@@ -223,7 +223,7 @@ func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
 			},
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, _ time.Duration) error {
+			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
 				return nil
 			},
 		},
@@ -264,7 +264,7 @@ func TestRecreate_deploymentPreHookFail(t *testing.T) {
 			},
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, _ time.Duration) error {
+			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
 				return fmt.Errorf("hook execution failure")
 			},
 		},
@@ -296,7 +296,7 @@ func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
 			},
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, _ time.Duration) error {
+			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
 				return nil
 			},
 		},
@@ -337,7 +337,7 @@ func TestRecreate_deploymentPostHookFailureIgnored(t *testing.T) {
 			},
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, _ time.Duration) error {
+			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
 				return fmt.Errorf("hook execution failure")
 			},
 		},

--- a/pkg/deploy/strategy/rolling/rolling_test.go
+++ b/pkg/deploy/strategy/rolling/rolling_test.go
@@ -231,7 +231,7 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 			return nil
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, _ time.Duration) error {
+			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
 				return hookError
 			},
 		},
@@ -295,7 +295,7 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 			return nil
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, _ time.Duration) error {
+			executeFunc: func(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationController, label string) error {
 				return hookError
 			},
 		},

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -10,11 +10,15 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	namer "github.com/openshift/origin/pkg/util/namer"
 )
 
 func TestHookExecutor_executeExecNewCreatePodFailure(t *testing.T) {
-	hook := &deployapi.ExecNewPodHook{
-		ContainerName: "container1",
+	hook := &deployapi.LifecycleHook{
+		FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+		},
 	}
 
 	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
@@ -30,7 +34,7 @@ func TestHookExecutor_executeExecNewCreatePodFailure(t *testing.T) {
 		},
 	}
 
-	err := executor.executeExecNewPod(hook, deployment)
+	err := executor.executeExecNewPod(hook, deployment, "hook")
 
 	if err == nil {
 		t.Fatalf("expected an error")
@@ -39,8 +43,11 @@ func TestHookExecutor_executeExecNewCreatePodFailure(t *testing.T) {
 }
 
 func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
-	hook := &deployapi.ExecNewPodHook{
-		ContainerName: "container1",
+	hook := &deployapi.LifecycleHook{
+		FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+		},
 	}
 
 	config := deploytest.OkDeploymentConfig(1)
@@ -60,7 +67,7 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 		},
 	}
 
-	err := executor.executeExecNewPod(hook, deployment)
+	err := executor.executeExecNewPod(hook, deployment, "hook")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -76,8 +83,11 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 }
 
 func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
-	hook := &deployapi.ExecNewPodHook{
-		ContainerName: "container1",
+	hook := &deployapi.LifecycleHook{
+		FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+		},
 	}
 
 	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
@@ -96,7 +106,7 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 		},
 	}
 
-	err := executor.executeExecNewPod(hook, deployment)
+	err := executor.executeExecNewPod(hook, deployment, "hook")
 
 	if err == nil {
 		t.Fatalf("expected an error", err)
@@ -105,13 +115,16 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 }
 
 func TestHookExecutor_makeHookPodInvalidContainerRef(t *testing.T) {
-	hook := &deployapi.ExecNewPodHook{
-		ContainerName: "undefined",
+	hook := &deployapi.LifecycleHook{
+		FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "undefined",
+		},
 	}
 
 	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
 
-	_, err := makeHookPod(hook, deployment)
+	_, err := makeHookPod(hook, deployment, "hook")
 
 	if err == nil {
 		t.Fatalf("expected an error")
@@ -120,17 +133,20 @@ func TestHookExecutor_makeHookPodInvalidContainerRef(t *testing.T) {
 }
 
 func TestHookExecutor_makeHookPodOk(t *testing.T) {
-	hook := &deployapi.ExecNewPodHook{
-		ContainerName: "container1",
-		Command:       []string{"overridden"},
-		Env: []kapi.EnvVar{
-			{
-				Name:  "name",
-				Value: "value",
-			},
-			{
-				Name:  "ENV1",
-				Value: "overridden",
+	hook := &deployapi.LifecycleHook{
+		FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+			Command:       []string{"overridden"},
+			Env: []kapi.EnvVar{
+				{
+					Name:  "name",
+					Value: "value",
+				},
+				{
+					Name:  "ENV1",
+					Value: "overridden",
+				},
 			},
 		},
 	}
@@ -148,9 +164,17 @@ func TestHookExecutor_makeHookPodOk(t *testing.T) {
 
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 
-	pod, err := makeHookPod(hook, deployment)
+	pod, err := makeHookPod(hook, deployment, "hook")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if e, a := namer.GetPodName(deployment.Name, "hook"), pod.Name; e != a {
+		t.Errorf("expected pod name %s, got %s", e, a)
+	}
+
+	if e, a := kapi.RestartPolicyNever, pod.Spec.RestartPolicy; e != a {
+		t.Errorf("expected pod restart policy %s, got %s", e, a)
 	}
 
 	gotContainer := pod.Spec.Containers[0]
@@ -214,5 +238,25 @@ func TestHookExecutor_makeHookPodOk(t *testing.T) {
 		deployment.Name,
 		pod.Annotations[deployapi.DeploymentAnnotation]; e != a {
 		t.Errorf("expected annotation %s=%s, got %s", l, e, a)
+	}
+}
+
+func TestHookExecutor_makeHookPodRestart(t *testing.T) {
+	hook := &deployapi.LifecycleHook{
+		FailurePolicy: deployapi.LifecycleHookFailurePolicyRetry,
+		ExecNewPod: &deployapi.ExecNewPodHook{
+			ContainerName: "container1",
+		},
+	}
+
+	deployment, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(1), kapi.Codec)
+
+	pod, err := makeHookPod(hook, deployment, "hook")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if e, a := kapi.RestartPolicyOnFailure, pod.Spec.RestartPolicy; e != a {
+		t.Errorf("expected pod restart policy %s, got %s", e, a)
 	}
 }


### PR DESCRIPTION
Remove the ad-hoc deployment hook retry mechanism and instead allow
the Kubelet to manage hook pod retries. When a user requests a Retry
hook failure policy, use an OnFailure pod restart policy to let the
Kubelet manage retries in a way that's compatible with deadlines.

Make deployment hook pod names deterministic.

Closes https://github.com/openshift/origin/issues/2592