### PR TITLE
Impose a high default QPS and rate limit

### DIFF
--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -19,6 +19,9 @@ func init() {
 			if obj.ServingInfo.RequestTimeoutSeconds == 0 {
 				obj.ServingInfo.RequestTimeoutSeconds = 60 * 60
 			}
+			if obj.ServingInfo.MaxRequestsInFlight == 0 {
+				obj.ServingInfo.MaxRequestsInFlight = 500
+			}
 			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
 				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace
 			}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -140,6 +140,9 @@ const (
 var (
 	excludedV1Beta3Types = util.NewStringSet()
 	excludedV1Types      = excludedV1Beta3Types
+
+	// TODO: correctly solve identifying requests by type
+	longRunningRE = regexp.MustCompile("watch|proxy|logs|exec|portforward")
 )
 
 // APIInstaller installs additional API components into this server
@@ -520,8 +523,9 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 		handler = contextHandler
 	}
 
+	// TODO: MaxRequestsInFlight should be subdivided by intent, type of behavior, and speed of
+	// execution - updates vs reads, long reads vs short reads, fat reads vs skinny reads.
 	if c.Options.ServingInfo.MaxRequestsInFlight > 0 {
-		longRunningRE := regexp.MustCompile("[.*\\/watch$][^\\/proxy.*]")
 		sem := make(chan bool, c.Options.ServingInfo.MaxRequestsInFlight)
 		handler = apiserver.MaxInFlightLimit(sem, longRunningRE, handler)
 	}


### PR DESCRIPTION
Default rate limit to 500, set QPS on Kube and OpenShift default
infra clients.  Leave TODOs for future improvements.

@liggitt review
@derekwaynecarr fyi

Felt it was safer to ship this way.