### PR TITLE
Add tooltips to values we elide in the Web Console

### DIFF
--- a/assets/app/views/_templateopt.html
+++ b/assets/app/views/_templateopt.html
@@ -15,8 +15,8 @@
   </div>
   <ul class="list-unstyled env-variable-list" ng-hide="optionsExpanded">
     <li class="options" ng-repeat="parameter in template.parameters">
-        <label for="" class="key truncate" title="{{ parameter.description }}">{{parameter.name}}</label>
-        <span class="value truncate">{{ parameter | parameterValue }}</span>
+        <label for="" class="key truncate" ng-attr-title="{{ parameter.name }}">{{parameter.name}}</label>
+        <span class="value truncate" ng-attr-title="{{parameter | parameterValue}}">{{ parameter | parameterValue }}</span>
         <div class="help-block" ng-if="parameter.description">{{parameter.description}}</div>
     </li>
   </ul>

--- a/assets/app/views/directives/osc-key-values.html
+++ b/assets/app/views/directives/osc-key-values.html
@@ -37,14 +37,14 @@
       </form>
       <ul class="list-unstyled label-list">
         <li ng-repeat="(key,value) in entries | valuesIn:readonlyKeys">
-          <span class="key truncate">{{key}}</span>
-          <span class="value truncate">{{value}}</span>
+          <span class="key truncate" ng-attr-title="{{key}}">{{key}}</span>
+          <span class="value truncate" ng-attr-title="{{value}}">{{value}}</span>
         </li>
         <li ng-repeat="(key,value) in entries | valuesNotIn:readonlyKeys">
           <span ng-controller="KeyValuesEntryController">
-            <span class="key truncate">{{key}}</span>
+            <span class="key truncate" ng-attr-title="{{key}}">{{key}}</span>
             <span ng-hide="editing">
-              <span class="value truncate">{{ value}}</span>
+              <span class="value truncate" ng-attr-title="{{value}}">{{value}}</span>
               <a href="" ng-click="edit()" class="btn btn-default btn-xs" title="Edit">
                 <i class="icon icon-pencil"></i>
               </a>
@@ -71,8 +71,8 @@
       <div ng-if="(entries | hashSize) === 0"><strong>None</strong></div>
       <ul ng-if="(entries | hashSize) !== 0" class="labels-readonly label-list list-unstyled">
         <li ng-repeat="(key,value) in entries">
-          <span class="key truncate">{{key}}</span>
-          <span class="value truncate">{{ value }}</span>
+          <span class="key truncate" ng-attr-title="{{key}}">{{key}}</span>
+          <span class="value truncate" ng-attr-title="{{value}}">{{value}}</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
In the create pages, we elide long values for env vars and other fields.
Add a tooltip, so users can hover to see the full value.

Fixes #2882