### PR TITLE
Make etcd example more resilient to failure

### DIFF
--- a/examples/etcd/Dockerfile
+++ b/examples/etcd/Dockerfile
@@ -19,6 +19,9 @@ RUN ETCD_URL=https://github.com/coreos/etcd/releases/download/${ETCD_RELEASE}/et
 
 EXPOSE 2379 2380
 
+# Make the datadir world writeable
+RUN mkdir -p /var/lib/etcd && chmod go+rwx /var/lib/etcd
+
 VOLUME ["/var/lib/etcd"]
 
 ADD etcd*.sh /usr/local/bin/

--- a/examples/etcd/etcd-discovery.sh
+++ b/examples/etcd/etcd-discovery.sh
@@ -6,7 +6,7 @@
 address=$(getent ahosts ${HOSTNAME} | grep RAW | cut -d ' ' -f 1)
 
 exec /usr/local/bin/etcd \
-  -advertise-client-urls http://${address}:2379 \
-  -listen-client-urls http://${address}:2379 \
-  -data-dir /var/lib/etcd \
-  -name discovery
+  --advertise-client-urls http://${address}:2379 \
+  --listen-client-urls http://${address}:2379 \
+  --data-dir /var/lib/etcd \
+  --name discovery

--- a/examples/etcd/etcd.sh
+++ b/examples/etcd/etcd.sh
@@ -7,22 +7,59 @@
 # size of the cluster in the discovery service and register itself.
 
 # If we are not running in cluster, then just execute the etcd binary
-if [[ -z "${ETCD_DISCOVERY-}" ]]; then
+if [[ -z "${ETCD_DISCOVERY_TOKEN-}" ]]; then
   exec /usr/local/bin/etcd "$@"
 fi
 
+# This variable is used by etcd server
+export ETCD_DISCOVERY="${ETCD_DISCOVERY_URL}/v2/keys/discovery/${ETCD_DISCOVERY_TOKEN}"
+
+# Set the size of this cluster to pre-defined number
+# Will retry several times till the etcd-discovery service is not ready
+for i in {1..5}; do
+  echo "Attempt #${i} to update the cluster size in ${ETCD_DISCOVERY_URL} ..."
+  etcdctl --peers "${ETCD_DISCOVERY_URL}" set discovery/${ETCD_DISCOVERY_TOKEN}/_config/size ${ETCD_NUM_MEMBERS} && break || sleep 2
+done
+
+# The IP address of this container
 address=$(getent ahosts ${HOSTNAME} | grep RAW | cut -d ' ' -f 1)
 
-curl -sX PUT ${ETCD_DISCOVERY}/_config/size -d value=${ETCD_NUM_MEMBERS}
+# In case of failure when this container will be restarted, we have to remove
+# this member from the list of members in discovery service. The new container
+# will be added automatically and the data will be replicated.
+ETCDCTL_PEERS="${ETCD_DISCOVERY_URL}"
+initial_cluster=""
+new_member=0
 
-# Adding UNIX timestamp prevents having duplicate member id's
-member_id="${HOSTNAME}-$(date +"%s")"
+for member_url in $(etcdctl ls discovery/${ETCD_DISCOVERY_TOKEN}/); do
+  out=$(etcdctl get ${member_url})
+  if ! echo $out | grep -q "${address}"; then
+    initial_cluster+="${out},"
+    continue
+  fi
+  etcdctl rm ${member_url}
+  member_id=$(echo "${member_url}" | cut -d '/' -f 4)
+  new_member=1
+  etcdctl --peers http://etcd:2379 member remove ${member_id}
+  echo "Waiting for ${member_id} removal to propagate ..."
+  sleep 3
+done
 
-echo "Starting member ${member_id} (${address})..."
+# If this member already exists in the cluster, perform recovery using
+# 'existing' cluster state.
+if [ $new_member != 0 ]; then
+  out=$(etcdctl --peers http://etcd:2379 member add ${HOSTNAME} http://${address}:2380 | grep ETCD_INITIAL_CLUSTER)
+  echo "Waiting for ${HOSTNAME} to be added into cluster ..." && sleep 5
+  eval "export ${out}"
+  export ETCD_INITIAL_CLUSTER_STATE="existing"
+  unset ETCD_DISCOVERY
+fi
+
+echo "Starting etcd member ${HOSTNAME} on ${address} ..."
 exec /usr/local/bin/etcd \
-  -initial-advertise-peer-urls http://${address}:2380 \
-  -listen-peer-urls http://${address}:2380 \
-  -advertise-client-urls http://${address}:2379 \
-  -listen-client-urls http://${address}:2379 \
-  -data-dir /var/lib/etcd \
-  -name ${member_id}
+  --initial-advertise-peer-urls http://${address}:2380 \
+  --listen-peer-urls http://${address}:2380 \
+  --advertise-client-urls http://${address}:2379 \
+  --listen-client-urls http://127.0.0.1:2379,http://${address}:2379 \
+  --data-dir /var/lib/etcd \
+  --name ${HOSTNAME}

--- a/examples/etcd/template.json
+++ b/examples/etcd/template.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "metadata": {
     "name": "etcd",
     "creationTimestamp": null,
@@ -13,7 +13,7 @@
   "objects": [
     {
       "kind": "ImageStream",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "etcd",
         "creationTimestamp": null
@@ -38,7 +38,7 @@
     },
     {
       "kind": "Service",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "etcd-discovery",
         "creationTimestamp": null,
@@ -68,7 +68,7 @@
     },
     {
       "kind": "Service",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "etcd",
         "creationTimestamp": null,
@@ -106,7 +106,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "etcd-discovery",
         "creationTimestamp": null
@@ -149,7 +149,6 @@
                 "resources": {},
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
-                "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
@@ -157,8 +156,7 @@
               }
             ],
             "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst",
-            "serviceAccount": ""
+            "dnsPolicy": "ClusterFirst"
           }
         }
       },
@@ -166,7 +164,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "etcd",
         "creationTimestamp": null
@@ -221,14 +219,21 @@
                     "value": "${ETCD_CLUSTER_TOKEN}"
                   },
                   {
-                    "name": "ETCD_DISCOVERY",
-                    "value": "${ETCD_DISCOVERY}"
+                    "name": "ETCD_DISCOVERY_TOKEN",
+                    "value": "${ETCD_DISCOVERY_TOKEN}"
+                  },
+                  {
+                    "name": "ETCD_DISCOVERY_URL",
+                    "value": "${ETCD_DISCOVERY_URL}"
+                  },
+                  {
+                    "name": "ETCDCTL_PEERS",
+                    "value": "http://etcd:2379"
                   }
                 ],
                 "resources": {},
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
-                "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
@@ -236,8 +241,7 @@
               }
             ],
             "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst",
-            "serviceAccount": ""
+            "dnsPolicy": "ClusterFirst"
           }
         }
       },
@@ -256,10 +260,15 @@
       "value": "3"
     },
     {
-      "name": "ETCD_DISCOVERY",
-      "description": "A token used for etcd discovery",
+      "name": "ETCD_DISCOVERY_URL",
+      "description": "Discovery URL connects etcd instances together by storing a list of peer addresses, metadata and the initial size of the cluster under a unique address",
+      "value": "http://etcd-discovery:2379"
+    },
+    {
+      "name": "ETCD_DISCOVERY_TOKEN",
+      "description": "A unique token used by the discovery service",
       "generate": "expression",
-      "from": "http://etcd-discovery:2379/v2/keys/discovery/[a-z0-9]{40}"
+      "from": "[a-z0-9]{40}"
     },
     {
       "name": "ETCD_CLUSTER_TOKEN",


### PR DESCRIPTION
This will make the etcd more resilient to failure when a single etcd container is killed or crash. In that case k8s automatically restart the failed container and the member is re-added to the cluster.