### PR TITLE
Clean up orphaned deployers and use pod watches

### DIFF
--- a/pkg/deploy/controller/deployerpod/factory.go
+++ b/pkg/deploy/controller/deployerpod/factory.go
@@ -1,13 +1,9 @@
 package deployerpod
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/golang/glog"
-
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
@@ -17,13 +13,11 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	controller "github.com/openshift/origin/pkg/controller"
-	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
-// DeployerPodControllerFactory can create a DeployerPodController which gets
-// pods from a queue populated from a watch of all pods filtered by a cache of
-// deployments associated with pods.
+// DeployerPodControllerFactory can create a DeployerPodController which
+// handles processing deployer pods.
 type DeployerPodControllerFactory struct {
 	// KubeClient is a Kubernetes client.
 	KubeClient kclient.Interface
@@ -42,23 +36,33 @@ func (factory *DeployerPodControllerFactory) Create() controller.RunnableControl
 	deploymentStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	cache.NewReflector(deploymentLW, &kapi.ReplicationController{}, deploymentStore, 2*time.Minute).Run()
 
-	// Kubernetes does not currently synchronize Pod status in storage with a Pod's container
-	// states. Because of this, we can't receive events related to container (and thus Pod)
-	// state changes, such as Running -> Terminated. As a workaround, populate the FIFO with
-	// a polling implementation which relies on client calls to list Pods - the Get/List
-	// REST implementations will populate the synchronized container/pod status on-demand.
-	//
-	// TODO: Find a way to get watch events for Pod/container status updates. The polling
-	// strategy is horribly inefficient and should be addressed upstream somehow.
-	podQueue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
-	pollFunc := func() (cache.Enumerator, error) {
-		return pollPods(deploymentStore, factory.KubeClient)
+	// TODO: These should be filtered somehow to include only the primary
+	// deployer pod. For now, the controller is filtering.
+	// TODO: Even with the label selector, this is inefficient on the backend
+	// and we should work to consolidate namespace-spanning pod watches. For
+	// example, the build infra is also watching pods across namespaces.
+	podLW := &deployutil.ListWatcherImpl{
+		ListFunc: func() (runtime.Object, error) {
+			return factory.KubeClient.Pods(kapi.NamespaceAll).List(deployutil.AnyDeployerPodSelector(), fields.Everything())
+		},
+		WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+			return factory.KubeClient.Pods(kapi.NamespaceAll).Watch(deployutil.AnyDeployerPodSelector(), fields.Everything(), resourceVersion)
+		},
 	}
-	cache.NewPoller(pollFunc, 10*time.Second, podQueue).Run()
+	podQueue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
+	cache.NewReflector(podLW, &kapi.Pod{}, podQueue, 2*time.Minute).Run()
 
 	podController := &DeployerPodController{
 		deploymentClient: &deploymentClientImpl{
 			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+				// Try to use the cache first. Trust hits and return them.
+				example := &kapi.ReplicationController{ObjectMeta: kapi.ObjectMeta{Namespace: namespace, Name: name}}
+				cached, exists, err := deploymentStore.Get(example)
+				if err == nil && exists {
+					return cached.(*kapi.ReplicationController), nil
+				}
+				// Double-check with the master for cache misses/errors, since those
+				// are rare and API calls are expensive but more reliable.
 				return factory.KubeClient.ReplicationControllers(namespace).Get(name)
 			},
 			updateDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
@@ -67,6 +71,12 @@ func (factory *DeployerPodControllerFactory) Create() controller.RunnableControl
 			listDeploymentsForConfigFunc: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
 				return factory.KubeClient.ReplicationControllers(namespace).List(deployutil.ConfigSelector(configName))
 			},
+		},
+		deployerPodsFor: func(namespace, name string) (*kapi.PodList, error) {
+			return factory.KubeClient.Pods(namespace).List(deployutil.DeployerPodSelector(name), fields.Everything())
+		},
+		deletePod: func(namespace, name string) error {
+			return factory.KubeClient.Pods(namespace).Delete(name, kapi.NewDeleteOptions(0))
 		},
 	}
 
@@ -94,67 +104,4 @@ func (factory *DeployerPodControllerFactory) Create() controller.RunnableControl
 			return podController.Handle(pod)
 		},
 	}
-}
-
-// pollPods lists all pods associated with pending or running deployments and returns
-// a cache.Enumerator suitable for use with a cache.Poller.
-func pollPods(deploymentStore cache.Store, kClient kclient.Interface) (cache.Enumerator, error) {
-	list := &kapi.PodList{}
-
-	for _, obj := range deploymentStore.List() {
-		deployment := obj.(*kapi.ReplicationController)
-		currentStatus := deployutil.DeploymentStatusFor(deployment)
-
-		switch currentStatus {
-		case deployapi.DeploymentStatusPending, deployapi.DeploymentStatusRunning:
-			// Validate the correlating pod annotation
-			podID := deployutil.DeployerPodNameFor(deployment)
-			if len(podID) == 0 {
-				glog.V(2).Infof("Unexpected state: deployment %s has no pod annotation; skipping pod polling", deployment.Name)
-				continue
-			}
-
-			pod, err := kClient.Pods(deployment.Namespace).Get(podID)
-			if err != nil {
-				glog.V(2).Infof("Couldn't find pod %s for deployment %s: %#v", podID, deployment.Name, err)
-
-				// if the deployer pod doesn't exist, update the deployment status to failed
-				// TODO: This update should be moved the controller
-				// once this poll is changed in favor of pod status updates.
-				if kerrors.IsNotFound(err) {
-					nextStatus := deployapi.DeploymentStatusFailed
-					deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(nextStatus)
-					deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentFailedDeployerPodNoLongerExists
-
-					if _, err := kClient.ReplicationControllers(deployment.Namespace).Update(deployment); err != nil {
-						kutil.HandleError(fmt.Errorf("couldn't update deployment %s to status %s: %v", deployutil.LabelForDeployment(deployment), nextStatus, err))
-					}
-					glog.V(2).Infof("Updated deployment %s status from %s to %s", deployutil.LabelForDeployment(deployment), currentStatus, nextStatus)
-				}
-				continue
-			}
-
-			list.Items = append(list.Items, *pod)
-		}
-	}
-
-	return &podEnumerator{list}, nil
-}
-
-// podEnumerator allows a cache.Poller to enumerate items in an api.PodList
-type podEnumerator struct {
-	*kapi.PodList
-}
-
-// Len returns the number of items in the pod list.
-func (pe *podEnumerator) Len() int {
-	if pe.PodList == nil {
-		return 0
-	}
-	return len(pe.Items)
-}
-
-// Get returns the item (and ID) with the particular index.
-func (pe *podEnumerator) Get(index int) interface{} {
-	return &pe.Items[index]
 }

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -84,7 +84,7 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 		// succeeded but the deployment state update failed and now we're re-
 		// entering. Ensure that the pod is the one we created by verifying the
 		// annotation on it, and throw a retryable error.
-		existingPod, err := c.podClient.getPod(deployment.Namespace, deployutil.DeployerPodNameForDeployment(deployment))
+		existingPod, err := c.podClient.getPod(deployment.Namespace, deployutil.DeployerPodNameForDeployment(deployment.Name))
 		if err != nil {
 			c.recorder.Eventf(deployment, "failedCreate", "Error getting existing deployer pod for %s: %v", deployutil.LabelForDeployment(deployment), err)
 			return fmt.Errorf("couldn't fetch existing deployer pod for %s: %v", deployutil.LabelForDeployment(deployment), err)
@@ -111,9 +111,20 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 		nextStatus = deployapi.DeploymentStatusPending
 		glog.V(4).Infof("Detected existing deployer pod %s for deployment %s", existingPod.Name, deployutil.LabelForDeployment(deployment))
 	case deployapi.DeploymentStatusPending, deployapi.DeploymentStatusRunning:
-		// If the deployment isn't cancelled, let the deployment run.
-		if !deployutil.IsDeploymentCancelled(deployment) {
-			break
+		// If the deployer pod has vanished, consider the deployment a failure.
+		deployerPodName := deployutil.DeployerPodNameForDeployment(deployment.Name)
+		if _, err := c.podClient.getPod(deployment.Namespace, deployerPodName); err != nil {
+			if kerrors.IsNotFound(err) {
+				nextStatus = deployapi.DeploymentStatusFailed
+				deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(nextStatus)
+				deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentFailedDeployerPodNoLongerExists
+				c.recorder.Eventf(deployment, "failed", "Deployer pod %q has gone missing", deployerPodName)
+				glog.V(4).Infof("Failing deployment %q because its deployer pod %q disappeared", deployutil.LabelForDeployment(deployment), deployerPodName)
+				break
+			} else {
+				// We'll try again later on resync. Continue to process cancellations.
+				glog.V(2).Infof("Error getting deployer pod %s for deployment %s: %#v", deployerPodName, deployutil.LabelForDeployment(deployment), err)
+			}
 		}
 
 		// If the deployment is cancelled, terminate any deployer/hook pods.
@@ -122,24 +133,26 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 		// when the deployer pod failure state is picked up
 		// Also, it will scale down the failed deployment and scale back up
 		// the last successful completed deployment
-		deployerPods, err := c.podClient.getDeployerPodsFor(deployment.Namespace, deployment.Name)
-		if err != nil {
-			return fmt.Errorf("couldn't fetch deployer pods for %s while trying to cancel deployment: %v", deployutil.LabelForDeployment(deployment), err)
-		}
-		glog.V(4).Infof("Cancelling %d deployer pods for deployment %s", len(deployerPods), deployutil.LabelForDeployment(deployment))
-		zeroDelay := int64(1)
-		for _, deployerPod := range deployerPods {
-			// Set the ActiveDeadlineSeconds on the pod so it's terminated very soon.
-			if deployerPod.Spec.ActiveDeadlineSeconds == nil || *deployerPod.Spec.ActiveDeadlineSeconds != zeroDelay {
-				deployerPod.Spec.ActiveDeadlineSeconds = &zeroDelay
-				if _, err := c.podClient.updatePod(deployerPod.Namespace, &deployerPod); err != nil {
-					c.recorder.Eventf(deployment, "failedCancellation", "Error cancelling deployer pod %s for deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
-					return fmt.Errorf("couldn't cancel deployer pod %s for deployment %s: %v", deployutil.LabelForDeployment(deployment), err)
-				}
-				glog.V(4).Infof("Cancelled deployer pod %s for deployment %s", deployerPod.Name, deployutil.LabelForDeployment(deployment))
+		if deployutil.IsDeploymentCancelled(deployment) {
+			deployerPods, err := c.podClient.getDeployerPodsFor(deployment.Namespace, deployment.Name)
+			if err != nil {
+				return fmt.Errorf("couldn't fetch deployer pods for %s while trying to cancel deployment: %v", deployutil.LabelForDeployment(deployment), err)
 			}
+			glog.V(4).Infof("Cancelling %d deployer pods for deployment %s", len(deployerPods), deployutil.LabelForDeployment(deployment))
+			zeroDelay := int64(1)
+			for _, deployerPod := range deployerPods {
+				// Set the ActiveDeadlineSeconds on the pod so it's terminated very soon.
+				if deployerPod.Spec.ActiveDeadlineSeconds == nil || *deployerPod.Spec.ActiveDeadlineSeconds != zeroDelay {
+					deployerPod.Spec.ActiveDeadlineSeconds = &zeroDelay
+					if _, err := c.podClient.updatePod(deployerPod.Namespace, &deployerPod); err != nil {
+						c.recorder.Eventf(deployment, "failedCancellation", "Error cancelling deployer pod %s for deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
+						return fmt.Errorf("couldn't cancel deployer pod %s for deployment %s: %v", deployutil.LabelForDeployment(deployment), err)
+					}
+					glog.V(4).Infof("Cancelled deployer pod %s for deployment %s", deployerPod.Name, deployutil.LabelForDeployment(deployment))
+				}
+			}
+			c.recorder.Eventf(deployment, "cancelled", "Cancelled deployment")
 		}
-		c.recorder.Eventf(deployment, "cancelled", "Cancelled deployment")
 	case deployapi.DeploymentStatusFailed:
 		// Nothing to do in this terminal state.
 		glog.V(4).Infof("Ignoring deployment %s (status %s)", deployutil.LabelForDeployment(deployment), currentStatus)
@@ -178,7 +191,6 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 		}
 		glog.V(4).Infof("Updated deployment %s status from %s to %s", deployutil.LabelForDeployment(deployment), currentStatus, nextStatus)
 	}
-
 	return nil
 }
 
@@ -208,7 +220,7 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 
 	pod := &kapi.Pod{
 		ObjectMeta: kapi.ObjectMeta{
-			Name: deployutil.DeployerPodNameForDeployment(deployment),
+			Name: deployutil.DeployerPodNameForDeployment(deployment.Name),
 			Annotations: map[string]string{
 				deployapi.DeploymentAnnotation: deployment.Name,
 			},

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -95,8 +95,8 @@ func LatestDeploymentNameForConfig(config *deployapi.DeploymentConfig) string {
 const DeployerPodSuffix = "deploy"
 
 // DeployerPodNameForDeployment returns the name of a pod for a given deployment
-func DeployerPodNameForDeployment(deployment *api.ReplicationController) string {
-	return namer.GetPodName(deployment.Name, DeployerPodSuffix)
+func DeployerPodNameForDeployment(deployment string) string {
+	return namer.GetPodName(deployment, DeployerPodSuffix)
 }
 
 // LabelForDeployment builds a string identifier for a Deployment.
@@ -116,6 +116,20 @@ func LabelForDeploymentConfig(config *deployapi.DeploymentConfig) string {
 // but we could consider adding a new constant to the public types.
 func ConfigSelector(name string) labels.Selector {
 	return labels.Set{deployapi.DeploymentConfigAnnotation: name}.AsSelector()
+}
+
+// DeployerPodSelector returns a label Selector which can be used to find all
+// deployer pods associated with a deployment with name.
+func DeployerPodSelector(name string) labels.Selector {
+	return labels.Set{deployapi.DeployerPodForDeploymentLabel: name}.AsSelector()
+}
+
+// AnyDeployerPodSelector returns a label Selector which can be used to find
+// all deployer pods across all deployments, including hook and custom
+// deployer pods.
+func AnyDeployerPodSelector() labels.Selector {
+	sel, _ := labels.Parse(deployapi.DeployerPodForDeploymentLabel)
+	return sel
 }
 
 // DecodeDeploymentConfig decodes a DeploymentConfig from controller using codec. An error is returned

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -52,7 +52,7 @@ func TestPodName(t *testing.T) {
 		},
 	}
 	expected := "testName-deploy"
-	actual := DeployerPodNameForDeployment(deployment)
+	actual := DeployerPodNameForDeployment(deployment.Name)
 	if expected != actual {
 		t.Errorf("Unexpected pod name for deployment. Expected: %s Got: %s", expected, actual)
 	}


### PR DESCRIPTION
Clean up deployer pods whose deployments have disappeared. Port the
DeployerPodController to use a pod watch, and move failed deployment
checking to DeploymentController where it belongs.

Closes #2316.
Closes #2824.