### PR TITLE
reduce memory allocation for cluster policy evaluation

### DIFF
--- a/examples/project-spawner/project-spawner.sh
+++ b/examples/project-spawner/project-spawner.sh
@@ -7,5 +7,5 @@ set -o pipefail
 #!/bin/bash
 for i in {1..500}
 do
-  openshift ex new-project projects-${i}
+  oc new-project projects-${i}
 done

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -35,13 +35,13 @@ func deepCopy_api_ClusterPolicy(in authorizationapi.ClusterPolicy, out *authoriz
 		out.LastModified = newVal.(util.Time)
 	}
 	if in.Roles != nil {
-		out.Roles = make(map[string]authorizationapi.ClusterRole)
+		out.Roles = make(map[string]*authorizationapi.ClusterRole)
 		for key, val := range in.Roles {
-			newVal := new(authorizationapi.ClusterRole)
-			if err := deepCopy_api_ClusterRole(val, newVal, c); err != nil {
+			if newVal, err := c.DeepCopy(val); err != nil {
 				return err
+			} else {
+				out.Roles[key] = newVal.(*authorizationapi.ClusterRole)
 			}
-			out.Roles[key] = *newVal
 		}
 	} else {
 		out.Roles = nil
@@ -71,13 +71,13 @@ func deepCopy_api_ClusterPolicyBinding(in authorizationapi.ClusterPolicyBinding,
 		out.PolicyRef = newVal.(api.ObjectReference)
 	}
 	if in.RoleBindings != nil {
-		out.RoleBindings = make(map[string]authorizationapi.ClusterRoleBinding)
+		out.RoleBindings = make(map[string]*authorizationapi.ClusterRoleBinding)
 		for key, val := range in.RoleBindings {
-			newVal := new(authorizationapi.ClusterRoleBinding)
-			if err := deepCopy_api_ClusterRoleBinding(val, newVal, c); err != nil {
+			if newVal, err := c.DeepCopy(val); err != nil {
 				return err
+			} else {
+				out.RoleBindings[key] = newVal.(*authorizationapi.ClusterRoleBinding)
 			}
-			out.RoleBindings[key] = *newVal
 		}
 	} else {
 		out.RoleBindings = nil
@@ -274,13 +274,13 @@ func deepCopy_api_Policy(in authorizationapi.Policy, out *authorizationapi.Polic
 		out.LastModified = newVal.(util.Time)
 	}
 	if in.Roles != nil {
-		out.Roles = make(map[string]authorizationapi.Role)
+		out.Roles = make(map[string]*authorizationapi.Role)
 		for key, val := range in.Roles {
-			newVal := new(authorizationapi.Role)
-			if err := deepCopy_api_Role(val, newVal, c); err != nil {
+			if newVal, err := c.DeepCopy(val); err != nil {
 				return err
+			} else {
+				out.Roles[key] = newVal.(*authorizationapi.Role)
 			}
-			out.Roles[key] = *newVal
 		}
 	} else {
 		out.Roles = nil
@@ -310,13 +310,13 @@ func deepCopy_api_PolicyBinding(in authorizationapi.PolicyBinding, out *authoriz
 		out.PolicyRef = newVal.(api.ObjectReference)
 	}
 	if in.RoleBindings != nil {
-		out.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+		out.RoleBindings = make(map[string]*authorizationapi.RoleBinding)
 		for key, val := range in.RoleBindings {
-			newVal := new(authorizationapi.RoleBinding)
-			if err := deepCopy_api_RoleBinding(val, newVal, c); err != nil {
+			if newVal, err := c.DeepCopy(val); err != nil {
 				return err
+			} else {
+				out.RoleBindings[key] = newVal.(*authorizationapi.RoleBinding)
 			}
-			out.RoleBindings[key] = *newVal
 		}
 	} else {
 		out.RoleBindings = nil

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -31,10 +31,16 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 	f.Funcs(
 		// Roles and RoleBindings maps are never nil
 		func(j *authorizationapi.Policy, c fuzz.Continue) {
-			j.Roles = make(map[string]authorizationapi.Role)
+			j.Roles = make(map[string]*authorizationapi.Role)
 		},
 		func(j *authorizationapi.PolicyBinding, c fuzz.Continue) {
-			j.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+			j.RoleBindings = make(map[string]*authorizationapi.RoleBinding)
+		},
+		func(j *authorizationapi.ClusterPolicy, c fuzz.Continue) {
+			j.Roles = make(map[string]*authorizationapi.ClusterRole)
+		},
+		func(j *authorizationapi.ClusterPolicyBinding, c fuzz.Continue) {
+			j.RoleBindings = make(map[string]*authorizationapi.ClusterRoleBinding)
 		},
 		func(j *template.Template, c fuzz.Continue) {
 			c.Fuzz(&j.ObjectMeta)

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -170,12 +170,173 @@ func convert_v1_TypeMeta_To_api_TypeMeta(in *v1.TypeMeta, out *api.TypeMeta, s c
 	return nil
 }
 
+func convert_api_ClusterPolicyBindingList_To_v1_ClusterPolicyBindingList(in *authorizationapi.ClusterPolicyBindingList, out *apiv1.ClusterPolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterPolicyBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.ClusterPolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterPolicyList_To_v1_ClusterPolicyList(in *authorizationapi.ClusterPolicyList, out *apiv1.ClusterPolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterPolicyList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.ClusterPolicy, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterRole_To_v1_ClusterRole(in *authorizationapi.ClusterRole, out *apiv1.ClusterRole, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterRole))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]apiv1.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterRoleBindingList_To_v1_ClusterRoleBindingList(in *authorizationapi.ClusterRoleBindingList, out *apiv1.ClusterRoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterRoleBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.ClusterRoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterRoleList_To_v1_ClusterRoleList(in *authorizationapi.ClusterRoleList, out *apiv1.ClusterRoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterRoleList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.ClusterRole, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_ClusterRole_To_v1_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_api_IsPersonalSubjectAccessReview_To_v1_IsPersonalSubjectAccessReview(in *authorizationapi.IsPersonalSubjectAccessReview, out *apiv1.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
+	}
+	return nil
+}
+
+func convert_api_PolicyBindingList_To_v1_PolicyBindingList(in *authorizationapi.PolicyBindingList, out *apiv1.PolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.PolicyBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.PolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_PolicyList_To_v1_PolicyList(in *authorizationapi.PolicyList, out *apiv1.PolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.PolicyList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.Policy, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
 	}
 	return nil
 }
@@ -196,6 +357,75 @@ func convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *authorizati
 	return nil
 }
 
+func convert_api_Role_To_v1_Role(in *authorizationapi.Role, out *apiv1.Role, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.Role))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]apiv1.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_api_RoleBindingList_To_v1_RoleBindingList(in *authorizationapi.RoleBindingList, out *apiv1.RoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.RoleBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.RoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_RoleList_To_v1_RoleList(in *authorizationapi.RoleList, out *apiv1.RoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.RoleList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1.Role, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_Role_To_v1_Role(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse(in *authorizationapi.SubjectAccessReviewResponse, out *apiv1.SubjectAccessReviewResponse, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.SubjectAccessReviewResponse))(in)
@@ -209,12 +439,173 @@ func convert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse(i
 	return nil
 }
 
+func convert_v1_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList(in *apiv1.ClusterPolicyBindingList, out *authorizationapi.ClusterPolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.ClusterPolicyBindingList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterPolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_ClusterPolicyList_To_api_ClusterPolicyList(in *apiv1.ClusterPolicyList, out *authorizationapi.ClusterPolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.ClusterPolicyList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterPolicy, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_ClusterRole_To_api_ClusterRole(in *apiv1.ClusterRole, out *authorizationapi.ClusterRole, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.ClusterRole))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_v1_ClusterRoleBindingList_To_api_ClusterRoleBindingList(in *apiv1.ClusterRoleBindingList, out *authorizationapi.ClusterRoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.ClusterRoleBindingList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterRoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_ClusterRoleList_To_api_ClusterRoleList(in *apiv1.ClusterRoleList, out *authorizationapi.ClusterRoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.ClusterRoleList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterRole, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1_ClusterRole_To_api_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_v1_IsPersonalSubjectAccessReview_To_api_IsPersonalSubjectAccessReview(in *apiv1.IsPersonalSubjectAccessReview, out *authorizationapi.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
+	}
+	return nil
+}
+
+func convert_v1_PolicyBindingList_To_api_PolicyBindingList(in *apiv1.PolicyBindingList, out *authorizationapi.PolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.PolicyBindingList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.PolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_PolicyList_To_api_PolicyList(in *apiv1.PolicyList, out *authorizationapi.PolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.PolicyList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.Policy, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
 	}
 	return nil
 }
@@ -232,6 +623,75 @@ func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *apiv1.Resou
 		return err
 	}
 	out.ResourceName = in.ResourceName
+	return nil
+}
+
+func convert_v1_Role_To_api_Role(in *apiv1.Role, out *authorizationapi.Role, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.Role))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_v1_RoleBindingList_To_api_RoleBindingList(in *apiv1.RoleBindingList, out *authorizationapi.RoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.RoleBindingList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.RoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_RoleList_To_api_RoleList(in *apiv1.RoleList, out *authorizationapi.RoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.RoleList))(in)
+	}
+	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.Role, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1_Role_To_api_Role(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1891,6 +2351,11 @@ func init() {
 		convert_api_BuildRequest_To_v1_BuildRequest,
 		convert_api_ClusterNetworkList_To_v1_ClusterNetworkList,
 		convert_api_ClusterNetwork_To_v1_ClusterNetwork,
+		convert_api_ClusterPolicyBindingList_To_v1_ClusterPolicyBindingList,
+		convert_api_ClusterPolicyList_To_v1_ClusterPolicyList,
+		convert_api_ClusterRoleBindingList_To_v1_ClusterRoleBindingList,
+		convert_api_ClusterRoleList_To_v1_ClusterRoleList,
+		convert_api_ClusterRole_To_v1_ClusterRole,
 		convert_api_DeploymentConfigList_To_v1_DeploymentConfigList,
 		convert_api_DeploymentConfigRollbackSpec_To_v1_DeploymentConfigRollbackSpec,
 		convert_api_DeploymentConfigRollback_To_v1_DeploymentConfigRollback,
@@ -1917,12 +2382,17 @@ func init() {
 		convert_api_ObjectMeta_To_v1_ObjectMeta,
 		convert_api_ObjectReference_To_v1_ObjectReference,
 		convert_api_Parameter_To_v1_Parameter,
+		convert_api_PolicyBindingList_To_v1_PolicyBindingList,
+		convert_api_PolicyList_To_v1_PolicyList,
 		convert_api_ProjectList_To_v1_ProjectList,
 		convert_api_ProjectRequest_To_v1_ProjectRequest,
 		convert_api_ProjectSpec_To_v1_ProjectSpec,
 		convert_api_ProjectStatus_To_v1_ProjectStatus,
 		convert_api_Project_To_v1_Project,
 		convert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
+		convert_api_RoleBindingList_To_v1_RoleBindingList,
+		convert_api_RoleList_To_v1_RoleList,
+		convert_api_Role_To_v1_Role,
 		convert_api_RouteList_To_v1_RouteList,
 		convert_api_SourceControlUser_To_v1_SourceControlUser,
 		convert_api_SourceRevision_To_v1_SourceRevision,
@@ -1939,6 +2409,11 @@ func init() {
 		convert_v1_BuildRequest_To_api_BuildRequest,
 		convert_v1_ClusterNetworkList_To_api_ClusterNetworkList,
 		convert_v1_ClusterNetwork_To_api_ClusterNetwork,
+		convert_v1_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList,
+		convert_v1_ClusterPolicyList_To_api_ClusterPolicyList,
+		convert_v1_ClusterRoleBindingList_To_api_ClusterRoleBindingList,
+		convert_v1_ClusterRoleList_To_api_ClusterRoleList,
+		convert_v1_ClusterRole_To_api_ClusterRole,
 		convert_v1_DeploymentConfigList_To_api_DeploymentConfigList,
 		convert_v1_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec,
 		convert_v1_DeploymentConfigRollback_To_api_DeploymentConfigRollback,
@@ -1965,12 +2440,17 @@ func init() {
 		convert_v1_ObjectMeta_To_api_ObjectMeta,
 		convert_v1_ObjectReference_To_api_ObjectReference,
 		convert_v1_Parameter_To_api_Parameter,
+		convert_v1_PolicyBindingList_To_api_PolicyBindingList,
+		convert_v1_PolicyList_To_api_PolicyList,
 		convert_v1_ProjectList_To_api_ProjectList,
 		convert_v1_ProjectRequest_To_api_ProjectRequest,
 		convert_v1_ProjectSpec_To_api_ProjectSpec,
 		convert_v1_ProjectStatus_To_api_ProjectStatus,
 		convert_v1_Project_To_api_Project,
 		convert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
+		convert_v1_RoleBindingList_To_api_RoleBindingList,
+		convert_v1_RoleList_To_api_RoleList,
+		convert_v1_Role_To_api_Role,
 		convert_v1_RouteList_To_api_RouteList,
 		convert_v1_SourceControlUser_To_api_SourceControlUser,
 		convert_v1_SourceRevision_To_api_SourceRevision,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -170,173 +170,12 @@ func convert_v1_TypeMeta_To_api_TypeMeta(in *v1.TypeMeta, out *api.TypeMeta, s c
 	return nil
 }
 
-func convert_api_ClusterPolicyBindingList_To_v1_ClusterPolicyBindingList(in *authorizationapi.ClusterPolicyBindingList, out *apiv1.ClusterPolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterPolicyBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.ClusterPolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterPolicyList_To_v1_ClusterPolicyList(in *authorizationapi.ClusterPolicyList, out *apiv1.ClusterPolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterPolicyList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.ClusterPolicy, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterRole_To_v1_ClusterRole(in *authorizationapi.ClusterRole, out *apiv1.ClusterRole, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterRole))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]apiv1.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterRoleBindingList_To_v1_ClusterRoleBindingList(in *authorizationapi.ClusterRoleBindingList, out *apiv1.ClusterRoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterRoleBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.ClusterRoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterRoleList_To_v1_ClusterRoleList(in *authorizationapi.ClusterRoleList, out *apiv1.ClusterRoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterRoleList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.ClusterRole, len(in.Items))
-		for i := range in.Items {
-			if err := convert_api_ClusterRole_To_v1_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
 func convert_api_IsPersonalSubjectAccessReview_To_v1_IsPersonalSubjectAccessReview(in *authorizationapi.IsPersonalSubjectAccessReview, out *apiv1.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
-	}
-	return nil
-}
-
-func convert_api_PolicyBindingList_To_v1_PolicyBindingList(in *authorizationapi.PolicyBindingList, out *apiv1.PolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.PolicyBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.PolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_PolicyList_To_v1_PolicyList(in *authorizationapi.PolicyList, out *apiv1.PolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.PolicyList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.Policy, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
 	}
 	return nil
 }
@@ -357,75 +196,6 @@ func convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *authorizati
 	return nil
 }
 
-func convert_api_Role_To_v1_Role(in *authorizationapi.Role, out *apiv1.Role, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.Role))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]apiv1.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_api_RoleBindingList_To_v1_RoleBindingList(in *authorizationapi.RoleBindingList, out *apiv1.RoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.RoleBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.RoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_RoleList_To_v1_RoleList(in *authorizationapi.RoleList, out *apiv1.RoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.RoleList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1.Role, len(in.Items))
-		for i := range in.Items {
-			if err := convert_api_Role_To_v1_Role(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
 func convert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse(in *authorizationapi.SubjectAccessReviewResponse, out *apiv1.SubjectAccessReviewResponse, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.SubjectAccessReviewResponse))(in)
@@ -439,173 +209,12 @@ func convert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse(i
 	return nil
 }
 
-func convert_v1_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList(in *apiv1.ClusterPolicyBindingList, out *authorizationapi.ClusterPolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.ClusterPolicyBindingList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterPolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1_ClusterPolicyList_To_api_ClusterPolicyList(in *apiv1.ClusterPolicyList, out *authorizationapi.ClusterPolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.ClusterPolicyList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterPolicy, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1_ClusterRole_To_api_ClusterRole(in *apiv1.ClusterRole, out *authorizationapi.ClusterRole, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.ClusterRole))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_v1_ClusterRoleBindingList_To_api_ClusterRoleBindingList(in *apiv1.ClusterRoleBindingList, out *authorizationapi.ClusterRoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.ClusterRoleBindingList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterRoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1_ClusterRoleList_To_api_ClusterRoleList(in *apiv1.ClusterRoleList, out *authorizationapi.ClusterRoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.ClusterRoleList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterRole, len(in.Items))
-		for i := range in.Items {
-			if err := convert_v1_ClusterRole_To_api_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
 func convert_v1_IsPersonalSubjectAccessReview_To_api_IsPersonalSubjectAccessReview(in *apiv1.IsPersonalSubjectAccessReview, out *authorizationapi.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
-	}
-	return nil
-}
-
-func convert_v1_PolicyBindingList_To_api_PolicyBindingList(in *apiv1.PolicyBindingList, out *authorizationapi.PolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.PolicyBindingList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.PolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1_PolicyList_To_api_PolicyList(in *apiv1.PolicyList, out *authorizationapi.PolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.PolicyList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.Policy, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
 	}
 	return nil
 }
@@ -623,75 +232,6 @@ func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *apiv1.Resou
 		return err
 	}
 	out.ResourceName = in.ResourceName
-	return nil
-}
-
-func convert_v1_Role_To_api_Role(in *apiv1.Role, out *authorizationapi.Role, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.Role))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_v1_RoleBindingList_To_api_RoleBindingList(in *apiv1.RoleBindingList, out *authorizationapi.RoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.RoleBindingList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.RoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1_RoleList_To_api_RoleList(in *apiv1.RoleList, out *authorizationapi.RoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1.RoleList))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.Role, len(in.Items))
-		for i := range in.Items {
-			if err := convert_v1_Role_To_api_Role(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
 	return nil
 }
 
@@ -2351,11 +1891,6 @@ func init() {
 		convert_api_BuildRequest_To_v1_BuildRequest,
 		convert_api_ClusterNetworkList_To_v1_ClusterNetworkList,
 		convert_api_ClusterNetwork_To_v1_ClusterNetwork,
-		convert_api_ClusterPolicyBindingList_To_v1_ClusterPolicyBindingList,
-		convert_api_ClusterPolicyList_To_v1_ClusterPolicyList,
-		convert_api_ClusterRoleBindingList_To_v1_ClusterRoleBindingList,
-		convert_api_ClusterRoleList_To_v1_ClusterRoleList,
-		convert_api_ClusterRole_To_v1_ClusterRole,
 		convert_api_DeploymentConfigList_To_v1_DeploymentConfigList,
 		convert_api_DeploymentConfigRollbackSpec_To_v1_DeploymentConfigRollbackSpec,
 		convert_api_DeploymentConfigRollback_To_v1_DeploymentConfigRollback,
@@ -2382,17 +1917,12 @@ func init() {
 		convert_api_ObjectMeta_To_v1_ObjectMeta,
 		convert_api_ObjectReference_To_v1_ObjectReference,
 		convert_api_Parameter_To_v1_Parameter,
-		convert_api_PolicyBindingList_To_v1_PolicyBindingList,
-		convert_api_PolicyList_To_v1_PolicyList,
 		convert_api_ProjectList_To_v1_ProjectList,
 		convert_api_ProjectRequest_To_v1_ProjectRequest,
 		convert_api_ProjectSpec_To_v1_ProjectSpec,
 		convert_api_ProjectStatus_To_v1_ProjectStatus,
 		convert_api_Project_To_v1_Project,
 		convert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
-		convert_api_RoleBindingList_To_v1_RoleBindingList,
-		convert_api_RoleList_To_v1_RoleList,
-		convert_api_Role_To_v1_Role,
 		convert_api_RouteList_To_v1_RouteList,
 		convert_api_SourceControlUser_To_v1_SourceControlUser,
 		convert_api_SourceRevision_To_v1_SourceRevision,
@@ -2409,11 +1939,6 @@ func init() {
 		convert_v1_BuildRequest_To_api_BuildRequest,
 		convert_v1_ClusterNetworkList_To_api_ClusterNetworkList,
 		convert_v1_ClusterNetwork_To_api_ClusterNetwork,
-		convert_v1_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList,
-		convert_v1_ClusterPolicyList_To_api_ClusterPolicyList,
-		convert_v1_ClusterRoleBindingList_To_api_ClusterRoleBindingList,
-		convert_v1_ClusterRoleList_To_api_ClusterRoleList,
-		convert_v1_ClusterRole_To_api_ClusterRole,
 		convert_v1_DeploymentConfigList_To_api_DeploymentConfigList,
 		convert_v1_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec,
 		convert_v1_DeploymentConfigRollback_To_api_DeploymentConfigRollback,
@@ -2440,17 +1965,12 @@ func init() {
 		convert_v1_ObjectMeta_To_api_ObjectMeta,
 		convert_v1_ObjectReference_To_api_ObjectReference,
 		convert_v1_Parameter_To_api_Parameter,
-		convert_v1_PolicyBindingList_To_api_PolicyBindingList,
-		convert_v1_PolicyList_To_api_PolicyList,
 		convert_v1_ProjectList_To_api_ProjectList,
 		convert_v1_ProjectRequest_To_api_ProjectRequest,
 		convert_v1_ProjectSpec_To_api_ProjectSpec,
 		convert_v1_ProjectStatus_To_api_ProjectStatus,
 		convert_v1_Project_To_api_Project,
 		convert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
-		convert_v1_RoleBindingList_To_api_RoleBindingList,
-		convert_v1_RoleList_To_api_RoleList,
-		convert_v1_Role_To_api_Role,
 		convert_v1_RouteList_To_api_RouteList,
 		convert_v1_SourceControlUser_To_api_SourceControlUser,
 		convert_v1_SourceRevision_To_api_SourceRevision,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -170,192 +170,12 @@ func convert_v1beta3_TypeMeta_To_api_TypeMeta(in *v1beta3.TypeMeta, out *api.Typ
 	return nil
 }
 
-func convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(in *authorizationapi.ClusterPolicy, out *apiv1beta3.ClusterPolicy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterPolicy))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.LastModified, &out.LastModified, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_ClusterPolicyBindingList_To_v1beta3_ClusterPolicyBindingList(in *authorizationapi.ClusterPolicyBindingList, out *apiv1beta3.ClusterPolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterPolicyBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.ClusterPolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterPolicyList_To_v1beta3_ClusterPolicyList(in *authorizationapi.ClusterPolicyList, out *apiv1beta3.ClusterPolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterPolicyList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.ClusterPolicy, len(in.Items))
-		for i := range in.Items {
-			if err := convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterRole_To_v1beta3_ClusterRole(in *authorizationapi.ClusterRole, out *apiv1beta3.ClusterRole, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterRole))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]apiv1beta3.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterRoleBindingList_To_v1beta3_ClusterRoleBindingList(in *authorizationapi.ClusterRoleBindingList, out *apiv1beta3.ClusterRoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterRoleBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.ClusterRoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_ClusterRoleList_To_v1beta3_ClusterRoleList(in *authorizationapi.ClusterRoleList, out *apiv1beta3.ClusterRoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.ClusterRoleList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.ClusterRole, len(in.Items))
-		for i := range in.Items {
-			if err := convert_api_ClusterRole_To_v1beta3_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
 func convert_api_IsPersonalSubjectAccessReview_To_v1beta3_IsPersonalSubjectAccessReview(in *authorizationapi.IsPersonalSubjectAccessReview, out *apiv1beta3.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
-	}
-	return nil
-}
-
-func convert_api_PolicyBindingList_To_v1beta3_PolicyBindingList(in *authorizationapi.PolicyBindingList, out *apiv1beta3.PolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.PolicyBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.PolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_PolicyList_To_v1beta3_PolicyList(in *authorizationapi.PolicyList, out *apiv1beta3.PolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.PolicyList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.Policy, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
 	}
 	return nil
 }
@@ -376,75 +196,6 @@ func convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *author
 	return nil
 }
 
-func convert_api_Role_To_v1beta3_Role(in *authorizationapi.Role, out *apiv1beta3.Role, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.Role))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]apiv1beta3.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_api_RoleBindingList_To_v1beta3_RoleBindingList(in *authorizationapi.RoleBindingList, out *apiv1beta3.RoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.RoleBindingList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.RoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_api_RoleList_To_v1beta3_RoleList(in *authorizationapi.RoleList, out *apiv1beta3.RoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*authorizationapi.RoleList))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]apiv1beta3.Role, len(in.Items))
-		for i := range in.Items {
-			if err := convert_api_Role_To_v1beta3_Role(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
 func convert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewResponse(in *authorizationapi.SubjectAccessReviewResponse, out *apiv1beta3.SubjectAccessReviewResponse, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.SubjectAccessReviewResponse))(in)
@@ -458,192 +209,12 @@ func convert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewRespo
 	return nil
 }
 
-func convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(in *apiv1beta3.ClusterPolicy, out *authorizationapi.ClusterPolicy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.ClusterPolicy))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.LastModified, &out.LastModified, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1beta3_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList(in *apiv1beta3.ClusterPolicyBindingList, out *authorizationapi.ClusterPolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.ClusterPolicyBindingList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterPolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_ClusterPolicyList_To_api_ClusterPolicyList(in *apiv1beta3.ClusterPolicyList, out *authorizationapi.ClusterPolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.ClusterPolicyList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterPolicy, len(in.Items))
-		for i := range in.Items {
-			if err := convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_ClusterRole_To_api_ClusterRole(in *apiv1beta3.ClusterRole, out *authorizationapi.ClusterRole, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.ClusterRole))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_ClusterRoleBindingList_To_api_ClusterRoleBindingList(in *apiv1beta3.ClusterRoleBindingList, out *authorizationapi.ClusterRoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.ClusterRoleBindingList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterRoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_ClusterRoleList_To_api_ClusterRoleList(in *apiv1beta3.ClusterRoleList, out *authorizationapi.ClusterRoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.ClusterRoleList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.ClusterRole, len(in.Items))
-		for i := range in.Items {
-			if err := convert_v1beta3_ClusterRole_To_api_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
 func convert_v1beta3_IsPersonalSubjectAccessReview_To_api_IsPersonalSubjectAccessReview(in *apiv1beta3.IsPersonalSubjectAccessReview, out *authorizationapi.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1beta3.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
-	}
-	return nil
-}
-
-func convert_v1beta3_PolicyBindingList_To_api_PolicyBindingList(in *apiv1beta3.PolicyBindingList, out *authorizationapi.PolicyBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.PolicyBindingList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.PolicyBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_PolicyList_To_api_PolicyList(in *apiv1beta3.PolicyList, out *authorizationapi.PolicyList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.PolicyList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.Policy, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
 	}
 	return nil
 }
@@ -661,75 +232,6 @@ func convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *apiv1b
 		return err
 	}
 	out.ResourceName = in.ResourceName
-	return nil
-}
-
-func convert_v1beta3_Role_To_api_Role(in *apiv1beta3.Role, out *authorizationapi.Role, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.Role))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
-		return err
-	}
-	if in.Rules != nil {
-		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
-		for i := range in.Rules {
-			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Rules = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_RoleBindingList_To_api_RoleBindingList(in *apiv1beta3.RoleBindingList, out *authorizationapi.RoleBindingList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.RoleBindingList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.RoleBinding, len(in.Items))
-		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
-	return nil
-}
-
-func convert_v1beta3_RoleList_To_api_RoleList(in *apiv1beta3.RoleList, out *authorizationapi.RoleList, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*apiv1beta3.RoleList))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
-		return err
-	}
-	if in.Items != nil {
-		out.Items = make([]authorizationapi.Role, len(in.Items))
-		for i := range in.Items {
-			if err := convert_v1beta3_Role_To_api_Role(&in.Items[i], &out.Items[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
 	return nil
 }
 
@@ -2287,12 +1789,6 @@ func init() {
 		convert_api_BuildRequest_To_v1beta3_BuildRequest,
 		convert_api_ClusterNetworkList_To_v1beta3_ClusterNetworkList,
 		convert_api_ClusterNetwork_To_v1beta3_ClusterNetwork,
-		convert_api_ClusterPolicyBindingList_To_v1beta3_ClusterPolicyBindingList,
-		convert_api_ClusterPolicyList_To_v1beta3_ClusterPolicyList,
-		convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy,
-		convert_api_ClusterRoleBindingList_To_v1beta3_ClusterRoleBindingList,
-		convert_api_ClusterRoleList_To_v1beta3_ClusterRoleList,
-		convert_api_ClusterRole_To_v1beta3_ClusterRole,
 		convert_api_DeploymentConfigList_To_v1beta3_DeploymentConfigList,
 		convert_api_DeploymentConfigRollbackSpec_To_v1beta3_DeploymentConfigRollbackSpec,
 		convert_api_DeploymentConfigRollback_To_v1beta3_DeploymentConfigRollback,
@@ -2316,17 +1812,12 @@ func init() {
 		convert_api_ObjectMeta_To_v1beta3_ObjectMeta,
 		convert_api_ObjectReference_To_v1beta3_ObjectReference,
 		convert_api_Parameter_To_v1beta3_Parameter,
-		convert_api_PolicyBindingList_To_v1beta3_PolicyBindingList,
-		convert_api_PolicyList_To_v1beta3_PolicyList,
 		convert_api_ProjectList_To_v1beta3_ProjectList,
 		convert_api_ProjectRequest_To_v1beta3_ProjectRequest,
 		convert_api_ProjectSpec_To_v1beta3_ProjectSpec,
 		convert_api_ProjectStatus_To_v1beta3_ProjectStatus,
 		convert_api_Project_To_v1beta3_Project,
 		convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
-		convert_api_RoleBindingList_To_v1beta3_RoleBindingList,
-		convert_api_RoleList_To_v1beta3_RoleList,
-		convert_api_Role_To_v1beta3_Role,
 		convert_api_RouteList_To_v1beta3_RouteList,
 		convert_api_SourceControlUser_To_v1beta3_SourceControlUser,
 		convert_api_SourceRevision_To_v1beta3_SourceRevision,
@@ -2343,12 +1834,6 @@ func init() {
 		convert_v1beta3_BuildRequest_To_api_BuildRequest,
 		convert_v1beta3_ClusterNetworkList_To_api_ClusterNetworkList,
 		convert_v1beta3_ClusterNetwork_To_api_ClusterNetwork,
-		convert_v1beta3_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList,
-		convert_v1beta3_ClusterPolicyList_To_api_ClusterPolicyList,
-		convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy,
-		convert_v1beta3_ClusterRoleBindingList_To_api_ClusterRoleBindingList,
-		convert_v1beta3_ClusterRoleList_To_api_ClusterRoleList,
-		convert_v1beta3_ClusterRole_To_api_ClusterRole,
 		convert_v1beta3_DeploymentConfigList_To_api_DeploymentConfigList,
 		convert_v1beta3_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec,
 		convert_v1beta3_DeploymentConfigRollback_To_api_DeploymentConfigRollback,
@@ -2372,17 +1857,12 @@ func init() {
 		convert_v1beta3_ObjectMeta_To_api_ObjectMeta,
 		convert_v1beta3_ObjectReference_To_api_ObjectReference,
 		convert_v1beta3_Parameter_To_api_Parameter,
-		convert_v1beta3_PolicyBindingList_To_api_PolicyBindingList,
-		convert_v1beta3_PolicyList_To_api_PolicyList,
 		convert_v1beta3_ProjectList_To_api_ProjectList,
 		convert_v1beta3_ProjectRequest_To_api_ProjectRequest,
 		convert_v1beta3_ProjectSpec_To_api_ProjectSpec,
 		convert_v1beta3_ProjectStatus_To_api_ProjectStatus,
 		convert_v1beta3_Project_To_api_Project,
 		convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
-		convert_v1beta3_RoleBindingList_To_api_RoleBindingList,
-		convert_v1beta3_RoleList_To_api_RoleList,
-		convert_v1beta3_Role_To_api_Role,
 		convert_v1beta3_RouteList_To_api_RouteList,
 		convert_v1beta3_SourceControlUser_To_api_SourceControlUser,
 		convert_v1beta3_SourceRevision_To_api_SourceRevision,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -170,12 +170,192 @@ func convert_v1beta3_TypeMeta_To_api_TypeMeta(in *v1beta3.TypeMeta, out *api.Typ
 	return nil
 }
 
+func convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(in *authorizationapi.ClusterPolicy, out *apiv1beta3.ClusterPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterPolicy))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.LastModified, &out.LastModified, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_ClusterPolicyBindingList_To_v1beta3_ClusterPolicyBindingList(in *authorizationapi.ClusterPolicyBindingList, out *apiv1beta3.ClusterPolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterPolicyBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.ClusterPolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterPolicyList_To_v1beta3_ClusterPolicyList(in *authorizationapi.ClusterPolicyList, out *apiv1beta3.ClusterPolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterPolicyList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.ClusterPolicy, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterRole_To_v1beta3_ClusterRole(in *authorizationapi.ClusterRole, out *apiv1beta3.ClusterRole, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterRole))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]apiv1beta3.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterRoleBindingList_To_v1beta3_ClusterRoleBindingList(in *authorizationapi.ClusterRoleBindingList, out *apiv1beta3.ClusterRoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterRoleBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.ClusterRoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_ClusterRoleList_To_v1beta3_ClusterRoleList(in *authorizationapi.ClusterRoleList, out *apiv1beta3.ClusterRoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.ClusterRoleList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.ClusterRole, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_ClusterRole_To_v1beta3_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_api_IsPersonalSubjectAccessReview_To_v1beta3_IsPersonalSubjectAccessReview(in *authorizationapi.IsPersonalSubjectAccessReview, out *apiv1beta3.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
+	}
+	return nil
+}
+
+func convert_api_PolicyBindingList_To_v1beta3_PolicyBindingList(in *authorizationapi.PolicyBindingList, out *apiv1beta3.PolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.PolicyBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.PolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_PolicyList_To_v1beta3_PolicyList(in *authorizationapi.PolicyList, out *apiv1beta3.PolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.PolicyList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.Policy, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
 	}
 	return nil
 }
@@ -196,6 +376,75 @@ func convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *author
 	return nil
 }
 
+func convert_api_Role_To_v1beta3_Role(in *authorizationapi.Role, out *apiv1beta3.Role, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.Role))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]apiv1beta3.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_api_RoleBindingList_To_v1beta3_RoleBindingList(in *authorizationapi.RoleBindingList, out *apiv1beta3.RoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.RoleBindingList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.RoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_RoleList_To_v1beta3_RoleList(in *authorizationapi.RoleList, out *apiv1beta3.RoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*authorizationapi.RoleList))(in)
+	}
+	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_api_ListMeta_To_v1beta3_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]apiv1beta3.Role, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_Role_To_v1beta3_Role(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewResponse(in *authorizationapi.SubjectAccessReviewResponse, out *apiv1beta3.SubjectAccessReviewResponse, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*authorizationapi.SubjectAccessReviewResponse))(in)
@@ -209,12 +458,192 @@ func convert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewRespo
 	return nil
 }
 
+func convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(in *apiv1beta3.ClusterPolicy, out *authorizationapi.ClusterPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.ClusterPolicy))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.LastModified, &out.LastModified, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Roles, &out.Roles, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList(in *apiv1beta3.ClusterPolicyBindingList, out *authorizationapi.ClusterPolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.ClusterPolicyBindingList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterPolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_ClusterPolicyList_To_api_ClusterPolicyList(in *apiv1beta3.ClusterPolicyList, out *authorizationapi.ClusterPolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.ClusterPolicyList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterPolicy, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_ClusterRole_To_api_ClusterRole(in *apiv1beta3.ClusterRole, out *authorizationapi.ClusterRole, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.ClusterRole))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_ClusterRoleBindingList_To_api_ClusterRoleBindingList(in *apiv1beta3.ClusterRoleBindingList, out *authorizationapi.ClusterRoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.ClusterRoleBindingList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterRoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_ClusterRoleList_To_api_ClusterRoleList(in *apiv1beta3.ClusterRoleList, out *authorizationapi.ClusterRoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.ClusterRoleList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.ClusterRole, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta3_ClusterRole_To_api_ClusterRole(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
 func convert_v1beta3_IsPersonalSubjectAccessReview_To_api_IsPersonalSubjectAccessReview(in *apiv1beta3.IsPersonalSubjectAccessReview, out *authorizationapi.IsPersonalSubjectAccessReview, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1beta3.IsPersonalSubjectAccessReview))(in)
 	}
 	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
 		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_PolicyBindingList_To_api_PolicyBindingList(in *apiv1beta3.PolicyBindingList, out *authorizationapi.PolicyBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.PolicyBindingList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.PolicyBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_PolicyList_To_api_PolicyList(in *apiv1beta3.PolicyList, out *authorizationapi.PolicyList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.PolicyList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.Policy, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
 	}
 	return nil
 }
@@ -232,6 +661,75 @@ func convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *apiv1b
 		return err
 	}
 	out.ResourceName = in.ResourceName
+	return nil
+}
+
+func convert_v1beta3_Role_To_api_Role(in *apiv1beta3.Role, out *authorizationapi.Role, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.Role))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if in.Rules != nil {
+		out.Rules = make([]authorizationapi.PolicyRule, len(in.Rules))
+		for i := range in.Rules {
+			if err := s.Convert(&in.Rules[i], &out.Rules[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Rules = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_RoleBindingList_To_api_RoleBindingList(in *apiv1beta3.RoleBindingList, out *authorizationapi.RoleBindingList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.RoleBindingList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.RoleBinding, len(in.Items))
+		for i := range in.Items {
+			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_RoleList_To_api_RoleList(in *apiv1beta3.RoleList, out *authorizationapi.RoleList, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.RoleList))(in)
+	}
+	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_ListMeta_To_api_ListMeta(&in.ListMeta, &out.ListMeta, s); err != nil {
+		return err
+	}
+	if in.Items != nil {
+		out.Items = make([]authorizationapi.Role, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta3_Role_To_api_Role(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -1789,6 +2287,12 @@ func init() {
 		convert_api_BuildRequest_To_v1beta3_BuildRequest,
 		convert_api_ClusterNetworkList_To_v1beta3_ClusterNetworkList,
 		convert_api_ClusterNetwork_To_v1beta3_ClusterNetwork,
+		convert_api_ClusterPolicyBindingList_To_v1beta3_ClusterPolicyBindingList,
+		convert_api_ClusterPolicyList_To_v1beta3_ClusterPolicyList,
+		convert_api_ClusterPolicy_To_v1beta3_ClusterPolicy,
+		convert_api_ClusterRoleBindingList_To_v1beta3_ClusterRoleBindingList,
+		convert_api_ClusterRoleList_To_v1beta3_ClusterRoleList,
+		convert_api_ClusterRole_To_v1beta3_ClusterRole,
 		convert_api_DeploymentConfigList_To_v1beta3_DeploymentConfigList,
 		convert_api_DeploymentConfigRollbackSpec_To_v1beta3_DeploymentConfigRollbackSpec,
 		convert_api_DeploymentConfigRollback_To_v1beta3_DeploymentConfigRollback,
@@ -1812,12 +2316,17 @@ func init() {
 		convert_api_ObjectMeta_To_v1beta3_ObjectMeta,
 		convert_api_ObjectReference_To_v1beta3_ObjectReference,
 		convert_api_Parameter_To_v1beta3_Parameter,
+		convert_api_PolicyBindingList_To_v1beta3_PolicyBindingList,
+		convert_api_PolicyList_To_v1beta3_PolicyList,
 		convert_api_ProjectList_To_v1beta3_ProjectList,
 		convert_api_ProjectRequest_To_v1beta3_ProjectRequest,
 		convert_api_ProjectSpec_To_v1beta3_ProjectSpec,
 		convert_api_ProjectStatus_To_v1beta3_ProjectStatus,
 		convert_api_Project_To_v1beta3_Project,
 		convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
+		convert_api_RoleBindingList_To_v1beta3_RoleBindingList,
+		convert_api_RoleList_To_v1beta3_RoleList,
+		convert_api_Role_To_v1beta3_Role,
 		convert_api_RouteList_To_v1beta3_RouteList,
 		convert_api_SourceControlUser_To_v1beta3_SourceControlUser,
 		convert_api_SourceRevision_To_v1beta3_SourceRevision,
@@ -1834,6 +2343,12 @@ func init() {
 		convert_v1beta3_BuildRequest_To_api_BuildRequest,
 		convert_v1beta3_ClusterNetworkList_To_api_ClusterNetworkList,
 		convert_v1beta3_ClusterNetwork_To_api_ClusterNetwork,
+		convert_v1beta3_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList,
+		convert_v1beta3_ClusterPolicyList_To_api_ClusterPolicyList,
+		convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy,
+		convert_v1beta3_ClusterRoleBindingList_To_api_ClusterRoleBindingList,
+		convert_v1beta3_ClusterRoleList_To_api_ClusterRoleList,
+		convert_v1beta3_ClusterRole_To_api_ClusterRole,
 		convert_v1beta3_DeploymentConfigList_To_api_DeploymentConfigList,
 		convert_v1beta3_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec,
 		convert_v1beta3_DeploymentConfigRollback_To_api_DeploymentConfigRollback,
@@ -1857,12 +2372,17 @@ func init() {
 		convert_v1beta3_ObjectMeta_To_api_ObjectMeta,
 		convert_v1beta3_ObjectReference_To_api_ObjectReference,
 		convert_v1beta3_Parameter_To_api_Parameter,
+		convert_v1beta3_PolicyBindingList_To_api_PolicyBindingList,
+		convert_v1beta3_PolicyList_To_api_PolicyList,
 		convert_v1beta3_ProjectList_To_api_ProjectList,
 		convert_v1beta3_ProjectRequest_To_api_ProjectRequest,
 		convert_v1beta3_ProjectSpec_To_api_ProjectSpec,
 		convert_v1beta3_ProjectStatus_To_api_ProjectStatus,
 		convert_v1beta3_Project_To_api_Project,
 		convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
+		convert_v1beta3_RoleBindingList_To_api_RoleBindingList,
+		convert_v1beta3_RoleList_To_api_RoleList,
+		convert_v1beta3_Role_To_api_Role,
 		convert_v1beta3_RouteList_To_api_RouteList,
 		convert_v1beta3_SourceControlUser_To_api_SourceControlUser,
 		convert_v1beta3_SourceRevision_To_api_SourceRevision,

--- a/pkg/authorization/api/casts.go
+++ b/pkg/authorization/api/casts.go
@@ -28,10 +28,10 @@ func ToPolicy(in *ClusterPolicy) *Policy {
 	return ret
 }
 
-func ToRoleMap(in map[string]ClusterRole) map[string]Role {
-	ret := map[string]Role{}
+func ToRoleMap(in map[string]*ClusterRole) map[string]*Role {
+	ret := map[string]*Role{}
 	for key, role := range in {
-		ret[key] = *ToRole(&role)
+		ret[key] = ToRole(role)
 	}
 
 	return ret
@@ -80,10 +80,10 @@ func ToClusterPolicy(in *Policy) *ClusterPolicy {
 	return ret
 }
 
-func ToClusterRoleMap(in map[string]Role) map[string]ClusterRole {
-	ret := map[string]ClusterRole{}
+func ToClusterRoleMap(in map[string]*Role) map[string]*ClusterRole {
+	ret := map[string]*ClusterRole{}
 	for key, role := range in {
-		ret[key] = *ToClusterRole(&role)
+		ret[key] = ToClusterRole(role)
 	}
 
 	return ret
@@ -142,10 +142,10 @@ func ToPolicyRef(in kapi.ObjectReference) kapi.ObjectReference {
 	return ret
 }
 
-func ToRoleBindingMap(in map[string]ClusterRoleBinding) map[string]RoleBinding {
-	ret := map[string]RoleBinding{}
+func ToRoleBindingMap(in map[string]*ClusterRoleBinding) map[string]*RoleBinding {
+	ret := map[string]*RoleBinding{}
 	for key, RoleBinding := range in {
-		ret[key] = *ToRoleBinding(&RoleBinding)
+		ret[key] = ToRoleBinding(RoleBinding)
 	}
 
 	return ret
@@ -210,10 +210,10 @@ func ToClusterPolicyRef(in kapi.ObjectReference) kapi.ObjectReference {
 	return ret
 }
 
-func ToClusterRoleBindingMap(in map[string]RoleBinding) map[string]ClusterRoleBinding {
-	ret := map[string]ClusterRoleBinding{}
+func ToClusterRoleBindingMap(in map[string]*RoleBinding) map[string]*ClusterRoleBinding {
+	ret := map[string]*ClusterRoleBinding{}
 	for key, RoleBinding := range in {
-		ret[key] = *ToClusterRoleBinding(&RoleBinding)
+		ret[key] = ToClusterRoleBinding(RoleBinding)
 	}
 
 	return ret

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -37,15 +37,15 @@ func (r PolicyRule) String() string {
 	return fmt.Sprintf("PolicyRule{Verbs:%v, Resources:%v, ResourceNames:%v, Restrictions:%v}", r.Verbs.List(), r.Resources.List(), r.ResourceNames.List(), r.AttributeRestrictions)
 }
 
-func getRoleBindingValues(roleBindingMap map[string]RoleBinding) []RoleBinding {
-	ret := []RoleBinding{}
+func getRoleBindingValues(roleBindingMap map[string]*RoleBinding) []*RoleBinding {
+	ret := []*RoleBinding{}
 	for _, currBinding := range roleBindingMap {
 		ret = append(ret, currBinding)
 	}
 
 	return ret
 }
-func SortRoleBindings(roleBindingMap map[string]RoleBinding, reverse bool) []RoleBinding {
+func SortRoleBindings(roleBindingMap map[string]*RoleBinding, reverse bool) []*RoleBinding {
 	roleBindings := getRoleBindingValues(roleBindingMap)
 	if reverse {
 		sort.Sort(sort.Reverse(RoleBindingSorter(roleBindings)))
@@ -68,7 +68,7 @@ func (s PolicyBindingSorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-type RoleBindingSorter []RoleBinding
+type RoleBindingSorter []*RoleBinding
 
 func (s RoleBindingSorter) Len() int {
 	return len(s)

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -160,7 +160,7 @@ type Policy struct {
 	LastModified util.Time
 
 	// Roles holds all the Roles held by this Policy, mapped by Role.Name
-	Roles map[string]Role
+	Roles map[string]*Role
 }
 
 // PolicyBinding is a object that holds all the RoleBindings for a particular namespace.  There is
@@ -175,7 +175,7 @@ type PolicyBinding struct {
 	// PolicyRef is a reference to the Policy that contains all the Roles that this PolicyBinding's RoleBindings may reference
 	PolicyRef kapi.ObjectReference
 	// RoleBindings holds all the RoleBindings held by this PolicyBinding, mapped by RoleBinding.Name
-	RoleBindings map[string]RoleBinding
+	RoleBindings map[string]*RoleBinding
 }
 
 // ResourceAccessReviewResponse describes who can perform the action
@@ -308,7 +308,7 @@ type ClusterPolicy struct {
 	LastModified util.Time
 
 	// Roles holds all the ClusterRoles held by this ClusterPolicy, mapped by Role.Name
-	Roles map[string]ClusterRole
+	Roles map[string]*ClusterRole
 }
 
 // ClusterPolicyBinding is a object that holds all the ClusterRoleBindings for a particular namespace.  There is
@@ -323,7 +323,7 @@ type ClusterPolicyBinding struct {
 	// ClusterPolicyRef is a reference to the ClusterPolicy that contains all the ClusterRoles that this ClusterPolicyBinding's RoleBindings may reference
 	PolicyRef kapi.ObjectReference
 	// RoleBindings holds all the RoleBindings held by this ClusterPolicyBinding, mapped by RoleBinding.Name
-	RoleBindings map[string]ClusterRoleBinding
+	RoleBindings map[string]*ClusterRoleBinding
 }
 
 // ClusterPolicyList is a collection of ClusterPolicies

--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -90,7 +90,7 @@ func convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRu
 
 func convert_v1_Policy_To_api_Policy(in *Policy, out *newer.Policy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.Roles = make(map[string]newer.Role)
+	out.Roles = make(map[string]*newer.Role)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -124,7 +124,7 @@ func convert_api_RoleBinding_To_v1_RoleBinding(in *newer.RoleBinding, out *RoleB
 
 func convert_v1_PolicyBinding_To_api_PolicyBinding(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.RoleBindings = make(map[string]newer.RoleBinding)
+	out.RoleBindings = make(map[string]*newer.RoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -137,7 +137,7 @@ func convert_api_PolicyBinding_To_v1_PolicyBinding(in *newer.PolicyBinding, out 
 // and now the globals
 func convert_v1_ClusterPolicy_To_api_ClusterPolicy(in *ClusterPolicy, out *newer.ClusterPolicy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.Roles = make(map[string]newer.ClusterRole)
+	out.Roles = make(map[string]*newer.ClusterRole)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -171,7 +171,7 @@ func convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *newer.ClusterRo
 
 func convert_v1_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *ClusterPolicyBinding, out *newer.ClusterPolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.RoleBindings = make(map[string]newer.ClusterRoleBinding)
+	out.RoleBindings = make(map[string]*newer.ClusterRoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -183,18 +183,18 @@ func convert_api_ClusterPolicyBinding_To_v1_ClusterPolicyBinding(in *newer.Clust
 
 func init() {
 	err := api.Scheme.AddConversionFuncs(
-		func(in *[]NamedRole, out *map[string]newer.Role, s conversion.Scope) error {
+		func(in *[]NamedRole, out *map[string]*newer.Role, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRole := &newer.Role{}
 				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRole
+				(*out)[curr.Name] = newRole
 			}
 
 			return nil
 		},
-		func(in *map[string]newer.Role, out *[]NamedRole, s conversion.Scope) error {
+		func(in *map[string]*newer.Role, out *[]NamedRole, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -204,7 +204,7 @@ func init() {
 			for _, key := range allKeys {
 				newRole := (*in)[key]
 				oldRole := &Role{}
-				if err := s.Convert(&newRole, oldRole, 0); err != nil {
+				if err := s.Convert(newRole, oldRole, 0); err != nil {
 					return err
 				}
 
@@ -215,18 +215,18 @@ func init() {
 			return nil
 		},
 
-		func(in *[]NamedRoleBinding, out *map[string]newer.RoleBinding, s conversion.Scope) error {
+		func(in *[]NamedRoleBinding, out *map[string]*newer.RoleBinding, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRoleBinding := &newer.RoleBinding{}
 				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRoleBinding
+				(*out)[curr.Name] = newRoleBinding
 			}
 
 			return nil
 		},
-		func(in *map[string]newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
+		func(in *map[string]*newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -236,7 +236,7 @@ func init() {
 			for _, key := range allKeys {
 				newRoleBinding := (*in)[key]
 				oldRoleBinding := &RoleBinding{}
-				if err := s.Convert(&newRoleBinding, oldRoleBinding, 0); err != nil {
+				if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
 					return err
 				}
 
@@ -247,18 +247,18 @@ func init() {
 			return nil
 		},
 
-		func(in *[]NamedClusterRole, out *map[string]newer.ClusterRole, s conversion.Scope) error {
+		func(in *[]NamedClusterRole, out *map[string]*newer.ClusterRole, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRole := &newer.ClusterRole{}
 				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRole
+				(*out)[curr.Name] = newRole
 			}
 
 			return nil
 		},
-		func(in *map[string]newer.ClusterRole, out *[]NamedClusterRole, s conversion.Scope) error {
+		func(in *map[string]*newer.ClusterRole, out *[]NamedClusterRole, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -268,7 +268,7 @@ func init() {
 			for _, key := range allKeys {
 				newRole := (*in)[key]
 				oldRole := &ClusterRole{}
-				if err := s.Convert(&newRole, oldRole, 0); err != nil {
+				if err := s.Convert(newRole, oldRole, 0); err != nil {
 					return err
 				}
 
@@ -278,18 +278,18 @@ func init() {
 
 			return nil
 		},
-		func(in *[]NamedClusterRoleBinding, out *map[string]newer.ClusterRoleBinding, s conversion.Scope) error {
+		func(in *[]NamedClusterRoleBinding, out *map[string]*newer.ClusterRoleBinding, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRoleBinding := &newer.ClusterRoleBinding{}
 				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRoleBinding
+				(*out)[curr.Name] = newRoleBinding
 			}
 
 			return nil
 		},
-		func(in *map[string]newer.ClusterRoleBinding, out *[]NamedClusterRoleBinding, s conversion.Scope) error {
+		func(in *map[string]*newer.ClusterRoleBinding, out *[]NamedClusterRoleBinding, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -299,7 +299,7 @@ func init() {
 			for _, key := range allKeys {
 				newRoleBinding := (*in)[key]
 				oldRoleBinding := &ClusterRoleBinding{}
-				if err := s.Convert(&newRoleBinding, oldRoleBinding, 0); err != nil {
+				if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
 					return err
 				}
 

--- a/pkg/authorization/api/v1beta3/conversion.go
+++ b/pkg/authorization/api/v1beta3/conversion.go
@@ -91,7 +91,7 @@ func convert_api_PolicyRule_To_v1beta3_PolicyRule(in *newer.PolicyRule, out *Pol
 
 func convert_v1beta3_Policy_To_api_Policy(in *Policy, out *newer.Policy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.Roles = make(map[string]newer.Role)
+	out.Roles = make(map[string]*newer.Role)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -125,7 +125,7 @@ func convert_api_RoleBinding_To_v1beta3_RoleBinding(in *newer.RoleBinding, out *
 
 func convert_v1beta3_PolicyBinding_To_api_PolicyBinding(in *PolicyBinding, out *newer.PolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.RoleBindings = make(map[string]newer.RoleBinding)
+	out.RoleBindings = make(map[string]*newer.RoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -138,7 +138,7 @@ func convert_api_PolicyBinding_To_v1beta3_PolicyBinding(in *newer.PolicyBinding,
 // and now the globals
 func convert_v1beta3_ClusterPolicy_To_api_ClusterPolicy(in *ClusterPolicy, out *newer.ClusterPolicy, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.Roles = make(map[string]newer.ClusterRole)
+	out.Roles = make(map[string]*newer.ClusterRole)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -172,7 +172,7 @@ func convert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding(in *newer.Clus
 
 func convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding(in *ClusterPolicyBinding, out *newer.ClusterPolicyBinding, s conversion.Scope) error {
 	out.LastModified = in.LastModified
-	out.RoleBindings = make(map[string]newer.ClusterRoleBinding)
+	out.RoleBindings = make(map[string]*newer.ClusterRoleBinding)
 	return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 }
 
@@ -202,19 +202,19 @@ func init() {
 		convert_v1beta3_ClusterPolicyBinding_To_api_ClusterPolicyBinding,
 		convert_api_ClusterPolicyBinding_To_v1beta3_ClusterPolicyBinding,
 
-		func(in *[]NamedRoleBinding, out *map[string]newer.RoleBinding, s conversion.Scope) error {
+		func(in *[]NamedRoleBinding, out *map[string]*newer.RoleBinding, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRoleBinding := &newer.RoleBinding{}
 				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRoleBinding
+				(*out)[curr.Name] = newRoleBinding
 			}
 
 			return nil
 		},
 
-		func(in *map[string]newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
+		func(in *map[string]*newer.RoleBinding, out *[]NamedRoleBinding, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -224,7 +224,7 @@ func init() {
 			for _, key := range allKeys {
 				newRoleBinding := (*in)[key]
 				oldRoleBinding := &RoleBinding{}
-				if err := s.Convert(&newRoleBinding, oldRoleBinding, 0); err != nil {
+				if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
 					return err
 				}
 
@@ -235,23 +235,23 @@ func init() {
 			return nil
 		},
 
-		func(in *[]NamedClusterRole, out *map[string]newer.ClusterRole, s conversion.Scope) error {
+		func(in *[]NamedClusterRole, out *map[string]*newer.ClusterRole, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRole := &newer.ClusterRole{}
 				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
 					return err
 				}
 				if *out == nil {
-					m := make(map[string]newer.ClusterRole)
+					m := make(map[string]*newer.ClusterRole)
 					*out = m
 				}
-				(*out)[curr.Name] = *newRole
+				(*out)[curr.Name] = newRole
 			}
 
 			return nil
 		},
 
-		func(in *map[string]newer.ClusterRole, out *[]NamedClusterRole, s conversion.Scope) error {
+		func(in *map[string]*newer.ClusterRole, out *[]NamedClusterRole, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -261,7 +261,7 @@ func init() {
 			for _, key := range allKeys {
 				newRole := (*in)[key]
 				oldRole := &ClusterRole{}
-				if err := s.Convert(&newRole, oldRole, 0); err != nil {
+				if err := s.Convert(newRole, oldRole, 0); err != nil {
 					return err
 				}
 
@@ -272,19 +272,19 @@ func init() {
 			return nil
 		},
 
-		func(in *[]NamedRole, out *map[string]newer.Role, s conversion.Scope) error {
+		func(in *[]NamedRole, out *map[string]*newer.Role, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRole := &newer.Role{}
 				if err := s.Convert(&curr.Role, newRole, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRole
+				(*out)[curr.Name] = newRole
 			}
 
 			return nil
 		},
 
-		func(in *map[string]newer.Role, out *[]NamedRole, s conversion.Scope) error {
+		func(in *map[string]*newer.Role, out *[]NamedRole, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -294,7 +294,7 @@ func init() {
 			for _, key := range allKeys {
 				newRole := (*in)[key]
 				oldRole := &Role{}
-				if err := s.Convert(&newRole, oldRole, 0); err != nil {
+				if err := s.Convert(newRole, oldRole, 0); err != nil {
 					return err
 				}
 
@@ -305,18 +305,18 @@ func init() {
 			return nil
 		},
 
-		func(in *[]NamedClusterRoleBinding, out *map[string]newer.ClusterRoleBinding, s conversion.Scope) error {
+		func(in *[]NamedClusterRoleBinding, out *map[string]*newer.ClusterRoleBinding, s conversion.Scope) error {
 			for _, curr := range *in {
 				newRoleBinding := &newer.ClusterRoleBinding{}
 				if err := s.Convert(&curr.RoleBinding, newRoleBinding, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = *newRoleBinding
+				(*out)[curr.Name] = newRoleBinding
 			}
 
 			return nil
 		},
-		func(in *map[string]newer.ClusterRoleBinding, out *[]NamedClusterRoleBinding, s conversion.Scope) error {
+		func(in *map[string]*newer.ClusterRoleBinding, out *[]NamedClusterRoleBinding, s conversion.Scope) error {
 			allKeys := make([]string, 0, len(*in))
 			for key := range *in {
 				allKeys = append(allKeys, key)
@@ -326,7 +326,7 @@ func init() {
 			for _, key := range allKeys {
 				newRoleBinding := (*in)[key]
 				oldRoleBinding := &ClusterRoleBinding{}
-				if err := s.Convert(&newRoleBinding, oldRoleBinding, 0); err != nil {
+				if err := s.Convert(newRoleBinding, oldRoleBinding, 0); err != nil {
 					return err
 				}
 

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -72,7 +72,7 @@ func ValidatePolicy(policy *authorizationapi.Policy, isNamespaced bool) fielderr
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("roles."+roleKey+".metadata.name", role.Name, "must be "+roleKey))
 		}
 
-		allErrs = append(allErrs, ValidateRole(&role, isNamespaced).Prefix("roles."+roleKey)...)
+		allErrs = append(allErrs, ValidateRole(role, isNamespaced).Prefix("roles."+roleKey)...)
 	}
 
 	return allErrs
@@ -134,7 +134,7 @@ func ValidatePolicyBinding(policyBinding *authorizationapi.PolicyBinding, isName
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("roleBindings."+roleBindingKey+".metadata.name", roleBinding.Name, "must be "+roleBindingKey))
 		}
 
-		allErrs = append(allErrs, ValidateRoleBinding(&roleBinding, isNamespaced).Prefix("roleBindings."+roleBindingKey)...)
+		allErrs = append(allErrs, ValidateRoleBinding(roleBinding, isNamespaced).Prefix("roleBindings."+roleBindingKey)...)
 	}
 
 	return allErrs

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -68,6 +68,10 @@ func ValidatePolicy(policy *authorizationapi.Policy, isNamespaced bool) fielderr
 	allErrs = append(allErrs, validation.ValidateObjectMeta(&policy.ObjectMeta, isNamespaced, ValidatePolicyName).Prefix("metadata")...)
 
 	for roleKey, role := range policy.Roles {
+		if role == nil {
+			allErrs = append(allErrs, fielderrors.NewFieldRequired("roles."+roleKey))
+		}
+
 		if roleKey != role.Name {
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("roles."+roleKey+".metadata.name", role.Name, "must be "+roleKey))
 		}
@@ -126,6 +130,10 @@ func ValidatePolicyBinding(policyBinding *authorizationapi.PolicyBinding, isName
 	}
 
 	for roleBindingKey, roleBinding := range policyBinding.RoleBindings {
+		if roleBinding == nil {
+			allErrs = append(allErrs, fielderrors.NewFieldRequired("roleBindings."+roleBindingKey))
+		}
+
 		if roleBinding.RoleRef.Namespace != policyBinding.PolicyRef.Namespace {
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("roleBindings."+roleBindingKey+".roleRef.namespace", policyBinding.PolicyRef.Namespace, "must be "+policyBinding.PolicyRef.Namespace))
 		}

--- a/pkg/authorization/api/validation/validation_test.go
+++ b/pkg/authorization/api/validation/validation_test.go
@@ -49,7 +49,7 @@ func TestValidatePolicy(t *testing.T) {
 		"mismatched name": {
 			A: authorizationapi.Policy{
 				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.PolicyName},
-				Roles: map[string]authorizationapi.Role{
+				Roles: map[string]*authorizationapi.Role{
 					"any1": {
 						ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: "any"},
 					},
@@ -121,7 +121,7 @@ func TestValidatePolicyBinding(t *testing.T) {
 			A: authorizationapi.PolicyBinding{
 				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.GetPolicyBindingName(authorizationapi.PolicyName)},
 				PolicyRef:  kapi.ObjectReference{Namespace: authorizationapi.PolicyName},
-				RoleBindings: map[string]authorizationapi.RoleBinding{
+				RoleBindings: map[string]*authorizationapi.RoleBinding{
 					"any": {
 						ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: "any"},
 						RoleRef:    kapi.ObjectReference{Namespace: authorizationapi.PolicyName},
@@ -135,7 +135,7 @@ func TestValidatePolicyBinding(t *testing.T) {
 			A: authorizationapi.PolicyBinding{
 				ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: authorizationapi.GetPolicyBindingName(authorizationapi.PolicyName)},
 				PolicyRef:  kapi.ObjectReference{Namespace: authorizationapi.PolicyName},
-				RoleBindings: map[string]authorizationapi.RoleBinding{
+				RoleBindings: map[string]*authorizationapi.RoleBinding{
 					"any1": {
 						ObjectMeta: kapi.ObjectMeta{Namespace: kapi.NamespaceDefault, Name: "any"},
 						RoleRef:    kapi.ObjectReference{Namespace: authorizationapi.PolicyName, Name: "valid"},

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -99,15 +99,15 @@ func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.C
 			return nil, nil, err
 		}
 
-		for _, rule := range role.Rules {
+		for _, rule := range role.Rules() {
 			matches, err := attributes.RuleMatches(rule)
 			if err != nil {
 				return nil, nil, err
 			}
 
 			if matches {
-				users.Insert(roleBinding.Users.List()...)
-				groups.Insert(roleBinding.Groups.List()...)
+				users.Insert(roleBinding.Users().List()...)
+				groups.Insert(roleBinding.Groups().List()...)
 			}
 		}
 	}

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -81,7 +81,7 @@ func TestDeniedWithError(t *testing.T) {
 	test.policies = append(test.policies, newAdzePolicies()...)
 	test.clusterBindings = newDefaultClusterPolicyBindings()
 	test.bindings = append(test.bindings, newAdzeBindings()...)
-	test.bindings[0].RoleBindings["missing"] = authorizationapi.RoleBinding{
+	test.bindings[0].RoleBindings["missing"] = &authorizationapi.RoleBinding{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "missing",
 		},
@@ -109,7 +109,7 @@ func TestAllowedWithMissingBinding(t *testing.T) {
 	test.policies = append(test.policies, newAdzePolicies()...)
 	test.clusterBindings = newDefaultClusterPolicyBindings()
 	test.bindings = append(test.bindings, newAdzeBindings()...)
-	test.bindings[0].RoleBindings["missing"] = authorizationapi.RoleBinding{
+	test.bindings[0].RoleBindings["missing"] = &authorizationapi.RoleBinding{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "missing",
 		},
@@ -440,7 +440,7 @@ func newDefaultClusterPolicyBindings() []authorizationapi.ClusterPolicyBinding {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: authorizationapi.ClusterPolicyBindingName,
 		},
-		RoleBindings: map[string]authorizationapi.ClusterRoleBinding{
+		RoleBindings: map[string]*authorizationapi.ClusterRoleBinding{
 			"extra-cluster-admins": {
 				ObjectMeta: kapi.ObjectMeta{
 					Name: "cluster-admins",
@@ -475,7 +475,7 @@ func newAdzePolicies() []authorizationapi.Policy {
 				Name:      authorizationapi.PolicyName,
 				Namespace: "adze",
 			},
-			Roles: map[string]authorizationapi.Role{
+			Roles: map[string]*authorizationapi.Role{
 				"restrictedViewer": {
 					ObjectMeta: kapi.ObjectMeta{
 						Name:      "admin",
@@ -497,7 +497,7 @@ func newAdzeBindings() []authorizationapi.PolicyBinding {
 				Name:      authorizationapi.ClusterPolicyBindingName,
 				Namespace: "adze",
 			},
-			RoleBindings: map[string]authorizationapi.RoleBinding{
+			RoleBindings: map[string]*authorizationapi.RoleBinding{
 				"projectAdmins": {
 					ObjectMeta: kapi.ObjectMeta{
 						Name:      "projectAdmins",
@@ -535,7 +535,7 @@ func newAdzeBindings() []authorizationapi.PolicyBinding {
 				Name:      authorizationapi.GetPolicyBindingName("adze"),
 				Namespace: "adze",
 			},
-			RoleBindings: map[string]authorizationapi.RoleBinding{
+			RoleBindings: map[string]*authorizationapi.RoleBinding{
 				"restrictedViewers": {
 					ObjectMeta: kapi.ObjectMeta{
 						Name:      "restrictedViewers",

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
-	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
-	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -375,8 +373,8 @@ func TestVerbRestrictionsWork(t *testing.T) {
 func (test *authorizeTest) test(t *testing.T) {
 	policyRegistry := testpolicyregistry.NewPolicyRegistry(test.policies, test.policyRetrievalError)
 	policyBindingRegistry := testpolicyregistry.NewPolicyBindingRegistry(test.bindings, test.bindingRetrievalError)
-	clusterPolicyRegistry := clusterpolicyregistry.NewSimulatedRegistry(testpolicyregistry.NewClusterPolicyRegistry(test.clusterPolicies, test.policyRetrievalError))
-	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(testpolicyregistry.NewClusterPolicyBindingRegistry(test.clusterBindings, test.bindingRetrievalError))
+	clusterPolicyRegistry := testpolicyregistry.NewClusterPolicyRegistry(test.clusterPolicies, test.policyRetrievalError)
+	clusterPolicyBindingRegistry := testpolicyregistry.NewClusterPolicyBindingRegistry(test.clusterBindings, test.bindingRetrievalError)
 	authorizer := NewAuthorizer(rulevalidation.NewDefaultRuleResolver(policyRegistry, policyBindingRegistry, clusterPolicyRegistry, clusterPolicyBindingRegistry), NewForbiddenMessageResolver(""))
 
 	actualAllowed, actualReason, actualError := authorizer.Authorize(test.context, *test.attributes)

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -444,7 +444,7 @@ func newMalletPolicies() []authorizationapi.Policy {
 				Name:      authorizationapi.PolicyName,
 				Namespace: "mallet",
 			},
-			Roles: map[string]authorizationapi.Role{},
+			Roles: map[string]*authorizationapi.Role{},
 		}}
 }
 func newMalletBindings() []authorizationapi.PolicyBinding {
@@ -454,7 +454,7 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 				Name:      authorizationapi.ClusterPolicyBindingName,
 				Namespace: "mallet",
 			},
-			RoleBindings: map[string]authorizationapi.RoleBinding{
+			RoleBindings: map[string]*authorizationapi.RoleBinding{
 				"projectAdmins": {
 					ObjectMeta: kapi.ObjectMeta{
 						Name:      "projectAdmins",
@@ -496,7 +496,7 @@ func newInvalidExtensionPolicies() []authorizationapi.Policy {
 				Name:      authorizationapi.PolicyName,
 				Namespace: "mallet",
 			},
-			Roles: map[string]authorizationapi.Role{
+			Roles: map[string]*authorizationapi.Role{
 				"badExtension": {
 					ObjectMeta: kapi.ObjectMeta{
 						Name:      "failure",
@@ -524,7 +524,7 @@ func newInvalidExtensionBindings() []authorizationapi.PolicyBinding {
 				Name:      "mallet",
 				Namespace: "mallet",
 			},
-			RoleBindings: map[string]authorizationapi.RoleBinding{
+			RoleBindings: map[string]*authorizationapi.RoleBinding{
 				"borked": {
 					ObjectMeta: kapi.ObjectMeta{
 						Name:      "borked",
@@ -549,11 +549,12 @@ func GetBootstrapPolicy() *authorizationapi.ClusterPolicy {
 			UID:               util.NewUUID(),
 		},
 		LastModified: util.Now(),
-		Roles:        make(map[string]authorizationapi.ClusterRole),
+		Roles:        make(map[string]*authorizationapi.ClusterRole),
 	}
 
-	for _, role := range bootstrappolicy.GetBootstrapClusterRoles() {
-		policy.Roles[role.Name] = role
+	roles := bootstrappolicy.GetBootstrapClusterRoles()
+	for i := range roles {
+		policy.Roles[roles[i].Name] = &roles[i]
 	}
 
 	return policy
@@ -567,11 +568,12 @@ func GetBootstrapPolicyBinding() *authorizationapi.ClusterPolicyBinding {
 			UID:               util.NewUUID(),
 		},
 		LastModified: util.Now(),
-		RoleBindings: make(map[string]authorizationapi.ClusterRoleBinding),
+		RoleBindings: make(map[string]*authorizationapi.ClusterRoleBinding),
 	}
 
-	for _, roleBinding := range bootstrappolicy.GetBootstrapClusterRoleBindings() {
-		policyBinding.RoleBindings[roleBinding.Name] = roleBinding
+	bindings := bootstrappolicy.GetBootstrapClusterRoleBindings()
+	for i := range bindings {
+		policyBinding.RoleBindings[bindings[i].Name] = &bindings[i]
 	}
 
 	return policyBinding

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
-	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
-	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	testpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/test"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 )
@@ -50,8 +48,8 @@ func TestSubjects(t *testing.T) {
 func (test *subjectsTest) test(t *testing.T) {
 	policyRegistry := testpolicyregistry.NewPolicyRegistry(test.policies, test.policyRetrievalError)
 	policyBindingRegistry := testpolicyregistry.NewPolicyBindingRegistry(test.bindings, test.bindingRetrievalError)
-	clusterPolicyRegistry := clusterpolicyregistry.NewSimulatedRegistry(testpolicyregistry.NewClusterPolicyRegistry(test.clusterPolicies, test.policyRetrievalError))
-	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(testpolicyregistry.NewClusterPolicyBindingRegistry(test.clusterBindings, test.bindingRetrievalError))
+	clusterPolicyRegistry := testpolicyregistry.NewClusterPolicyRegistry(test.clusterPolicies, test.policyRetrievalError)
+	clusterPolicyBindingRegistry := testpolicyregistry.NewClusterPolicyBindingRegistry(test.clusterBindings, test.bindingRetrievalError)
 
 	authorizer := NewAuthorizer(rulevalidation.NewDefaultRuleResolver(policyRegistry, policyBindingRegistry, clusterPolicyRegistry, clusterPolicyBindingRegistry), NewForbiddenMessageResolver(""))
 

--- a/pkg/authorization/cache/readonlycache.go
+++ b/pkg/authorization/cache/readonlycache.go
@@ -139,3 +139,21 @@ func (c readOnlyAuthorizationCache) ListPolicyBindings(ctx kapi.Context, label l
 		return policyBindingList, nil
 	}
 }
+
+// GetPolicy retrieves a specific policy.  It conforms to rulevalidation.PolicyGetter.
+func (c readOnlyAuthorizationCache) GetClusterPolicy(ctx kapi.Context, name string) (*authorizationapi.ClusterPolicy, error) {
+	clusterPolicy, err := c.ReadOnlyClusterPolicies().Get(name)
+	if err != nil {
+		return &authorizationapi.ClusterPolicy{}, err
+	}
+	return clusterPolicy, nil
+}
+
+// ListPolicyBindings obtains list of policyBindings that match a selector.  It conforms to rulevalidation.BindingLister
+func (c readOnlyAuthorizationCache) ListClusterPolicyBindings(ctx kapi.Context, label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyBindingList, error) {
+	clusterPolicyBindingList, err := c.ReadOnlyClusterPolicyBindings().List(label, field)
+	if err != nil {
+		return &authorizationapi.ClusterPolicyBindingList{}, err
+	}
+	return clusterPolicyBindingList, nil
+}

--- a/pkg/authorization/client/readonlyclient.go
+++ b/pkg/authorization/client/readonlyclient.go
@@ -22,4 +22,6 @@ type ReadOnlyPolicyClient interface {
 	// Methods that enable the ReadOnlyPolicyClient to conform to rulevalidation.PolicyGetter and rulevalidation.BindingLister interfaces
 	GetPolicy(ctx kapi.Context, name string) (*authorizationapi.Policy, error)
 	ListPolicyBindings(ctx kapi.Context, label labels.Selector, field fields.Selector) (*authorizationapi.PolicyBindingList, error)
+	GetClusterPolicy(ctx kapi.Context, name string) (*authorizationapi.ClusterPolicy, error)
+	ListClusterPolicyBindings(ctx kapi.Context, label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyBindingList, error)
 }

--- a/pkg/authorization/interfaces/interfaces.go
+++ b/pkg/authorization/interfaces/interfaces.go
@@ -1,0 +1,253 @@
+package interfaces
+
+import (
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type Policy interface {
+	Name() string
+	Namespace() string
+
+	Roles() map[string]Role
+}
+
+type PolicyBinding interface {
+	Name() string
+	Namespace() string
+
+	PolicyRef() kapi.ObjectReference
+	RoleBindings() map[string]RoleBinding
+}
+
+type Role interface {
+	Name() string
+	Namespace() string
+
+	Rules() []authorizationapi.PolicyRule
+}
+
+type RoleBinding interface {
+	Name() string
+	Namespace() string
+
+	RoleRef() kapi.ObjectReference
+	Users() util.StringSet
+	Groups() util.StringSet
+}
+
+func NewClusterPolicyAdapter(policy *authorizationapi.ClusterPolicy) Policy {
+	return ClusterPolicyAdapter{policy: policy}
+}
+func NewLocalPolicyAdapter(policy *authorizationapi.Policy) Policy {
+	return PolicyAdapter{policy: policy}
+}
+
+func NewClusterPolicyBindingAdapter(policyBinding *authorizationapi.ClusterPolicyBinding) PolicyBinding {
+	return ClusterPolicyBindingAdapter{policyBinding: policyBinding}
+}
+func NewLocalPolicyBindingAdapter(policyBinding *authorizationapi.PolicyBinding) PolicyBinding {
+	return PolicyBindingAdapter{policyBinding: policyBinding}
+}
+func NewClusterPolicyBindingAdapters(list *authorizationapi.ClusterPolicyBindingList) []PolicyBinding {
+	ret := make([]PolicyBinding, 0, len(list.Items))
+	for i := range list.Items {
+		ret = append(ret, NewClusterPolicyBindingAdapter(&list.Items[i]))
+	}
+	return ret
+}
+func NewLocalPolicyBindingAdapters(list *authorizationapi.PolicyBindingList) []PolicyBinding {
+	ret := make([]PolicyBinding, 0, len(list.Items))
+	for i := range list.Items {
+		ret = append(ret, NewLocalPolicyBindingAdapter(&list.Items[i]))
+	}
+	return ret
+}
+
+type PolicyAdapter struct {
+	policy *authorizationapi.Policy
+
+	adaptedRoles map[string]Role
+}
+
+func (a PolicyAdapter) Name() string {
+	return a.policy.Name
+}
+
+func (a PolicyAdapter) Namespace() string {
+	return a.policy.Namespace
+}
+
+func (a PolicyAdapter) Roles() map[string]Role {
+	if a.adaptedRoles == nil {
+		adaptedRoles := map[string]Role{}
+		for key := range a.policy.Roles {
+			adaptedRoles[key] = RoleAdapter{a.policy.Roles[key]}
+		}
+		a.adaptedRoles = adaptedRoles
+	}
+	return a.adaptedRoles
+}
+
+type RoleAdapter struct {
+	role *authorizationapi.Role
+}
+
+func (a RoleAdapter) Name() string {
+	return a.role.Name
+}
+
+func (a RoleAdapter) Namespace() string {
+	return a.role.Namespace
+}
+
+func (a RoleAdapter) Rules() []authorizationapi.PolicyRule {
+	return a.role.Rules
+}
+
+type ClusterPolicyAdapter struct {
+	policy *authorizationapi.ClusterPolicy
+
+	adaptedRoles map[string]Role
+}
+
+func (a ClusterPolicyAdapter) Name() string {
+	return a.policy.Name
+}
+
+func (a ClusterPolicyAdapter) Namespace() string {
+	return a.policy.Namespace
+}
+
+func (a ClusterPolicyAdapter) Roles() map[string]Role {
+	if a.adaptedRoles == nil {
+		adaptedRoles := map[string]Role{}
+		for key := range a.policy.Roles {
+			adaptedRoles[key] = ClusterRoleAdapter{a.policy.Roles[key]}
+		}
+		a.adaptedRoles = adaptedRoles
+	}
+	return a.adaptedRoles
+}
+
+type ClusterRoleAdapter struct {
+	role *authorizationapi.ClusterRole
+}
+
+func (a ClusterRoleAdapter) Name() string {
+	return a.role.Name
+}
+
+func (a ClusterRoleAdapter) Namespace() string {
+	return a.role.Namespace
+}
+
+func (a ClusterRoleAdapter) Rules() []authorizationapi.PolicyRule {
+	return a.role.Rules
+}
+
+type PolicyBindingAdapter struct {
+	policyBinding *authorizationapi.PolicyBinding
+
+	adaptedRoleBindings map[string]RoleBinding
+}
+
+func (a PolicyBindingAdapter) Name() string {
+	return a.policyBinding.Name
+}
+
+func (a PolicyBindingAdapter) Namespace() string {
+	return a.policyBinding.Namespace
+}
+
+func (a PolicyBindingAdapter) PolicyRef() kapi.ObjectReference {
+	return a.policyBinding.PolicyRef
+}
+
+func (a PolicyBindingAdapter) RoleBindings() map[string]RoleBinding {
+	if a.adaptedRoleBindings == nil {
+		adaptedRoleBindings := map[string]RoleBinding{}
+		for key := range a.policyBinding.RoleBindings {
+			adaptedRoleBindings[key] = RoleBindingAdapter{a.policyBinding.RoleBindings[key]}
+		}
+		a.adaptedRoleBindings = adaptedRoleBindings
+	}
+	return a.adaptedRoleBindings
+}
+
+type RoleBindingAdapter struct {
+	roleBinding *authorizationapi.RoleBinding
+}
+
+func (a RoleBindingAdapter) Name() string {
+	return a.roleBinding.Name
+}
+
+func (a RoleBindingAdapter) Namespace() string {
+	return a.roleBinding.Namespace
+}
+
+func (a RoleBindingAdapter) RoleRef() kapi.ObjectReference {
+	return a.roleBinding.RoleRef
+}
+
+func (a RoleBindingAdapter) Users() util.StringSet {
+	return a.roleBinding.Users
+}
+func (a RoleBindingAdapter) Groups() util.StringSet {
+	return a.roleBinding.Groups
+}
+
+type ClusterPolicyBindingAdapter struct {
+	policyBinding *authorizationapi.ClusterPolicyBinding
+
+	adaptedRoleBindings map[string]RoleBinding
+}
+
+func (a ClusterPolicyBindingAdapter) Name() string {
+	return a.policyBinding.Name
+}
+
+func (a ClusterPolicyBindingAdapter) Namespace() string {
+	return a.policyBinding.Namespace
+}
+
+func (a ClusterPolicyBindingAdapter) PolicyRef() kapi.ObjectReference {
+	return a.policyBinding.PolicyRef
+}
+
+func (a ClusterPolicyBindingAdapter) RoleBindings() map[string]RoleBinding {
+	if a.adaptedRoleBindings == nil {
+		adaptedRoleBindings := map[string]RoleBinding{}
+		for key := range a.policyBinding.RoleBindings {
+			adaptedRoleBindings[key] = ClusterRoleBindingAdapter{a.policyBinding.RoleBindings[key]}
+		}
+		a.adaptedRoleBindings = adaptedRoleBindings
+	}
+	return a.adaptedRoleBindings
+}
+
+type ClusterRoleBindingAdapter struct {
+	roleBinding *authorizationapi.ClusterRoleBinding
+}
+
+func (a ClusterRoleBindingAdapter) Name() string {
+	return a.roleBinding.Name
+}
+
+func (a ClusterRoleBindingAdapter) Namespace() string {
+	return a.roleBinding.Namespace
+}
+
+func (a ClusterRoleBindingAdapter) RoleRef() kapi.ObjectReference {
+	return a.roleBinding.RoleRef
+}
+
+func (a ClusterRoleBindingAdapter) Users() util.StringSet {
+	return a.roleBinding.Users
+}
+func (a ClusterRoleBindingAdapter) Groups() util.StringSet {
+	return a.roleBinding.Groups
+}

--- a/pkg/authorization/interfaces/interfaces.go
+++ b/pkg/authorization/interfaces/interfaces.go
@@ -66,6 +66,20 @@ func NewLocalPolicyBindingAdapters(list *authorizationapi.PolicyBindingList) []P
 	return ret
 }
 
+func NewClusterRoleBindingAdapter(roleBinding *authorizationapi.ClusterRoleBinding) RoleBinding {
+	return ClusterRoleBindingAdapter{roleBinding: roleBinding}
+}
+func NewLocalRoleBindingAdapter(roleBinding *authorizationapi.RoleBinding) RoleBinding {
+	return RoleBindingAdapter{roleBinding: roleBinding}
+}
+
+func NewClusterRoleAdapter(role *authorizationapi.ClusterRole) Role {
+	return ClusterRoleAdapter{role: role}
+}
+func NewLocalRoleAdapter(role *authorizationapi.Role) Role {
+	return RoleAdapter{role: role}
+}
+
 type PolicyAdapter struct {
 	policy *authorizationapi.Policy
 

--- a/pkg/authorization/registry/policybinding/strategy.go
+++ b/pkg/authorization/registry/policybinding/strategy.go
@@ -103,7 +103,7 @@ func NewEmptyPolicyBinding(namespace, policyNamespace, policyBindingName string)
 	binding.CreationTimestamp = util.Now()
 	binding.LastModified = util.Now()
 	binding.PolicyRef = kapi.ObjectReference{Name: authorizationapi.PolicyName, Namespace: policyNamespace}
-	binding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+	binding.RoleBindings = make(map[string]*authorizationapi.RoleBinding)
 
 	return binding
 }

--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -49,7 +49,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, label labels.Selector, field fie
 	for _, policy := range policyList.Items {
 		for _, role := range policy.Roles {
 			if label.Matches(labels.Set(role.Labels)) {
-				roleList.Items = append(roleList.Items, role)
+				roleList.Items = append(roleList.Items, *role)
 			}
 		}
 	}
@@ -71,7 +71,7 @@ func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, err
 		return nil, kapierrors.NewNotFound("Role", name)
 	}
 
-	return &role, nil
+	return role, nil
 }
 
 // Delete(ctx api.Context, name string) (runtime.Object, error)
@@ -113,7 +113,7 @@ func (m *VirtualStorage) Create(ctx kapi.Context, obj runtime.Object) (runtime.O
 	}
 
 	role.ResourceVersion = policy.ResourceVersion
-	policy.Roles[role.Name] = *role
+	policy.Roles[role.Name] = role
 	policy.LastModified = util.Now()
 
 	if err := m.PolicyStorage.UpdatePolicy(ctx, policy); err != nil {
@@ -151,7 +151,7 @@ func (m *VirtualStorage) Update(ctx kapi.Context, obj runtime.Object) (runtime.O
 	}
 
 	role.ResourceVersion = policy.ResourceVersion
-	policy.Roles[role.Name] = *role
+	policy.Roles[role.Name] = role
 	policy.LastModified = util.Now()
 
 	if err := m.PolicyStorage.UpdatePolicy(ctx, policy); err != nil {
@@ -183,7 +183,7 @@ func (m *VirtualStorage) EnsurePolicy(ctx kapi.Context) (*authorizationapi.Polic
 	}
 
 	if policy.Roles == nil {
-		policy.Roles = make(map[string]authorizationapi.Role)
+		policy.Roles = make(map[string]*authorizationapi.Role)
 	}
 
 	return policy, nil
@@ -195,7 +195,7 @@ func NewEmptyPolicy(namespace string) *authorizationapi.Policy {
 	policy.Namespace = namespace
 	policy.CreationTimestamp = util.Now()
 	policy.LastModified = util.Now()
-	policy.Roles = make(map[string]authorizationapi.Role)
+	policy.Roles = make(map[string]*authorizationapi.Role)
 
 	return policy
 }

--- a/pkg/authorization/registry/role/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage_test.go
@@ -18,7 +18,7 @@ func testNewClusterPolicies() []authorizationapi.ClusterPolicy {
 	return []authorizationapi.ClusterPolicy{
 		{
 			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName},
-			Roles: map[string]authorizationapi.ClusterRole{
+			Roles: map[string]*authorizationapi.ClusterRole{
 				"cluster-admin": {
 					ObjectMeta: kapi.ObjectMeta{Name: "cluster-admin"},
 					Rules:      []authorizationapi.PolicyRule{{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("*")}},
@@ -35,7 +35,7 @@ func testNewLocalPolicies() []authorizationapi.Policy {
 	return []authorizationapi.Policy{
 		{
 			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName, Namespace: "unittest"},
-			Roles:      map[string]authorizationapi.Role{},
+			Roles:      map[string]*authorizationapi.Role{},
 		},
 	}
 }

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -252,8 +252,8 @@ func (m *VirtualStorage) confirmNoEscalation(ctx kapi.Context, roleBinding *auth
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
 		m.PolicyRegistry,
 		m.BindingRegistry,
-		clusterpolicyregistry.NewSimulatedRegistry(m.ClusterPolicyRegistry),
-		clusterpolicybindingregistry.NewSimulatedRegistry(m.ClusterPolicyBindingRegistry),
+		m.ClusterPolicyRegistry,
+		m.ClusterPolicyBindingRegistry,
 	)
 	ownerLocalRules, err := ruleResolver.GetEffectivePolicyRules(ctx)
 	if err != nil {

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -63,7 +63,7 @@ func (m *VirtualStorage) List(ctx kapi.Context, label labels.Selector, field fie
 	for _, policyBinding := range policyBindingList.Items {
 		for _, roleBinding := range policyBinding.RoleBindings {
 			if label.Matches(labels.Set(roleBinding.Labels)) {
-				roleBindingList.Items = append(roleBindingList.Items, roleBinding)
+				roleBindingList.Items = append(roleBindingList.Items, *roleBinding)
 			}
 		}
 	}
@@ -84,7 +84,7 @@ func (m *VirtualStorage) Get(ctx kapi.Context, name string) (runtime.Object, err
 	if !exists {
 		return nil, kapierrors.NewNotFound("RoleBinding", name)
 	}
-	return &binding, nil
+	return binding, nil
 }
 
 func (m *VirtualStorage) Delete(ctx kapi.Context, name string, options *kapi.DeleteOptions) (runtime.Object, error) {
@@ -145,7 +145,7 @@ func (m *VirtualStorage) createRoleBinding(ctx kapi.Context, obj runtime.Object,
 	}
 
 	roleBinding.ResourceVersion = policyBinding.ResourceVersion
-	policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
+	policyBinding.RoleBindings[roleBinding.Name] = roleBinding
 	policyBinding.LastModified = util.Now()
 
 	if err := m.BindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
@@ -200,7 +200,7 @@ func (m *VirtualStorage) updateRoleBinding(ctx kapi.Context, obj runtime.Object,
 	}
 
 	roleBinding.ResourceVersion = policyBinding.ResourceVersion
-	policyBinding.RoleBindings[roleBinding.Name] = *roleBinding
+	policyBinding.RoleBindings[roleBinding.Name] = roleBinding
 	policyBinding.LastModified = util.Now()
 
 	if err := m.BindingRegistry.UpdatePolicyBinding(ctx, policyBinding); err != nil {
@@ -240,7 +240,7 @@ func (m *VirtualStorage) getReferencedRole(roleRef kapi.ObjectReference) (*autho
 		return nil, kapierrors.NewNotFound("Role", roleRef.Name)
 	}
 
-	return &role, nil
+	return role, nil
 }
 
 func (m *VirtualStorage) confirmNoEscalation(ctx kapi.Context, roleBinding *authorizationapi.RoleBinding) error {
@@ -299,7 +299,7 @@ func (m *VirtualStorage) ensurePolicyBindingToMaster(ctx kapi.Context, policyNam
 	}
 
 	if policyBinding.RoleBindings == nil {
-		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+		policyBinding.RoleBindings = make(map[string]*authorizationapi.RoleBinding)
 	}
 
 	return policyBinding, nil
@@ -319,7 +319,7 @@ func (m *VirtualStorage) getPolicyBindingForPolicy(ctx kapi.Context, policyNames
 	}
 
 	if policyBinding.RoleBindings == nil {
-		policyBinding.RoleBindings = make(map[string]authorizationapi.RoleBinding)
+		policyBinding.RoleBindings = make(map[string]*authorizationapi.RoleBinding)
 	}
 
 	return policyBinding, nil

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
@@ -22,7 +22,7 @@ func testNewClusterPolicies() []authorizationapi.ClusterPolicy {
 	return []authorizationapi.ClusterPolicy{
 		{
 			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.PolicyName},
-			Roles: map[string]authorizationapi.ClusterRole{
+			Roles: map[string]*authorizationapi.ClusterRole{
 				"cluster-admin": {
 					ObjectMeta: kapi.ObjectMeta{Name: "cluster-admin"},
 					Rules:      []authorizationapi.PolicyRule{{Verbs: util.NewStringSet("*"), Resources: util.NewStringSet("*")}},
@@ -40,7 +40,7 @@ func testNewClusterBindings() []authorizationapi.ClusterPolicyBinding {
 	return []authorizationapi.ClusterPolicyBinding{
 		{
 			ObjectMeta: kapi.ObjectMeta{Name: authorizationapi.ClusterPolicyBindingName},
-			RoleBindings: map[string]authorizationapi.ClusterRoleBinding{
+			RoleBindings: map[string]*authorizationapi.ClusterRoleBinding{
 				"cluster-admins": {
 					ObjectMeta: kapi.ObjectMeta{Name: "cluster-admins"},
 					RoleRef:    kapi.ObjectReference{Name: "cluster-admin"},
@@ -54,7 +54,7 @@ func testNewLocalBindings() []authorizationapi.PolicyBinding {
 	return []authorizationapi.PolicyBinding{
 		{
 			ObjectMeta:   kapi.ObjectMeta{Name: authorizationapi.GetPolicyBindingName("unittest"), Namespace: "unittest"},
-			RoleBindings: map[string]authorizationapi.RoleBinding{},
+			RoleBindings: map[string]*authorizationapi.RoleBinding{},
 		},
 	}
 }

--- a/pkg/authorization/rulevalidation/find_rules.go
+++ b/pkg/authorization/rulevalidation/find_rules.go
@@ -28,8 +28,8 @@ func NewDefaultRuleResolver(policyGetter PolicyGetter, bindingLister BindingList
 }
 
 type AuthorizationRuleResolver interface {
-	GetRoleBindings(ctx kapi.Context) ([]authorizationapi.RoleBinding, error)
-	GetRole(roleBinding authorizationapi.RoleBinding) (*authorizationapi.Role, error)
+	GetRoleBindings(ctx kapi.Context) ([]*authorizationapi.RoleBinding, error)
+	GetRole(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.Role, error)
 	// GetEffectivePolicyRules returns the list of rules that apply to a given user in a given namespace and error.  If an error is returned, the slice of
 	// PolicyRules may not be complete, but it contains all retrievable rules.  This is done because policy rules are purely additive and policy determinations
 	// can be made on the basis of those rules that are found.
@@ -83,13 +83,13 @@ func (a *DefaultRuleResolver) getPolicyBindings(ctx kapi.Context) ([]authorizati
 	return policyBindingList.Items, nil
 }
 
-func (a *DefaultRuleResolver) GetRoleBindings(ctx kapi.Context) ([]authorizationapi.RoleBinding, error) {
+func (a *DefaultRuleResolver) GetRoleBindings(ctx kapi.Context) ([]*authorizationapi.RoleBinding, error) {
 	policyBindings, err := a.getPolicyBindings(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]authorizationapi.RoleBinding, 0, len(policyBindings))
+	ret := make([]*authorizationapi.RoleBinding, 0, len(policyBindings))
 	for _, policyBinding := range policyBindings {
 		for _, value := range policyBinding.RoleBindings {
 			ret = append(ret, value)
@@ -99,7 +99,7 @@ func (a *DefaultRuleResolver) GetRoleBindings(ctx kapi.Context) ([]authorization
 	return ret, nil
 }
 
-func (a *DefaultRuleResolver) GetRole(roleBinding authorizationapi.RoleBinding) (*authorizationapi.Role, error) {
+func (a *DefaultRuleResolver) GetRole(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.Role, error) {
 	namespace := roleBinding.RoleRef.Namespace
 	name := roleBinding.RoleRef.Name
 
@@ -117,7 +117,7 @@ func (a *DefaultRuleResolver) GetRole(roleBinding authorizationapi.RoleBinding) 
 		return nil, fmt.Errorf("role %#v not found", roleBinding.RoleRef)
 	}
 
-	return &role, nil
+	return role, nil
 }
 
 // GetEffectivePolicyRules returns the list of rules that apply to a given user in a given namespace and error.  If an error is returned, the slice of

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -99,7 +99,7 @@ func (a LocalRoleBindingAccessor) GetExistingRoleBindingsForRole(roleNamespace, 
 	for _, currBinding := range existingBindings.RoleBindings {
 		if currBinding.RoleRef.Name == role {
 			t := currBinding
-			ret = append(ret, &t)
+			ret = append(ret, t)
 		}
 	}
 
@@ -155,7 +155,7 @@ func (a ClusterRoleBindingAccessor) GetExistingRoleBindingsForRole(roleNamespace
 	for _, currBinding := range existingBindings.RoleBindings {
 		if currBinding.RoleRef.Name == role {
 			t := currBinding
-			ret = append(ret, &t)
+			ret = append(ret, t)
 		}
 	}
 

--- a/pkg/cmd/admin/policy/remove_from_project.go
+++ b/pkg/cmd/admin/policy/remove_from_project.go
@@ -118,7 +118,7 @@ func (o *RemoveFromProjectOptions) Run() error {
 			currBinding.Groups.Delete(o.Groups...)
 			currBinding.Users.Delete(o.Users...)
 
-			_, err = o.Client.RoleBindings(o.BindingNamespace).Update(&currBinding)
+			_, err = o.Client.RoleBindings(o.BindingNamespace).Update(currBinding)
 			if err != nil {
 				return err
 			}

--- a/pkg/project/auth/cache_test.go
+++ b/pkg/project/auth/cache_test.go
@@ -94,6 +94,14 @@ func (this *MockReadOnlyPolicyClient) ListPolicyBindings(ctx kapi.Context, label
 	return &authorizationapi.PolicyBindingList{}, nil
 }
 
+func (this *MockReadOnlyPolicyClient) GetClusterPolicy(ctx kapi.Context, name string) (*authorizationapi.ClusterPolicy, error) {
+	return &authorizationapi.ClusterPolicy{}, nil
+}
+
+func (this *MockReadOnlyPolicyClient) ListClusterPolicyBindings(ctx kapi.Context, label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyBindingList, error) {
+	return &authorizationapi.ClusterPolicyBindingList{}, nil
+}
+
 // mockReview implements the Review interface for test cases
 type mockReview struct {
 	users  []string


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3233

This switches policy maps from `map[string]struct` to `map[string]*struct` and stops casting and copying cached objects by adapting them to an interface.

We really want to just cache the `Roles` and `RoleBindings`, but that would require a larger change.

@smarterclayton If I'm reading the memprof right, this helped significantly.