### PR TITLE
Ensure KubeletConfig's RootDirectory is correct

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -134,6 +134,8 @@ func (c *NodeConfig) RunKubelet() {
 		}
 	}
 	c.KubeletConfig.DockerClient = c.DockerClient
+	// updated by NodeConfig.EnsureVolumeDir
+	c.KubeletConfig.RootDirectory = c.VolumeDir
 	glog.Fatal(c.KubeletServer.Run(c.KubeletConfig))
 }
 


### PR DESCRIPTION
When *not* running from a config file, the KubeletConfig wasn't getting
an absolute path for RootDirectory.

Fixes bug 1228471