### PR TITLE
do not bounce router for endpoint changes that do not change the data

### DIFF
--- a/plugins/router/template/plugin_test.go
+++ b/plugins/router/template/plugin_test.go
@@ -2,6 +2,7 @@ package templaterouter
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -44,16 +45,17 @@ func (r *TestRouter) FindServiceUnit(id string) (v ServiceUnit, ok bool) {
 }
 
 // AddEndpoints adds the endpoints to the service unit identified by id
-func (r *TestRouter) AddEndpoints(id string, endpoints []Endpoint) {
+func (r *TestRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
 	r.Committed = false //expect any call to this method to subsequently call commit
 	su, _ := r.FindServiceUnit(id)
 
-	for _, ep := range endpoints {
-		newEndpoint := Endpoint{ep.ID, ep.IP, ep.Port, "foo"}
-		su.EndpointTable = append(su.EndpointTable, newEndpoint)
+	// simulate the logic that compares endpoints
+	if reflect.DeepEqual(su.EndpointTable, endpoints) {
+		return false
 	}
-
+	su.EndpointTable = endpoints
 	r.State[id] = su
+	return true
 }
 
 // DeleteEndpoints removes all endpoints from the service unit
@@ -68,7 +70,7 @@ func (r *TestRouter) DeleteEndpoints(id string) {
 }
 
 // AddRoute adds a ServiceAliasConfig for the route to the ServiceUnit identified by id
-func (r *TestRouter) AddRoute(id string, route *routeapi.Route) {
+func (r *TestRouter) AddRoute(id string, route *routeapi.Route) bool {
 	r.Committed = false //expect any call to this method to subsequently call commit
 	su, _ := r.FindServiceUnit(id)
 	routeKey := r.routeKey(route)
@@ -80,6 +82,7 @@ func (r *TestRouter) AddRoute(id string, route *routeapi.Route) {
 
 	su.ServiceAliasConfigs[routeKey] = config
 	r.State[id] = su
+	return true
 }
 
 // RemoveRoute removes the service alias config for Route from the ServiceUnit
@@ -285,4 +288,72 @@ func TestHandleRoute(t *testing.T) {
 		}
 	}
 
+}
+
+func TestUnchangingEndpointsDoesNotCommit(t *testing.T) {
+	router := newTestRouter(make(map[string]ServiceUnit))
+	plugin := TemplatePlugin{Router: router}
+	endpoints := &kapi.Endpoints{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "foo",
+			Name:      "test",
+		},
+		Subsets: []kapi.EndpointSubset{{
+			Addresses: []kapi.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}},
+			Ports:     []kapi.EndpointPort{{Port: 0}},
+		}},
+	}
+	changedEndpoints := &kapi.Endpoints{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "foo",
+			Name:      "test",
+		},
+		Subsets: []kapi.EndpointSubset{{
+			Addresses: []kapi.EndpointAddress{{IP: "3.3.3.3"}, {IP: "2.2.2.2"}},
+			Ports:     []kapi.EndpointPort{{Port: 0}},
+		}},
+	}
+
+	testCases := []struct {
+		name         string
+		event        watch.EventType
+		endpoints    *kapi.Endpoints
+		expectCommit bool
+	}{
+		{
+			name:         "initial add",
+			event:        watch.Added,
+			endpoints:    endpoints,
+			expectCommit: true,
+		},
+		{
+			name:         "mod with no change",
+			event:        watch.Modified,
+			endpoints:    endpoints,
+			expectCommit: false,
+		},
+		{
+			name:         "add with change",
+			event:        watch.Added,
+			endpoints:    changedEndpoints,
+			expectCommit: true,
+		},
+		{
+			name:         "add with no change",
+			event:        watch.Added,
+			endpoints:    changedEndpoints,
+			expectCommit: false,
+		},
+	}
+
+	for _, v := range testCases {
+		err := plugin.HandleEndpoints(v.event, v.endpoints)
+		if err != nil {
+			t.Errorf("%s had unexecpected error in handle endpoints %v", v.name, err)
+			continue
+		}
+		if router.Committed != v.expectCommit {
+			t.Errorf("%s expected router commit to be %v but found %v", v.name, v.expectCommit, router.Committed)
+		}
+	}
 }

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -271,7 +271,7 @@ func (r *templateRouter) routeKey(route *routeapi.Route) string {
 }
 
 // AddRoute adds a route for the given id
-func (r *templateRouter) AddRoute(id string, route *routeapi.Route) {
+func (r *templateRouter) AddRoute(id string, route *routeapi.Route) bool {
 	frontend, _ := r.FindServiceUnit(id)
 
 	backendKey := r.routeKey(route)
@@ -323,6 +323,7 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route) {
 	//create or replace
 	frontend.ServiceAliasConfigs[backendKey] = config
 	r.state[id] = frontend
+	return true
 }
 
 // RemoveRoute removes the given route for the given id.
@@ -342,12 +343,13 @@ func (r *templateRouter) RemoveRoute(id string, route *routeapi.Route) {
 }
 
 // AddEndpoints adds new Endpoints for the given id.
-func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) {
+func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) bool {
 	frontend, _ := r.FindServiceUnit(id)
 
 	//only make the change if there is a difference
 	if reflect.DeepEqual(frontend.EndpointTable, endpoints) {
-		return
+		glog.V(4).Infof("Ignoring change for %s, endpoints are the same", id)
+		return false
 	}
 
 	frontend.EndpointTable = endpoints
@@ -357,6 +359,8 @@ func (r *templateRouter) AddEndpoints(id string, endpoints []Endpoint) {
 		r.peerEndpoints = frontend.EndpointTable
 		glog.V(4).Infof("Peer endpoints updated to: %#v", r.peerEndpoints)
 	}
+
+	return true
 }
 
 // cleanUpServiceAliasConfig performs any necessary steps to clean up a service alias config before deleting it from


### PR DESCRIPTION
Endpoints sync approximately every 2 minutes.  This will cause the router to receive endpoint events that do not change the endpoint data.  We should not change anything and tell the plugin it doesn't need to perform a commit (which causes a reload of haproxy).

Fixes https://github.com/openshift/origin/issues/1592

@rajatchopra @smarterclayton @pmorie PTAL

/cc @sdodson @jimmidyson 