### PR TITLE
Correlate and retrieve deployments by label

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -145,13 +145,11 @@ func (o DeployOptions) RunDeploy() error {
 			return o.kubeClient.ReplicationControllers(namespace).Get(name)
 		},
 		ListDeploymentsForConfigFn: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
-			rcs, err := o.kubeClient.ReplicationControllers(namespace).List(labels.Everything())
+			list, err := o.kubeClient.ReplicationControllers(namespace).List(deployutil.ConfigSelector(configName))
 			if err != nil {
 				return nil, err
 			}
-			return &kapi.ReplicationControllerList{
-				Items: deployutil.ConfigSelector(configName, rcs.Items),
-			}, nil
+			return list, nil
 		},
 
 		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {

--- a/pkg/cmd/infra/deployer/deployer_test.go
+++ b/pkg/cmd/infra/deployer/deployer_test.go
@@ -23,7 +23,7 @@ func TestDeployer_getDeploymentFail(t *testing.T) {
 		getDeployment: func(namespace, name string) (*kapi.ReplicationController, error) {
 			return nil, fmt.Errorf("get error")
 		},
-		getControllers: func(namespace string) (*kapi.ReplicationControllerList, error) {
+		getDeployments: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
 			t.Fatal("unexpected call")
 			return nil, nil
 		},
@@ -144,7 +144,7 @@ func TestDeployer_deployScenarios(t *testing.T) {
 			getDeployment: func(namespace, name string) (*kapi.ReplicationController, error) {
 				return to, nil
 			},
-			getControllers: func(namespace string) (*kapi.ReplicationControllerList, error) {
+			getDeployments: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
 				list := &kapi.ReplicationControllerList{}
 				for _, d := range s.deployments {
 					list.Items = append(list.Items, *d)

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -52,12 +52,12 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 				return factory.KubeClient.ReplicationControllers(namespace).Create(deployment)
 			},
 			listDeploymentsForConfigFunc: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
-				rcList, err := factory.KubeClient.ReplicationControllers(namespace).List(labels.Everything())
+				sel := deployutil.ConfigSelector(configName)
+				list, err := factory.KubeClient.ReplicationControllers(namespace).List(sel)
 				if err != nil {
 					return nil, err
 				}
-				rcList.Items = deployutil.ConfigSelector(configName, rcList.Items)
-				return rcList, nil
+				return list, nil
 			},
 			updateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
 				return factory.KubeClient.ReplicationControllers(namespace).Update(deployment)

--- a/pkg/deploy/reaper/reaper.go
+++ b/pkg/deploy/reaper/reaper.go
@@ -8,7 +8,6 @@ import (
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/golang/glog"
 
 	"github.com/openshift/origin/pkg/client"
@@ -52,7 +51,7 @@ func (reaper *DeploymentConfigReaper) Stop(namespace, name string, gracePeriod *
 	}
 
 	// Clean up deployments related to the config.
-	rcList, err := reaper.kc.ReplicationControllers(namespace).List(labels.Everything())
+	rcList, err := reaper.kc.ReplicationControllers(namespace).List(util.ConfigSelector(name))
 	if err != nil {
 		return "", err
 	}
@@ -62,7 +61,7 @@ func (reaper *DeploymentConfigReaper) Stop(namespace, name string, gracePeriod *
 	}
 
 	// If there is neither a config nor any deployments, we can return NotFound.
-	deployments := util.ConfigSelector(name, rcList.Items)
+	deployments := rcList.Items
 	if configNotFound && len(deployments) == 0 {
 		return "", kerrors.NewNotFound("DeploymentConfig", name)
 	}

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -107,6 +107,10 @@ func TestMakeDeploymentOk(t *testing.T) {
 		t.Fatalf("expected deployment replicas to be 0")
 	}
 
+	if l, e, a := deployapi.DeploymentConfigAnnotation, config.Name, deployment.Labels[deployapi.DeploymentConfigAnnotation]; e != a {
+		t.Fatalf("expected label %s=%s, got %s", l, e, a)
+	}
+
 	if e, a := config.Name, deployment.Spec.Template.Labels[deployapi.DeploymentConfigLabel]; e != a {
 		t.Fatalf("expected label DeploymentConfigLabel=%s, got %s", e, a)
 	}


### PR DESCRIPTION
Use a label to correlate deployments with their deploymentConfig.
This allows efficient query of the deployments for a config without
performance degradation as a factor of increasing non-deployment
controller count in the project.

Closes #3071