### PR TITLE
update prune error message to mention --confirm 

### DIFF
--- a/pkg/cmd/admin/prune/builds.go
+++ b/pkg/cmd/admin/prune/builds.go
@@ -97,7 +97,7 @@ func NewCmdPruneBuilds(f *clientcmd.Factory, parentName, name string, out io.Wri
 					return nil
 				}
 			default:
-				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made.")
+				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made. Add --confirm to remove builds")
 				buildPruneFunc = describingPruneBuildFunc
 			}
 

--- a/pkg/cmd/admin/prune/deployments.go
+++ b/pkg/cmd/admin/prune/deployments.go
@@ -96,7 +96,7 @@ func NewCmdPruneDeployments(f *clientcmd.Factory, parentName, name string, out i
 					return nil
 				}
 			default:
-				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made.")
+				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made. Add --confirm to remove deployments")
 				deploymentPruneFunc = describingPruneDeploymentFunc
 			}
 

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -156,7 +156,7 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 				blobPruneFunc = prune.DeletingBlobPruneFunc(registryClient)
 				manifestPruneFunc = prune.DeletingManifestPruneFunc(registryClient)
 			default:
-				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made.")
+				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made. Add --confirm to remove images")
 				imagePruneFunc = describingImagePruneFunc
 				imageStreamPruneFunc = describingImageStreamPruneFunc
 				layerPruneFunc = describingLayerPruneFunc


### PR DESCRIPTION
When running a oadm image prune we are getting :

Dry run enabled - no modifications will be made.

The confirm option seems to behave as dry-run and consistent with other
options, let's rename it so not confuse users.