### PR TITLE
indicate builds that can't push

### DIFF
--- a/pkg/api/graph/test/pushable-build.yaml
+++ b/pkg/api/graph/test/pushable-build.yaml
@@ -1,0 +1,161 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ruby-hello-world:latest
+    resources: {}
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: ruby-20-centos7:latest
+      type: Docker
+    triggers:
+    - github:
+        secret: LyddbeCAaw1a0x08xz9n
+      type: GitHub
+    - generic:
+        secret: ZnYJJeEvo1ri0Gk0f6YY
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0
+- apiVersion: v1
+  kind: Build
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+      buildconfig: ruby-hello-world
+    name: ruby-hello-world-1
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ruby-hello-world:latest
+    resources: {}
+    serviceAccount: builder
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: openshift/ruby-20-centos7:latest
+      type: Docker
+  status:
+    config:
+      name: ruby-hello-world
+    phase: New
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/image.dockerRepositoryCheck: 2015-07-06T19:05:12Z
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-20-centos7
+  spec:
+    dockerImageRepository: openshift/ruby-20-centos7
+  status:
+    dockerImageRepository: openshift/ruby-20-centos7
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec: {}
+  status:
+    dockerImageRepository: 172.30.222.57:5000/foo/ruby-hello-world
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: ruby-hello-world
+    strategy:
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: ruby-hello-world
+      spec:
+        containers:
+        - image: library/ruby-hello-world:latest
+          imagePullPolicy: Always
+          name: ruby-hello-world
+          ports:
+          - containerPort: 8080
+            name: ruby-hello-world-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ruby-hello-world
+        from:
+          kind: ImageStreamTag
+          name: ruby-hello-world:latest
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    portalIP: ""
+    ports:
+    - name: ruby-hello-world-tcp-8080
+      nodePort: 0
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: ruby-hello-world
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+kind: List
+metadata: {}

--- a/pkg/api/graph/test/unpushable-build.yaml
+++ b/pkg/api/graph/test/unpushable-build.yaml
@@ -1,0 +1,161 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ruby-hello-world:latest
+    resources: {}
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: ruby-20-centos7:latest
+      type: Docker
+    triggers:
+    - github:
+        secret: LyddbeCAaw1a0x08xz9n
+      type: GitHub
+    - generic:
+        secret: ZnYJJeEvo1ri0Gk0f6YY
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+  status:
+    lastVersion: 0
+- apiVersion: v1
+  kind: Build
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+      buildconfig: ruby-hello-world
+    name: ruby-hello-world-1
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ruby-hello-world:latest
+    resources: {}
+    serviceAccount: builder
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: openshift/ruby-20-centos7:latest
+      type: Docker
+  status:
+    config:
+      name: ruby-hello-world
+    phase: New
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/image.dockerRepositoryCheck: 2015-07-06T19:05:12Z
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-20-centos7
+  spec:
+    dockerImageRepository: openshift/ruby-20-centos7
+  status:
+    dockerImageRepository: openshift/ruby-20-centos7
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec: {}
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: ruby-hello-world
+    strategy:
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: ruby-hello-world
+      spec:
+        containers:
+        - image: library/ruby-hello-world:latest
+          imagePullPolicy: Always
+          name: ruby-hello-world
+          ports:
+          - containerPort: 8080
+            name: ruby-hello-world-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ruby-hello-world
+        from:
+          kind: ImageStreamTag
+          name: ruby-hello-world:latest
+      type: ImageChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    portalIP: ""
+    ports:
+    - name: ruby-hello-world-tcp-8080
+      nodePort: 0
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: ruby-hello-world
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+kind: List
+metadata: {}

--- a/pkg/image/graph/edges.go
+++ b/pkg/image/graph/edges.go
@@ -1,0 +1,34 @@
+package graph
+
+import (
+	"github.com/gonum/graph"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
+)
+
+const (
+	// ReferencedImageStreamGraphEdgeKind is an edge that goes from an ImageStreamTag node back to an ImageStream
+	ReferencedImageStreamGraphEdgeKind = "ReferencedImageStreamGraphEdge"
+)
+
+// AddImageStreamRefEdge ensures that a directed edge exists between an IST Node and the IS it references
+func AddImageStreamRefEdge(g osgraph.MutableUniqueGraph, node *imagegraph.ImageStreamTagNode) {
+	isName, _, _ := imageapi.SplitImageStreamTag(node.Name)
+	imageStream := &imageapi.ImageStream{}
+	imageStream.Namespace = node.Namespace
+	imageStream.Name = isName
+
+	imageStreamNode := imagegraph.FindOrCreateSyntheticImageStreamNode(g, imageStream)
+	g.AddEdge(node, imageStreamNode, ReferencedImageStreamGraphEdgeKind)
+}
+
+// AddAllImageStreamRefEdges calls AddImageStreamRefEdge for every ImageStreamTagNode in the graph
+func AddAllImageStreamRefEdges(g osgraph.MutableUniqueGraph) {
+	for _, node := range g.(graph.Graph).NodeList() {
+		if istNode, ok := node.(*imagegraph.ImageStreamTagNode); ok {
+			AddImageStreamRefEdge(g, istNode)
+		}
+	}
+}

--- a/pkg/image/graph/nodes/nodes.go
+++ b/pkg/image/graph/nodes/nodes.go
@@ -85,7 +85,7 @@ func EnsureImageStreamTagNode(g osgraph.MutableUniqueGraph, ist *imageapi.ImageS
 	return osgraph.EnsureUnique(g,
 		ImageStreamTagNodeName(ist),
 		func(node osgraph.Node) graph.Node {
-			return &ImageStreamTagNode{node, ist, false}
+			return &ImageStreamTagNode{node, ist, true}
 		},
 	).(*ImageStreamTagNode)
 }
@@ -95,19 +95,29 @@ func FindOrCreateSyntheticImageStreamTagNode(g osgraph.MutableUniqueGraph, ist *
 	return osgraph.EnsureUnique(g,
 		ImageStreamTagNodeName(ist),
 		func(node osgraph.Node) graph.Node {
-			return &ImageStreamTagNode{node, ist, true}
+			return &ImageStreamTagNode{node, ist, false}
 		},
 	).(*ImageStreamTagNode)
 }
 
 // EnsureImageStreamNode adds a graph node for the Image Stream if it does not already exist.
-func EnsureImageStreamNode(g osgraph.MutableUniqueGraph, stream *imageapi.ImageStream) graph.Node {
+func EnsureImageStreamNode(g osgraph.MutableUniqueGraph, is *imageapi.ImageStream) graph.Node {
 	return osgraph.EnsureUnique(g,
-		ImageStreamNodeName(stream),
+		ImageStreamNodeName(is),
 		func(node osgraph.Node) graph.Node {
-			return &ImageStreamNode{node, stream}
+			return &ImageStreamNode{node, is, true}
 		},
 	)
+}
+
+// FindOrCreateSyntheticImageStreamNode returns the existing ISNode or creates a synthetic node in its place
+func FindOrCreateSyntheticImageStreamNode(g osgraph.MutableUniqueGraph, is *imageapi.ImageStream) *ImageStreamNode {
+	return osgraph.EnsureUnique(g,
+		ImageStreamNodeName(is),
+		func(node osgraph.Node) graph.Node {
+			return &ImageStreamNode{node, is, false}
+		},
+	).(*ImageStreamNode)
 }
 
 // EnsureImageLayerNode adds a graph node for the layer if it does not already exist.

--- a/pkg/image/graph/nodes/types.go
+++ b/pkg/image/graph/nodes/types.go
@@ -25,6 +25,12 @@ func ImageStreamNodeName(o *imageapi.ImageStream) osgraph.UniqueName {
 type ImageStreamNode struct {
 	osgraph.Node
 	*imageapi.ImageStream
+
+	IsFound bool
+}
+
+func (n ImageStreamNode) Found() bool {
+	return n.IsFound
 }
 
 func (n ImageStreamNode) Object() interface{} {
@@ -47,11 +53,11 @@ type ImageStreamTagNode struct {
 	osgraph.Node
 	*imageapi.ImageStreamTag
 
-	Synthetic bool
+	IsFound bool
 }
 
-func (n ImageStreamTagNode) IsSynthetic() bool {
-	return n.Synthetic
+func (n ImageStreamTagNode) Found() bool {
+	return n.IsFound
 }
 
 func (n ImageStreamTagNode) ImageSpec() string {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3243

This adds a target *ImageStreamNode into the ImagePipeline.  It does this by creating an edge between an `ImageStreamTagNode` and an associated `ImageStreamNode`.  When the graph is traversed to build the `ImagePipeline`, the edge is chased and resolved.

Output looks like this if the build won't be able to push:
```
In project foo

docker-nfs-server deploys docker-nfs-server:latest <- docker build of https://github.com/deads2k/docker-nfs-server 
  build 1 new for 14 minutes (can't push to image)
  #1 deployed 14 minutes ago - 1 pod

Warning: Some of your builds are pointing to image streams, but the administrator has not configured the integrated Docker registry (oadm registry).
To see more information about a Service or DeploymentConfig, use 'oc describe service <name>' or 'oc describe dc <name>'.
You can use 'oc get all' to see lists of each of the types described above.
```


@smarterclayton sidebar: why do we have veneers over the map traversals?  "Math is hard"?