### PR TITLE
Fix incorrect Content-Type in some Web Console responses

### DIFF
--- a/assets/app/views/directives/_custom-icon.html
+++ b/assets/app/views/directives/_custom-icon.html
@@ -1,2 +1,2 @@
 <span ng-if="!isDataIcon" aria-hidden="true" class="font-icon {{icon}}"></span>
-<img ng-if="isDataIcon" src="{{icon}}">
+<img ng-if="isDataIcon" alt="" ng-src="{{icon}}">

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -184,6 +184,7 @@ func GeneratedConfigHandler(config WebConsoleConfig, h http.Handler) http.Handle
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.TrimPrefix(r.URL.Path, "/") == "config.js" {
 			w.Header().Add("Cache-Control", "no-cache, no-store")
+			w.Header().Add("Content-Type", "application/json")
 			if err := configTemplate.Execute(w, config); err != nil {
 				glog.Errorf("Unable to render config template: %v", err)
 			}


### PR DESCRIPTION
* Set application/json Content-Type for config.js
* Use `ng-src` rather than `src` for custom data icons

Fixes #2652