### PR TITLE
Remove --node-selector from osc new-project

### DIFF
--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -41,8 +41,8 @@ After your project is created you can switch to it using %[2]s <project name>.`
 	requestProjectExample = `  // Create a new project with minimal information
   $ %[1]s web-team-dev
 
-  // Create a new project with a description and node selector
-  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team." --node-selector="env=dev"`
+  // Create a new project with a display name and description
+  $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."`
 )
 
 func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
@@ -50,7 +50,7 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 	options.Out = out
 
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION] [--node-selector=<label selector>]", name),
+		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
 		Short:   "Request a new project",
 		Long:    fmt.Sprintf(requestProjectLong, oscLoginName, oscProjectName),
 		Example: fmt.Sprintf(requestProjectExample, fullName),
@@ -70,9 +70,8 @@ func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f
 	}
 	cmd.SetOutput(out)
 
-	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "project display name")
-	cmd.Flags().StringVar(&options.Description, "description", "", "project description")
-	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "Restrict pods onto nodes matching given label selector. Format: '<key1>=<value1>, <key2>=<value2>...'")
+	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", "Project display name")
+	cmd.Flags().StringVar(&options.Description, "description", "", "Project description")
 
 	return cmd
 }


### PR DESCRIPTION
specifying a node selector is not allowed when requesting a new project as a user (`osc new-project`). That is only supported when creating a project as an admin (`osadm new-project`)