### PR TITLE
Update `osc logs` examples

### DIFF
--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -116,10 +116,10 @@ const (
 	log_long = `Print the logs for a container in a pod. If the pod has only one container, the container name is optional.`
 
 	log_example = `  // Returns snapshot of ruby-container logs from pod 123456-7890.
-  $ %[1]s log 123456-7890 ruby-container
+  $ %[1]s logs 123456-7890 ruby-container
 
   // Starts streaming of ruby-container logs from pod 123456-7890.
-  $ %[1]s log -f 123456-7890 ruby-container`
+  $ %[1]s logs -f 123456-7890 ruby-container`
 )
 
 // NewCmdLog is a wrapper for the Kubernetes cli log command


### PR DESCRIPTION
Using `log` is deprecated