### PR TITLE
make imagestreamtag usage consistent

### DIFF
--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -293,7 +293,7 @@ func TestGraph(t *testing.T) {
 
 	t.Log(g)
 
-	ir, dc, bc, other := 0, 0, 0, 0
+	ist, dc, bc, other := 0, 0, 0, 0
 	for _, node := range g.NodeList() {
 		switch g.Object(node).(type) {
 		case *deployapi.DeploymentConfig:
@@ -306,19 +306,18 @@ func TestGraph(t *testing.T) {
 				t.Fatalf("unexpected kind: %v", g.Kind(node))
 			}
 			bc++
-		case *imageapi.ImageStream:
-			// TODO resolve this check for 2 kinds, since both have the same object type
-			if g.Kind(node) != imagegraph.ImageStreamNodeKind && g.Kind(node) != imagegraph.ImageStreamTagNodeKind {
+		case *imageapi.ImageStreamTag:
+			if g.Kind(node) != imagegraph.ImageStreamTagNodeKind {
 				t.Fatalf("unexpected kind: %v", g.Kind(node))
 			}
-			ir++
+			ist++
 		default:
 			other++
 		}
 	}
 
-	if dc != 2 || bc != 3 || ir != 3 || other != 12 {
-		t.Errorf("unexpected nodes: %d %d %d %d", dc, bc, ir, other)
+	if dc != 2 || bc != 3 || ist != 3 || other != 12 {
+		t.Errorf("unexpected nodes: %d %d %d %d", dc, bc, ist, other)
 	}
 	for _, edge := range g.EdgeList() {
 		if g.EdgeKind(edge) == osgraph.UnknownEdgeKind {
@@ -329,7 +328,7 @@ func TestGraph(t *testing.T) {
 	// imagestreamtag default/other:base-image
 	istID := 0
 	for _, node := range g.NodeList() {
-		if g.Name(node) == "<imagestreamtag default/other:base-image>" {
+		if g.Name(node) == "ImageStreamTag|default/other:base-image" {
 			istID = node.ID()
 			break
 		}

--- a/pkg/api/kubegraph/nodes/types.go
+++ b/pkg/api/kubegraph/nodes/types.go
@@ -32,7 +32,7 @@ func (n ServiceNode) Object() interface{} {
 }
 
 func (n ServiceNode) String() string {
-	return fmt.Sprintf("<service %s/%s>", n.Namespace, n.Name)
+	return string(ServiceNodeName(n.Service))
 }
 
 func (*ServiceNode) Kind() string {
@@ -53,7 +53,7 @@ func (n PodNode) Object() interface{} {
 }
 
 func (n PodNode) String() string {
-	return fmt.Sprintf("<pod %s/%s>", n.Namespace, n.Name)
+	return string(PodNodeName(n.Pod))
 }
 
 func (n PodNode) UniqueName() osgraph.UniqueName {
@@ -105,7 +105,7 @@ func (n ReplicationControllerNode) Object() interface{} {
 }
 
 func (n ReplicationControllerNode) String() string {
-	return fmt.Sprintf("<replicationcontroller %s/%s>", n.Namespace, n.Name)
+	return string(ReplicationControllerNodeName(n.ReplicationController))
 }
 
 func (n ReplicationControllerNode) UniqueName() osgraph.UniqueName {

--- a/pkg/build/graph/edges.go
+++ b/pkg/build/graph/edges.go
@@ -26,7 +26,7 @@ func AddInputOutputEdges(g osgraph.MutableUniqueGraph, node *buildgraph.BuildCon
 	to := output.To
 	switch {
 	case to != nil && len(to.Name) > 0:
-		out := imagegraph.EnsureImageStreamTagNode(g, defaultNamespace(to.Namespace, node.BuildConfig.Namespace), to.Name, output.Tag)
+		out := imagegraph.FindOrCreateSyntheticImageStreamTagNode(g, imagegraph.MakeImageStreamTagObjectMeta(defaultNamespace(to.Namespace, node.BuildConfig.Namespace), to.Name, output.Tag))
 		g.AddEdge(node, out, BuildOutputEdgeKind)
 	case len(output.DockerImageReference) > 0:
 		out := imagegraph.EnsureDockerRepositoryNode(g, output.DockerImageReference, output.Tag)
@@ -49,11 +49,11 @@ func AddInputOutputEdges(g osgraph.MutableUniqueGraph, node *buildgraph.BuildCon
 			}
 		case "ImageStream":
 			tag := imageapi.DefaultImageTag
-			in := imagegraph.EnsureImageStreamTagNode(g, defaultNamespace(from.Namespace, node.BuildConfig.Namespace), from.Name, tag)
+			in := imagegraph.FindOrCreateSyntheticImageStreamTagNode(g, imagegraph.MakeImageStreamTagObjectMeta(defaultNamespace(from.Namespace, node.BuildConfig.Namespace), from.Name, tag))
 			g.AddEdge(in, node, BuildInputImageEdgeKind)
 		case "ImageStreamTag":
 			name, tag, _ := imageapi.SplitImageStreamTag(from.Name)
-			in := imagegraph.EnsureImageStreamTagNode(g, defaultNamespace(from.Namespace, node.BuildConfig.Namespace), name, tag)
+			in := imagegraph.FindOrCreateSyntheticImageStreamTagNode(g, imagegraph.MakeImageStreamTagObjectMeta(defaultNamespace(from.Namespace, node.BuildConfig.Namespace), name, tag))
 			g.AddEdge(in, node, BuildInputImageEdgeKind)
 		case "ImageStreamImage":
 			glog.V(4).Infof("Ignoring ImageStreamImage reference in BuildConfig %s/%s", node.BuildConfig.Namespace, node.BuildConfig.Name)

--- a/pkg/build/graph/nodes/types.go
+++ b/pkg/build/graph/nodes/types.go
@@ -34,7 +34,7 @@ func (n BuildConfigNode) Object() interface{} {
 }
 
 func (n BuildConfigNode) String() string {
-	return fmt.Sprintf("<buildconfig %s/%s>", n.Namespace, n.Name)
+	return string(BuildConfigNodeName(n.BuildConfig))
 }
 
 func (*BuildConfigNode) Kind() string {
@@ -57,10 +57,7 @@ type SourceRepositoryNode struct {
 }
 
 func (n SourceRepositoryNode) String() string {
-	if n.Source.Git != nil {
-		return fmt.Sprintf("<sourcerepository %s#%s>", n.Source.Git.URI, n.Source.Git.Ref)
-	}
-	return fmt.Sprintf("<source repository unknown>")
+	return string(SourceRepositoryNodeName(n.Source))
 }
 
 func (SourceRepositoryNode) Kind() string {
@@ -81,7 +78,7 @@ func (n BuildNode) Object() interface{} {
 }
 
 func (n BuildNode) String() string {
-	return fmt.Sprintf("<build %s/%s>", n.Build.Namespace, n.Build.Name)
+	return string(BuildNodeName(n.Build))
 }
 
 func (*BuildNode) Kind() string {

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -42,6 +42,11 @@ func (d *ProjectStatusDescriber) MakeGraph(namespace string) (osgraph.Graph, err
 		return g, err
 	}
 
+	iss, err := d.C.ImageStreams(namespace).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return g, err
+	}
+
 	bcs, err := d.C.BuildConfigs(namespace).List(labels.Everything(), fields.Everything())
 	if err != nil {
 		return g, err
@@ -64,6 +69,10 @@ func (d *ProjectStatusDescriber) MakeGraph(namespace string) (osgraph.Graph, err
 		rcs = &kapi.ReplicationControllerList{}
 	}
 
+	for i := range iss.Items {
+		imagegraph.EnsureImageStreamNode(g, &iss.Items[i])
+		imagegraph.EnsureAllImageStreamTagNodes(g, &iss.Items[i])
+	}
 	for i := range bcs.Items {
 		build := buildgraph.EnsureBuildConfigNode(g, &bcs.Items[i])
 		buildedges.AddInputOutputEdges(g, build)
@@ -214,10 +223,10 @@ func describeImageInPipeline(pipeline graphview.ImagePipeline, namespace string)
 func describeImageTagInPipeline(image graphview.ImageTagLocation, namespace string) string {
 	switch t := image.(type) {
 	case *imagegraph.ImageStreamTagNode:
-		if t.ImageStream.Namespace != namespace {
+		if t.ImageStreamTag.Namespace != namespace {
 			return image.ImageSpec()
 		}
-		return fmt.Sprintf("%s:%s", t.ImageStream.Name, image.ImageTag())
+		return t.ImageStreamTag.Name
 	default:
 		return image.ImageSpec()
 	}

--- a/pkg/deploy/graph/edges.go
+++ b/pkg/deploy/graph/edges.go
@@ -36,7 +36,8 @@ func AddTriggerEdges(g osgraph.MutableUniqueGraph, node *deploygraph.DeploymentC
 				if len(image.From.Name) == 0 {
 					return
 				}
-				in := imagegraph.EnsureImageStreamTagNode(g, image.From.Namespace, image.From.Name, image.FromTag)
+
+				in := imagegraph.FindOrCreateSyntheticImageStreamTagNode(g, imagegraph.MakeImageStreamTagObjectMeta(image.From.Namespace, image.From.Name, image.FromTag))
 				g.AddEdge(in, node, TriggersDeploymentEdgeKind)
 				return
 			}

--- a/pkg/deploy/graph/nodes/types.go
+++ b/pkg/deploy/graph/nodes/types.go
@@ -1,7 +1,6 @@
 package nodes
 
 import (
-	"fmt"
 	"reflect"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -31,7 +30,7 @@ func (n DeploymentConfigNode) Object() interface{} {
 }
 
 func (n DeploymentConfigNode) String() string {
-	return fmt.Sprintf("<deploymentconfig %s/%s>", n.Namespace, n.Name)
+	return string(DeploymentConfigNodeName(n.DeploymentConfig))
 }
 
 func (*DeploymentConfigNode) Kind() string {

--- a/pkg/image/graph/nodes/nodes.go
+++ b/pkg/image/graph/nodes/nodes.go
@@ -1,8 +1,6 @@
 package nodes
 
 import (
-	"strings"
-
 	"github.com/gonum/graph"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
@@ -20,13 +18,30 @@ func EnsureImageNode(g osgraph.MutableUniqueGraph, img *imageapi.Image) graph.No
 	)
 }
 
+// EnsureAllImageStreamTagNodes creates all the ImageStreamTagNodes that are guaranteed to be present based on the ImageStream.
+// This is different than inferring the presence of an object, since the IST is an object derived from a join between the ImageStream
+// and the Image it references.
+func EnsureAllImageStreamTagNodes(g osgraph.MutableUniqueGraph, is *imageapi.ImageStream) []*ImageStreamTagNode {
+	ret := []*ImageStreamTagNode{}
+
+	for tag := range is.Status.Tags {
+		ist := &imageapi.ImageStreamTag{}
+		ist.Namespace = is.Namespace
+		ist.Name = imageapi.JoinImageStreamTag(is.Name, tag)
+
+		istNode := EnsureImageStreamTagNode(g, ist)
+		ret = append(ret, istNode)
+	}
+
+	return ret
+}
+
 func FindImage(g osgraph.MutableUniqueGraph, imageName string) graph.Node {
 	return g.Find(ImageNodeName(&imageapi.Image{ObjectMeta: kapi.ObjectMeta{Name: imageName}}))
 }
 
 // EnsureDockerRepositoryNode adds the named Docker repository tag reference to the graph if it does
-// not already exist. If the reference is invalid, the Name field of the graph will be
-// used directly.
+// not already exist. If the reference is invalid, the Name field of the graph will be used directly.
 func EnsureDockerRepositoryNode(g osgraph.MutableUniqueGraph, name, tag string) graph.Node {
 	ref, err := imageapi.ParseDockerImageReference(name)
 	if err == nil {
@@ -54,27 +69,35 @@ func EnsureDockerRepositoryNode(g osgraph.MutableUniqueGraph, name, tag string) 
 	)
 }
 
-// EnsureImageStreamTagNode adds a graph node for the specific tag in an Image Stream if it
-// does not already exist.
-func EnsureImageStreamTagNode(g osgraph.MutableUniqueGraph, namespace, name, tag string) graph.Node {
-	if len(tag) == 0 {
-		tag = imageapi.DefaultImageTag
-	}
-	if strings.Contains(name, ":") {
-		panic(name)
-	}
-	is := &imageapi.ImageStream{
+// MakeImageStreamTagObjectMeta returns an ImageStreamTag that has enough information to join the graph, but it is not
+// based on a full IST object.  This can be used to properly initialize the graph without having to retrieve all ISTs
+func MakeImageStreamTagObjectMeta(namespace, name, tag string) *imageapi.ImageStreamTag {
+	return &imageapi.ImageStreamTag{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: namespace,
-			Name:      name,
+			Name:      imageapi.JoinImageStreamTag(name, tag),
 		},
 	}
+}
+
+// EnsureImageStreamTagNode adds a graph node for the specific tag in an Image Stream if it does not already exist.
+func EnsureImageStreamTagNode(g osgraph.MutableUniqueGraph, ist *imageapi.ImageStreamTag) *ImageStreamTagNode {
 	return osgraph.EnsureUnique(g,
-		ImageStreamTagNodeName(is, tag),
+		ImageStreamTagNodeName(ist),
 		func(node osgraph.Node) graph.Node {
-			return &ImageStreamTagNode{node, is, tag}
+			return &ImageStreamTagNode{node, ist, false}
 		},
-	)
+	).(*ImageStreamTagNode)
+}
+
+// FindOrCreateSyntheticImageStreamTagNode returns the existing ISTNode or creates a synthetic node in its place
+func FindOrCreateSyntheticImageStreamTagNode(g osgraph.MutableUniqueGraph, ist *imageapi.ImageStreamTag) *ImageStreamTagNode {
+	return osgraph.EnsureUnique(g,
+		ImageStreamTagNodeName(ist),
+		func(node osgraph.Node) graph.Node {
+			return &ImageStreamTagNode{node, ist, true}
+		},
+	).(*ImageStreamTagNode)
 }
 
 // EnsureImageStreamNode adds a graph node for the Image Stream if it does not already exist.
@@ -85,10 +108,6 @@ func EnsureImageStreamNode(g osgraph.MutableUniqueGraph, stream *imageapi.ImageS
 			return &ImageStreamNode{node, stream}
 		},
 	)
-}
-
-func FindImageStream(g osgraph.MutableUniqueGraph, stream *imageapi.ImageStream) graph.Node {
-	return g.Find(ImageStreamNodeName(stream))
 }
 
 // EnsureImageLayerNode adds a graph node for the layer if it does not already exist.

--- a/pkg/image/graph/nodes/types.go
+++ b/pkg/image/graph/nodes/types.go
@@ -32,37 +32,44 @@ func (n ImageStreamNode) Object() interface{} {
 }
 
 func (n ImageStreamNode) String() string {
-	return fmt.Sprintf("<imagestream %s/%s>", n.Namespace, n.Name)
+	return string(ImageStreamNodeName(n.ImageStream))
 }
 
 func (*ImageStreamNode) Kind() string {
 	return ImageStreamNodeKind
 }
 
-func ImageStreamTagNodeName(o *imageapi.ImageStream, tag string) osgraph.UniqueName {
-	return osgraph.UniqueName(fmt.Sprintf("%s|%s/%s:%s", ImageStreamTagNodeKind, o.Namespace, o.Name, tag))
+func ImageStreamTagNodeName(o *imageapi.ImageStreamTag) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(ImageStreamTagNodeKind, o)
 }
 
 type ImageStreamTagNode struct {
 	osgraph.Node
-	*imageapi.ImageStream
-	Tag string
+	*imageapi.ImageStreamTag
+
+	Synthetic bool
+}
+
+func (n ImageStreamTagNode) IsSynthetic() bool {
+	return n.Synthetic
 }
 
 func (n ImageStreamTagNode) ImageSpec() string {
-	return imageapi.DockerImageReference{Namespace: n.Namespace, Name: n.Name, Tag: n.Tag}.String()
+	name, tag, _ := imageapi.SplitImageStreamTag(n.ImageStreamTag.Name)
+	return imageapi.DockerImageReference{Namespace: n.Namespace, Name: name, Tag: tag}.String()
 }
 
 func (n ImageStreamTagNode) ImageTag() string {
-	return n.Tag
+	_, tag, _ := imageapi.SplitImageStreamTag(n.ImageStreamTag.Name)
+	return tag
 }
 
 func (n ImageStreamTagNode) Object() interface{} {
-	return n.ImageStream
+	return n.ImageStreamTag
 }
 
 func (n ImageStreamTagNode) String() string {
-	return fmt.Sprintf("<imagestreamtag %s/%s:%s>", n.Namespace, n.Name, n.Tag)
+	return string(ImageStreamTagNodeName(n.ImageStreamTag))
 }
 
 func (*ImageStreamTagNode) Kind() string {
@@ -87,7 +94,7 @@ func (n DockerImageRepositoryNode) ImageTag() string {
 }
 
 func (n DockerImageRepositoryNode) String() string {
-	return fmt.Sprintf("<dockerrepository %s>", n.Ref.String())
+	return string(DockerImageRepositoryNodeName(n.Ref))
 }
 
 func (*DockerImageRepositoryNode) Kind() string {
@@ -108,7 +115,7 @@ func (n ImageNode) Object() interface{} {
 }
 
 func (n ImageNode) String() string {
-	return fmt.Sprintf("<image %s>", n.Image.Name)
+	return string(ImageNodeName(n.Image))
 }
 
 func (*ImageNode) Kind() string {
@@ -129,7 +136,7 @@ func (n ImageLayerNode) Object() interface{} {
 }
 
 func (n ImageLayerNode) String() string {
-	return fmt.Sprintf("<image layer %s>", n.Layer)
+	return string(ImageLayerNodeName(n.Layer))
 }
 
 func (*ImageLayerNode) Kind() string {


### PR DESCRIPTION
This allows oc status to locate unresolved references and point them out.  I used imagestreamtags as an example.

```
In project cmd

service ruby-hello-world (172.30.229.39:8080)
  ruby-hello-world deploys ruby-hello-world:latest <- docker build of https://github.com/openshift/ruby-hello-world 
    build 1 failed 15 hours ago
    #1 deployment waiting on image or update

Warning: some references could not be resolved:
	ImageStreamTag|cmd/ruby-hello-world:latest used by BuildConfig|cmd/ruby-hello-world referencing DeploymentConfig|cmd/ruby-hello-world was not found
	ImageStreamTag|cmd/ruby-20-centos7:latest referencing BuildConfig|cmd/ruby-hello-world was not found
To see more information about a Service or DeploymentConfig, use 'oc describe service <name>' or 'oc describe dc <name>'.
You can use 'oc get all' to see lists of each of the types described above.
```

@ncdc