### PR TITLE
Add emtpyDir volumes to ephemeral database templates

### DIFF
--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -111,12 +111,26 @@
                   }
                 ],
                 "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "mongodb-data",
+                    "mountPath": "/var/lib/mongodb/data"
+                  }
+                ],
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
                 "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "mongodb-data",
+                "emptyDir": {
+                  "medium": ""
                 }
               }
             ],

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -107,12 +107,26 @@
                   }
                 ],
                 "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "mysql-data",
+                    "mountPath": "/var/lib/mysql/data"
+                  }
+                ],
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
                 "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "mysql-data",
+                "emptyDir": {
+                  "medium": ""
                 }
               }
             ],

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -107,12 +107,26 @@
                   }
                 ],
                 "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "postgresql-data",
+                    "mountPath": "/var/lib/pgsql/data"
+                  }
+                ],
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
                 "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "postgresql-data",
+                "emptyDir": {
+                  "medium": ""
                 }
               }
             ],


### PR DESCRIPTION
Follow up to #2644
Waiting for https://github.com/GoogleCloudPlatform/kubernetes/issues/2630