### PR TITLE
Run pod-creating controllers under infra-namespace service accounts

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -192,6 +192,9 @@ type PolicyConfig struct {
 
 	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)
 	OpenShiftSharedResourcesNamespace string
+
+	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
+	OpenShiftInfrastructureNamespace string
 }
 
 // NetworkConfig to be passed to the compiled in network plugin

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -4,6 +4,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 
 	newer "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 func init() {
@@ -17,6 +18,9 @@ func init() {
 			}
 			if obj.ServingInfo.RequestTimeoutSeconds == 0 {
 				obj.ServingInfo.RequestTimeoutSeconds = 60 * 60
+			}
+			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
+				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace
 			}
 		},
 		func(obj *KubernetesMasterConfig) {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -181,6 +181,9 @@ type PolicyConfig struct {
 
 	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)
 	OpenShiftSharedResourcesNamespace string `json:"openshiftSharedResourcesNamespace"`
+
+	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
+	OpenShiftInfrastructureNamespace string `json:"openshiftInfrastructureNamespace"`
 }
 
 // NetworkConfig to be passed to the compiled in network plugin

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -202,6 +202,7 @@ oauthConfig:
     authorizeTokenMaxAgeSeconds: 0
 policyConfig:
   bootstrapPolicyFile: ""
+  openshiftInfrastructureNamespace: ""
   openshiftSharedResourcesNamespace: ""
 projectConfig:
   defaultNodeSelector: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -329,6 +329,7 @@ func ValidatePolicyConfig(config api.PolicyConfig) fielderrors.ValidationErrorLi
 
 	allErrs = append(allErrs, ValidateFile(config.BootstrapPolicyFile, "bootstrapPolicyFile")...)
 	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftSharedResourcesNamespace, "openShiftSharedResourcesNamespace")...)
+	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftInfrastructureNamespace, "openShiftInfrastructureNamespace")...)
 
 	return allErrs
 }

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -3,6 +3,7 @@ package bootstrappolicy
 // known namespaces
 const (
 	DefaultOpenShiftSharedResourcesNamespace = "openshift"
+	DefaultOpenShiftInfraNamespace           = "openshift-infra"
 )
 
 // users
@@ -10,6 +11,10 @@ const (
 	DefaultServiceAccountName  = "default"
 	BuilderServiceAccountName  = "builder"
 	DeployerServiceAccountName = "deployer"
+
+	InfraBuildControllerServiceAccountName       = "build-controller"
+	InfraReplicationControllerServiceAccountName = "replication-controller"
+	InfraDeploymentControllerServiceAccountName  = "deployment-controller"
 
 	RouterUnqualifiedUsername   = "openshift-router"
 	RegistryUnqualifiedUsername = "openshift-registry"
@@ -34,14 +39,19 @@ const (
 
 // Roles
 const (
-	ClusterAdminRoleName      = "cluster-admin"
-	ClusterReaderRoleName     = "cluster-reader"
-	AdminRoleName             = "admin"
-	EditRoleName              = "edit"
-	ViewRoleName              = "view"
-	SelfProvisionerRoleName   = "self-provisioner"
-	BasicUserRoleName         = "basic-user"
-	StatusCheckerRoleName     = "cluster-status"
+	ClusterAdminRoleName    = "cluster-admin"
+	ClusterReaderRoleName   = "cluster-reader"
+	AdminRoleName           = "admin"
+	EditRoleName            = "edit"
+	ViewRoleName            = "view"
+	SelfProvisionerRoleName = "self-provisioner"
+	BasicUserRoleName       = "basic-user"
+	StatusCheckerRoleName   = "cluster-status"
+
+	BuildControllerRoleName       = "system:build-controller"
+	ReplicationControllerRoleName = "system:replication-controller"
+	DeploymentControllerRoleName  = "system:deployment-controller"
+
 	ImagePullerRoleName       = "system:image-puller"
 	ImageBuilderRoleName      = "system:image-builder"
 	ImagePrunerRoleName       = "system:image-pruner"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -213,6 +213,100 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: BuildControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				// BuildControllerFactory.buildLW
+				// BuildControllerFactory.buildDeleteLW
+				{
+					Verbs:     util.NewStringSet("get", "list", "watch"),
+					Resources: util.NewStringSet("builds"),
+				},
+				// BuildController.BuildUpdater (OSClientBuildClient)
+				{
+					Verbs:     util.NewStringSet("update"),
+					Resources: util.NewStringSet("builds"),
+				},
+				// BuildController.ImageStreamClient (ControllerClient)
+				{
+					Verbs:     util.NewStringSet("get"),
+					Resources: util.NewStringSet("imagestreams"),
+				},
+				// BuildController.PodManager (ControllerClient)
+				// BuildDeleteController.PodManager (ControllerClient)
+				// BuildControllerFactory.buildDeleteLW
+				{
+					Verbs:     util.NewStringSet("get", "list", "create", "delete"),
+					Resources: util.NewStringSet("pods"),
+				},
+				// BuildController.Recorder (EventBroadcaster)
+				{
+					Verbs:     util.NewStringSet("create", "update"),
+					Resources: util.NewStringSet("events"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: DeploymentControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				// DeploymentControllerFactory.deploymentLW
+				{
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("replicationcontrollers"),
+				},
+				// DeploymentControllerFactory.deploymentClient
+				{
+					Verbs:     util.NewStringSet("get", "update"),
+					Resources: util.NewStringSet("replicationcontrollers"),
+				},
+				// DeploymentController.podClient
+				{
+					Verbs:     util.NewStringSet("get", "list", "create", "delete", "update"),
+					Resources: util.NewStringSet("pods"),
+				},
+				// DeploymentController.recorder (EventBroadcaster)
+				{
+					Verbs:     util.NewStringSet("create", "update"),
+					Resources: util.NewStringSet("events"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: ReplicationControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{
+				// ReplicationManager.rcController.ListWatch
+				{
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("replicationcontrollers"),
+				},
+				// ReplicationManager.syncReplicationController() -> updateReplicaCount()
+				{
+					Verbs:     util.NewStringSet("get", "update"),
+					Resources: util.NewStringSet("replicationcontrollers"),
+				},
+				// ReplicationManager.podController.ListWatch
+				{
+					Verbs:     util.NewStringSet("list", "watch"),
+					Resources: util.NewStringSet("pods"),
+				},
+				// ReplicationManager.podControl (RealPodControl)
+				{
+					Verbs:     util.NewStringSet("create", "delete"),
+					Resources: util.NewStringSet("pods"),
+				},
+				// ReplicationManager.podControl.recorder
+				{
+					Verbs:     util.NewStringSet("create", "update"),
+					Resources: util.NewStringSet("events"),
+				},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: OAuthTokenDeleterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/glog"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/cloudprovider/nodecontroller"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/controller"
@@ -67,8 +68,8 @@ func (c *MasterConfig) RunPersistentVolumeClaimBinder() {
 }
 
 // RunReplicationController starts the Kubernetes replication controller sync loop
-func (c *MasterConfig) RunReplicationController() {
-	controllerManager := controller.NewReplicationManager(c.KubeClient, controller.BurstReplicas)
+func (c *MasterConfig) RunReplicationController(client *client.Client) {
+	controllerManager := controller.NewReplicationManager(client, controller.BurstReplicas)
 	go controllerManager.Run(c.ControllerManager.ConcurrentRCSyncs, util.NeverStop)
 	glog.Infof("Started Kubernetes Replication Manager")
 }

--- a/pkg/serviceaccounts/client.go
+++ b/pkg/serviceaccounts/client.go
@@ -1,0 +1,105 @@
+package serviceaccounts
+
+import (
+	"fmt"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
+	"github.com/openshift/origin/pkg/client"
+)
+
+// TokenRetriever defined an interface for getting an API token for a service account
+type TokenRetriever interface {
+	GetToken(serviceAccountNamespace, serviceAccountName string) (token string, err error)
+}
+
+// ClientLookupTokenRetriever uses its client to look up a service account token
+type ClientLookupTokenRetriever struct {
+	Client kclient.Interface
+}
+
+// GetToken returns a token for the named service account or an error if none existed after a timeout
+func (s *ClientLookupTokenRetriever) GetToken(namespace, name string) (string, error) {
+	for i := 0; i < 30; i++ {
+		// Wait on subsequent retries
+		if i != 0 {
+			time.Sleep(time.Second)
+		}
+
+		// Get the service account
+		serviceAccount, err := s.Client.ServiceAccounts(namespace).Get(name)
+		if err != nil {
+			continue
+		}
+
+		// Get the secrets
+		// TODO: JTL: create one directly once we have that ability
+		for _, secretRef := range serviceAccount.Secrets {
+			secret, err := s.Client.Secrets(namespace).Get(secretRef.Name)
+			if err != nil {
+				// Tolerate fetch errors on a particular secret
+				continue
+			}
+			if IsValidServiceAccountToken(serviceAccount, secret) {
+				// Return a valid token
+				return string(secret.Data[kapi.ServiceAccountTokenKey]), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("Could not get token for %s/%s", namespace, name)
+}
+
+// Clients returns an OpenShift and Kubernetes client with the credentials of the named service account
+// TODO: change return types to client.Interface/kclient.Interface to allow auto-reloading credentials
+func Clients(config kclient.Config, tokenRetriever TokenRetriever, namespace, name string) (*client.Client, *kclient.Client, error) {
+	// Clear existing auth info
+	config.Username = ""
+	config.Password = ""
+	config.CertFile = ""
+	config.CertData = []byte{}
+	config.KeyFile = ""
+	config.KeyData = []byte{}
+
+	// For now, just initialize the token once
+	// TODO: refetch the token if the client encounters 401 errors
+	token, err := tokenRetriever.GetToken(namespace, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	config.BearerToken = token
+
+	c, err := client.New(&config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kc, err := kclient.New(&config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return c, kc, nil
+}
+
+// IsValidServiceAccountToken returns true if the given secret contains a service account token valid for the given service account
+func IsValidServiceAccountToken(serviceAccount *kapi.ServiceAccount, secret *kapi.Secret) bool {
+	if secret.Type != kapi.SecretTypeServiceAccountToken {
+		return false
+	}
+	if secret.Namespace != serviceAccount.Namespace {
+		return false
+	}
+	if secret.Annotations[kapi.ServiceAccountNameKey] != serviceAccount.Name {
+		return false
+	}
+	if secret.Annotations[kapi.ServiceAccountUIDKey] != string(serviceAccount.UID) {
+		return false
+	}
+	if len(secret.Data[kapi.ServiceAccountTokenKey]) == 0 {
+		return false
+	}
+	return true
+}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -28,7 +28,7 @@ var (
 
 	// ConcurrentBuildControllersTestWait is the time that TestConcurrentBuildControllers waits
 	// for any other changes to happen when testing whether only a single build got processed
-	ConcurrentBuildControllersTestWait = 5 * time.Second
+	ConcurrentBuildControllersTestWait = 10 * time.Second
 
 	// ConcurrentBuildPodControllersTestWait is the time that TestConcurrentBuildPodControllers waits
 	// after a state transition to make sure other state transitions don't occur unexpectedly
@@ -36,7 +36,7 @@ var (
 
 	// BuildControllersWatchTimeout is used by all tests to wait for watch events. In case where only
 	// a single watch event is expected, the test will fail after the timeout.
-	BuildControllersWatchTimeout = 5 * time.Second
+	BuildControllersWatchTimeout = 10 * time.Second
 )
 
 func init() {
@@ -307,6 +307,11 @@ func setupBuildControllerTest(additionalBuildControllers, additionalBuildPodCont
 
 	openshiftConfig, err := origin.BuildMasterConfig(*master)
 	checkErr(t, err)
+
+	// Get the build controller clients, since those rely on service account tokens
+	// We don't want to proceed with the rest of the test until those are available
+	openshiftConfig.BuildControllerClients()
+
 	for i := 0; i < additionalBuildControllers; i++ {
 		openshiftConfig.RunBuildController()
 	}


### PR DESCRIPTION
- [x] Add config option for infra namespace
- [x] Ensure namespace exists on startup
- [x] Ensure replicationController, buildController, deploymentController service accounts exist
- [x] Define roles for ^
- [x] Ensure service accounts are mapped to roles at startup
- [x] Build clients using service account credentials when starting controllers
- [ ] Open issue for doc to add infra namespace config
- [ ] Open issue for install to add infra namespace config to templates
- [x] check this item

Resolves #2774