### PR TITLE
UPSTREAM: Pass memory swap limit -1 by default

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools/manager.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools/manager.go
@@ -590,6 +590,7 @@ func (dm *DockerManager) runContainer(
 			Image:        container.Image,
 			// Memory and CPU are set here for older versions of Docker (pre-1.6).
 			Memory:     memoryLimit,
+			MemorySwap: -1,
 			CPUShares:  cpuShares,
 			WorkingDir: container.WorkingDir,
 			Labels:     labels,
@@ -640,8 +641,9 @@ func (dm *DockerManager) runContainer(
 		NetworkMode:  netMode,
 		IpcMode:      ipcMode,
 		// Memory and CPU are set here for newer versions of Docker (1.6+).
-		Memory:    memoryLimit,
-		CPUShares: cpuShares,
+		Memory:     memoryLimit,
+		MemorySwap: -1,
+		CPUShares:  cpuShares,
 	}
 	if len(opts.DNS) > 0 {
 		hc.DNS = opts.DNS


### PR DESCRIPTION
See upstream PR: https://github.com/GoogleCloudPlatform/kubernetes/pull/9358

