### PR TITLE
Use ~/.kube/config instead of ~/.config/openshift/config

### DIFF
--- a/pkg/cmd/cli/cmd/config.go
+++ b/pkg/cmd/cli/cmd/config.go
@@ -26,10 +26,10 @@ Reference: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/ku
 func NewCmdConfig(parentName, name string) *cobra.Command {
 	pathOptions := &config.PathOptions{
 		GlobalFile:       cmdconfig.RecommendedHomeFile,
-		EnvVar:           cmdconfig.OpenShiftConfigPathEnvVar,
+		EnvVar:           cmdconfig.KubernetesConfigPathEnvVar,
 		ExplicitFileFlag: cmdconfig.OpenShiftConfigFlagName,
 
-		GlobalFileSubpath: cmdconfig.OpenShiftConfigHomeDirFileName,
+		GlobalFileSubpath: cmdconfig.KubernetesConfigHomeDirFileName,
 
 		LoadingRules: cmdconfig.NewOpenShiftClientConfigLoadingRules(),
 	}


### PR DESCRIPTION
Kubernetes authentication is tricky enough as it is. We need kubectl,
oc, and oadmn to share authentication data, cluster context, namespace
configuration and so on.

People who build scripts around kubectl should have a reasonable expectation
of them working when they have logged into openshift via 'oc login'. To make this
work, as well as other cases where auth data is read (such as Cockpit)
the auth configuration should live in one place, not two.

While ~/.config is nice and clean, the upstream path of ~/.kube carries
a lot of weight and standardizing on that seems most consistent and painless.