### PR TITLE
Use line-height: 1.3 for component headers

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -79,6 +79,7 @@
           margin: 0 0 5px;
           overflow: hidden;
           text-overflow: ellipsis;
+          line-height: 1.3;
         }
         &.meta-data {
           @media (min-width: @screen-sm-min) {


### PR DESCRIPTION
Avoid clipping descenders in service, deployment, and route names.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/8110535/e2e63440-102a-11e5-979b-5184f96722da.png)

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/8110539/e6249ce6-102a-11e5-8598-28075fae1f30.png)


Fixes #2990