### PR TITLE
fix output messages for api versions

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -86,12 +86,21 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 	}
 	_ = master.New(masterConfig)
 
-	return []string{
-		fmt.Sprintf("Started Kubernetes API at %%s%s", KubeAPIPrefixV1Beta1),
-		fmt.Sprintf("Started Kubernetes API at %%s%s", KubeAPIPrefixV1Beta3),
-		fmt.Sprintf("Started Kubernetes API at %%s%s", KubeAPIPrefixV1Beta3),
-		fmt.Sprintf("Started Kubernetes API at %%s%s (experimental)", KubeAPIPrefixV1),
+	messages := []string{}
+	if !masterConfig.DisableV1Beta1 {
+		messages = append(messages, fmt.Sprintf("Started Kubernetes API at %%s%s", KubeAPIPrefixV1Beta1))
 	}
+	if !masterConfig.DisableV1Beta2 {
+		messages = append(messages, fmt.Sprintf("Started Kubernetes API at %%s%s", KubeAPIPrefixV1Beta2))
+	}
+	if !masterConfig.DisableV1Beta3 {
+		messages = append(messages, fmt.Sprintf("Started Kubernetes API at %%s%s", KubeAPIPrefixV1Beta3))
+	}
+	if masterConfig.EnableV1 {
+		messages = append(messages, fmt.Sprintf("Started Kubernetes API at %%s%s (experimental)", KubeAPIPrefixV1))
+	}
+
+	return messages
 }
 
 func (c *MasterConfig) RunNamespaceController() {

--- a/pkg/cmd/server/origin/master_test.go
+++ b/pkg/cmd/server/origin/master_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestInitializeOpenshiftAPIVersionRouteHandler(t *testing.T) {
 	service := new(restful.WebService)
-	initAPIVersionRoute(service, "v1beta1")
+	initAPIVersionRoute(service, "osapi", "v1beta3")
 
 	if len(service.Routes()) != 1 {
 		t.Fatalf("Exp. the OSAPI route but found none")


### PR DESCRIPTION
`openshift start` output listed API versions it didn't start.  This fixes that.

@liggitt 