### PR TITLE
use cookies for sticky sessions on http based routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -153,11 +153,15 @@ backend be_http_{{$cfgIdx}}
 backend be_edge_http_{{$cfgIdx}}
                 {{ end }}
   mode http
-  balance source
-  hash-type consistent
+  balance leastconn
   timeout check 5000ms
+  {{ if (eq $cfg.TLSTermination "") }}
+    cookie OPENSHIFT_{{$cfgIdx}}_SERVERID insert indirect nocache httponly
+  {{ else }}
+    cookie OPENSHIFT_EDGE_{{$cfgIdx}}_SERVERID insert indirect nocache httponly secure
+  {{ end }}
                 {{ range $idx, $endpoint := $serviceUnit.EndpointTable }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms cookie {{$endpoint.ID}}
                 {{ end }}
             {{ end }}
 
@@ -174,11 +178,11 @@ backend be_tcp_{{$cfgIdx}}
             {{ if eq $cfg.TLSTermination "reencrypt" }}
 backend be_secure_{{$cfgIdx}}
   mode http
-  balance source
-  hash-type consistent
+  balance leastconn
   timeout check 5000ms
+  cookie OPENSHIFT_REENCRYPT_{{$cfgIdx}}_SERVERID insert indirect nocache httponly secure
                 {{ range $idx, $endpoint := $serviceUnit.EndpointTable }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file /var/lib/containers/router/cacerts/{{$cfgIdx}}.pem
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file /var/lib/containers/router/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.ID}}
                 {{ end }}
             {{ end  }}
         {{ end  }}{{/* $serviceUnit.ServiceAliasConfigs*/}}


### PR DESCRIPTION
Just wanted to throw this out there one more time because it fixes our issue for http based routes (everything except passthrough routes) and it is what I have on my list to document tomorrow in an admin guide (along with stick-tables).

(full disclosure, I only tested unsecure on this go round, I'd want to run through the other two http types if we want to move on this)

@danmcp @smarterclayton @rajatchopra 


```
# no cookie settings with curl - balance leastconn
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com localhost
Hello World
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com localhost
Test2!!!
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com localhost
Hello World
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com localhost
Test2!!!

# cookie settings leastconn w/ cookie match
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -c cookies.txt localhost
Hello World
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies.txt localhost
Hello World
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies.txt localhost
Hello World
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies.txt localhost
Hello World

# use a new cookie...
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -c cookies2.txt localhost
Test2!!!
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies2.txt localhost
Test2!!!
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies2.txt localhost
Test2!!!
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies2.txt localhost
Test2!!!
[vagrant@openshiftdev sticky]$ curl -H Host:www.example.com -b cookies2.txt localhost
Test2!!!
```