### PR TITLE
Fixed the message about image being pushed with authorization

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -93,7 +93,7 @@ func (s *STIBuilder) Build() error {
 			dockercfg.PushAuthType,
 		)
 		if authPresent {
-			glog.Infof("Using provided push secret for pushing %s image", config.BuilderImage)
+			glog.Infof("Using provided push secret for pushing %s image", dockerImageRef)
 			s.auth = pushAuthConfig
 		}
 		glog.Infof("Pushing %s image ...", dockerImageRef)


### PR DESCRIPTION
I've noticed we're informing user about pushing builder image:
```
I0616 10:28:10.593251       1 sti.go:96] Using provided push secret for pushing openshift/ruby-20-centos7:latest image
```
Eventually I'm thinking about removing the image part from this log, since it's being logged 3 lines later.

@bparees @smarterclayton ptal