### PR TITLE
Add admission controller for build strategy policy check

### DIFF
--- a/pkg/authorization/api/synthetic.go
+++ b/pkg/authorization/api/synthetic.go
@@ -1,0 +1,8 @@
+package api
+
+// Synthetic authorization endpoints
+const (
+	DockerBuildResource = "builds/docker"
+	SourceBuildResource = "builds/source"
+	CustomBuildResource = "builds/custom"
+)

--- a/pkg/build/admission/admission.go
+++ b/pkg/build/admission/admission.go
@@ -1,0 +1,123 @@
+package admission
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client"
+)
+
+func init() {
+	admission.RegisterPlugin("BuildByStrategy", func(c kclient.Interface, config io.Reader) (admission.Interface, error) {
+		osClient, ok := c.(client.Interface)
+		if !ok {
+			return nil, errors.New("client is not an OpenShift client")
+		}
+		return NewBuildByStrategy(osClient), nil
+	})
+}
+
+type buildByStrategy struct {
+	*admission.Handler
+	client client.Interface
+}
+
+// NewBuildByStrategy returns an admission control for builds that checks
+// on policy based on the build strategy type
+func NewBuildByStrategy(client client.Interface) admission.Interface {
+	return &buildByStrategy{
+		Handler: admission.NewHandler(admission.Create),
+		client:  client,
+	}
+}
+
+const (
+	buildsResource       = "builds"
+	buildConfigsResource = "buildconfigs"
+)
+
+func (a *buildByStrategy) Admit(attr admission.Attributes) error {
+	if resource := attr.GetResource(); resource != buildsResource && resource != buildConfigsResource {
+		return nil
+	}
+	var err error
+	switch obj := attr.GetObject().(type) {
+	case *buildapi.Build:
+		err = a.checkBuildAuthorization(obj, attr)
+	case *buildapi.BuildConfig:
+		err = a.checkBuildConfigAuthorization(obj, attr)
+	}
+
+	return err
+}
+
+func resourceForStrategyType(strategyType buildapi.BuildStrategyType) string {
+	var resource string
+	switch strategyType {
+	case buildapi.DockerBuildStrategyType:
+		resource = authorizationapi.DockerBuildResource
+	case buildapi.CustomBuildStrategyType:
+		resource = authorizationapi.CustomBuildResource
+	case buildapi.SourceBuildStrategyType:
+		resource = authorizationapi.SourceBuildResource
+	}
+	return resource
+
+}
+
+func resourceName(objectMeta kapi.ObjectMeta) string {
+	if len(objectMeta.GenerateName) > 0 {
+		return objectMeta.GenerateName
+	}
+	return objectMeta.Name
+}
+
+func (a *buildByStrategy) checkBuildAuthorization(build *buildapi.Build, attr admission.Attributes) error {
+	strategyType := build.Parameters.Strategy.Type
+	subjectAccessReview := &authorizationapi.SubjectAccessReview{
+		Verb:         "create",
+		Resource:     resourceForStrategyType(strategyType),
+		User:         attr.GetUserInfo().GetName(),
+		Groups:       util.NewStringSet(attr.GetUserInfo().GetGroups()...),
+		Content:      runtime.EmbeddedObject{Object: build},
+		ResourceName: resourceName(build.ObjectMeta),
+	}
+	return a.checkAccess(strategyType, subjectAccessReview, attr)
+}
+
+func (a *buildByStrategy) checkBuildConfigAuthorization(buildConfig *buildapi.BuildConfig, attr admission.Attributes) error {
+	strategyType := buildConfig.Parameters.Strategy.Type
+	subjectAccessReview := &authorizationapi.SubjectAccessReview{
+		Verb:         "create",
+		Resource:     resourceForStrategyType(strategyType),
+		User:         attr.GetUserInfo().GetName(),
+		Groups:       util.NewStringSet(attr.GetUserInfo().GetGroups()...),
+		Content:      runtime.EmbeddedObject{Object: buildConfig},
+		ResourceName: resourceName(buildConfig.ObjectMeta),
+	}
+	return a.checkAccess(strategyType, subjectAccessReview, attr)
+}
+
+func (a *buildByStrategy) checkAccess(strategyType buildapi.BuildStrategyType, subjectAccessReview *authorizationapi.SubjectAccessReview, attr admission.Attributes) error {
+	resp, err := a.client.SubjectAccessReviews(attr.GetNamespace()).Create(subjectAccessReview)
+	if err != nil {
+		return err
+	}
+	if !resp.Allowed {
+		return notAllowed(strategyType, attr)
+	}
+	return nil
+}
+
+func notAllowed(strategyType buildapi.BuildStrategyType, attr admission.Attributes) error {
+	return admission.NewForbidden(attr, fmt.Errorf("build strategy type %s is not allowed", strategyType))
+}

--- a/pkg/build/admission/admission_test.go
+++ b/pkg/build/admission/admission_test.go
@@ -1,0 +1,147 @@
+package admission
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/client/testclient"
+)
+
+func TestBuildAdmission(t *testing.T) {
+	tests := []struct {
+		name             string
+		kind             string
+		resource         string
+		object           runtime.Object
+		reviewResponse   *authorizationapi.SubjectAccessReviewResponse
+		expectedResource string
+		expectAccept     bool
+	}{
+		{
+			name:             "allowed source build",
+			object:           testBuild(buildapi.SourceBuildStrategyType),
+			kind:             "Build",
+			resource:         buildsResource,
+			reviewResponse:   reviewResponse(true, ""),
+			expectedResource: authorizationapi.SourceBuildResource,
+			expectAccept:     true,
+		},
+		{
+			name:             "denied docker build",
+			object:           testBuild(buildapi.DockerBuildStrategyType),
+			kind:             "Build",
+			resource:         buildsResource,
+			reviewResponse:   reviewResponse(false, "cannot create build of type docker build"),
+			expectAccept:     false,
+			expectedResource: authorizationapi.DockerBuildResource,
+		},
+		{
+			name:             "allowed custom build",
+			object:           testBuild(buildapi.CustomBuildStrategyType),
+			kind:             "Build",
+			resource:         buildsResource,
+			reviewResponse:   reviewResponse(true, ""),
+			expectedResource: authorizationapi.CustomBuildResource,
+			expectAccept:     true,
+		},
+		{
+			name:             "allowed build config",
+			object:           testBuildConfig(buildapi.DockerBuildStrategyType),
+			kind:             "BuildConfig",
+			resource:         buildConfigsResource,
+			reviewResponse:   reviewResponse(true, ""),
+			expectAccept:     true,
+			expectedResource: authorizationapi.DockerBuildResource,
+		},
+		{
+			name:             "forbidden build config",
+			object:           testBuildConfig(buildapi.CustomBuildStrategyType),
+			kind:             "BuildConfig",
+			resource:         buildConfigsResource,
+			reviewResponse:   reviewResponse(false, ""),
+			expectAccept:     false,
+			expectedResource: authorizationapi.CustomBuildResource,
+		},
+	}
+
+	for _, test := range tests {
+		c := NewBuildByStrategy(fakeClient(test.expectedResource, test.reviewResponse))
+		attrs := admission.NewAttributesRecord(test.object, test.kind, "default", test.resource, admission.Create, fakeUser())
+		err := c.Admit(attrs)
+		if err != nil && test.expectAccept {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+		if (err == nil || !apierrors.IsForbidden(err)) && !test.expectAccept {
+			t.Errorf("%s: expecting reject error", test.name)
+		}
+	}
+}
+
+func fakeUser() user.Info {
+	return &user.DefaultInfo{
+		Name: "testuser",
+	}
+}
+
+func fakeClient(expectedResource string, reviewResponse *authorizationapi.SubjectAccessReviewResponse) client.Interface {
+	emptyResponse := &authorizationapi.SubjectAccessReviewResponse{}
+	return &testclient.Fake{
+		ReactFn: func(action ktestclient.FakeAction) (runtime.Object, error) {
+			if action.Action == "create-subjectAccessReview" {
+				review, ok := action.Value.(*authorizationapi.SubjectAccessReview)
+				if !ok {
+					return emptyResponse, fmt.Errorf("unexpected object received: %#v", review)
+				}
+				if review.Resource != expectedResource {
+					return emptyResponse, fmt.Errorf("unexpected resource received: %s. expected: %s",
+						review.Resource, expectedResource)
+				}
+				return reviewResponse, nil
+			}
+			return nil, nil
+		},
+	}
+}
+
+func testBuild(strategy buildapi.BuildStrategyType) *buildapi.Build {
+	return &buildapi.Build{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "test-build",
+		},
+		Parameters: buildapi.BuildParameters{
+			Strategy: buildapi.BuildStrategy{
+				Type: strategy,
+			},
+		},
+	}
+}
+
+func testBuildConfig(strategy buildapi.BuildStrategyType) *buildapi.BuildConfig {
+	return &buildapi.BuildConfig{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "test-buildconfig",
+		},
+		Parameters: buildapi.BuildParameters{
+			Strategy: buildapi.BuildStrategy{
+				Type: strategy,
+			},
+		},
+	}
+}
+
+func reviewResponse(allowed bool, msg string) *authorizationapi.SubjectAccessReviewResponse {
+	return &authorizationapi.SubjectAccessReviewResponse{
+		Allowed: allowed,
+		Reason:  msg,
+	}
+}

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -148,6 +148,7 @@ func (d *BuildDescriber) Describe(namespace, name string) (string, error) {
 func describeBuildDuration(build *buildapi.Build) string {
 	t := util.Now().Rfc3339Copy()
 	if build.StartTimestamp == nil &&
+		build.CompletionTimestamp != nil &&
 		(build.Status == buildapi.BuildStatusCancelled ||
 			build.Status == buildapi.BuildStatusFailed ||
 			build.Status == buildapi.BuildStatusError) {

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -72,7 +72,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "delete"),
-					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/proxy"),
+					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/proxy", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
 				},
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch"),
@@ -92,7 +92,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "delete"),
-					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/proxy"),
+					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/proxy", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
 				},
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch"),

--- a/pkg/cmd/server/start/plugins.go
+++ b/pkg/cmd/server/start/plugins.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/resourcequota"
 	_ "github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/serviceaccount"
+	_ "github.com/openshift/origin/pkg/build/admission"
 	_ "github.com/openshift/origin/pkg/project/admission/lifecycle"
 	_ "github.com/openshift/origin/pkg/project/admission/nodeenv"
 	_ "github.com/openshift/origin/pkg/security/admission"

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -1,0 +1,276 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kapierror "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client"
+	policy "github.com/openshift/origin/pkg/cmd/admin/policy"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+func TestPolicyBasedRestrictionOfBuildStrategies(t *testing.T) {
+	const namespace = "hammer"
+
+	_, clusterAdminKubeConfig, err := testutil.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	haroldClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "harold")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joeClient, err := testutil.GetClientForUser(*clusterAdminClientConfig, "joe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	addJoe := &policy.RoleModificationOptions{
+		RoleNamespace:       "",
+		RoleName:            bootstrappolicy.EditRoleName,
+		RoleBindingAccessor: policy.NewLocalRoleBindingAccessor(namespace, haroldClient),
+		Users:               []string{"joe"},
+	}
+	if err := addJoe.AddRole(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// by default admins and editors can create all type of builds
+	_, err = createDockerBuild(t, haroldClient.Builds(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = createDockerBuild(t, joeClient.Builds(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = createSourceBuild(t, haroldClient.Builds(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = createSourceBuild(t, joeClient.Builds(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = createCustomBuild(t, haroldClient.Builds(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = createCustomBuild(t, joeClient.Builds(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// remove resources from role so that certain build strategies are forbidden
+	removeBuildStrategyPrivileges(t, clusterAdminClient.ClusterRoles(), bootstrappolicy.EditRoleName)
+	removeBuildStrategyPrivileges(t, clusterAdminClient.ClusterRoles(), bootstrappolicy.AdminRoleName)
+
+	// make sure builds are rejected
+	if _, err = createDockerBuild(t, haroldClient.Builds(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createDockerBuild(t, joeClient.Builds(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createSourceBuild(t, haroldClient.Builds(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createSourceBuild(t, joeClient.Builds(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createCustomBuild(t, haroldClient.Builds(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createCustomBuild(t, joeClient.Builds(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+}
+
+func removeBuildStrategyPrivileges(t *testing.T, clusterRoleInterface client.ClusterRoleInterface, roleName string) {
+	role, err := clusterRoleInterface.Get(roleName)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	for i := range role.Rules {
+		role.Rules[i].Resources.Delete(authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource)
+	}
+	if _, err := clusterRoleInterface.Update(role); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+}
+
+func createDockerBuild(t *testing.T, buildInterface client.BuildInterface) (*buildapi.Build, error) {
+	dockerBuild := &buildapi.Build{}
+	dockerBuild.GenerateName = "docker-build-"
+	dockerBuild.Parameters.Strategy.Type = buildapi.DockerBuildStrategyType
+	dockerBuild.Parameters.Source.Type = buildapi.BuildSourceGit
+	dockerBuild.Parameters.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	return buildInterface.Create(dockerBuild)
+}
+
+func createSourceBuild(t *testing.T, buildInterface client.BuildInterface) (*buildapi.Build, error) {
+	dockerBuild := &buildapi.Build{}
+	dockerBuild.GenerateName = "source-build-"
+	dockerBuild.Parameters.Strategy.Type = buildapi.SourceBuildStrategyType
+	dockerBuild.Parameters.Strategy.SourceStrategy = &buildapi.SourceBuildStrategy{From: &kapi.ObjectReference{Name: "name:tag"}}
+	dockerBuild.Parameters.Source.Type = buildapi.BuildSourceGit
+	dockerBuild.Parameters.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	return buildInterface.Create(dockerBuild)
+}
+
+func createCustomBuild(t *testing.T, buildInterface client.BuildInterface) (*buildapi.Build, error) {
+	dockerBuild := &buildapi.Build{}
+	dockerBuild.GenerateName = "custom-build-"
+	dockerBuild.Parameters.Strategy.Type = buildapi.CustomBuildStrategyType
+	dockerBuild.Parameters.Strategy.CustomStrategy = &buildapi.CustomBuildStrategy{From: &kapi.ObjectReference{Name: "name:tag"}}
+	dockerBuild.Parameters.Source.Type = buildapi.BuildSourceGit
+	dockerBuild.Parameters.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	return buildInterface.Create(dockerBuild)
+}
+
+func TestPolicyBasedRestrictionOfBuildConfigStrategies(t *testing.T) {
+	const namespace = "hammer"
+
+	_, clusterAdminKubeConfig, err := testutil.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	haroldClient, err := testutil.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "harold")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joeClient, err := testutil.GetClientForUser(*clusterAdminClientConfig, "joe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	addJoe := &policy.RoleModificationOptions{
+		RoleNamespace:       "",
+		RoleName:            bootstrappolicy.EditRoleName,
+		RoleBindingAccessor: policy.NewLocalRoleBindingAccessor(namespace, haroldClient),
+		Users:               []string{"joe"},
+	}
+	if err := addJoe.AddRole(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// by default admins and editors can create all type of buildconfigs
+	_, err = createDockerBuildConfig(t, haroldClient.BuildConfigs(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = createDockerBuildConfig(t, joeClient.BuildConfigs(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = createSourceBuildConfig(t, haroldClient.BuildConfigs(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = createSourceBuildConfig(t, joeClient.BuildConfigs(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = createCustomBuildConfig(t, haroldClient.BuildConfigs(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = createCustomBuildConfig(t, joeClient.BuildConfigs(namespace))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// remove resources from role so that certain build strategies are forbidden
+	removeBuildStrategyPrivileges(t, clusterAdminClient.ClusterRoles(), bootstrappolicy.EditRoleName)
+	removeBuildStrategyPrivileges(t, clusterAdminClient.ClusterRoles(), bootstrappolicy.AdminRoleName)
+
+	// make sure buildconfigs are rejected
+	if _, err = createDockerBuildConfig(t, haroldClient.BuildConfigs(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createDockerBuildConfig(t, joeClient.BuildConfigs(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createSourceBuildConfig(t, haroldClient.BuildConfigs(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createSourceBuildConfig(t, joeClient.BuildConfigs(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createCustomBuildConfig(t, haroldClient.BuildConfigs(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+	if _, err = createCustomBuildConfig(t, joeClient.BuildConfigs(namespace)); !kapierror.IsForbidden(err) {
+		t.Errorf("expected forbidden, got %v", err)
+	}
+}
+
+func createDockerBuildConfig(t *testing.T, buildConfigInterface client.BuildConfigInterface) (*buildapi.BuildConfig, error) {
+	dockerBuild := &buildapi.BuildConfig{}
+	dockerBuild.GenerateName = "docker-buildconfig-"
+	dockerBuild.Parameters.Strategy.Type = buildapi.DockerBuildStrategyType
+	dockerBuild.Parameters.Source.Type = buildapi.BuildSourceGit
+	dockerBuild.Parameters.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	return buildConfigInterface.Create(dockerBuild)
+}
+
+func createSourceBuildConfig(t *testing.T, buildConfigInterface client.BuildConfigInterface) (*buildapi.BuildConfig, error) {
+	dockerBuild := &buildapi.BuildConfig{}
+	dockerBuild.GenerateName = "source-buildconfig-"
+	dockerBuild.Parameters.Strategy.Type = buildapi.SourceBuildStrategyType
+	dockerBuild.Parameters.Strategy.SourceStrategy = &buildapi.SourceBuildStrategy{From: &kapi.ObjectReference{Name: "name:tag"}}
+	dockerBuild.Parameters.Source.Type = buildapi.BuildSourceGit
+	dockerBuild.Parameters.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	return buildConfigInterface.Create(dockerBuild)
+}
+
+func createCustomBuildConfig(t *testing.T, buildConfigInterface client.BuildConfigInterface) (*buildapi.BuildConfig, error) {
+	dockerBuild := &buildapi.BuildConfig{}
+	dockerBuild.GenerateName = "custom-buildconfig-"
+	dockerBuild.Parameters.Strategy.Type = buildapi.CustomBuildStrategyType
+	dockerBuild.Parameters.Strategy.CustomStrategy = &buildapi.CustomBuildStrategy{From: &kapi.ObjectReference{Name: "name:tag"}}
+	dockerBuild.Parameters.Source.Type = buildapi.BuildSourceGit
+	dockerBuild.Parameters.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
+
+	return buildConfigInterface.Create(dockerBuild)
+}


### PR DESCRIPTION
Makes it possible to grant access to build creation based on build strategy (custom, docker, or source)