### PR TITLE
Fix registry auth for pruning

### DIFF
--- a/images/dockerregistry/Dockerfile
+++ b/images/dockerregistry/Dockerfile
@@ -6,14 +6,14 @@
 #
 FROM openshift/origin-base
 
-ADD config.yml /config.yml
-ADD bin/dockerregistry /dockerregistry
-
-ENV REGISTRY_CONFIGURATION_PATH=/config.yml
-
 RUN yum install -y tree findutils epel-release && \
     yum clean all
+
+ENV REGISTRY_CONFIGURATION_PATH=/config.yml
 
 EXPOSE 5000
 VOLUME /registry
 CMD REGISTRY_URL=${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT} /dockerregistry /config.yml
+
+ADD config.yml /config.yml
+ADD bin/dockerregistry /dockerregistry

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -234,6 +234,32 @@ func TestAccessController(t *testing.T) {
 			expectedChallenge: false,
 			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/subjectaccessreviews"},
 		},
+		"pruning": {
+			access: []auth.Access{
+				{
+					Resource: auth.Resource{
+						Type: "admin",
+					},
+					Action: "prune",
+				},
+				{
+					Resource: auth.Resource{
+						Type: "repository",
+						Name: "foo/bar",
+					},
+					Action: "*",
+				},
+			},
+			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
+			openshiftResponses: []response{
+				{200, runtime.EncodeOrDie(latest.Codec, &api.SubjectAccessReviewResponse{Allowed: true, Reason: "authorized!"})},
+			},
+			expectedError:     nil,
+			expectedChallenge: false,
+			expectedActions: []string{
+				"POST /oapi/v1/subjectaccessreviews",
+			},
+		},
 	}
 
 	for k, test := range tests {


### PR DESCRIPTION
With #3166, we modified the registry authorization handler to reject
unknown resource types and/or actions. This unfortunately broke layer
and signature pruning, as those operations use both admin/prune and
repo/* (aka DELETE).

Fix authorization check to associate repo/* with admin/prune.

Also adds e2e test for image pruning.

Fixes bug 1235148.