### PR TITLE
Allow setting service account on registry/router pod templates

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation/validation.go
@@ -998,6 +998,11 @@ func ValidatePodSpec(spec *api.PodSpec) errs.ValidationErrorList {
 	allErrs = append(allErrs, ValidateLabels(spec.NodeSelector, "nodeSelector")...)
 	allErrs = append(allErrs, validateHostNetwork(spec.HostNetwork, spec.Containers).Prefix("hostNetwork")...)
 	allErrs = append(allErrs, validateImagePullSecrets(spec.ImagePullSecrets).Prefix("imagePullSecrets")...)
+	if len(spec.ServiceAccount) > 0 {
+		if ok, msg := ValidateServiceAccountName(spec.ServiceAccount, false); !ok {
+			allErrs = append(allErrs, errs.NewFieldInvalid("serviceAccount", spec.ServiceAccount, msg))
+		}
+	}
 
 	if spec.ActiveDeadlineSeconds != nil {
 		if *spec.ActiveDeadlineSeconds <= 0 {

--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -55,16 +55,17 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
 )
 
 type RegistryConfig struct {
-	Type          string
-	ImageTemplate variable.ImageTemplate
-	Ports         string
-	Replicas      int
-	Labels        string
-	Volume        string
-	HostMount     string
-	DryRun        bool
-	Credentials   string
-	Selector      string
+	Type           string
+	ImageTemplate  variable.ImageTemplate
+	Ports          string
+	Replicas       int
+	Labels         string
+	Volume         string
+	HostMount      string
+	DryRun         bool
+	Credentials    string
+	Selector       string
+	ServiceAccount string
 
 	// TODO: accept environment values.
 }
@@ -110,6 +111,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 	cmd.Flags().BoolVar(&cfg.DryRun, "dry-run", cfg.DryRun, "Check if the registry exists instead of creating.")
 	cmd.Flags().Bool("create", false, "deprecated; this is now the default behavior")
 	cmd.Flags().StringVar(&cfg.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the registry should use to contact the master.")
+	cmd.Flags().StringVar(&cfg.ServiceAccount, "service-account", cfg.ServiceAccount, "Name of the service account to use to run the registry pod.")
 	cmd.Flags().StringVar(&cfg.Selector, "selector", cfg.Selector, "Selector used to filter nodes on deployment. Used to run registries on a specific set of nodes.")
 
 	cmdutil.AddPrinterFlags(cmd)
@@ -227,7 +229,8 @@ func RunCmdRegistry(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg
 		podTemplate := &kapi.PodTemplateSpec{
 			ObjectMeta: kapi.ObjectMeta{Labels: label},
 			Spec: kapi.PodSpec{
-				NodeSelector: nodeSelector,
+				ServiceAccount: cfg.ServiceAccount,
+				NodeSelector:   nodeSelector,
 				Containers: []kapi.Container{
 					{
 						Name:  "registry",

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -66,6 +66,7 @@ type RouterConfig struct {
 	Credentials        string
 	DefaultCertificate string
 	Selector           string
+	ServiceAccount     string
 	StatsPort          int
 	StatsPassword      string
 	StatsUsername      string
@@ -113,6 +114,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 	cmd.Flags().StringVar(&cfg.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.")
 	cmd.Flags().StringVar(&cfg.DefaultCertificate, "default-cert", cfg.DefaultCertificate, "Optional path to a certificate file that be used as the default certificate.  The file should contain the cert, key, and any CA certs necessary for the router to serve the certificate.")
 	cmd.Flags().StringVar(&cfg.Selector, "selector", cfg.Selector, "Selector used to filter nodes on deployment. Used to run routers on a specific set of nodes.")
+	cmd.Flags().StringVar(&cfg.ServiceAccount, "service-account", cfg.ServiceAccount, "Name of the service account to use to run the router pod.")
 	cmd.Flags().IntVar(&cfg.StatsPort, "stats-port", 1936, "If the underlying router implementation can provide statistics this is a hint to expose it on this port.")
 	cmd.Flags().StringVar(&cfg.StatsPassword, "stats-password", cfg.StatsPassword, "If the underlying router implementation can provide statistics this is the requested password for auth.  If not set a password will be generated.")
 	cmd.Flags().StringVar(&cfg.StatsUsername, "stats-user", cfg.StatsUsername, "If the underlying router implementation can provide statistics this is the requested username for auth.")
@@ -286,7 +288,8 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 						Template: &kapi.PodTemplateSpec{
 							ObjectMeta: kapi.ObjectMeta{Labels: label},
 							Spec: kapi.PodSpec{
-								NodeSelector: nodeSelector,
+								ServiceAccount: cfg.ServiceAccount,
+								NodeSelector:   nodeSelector,
 								Containers: []kapi.Container{
 									{
 										Name:  "router",


### PR DESCRIPTION
Anything that allows creating a pod, pod template, replication controller, or deployment config should allow selecting the service account to run the pod with