### PR TITLE
UPSTREAM: make getFromCache more tolerant

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcd_helper.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/tools/etcd_helper.go
@@ -228,7 +228,7 @@ type etcdCache interface {
 
 func (h *EtcdHelper) getFromCache(index uint64) (runtime.Object, bool) {
 	trace := util.NewTrace("getFromCache")
-	defer trace.LogIfLong(200 * time.Microsecond)
+	defer trace.LogIfLong(1 * time.Millisecond)
 	startTime := time.Now()
 	defer func() {
 		cacheGetLatency.Observe(float64(time.Since(startTime) / time.Microsecond))


### PR DESCRIPTION
This is driving me bonkers.  Upstream has changed the implementation, so this is just to keep us able to inspect the log until we re-rebase.

@liggitt 