### PR TITLE
Setting NodeSelector on deployer/hook pods

### DIFF
--- a/pkg/deploy/controller/deployment/controller_test.go
+++ b/pkg/deploy/controller/deployment/controller_test.go
@@ -52,6 +52,7 @@ func TestHandle_createPodOk(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	deployment.Annotations[deployapi.DeploymentStatusAnnotation] = string(deployapi.DeploymentStatusNew)
+	deployment.Spec.Template.Spec.NodeSelector = map[string]string{"labelKey1": "labelValue1", "labelKey2": "labelValue2"}
 	err := controller.Handle(deployment)
 
 	if err != nil {
@@ -84,6 +85,10 @@ func TestHandle_createPodOk(t *testing.T) {
 
 	if e, a := updatedDeployment.Name, deployutil.DeploymentNameFor(createdPod); e != a {
 		t.Fatalf("expected pod deployment annotation %s, got %s", e, a)
+	}
+
+	if e, a := deployment.Spec.Template.Spec.NodeSelector, createdPod.Spec.NodeSelector; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected pod NodeSelector %v, got %v", e, a)
 	}
 
 	if createdPod.Spec.ActiveDeadlineSeconds == nil {

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -159,7 +159,10 @@ func makeHookPod(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationCont
 				},
 			},
 			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
-			RestartPolicy:         restartPolicy,
+			// Setting the node selector on the hook pod so that it is created
+			// on the same set of nodes as the deployment pods.
+			NodeSelector:  deployment.Spec.Template.Spec.NodeSelector,
+			RestartPolicy: restartPolicy,
 		},
 	}
 

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -2,6 +2,7 @@ package support
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -54,6 +55,7 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 
 	config := deploytest.OkDeploymentConfig(1)
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
+	deployment.Spec.Template.Spec.NodeSelector = map[string]string{"labelKey1": "labelValue1", "labelKey2": "labelValue2"}
 
 	var createdPod *kapi.Pod
 	executor := &HookExecutor{
@@ -73,6 +75,10 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if e, a := deployment.Spec.Template.Spec.NodeSelector, createdPod.Spec.NodeSelector; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected pod NodeSelector %v, got %v", e, a)
 	}
 
 	if createdPod.Spec.ActiveDeadlineSeconds == nil {


### PR DESCRIPTION
Closes https://github.com/openshift/origin/issues/3087

We now set the NodeSelector from the pod template in the deployment/RC and use that as the NodeSelector for the deployer pod and the hook pods.