### PR TITLE
DeploymentConfig stop fixes

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -343,8 +343,9 @@ osadm registry --create --credentials="${OPENSHIFTCONFIG}"
 # ensure the registry rc has been created
 wait_for_command 'osc get rc docker-registry-1' "${TIME_MIN}"
 # delete the registry resources
-osc delete dc docker-registry
 osc delete svc docker-registry
+osc delete dc docker-registry
+[ ! "$(osc get dc docker-registry)" ]
 [ ! "$(osc get rc docker-registry-1)" ]
 # done deleting registry resources
 osc delete imageStreams test
@@ -464,8 +465,8 @@ osc process -f examples/sample-app/application-template-dockerbuild.json -l app=
 wait_for_command 'osc get rc/database-1' "${TIME_MIN}"
 osc get dc/database
 osc stop dc/database
-[ ! "$(osc get rc/database-1)" ]
 [ ! "$(osc get dc/database)" ]
+[ ! "$(osc get rc/database-1)" ]
 echo "stop: ok"
 osc label bc ruby-sample-build acustom=label
 [ "$(osc describe bc/ruby-sample-build | grep 'acustom=label')" ]

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -1,9 +1,11 @@
 package testclient
 
 import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
+	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/client"
 )
 
@@ -20,6 +22,17 @@ type Fake struct {
 	// ReactFn is an optional function that will be invoked with the provided action
 	// and return a response.
 	ReactFn ktestclient.ReactionFunc
+}
+
+// NewSimpleFake returns a client that will respond with the provided objects
+func NewSimpleFake(objects ...runtime.Object) *Fake {
+	o := ktestclient.NewObjects(kapi.Scheme, kapi.Scheme)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+	return &Fake{ReactFn: ktestclient.ObjectReaction(o, latest.RESTMapper)}
 }
 
 // Invokes registers the passed fake action and reacts on it if a ReactFn
@@ -167,7 +180,6 @@ func (c *Fake) SubjectAccessReviews(namespace string) client.SubjectAccessReview
 // OAuthAccessTokens provides a fake REST client for OAuthAccessTokens
 func (c *Fake) OAuthAccessTokens() client.OAuthAccessTokenInterface {
 	return &FakeOAuthAccessTokens{Fake: c}
-
 }
 
 // ClusterSubjectAccessReviews provides a fake REST client for ClusterSubjectAccessReviews

--- a/pkg/deploy/reaper/reaper_test.go
+++ b/pkg/deploy/reaper/reaper_test.go
@@ -4,51 +4,133 @@ import (
 	"testing"
 	"time"
 
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 
 	"github.com/openshift/origin/pkg/client/testclient"
+	"github.com/openshift/origin/pkg/deploy/api"
 )
 
 func TestStop(t *testing.T) {
-	fakeOsc := &testclient.Fake{}
-	fakeKc := &ktestclient.Fake{}
-	reaper := &DeploymentConfigReaper{osc: fakeOsc, kc: fakeKc, pollInterval: time.Millisecond, timeout: time.Millisecond}
+	fakeClients := []*testclient.Fake{
+		testclient.NewSimpleFake(&api.DeploymentConfig{
+			LatestVersion: 1,
+		}),
+		testclient.NewSimpleFake(&api.DeploymentConfig{
+			LatestVersion: 5,
+		}),
+	}
+	fakeKClients := []*ktestclient.Fake{
+		ktestclient.NewSimpleFake(&kapi.ReplicationController{}),
+		ktestclient.NewSimpleFake(&kapi.ReplicationControllerList{
+			Items: []kapi.ReplicationController{
+				{},
+				{},
+				{},
+				{},
+				{},
+			},
+		}),
+	}
 
-	expectedOsc := []string{
-		"get-deploymentconfig",
-		"update-deploymentconfig",
-		"get-deploymentconfig",
-		"delete-deploymentconfig",
-	}
-	expectedKc := []string{
-		"get-replicationController",
-		"update-replicationController",
-		"get-replicationController",
-		"delete-replicationController",
+	tests := []struct {
+		testName  string
+		namespace string
+		name      string
+		osc       *testclient.Fake
+		kc        *ktestclient.Fake
+		reaper    *DeploymentConfigReaper
+		expected  []string
+		kexpected []string
+		output    string
+	}{
+		{
+			testName:  "simple stop",
+			namespace: "default",
+			name:      "foo",
+			osc:       fakeClients[0],
+			kc:        fakeKClients[0],
+			reaper:    &DeploymentConfigReaper{osc: fakeClients[0], kc: fakeKClients[0], pollInterval: time.Millisecond, timeout: time.Millisecond},
+			expected: []string{
+				"get-deploymentconfig",
+				"update-deploymentconfig",
+				"delete-deploymentconfig",
+			},
+			kexpected: []string{
+				"list-replicationControllers",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+			},
+			output: "foo stopped",
+		},
+		{
+			testName:  "stop multiple controllers",
+			namespace: "default",
+			name:      "foo",
+			osc:       fakeClients[1],
+			kc:        fakeKClients[1],
+			reaper:    &DeploymentConfigReaper{osc: fakeClients[1], kc: fakeKClients[1], pollInterval: time.Millisecond, timeout: time.Millisecond},
+			expected: []string{
+				"get-deploymentconfig",
+				"update-deploymentconfig",
+				"delete-deploymentconfig",
+			},
+			kexpected: []string{
+				"list-replicationControllers",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+			},
+			output: "foo stopped",
+		},
 	}
 
-	str, err := reaper.Stop("default", "foo", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if len(fakeClients) != len(tests) {
+		t.Fatalf("no. of clients should equal to the no. of tests. Fix those tests.")
 	}
-	if len(fakeOsc.Actions) != len(expectedOsc) {
-		t.Fatalf("unexpected actions: %v, expected %v", fakeOsc.Actions, expectedOsc)
-	}
-	for i, fake := range fakeOsc.Actions {
-		if fake.Action != expectedOsc[i] {
-			t.Fatalf("unexpected action: %s, expected %s", fake.Action, expectedOsc[i])
+
+	for i, test := range tests {
+		out, err := test.reaper.Stop(test.namespace, test.name, nil)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", test.testName, err)
+		}
+		if len(fakeClients[i].Actions) != len(test.expected) {
+			t.Fatalf("%s: unexpected actions: %v, expected %v", test.testName, fakeClients[i].Actions, test.expected)
+		}
+		for j, fake := range fakeClients[i].Actions {
+			if fake.Action != test.expected[j] {
+				t.Fatalf("%s: unexpected action: %s, expected %s", test.testName, fake.Action, test.expected[j])
+			}
+		}
+		if len(fakeKClients[i].Actions) != len(test.kexpected) {
+			t.Fatalf("%s: unexpected actions: %v, expected %v", test.testName, fakeKClients[i].Actions, test.kexpected)
+		}
+		for j, fake := range fakeKClients[i].Actions {
+			if fake.Action != test.kexpected[j] {
+				t.Fatalf("%s: unexpected action: %s, expected %s", test.testName, fake.Action, test.kexpected[j])
+			}
+		}
+		if out != test.output {
+			t.Fatalf("%s: unexpected output %q, expected %q", test.testName, out, test.output)
 		}
 	}
-	if len(fakeKc.Actions) != len(expectedKc) {
-		t.Fatalf("unexpected actions: %v, expected %v", fakeKc.Actions, expectedKc)
-	}
-	for i, fake := range fakeKc.Actions {
-		if fake.Action != expectedKc[i] {
-			t.Fatalf("unexpected action: %s, expected %s", fake.Action, expectedKc[i])
-		}
-	}
-	if str != "foo stopped" {
-		t.Fatalf("unexpected output %q, expected 'foo stopped'", str)
-	}
-
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -73,10 +73,10 @@ func LabelForDeploymentConfig(config *deployapi.DeploymentConfig) string {
 }
 
 // ConfigSelector matches all the deployments of the provided DeploymentConfig
-func ConfigSelector(config *deployapi.DeploymentConfig, list []api.ReplicationController) []api.ReplicationController {
+func ConfigSelector(name string, list []api.ReplicationController) []api.ReplicationController {
 	matches := []api.ReplicationController{}
 	for _, rc := range list {
-		if DeploymentConfigNameFor(&rc) == config.Name {
+		if DeploymentConfigNameFor(&rc) == name {
 			matches = append(matches, rc)
 		}
 	}

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -51,7 +51,7 @@ var annotationMap = map[string][]string{
 
 // LatestDeploymentNameForConfig returns a stable identifier for config based on its version.
 func LatestDeploymentNameForConfig(config *deployapi.DeploymentConfig) string {
-	return config.Name + "-" + strconv.Itoa(config.LatestVersion)
+	return fmt.Sprintf("%s-%d", config.Name, config.LatestVersion)
 }
 
 // DeployerPodSuffix is the suffix added to pods created from a deployment
@@ -70,6 +70,17 @@ func LabelForDeployment(deployment *api.ReplicationController) string {
 // LabelForDeploymentConfig builds a string identifier for a DeploymentConfig.
 func LabelForDeploymentConfig(config *deployapi.DeploymentConfig) string {
 	return fmt.Sprintf("%s/%s:%d", config.Namespace, config.Name, config.LatestVersion)
+}
+
+// ConfigSelector matches all the deployments of the provided DeploymentConfig
+func ConfigSelector(config *deployapi.DeploymentConfig, list []api.ReplicationController) []api.ReplicationController {
+	matches := []api.ReplicationController{}
+	for _, rc := range list {
+		if DeploymentConfigNameFor(&rc) == config.Name {
+			matches = append(matches, rc)
+		}
+	}
+	return matches
 }
 
 // DecodeDeploymentConfig decodes a DeploymentConfig from controller using codec. An error is returned


### PR DESCRIPTION
This PR supercedes #2692. It adds a commit which deletes the DeploymentConfig prior to reaping its deployments prevent the kind of races outlined in #2721.

Closes #2721.