### PR TITLE
[DO NOT MERGE] make router bind to hostNetwork

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/kubelet.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/kubelet.go
@@ -2098,6 +2098,9 @@ func (kl *Kubelet) generatePodStatus(pod *api.Pod) (api.PodStatus, error) {
 		glog.Errorf("Cannot get host IP: %v", err)
 	} else {
 		podStatus.HostIP = hostIP.String()
+		if pod.Spec.HostNetwork && podStatus.PodIP == "" {
+			podStatus.PodIP = hostIP.String()
+		}
 	}
 
 	return *podStatus, nil

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -287,6 +287,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 							Spec: kapi.PodSpec{
 								ServiceAccount: cfg.ServiceAccount,
 								NodeSelector:   nodeSelector,
+								HostNetwork: true,
 								Containers: []kapi.Container{
 									{
 										Name:  "router",


### PR DESCRIPTION
@smarterclayton @pweil- @mrunalp @danmcp 
If we ever want the hostNetwork, then the changes with kubelet reporting the IP included with this PR.
Tested this with deploying hello-openshift pod with hostNetwork: true
IP reported is the host's IP.

http://fpaste.org/233383/
