### PR TITLE
[WIP][DO_NOT_MERGE] Issue 2881: osc-key-values directive layout wrapping issues on browser resize

### DIFF
--- a/assets/app/styles/_flexbox.less
+++ b/assets/app/styles/_flexbox.less
@@ -133,3 +133,181 @@
       -ms-align-self: @align;
           align-self: @align;
 }
+
+
+
+
+// Generic layout attr utils, inspired by Angular Material/Polymer flex layouts
+// - TODO (bpeterse): Grunt autoprefixer should handle compatibility...check?
+//
+// - simple example:
+//   <div layout row reverse align-items="center">
+//      <div flex>foo</div>
+//      <div layout column main-axis="center">
+//        <div flex grow="2" shrink="2">bar</div>
+//        <div>bar</div>
+//      </div>
+//      <div>Not flexed.</div>
+//   </div>
+//
+[outline] {
+  outline: 1px dotted #ED9AF2;
+}
+// flex container 
+[layout] {
+  display: flex; 
+}
+// flex child 
+[flex] {
+  flex: 1; 
+}
+
+// container modifiers 
+[column] {
+  flex-direction: column;
+}
+
+[column="reverse"],
+[column][reverse] {
+  flex-direction: column-reverse;
+}
+
+[row] {
+  flex-direction: row;
+}
+
+[row="reverse"],
+[row][reverse] {
+  flex-direction: row-reverse;
+}
+
+[wrap] {
+  flex-wrap: wrap;
+}
+
+[fit] {
+  margin: 0px;
+  width: 100%;
+  min-height: auto;
+  height: inherit; // 100%?
+}
+
+[basis="auto"] {
+  flex-basis: auto; 
+};
+
+[align-items],
+[align-items="center"] {
+  align-items: center;
+}
+
+[align-items="start"] {
+  align-items: flex-start;
+}
+
+[align-items="end"] {
+  align-items: flex-end;
+}
+
+[align-items="baseline"] {
+  align-items: baseline;
+}
+
+// main axis
+[main-axis="start"] {
+  justify-content: flex-start; 
+}
+
+[main-axis="end"] {
+  justify-content: flex-end; 
+}
+
+[main-axis="center"] {
+  justify-content: center; 
+}
+
+[main-axis="space-between"] {
+  justify-content: space-between; 
+}
+
+[main-axis="space-around"] {
+  justify-content: space-around; 
+}
+
+// cross axis
+[cross-axis="start"] {
+  align-items: flex-start; 
+}
+
+[cross-axis="end"] {
+  align-items: flex-end; 
+}
+
+[cross-axis="center"] {
+  align-items: center; 
+}
+
+[cross-axis="stretch"] {
+  align-items: stretch; 
+}
+
+[cross-axis="baseline"] {
+  align-items: baseline; 
+}
+
+// flex item modifiers
+
+// flex grow, should have a flex shrink pairing
+// should generate with a loop
+[grow="0"] {
+  flex-grow: 0;
+}
+
+[grow="1"] {
+  flex-grow: 1;
+}
+
+[grow="2"] {
+  flex-grow: 2;
+}
+
+[grow="3"] {
+  flex-grow: 3;
+}
+
+[grow="4"] {
+  flex-grow: 4;
+}
+
+[grow="5"] {
+  flex-grow: 5;
+}
+
+[shrink="0"] {
+  flex-shrink: 0;
+}
+
+[shrink="1"] {
+  flex-shrink: 1;
+}
+
+[shrink="2"] {
+  flex-shrink: 2;
+}
+
+[shrink="3"] {
+  flex-shrink: 3;
+}
+
+[shrink="4"] {
+  flex-shrink: 4;
+}
+
+[shrink="5"] {
+  flex-shrink: 5;
+}
+
+
+
+
+

--- a/assets/app/views/directives/osc-key-values.html
+++ b/assets/app/views/directives/osc-key-values.html
@@ -1,20 +1,48 @@
 <div ng-controller="KeyValuesController" class="labels">
     <div class="form-inline labels-edit" ng-show="editable">
       <form class="edit-label" name="form" novalidate>
-        <div class='form-group' ng-class="{'has-error': form.key.$error.oscKeyValid}">
-          <input class="form-control" type="text" name="key" placeholder="{{keyTitle}}" ng-model="key" 
-                 osc-input-validator="key">
+        
+        <div layout row>
+
+          <div 
+            flex grow="5" 
+            class='form-group' 
+            ng-class="{'has-error': form.key.$error.oscKeyValid}" 
+            style="margin-right: 10px;">
+            <input class="form-control" 
+                   type="text" 
+                   name="key" 
+                   placeholder="{{keyTitle}}" 
+                   ng-model="key" 
+                   osc-input-validator="key">
+          </div>
+          
+          <div 
+            flex grow="5" 
+            class="form-group" 
+            ng-class="{'has-error': form.value.$error.oscValueValid}" 
+            style="margin-right: 10px;">
+            <input class="form-control" 
+                   type="text"
+                   name="value" 
+                   placeholder="Value"
+                   ng-model="value" 
+                   osc-input-validator="value">
+          </div>
+          <div 
+            flex layout 
+            grow="1" shrink="1" basis="auto" 
+            main-axis="end" cross-axis="baseline">
+            <button 
+              class="btn btn-default" 
+              ng-click="addEntry()" 
+              ng-disabled="form.key.$error.oscKeyValid || form.value.$error.oscValueValid">Add</button>
+          </div>
         </div>
-        <div class="form-group" ng-class="{'has-error': form.value.$error.oscValueValid}">
-          <input class="form-control" 
-                 type="text"
-                 name="value" 
-                 placeholder="Value"
-                 ng-model="value" 
-                 osc-input-validator="value">
-        </div>
-        <button class="btn btn-default" ng-click="addEntry()" ng-disabled="form.key.$error.oscKeyValid || form.value.$error.oscValueValid">Add</button>
-        <div class="has-error" ng-show="form.key.$error.oscKeyValid">
+
+      
+
+        <div layout row class="has-error" ng-show="form.key.$error.oscKeyValid">
           <span class="help-block">Please enter a valid key
             <span class="help action-inline" ng-if="keyValidationTooltip">
               <a  data-toggle="tooltip" data-placement="bottom"
@@ -24,7 +52,10 @@
             </span>
           </span>
         </div>      
-        <div class="has-error" ng-show="form.value.$error.oscValueValid">
+        
+
+
+        <div layout row class="has-error" ng-show="form.value.$error.oscValueValid">
           <span class="help-block">Please enter a valid value
             <span class="help action-inline" ng-if="keyValidationTooltip">
               <a  data-toggle="tooltip" data-placement="bottom"
@@ -34,38 +65,82 @@
             </span>
           </span>
         </div>      
+      
       </form>
-      <ul class="list-unstyled label-list">
-        <li ng-repeat="(key,value) in entries | valuesIn:readonlyKeys">
-          <span class="key truncate">{{key}}</span>
-          <span class="value truncate">{{value}}</span>
-        </li>
-        <li ng-repeat="(key,value) in entries | valuesNotIn:readonlyKeys">
-          <span ng-controller="KeyValuesEntryController">
-            <span class="key truncate">{{key}}</span>
-            <span ng-hide="editing">
-              <span class="value truncate">{{ value}}</span>
-              <a href="" ng-click="edit()" class="btn btn-default btn-xs" title="Edit">
+      
+      <div style="margin-top: 20px">
+        <!-- predefined keys -->
+        <div ng-repeat="(key,value) in entries | valuesIn:readonlyKeys">
+          <div layout row>
+            <div flex grow="5" shrink="5" class="truncate">{{key}}</div>
+            <div flex grow="5" shrink="5" class="truncate">{{value}}</div>
+            <div 
+              flex layout grow="1" shrink="1"
+              main-axis="end" cross-axis="baseline" 
+              style="flex-basis: 50px;">
+              &nbsp;  
+            </div>
+          </div>
+        </div>
+        
+        <!-- user defined keys -->
+        <div ng-repeat="(key,value) in entries | valuesNotIn:readonlyKeys">
+          <div layout row ng-controller="KeyValuesEntryController">
+            
+            <!-- view, edit/delete -->
+            <div flex grow="5" shrink="5" class="truncate">{{key}}</div>
+            
+            <div flex grow="5" shrink="5" class="truncate" ng-hide="editing">
+              {{value}}  
+            </div>
+
+            <div flex layout grow="1" shrink="1"
+              main-axis="end" cross-axis="baseline" ng-hide="editing" 
+              style="flex-basis: 50px;">
+              <a ng-click="edit()" 
+                 class="btn btn-default btn-xs" 
+                 title="Edit">
                 <i class="icon icon-pencil"></i>
               </a>
-              <a href="" ng-click="deleteEntry(key)" class="btn btn-default btn-xs" title="Delete" ng-if="allowDelete(key)">
+              <a ng-click="deleteEntry(key)" 
+                 class="btn btn-default btn-xs" 
+                 title="Delete" 
+                 ng-if="allowDelete(key)">
                 <i class="fa fa-times"></i>
               </a>
-            </span>
-            <span ng-show="editing" class="form-inline">
-              <div class="form-group">
-                  <input class="form-control" type="text" value="{{value}}" ng-model="value">
-                  <a href="" ng-click="update(key, value, $parent.entries)" class="btn btn-default" style="vertical-align: middle" title="Submit">
-                    <i class="icon icon-ok"></i>
-                  </a>
-                  <a href="" ng-click="cancel()" class="btn btn-default" style="vertical-align: middle" title="Cancel">
-                    <i class="icon icon-remove"></i>
-                  </a>
-              </div>
-            </span>
-          </span>
-        </li>
-      </ul>
+            </div>
+
+            <!-- editing view, save/cancel -->
+            <div layout row flex grow="5" shrink="5" ng-show="editing">
+              <input 
+                flex
+                type="text" 
+                value="{{value}}" 
+                ng-model="value" 
+                class="form-control input-sm"
+                style="margin-right: 10px;">
+            </div>
+
+            <div flex layout grow="1" shrink="1"
+              main-axis="end" cross-axis="baseline" ng-show="editing" 
+              style="flex-basis: 50px;">
+              <a ng-click="update(key, value, $parent.entries)" 
+                 class="btn btn-default btn-xs" 
+                 title="Submit">
+                <i class="icon icon-ok"></i>
+              </a>
+              <a ng-click="cancel()" 
+                 class="btn btn-default btn-xs" 
+                 title="Cancel">
+                <i class="icon icon-remove"></i>
+              </a>
+            </div>
+
+          </div>
+        </div>
+
+        
+      </div>
     </div>
     <div ng-hide="editable">
       <div ng-if="(entries | hashSize) === 0"><strong>None</strong></div>


### PR DESCRIPTION
This is meant to initially address [Issue 2881](https://github.com/openshift/origin/issues/2881), but also includes some thoughts on flexbox usage in general.

* Expands flexbox utilities in _flexbox.less
* updates osc-key-values.html directive view to handle resize more gracefully

@spadgett @liggitt and anyone else interested in css/flex discussion!

I expanded on _flexbox.less a bit, adding some additional utilities for describing layout in html.  The additional css is inspired by the layout frameworks in the [Angular Material](https://material.angularjs.org/latest/#/layout/grid) & [Polymer](https://www.polymer-project.org/0.5/docs/polymer/layout-attrs.html) projects.  Both use attribute selectors for layout (rather than classes) which makes it easier to reason about & change the markup.  The idea is something like "attributes for layout, classes for look/feel".  Check out the files changed & feel free to share any thoughts. Thanks!

Quick example, simplified to show how flex layout attrs can be used:

```html
<div layout row reverse align-items="center">
  <div flex>flex foo</div>
  <div layout column>
    <div flex grow="2" shrink="2">flex bar</div>
    <div>no flex baz</div>
  </div>
  <div>no flex.</div>
</div>
```

(This pull request is not yet ready, I have a few more items to address, but wanted to get some feedback early.  Also, I'll have to update my html formatting before the final, I tend to have aggressively short line lengths.) 
