### PR TITLE
UPSTREAM: add debug output for client calls

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/transport.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/transport.go
@@ -19,9 +19,12 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/golang/glog"
 )
 
 type userAgentRoundTripper struct {
@@ -37,6 +40,7 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	if len(req.Header.Get("User-Agent")) != 0 {
 		return rt.rt.RoundTrip(req)
 	}
+	glog.V(7).Infof("-H 'User-Agent: %s'", rt.agent)
 	req = cloneRequest(req)
 	req.Header.Set("User-Agent", rt.agent)
 	return rt.rt.RoundTrip(req)
@@ -53,6 +57,7 @@ func NewBasicAuthRoundTripper(username, password string, rt http.RoundTripper) h
 }
 
 func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	glog.V(7).Infof("-H 'Authorization: Basic %s'", base64.StdEncoding.EncodeToString([]byte(rt.username+":"+rt.password)))
 	req = cloneRequest(req)
 	req.SetBasicAuth(rt.username, rt.password)
 	return rt.rt.RoundTrip(req)
@@ -68,6 +73,7 @@ func NewBearerAuthRoundTripper(bearer string, rt http.RoundTripper) http.RoundTr
 }
 
 func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	glog.V(7).Infof("-H 'Authorization: Bearer %s'", rt.bearer)
 	req = cloneRequest(req)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
 	return rt.rt.RoundTrip(req)


### PR DESCRIPTION
```
[deads@deads-dev-01 origin]$ oc get pods --loglevel=7
I0610 16:16:39.635767   20540 request.go:662] GET https://localhost:8443/api/v1/namespaces/default/pods
I0610 16:16:39.635858   20540 transport.go:43] -H 'User-Agent: oc/v0.17.1 (linux/amd64) kubernetes/496be63'
I0610 16:16:39.635871   20540 transport.go:76] -H 'Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I'
I0610 16:16:39.657035   20540 request.go:687] Response Status: 200 OK
I0610 16:16:39.657077   20540 request.go:690] Response Header: Content-Type: application/json
I0610 16:16:39.657091   20540 request.go:690] Response Header: Date: Wed, 10 Jun 2015 20:16:39 GMT
I0610 16:16:39.657103   20540 request.go:690] Response Header: Content-Length: 162
I0610 16:16:39.657135   20540 request.go:694] Response Body: {
  "kind": "PodList",
  "apiVersion": "v1",
  "metadata": {
    "selfLink": "/api/v1/namespaces/default/pods",
    "resourceVersion": "1083"
  },
  "items": []
}
NAME      READY     REASON    RESTARTS   AGE

```

@smarterclayton 