### PR TITLE
Make deployment config reaper reentrant

### DIFF
--- a/pkg/client/testclient/fake_deploymentconfigs.go
+++ b/pkg/client/testclient/fake_deploymentconfigs.go
@@ -36,8 +36,8 @@ func (c *FakeDeploymentConfigs) Update(config *deployapi.DeploymentConfig) (*dep
 }
 
 func (c *FakeDeploymentConfigs) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-deploymentconfig"})
-	return nil
+	_, err := c.Fake.Invokes(FakeAction{Action: "delete-deploymentconfig"}, nil)
+	return err
 }
 
 func (c *FakeDeploymentConfigs) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {

--- a/pkg/deploy/reaper/reaper_test.go
+++ b/pkg/deploy/reaper/reaper_test.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	"github.com/openshift/origin/pkg/client/testclient"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
@@ -17,26 +19,17 @@ func mkdeployment(version int) kapi.ReplicationController {
 	return *deployment
 }
 
-func TestStop(t *testing.T) {
-	fakeClients := []*testclient.Fake{
-		testclient.NewSimpleFake(deploytest.OkDeploymentConfig(1)),
-		testclient.NewSimpleFake(deploytest.OkDeploymentConfig(5)),
+func mkdeploymentlist(versions ...int) *kapi.ReplicationControllerList {
+	list := &kapi.ReplicationControllerList{}
+	for _, v := range versions {
+		list.Items = append(list.Items, mkdeployment(v))
 	}
-	fakeKClients := []*ktestclient.Fake{
-		ktestclient.NewSimpleFake(&kapi.ReplicationControllerList{
-			Items: []kapi.ReplicationController{
-				mkdeployment(1),
-			},
-		}),
-		ktestclient.NewSimpleFake(&kapi.ReplicationControllerList{
-			Items: []kapi.ReplicationController{
-				mkdeployment(1),
-				mkdeployment(2),
-				mkdeployment(3),
-				mkdeployment(4),
-				mkdeployment(5),
-			},
-		}),
+	return list
+}
+
+func TestStop(t *testing.T) {
+	notfound := func() runtime.Object {
+		return &(kerrors.NewNotFound("DeploymentConfig", "config").(*kerrors.StatusError).ErrStatus)
 	}
 
 	tests := []struct {
@@ -45,18 +38,17 @@ func TestStop(t *testing.T) {
 		name      string
 		osc       *testclient.Fake
 		kc        *ktestclient.Fake
-		reaper    *DeploymentConfigReaper
 		expected  []string
 		kexpected []string
 		output    string
+		err       bool
 	}{
 		{
 			testName:  "simple stop",
 			namespace: "default",
 			name:      "config",
-			osc:       fakeClients[0],
-			kc:        fakeKClients[0],
-			reaper:    &DeploymentConfigReaper{osc: fakeClients[0], kc: fakeKClients[0], pollInterval: time.Millisecond, timeout: time.Millisecond},
+			osc:       testclient.NewSimpleFake(deploytest.OkDeploymentConfig(1)),
+			kc:        ktestclient.NewSimpleFake(mkdeploymentlist(1)),
 			expected: []string{
 				"delete-deploymentconfig",
 			},
@@ -68,14 +60,14 @@ func TestStop(t *testing.T) {
 				"delete-replicationController",
 			},
 			output: "config stopped",
+			err:    false,
 		},
 		{
 			testName:  "stop multiple controllers",
 			namespace: "default",
 			name:      "config",
-			osc:       fakeClients[1],
-			kc:        fakeKClients[1],
-			reaper:    &DeploymentConfigReaper{osc: fakeClients[1], kc: fakeKClients[1], pollInterval: time.Millisecond, timeout: time.Millisecond},
+			osc:       testclient.NewSimpleFake(deploytest.OkDeploymentConfig(5)),
+			kc:        ktestclient.NewSimpleFake(mkdeploymentlist(1, 2, 3, 4, 5)),
 			expected: []string{
 				"delete-deploymentconfig",
 			},
@@ -103,36 +95,86 @@ func TestStop(t *testing.T) {
 				"delete-replicationController",
 			},
 			output: "config stopped",
+			err:    false,
+		},
+		{
+			testName:  "no config, some deployments",
+			namespace: "default",
+			name:      "config",
+			osc:       testclient.NewSimpleFake(notfound()),
+			kc:        ktestclient.NewSimpleFake(mkdeploymentlist(1)),
+			expected: []string{
+				"delete-deploymentconfig",
+			},
+			kexpected: []string{
+				"list-replicationControllers",
+				"get-replicationController",
+				"update-replicationController",
+				"get-replicationController",
+				"delete-replicationController",
+			},
+			output: "config stopped",
+			err:    false,
+		},
+		{
+			testName:  "no config, no deployments",
+			namespace: "default",
+			name:      "config",
+			osc:       testclient.NewSimpleFake(notfound()),
+			kc:        ktestclient.NewSimpleFake(&kapi.ReplicationControllerList{}),
+			expected: []string{
+				"delete-deploymentconfig",
+			},
+			kexpected: []string{
+				"list-replicationControllers",
+			},
+			output: "",
+			err:    true,
+		},
+		{
+			testName:  "config, no deployments",
+			namespace: "default",
+			name:      "config",
+			osc:       testclient.NewSimpleFake(deploytest.OkDeploymentConfig(5)),
+			kc:        ktestclient.NewSimpleFake(&kapi.ReplicationControllerList{}),
+			expected: []string{
+				"delete-deploymentconfig",
+			},
+			kexpected: []string{
+				"list-replicationControllers",
+			},
+			output: "config stopped",
+			err:    false,
 		},
 	}
 
-	if len(fakeClients) != len(tests) {
-		t.Fatalf("no. of clients should equal to the no. of tests. Fix those tests.")
-	}
-
-	for i, test := range tests {
-		out, err := test.reaper.Stop(test.namespace, test.name, nil)
-		if err != nil {
-			t.Fatalf("%s: unexpected error: %v", test.testName, err)
+	for _, test := range tests {
+		reaper := &DeploymentConfigReaper{osc: test.osc, kc: test.kc, pollInterval: time.Millisecond, timeout: time.Millisecond}
+		out, err := reaper.Stop(test.namespace, test.name, nil)
+		if !test.err && err != nil {
+			t.Errorf("%s: unexpected error: %v", test.testName, err)
 		}
-		if len(fakeClients[i].Actions) != len(test.expected) {
-			t.Fatalf("%s: unexpected actions: %v, expected %v", test.testName, fakeClients[i].Actions, test.expected)
+		if test.err && err == nil {
+			t.Errorf("%s: expected an error", test.testName)
 		}
-		for j, fake := range fakeClients[i].Actions {
+		if len(test.osc.Actions) != len(test.expected) {
+			t.Errorf("%s: unexpected actions: %v, expected %v", test.testName, test.osc.Actions, test.expected)
+		}
+		for j, fake := range test.osc.Actions {
 			if fake.Action != test.expected[j] {
-				t.Fatalf("%s: unexpected action: %s, expected %s", test.testName, fake.Action, test.expected[j])
+				t.Errorf("%s: unexpected action: %s, expected %s", test.testName, fake.Action, test.expected[j])
 			}
 		}
-		if len(fakeKClients[i].Actions) != len(test.kexpected) {
-			t.Fatalf("%s: unexpected actions: %v, expected %v", test.testName, fakeKClients[i].Actions, test.kexpected)
+		if len(test.kc.Actions) != len(test.kexpected) {
+			t.Errorf("%s: unexpected actions: %v, expected %v", test.testName, test.kc.Actions, test.kexpected)
 		}
-		for j, fake := range fakeKClients[i].Actions {
+		for j, fake := range test.kc.Actions {
 			if fake.Action != test.kexpected[j] {
-				t.Fatalf("%s: unexpected action: %s, expected %s", test.testName, fake.Action, test.kexpected[j])
+				t.Errorf("%s: unexpected action: %s, expected %s", test.testName, fake.Action, test.kexpected[j])
 			}
 		}
 		if out != test.output {
-			t.Fatalf("%s: unexpected output %q, expected %q", test.testName, out, test.output)
+			t.Errorf("%s: unexpected output %q, expected %q", test.testName, out, test.output)
 		}
 	}
 }


### PR DESCRIPTION
If the given config can't be found, try and clean up any of its leftover
associated deployments anyway.

This is a followup to #2772.