### PR TITLE
Support processing using standard input

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -223,28 +223,16 @@ export OPENSHIFTCONFIG="${HOME}/.config/openshift/non-default-config"
 
 # from this point every command will use config from the OPENSHIFTCONFIG env var
 
-<<<<<<< HEAD
 oc get templates
 oc create -f examples/sample-app/application-template-dockerbuild.json
 oc get templates
 oc get templates ruby-helloworld-sample
+oc get template ruby-helloworld-sample -o json | oc process -f -
 oc process ruby-helloworld-sample
 oc describe templates ruby-helloworld-sample
 [ "$(oc describe templates ruby-helloworld-sample | grep -E "BuildConfig.*ruby-sample-build")" ]
 oc delete templates ruby-helloworld-sample
 oc get templates
-=======
-osc get templates
-osc create -f examples/sample-app/application-template-dockerbuild.json
-osc get templates
-osc get templates ruby-helloworld-sample
-osc get template ruby-helloworld-sample -o json | osc process -f -
-osc process ruby-helloworld-sample
-osc describe templates ruby-helloworld-sample
-[ "$(osc describe templates ruby-helloworld-sample | grep -E "BuildConfig.*ruby-sample-build")" ]
-osc delete templates ruby-helloworld-sample
-osc get templates
->>>>>>> 4e038de... Add process from stdin to hack/test-cmd.sh
 # TODO: create directly from template
 echo "templates: ok"
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -223,6 +223,7 @@ export OPENSHIFTCONFIG="${HOME}/.config/openshift/non-default-config"
 
 # from this point every command will use config from the OPENSHIFTCONFIG env var
 
+<<<<<<< HEAD
 oc get templates
 oc create -f examples/sample-app/application-template-dockerbuild.json
 oc get templates
@@ -232,6 +233,18 @@ oc describe templates ruby-helloworld-sample
 [ "$(oc describe templates ruby-helloworld-sample | grep -E "BuildConfig.*ruby-sample-build")" ]
 oc delete templates ruby-helloworld-sample
 oc get templates
+=======
+osc get templates
+osc create -f examples/sample-app/application-template-dockerbuild.json
+osc get templates
+osc get templates ruby-helloworld-sample
+osc get template ruby-helloworld-sample -o json | osc process -f -
+osc process ruby-helloworld-sample
+osc describe templates ruby-helloworld-sample
+[ "$(osc describe templates ruby-helloworld-sample | grep -E "BuildConfig.*ruby-sample-build")" ]
+osc delete templates ruby-helloworld-sample
+osc get templates
+>>>>>>> 4e038de... Add process from stdin to hack/test-cmd.sh
 # TODO: create directly from template
 echo "templates: ok"
 

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -139,13 +138,30 @@ func RunProcess(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []
 			return err
 		}
 
-		var ok bool
-		templateObj, ok = obj.(*api.Template)
-		if !ok {
-			return fmt.Errorf("cannot convert input to Template: ", reflect.TypeOf(obj))
+		// FIXME: For now, only the first Template item is processed.
+		// When the input is provided in STDIN then all Template objects are loaded
+		// into api.List items, which assumes that we will process them
+		// sequentially. However, this is not (yet) supported as we will have to
+		// deal with multiple parameters set by different templates.
+		switch t := obj.(type) {
+		case *kapi.List:
+			if len(t.Items) == 0 {
+				return fmt.Errorf("no valid Template items found in the input")
+			}
+			if len(t.Items) > 1 {
+				return fmt.Errorf("you can pass only one Template using standard input")
+			}
+			var ok bool
+			if templateObj, ok = t.Items[0].(*api.Template); !ok {
+				return fmt.Errorf("cannot convert input to Template: %v", t)
+			}
+		case *api.Template:
+			templateObj = t
+		default:
+			return fmt.Errorf("cannot convert input to Template: %v", t)
 		}
-		templateObj.CreationTimestamp = util.Now()
 
+		templateObj.CreationTimestamp = util.Now()
 		version, kind, err := kapi.Scheme.ObjectVersionAndKind(templateObj)
 		if err != nil {
 			return err


### PR DESCRIPTION
When the `osc process` is called using `-f -` this change takes the
first template object that is passed and process it.

Fixes: #2680 