### PR TITLE
Bug 1230066 - fixes oc help to use public git repo

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -29,7 +29,7 @@ To create a new application, you can use the example app source. Login to your s
 run new-app:
 
   $ %[1]s login
-  $ %[1]s new-app openshift/ruby-20-centos7~git@github.com/openshift/ruby-hello-world.git
+  $ %[1]s new-app openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world.git
 
 This will create an application based on the Docker image 'openshift/ruby-20-centos7' that builds
 the source code at 'github.com/openshift/ruby-hello-world.git'. To start the build, run


### PR DESCRIPTION
The `new-app` help says "This command will try to build up the components of an application using images, templates, or code **that has a public repository**". So this fixes the main help in `oc -h` to point to the public Github repo of "ruby-hello-world".