### PR TITLE
Set ProxyFromEnvironment and some timeouts explicitly

### DIFF
--- a/pkg/dockerregistry/client.go
+++ b/pkg/dockerregistry/client.go
@@ -125,7 +125,10 @@ type connection struct {
 func newConnection(url url.URL, allowInsecure bool) *connection {
 	client := http.DefaultClient
 	if allowInsecure {
-		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:           http.ProxyFromEnvironment,
+		}
 		client = &http.Client{Transport: tr}
 	}
 	return &connection{

--- a/pkg/dockerregistry/client.go
+++ b/pkg/dockerregistry/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
@@ -128,6 +129,11 @@ func newConnection(url url.URL, allowInsecure bool) *connection {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			Proxy:           http.ProxyFromEnvironment,
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 10 * time.Second,
 		}
 		client = &http.Client{Transport: tr}
 	}


### PR DESCRIPTION
ProxyFromEnvironment is not set dockerregistry client due to replacing  `&http.DefaultTransport` with `&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}`. 
This patch sets ProxyFromEnvironment and some timeout values explicitly.