### PR TITLE
Show template parameter descriptions on create page

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -196,6 +196,17 @@ html, body {
     margin-top: (@grid-gutter-width / 2);
     border-top: 0;
   }
+  .template-options {
+    .list-unstyled {
+      line-height: 1.5;
+      .help-block {
+        margin-top: 0;
+      }
+    }
+    .help-block {
+      margin-left: 2px;
+    }
+  }
 }
 
 @media (min-width: 767px) {

--- a/assets/app/views/_templateopt.html
+++ b/assets/app/views/_templateopt.html
@@ -10,12 +10,14 @@
   </div>
   <div class="form-group options" ng-repeat="parameter in template.parameters" ng-show="optionsExpanded">
     <label for="param-{{$index}}" title="{{ parameter.description }}">{{parameter.name}}</label>
-    <input id="param-{{$index}}" class="form-control" type="text" title="{{ parameter.description }}"  placeholder="{{ parameter | parameterPlaceholder }}" ng-model="parameter.value">
+    <input id="param-{{$index}}" class="form-control" type="text" placeholder="{{ parameter | parameterPlaceholder }}" ng-model="parameter.value">
+    <div class="help-block" ng-if="parameter.description">{{parameter.description}}</div>
   </div>
   <ul class="list-unstyled env-variable-list" ng-hide="optionsExpanded">
     <li class="options" ng-repeat="parameter in template.parameters">
         <label for="" class="key truncate" title="{{ parameter.description }}">{{parameter.name}}</label>
         <span class="value truncate">{{ parameter | parameterValue }}</span>
+        <div class="help-block" ng-if="parameter.description">{{parameter.description}}</div>
     </li>
   </ul>
  </div>


### PR DESCRIPTION
Previously you had to hover over the label. Instead we should show the
template parameter description below the fields.

Read only:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/7938389/4307bf8e-0913-11e5-9551-d72f5a38b414.png)

When editing:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/7938404/4fedf34e-0913-11e5-92e0-6b18baf644ea.png)

See also #2689.

/cc @mfojtik 