### PR TITLE
Correct Docker image Config type

### DIFF
--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1541,8 +1541,13 @@ func deepCopy_api_DockerImage(in imageapi.DockerImage, out *imageapi.DockerImage
 	}
 	out.DockerVersion = in.DockerVersion
 	out.Author = in.Author
-	if err := deepCopy_api_DockerConfig(in.Config, &out.Config, c); err != nil {
-		return err
+	if in.Config != nil {
+		out.Config = new(imageapi.DockerConfig)
+		if err := deepCopy_api_DockerConfig(*in.Config, out.Config, c); err != nil {
+			return err
+		}
+	} else {
+		out.Config = nil
 	}
 	out.Architecture = in.Architecture
 	out.Size = in.Size

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -402,12 +402,15 @@ func describeImage(image *imageapi.Image, imageName string) (string, error) {
 		formatString(out, "Image Created", fmt.Sprintf("%s ago", formatRelativeTime(image.DockerImageMetadata.Created.Time)))
 		formatString(out, "Author", image.DockerImageMetadata.Author)
 		formatString(out, "Arch", image.DockerImageMetadata.Architecture)
-		describeDockerImage(out, &image.DockerImageMetadata.Config)
+		describeDockerImage(out, image.DockerImageMetadata.Config)
 		return nil
 	})
 }
 
 func describeDockerImage(out *tabwriter.Writer, image *imageapi.DockerConfig) {
+	if image == nil {
+		return
+	}
 	hasCommand := false
 	if len(image.Entrypoint) > 0 {
 		hasCommand = true

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -320,7 +320,7 @@ func (r *ImageRef) DeployableContainer() (container *kapi.Container, triggers []
 	}
 
 	// If imageInfo present, append ports
-	if r.Info != nil {
+	if r.Info != nil && r.Info.Config != nil {
 		ports := []string{}
 		// ExposedPorts can consist of multiple space-separated ports
 		for exposed := range r.Info.Config.ExposedPorts {

--- a/pkg/generate/app/app_test.go
+++ b/pkg/generate/app/app_test.go
@@ -17,7 +17,7 @@ import (
 
 func testImageInfo() *imageapi.DockerImage {
 	return &imageapi.DockerImage{
-		Config: imageapi.DockerConfig{},
+		Config: &imageapi.DockerConfig{},
 	}
 }
 
@@ -170,6 +170,7 @@ func TestImageRefDeployableContainerPorts(t *testing.T) {
 		inputPorts    map[string]struct{}
 		expectedPorts map[int]string
 		expectError   bool
+		noConfig      bool
 	}{
 		{
 			name: "tcp implied, individual ports",
@@ -231,6 +232,12 @@ func TestImageRefDeployableContainerPorts(t *testing.T) {
 			expectedPorts: map[int]string{},
 			expectError:   true,
 		},
+		{
+			name:          "no image config",
+			expectedPorts: map[int]string{},
+			expectError:   false,
+			noConfig:      true,
+		},
 	}
 	for _, test := range tests {
 		imageRef := &ImageRef{
@@ -240,10 +247,13 @@ func TestImageRefDeployableContainerPorts(t *testing.T) {
 				Tag:       imageapi.DefaultImageTag,
 			},
 			Info: &imageapi.DockerImage{
-				Config: imageapi.DockerConfig{
+				Config: &imageapi.DockerConfig{
 					ExposedPorts: test.inputPorts,
 				},
 			},
+		}
+		if test.noConfig {
+			imageRef.Info.Config = nil
 		}
 		container, _, err := imageRef.DeployableContainer()
 		if err != nil && !test.expectError {

--- a/pkg/generate/app/builder.go
+++ b/pkg/generate/app/builder.go
@@ -11,6 +11,9 @@ var stiEnvironmentNames = []string{"STI_LOCATION", "STI_SCRIPTS_URL", "STI_BUILD
 // IsBuilderImage checks whether the provided Docker image is
 // a builder image or not
 func IsBuilderImage(image *imageapi.DockerImage) bool {
+	if image.Config == nil {
+		return false
+	}
 	for _, env := range image.Config.Env {
 		for _, name := range stiEnvironmentNames {
 			if strings.HasPrefix(env, name+"=") {

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -430,7 +430,9 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 					exposed, ok := ref.Input().Uses.Info().Dockerfile.GetDirective("EXPOSE")
 					if ok {
 						if input.Info == nil {
-							input.Info = &imageapi.DockerImage{}
+							input.Info = &imageapi.DockerImage{
+								Config: &imageapi.DockerConfig{},
+							}
 						}
 						input.Info.Config.ExposedPorts = map[string]struct{}{}
 						for _, p := range exposed {

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -858,6 +858,53 @@ tests:
 	}
 }
 
+// Make sure that buildPipelines defaults DockerImage.Config if needed to
+// avoid a nil panic.
+func TestBuildPipelinesWithUnresolvedImage(t *testing.T) {
+	dockerParser := dockerfile.NewParser()
+
+	dockerFileInput := strings.NewReader("EXPOSE 1234\nEXPOSE 4567")
+	dockerFile, err := dockerParser.Parse(dockerFileInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sourceRepo, err := app.NewSourceRepository("https://github.com/foo/bar.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceRepo.BuildWithDocker()
+	sourceRepo.SetInfo(&app.SourceRepositoryInfo{
+		Dockerfile: dockerFile,
+	})
+
+	refs := app.ComponentReferences{
+		app.ComponentReference(&app.ComponentInput{
+			Value:         "mysql",
+			Uses:          sourceRepo,
+			ExpectToBuild: true,
+			Match: &app.ComponentMatch{
+				Value: "mysql",
+			},
+		}),
+	}
+
+	a := AppConfig{}
+	group, err := a.buildPipelines(refs, app.Environment{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedPorts := util.NewStringSet("1234", "4567")
+	actualPorts := util.NewStringSet()
+	for port := range group[0].InputImage.Info.Config.ExposedPorts {
+		actualPorts.Insert(port)
+	}
+	if e, a := expectedPorts.List(), actualPorts.List(); !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected ports=%v, got %v", e, a)
+	}
+}
+
 func builderImageStream() *imageapi.ImageStream {
 	return &imageapi.ImageStream{
 		ObjectMeta: kapi.ObjectMeta{
@@ -885,7 +932,7 @@ func builderImage() *imageapi.ImageStreamImage {
 		Image: imageapi.Image{
 			DockerImageReference: "example/ruby:latest",
 			DockerImageMetadata: imageapi.DockerImage{
-				Config: imageapi.DockerConfig{
+				Config: &imageapi.DockerConfig{
 					Env: []string{
 						"STI_SCRIPTS_URL=http://repo/git/ruby",
 					},

--- a/pkg/generate/app/imageref.go
+++ b/pkg/generate/app/imageref.go
@@ -58,7 +58,7 @@ func (g *imageRefGenerator) FromNameAndPorts(name string, ports []string) (*Imag
 	}
 
 	imageRef.Info = &imageapi.DockerImage{
-		Config: imageapi.DockerConfig{
+		Config: &imageapi.DockerConfig{
 			ExposedPorts: exposedPorts,
 		},
 	}

--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -99,6 +99,11 @@ func (r *SourceRepository) Detect(d Detector) error {
 	return nil
 }
 
+// SetInfo sets the source repository info. This is to facilitate certain tests.
+func (r *SourceRepository) SetInfo(info *SourceRepositoryInfo) {
+	r.info = info
+}
+
 // Info returns the source repository info generated on code detection
 func (r *SourceRepository) Info() *SourceRepositoryInfo {
 	return r.info

--- a/pkg/image/api/conversion.go
+++ b/pkg/image/api/conversion.go
@@ -12,7 +12,7 @@ func init() {
 	err := kapi.Scheme.AddConversionFuncs(
 		// Convert docker client object to internal object
 		func(in *docker.Image, out *DockerImage, s conversion.Scope) error {
-			if err := s.Convert(in.Config, &out.Config, conversion.AllowDifferentFieldTypeNames); err != nil {
+			if err := s.Convert(&in.Config, &out.Config, conversion.AllowDifferentFieldTypeNames); err != nil {
 				return err
 			}
 			if err := s.Convert(&in.ContainerConfig, &out.ContainerConfig, conversion.AllowDifferentFieldTypeNames); err != nil {

--- a/pkg/image/api/docker10/dockertypes.go
+++ b/pkg/image/api/docker10/dockertypes.go
@@ -10,17 +10,17 @@ import (
 type DockerImage struct {
 	kapi.TypeMeta `json:",inline"`
 
-	ID              string       `json:"Id"`
-	Parent          string       `json:"Parent,omitempty"`
-	Comment         string       `json:"Comment,omitempty"`
-	Created         util.Time    `json:"Created,omitempty"`
-	Container       string       `json:"Container,omitempty"`
-	ContainerConfig DockerConfig `json:"ContainerConfig,omitempty"`
-	DockerVersion   string       `json:"DockerVersion,omitempty"`
-	Author          string       `json:"Author,omitempty"`
-	Config          DockerConfig `json:"Config,omitempty"`
-	Architecture    string       `json:"Architecture,omitempty"`
-	Size            int64        `json:"Size,omitempty"`
+	ID              string        `json:"Id"`
+	Parent          string        `json:"Parent,omitempty"`
+	Comment         string        `json:"Comment,omitempty"`
+	Created         util.Time     `json:"Created,omitempty"`
+	Container       string        `json:"Container,omitempty"`
+	ContainerConfig DockerConfig  `json:"ContainerConfig,omitempty"`
+	DockerVersion   string        `json:"DockerVersion,omitempty"`
+	Author          string        `json:"Author,omitempty"`
+	Config          *DockerConfig `json:"Config,omitempty"`
+	Architecture    string        `json:"Architecture,omitempty"`
+	Size            int64         `json:"Size,omitempty"`
 }
 
 // DockerConfig is the list of configuration options used when creating a container.

--- a/pkg/image/api/dockerpre012/dockertypes.go
+++ b/pkg/image/api/dockerpre012/dockertypes.go
@@ -10,17 +10,17 @@ import (
 type DockerImage struct {
 	kapi.TypeMeta `json:",inline"`
 
-	ID              string       `json:"id"`
-	Parent          string       `json:"parent,omitempty"`
-	Comment         string       `json:"comment,omitempty"`
-	Created         util.Time    `json:"created"`
-	Container       string       `json:"container,omitempty"`
-	ContainerConfig DockerConfig `json:"container_config,omitempty"`
-	DockerVersion   string       `json:"docker_version,omitempty"`
-	Author          string       `json:"author,omitempty"`
-	Config          DockerConfig `json:"config,omitempty"`
-	Architecture    string       `json:"architecture,omitempty"`
-	Size            int64        `json:"size,omitempty"`
+	ID              string        `json:"id"`
+	Parent          string        `json:"parent,omitempty"`
+	Comment         string        `json:"comment,omitempty"`
+	Created         util.Time     `json:"created"`
+	Container       string        `json:"container,omitempty"`
+	ContainerConfig DockerConfig  `json:"container_config,omitempty"`
+	DockerVersion   string        `json:"docker_version,omitempty"`
+	Author          string        `json:"author,omitempty"`
+	Config          *DockerConfig `json:"config,omitempty"`
+	Architecture    string        `json:"architecture,omitempty"`
+	Size            int64         `json:"size,omitempty"`
 }
 
 // DockerConfig is the list of configuration options used when creating a container.

--- a/pkg/image/api/dockertypes.go
+++ b/pkg/image/api/dockertypes.go
@@ -10,17 +10,17 @@ import (
 type DockerImage struct {
 	kapi.TypeMeta `json:",inline"`
 
-	ID              string       `json:"Id"`
-	Parent          string       `json:"Parent,omitempty"`
-	Comment         string       `json:"Comment,omitempty"`
-	Created         util.Time    `json:"Created,omitempty"`
-	Container       string       `json:"Container,omitempty"`
-	ContainerConfig DockerConfig `json:"ContainerConfig,omitempty"`
-	DockerVersion   string       `json:"DockerVersion,omitempty"`
-	Author          string       `json:"Author,omitempty"`
-	Config          DockerConfig `json:"Config,omitempty"`
-	Architecture    string       `json:"Architecture,omitempty"`
-	Size            int64        `json:"Size,omitempty"`
+	ID              string        `json:"Id"`
+	Parent          string        `json:"Parent,omitempty"`
+	Comment         string        `json:"Comment,omitempty"`
+	Created         util.Time     `json:"Created,omitempty"`
+	Container       string        `json:"Container,omitempty"`
+	ContainerConfig DockerConfig  `json:"ContainerConfig,omitempty"`
+	DockerVersion   string        `json:"DockerVersion,omitempty"`
+	Author          string        `json:"Author,omitempty"`
+	Config          *DockerConfig `json:"Config,omitempty"`
+	Architecture    string        `json:"Architecture,omitempty"`
+	Size            int64         `json:"Size,omitempty"`
 }
 
 // DockerConfig is the list of configuration options used when creating a container.
@@ -80,15 +80,15 @@ type DockerHistory struct {
 // DockerV1CompatibilityImage represents the structured v1
 // compatibility information.
 type DockerV1CompatibilityImage struct {
-	ID              string       `json:"id"`
-	Parent          string       `json:"parent,omitempty"`
-	Comment         string       `json:"comment,omitempty"`
-	Created         util.Time    `json:"created"`
-	Container       string       `json:"container,omitempty"`
-	ContainerConfig DockerConfig `json:"container_config,omitempty"`
-	DockerVersion   string       `json:"docker_version,omitempty"`
-	Author          string       `json:"author,omitempty"`
-	Config          DockerConfig `json:"config,omitempty"`
-	Architecture    string       `json:"architecture,omitempty"`
-	Size            int64        `json:"size,omitempty"`
+	ID              string        `json:"id"`
+	Parent          string        `json:"parent,omitempty"`
+	Comment         string        `json:"comment,omitempty"`
+	Created         util.Time     `json:"created"`
+	Container       string        `json:"container,omitempty"`
+	ContainerConfig DockerConfig  `json:"container_config,omitempty"`
+	DockerVersion   string        `json:"docker_version,omitempty"`
+	Author          string        `json:"author,omitempty"`
+	Config          *DockerConfig `json:"config,omitempty"`
+	Architecture    string        `json:"architecture,omitempty"`
+	Size            int64         `json:"size,omitempty"`
 }

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -408,7 +408,7 @@ func TestImageWithMetadata(t *testing.T) {
 					},
 					DockerVersion: "1.4.1",
 					Author:        "",
-					Config: DockerConfig{
+					Config: &DockerConfig{
 						Hostname:        "43bd710ec89a",
 						Domainname:      "",
 						User:            "",

--- a/pkg/image/api/v1/conversion_test.go
+++ b/pkg/image/api/v1/conversion_test.go
@@ -15,7 +15,7 @@ var Convert = kapi.Scheme.Convert
 
 func TestRoundTripVersionedObject(t *testing.T) {
 	d := &newer.DockerImage{
-		Config: newer.DockerConfig{
+		Config: &newer.DockerConfig{
 			Env: []string{"A=1", "B=2"},
 		},
 	}

--- a/pkg/image/api/v1beta3/conversion_test.go
+++ b/pkg/image/api/v1beta3/conversion_test.go
@@ -15,7 +15,7 @@ var Convert = kapi.Scheme.Convert
 
 func TestRoundTripVersionedObject(t *testing.T) {
 	d := &newer.DockerImage{
-		Config: newer.DockerConfig{
+		Config: &newer.DockerConfig{
 			Env: []string{"A=1", "B=2"},
 		},
 	}

--- a/pkg/image/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/registry/imagestreammapping/rest_test.go
@@ -66,7 +66,7 @@ func validNewMappingWithName() *api.ImageStreamMapping {
 			},
 			DockerImageReference: "localhost:5000/default/somerepo:imageID1",
 			DockerImageMetadata: api.DockerImage{
-				Config: api.DockerConfig{
+				Config: &api.DockerConfig{
 					Cmd:          []string{"ls", "/"},
 					Env:          []string{"a=1"},
 					ExposedPorts: map[string]struct{}{"1234/tcp": {}},
@@ -200,7 +200,7 @@ func TestAddExistingImageWithNewTag(t *testing.T) {
 		},
 		DockerImageReference: "localhost:5000/someproject/somerepo:" + imageID,
 		DockerImageMetadata: api.DockerImage{
-			Config: api.DockerConfig{
+			Config: &api.DockerConfig{
 				Cmd:          []string{"ls", "/"},
 				Env:          []string{"a=1"},
 				ExposedPorts: map[string]struct{}{"1234/tcp": {}},
@@ -279,7 +279,7 @@ func TestAddExistingImageAndTag(t *testing.T) {
 		},
 		DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
 		DockerImageMetadata: api.DockerImage{
-			Config: api.DockerConfig{
+			Config: &api.DockerConfig{
 				Cmd:          []string{"ls", "/"},
 				Env:          []string{"a=1"},
 				ExposedPorts: map[string]struct{}{"1234/tcp": {}},

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -143,7 +143,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	image := &imageapi.Image{
 		ObjectMeta: kapi.ObjectMeta{Name: "image2"},
 		DockerImageMetadata: imageapi.DockerImage{
-			Config: imageapi.DockerConfig{
+			Config: &imageapi.DockerConfig{
 				Env: []string{"A=B"},
 			},
 		},


### PR DESCRIPTION
Because not all images have a config section, we need to change Config
to be a pointer.

This will allow us to import images from the rhel repo - it has 1 image
without a config element.