### PR TITLE
elminate internal json tags forever

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -17,37 +17,37 @@ const (
 // Build encapsulates the inputs needed to produce a new deployable image, as well as
 // the status of the execution and a reference to the Pod which executed the build.
 type Build struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// Parameters are all the inputs used to create the build pod.
-	Parameters BuildParameters `json:"parameters,omitempty"`
+	Parameters BuildParameters
 
 	// Status is the current status of the build.
-	Status BuildStatus `json:"status,omitempty"`
+	Status BuildStatus
 
 	// Message is a human readable message indicating details about why the build has this status
-	Message string `json:"message,omitempty"`
+	Message string
 
 	// Cancelled describes if a cancelling event was triggered for the build.
-	Cancelled bool `json:"cancelled,omitempty"`
+	Cancelled bool
 
 	// StartTimestamp is a timestamp representing the server time when this Build started
 	// running in a Pod.
 	// It is represented in RFC3339 form and is in UTC.
-	StartTimestamp *util.Time `json:"startTimestamp,omitempty"`
+	StartTimestamp *util.Time
 
 	// CompletionTimestamp is a timestamp representing the server time when this Build was
 	// finished, whether that build failed or succeeded.  It reflects the time at which
 	// the Pod running the Build terminated.
 	// It is represented in RFC3339 form and is in UTC.
-	CompletionTimestamp *util.Time `json:"completionTimestamp,omitempty"`
+	CompletionTimestamp *util.Time
 
 	// Duration contains time.Duration object describing build time.
-	Duration time.Duration `json:"duration,omitempty"`
+	Duration time.Duration
 
 	// Config is an ObjectReference to the BuildConfig this Build is based on.
-	Config *kapi.ObjectReference `json:"config,omitempty"`
+	Config *kapi.ObjectReference
 }
 
 // BuildParameters encapsulates all the inputs necessary to represent a build.
@@ -55,23 +55,23 @@ type BuildParameters struct {
 	// ServiceAccount is the name of the ServiceAccount to use to run the pod
 	// created by this build.
 	// The pod will be allowed to use secrets referenced by the ServiceAccount
-	ServiceAccount string `json:"serviceAccount,omitempty"`
+	ServiceAccount string
 
 	// Source describes the SCM in use.
-	Source BuildSource `json:"source,omitempty"`
+	Source BuildSource
 
 	// Revision is the information from the source for a specific repo snapshot.
 	// This is optional.
-	Revision *SourceRevision `json:"revision,omitempty"`
+	Revision *SourceRevision
 
 	// Strategy defines how to perform a build.
-	Strategy BuildStrategy `json:"strategy"`
+	Strategy BuildStrategy
 
 	// Output describes the Docker image the Strategy should produce.
-	Output BuildOutput `json:"output,omitempty"`
+	Output BuildOutput
 
 	// Compute resource requirements to execute the build
-	Resources kapi.ResourceRequirements `json:"resources,omitempty"`
+	Resources kapi.ResourceRequirements
 }
 
 // BuildStatus represents the status of a build at a point in time.
@@ -114,15 +114,15 @@ const (
 // BuildSource is the SCM used for the build
 type BuildSource struct {
 	// Type of source control management system
-	Type BuildSourceType `json:"type,omitempty"`
+	Type BuildSourceType
 
 	// Git contains optional information about git build source
-	Git *GitBuildSource `json:"git,omitempty"`
+	Git *GitBuildSource
 
 	// ContextDir specifies the sub-directory where the source code for the application exists.
 	// This allows to have buildable sources in directory other than root of
 	// repository.
-	ContextDir string `json:"contextDir,omitempty"`
+	ContextDir string
 
 	// SourceSecret is the name of a Secret that would be used for setting
 	// up the authentication for cloning private repository.
@@ -135,59 +135,59 @@ type BuildSource struct {
 // SourceRevision is the revision or commit information from the source for the build
 type SourceRevision struct {
 	// Type of the build source
-	Type BuildSourceType `json:"type,omitempty"`
+	Type BuildSourceType
 
 	// Git contains information about git-based build source
-	Git *GitSourceRevision `json:"git,omitempty"`
+	Git *GitSourceRevision
 }
 
 // GitSourceRevision is the commit information from a git source for a build
 type GitSourceRevision struct {
 	// Commit is the commit hash identifying a specific commit
-	Commit string `json:"commit,omitempty"`
+	Commit string
 
 	// Author is the author of a specific commit
-	Author SourceControlUser `json:"author,omitempty"`
+	Author SourceControlUser
 
 	// Committer is the committer of a specific commit
-	Committer SourceControlUser `json:"committer,omitempty"`
+	Committer SourceControlUser
 
 	// Message is the description of a specific commit
-	Message string `json:"message,omitempty"`
+	Message string
 }
 
 // GitBuildSource defines the parameters of a Git SCM
 type GitBuildSource struct {
 	// URI points to the source that will be built. The structure of the source
 	// will depend on the type of build to run
-	URI string `json:"uri,omitempty"`
+	URI string
 
 	// Ref is the branch/tag/ref to build.
-	Ref string `json:"ref,omitempty"`
+	Ref string
 }
 
 // SourceControlUser defines the identity of a user of source control
 type SourceControlUser struct {
 	// Name of the source control user
-	Name string `json:"name,omitempty"`
+	Name string
 
 	// Email of the source control user
-	Email string `json:"email,omitempty"`
+	Email string
 }
 
 // BuildStrategy contains the details of how to perform a build.
 type BuildStrategy struct {
 	// Type is the kind of build strategy.
-	Type BuildStrategyType `json:"type"`
+	Type BuildStrategyType
 
 	// DockerStrategy holds the parameters to the Docker build strategy.
-	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty"`
+	DockerStrategy *DockerBuildStrategy
 
 	// SourceStrategy holds the parameters to the STI build strategy.
-	SourceStrategy *SourceBuildStrategy `json:"stiStrategy,omitempty"`
+	SourceStrategy *SourceBuildStrategy
 
 	// CustomStrategy holds the parameters to the Custom build strategy.
-	CustomStrategy *CustomBuildStrategy `json:"customStrategy,omitempty"`
+	CustomStrategy *CustomBuildStrategy
 }
 
 // BuildStrategyType describes a particular way of performing a build.
@@ -215,59 +215,59 @@ const (
 // CustomBuildStrategy defines input parameters specific to Custom build.
 type CustomBuildStrategy struct {
 	// Env contains additional environment variables you want to pass into a builder container
-	Env []kapi.EnvVar `json:"env,omitempty"`
+	Env []kapi.EnvVar
 
 	// ExposeDockerSocket will allow running Docker commands (and build Docker images) from
 	// inside the Docker container.
 	// TODO: Allow admins to enforce 'false' for this option
-	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty"`
+	ExposeDockerSocket bool
 
 	// From is reference to an ImageStream, ImageStreamTag, or ImageStreamImage from which
 	// the docker image should be pulled
-	From *kapi.ObjectReference `json:"from,omitempty"`
+	From *kapi.ObjectReference
 
 	// PullSecret is the name of a Secret that would be used for setting up
 	// the authentication for pulling the Docker images from the private Docker
 	// registries
-	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" description:"supported type: dockercfg"`
+	PullSecret *kapi.LocalObjectReference
 }
 
 // DockerBuildStrategy defines input parameters specific to Docker build.
 type DockerBuildStrategy struct {
 	// NoCache if set to true indicates that the docker build must be executed with the
 	// --no-cache=true flag
-	NoCache bool `json:"noCache,omitempty"`
+	NoCache bool
 
 	// From is reference to an ImageStream, ImageStreamTag, or ImageStreamImage from which
 	// the docker image should be pulled
 	// the resulting image will be used in the FROM line of the Dockerfile for this build.
-	From *kapi.ObjectReference `json:"from,omitempty"`
+	From *kapi.ObjectReference
 
 	// PullSecret is the name of a Secret that would be used for setting up
 	// the authentication for pulling the Docker images from the private Docker
 	// registries
-	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" description:"supported type: dockercfg"`
+	PullSecret *kapi.LocalObjectReference
 }
 
 // SourceBuildStrategy defines input parameters specific to an STI build.
 type SourceBuildStrategy struct {
 	// From is reference to an ImageStream, ImageStreamTag, or ImageStreamImage from which
 	// the docker image should be pulled
-	From *kapi.ObjectReference `json:"from,omitempty"`
+	From *kapi.ObjectReference
 
 	// PullSecret is the name of a Secret that would be used for setting up
 	// the authentication for pulling the Docker images from the private Docker
 	// registries
-	PullSecret *kapi.LocalObjectReference `json:"pullSecret,omitempty" description:"supported type: dockercfg"`
+	PullSecret *kapi.LocalObjectReference
 
 	// Env contains additional environment variables you want to pass into a builder container
-	Env []kapi.EnvVar `json:"env,omitempty"`
+	Env []kapi.EnvVar
 
 	// Scripts is the location of STI scripts
-	Scripts string `json:"scripts,omitempty"`
+	Scripts string
 
 	// Incremental flag forces the STI build to do incremental builds if true.
-	Incremental bool `json:"incremental,omitempty"`
+	Incremental bool
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy
@@ -278,22 +278,22 @@ type BuildOutput struct {
 	// of the build. Kind must be set to 'ImageStream' and is the only supported value. If set,
 	// this field takes priority over DockerImageReference. This value will be used to look up
 	// a Docker image repository to push to. Failure to find the To will result in a build error.
-	To *kapi.ObjectReference `json:"to,omitempty"`
+	To *kapi.ObjectReference
 
 	// PushSecret is the name of a Secret that would be used for setting
 	// up the authentication for executing the Docker push to authentication
 	// enabled Docker Registry (or Docker Hub).
-	PushSecret *kapi.LocalObjectReference `json:"pushSecret,omitempty"`
+	PushSecret *kapi.LocalObjectReference
 
 	// Tag is the "version name" that will be associated with the output image. This
 	// field is only used if the To field is set, and is ignored when DockerImageReference is used.
 	// This value represents a consistent name for a set of related changes (v1, 5.x, 5.5, dev, stable)
 	// and defaults to the preferred tag for "To" if not specified.
-	Tag string `json:"tag,omitempty"`
+	Tag string
 
 	// DockerImageReference is the full name of an image ([registry/]name[:tag]), and will be the
 	// value sent to Docker push at the end of a build if the To field is not defined.
-	DockerImageReference string `json:"dockerImageReference,omitempty"`
+	DockerImageReference string
 }
 
 // BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig
@@ -302,47 +302,47 @@ const BuildConfigLabel = "buildconfig"
 
 // BuildConfig is a template which can be used to create new builds.
 type BuildConfig struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// Triggers determine how new Builds can be launched from a BuildConfig. If no triggers
 	// are defined, a new build can only occur as a result of an explicit client build creation.
-	Triggers []BuildTriggerPolicy `json:"triggers,omitempty"`
+	Triggers []BuildTriggerPolicy
 
 	// LastVersion is used to inform about number of last triggered build.
-	LastVersion int `json:"lastVersion,omitempty"`
+	LastVersion int
 
 	// Parameters holds all the input necessary to produce a new build. A build config may only
 	// define either the Output.To or Output.DockerImageReference fields, but not both.
-	Parameters BuildParameters `json:"parameters,omitempty"`
+	Parameters BuildParameters
 }
 
 // WebHookTrigger is a trigger that gets invoked using a webhook type of post
 type WebHookTrigger struct {
 	// Secret used to validate requests.
-	Secret string `json:"secret,omitempty"`
+	Secret string
 }
 
 // ImageChangeTrigger allows builds to be triggered when an ImageStream changes
 type ImageChangeTrigger struct {
 	// LastTriggeredImageID is used internally by the ImageChangeController to save last
 	// used image ID for build
-	LastTriggeredImageID string `json:"lastTriggeredImageID,omitempty"`
+	LastTriggeredImageID string
 }
 
 // BuildTriggerPolicy describes a policy for a single trigger that results in a new Build.
 type BuildTriggerPolicy struct {
 	// Type is the type of build trigger
-	Type BuildTriggerType `json:"type,omitempty"`
+	Type BuildTriggerType
 
 	// GitHubWebHook contains the parameters for a GitHub webhook type of trigger
-	GitHubWebHook *WebHookTrigger `json:"github,omitempty"`
+	GitHubWebHook *WebHookTrigger
 
 	// GenericWebHook contains the parameters for a Generic webhook type of trigger
-	GenericWebHook *WebHookTrigger `json:"generic,omitempty"`
+	GenericWebHook *WebHookTrigger
 
 	// ImageChange contains parameters for an ImageChange type of trigger
-	ImageChange *ImageChangeTrigger `json:"imageChange,omitempty"`
+	ImageChange *ImageChangeTrigger
 }
 
 // BuildTriggerType refers to a specific BuildTriggerPolicy implementation.
@@ -364,61 +364,61 @@ const (
 
 // BuildList is a collection of Builds.
 type BuildList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ListMeta
 
 	// Items is a list of builds
-	Items []Build `json:"items"`
+	Items []Build
 }
 
 // BuildConfigList is a collection of BuildConfigs.
 type BuildConfigList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ListMeta
 
 	// Items is a list of build configs
-	Items []BuildConfig `json:"items"`
+	Items []BuildConfig
 }
 
 // GenericWebHookEvent is the payload expected for a generic webhook post
 type GenericWebHookEvent struct {
 	// Type is the type of source repository
-	Type BuildSourceType `json:"type,omitempty"`
+	Type BuildSourceType
 
 	// Git is the git information if the Type is BuildSourceGit
-	Git *GitInfo `json:"git,omitempty"`
+	Git *GitInfo
 }
 
 // GitInfo is the aggregated git information for a generic webhook post
 type GitInfo struct {
-	GitBuildSource    `json:",inline"`
-	GitSourceRevision `json:",inline"`
+	GitBuildSource
+	GitSourceRevision
 
 	// Refs is a list of GitRefs for the provided repo - generally sent
 	// when used from a post-receive hook. This field is optional and is
 	// used when sending multiple refs
-	Refs []GitRefInfo `json:"refs,omitempty"`
+	Refs []GitRefInfo
 }
 
 // GitRefInfo is a single ref
 type GitRefInfo struct {
-	GitBuildSource    `json:",inline"`
-	GitSourceRevision `json:",inline"`
+	GitBuildSource
+	GitSourceRevision
 }
 
 // BuildLog is the (unused) resource associated with the build log redirector
 type BuildLog struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ListMeta
 }
 
 // BuildRequest is the resource used to pass parameters to build generator
 type BuildRequest struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// Revision is the information from the source for a specific repo snapshot.
-	Revision *SourceRevision `json:"revision,omitempty"`
+	Revision *SourceRevision
 
 	// TriggeredByImage is the Image that triggered this build.
 	TriggeredByImage *kapi.ObjectReference

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -25,15 +25,15 @@ const (
 // DeploymentStrategy describes how to perform a deployment.
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
-	Type DeploymentStrategyType `json:"type,omitempty"`
+	Type DeploymentStrategyType
 	// CustomParams are the input to the Custom deployment strategy.
-	CustomParams *CustomDeploymentStrategyParams `json:"customParams,omitempty"`
+	CustomParams *CustomDeploymentStrategyParams
 	// RecreateParams are the input to the Recreate deployment strategy.
-	RecreateParams *RecreateDeploymentStrategyParams `json:"recreateParams,omitempty"`
+	RecreateParams *RecreateDeploymentStrategyParams
 	// RollingParams are the input to the Rolling deployment strategy.
-	RollingParams *RollingDeploymentStrategyParams `json:"rollingParams,omitempty"`
+	RollingParams *RollingDeploymentStrategyParams
 	// Resources contains resource requirements to execute the deployment
-	Resources kapi.ResourceRequirements `json:"resources,omitempty"`
+	Resources kapi.ResourceRequirements
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.
@@ -51,11 +51,11 @@ const (
 // CustomDeploymentStrategyParams are the input to the Custom deployment strategy.
 type CustomDeploymentStrategyParams struct {
 	// Image specifies a Docker image which can carry out a deployment.
-	Image string `json:"image,omitempty"`
+	Image string
 	// Environment holds the environment which will be given to the container for Image.
-	Environment []kapi.EnvVar `json:"environment,omitempty"`
+	Environment []kapi.EnvVar
 	// Command is optional and overrides CMD in the container Image.
-	Command []string `json:"command,omitempty"`
+	Command []string
 }
 
 // RecreateDeploymentStrategyParams are the input to the Recreate deployment
@@ -63,19 +63,19 @@ type CustomDeploymentStrategyParams struct {
 type RecreateDeploymentStrategyParams struct {
 	// Pre is a lifecycle hook which is executed before the strategy manipulates
 	// the deployment. All LifecycleHookFailurePolicy values are supported.
-	Pre *LifecycleHook `json:"pre,omitempty"`
+	Pre *LifecycleHook
 	// Post is a lifecycle hook which is executed after the strategy has
 	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
 	// is NOT supported.
-	Post *LifecycleHook `json:"post,omitempty"`
+	Post *LifecycleHook
 }
 
 // LifecycleHook defines a specific deployment lifecycle action.
 type LifecycleHook struct {
 	// FailurePolicy specifies what action to take if the hook fails.
-	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy"`
+	FailurePolicy LifecycleHookFailurePolicy
 	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
-	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty"`
+	ExecNewPod *ExecNewPodHook
 }
 
 // LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
@@ -95,12 +95,12 @@ const (
 // deployment template.
 type ExecNewPodHook struct {
 	// Command is the action command and its arguments.
-	Command []string `json:"command"`
+	Command []string
 	// Env is a set of environment variables to supply to the hook pod's container.
-	Env []kapi.EnvVar `json:"env,omitempty"`
+	Env []kapi.EnvVar
 	// ContainerName is the name of a container in the deployment pod template
 	// whose Docker image will be used for the hook pod's container.
-	ContainerName string `json:"containerName"`
+	ContainerName string
 }
 
 // RollingDeploymentStrategyParams are the input to the Rolling deployment
@@ -108,20 +108,20 @@ type ExecNewPodHook struct {
 type RollingDeploymentStrategyParams struct {
 	// UpdatePeriodSeconds is the time to wait between individual pod updates.
 	// If the value is nil, a default will be used.
-	UpdatePeriodSeconds *int64 `json:"updatePeriodSeconds,omitempty" description:"the time to wait between individual pod updates"`
+	UpdatePeriodSeconds *int64
 	// IntervalSeconds is the time to wait between polling deployment status
 	// after update. If the value is nil, a default will be used.
-	IntervalSeconds *int64 `json:"intervalSeconds,omitempty" description:"the time to wait between polling deployment status after update"`
+	IntervalSeconds *int64
 	// TimeoutSeconds is the time to wait for updates before giving up. If the
 	// value is nil, a default will be used.
-	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty" description:"the time to wait for updates before giving up"`
+	TimeoutSeconds *int64
 	// Pre is a lifecycle hook which is executed before the deployment process
 	// begins. All LifecycleHookFailurePolicy values are supported.
-	Pre *LifecycleHook `json:"pre,omitempty" description:"a hook executed before the strategy starts the deployment"`
+	Pre *LifecycleHook
 	// Post is a lifecycle hook which is executed after the strategy has
 	// finished all deployment logic. The LifecycleHookFailurePolicyAbort policy
 	// is NOT supported.
-	Post *LifecycleHook `json:"post,omitempty" description:"a hook executed after the strategy finishes the deployment"`
+	Post *LifecycleHook
 }
 
 // These constants represent keys used for correlating objects related to deployments.
@@ -195,37 +195,37 @@ const DeploymentCancelledAnnotationValue = "true"
 // state of the DeploymentConfig. Each change to the DeploymentConfig which should result in
 // a new deployment results in an increment of LatestVersion.
 type DeploymentConfig struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
 	// are defined, a new deployment can only occur as a result of an explicit client update to the
 	// DeploymentConfig with a new LatestVersion.
-	Triggers []DeploymentTriggerPolicy `json:"triggers,omitempty"`
+	Triggers []DeploymentTriggerPolicy
 	// Template represents a desired deployment state and how to deploy it.
-	Template DeploymentTemplate `json:"template,omitempty"`
+	Template DeploymentTemplate
 	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
 	// is out of sync.
-	LatestVersion int `json:"latestVersion,omitempty"`
+	LatestVersion int
 	// Details are the reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
-	Details *DeploymentDetails `json:"details,omitempty"`
+	Details *DeploymentDetails
 }
 
 // DeploymentTemplate contains all the necessary information to create a deployment from a
 // DeploymentStrategy.
 type DeploymentTemplate struct {
 	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy `json:"strategy,omitempty"`
+	Strategy DeploymentStrategy
 	// ControllerTemplate is the desired replication state the deployment works to materialize.
-	ControllerTemplate kapi.ReplicationControllerSpec `json:"controllerTemplate,omitempty"`
+	ControllerTemplate kapi.ReplicationControllerSpec
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
 type DeploymentTriggerPolicy struct {
 	// Type of the trigger
-	Type DeploymentTriggerType `json:"type,omitempty"`
+	Type DeploymentTriggerType
 	// ImageChangeParams represents the parameters for the ImageChange trigger.
-	ImageChangeParams *DeploymentTriggerImageChangeParams `json:"imageChangeParams,omitempty"`
+	ImageChangeParams *DeploymentTriggerImageChangeParams
 }
 
 // DeploymentTriggerType refers to a specific DeploymentTriggerPolicy implementation.
@@ -245,74 +245,74 @@ const (
 // DeploymentTriggerImageChangeParams represents the parameters to the ImageChange trigger.
 type DeploymentTriggerImageChangeParams struct {
 	// Automatic means that the detection of a new tag value should result in a new deployment.
-	Automatic bool `json:"automatic,omitempty"`
+	Automatic bool
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
-	ContainerNames []string `json:"containerNames,omitempty"`
+	ContainerNames []string
 	// RepositoryName is the identifier for a Docker image repository to watch for changes.
 	// DEPRECATED: will be removed in v1beta3.
-	RepositoryName string `json:"repositoryName,omitempty"`
+	RepositoryName string
 	// From is a reference to a Docker image repository to watch for changes. This field takes
 	// precedence over RepositoryName, which is deprecated and will be removed in v1beta3. The
 	// Kind may be left blank, in which case it defaults to "ImageRepository". The "Name" is
 	// the only required subfield - if Namespace is blank, the namespace of the current deployment
 	// trigger will be used.
-	From kapi.ObjectReference `json:"from"`
+	From kapi.ObjectReference
 	// Tag is the name of an image repository tag to watch for changes.
-	Tag string `json:"tag,omitempty"`
+	Tag string
 	// LastTriggeredImage is the last image to be triggered.
-	LastTriggeredImage string `json:"lastTriggeredImage"`
+	LastTriggeredImage string
 }
 
 // DeploymentDetails captures information about the causes of a deployment.
 type DeploymentDetails struct {
 	// Message is the user specified change message, if this deployment was triggered manually by the user
-	Message string `json:"message,omitempty"`
+	Message string
 	// Causes are extended data associated with all the causes for creating a new deployment
-	Causes []*DeploymentCause `json:"causes,omitempty"`
+	Causes []*DeploymentCause
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.
 type DeploymentCause struct {
 	// Type is the type of the trigger that resulted in the creation of a new deployment
-	Type DeploymentTriggerType `json:"type"`
+	Type DeploymentTriggerType
 	// ImageTrigger contains the image trigger details, if this trigger was fired based on an image change
-	ImageTrigger *DeploymentCauseImageTrigger `json:"imageTrigger,omitempty"`
+	ImageTrigger *DeploymentCauseImageTrigger
 }
 
 // DeploymentCauseImageTrigger contains information about a deployment caused by an image trigger
 type DeploymentCauseImageTrigger struct {
 	// RepositoryName is the identifier for a Docker image repository that was updated.
-	RepositoryName string `json:"repositoryName,omitempty"`
+	RepositoryName string
 	// Tag is the name of an image repository tag that is now pointing to a new image.
-	Tag string `json:"tag,omitempty"`
+	Tag string
 }
 
 // DeploymentConfigList is a collection of deployment configs.
 type DeploymentConfigList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ListMeta
 
 	// Items is a list of deployment configs
-	Items []DeploymentConfig `json:"items"`
+	Items []DeploymentConfig
 }
 
 // DeploymentConfigRollback provides the input to rollback generation.
 type DeploymentConfigRollback struct {
-	kapi.TypeMeta `json:",inline"`
+	kapi.TypeMeta
 	// Spec defines the options to rollback generation.
-	Spec DeploymentConfigRollbackSpec `json:"spec"`
+	Spec DeploymentConfigRollbackSpec
 }
 
 // DeploymentConfigRollbackSpec represents the options for rollback generation.
 type DeploymentConfigRollbackSpec struct {
 	// From points to a ReplicationController which is a deployment.
-	From kapi.ObjectReference `json:"from"`
+	From kapi.ObjectReference
 	// IncludeTriggers specifies whether to include config Triggers.
-	IncludeTriggers bool `json:"includeTriggers"`
+	IncludeTriggers bool
 	// IncludeTemplate specifies whether to include the PodTemplateSpec.
-	IncludeTemplate bool `json:"includeTemplate"`
+	IncludeTemplate bool
 	// IncludeReplicationMeta specifies whether to include the replica count and selector.
-	IncludeReplicationMeta bool `json:"includeReplicationMeta"`
+	IncludeReplicationMeta bool
 	// IncludeStrategy specifies whether to include the deployment Strategy.
-	IncludeStrategy bool `json:"includeStrategy"`
+	IncludeStrategy bool
 }

--- a/pkg/oauth/api/types.go
+++ b/pkg/oauth/api/types.go
@@ -5,113 +5,113 @@ import (
 )
 
 type OAuthAccessToken struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// ClientName references the client that created this token.
-	ClientName string `json:"clientName,omitempty"`
+	ClientName string
 
 	// ExpiresIn is the seconds from CreationTime before this token expires.
-	ExpiresIn int64 `json:"expiresIn,omitempty"`
+	ExpiresIn int64
 
 	// Scopes is an array of the requested scopes.
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes []string
 
 	// RedirectURI is the redirection associated with the token.
-	RedirectURI string `json:"redirectURI,omitempty"`
+	RedirectURI string
 
 	// UserName is the user name associated with this token
-	UserName string `json:"userName,omitempty"`
+	UserName string
 
 	// UserUID is the unique UID associated with this token
-	UserUID string `json:"userUID,omitempty"`
+	UserUID string
 
 	// AuthorizeToken contains the token that authorized this token
-	AuthorizeToken string `json:"authorizeToken,omitempty"`
+	AuthorizeToken string
 
 	// RefreshToken is the value by which this token can be renewed. Can be blank.
-	RefreshToken string `json:"refreshToken,omitempty"`
+	RefreshToken string
 }
 
 type OAuthAuthorizeToken struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// ClientName references the client that created this token.
-	ClientName string `json:"clientName,omitempty"`
+	ClientName string
 
 	// ExpiresIn is the seconds from CreationTime before this token expires.
-	ExpiresIn int64 `json:"expiresIn,omitempty"`
+	ExpiresIn int64
 
 	// Scopes is an array of the requested scopes.
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes []string
 
 	// RedirectURI is the redirection associated with the token.
-	RedirectURI string `json:"redirectURI,omitempty"`
+	RedirectURI string
 
 	// State data from request
-	State string `json:"state,omitempty"`
+	State string
 
 	// UserName is the user name associated with this token
-	UserName string `json:"userName,omitempty"`
+	UserName string
 
 	// UserUID is the unique UID associated with this token. UserUID and UserName must both match
 	// for this token to be valid.
-	UserUID string `json:"userUID,omitempty"`
+	UserUID string
 }
 
 type OAuthClient struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// Secret is the unique secret associated with a client
-	Secret string `json:"secret,omitempty"`
+	Secret string
 
 	// RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects
-	RespondWithChallenges bool `json:"respondWithChallenges,omitempty"`
+	RespondWithChallenges bool
 
 	// RedirectURIs is the valid redirection URIs associated with a client
-	RedirectURIs []string `json:"redirectURIs,omitempty"`
+	RedirectURIs []string
 }
 
 type OAuthClientAuthorization struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// ClientName references the client that created this authorization
-	ClientName string `json:"clientName,omitempty"`
+	ClientName string
 
 	// UserName is the user name that authorized this client
-	UserName string `json:"userName,omitempty"`
+	UserName string
 
 	// UserUID is the unique UID associated with this authorization. UserUID and UserName
 	// must both match for this authorization to be valid.
-	UserUID string `json:"userUID,omitempty"`
+	UserUID string
 
 	// Scopes is an array of the granted scopes.
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes []string
 }
 
 type OAuthAccessTokenList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
-	Items         []OAuthAccessToken `json:"items"`
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []OAuthAccessToken
 }
 
 type OAuthAuthorizeTokenList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
-	Items         []OAuthAuthorizeToken `json:"items,"`
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []OAuthAuthorizeToken
 }
 
 type OAuthClientList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
-	Items         []OAuthClient `json:"items"`
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []OAuthClient
 }
 
 type OAuthClientAuthorizationList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
-	Items         []OAuthClientAuthorization `json:"items"`
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []OAuthClientAuthorization
 }

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -6,30 +6,30 @@ import (
 
 // Route encapsulates the inputs needed to connect an alias to endpoints.
 type Route struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// Host is an alias/DNS that points to the service. Required
 	// Can be host or host:port
 	// host and port are combined to follow the net/url URL struct
-	Host string `json:"host"`
+	Host string
 	// Path that the router watches for, to route traffic for to the service. Optional
-	Path string `json:"path,omitempty"`
+	Path string
 
 	// ServiceName is the name of the service that this route points to
-	ServiceName string `json:"serviceName"`
+	ServiceName string
 
 	//TLS provides the ability to configure certificates and termination for the route
-	TLS *TLSConfig `json:"tls,omitempty"`
+	TLS *TLSConfig
 }
 
 // RouteList is a collection of Routes.
 type RouteList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ListMeta
 
 	// Items is a list of routes
-	Items []Route `json:"items"`
+	Items []Route
 }
 
 // RouterShard has information of a routing shard and is used to

--- a/pkg/sdn/api/types.go
+++ b/pkg/sdn/api/types.go
@@ -5,33 +5,33 @@ import (
 )
 
 type ClusterNetwork struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
-	Network          string `json:"network" description:"CIDR string to specify the global overlay network's L3 space"`
-	HostSubnetLength int    `json:"hostsubnetlength" description:"number of bits to allocate to each host's subnet e.g. 8 would mean a /24 network on the host"`
+	Network          string
+	HostSubnetLength int
 }
 
 type ClusterNetworkList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
-	Items         []ClusterNetwork `json:"items"`
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []ClusterNetwork
 }
 
 // HostSubnet encapsulates the inputs needed to define the container subnet network on a minion
 type HostSubnet struct {
-	kapi.TypeMeta   `json:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty"`
+	kapi.TypeMeta
+	kapi.ObjectMeta
 
 	// host may just be an IP address, resolvable hostname or a complete DNS
-	Host   string `json:"host" description:"Name of the host that is registered at the master. A lease will be sought after this name."`
-	HostIP string `json:"hostIP" description:"IP address to be used as vtep by other hosts in the overlay network"`
-	Subnet string `json:"subnet" description:"Actual subnet CIDR lease assigned to the host"`
+	Host   string
+	HostIP string
+	Subnet string
 }
 
 // HostSubnetList is a collection of HostSubnets
 type HostSubnetList struct {
-	kapi.TypeMeta `json:",inline"`
-	kapi.ListMeta `json:"metadata,omitempty"`
-	Items         []HostSubnet `json:"items"`
+	kapi.TypeMeta
+	kapi.ListMeta
+	Items []HostSubnet
 }


### PR DESCRIPTION
Removes json tags on internal `runtime.Objects` and adds a unit test to be sure that they stay that way.

@liggitt 