### PR TITLE
Issue 2586 - allow only one ImageChangeTrigger for BuildConfig.

### DIFF
--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -105,8 +105,18 @@ func TestBuildConfigValidationFailure(t *testing.T) {
 				DockerImageReference: "repository/data",
 			},
 		},
+		Triggers: []buildapi.BuildTriggerPolicy{
+			{
+				Type:        buildapi.ImageChangeBuildTriggerType,
+				ImageChange: &buildapi.ImageChangeTrigger{},
+			},
+			{
+				Type:        buildapi.ImageChangeBuildTriggerType,
+				ImageChange: &buildapi.ImageChangeTrigger{},
+			},
+		},
 	}
-	if result := ValidateBuildConfig(buildConfig); len(result) != 1 {
+	if result := ValidateBuildConfig(buildConfig); len(result) != 2 {
 		t.Errorf("Unexpected validation result %v", result)
 	}
 }


### PR DESCRIPTION
@bparees as discussed, added just single validation for ImageChangeTrigger to fix #2586. ptal

[test] in the mean time.