### PR TITLE
Fixed the error from webhook when secret mismatch

### DIFF
--- a/pkg/build/registry/buildconfig/webhook.go
+++ b/pkg/build/registry/buildconfig/webhook.go
@@ -52,7 +52,7 @@ func (c *controller) ServeHTTP(w http.ResponseWriter, req *http.Request, ctx kap
 	revision, proceed, err := plugin.Extract(config, secret, "", req)
 	switch err {
 	case webhook.ErrSecretMismatch, webhook.ErrHookNotEnabled:
-		return errors.NewUnauthorized(fmt.Sprintf("the webhook %q for %q did not accept your secret", plugin, name))
+		return errors.NewUnauthorized(fmt.Sprintf("the webhook %q for %q did not accept your secret", hookType, name))
 	case nil:
 	default:
 		return errors.NewInternalError(fmt.Errorf("hook failed: %v", err))


### PR DESCRIPTION
@smarterclayton this was giving useless information to the user:
`the webhook \u0026{} for \"ruby-sample-build\" did not accept your secret`
I've changed it to be the name of the webhook as we have it couple lines before.