### PR TITLE
Create default SCC for cluster

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -1,0 +1,52 @@
+package bootstrappolicy
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+)
+
+const (
+	// SecurityContextConstraintPrivileged is used as the name for the system default privileged scc.
+	SecurityContextConstraintPrivileged = "privileged"
+	// SecurityContextConstraintRestricted is used as the name for the system default restricted scc.
+	SecurityContextConstraintRestricted = "restricted"
+)
+
+// GetBootstrapSecurityContextConstraints returns the slice of default SecurityContextConstraints
+// for system bootstrapping.
+func GetBootstrapSecurityContextConstraints() []kapi.SecurityContextConstraints {
+	constraints := []kapi.SecurityContextConstraints{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: SecurityContextConstraintPrivileged,
+			},
+			AllowPrivilegedContainer: true,
+			AllowHostDirVolumePlugin: true,
+			SELinuxContext: kapi.SELinuxContextStrategyOptions{
+				Type: kapi.SELinuxStrategyRunAsAny,
+			},
+			RunAsUser: kapi.RunAsUserStrategyOptions{
+				Type: kapi.RunAsUserStrategyRunAsAny,
+			},
+			// TODO: AuthenticatedGroup should be removed from this list ASAP
+			Groups: []string{AuthenticatedGroup, ClusterAdminGroup},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: SecurityContextConstraintRestricted,
+			},
+			SELinuxContext: kapi.SELinuxContextStrategyOptions{
+				// This strategy requires that annotations on the namespace which will be populated
+				// by the admission controller.  If namespaces are not annotated creating the strategy
+				// will fail.
+				Type: kapi.SELinuxStrategyMustRunAs,
+			},
+			RunAsUser: kapi.RunAsUserStrategyOptions{
+				// This strategy requires that annotations on the namespace which will be populated
+				// by the admission controller.  If namespaces are not annotated creating the strategy
+				// will fail.
+				Type: kapi.RunAsUserStrategyMustRunAsRange,
+			},
+		},
+	}
+	return constraints
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -29,6 +29,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	kmaster "github.com/GoogleCloudPlatform/kubernetes/pkg/master"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator"
 	etcdallocator "github.com/GoogleCloudPlatform/kubernetes/pkg/registry/service/allocator/etcd"
@@ -526,6 +528,8 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 
 	// Create required policy rules if needed
 	c.ensureComponentAuthorizationRules()
+	// Ensure the default SCCs are created
+	c.ensureDefaultSecurityContextConstraints()
 	// Bind default roles for service accounts in the default namespace if needed
 	c.ensureDefaultNamespaceServiceAccountRoles()
 	// Create the shared resource namespace
@@ -676,6 +680,23 @@ func (c *MasterConfig) ensureDefaultNamespaceServiceAccountRoles() {
 		defaultNamespace.Annotations[ServiceAccountRolesInitializedAnnotation] = "true"
 		if _, err := c.KubeClient().Namespaces().Update(defaultNamespace); err != nil {
 			glog.Errorf("Error recording adding service account roles to default namespace: %v", err)
+		}
+	}
+}
+
+func (c *MasterConfig) ensureDefaultSecurityContextConstraints() {
+	sccList, err := c.KubeClient().SecurityContextConstraints().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		glog.Errorf("Unable to initialize security context constraints: %v", err)
+	}
+	if len(sccList.Items) > 0 {
+		return
+	}
+	glog.Infof("No security context constraints detected, adding defaults")
+	for _, scc := range bootstrappolicy.GetBootstrapSecurityContextConstraints() {
+		_, err = c.KubeClient().SecurityContextConstraints().Create(&scc)
+		if err != nil {
+			glog.Errorf("Unable to create default security context constraint %s.  Got error: %v", scc.Name, err)
 		}
 	}
 }


### PR DESCRIPTION
Right now just a run as any SCC until we solve the issue with volume permissions and identifying build pod creators.  Will follow up with a real set of SCCs.

Based on https://github.com/openshift/origin/pull/2856 which should be merged first.  Only the second commit is new code.

Fixes https://github.com/openshift/origin/issues/2775

@liggitt @pmorie @smarterclayton 