### PR TITLE
sdn should ignore containers that have net=host

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -987,16 +987,16 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/ovssubnet",
-			"Rev": "962bcbc2400f6e66e951e61ba259e81a6036f1a2"
+			"Rev": "2bf8606dd9e0d5c164464f896e2223431f4b5099"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/api",
-			"Rev": "962bcbc2400f6e66e951e61ba259e81a6036f1a2"
+			"Rev": "2bf8606dd9e0d5c164464f896e2223431f4b5099"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/netutils",
 			"Comment": "v0.1-85-g7752990",
-			"Rev": "962bcbc2400f6e66e951e61ba259e81a6036f1a2"
+			"Rev": "2bf8606dd9e0d5c164464f896e2223431f4b5099"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-ovs-subnet
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/ovssubnet/bin/openshift-ovs-subnet
@@ -25,6 +25,11 @@ Setup() {
     tap_ip=${OPENSHIFT_SDN_TAP1_ADDR}
 
     pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
+    if [ "$network_mode"=="host" ]; then
+      # quit, nothing for the SDN here
+      exit 0
+    fi
     ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
     new_ip=$ipaddr
     ipaddr_sub=$(docker inspect --format "{{.NetworkSettings.IPPrefixLen}}" ${net_container})
@@ -48,6 +53,11 @@ Teardown() {
     tap_ip=${OPENSHIFT_SDN_TAP1_ADDR}
 
     pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
+    if [ "$network_mode"=="host" ]; then
+      # quit, nothing for the SDN here
+      exit 0
+    fi
     veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
     veth_host=$(ip link show | sed -ne "s/^$veth_ifindex: \([^:]*\).*/\1/p")
     ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')


### PR DESCRIPTION
reflecting changes from upstream sdn