### PR TITLE
deployconfig requires kind

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -282,6 +282,7 @@ func (r *ImageRef) DeployableContainer() (container *kapi.Container, triggers []
 					ContainerNames: []string{name},
 					From: kapi.ObjectReference{
 						Name: name,
+						Kind: "ImageStream",
 					},
 					Tag: tag,
 				},


### PR DESCRIPTION
new-app using v1beta3 fails:

```
osc new-app https://github.com/openshift/ruby-hello-world -l app=ruby --api-version=v1beta3
imagestreams/ruby-20-centos7
imagestreams/ruby-hello-world
buildconfigs/ruby-hello-world
Error: DeploymentConfig in version v1beta3 cannot be handled as a DeploymentConfig: ImageStreamTag object references must be in the form <name>:<tag>: ruby-hello-world
services/ruby-hello-world
```

This gets past the client error, so that you can fail on something else server side.

@ironcladlou  or @csrwng ptal.