### PR TITLE
make conversions convert and validation validate

### DIFF
--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -243,11 +243,6 @@ func convert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBuildSt
 		case "ImageStream":
 			out.From.Kind = "ImageStreamTag"
 			out.From.Name = imageapi.JoinImageStreamTag(in.From.Name, "")
-		case "ImageStreamTag":
-			_, _, ok := imageapi.SplitImageStreamTag(in.From.Name)
-			if !ok {
-				return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
-			}
 		}
 	}
 	return nil
@@ -273,11 +268,6 @@ func convert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBuildSt
 		case "ImageStream":
 			out.From.Kind = "ImageStreamTag"
 			out.From.Name = imageapi.JoinImageStreamTag(in.From.Name, "")
-		case "ImageStreamTag":
-			_, _, ok := imageapi.SplitImageStreamTag(in.From.Name)
-			if !ok {
-				return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
-			}
 		}
 	}
 	return nil
@@ -355,6 +345,14 @@ func convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPol
 
 func init() {
 	err := kapi.Scheme.AddDefaultingFuncs(
+		func(strategy *BuildStrategy) {
+			if (strategy != nil) && (strategy.Type == DockerBuildStrategyType) {
+				//  initialize DockerStrategy to a default state if it's not set.
+				if strategy.DockerStrategy == nil {
+					strategy.DockerStrategy = &DockerBuildStrategy{}
+				}
+			}
+		},
 		func(obj *SourceBuildStrategy) {
 			if obj.From != nil && len(obj.From.Kind) == 0 {
 				obj.From.Kind = "ImageStreamTag"

--- a/pkg/build/api/v1beta3/conversion.go
+++ b/pkg/build/api/v1beta3/conversion.go
@@ -213,11 +213,6 @@ func convert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy(in *SourceBu
 		case "ImageStream":
 			out.From.Kind = "ImageStreamTag"
 			out.From.Name = imageapi.JoinImageStreamTag(in.From.Name, "")
-		case "ImageStreamTag":
-			_, _, ok := imageapi.SplitImageStreamTag(in.From.Name)
-			if !ok {
-				return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
-			}
 		}
 	}
 	return nil
@@ -243,11 +238,6 @@ func convert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy(in *DockerBu
 		case "ImageStream":
 			out.From.Kind = "ImageStreamTag"
 			out.From.Name = imageapi.JoinImageStreamTag(in.From.Name, "")
-		case "ImageStreamTag":
-			_, _, ok := imageapi.SplitImageStreamTag(in.From.Name)
-			if !ok {
-				return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
-			}
 		}
 	}
 	return nil
@@ -273,11 +263,6 @@ func convert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy(in *CustomBu
 		case "ImageStream":
 			out.From.Kind = "ImageStreamTag"
 			out.From.Name = imageapi.JoinImageStreamTag(in.From.Name, "")
-		case "ImageStreamTag":
-			_, _, ok := imageapi.SplitImageStreamTag(in.From.Name)
-			if !ok {
-				return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
-			}
 		}
 	}
 	return nil
@@ -370,6 +355,20 @@ func convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTrigg
 
 func init() {
 	err := kapi.Scheme.AddDefaultingFuncs(
+		func(strategy *BuildStrategy) {
+			if (strategy != nil) && (strategy.Type == DockerBuildStrategyType) {
+				//  initialize DockerStrategy to a default state if it's not set.
+				if strategy.DockerStrategy == nil {
+					strategy.DockerStrategy = &DockerBuildStrategy{}
+				}
+			}
+		},
+	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = kapi.Scheme.AddDefaultingFuncs(
 		func(obj *SourceBuildStrategy) {
 			if obj.From != nil && len(obj.From.Kind) == 0 {
 				obj.From.Kind = "ImageStreamTag"

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -194,12 +194,15 @@ func validateStrategy(strategy *buildapi.BuildStrategy) fielderrors.ValidationEr
 		} else {
 			allErrs = append(allErrs, validateSourceStrategy(strategy.SourceStrategy).Prefix("stiStrategy")...)
 		}
+
 	case strategy.Type == buildapi.DockerBuildStrategyType:
 		// DockerStrategy is currently optional, initialize it to a default state if it's not set.
 		if strategy.DockerStrategy == nil {
-			strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}
+			allErrs = append(allErrs, fielderrors.NewFieldRequired("dockerStrategy"))
+		} else {
+			allErrs = append(allErrs, validateDockerStrategy(strategy.DockerStrategy).Prefix("dockerStrategy")...)
 		}
-		allErrs = append(allErrs, validateSecretRef(strategy.DockerStrategy.PullSecret).Prefix("pullSecret")...)
+
 	case strategy.Type == buildapi.CustomBuildStrategyType:
 		if strategy.CustomStrategy == nil {
 			allErrs = append(allErrs, fielderrors.NewFieldRequired("customStrategy"))
@@ -213,10 +216,29 @@ func validateStrategy(strategy *buildapi.BuildStrategy) fielderrors.ValidationEr
 	return allErrs
 }
 
+func validateDockerStrategy(strategy *buildapi.DockerBuildStrategy) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if strategy.From != nil && strategy.From.Kind == "ImageStreamTag" {
+		if _, _, ok := imageapi.SplitImageStreamTag(strategy.From.Name); !ok {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("from.name", strategy.From.Name, "ImageStreamTag object references must be in the form <name>:<tag>"))
+		}
+	}
+
+	allErrs = append(allErrs, validateSecretRef(strategy.PullSecret).Prefix("pullSecret")...)
+	return allErrs
+}
+
 func validateSourceStrategy(strategy *buildapi.SourceBuildStrategy) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 	if strategy.From == nil || len(strategy.From.Name) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("from"))
+
+	}
+	if strategy.From != nil && strategy.From.Kind == "ImageStreamTag" {
+		if _, _, ok := imageapi.SplitImageStreamTag(strategy.From.Name); !ok {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("from.name", strategy.From.Name, "ImageStreamTag object references must be in the form <name>:<tag>"))
+		}
 	}
 	allErrs = append(allErrs, validateSecretRef(strategy.PullSecret).Prefix("pullSecret")...)
 	return allErrs
@@ -226,6 +248,11 @@ func validateCustomStrategy(strategy *buildapi.CustomBuildStrategy) fielderrors.
 	allErrs := fielderrors.ValidationErrorList{}
 	if strategy.From == nil || len(strategy.From.Name) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("from"))
+	}
+	if strategy.From != nil && strategy.From.Kind == "ImageStreamTag" {
+		if _, _, ok := imageapi.SplitImageStreamTag(strategy.From.Name); !ok {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("from.name", strategy.From.Name, "ImageStreamTag object references must be in the form <name>:<tag>"))
+		}
 	}
 	allErrs = append(allErrs, validateSecretRef(strategy.PullSecret).Prefix("pullSecret")...)
 	return allErrs

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -475,6 +475,27 @@ func TestValidateBuildParameters(t *testing.T) {
 				},
 			},
 		},
+		// invalid because from name is a bad format
+		{
+			string(fielderrors.ValidationErrorTypeInvalid) + "strategy.stiStrategy.from.name",
+			&buildapi.BuildParameters{
+				Source: buildapi.BuildSource{
+					Type: buildapi.BuildSourceGit,
+					Git: &buildapi.GitBuildSource{
+						URI: "http://github.com/my/repository",
+					},
+				},
+				Strategy: buildapi.BuildStrategy{
+					Type: buildapi.SourceBuildStrategyType,
+					SourceStrategy: &buildapi.SourceBuildStrategy{
+						From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "bad format"},
+					},
+				},
+				Output: buildapi.BuildOutput{
+					DockerImageReference: "repository/data",
+				},
+			},
+		},
 		// invalid because from is not specified in the
 		// custom strategy definition
 		{
@@ -489,6 +510,28 @@ func TestValidateBuildParameters(t *testing.T) {
 				Strategy: buildapi.BuildStrategy{
 					Type:           buildapi.CustomBuildStrategyType,
 					CustomStrategy: &buildapi.CustomBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					DockerImageReference: "repository/data",
+				},
+			},
+		},
+		// invalid because from is not specified in the
+		// custom strategy definition
+		{
+			string(fielderrors.ValidationErrorTypeInvalid) + "strategy.customStrategy.from.name",
+			&buildapi.BuildParameters{
+				Source: buildapi.BuildSource{
+					Type: buildapi.BuildSourceGit,
+					Git: &buildapi.GitBuildSource{
+						URI: "http://github.com/my/repository",
+					},
+				},
+				Strategy: buildapi.BuildStrategy{
+					Type: buildapi.CustomBuildStrategyType,
+					CustomStrategy: &buildapi.CustomBuildStrategy{
+						From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "bad format"},
+					},
 				},
 				Output: buildapi.BuildOutput{
 					DockerImageReference: "repository/data",


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3216

This makes conversions a pass through and validation checks to make sure the fields are well formed.  It also creates a defaulter for handling missing docker strategies.

@bparees 