### PR TITLE
Add routingConfig.subdomain to master config

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -144,6 +144,9 @@ type MasterConfig struct {
 	// ProjectConfig holds information about project creation and defaults
 	ProjectConfig ProjectConfig
 
+	// RoutingConfig holds information about routing and route generation
+	RoutingConfig RoutingConfig
+
 	// NetworkConfig to be passed to the compiled in network plugin
 	NetworkConfig NetworkConfig
 }
@@ -162,6 +165,11 @@ type ProjectConfig struct {
 
 	// SecurityAllocator controls the automatic allocation of UIDs and MCS labels to a project. If nil, allocation is disabled.
 	SecurityAllocator *SecurityAllocator
+}
+
+type RoutingConfig struct {
+	// Subdomain is the suffix appended to $service.$namespace. to form the default route hostname
+	Subdomain string
 }
 
 type SecurityAllocator struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -22,6 +22,9 @@ func init() {
 			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
 				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace
 			}
+			if len(obj.RoutingConfig.Subdomain) == 0 {
+				obj.RoutingConfig.Subdomain = "router.default.local"
+			}
 		},
 		func(obj *KubernetesMasterConfig) {
 			if obj.MasterCount == 0 {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -133,6 +133,9 @@ type MasterConfig struct {
 	// ProjectConfig holds information about project creation and defaults
 	ProjectConfig ProjectConfig `json:"projectConfig"`
 
+	// RoutingConfig holds information about routing and route generation
+	RoutingConfig RoutingConfig `json:"routingConfig"`
+
 	// NetworkConfig to be passed to the compiled in network plugin
 	NetworkConfig NetworkConfig `json:"networkConfig"`
 }
@@ -184,6 +187,11 @@ type PolicyConfig struct {
 
 	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
 	OpenShiftInfrastructureNamespace string `json:"openshiftInfrastructureNamespace"`
+}
+
+type RoutingConfig struct {
+	// Subdomain is the suffix appended to $service.$namespace. to form the default route hostname
+	Subdomain string `json:"subdomain"`
 }
 
 // NetworkConfig to be passed to the compiled in network plugin

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -209,6 +209,8 @@ projectConfig:
   projectRequestMessage: ""
   projectRequestTemplate: ""
   securityAllocator: null
+routingConfig:
+  subdomain: ""
 serviceAccountConfig:
   managedNames: null
   privateKeyFile: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -135,6 +135,8 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 
 	validationResults.AddErrors(ValidateProjectConfig(config.ProjectConfig).Prefix("projectConfig")...)
 
+	validationResults.AddErrors(ValidateRoutingConfig(config.RoutingConfig).Prefix("routingConfig")...)
+
 	validationResults.Append(ValidateAPILevels(config.APILevels, api.KnownOpenShiftAPILevels, api.DeadOpenShiftAPILevels, "apiLevels"))
 
 	return validationResults
@@ -359,5 +361,17 @@ func ValidateProjectConfig(config api.ProjectConfig) fielderrors.ValidationError
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("mcsLabelsPerProject", alloc.MCSLabelsPerProject, "must be a positive integer"))
 		}
 	}
+	return allErrs
+}
+
+func ValidateRoutingConfig(config api.RoutingConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.Subdomain) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("subdomain"))
+	} else if !util.IsDNS1123Subdomain(config.Subdomain) {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("subdomain", config.Subdomain, "must be a valid subdomain"))
+	}
+
 	return allErrs
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -134,7 +134,6 @@ const (
 	OpenShiftAPIV1            = "v1"
 	OpenShiftAPIPrefixV1Beta3 = LegacyOpenShiftAPIPrefix + "/" + OpenShiftAPIV1Beta3
 	OpenShiftAPIPrefixV1      = OpenShiftAPIPrefix + "/" + OpenShiftAPIV1
-	OpenShiftRouteSubdomain   = "router.default.local"
 	swaggerAPIPrefix          = "/swaggerapi/"
 )
 
@@ -1108,9 +1107,7 @@ func (c *MasterConfig) RouteAllocator() *routeallocationcontroller.RouteAllocati
 		KubeClient: kclient,
 	}
 
-	subdomain := env("OPENSHIFT_ROUTE_SUBDOMAIN", OpenShiftRouteSubdomain)
-
-	plugin, err := routeplugin.NewSimpleAllocationPlugin(subdomain)
+	plugin, err := routeplugin.NewSimpleAllocationPlugin(c.Options.RoutingConfig.Subdomain)
 	if err != nil {
 		glog.Fatalf("Route plugin initialization failed: %v", err)
 	}


### PR DESCRIPTION
Adds a "routingConfig" stanza to master-config.yaml:
```
routingConfig:
  subdomain: router.default.local
```

If omitted, a subdomain of "router.default.local" is used

Fixes #3172 

- [x] Adds configurable option for generated route subdomains (defaults to "router.default.local")
- [x] Open doc issue https://github.com/openshift/openshift-docs/issues/498
- [x] Open install issue https://github.com/openshift/openshift-ansible/issues/282