### PR TITLE
Force update validation

### DIFF
--- a/pkg/api/validation/coverage_test.go
+++ b/pkg/api/validation/coverage_test.go
@@ -26,13 +26,9 @@ var KnownValidationExceptions = []reflect.Type{
 // MissingValidationExceptions is the list of types that were missing validation methods when I started
 // You should never add to this list
 var MissingValidationExceptions = []reflect.Type{
-	reflect.TypeOf(&buildapi.BuildLogOptions{}),              // TODO, looks like this one should have validation
-	reflect.TypeOf(&buildapi.BuildLog{}),                     // TODO, I have no idea what this is doing
-	reflect.TypeOf(&buildapi.BuildRequest{}),                 // TODO, looks to be used internally, but needs review
-	reflect.TypeOf(&imageapi.ImageStreamMapping{}),           // TODO, looks like this one should have validation
-	reflect.TypeOf(&imageapi.DockerImage{}),                  // TODO, I think this type is ok to skip validation (internal), but needs review
-	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),  // TODO, this one should have validation
-	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}), // TODO, this one should have validation
+	reflect.TypeOf(&buildapi.BuildLogOptions{}), // TODO, looks like this one should have validation
+	reflect.TypeOf(&buildapi.BuildLog{}),        // TODO, I have no idea what this is doing
+	reflect.TypeOf(&imageapi.DockerImage{}),     // TODO, I think this type is ok to skip validation (internal), but needs review
 }
 
 func TestCoverage(t *testing.T) {

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -25,6 +25,9 @@ import (
 )
 
 func init() {
+	Validator.Register(&authorizationapi.SubjectAccessReview{}, authorizationvalidation.ValidateSubjectAccessReview, nil)
+	Validator.Register(&authorizationapi.ResourceAccessReview{}, authorizationvalidation.ValidateResourceAccessReview, nil)
+
 	Validator.Register(&authorizationapi.Policy{}, authorizationvalidation.ValidateLocalPolicy, authorizationvalidation.ValidateLocalPolicyUpdate)
 	Validator.Register(&authorizationapi.PolicyBinding{}, authorizationvalidation.ValidateLocalPolicyBinding, authorizationvalidation.ValidateLocalPolicyBindingUpdate)
 	Validator.Register(&authorizationapi.Role{}, authorizationvalidation.ValidateLocalRole, authorizationvalidation.ValidateLocalRoleUpdate)
@@ -35,14 +38,16 @@ func init() {
 	Validator.Register(&authorizationapi.ClusterRole{}, authorizationvalidation.ValidateClusterRole, authorizationvalidation.ValidateClusterRoleUpdate)
 	Validator.Register(&authorizationapi.ClusterRoleBinding{}, authorizationvalidation.ValidateClusterRoleBinding, authorizationvalidation.ValidateClusterRoleBindingUpdate)
 
-	Validator.Register(&buildapi.Build{}, buildvalidation.ValidateBuild, nil)
-	Validator.Register(&buildapi.BuildConfig{}, buildvalidation.ValidateBuildConfig, nil)
+	Validator.Register(&buildapi.Build{}, buildvalidation.ValidateBuild, buildvalidation.ValidateBuildUpdate)
+	Validator.Register(&buildapi.BuildConfig{}, buildvalidation.ValidateBuildConfig, buildvalidation.ValidateBuildConfigUpdate)
+	Validator.Register(&buildapi.BuildRequest{}, buildvalidation.ValidateBuildRequest, nil)
 
 	Validator.Register(&deployapi.DeploymentConfig{}, deployvalidation.ValidateDeploymentConfig, deployvalidation.ValidateDeploymentConfigUpdate)
 	Validator.Register(&deployapi.DeploymentConfigRollback{}, deployvalidation.ValidateDeploymentConfigRollback, nil)
 
 	Validator.Register(&imageapi.Image{}, imagevalidation.ValidateImage, nil)
 	Validator.Register(&imageapi.ImageStream{}, imagevalidation.ValidateImageStream, imagevalidation.ValidateImageStreamUpdate)
+	Validator.Register(&imageapi.ImageStreamMapping{}, imagevalidation.ValidateImageStreamMapping, nil)
 
 	Validator.Register(&oauthapi.OAuthAccessToken{}, oauthvalidation.ValidateAccessToken, nil)
 	Validator.Register(&oauthapi.OAuthAuthorizeToken{}, oauthvalidation.ValidateAuthorizeToken, nil)
@@ -52,7 +57,7 @@ func init() {
 	Validator.Register(&projectapi.Project{}, projectvalidation.ValidateProject, projectvalidation.ValidateProjectUpdate)
 	Validator.Register(&projectapi.ProjectRequest{}, projectvalidation.ValidateProjectRequest, nil)
 
-	Validator.Register(&routeapi.Route{}, routevalidation.ValidateRoute, nil)
+	Validator.Register(&routeapi.Route{}, routevalidation.ValidateRoute, routevalidation.ValidateRouteUpdate)
 
 	Validator.Register(&sdnapi.ClusterNetwork{}, sdnvalidation.ValidateClusterNetwork, sdnvalidation.ValidateClusterNetworkUpdate)
 	Validator.Register(&sdnapi.HostSubnet{}, sdnvalidation.ValidateHostSubnet, sdnvalidation.ValidateHostSubnetUpdate)

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -25,10 +25,15 @@ type RuntimeObjectsValidator struct {
 }
 
 type RuntimeObjectValidatorInfo struct {
-	validator     RuntimeObjectValidator
-	isNamespaced  bool
-	hasObjectMeta bool
-	updateAllowed bool
+	Validator     RuntimeObjectValidator
+	IsNamespaced  bool
+	HasObjectMeta bool
+	UpdateAllowed bool
+}
+
+func (v *RuntimeObjectsValidator) GetInfo(obj runtime.Object) (RuntimeObjectValidatorInfo, bool) {
+	ret, ok := v.typeToValidator[reflect.TypeOf(obj)]
+	return ret, ok
 }
 
 func (v *RuntimeObjectsValidator) Register(obj runtime.Object, validateFunction interface{}, validateUpdateFunction interface{}) error {
@@ -67,7 +72,7 @@ func (v *RuntimeObjectsValidator) Validate(obj runtime.Object) fielderrors.Valid
 		return allErrs
 	}
 
-	allErrs = append(allErrs, specificValidationInfo.validator.Validate(obj)...)
+	allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
 	return allErrs
 }
 
@@ -87,11 +92,11 @@ func (v *RuntimeObjectsValidator) ValidateUpdate(obj, old runtime.Object) fielde
 		return allErrs
 	}
 
-	allErrs = append(allErrs, specificValidationInfo.validator.ValidateUpdate(obj, old)...)
+	allErrs = append(allErrs, specificValidationInfo.Validator.ValidateUpdate(obj, old)...)
 
 	// no errors so far, make sure that the new object is actually valid against the original validator
 	if len(allErrs) == 0 {
-		allErrs = append(allErrs, specificValidationInfo.validator.Validate(obj)...)
+		allErrs = append(allErrs, specificValidationInfo.Validator.Validate(obj)...)
 	}
 
 	return allErrs

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestNameFunc(t *testing.T) {
 	for apiType, validationInfo := range Validator.typeToValidator {
-		if !validationInfo.hasObjectMeta {
+		if !validationInfo.HasObjectMeta {
 			continue
 		}
 
@@ -28,7 +28,7 @@ func TestNameFunc(t *testing.T) {
 		for _, illegalName := range api.NameMayNotBe {
 			apiObjectMeta.Set(reflect.ValueOf(kapi.ObjectMeta{Name: illegalName}))
 
-			errList := validationInfo.validator.Validate(apiValue.Interface().(runtime.Object))
+			errList := validationInfo.Validator.Validate(apiValue.Interface().(runtime.Object))
 			_, requiredMessage := api.MinimalNameRequirements(illegalName, false)
 
 			if len(errList) == 0 {
@@ -65,7 +65,7 @@ func TestNameFunc(t *testing.T) {
 
 			apiObjectMeta.Set(reflect.ValueOf(kapi.ObjectMeta{Name: illegalName}))
 
-			errList := validationInfo.validator.Validate(apiValue.Interface().(runtime.Object))
+			errList := validationInfo.Validator.Validate(apiValue.Interface().(runtime.Object))
 			_, requiredMessage := api.MinimalNameRequirements(illegalName, false)
 
 			if len(errList) == 0 {
@@ -99,21 +99,21 @@ func TestNameFunc(t *testing.T) {
 
 func TestObjectMeta(t *testing.T) {
 	for apiType, validationInfo := range Validator.typeToValidator {
-		if !validationInfo.hasObjectMeta {
+		if !validationInfo.HasObjectMeta {
 			continue
 		}
 
 		apiValue := reflect.New(apiType.Elem())
 		apiObjectMeta := apiValue.Elem().FieldByName("ObjectMeta")
 
-		if validationInfo.isNamespaced {
+		if validationInfo.IsNamespaced {
 			apiObjectMeta.Set(reflect.ValueOf(kapi.ObjectMeta{Name: getValidName(apiType)}))
 		} else {
 			apiObjectMeta.Set(reflect.ValueOf(kapi.ObjectMeta{Name: getValidName(apiType), Namespace: kapi.NamespaceDefault}))
 		}
 
-		errList := validationInfo.validator.Validate(apiValue.Interface().(runtime.Object))
-		requiredErrors := validation.ValidateObjectMeta(apiObjectMeta.Addr().Interface().(*kapi.ObjectMeta), validationInfo.isNamespaced, api.MinimalNameRequirements).Prefix("metadata")
+		errList := validationInfo.Validator.Validate(apiValue.Interface().(runtime.Object))
+		requiredErrors := validation.ValidateObjectMeta(apiObjectMeta.Addr().Interface().(*kapi.ObjectMeta), validationInfo.IsNamespaced, api.MinimalNameRequirements).Prefix("metadata")
 
 		if len(errList) == 0 {
 			t.Errorf("expected errors %v in %v not found amongst %v.  You probably need to call kube/validation.ValidateObjectMeta in your validator.", requiredErrors, apiType.Elem(), errList)
@@ -164,10 +164,10 @@ func getValidName(apiType reflect.Type) string {
 // 4. mismatched UID
 func TestObjectMetaUpdate(t *testing.T) {
 	for apiType, validationInfo := range Validator.typeToValidator {
-		if !validationInfo.hasObjectMeta {
+		if !validationInfo.HasObjectMeta {
 			continue
 		}
-		if !validationInfo.updateAllowed {
+		if !validationInfo.UpdateAllowed {
 			continue
 		}
 
@@ -183,7 +183,7 @@ func TestObjectMetaUpdate(t *testing.T) {
 		newObj := newAPIValue.Interface().(runtime.Object)
 		newObjMeta := newAPIObjectMeta.Addr().Interface().(*kapi.ObjectMeta)
 
-		errList := validationInfo.validator.ValidateUpdate(newObj, oldObj)
+		errList := validationInfo.Validator.ValidateUpdate(newObj, oldObj)
 		requiredErrors := validation.ValidateObjectMetaUpdate(newObjMeta, oldObjMeta).Prefix("metadata")
 
 		if len(errList) == 0 {

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -9,6 +9,32 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
+func ValidateSubjectAccessReview(review *authorizationapi.SubjectAccessReview) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(review.Verb) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("verb"))
+	}
+	if len(review.Resource) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("resource"))
+	}
+
+	return allErrs
+}
+
+func ValidateResourceAccessReview(review *authorizationapi.ResourceAccessReview) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(review.Verb) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("verb"))
+	}
+	if len(review.Resource) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("resource"))
+	}
+
+	return allErrs
+}
+
 func ValidatePolicyName(name string, prefix bool) (bool, string) {
 	if ok, reason := oapi.MinimalNameRequirements(name, prefix); !ok {
 		return ok, reason

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -5,8 +5,10 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutilerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationvalidation "github.com/openshift/origin/pkg/authorization/api/validation"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 )
 
@@ -30,6 +32,9 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	resourceAccessReview, ok := obj.(*authorizationapi.ResourceAccessReview)
 	if !ok {
 		return nil, fmt.Errorf("not a resourceAccessReview: %#v", obj)
+	}
+	if err := kutilerrors.NewAggregate(authorizationvalidation.ValidateResourceAccessReview(resourceAccessReview)); err != nil {
+		return nil, err
 	}
 
 	namespace := kapi.NamespaceValue(ctx)

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -7,8 +7,10 @@ import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	kutilerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/util/errors"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationvalidation "github.com/openshift/origin/pkg/authorization/api/validation"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 )
 
@@ -32,6 +34,9 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	subjectAccessReview, ok := obj.(*authorizationapi.SubjectAccessReview)
 	if !ok {
 		return nil, fmt.Errorf("not a subjectAccessReview: %#v", obj)
+	}
+	if err := kutilerrors.NewAggregate(authorizationvalidation.ValidateSubjectAccessReview(subjectAccessReview)); err != nil {
+		return nil, err
 	}
 
 	var userToCheck user.Info

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -22,6 +22,14 @@ func ValidateBuild(build *buildapi.Build) fielderrors.ValidationErrorList {
 	return allErrs
 }
 
+func ValidateBuildUpdate(build *buildapi.Build, older *buildapi.Build) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&build.ObjectMeta, &older.ObjectMeta).Prefix("metadata")...)
+
+	allErrs = append(allErrs, ValidateBuild(build)...)
+	return allErrs
+}
+
 // ValidateBuildConfig tests required fields for a Build.
 func ValidateBuildConfig(config *buildapi.BuildConfig) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
@@ -40,6 +48,14 @@ func ValidateBuildConfig(config *buildapi.BuildConfig) fielderrors.ValidationErr
 	}
 	allErrs = append(allErrs, validateBuildParameters(&config.Parameters).Prefix("parameters")...)
 	allErrs = append(allErrs, validateBuildConfigOutput(&config.Parameters.Output).Prefix("parameters.output")...)
+	return allErrs
+}
+
+func ValidateBuildConfigUpdate(config *buildapi.BuildConfig, older *buildapi.BuildConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&config.ObjectMeta, &older.ObjectMeta).Prefix("metadata")...)
+
+	allErrs = append(allErrs, ValidateBuildConfig(config)...)
 	return allErrs
 }
 

--- a/pkg/build/registry/build/strategy.go
+++ b/pkg/build/registry/build/strategy.go
@@ -75,8 +75,7 @@ func (strategy) Validate(ctx kapi.Context, obj runtime.Object) fielderrors.Valid
 
 // ValidateUpdate is the default update validation for an end user.
 func (strategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
-	// TODO: distinguish updates from create, for now, this is preserving old implementation behavior
-	return validation.ValidateBuild(obj.(*api.Build))
+	return validation.ValidateBuildUpdate(obj.(*api.Build), old.(*api.Build))
 }
 
 // CheckGracefulDelete allows a build to be gracefully deleted.

--- a/pkg/build/registry/build/strategy_test.go
+++ b/pkg/build/registry/build/strategy_test.go
@@ -45,6 +45,8 @@ func TestBuildStrategy(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
+
+	build.ResourceVersion = "foo"
 	errs = Strategy.ValidateUpdate(ctx, build, build)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)

--- a/pkg/build/registry/buildconfig/strategy.go
+++ b/pkg/build/registry/buildconfig/strategy.go
@@ -49,8 +49,7 @@ func (strategy) Validate(ctx kapi.Context, obj runtime.Object) fielderrors.Valid
 
 // ValidateUpdate is the default update validation for an end user.
 func (strategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) fielderrors.ValidationErrorList {
-	// TODO: distinguish updates from create, for now, this is preserving old implementation behavior
-	return validation.ValidateBuildConfig(obj.(*api.BuildConfig))
+	return validation.ValidateBuildConfigUpdate(obj.(*api.BuildConfig), old.(*api.BuildConfig))
 }
 
 // Matcher returns a generic matcher for a given label and field selector.

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -40,6 +40,8 @@ func TestBuildConfigStrategy(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
+
+	buildConfig.ResourceVersion = "foo"
 	errs = Strategy.ValidateUpdate(ctx, buildConfig, buildConfig)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -158,7 +158,7 @@ func (fn APIInstallFunc) InstallAPI(container *restful.Container) []string {
 	return fn(container)
 }
 
-func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []string {
+func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	defaultRegistry := env("OPENSHIFT_DEFAULT_REGISTRY", "${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT}")
 	svcCache := service.NewServiceResolverCache(c.KubeClient().Services(api.NamespaceDefault).Get)
 	defaultRegistryFunc, err := svcCache.Defer(defaultRegistry)
@@ -269,7 +269,6 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		},
 	)
 
-	// initialize OpenShift API
 	storage := map[string]rest.Storage{
 		"builds":                   buildStorage,
 		"buildConfigs":             buildConfigStorage,
@@ -322,6 +321,13 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		"clusterRoleBindings":   clusterRoleBindingStorage,
 		"clusterRoles":          clusterRoleStorage,
 	}
+
+	return storage
+}
+
+func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []string {
+	// initialize OpenShift API
+	storage := c.GetRestStorage()
 
 	messages := []string{}
 	legacyAPIVersions := []string{}

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -1,0 +1,46 @@
+package origin
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/rest"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
+	"github.com/openshift/origin/pkg/api/validation"
+)
+
+// TestValidationRegistration makes sure that any RESTStorage that allows create or update has the correct validation register.
+// It doesn't guarantee that it's actually called, but it does guarantee that it at least exists
+func TestValidationRegistration(t *testing.T) {
+	config := &MasterConfig{
+		KubeletClientConfig: &kclient.KubeletConfig{},
+	}
+
+	storageMap := config.GetRestStorage()
+	for key, storage := range storageMap {
+		obj := storage.New()
+		kindType := reflect.TypeOf(obj)
+
+		validationInfo, validatorExists := validation.Validator.GetInfo(obj)
+
+		if _, ok := storage.(rest.Creater); ok {
+			// if we're a creater, then we must have a validate method registered
+			if !validatorExists {
+				t.Errorf("No validator registered for %v (used by %v).  Register in pkg/api/validation/register.go.", kindType, key)
+			}
+		}
+
+		if _, ok := storage.(rest.Updater); ok {
+			// if we're an updater, then we must have a validateUpdate method registered
+			if !validatorExists {
+				t.Errorf("No validator registered for %v (used by %v).  Register in pkg/api/validation/register.go.", kindType, key)
+			}
+
+			if !validationInfo.UpdateAllowed {
+				t.Errorf("No validateUpdate method registered for %v (used by %v).  Register in pkg/api/validation/register.go.", kindType, key)
+			}
+		}
+
+	}
+}

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -105,6 +105,7 @@ func ValidateImageStreamStatusUpdate(newStream, oldStream *api.ImageStream) fiel
 // ValidateImageStreamMapping tests required fields for an ImageStreamMapping.
 func ValidateImageStreamMapping(mapping *api.ImageStreamMapping) fielderrors.ValidationErrorList {
 	result := fielderrors.ValidationErrorList{}
+	result = append(result, validation.ValidateObjectMeta(&mapping.ObjectMeta, true, oapi.MinimalNameRequirements).Prefix("metadata")...)
 
 	hasRepository := len(mapping.DockerImageRepository) != 0
 	hasName := len(mapping.Name) != 0

--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	kval "github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
@@ -39,6 +40,14 @@ func ValidateRoute(route *routeapi.Route) fielderrors.ValidationErrorList {
 	}
 
 	return result
+}
+
+func ValidateRouteUpdate(route *routeapi.Route, older *routeapi.Route) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&route.ObjectMeta, &older.ObjectMeta).Prefix("metadata")...)
+
+	allErrs = append(allErrs, ValidateRoute(route)...)
+	return allErrs
 }
 
 // ValidateTLS tests fields for different types of TLS combinations are set.  Called

--- a/pkg/route/registry/route/rest.go
+++ b/pkg/route/registry/route/rest.go
@@ -121,7 +121,11 @@ func (rs *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bo
 		return nil, false, errors.NewConflict("route", route.Namespace, fmt.Errorf("Route.Namespace does not match the provided context"))
 	}
 
-	if errs := validation.ValidateRoute(route); len(errs) > 0 {
+	old, err := rs.Get(ctx, route.Name)
+	if err != nil {
+		return nil, false, err
+	}
+	if errs := validation.ValidateRouteUpdate(route, old.(*api.Route)); len(errs) > 0 {
 		return nil, false, errors.NewInvalid("route", route.Name, errs)
 	}
 
@@ -129,7 +133,7 @@ func (rs *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bo
 	// TODO: Call ValidateRouteUpdate->ValidateObjectMetaUpdate
 	// TODO: In the UpdateStrategy.PrepareForUpdate, set the HostGeneratedAnnotationKey annotation to "false" if the updated route object modifies the host
 
-	err := rs.registry.UpdateRoute(ctx, route)
+	err = rs.registry.UpdateRoute(ctx, route)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3001
Fixes https://github.com/openshift/origin/issues/2822

Adds missing validateUpdate methods.  Also adds unit test for ensuring that validationUpdate methods exists for API objects that need them.

@liggitt or @derekwaynecarr ptal

@smarterclayton Approval and either accept or rejected the unit test commit.  Relatively minor changes in `master.go` for significant gain.