### PR TITLE
UPSTREAM: tighten getController checks for UID

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/annotations.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/annotations.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+const (
+	CreatedByAnnotation = "kubernetes.io/created-by"
+)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/controller/controller_utils.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/controller/controller_utils.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	CreatedByAnnotation = "kubernetes.io/created-by"
-	updateRetries       = 1
+	updateRetries = 1
 )
 
 // Expectations are a way for replication controllers to tell the rc manager what they expect. eg:
@@ -231,7 +230,7 @@ func (r RealPodControl) createReplica(namespace string, controller *api.Replicat
 		return fmt.Errorf("unable to serialize controller reference: %v", err)
 	}
 
-	desiredAnnotations[CreatedByAnnotation] = string(createdByRefJson)
+	desiredAnnotations[api.CreatedByAnnotation] = string(createdByRefJson)
 
 	// use the dash (if the name isn't too long) to make the pod name a bit prettier
 	prefix := fmt.Sprintf("%s-", controller.Name)
@@ -298,6 +297,18 @@ func filterActivePods(pods []api.Pod) []*api.Pod {
 			result = append(result, &pods[i])
 		}
 	}
+	return result
+}
+
+// filterPodsOnMatching returns pods that match the RC
+func filterPodsOnMatching(pods []*api.Pod, rc *api.ReplicationController) []*api.Pod {
+	var result []*api.Pod
+	for i := range pods {
+		if cache.PodMatchesRC(pods[i], rc) {
+			result = append(result, pods[i])
+		}
+	}
+
 	return result
 }
 


### PR DESCRIPTION
This tightens the `getController` check so that it checks to be sure that returned controller matches the UID from the annotation in the pod.

@liggitt you asked.