### PR TITLE
have osc status highlight disabled deployment configs

### DIFF
--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -40,7 +40,7 @@ func TestProjectStatus(t *testing.T) {
 						Name:      "example",
 						Namespace: "",
 						Annotations: map[string]string{
-							"openshift.io/display-name": "Test",
+							projectapi.ProjectDisplayName: "Test",
 						},
 					},
 				},


### PR DESCRIPTION
If any DeploymentConfigs lack triggers, it produces:
```
In project default

service docker-registry (172.30.139.142:5000)
  docker-registry deploys docker.io/openshift/origin-docker-registry:v0.5.4 (manual)
    #1 deployed 2 hours ago - 1 pod

service kubernetes (172.30.0.2:443)

service kubernetes-ro (172.30.0.1:80)

To see more information about a Service or DeploymentConfig, use 'osc describe service <name>' or 'osc describe dc <name>'.
You can use 'osc get all' to see lists of each of the types described above.
```

@smarterclayton I debating wiring this into the graph structure, but it felt weird to have a DeploymentConfig with an edge back to itself.