### PR TITLE
Prevent invalid names in new-app pipelines

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -164,6 +164,10 @@ type ImageRef struct {
 	OutputImage   bool
 	Insecure      bool
 
+	// ObjectName overrides the name of the ImageStream produced
+	// but does not affect the DockerImageReference
+	ObjectName string
+
 	Stream *imageapi.ImageStream
 	Info   *imageapi.DockerImage
 }
@@ -217,6 +221,9 @@ func (r *ImageRef) RepoName() string {
 
 // SuggestName suggests a name for an image reference
 func (r *ImageRef) SuggestName() (string, bool) {
+	if r != nil && len(r.ObjectName) > 0 {
+		return r.ObjectName, true
+	}
 	if r == nil || len(r.Name) == 0 {
 		return "", false
 	}

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/origin/pkg/generate/dockerfile"
 	"github.com/openshift/origin/pkg/generate/source"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/util/namer"
 )
 
 func TestAddArguments(t *testing.T) {
@@ -731,6 +732,67 @@ func TestRunBuild(t *testing.T) {
 				t.Errorf("%s: Resource names mismatch! Expected %v, got %v", test.name, exp, g)
 				continue
 			}
+		}
+	}
+}
+
+func TestEnsureValidUniqueName(t *testing.T) {
+	chars := []byte("abcdefghijk")
+	longBytes := []byte{}
+	for i := 0; i < (util.DNS1123SubdomainMaxLength + 20); i++ {
+		longBytes = append(longBytes, chars[i%len(chars)])
+	}
+	longName := string(longBytes)
+	tests := []struct {
+		name        string
+		input       []string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:     "duplicate names",
+			input:    []string{"one", "two", "three", "one", "one", "two"},
+			expected: []string{"one", "two", "three", "one-1", "one-2", "two-1"},
+		},
+		{
+			name:     "mixed case names",
+			input:    []string{"One", "ONE", "tWo"},
+			expected: []string{"one", "one-1", "two"},
+		},
+		{
+			name:        "short name",
+			input:       []string{"t"},
+			expectError: true,
+		},
+		{
+			name:  "long name",
+			input: []string{longName, longName, longName},
+			expected: []string{longName[:util.DNS1123SubdomainMaxLength],
+				namer.GetName(longName[:util.DNS1123SubdomainMaxLength], "1", util.DNS1123SubdomainMaxLength),
+				namer.GetName(longName[:util.DNS1123SubdomainMaxLength], "2", util.DNS1123SubdomainMaxLength),
+			},
+		},
+	}
+
+tests:
+	for _, test := range tests {
+		result := []string{}
+		names := make(map[string]int)
+		for _, i := range test.input {
+			name, err := ensureValidUniqueName(names, i)
+			if err != nil && !test.expectError {
+				t.Errorf("%s: unexpected error: %v", test.name, err)
+			}
+			if err == nil && test.expectError {
+				t.Errorf("%s: did not get an error.", test.name)
+			}
+			if err != nil {
+				continue tests
+			}
+			result = append(result, name)
+		}
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("%s: unexpected output. Expected: %#v, Got: %#v", test.name, test.expected, result)
 		}
 	}
 }


### PR DESCRIPTION
Fixes bug 1203592
Fixes #2886
Prevents new-app from tripping on itself when specifying components
that will result in duplicate names for pipelines:
'osc new-app myco/sql yourco/sql'
'osc new-app https://src/company/repo https://src/myown/repo'
or when using the same source repo to build multiple images.

Ensures that names are valid (all lowercase) and within length limits.