### PR TITLE
LimitSecretReferences in service account admission, fix service account round-tripping in builds

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/serviceaccount/admission.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/serviceaccount/admission.go
@@ -107,7 +107,7 @@ func NewServiceAccount(cl client.Interface) *serviceAccount {
 	return &serviceAccount{
 		Handler: admission.NewHandler(admission.Create),
 		// TODO: enable this once we've swept secret usage to account for adding secret references to service accounts
-		LimitSecretReferences: false,
+		LimitSecretReferences: true,
 		// Auto mount service account API token secrets
 		MountServiceAccountToken: true,
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -20,11 +20,6 @@ type Build struct {
 	kapi.TypeMeta   `json:",inline"`
 	kapi.ObjectMeta `json:"metadata,omitempty"`
 
-	// ServiceAccount is the name of the ServiceAccount to use to run the pod
-	// created by this build.
-	// The pod will be allowed to use secrets referenced by the ServiceAccount
-	ServiceAccount string `json:"serviceAccount,omitempty"`
-
 	// Parameters are all the inputs used to create the build pod.
 	Parameters BuildParameters `json:"parameters,omitempty"`
 
@@ -57,6 +52,11 @@ type Build struct {
 
 // BuildParameters encapsulates all the inputs necessary to represent a build.
 type BuildParameters struct {
+	// ServiceAccount is the name of the ServiceAccount to use to run the pod
+	// created by this build.
+	// The pod will be allowed to use secrets referenced by the ServiceAccount
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+
 	// Source describes the SCM in use.
 	Source BuildSource `json:"source,omitempty"`
 

--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -49,7 +49,6 @@ func init() {
 			if err := s.Convert(in, &out.Status, 0); err != nil {
 				return err
 			}
-			in.ServiceAccount = out.Spec.ServiceAccount
 			return s.Convert(&in.Status, &out.Status.Phase, 0)
 		},
 		func(in *Build, out *newer.Build, s conversion.Scope) error {
@@ -62,7 +61,6 @@ func init() {
 			if err := s.Convert(&in.Spec, &out.Parameters, 0); err != nil {
 				return err
 			}
-			in.Spec.ServiceAccount = out.ServiceAccount
 			return s.Convert(&in.Status.Phase, &out.Status, 0)
 		},
 
@@ -128,6 +126,7 @@ func init() {
 		},
 
 		func(in *newer.BuildParameters, out *BuildSpec, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}
@@ -149,6 +148,7 @@ func init() {
 			return nil
 		},
 		func(in *BuildSpec, out *newer.BuildParameters, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}
@@ -171,6 +171,7 @@ func init() {
 		},
 
 		func(in *newer.BuildParameters, out *BuildConfigSpec, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}
@@ -192,6 +193,7 @@ func init() {
 			return nil
 		},
 		func(in *BuildConfigSpec, out *newer.BuildParameters, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}

--- a/pkg/build/api/v1beta3/conversion.go
+++ b/pkg/build/api/v1beta3/conversion.go
@@ -44,7 +44,6 @@ func init() {
 			if err := s.Convert(in, &out.Status, 0); err != nil {
 				return err
 			}
-			in.ServiceAccount = out.Spec.ServiceAccount
 			return s.Convert(&in.Status, &out.Status.Phase, 0)
 		},
 		func(in *Build, out *newer.Build, s conversion.Scope) error {
@@ -57,7 +56,6 @@ func init() {
 			if err := s.Convert(&in.Spec, &out.Parameters, 0); err != nil {
 				return err
 			}
-			in.Spec.ServiceAccount = out.ServiceAccount
 			return s.Convert(&in.Status.Phase, &out.Status, 0)
 		},
 
@@ -123,6 +121,7 @@ func init() {
 		},
 
 		func(in *newer.BuildParameters, out *BuildSpec, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}
@@ -144,6 +143,7 @@ func init() {
 			return nil
 		},
 		func(in *BuildSpec, out *newer.BuildParameters, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}
@@ -166,6 +166,7 @@ func init() {
 		},
 
 		func(in *newer.BuildParameters, out *BuildConfigSpec, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}
@@ -187,6 +188,7 @@ func init() {
 			return nil
 		},
 		func(in *BuildConfigSpec, out *newer.BuildParameters, s conversion.Scope) error {
+			out.ServiceAccount = in.ServiceAccount
 			if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 				return err
 			}

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -57,7 +57,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 			Labels:    getPodLabels(build),
 		},
 		Spec: kapi.PodSpec{
-			ServiceAccount: build.ServiceAccount,
+			ServiceAccount: build.Parameters.ServiceAccount,
 			Containers: []kapi.Container{
 				{
 					Name:  "custom-build",

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -38,7 +38,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 			Labels:    getPodLabels(build),
 		},
 		Spec: kapi.PodSpec{
-			ServiceAccount: build.ServiceAccount,
+			ServiceAccount: build.Parameters.ServiceAccount,
 			Containers: []kapi.Container{
 				{
 					Name:  "docker-build",

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -61,7 +61,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 			Labels:    getPodLabels(build),
 		},
 		Spec: kapi.PodSpec{
-			ServiceAccount: build.ServiceAccount,
+			ServiceAccount: build.Parameters.ServiceAccount,
 			Containers: []kapi.Container{
 				{
 					Name:  "sti-build",


### PR DESCRIPTION
Fixes #2883

- [x] Moved `ServiceAccount` field to `BuildParameters` in internal API (doesn't change external API)
  - Allows round-tripping BuildConfig correctly
  - Maps better to BuildSpec anyway
- [x] Made the BuildGenerator honor a service account set on a BuildConfig, or fall back to `DefaultServiceAccountName`/`bootstrappolicy.BuilderServiceAccountName`
- [x] Fixed conversions to set output fields, not input fields
- [x] Adjusted serialization test to clone the original item for comparison to catch cases where conversion messed with the input
- [x] Enabled admission controller limiting secret access to the service account for the pod