### PR TITLE
'oc volume' test cases and fixes

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -514,6 +514,22 @@ oc describe deploymentConfigs test-deployment-config
 [ "$(echo "OTHER=foo" | oc env dc/test-deployment-config -e - --list | grep OTHER=foo)" ]
 [ ! "$(echo "#OTHER=foo" | oc env dc/test-deployment-config -e - --list | grep OTHER=foo)" ]
 [ "$(oc env dc/test-deployment-config TEST=bar OTHER=baz BAR-)" ]
+
+[ "$(oc volume dc/test-deployment-config --list | grep vol1)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol2 -m /opt)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol1 --type=secret --secret-name='$ecret' -m /data | grep overwrite)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol1 --type=emptyDir -m /data --overwrite)" ]
+[ "$(oc volume dc/test-deployment-config --add -m /opt | grep exists)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby' --overwrite | grep warning)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby*' --overwrite)" ]
+[ "$(oc volume dc/test-deployment-config --list --name=vol2 | grep /etc)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol3 -o yaml | grep vol3)" ]
+[ "$(oc volume dc/test-deployment-config --list --name=vol3 | grep 'not found')" ]
+[ "$(oc volume dc/test-deployment-config --remove 2>&1 | grep confirm)" ]
+[ "$(oc volume dc/test-deployment-config --remove --name=vol2)" ]
+[ ! "$(oc volume dc/test-deployment-config --list | grep vol2)" ]
+[ "$(oc volume dc/test-deployment-config --remove --confirm)" ]
+[ ! "$(oc volume dc/test-deployment-config --list | grep vol1)" ]
 oc deploy test-deployment-config
 oc delete deploymentConfigs test-deployment-config
 echo "deploymentConfigs: ok"

--- a/test/integration/fixtures/test-deployment-config.json
+++ b/test/integration/fixtures/test-deployment-config.json
@@ -22,6 +22,12 @@
         }
       },
       "spec": {
+	"volumes": [
+	  {
+	    "name": "vol1",
+	    "emptyDir": {}
+	  }
+	],
         "containers": [
           {
             "name": "ruby-helloworld",


### PR DESCRIPTION
Fixes:
 - Update help message (fixes bug #1232597)
 - Normalize volume mount path.
 - Check if volume mount already exists in the container.
   No two volumes can have same mount point inside the container.
 - Don't update info objects that returned error.
 - Throw error if given volume not found for --list/--remove operation.
 - Return non-zero error code in case of errors.
 - Display warning msg if given containers are not found.