### PR TITLE
add api description unit test

### DIFF
--- a/pkg/api/latest/description_test.go
+++ b/pkg/api/latest/description_test.go
@@ -1,0 +1,60 @@
+package latest
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+)
+
+func TestDescriptions(t *testing.T) {
+	for _, version := range Versions {
+		if version == "v1beta3" {
+			// we don't care about descriptions here
+			continue
+		}
+
+		seen := map[reflect.Type]bool{}
+
+		for _, apiType := range kapi.Scheme.KnownTypes(version) {
+			if !strings.Contains(apiType.PkgPath(), "openshift/origin") {
+				continue
+			}
+
+			checkDescriptions(apiType, &seen, t)
+		}
+	}
+}
+
+func checkDescriptions(objType reflect.Type, seen *map[reflect.Type]bool, t *testing.T) {
+	if _, exists := (*seen)[objType]; exists {
+		return
+	}
+	(*seen)[objType] = true
+
+	for i := 0; i < objType.NumField(); i++ {
+		structField := objType.FieldByIndex([]int{i})
+
+		// these fields don't need descriptions
+		if structField.Name == "TypeMeta" || structField.Name == "ObjectMeta" || structField.Name == "ListMeta" {
+			continue
+		}
+		if structField.Type == reflect.TypeOf(util.Time{}) || structField.Type == reflect.TypeOf(time.Time{}) || structField.Type == reflect.TypeOf(runtime.RawExtension{}) {
+			continue
+		}
+
+		descriptionTag := structField.Tag.Get("description")
+		if len(descriptionTag) == 0 {
+			t.Errorf("%v.%v does not have a description", objType, structField.Name)
+		}
+
+		switch structField.Type.Kind() {
+		case reflect.Struct:
+			checkDescriptions(structField.Type, seen, t)
+		}
+	}
+}

--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -11,7 +11,7 @@ type ImageList struct {
 	kapi.TypeMeta `json:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty"`
 
-	Items []Image `json:"items"`
+	Items []Image `json:"items" description:"list of image objects"`
 }
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.


### PR DESCRIPTION
Adds a unit test to make sure that all external API fields have descriptions.

@derekwaynecarr obviously this fails now, but you'll want it after.