### PR TITLE
Controllers should be able to be lazily started

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -75,6 +75,11 @@ const (
 	DockerExecHandlerNative DockerExecHandlerType = "native"
 	// DockerExecHandlerNative uses nsenter for executing commands in containers.
 	DockerExecHandlerNsenter DockerExecHandlerType = "nsenter"
+
+	// ControllersDisabled indicates no controllers should be enabled.
+	ControllersDisabled = "none"
+	// ControllersAll indicates all controllers should be started.
+	ControllersAll = "*"
 )
 
 type MasterConfig struct {
@@ -91,6 +96,15 @@ type MasterConfig struct {
 
 	// MasterPublicURL is how clients can access the OpenShift API server
 	MasterPublicURL string
+
+	// Controllers is a list of the controllers that should be started. If set to "none", no controllers
+	// will start automatically. The default value is "*" which will start all controllers. When
+	// using "*", you may exclude controllers by prepending a "-" in front of their name. No other
+	// values are recognized at this time.
+	Controllers string
+	// PauseControllers instructs the master to not automatically start controllers, but instead
+	// to wait until a notification to the server is received before launching them.
+	PauseControllers bool
 
 	// EtcdStorageConfig contains information about how API resources are
 	// stored in Etcd. These values are only relevant when etcd is the

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -12,6 +12,9 @@ func init() {
 			if len(obj.APILevels) == 0 {
 				obj.APILevels = newer.DefaultOpenShiftAPILevels
 			}
+			if len(obj.Controllers) == 0 {
+				obj.Controllers = ControllersAll
+			}
 		},
 		func(obj *KubernetesMasterConfig) {
 			if obj.MasterCount == 0 {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -65,6 +65,11 @@ const (
 	DockerExecHandlerNative DockerExecHandlerType = "native"
 	// DockerExecHandlerNative uses nsenter for executing commands in containers.
 	DockerExecHandlerNsenter DockerExecHandlerType = "nsenter"
+
+	// ControllersDisabled indicates no controllers should be enabled.
+	ControllersDisabled = "none"
+	// ControllersAll indicates all controllers should be started.
+	ControllersAll = "*"
 )
 
 type MasterConfig struct {
@@ -81,6 +86,15 @@ type MasterConfig struct {
 
 	// MasterPublicURL is how clients can access the OpenShift API server
 	MasterPublicURL string `json:"masterPublicURL"`
+
+	// Controllers is a list of the controllers that should be started. If set to "none", no controllers
+	// will start automatically. The default value is "*" which will start all controllers. When
+	// using "*", you may exclude controllers by prepending a "-" in front of their name. No other
+	// values are recognized at this time.
+	Controllers string `json:"controllers,omitempty"`
+	// PauseControllers instructs the master to not automatically start controllers, but instead
+	// to wait until a notification to the server is received before launching them.
+	PauseControllers bool `json:"pauseControllers,omitempty"`
 
 	// EtcdStorageConfig contains information about how API resources are
 	// stored in Etcd. These values are only relevant when etcd is the

--- a/pkg/cmd/server/origin/control.go
+++ b/pkg/cmd/server/origin/control.go
@@ -1,0 +1,55 @@
+package origin
+
+import (
+	"fmt"
+	"net/http"
+
+	restful "github.com/emicklei/go-restful"
+
+	"github.com/openshift/origin/pkg/cmd/util/plug"
+)
+
+// initControllerRoutes adds a web service endpoint for managing the execution
+// state of the controllers.
+func initControllerRoutes(root *restful.WebService, path string, canStart bool, plug plug.Plug) {
+	root.Route(root.GET(path).To(func(req *restful.Request, resp *restful.Response) {
+		if !canStart {
+			resp.ResponseWriter.WriteHeader(http.StatusMethodNotAllowed)
+			fmt.Fprintf(resp, "disabled")
+			return
+		}
+		if plug.IsStarted() {
+			resp.ResponseWriter.WriteHeader(http.StatusOK)
+			fmt.Fprintf(resp, "ok")
+		} else {
+			resp.ResponseWriter.WriteHeader(http.StatusAccepted)
+			fmt.Fprintf(resp, "waiting")
+		}
+	}).Doc("Check whether the controllers are running on this master").
+		Returns(http.StatusOK, "if controllers are running", nil).
+		Returns(http.StatusMethodNotAllowed, "if controllers are disabled", nil).
+		Returns(http.StatusAccepted, "if controllers are waiting to be started", nil).
+		Produces(restful.MIME_JSON))
+
+	root.Route(root.PUT(path).To(func(req *restful.Request, resp *restful.Response) {
+		if !canStart {
+			resp.ResponseWriter.WriteHeader(http.StatusMethodNotAllowed)
+			fmt.Fprintf(resp, "disabled")
+			return
+		}
+		plug.Start()
+		resp.ResponseWriter.WriteHeader(http.StatusOK)
+		fmt.Fprintf(resp, "ok")
+	}).Doc("Start controllers on this master").
+		Returns(http.StatusOK, "if controllers have started", nil).
+		Returns(http.StatusMethodNotAllowed, "if controllers are disabled", nil).
+		Produces(restful.MIME_JSON))
+
+	root.Route(root.DELETE(path).To(func(req *restful.Request, resp *restful.Response) {
+		resp.ResponseWriter.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(resp, "terminating")
+		plug.Stop()
+	}).Doc("Stop the master").
+		Returns(http.StatusAccepted, "if the master will stop", nil).
+		Produces(restful.MIME_JSON))
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -356,6 +356,7 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		container.Add(root)
 	}
 
+	initControllerRoutes(root, "/controllers", c.Options.Controllers != configapi.ControllersDisabled, c.ControllerPlug)
 	initAPIVersionRoute(root, LegacyOpenShiftAPIPrefix, legacyAPIVersions...)
 	initAPIVersionRoute(root, OpenShiftAPIPrefix, currentAPIVersions...)
 
@@ -407,6 +408,7 @@ func indexAPIPaths(handler http.Handler) http.Handler {
 				"/api",
 				"/api/v1beta3",
 				"/api/v1",
+				"/controllers",
 				"/healthz",
 				"/healthz/ping",
 				"/logs/",

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -42,6 +42,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
+	"github.com/openshift/origin/pkg/cmd/util/plug"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	accesstokenregistry "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
@@ -71,6 +72,8 @@ type MasterConfig struct {
 	AdmissionControl admission.Interface
 
 	TLS bool
+
+	ControllerPlug plug.Plug
 
 	// a function that returns the appropriate image to use for a named component
 	ImageFor func(component string) string
@@ -159,6 +162,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		AdmissionControl: admissionController,
 
 		TLS: configapi.UseTLS(options.ServingInfo),
+
+		ControllerPlug: plug.NewPlug(!options.PauseControllers),
 
 		ImageFor:            imageTemplate.ExpandOrDie,
 		EtcdHelper:          etcdHelper,

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -32,6 +32,8 @@ type MasterArgs struct {
 	// addresses for external clients
 	MasterPublicAddr flagtypes.Addr
 
+	PauseControllers bool
+
 	// DNSBindAddr exposed for integration tests to set
 	DNSBindAddr flagtypes.Addr
 
@@ -58,6 +60,7 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 	flags.Var(&args.EtcdAddr, prefix+"etcd", "The address of the etcd server (host, host:port, or URL). If specified, no built-in etcd will be started.")
 	flags.Var(&args.PortalNet, prefix+"portal-net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
 	flags.Var(&args.DNSBindAddr, prefix+"dns", "The address to listen for DNS requests on.")
+	flags.BoolVar(&args.PauseControllers, prefix+"pause", false, "If true, wait for a signal before starting the controllers.")
 
 	flags.StringVar(&args.EtcdDir, prefix+"etcd-dir", "openshift.local.etcd", "The etcd data directory.")
 
@@ -157,6 +160,8 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		EtcdConfig:             etcdConfig,
 
 		OAuthConfig: oauthConfig,
+
+		PauseControllers: args.PauseControllers,
 
 		AssetConfig: &configapi.AssetConfig{
 			ServingInfo: configapi.ServingInfo{

--- a/pkg/cmd/util/plug/plug.go
+++ b/pkg/cmd/util/plug/plug.go
@@ -1,0 +1,56 @@
+package plug
+
+import (
+	"sync"
+)
+
+type Plug interface {
+	Start()
+	Stop()
+	WaitForStart()
+	WaitForStop()
+	IsStarted() bool
+}
+
+type plug struct {
+	start   sync.Once
+	stop    sync.Once
+	startCh chan struct{}
+	stopCh  chan struct{}
+}
+
+func NewPlug(started bool) Plug {
+	p := &plug{
+		startCh: make(chan struct{}),
+		stopCh:  make(chan struct{}),
+	}
+	if started {
+		p.Start()
+	}
+	return p
+}
+
+func (p *plug) Start() {
+	p.start.Do(func() { close(p.startCh) })
+}
+
+func (p *plug) Stop() {
+	p.stop.Do(func() { close(p.stopCh) })
+}
+
+func (p *plug) IsStarted() bool {
+	select {
+	case <-p.startCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *plug) WaitForStart() {
+	<-p.startCh
+}
+
+func (p *plug) WaitForStop() {
+	<-p.stopCh
+}


### PR DESCRIPTION
Allows HA master enablement after start. New endpoint
/controllers which supports GET (200 if controllers are running, 202 if
they are not, 405 if they can't be started), PUT (200 if they are started,
405 if they can't be started), and DELETE (200 causes server to shut down).

Add two new config values - Controllers (string with 'none' and '*') which
is the list of controllers to start, and PauseControllers which if true
waits for PUT /controllers to start the second controller.

Allows external control of HA state