### PR TITLE
Handle watch window expirations in UI

### DIFF
--- a/assets/app/scripts/services/ws.js
+++ b/assets/app/scripts/services/ws.js
@@ -39,7 +39,7 @@ angular.module('openshiftConsole')
         var ws = new WebSocket(config.url);
         if (config.onclose)   { ws.onclose   = config.onclose;   }
         if (config.onmessage) { ws.onmessage = config.onmessage; }
-        if (config.onopen) { ws.onopen = config.onopen; }
+        if (config.onopen)    { ws.onopen    = config.onopen;    }
         return ws;
       };
 


### PR DESCRIPTION
The UI was not handling cases where the resource version it was watching fell outside the allowed watch window. It would continuously attempt to reopen a watch at it's last known resourceVersion. The web socket would open successfully, resetting the retry count, then immediate get an API error and close, causing a retry.

Fixes #2725 
Fixes #1921