### PR TITLE
new-build command for creating BuildConfigs

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -68,6 +68,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 	cmds.AddCommand(cmd.NewCmdRequestProject("new-project", fullName+" new-project", fullName+" login", fullName+" project", f, out))
 	cmds.AddCommand(cmd.NewCmdNewApplication(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdStatus(fullName, f, out))
+	cmds.AddCommand(cmd.NewCmdNewBuild(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdStartBuild(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdCancelBuild(fullName, f, out))
 	cmds.AddCommand(cmd.NewCmdBuildLogs(fullName, f, out))

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -81,7 +81,7 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 		Long:    newAppLong,
 		Example: fmt.Sprintf(newAppExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
-			err := RunNewApplication(f, out, c, args, config)
+			err := RunNewApplication(fullName, f, out, c, args, config)
 			if err == errExit {
 				os.Exit(1)
 			}
@@ -99,7 +99,7 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 	cmd.Flags().Var(&config.Groups, "group", "Indicate components that should be grouped together as <comp1>+<comp2>.")
 	cmd.Flags().VarP(&config.Environment, "env", "e", "Specify key value pairs of environment variables to set into each container.")
 	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated application artifacts")
-	cmd.Flags().StringVar(&config.TypeOfBuild, "build", "", "Specify the type of build to use if you don't want to detect (docker|source).")
+	cmd.Flags().StringVar(&config.Strategy, "strategy", "", "Specify the build strategy to use if you don't want to detect (docker|source).")
 	cmd.Flags().StringP("labels", "l", "", "Label to set in all resources for this application.")
 
 	// TODO AddPrinterFlags disabled so that it doesn't conflict with our own "template" flag.
@@ -114,7 +114,7 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 }
 
 // RunNewApplication contains all the necessary functionality for the OpenShift cli new-app command
-func RunNewApplication(f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
+func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
 	if err := setupAppConfig(f, c, args, config); err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func RunNewApplication(f *clientcmd.Factory, out io.Writer, c *cobra.Command, ar
 			}
 			fmt.Fprintf(c.Out(), "Service %q created at %s%s\n", t.Name, t.Spec.PortalIP, portMappings)
 		case *buildapi.BuildConfig:
-			fmt.Fprintf(c.Out(), "A build was created - you can run `osc start-build %s` to start it.\n", t.Name)
+			fmt.Fprintf(c.Out(), "A build was created - you can run `%s start-build %s` to start it.\n", fullName, t.Name)
 		case *imageapi.ImageStream:
 			if len(t.Status.DockerImageRepository) == 0 {
 				if hasMissingRepo {

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -48,7 +48,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 		Long:    newBuildLong,
 		Example: fmt.Sprintf(newBuildExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
-			err := RunNewBuild(f, out, c, args, config)
+			err := RunNewBuild(fullName, f, out, c, args, config)
 			if err == errExit {
 				os.Exit(1)
 			}
@@ -60,7 +60,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	cmd.Flags().VarP(&config.ImageStreams, "image", "i", "Name of an OpenShift image stream to to use as a builder.")
 	cmd.Flags().Var(&config.DockerImages, "docker-image", "Name of a Docker image to use as a builder.")
 	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated build artifacts")
-	cmd.Flags().StringVar(&config.TypeOfBuild, "build", "", "Specify the type of build to use if you don't want to detect (docker|source).")
+	cmd.Flags().StringVar(&config.Strategy, "strategy", "", "Specify the build strategy to use if you don't want to detect (docker|source).")
 	cmd.Flags().BoolVar(&config.OutputDocker, "to-docker", false, "Force the Build output to be DockerImage.")
 	cmd.Flags().StringP("labels", "l", "", "Label to set in all generated resources.")
 	cmdutil.AddPrinterFlags(cmd)
@@ -69,7 +69,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 }
 
 // RunNewBuild contains all the necessary functionality for the OpenShift cli new-build command
-func RunNewBuild(f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
+func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
 	if err := setupAppConfig(f, c, args, config); err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func RunNewBuild(f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []s
 	for _, item := range result.List.Items {
 		switch t := item.(type) {
 		case *buildapi.BuildConfig:
-			fmt.Fprintf(c.Out(), "A build was created - you can run `osc start-build %s` to start it.\n", t.Name)
+			fmt.Fprintf(c.Out(), "A build was created - you can run `%s start-build %s` to start it.\n", fullName, t.Name)
 		}
 	}
 

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/spf13/cobra"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	newcmd "github.com/openshift/origin/pkg/generate/app/cmd"
+)
+
+const (
+	newBuildLong = `Create a new build in OpenShift by specifying source code.
+
+This command will try to create a build configuration (BuildConfig) for your application using images and
+code that has a public repository. It will lookup the images on the local Docker installation
+(if available), a Docker registry, or an OpenShift image stream.
+If you specify a source code URL, it will set up a build that takes your source code and converts
+it into an image that can run inside of a pod. Local source must be in a git repository that has a
+remote repository that the OpenShift instance can see.
+
+Once the BuildConfig is created you may need to run a build with 'start-build'.`
+
+	newBuildExample = `  // Create a BuildConfig based on the source code in the current git repository (with a public remote) and a Docker image
+  $ %[1]s new-build . --docker-image=repo/langimage
+
+  // Create a NodeJS BuildConfig based on the provided [image]~[source code] combination
+  $ %[1]s new-build openshift/nodejs-010-centos7~https://bitbucket.com/user/nodejs-app
+
+  // Create a BuildConfig from a remote repository using its beta2 branch
+  $ %[1]s new-build https://github.com/openshift/ruby-hello-world#beta2`
+)
+
+// NewCmdNewBuild implements the OpenShift cli new-build command
+func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	mapper, typer := f.Object()
+	clientMapper := f.ClientMapperForCommand()
+	config := newcmd.NewAppConfig(typer, mapper, clientMapper)
+
+	cmd := &cobra.Command{
+		Use:     "new-build (IMAGE | IMAGESTREAM | PATH | URL ...)",
+		Short:   "Create a new BuildConfig",
+		Long:    newBuildLong,
+		Example: fmt.Sprintf(newBuildExample, fullName),
+		Run: func(c *cobra.Command, args []string) {
+			err := RunNewBuild(f, out, c, args, config)
+			if err == errExit {
+				os.Exit(1)
+			}
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().Var(&config.SourceRepositories, "code", "Source code in the build configuration.")
+	cmd.Flags().VarP(&config.ImageStreams, "image", "i", "Name of an OpenShift image stream to to use as a builder.")
+	cmd.Flags().Var(&config.DockerImages, "docker-image", "Name of a Docker image to use as a builder.")
+	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated build artifacts")
+	cmd.Flags().StringVar(&config.TypeOfBuild, "build", "", "Specify the type of build to use if you don't want to detect (docker|source).")
+	cmd.Flags().BoolVar(&config.OutputDocker, "to-docker", false, "Force the Build output to be DockerImage.")
+	cmd.Flags().StringP("labels", "l", "", "Label to set in all generated resources.")
+	cmdutil.AddPrinterFlags(cmd)
+
+	return cmd
+}
+
+// RunNewBuild contains all the necessary functionality for the OpenShift cli new-build command
+func RunNewBuild(f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
+	if err := setupAppConfig(f, c, args, config); err != nil {
+		return err
+	}
+
+	result, err := config.RunBuilds(out)
+	if err != nil {
+		if errs, ok := err.(errors.Aggregate); ok {
+			if len(errs.Errors()) == 1 {
+				err = errs.Errors()[0]
+			}
+		}
+		if err == newcmd.ErrNoInputs {
+			// TODO: suggest things to the user
+			return cmdutil.UsageError(c, "You must specify one or more images, image streams and source code locations to create a BuildConfig.")
+		}
+		return err
+	}
+
+	if err := setLabels(c, result); err != nil {
+		return err
+	}
+	if len(cmdutil.GetFlagString(c, "output")) != 0 {
+		return f.Factory.PrintObject(c, result.List, out)
+	}
+	if err := createObjects(f, out, result); err != nil {
+		return err
+	}
+
+	for _, item := range result.List.Items {
+		switch t := item.(type) {
+		case *buildapi.BuildConfig:
+			fmt.Fprintf(c.Out(), "A build was created - you can run `osc start-build %s` to start it.\n", t.Name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -231,8 +231,13 @@ func (r *ImageRef) BuildOutput() (*buildapi.BuildOutput, error) {
 	if err != nil {
 		return nil, err
 	}
+	kind := ""
+	if !r.AsImageStream {
+		kind = "DockerImage"
+	}
 	return &buildapi.BuildOutput{
 		To: &kapi.ObjectReference{
+			Kind: kind,
 			Name: imageRepo.Name,
 		},
 		Tag: r.Tag,

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -388,7 +388,7 @@ func TestResolve(t *testing.T) {
 		{
 			name: "Successful docker build",
 			cfg: AppConfig{
-				TypeOfBuild: "docker",
+				Strategy: "docker",
 			},
 			components: app.ComponentReferences{
 				app.ComponentReference(&app.ComponentInput{

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -471,7 +471,7 @@ func TestDetectSource(t *testing.T) {
 	}
 }
 
-func TestRun(t *testing.T) {
+func TestRunAll(t *testing.T) {
 	dockerResolver := app.DockerRegistryResolver{
 		Client: dockerregistry.NewClient(),
 	}
@@ -553,7 +553,7 @@ func TestRun(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res, err := test.config.Run(os.Stdout)
+		res, err := test.config.RunAll(os.Stdout)
 		if err != test.expectedErr {
 			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
 			continue
@@ -569,6 +569,87 @@ func TestRun(t *testing.T) {
 				got["imageStream"] = append(got["imageStream"], tp.Name)
 			case *deploy.DeploymentConfig:
 				got["deploymentConfig"] = append(got["deploymentConfig"], tp.Name)
+			}
+		}
+
+		if len(test.expected) != len(got) {
+			t.Errorf("%s: Resource kind size mismatch! Expected %d, got %d", test.name, len(test.expected), len(got))
+			continue
+		}
+
+		for k, exp := range test.expected {
+			g, ok := got[k]
+			if !ok {
+				t.Errorf("%s: Didn't find expected kind %s", test.name, k)
+			}
+
+			sort.Strings(g)
+			sort.Strings(exp)
+
+			if !reflect.DeepEqual(g, exp) {
+				t.Errorf("%s: Resource names mismatch! Expected %v, got %v", test.name, exp, g)
+				continue
+			}
+		}
+	}
+}
+
+func TestRunBuild(t *testing.T) {
+	dockerResolver := app.DockerRegistryResolver{
+		Client: dockerregistry.NewClient(),
+	}
+
+	tests := []struct {
+		name        string
+		config      *AppConfig
+		expected    map[string][]string
+		expectedErr error
+	}{
+		{
+			name: "successful ruby app generation",
+			config: &AppConfig{
+				SourceRepositories: util.StringList{"https://github.com/openshift/ruby-hello-world"},
+				OutputDocker:       true,
+
+				dockerResolver: dockerResolver,
+				imageStreamResolver: app.ImageStreamResolver{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				templateResolver: app.TemplateResolver{
+					Client: &client.Fake{},
+					TemplateConfigsNamespacer: &client.Fake{},
+					Namespaces:                []string{"openshift", "default"},
+				},
+
+				detector: app.SourceRepositoryEnumerator{
+					Detectors: source.DefaultDetectors,
+					Tester:    dockerfile.NewTester(),
+				},
+				searcher:        &simpleSearcher{dockerResolver},
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+			},
+			expected: map[string][]string{
+				"buildConfig": {"ruby-hello-world"},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		res, err := test.config.RunBuilds(os.Stdout)
+		if err != test.expectedErr {
+			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
+			continue
+		}
+		got := map[string][]string{}
+		for _, obj := range res.List.Items {
+			switch tp := obj.(type) {
+			case *buildapi.BuildConfig:
+				got["buildConfig"] = append(got["buildConfig"], tp.Name)
 			}
 		}
 


### PR DESCRIPTION
This should fix #2695.
@smarterclayton @csrwng ptal

This PR also includes a fix (2nd commit) for the case when generating new-app/new-build from repo containing Dockerfile (eg. https://github.com/openshift/ruby-hello-world) with forced build type (`--build=source`), previously that always created dockerStrategy.
