### PR TITLE
Fix deployment scaling race in test-cmd.sh

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -562,8 +562,7 @@ wait_for_command 'oc get rc/test-deployment-config-1' "${TIME_MIN}"
 # scale rc via deployment configuration
 oc scale dc test-deployment-config --replicas=1
 # scale directly
-oc scale rc test-deployment-config-1 --current-replicas=1 --replicas=5
-[ "$(oc get rc/test-deployment-config-1 | grep 5)" ]
+oc scale rc test-deployment-config-1 --replicas=5
 oc delete all --all
 echo "scale: ok"
 


### PR DESCRIPTION
Relax the expectations in test-cmd.sh for deployment scaling scenarios.
The current test attempts to scale a failed deployment and make assertions
which assume a more realistic OpenShift environment (like working deployments).

The existing test scenarios race by manipulating the replicas of a failed
deployment in a way that can sometimes fail due to the failed deployment
replica count being set back to 0 (possibly by the deployment controller) prior
to a later assertion that the count will be 1.

This test should just validate that the scale commands work against a certain
type of resource and shouldn't try to validate actual scaling scenarios.
Realistic scaling scenarios belong somewhere like the e2e tests.

Closes #3460.