### PR TITLE
Revert SDN and Kubelet initialization ordering

### DIFF
--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -246,11 +246,11 @@ func StartNode(config configapi.NodeConfig) error {
 		return err
 	}
 
+	RunSDNController(config)
 	nodeConfig.EnsureVolumeDir()
 	nodeConfig.EnsureDocker(docker.NewHelper())
 	nodeConfig.RunProxy()
 	nodeConfig.RunKubelet()
-	RunSDNController(config)
 	go daemon.SdNotify("READY=1")
 
 	return nil


### PR DESCRIPTION
This avoids restarting docker after the kubelet has been started.

Need to sort out node auto-registration issues so we can ensure that the node is registered but not bring up the kubelet before sdn initializes.