### PR TITLE
UPSTREAM: better client debugging

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/helper.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/helper.go
@@ -31,6 +31,8 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/version"
+
+	"github.com/golang/glog"
 )
 
 // Config holds the common attributes that can be passed to a Kubernetes client on
@@ -261,6 +263,18 @@ func TransportFor(config *Config) (http.RoundTripper, error) {
 			transport = http.DefaultTransport
 		}
 	}
+
+	switch {
+	case bool(glog.V(9)):
+		transport = NewDebuggingRoundTripper(transport, CurlCommand, URLTiming, ResponseHeaders, ResponseBody)
+	case bool(glog.V(8)):
+		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, RequestBody, ResponseStatus, ResponseHeaders, ResponseBody)
+	case bool(glog.V(7)):
+		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, ResponseStatus)
+	case bool(glog.V(6)):
+		transport = NewDebuggingRoundTripper(transport, URLTiming)
+	}
+
 	if config.WrapTransport != nil {
 		transport = config.WrapTransport(transport)
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/request.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/request.go
@@ -672,19 +672,6 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 	for {
 		url := r.URL().String()
 
-		glog.V(6).Infof("%s %s", r.verb, url)
-		if glog.V(7) && (r.body != nil) {
-			if body, err := ioutil.ReadAll(r.body); err == nil {
-				r.body = ioutil.NopCloser(bytes.NewBuffer(body))
-				glog.V(7).Infof("-d '%s'", string(body))
-			}
-			for key, values := range r.headers {
-				for value := range values {
-					glog.V(7).Infof("-H '%s: %s'", key, value)
-				}
-			}
-		}
-
 		req, err := http.NewRequest(r.verb, url, r.body)
 		if err != nil {
 			return err
@@ -695,17 +682,6 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		if err != nil {
 			glog.V(6).Infof("Response Error: %v", err)
 			return err
-		}
-
-		glog.V(6).Infof("Response Status: %s", resp.Status)
-		if glog.V(7) {
-			for key, _ := range resp.Header {
-				glog.V(7).Infof("Response Header: %s: %s", key, resp.Header.Get(key))
-			}
-			if body, err := ioutil.ReadAll(resp.Body); err == nil {
-				resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-				glog.V(7).Infof("Response Body: %s", string(body))
-			}
 		}
 
 		done := func() bool {


### PR DESCRIPTION
@smarterclayton a slightly cleaner factoring with more useful output levels

6 - Verb URL Status Timing
```
oc login --loglevel=6 -u david
I0611 09:23:02.588530   18580 transport.go:168] GET https://localhost:8443/osapi  in 25 milliseconds
I0611 09:23:02.588609   18580 request.go:683] Response Error: Get https://localhost:8443/osapi: x509: certificate signed by unknown authority
I0611 09:23:02.606301   18580 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 401 Unauthorized in 15 milliseconds
I0611 09:23:02.623896   18580 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 17 milliseconds
I0611 09:23:02.641138   18580 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 16 milliseconds
I0611 09:23:02.672769   18580 transport.go:168] GET https://localhost:8443/oapi/v1/projects 200 OK in 31 milliseconds
I0611 09:23:02.675513   18580 transport.go:168] GET https://localhost:8443/oapi/v1/projects/default 200 OK in 2 milliseconds
Using project "default".

You have access to the following projects and can switch between them with 'oc project <projectname>':

  * default (current)
  * openshift
  * openshift-infra

I0611 09:23:02.690298   18580 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 14 milliseconds
I0611 09:23:02.705358   18580 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 14 milliseconds
```

7 - +requestheaders
```
oc login --loglevel=7 -u david
I0611 09:24:27.917283   18734 transport.go:143] GET https://localhost:8443/osapi
I0611 09:24:27.917339   18734 transport.go:153] Request Headers:
I0611 09:24:27.917349   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:27.936462   18734 transport.go:168] GET https://localhost:8443/osapi  in 19 milliseconds
I0611 09:24:27.936501   18734 transport.go:171] Response Status:  in 19 milliseconds
I0611 09:24:27.936515   18734 request.go:683] Response Error: Get https://localhost:8443/osapi: x509: certificate signed by unknown authority
I0611 09:24:27.936717   18734 transport.go:143] GET https://localhost:8443/oapi/v1/users/~
I0611 09:24:27.936728   18734 transport.go:153] Request Headers:
I0611 09:24:27.936734   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:27.936740   18734 transport.go:156]     Authorization: Bearer kfZzcFanfiC2DUy3N3naB735ci8HV5g92vBVDDJVYf0
I0611 09:24:27.951099   18734 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 401 Unauthorized in 14 milliseconds
I0611 09:24:27.951125   18734 transport.go:171] Response Status: 401 Unauthorized in 14 milliseconds
I0611 09:24:27.952699   18734 transport.go:143] GET https://localhost:8443/oapi/v1/users/~
I0611 09:24:27.952716   18734 transport.go:153] Request Headers:
I0611 09:24:27.952723   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:27.952730   18734 transport.go:156]     Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I
I0611 09:24:27.967676   18734 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 14 milliseconds
I0611 09:24:27.967712   18734 transport.go:171] Response Status: 200 OK in 14 milliseconds
I0611 09:24:27.968350   18734 transport.go:143] GET https://localhost:8443/oapi/v1/users/~
I0611 09:24:27.968419   18734 transport.go:153] Request Headers:
I0611 09:24:27.968441   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:27.968461   18734 transport.go:156]     Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I
I0611 09:24:27.984140   18734 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 15 milliseconds
I0611 09:24:27.984165   18734 transport.go:171] Response Status: 200 OK in 15 milliseconds
I0611 09:24:27.984359   18734 transport.go:143] GET https://localhost:8443/oapi/v1/projects
I0611 09:24:27.984374   18734 transport.go:153] Request Headers:
I0611 09:24:27.984381   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:27.984388   18734 transport.go:156]     Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I
I0611 09:24:28.001484   18734 transport.go:168] GET https://localhost:8443/oapi/v1/projects 200 OK in 17 milliseconds
I0611 09:24:28.001635   18734 transport.go:171] Response Status: 200 OK in 17 milliseconds
I0611 09:24:28.002083   18734 transport.go:143] GET https://localhost:8443/oapi/v1/projects/default
I0611 09:24:28.002100   18734 transport.go:153] Request Headers:
I0611 09:24:28.002109   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:28.002119   18734 transport.go:156]     Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I
I0611 09:24:28.005283   18734 transport.go:168] GET https://localhost:8443/oapi/v1/projects/default 200 OK in 3 milliseconds
I0611 09:24:28.005311   18734 transport.go:171] Response Status: 200 OK in 3 milliseconds
Using project "default".

You have access to the following projects and can switch between them with 'oc project <projectname>':

  * default (current)
  * openshift
  * openshift-infra

I0611 09:24:28.005633   18734 transport.go:143] GET https://localhost:8443/oapi/v1/users/~
I0611 09:24:28.005646   18734 transport.go:153] Request Headers:
I0611 09:24:28.005655   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:28.005665   18734 transport.go:156]     Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I
I0611 09:24:28.020248   18734 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 14 milliseconds
I0611 09:24:28.020292   18734 transport.go:171] Response Status: 200 OK in 14 milliseconds
I0611 09:24:28.020474   18734 transport.go:143] GET https://localhost:8443/oapi/v1/users/~
I0611 09:24:28.020496   18734 transport.go:153] Request Headers:
I0611 09:24:28.020503   18734 transport.go:156]     User-Agent: oc/v0.6 (linux/amd64) openshift/c0342f5
I0611 09:24:28.020509   18734 transport.go:156]     Authorization: Bearer HCjFECDXWtzsfyFWUy1UoHP5LtNOnlSkibJPxc7BN3I
I0611 09:24:28.036657   18734 transport.go:168] GET https://localhost:8443/oapi/v1/users/~ 200 OK in 16 milliseconds
I0611 09:24:28.036688   18734 transport.go:171] Response Status: 200 OK in 16 milliseconds
```

8 - includes body content
```
```

9 - curl commands
```
```