### PR TITLE
Fix volume dir label for e2e-docker

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -47,7 +47,15 @@ set -e
 # Prevent user environment from colliding with the test setup
 unset KUBECONFIG
 
-USE_LOCAL_IMAGES=${USE_LOCAL_IMAGES:-true}
+# Use either the latest release built images, or latest.
+if [[ -z "${USE_IMAGES-}" ]]; then
+  tag="latest"
+  if [[ -e "${OS_ROOT}/_output/local/releases/.commit" ]]; then
+    COMMIT="$(cat "${OS_ROOT}/_output/local/releases/.commit")"
+    tag="${COMMIT}"
+  fi
+  USE_IMAGES="openshift/origin-\${component}:${tag}"
+fi
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-4001}
@@ -133,7 +141,8 @@ openshift start \
   --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" \
   --hostname="${KUBELET_HOST}" \
   --volume-dir="${VOLUME_DIR}" \
-  --etcd-dir="${ETCD_DATA_DIR}"
+  --etcd-dir="${ETCD_DATA_DIR}" \
+  --images="${USE_IMAGES}"
 
 
 # Start openshift
@@ -373,7 +382,7 @@ oc create -f test/integration/fixtures/test-image-stream.json
 # make sure stream.status.dockerImageRepository isn't set (no registry)
 [ -z "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]
 # create the registry
-oadm registry --create --credentials="${KUBECONFIG}"
+oadm registry --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
 # make sure stream.status.dockerImageRepository IS set
 [ -n "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]
 # ensure the registry rc has been created
@@ -649,14 +658,14 @@ echo "new-project: ok"
 # Test running a router
 [ ! "$(oadm router --dry-run | grep 'does not exist')" ]
 [ "$(oadm router -o yaml --credentials="${KUBECONFIG}" | grep 'openshift/origin-haproxy-')" ]
-oadm router --create --credentials="${KUBECONFIG}"
+oadm router --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
 [ "$(oadm router | grep 'service exists')" ]
 echo "router: ok"
 
 # Test running a registry
 [ ! "$(oadm registry --dry-run | grep 'does not exist')"]
 [ "$(oadm registry -o yaml --credentials="${KUBECONFIG}" | grep 'openshift/origin-docker-registry')" ]
-oadm registry --create --credentials="${KUBECONFIG}"
+oadm registry --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
 [ "$(oadm registry | grep 'service exists')" ]
 echo "registry: ok"
 

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -76,6 +76,9 @@ function cleanup()
     echo "[INFO] Stopping k8s docker containers"; docker ps | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker stop
     if [[ -z "${SKIP_IMAGE_CLEANUP-}" ]]; then
       echo "[INFO] Removing k8s docker containers"; docker ps -a | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker rm
+
+      # clean up any residual volume mounts
+      mount | grep pods | grep "${VOLUME_DIR}" | awk '{print $3}' | sudo xargs -r -n 1 umount
     fi
     set -u
   fi

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -146,7 +146,7 @@ sudo docker run -d --name="origin" \
   --privileged --net=host \
   -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
   -v "${VOLUME_DIR}:${VOLUME_DIR}" \
-  "openshift/origin:${tag}" start --volume-dir=${VOLUME_DIR}
+  "openshift/origin:${tag}" start --volume-dir=${VOLUME_DIR} --images="${USE_IMAGES}"
 
 export HOME="${FAKE_HOME_DIR}"
 # This directory must exist so Docker can store credentials in $HOME/.dockercfg

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -91,10 +91,7 @@ function cleanup()
 	echo
 
 	set +e
-	echo "[INFO] Dumping container logs to ${LOG_DIR}"
-	for container in $(docker ps -aq); do
-		docker logs "$container" >&"${LOG_DIR}/container-$container.log"
-	done
+	dump_container_logs
 
 	echo "[INFO] Dumping build log to ${LOG_DIR}"
 
@@ -129,11 +126,7 @@ function cleanup()
 	fi
 	set -e
 
-	# clean up zero byte log files
-	# Clean up large log files so they don't end up on jenkins
-	find ${ARTIFACT_DIR} -name *.log -size +20M -exec echo Deleting {} because it is too big. \; -exec rm -f {} \;
-	find ${LOG_DIR} -name *.log -size +20M -exec echo Deleting {} because it is too big. \; -exec rm -f {} \;
-	find ${LOG_DIR} -name *.log -size 0 -exec echo Deleting {} because it is empty. \; -exec rm -f {} \;
+	delete_large_and_empty_logs
 
 	echo "[INFO] Exiting"
 	exit $out


### PR DESCRIPTION
For test-end-to-end-docker.sh, use a volume directory under BASETMPDIR
and label it correctly.

The intermediate labeling solution is to chcon the volume dir on the host to
svirt_sandbox_file_t.

Longer term, we could

1. Update the selinux policy for volume dirs under /var/lib/openshift,
assuming that's the default location for volumes.
2. Modify
https://github.com/openshift/origin/blob/master/pkg/cmd/server/kubernetes/node.go#L102-L121
to always call chcon when the node starts, instead of only if the volume
dir doesn't exist and is therefore newly created.

This commit also changes the file name format of container logs captured
by the e2e tests. Instead of being container-$containerID.log, they are
now container-$podName-$containerName.log, such as
container-docker-registry-1-7sm9l-registry.log.