### PR TITLE
add service account to ipfailover

### DIFF
--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -76,6 +76,7 @@ func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out i
 	cmd.Flags().BoolVar(&options.ImageTemplate.Latest, "latest-images", options.ImageTemplate.Latest, "If true, attempt to use the latest images instead of the current release")
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter nodes on.")
 	cmd.Flags().StringVar(&options.Credentials, "credentials", "", "Path to a .kubeconfig file that will contain the credentials the router should use to contact the master.")
+	cmd.Flags().StringVar(&options.ServiceAccount, "service-account", options.ServiceAccount, "Name of the service account to use to run the ipfailover pod.")
 
 	cmd.Flags().BoolVar(&options.Create, "create", options.Create, "Create the configuration if it does not exist.")
 

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -155,10 +155,11 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 	podTemplate := &kapi.PodTemplateSpec{
 		ObjectMeta: kapi.ObjectMeta{Labels: selector},
 		Spec: kapi.PodSpec{
-			HostNetwork:  true,
-			NodeSelector: generateNodeSelector(name, selector),
-			Containers:   containers,
-			Volumes:      generateVolumeConfig(),
+			HostNetwork:    true,
+			NodeSelector:   generateNodeSelector(name, selector),
+			Containers:     containers,
+			Volumes:        generateVolumeConfig(),
+			ServiceAccount: options.ServiceAccount,
 		},
 	}
 

--- a/pkg/ipfailover/types.go
+++ b/pkg/ipfailover/types.go
@@ -26,12 +26,13 @@ const (
 
 // IPFailoverConfigCmdOptions are options supported by the IP Failover admin command.
 type IPFailoverConfigCmdOptions struct {
-	Type          string
-	ImageTemplate variable.ImageTemplate
-	Credentials   string
-	ServicePort   int
-	Selector      string
-	Create        bool
+	Type           string
+	ImageTemplate  variable.ImageTemplate
+	Credentials    string
+	ServicePort    int
+	Selector       string
+	Create         bool
+	ServiceAccount string
 
 	//  Failover options.
 	VirtualIPs       string


### PR DESCRIPTION
The IP failover pod utilizes privileged=true, a host mount, and host networking.  This adds the ability to specify the service account in the oadm command so that we can grant it the privileged SCC.

@liggitt @ramr @smarterclayton @pmorie 