### PR TITLE
Reap deployments and ReplicationControllers

### DIFF
--- a/pkg/deploy/reaper/reaper_test.go
+++ b/pkg/deploy/reaper/reaper_test.go
@@ -1,6 +1,7 @@
 package reaper
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -177,4 +178,146 @@ func TestStop(t *testing.T) {
 			t.Errorf("%s: unexpected output %q, expected %q", test.testName, out, test.output)
 		}
 	}
+}
+
+// TestDeploymentReaper_scenarios verifies DeploymentReaper functionality
+// using table tests.
+func TestDeploymentReaper_scenarios(t *testing.T) {
+	type pod struct {
+		name        string
+		canBeReaped bool
+	}
+	scenarios := []struct {
+		name                  string
+		pods                  []pod
+		deploymentCanBeReaped bool
+	}{
+		{
+			name: "scenario 1",
+			pods: []pod{
+				{"pod1", true},
+				{"pod2", true},
+				{"pod3", false},
+				{"pod4", true},
+			},
+			deploymentCanBeReaped: true,
+		},
+		{
+			name: "scenario 2",
+			pods: []pod{
+				{"pod1", true},
+				{"pod2", true},
+				{"pod3", true},
+				{"pod4", true},
+			},
+			deploymentCanBeReaped: true,
+		},
+		{
+			name: "scenario 3",
+			pods: []pod{
+				{"pod1", false},
+				{"pod2", false},
+			},
+			deploymentCanBeReaped: true,
+		},
+		{
+			name: "scenario 4",
+			pods: []pod{},
+			deploymentCanBeReaped: true,
+		},
+		{
+			name: "scenario 5",
+			pods: []pod{},
+			deploymentCanBeReaped: false,
+		},
+		{
+			name: "scenario 6",
+			pods: []pod{
+				{"pod1", true},
+				{"pod2", false},
+			},
+			deploymentCanBeReaped: false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Logf("testing scenario: %s", s.name)
+		reapedPods := []string{}
+		reaper := &DeploymentReaper{
+			deployerPodsFor: func(namespace, name string) (*kapi.PodList, error) {
+				list := &kapi.PodList{}
+				for _, pod := range s.pods {
+					list.Items = append(list.Items, kapi.Pod{ObjectMeta: kapi.ObjectMeta{Name: pod.name}})
+				}
+				return list, nil
+			},
+			controllerReaper: &testReaper{
+				stop: func(namespace, name string, gracePeriod *kapi.DeleteOptions) (string, error) {
+					if s.deploymentCanBeReaped {
+						return name, nil
+					}
+					return name, fmt.Errorf("error stopping %s", name)
+				},
+			},
+			podReaper: &testReaper{
+				stop: func(namespace, name string, gracePeriod *kapi.DeleteOptions) (string, error) {
+					for _, pod := range s.pods {
+						if pod.name == name && !pod.canBeReaped {
+							return name, fmt.Errorf("error stopping %s", name)
+						}
+					}
+					reapedPods = append(reapedPods, name)
+					return name, nil
+				},
+			},
+		}
+		result, err := reaper.Stop("test", "frontend-1", &kapi.DeleteOptions{})
+		t.Logf("Reaper output:\n%s", result)
+
+		// Verify absence deployment reaping error
+		if s.deploymentCanBeReaped && err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify expected deployment reaping error
+		if !s.deploymentCanBeReaped && err == nil {
+			t.Fatalf("expected an error")
+		} else if !s.deploymentCanBeReaped && err != nil {
+			t.Logf("got expected error: %v", err)
+		}
+
+		// Verify that expected pods were reaped.
+		for _, pod := range s.pods {
+			reaped := false
+			for _, name := range reapedPods {
+				if pod.name == name {
+					reaped = true
+				}
+			}
+			if pod.canBeReaped && !reaped {
+				t.Errorf("expected %s to be reaped", pod.name)
+			}
+		}
+
+		// Verify that no unexpected pods were reaped.
+		for _, reaped := range reapedPods {
+			expected := false
+			for _, pod := range s.pods {
+				if pod.name == reaped && pod.canBeReaped {
+					expected = true
+				}
+			}
+			if !expected {
+				t.Errorf("unexpected reaping of pod %s", reaped)
+			}
+		}
+	}
+}
+
+type testReaper struct {
+	stop func(namespace, name string, gracePeriod *kapi.DeleteOptions) (string, error)
+}
+
+func (r *testReaper) Stop(namespace, name string, gracePeriod *kapi.DeleteOptions) (string, error) {
+	return r.stop(namespace, name, gracePeriod)
 }

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -118,6 +118,12 @@ func ConfigSelector(name string) labels.Selector {
 	return labels.Set{deployapi.DeploymentConfigAnnotation: name}.AsSelector()
 }
 
+// DeployerPodSelector returns a label Selector which can be used to find all
+// deployer pods associated with a deployment with name.
+func DeployerPodSelector(name string) labels.Selector {
+	return labels.Set{deployapi.DeployerPodForDeploymentLabel: name}.AsSelector()
+}
+
 // DecodeDeploymentConfig decodes a DeploymentConfig from controller using codec. An error is returned
 // if the controller doesn't contain an encoded config.
 func DecodeDeploymentConfig(controller *api.ReplicationController, codec runtime.Codec) (*deployapi.DeploymentConfig, error) {
@@ -283,6 +289,13 @@ func DeploymentVersionFor(obj runtime.Object) int {
 func IsDeploymentCancelled(deployment *api.ReplicationController) bool {
 	value := mappedAnnotationFor(deployment, deployapi.DeploymentCancelledAnnotation)
 	return strings.EqualFold(value, deployapi.DeploymentCancelledAnnotationValue)
+}
+
+// IsDeployment returns true if controller is a deployment. The controller is
+// considered a deployment if it contains a deployment version annotation.
+func IsDeployment(controller *api.ReplicationController) bool {
+	_, hasVersion := controller.Annotations[deployapi.DeploymentVersionAnnotation]
+	return hasVersion
 }
 
 // mappedAnnotationFor finds the given annotation in obj using the annotation


### PR DESCRIPTION
Implement reaping for deployments and ReplicationControllers, reusing
upstream reapers wherever possible.

Closes #2316