### PR TITLE
Umount secret volumes before trying to remove

### DIFF
--- a/examples/sample-app/cleanup.sh
+++ b/examples/sample-app/cleanup.sh
@@ -3,6 +3,9 @@
 echo "Killing openshift all-in-one server ..."
 killall openshift
 
+echo "Unmounting volumes ..."
+findmnt -lo TARGET | grep openshift.local.volumes | xargs -r sudo umount
+
 echo "Cleaning up openshift runtime files ..."
 rm -rf openshift.local.*
 


### PR DESCRIPTION
After running a development OpenShift server, we want to clean up and remove some files:

```bash
$ sudo rm -rf openshift.local.*
rm: cannot remove ‘openshift.local.volumes/pods/19f007bf-051f-11e5-8aa9-080027c5bfa9/volumes/kubernetes.io~secret/default-token-e3bx3’: Device or resource busy
....
```

That won't work until we unmount some volumes.

There might be a better way to call `umount` without the magic number 5.

@bparees @mfojtik @soltysh PTAL