### PR TITLE
Disable QPS for internal API client

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -151,6 +151,11 @@ func GetKubeClient(kubeConfigFile string) (*kclient.Client, *kclient.Config, err
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// This is an internal client which is shared by most controllers, so turn off QPS limiting
+	// TODO: make QPS/Burst configurable
+	kubeConfig.QPS = -1
+
 	kubeConfig.WrapTransport = DefaultClientTransport
 	kubeClient, err := kclient.New(kubeConfig)
 	if err != nil {


### PR DESCRIPTION
hack/test-integration.sh runs on my laptop:

Before:
```
real 16m35.476s
user 5m36.344s
sys  0m10.220s
```

After:
```
real	7m9.585s
user	5m14.172s
sys	0m6.847s
```