### PR TITLE
Need to add two parameters to work with docker hub mysql images

### DIFF
--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -107,8 +107,8 @@
                     "value": "${MYSQL_DATABASE}"
                   },
                   {
-                    "name": "MYSQL_ROOT_DATABASE",
-                    "value": "${MYSQL_ROOT_DATABASE}"
+                    "name": "MYSQL_ALLOW_EMPTY_PASSWORD",
+                    "value": "${MYSQL_ALLOW_EMPTY_PASSWORD}"
                   }
                 ],
                 "resources": {},

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -105,6 +105,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_DATABASE",
+                    "value": "${MYSQL_ROOT_DATABASE}"
                   }
                 ],
                 "resources": {},

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -2,7 +2,7 @@
   "kind": "Template",
   "apiVersion": "v1beta3",
   "metadata": {
-    "name": "mysql-ephemeral",
+    "name": "mysql-ephemeral-rettori",
     "creationTimestamp": null,
     "annotations": {
       "description": "MySQL database service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
@@ -161,6 +161,11 @@
       "name": "MYSQL_DATABASE",
       "description": "Database name",
       "value": "sampledb"
+    }
+    {
+      "name": "MYSQL_ALLOW_EMPTY_PASSWORD",
+      "description": "allow empty password?",
+      "value": "true"
     }
   ],
   "labels": {

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -2,7 +2,7 @@
   "kind": "Template",
   "apiVersion": "v1beta3",
   "metadata": {
-    "name": "mysql-ephemeral-rettori",
+    "name": "mysql-ephemeral",
     "creationTimestamp": null,
     "annotations": {
       "description": "MySQL database service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
@@ -109,6 +109,10 @@
                   {
                     "name": "MYSQL_ALLOW_EMPTY_PASSWORD",
                     "value": "${MYSQL_ALLOW_EMPTY_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "${MYSQL_ROOT_PASSWORD}"
                   }
                 ],
                 "resources": {},
@@ -170,6 +174,11 @@
       "name": "MYSQL_ALLOW_EMPTY_PASSWORD",
       "description": "allow empty password?",
       "value": "true"
+    },
+    {
+      "name": "MYSQL_ROOT_PASSWORD",
+      "description": "Mysql Root Password. Can be empty if MYSQL_ALLOW_EMPTY_PASSWORD set to true",
+      "value": ""
     }
   ],
   "labels": {

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -161,7 +161,7 @@
       "name": "MYSQL_DATABASE",
       "description": "Database name",
       "value": "sampledb"
-    }
+    },
     {
       "name": "MYSQL_ALLOW_EMPTY_PASSWORD",
       "description": "allow empty password?",


### PR DESCRIPTION
Either one of the parameters MYSQL_ROOT_PASSOWORD / MYSQL_ALLOW_EMPTY_PASSWORD are required according to https://github.com/docker-library/mysql/blob/master/5.5/docker-entrypoint.sh. I added both, tested and it worked.
Before that I was getting the error: 
error: database is uninitialized and MYSQL_ROOT_PASSWORD not set
  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?