### PR TITLE
UPSTREAM: adding downward api volume plugin

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app/plugins.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/cmd/kubelet/app/plugins.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/glusterfs"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/host_path"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/iscsi"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/metadata"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/nfs"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/persistent_claim"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/rbd"
@@ -64,7 +65,7 @@ func ProbeVolumePlugins() []volume.VolumePlugin {
 	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, persistent_claim.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, rbd.ProbeVolumePlugins()...)
-
+	allPlugins = append(allPlugins, metadata.ProbeVolumePlugins()...)
 	return allPlugins
 }
 

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/testing/fuzzer.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/testing/fuzzer.go
@@ -172,7 +172,18 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			i := int(c.RandUint64() % uint64(v.NumField()))
 			v = v.Field(i).Addr()
 			// Use a new fuzzer which cannot populate nil to ensure one field will be set.
-			fuzz.New().NilChance(0).NumElements(1, 1).Fuzz(v.Interface())
+			f := fuzz.New().NilChance(0).NumElements(1, 1)
+			f.Funcs(
+				// Only api.Metadatafile needs to have a specific func since FieldRef has to be
+				// defaulted to a version otherwise roundtrip will fail
+				// For the remaining volume plugins the default fuzzer  is enough.
+				func(m *api.MetadataFile, c fuzz.Continue) {
+					m.Name = c.RandString()
+					versions := []string{"v1beta3", "v1"}
+					m.FieldRef.APIVersion = versions[c.Rand.Intn(len(versions))]
+					m.FieldRef.FieldPath = c.RandString()
+				},
+			).Fuzz(v.Interface())
 		},
 		func(d *api.DNSPolicy, c fuzz.Continue) {
 			policies := []api.DNSPolicy{api.DNSClusterFirst, api.DNSDefault}
@@ -242,6 +253,7 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			types := []api.PersistentVolumeClaimPhase{api.ClaimBound, api.ClaimPending}
 			pvc.Status.Phase = types[c.Rand.Intn(len(types))]
 		},
+
 		func(s *api.NamespaceSpec, c fuzz.Continue) {
 			s.Finalizers = []api.FinalizerName{api.FinalizerKubernetes}
 		},

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go
@@ -207,6 +207,8 @@ type VolumeSource struct {
 	PersistentVolumeClaimVolumeSource *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
 	RBD *RBDVolumeSource `json:"rbd"`
+	// Metadata represents metadata about the pod that should populate this volume
+	Metadata *MetadataVolumeSource `json:"metadata"`
 }
 
 // Similar to VolumeSource but meant for the administrator who creates PVs.
@@ -508,6 +510,20 @@ type RBDVolumeSource struct {
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
 	ReadOnly bool `json:"readOnly,omitempty"`
+}
+
+// MetadataVolumeSource represents a volume containing metadata about a pod.
+type MetadataVolumeSource struct {
+	// Items is a list of metadata file name
+	Items []MetadataFile `json:"items",omitempty"`
+}
+
+// MetadataFile represents information to create the file containing the pod field
+type MetadataFile struct {
+	// Required: Name is the name of the file
+	Name string `json:"name,omitempty"`
+	// Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+	FieldRef ObjectFieldSelector `json:"fieldRef"`
 }
 
 // ContainerPort represents a network port in a single container

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion.go
@@ -43,6 +43,8 @@ func addConversionFuncs() {
 			switch label {
 			case "metadata.name",
 				"metadata.namespace",
+				"metadata.labels",
+				"metadata.annotations",
 				"status.phase",
 				"spec.host":
 				return label, value, nil

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion_generated.go
@@ -846,6 +846,34 @@ func convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *api.LocalOb
 	return nil
 }
 
+func convert_api_MetadataFile_To_v1_MetadataFile(in *api.MetadataFile, out *MetadataFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.MetadataFile))(in)
+	}
+	out.Name = in.Name
+	if err := convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_MetadataVolumeSource_To_v1_MetadataVolumeSource(in *api.MetadataVolumeSource, out *MetadataVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.MetadataVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]MetadataFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_MetadataFile_To_v1_MetadataFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NFSVolumeSource))(in)
@@ -2288,6 +2316,14 @@ func convert_api_VolumeSource_To_v1_VolumeSource(in *api.VolumeSource, out *Volu
 	} else {
 		out.RBD = nil
 	}
+	if in.Metadata != nil {
+		out.Metadata = new(MetadataVolumeSource)
+		if err := convert_api_MetadataVolumeSource_To_v1_MetadataVolumeSource(in.Metadata, out.Metadata, s); err != nil {
+			return err
+		}
+	} else {
+		out.Metadata = nil
+	}
 	return nil
 }
 
@@ -3109,6 +3145,34 @@ func convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *LocalObject
 		defaulting.(func(*LocalObjectReference))(in)
 	}
 	out.Name = in.Name
+	return nil
+}
+
+func convert_v1_MetadataFile_To_api_MetadataFile(in *MetadataFile, out *api.MetadataFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*MetadataFile))(in)
+	}
+	out.Name = in.Name
+	if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_MetadataVolumeSource_To_api_MetadataVolumeSource(in *MetadataVolumeSource, out *api.MetadataVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*MetadataVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]api.MetadataFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1_MetadataFile_To_api_MetadataFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -4554,6 +4618,14 @@ func convert_v1_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api.Volu
 	} else {
 		out.RBD = nil
 	}
+	if in.Metadata != nil {
+		out.Metadata = new(api.MetadataVolumeSource)
+		if err := convert_v1_MetadataVolumeSource_To_api_MetadataVolumeSource(in.Metadata, out.Metadata, s); err != nil {
+			return err
+		}
+	} else {
+		out.Metadata = nil
+	}
 	return nil
 }
 
@@ -4603,6 +4675,8 @@ func init() {
 		convert_api_LoadBalancerIngress_To_v1_LoadBalancerIngress,
 		convert_api_LoadBalancerStatus_To_v1_LoadBalancerStatus,
 		convert_api_LocalObjectReference_To_v1_LocalObjectReference,
+		convert_api_MetadataFile_To_v1_MetadataFile,
+		convert_api_MetadataVolumeSource_To_v1_MetadataVolumeSource,
 		convert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
 		convert_api_NamespaceList_To_v1_NamespaceList,
 		convert_api_NamespaceSpec_To_v1_NamespaceSpec,
@@ -4714,6 +4788,8 @@ func init() {
 		convert_v1_LoadBalancerIngress_To_api_LoadBalancerIngress,
 		convert_v1_LoadBalancerStatus_To_api_LoadBalancerStatus,
 		convert_v1_LocalObjectReference_To_api_LocalObjectReference,
+		convert_v1_MetadataFile_To_api_MetadataFile,
+		convert_v1_MetadataVolumeSource_To_api_MetadataVolumeSource,
 		convert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
 		convert_v1_NamespaceList_To_api_NamespaceList,
 		convert_v1_NamespaceSpec_To_api_NamespaceSpec,

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/types.go
@@ -224,6 +224,8 @@ type VolumeSource struct {
 	PersistentVolumeClaimVolumeSource *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" description:"a reference to a PersistentVolumeClaim in the same namespace"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
 	RBD *RBDVolumeSource `json:"rbd" description:"rados block volume that will be mounted on the host machine"`
+	// Metadata represents an host volume which contains pod's metadata
+	Metadata *MetadataVolumeSource `json:"metadata,omitempty" description:"Metadata volume containing information about the pod"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {
@@ -1885,6 +1887,20 @@ type ComponentStatusList struct {
 	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"`
 
 	Items []ComponentStatus `json:"items" description:"list of component status objects"`
+}
+
+// MetadataVolumeSource represents a volume containing metadata about a pod.
+type MetadataVolumeSource struct {
+	// Items is a list of metadata file name
+	Items []MetadataFile `json:"items,omitempty" description:"list of metadata files"`
+}
+
+// MetadataFile expresses information about a file holding pod metadata.
+type MetadataFile struct {
+	// Required: Name is the name of the file
+	Name string `json:"name" description:"the name of the file to be created"`
+	// Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+	FieldRef ObjectFieldSelector `json:"fieldRef" description:"selects a field of the pod. Supported fields: metadata.annotations, metadata.labels, metadata.name, metadata.namespace"`
 }
 
 // SecurityContext holds security configuration that will be applied to a container.  SecurityContext

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/conversion.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/conversion.go
@@ -43,6 +43,8 @@ func addConversionFuncs() {
 			switch label {
 			case "metadata.name",
 				"metadata.namespace",
+				"metadata.labels",
+				"metadata.annotations",
 				"status.phase",
 				"spec.host":
 				return label, value, nil

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -753,6 +753,34 @@ func convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in *api.Lo
 	return nil
 }
 
+func convert_api_MetadataFile_To_v1beta3_MetadataFile(in *api.MetadataFile, out *MetadataFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.MetadataFile))(in)
+	}
+	out.Name = in.Name
+	if err := convert_api_ObjectFieldSelector_To_v1beta3_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_MetadataVolumeSource_To_v1beta3_MetadataVolumeSource(in *api.MetadataVolumeSource, out *MetadataVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.MetadataVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]MetadataFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_MetadataFile_To_v1beta3_MetadataFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource(in *api.NFSVolumeSource, out *NFSVolumeSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.NFSVolumeSource))(in)
@@ -2221,6 +2249,14 @@ func convert_api_VolumeSource_To_v1beta3_VolumeSource(in *api.VolumeSource, out 
 	} else {
 		out.RBD = nil
 	}
+	if in.Metadata != nil {
+		out.Metadata = new(MetadataVolumeSource)
+		if err := convert_api_MetadataVolumeSource_To_v1beta3_MetadataVolumeSource(in.Metadata, out.Metadata, s); err != nil {
+			return err
+		}
+	} else {
+		out.Metadata = nil
+	}
 	return nil
 }
 
@@ -2949,6 +2985,34 @@ func convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in *LocalO
 		defaulting.(func(*LocalObjectReference))(in)
 	}
 	out.Name = in.Name
+	return nil
+}
+
+func convert_v1beta3_MetadataFile_To_api_MetadataFile(in *MetadataFile, out *api.MetadataFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*MetadataFile))(in)
+	}
+	out.Name = in.Name
+	if err := convert_v1beta3_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_MetadataVolumeSource_To_api_MetadataVolumeSource(in *MetadataVolumeSource, out *api.MetadataVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*MetadataVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]api.MetadataFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta3_MetadataFile_To_api_MetadataFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -4420,6 +4484,14 @@ func convert_v1beta3_VolumeSource_To_api_VolumeSource(in *VolumeSource, out *api
 	} else {
 		out.RBD = nil
 	}
+	if in.Metadata != nil {
+		out.Metadata = new(api.MetadataVolumeSource)
+		if err := convert_v1beta3_MetadataVolumeSource_To_api_MetadataVolumeSource(in.Metadata, out.Metadata, s); err != nil {
+			return err
+		}
+	} else {
+		out.Metadata = nil
+	}
 	return nil
 }
 
@@ -4468,6 +4540,8 @@ func init() {
 		convert_api_LoadBalancerIngress_To_v1beta3_LoadBalancerIngress,
 		convert_api_LoadBalancerStatus_To_v1beta3_LoadBalancerStatus,
 		convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference,
+		convert_api_MetadataFile_To_v1beta3_MetadataFile,
+		convert_api_MetadataVolumeSource_To_v1beta3_MetadataVolumeSource,
 		convert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource,
 		convert_api_NamespaceList_To_v1beta3_NamespaceList,
 		convert_api_NamespaceSpec_To_v1beta3_NamespaceSpec,
@@ -4580,6 +4654,8 @@ func init() {
 		convert_v1beta3_LoadBalancerIngress_To_api_LoadBalancerIngress,
 		convert_v1beta3_LoadBalancerStatus_To_api_LoadBalancerStatus,
 		convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference,
+		convert_v1beta3_MetadataFile_To_api_MetadataFile,
+		convert_v1beta3_MetadataVolumeSource_To_api_MetadataVolumeSource,
 		convert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource,
 		convert_v1beta3_NamespaceList_To_api_NamespaceList,
 		convert_v1beta3_NamespaceSpec_To_api_NamespaceSpec,

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/types.go
@@ -224,6 +224,8 @@ type VolumeSource struct {
 	PersistentVolumeClaimVolumeSource *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" description:"a reference to a PersistentVolumeClaim in the same namespace"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
 	RBD *RBDVolumeSource `json:"rbd" description:"rados block volume that will be mounted on the host machine"`
+	// Metadata represents metadata about the pod that should populate this volume
+	Metadata *MetadataVolumeSource `json:"metadata,omitempty" description: "Metadata volume containing information about the pod"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {
@@ -384,6 +386,20 @@ type GlusterfsVolumeSource struct {
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the Glusterfs volume to be mounted with read-only permissions
 	ReadOnly bool `json:"readOnly,omitempty" description:"glusterfs volume to be mounted with read-only permissions"`
+}
+
+// MetadataVolumeSource represents a volume containing metadata about a pod.
+type MetadataVolumeSource struct {
+	// Items is a list of metadata file name
+	Items []MetadataFile `json:"items,omitempty" description:"list of metadata files"`
+}
+
+// MetadataFile expresses information about a file holding pod metadata.
+type MetadataFile struct {
+	// Required: Name is the name of the file
+	Name string `json:"name" description:"the name of the file to be created"`
+	// Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+	FieldRef ObjectFieldSelector `json:"fieldRef" description:"selects a field of the pod. Supported fields: metadata.annotations, metadata.labels, metadata.name, metadata.namespace"`
 }
 
 // StorageMedium defines ways that storage can be allocated to a volume.

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"path"
 	"reflect"
 	"regexp"
@@ -346,6 +347,10 @@ func validateSource(source *api.VolumeSource) errs.ValidationErrorList {
 		numVolumes++
 		allErrs = append(allErrs, validateRBD(source.RBD).Prefix("rbd")...)
 	}
+	if source.Metadata != nil {
+		numVolumes++
+		allErrs = append(allErrs, validateMetadataVolumeSource(source.Metadata).Prefix("metadata")...)
+	}
 	if numVolumes != 1 {
 		allErrs = append(allErrs, errs.NewFieldInvalid("", source, "exactly 1 volume type is required"))
 	}
@@ -451,6 +456,28 @@ func validateGlusterfs(glusterfs *api.GlusterfsVolumeSource) errs.ValidationErro
 	}
 	if glusterfs.Path == "" {
 		allErrs = append(allErrs, errs.NewFieldRequired("path"))
+	}
+	return allErrs
+}
+
+var validMetadataFieldPathExpressions = util.NewStringSet("metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations")
+
+func validateMetadataVolumeSource(metadata *api.MetadataVolumeSource) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	for _, metadataFile := range metadata.Items {
+		if len(metadataFile.Name) == 0 {
+			allErrs = append(allErrs, errs.NewFieldRequired("name"))
+		}
+		if path.IsAbs(metadataFile.Name) {
+			allErrs = append(allErrs, errs.NewFieldForbidden("name", "must not be an absolute path"))
+		}
+		items := strings.Split(metadataFile.Name, string(os.PathSeparator))
+		for _, item := range items {
+			if item == ".." {
+				allErrs = append(allErrs, errs.NewFieldForbidden("name", "must not contain `..`"))
+			}
+		}
+		allErrs = append(allErrs, validateObjectFieldSelector(&metadataFile.FieldRef, &validMetadataFieldPathExpressions).Prefix("FieldRef")...)
 	}
 	return allErrs
 }
@@ -630,6 +657,8 @@ func validateEnv(vars []api.EnvVar) errs.ValidationErrorList {
 	return allErrs
 }
 
+var validFieldPathExpressions = util.NewStringSet("metadata.name", "metadata.namespace")
+
 func validateEnvVarValueFrom(ev api.EnvVar) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 
@@ -642,7 +671,7 @@ func validateEnvVarValueFrom(ev api.EnvVar) errs.ValidationErrorList {
 	switch {
 	case ev.ValueFrom.FieldRef != nil:
 		numSources++
-		allErrs = append(allErrs, validateObjectFieldSelector(ev.ValueFrom.FieldRef).Prefix("fieldRef")...)
+		allErrs = append(allErrs, validateObjectFieldSelector(ev.ValueFrom.FieldRef, &validFieldPathExpressions).Prefix("fieldRef")...)
 	}
 
 	if ev.Value != "" && numSources != 0 {
@@ -652,9 +681,7 @@ func validateEnvVarValueFrom(ev api.EnvVar) errs.ValidationErrorList {
 	return allErrs
 }
 
-var validFieldPathExpressions = util.NewStringSet("metadata.name", "metadata.namespace")
-
-func validateObjectFieldSelector(fs *api.ObjectFieldSelector) errs.ValidationErrorList {
+func validateObjectFieldSelector(fs *api.ObjectFieldSelector, expressions *util.StringSet) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 
 	if fs.APIVersion == "" {
@@ -665,7 +692,7 @@ func validateObjectFieldSelector(fs *api.ObjectFieldSelector) errs.ValidationErr
 		internalFieldPath, _, err := api.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
 		if err != nil {
 			allErrs = append(allErrs, errs.NewFieldInvalid("fieldPath", fs.FieldPath, "error converting fieldPath"))
-		} else if !validFieldPathExpressions.Has(internalFieldPath) {
+		} else if !expressions.Has(internalFieldPath) {
 			allErrs = append(allErrs, errs.NewFieldNotSupported("fieldPath", internalFieldPath))
 		}
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation_test.go
@@ -435,6 +435,29 @@ func TestValidateVolumes(t *testing.T) {
 		{Name: "secret", VolumeSource: api.VolumeSource{Secret: &api.SecretVolumeSource{"my-secret"}}},
 		{Name: "glusterfs", VolumeSource: api.VolumeSource{Glusterfs: &api.GlusterfsVolumeSource{"host1", "path", false}}},
 		{Name: "rbd", VolumeSource: api.VolumeSource{RBD: &api.RBDVolumeSource{CephMonitors: []string{"foo"}, RBDImage: "bar", FSType: "ext4"}}},
+		{Name: "metadata", VolumeSource: api.VolumeSource{Metadata: &api.MetadataVolumeSource{Items: []api.MetadataFile{
+			{Name: "labels", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.labels"}},
+			{Name: "annotations", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.annotations"}},
+			{Name: "namespace", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.namespace"}},
+			{Name: "name", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.name"}},
+			{Name: "path/withslash/andslash", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.labels"}},
+			{Name: "path/./withdot", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.labels"}},
+			{Name: "path/with..dot", FieldRef: api.ObjectFieldSelector{
+				APIVersion: "v1beta3",
+				FieldPath:  "metadata.labels"}},
+		}}}},
 	}
 	names, errs := validateVolumes(successCase)
 	if len(errs) != 0 {
@@ -450,6 +473,21 @@ func TestValidateVolumes(t *testing.T) {
 	emptyPath := api.VolumeSource{Glusterfs: &api.GlusterfsVolumeSource{"host", "", false}}
 	emptyMon := api.VolumeSource{RBD: &api.RBDVolumeSource{CephMonitors: []string{}, RBDImage: "bar", FSType: "ext4"}}
 	emptyImage := api.VolumeSource{RBD: &api.RBDVolumeSource{CephMonitors: []string{"foo"}, RBDImage: "", FSType: "ext4"}}
+	emptyPathName := api.VolumeSource{Metadata: &api.MetadataVolumeSource{[]api.MetadataFile{{Name: "",
+		FieldRef: api.ObjectFieldSelector{
+			APIVersion: "v1beta3",
+			FieldPath:  "metadata.labels"}}},
+	}}
+	absolutePathName := api.VolumeSource{Metadata: &api.MetadataVolumeSource{[]api.MetadataFile{{Name: "/absolutepath",
+		FieldRef: api.ObjectFieldSelector{
+			APIVersion: "v1beta3",
+			FieldPath:  "metadata.labels"}}},
+	}}
+	dotDotPathName := api.VolumeSource{Metadata: &api.MetadataVolumeSource{[]api.MetadataFile{{Name: "../../passwd",
+		FieldRef: api.ObjectFieldSelector{
+			APIVersion: "v1beta3",
+			FieldPath:  "metadata.labels"}}},
+	}}
 	errorCases := map[string]struct {
 		V []api.Volume
 		T errors.ValidationErrorType
@@ -465,6 +503,9 @@ func TestValidateVolumes(t *testing.T) {
 		"empty path":           {[]api.Volume{{Name: "badpath", VolumeSource: emptyPath}}, errors.ValidationErrorTypeRequired, "[0].source.glusterfs.path"},
 		"empty mon":            {[]api.Volume{{Name: "badmon", VolumeSource: emptyMon}}, errors.ValidationErrorTypeRequired, "[0].source.rbd.monitors"},
 		"empty image":          {[]api.Volume{{Name: "badimage", VolumeSource: emptyImage}}, errors.ValidationErrorTypeRequired, "[0].source.rbd.image"},
+		"empty metatada path":  {[]api.Volume{{Name: "emptyname", VolumeSource: emptyPathName}}, errors.ValidationErrorTypeRequired, "[0].source.metadata.name"},
+		"absolute path":        {[]api.Volume{{Name: "absolutepath", VolumeSource: absolutePathName}}, errors.ValidationErrorTypeForbidden, "[0].source.metadata.name"},
+		"dot dot path":         {[]api.Volume{{Name: "dotdotpath", VolumeSource: dotDotPathName}}, errors.ValidationErrorTypeForbidden, "[0].source.metadata.name"},
 	}
 	for k, v := range errorCases {
 		_, errs := validateVolumes(v.V)
@@ -630,6 +671,32 @@ func TestValidateEnv(t *testing.T) {
 				},
 			}},
 			expectedError: "[0].valueFrom.fieldRef.fieldPath: invalid value 'metadata.whoops': error converting fieldPath",
+		},
+		{
+			name: "invalid fieldPath labels",
+			envs: []api.EnvVar{{
+				Name: "labels",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						FieldPath:  "metadata.labels",
+						APIVersion: "v1beta3",
+					},
+				},
+			}},
+			expectedError: "[0].valueFrom.fieldRef.fieldPath: unsupported value 'metadata.labels'",
+		},
+		{
+			name: "invalid fieldPath annotations",
+			envs: []api.EnvVar{{
+				Name: "abc",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						FieldPath:  "metadata.annotations",
+						APIVersion: "v1beta3",
+					},
+				},
+			}},
+			expectedError: "[0].valueFrom.fieldRef.fieldPath: unsupported value 'metadata.annotations'",
 		},
 		{
 			name: "unsupported fieldPath",

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/fieldpath/fieldpath.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/fieldpath/fieldpath.go
@@ -22,6 +22,15 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 )
 
+// formatMap formats map[string]string to a string.
+func formatMap(m map[string]string) string {
+	var l string
+	for key, value := range m {
+		l += key + "=" + value + "\n"
+	}
+	return l
+}
+
 // ExtractFieldPathAsString extracts the field from the given object
 // and returns it as a string.  The object must be a pointer to an
 // API type.
@@ -37,6 +46,10 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 	}
 
 	switch fieldPath {
+	case "metadata.annotations":
+		return formatMap(accessor.Annotations()), nil
+	case "metadata.labels":
+		return formatMap(accessor.Labels()), nil
 	case "metadata.name":
 		return accessor.Name(), nil
 	case "metadata.namespace":

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/fieldpath/fieldpath_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/fieldpath/fieldpath_test.go
@@ -58,6 +58,27 @@ func TestExtractFieldPathAsString(t *testing.T) {
 			expectedValue: "object-name",
 		},
 		{
+			name:      "ok - labels",
+			fieldPath: "metadata.labels",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{"key": "value"},
+				},
+			},
+			expectedValue: "key=value\n",
+		},
+		{
+			name:      "ok - annotations",
+			fieldPath: "metadata.annotations",
+			obj: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: map[string]string{"builder": "john-doe"},
+				},
+			},
+			expectedValue: "builder=john-doe\n",
+		},
+
+		{
 			name:      "invalid expression",
 			fieldPath: "metadata.whoops",
 			obj: &api.Pod{

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/metadata/metadata.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/metadata/metadata.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fieldpath"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	utilErrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
+	"github.com/golang/glog"
+)
+
+// ProbeVolumePlugins is the entry point for plugin detection in a package.
+func ProbeVolumePlugins() []volume.VolumePlugin {
+	return []volume.VolumePlugin{&metadataPlugin{}}
+}
+
+const (
+	metadataPluginName = "kubernetes.io/metadata"
+)
+
+// metadataPlugin implements the VolumePlugin interface.
+type metadataPlugin struct {
+	host volume.VolumeHost
+}
+
+func (plugin *metadataPlugin) Init(host volume.VolumeHost) {
+	plugin.host = host
+}
+
+func (plugin *metadataPlugin) Name() string {
+	return metadataPluginName
+}
+
+func (plugin *metadataPlugin) CanSupport(spec *volume.Spec) bool {
+	return spec.VolumeSource.Metadata != nil
+}
+
+func (plugin *metadataPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions, mounter mount.Interface) (volume.Builder, error) {
+	return plugin.newBuilderInternal(spec, pod, opts, mounter)
+}
+
+func (plugin *metadataPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions, mounter mount.Interface) (volume.Builder, error) {
+	v := &metadataVolume{volName: spec.Name,
+		pod:     pod,
+		plugin:  plugin,
+		opts:    &opts,
+		mounter: mounter}
+	v.fieldReferenceFileNames = make(map[string]string)
+	for _, fileInfo := range spec.VolumeSource.Metadata.Items {
+		v.fieldReferenceFileNames[fileInfo.FieldRef.FieldPath] = fileInfo.Name
+	}
+	return v, nil
+}
+
+func (plugin *metadataPlugin) NewCleaner(volName string, podUID types.UID, mounter mount.Interface) (volume.Cleaner, error) {
+	return plugin.newCleanerInternal(volName, podUID, mounter)
+}
+
+func (plugin *metadataPlugin) newCleanerInternal(volName string, podUID types.UID, mounter mount.Interface) (volume.Cleaner, error) {
+	return &metadataVolume{volName: volName,
+		pod:     &api.Pod{ObjectMeta: api.ObjectMeta{UID: podUID}},
+		plugin:  plugin,
+		mounter: mounter}, nil
+}
+
+// metadataVolume handles retrieving metadata from the API server
+// and placing them into the volume on the host.
+type metadataVolume struct {
+	volName                 string
+	fieldReferenceFileNames map[string]string
+	pod                     *api.Pod
+	plugin                  *metadataPlugin
+	opts                    *volume.VolumeOptions
+	mounter                 mount.Interface
+}
+
+// This is the spec for the volume that this plugin wraps.
+var wrappedVolumeSpec = &volume.Spec{
+	Name:         "not-used",
+	VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{Medium: api.StorageMediumMemory}},
+}
+
+// SetUp puts in place the volume plugin.
+// This function is not idempotent by design. We want the data to be refreshed periodically.
+// The internal sync interval of kubelet will drive the refresh of data.
+func (m *metadataVolume) SetUp() error {
+	return m.SetUpAt(m.GetPath())
+}
+
+func (m *metadataVolume) SetUpAt(dir string) error {
+	glog.V(3).Infof("Setting up a metadata volume %v for pod %v at %v", m.volName, m.pod.UID, dir)
+	// Wrap EmptyDir,let it do the setup.
+	wrapped, err := m.plugin.host.NewWrapperBuilder(wrappedVolumeSpec, m.pod, *m.opts, m.mounter)
+	if err != nil {
+		return err
+	}
+	if err := wrapped.SetUpAt(dir); err != nil {
+		return err
+	}
+
+	data := make(map[string]string)
+	if err := m.collectData(&data); err != nil {
+		return err
+	}
+
+	// files are fully regenerated only if requested metadata changed
+	if m.isDataChanged(&data) {
+		err = m.writeData(&data)
+	}
+	return err
+}
+
+// collectData collects requested metadata in data map.
+// Map's key is the requested name of file to dump
+// Map's value is the (sorted) content of the field to be dumped in the file.
+func (m *metadataVolume) collectData(data *map[string]string) error {
+	errlist := []error{}
+	for fieldReference, fileName := range m.fieldReferenceFileNames {
+		if values, err := fieldpath.ExtractFieldPathAsString(m.pod, fieldReference); err != nil {
+			glog.Error(err)
+			errlist = append(errlist, err)
+		} else {
+			(*data)[fileName] = sortLines(values)
+		}
+	}
+	return utilErrors.NewAggregate(errlist)
+}
+
+// isDataChanged iterate over all the entries to check wether at least one
+// file needs to be updated.
+func (m *metadataVolume) isDataChanged(data *map[string]string) bool {
+	for fileName, values := range *data {
+		if isFileToGenerate(path.Join(m.GetPath(), fileName), values) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFileToGenerate compares actual file with the new values. If
+// different (or the file does not exist) return true
+func isFileToGenerate(fileName, values string) bool {
+	if _, err := os.Lstat(fileName); os.IsNotExist(err) {
+		return true
+	}
+	return readFile(fileName) != values
+}
+
+const currentDir = ".current"
+const currentTmpDir = ".current_tmp"
+
+// writeData writes requested metadata in specified files.
+//
+// The file visible in this volume are symlinks to files in the '.current'
+// directory. Actual files are stored in an hidden timestamped directory which is
+// symlinked to by '.current'. The timestamped directory and '.current' symlink
+// are created in the plugin root dir.  This scheme allows the files to be
+// atomically updated by changing the target of the '.current' symlink.  When new
+// data is available:
+//
+// 1.  A new timestamped dir is created by writeDataInTimestampDir
+// 2.  Symlinks for new files are created if needed
+// 3.  The previous timestamped directory is detected reading the '.current' symlink
+// 4.  In case no symlink exists then it's created and func returns (first execution)
+// 5.  In case symlink exists a new temporary symlink is created .current_tmp
+// 6.  .current_tmp is renamed to .current
+// 7.  The previous timestamped directory is removed
+func (m *metadataVolume) writeData(data *map[string]string) error {
+	var timestampDir string
+	var err error
+	timestampDir, err = m.writeDataInTimestampDir(data)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+	// update symbolic links for relative paths
+	if err = m.updateSymlinksToCurrentDir(); err != nil {
+		os.RemoveAll(timestampDir)
+		glog.Error(err)
+		return err
+	}
+
+	_, timestampDirBaseName := filepath.Split(timestampDir)
+	var oldTimestampDirectory string
+	oldTimestampDirectory, err = os.Readlink(path.Join(m.GetPath(), currentDir))
+	if err != nil {
+		if os.IsNotExist(err) { // no link to currentDir so creates it
+			err = os.Symlink(timestampDirBaseName, path.Join(m.GetPath(), currentDir))
+		}
+		return err // in any cases return
+	}
+
+	// nominal case: link to currentDir exists create the link to currentTmpDir
+	if err = os.Symlink(timestampDirBaseName, path.Join(m.GetPath(), currentTmpDir)); err != nil {
+		os.RemoveAll(timestampDir)
+		glog.Error(err)
+		return err
+	}
+
+	// Rename the symbolic link currentTmpDir to currentDir
+	if err = os.Rename(path.Join(m.GetPath(), currentTmpDir), path.Join(m.GetPath(), currentDir)); err != nil {
+		// in case of error remove latest data and currentTmpDir
+		os.Remove(path.Join(m.GetPath(), currentTmpDir))
+		os.RemoveAll(timestampDir)
+		glog.Error(err)
+		return err
+	}
+	// Remove oldTimestampDirectory
+	if len(oldTimestampDirectory) > 0 {
+		if e := os.RemoveAll(path.Join(m.GetPath(), oldTimestampDirectory)); e != nil {
+			glog.Error(e)
+			return e
+		}
+	}
+	return nil
+}
+
+// writeDataInTimestampDir writes the latest data into a new temporary directory with a timestamp.
+func (m *metadataVolume) writeDataInTimestampDir(data *map[string]string) (string, error) {
+	errlist := []error{}
+	timestampDir, err := ioutil.TempDir(m.GetPath(), "."+time.Now().Format("2006_01_02_15_04_05"))
+	for fileName, values := range *data {
+		fullPathFile := path.Join(timestampDir, fileName)
+		dir, _ := filepath.Split(fullPathFile)
+		if err = os.MkdirAll(dir, os.ModePerm); err != nil {
+			return "", err
+		}
+		if e := ioutil.WriteFile(fullPathFile, []byte(values), 0644); e != nil {
+			glog.Error(e)
+			errlist = append(errlist, err)
+		}
+	}
+	return timestampDir, utilErrors.NewAggregate(errlist)
+}
+
+// updateSymlinksToCurrentDir creates the relative symlinks for all the files configured in this volume.
+// If the directory in a file path does not exist, it is created.
+func (m *metadataVolume) updateSymlinksToCurrentDir() error {
+	for _, f := range m.fieldReferenceFileNames {
+		dir, _ := filepath.Split(f)
+		nbOfSubdir := 0
+		if len(dir) > 0 {
+			nbOfSubdir = len(strings.Split(dir, "/")) - 1
+			if e := os.MkdirAll(path.Join(m.GetPath(), dir), os.ModePerm); e != nil {
+				return e
+			}
+		}
+		if _, e := os.Readlink(path.Join(m.GetPath(), f)); e != nil {
+			// link does not exist create it
+			if e := os.Symlink(path.Join(strings.Repeat("../", nbOfSubdir)+currentDir, f), path.Join(m.GetPath(), f)); e != nil {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+// readFile reads the file at the given path and returns the content as a string.
+func readFile(path string) string {
+	if data, err := ioutil.ReadFile(path); err == nil {
+		return string(data)
+	}
+	return ""
+}
+
+// sortLines sorts the strings generated from map based metadata
+// (annotations and labels)
+func sortLines(values string) string {
+	splitted := strings.Split(values, "\n")
+	sort.Strings(splitted)
+	return strings.Join(splitted, "\n")
+}
+
+func (m *metadataVolume) GetPath() string {
+	return m.plugin.host.GetPodVolumeDir(m.pod.UID, util.EscapeQualifiedNameForDisk(metadataPluginName), m.volName)
+}
+
+func (m *metadataVolume) TearDown() error {
+	return m.TearDownAt(m.GetPath())
+}
+
+func (m *metadataVolume) TearDownAt(dir string) error {
+	glog.V(3).Infof("Tearing down volume %v for pod %v at %v", m.volName, m.pod.UID, dir)
+
+	// Wrap EmptyDir, let it do the teardown.
+	wrapped, err := m.plugin.host.NewWrapperCleaner(wrappedVolumeSpec, m.pod.UID, m.mounter)
+	if err != nil {
+		return err
+	}
+	return wrapped.TearDownAt(dir)
+}
+
+func (m *metadataVolume) getMetaDir() string {
+	return path.Join(m.plugin.host.GetPodPluginDir(m.pod.UID, util.EscapeQualifiedNameForDisk(metadataPluginName)), m.volName)
+}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/metadata/metadata_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/metadata/metadata_test.go
@@ -1,0 +1,592 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/types"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/mount"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/volume/empty_dir"
+)
+
+const basePath = "/tmp/fake"
+
+func formatMap(m map[string]string) string {
+	var l string
+	for key, value := range m {
+		l += key + "=" + value + "\n"
+	}
+	return l
+}
+
+func newTestHost(t *testing.T, client client.Interface) volume.VolumeHost {
+	tempDir, err := ioutil.TempDir(basePath, "metadata_volume_test.")
+	if err != nil {
+		t.Fatalf("can't make a temp rootdir: %v", err)
+	}
+	return volume.NewFakeVolumeHost(tempDir, client, empty_dir.ProbeVolumePlugins())
+}
+
+func TestCanSupport(t *testing.T) {
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, nil))
+
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	if plugin.Name() != metadataPluginName {
+		t.Errorf("Wrong name: %s", plugin.Name())
+	}
+}
+
+func CleanEverything(plugin volume.VolumePlugin, testVolumeName, volumePath string, testPodUID types.UID, t *testing.T) {
+
+	cleaner, err := plugin.NewCleaner(testVolumeName, testPodUID, mount.New())
+	if err != nil {
+		t.Errorf("Failed to make a new Cleaner: %v", err)
+	}
+	if cleaner == nil {
+		t.Errorf("Got a nil Cleaner")
+	}
+
+	if err := cleaner.TearDown(); err != nil {
+		t.Errorf("Expected success, got: %v", err)
+	}
+	if _, err := os.Stat(volumePath); err == nil {
+		t.Errorf("TearDown() failed, volume path still exists: %s", volumePath)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("SetUp() failed: %v", err)
+	}
+}
+
+func TestLabels(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_labels"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	labels := map[string]string{
+		"key1": "value1",
+		"key2": "value2"}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	})
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "labels", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.labels"}}}},
+		},
+	}
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Labels: labels}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "labels"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if sortLines(string(data)) != sortLines(formatMap(labels)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(labels))
+	}
+
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+
+}
+
+func TestAnnotations(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_annotations"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	annotations := map[string]string{
+		"a1": "value1",
+		"a2": "value2"}
+
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "annotations", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.annotations"}}}},
+		},
+	}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:        testName,
+			Namespace:   testNamespace,
+			Annotations: annotations,
+		},
+	})
+
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Annotations: annotations}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "annotations"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if sortLines(string(data)) != sortLines(formatMap(annotations)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(annotations))
+	}
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+
+}
+
+func TestName(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_name"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "name_file_name", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.name"}}}},
+		},
+	}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+	})
+
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Name: testName}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "name_file_name"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if string(data) != testName {
+		t.Errorf("Found `%s` expected %s", string(data), testName)
+	}
+
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+
+}
+
+func TestNamespace(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_namespace"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "namespace_file_name", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.namespace"}}}},
+		},
+	}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+	})
+
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Namespace: testNamespace}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "namespace_file_name"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if string(data) != testNamespace {
+		t.Errorf("Found `%s` expected %s", string(data), testNamespace)
+	}
+
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+
+}
+
+func TestWriteTwiceNoUpdate(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_write_twice_no_update"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	labels := map[string]string{
+		"key1": "value1",
+		"key2": "value2"}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	})
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "labels", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.labels"}}}},
+		},
+	}
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Labels: labels}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	// get the link of the link
+	var currentTarget string
+	if currentTarget, err = os.Readlink(path.Join(volumePath, ".current")); err != nil {
+		t.Errorf(".current should be a link... %s\n", err.Error())
+	}
+
+	err = builder.SetUp() // now re-run Setup
+	if err != nil {
+		t.Errorf("Failed to re-setup volume: %v", err)
+	}
+
+	// get the link of the link
+	var currentTarget2 string
+	if currentTarget2, err = os.Readlink(path.Join(volumePath, ".current")); err != nil {
+		t.Errorf(".current should be a link... %s\n", err.Error())
+	}
+
+	if currentTarget2 != currentTarget {
+		t.Errorf("No update between the two Setup... Target link should be the same %s %s\n", currentTarget, currentTarget2)
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "labels"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if sortLines(string(data)) != sortLines(formatMap(labels)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(labels))
+	}
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+
+}
+
+func TestWriteTwiceWithUpdate(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_write_twice_with_update"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	labels := map[string]string{
+		"key1": "value1",
+		"key2": "value2"}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	})
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "labels", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.labels"}}}},
+		},
+	}
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Labels: labels}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	var currentTarget string
+	if currentTarget, err = os.Readlink(path.Join(volumePath, ".current")); err != nil {
+		t.Errorf("labels file should be a link... %s\n", err.Error())
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "labels"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if sortLines(string(data)) != sortLines(formatMap(labels)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(labels))
+	}
+
+	newLabels := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3"}
+
+	// Now update the labels
+	pod.ObjectMeta.Labels = newLabels
+	err = builder.SetUp() // now re-run Setup
+	if err != nil {
+		t.Errorf("Failed to re-setup volume: %v", err)
+	}
+
+	// get the link of the link
+	var currentTarget2 string
+	if currentTarget2, err = os.Readlink(path.Join(volumePath, ".current")); err != nil {
+		t.Errorf(".current should be a link... %s\n", err.Error())
+	}
+
+	if currentTarget2 == currentTarget {
+		t.Errorf("Got and update between the two Setup... Target link should NOT be the same\n")
+	}
+
+	data, err = ioutil.ReadFile(path.Join(volumePath, "labels"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if sortLines(string(data)) != sortLines(formatMap(newLabels)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(newLabels))
+	}
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+}
+
+func TestWriteWithUnixPath(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid")
+		testVolumeName = "test_write_with_unix_path"
+		testNamespace  = "test_metadata_namespace"
+		testName       = "test_metadata_name"
+	)
+
+	labels := map[string]string{
+		"key1": "value1",
+		"key2": "value2"}
+
+	annotations := map[string]string{
+		"a1": "value1",
+		"a2": "value2"}
+
+	fake := testclient.NewSimpleFake(&api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	})
+
+	pluginMgr := volume.VolumePluginMgr{}
+	pluginMgr.InitPlugins(ProbeVolumePlugins(), newTestHost(t, fake))
+	plugin, err := pluginMgr.FindPluginByName(metadataPluginName)
+	volumeSpec := &api.Volume{
+		Name: testVolumeName,
+		VolumeSource: api.VolumeSource{
+			Metadata: &api.MetadataVolumeSource{
+				Items: []api.MetadataFile{
+					{Name: "this/is/mine/labels", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.labels"}},
+					{Name: "this/is/yours/annotations", FieldRef: api.ObjectFieldSelector{
+						FieldPath: "metadata.annotations"}},
+				}}},
+	}
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+	pod := &api.Pod{ObjectMeta: api.ObjectMeta{UID: testPodUID, Labels: labels, Annotations: annotations}}
+	builder, err := plugin.NewBuilder(volume.NewSpecFromVolume(volumeSpec), pod, volume.VolumeOptions{}, &mount.FakeMounter{})
+
+	if err != nil {
+		t.Errorf("Failed to make a new Builder: %v", err)
+	}
+	if builder == nil {
+		t.Errorf("Got a nil Builder")
+	}
+
+	volumePath := builder.GetPath()
+	err = builder.SetUp()
+	if err != nil {
+		t.Errorf("Failed to setup volume: %v", err)
+	}
+
+	var data []byte
+	data, err = ioutil.ReadFile(path.Join(volumePath, "this/is/mine/labels"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if sortLines(string(data)) != sortLines(formatMap(labels)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(labels))
+	}
+
+	data, err = ioutil.ReadFile(path.Join(volumePath, "this/is/yours/annotations"))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if sortLines(string(data)) != sortLines(formatMap(annotations)) {
+		t.Errorf("Found `%s` expected %s", data, formatMap(annotations))
+	}
+	CleanEverything(plugin, testVolumeName, volumePath, testPodUID, t)
+}


### PR DESCRIPTION
Patch for https://github.com/GoogleCloudPlatform/kubernetes/pull/5093

1) It's a volume plugin kubernetes/pkg/volume/metadata/...
2) Obviously API have been modified
3) The only non obvious modification is the fact that the fuzzer has been modified since the default fuzzer is not enough (for defaulting)
4) I didn't add the kube e2e test neither the examples kubernetes/examples/metadata in the upstream PR since I didn't find where to place them. 
5) Let me know if I need to modify something

@pmorie @smarterclayton 