### PR TITLE
Add EmptyDir volumes for new-app containers

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -14,6 +14,7 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/conversion"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/fsouza/go-dockerclient"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -355,7 +356,22 @@ func (r *ImageRef) DeployableContainer() (container *kapi.Container, triggers []
 				Protocol:      kapi.Protocol(strings.ToUpper(p.Proto())),
 			})
 		}
-		// TODO: Append volume information and environment variables
+
+		// Create volume mounts with names based on container name
+		infix := "-volume-"
+		maxDigits := len(fmt.Sprintf("%d", len(r.Info.Config.Volumes)))
+		baseLen := util.LabelValueMaxLength - maxDigits - len(infix)
+		nameBase := fmt.Sprintf("%.*s%s", baseLen, container.Name, infix)
+		i := 1
+		for volume := range r.Info.Config.Volumes {
+			container.VolumeMounts = append(container.VolumeMounts, kapi.VolumeMount{
+				Name:      fmt.Sprintf("%s%d", nameBase, i),
+				ReadOnly:  false,
+				MountPath: volume,
+			})
+			i++
+		}
+		// TODO: Append environment variables
 	}
 
 	return container, triggers, nil
@@ -446,7 +462,18 @@ func (r *DeploymentConfigRef) DeploymentConfig() (*deployapi.DeploymentConfig, e
 		triggers = append(triggers, containerTriggers...)
 		template.Containers = append(template.Containers, *c)
 	}
-	// TODO: populate volumes
+
+	// Create EmptyDir volumes for all container volume mounts
+	for _, c := range template.Containers {
+		for _, v := range c.VolumeMounts {
+			template.Volumes = append(template.Volumes, kapi.Volume{
+				Name: v.Name,
+				VolumeSource: kapi.VolumeSource{
+					EmptyDir: &kapi.EmptyDirVolumeSource{Medium: kapi.StorageMediumDefault},
+				},
+			})
+		}
+	}
 
 	for i := range template.Containers {
 		template.Containers[i].Env = append(template.Containers[i].Env, r.Env.List()...)

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -594,6 +594,42 @@ func TestRunAll(t *testing.T) {
 			expectedErr:    nil,
 			expectInsecure: util.NewStringSet("example"),
 		},
+		{
+			name: "emptyDir volumes",
+			config: &AppConfig{
+				DockerImages: util.StringList{"mysql"},
+
+				dockerResolver: dockerResolver,
+				imageStreamResolver: app.ImageStreamResolver{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				templateResolver: app.TemplateResolver{
+					Client: &client.Fake{},
+					TemplateConfigsNamespacer: &client.Fake{},
+					Namespaces:                []string{"openshift", "default"},
+				},
+
+				detector: app.SourceRepositoryEnumerator{
+					Detectors: source.DefaultDetectors,
+					Tester:    dockerfile.NewTester(),
+				},
+				searcher:        &simpleSearcher{dockerResolver},
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+			},
+
+			expected: map[string][]string{
+				"imageStream":      {"mysql"},
+				"deploymentConfig": {"mysql"},
+				"service":          {"mysql"},
+				"volumes":          {"mysql-volume-1♥EmptyDir"},
+				"volumeMounts":     {"mysql-volume-1"},
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, test := range tests {
@@ -615,6 +651,22 @@ func TestRunAll(t *testing.T) {
 				imageStreams = append(imageStreams, tp)
 			case *deploy.DeploymentConfig:
 				got["deploymentConfig"] = append(got["deploymentConfig"], tp.Name)
+				if podTemplate := tp.Template.ControllerTemplate.Template; podTemplate != nil {
+					for _, volume := range podTemplate.Spec.Volumes {
+						var srcType string
+						if volume.VolumeSource.EmptyDir != nil {
+							srcType = "EmptyDir"
+						} else {
+							srcType = "UNKNOWN"
+						}
+						got["volumes"] = append(got["volumes"], volume.Name+"♥"+srcType)
+					}
+					for _, container := range podTemplate.Spec.Containers {
+						for _, volumeMount := range container.VolumeMounts {
+							got["volumeMounts"] = append(got["volumeMounts"], volumeMount.Name)
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Modifies new-app so it defines volumes and volume mounts for containers based on volumes defined in docker images. Created volume sources are EmptyDir. Currently, the naming scheme is "containerName-volume-1".

For this to work and not break new-app with our images, #3037 must be merged first.

Example with json modified for brevity:
```
$ osc new-app --docker-image=openshift/mysql-55-centos7 -o json
{
    "kind": "List",
    "apiVersion": "v1",
    "metadata": {},
    "items": [
        {
            "kind": "DeploymentConfig",
            "apiVersion": "v1",
            "metadata": {
                "name": "mysql-55-centos7",
                "creationTimestamp": null
            },
            "spec": {
                "template": {
                    "spec": {
                        "volumes": [
                            {
                                "name": "mysql-55-centos7-volume-1",
                                "emptyDir": {},
                                "rbd": null
                            }
                        ],
                        "containers": [
                            {
                                "name": "mysql-55-centos7",
                                "image": "openshift/mysql-55-centos7:latest",
                                "volumeMounts": [
                                    {
                                        "name": "mysql-55-centos7-volume-1",
                                        "mountPath": "/var/lib/mysql/data"
                                    }
                                ]
                            }
                        ]
                    }
                }
            },
        }
    ]
}
```

Fixes #2929 