### PR TITLE
Enable and require registry authentication

### DIFF
--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -237,6 +237,8 @@ sudo env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift
 OS_PID=$!
 
 export HOME="${FAKE_HOME_DIR}"
+# This directory must exist so Docker can store credentials in $HOME/.dockercfg
+mkdir -p ${FAKE_HOME_DIR}
 
 if [[ "${API_SCHEME}" == "https" ]]; then
 	export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
@@ -285,7 +287,7 @@ wait_for_command '[[ "$(osc get endpoints docker-registry --output-version=v1bet
 DOCKER_REGISTRY=$(osc get --output-version=v1beta3 --template="{{ .spec.portalIP }}:{{ with index .spec.ports 0 }}{{ .port }}{{ end }}" service docker-registry)
 
 echo "[INFO] Verifying the docker-registry is up at ${DOCKER_REGISTRY}"
-wait_for_url_timed "http://${DOCKER_REGISTRY}/v2/" "[INFO] Docker registry says: " $((2*TIME_MIN))
+wait_for_url_timed "http://${DOCKER_REGISTRY}/healthz" "[INFO] Docker registry says: " $((2*TIME_MIN))
 
 [ "$(dig @${API_HOST} "docker-registry.default.local." A)" ]
 
@@ -297,17 +299,22 @@ osc project cache
 token=$(osc config view --flatten -o template -t '{{with index .users 0}}{{.user.token}}{{end}}')
 [[ -n ${token} ]]
 
-# TODO reenable this once we've got docker push secrets 100% ready
-#docker login -u e2e-user -p ${token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}
-# TODO remove the following line once we've got docker push secrets 100% ready
-echo '{"apiVersion": "v1beta3", "kind": "ImageStream", "metadata": {"name": "ruby-20-centos7"}}' | osc create -f -
+echo "[INFO] Docker login as e2e-user to ${DOCKER_REGISTRY}"
+docker login -u e2e-user -p ${token} -e e2e-user@openshift.com ${DOCKER_REGISTRY}
+echo "[INFO] Docker login successful"
 
+echo "[INFO] Tagging and pushing ruby-20-centos7 to ${DOCKER_REGISTRY}/cache/ruby-20-centos7:latest"
 docker tag -f openshift/ruby-20-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-20-centos7:latest
 docker push ${DOCKER_REGISTRY}/cache/ruby-20-centos7:latest
 echo "[INFO] Pushed ruby-20-centos7"
 
 echo "[INFO] Back to 'master' context with 'admin' user..."
 osc project default
+
+# The build requires a dockercfg secret in the builder service account in order
+# to be able to push to the registry.  Make sure it exists first.
+echo "[INFO] Waiting for dockercfg secrets to be generated in project 'test' before building"
+wait_for_command "osc get -n test serviceaccount/builder -o yaml | grep dockercfg > /dev/null" $((60*TIME_SEC))
 
 # Process template and create
 echo "[INFO] Submitting application template json for processing..."

--- a/images/dockerregistry/Dockerfile
+++ b/images/dockerregistry/Dockerfile
@@ -9,7 +9,7 @@ FROM openshift/origin-base
 ADD config.yml /config.yml
 ADD bin/dockerregistry /dockerregistry
 
-ENV REGISTRY_CONFIGURATION_PATH=/config.yml DISABLE_USER_AUTH=true
+ENV REGISTRY_CONFIGURATION_PATH=/config.yml
 
 EXPOSE 5000
 VOLUME /registry

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -54,7 +54,7 @@ const (
 var (
 	GroupsToResources = map[string][]string{
 		BuildGroupName:              {"builds", "buildconfigs", "buildlogs", "buildconfigs/instantiate", "builds/log", "builds/clone"},
-		ImageGroupName:              {"images", "imagerepositories", "imagerepositorymappings", "imagerepositorytags", "imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages"},
+		ImageGroupName:              {"imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages"},
 		DeploymentGroupName:         {"deployments", "deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks"},
 		SDNGroupName:                {"clusternetworks", "hostsubnets"},
 		TemplateGroupName:           {"templates", "templateconfigs", "processedtemplates"},

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -2,6 +2,7 @@ package prune
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/prune"
@@ -49,10 +51,10 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) > 0 {
-				glog.Fatalf("No arguments are allowed to this command")
+				glog.Fatal("No arguments are allowed to this command")
 			}
 
-			osClient, kClient, err := f.Clients()
+			osClient, kClient, registryClient, err := getClients(f, cfg)
 			cmdutil.CheckErr(err)
 
 			allImages, err := osClient.Images().List(labels.Everything(), fields.Everything())
@@ -136,30 +138,6 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 				manifestPruneFunc    prune.ManifestPruneFunc
 			)
 
-			// get the client config so we can get the TLS config
-			clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
-			cmdutil.CheckErr(err)
-
-			tlsConfig, err := kclient.TLSConfigFor(clientConfig)
-			cmdutil.CheckErr(err)
-
-			// if the user specified a CA on the command line, add it to the
-			// client config's CA roots
-			if len(cfg.CABundle) > 0 {
-				data, err := ioutil.ReadFile(cfg.CABundle)
-				cmdutil.CheckErr(err)
-				if tlsConfig.RootCAs == nil {
-					tlsConfig.RootCAs = x509.NewCertPool()
-				}
-				tlsConfig.RootCAs.AppendCertsFromPEM(data)
-			}
-
-			registryClient := &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: tlsConfig,
-				},
-			}
-
 			switch cfg.DryRun {
 			case false:
 				imagePruneFunc = func(image *imageapi.Image) error {
@@ -199,4 +177,82 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 	cmd.Flags().StringVar(&cfg.CABundle, "certificate-authority", cfg.CABundle, "The path to a certificate authority bundle to use when communicating with the OpenShift-managed registries. Defaults to the certificate authority data from the current user's config file.")
 
 	return cmd
+}
+
+func getClients(f *clientcmd.Factory, cfg *pruneImagesConfig) (*client.Client, *kclient.Client, *http.Client, error) {
+	clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var (
+		token          string
+		osClient       *client.Client
+		kClient        *kclient.Client
+		registryClient *http.Client
+	)
+
+	switch {
+	case len(clientConfig.BearerToken) > 0:
+		osClient, kClient, err = f.Clients()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		token = clientConfig.BearerToken
+	default:
+		err = errors.New("You must use a client config with a token")
+		return nil, nil, nil, err
+	}
+
+	// copy the config
+	registryClientConfig := *clientConfig
+
+	// zero out everything we don't want to use
+	registryClientConfig.BearerToken = ""
+	registryClientConfig.CertFile = ""
+	registryClientConfig.CertData = []byte{}
+	registryClientConfig.KeyFile = ""
+	registryClientConfig.KeyData = []byte{}
+
+	// we have to set a username to something for the Docker login
+	// but it's not actually used
+	registryClientConfig.Username = "unused"
+
+	// set the "password" to be the token
+	registryClientConfig.Password = token
+
+	tlsConfig, err := kclient.TLSConfigFor(&registryClientConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// if the user specified a CA on the command line, add it to the
+	// client config's CA roots
+	if len(cfg.CABundle) > 0 {
+		data, err := ioutil.ReadFile(cfg.CABundle)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if tlsConfig.RootCAs == nil {
+			tlsConfig.RootCAs = x509.NewCertPool()
+		}
+
+		tlsConfig.RootCAs.AppendCertsFromPEM(data)
+	}
+
+	transport := http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	wrappedTransport, err := kclient.HTTPWrappersForConfig(&registryClientConfig, &transport)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	registryClient = &http.Client{
+		Transport: wrappedTransport,
+	}
+
+	return osClient, kClient, registryClient, nil
 }

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -44,6 +44,7 @@ const (
 	StatusCheckerRoleName     = "cluster-status"
 	ImagePullerRoleName       = "system:image-puller"
 	ImageBuilderRoleName      = "system:image-builder"
+	ImagePrunerRoleName       = "system:image-pruner"
 	DeployerRoleName          = "system:deployer"
 	RouterRoleName            = "system:router"
 	RegistryRoleName          = "system:registry"

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -69,6 +69,8 @@ const (
 	BasicUserRoleBindingName         = BasicUserRoleName + "s"
 	OAuthTokenDeleterRoleBindingName = OAuthTokenDeleterRoleName + "s"
 	StatusCheckerRoleBindingName     = StatusCheckerRoleName + "-binding"
+	ImagePullerRoleBindingName       = ImagePullerRoleName + "s"
+	ImageBuilderRoleBindingName      = ImageBuilderRoleName + "s"
 	RouterRoleBindingName            = RouterRoleName + "s"
 	RegistryRoleBindingName          = RegistryRoleName + "s"
 	NodeRoleBindingName              = NodeRoleName + "s"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -70,7 +70,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Resources: util.NewStringSet(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "pods/exec", "pods/portforward"),
 				},
 				{
-					Verbs:     util.NewStringSet("get", "update"),
+					Verbs: util.NewStringSet("get", "update"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
 					Resources: util.NewStringSet("imagestreams/layers"),
 				},
 			},
@@ -138,7 +139,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     util.NewStringSet("get"),
+					Verbs: util.NewStringSet("get"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
 					Resources: util.NewStringSet("imagestreams/layers"),
 				},
 			},
@@ -149,7 +151,8 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     util.NewStringSet("get", "update"),
+					Verbs: util.NewStringSet("get", "update"),
+					// this is used by verifyImageStreamAccess in pkg/dockerregistry/server/auth.go
 					Resources: util.NewStringSet("imagestreams/layers"),
 				},
 			},

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -135,7 +135,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get"),
-					Resources: util.NewStringSet("imagestreams"),
+					Resources: util.NewStringSet("imagestreams/layers"),
 				},
 			},
 		},
@@ -146,7 +146,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get", "update"),
-					Resources: util.NewStringSet("imagestreams"),
+					Resources: util.NewStringSet("imagestreams/layers"),
 				},
 			},
 		},
@@ -221,13 +221,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Resources: util.NewStringSet("imagestreamimages", "imagestreamtags", "imagestreams"),
 				},
 				{
-					// TODO: remove "create" once we re-enable user authentication in the registry
-					Verbs:     util.NewStringSet("create", "update"),
+					Verbs:     util.NewStringSet("update"),
 					Resources: util.NewStringSet("imagestreams"),
 				},
 				{
 					Verbs:     util.NewStringSet("create"),
-					Resources: util.NewStringSet("imagerepositorymappings", "imagestreammappings"),
+					Resources: util.NewStringSet("imagestreammappings"),
 				},
 			},
 		},

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -69,6 +69,10 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     util.NewStringSet("get", "list", "watch"),
 					Resources: util.NewStringSet(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "pods/exec", "pods/portforward"),
 				},
+				{
+					Verbs:     util.NewStringSet("get", "update"),
+					Resources: util.NewStringSet("imagestreams/layers"),
+				},
 			},
 		},
 		{
@@ -147,6 +151,25 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					Verbs:     util.NewStringSet("get", "update"),
 					Resources: util.NewStringSet("imagestreams/layers"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ImagePrunerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				{
+					Verbs:     util.NewStringSet("delete"),
+					Resources: util.NewStringSet("images"),
+				},
+				{
+					Verbs:     util.NewStringSet("get", "list"),
+					Resources: util.NewStringSet("images", "imagestreams", "pods", "replicationcontrollers", "buildconfigs", "builds", "deploymentconfigs"),
+				},
+				{
+					Verbs:     util.NewStringSet("update"),
+					Resources: util.NewStringSet("imagestreams/status"),
 				},
 			},
 		},

--- a/pkg/cmd/server/bootstrappolicy/project_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/project_policy.go
@@ -1,0 +1,34 @@
+package bootstrappolicy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func GetBootstrapServiceAccountProjectRoleBindings(namespace string) []authorizationapi.RoleBinding {
+	return []authorizationapi.RoleBinding{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      ImagePullerRoleBindingName,
+				Namespace: namespace,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: ImagePullerRoleName,
+			},
+			Groups: util.NewStringSet(serviceaccount.MakeNamespaceGroupName(namespace)),
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      ImageBuilderRoleBindingName,
+				Namespace: namespace,
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: ImageBuilderRoleName,
+			},
+			Users: util.NewStringSet(serviceaccount.MakeUsername(namespace, BuilderServiceAccountName)),
+		},
+	}
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -306,6 +306,13 @@ func (c *MasterConfig) PolicyClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
+// ServiceAccountRoleBindingClient returns the client object used to bind roles to service accounts
+// It must have the following capabilities:
+//  get, list, update, create policyBindings in all namespaces
+func (c *MasterConfig) ServiceAccountRoleBindingClient() *osclient.Client {
+	return c.PrivilegedLoopbackOpenShiftClient
+}
+
 // SdnClient returns the sdn client object
 // It must have the capability to get/list/watch/create/delete
 // HostSubnets. And have the capability to get ClusterNetwork.

--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -122,7 +122,6 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 			challenge.err = ErrOpenShiftTokenRequired
 			return nil, challenge
 		}
-		user := osAuthParts[0]
 		bearerToken := osAuthParts[1]
 
 		client, err = NewUserOpenShiftClient(bearerToken)
@@ -132,7 +131,7 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 
 		// In case of docker login, hits endpoint /v2
 		if len(accessRecords) == 0 {
-			err = verifyOpenShiftUser(user, client)
+			err = verifyOpenShiftUser(client)
 			if err != nil {
 				challenge.err = err
 				return nil, challenge
@@ -187,14 +186,9 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 	return ctx, nil
 }
 
-func verifyOpenShiftUser(user string, client *client.Client) error {
-	userObj, err := client.Users().Get("~")
-	if err != nil {
+func verifyOpenShiftUser(client *client.Client) error {
+	if _, err := client.Users().Get("~"); err != nil {
 		log.Errorf("Get user failed with error: %s", err)
-		return ErrOpenShiftAccessDenied
-	}
-	if user != userObj.Name {
-		log.Errorf("Token valid but user name mismatch")
 		return ErrOpenShiftAccessDenied
 	}
 	return nil

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -100,13 +100,14 @@ func (r *repository) ExistsByTag(ctx context.Context, tag string) (bool, error) 
 
 // Get retrieves the manifest with digest `dgst`.
 func (r *repository) Get(ctx context.Context, dgst digest.Digest) (*manifest.SignedManifest, error) {
-	_, err := r.getImageStreamImage(ctx, dgst)
-	if err != nil {
+	if _, err := r.getImageStreamImage(ctx, dgst); err != nil {
+		log.Errorf("Error retrieving ImageStreamImage %s/%s@%s: %v", r.namespace, r.name, dgst.String(), err)
 		return nil, err
 	}
-	// TODO: we already fetched it above
+
 	image, err := r.getImage(dgst)
 	if err != nil {
+		log.Errorf("Error retrieving image %s: %v", dgst.String(), err)
 		return nil, err
 	}
 
@@ -233,16 +234,10 @@ func (r *repository) Delete(ctx context.Context, dgst digest.Digest) error {
 
 // getImageStream retrieves the ImageStream for r.
 func (r *repository) getImageStream(ctx context.Context) (*imageapi.ImageStream, error) {
-	client, ok := UserClientFrom(ctx)
-	if !ok {
-		return nil, fmt.Errorf("error retrieving ImageStream: OpenShift user client unavailable")
-	}
-	return client.ImageStreams(r.namespace).Get(r.name)
+	return r.registryClient.ImageStreams(r.namespace).Get(r.name)
 }
 
-// getImage retrieves the Image with digest `dgst`. This uses the registry's
-// credentials and should ONLY be called after verifying the user has access
-// to the image stream the imgae belongs to.
+// getImage retrieves the Image with digest `dgst`.
 func (r *repository) getImage(dgst digest.Digest) (*imageapi.Image, error) {
 	return r.registryClient.Images().Get(dgst.String())
 }
@@ -250,21 +245,13 @@ func (r *repository) getImage(dgst digest.Digest) (*imageapi.Image, error) {
 // getImageStreamTag retrieves the Image with tag `tag` for the ImageStream
 // associated with r.
 func (r *repository) getImageStreamTag(ctx context.Context, tag string) (*imageapi.ImageStreamTag, error) {
-	client, ok := UserClientFrom(ctx)
-	if !ok {
-		return nil, fmt.Errorf("error retrieving ImageStreamTag: OpenShift user client unavailable")
-	}
-	return client.ImageStreamTags(r.namespace).Get(r.name, tag)
+	return r.registryClient.ImageStreamTags(r.namespace).Get(r.name, tag)
 }
 
 // getImageStreamImage retrieves the Image with digest `dgst` for the ImageStream
-// associated with r. This ensures the user has access to the image.
+// associated with r. This ensures the image belongs to the image stream.
 func (r *repository) getImageStreamImage(ctx context.Context, dgst digest.Digest) (*imageapi.ImageStreamImage, error) {
-	client, ok := UserClientFrom(ctx)
-	if !ok {
-		return nil, fmt.Errorf("error retrieving ImageStreamImage: OpenShift user client unavailable")
-	}
-	return client.ImageStreamImages(r.namespace).Get(r.name, dgst.String())
+	return r.registryClient.ImageStreamImages(r.namespace).Get(r.name, dgst.String())
 }
 
 // manifestFromImage converts an Image to a SignedManifest.

--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -636,10 +636,12 @@ func deleteFromRegistry(registryClient *http.Client, url string) error {
 
 	var err error
 	for _, proto := range []string{"https", "http"} {
+		glog.V(4).Infof("Trying %s for %s", proto, url)
 		err = deleteFunc(proto, fmt.Sprintf("%s://%s", proto, url))
 		if err == nil {
 			return nil
 		}
+		glog.V(4).Infof("Error with %s for %s: %v", proto, url, err)
 	}
 	return err
 }

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -3,7 +3,6 @@ package delegated
 import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	projectapi "github.com/openshift/origin/pkg/project/api"
@@ -44,19 +43,10 @@ func DefaultTemplate() *templateapi.Template {
 	binding.RoleRef.Name = bootstrappolicy.AdminRoleName
 	ret.Objects = append(ret.Objects, binding)
 
-	serviceAccountsBinding := &authorizationapi.RoleBinding{}
-	serviceAccountsBinding.Name = "image-pullers"
-	serviceAccountsBinding.Namespace = ns
-	serviceAccountsBinding.Groups = util.NewStringSet(serviceaccount.MakeNamespaceGroupName(ns))
-	serviceAccountsBinding.RoleRef.Name = bootstrappolicy.ImagePullerRoleName
-	ret.Objects = append(ret.Objects, serviceAccountsBinding)
-
-	serviceAccountBuilderBinding := &authorizationapi.RoleBinding{}
-	serviceAccountBuilderBinding.Name = "image-builders"
-	serviceAccountBuilderBinding.Namespace = ns
-	serviceAccountBuilderBinding.Users = util.NewStringSet(serviceaccount.MakeUsername(ns, bootstrappolicy.BuilderServiceAccountName))
-	serviceAccountBuilderBinding.RoleRef.Name = bootstrappolicy.ImageBuilderRoleName
-	ret.Objects = append(ret.Objects, serviceAccountBuilderBinding)
+	serviceAccountRoleBindings := bootstrappolicy.GetBootstrapServiceAccountProjectRoleBindings(ns)
+	for i := range serviceAccountRoleBindings {
+		ret.Objects = append(ret.Objects, &serviceAccountRoleBindings[i])
+	}
 
 	for _, parameterName := range parameters {
 		parameter := templateapi.Parameter{}


### PR DESCRIPTION
Remove DISABLE_USER_AUTH setting the registry used to disable authentication. Auth is now on by default and can't be disabled any more.

Modify the bootstrap policy to

- add a new subresource `imagestreams/layers` for pushing/pulling images.
- add a new system:image-pruner role

Update `osadm prune images` to require the client use a config with a token. The associated user must be able to do everything that system:image-pruner can do.

Fixes #1652

@smarterclayton @liggitt @deads2k PTAL