### PR TITLE
Don't import if a spec.tag is tracking another

### DIFF
--- a/pkg/image/controller/controller.go
+++ b/pkg/image/controller/controller.go
@@ -14,56 +14,44 @@ import (
 )
 
 type ImportController struct {
-	repositories client.ImageStreamsNamespacer
-	mappings     client.ImageStreamMappingsNamespacer
-	client       dockerregistry.Client
+	streams  client.ImageStreamsNamespacer
+	mappings client.ImageStreamMappingsNamespacer
+	client   dockerregistry.Client
 }
 
-// needsImport returns true if the provided repository should have its tags imported.
-func needsImport(repo *api.ImageStream) bool {
-	if len(repo.Spec.DockerImageRepository) == 0 {
+// needsImport returns true if the provided image stream should have its tags imported.
+func needsImport(stream *api.ImageStream) bool {
+	if len(stream.Spec.DockerImageRepository) == 0 {
 		return false
 	}
-	if repo.Annotations != nil && len(repo.Annotations[api.DockerImageRepositoryCheckAnnotation]) != 0 {
+	if stream.Annotations != nil && len(stream.Annotations[api.DockerImageRepositoryCheckAnnotation]) != 0 {
 		return false
 	}
 	return true
-	/*
-		if len(repo.Spec.Tags) == 0 {
-			return true
-		}
-		emptyTags := 0
-		for _, v := range repo.Spec.Tags {
-			if len(v.DockerImageReference) == 0 {
-				emptyTags++
-			}
-		}
-		return emptyTags > 0
-	*/
 }
 
 // retryCount is the number of times to retry on a conflict when updating an image stream
 const retryCount = 2
 
-// Next processes the given image repository, looking for repos that have DockerImageRepository
+// Next processes the given image stream, looking for streams that have DockerImageRepository
 // set but have not yet been marked as "ready". If transient errors occur, err is returned but
-// the image repository is not modified (so it will be tried again later). If a permanent
+// the image stream is not modified (so it will be tried again later). If a permanent
 // failure occurs the image is marked with an annotation. The tags of the original spec image
 // are left as is (those are updated through status).
-func (c *ImportController) Next(repo *api.ImageStream) error {
-	if !needsImport(repo) {
+func (c *ImportController) Next(stream *api.ImageStream) error {
+	if !needsImport(stream) {
 		return nil
 	}
-	name := repo.Spec.DockerImageRepository
+	name := stream.Spec.DockerImageRepository
 
 	ref, err := api.ParseDockerImageReference(name)
 	if err != nil {
 		err = fmt.Errorf("invalid docker image repository, cannot import data: %v", err)
 		util.HandleError(err)
-		return c.done(repo, err.Error(), retryCount)
+		return c.done(stream, err.Error(), retryCount)
 	}
 
-	insecure := repo.Annotations != nil && repo.Annotations[api.InsecureRepositoryAnnotation] == "true"
+	insecure := stream.Annotations != nil && stream.Annotations[api.InsecureRepositoryAnnotation] == "true"
 
 	conn, err := c.client.Connect(ref.Registry, insecure)
 	if err != nil {
@@ -72,56 +60,32 @@ func (c *ImportController) Next(repo *api.ImageStream) error {
 	tags, err := conn.ImageTags(ref.Namespace, ref.Name)
 	switch {
 	case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err):
-		return c.done(repo, err.Error(), retryCount)
+		return c.done(stream, err.Error(), retryCount)
 	case err != nil:
 		return err
 	}
 
-	newTags := make(map[string]string) //, len(repo.Spec.Tags))
 	imageToTag := make(map[string][]string)
-	//switch {
-	//case len(repo.Tags) == 0:
-	// copy all tags
-	for tag := range tags {
-		// TODO: switch to image when pull by ID is automatic
-		newTags[tag] = tag
-	}
 	for tag, image := range tags {
+		if specTag, ok := stream.Spec.Tags[tag]; ok && (len(specTag.DockerImageReference) != 0 || specTag.From != nil) {
+			// spec tag is set to track another tag - do not import
+			continue
+		}
+
 		imageToTag[image] = append(imageToTag[image], tag)
 	}
-	/*
-		default:
-			for tag, v := range repo.Tags {
-				if len(v) != 0 {
-					newTags[tag] = v
-					continue
-				}
-				image, ok := tags[tag]
-				if !ok {
-					// tag not found, set empty
-					continue
-				}
-				imageToTag[image] = append(imageToTag[image], tag)
-				// TODO: switch to image when pull by ID is automatic
-				newTags[tag] = tag
-			}
-		}
-	*/
 
-	// nothing to tag - no images in the upstream repo, or we're in sync
+	// no tags to import
 	if len(imageToTag) == 0 {
-		return c.done(repo, "", retryCount)
+		return c.done(stream, "", retryCount)
 	}
 
 	for id, tags := range imageToTag {
 		dockerImage, err := conn.ImageByID(ref.Namespace, ref.Name, id)
 		switch {
 		case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err):
-			return c.done(repo, err.Error(), retryCount)
+			return c.done(stream, err.Error(), retryCount)
 		case dockerregistry.IsImageNotFound(err):
-			for _, tag := range tags {
-				delete(newTags, tag)
-			}
 			continue
 		case err != nil:
 			return err
@@ -130,7 +94,7 @@ func (c *ImportController) Next(repo *api.ImageStream) error {
 		if err := kapi.Scheme.Convert(dockerImage, &image); err != nil {
 			err = fmt.Errorf("could not convert image: %#v", err)
 			util.HandleError(err)
-			return c.done(repo, err.Error(), retryCount)
+			return c.done(stream, err.Error(), retryCount)
 		}
 
 		idTagPresent := false
@@ -156,8 +120,8 @@ func (c *ImportController) Next(repo *api.ImageStream) error {
 
 			mapping := &api.ImageStreamMapping{
 				ObjectMeta: kapi.ObjectMeta{
-					Name:      repo.Name,
-					Namespace: repo.Namespace,
+					Name:      stream.Name,
+					Namespace: stream.Namespace,
 				},
 				Tag: tag,
 				Image: api.Image{
@@ -168,9 +132,9 @@ func (c *ImportController) Next(repo *api.ImageStream) error {
 					DockerImageMetadata:  image,
 				},
 			}
-			if err := c.mappings.ImageStreamMappings(repo.Namespace).Create(mapping); err != nil {
+			if err := c.mappings.ImageStreamMappings(stream.Namespace).Create(mapping); err != nil {
 				if errors.IsNotFound(err) {
-					return c.done(repo, err.Error(), retryCount)
+					return c.done(stream, err.Error(), retryCount)
 				}
 				return err
 			}
@@ -178,22 +142,22 @@ func (c *ImportController) Next(repo *api.ImageStream) error {
 	}
 
 	// we've completed our updates
-	return c.done(repo, "", retryCount)
+	return c.done(stream, "", retryCount)
 }
 
-// done marks the repository as being processed due to an error or failure condition
-func (c *ImportController) done(repo *api.ImageStream, reason string, retry int) error {
+// done marks the stream as being processed due to an error or failure condition
+func (c *ImportController) done(stream *api.ImageStream, reason string, retry int) error {
 	if len(reason) == 0 {
 		reason = util.Now().UTC().Format(time.RFC3339)
 	}
-	if repo.Annotations == nil {
-		repo.Annotations = make(map[string]string)
+	if stream.Annotations == nil {
+		stream.Annotations = make(map[string]string)
 	}
-	repo.Annotations[api.DockerImageRepositoryCheckAnnotation] = reason
-	if _, err := c.repositories.ImageStreams(repo.Namespace).Update(repo); err != nil && !errors.IsNotFound(err) {
+	stream.Annotations[api.DockerImageRepositoryCheckAnnotation] = reason
+	if _, err := c.streams.ImageStreams(stream.Namespace).Update(stream); err != nil && !errors.IsNotFound(err) {
 		if errors.IsConflict(err) && retry > 0 {
-			if repo, err := c.repositories.ImageStreams(repo.Namespace).Get(repo.Name); err == nil {
-				return c.done(repo, reason, retry-1)
+			if stream, err := c.streams.ImageStreams(stream.Namespace).Get(stream.Name); err == nil {
+				return c.done(stream, reason, retry-1)
 			}
 		}
 		return err

--- a/pkg/image/controller/factory.go
+++ b/pkg/image/controller/factory.go
@@ -37,9 +37,9 @@ func (f *ImportControllerFactory) Create() controller.RunnableController {
 	cache.NewReflector(lw, &api.ImageStream{}, q, 2*time.Minute).Run()
 
 	c := &ImportController{
-		client:       dockerregistry.NewClient(),
-		repositories: f.Client,
-		mappings:     f.Client,
+		client:   dockerregistry.NewClient(),
+		streams:  f.Client,
+		mappings: f.Client,
 	}
 
 	return &controller.RetryController{


### PR DESCRIPTION
When importing tag and image metadata from an external Docker image
repository, don't import a tag if it has an entry in spec.tags with a
dockerImageReference or from set.