### PR TITLE
allow http proxy env variables to be set in privileged sti container

### DIFF
--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1beta3",
+  "apiVersion": "v1",
   "metadata": {
     "name": "ruby-helloworld-sample",
     "creationTimestamp": null,
@@ -13,7 +13,7 @@
   "objects": [
     {
       "kind": "Service",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null
@@ -41,7 +41,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "route-edge",
         "creationTimestamp": null
@@ -63,7 +63,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "origin-ruby-sample",
         "creationTimestamp": null
@@ -75,7 +75,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "ruby-20-centos7",
         "creationTimestamp": null
@@ -89,7 +89,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "ruby-sample-build",
         "creationTimestamp": null,
@@ -100,26 +100,26 @@
       "spec": {
         "triggers": [
           {
-            "type": "github",
+            "type": "GitHub",
             "github": {
               "secret": "secret101"
             }
           },
           {
-            "type": "generic",
+            "type": "Generic",
             "generic": {
               "secret": "secret101"
             }
           },
           {
-            "type": "imageChange",
+            "type": "ImageChange",
             "imageChange": {}
           }
         ],
         "source": {
           "type": "Git",
           "git": {
-            "uri": "git://github.com/openshift/ruby-hello-world.git"
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
           }
         },
         "strategy": {
@@ -128,8 +128,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "name": "ruby-20-centos7:latest"
-            },
-            "incremental": true
+            }
           }
         },
         "output": {
@@ -146,7 +145,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null
@@ -202,8 +201,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "name": "origin-ruby-sample:latest"
-              },
-              "lastTriggeredImage": ""
+              }
             }
           },
           {
@@ -257,7 +255,6 @@
                 "resources": {},
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
-                "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
@@ -265,8 +262,7 @@
               }
             ],
             "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst",
-            "serviceAccount": ""
+            "dnsPolicy": "ClusterFirst"
           }
         }
       },
@@ -274,7 +270,7 @@
     },
     {
       "kind": "Service",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "database",
         "creationTimestamp": null
@@ -302,7 +298,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1beta3",
+      "apiVersion": "v1",
       "metadata": {
         "name": "database",
         "creationTimestamp": null
@@ -388,7 +384,6 @@
                 "resources": {},
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "Always",
-                "capabilities": {},
                 "securityContext": {
                   "capabilities": {},
                   "privileged": false
@@ -396,8 +391,7 @@
               }
             ],
             "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst",
-            "serviceAccount": ""
+            "dnsPolicy": "ClusterFirst"
           }
         }
       },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1004,12 +1004,26 @@ func deepCopy_api_DockerBuildStrategy(in buildapi.DockerBuildStrategy, out *buil
 	} else {
 		out.PullSecret = nil
 	}
+	if in.Env != nil {
+		out.Env = make([]api.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if newVal, err := c.DeepCopy(in.Env[i]); err != nil {
+				return err
+			} else {
+				out.Env[i] = newVal.(api.EnvVar)
+			}
+		}
+	} else {
+		out.Env = nil
+	}
 	return nil
 }
 
 func deepCopy_api_GitBuildSource(in buildapi.GitBuildSource, out *buildapi.GitBuildSource, c *conversion.Cloner) error {
 	out.URI = in.URI
 	out.Ref = in.Ref
+	out.HTTPProxy = in.HTTPProxy
+	out.HTTPSProxy = in.HTTPSProxy
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1004,12 +1004,26 @@ func deepCopy_v1_DockerBuildStrategy(in buildapiv1.DockerBuildStrategy, out *bui
 		out.PullSecret = nil
 	}
 	out.NoCache = in.NoCache
+	if in.Env != nil {
+		out.Env = make([]v1.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if newVal, err := c.DeepCopy(in.Env[i]); err != nil {
+				return err
+			} else {
+				out.Env[i] = newVal.(v1.EnvVar)
+			}
+		}
+	} else {
+		out.Env = nil
+	}
 	return nil
 }
 
 func deepCopy_v1_GitBuildSource(in buildapiv1.GitBuildSource, out *buildapiv1.GitBuildSource, c *conversion.Cloner) error {
 	out.URI = in.URI
 	out.Ref = in.Ref
+	out.HTTPProxy = in.HTTPProxy
+	out.HTTPSProxy = in.HTTPSProxy
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1012,12 +1012,26 @@ func deepCopy_v1beta3_DockerBuildStrategy(in buildapiv1beta3.DockerBuildStrategy
 		out.PullSecret = nil
 	}
 	out.NoCache = in.NoCache
+	if in.Env != nil {
+		out.Env = make([]v1beta3.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if newVal, err := c.DeepCopy(in.Env[i]); err != nil {
+				return err
+			} else {
+				out.Env[i] = newVal.(v1beta3.EnvVar)
+			}
+		}
+	} else {
+		out.Env = nil
+	}
 	return nil
 }
 
 func deepCopy_v1beta3_GitBuildSource(in buildapiv1beta3.GitBuildSource, out *buildapiv1beta3.GitBuildSource, c *conversion.Cloner) error {
 	out.URI = in.URI
 	out.Ref = in.Ref
+	out.HTTPProxy = in.HTTPProxy
+	out.HTTPSProxy = in.HTTPSProxy
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -164,6 +164,12 @@ type GitBuildSource struct {
 
 	// Ref is the branch/tag/ref to build.
 	Ref string
+
+	// HTTPProxy is a proxy used to reach the git repository over http
+	HTTPProxy string
+
+	// HTTPSProxy is a proxy used to reach the git repository over https
+	HTTPSProxy string
 }
 
 // SourceControlUser defines the identity of a user of source control
@@ -247,6 +253,9 @@ type DockerBuildStrategy struct {
 	// the authentication for pulling the Docker images from the private Docker
 	// registries
 	PullSecret *kapi.LocalObjectReference
+
+	// Env contains additional environment variables you want to pass into a builder container
+	Env []kapi.EnvVar `json:"env,omitempty" description:"additional environment variables you want to pass into a builder container"`
 }
 
 // SourceBuildStrategy defines input parameters specific to an STI build.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -166,6 +166,12 @@ type GitBuildSource struct {
 
 	// Ref is the branch/tag/ref to build.
 	Ref string `json:"ref,omitempty" description:"identifies the branch/tag/ref to build"`
+
+	// HTTPProxy is a proxy used to reach the git repository over http
+	HTTPProxy string `json:"httpProxy,omitempty" description:"specifies a http proxy to be used during git clone operations"`
+
+	// HTTPSProxy is a proxy used to reach the git repository over https
+	HTTPSProxy string `json:"httpsProxy,omitempty" description:"specifies a https proxy to be used during git clone operations"`
 }
 
 // SourceControlUser defines the identity of a user of source control
@@ -243,6 +249,9 @@ type DockerBuildStrategy struct {
 	// NoCache if set to true indicates that the docker build must be executed with the
 	// --no-cache=true flag
 	NoCache bool `json:"noCache,omitempty" description:"if true, indicates that the Docker build must be executed with the --no-cache=true flag"`
+
+	// Env contains additional environment variables you want to pass into a builder container
+	Env []kapi.EnvVar `json:"env,omitempty" description:"additional environment variables you want to pass into a builder container"`
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -160,6 +160,12 @@ type GitBuildSource struct {
 
 	// Ref is the branch/tag/ref to build.
 	Ref string `json:"ref,omitempty"`
+
+	// HTTPProxy is a proxy used to reach the git repository over http
+	HTTPProxy string `json:"httpProxy,omitempty" description:"specifies a http proxy to be used during git clone operations"`
+
+	// HTTPSProxy is a proxy used to reach the git repository over https
+	HTTPSProxy string `json:"httpsProxy,omitempty" description:"specifies a https proxy to be used during git clone operations"`
 }
 
 // SourceControlUser defines the identity of a user of source control
@@ -234,6 +240,9 @@ type DockerBuildStrategy struct {
 	// NoCache if set to true indicates that the docker build must be executed with the
 	// --no-cache=true flag
 	NoCache bool `json:"noCache,omitempty"`
+
+	// Env contains additional environment variables you want to pass into a builder container
+	Env []kapi.EnvVar `json:"env,omitempty" description:"additional environment variables you want to pass into a builder container"`
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -135,9 +135,45 @@ func (d *DockerBuilder) fetchSource(dir string) error {
 	if err := d.checkSourceURI(); err != nil {
 		return err
 	}
+	origProxy := make(map[string]string)
+	var setHttp, setHttps bool
+	// set the http proxy to be used by the git clone performed by S2I
+	if len(d.build.Parameters.Source.Git.HTTPSProxy) != 0 {
+		glog.V(2).Infof("Setting https proxy variables for Git to %s", d.build.Parameters.Source.Git.HTTPSProxy)
+		origProxy["HTTPS_PROXY"] = os.Getenv("HTTPS_PROXY")
+		origProxy["https_proxy"] = os.Getenv("https_proxy")
+		os.Setenv("HTTPS_PROXY", d.build.Parameters.Source.Git.HTTPSProxy)
+		os.Setenv("https_proxy", d.build.Parameters.Source.Git.HTTPSProxy)
+		setHttps = true
+	}
+	if len(d.build.Parameters.Source.Git.HTTPProxy) != 0 {
+		glog.V(2).Infof("Setting http proxy variables for Git to %s", d.build.Parameters.Source.Git.HTTPSProxy)
+		origProxy["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")
+		origProxy["http_proxy"] = os.Getenv("http_proxy")
+		os.Setenv("HTTP_PROXY", d.build.Parameters.Source.Git.HTTPProxy)
+		os.Setenv("http_proxy", d.build.Parameters.Source.Git.HTTPProxy)
+		setHttp = true
+	}
+	defer func() {
+		// reset http proxy env variables to original value
+		if setHttps {
+			glog.V(4).Infof("Resetting HTTPS_PROXY variable for Git to %s", origProxy["HTTPS_PROXY"])
+			os.Setenv("HTTPS_PROXY", origProxy["HTTPS_PROXY"])
+			glog.V(4).Infof("Resetting https_proxy variable for Git to %s", origProxy["https_proxy"])
+			os.Setenv("https_proxy", origProxy["https_proxy"])
+		}
+		if setHttp {
+			glog.V(4).Infof("Resetting HTTP_PROXY variable for Git to %s", origProxy["HTTP_PROXY"])
+			os.Setenv("HTTP_PROXY", origProxy["HTTP_PROXY"])
+			glog.V(4).Infof("Resetting http_proxy variable for Git to %s", origProxy["http_proxy"])
+			os.Setenv("http_proxy", origProxy["http_proxy"])
+		}
+	}()
+
 	if err := d.git.Clone(d.build.Parameters.Source.Git.URI, dir); err != nil {
 		return err
 	}
+
 	if d.build.Parameters.Source.Git.Ref == "" &&
 		(d.build.Parameters.Revision == nil ||
 			d.build.Parameters.Revision.Git == nil ||

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -52,7 +52,6 @@ func (s *STIBuilder) Build() error {
 		Environment:   getBuildEnvVars(s.build),
 		Incremental:   s.build.Parameters.Strategy.SourceStrategy.Incremental,
 	}
-
 	if s.build.Parameters.Revision != nil && s.build.Parameters.Revision.Git != nil &&
 		s.build.Parameters.Revision.Git.Commit != "" {
 		config.Ref = s.build.Parameters.Revision.Git.Commit
@@ -82,9 +81,45 @@ func (s *STIBuilder) Build() error {
 	}
 	defer removeImage(s.dockerClient, tag)
 	glog.V(4).Infof("Starting S2I build from %s/%s BuildConfig ...", s.build.Namespace, s.build.Name)
+
+	origProxy := make(map[string]string)
+	var setHttp, setHttps bool
+	// set the http proxy to be used by the git clone performed by S2I
+	if len(s.build.Parameters.Source.Git.HTTPSProxy) != 0 {
+		glog.V(2).Infof("Setting https proxy variables for Git to %s", s.build.Parameters.Source.Git.HTTPSProxy)
+		origProxy["HTTPS_PROXY"] = os.Getenv("HTTPS_PROXY")
+		origProxy["https_proxy"] = os.Getenv("https_proxy")
+		os.Setenv("HTTPS_PROXY", s.build.Parameters.Source.Git.HTTPSProxy)
+		os.Setenv("https_proxy", s.build.Parameters.Source.Git.HTTPSProxy)
+		setHttps = true
+	}
+	if len(s.build.Parameters.Source.Git.HTTPProxy) != 0 {
+		glog.V(2).Infof("Setting http proxy variables for Git to %s", s.build.Parameters.Source.Git.HTTPSProxy)
+		origProxy["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")
+		origProxy["http_proxy"] = os.Getenv("http_proxy")
+		os.Setenv("HTTP_PROXY", s.build.Parameters.Source.Git.HTTPProxy)
+		os.Setenv("http_proxy", s.build.Parameters.Source.Git.HTTPProxy)
+		setHttp = true
+	}
+
 	if _, err = builder.Build(config); err != nil {
 		return err
 	}
+
+	// reset http proxy env variables to original value
+	if setHttps {
+		glog.V(4).Infof("Resetting HTTPS_PROXY variable for Git to %s", origProxy["HTTPS_PROXY"])
+		os.Setenv("HTTPS_PROXY", origProxy["HTTPS_PROXY"])
+		glog.V(4).Infof("Resetting https_proxy variable for Git to %s", origProxy["https_proxy"])
+		os.Setenv("https_proxy", origProxy["https_proxy"])
+	}
+	if setHttp {
+		glog.V(4).Infof("Resetting HTTP_PROXY variable for Git to %s", origProxy["HTTP_PROXY"])
+		os.Setenv("HTTP_PROXY", origProxy["HTTP_PROXY"])
+		glog.V(4).Infof("Resetting http_proxy variable for Git to %s", origProxy["http_proxy"])
+		os.Setenv("http_proxy", origProxy["http_proxy"])
+	}
+
 	dockerImageRef := s.build.Parameters.Output.DockerImageReference
 	if len(dockerImageRef) != 0 {
 		// Get the Docker push authentication

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -55,10 +55,10 @@ func TestSTICreateBuildPod(t *testing.T) {
 	if actual.Spec.RestartPolicy != kapi.RestartPolicyNever {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
-	// strategy ENV is not copied into the container environment, so only
-	// expect 6 not 7 values.
+	// strategy ENV is whitelisted into the container environment, and not all
+	// the values are allowed, so only expect 6 not 7 values.
 	if len(container.Env) != 6 {
-		t.Fatalf("Expected 6 elements in Env table, got %d", len(container.Env))
+		t.Fatalf("Expected 6 elements in Env table, got %d: %+v", len(container.Env), container.Env)
 	}
 	if len(container.VolumeMounts) != 4 {
 		t.Fatalf("Expected 4 volumes in container, got %d", len(container.VolumeMounts))
@@ -75,13 +75,20 @@ func TestSTICreateBuildPod(t *testing.T) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, expected.Parameters.Resources)
 	}
 	found := false
+	foundIllegal := false
 	for _, v := range container.Env {
 		if v.Name == "BUILD_LOGLEVEL" && v.Value == "bar" {
 			found = true
 		}
+		if v.Name == "ILLEGAL" {
+			foundIllegal = true
+		}
 	}
 	if !found {
 		t.Fatalf("Expected variable BUILD_LOGLEVEL be defined for the container")
+	}
+	if foundIllegal {
+		t.Fatalf("Found illegal environment variable 'ILLEGAL' defined on container")
 	}
 	buildJSON, _ := latest.Codec.Encode(expected)
 	errorCases := map[int][]string{
@@ -123,6 +130,7 @@ func mockSTIBuild() *buildapi.Build {
 					Scripts:    "http://my.build.com/the/sti/scripts",
 					Env: []kapi.EnvVar{
 						{Name: "BUILD_LOGLEVEL", Value: "bar"},
+						{Name: "ILLEGAL", Value: "foo"},
 					},
 				},
 			},


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/3395

lots of changes here now:
1) updated the sample template to v1 api
2) added Env field to Docker builds
3) whitelist remains what it was (build_loglevel is the only allowed env variable for now in the privileged containers)
4) added httpProxy and httpsProxy fields to GitBuildSource.  If present, those values are set as env variables just before we invoke git clone and unset immediately after, so they only impact the clone step - applicable to S2I and Docker type builds

