### PR TITLE
Replacing glog.Errof() with util.HandleError()

### DIFF
--- a/hack/conversion/conversion.go
+++ b/hack/conversion/conversion.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	//"github.com/openshift/origin/pkg/api"
 	_ "github.com/openshift/origin/pkg/api/v1beta1"
@@ -59,7 +61,7 @@ func main() {
 			continue
 		}
 		if err := generator.GenerateConversionsForType(*version, knownType); err != nil {
-			glog.Errorf("error while generating conversion functions for %v: %v", knownType, err)
+			util.HandleError(fmt.Errorf("error while generating conversion functions for %v: %v", knownType, err))
 		}
 	}
 	if err := generator.WriteConversionFunctions(funcOut); err != nil {

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 var varyHeaderRegexp = regexp.MustCompile("\\s*,\\s*")
@@ -186,7 +186,7 @@ func GeneratedConfigHandler(config WebConsoleConfig, h http.Handler) http.Handle
 			w.Header().Add("Cache-Control", "no-cache, no-store")
 			w.Header().Add("Content-Type", "application/json")
 			if err := configTemplate.Execute(w, config); err != nil {
-				glog.Errorf("Unable to render config template: %v", err)
+				util.HandleError(fmt.Errorf("unable to render config template: %v", err))
 			}
 			return
 		}

--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -1,6 +1,7 @@
 package grant
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -8,6 +9,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/auth/authenticator"
@@ -257,7 +259,7 @@ func (r grantTemplateRenderer) Render(form Form, w http.ResponseWriter, req *htt
 	w.Header().Add("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 	if err := grantTemplate.Execute(w, form); err != nil {
-		glog.Errorf("Unable to render grant template: %v", err)
+		util.HandleError(fmt.Errorf("unable to render grant template: %v", err))
 	}
 }
 

--- a/pkg/auth/server/login/implicit.go
+++ b/pkg/auth/server/login/implicit.go
@@ -1,12 +1,15 @@
 package login
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 
 	"github.com/golang/glog"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
@@ -82,7 +85,7 @@ func (c *Confirm) handleConfirmForm(w http.ResponseWriter, req *http.Request) {
 
 	csrf, err := c.csrf.Generate(w, req)
 	if err != nil {
-		glog.Errorf("Unable to generate CSRF token: %v", err)
+		util.HandleError(fmt.Errorf("unable to generate CSRF token: %v", err))
 	}
 	form.Values.CSRF = csrf
 
@@ -128,7 +131,7 @@ func (r confirmTemplateRenderer) Render(form ConfirmForm, w http.ResponseWriter,
 	w.Header().Add("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 	if err := confirmTemplate.Execute(w, form); err != nil {
-		glog.Errorf("Unable render confirm template: %v", err)
+		util.HandleError(fmt.Errorf("unable render confirm template: %v", err))
 	}
 }
 

--- a/pkg/auth/server/login/login.go
+++ b/pkg/auth/server/login/login.go
@@ -1,11 +1,14 @@
 package login
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 	"strings"
 
 	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
@@ -98,7 +101,7 @@ func (l *Login) handleLoginForm(w http.ResponseWriter, req *http.Request) {
 
 	csrf, err := l.csrf.Generate(w, req)
 	if err != nil {
-		glog.Errorf("Unable to generate CSRF token: %v", err)
+		util.HandleError(fmt.Errorf("unable to generate CSRF token: %v", err))
 	}
 	form.Values.CSRF = csrf
 
@@ -138,7 +141,7 @@ func (r loginTemplateRenderer) Render(form LoginForm, w http.ResponseWriter, req
 	w.Header().Add("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 	if err := loginTemplate.Execute(w, form); err != nil {
-		glog.Errorf("Unable to render login template: %v", err)
+		util.HandleError(fmt.Errorf("unable to render login template: %v", err))
 	}
 }
 

--- a/pkg/auth/server/tokenrequest/endpoints.go
+++ b/pkg/auth/server/tokenrequest/endpoints.go
@@ -9,7 +9,8 @@ import (
 	"path"
 
 	"github.com/RangelReale/osincli"
-	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/auth/server/login"
 )
@@ -86,7 +87,7 @@ func (endpoints *endpointDetails) displayToken(w http.ResponseWriter, req *http.
 
 func renderToken(w io.Writer, data tokenData) {
 	if err := tokenTemplate.Execute(w, data); err != nil {
-		glog.Errorf("Unable to render token template: %v", err)
+		util.HandleError(fmt.Errorf("unable to render token template: %v", err))
 	}
 }
 

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -1,8 +1,11 @@
 package builder
 
 import (
+	"fmt"
 	"os"
 	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
@@ -41,7 +44,7 @@ func pushImage(client DockerClient, name string, authConfig docker.AuthConfigura
 		if retries == DefaultPushRetryCount {
 			return err
 		}
-		glog.Errorf("Push for image %s failed, will retry in %ds ...", name, DefaultPushRetryDelay)
+		util.HandleError(fmt.Errorf("push for image %s failed, will retry in %ds ...", name, DefaultPushRetryDelay))
 		glog.Flush()
 		time.Sleep(DefaultPushRetryDelay)
 	}

--- a/pkg/deploy/controller/deployerpod/factory.go
+++ b/pkg/deploy/controller/deployerpod/factory.go
@@ -1,6 +1,7 @@
 package deployerpod
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -112,7 +113,7 @@ func pollPods(deploymentStore cache.Store, kClient kclient.Interface) (cache.Enu
 					deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentFailedDeployerPodNoLongerExists
 
 					if _, err := kClient.ReplicationControllers(deployment.Namespace).Update(deployment); err != nil {
-						glog.Errorf("couldn't update deployment %s to status %s: %v", deployutil.LabelForDeployment(deployment), nextStatus, err)
+						kutil.HandleError(fmt.Errorf("couldn't update deployment %s to status %s: %v", deployutil.LabelForDeployment(deployment), nextStatus, err))
 					}
 					glog.V(2).Infof("Updated deployment %s status from %s to %s", deployutil.LabelForDeployment(deployment), currentStatus, nextStatus)
 				}

--- a/pkg/deploy/controller/deploymentconfig/controller.go
+++ b/pkg/deploy/controller/deploymentconfig/controller.go
@@ -9,6 +9,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
@@ -84,7 +85,7 @@ func (c *DeploymentConfigController) Handle(config *deployapi.DeploymentConfig) 
 			deploymentForCancellation.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
 			deploymentForCancellation.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledNewerDeploymentExists
 			if _, err := c.deploymentClient.updateDeployment(deploymentForCancellation.Namespace, deploymentForCancellation); err != nil {
-				glog.Errorf("couldn't cancel Deployment %s: %v", deployutil.LabelForDeployment(deploymentForCancellation), err)
+				util.HandleError(fmt.Errorf("couldn't cancel Deployment %s: %v", deployutil.LabelForDeployment(deploymentForCancellation), err))
 			}
 			glog.V(4).Infof("Cancelled Deployment %s for DeploymentConfig %s", deployutil.LabelForDeployment(deploymentForCancellation), deployutil.LabelForDeploymentConfig(config))
 		}

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -136,7 +137,7 @@ func (s *RollingDeploymentStrategy) Deploy(deployment *kapi.ReplicationControlle
 		if params.Post != nil {
 			err := s.hookExecutor.Execute(params.Post, deployment, "posthook")
 			if err != nil {
-				glog.Errorf("Post hook failed: %s", err)
+				util.HandleError(fmt.Errorf("post hook failed: %s", err))
 			} else {
 				glog.Infof("Post hook finished")
 			}
@@ -151,7 +152,7 @@ func (s *RollingDeploymentStrategy) Deploy(deployment *kapi.ReplicationControlle
 	if params.Pre != nil {
 		err := s.hookExecutor.Execute(params.Pre, deployment, "prehook")
 		if err != nil {
-			return fmt.Errorf("Pre hook failed: %s", err)
+			return fmt.Errorf("pre hook failed: %s", err)
 		}
 		glog.Infof("Pre hook finished")
 	}
@@ -212,7 +213,7 @@ func (s *RollingDeploymentStrategy) Deploy(deployment *kapi.ReplicationControlle
 	if params.Post != nil {
 		err := s.hookExecutor.Execute(params.Post, deployment, "posthook")
 		if err != nil {
-			glog.Errorf("Post hook failed: %s", err)
+			util.HandleError(fmt.Errorf("Post hook failed: %s", err))
 		} else {
 			glog.Info("Post hook finished")
 		}

--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -187,7 +187,7 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) fielderrors.Validati
 		}
 
 		if event == nil {
-			glog.Errorf("unable to find tag event for %#v", tagRef.From)
+			util.HandleError(fmt.Errorf("unable to find tag event for %#v", tagRef.From))
 			continue
 		}
 

--- a/pkg/oauth/server/osinserver/osinserver.go
+++ b/pkg/oauth/server/osinserver/osinserver.go
@@ -1,11 +1,13 @@
 package osinserver
 
 import (
+	"fmt"
 	"net/http"
 	"path"
 
 	"github.com/RangelReale/osin"
-	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
 
 const (
@@ -94,7 +96,7 @@ func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if resp.IsError && resp.InternalError != nil {
-		glog.Errorf("Internal error: %s", resp.InternalError)
+		util.HandleError(fmt.Errorf("internal error: %s", resp.InternalError))
 	}
 	osin.OutputJSON(resp, w, r)
 }
@@ -111,7 +113,7 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 		s.server.FinishAccessRequest(resp, r, ar)
 	}
 	if resp.IsError && resp.InternalError != nil {
-		glog.Errorf("Internal error: %s", resp.InternalError)
+		util.HandleError(fmt.Errorf("internal error: %s", resp.InternalError))
 	}
 	osin.OutputJSON(resp, w, r)
 }

--- a/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
+++ b/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go
@@ -105,7 +105,7 @@ func (e *DockercfgController) serviceAccountAdded(obj interface{}) {
 	serviceAccount := obj.(*api.ServiceAccount)
 
 	if err := e.createDockercfgSecretIfNeeded(serviceAccount); err != nil {
-		glog.Error(err)
+		util.HandleError(err)
 	}
 }
 
@@ -114,7 +114,7 @@ func (e *DockercfgController) serviceAccountUpdated(oldObj interface{}, newObj i
 	newServiceAccount := newObj.(*api.ServiceAccount)
 
 	if err := e.createDockercfgSecretIfNeeded(newServiceAccount); err != nil {
-		glog.Error(err)
+		util.HandleError(err)
 	}
 }
 
@@ -188,7 +188,7 @@ func (e *DockercfgController) createDockercfgSecretIfNeeded(serviceAccount *api.
 		// we do need to clean up our dockercfgSecret.  token secrets are cleaned up by the controller handling service account dockercfg secret deletes
 		glog.V(2).Infof("Deleting secret %s/%s (err=%v)", dockercfgSecret.Namespace, dockercfgSecret.Name, err)
 		if err := e.client.Secrets(dockercfgSecret.Namespace).Delete(dockercfgSecret.Name); err != nil {
-			glog.Error(err)
+			util.HandleError(err)
 		}
 		return nil
 	}
@@ -275,7 +275,7 @@ func (e *DockercfgController) createTokenSecret(serviceAccount *api.ServiceAccou
 	// the token wasn't ever created, attempt deletion
 	glog.Warningf("Deleting unfilled token secret %s/%s", tokenSecret.Namespace, tokenSecret.Name)
 	if err := e.client.Secrets(tokenSecret.Namespace).Delete(tokenSecret.Name); err != nil {
-		glog.Error(err)
+		util.HandleError(err)
 	}
 	return nil, fmt.Errorf("token never generated for %s", tokenSecret.Name)
 }

--- a/pkg/serviceaccounts/controllers/deleted_token_secrets.go
+++ b/pkg/serviceaccounts/controllers/deleted_token_secrets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 )
@@ -92,7 +93,7 @@ func (e *DockercfgTokenDeletedController) secretDeleted(obj interface{}) {
 	// remove the reference token secrets
 	for _, dockercfgSecret := range dockercfgSecrets {
 		if err := e.client.Secrets(dockercfgSecret.Namespace).Delete(dockercfgSecret.Name); err != nil {
-			glog.Error(err)
+			util.HandleError(err)
 		}
 	}
 }

--- a/pkg/serviceaccounts/controllers/docker_registry_service.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
-	"github.com/golang/glog"
 )
 
 const DefaultOpenshiftDockerURL = "docker-registry.default.svc.cluster.local:5000"
@@ -114,7 +113,7 @@ func (e *DockerRegistryServiceController) serviceAdded(obj interface{}) {
 	}
 
 	if err := e.handleLocationChange(e.getServiceLocation(service)); err != nil {
-		glog.Error(err)
+		util.HandleError(err)
 	}
 }
 
@@ -131,7 +130,7 @@ func (e *DockerRegistryServiceController) serviceUpdated(oldObj interface{}, new
 	}
 
 	if err := e.handleLocationChange(e.getServiceLocation(newService)); err != nil {
-		glog.Error(err)
+		util.HandleError(err)
 	}
 }
 
@@ -146,7 +145,7 @@ func (e *DockerRegistryServiceController) serviceDeleted(obj interface{}) {
 	}
 
 	if err := e.handleLocationChange(e.defaultDockerURL); err != nil {
-		glog.Error(err)
+		util.HandleError(err)
 	}
 }
 
@@ -162,14 +161,14 @@ func (e *DockerRegistryServiceController) handleLocationChange(serviceLocation s
 	for _, dockercfgSecret := range dockercfgSecrets {
 		dockercfg := &credentialprovider.DockerConfig{}
 		if err := json.Unmarshal(dockercfgSecret.Data[api.DockerConfigKey], dockercfg); err != nil {
-			glog.Error(err)
+			util.HandleError(err)
 			continue
 		}
 
 		dockercfgMap := map[string]credentialprovider.DockerConfigEntry(*dockercfg)
 		keys := util.KeySet(reflect.ValueOf(dockercfgMap))
 		if len(keys) != 1 {
-			glog.Error(err)
+			util.HandleError(err)
 			continue
 		}
 		oldKey := keys.List()[0]
@@ -186,13 +185,13 @@ func (e *DockerRegistryServiceController) handleLocationChange(serviceLocation s
 
 		dockercfgContent, err := json.Marshal(dockercfg)
 		if err != nil {
-			glog.Error(err)
+			util.HandleError(err)
 			continue
 		}
 		dockercfgSecret.Data[api.DockerConfigKey] = dockercfgContent
 
 		if _, err := e.client.Secrets(dockercfgSecret.Namespace).Update(dockercfgSecret); err != nil {
-			glog.Error(err)
+			util.HandleError(err)
 			continue
 		}
 	}

--- a/pkg/user/registry/useridentitymapping/rest.go
+++ b/pkg/user/registry/useridentitymapping/rest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
-	"github.com/golang/glog"
 
 	"github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/api/validation"
@@ -229,7 +228,7 @@ func (s *REST) createOrUpdate(ctx kapi.Context, obj runtime.Object, forceCreate 
 	// If this fails, log the error, but continue, because Update is no longer re-entrant
 	if oldUser != nil && removeIdentityFromUser(identity, oldUser) {
 		if _, err := s.userRegistry.UpdateUser(ctx, oldUser); err != nil {
-			glog.Errorf("Error removing identity reference %s from user %s: %v", identity.Name, oldUser.Name, err)
+			util.HandleError(fmt.Errorf("error removing identity reference %s from user %s: %v", identity.Name, oldUser.Name, err))
 		}
 	}
 
@@ -258,7 +257,7 @@ func (s *REST) Delete(ctx kapi.Context, name string) (runtime.Object, error) {
 	// At this point, the mapping for the identity no longer exists
 	if unsetIdentityUser(identity) {
 		if _, err := s.identityRegistry.UpdateIdentity(ctx, identity); err != nil {
-			glog.Errorf("Error removing user reference %s from identity %s: %v", user.Name, identity.Name, err)
+			util.HandleError(fmt.Errorf("error removing user reference %s from identity %s: %v", user.Name, identity.Name, err))
 		}
 	}
 


### PR DESCRIPTION
Changed `glog.Errorf(<>)` into `util.HandleError(fmt.Errorf(<>))` and `glog.Error(<>)` into `util.HandleError(<>)` in code outside of `origin/pkg/cmd` where the error was eaten.

Works on #2628 @smarterclayton