### PR TITLE
Render graph

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -771,6 +771,7 @@ oc project example
 wait_for_command 'oc get serviceaccount default' "${TIME_MIN}"
 oc create -f test/fixtures/app-scenarios
 oc status
+oc status -o dot
 echo "complex-scenarios: ok"
 
 [ "$(oc export svc --all -t '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | wc -l)" -ne 0 ]

--- a/pkg/api/graph/graph.go
+++ b/pkg/api/graph/graph.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/concrete"
+	"github.com/gonum/graph/encoding/dot"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 )
@@ -14,6 +16,11 @@ import (
 type Node struct {
 	concrete.Node
 	UniqueName
+}
+
+// DOTAttributes implements an attribute getter for the DOT encoding
+func (n Node) DOTAttributes() []dot.Attribute {
+	return []dot.Attribute{{"label", fmt.Sprintf("%q", n.UniqueName)}}
 }
 
 // ExistenceChecker is an interface for those nodes that can be created without a backing object.
@@ -84,6 +91,11 @@ func (e Edge) Kinds() util.StringSet {
 
 func (e Edge) IsKind(kind string) bool {
 	return e.kinds.Has(kind)
+}
+
+// DOTAttributes implements an attribute getter for the DOT encoding
+func (e Edge) DOTAttributes() []dot.Attribute {
+	return []dot.Attribute{{"label", fmt.Sprintf("%q", strings.Join(e.Kinds().List(), ","))}}
 }
 
 type GraphDescriber interface {

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -76,7 +76,7 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 				loginCmd,
 				cmd.NewCmdRequestProject("new-project", fullName+" new-project", fullName+" login", fullName+" project", f, out),
 				cmd.NewCmdNewApplication(fullName, f, out),
-				cmd.NewCmdStatus(fullName, f, out),
+				cmd.NewCmdStatus(cmd.StatusRecommendedName, fullName+" "+cmd.StatusRecommendedName, f, out),
 				cmd.NewCmdProject(fullName+" project", f, out),
 			},
 		},

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/gonum/graph/encoding/dot"
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
@@ -13,30 +15,44 @@ import (
 )
 
 const (
+	StatusRecommendedName = "status"
+
 	statusLong = `
 Show a high level overview of the current project
 
 This command will show services, deployment configs, build configurations, and active deployments.
 If you have any misconfigured components information about them will be shown. For more information
 about individual items, use the describe command (e.g. oc describe buildConfig,
-oc describe deploymentConfig, oc describe service).`
+oc describe deploymentConfig, oc describe service).
+
+You can specify an output format of "-o dot" to have this command output the generated status
+graph in DOT format that is suitable for use by the "dot" command.`
 
 	statusExample = `  // Show an overview of the current project
-  $ %[1]s status`
+  $ %[1]s`
 )
 
 // NewCmdStatus implements the OpenShift cli status command
-func NewCmdStatus(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdStatus(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	outputFormat := ""
+
 	cmd := &cobra.Command{
 		Use:     "status",
 		Short:   "Show an overview of the current project",
 		Long:    statusLong,
 		Example: fmt.Sprintf(statusExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunStatus(f, out)
-			cmdutil.CheckErr(err)
+			if strings.ToLower(outputFormat) == "dot" {
+				cmdutil.CheckErr(RunGraph(f, out))
+				return
+			}
+
+			cmdutil.CheckErr(RunStatus(f, out))
 		},
 	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", outputFormat, "Output format. One of: dot.")
+
 	return cmd
 }
 
@@ -59,5 +75,32 @@ func RunStatus(f *clientcmd.Factory, out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, s)
+	return nil
+}
+
+// RunGraph contains all the necessary functionality for the OpenShift cli graph command
+func RunGraph(f *clientcmd.Factory, out io.Writer) error {
+	client, kclient, err := f.Clients()
+	if err != nil {
+		return err
+	}
+
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	describer := &describe.ProjectStatusDescriber{kclient, client}
+	g, _, err := describer.MakeGraph(namespace)
+	if err != nil {
+		return err
+	}
+
+	data, err := dot.Marshal(g, namespace, "", "  ", false)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "%s", string(data))
 	return nil
 }

--- a/rel-eng/completions/bash/oc
+++ b/rel-eng/completions/bash/oc
@@ -339,6 +339,8 @@ _oc_status()
 
     flags+=("--help")
     flags+=("-h")
+    flags+=("--output=")
+    two_word_flags+=("-o")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -1758,6 +1758,8 @@ _openshift_cli_status()
 
     flags+=("--help")
     flags+=("-h")
+    flags+=("--output=")
+    two_word_flags+=("-o")
 
     must_have_one_flag=()
     must_have_one_noun=()


### PR DESCRIPTION
I'm 95% sure that we don't want this, but on the bizarre offchance, this adds a `--graph` flag that produces an html file that renders out the graph like this:

![project-graph](https://cloud.githubusercontent.com/assets/8225098/8756032/3b7b9b34-2c9d-11e5-8c31-f2e4a7da906b.png)



@ncdc 