### PR TITLE
Don't mutate build.spec in API when creating build pod

### DIFF
--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -100,15 +100,17 @@ func (bc *BuildController) nextBuildStatus(build *buildapi.Build) error {
 
 	// set the expected build parameters, which will be saved if no error occurs
 	build.Status = buildapi.BuildStatusPending
-	// override DockerImageReference in the strategy for the copy we send to the server
-	build.Parameters.Output.DockerImageReference = spec
-	build.Parameters.Output.To = nil
 
+	// Make a copy to avoid mutating the build from this point on
 	copy, err := kapi.Scheme.Copy(build)
 	if err != nil {
 		return fmt.Errorf("unable to copy Build: %v", err)
 	}
 	buildCopy := copy.(*buildapi.Build)
+
+	// override DockerImageReference in the strategy for the copy we send to the build pod
+	buildCopy.Parameters.Output.DockerImageReference = spec
+	buildCopy.Parameters.Output.To = nil
 
 	// invoke the strategy to get a build pod
 	podSpec, err := bc.BuildStrategy.CreateBuildPod(buildCopy)

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -394,10 +394,8 @@ func runImageChangeTriggerTest(t *testing.T, clusterAdminClient *client.Client, 
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild = event.Object.(*buildapi.Build)
-	if newBuild.Parameters.Output.To != nil {
-		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
-	}
-	if newBuild.Parameters.Output.DockerImageReference != "registry:8080/openshift/test-image-trigger" || newBuild.Parameters.Output.Tag != "outputtag" {
+	// Make sure the resolution of the build's docker image pushspec didn't mutate the persisted API object
+	if newBuild.Parameters.Output.To.Name != "test-image-trigger-repo" || newBuild.Parameters.Output.Tag != "outputtag" || newBuild.Parameters.Output.DockerImageReference != "" {
 		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
 	}
 	if newBuild.Labels["testlabel"] != "testvalue" {
@@ -488,10 +486,8 @@ WaitLoop2:
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild = event.Object.(*buildapi.Build)
-	if newBuild.Parameters.Output.To != nil {
-		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
-	}
-	if newBuild.Parameters.Output.DockerImageReference != "registry:8080/openshift/test-image-trigger" || newBuild.Parameters.Output.Tag != "outputtag" {
+	// Make sure the resolution of the build's docker image pushspec didn't mutate the persisted API object
+	if newBuild.Parameters.Output.To.Name != "test-image-trigger-repo" || newBuild.Parameters.Output.Tag != "outputtag" || newBuild.Parameters.Output.DockerImageReference != "" {
 		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
 	}
 	if newBuild.Labels["testlabel"] != "testvalue" {

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -231,7 +231,8 @@ func runTest(t *testing.T, testname string, clusterAdminClient *client.Client, i
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild = event.Object.(*buildapi.Build)
-	if newBuild.Parameters.Output.DockerImageReference != "registry:8080/openshift/test-image-trigger" || newBuild.Parameters.Output.Tag != "outputtag" {
+	// Make sure the resolution of the build's docker image pushspec didn't mutate the persisted API object
+	if newBuild.Parameters.Output.To.Name != "test-image-trigger-repo" || newBuild.Parameters.Output.Tag != "outputtag" || newBuild.Parameters.Output.DockerImageReference != "" {
 		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
 	}
 	if newBuild.Labels["testlabel"] != "testvalue" {
@@ -296,10 +297,8 @@ func runTest(t *testing.T, testname string, clusterAdminClient *client.Client, i
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild = event.Object.(*buildapi.Build)
-	if newBuild.Parameters.Output.To != nil {
-		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
-	}
-	if newBuild.Parameters.Output.DockerImageReference != "registry:8080/openshift/test-image-trigger" || newBuild.Parameters.Output.Tag != "outputtag" {
+	// Make sure the resolution of the build's docker image pushspec didn't mutate the persisted API object
+	if newBuild.Parameters.Output.To.Name != "test-image-trigger-repo" || newBuild.Parameters.Output.Tag != "outputtag" || newBuild.Parameters.Output.DockerImageReference != "" {
 		t.Fatalf("unexpected build output: %#v %#v", newBuild.Parameters.Output.To, newBuild.Parameters.Output)
 	}
 	if newBuild.Labels["testlabel"] != "testvalue" {


### PR DESCRIPTION
Fixes #2977