### PR TITLE
Fix device busy issues on serial e2e runs

### DIFF
--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -108,6 +108,13 @@ function cleanup()
 	echo
 
 	if [[ -z "${SKIP_TEARDOWN-}" ]]; then
+		echo "[INFO] Deleting test constructs"
+		osc delete -n test all --all
+		osc delete -n docker all --all
+		osc delete -n custom all --all
+		osc delete -n cache all --all
+		osc delete -n default all --all
+
 		echo "[INFO] Tearing down test"
 		pids="$(jobs -pr)"
 		echo "[INFO] Children: ${pids}"


### PR DESCRIPTION
Fixes the issue where serial e2e runs fail because of volumes that were not unmounted.