### PR TITLE
Fix the example command to list the projects

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -713,7 +713,7 @@ An introduction to the concepts and types in OpenShift
 [options="nowrap"]
 ----
   // View all projects you have access to
-  $ openshift cli projects
+  $ openshift cli get projects
 
   // See a list of all services in the current project
   $ openshift cli get svc

--- a/pkg/cmd/cli/cmd/types.go
+++ b/pkg/cmd/cli/cmd/types.go
@@ -184,7 +184,7 @@ var (
   `)
 
 	typesExample = `  // View all projects you have access to
-  $ %[1]s projects
+  $ %[1]s get projects
 
   // See a list of all services in the current project
   $ %[1]s get svc


### PR DESCRIPTION
     # oc projects
     Error: unknown command "projects"
     Run 'oc help' for usage.

However, the proper command would be oc get projects.