### PR TITLE
Use predictable test-cmd.sh tempdir

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -68,7 +68,7 @@ KUBELET_SCHEME=${KUBELET_SCHEME:-https}
 KUBELET_HOST=${KUBELET_HOST:-127.0.0.1}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 
-TEMP_DIR=${USE_TEMP:-$(mktemp -d /tmp/openshift-cmd.XXXX)}
+TEMP_DIR=${USE_TEMP:-$(mkdir -p /tmp/openshift-cmd && mktemp -d /tmp/openshift-cmd/XXXX)}
 ETCD_DATA_DIR="${TEMP_DIR}/etcd"
 VOLUME_DIR="${TEMP_DIR}/volumes"
 FAKE_HOME_DIR="${TEMP_DIR}/openshift.local.home"


### PR DESCRIPTION
Use a more predictable temp dir name for the test-cmd.sh script to
facilitate CI artifact downloads.