### PR TITLE
Show "no deployments" message on browse page consistently

### DIFF
--- a/assets/app/views/deployments.html
+++ b/assets/app/views/deployments.html
@@ -5,11 +5,9 @@
         <h1>Deployments</h1>
       </div>
       <alerts alerts="alerts"></alerts>
-      <div ng-if="(deployments | hashSize) == 0">
-        <div>
-          <em>{{emptyMessage}}</em>
-        </div>
-      </div> 
+      <div ng-if="(deploymentConfigs | hashSize) === 0 && (deploymentsByDeploymentConfig | hashSize) === 0">
+        <em>{{emptyMessage}}</em>
+      </div>
 
       <div class="tile" ng-repeat="(deploymentConfigName, deploymentConfig) in deploymentConfigs track by (deploymentConfig | uid)">
         <div> 
@@ -153,7 +151,7 @@
         <div>
           <h2 ng-if="deploymentConfigName != ''">
             {{deploymentConfigName}}
-            <span class="pficon-layered" data-toggle="tooltip" data-placement="right" title="This deployment config no longer exists" style="cursor: help;">
+            <span class="pficon-layered" data-toggle="tooltip" data-placement="right" title="This deployment config no longer exists." style="cursor: help;">
               <span class="pficon pficon-warning-triangle"></span>
               <span class="pficon pficon-warning-exclamation"></span>
             </span>            


### PR DESCRIPTION
The message was hidden, but nothing displayed when only replication
controllers with no `deploymentConfig` annotations existed. These can
be seen on the overview page, but are not displayed on the browse
deployments page.

Show the message when the page has no content and remove the message
when there is anything to show (including deployment configurations with
no deployments).

Fixes #3120
Fixes #2862