### PR TITLE
UPSTREAM: fix exec infinite loop

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools/exec.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools/exec.go
@@ -25,6 +25,7 @@ import (
 
 	kubecontainer "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/container"
 	"github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
 )
 
 // ExecHandler knows how to execute a command in a running Docker container.
@@ -123,6 +124,7 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 		return err
 	}
 	tick := time.Tick(2 * time.Second)
+	count := 0
 	for {
 		inspect, err2 := client.InspectExec(execObj.ID)
 		if err2 != nil {
@@ -134,6 +136,13 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 			}
 			break
 		}
+
+		count++
+		if count == 5 {
+			glog.Errorf("Exec session %s in container %s terminated but process still running!", execObj.ID, container.ID)
+			break
+		}
+
 		<-tick
 	}
 


### PR DESCRIPTION
After the native Docker exec call finishes, instead of waiting forever
for the process to terminate, try up to 5 times, every 2 seconds, to get
the exit code. If the process is still running, log an error, and
return.

Fixes bug 1231848