### PR TITLE
Router: fix reverted code

### DIFF
--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -155,7 +155,7 @@ func (r *templateRouter) writeConfig() error {
 	//write out any certificate files that don't exist
 	for _, serviceUnit := range r.state {
 		for k, cfg := range serviceUnit.ServiceAliasConfigs {
-			err := r.certManager.WriteCertificatesForConfig(&cfg)
+			err := r.writeCertificates(&cfg)
 			if err != nil {
 				glog.Errorf("Error writing certificates for %s: %v", serviceUnit.Name, err)
 				return err


### PR DESCRIPTION
PR https://github.com/openshift/origin/pull/1817 reverted the call to the local method that ensures that TLS routes that don't specify certificates do not write a file so that they can use the default certificate.  This puts the code back into working order.

@smarterclayton @rajatchopra PTAL

/cc @thoraxe 

```
[vagrant@openshiftdev ~]$ osadm router --credentials="$OPENSHIFTCONFIG" --default-cert="/home/vagrant/hello-nginx-docker/certs/router.default.local.chain.pem" --images=openshift/origin-haproxy-router
deploymentconfigs/router
services/router
[vagrant@openshiftdev ~]$ osc create -f hello-nginx-docker/openshift/nginx_pod.json 
pods/hello-nginx-docker
[vagrant@openshiftdev ~]$ osc create -f hello-nginx-docker/openshift/unsecure/service.json
services/hello-nginx
[vagrant@openshiftdev ~]$ osc create -f route_default.json 
routes/hello-openshift-route
[vagrant@openshiftdev ~]$ curl --resolve www.example.com:443:10.0.2.15 https://www.example.com -k
Hello World
[vagrant@openshiftdev ~]$ cat route_default.json 
{
      "kind": "Route",
      "apiVersion": "v1beta3",
      "metadata": {
        "name": "hello-openshift-route"
      },
      "spec": {
        "host": "www.example.com",
        "to": {
          "name": "hello-nginx"
        },
       "tls": {
         "termination": "edge"
       }
      }
    }
[vagrant@openshiftdev ~]$ docker exec 80d ls -l /var/lib/containers/router/certs
total 8
-rw-r--r--. 1 root root 3531 Jun  3 14:27 default.pem
-rw-r--r--. 1 root root 2042 Jun  3 12:33 default_pub_keys.pem
```