### PR TITLE
Tests with openshift/mock-app

### DIFF
--- a/examples/mock-app-template/mock-template.json
+++ b/examples/mock-app-template/mock-template.json
@@ -1,0 +1,99 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1beta3",
+    "metadata": {
+        "name": "mock-app-sample" , 
+        "description": "Example of using mock-app"
+    } ,
+    "objects": [
+        {
+            "apiVersion": "v1beta3",
+            "kind": "Service",
+            "metadata": {
+                "creationTimestamp": null,
+                "name": "mock-service"
+            },
+            
+            "spec": {
+                "ports": [
+                    {
+                        "nodePort": 0,
+                        "port": 5018,
+                        "protocol": "TCP",
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "name": "mock-app-pod"
+                },
+                "sessionAffinity": "None",
+                "type":"ClusterIP"
+                
+            }
+        },
+        
+        {
+            "apiVersion": "v1beta3",
+            "kind": "ReplicationController",
+            "id": "mock-rc",
+            
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "name": "mock-app-pod"
+                },
+                "name": "mock-rc"
+            },
+            
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "name": "mock-app-pod"
+                },
+                "template" : {
+                    "metadata": {
+                        "labels": {
+                            "name" : "mock-app-pod"
+                        }
+                    } ,
+                    "spec": {
+                        "containers": [
+                            {
+                                "capabilities": {},
+                                "env": [
+                                    {
+                                        "name": "MOCK_NAME",
+                                        "value": "${MOCK_NAME}"
+                                    }
+                                ],
+                                "image": "openshift/mock-app",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "mock-app",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "securityContext": {
+                                    "capabilities": {},
+                                    "privileged": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ] ,
+    
+    "parameters": [
+        {
+            "name": "MOCK_NAME",
+            "description": "The name of mock",
+            "value": "mock1"
+        }
+    ]
+    
+}

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -47,6 +47,7 @@ cp -f "${imagedir}/hello-openshift" examples/hello-openshift/bin
 cp -f "${imagedir}/deployment"      examples/deployment/bin
 cp -f "${imagedir}/gitserver"       examples/gitserver/bin
 cp -f "${imagedir}/dockerregistry"  images/dockerregistry/bin
+cp -f "${imagedir}/mock-app" images/test/mock-app/bin
 
 # builds an image and tags it two ways - with latest, and with the release tag
 function image {
@@ -67,6 +68,7 @@ image openshift/origin-deployer              images/deployer
 image openshift/origin-docker-builder        images/builder/docker/docker-builder
 image openshift/origin-gitserver             examples/gitserver
 image openshift/origin-sti-builder           images/builder/docker/sti-builder
+image openshift/mock-app                     images/test/mock-app
 # unpublished images
 image openshift/origin-custom-docker-builder images/builder/docker/custom-docker-builder
 image openshift/sti-image-builder            images/builder/docker/sti-image-builder

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -35,6 +35,7 @@ readonly OS_IMAGE_COMPILE_TARGETS=(
 readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS=(
   examples/hello-openshift
   examples/deployment
+  images/test/mock-app
 )
 readonly OS_IMAGE_COMPILE_BINARIES=("${OS_SCRATCH_IMAGE_COMPILE_TARGETS[@]##*/}" "${OS_IMAGE_COMPILE_TARGETS[@]##*/}")
 

--- a/hack/mock-based-tests.sh
+++ b/hack/mock-based-tests.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+openshift admin new-project mock --description="This is an example project to demonstrate OpenShift v3" --admin="e2e-user"
+
+osc project mock
+
+# upload the template
+osc create -f examples/mock-app-template/mock-template.json -n mock
+
+# create the config
+
+# create the new app
+osc new-app mock-app-sample -p MOCK_NAME=mock1
+
+# wait for
+echo "[INFO] Waiting pod mock"
+wait_for_command "osc get -n mock pods -l name=mock-app-pod | grep -i Running" $((60*TIME_SEC))
+
+echo "[INFO] Waiting service mock"
+wait_for_command "osc get -n mock services | grep mock-service" $((20*TIME_SEC))
+MOCK_IP=$(osc get -n mock -o template --template="{{ .spec.portalIP }}" service mock-service)
+echo "[INFO] IP Mock Service $MOCK_IP ."
+
+echo "[INFO] Setting in-memory value for the container "
+# put "value1" for key "key1"
+wait_for_command '[[ "$(curl -s http://${MOCK_IP}:5018/put/key1/value1)" = "ok" ]]' $((60*TIME_SEC))
+# asserting value is well "value1"
+wait_for_command '[[ "$(curl -s http://${MOCK_IP}:5018/get/key1)" = "value1" ]]' $((60*TIME_SEC))
+
+get_container_id () {
+    echo $(osc get -o template pod $1 --template='{{range .status.containerStatuses}}{{.containerID}}{{end}}')
+}
+
+# Kill the only pod container
+POD_NAME=$(curl -s http://${MOCK_IP}:5018/hostname)
+CONTAINER_ID=$(get_container_id ${POD_NAME})
+# $(osc get -o template pod ${POD_NAME} --template="{{range .status.containerStatuses}}{{.containerID}}{{end}}")
+echo "Pod Name ${POD_NAME}"
+echo "Container Id ${CONTAINER_ID}"
+
+wait_for_command '[[ "$(curl -s http://${MOCK_IP}:5018/shutdown)" = "ok" ]]' $((60*TIME_SEC))
+
+# asserting the containerid have changed
+
+wait_for_command '[[ "$(get_container_id $POD_NAME)" != "${CONTAINER_ID}" ]]' $((60*TIME_SEC))
+
+# asserting value for "key1" is not "value1" anymore as the container is dead.
+wait_for_command '[[ "$(curl -s http://${MOCK_IP}:5018/get/key1)" = "" ]]' $((60*TIME_SEC))
+
+# resize the rC mock-rc to 3 
+osc scale -n mock --replicas=3 replicationcontrollers mock-rc
+
+# we wait the effective resizing
+mockrc_size=$(osc get -n mock pods -l name=mock-app-pod | grep mock-rc | wc -l)
+wait_for_command '[[ "$mockrc_size" = "3" ]]' $((60*TIME_SEC))
+
+
+# Test inter communication pod
+# getting endoints like "172.17.0.62:8080,172.17.0.63:8080,172.17.0.64:8080"
+
+# we need that endpoints have 3 ips,
+# we'll count the ':' char, we need to have 3 of them
+endpointstring=""
+number_of_occurrences=0
+cnt=0
+until [ $number_of_occurrences = 3 ]; do
+
+    endpointstring=$(osc get -n mock endpoints | grep mock-service |  awk '{print $2}')
+
+    # we're looking of the number of char ":" in endpointstring
+    number_of_occurrences=$(grep -o ":" <<< "$endpointstring" | wc -l) || true
+    cnt=$((cnt+1))
+    echo "[INFO] Waiting all 3 endpoints present. Actual = $number_of_occurrences."
+    echo "[INFO]  $endpointstring"
+    if [ $cnt = 19 ];
+    then
+        
+        exit 2
+        #error ${LINENO} "Too much time for endpoints to appear." 2
+    fi
+    
+    sleep 3
+done
+
+
+declare -a endpoints=()
+hostnames=""
+echo "[INFO] endpointstring => $endpointstring"
+i=0
+
+
+# build this
+#mock-rc-55lsa
+#mock-rc-t0lb9
+#mock-rc-zet3o
+
+
+# Preparing Test intra pod communication
+# mock-app allows chain communication between containers
+# if we provide a special string, like this one
+# #http://172.17.0.62:8080/chainredirect/http/172.17.0.62_8080_hostname-172.17.0.63_8080_hostname-172.17.0.64_8080_hostname
+
+magic_string_suffix=""
+
+
+# In the loop we 
+# 1) asking each mock-app container in the pod its hostname directly via the endpoints
+# 2) construct the string for the intra pod communication
+for m in $(echo $endpointstring | tr "," "\n") ;
+do
+    endpoints[$i]=$m
+    echo "[INFO] endpoint => ${endpoints[$i]}"
+    
+    # all 3 containers have "mock1" for name
+    # asserting that
+    wait_for_command '[[ "$(curl -s http://${endpoints[$i]}/name)" = "mock1" ]]' $((60*TIME_SEC))
+
+    sep1=$'\n'
+    sep2="-"
+    if [[ $i == "0" ]];
+    then
+        sep1=""
+        sep2=""
+    fi
+    # 1) concatening the 3 hostname directly asking them
+    hostnames+="$sep1$(curl -s http://${endpoints[$i]}/hostname)"
+
+    # 2) concatening the string for the intra pod commuication
+    magic_string_suffix+="${sep2}${m/:/_}_hostname"
+    
+    i=$((i+1))
+done
+
+magic_string_prefix="http://${endpoints[0]}/chainredirect/http/"
+
+magic_string="$magic_string_prefix$magic_string_suffix"
+
+echo "[INFO] Chain call : $magic_string"
+
+hostnames_via_intra_communication=$(curl -s $magic_string)
+
+echo "[INFO] "
+echo "[INFO] Hostnames : $hostnames ."
+echo "[INFO] Hostnames : $hostnames_via_intra_communication ."
+
+wait_for_command '[[ "$hostnames_via_intra_communication" = "$hostnames" ]]'

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -61,8 +61,7 @@ function cleanup()
 	else
 		echo "[INFO] Test Succeeded"
 	fi
-	echo
-
+	        
 	set +e
 	dump_container_logs
 
@@ -193,6 +192,14 @@ start_os_server
 
 # add e2e-user as a viewer for the default namespace so we can see infrastructure pieces appear
 openshift admin policy add-role-to-user view e2e-user --namespace=default
+
+source "${OS_ROOT}/hack/mock-based-tests.sh"
+echo " =========================== ============== ==========================="
+echo " =========================== end mock tests ==========================="
+echo " =========================== ============== ==========================="
+
+# switching back to default project
+osc project default
 
 # pre-load some image streams and templates
 oc create -f examples/image-streams/image-streams-centos7.json --namespace=openshift

--- a/images/test/mock-app/.gitignore
+++ b/images/test/mock-app/.gitignore
@@ -1,0 +1,1 @@
+mock-app

--- a/images/test/mock-app/Dockerfile
+++ b/images/test/mock-app/Dockerfile
@@ -1,0 +1,21 @@
+#
+# This is a mock pod used to facilitate inter/intra communication 
+# It contains a mockserver that has usefull primitives as REST API
+#
+# - /name              : return the "functional name" of the mockpod             
+# - /put/{key}/{value} : put a value for a key                                   
+# - /get/{key}         : get a value for gey . send error if key is not present. 
+# - /contains/{key}    : tell if it contains a given key                         
+# - /send/{message}    : will send a get message another pod via an url.         
+# - /listkeys          : will list all the keys                                  
+# - /kill              : will terminate the server so the pod.
+# 
+# The standard name for this image is openshift/mock-app
+#
+FROM scratch
+
+ADD bin/mock-app /mock-app
+
+EXPOSE 8080
+
+CMD ["/mock-app" , "-logtostderr"]

--- a/images/test/mock-app/README.md
+++ b/images/test/mock-app/README.md
@@ -1,0 +1,190 @@
+Mock
+----
+
+# Overview
+
+The origin/mock is a docker image that is built during 'make release'.
+Its main purpose is to have a flexible component that can safely be
+used and asserted in tests and that have an expected behaviour:
+
+- CRUD on key/value,
+- name/hostname
+- shutdown,
+- simple redirect
+- chaining call concept 
+
+The server must have MOCK_NAME as env variable that will contains
+the name of the server otherwise it raise a panic.
+
+By default the server serves on the port 8080. By setting environment
+variable MOCK_PORT to another port the server will use this particular
+port.
+
+# Server spawning
+
+Although this server is expected to run as docker container you can
+run it this way:
+
+    $ cd test/mock-app
+    $ MOCK_NAME=mock1 go run server.go -logtostderr
+    Started mock1, serving at 8080
+
+Starting a second server:
+
+    $ MOCK_NAME=mock2 MOCK_PORT=8081 go run server.go -logtostderr
+    Started mock2, serving at 8081
+    
+# API
+
+## /name
+
+Returns the name of the server
+
+    $ curl http://localhost:8080/name
+    mock1
+    
+    $ curl http://localhost:8081/name
+    mock2
+
+## /hostname
+
+Returns the hostname of the server
+
+    $ curl http://localhost:8080/hostname
+    zerihgerg
+    
+## /put/{key}/{value}
+
+Puts the value "value" under the key {key}. Always returns ok.
+
+    $ curl http://localhost:8080/put/k1/value1
+    ok
+    $ curl http://localhost:8080/put/k2/value2
+    ok
+    $ curl http://localhost:8080/put/k3/value3
+    ok
+
+## /contains/{key}
+
+Returns "ok" if the server contains {key}, "ko" otherwise.
+
+    $ curl http://localhost:8080/contains/k1
+    ok
+     
+    $ curl http://localhost:8081/contains/k1
+    ko
+     
+## /get/{key}
+
+Returns the value behind the key {key}, empty string if there is no
+value for this key.
+
+    $ curl http://localhost:8080/get/k1
+    value1
+
+    $ curl http://localhost:8081/get/k1
+    ""           <-- empty string without "
+
+## /keys
+
+Returns all the keys
+
+   $ curl http://localhost:8080/keys
+   k1
+   k2
+   k3
+
+## /delete/{key}
+
+Deletes the entry where key {key} is stored. Returns "ok" if deletion occurs, "ko" if not.
+
+    $  curl http://localhost:8080/delete/k2
+    ok
+    
+    $  curl http://localhost:8080/delete/k2
+    ko
+    
+## /redirect/{scheme}/{host}/{port}/{path}
+
+This redirects the contents of the url {scheme}://{host}:{port}/{path} 
+
+    $ curl http://localhost:8080/redirect/http/localhost/8081/name
+    Querying http://localhost:8081/name got response mock2
+
+## /env/{var}
+
+This returns the value of the environment variable {var} on the
+server. Returns "" (empty string if {var} does not exist.
+
+    $ curl http://localhost:8080/env/MOCK_NAME
+    mock1
+    
+    $ curl http://localhost:8080/env/SHELL
+    /bin/shell
+    
+
+## /shutdown
+
+This properly shutdowns the server itself immediatly. (exit code to 0)
+
+## /shutdown/{delay}
+
+This properly shutdowns the server itself in a delay of {delay} seconds. (exit code to 0)
+
+## /fail
+
+This kills the server itself immediatly with exit code to -1
+
+## /fail/{exitCode}
+
+This kills the server itself immediately with exit code to {exitCode}.
+
+
+## /chainredirect/{scheme}/{chainPath}
+
+Chain Redirect is /redirect on steroids, it allows communication
+scheme between several mock servers and returns the concatenation of
+all calls. For instance:
+
+- mock1 calls mock2/name,
+- mock2 calls mock1/put/k1/newvalue
+- mock1 calls mock1/get/k1
+
+the output will be:
+
+    mock2
+    ok
+    newvalue
+
+### {scheme}
+
+Scheme is the protocol that is use for all communications. For now:
+http 
+
+### {chainPath} format explained
+
+    (host "_" port "_" path) ("-" (host "_" port "_" path))+
+
+where 'path' itself can be composed with '_' in between like
+
+    "put_k1_v1"
+    
+For instance
+
+    localhost_8081_name-localhost_8080_put_k1_v1
+    
+is a valid chainPath. In command line, this gives:
+
+    $ curl http://localhost:8080/chainredirect/http/localhost_8081_name-localhost_8080_put_k1_v1
+    mock2
+    ok
+
+curl calls mock1 initiating chainredirect, mock1 calls mock2 name then
+mock2 calls mock1 put/k1/v1. This can be as long as GET allows it.
+
+We can shutdown all the servers with this command line
+
+    $ http://localhost:8080/chainredirect/http/localhost_8081_shutdown_2-localhost_8080_shutdown_2
+    ok
+    ok
+

--- a/images/test/mock-app/bin/.gitignore
+++ b/images/test/mock-app/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/images/test/mock-app/server.go
+++ b/images/test/mock-app/server.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+	"github.com/openshift/origin/pkg/cmd/util"
+)
+
+type Server struct {
+	Name     string
+	Port     string
+	Hostname string
+	Data     map[string]string
+}
+
+var server Server
+
+func init() {
+
+	// name of the mock server
+	name := util.Env("MOCK_NAME", "")
+
+	// port of the mock server
+	port := util.Env("MOCK_PORT", "8080")
+
+	hostname, _ := os.Hostname()
+
+	// initialize the new server
+	server = newServer(name, hostname, port)
+}
+
+func newServer(name, hostname, port string) Server {
+
+	if name == "" || len(strings.TrimSpace(name)) == 0 {
+		glog.Fatalf("This server must have a name, found in MOCK_NAME env variable")
+	}
+
+	if port == "" || len(strings.TrimSpace(port)) == 0 {
+		port = "8080"
+	}
+
+	data := make(map[string]string)
+
+	_server := Server{Name: name, Hostname: hostname, Port: port, Data: data}
+
+	return _server
+
+}
+
+func failHandler(w http.ResponseWriter, r *http.Request) {
+
+	p := mux.Vars(r)
+
+	// delay
+	exitCodeStr := p["exitcode"]
+	exitCode, err := strconv.Atoi(exitCodeStr)
+	if err != nil {
+		exitCode = -1
+	}
+
+	fmt.Fprintln(w, "ok")
+
+	// flush before shutdown
+	f, ok := w.(http.Flusher)
+	if ok && f != nil {
+		f.Flush()
+	}
+
+	timer := time.NewTimer(time.Second * time.Duration(0))
+	glog.Infof("%s will fail with exit code \"%d\" now\n", server.Name, exitCode)
+	go func(code int) {
+		<-timer.C
+		glog.Infof("%s stopping now (%d).\n", server.Name, code)
+		os.Exit(code)
+	}(exitCode)
+}
+
+func shutdownHandler(w http.ResponseWriter, r *http.Request) {
+
+	p := mux.Vars(r)
+
+	// delay
+	delayStr := p["delay"]
+	delay, err := strconv.Atoi(delayStr)
+	if err != nil {
+		delay = 0
+	}
+
+	fmt.Fprintln(w, "ok")
+
+	// flush before shutdown
+	f, ok := w.(http.Flusher)
+	if ok && f != nil {
+		f.Flush()
+	}
+
+	timer := time.NewTimer(time.Second * time.Duration(delay))
+	glog.Infof("%s will shutdown in %d second(s)\n", server.Name, delay)
+	go func() {
+		<-timer.C
+		glog.Infof("%s stopping now.\n", server.Name)
+		os.Exit(0)
+	}()
+}
+
+func nameHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, server.Name)
+}
+
+func hostnameHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, server.Hostname)
+}
+
+func envHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+
+	key := p["var"]
+	v := util.Env(key, "")
+
+	fmt.Fprintln(w, v)
+}
+
+func putHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+
+	key := p["key"]
+	value := p["value"]
+
+	server.Data[key] = value
+
+	fmt.Fprintln(w, "ok")
+}
+
+func getHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	key := p["key"]
+
+	value, _ := server.Data[key]
+
+	fmt.Fprintln(w, value)
+}
+
+func deleteHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	key := p["key"]
+
+	_, z := server.Data[key]
+	if z {
+		delete(server.Data, key)
+		fmt.Fprintln(w, "ok")
+	} else {
+		fmt.Fprintln(w, "ko")
+	}
+}
+
+func containsHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	key := p["key"]
+
+	_, z := server.Data[key]
+
+	if z {
+		fmt.Fprintln(w, "ok")
+	} else {
+		fmt.Fprintln(w, "ko")
+	}
+}
+
+func keysHandler(w http.ResponseWriter, r *http.Request) {
+
+	for k := range server.Data {
+		fmt.Fprintln(w, k)
+	}
+}
+
+func redirectHandler(w http.ResponseWriter, r *http.Request) {
+
+	p := mux.Vars(r)
+
+	scheme := p["scheme"]
+	host := p["host"]
+	port := p["port"]
+	path := p["path"]
+
+	if scheme == "" {
+		scheme = "http"
+	}
+
+	if port == "" {
+		port = "8080"
+	}
+
+	if path == "" {
+		path = ""
+	} else {
+		path = fmt.Sprintf("/%s", path)
+	}
+
+	doRedirect(scheme, host, port, path, w)
+}
+
+// http://localhost:8080/chainredirect/http/localhost_8080_name-localhost_8080_contains_k1
+//                                     ^
+//                                     |scheme
+//
+func chainRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+
+	chainPath := p["chainPath"]
+	scheme := p["scheme"]
+
+	chainPathArr := strings.Split(chainPath, "-")
+
+	if len(chainPathArr) > 0 {
+
+		currentLinkArr := strings.Split(chainPathArr[0], "_")
+
+		if len(currentLinkArr) >= 3 {
+			host := currentLinkArr[0]
+			port := currentLinkArr[1]
+
+			var pathArr = make([]string, len(currentLinkArr)-2)
+
+			for i := 2; i < len(currentLinkArr); i++ {
+
+				pathArr[i-2] = currentLinkArr[i]
+
+			}
+
+			path := strings.Join(pathArr, "/")
+
+			if scheme == "" {
+				scheme = "http"
+			}
+			if port == "" {
+				port = "8080"
+			}
+
+			if path == "" {
+				path = ""
+			} else {
+				path = fmt.Sprintf("/%s", path)
+			}
+
+			// call the action
+			back := doCall(scheme, host, port, path)
+
+			// then continue the chain
+			if len(chainPathArr) > 1 {
+				idx := strings.Index(chainPath, "-")
+				nextLink := chainPath[idx+1:]
+				chainRedirect := fmt.Sprintf("/chainredirect/%s/%s", scheme, nextLink)
+				recursiveBack := doCall(scheme, host, port, chainRedirect)
+				back = fmt.Sprintf("%s%s", back, recursiveBack)
+			}
+
+			fmt.Fprintf(w, back)
+		}
+	}
+}
+
+func doRedirect(scheme, host, port, path string, w http.ResponseWriter) {
+	url := fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+
+	response, err := http.Get(url)
+
+	if err == nil {
+		defer response.Body.Close()
+		contents, _ := ioutil.ReadAll(response.Body)
+		fmt.Fprintf(w, "Querying %s got response %s", url, string(contents))
+	}
+}
+
+func doCall(scheme, host, port, path string) string {
+	url := fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+	response, err := http.Get(url)
+
+	if err == nil {
+		defer response.Body.Close()
+		contents, _ := ioutil.ReadAll(response.Body)
+		//fmt.Fprintf(w, "Querying %s got response %s", url, string(contents))
+		return string(contents)
+	} else {
+		return "{error}"
+	}
+}
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/name", nameHandler)
+	r.HandleFunc("/hostname", hostnameHandler)
+	r.HandleFunc("/env/{var}", envHandler)
+	r.HandleFunc("/shutdown", shutdownHandler)
+	r.HandleFunc("/fail", failHandler)
+	r.HandleFunc("/fail/{exitcode}", failHandler)
+	r.HandleFunc("/shutdown/{delay}", shutdownHandler)
+	r.HandleFunc("/redirect/{scheme}/{host}/{port}/{path}", redirectHandler)
+	r.HandleFunc("/chainredirect/{scheme}/{chainPath}", chainRedirectHandler)
+	r.HandleFunc("/get/{key}", getHandler)
+	r.HandleFunc("/delete/{key}", deleteHandler)
+	r.HandleFunc("/put/{key}/{value}", putHandler)
+	r.HandleFunc("/contains/{key}", containsHandler)
+	r.HandleFunc("/keys", keysHandler)
+
+	// glog package need flag parsing.
+	flag.Parse()
+
+	glog.Infof("Started %s, serving at %s\n", server.Name, server.Port)
+
+	http.Handle("/", r)
+	err := http.ListenAndServe(fmt.Sprintf(":%s", server.Port), r)
+	if err != nil {
+		glog.Fatalf("ListenAndServe: " + err.Error())
+	}
+}

--- a/test/mock-app/.gitignore
+++ b/test/mock-app/.gitignore
@@ -1,0 +1,1 @@
+mock-app

--- a/test/mock-app/Dockerfile
+++ b/test/mock-app/Dockerfile
@@ -1,0 +1,21 @@
+#
+# This is a mock pod used to facilitate inter/intra communication 
+# It contains a mockserver that has usefull primitives as REST API
+#
+# - /name              : return the "functional name" of the mockpod             
+# - /put/{key}/{value} : put a value for a key                                   
+# - /get/{key}         : get a value for gey . send error if key is not present. 
+# - /contains/{key}    : tell if it contains a given key                         
+# - /send/{message}    : will send a get message another pod via an url.         
+# - /listkeys          : will list all the keys                                  
+# - /kill              : will terminate the server so the pod.
+# 
+# The standard name for this image is openshift/mock-app
+#
+FROM scratch
+
+ADD bin/mock-app /mock-app
+
+EXPOSE 8080
+
+CMD ["/mock-app" , "-logtostderr"]

--- a/test/mock-app/README.md
+++ b/test/mock-app/README.md
@@ -1,0 +1,174 @@
+Mock
+----
+
+# Overview
+
+The origin/mock is a docker image that is built during 'make release'.
+Its main purpose is to have a flexible component that can safely be
+used and asserted in tests and that have an expected behaviour:
+
+- CRUD on key/value,
+- name/hostname
+- shutdown,
+- simple redirect
+- chaining call concept 
+
+The server must have MOCK_NAME as env variable that will contains
+the name of the server otherwise it raise a panic.
+
+By default the server serves on the port 8080. By setting environment
+variable MOCK_PORT to another port the server will use this particular
+port.
+
+# Server spawning
+
+Although this server is expected to run as docker container you can
+run it this way:
+
+    $ cd test/mock-app
+    $ MOCK_NAME=mock1 go run server.go -logtostderr
+    Started mock1, serving at 8080
+
+Starting a second server:
+
+    $ MOCK_NAME=mock2 MOCK_PORT=8081 go run server.go -logtostderr
+    Started mock2, serving at 8081
+    
+# API
+
+## /name
+
+Returns the name of the server
+
+    $ curl http://localhost:8080/name
+    mock1
+    
+    $ curl http://localhost:8081/name
+    mock2
+
+## /put/{key}/{value}
+
+Puts the value "value" under the key {key}. Always returns ok.
+
+    $ curl http://localhost:8080/put/k1/value1
+    ok
+    $ curl http://localhost:8080/put/k2/value2
+    ok
+    $ curl http://localhost:8080/put/k3/value3
+    ok
+
+## /contains/{key}
+
+Returns "ok" if the server contains {key}, "ko" otherwise.
+
+    $ curl http://localhost:8080/contains/k1
+    ok
+     
+    $ curl http://localhost:8081/contains/k1
+    ko
+     
+## /get/{key}
+
+Returns the value behind the key {key}, empty string if there is no
+value for this key.
+
+    $ curl http://localhost:8080/get/k1
+    value1
+
+    $ curl http://localhost:8081/get/k1
+    ""           <-- empty string without "
+
+## /keys
+
+Returns all the keys
+
+   $ curl http://localhost:8080/keys
+   k1
+   k2
+   k3
+
+## /delete/{key}
+
+Deletes the entry where key {key} is stored. Returns "ok" if deletion occurs, "ko" if not.
+
+    $  curl http://localhost:8080/delete/k2
+    ok
+    
+    $  curl http://localhost:8080/delete/k2
+    ko
+    
+## /redirect/{scheme}/{host}/{port}/{path}
+
+This redirects the contents of the url {scheme}://{host}:{port}/{path} 
+
+    $ curl http://localhost:8080/redirect/http/localhost/8081/name
+    Querying http://localhost:8081/name got response mock2
+
+## /env/{var}
+
+This returns the value of the environment variable {var} on the
+server. Returns "" (empty string if {var} does not exist.
+
+    $ curl http://localhost:8080/env/MOCK_NAME
+    mock1
+    
+    $ curl http://localhost:8080/env/SHELL
+    /bin/shell
+    
+
+## /shutdown
+
+This kills the server itself immediatly.
+
+## /shutdown/{delay}
+
+This kills the server itself in a delay of {delay} seconds.
+
+## /chainredirect/{scheme}/{chainPath}
+
+Chain Redirect is /redirect on steroids, it allows communication
+scheme between several mock servers and returns the concatenation of
+all calls. For instance:
+
+- mock1 calls mock2/name,
+- mock2 calls mock1/put/k1/newvalue
+- mock1 calls mock1/get/k1
+
+the output will be:
+
+    mock2
+    ok
+    newvalue
+
+### {scheme}
+
+Scheme is the protocol that is use for all communications. For now:
+http 
+
+### {chainPath} format explained
+
+    (host "_" port "_" path) ("-" (host "_" port "_" path))+
+
+where 'path' itself can be composed with '_' in between like
+
+    "put_k1_v1"
+    
+For instance
+
+    localhost_8081_name-localhost_8080_put_k1_v1
+    
+is a valid chainPath. In command line, this gives:
+
+    $ curl http://localhost:8080/chainredirect/http/localhost_8081_name-localhost_8080_put_k1_v1
+    mock2
+    ok
+
+curl calls mock1 initiating chainredirect, mock1 calls mock2 name then
+mock2 calls mock1 put/k1/v1. This can be as long as GET allows it.
+
+We can shutdown all the servers with this command line
+
+    $ http://localhost:8080/chainredirect/http/localhost_8081_shutdown_2-localhost_8080_shutdown_2
+    ok
+    ok
+

--- a/test/mock-app/bin/.gitignore
+++ b/test/mock-app/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/mock-app/server.go
+++ b/test/mock-app/server.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+	"github.com/openshift/origin/pkg/cmd/util"
+)
+
+type Server struct {
+	Name     string
+	Port     string
+	Hostname string
+	Data     map[string]string
+}
+
+var server Server
+
+func init() {
+
+	// name of the mock server
+	name := util.Env("MOCK_NAME", "")
+
+	// port of the mock server
+	port := util.Env("MOCK_PORT", "8080")
+
+	hostname, _ := os.Hostname()
+
+	// initialize the new server
+	server = newServer(name, hostname, port)
+}
+
+func newServer(name, hostname, port string) Server {
+
+	if name == "" || len(strings.TrimSpace(name)) == 0 {
+		glog.Fatalf("This server must have a name, found in MOCK_NAME env variable")
+	}
+
+	if port == "" || len(strings.TrimSpace(port)) == 0 {
+		port = "8080"
+	}
+
+	data := make(map[string]string)
+
+	_server := Server{Name: name, Hostname: hostname, Port: port, Data: data}
+
+	return _server
+
+}
+
+func shutdownHandler(w http.ResponseWriter, r *http.Request) {
+
+	p := mux.Vars(r)
+
+	// delay
+	delayStr := p["delay"]
+	delay, err := strconv.Atoi(delayStr)
+	if err != nil {
+		delay = 0
+	}
+
+	fmt.Fprintln(w, "ok")
+
+	// flush before shutdown
+	f, ok := w.(http.Flusher)
+	if ok && f != nil {
+		f.Flush()
+	}
+
+	timer := time.NewTimer(time.Second * time.Duration(delay))
+	glog.Infof("%s will shutdown in %d second(s)\n", server.Name, delay)
+	go func() {
+		<-timer.C
+		glog.Infof("%s stopping now.\n", server.Name)
+		os.Exit(0)
+	}()
+}
+
+func nameHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, server.Name)
+}
+
+func hostnameHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, server.Hostname)
+}
+
+func envHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+
+	key := p["var"]
+	v := util.Env(key, "")
+
+	fmt.Fprintln(w, v)
+}
+
+func putHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+
+	key := p["key"]
+	value := p["value"]
+
+	server.Data[key] = value
+
+	fmt.Fprintln(w, "ok")
+}
+
+func getHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	key := p["key"]
+
+	value, _ := server.Data[key]
+
+	fmt.Fprintln(w, value)
+}
+
+func deleteHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	key := p["key"]
+
+	_, z := server.Data[key]
+	if z {
+		delete(server.Data, key)
+		fmt.Fprintln(w, "ok")
+	} else {
+		fmt.Fprintln(w, "ko")
+	}
+}
+
+func containsHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+	key := p["key"]
+
+	_, z := server.Data[key]
+
+	if z {
+		fmt.Fprintln(w, "ok")
+	} else {
+		fmt.Fprintln(w, "ko")
+	}
+}
+
+func keysHandler(w http.ResponseWriter, r *http.Request) {
+
+	for k := range server.Data {
+		fmt.Fprintln(w, k)
+	}
+}
+
+func redirectHandler(w http.ResponseWriter, r *http.Request) {
+
+	p := mux.Vars(r)
+
+	scheme := p["scheme"]
+	host := p["host"]
+	port := p["port"]
+	path := p["path"]
+
+	if scheme == "" {
+		scheme = "http"
+	}
+
+	if port == "" {
+		port = "8080"
+	}
+
+	if path == "" {
+		path = ""
+	} else {
+		path = fmt.Sprintf("/%s", path)
+	}
+
+	doRedirect(scheme, host, port, path, w)
+}
+
+// http://localhost:8080/chainredirect/http/localhost_8080_name-localhost_8080_contains_k1
+//                                     ^
+//                                     |scheme
+//
+func chainRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	p := mux.Vars(r)
+
+	chainPath := p["chainPath"]
+	scheme := p["scheme"]
+
+	chainPathArr := strings.Split(chainPath, "-")
+
+	if len(chainPathArr) > 0 {
+
+		currentLinkArr := strings.Split(chainPathArr[0], "_")
+
+		if len(currentLinkArr) >= 3 {
+			host := currentLinkArr[0]
+			port := currentLinkArr[1]
+
+			var pathArr = make([]string, len(currentLinkArr)-2)
+
+			for i := 2; i < len(currentLinkArr); i++ {
+
+				pathArr[i-2] = currentLinkArr[i]
+
+			}
+
+			path := strings.Join(pathArr, "/")
+
+			if scheme == "" {
+				scheme = "http"
+			}
+			if port == "" {
+				port = "8080"
+			}
+
+			if path == "" {
+				path = ""
+			} else {
+				path = fmt.Sprintf("/%s", path)
+			}
+
+			// call the action
+			back := doCall(scheme, host, port, path)
+
+			// then continue the chain
+			if len(chainPathArr) > 1 {
+				idx := strings.Index(chainPath, "-")
+				nextLink := chainPath[idx+1:]
+				chainRedirect := fmt.Sprintf("/chainredirect/%s/%s", scheme, nextLink)
+				recursiveBack := doCall(scheme, host, port, chainRedirect)
+				back = fmt.Sprintf("%s%s", back, recursiveBack)
+			}
+
+			fmt.Fprintf(w, back)
+		}
+	}
+}
+
+func doRedirect(scheme, host, port, path string, w http.ResponseWriter) {
+	url := fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+
+	response, err := http.Get(url)
+
+	if err == nil {
+		defer response.Body.Close()
+		contents, _ := ioutil.ReadAll(response.Body)
+		fmt.Fprintf(w, "Querying %s got response %s", url, string(contents))
+	}
+}
+
+func doCall(scheme, host, port, path string) string {
+	url := fmt.Sprintf("%s://%s:%s%s", scheme, host, port, path)
+	response, err := http.Get(url)
+
+	if err == nil {
+		defer response.Body.Close()
+		contents, _ := ioutil.ReadAll(response.Body)
+		//fmt.Fprintf(w, "Querying %s got response %s", url, string(contents))
+		return string(contents)
+	} else {
+		return "{error}"
+	}
+}
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/name", nameHandler)
+	r.HandleFunc("/hostname", hostnameHandler)
+	r.HandleFunc("/env/{var}", envHandler)
+	r.HandleFunc("/shutdown", shutdownHandler)
+	r.HandleFunc("/shutdown/{delay}", shutdownHandler)
+	r.HandleFunc("/redirect/{scheme}/{host}/{port}/{path}", redirectHandler)
+	r.HandleFunc("/chainredirect/{scheme}/{chainPath}", chainRedirectHandler)
+	r.HandleFunc("/get/{key}", getHandler)
+	r.HandleFunc("/delete/{key}", deleteHandler)
+	r.HandleFunc("/put/{key}/{value}", putHandler)
+	r.HandleFunc("/contains/{key}", containsHandler)
+	r.HandleFunc("/keys", keysHandler)
+
+	// glog package need flag parsing.
+	flag.Parse()
+
+	glog.Infof("Started %s, serving at %s\n", server.Name, server.Port)
+
+	http.Handle("/", r)
+	err := http.ListenAndServe(fmt.Sprintf(":%s", server.Port), r)
+	if err != nil {
+		glog.Fatalf("ListenAndServe: " + err.Error())
+	}
+}


### PR DESCRIPTION
Tests using openshift/mock-app to show some of its usage.
The test is in `hack/mock-based-tests.sh` sourced from `hack/test-end-to-end.sh`
Was asked for https://github.com/openshift/origin/pull/1903

- access container in the pod then putting a value in its memory
- kill the pod via a mock command
- assert that the container in the pod is coming back.
- assert the value set in the pod is not there anymore because a new container has been created

- setting the replicas to 3
- preparing intra pod communication via the mock app
- getting hostnames via a mock command asking via the endpoints
- getting hostnames via intra pod containers communication, each container asking its sibling.
- comparing both

What else can be done easily
- Assertions against DeploymentConfig on ConfigChange : ensure env variable is well changed
- inter pods communivation : ensure all containers of one pod well access all containers of another pods
- if I upgrade the mock app to be able to write on disk, we will be able to test persistent volume as well.
- etc