### PR TITLE
Change system:openshift-client username to system:openshift-master

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -56,9 +56,9 @@ In order to run the router in a deployed environment the following conditions mu
 * The machine may or may not be registered with the master.  Optimally it will not serve pods while also serving as the router
 * The machine must not have services running on it that bind to host port 80 since this is what the router uses for traffic
 
-To install the router pod you use the `oadm router` command line, passing the flags `--create` and `--credentials=<kubeconfig_file>`.
+To install the router pod you use the `oadm router` command line, passing the flag `--credentials=<kubeconfig_file>`.
 The credentials flag controls the identity that the router will use to talk to the master (and the address of the master) so in most
-environments you can use the `${CONFIG_DIR}/master/openshift-client.kubeconfig` file. Once you run this command you can check the configuration
+environments you can use the `${CONFIG_DIR}/master/openshift-router.kubeconfig` file. Once you run this command you can check the configuration
 of the router by running `oc get dc router` to check the deployment status.
 
 `oadm router` offers other options for deploying routers - run `oadm router --help` for more details.

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -36,8 +36,8 @@ func TestSubjects(t *testing.T) {
 			Verb:     "get",
 			Resource: "pods",
 		},
-		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:openshift-client"),
-		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:nodes"),
+		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie"),
+		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:masters", "system:nodes"),
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = newAdzePolicies()

--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -251,7 +251,7 @@ func (o CreateNodeConfigOptions) MakeClientCert(clientCertFile, clientKeyFile st
 			CertFile: clientCertFile,
 			KeyFile:  clientKeyFile,
 
-			User:   "system:node-" + o.NodeName,
+			User:   "system:node:" + o.NodeName,
 			Groups: util.StringList([]string{bootstrappolicy.NodesGroup}),
 			Output: o.Output,
 		}

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -111,11 +111,12 @@ func DefaultRegistryClientCertInfo(certDir string) ClientCertInfo {
 func DefaultOpenshiftLoopbackClientCertInfo(certDir string) ClientCertInfo {
 	return ClientCertInfo{
 		CertLocation: configapi.CertInfo{
-			CertFile: DefaultCertFilename(certDir, "openshift-client"),
-			KeyFile:  DefaultKeyFilename(certDir, "openshift-client"),
+			CertFile: DefaultCertFilename(certDir, bootstrappolicy.MasterUnqualifiedUsername),
+			KeyFile:  DefaultKeyFilename(certDir, bootstrappolicy.MasterUnqualifiedUsername),
 		},
-		UnqualifiedUser: "openshift-client",
-		User:            "system:openshift-client",
+		UnqualifiedUser: bootstrappolicy.MasterUnqualifiedUsername,
+		User:            bootstrappolicy.MasterUsername,
+		Groups:          util.NewStringSet(bootstrappolicy.MastersGroup),
 	}
 }
 
@@ -127,7 +128,7 @@ func DefaultClusterAdminClientCertInfo(certDir string) ClientCertInfo {
 		},
 		UnqualifiedUser: "admin",
 		User:            "system:admin",
-		Groups:          util.NewStringSet("system:cluster-admins"),
+		Groups:          util.NewStringSet(bootstrappolicy.ClusterAdminGroup),
 	}
 }
 

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -16,22 +16,24 @@ const (
 	InfraReplicationControllerServiceAccountName = "replication-controller"
 	InfraDeploymentControllerServiceAccountName  = "deployment-controller"
 
+	MasterUnqualifiedUsername   = "openshift-master"
 	RouterUnqualifiedUsername   = "openshift-router"
 	RegistryUnqualifiedUsername = "openshift-registry"
 
+	MasterUsername   = "system:" + MasterUnqualifiedUsername
 	RouterUsername   = "system:" + RouterUnqualifiedUsername
 	RegistryUsername = "system:" + RegistryUnqualifiedUsername
 )
 
 // groups
 const (
-	UnauthenticatedUsername   = "system:anonymous"
-	InternalComponentUsername = "system:openshift-client"
+	UnauthenticatedUsername = "system:anonymous"
 
 	AuthenticatedGroup   = "system:authenticated"
 	UnauthenticatedGroup = "system:unauthenticated"
 	ClusterAdminGroup    = "system:cluster-admins"
 	ClusterReaderGroup   = "system:cluster-readers"
+	MastersGroup         = "system:masters"
 	NodesGroup           = "system:nodes"
 	RouterGroup          = "system:routers"
 	RegistryGroup        = "system:registries"
@@ -58,11 +60,11 @@ const (
 	DeployerRoleName          = "system:deployer"
 	RouterRoleName            = "system:router"
 	RegistryRoleName          = "system:registry"
+	MasterRoleName            = "system:master"
 	NodeRoleName              = "system:node"
 	NodeProxierRoleName       = "system:node-proxier"
 	SDNReaderRoleName         = "system:sdn-reader"
 	SDNManagerRoleName        = "system:sdn-manager"
-	InternalComponentRoleName = "system:component"
 	OAuthTokenDeleterRoleName = "system:oauth-token-deleter"
 	WebHooksRoleName          = "system:webhook"
 
@@ -72,7 +74,6 @@ const (
 // RoleBindings
 const (
 	SelfProvisionerRoleBindingName   = SelfProvisionerRoleName + "s"
-	InternalComponentRoleBindingName = InternalComponentRoleName + "s"
 	DeployerRoleBindingName          = DeployerRoleName + "s"
 	ClusterAdminRoleBindingName      = ClusterAdminRoleName + "s"
 	ClusterReaderRoleBindingName     = ClusterReaderRoleName + "s"
@@ -83,6 +84,7 @@ const (
 	ImageBuilderRoleBindingName      = ImageBuilderRoleName + "s"
 	RouterRoleBindingName            = RouterRoleName + "s"
 	RegistryRoleBindingName          = RegistryRoleName + "s"
+	MasterRoleBindingName            = MasterRoleName + "s"
 	NodeRoleBindingName              = NodeRoleName + "s"
 	NodeProxierRoleBindingName       = NodeProxierRoleName + "s"
 	SDNReaderRoleBindingName         = SDNReaderRoleName + "s"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -212,7 +212,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: InternalComponentRoleName,
+				Name: MasterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
@@ -515,12 +515,12 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 	return []authorizationapi.ClusterRoleBinding{
 		{
 			ObjectMeta: kapi.ObjectMeta{
-				Name: InternalComponentRoleBindingName,
+				Name: MasterRoleBindingName,
 			},
 			RoleRef: kapi.ObjectReference{
-				Name: InternalComponentRoleName,
+				Name: MasterRoleName,
 			},
-			Users: util.NewStringSet(InternalComponentUsername),
+			Groups: util.NewStringSet(MastersGroup),
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -202,7 +202,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		},
 
 		MasterClients: configapi.MasterClients{
-			OpenShiftLoopbackKubeConfig:  admin.DefaultKubeConfigFilename(args.ConfigDir.Value(), "openshift-client"),
+			OpenShiftLoopbackKubeConfig:  admin.DefaultKubeConfigFilename(args.ConfigDir.Value(), bootstrappolicy.MasterUnqualifiedUsername),
 			ExternalKubernetesKubeConfig: args.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath,
 		},
 

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -134,8 +134,8 @@ func TestAuthorizationOnlyResolveRolesForBindingsThatMatter(t *testing.T) {
 }
 
 // TODO this list should start collapsing as we continue to tighten access on generated system ids
-var globalClusterAdminUsers = util.NewStringSet("system:openshift-client")
-var globalClusterAdminGroups = util.NewStringSet("system:cluster-admins")
+var globalClusterAdminUsers = util.NewStringSet()
+var globalClusterAdminGroups = util.NewStringSet("system:cluster-admins", "system:masters")
 
 type resourceAccessReviewTest struct {
 	clientInterface client.ResourceAccessReviewInterface


### PR DESCRIPTION
When running `who-can` commands to check https://github.com/openshift/origin/pull/3133, having "system:openshift-client" show up as highly privileged was somewhat disconcerting.

The username `system:openshift-client` and the role `system:component` don't convey how highly privileged those things are. It could lead to people misusing the roles or credentials.

This changes the role name to `system:master`, binds it to the `system:masters` group, and changes the loopback client username to `system:openshift-master`.

It also changes the node username to follow the service account pattern (`system:node:$nodename`) which will make it easier to apply per-node restrictions based on the particular user in the future