### PR TITLE
Export command to template should let me provide template name

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -672,7 +672,7 @@ echo "complex-scenarios: ok"
 
 [ "$(oc export svc --all -t '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | wc -l)" -ne 0 ]
 [ "$(oc export svc --all | grep 'portalIP: ""')" ]
-[ "$(oc export svc --all --as-template | grep 'kind: Template')" ]
+[ "$(oc export svc --all --as-template=template | grep 'kind: Template')" ]
 [ ! "$(oc export svc --all --exact | grep 'portalIP: ""')" ]
 [ ! "$(oc export svc --all --raw | grep 'portalIP: ""')" ]
 [ ! "$(oc export svc --all --raw --exact)" ]


### PR DESCRIPTION
When exporting data to a template, the template needs a name in order to be created on the server.

This PR changes the --as-template flag from a boolean to a string in order to let the user provide the name of the template that is exported so it can then be piped to a create call.