### PR TITLE
Expose _endpoints.<> as a DNS endpoint

### DIFF
--- a/pkg/dns/server.go
+++ b/pkg/dns/server.go
@@ -42,8 +42,8 @@ func openshiftFallback(name string, exact bool) (string, bool) {
 	if name == "openshift.default.svc" {
 		return "kubernetes.default.svc.", true
 	}
-	if name == "openshift.default.endpoints" {
-		return "kubernetes.default.endpoints.", true
+	if name == "_endpoints.openshift.default.svc" {
+		return "_endpoints.kubernetes.default.", true
 	}
 	return "", false
 }

--- a/pkg/dns/serviceresolver.go
+++ b/pkg/dns/serviceresolver.go
@@ -94,8 +94,10 @@ func (b *ServiceResolver) Records(name string, exact bool) ([]msg.Service, error
 			return nil, nil
 		}
 
+		retrieveEndpoints := segments[0] == "endpoints" || (len(segments) > 3 && segments[3] == "_endpoints")
+
 		// if has a portal IP and looking at svc
-		if svc.Spec.PortalIP != kapi.PortalIPNone && segments[0] == "svc" {
+		if svc.Spec.PortalIP != kapi.PortalIPNone && !retrieveEndpoints {
 			if len(svc.Spec.Ports) == 0 {
 				return nil, nil
 			}

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -128,7 +128,7 @@ func TestDNS(t *testing.T) {
 			expect:          []*net.IP{&masterIP},
 		},
 		{ // resolving endpoints of a service works
-			dnsQuestionName: "kubernetes.default.endpoints.cluster.local.",
+			dnsQuestionName: "_endpoints.kubernetes.default.svc.cluster.local.",
 			expect:          []*net.IP{&localIP},
 		},
 		{ // openshift override works


### PR DESCRIPTION
Allows local search lookup "_endpoints.servicename" without requiring
a search domain.

[test] @pweil- review

@jimmidyson this resolves part of #2731