### PR TITLE
add tls termination type to printer and describer

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -539,6 +539,12 @@ func (d *RouteDescriber) Describe(namespace, name string) (string, error) {
 		formatString(out, "Host", route.Host)
 		formatString(out, "Path", route.Path)
 		formatString(out, "Service", route.ServiceName)
+
+		tlsTerm := ""
+		if route.TLS != nil {
+			tlsTerm = string(route.TLS.Termination)
+		}
+		formatString(out, "TLS Termination", tlsTerm)
 		return nil
 	})
 }

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -33,7 +33,7 @@ var (
 	imageStreamImageColumns = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
 	imageStreamColumns      = []string{"NAME", "DOCKER REPO", "TAGS", "UPDATED"}
 	projectColumns          = []string{"NAME", "DISPLAY NAME", "STATUS"}
-	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "LABELS"}
+	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "LABELS", "TLS TERMINATION"}
 	deploymentColumns       = []string{"NAME", "STATUS", "CAUSE"}
 	deploymentConfigColumns = []string{"NAME", "TRIGGERS", "LATEST VERSION"}
 	templateColumns         = []string{"NAME", "DESCRIPTION", "PARAMETERS", "OBJECTS"}
@@ -305,7 +305,11 @@ func printProjectList(projects *projectapi.ProjectList, w io.Writer, withNamespa
 }
 
 func printRoute(route *routeapi.Route, w io.Writer, withNamespace, wide bool, columnLabels []string) error {
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", route.Name, route.Host, route.Path, route.ServiceName, labels.Set(route.Labels))
+	tlsTerm := ""
+	if route.TLS != nil {
+		tlsTerm = string(route.TLS.Termination)
+	}
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", route.Name, route.Host, route.Path, route.ServiceName, labels.Set(route.Labels), tlsTerm)
 	return err
 }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/2724

```
[pweil@localhost sticky]$ oc get routes
NAME             HOST/PORT         PATH      SERVICE       LABELS    TLS
route-edge       www.example.com             hello-nginx             edge
route-unsecure   www.example.com             hello-nginx             
[pweil@localhost sticky]$ oc describe route route-edge
Name:		route-edge
Created:	12 seconds ago
Labels:		<none>
Annotations:	openshift.io/host.generated=false
Host:		www.example.com
Path:		<none>
Service:	hello-nginx
TLS:		edge

[pweil@localhost sticky]$ oc describe route route-unsecure
Name:		route-unsecure
Created:	About a minute ago
Labels:		<none>
Annotations:	openshift.io/host.generated=false
Host:		www.example.com
Path:		<none>
Service:	hello-nginx
TLS:		<none>
```

@fabianofranz PTAL