### PR TITLE
When using 'make run' enable broad cross origin resource sharing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 # Example:
 #   make run
 run: build
-	$(OUT_DIR)/local/go/bin/openshift start
+	$(OUT_DIR)/local/go/bin/openshift start --cors-allowed-origins=.*
 .PHONY: run
 
 # Remove all build artifacts.


### PR DESCRIPTION
This is development mode, and enables simple usage with
hack/serve-local-assets.sh