### PR TITLE
New-app: Support insecure registries

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -101,6 +101,7 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated application artifacts")
 	cmd.Flags().StringVar(&config.Strategy, "strategy", "", "Specify the build strategy to use if you don't want to detect (docker|source).")
 	cmd.Flags().StringP("labels", "l", "", "Label to set in all resources for this application.")
+	cmd.Flags().BoolVar(&config.InsecureRegistry, "insecure-registry", false, "If true, indicates that the referenced Docker images are on insecure registries and should bypass certificate checking")
 
 	// TODO AddPrinterFlags disabled so that it doesn't conflict with our own "template" flag.
 	// Need a better solution.

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -162,6 +162,7 @@ type ImageRef struct {
 	imageapi.DockerImageReference
 	AsImageStream bool
 	OutputImage   bool
+	Insecure      bool
 
 	Stream *imageapi.ImageStream
 	Info   *imageapi.DockerImage
@@ -283,6 +284,11 @@ func (r *ImageRef) ImageStream() (*imageapi.ImageStream, error) {
 	if !r.OutputImage {
 		stream.Spec.DockerImageRepository = r.String()
 		stream.Spec.Tags = map[string]imageapi.TagReference{}
+		if r.Insecure {
+			stream.ObjectMeta.Annotations = map[string]string{
+				imageapi.InsecureRepositoryAnnotation: "true",
+			}
+		}
 	}
 
 	return stream, nil

--- a/pkg/generate/app/app_test.go
+++ b/pkg/generate/app/app_test.go
@@ -123,7 +123,7 @@ func TestBuildConfigOutput(t *testing.T) {
 			if trigger.Type == buildapi.ImageChangeBuildTriggerType {
 				imageChangeTrigger = true
 				if trigger.ImageChange == nil {
-					t.Errorf("invalid image change trigger found: %#v", i, trigger)
+					t.Errorf("(%d) invalid image change trigger found: %#v", i, trigger)
 				}
 			}
 		}

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -116,6 +116,7 @@ type ComponentMatch struct {
 	Name        string
 	Description string
 	Score       float32
+	Insecure    bool
 
 	Builder     bool
 	Image       *imageapi.DockerImage


### PR DESCRIPTION
Add a flag to the new-app command line that will make it generate source image streams that have the insecure registry annotation.

Fixes https://github.com/openshift/origin/issues/2526