### PR TITLE
Secret/SA check

### DIFF
--- a/pkg/api/graph/graph.go
+++ b/pkg/api/graph/graph.go
@@ -25,6 +25,10 @@ type ExistenceChecker interface {
 	Found() bool
 }
 
+type ResourceNode interface {
+	ResourceString() string
+}
+
 type UniqueName string
 
 type UniqueNameFunc func(obj interface{}) UniqueName
@@ -158,7 +162,7 @@ func (g Graph) SyntheticNodes() []graph.Node {
 	sort.Sort(SortedNodeList(nodeList))
 	for _, node := range nodeList {
 		if potentiallySyntheticNode, ok := node.(ExistenceChecker); ok {
-			if potentiallySyntheticNode.Found() {
+			if !potentiallySyntheticNode.Found() {
 				ret = append(ret, node)
 			}
 		}

--- a/pkg/api/graph/test/runtimeobject_nodebuilder.go
+++ b/pkg/api/graph/test/runtimeobject_nodebuilder.go
@@ -46,6 +46,12 @@ func init() {
 	if err := RegisterEnsureNode(&kapi.Service{}, kubegraph.EnsureServiceNode); err != nil {
 		panic(err)
 	}
+	if err := RegisterEnsureNode(&kapi.ServiceAccount{}, kubegraph.EnsureServiceAccountNode); err != nil {
+		panic(err)
+	}
+	if err := RegisterEnsureNode(&kapi.Secret{}, kubegraph.EnsureSecretNode); err != nil {
+		panic(err)
+	}
 	if err := RegisterEnsureNode(&kapi.ReplicationController{}, kubegraph.EnsureReplicationControllerNode); err != nil {
 		panic(err)
 	}

--- a/pkg/api/kubegraph/analysis/podspec.go
+++ b/pkg/api/kubegraph/analysis/podspec.go
@@ -1,0 +1,45 @@
+package analysis
+
+import (
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubeedges "github.com/openshift/origin/pkg/api/kubegraph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+)
+
+// CheckMountedSecrets checks to be sure that all the referenced secrets are mountable (by service account) and present (not synthetic)
+func CheckMountedSecrets(g osgraph.Graph, podSpecNode *kubegraph.PodSpecNode) ( /*unmountable secrets*/ []*kubegraph.SecretNode /*unresolved secrets*/, []*kubegraph.SecretNode) {
+	saNodes := g.SuccessorNodesByNodeAndEdgeKind(podSpecNode, kubegraph.ServiceAccountNodeKind, kubeedges.ReferencedServiceAccountEdgeKind)
+	saMountableSecrets := []*kubegraph.SecretNode{}
+
+	if len(saNodes) > 0 {
+		saNode := saNodes[0].(*kubegraph.ServiceAccountNode)
+		for _, secretNode := range g.SuccessorNodesByNodeAndEdgeKind(saNode, kubegraph.SecretNodeKind, kubeedges.MountableSecretEdgeKind) {
+			saMountableSecrets = append(saMountableSecrets, secretNode.(*kubegraph.SecretNode))
+		}
+	}
+
+	unmountableSecrets := []*kubegraph.SecretNode{}
+	missingSecrets := []*kubegraph.SecretNode{}
+
+	for _, uncastMountedSecretNode := range g.SuccessorNodesByNodeAndEdgeKind(podSpecNode, kubegraph.SecretNodeKind, kubeedges.MountedSecretEdgeKind) {
+		mountedSecretNode := uncastMountedSecretNode.(*kubegraph.SecretNode)
+		if !mountedSecretNode.Found() {
+			missingSecrets = append(missingSecrets, mountedSecretNode)
+		}
+
+		mountable := false
+		for _, mountableSecretNode := range saMountableSecrets {
+			if mountableSecretNode == mountedSecretNode {
+				mountable = true
+				break
+			}
+		}
+
+		if !mountable {
+			unmountableSecrets = append(unmountableSecrets, mountedSecretNode)
+			continue
+		}
+	}
+
+	return unmountableSecrets, missingSecrets
+}

--- a/pkg/api/kubegraph/edge_test.go
+++ b/pkg/api/kubegraph/edge_test.go
@@ -1,0 +1,55 @@
+package kubegraph
+
+import (
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+)
+
+func TestSecretEdges(t *testing.T) {
+	sa := &kapi.ServiceAccount{}
+	sa.Namespace = "ns"
+	sa.Name = "shultz"
+	sa.Secrets = []kapi.ObjectReference{{Name: "i-know-nothing"}, {Name: "missing"}}
+
+	secret1 := &kapi.Secret{}
+	secret1.Namespace = "ns"
+	secret1.Name = "i-know-nothing"
+
+	pod := &kapi.Pod{}
+	pod.Namespace = "ns"
+	pod.Name = "the-pod"
+	pod.Spec.Volumes = []kapi.Volume{{Name: "rose", VolumeSource: kapi.VolumeSource{Secret: &kapi.SecretVolumeSource{SecretName: "i-know-nothing"}}}}
+
+	g := osgraph.New()
+	saNode := kubegraph.EnsureServiceAccountNode(g, sa)
+	secretNode := kubegraph.EnsureSecretNode(g, secret1)
+	podNode := kubegraph.EnsurePodNode(g, pod)
+
+	AddAllMountableSecretEdges(g)
+	AddAllMountedSecretEdges(g)
+
+	if edge := g.EdgeBetween(saNode, secretNode); edge == nil {
+		t.Errorf("edge missing")
+	} else {
+		if edgeKind := g.EdgeKind(edge); edgeKind != MountableSecretEdgeKind {
+			t.Errorf("expected %v, got %v", MountableSecretEdgeKind, edgeKind)
+		}
+	}
+
+	podSpecNodes := g.SuccessorNodesByNodeAndEdgeKind(podNode, kubegraph.PodSpecNodeKind, osgraph.ContainsEdgeKind)
+	if len(podSpecNodes) != 1 {
+		t.Fatalf("wrong number of podspecs: %v", podSpecNodes)
+	}
+
+	if edge := g.EdgeBetween(podSpecNodes[0], secretNode); edge == nil {
+		t.Errorf("edge missing")
+	} else {
+		if edgeKind := g.EdgeKind(edge); edgeKind != MountedSecretEdgeKind {
+			t.Errorf("expected %v, got %v", MountedSecretEdgeKind, edgeKind)
+		}
+	}
+}

--- a/pkg/api/kubegraph/edges.go
+++ b/pkg/api/kubegraph/edges.go
@@ -3,18 +3,25 @@ package kubegraph
 import (
 	"github.com/gonum/graph"
 
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 )
 
 const (
-	// ExposedThroughServiceEdgeKind is an edge that goes from a podtemplatespec or a pod to service.
-	// The head should make the service's selector
+	// ExposedThroughServiceEdgeKind goes from a PodTemplateSpec or a Pod to Service.  The head should make the service's selector.
 	ExposedThroughServiceEdgeKind = "ExposedThroughService"
 	// ManagedByRCEdgeKind goes from Pod to ReplicationController when the Pod satisfies the ReplicationController's label selector
 	ManagedByRCEdgeKind = "ManagedByRC"
+	// MountedSecretEdgeKind goes from PodSpec to Secret indicating that is or will be a request to mount a volume with the Secret.
+	MountedSecretEdgeKind = "MountedSecret"
+	// MountableSecretEdgeKind goes from ServiceAccount to Secret indicating that the SA allows the Secret to be mounted
+	MountableSecretEdgeKind = "MountableSecret"
+	// ReferencedServiceAccountEdgeKind goes from PodSpec to ServiceAccount indicating that Pod is or will be running as the SA.
+	ReferencedServiceAccountEdgeKind = "ReferencedServiceAccount"
 )
 
 // AddExposedPodTemplateSpecEdges ensures that a directed edge exists between a service and all the PodTemplateSpecs
@@ -91,6 +98,92 @@ func AddAllManagedByRCPodEdges(g osgraph.MutableUniqueGraph) {
 	for _, node := range g.(graph.Graph).NodeList() {
 		if rcNode, ok := node.(*kubegraph.ReplicationControllerNode); ok {
 			AddManagedByRCPodEdges(g, rcNode)
+		}
+	}
+}
+
+func AddMountedSecretEdges(g osgraph.Graph, podSpec *kubegraph.PodSpecNode) {
+	//pod specs are always contained.  We'll get the toplevel container so that we can pull a namespace from it
+	containerNode := osgraph.GetTopLevelContainerNode(g, podSpec)
+	containerObj := g.GraphDescriber.Object(containerNode)
+
+	meta, err := kapi.ObjectMetaFor(containerObj.(runtime.Object))
+	if err != nil {
+		// this should never happen.  it means that a podSpec is owned by a top level container that is not a runtime.Object
+		panic(err)
+	}
+
+	for _, volume := range podSpec.Volumes {
+		source := volume.VolumeSource
+		if source.Secret == nil {
+			continue
+		}
+
+		// pod secrets must be in the same namespace
+		syntheticSecret := &kapi.Secret{}
+		syntheticSecret.Namespace = meta.Namespace
+		syntheticSecret.Name = source.Secret.SecretName
+
+		secretNode := kubegraph.FindOrCreateSyntheticSecretNode(g, syntheticSecret)
+		g.AddEdge(podSpec, secretNode, MountedSecretEdgeKind)
+	}
+}
+
+func AddAllMountedSecretEdges(g osgraph.Graph) {
+	for _, node := range g.NodeList() {
+		if podSpecNode, ok := node.(*kubegraph.PodSpecNode); ok {
+			AddMountedSecretEdges(g, podSpecNode)
+		}
+	}
+}
+
+func AddMountableSecretEdges(g osgraph.Graph, saNode *kubegraph.ServiceAccountNode) {
+	for _, mountableSecret := range saNode.ServiceAccount.Secrets {
+		syntheticSecret := &kapi.Secret{}
+		syntheticSecret.Namespace = saNode.ServiceAccount.Namespace
+		syntheticSecret.Name = mountableSecret.Name
+
+		secretNode := kubegraph.FindOrCreateSyntheticSecretNode(g, syntheticSecret)
+		g.AddEdge(saNode, secretNode, MountableSecretEdgeKind)
+	}
+}
+
+func AddAllMountableSecretEdges(g osgraph.Graph) {
+	for _, node := range g.NodeList() {
+		if saNode, ok := node.(*kubegraph.ServiceAccountNode); ok {
+			AddMountableSecretEdges(g, saNode)
+		}
+	}
+}
+
+func AddRequestedServiceAccountEdges(g osgraph.Graph, podSpecNode *kubegraph.PodSpecNode) {
+	//pod specs are always contained.  We'll get the toplevel container so that we can pull a namespace from it
+	containerNode := osgraph.GetTopLevelContainerNode(g, podSpecNode)
+	containerObj := g.GraphDescriber.Object(containerNode)
+
+	meta, err := kapi.ObjectMetaFor(containerObj.(runtime.Object))
+	if err != nil {
+		panic(err)
+	}
+
+	// if no SA name is present, admission will set 'default'
+	name := "default"
+	if len(podSpecNode.ServiceAccountName) > 0 {
+		name = podSpecNode.ServiceAccountName
+	}
+
+	syntheticSA := &kapi.ServiceAccount{}
+	syntheticSA.Namespace = meta.Namespace
+	syntheticSA.Name = name
+
+	saNode := kubegraph.FindOrCreateSyntheticServiceAccountNode(g, syntheticSA)
+	g.AddEdge(podSpecNode, saNode, ReferencedServiceAccountEdgeKind)
+}
+
+func AddAllRequestedServiceAccountEdges(g osgraph.Graph) {
+	for _, node := range g.NodeList() {
+		if podSpecNode, ok := node.(*kubegraph.PodSpecNode); ok {
+			AddRequestedServiceAccountEdges(g, podSpecNode)
 		}
 	}
 }

--- a/pkg/api/kubegraph/nodes/nodes.go
+++ b/pkg/api/kubegraph/nodes/nodes.go
@@ -42,6 +42,42 @@ func EnsureServiceNode(g osgraph.MutableUniqueGraph, svc *kapi.Service) *Service
 	).(*ServiceNode)
 }
 
+func EnsureServiceAccountNode(g osgraph.MutableUniqueGraph, o *kapi.ServiceAccount) *ServiceAccountNode {
+	return osgraph.EnsureUnique(g,
+		ServiceAccountNodeName(o),
+		func(node osgraph.Node) graph.Node {
+			return &ServiceAccountNode{node, o, true}
+		},
+	).(*ServiceAccountNode)
+}
+
+func FindOrCreateSyntheticServiceAccountNode(g osgraph.MutableUniqueGraph, o *kapi.ServiceAccount) *ServiceAccountNode {
+	return osgraph.EnsureUnique(g,
+		ServiceAccountNodeName(o),
+		func(node osgraph.Node) graph.Node {
+			return &ServiceAccountNode{node, o, false}
+		},
+	).(*ServiceAccountNode)
+}
+
+func EnsureSecretNode(g osgraph.MutableUniqueGraph, o *kapi.Secret) *SecretNode {
+	return osgraph.EnsureUnique(g,
+		SecretNodeName(o),
+		func(node osgraph.Node) graph.Node {
+			return &SecretNode{node, o, true}
+		},
+	).(*SecretNode)
+}
+
+func FindOrCreateSyntheticSecretNode(g osgraph.MutableUniqueGraph, o *kapi.Secret) *SecretNode {
+	return osgraph.EnsureUnique(g,
+		SecretNodeName(o),
+		func(node osgraph.Node) graph.Node {
+			return &SecretNode{node, o, false}
+		},
+	).(*SecretNode)
+}
+
 // EnsureReplicationControllerNode adds a graph node for the ReplicationController if it does not already exist.
 func EnsureReplicationControllerNode(g osgraph.MutableUniqueGraph, rc *kapi.ReplicationController) *ReplicationControllerNode {
 	rcNodeName := ReplicationControllerNodeName(rc)

--- a/pkg/api/kubegraph/nodes/types.go
+++ b/pkg/api/kubegraph/nodes/types.go
@@ -37,6 +37,10 @@ func (n ServiceNode) String() string {
 	return string(ServiceNodeName(n.Service))
 }
 
+func (n ServiceNode) ResourceString() string {
+	return "svc/" + n.Name
+}
+
 func (*ServiceNode) Kind() string {
 	return ServiceNodeKind
 }
@@ -56,6 +60,10 @@ func (n PodNode) Object() interface{} {
 
 func (n PodNode) String() string {
 	return string(PodNodeName(n.Pod))
+}
+
+func (n PodNode) ResourceString() string {
+	return "pod/" + n.Name
 }
 
 func (n PodNode) UniqueName() osgraph.UniqueName {
@@ -108,6 +116,10 @@ func (n ReplicationControllerNode) Object() interface{} {
 
 func (n ReplicationControllerNode) String() string {
 	return string(ReplicationControllerNodeName(n.ReplicationController))
+}
+
+func (n ReplicationControllerNode) ResourceString() string {
+	return "rc/" + n.Name
 }
 
 func (n ReplicationControllerNode) UniqueName() osgraph.UniqueName {
@@ -195,6 +207,10 @@ func (n ServiceAccountNode) String() string {
 	return string(ServiceAccountNodeName(n.ServiceAccount))
 }
 
+func (n ServiceAccountNode) ResourceString() string {
+	return "sa/" + n.Name
+}
+
 func (*ServiceAccountNode) Kind() string {
 	return ServiceAccountNodeKind
 }
@@ -220,6 +236,10 @@ func (n SecretNode) Object() interface{} {
 
 func (n SecretNode) String() string {
 	return string(SecretNodeName(n.Secret))
+}
+
+func (n SecretNode) ResourceString() string {
+	return "secret/" + n.Name
 }
 
 func (*SecretNode) Kind() string {

--- a/pkg/api/kubegraph/nodes/types.go
+++ b/pkg/api/kubegraph/nodes/types.go
@@ -16,6 +16,8 @@ var (
 	PodTemplateSpecNodeKind           = reflect.TypeOf(kapi.PodTemplateSpec{}).Name()
 	ReplicationControllerNodeKind     = reflect.TypeOf(kapi.ReplicationController{}).Name()
 	ReplicationControllerSpecNodeKind = reflect.TypeOf(kapi.ReplicationControllerSpec{}).Name()
+	ServiceAccountNodeKind            = reflect.TypeOf(kapi.ServiceAccount{}).Name()
+	SecretNodeKind                    = reflect.TypeOf(kapi.Secret{}).Name()
 )
 
 func ServiceNodeName(o *kapi.Service) osgraph.UniqueName {
@@ -168,4 +170,58 @@ func (n PodTemplateSpecNode) UniqueName() osgraph.UniqueName {
 
 func (*PodTemplateSpecNode) Kind() string {
 	return PodTemplateSpecNodeKind
+}
+
+func ServiceAccountNodeName(o *kapi.ServiceAccount) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(ServiceAccountNodeKind, o)
+}
+
+type ServiceAccountNode struct {
+	osgraph.Node
+	*kapi.ServiceAccount
+
+	IsFound bool
+}
+
+func (n ServiceAccountNode) Found() bool {
+	return n.IsFound
+}
+
+func (n ServiceAccountNode) Object() interface{} {
+	return n.ServiceAccount
+}
+
+func (n ServiceAccountNode) String() string {
+	return string(ServiceAccountNodeName(n.ServiceAccount))
+}
+
+func (*ServiceAccountNode) Kind() string {
+	return ServiceAccountNodeKind
+}
+
+func SecretNodeName(o *kapi.Secret) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(SecretNodeKind, o)
+}
+
+type SecretNode struct {
+	osgraph.Node
+	*kapi.Secret
+
+	IsFound bool
+}
+
+func (n SecretNode) Found() bool {
+	return n.IsFound
+}
+
+func (n SecretNode) Object() interface{} {
+	return n.Secret
+}
+
+func (n SecretNode) String() string {
+	return string(SecretNodeName(n.Secret))
+}
+
+func (*SecretNode) Kind() string {
+	return SecretNodeKind
 }

--- a/pkg/build/graph/nodes/types.go
+++ b/pkg/build/graph/nodes/types.go
@@ -33,6 +33,10 @@ func (n BuildConfigNode) String() string {
 	return string(BuildConfigNodeName(n.BuildConfig))
 }
 
+func (n BuildConfigNode) ResourceString() string {
+	return "bc/" + n.Name
+}
+
 func (*BuildConfigNode) Kind() string {
 	return BuildConfigNodeKind
 }
@@ -75,6 +79,10 @@ func (n BuildNode) Object() interface{} {
 
 func (n BuildNode) String() string {
 	return string(BuildNodeName(n.Build))
+}
+
+func (n BuildNode) ResourceString() string {
+	return "build/" + n.Build.Name
 }
 
 func (*BuildNode) Kind() string {

--- a/pkg/deploy/graph/analysis/dc.go
+++ b/pkg/deploy/graph/analysis/dc.go
@@ -1,0 +1,53 @@
+package analysis
+
+import (
+	"github.com/gonum/graph"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	"github.com/openshift/origin/pkg/api/graph/graphview"
+	kubeanalysis "github.com/openshift/origin/pkg/api/kubegraph/analysis"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
+)
+
+// DescendentNodesByNodeKind starts at the root navigates down the root.  Every edge is checked against the edgeChecker
+// to determine whether or not to follow it.  The nodes at the tail end of every chased edge are then checked against the
+// the targetNodeKind.  Matches are added to the return and every checked node then has its edges checked: lather, rinse, repeat
+func DescendentNodesByNodeKind(g osgraph.Graph, visitedNodes graphview.IntSet, node graph.Node, targetNodeKind string, edgeChecker osgraph.EdgeFunc) []graph.Node {
+	if visitedNodes.Has(node.ID()) {
+		return []graph.Node{}
+	}
+	visitedNodes.Insert(node.ID())
+
+	ret := []graph.Node{}
+	for _, successor := range g.Successors(node) {
+		edge := g.EdgeBetween(node, successor)
+		kind := g.EdgeKind(edge)
+
+		if edgeChecker(osgraph.New(), node, successor, kind) {
+			if g.Kind(successor) == targetNodeKind {
+				ret = append(ret, successor)
+			}
+
+			ret = append(ret, DescendentNodesByNodeKind(g, visitedNodes, successor, targetNodeKind, edgeChecker)...)
+		}
+	}
+
+	return ret
+}
+
+// CheckMountedSecrets checks to be sure that all the referenced secrets are mountable (by service account) and present (not synthetic)
+func CheckMountedSecrets(g osgraph.Graph, dcNode *deploygraph.DeploymentConfigNode) ( /*unmountable secrets*/ []*kubegraph.SecretNode /*unresolved secrets*/, []*kubegraph.SecretNode) {
+	podSpecs := DescendentNodesByNodeKind(g, graphview.IntSet{}, dcNode, kubegraph.PodSpecNodeKind, func(g osgraph.Interface, head, tail graph.Node, edgeKind string) bool {
+		if edgeKind == osgraph.ContainsEdgeKind {
+			return true
+		}
+		return false
+	})
+
+	if len(podSpecs) > 0 {
+		return kubeanalysis.CheckMountedSecrets(g, podSpecs[0].(*kubegraph.PodSpecNode))
+	}
+
+	return []*kubegraph.SecretNode{}, []*kubegraph.SecretNode{}
+}

--- a/pkg/deploy/graph/analysis/dc_test.go
+++ b/pkg/deploy/graph/analysis/dc_test.go
@@ -1,0 +1,45 @@
+package analysis
+
+import (
+	"testing"
+
+	osgraphtest "github.com/openshift/origin/pkg/api/graph/test"
+	kubeedges "github.com/openshift/origin/pkg/api/kubegraph"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
+)
+
+func TestCheckMountedSecrets(t *testing.T) {
+	g, objs, err := osgraphtest.BuildGraph("../../../api/graph/test/bad_secret_refs.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var dc *deployapi.DeploymentConfig
+	for _, obj := range objs {
+		if currDC, ok := obj.(*deployapi.DeploymentConfig); ok {
+			if dc != nil {
+				t.Errorf("got more than one dc: %v", currDC)
+			}
+			dc = currDC
+		}
+	}
+
+	kubeedges.AddAllRequestedServiceAccountEdges(g)
+	kubeedges.AddAllMountableSecretEdges(g)
+	kubeedges.AddAllMountedSecretEdges(g)
+
+	dcNode := g.Find(deploygraph.DeploymentConfigNodeName(dc))
+	unmountable, missing := CheckMountedSecrets(g, dcNode.(*deploygraph.DeploymentConfigNode))
+
+	if e, a := 2, len(unmountable); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	if e, a := 1, len(missing); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := "missing-secret", missing[0].Name; e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+}

--- a/pkg/deploy/graph/nodes/types.go
+++ b/pkg/deploy/graph/nodes/types.go
@@ -28,6 +28,10 @@ func (n DeploymentConfigNode) String() string {
 	return string(DeploymentConfigNodeName(n.DeploymentConfig))
 }
 
+func (n DeploymentConfigNode) ResourceString() string {
+	return "dc/" + n.Name
+}
+
 func (*DeploymentConfigNode) Kind() string {
 	return DeploymentConfigNodeKind
 }

--- a/pkg/image/graph/nodes/types.go
+++ b/pkg/image/graph/nodes/types.go
@@ -42,6 +42,10 @@ func (n ImageStreamNode) String() string {
 	return string(ImageStreamNodeName(n.ImageStream))
 }
 
+func (n ImageStreamNode) ResourceString() string {
+	return "is/" + n.Name
+}
+
 func (*ImageStreamNode) Kind() string {
 	return ImageStreamNodeKind
 }
@@ -77,6 +81,10 @@ func (n ImageStreamTagNode) Object() interface{} {
 
 func (n ImageStreamTagNode) String() string {
 	return string(ImageStreamTagNodeName(n.ImageStreamTag))
+}
+
+func (n ImageStreamTagNode) ResourceString() string {
+	return "imagestreamtag/" + n.Name
 }
 
 func (*ImageStreamTagNode) Kind() string {
@@ -146,6 +154,10 @@ func (n ImageNode) Object() interface{} {
 
 func (n ImageNode) String() string {
 	return string(ImageNodeName(n.Image))
+}
+
+func (n ImageNode) ResourceString() string {
+	return "image/" + n.Image.Name
 }
 
 func (*ImageNode) Kind() string {


### PR DESCRIPTION
Adds map navigation and output to locate `PodSpec`s that have disallowed secret references.  The graph navigation allows that information to be attached to the correct `ReplicationController`, `DeploymentConfig`, `PodTemplate`, or `Pod` for display.


```
[deads@deads-dev-01 origin]$ oc status
In project foo

service ruby-hello-world - 172.30.106.213:8080
  ruby-hello-world deploys ruby-hello-world:latest <- docker build of https://github.com/openshift/ruby-hello-world 
    build 1 new for 59 seconds (can't push to image)
    #1 deployment waiting on image or update

Warning: Some of your builds are pointing to image streams, but the administrator has not configured the integrated Docker registry (oadm registry).
Warning: some requested secrets are not allowed:
	dc/ruby-hello-world is not allowed to mount secret/missing-secret,secret/unmountable-secret and wants to mount these missing secrets secret/missing-secret,secret/unmountable-secret
To see more, use 'oc describe service <name>' or 'oc describe dc <name>'.
You can use 'oc get all' to see a list of other objects.
```

@ncdc 