### PR TITLE
UPSTREAM: Make admission errors clearer

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/admission/errors.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/admission/errors.go
@@ -34,7 +34,7 @@ func NewForbidden(a Attributes, internalError error) error {
 	if obj != nil {
 		objectMeta, err := api.ObjectMetaFor(obj)
 		if err != nil {
-			return apierrors.NewForbidden(kind, name, err)
+			return apierrors.NewForbidden(kind, name, internalError)
 		}
 
 		// this is necessary because name object name generation has not occurred yet


### PR DESCRIPTION
If the name can't be determined, return the original error (same as if the object is nil).

Fixes #3159