### PR TITLE
Upstream: make docker bridge configuration more dynamic

### DIFF
--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
@@ -72,17 +72,16 @@ function setup() {
         DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
     fi
 
-    if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfig/docker-network
-    then
-        cat <<EOF > /etc/sysconfig/docker-network
+    mkdir -p /run/openshift-sdn
+    cat <<EOF > /run/openshift-sdn/docker-network
 # This file has been modified by openshift-sdn. Please modify the
-# DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
-# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
-# files (depending on your setup).
+# DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
+# is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
+# standalone install.
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
-    fi
+
     systemctl daemon-reload
     systemctl restart docker.service
 

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
@@ -54,16 +54,15 @@ then
     DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
 fi
 
-if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfig/docker-network
-then
-    cat <<EOF > /etc/sysconfig/docker-network
+mkdir -p /run/openshift-sdn
+cat <<EOF > /run/openshift-sdn/docker-network
 # This file has been modified by openshift-sdn. Please modify the
-# DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
-# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
-# files (depending on your setup).
+# DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
+# is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
+# standalone install.
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
-fi
+
 systemctl daemon-reload
 systemctl restart docker.service

--- a/openshift.spec
+++ b/openshift.spec
@@ -183,6 +183,8 @@ pushd _thirdpartyhacks/src/%{sdn_import_path}/ovssubnet/bin
 popd
 install -d -m 0755 %{buildroot}%{_prefix}/lib/systemd/system/openshift-node.service.d
 install -p -m 0644 rel-eng/openshift-sdn-ovs.conf %{buildroot}%{_prefix}/lib/systemd/system/openshift-node.service.d/
+install -d -m 0755 %{buildroot}%{_prefix}/lib/systemd/system/docker.service.d
+install -p -m 0644 rel-eng/docker-sdn-ovs.conf %{buildroot}%{_prefix}/lib/systemd/system/docker.service.d/
 
 # Install bash completions
 install -d -m 755 %{buildroot}/etc/bash_completion.d/
@@ -233,6 +235,7 @@ install -p -m 644 rel-eng/completions/bash/* %{buildroot}/etc/bash_completion.d/
 %{_bindir}/openshift-sdn-kube-subnet-setup.sh
 %{kube_plugin_path}/openshift-ovs-subnet
 %{_prefix}/lib/systemd/system/openshift-node.service.d/openshift-sdn-ovs.conf
+%{_prefix}/lib/systemd/system/docker.service.d/docker-sdn-ovs.conf
 
 %files -n tuned-profiles-openshift-node
 %defattr(-,root,root,-)

--- a/rel-eng/docker-sdn-ovs.conf
+++ b/rel-eng/docker-sdn-ovs.conf
@@ -1,0 +1,2 @@
+[Service]
+EnvironmentFile=-/run/openshift-sdn/docker-network


### PR DESCRIPTION
This replicates https://github.com/openshift/openshift-sdn/pull/78 in the integrated sdn-ovs. Please see that PR for details on how I've tested it.

I've duplicated the docker.service.d dropfile here but we could add it to the godep to ensure that we don't miss any future changes. The rel-eng directory has some additional cruft and there's no go code so I'm fine either way.