### PR TITLE
Added stop channel to watched pods to prevent thread leak

### DIFF
--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -54,8 +54,8 @@ func NewRecreateDeploymentStrategy(client kclient.Interface, codec runtime.Codec
 				CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
 					return client.Pods(namespace).Create(pod)
 				},
-				PodWatchFunc: func(namespace, name, resourceVersion string) func() *kapi.Pod {
-					return stratsupport.NewPodWatch(client, namespace, name, resourceVersion)
+				PodWatchFunc: func(namespace, name, resourceVersion string, stopChannel chan struct{}) func() *kapi.Pod {
+					return stratsupport.NewPodWatch(client, namespace, name, resourceVersion, stopChannel)
 				},
 			},
 		},

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -105,8 +105,8 @@ func NewRollingDeploymentStrategy(namespace string, client kclient.Interface, co
 				CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
 					return client.Pods(namespace).Create(pod)
 				},
-				PodWatchFunc: func(namespace, name, resourceVersion string) func() *kapi.Pod {
-					return stratsupport.NewPodWatch(client, namespace, name, resourceVersion)
+				PodWatchFunc: func(namespace, name, resourceVersion string, stopChannel chan struct{}) func() *kapi.Pod {
+					return stratsupport.NewPodWatch(client, namespace, name, resourceVersion, stopChannel)
 				},
 			},
 		},

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -30,7 +30,7 @@ func TestHookExecutor_executeExecNewCreatePodFailure(t *testing.T) {
 			CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
 				return nil, fmt.Errorf("couldn't create pod")
 			},
-			PodWatchFunc: func(namespace, name, resourceVersion string) func() *kapi.Pod {
+			PodWatchFunc: func(namespace, name, resourceVersion string, stopChannel chan struct{}) func() *kapi.Pod {
 				return func() *kapi.Pod { return nil }
 			},
 		},
@@ -62,7 +62,7 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 				createdPod = pod
 				return createdPod, nil
 			},
-			PodWatchFunc: func(namespace, name, resourceVersion string) func() *kapi.Pod {
+			PodWatchFunc: func(namespace, name, resourceVersion string, stopChannel chan struct{}) func() *kapi.Pod {
 				createdPod.Status.Phase = kapi.PodSucceeded
 				return func() *kapi.Pod { return createdPod }
 			},
@@ -101,7 +101,7 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 				createdPod = pod
 				return createdPod, nil
 			},
-			PodWatchFunc: func(namespace, name, resourceVersion string) func() *kapi.Pod {
+			PodWatchFunc: func(namespace, name, resourceVersion string, stopChannel chan struct{}) func() *kapi.Pod {
 				createdPod.Status.Phase = kapi.PodFailed
 				return func() *kapi.Pod { return createdPod }
 			},


### PR DESCRIPTION
Resolves #2869.

@ironcladlou @abhgupta 

Edit:   Fixed the thread leak by returning a stop channel created at the same time/place where the reflector is created and started.  The caller of the watch is responsible for a deferred close on the channel.
