### PR TITLE
refactor graph node names

### DIFF
--- a/pkg/api/graph/types.go
+++ b/pkg/api/graph/types.go
@@ -22,17 +22,17 @@ import (
 
 const (
 	UnknownGraphKind = iota
-	ImageStreamTagGraphKind
+	ImageStreamGraphKind
+	ImageGraphKind
 	BuildConfigGraphKind
+	BuildGraphKind
 	DeploymentConfigGraphKind
 	ServiceGraphKind
-	ImageGraphKind
 	PodGraphKind
-	ImageStreamGraphKind
 	ReplicationControllerGraphKind
-	BuildGraphKind
 
 	// non-api types
+	ImageStreamTagGraphKind
 	DockerRepositoryGraphKind
 	SourceRepositoryGraphKind
 	ImageLayerGraphKind
@@ -54,7 +54,6 @@ const (
 var kindToGraphKind = map[reflect.Type]interface{}{}
 
 func init() {
-	kindToGraphKind[reflect.TypeOf(&image.ImageStream{})] = ImageStreamGraphKind
 	kindToGraphKind[reflect.TypeOf(&image.ImageStream{})] = ImageStreamGraphKind
 	kindToGraphKind[reflect.TypeOf(&image.Image{})] = ImageGraphKind
 	kindToGraphKind[reflect.TypeOf(&build.BuildConfig{})] = BuildConfigGraphKind

--- a/pkg/image/prune/imagepruner_test.go
+++ b/pkg/image/prune/imagepruner_test.go
@@ -694,33 +694,17 @@ func TestRegistryPruning(t *testing.T) {
 						tagEvent("id2", "registry1/foo/other@id2"),
 					),
 				)),
-				stream("registry2", "foo", "bar", tags(
-					tag("latest",
-						tagEvent("id2", "registry2/foo/bar@id2"),
-						tagEvent("id1", "registry2/foo/bar@id1"),
-					),
-				)),
-				stream("registry2", "foo", "other", tags(
-					tag("latest",
-						tagEvent("id2", "registry2/foo/other@id2"),
-					),
-				)),
 			),
 			expectedLayerDeletions: util.NewStringSet(
 				"registry1|foo/bar|layer1",
 				"registry1|foo/bar|layer2",
-				"registry2|foo/bar|layer1",
-				"registry2|foo/bar|layer2",
 			),
 			expectedBlobDeletions: util.NewStringSet(
 				"registry1|layer1",
 				"registry1|layer2",
-				"registry2|layer1",
-				"registry2|layer2",
 			),
 			expectedManifestDeletions: util.NewStringSet(
 				"registry1|foo/bar|id1",
-				"registry2|foo/bar|id1",
 			),
 		},
 		"no pruning when no images are pruned": {


### PR DESCRIPTION
It's a little hard to follow exactly how the different nodes are named and failure to standardize has produced some strange collisions in the general case.  This refactors the unique name determination to be easier to discover.

@smarterclayton I needed this to start adding secrets and service accounts in for bad pod templates.