### PR TITLE
change default kubeconfig location

### DIFF
--- a/docs/debugging-openshift.md
+++ b/docs/debugging-openshift.md
@@ -74,7 +74,7 @@ If it's not running, you will instead see:
 
 If it's not running, you can launch it via:
 
-    $ oadm registry --create --credentials="${OPENSHIFTCONFIG}"
+    $ oadm registry --create --credentials="${KUBECONFIG}"
 
 Probing Containers
 ------------------

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -32,8 +32,8 @@ Once it is pulled it will start and be visible in the `docker ps` list of contai
     [vagrant@openshiftdev origin]$ sudo /data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/openshift start &
 
     If running in https mode, ensure oc can authenticate to the master
-    [vagrant@openshiftdev origin]$ export OPENSHIFTCONFIG=/data/src/github.com/openshift/origin/openshift.local.config/master/admin.kubeconfig
-    [vagrant@openshiftdev origin]$ sudo chmod a+r "$OPENSHIFTCONFIG"
+    [vagrant@openshiftdev origin]$ export KUBECONFIG=/data/src/github.com/openshift/origin/openshift.local.config/master/admin.kubeconfig
+    [vagrant@openshiftdev origin]$ sudo chmod a+r "$KUBECONFIG"
     [vagrant@openshiftdev origin]$ sudo chmod a+r openshift.local.config/master/openshift-router.kubeconfig
     [vagrant@openshiftdev origin]$ oadm router --create --credentials="openshift.local.config/master/openshift-router.kubeconfig"
     [vagrant@openshiftdev origin]$ oc get pods
@@ -44,7 +44,7 @@ Once it is pulled it will start and be visible in the `docker ps` list of contai
     $ export OPENSHIFT_DEV_CLUSTER=true
     $ vagrant up
     $ vagrant ssh master
-    [vagrant@openshift-master ~]$ oadm router --create --credentials="${OPENSHIFTCONFIG}"
+    [vagrant@openshift-master ~]$ oadm router --create --credentials="${KUBECONFIG}"
 
 
 

--- a/examples/gitserver/template.yaml
+++ b/examples/gitserver/template.yaml
@@ -33,7 +33,7 @@ items:
           - name: AUTOLINK_HOOK
             value: null
           - name: REQUIRE_GIT_AUTH
-          - name: OPENSHIFTCONFIG
+          - name: KUBECONFIG
             value: /var/lib/gitsecrets/admin.kubeconfig
           image: openshift/origin-gitserver
           name: gitserver

--- a/examples/jenkins/job.xml
+++ b/examples/jenkins/job.xml
@@ -40,8 +40,8 @@ users:
   <builders>
     <hudson.tasks.Shell>
       <command>
-export OPENSHIFTCONFIG=.kubeconfig
-echo "${KUBECONFIG_CREDENTIALS}" > "${OPENSHIFTCONFIG}"
+export KUBECONFIG=.kubeconfig
+echo "${KUBECONFIG_CREDENTIALS}" > "${KUBECONFIG}"
 
 TEST_ENDPOINT=`oc get services -n test | grep frontend-test | awk '{print $4":"$5}'`
 

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -173,7 +173,7 @@ This section covers how to perform all the steps of building, deploying, and upd
 
         $ oc login --certificate-authority=openshift.local.config/master/ca.crt
 
-       **VAGRANT USERS**: If subsequent commands fail because of a config validation error, log out, unset the $OPENSHIFTCONFIG environment variable (if it is set) and then log in again.
+       **VAGRANT USERS**: If subsequent commands fail because of a config validation error, log out, unset the $KUBECONFIG environment variable (if it is set) and then log in again.
 
 
 

--- a/examples/sample-app/container-setup.md
+++ b/examples/sample-app/container-setup.md
@@ -65,7 +65,7 @@ step #3.
 
 ## Deploy the private docker registry
 
-    $ oadm registry --create --credentials="${OPENSHIFTCONFIG}"
+    $ oadm registry --create --credentials="${KUBECONFIG}"
     $ cd examples/sample-app
 
 For more information on this step, see [Application Build, Deploy, and Update

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -184,7 +184,7 @@ fi
 [ "$(oc login https://server1 https://server2.com 2>&1 | grep 'Only the server URL may be specified')" ]
 # logs in with a valid certificate authority
 oc login ${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything --api-version=v1beta3
-grep -q "v1beta3" ${HOME}/.config/openshift/config
+grep -q "v1beta3" ${HOME}/.kube/config
 oc logout
 # logs in skipping certificate check
 oc login ${KUBERNETES_MASTER} --insecure-skip-tls-verify -u test-user -p anything
@@ -218,12 +218,12 @@ oc get services --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" oc get services
 
 # test config files in the home directory
-mkdir -p ${HOME}/.config/openshift
-cp ${MASTER_CONFIG_DIR}/admin.kubeconfig ${HOME}/.config/openshift/config
+mkdir -p ${HOME}/.kube
+cp ${MASTER_CONFIG_DIR}/admin.kubeconfig ${HOME}/.kube/config
 oc get services
-mv ${HOME}/.config/openshift/config ${HOME}/.config/openshift/non-default-config
+mv ${HOME}/.kube/config ${HOME}/.kube/non-default-config
 echo "config files: ok"
-export KUBECONFIG="${HOME}/.config/openshift/non-default-config"
+export KUBECONFIG="${HOME}/.kube/non-default-config"
 
 # from this point every command will use config from the KUBECONFIG env var
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -45,7 +45,7 @@ trap "cleanup" EXIT
 set -e
 
 # Prevent user environment from colliding with the test setup
-unset OPENSHIFTCONFIG
+unset KUBECONFIG
 
 USE_LOCAL_IMAGES=${USE_LOCAL_IMAGES:-true}
 
@@ -215,7 +215,7 @@ oc project project-foo
 oc get services --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 
 # test config files from env vars
-OPENSHIFTCONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" oc get services
+KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" oc get services
 
 # test config files in the home directory
 mkdir -p ${HOME}/.config/openshift
@@ -223,9 +223,9 @@ cp ${MASTER_CONFIG_DIR}/admin.kubeconfig ${HOME}/.config/openshift/config
 oc get services
 mv ${HOME}/.config/openshift/config ${HOME}/.config/openshift/non-default-config
 echo "config files: ok"
-export OPENSHIFTCONFIG="${HOME}/.config/openshift/non-default-config"
+export KUBECONFIG="${HOME}/.config/openshift/non-default-config"
 
-# from this point every command will use config from the OPENSHIFTCONFIG env var
+# from this point every command will use config from the KUBECONFIG env var
 
 oc get templates
 oc create -f examples/sample-app/application-template-dockerbuild.json
@@ -370,7 +370,7 @@ oc create -f test/integration/fixtures/test-image-stream.json
 # make sure stream.status.dockerImageRepository isn't set (no registry)
 [ -z "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]
 # create the registry
-oadm registry --create --credentials="${OPENSHIFTCONFIG}"
+oadm registry --create --credentials="${KUBECONFIG}"
 # make sure stream.status.dockerImageRepository IS set
 [ -n "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]
 # ensure the registry rc has been created
@@ -645,15 +645,15 @@ echo "new-project: ok"
 
 # Test running a router
 [ ! "$(oadm router --dry-run | grep 'does not exist')" ]
-[ "$(oadm router -o yaml --credentials="${OPENSHIFTCONFIG}" | grep 'openshift/origin-haproxy-')" ]
-oadm router --create --credentials="${OPENSHIFTCONFIG}"
+[ "$(oadm router -o yaml --credentials="${KUBECONFIG}" | grep 'openshift/origin-haproxy-')" ]
+oadm router --create --credentials="${KUBECONFIG}"
 [ "$(oadm router | grep 'service exists')" ]
 echo "router: ok"
 
 # Test running a registry
 [ ! "$(oadm registry --dry-run | grep 'does not exist')"]
-[ "$(oadm registry -o yaml --credentials="${OPENSHIFTCONFIG}" | grep 'openshift/origin-docker-registry')" ]
-oadm registry --create --credentials="${OPENSHIFTCONFIG}"
+[ "$(oadm registry -o yaml --credentials="${KUBECONFIG}" | grep 'openshift/origin-docker-registry')" ]
+oadm registry --create --credentials="${KUBECONFIG}"
 [ "$(oadm registry | grep 'service exists')" ]
 echo "registry: ok"
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -247,7 +247,7 @@ export HOME="${FAKE_HOME_DIR}"
 # This directory must exist so Docker can store credentials in $HOME/.dockercfg
 mkdir -p ${FAKE_HOME_DIR}
 
-export OPENSHIFTCONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+export KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template -t '{{index . "current-context"}}')
 
 if [[ "${API_SCHEME}" == "https" ]]; then
@@ -256,8 +256,8 @@ if [[ "${API_SCHEME}" == "https" ]]; then
 	export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
 
 	# Make oc use ${MASTER_CONFIG_DIR}/admin.kubeconfig, and ignore anything in the running user's $HOME dir
-	sudo chmod -R a+rwX "${OPENSHIFTCONFIG}"
-	echo "[INFO] To debug: export OPENSHIFTCONFIG=$OPENSHIFTCONFIG"
+	sudo chmod -R a+rwX "${KUBECONFIG}"
+	echo "[INFO] To debug: export KUBECONFIG=$KUBECONFIG"
 fi
 
 

--- a/hack/test-extended.sh
+++ b/hack/test-extended.sh
@@ -35,7 +35,7 @@ export NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-127.0.0.1"
 export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
 export CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
 export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
-export OPENSHIFTCONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+export KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 export OPENSHIFT_ON_PANIC=crash
 
 cleanup() {
@@ -105,11 +105,11 @@ oadm create-bootstrap-policy-file --filename="${MASTER_CONFIG_DIR}/policy.json"
 start_docker_registry() {
   mkdir -p ${BASETMPDIR}/.registry
   echo "[INFO] Creating Router ..."
-  oadm router --create --credentials="${OPENSHIFTCONFIG}" \
+  oadm router --create --credentials="${KUBECONFIG}" \
     --images='openshift/origin-${component}:latest' &>/dev/null
 
   echo "[INFO] Creating Registry ..."
-  oadm registry --create --credentials="${OPENSHIFTCONFIG}" \
+  oadm registry --create --credentials="${KUBECONFIG}" \
     --mount-host="${BASETMPDIR}/.registry" \
     --images='openshift/origin-${component}:latest' &>/dev/null
 }

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -40,7 +40,7 @@ mkdir -p "${SWAGGER_ROOT_DIR}"
 SWAGGER_API_PATH="${HOST}/swaggerapi/"
 
 # Prevent user environment from colliding with the test setup
-unset OPENSHIFTCONFIG
+unset KUBECONFIG
 
 # set path so OpenShift is available
 GO_OUT="${OS_ROOT}/_output/local/go/bin"

--- a/images/ipfailover/keepalived/README.md
+++ b/images/ipfailover/keepalived/README.md
@@ -27,12 +27,12 @@ Pre-requisites/Prep Time
    with two (_2_) replicas.
 
         $ vagrant ssh minion-1  # (or master or minion-2).
-        #  Ensure OPENSHIFTCONFIG is set or else set it.
-        [ -n "$OPENSHIFTCONFIG" ] ||  \
-           export OPENSHIFTCONFIG=/openshift.local.config/master/admin.kubeconfig
+        #  Ensure KUBECONFIG is set or else set it.
+        [ -n "$KUBECONFIG" ] ||  \
+           export KUBECONFIG=/openshift.local.config/master/admin.kubeconfig
         #  openshift kube get dc,rc,pods,se,mi,routes
         oadm router arparp --create --replicas=2  \
-                                   --credentials="${OPENSHIFTCONFIG}"
+                                   --credentials="${KUBECONFIG}"
 
 
 3. Wait for the Router pods to get into running state (I'm just sitting

--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -19,6 +19,6 @@ RUN ln -s /usr/bin/openshift /usr/bin/oc && \
     ln -s /usr/bin/openshift /usr/bin/openshift-router
 
 ENV HOME /root
-ENV OPENSHIFTCONFIG /var/lib/openshift/openshift.local.config/master/admin.kubeconfig
+ENV KUBECONFIG /var/lib/openshift/openshift.local.config/master/admin.kubeconfig
 WORKDIR /var/lib/openshift
 ENTRYPOINT ["/usr/bin/openshift"]

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -24,7 +24,7 @@ const (
 First-time users of the OpenShift client should run this command to connect to a server,
 establish an authenticated session, and save connection to the configuration file. The
 default configuration will be saved to your home directory under
-".config/openshift/config".
+".kube/config".
 
 The information required to login -- like username and password, a session token, or
 the server details -- can be provided through flags. If not provided, the command will

--- a/pkg/cmd/cli/config/loader.go
+++ b/pkg/cmd/cli/config/loader.go
@@ -16,17 +16,17 @@ import (
 const (
 	OpenShiftConfigPathEnvVar      = "KUBECONFIG"
 	OpenShiftConfigFlagName        = "config"
-	OpenShiftConfigHomeDir         = ".config/openshift"
+	OpenShiftConfigHomeDir         = ".kube"
 	OpenShiftConfigHomeFileName    = "config"
 	OpenShiftConfigHomeDirFileName = OpenShiftConfigHomeDir + "/" + OpenShiftConfigHomeFileName
 )
 
-var OldRecommendedHomeFile = path.Join(os.Getenv("HOME"), ".config/openshift/.config")
+var OldRecommendedHomeFile = path.Join(os.Getenv("HOME"), ".kube/.config")
 var RecommendedHomeFile = path.Join(os.Getenv("HOME"), OpenShiftConfigHomeDirFileName)
 
 // NewOpenShiftClientConfigLoadingRules returns file priority loading rules for OpenShift.
 // 1. --config value
-// 2. if KUBECONFIG env var has a value, use it. Otherwise, ~/.config/openshift/config file
+// 2. if KUBECONFIG env var has a value, use it. Otherwise, ~/.kube/config file
 func NewOpenShiftClientConfigLoadingRules() *clientcmd.ClientConfigLoadingRules {
 	chain := []string{}
 	migrationRules := map[string]string{}

--- a/pkg/cmd/cli/config/loader.go
+++ b/pkg/cmd/cli/config/loader.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	OpenShiftConfigPathEnvVar      = "OPENSHIFTCONFIG"
+	OpenShiftConfigPathEnvVar      = "KUBECONFIG"
 	OpenShiftConfigFlagName        = "config"
 	OpenShiftConfigHomeDir         = ".config/openshift"
 	OpenShiftConfigHomeFileName    = "config"
@@ -26,7 +26,7 @@ var RecommendedHomeFile = path.Join(os.Getenv("HOME"), OpenShiftConfigHomeDirFil
 
 // NewOpenShiftClientConfigLoadingRules returns file priority loading rules for OpenShift.
 // 1. --config value
-// 2. if OPENSHIFTCONFIG env var has a value, use it. Otherwise, ~/.config/openshift/config file
+// 2. if KUBECONFIG env var has a value, use it. Otherwise, ~/.config/openshift/config file
 func NewOpenShiftClientConfigLoadingRules() *clientcmd.ClientConfigLoadingRules {
 	chain := []string{}
 	migrationRules := map[string]string{}

--- a/pkg/cmd/util/clientcmd/errors.go
+++ b/pkg/cmd/util/clientcmd/errors.go
@@ -16,7 +16,7 @@ const (
 	certificateAuthorityUnknownMsg = "The server uses a certificate signed by unknown authority. You may need to use the --certificate-authority flag to provide the path to a certificate file for the certificate authority, or --insecure-skip-tls-verify to bypass the certificate check and use insecure connections."
 	notConfiguredMsg               = `OpenShift is not configured. You need to run the login command in order to create a default config for your server and credentials:
   oc login
-You can also run this command again providing the path to a config file directly, either through the --config flag of the OPENSHIFTCONFIG environment variable.
+You can also run this command again providing the path to a config file directly, either through the --config flag of the KUBECONFIG environment variable.
 `
 )
 

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -105,6 +105,6 @@ if [ "${OPENSHIFT_SDN}" != "ovs-gre" ]; then
   $(dirname $0)/provision-master-sdn.sh $@
 fi
 
-# Set up the OPENSHIFTCONFIG environment variable for use by oc
-echo 'export OPENSHIFTCONFIG=/vagrant/openshift.local.config/master/admin.kubeconfig' >> /root/.bash_profile
-echo 'export OPENSHIFTCONFIG=/vagrant/openshift.local.config/master/admin.kubeconfig' >> /home/vagrant/.bash_profile
+# Set up the KUBECONFIG environment variable for use by oc
+echo 'export KUBECONFIG=/vagrant/openshift.local.config/master/admin.kubeconfig' >> /root/.bash_profile
+echo 'export KUBECONFIG=/vagrant/openshift.local.config/master/admin.kubeconfig' >> /home/vagrant/.bash_profile

--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -79,9 +79,9 @@ systemctl daemon-reload
 systemctl enable openshift-node.service
 systemctl start openshift-node.service
 
-# Set up the OPENSHIFTCONFIG environment variable for use by the client
-echo 'export OPENSHIFTCONFIG=/openshift.local.config/master/admin.kubeconfig' >> /root/.bash_profile
-echo 'export OPENSHIFTCONFIG=/openshift.local.config/master/admin.kubeconfig' >> /home/vagrant/.bash_profile
+# Set up the KUBECONFIG environment variable for use by the client
+echo 'export KUBECONFIG=/openshift.local.config/master/admin.kubeconfig' >> /root/.bash_profile
+echo 'export KUBECONFIG=/openshift.local.config/master/admin.kubeconfig' >> /home/vagrant/.bash_profile
 
 # Register with the master
 #curl -X POST -H 'Accept: application/json' -d "{\"kind\":\"Minion\", \"id\":"${MINION_IP}", \"apiVersion\":\"v1beta1\", \"hostIP\":"${MINION_IP}" }" http://${MASTER_IP}:8080/api/v1beta1/minions


### PR DESCRIPTION
Changes the default kubeconfig location to `~/.kube/config`.  Significantly smaller than I expected.

@liggitt @smarterclayton 