### PR TITLE
osc describe is should show spec tags when status empty

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -499,8 +499,8 @@ func (d *ImageStreamDescriber) Describe(namespace, name string) (string, error) 
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageStream.ObjectMeta)
+		formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
 		formatImageStreamTags(out, imageStream)
-		formatString(out, "Registry", imageStream.Status.DockerImageRepository)
 		return nil
 	})
 }


### PR DESCRIPTION
Handle image streams without status.Tags

```
$ osc describe is/wildfly
Name:			wildfly
Created:		11 minutes ago
Labels:			<none>
Annotations:		openshift.io/image.dockerRepositoryCheck=2015-06-08T20:27:35Z
Docker Pull Spec:	openshift/wildfly-8-centos

Tag	Spec	Created		PullSpec				Image
latest		11 minutes ago	openshift/wildfly-8-centos:latest	3495ad898a5a8e0ce96c62410202c5bc42d7f8184dfe6c5d74d300e519e835bd
test	other			<n/a>					<n/a>
```

@spadgett