### PR TITLE
BZ 1219420 - protocol error when kubelet writing or syncing data to openshift.local.volumes/pods/ in multi-node env

### DIFF
--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -67,7 +67,8 @@ pushd /vagrant
       --certificate-authority="${CERT_DIR}/ca.crt" \
       --signer-cert="${CERT_DIR}/ca.crt" \
       --signer-key="${CERT_DIR}/ca.key" \
-      --signer-serial="${CERT_DIR}/ca.serial.txt"
+      --signer-serial="${CERT_DIR}/ca.serial.txt" \
+      --volume-dir="/tmp/openshift.local.volumes"
   done
 
 popd


### PR DESCRIPTION
Fixed by not sharing the volume directories between nodes.  Master uses `/vagrant/openshift.local.volumes` nodes use their own `/tmp/openshift.local.volumes`

@mrunalp @rajatchopra PTAL