### PR TITLE
update generated kubeconfig keys to match osc login

### DIFF
--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -289,11 +289,9 @@ This section covers how to perform all the steps of building, deploying, and upd
 
      If you want to see the build logs of a complete build, use the
      command below (substituting your build name from the "osc get builds"
-     output). Notice that for now only cluster admins can run the `build-logs`
-     command, so we have to explicitly tell the command to use the `master`
-     context from the $OPENSHIFTCONFIG config file:
+     output). 
 
-         $ osc build-logs ruby-sample-build-1 --context=master -n test
+         $ osc build-logs ruby-sample-build-1 -n test
 
     The creation of the new image in the Docker registry will
     automatically trigger a deployment of the application, creating a

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -238,16 +238,19 @@ OS_PID=$!
 
 export HOME="${FAKE_HOME_DIR}"
 
+export OPENSHIFTCONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+CLUSTER_ADMIN_CONTEXT=$(osc config view --flatten -o template -t '{{index . "current-context"}}')
+
 if [[ "${API_SCHEME}" == "https" ]]; then
 	export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
 	export CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
 	export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
 
 	# Make osc use ${MASTER_CONFIG_DIR}/admin.kubeconfig, and ignore anything in the running user's $HOME dir
-	export OPENSHIFTCONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 	sudo chmod -R a+rwX "${OPENSHIFTCONFIG}"
 	echo "[INFO] To debug: export OPENSHIFTCONFIG=$OPENSHIFTCONFIG"
 fi
+
 
 wait_for_url "${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz" "[INFO] kubelet: " 0.5 60
 wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
@@ -307,7 +310,7 @@ docker push ${DOCKER_REGISTRY}/cache/ruby-20-centos7:latest
 echo "[INFO] Pushed ruby-20-centos7"
 
 echo "[INFO] Back to 'master' context with 'admin' user..."
-osc project default
+osc project ${CLUSTER_ADMIN_CONTEXT}
 
 # Process template and create
 echo "[INFO] Submitting application template json for processing..."

--- a/pkg/cmd/cli/config/smart_merge.go
+++ b/pkg/cmd/cli/config/smart_merge.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/x509"
 	"net/url"
 	"reflect"
 	"strings"
@@ -9,12 +10,18 @@ import (
 	clientcmdapi "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd/api"
 	"github.com/GoogleCloudPlatform/kubernetes/third_party/golang/netutil"
 
+	"github.com/openshift/origin/pkg/auth/authenticator/request/x509request"
 	osclient "github.com/openshift/origin/pkg/client"
 )
 
-// getClusterNickname returns host:port of the clientConfig.Host, with .'s replaced by -'s
-func getClusterNickname(clientCfg *client.Config) (string, error) {
-	u, err := url.Parse(clientCfg.Host)
+// GetClusterNicknameFromConfig returns host:port of the clientConfig.Host, with .'s replaced by -'s
+func GetClusterNicknameFromConfig(clientCfg *client.Config) (string, error) {
+	return GetClusterNicknameFromURL(clientCfg.Host)
+}
+
+// GetClusterNicknameFromURL returns host:port of the apiServerLocation, with .'s replaced by -'s
+func GetClusterNicknameFromURL(apiServerLocation string) (string, error) {
+	u, err := url.Parse(apiServerLocation)
 	if err != nil {
 		return "", err
 	}
@@ -24,9 +31,9 @@ func getClusterNickname(clientCfg *client.Config) (string, error) {
 	return strings.Replace(hostPort, ".", "-", -1), nil
 }
 
-// getUserNickname returns "username(as known by the server)/getClusterNickname".  This allows tab completion for switching users to
+// GetUserNicknameFromConfig returns "username(as known by the server)/GetClusterNicknameFromConfig".  This allows tab completion for switching users to
 // work easily and obviously.
-func getUserNickname(clientCfg *client.Config) (string, error) {
+func GetUserNicknameFromConfig(clientCfg *client.Config) (string, error) {
 	client, err := osclient.New(clientCfg)
 	if err != nil {
 		return "", err
@@ -36,7 +43,7 @@ func getUserNickname(clientCfg *client.Config) (string, error) {
 		return "", err
 	}
 
-	clusterNick, err := getClusterNickname(clientCfg)
+	clusterNick, err := GetClusterNicknameFromConfig(clientCfg)
 	if err != nil {
 		return "", err
 	}
@@ -44,10 +51,19 @@ func getUserNickname(clientCfg *client.Config) (string, error) {
 	return userInfo.Name + "/" + clusterNick, nil
 }
 
-// getContextNickname returns "namespace/getClusterNickname/username(as known by the server)".  This allows tab completion for switching projects/context
+func GetUserNicknameFromCert(clusterNick string, chain ...*x509.Certificate) (string, error) {
+	userInfo, _, err := x509request.SubjectToUserConversion(chain)
+	if err != nil {
+		return "", err
+	}
+
+	return userInfo.GetName() + "/" + clusterNick, nil
+}
+
+// GetContextNicknameFromConfig returns "namespace/GetClusterNicknameFromConfig/username(as known by the server)".  This allows tab completion for switching projects/context
 // to work easily.  First tab is the most selective on project.  Second stanza in the next most selective on cluster name.  The chances of a user trying having
 // one projects on a single server that they want to operate against with two identities is low, so username is last.
-func getContextNickname(namespace string, clientCfg *client.Config) (string, error) {
+func GetContextNicknameFromConfig(namespace string, clientCfg *client.Config) (string, error) {
 	client, err := osclient.New(clientCfg)
 	if err != nil {
 		return "", err
@@ -57,7 +73,7 @@ func getContextNickname(namespace string, clientCfg *client.Config) (string, err
 		return "", err
 	}
 
-	clusterNick, err := getClusterNickname(clientCfg)
+	clusterNick, err := GetClusterNicknameFromConfig(clientCfg)
 	if err != nil {
 		return "", err
 	}
@@ -65,19 +81,24 @@ func getContextNickname(namespace string, clientCfg *client.Config) (string, err
 	return namespace + "/" + clusterNick + "/" + userInfo.Name, nil
 }
 
+func GetContextNickname(namespace, clusterNick, userNick string) (string, error) {
+	tokens := strings.SplitN(userNick, "/", 2)
+	return namespace + "/" + clusterNick + "/" + tokens[0], nil
+}
+
 // CreatePartialConfig takes a clientCfg and builds a config (kubeconfig style) from it.
 func CreateConfig(namespace string, clientCfg *client.Config) (*clientcmdapi.Config, error) {
-	clusterNick, err := getClusterNickname(clientCfg)
+	clusterNick, err := GetClusterNicknameFromConfig(clientCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	userNick, err := getUserNickname(clientCfg)
+	userNick, err := GetUserNicknameFromConfig(clientCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	contextNick, err := getContextNickname(namespace, clientCfg)
+	contextNick, err := GetContextNicknameFromConfig(namespace, clientCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/admin/create_client.go
+++ b/pkg/cmd/server/admin/create_client.go
@@ -134,11 +134,9 @@ func (o CreateClientOptions) CreateClientFolder() error {
 		APIServerURL:       o.APIServerURL,
 		PublicAPIServerURL: o.PublicAPIServerURL,
 		APIServerCAFile:    clientCopyOfCAFile,
-		ServerNick:         "master",
 
 		CertFile: clientCertFile,
 		KeyFile:  clientKeyFile,
-		UserNick: o.User,
 
 		ContextNamespace: kapi.NamespaceDefault,
 

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -184,11 +184,9 @@ func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *GetSign
 			APIServerURL:       o.APIServerURL,
 			PublicAPIServerURL: o.PublicAPIServerURL,
 			APIServerCAFile:    getSignerCertOptions.CertFile,
-			ServerNick:         "master",
 
 			CertFile: clientCertInfo.CertLocation.CertFile,
 			KeyFile:  clientCertInfo.CertLocation.KeyFile,
-			UserNick: clientCertInfo.User,
 
 			ContextNamespace: kapi.NamespaceDefault,
 

--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -323,11 +323,9 @@ func (o CreateNodeConfigOptions) MakeKubeConfig(clientCertFile, clientKeyFile, c
 	createKubeConfigOptions := CreateKubeConfigOptions{
 		APIServerURL:    o.APIServerURL,
 		APIServerCAFile: clientCopyOfCAFile,
-		ServerNick:      "master",
 
 		CertFile: clientCertFile,
 		KeyFile:  clientKeyFile,
-		UserNick: "node",
 
 		ContextNamespace: kapi.NamespaceDefault,
 


### PR DESCRIPTION
makes generated .kubeconfig keys match the keys we choose during `osc login`.  This avoids conflicts and unexpected behavior when someone tries to use these files in unexpected ways ala @derekwaynecarr .

@liggitt  ptal.

Fixes https://github.com/openshift/origin/issues/2432