### PR TITLE
Add a types command

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -455,6 +455,10 @@
 			"Rev": "496be63c0078ce7323aede59005adbd3e9eef8c7"
 		},
 		{
+			"ImportPath": "github.com/MakeNowJust/heredoc",
+			"Rev": "1d91351acdc1cb2f2c995864674b754134b86ca7"
+		},
+		{
 			"ImportPath": "github.com/RangelReale/osin",
 			"Rev": "a9958a122a90a3b069389d394284283c19d58913"
 		},

--- a/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/LICENSE
+++ b/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 TSUYUSATO Kitsune
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/README.md
+++ b/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/README.md
@@ -1,0 +1,53 @@
+#heredoc [![Build Status](https://drone.io/github.com/MakeNowJust/heredoc/status.png)](https://drone.io/github.com/MakeNowJust/heredoc/latest) [![Go Walker](http://gowalker.org/api/v1/badge)](https://gowalker.org/github.com/MakeNowJust/heredoc)
+
+##About
+
+Package heredoc provides the here-document with keeping indent.
+
+##Install
+
+```console
+$ go get github.com/MakeNowJust/heredoc
+```
+
+##Import
+
+```go
+// usual
+import "github.com/MakeNowJust/heredoc"
+// shortcuts
+import . "github.com/MakeNowJust/heredoc/dot"
+```
+
+##Example
+
+```go
+package main
+
+import (
+	"fmt"
+	. "github.com/MakeNowJust/heredoc/dot"
+)
+
+func main() {
+	fmt.Println(D(`
+		Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+		sed do eiusmod tempor incididunt ut labore et dolore magna
+		aliqua. Ut enim ad minim veniam, ...
+	`))
+	// Output:
+	// Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+	// sed do eiusmod tempor incididunt ut labore et dolore magna
+	// aliqua. Ut enim ad minim veniam, ...
+	//
+}
+```
+
+##API Document
+
+ - [Go Walker - github.com/MakeNowJust/heredoc](https://gowalker.org/github.com/MakeNowJust/heredoc)
+ - [Go Walker - github.com/MakeNowJust/heredoc/dot](https://gowalker.org/github.com/MakeNowJust/heredoc/dot)
+
+##License
+
+This software is released under the MIT License, see LICENSE.

--- a/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/dot/dot.go
+++ b/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/dot/dot.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2014 TSUYUSATO Kitsune
+// This software is released under the MIT License.
+// http://opensource.org/licenses/mit-license.php
+
+// Package heredoc_dot is the set of shortcuts for dot import.
+//
+// For example:
+//     package main
+//
+//     import (
+//     	"fmt"
+//     	"runtime"
+//     	. "github.com/MakeNowJust/heredoc/dot"
+//     )
+//
+//     func main() {
+//     	fmt.Printf(D(`
+//     		GOROOT: %s
+//     		GOARCH: %s
+//     		GOOS  : %s
+//     	`), runtime.GOROOT(), runtime.GOARCH, runtime.GOOS)
+//     }
+package heredoc_dot
+
+import "github.com/MakeNowJust/heredoc"
+
+// Shortcut heredoc.Doc
+func D(raw string) string {
+	return heredoc.Doc(raw)
+}
+
+// Shortcut heredoc.Docf
+func Df(raw string, args ...interface{}) string {
+	return heredoc.Docf(raw, args...)
+}

--- a/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/example_test.go
+++ b/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/example_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2014 TSUYUSATO Kitsune
+// This software is released under the MIT License.
+// http://opensource.org/licenses/mit-license.php
+
+package heredoc_test
+
+import (
+	"fmt"
+)
+
+import "github.com/MakeNowJust/heredoc"
+
+func ExampleDoc_lipsum() {
+	fmt.Print(heredoc.Doc(`
+		Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+		sed do eiusmod tempor incididunt ut labore et dolore magna
+		aliqua. Ut enim ad minim veniam, ...
+	`))
+	// Output:
+	// Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+	// sed do eiusmod tempor incididunt ut labore et dolore magna
+	// aliqua. Ut enim ad minim veniam, ...
+	//
+}
+
+func ExampleDoc_spec() {
+	// Single line string is no change.
+	fmt.Println(heredoc.Doc(`It is single line.`))
+	// If first line is empty, heredoc.Doc removes first line.
+	fmt.Println(heredoc.Doc(`
+		It is first line.
+		It is second line.`))
+	// If last line is empty and more little length than indents,
+	// heredoc.Doc removes last line's content.
+	fmt.Println(heredoc.Doc(`
+		Next is last line.
+	`))
+	fmt.Println("Previous is last line.")
+	// Output:
+	// It is single line.
+	// It is first line.
+	// It is second line.
+	// Next is last line.
+	//
+	// Previous is last line.
+}
+
+func ExampleDocf() {
+	libName := "github.com/MakeNowJust/heredoc"
+	author := "TSUYUSATO Kitsune (@MakeNowJust)"
+	fmt.Printf(heredoc.Docf(`
+		Library Name  : %s
+		Author        : %s
+		Repository URL: http://%s.git
+	`, libName, author, libName))
+	// Output:
+	// Library Name  : github.com/MakeNowJust/heredoc
+	// Author        : TSUYUSATO Kitsune (@MakeNowJust)
+	// Repository URL: http://github.com/MakeNowJust/heredoc.git
+}

--- a/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/heredoc.go
+++ b/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/heredoc.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2014 TSUYUSATO Kitsune
+// This software is released under the MIT License.
+// http://opensource.org/licenses/mit-license.php
+
+// Package heredoc provides the here-document with keeping indent.
+//
+// Golang supports raw-string syntax.
+//     doc := `
+//     	Foo
+//     	Bar
+//     `
+// But raw-string cannot recognize indent. Thus such content is indented string, equivalent to
+//     "\n\tFoo\n\tBar\n"
+// I dont't want this!
+//
+// However this problem is solved by package heredoc.
+//     doc := heredoc.Doc(`
+//     	Foo
+//     	Bar
+//     `)
+// It is equivalent to
+//     "Foo\nBar\n"
+package heredoc
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// heredoc.Doc retutns unindented string as here-document.
+//
+// Process of making here-document:
+//     1. Find most little indent size. (Skip empty lines)
+//     2. Remove this indents of lines.
+func Doc(raw string) string {
+	skipFirstLine := false
+	if raw[0] == '\n' {
+		raw = raw[1:]
+	} else {
+		skipFirstLine = true
+	}
+
+	minIndentSize := int(^uint(0) >> 1) // Max value of type int
+	lines := strings.Split(raw, "\n")
+
+	// 1.
+	for i, line := range lines {
+		if i == 0 && skipFirstLine {
+			continue
+		}
+
+		indentSize := 0
+		for _, r := range []rune(line) {
+			if unicode.IsSpace(r) {
+				indentSize += 1
+			} else {
+				break
+			}
+		}
+
+		if len(line) == indentSize {
+			if i == len(lines)-1 && indentSize < minIndentSize {
+				lines[i] = ""
+			}
+		} else if indentSize < minIndentSize {
+			minIndentSize = indentSize
+		}
+	}
+
+	// 2.
+	for i, line := range lines {
+		if i == 0 && skipFirstLine {
+			continue
+		}
+
+		if len(lines[i]) >= minIndentSize {
+			lines[i] = line[minIndentSize:]
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// heredoc.Docf returns unindented and formatted string as here-document.
+// This format is same with package fmt's format.
+func Docf(raw string, args ...interface{}) string {
+	return fmt.Sprintf(Doc(raw), args...)
+}

--- a/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/heredoc_test.go
+++ b/Godeps/_workspace/src/github.com/MakeNowJust/heredoc/heredoc_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2014 TSUYUSATO Kitsune
+// This software is released under the MIT License.
+// http://opensource.org/licenses/mit-license.php
+
+package heredoc_test
+
+import (
+	"testing"
+)
+
+import "github.com/MakeNowJust/heredoc"
+
+type testCase struct {
+	raw, expect string
+}
+
+var tests = []testCase{
+	{`
+		Foo
+		Bar
+		`,
+		"Foo\nBar\n"},
+	{`Foo
+		Bar`,
+		"Foo\nBar"},
+	{`Foo
+			
+		Bar
+		`,
+		"Foo\n\t\nBar\n"},
+	{`
+		Foo
+			Bar
+				Hoge
+					`,
+		"Foo\n\tBar\n\t\tHoge\n\t\t\t"},
+	{`Foo Bar`, "Foo Bar"},
+	{
+		`
+		Foo
+		Bar
+	`, "Foo\nBar\n"},
+}
+
+func TestDoc(t *testing.T) {
+	for i, test := range tests {
+		result := heredoc.Doc(test.raw)
+		if result != test.expect {
+			t.Errorf("tests[%d] failed: expected=> %#v, result=> %#v", i, test.expect, result)
+		}
+	}
+}
+
+func TestDocf(t *testing.T) {
+	// test case
+	str := `
+		int: %3d
+		string: %s
+	`
+	i := 42
+	s := "Hello"
+	expect := "int:  42\nstring: Hello\n"
+
+	result := heredoc.Docf(str, i, s)
+	if result != expect {
+		t.Errorf("test failed: expected=> %#v, result=> %#v", expect, result)
+	}
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -267,6 +267,7 @@ echo "templates: ok"
 [ ! "$(oc 2>&1 | grep 'Options')" ]
 [ ! "$(oc 2>&1 | grep 'Global Options')" ]
 [ "$(openshift cli 2>&1 | grep 'OpenShift Client')" ]
+[ "$(oc types | grep 'Deployment Config')" ]
 [ "$(openshift kubectl 2>&1 | grep 'Kubernetes cluster')" ]
 [ "$(oadm 2>&1 | grep 'OpenShift Administrative Commands')" ]
 [ "$(openshift admin 2>&1 | grep 'OpenShift Administrative Commands')" ]

--- a/pkg/cmd/admin/node/node.go
+++ b/pkg/cmd/admin/node/node.go
@@ -51,7 +51,7 @@ func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, ou
 
 	cmd := &cobra.Command{
 		Use:     commandName,
-		Short:   "Manage node operations: schedulable, evacuate, list-pods",
+		Short:   "Manage nodes - list pods, evacuate, or mark ready",
 		Long:    manageNodeLong,
 		Example: fmt.Sprintf(manageNodeExample, fullName),
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -30,8 +30,8 @@ func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 
 	cmd := &cobra.Command{
 		Use:   "who-can VERB RESOURCE",
-		Short: "Indicates which users can perform the action on the resource.",
-		Long:  `Indicates which users can perform the action on the resource.`,
+		Short: "List who can perform the specified action on a resource",
+		Long:  "List who can perform the specified action on a resource",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.complete(args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))

--- a/pkg/cmd/admin/prune/builds.go
+++ b/pkg/cmd/admin/prune/builds.go
@@ -43,7 +43,7 @@ func NewCmdPruneBuilds(f *clientcmd.Factory, parentName, name string, out io.Wri
 
 	cmd := &cobra.Command{
 		Use:   name,
-		Short: "Remove older completed and failed builds",
+		Short: "Remove completed and failed builds",
 		Long:  fmt.Sprintf(buildsLongDesc, parentName, name),
 
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/admin/prune/deployments.go
+++ b/pkg/cmd/admin/prune/deployments.go
@@ -42,7 +42,7 @@ func NewCmdPruneDeployments(f *clientcmd.Factory, parentName, name string, out i
 
 	cmd := &cobra.Command{
 		Use:   name,
-		Short: "Remove older completed and failed deployments",
+		Short: "Remove completed and failed deployments",
 		Long:  fmt.Sprintf(deploymentsLongDesc, parentName, name),
 
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -47,7 +47,7 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 
 	cmd := &cobra.Command{
 		Use:   name,
-		Short: "Prune images",
+		Short: "Remove unreferenced images",
 		Long:  fmt.Sprintf(imagesLongDesc, parentName, name),
 
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -67,12 +67,12 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
+				cmd.NewCmdTypes(fullName, f, out),
 				loginCmd,
 				cmd.NewCmdRequestProject("new-project", fullName+" new-project", fullName+" login", fullName+" project", f, out),
 				cmd.NewCmdNewApplication(fullName, f, out),
 				cmd.NewCmdStatus(fullName, f, out),
 				cmd.NewCmdProject(fullName+" project", f, out),
-				cmd.NewCmdTypes(fullName, f, out),
 			},
 		},
 		{

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -72,6 +72,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 				cmd.NewCmdNewApplication(fullName, f, out),
 				cmd.NewCmdStatus(fullName, f, out),
 				cmd.NewCmdProject(fullName+" project", f, out),
+				cmd.NewCmdTypes(fullName, f, out),
 			},
 		},
 		{

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -31,7 +31,7 @@ const (
 func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cancel-build BUILD",
-		Short:   "Cancel a pending or running build.",
+		Short:   "Cancel a pending or running build",
 		Long:    cancelBuildLong,
 		Example: fmt.Sprintf(cancelBuildExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -65,7 +65,7 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 
 	cmd := &cobra.Command{
 		Use:     "deploy DEPLOYMENTCONFIG",
-		Short:   "View, start and restart deployments.",
+		Short:   "View, start and restart deployments",
 		Long:    deployLong,
 		Example: fmt.Sprintf(deployExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/edit.go
+++ b/pkg/cmd/cli/cmd/edit.go
@@ -60,7 +60,7 @@ func NewCmdEdit(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Com
 	var filenames util.StringList
 	cmd := &cobra.Command{
 		Use:     "edit (RESOURCE/NAME | -f FILENAME)",
-		Short:   "Edit a resource on the server and apply the update.",
+		Short:   "Edit a resource on the server",
 		Long:    editLong,
 		Example: fmt.Sprintf(editExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/importimage.go
+++ b/pkg/cmd/cli/cmd/importimage.go
@@ -30,7 +30,7 @@ have tag and image information imported.`
 func NewCmdImportImage(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "import-image IMAGESTREAM",
-		Short:   "Imports tag and image information from an external Docker image repository.",
+		Short:   "Imports images from a Docker registry",
 		Long:    importImageLong,
 		Example: fmt.Sprintf(importImageExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -50,7 +50,7 @@ func NewCmdRollback(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 
 	cmd := &cobra.Command{
 		Use:     "rollback DEPLOYMENT",
-		Short:   "Revert part of an application back to a previous deployment.",
+		Short:   "Revert part of an application back to a previous deployment",
 		Long:    rollbackLong,
 		Example: fmt.Sprintf(rollbackExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -49,7 +49,7 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 
 	cmd := &cobra.Command{
 		Use:     "start-build (BUILDCONFIG | --from-build=BUILD)",
-		Short:   "Starts a new build from existing Build or BuildConfig",
+		Short:   "Starts a new build",
 		Long:    startBuildLong,
 		Example: fmt.Sprintf(startBuildExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/cli/cmd/types.go
+++ b/pkg/cmd/cli/cmd/types.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	. "github.com/MakeNowJust/heredoc/dot"
+	"github.com/spf13/cobra"
+
+	ocutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+type term struct {
+	Name         string
+	Abbreviation string
+	Description  string
+}
+
+var concepts = []term{
+	{
+		"Containers",
+		"",
+		D(`
+      A definition of how to run one or more processes inside of a portable Linux
+      environment. Containers are started from an Image and are usually isolated
+      from other containers on the same machine.
+    `),
+	},
+	{
+		"Image",
+		"",
+		D(`
+      A layered Linux filesystem that contains application code, dependencies,
+      and any supporting operating system libraries. An image is identified by
+      a name that can be local to the current cluster or point to a remote Docker
+      registry (a storage server for images).
+    `),
+	}, {
+		"Pods",
+		"pod",
+		D(`
+      A set of one or more containers that are deployed onto a Node together and
+      share a unique IP and Volumes (persistent storage). Pods also define the
+      security and runtime policy for each container.
+    `),
+	}, {
+		"Labels",
+		"",
+		D(`
+      Labels are key value pairs that can be assigned to any resource in the
+      system for grouping and selection. Many resources use labels to identify
+      sets of other resources.
+    `),
+	}, {
+		"Volumes",
+		"",
+		D(`
+      Containers are not persistent by default - on restart their contents are
+      cleared. Volumes are mounted filesystems available to Pods and their
+      containers which may be backed by a number of host-local or network
+      attached storage endpoints. The simplest volume type is EmptyDir, which
+      is a temporary directory on a single machine. Administrators may also
+      allow you to request a Persistent Volume that is automatically attached
+      to your pods.
+    `),
+	}, {
+		"Nodes",
+		"node",
+		D(`
+      Machines set up in the cluster to run containers. Usually managed
+      by administrators and not by end users.
+    `),
+	}, {
+		"Services",
+		"svc",
+		D(`
+      A name representing a set of pods (or external servers) that are
+      accessed by other pods. The service gets an IP and a DNS name, and can be
+      exposed externally to the cluster via a port or a Route. It's also easy
+      to consume services from pods because an environment variable with the
+      name <SERVICE>_HOST is automatically injected into other pods.
+    `),
+	}, {
+		"Routes",
+		"route",
+		D(`
+      A route is an external DNS entry (either a top level domain or a
+      dynamically allocated name) that is created to point to a service so that
+      it can be accessed outside the cluster. The administrator may configure
+      one or more Routers to handle those routes, typically through an Apache
+      or HAProxy load balancer / proxy.
+    `),
+	},
+	{
+		"Replication Controllers",
+		"rc",
+		D(`
+      A replication controller maintains a specific number of pods based on a
+      template that match a set of labels. If pods are deleted (because the
+      node they run on is taken out of service) the controller creates a new
+      copy of that pod. A replication controller is most commonly used to
+      represent a single deployment of part of an application based on a
+      built image.
+    `),
+	},
+	{
+		"Deployment Configuration",
+		"dc",
+		D(`
+      Defines the template for a pod and manages deploying new images or 
+      configuration changes whenever those change. A single deployment 
+      configuration is usually analogous to a single micro-service. Can support 
+      many different deployment pattrens, including full restart, customizable 
+      rolling updates, and fully custom behaviors, as well as pre- and post- 
+      hooks. Each deployment is represented as a replication controller.
+    `),
+	},
+	{
+		"Build Configuration",
+		"bc",
+		D(`
+      Contains a description of how to build source code and a base image into a
+      new image - the primary method for delivering changes to your application.
+      Builds can be source based and use builder images for common languages like
+      Java, PHP, Ruby, or Python, or be Docker based and create builds from a
+      Dockerfile. Each build configuration has web-hooks and can be triggered
+      automatically by changes to their base images.
+    `),
+	},
+	{
+		"Image Streams and Image Stream Tags",
+		"is,istag",
+		D(`
+      An image stream groups sets of related images under tags - analogous to a
+      branch in a source code repository. Each image stream may have one or
+      more tags (the default tag is called "latest") and those tags may point
+      at external Docker registries, at other tags in the same stream, or be
+      controlled to directly point at known images. In addition, images can be
+      pushed to an image stream tag directly via the integrated Docker 
+      registry.
+    `),
+	},
+	{
+		"Projects",
+		"project",
+		D(`
+      All of the above resources (except Nodes) exist inside of a project.
+      Projects have a list of members and their roles, like viewer, editor,
+      or admin, as well as a set of security controls on the running pods, and
+      limits on how many resources the project can use. The names of each
+      resource are unique within a project. Developers may request projects
+      be created, but administrators control the resources allocated to
+      projects.
+    `),
+	},
+}
+
+func writeTerm(w io.Writer, t term) {
+	fmt.Fprintf(w, "* %s", t.Name)
+	if len(t.Abbreviation) > 0 {
+		fmt.Fprintf(w, " [%s]", t.Abbreviation)
+	}
+	fmt.Fprintln(w, ":")
+	for _, s := range strings.Split(t.Description, "\n") {
+		fmt.Fprintf(w, "    %s\n", s)
+	}
+}
+
+var (
+	typesLong = D(`
+    OpenShift Concepts and Types
+
+    OpenShift helps developers and operators build, test, and deploy applications in
+    a containerized cloud environment. Applications may be composed of all of the
+    components below, although most developers will be concerned with Services,
+    Deployments, and Builds for delivering changes.
+
+    Concepts:
+
+    %[1]sFor more, see https://docs.openshift.com
+  `)
+
+	typesExample = `  // View all projects you have access to
+  $ %[1]s projects
+
+  // See a list of all services in the current project
+  $ %[1]s get svc
+
+  // Describe a deployment configuration in detail
+  $ %[1]s describe dc mydeploymentconfig
+
+  // Show the images tagged into an image stream
+  $ %[1]s describe is ruby-centos7`
+)
+
+func NewCmdTypes(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	buf := &bytes.Buffer{}
+	for _, c := range concepts {
+		writeTerm(buf, c)
+	}
+	cmd := &cobra.Command{
+		Use:     "types",
+		Short:   "An introduction to the concepts and types in OpenShift",
+		Long:    fmt.Sprintf(typesLong, buf.String()),
+		Example: fmt.Sprintf(typesExample, fullName),
+		Run:     ocutil.DefaultSubCommandRun(out),
+	}
+	return cmd
+}

--- a/pkg/cmd/experimental/buildchain/buildchain.go
+++ b/pkg/cmd/experimental/buildchain/buildchain.go
@@ -89,7 +89,7 @@ func NewEdge(fullname, to string) *Edge {
 func NewCmdBuildChain(f *clientcmd.Factory, parentName, name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s [IMAGESTREAM:TAG | --all]", name),
-		Short:   "Output build dependencies of a specific ImageStream",
+		Short:   "Output build dependencies of a specific image stream",
 		Long:    buildChainLong,
 		Example: buildChainExample,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -98,8 +98,8 @@ func NewCmdBuildChain(f *clientcmd.Factory, parentName, name string) *cobra.Comm
 		},
 	}
 
-	cmd.Flags().Bool("all", false, "Build dependency trees for all ImageStreams")
-	cmd.Flags().Bool("all-tags", false, "Build dependency trees for all tags of a specific ImageStream")
+	cmd.Flags().Bool("all", false, "Build dependency trees for all image streams")
+	cmd.Flags().Bool("all-tags", false, "Build dependency trees for all tags of a specific image stream")
 	cmd.Flags().StringP("output", "o", "json", "Output format of dependency tree(s)")
 	return cmd
 }


### PR DESCRIPTION
Part of #2628

```
$ oc types
OpenShift Concepts and Types

OpenShift helps developers and operators build, test, and deploy applications in
a containerized cloud environment. Applications may be composed of all of the
components below, although most developers will be concerned with Services,
Deployments, and Builds for delivering changes.

Concepts:

* Containers:
    A definition of how to run one or more processes inside of a portable Linux
    environment. Containers are started from an Image and are usually isolated
    from other containers on the same machine.
    
* Image:
    A layered Linux filesystem that contains application code, dependencies,
    and any supporting operating system libraries. An image is identified by
    a name that can be local to the current cluster or point to a remote Docker
    registry (a storage server for images).
    
* Pods [pod]:
    A set of one or more containers that are deployed onto a Node together and
    share a unique IP and Volumes (persistent storage). Pods also define the
    security and runtime policy for each container.
    
* Labels:
    Labels are key value pairs that can be assigned to any resource in the
    system for grouping and selection. Many resources use labels to identify
    sets of other resources.
    
* Volumes:
    Containers are not persistent by default - on restart their contents are
    cleared. Volumes are mounted filesystems available to Pods and their
    containers which may be backed by a number of host-local or network
    attached storage endpoints. The simplest volume type is EmptyDir, which
    is a temporary directory on a single machine. Administrators may also
    allow you to request a Persistent Volume that is automatically attached
    to your pods.
    
* Nodes [node]:
    Machines set up in the cluster to run containers. Usually managed
    by administrators and not by end users.
    
* Services [svc]:
    A name representing a set of pods (or external servers) that are
    accessed by other pods. The service gets an IP and a DNS name, and can be
    exposed externally to the cluster via a port or a Route. It's also easy
    to consume services from pods because an environment variable with the
    name <SERVICE>_HOST is automatically injected into other pods.
    
* Routes [route]:
    A route is an external DNS entry (either a top level domain or a
    dynamically allocated name) that is created to point to a service so that
    it can be accessed outside the cluster. The administrator may configure
    one or more Routers to handle those routes, typically through an Apache
    or HAProxy load balancer / proxy.
    
* Replication Controllers [rc]:
    A replication controller maintains a specific number of pods based on a
    template that match a set of labels. If pods are deleted (because the
    node they run on is taken out of service) the controller creates a new
    copy of that pod. A replication controller is most commonly used to
    represent a single deployment of part of an application based on a
    built image.
    
* Deployment Configuration [dc]:
    Defines the template for a pod and manages deploying new images or 
    configuration changes whenever those change. A single deployment 
    configuration is usually analogous to a single micro-service. Can support 
    many different deployment pattrens, including full restart, customizable 
    rolling updates, and fully custom behaviors, as well as pre- and post- 
    hooks. Each deployment is represented as a replication controller.
    
* Build Configuration [bc]:
    Contains a description of how to build source code and a base image into a
    new image - the primary method for delivering changes to your application.
    Builds can be source based and use builder images for common languages like
    Java, PHP, Ruby, or Python, or be Docker based and create builds from a
    Dockerfile. Each build configuration has web-hooks and can be triggered
    automatically by changes to their base images.
    
* Image Streams and Image Stream Tags [is,istag]:
    An image stream groups sets of related images under tags - analogous to a
    branch in a source code repository. Each image stream may have one or
    more tags (the default tag is called "latest") and those tags may point
    at external Docker registries, at other tags in the same stream, or be
    controlled to directly point at known images. In addition, images can be
    pushed to an image stream tag directly via the integrated Docker 
    registry.
    
* Projects [project]:
    All of the above resources (except Nodes) exist inside of a project.
    Projects have a list of members and their roles, like viewer, editor,
    or admin, as well as a set of security controls on the running pods, and
    limits on how many resources the project can use. The names of each
    resource are unique within a project. Developers may request projects
    be created, but administrators control the resources allocated to
    projects.
    
For more, see https://docs.openshift.com

Usage:
  oc types [options]

Examples:
  // View all projects you have access to
  $ oc projects

  // See a list of all services in the current project
  $ oc get svc

  // Describe a deployment configuration in detail
  $ oc describe dc mydeploymentconfig

  // Show the images tagged into an image stream
  $ oc describe is ruby-centos7

Use "oc --help" for a list of all commands available in oc.
Use "oc options" for a list of global command-line options (applies to all commands).
```