### PR TITLE
Relax source repository URL validation

### DIFF
--- a/assets/app/scripts/controllers/create.js
+++ b/assets/app/scripts/controllers/create.js
@@ -14,7 +14,7 @@ angular.module('openshiftConsole')
 
     $scope.templatesByTag = {};
 
-    $scope.sourceURLPattern = /^((ftp|http|https|git):\/\/(\w+:{0,1}\w*@)|git@)?([^\s@]+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
+    $scope.sourceURLPattern = /^((ftp|http|https|git):\/\/(\w+:{0,1}[^\s@]*@)|git@)?([^\s@]+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/;
 
     DataService.list("templates", $scope, function(templates) {
       $scope.projectTemplates = templates.by("metadata.name");

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -14,11 +14,10 @@
             <div class="row">
               <div class="col-md-8">
                 <div class="input-group">
-                  <span ng-class="{'has-error': from_source_form.$invalid && from_source_form.from_source_url.$touched}">
+                  <span ng-class="{'has-warning': from_source_form.from_source_url.$dirty && !sourceURLPattern.test(from_source_url)}">
                     <input class="form-control input-lg"
                       name="from_source_url"
                       placeholder="Repository URL"
-                      ng-pattern="sourceURLPattern"
                       type="text"
                       required
                       aria-describedby="from_source_help"
@@ -32,7 +31,7 @@
                 <div id="from_source_help" class="help-block">For example,
                   <a href="#" ng-click="from_source_url = 'https://github.com/openshift/nodejs-ex'"
                     >https://github.com/openshift/nodejs-ex</a></div>
-                <span class="text-danger" ng-if="from_source_form.$invalid && from_source_form.from_source_url.$touched">Source repository must be a URL</span>
+                <span class="text-warning" ng-if="from_source_form.from_source_url.$dirty && !sourceURLPattern.test(from_source_url)">Source repository should be a URL</span>
               </div>
             </div>
           </form>

--- a/assets/test/spec/controllers/create.js
+++ b/assets/test/spec/controllers/create.js
@@ -37,6 +37,16 @@ describe("CreateController", function(){
     expect(match).not.toBeNull();
   });
 
+  it("invalid http URL with user and password containing space", function(){
+    var match = 'http://user:pa ss@example.com/dir1/dir2'.match($scope.sourceURLPattern)
+    expect(match).toBeNull();
+  });
+
+  it("valid http URL with user and password with special characters", function(){
+    var match = 'https://user:my!password@example.com/gerrit/p/myrepo.git'.match($scope.sourceURLPattern)
+    expect(match).not.toBeNull();
+  });
+
   it("valid http URL with port", function(){
     var match = 'http://example.com:8080/dir1/dir2'.match($scope.sourceURLPattern)
     expect(match).not.toBeNull();


### PR DESCRIPTION
* Allow special characters in passwords when URL has a userinfo subcomponent.
* Only warn about invalid URLs. Don't disable the Next button unless the field
  has no value. Use warning styles rather than error styles.
* Show the warning immediately if the field has been changed.

Fixes #2730