### PR TITLE
Make bl an alias to buildLogs

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -261,6 +261,7 @@ func expandResourceShortcut(resource string) string {
 	shortForms := map[string]string{
 		"dc":      "deploymentConfigs",
 		"bc":      "buildConfigs",
+		"bl":      "buildLogs",
 		"is":      "imageStreams",
 		"istag":   "imageStreamTags",
 		"isimage": "imageStreamImages",


### PR DESCRIPTION
BuildLogs is an often used command and having bl would save a lot of
typing :)