### PR TITLE
Remove `width: 100%` from tile class

### DIFF
--- a/assets/app/styles/_tile.less
+++ b/assets/app/styles/_tile.less
@@ -8,7 +8,6 @@
   padding: 10px 20px;
   margin-bottom: 20px;
   word-wrap: break-word;
-  width: 100%;
   .box-sizing(border-box);
   // Prevent long, unbroken words from extending outside the tile.
   overflow-x: hidden;


### PR DESCRIPTION
The 100% width prevents items using the tile class inside a flexbox from
displaying in columns in Safari, even when `max-width` is set.

See https://bugzilla.redhat.com/show_bug.cgi?id=1233598