### PR TITLE
promote whoami to osc

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -206,6 +206,7 @@ oc logout
 oc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
 oc get projects
 oc project project-foo
+[ "$(oc whoami | grep 'test-user')" ]
 
 # test config files from the --config flag
 oc get services --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -305,6 +305,7 @@ wait_for_url_timed "http://${DOCKER_REGISTRY}/healthz" "[INFO] Docker registry s
 # This is required to be able to push to the registry!
 echo "[INFO] Logging in as a regular user (e2e-user:pass) with project 'test'..."
 oc login -u e2e-user -p pass
+[ "$(oc whoami | grep 'e2e-user')" ]
 oc project cache
 token=$(oc config view --flatten -o template -t '{{with index .users 0}}{{.user.token}}{{end}}')
 [[ -n ${token} ]]
@@ -320,6 +321,7 @@ echo "[INFO] Pushed ruby-20-centos7"
 
 echo "[INFO] Back to 'default' project with 'admin' user..."
 oc project ${CLUSTER_ADMIN_CONTEXT}
+[ "$(oc whoami | grep 'system:admin')" ]
 
 # The build requires a dockercfg secret in the builder service account in order
 # to be able to push to the registry.  Make sure it exists first.

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -123,6 +123,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 			Commands: []*cobra.Command{
 				cmd.NewCmdLogout("logout", fullName+" logout", fullName+" login", f, in, out),
 				cmd.NewCmdConfig(fullName, "config"),
+				cmd.NewCmdWhoAmI(cmd.WhoAmIRecommendedCommandName, fullName+" "+cmd.WhoAmIRecommendedCommandName, f, out),
 			},
 		},
 	}

--- a/pkg/cmd/cli/cmd/whoami.go
+++ b/pkg/cmd/cli/cmd/whoami.go
@@ -1,4 +1,4 @@
-package tokens
+package cmd
 
 import (
 	"fmt"

--- a/pkg/cmd/experimental/tokens/tokens.go
+++ b/pkg/cmd/experimental/tokens/tokens.go
@@ -33,7 +33,6 @@ func NewCmdTokens(name, fullName string, f *osclientcmd.Factory, out io.Writer) 
 
 	cmds.AddCommand(NewCmdValidateToken(f))
 	cmds.AddCommand(NewCmdRequestToken(f))
-	cmds.AddCommand(NewCmdWhoAmI(WhoAmIRecommendedCommandName, fullName+" "+WhoAmIRecommendedCommandName, f, out))
 
 	return cmds
 }

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -16,7 +16,6 @@ import (
 	newproject "github.com/openshift/origin/pkg/cmd/admin/project"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
-	"github.com/openshift/origin/pkg/cmd/experimental/tokens"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/user/api"
 	testutil "github.com/openshift/origin/test/util"
@@ -102,7 +101,7 @@ func TestLogin(t *testing.T) {
 	// 	t.Fatalf("unexpected error: %v", err)
 	// }
 
-	userWhoamiOptions := tokens.WhoAmIOptions{oClient.Users(), ioutil.Discard}
+	userWhoamiOptions := cmd.WhoAmIOptions{oClient.Users(), ioutil.Discard}
 	retrievedUser, err := userWhoamiOptions.WhoAmI()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -111,7 +110,7 @@ func TestLogin(t *testing.T) {
 		t.Errorf("expected %v, got %v", retrievedUser.Name, username)
 	}
 
-	adminWhoamiOptions := tokens.WhoAmIOptions{clusterAdminClient.Users(), ioutil.Discard}
+	adminWhoamiOptions := cmd.WhoAmIOptions{clusterAdminClient.Users(), ioutil.Discard}
 	retrievedAdmin, err := adminWhoamiOptions.WhoAmI()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
Moves `openshift ex tokens whoami` to `osc whoami`.

@fabianofranz ptal

@smarterclayton Can you confirm that you're ok with promoting this command?