### PR TITLE
BZ1228514 - updating a route's service name leaves an old route

### DIFF
--- a/plugins/router/template/router_test.go
+++ b/plugins/router/template/router_test.go
@@ -419,3 +419,110 @@ func makeCertMap(host string, valid bool) map[string]Certificate {
 	}
 	return certMap
 }
+
+// TestRouteExistsUnderOneServiceOnly tests that a unique route  exists under only
+// one service unit
+// context: service units are keyed by route namespace/service name, routes are keyed by route namespace
+// and route name.
+//
+// steps:
+// 1. Add a route N1/R1 with service name N1/A - service unit N1/A is created with service alias
+//    config N1/R1
+// 2. Add a route N1/R1 with service name N1/B - service unit N1/B is created with SAC N1/R1, N1/R1
+//    should be removed from service unit N1/A
+// 3. Add a route N2/R1 (same name as N1/R1, differente ns) service name N2/A - service unit
+//    N2/A should be created with SAC N2/R1 and service unit N1/B should still exist with N1/R1
+func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
+	routeWithBadService := &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+		Host:        "host",
+		Path:        "path",
+		ServiceName: "bad-service",
+	}
+	routeWithGoodService := &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "foo",
+			Name:      "bar",
+		},
+		Host:        "host",
+		Path:        "path",
+		ServiceName: "good-service",
+	}
+	routeWithGoodServiceDifferentNamespace := &routeapi.Route{
+		ObjectMeta: kapi.ObjectMeta{
+			Namespace: "foo2",
+			Name:      "bar",
+		},
+		Host:        "host",
+		Path:        "path",
+		ServiceName: "good-service",
+	}
+
+	// setup the router
+	router := newFakeTemplateRouter()
+	routeWithBadServiceKey := routeKey(*routeWithBadService)
+	routeWithBadServiceCfgKey := router.routeKey(routeWithBadService)
+	routeWithGoodServiceKey := routeKey(*routeWithGoodService)
+	routeWithGoodServiceCfgKey := router.routeKey(routeWithGoodService)
+	routeWithGoodServiceDifferentNamespaceKey := routeKey(*routeWithGoodServiceDifferentNamespace)
+	routeWithGoodServiceDifferentNamespaceCfgKey := router.routeKey(routeWithGoodServiceDifferentNamespace)
+	router.CreateServiceUnit(routeWithBadServiceKey)
+	router.CreateServiceUnit(routeWithGoodServiceKey)
+	router.CreateServiceUnit(routeWithGoodServiceDifferentNamespaceKey)
+
+	// add the route with the bad service name, it should add fine
+	router.AddRoute(routeWithBadServiceKey, routeWithBadService)
+	route, ok := router.FindServiceUnit(routeWithBadServiceKey)
+
+	if !ok {
+		t.Fatal("unable to find route %s after adding", routeWithBadServiceKey)
+	}
+	_, ok = route.ServiceAliasConfigs[routeWithBadServiceCfgKey]
+	if !ok {
+		t.Fatalf("unable to find service alias config %s after adding route %s", routeWithBadServiceCfgKey, routeWithBadServiceKey)
+	}
+
+	// now add the same route with a modified service name, it should exists under the new service
+	// and no longer exist under the old service
+	router.AddRoute(routeWithGoodServiceKey, routeWithGoodService)
+	route, ok = router.FindServiceUnit(routeWithGoodServiceKey)
+	if !ok {
+		t.Fatal("unable to find route %s after adding", routeWithGoodServiceKey)
+	}
+	_, ok = route.ServiceAliasConfigs[routeWithGoodServiceCfgKey]
+	if !ok {
+		t.Fatalf("unable to find service alias config %s after adding route %s", routeWithGoodServiceCfgKey, routeWithGoodServiceKey)
+	}
+
+	route, ok = router.FindServiceUnit(routeWithBadServiceKey)
+	if !ok {
+		t.Fatal("route %s should already exists but was not found", routeWithBadServiceKey)
+	}
+	_, ok = route.ServiceAliasConfigs[routeWithBadServiceCfgKey]
+	if ok {
+		t.Fatalf("shouldn't have found service alias config %s under %s", routeWithBadServiceCfgKey, routeWithBadServiceKey)
+	}
+
+	// add a route with the same name but under a different namespace.
+	router.AddRoute(routeWithGoodServiceDifferentNamespaceKey, routeWithGoodServiceDifferentNamespace)
+	route, ok = router.FindServiceUnit(routeWithGoodServiceDifferentNamespaceKey)
+	if !ok {
+		t.Fatal("unable to find route %s after adding", routeWithGoodServiceDifferentNamespaceKey)
+	}
+	_, ok = route.ServiceAliasConfigs[routeWithGoodServiceDifferentNamespaceCfgKey]
+	if !ok {
+		t.Fatalf("unable to find service alias config %s after adding route %s", routeWithGoodServiceDifferentNamespaceCfgKey, routeWithGoodServiceDifferentNamespaceKey)
+	}
+
+	route, ok = router.FindServiceUnit(routeWithGoodServiceKey)
+	if !ok {
+		t.Fatal("unable to find route %s after adding", routeWithGoodServiceKey)
+	}
+	_, ok = route.ServiceAliasConfigs[routeWithGoodServiceCfgKey]
+	if !ok {
+		t.Fatalf("unable to find service alias config %s after adding route %s", routeWithGoodServiceCfgKey, routeWithGoodServiceKey)
+	}
+}


### PR DESCRIPTION
Issue:  The internal model of the router keys ServiceUnits by the service ns/name.  When updating a route's service name it sees it as a new ServiceUnit and was leaving the old ServiceAliasConfig.  This ensures the ServiceAliasConfig only exists in the most current ServiceUnit.

When refactoring the internal model is addressed in https://trello.com/c/jqEeiRxL/750-refactor-router-s-internal-model-routing-techdebt this can be removed.  TODO has been added in the code as a reminder.

@rajatchopra @ramr @pmorie @smarterclayton 