### PR TITLE
Add v1 descriptions to image api

### DIFF
--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -20,13 +20,13 @@ type Image struct {
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// The string that can be used to pull this image.
-	DockerImageReference string `json:"dockerImageReference,omitempty"`
+	DockerImageReference string `json:"dockerImageReference,omitempty" description:"string that can be used to pull this image"`
 	// Metadata about this image
-	DockerImageMetadata runtime.RawExtension `json:"dockerImageMetadata,omitempty"`
+	DockerImageMetadata runtime.RawExtension `json:"dockerImageMetadata,omitempty" description:"metadata about this image"`
 	// This attribute conveys the version of the object, which if empty defaults to "1.0"
-	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty"`
+	DockerImageMetadataVersion string `json:"dockerImageMetadataVersion,omitempty" description:"conveys version of the object, if empty defaults to '1.0'"`
 	// The raw JSON of the manifest
-	DockerImageManifest string `json:"dockerImageManifest,omitempty"`
+	DockerImageManifest string `json:"dockerImageManifest,omitempty" description:"raw JSON of the manifest"`
 }
 
 // ImageStreamList is a list of ImageStream objects.
@@ -34,7 +34,7 @@ type ImageStreamList struct {
 	kapi.TypeMeta `json:",inline"`
 	kapi.ListMeta `json:"metadata,omitempty"`
 
-	Items []ImageStream `json:"items"`
+	Items []ImageStream `json:"items" description:"list of image stream objects"`
 }
 
 // ImageStream stores a mapping of tags to images, metadata overrides that are applied
@@ -45,50 +45,50 @@ type ImageStream struct {
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired state of this stream
-	Spec ImageStreamSpec `json:"spec"`
+	Spec ImageStreamSpec `json:"spec" description:"desired state of the stream"`
 	// Status describes the current state of this stream
-	Status ImageStreamStatus `json:"status,omitempty"`
+	Status ImageStreamStatus `json:"status,omitempty" description:"current state of the stream as observed by the system"`
 }
 
 // ImageStreamSpec represents options for ImageStreams.
 type ImageStreamSpec struct {
 	// Optional, if specified this stream is backed by a Docker repository on this server
-	DockerImageRepository string `json:"dockerImageRepository,omitempty"`
+	DockerImageRepository string `json:"dockerImageRepository,omitempty" description:"optional field if specified this stream is backed by a Docker repository on this server"`
 	// Tags map arbitrary string values to specific image locators
-	Tags []NamedTagReference `json:"tags,omitempty"`
+	Tags []NamedTagReference `json:"tags,omitempty" description:"map arbitrary string values to specific image locators"`
 }
 
-// NamedTagReference allows a user to TODO.
+// NamedTagReference specifies optional annotations for images using this tag and an optional reference to another ImageStreamTag or ImageStreamImage this tag should track.
 type NamedTagReference struct {
-	Name        string                `json:"name"`
-	Annotations map[string]string     `json:"annotations,omitempty"`
-	From        *kapi.ObjectReference `json:"from,omitempty"`
+	Name        string                `json:"name" description:"name of tag"`
+	Annotations map[string]string     `json:"annotations,omitempty" description:"annotations associated with images using this tag"`
+	From        *kapi.ObjectReference `json:"from,omitempty" description:"a reference to an image stream tag or image stream this tag should track"`
 }
 
 // ImageStreamStatus contains information about the state of this image stream.
 type ImageStreamStatus struct {
 	// Represents the effective location this stream may be accessed at. May be empty until the server
 	// determines where the repository is located
-	DockerImageRepository string `json:"dockerImageRepository"`
+	DockerImageRepository string `json:"dockerImageRepository" description:"represents the effective location this stream may be accessed at, may be empty until the server determines where the repository is located"`
 	// A historical record of images associated with each tag. The first entry in the TagEvent array is
 	// the currently tagged image.
-	Tags []NamedTagEventList `json:"tags,omitempty"`
+	Tags []NamedTagEventList `json:"tags,omitempty" description:"historical record of images associated with each tag, the first entry is the currently tagged image"`
 }
 
 // NamedTagEventList relates a tag to its image history.
 type NamedTagEventList struct {
-	Tag   string     `json:"tag"`
-	Items []TagEvent `json:"items"`
+	Tag   string     `json:"tag" description:"the tag"`
+	Items []TagEvent `json:"items" description:"list of tag events related to the tag"`
 }
 
 // TagEvent is used by ImageRepositoryStatus to keep a historical record of images associated with a tag.
 type TagEvent struct {
 	// When the TagEvent was created
-	Created util.Time `json:"created"`
+	Created util.Time `json:"created" description:"when the event was created"`
 	// The string that can be used to pull this image
-	DockerImageReference string `json:"dockerImageReference"`
+	DockerImageReference string `json:"dockerImageReference" description:"the string that can be used to pull this image"`
 	// The image
-	Image string `json:"image"`
+	Image string `json:"image" description:"the image"`
 }
 
 // ImageStreamMapping represents a mapping from a single tag to a Docker image as
@@ -98,9 +98,9 @@ type ImageStreamMapping struct {
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 
 	// A Docker image.
-	Image Image `json:"image"`
+	Image Image `json:"image" description:"a Docker image"`
 	// A string value this image can be located with inside the repository.
-	Tag string `json:"tag"`
+	Tag string `json:"tag" description:"string value this image can be located with inside the repository"`
 }
 
 // ImageRepositoryTag exists to allow calls to `osc get imageRepositoryTag ...` to function.
@@ -113,13 +113,13 @@ type ImageRepositoryTag struct {
 // ImageStreamTag exists to allow calls to `osc get imageStreamTag ...` to function.
 type ImageStreamTag struct {
 	Image     `json:",inline"`
-	ImageName string `json:"imageName"`
+	ImageName string `json:"imageName" description:"name of image"`
 }
 
 // ImageStreamImage exists to allow calls to `osc get imageStreamImage ...` to function.
 type ImageStreamImage struct {
 	Image     `json:",inline"`
-	ImageName string `json:"imageName"`
+	ImageName string `json:"imageName" description:"name of image"`
 }
 
 // DockerImageReference points to a Docker image.


### PR DESCRIPTION
Every field in external API that is not inlined must have a description to properly generate documenation.

Please ensure you follow this practice now and forever into the future.

Image part of #2632 

@ncdc - review
