### PR TITLE
[DO NOT MERGE] use host network for router pod

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -290,6 +290,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 							Spec: kapi.PodSpec{
 								ServiceAccount: cfg.ServiceAccount,
 								NodeSelector:   nodeSelector,
+								HostNetwork:    true,
 								Containers: []kapi.Container{
 									{
 										Name:  "router",


### PR DESCRIPTION
Use host networking for the router pod so ip addresses are not NAT'd

@rajatchopra @danmcp 