### PR TITLE
UPSTREAM: check isNotExist when validating mountpoint

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/cephfs/cephfs.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/cephfs/cephfs.go
@@ -175,7 +175,7 @@ func (cephfsVolume *cephfs) TearDownAt(dir string) error {
 
 func (cephfsVolume *cephfs) cleanup(dir string) error {
 	mountpoint, err := cephfsVolume.mounter.IsMountPoint(dir)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("CephFS: Error checking IsMountPoint: %v", err)
 	}
 	if !mountpoint {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/rbd/rbd_util.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volume/rbd/rbd_util.go
@@ -101,7 +101,8 @@ func (util *RBDUtil) AttachDisk(rbd rbd) error {
 	// mount it
 	globalPDPath := rbd.manager.MakeGlobalPDName(rbd)
 	mountpoint, err := rbd.mounter.IsMountPoint(globalPDPath)
-	if err != nil {
+	// in the first time, the path shouldn't exist and IsMountPoint is expected to get NotExist
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("rbd: %s failed to check mountpoint", globalPDPath)
 	}
 	if mountpoint {


### PR DESCRIPTION
@smarterclayton @pmorie @rootfs 

RDB was already merged upstream.  This is the PR for the fix there: https://github.com/GoogleCloudPlatform/kubernetes/pull/9957

Ceph is not yet merged upstream.  It's PR:   GoogleCloudPlatform/kubernetes#6649

Ceph was merged into OpenShift with https://github.com/openshift/origin/pull/2960