### PR TITLE
make deployments respect new status keys

### DIFF
--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -306,13 +306,18 @@ func mappedAnnotationFor(obj runtime.Object, key string) string {
 	if err != nil {
 		return ""
 	}
+
+	// check to see if we have the actual key first.  This would indicate that we've transitioned to a newer kind of status
+	// TODO: allowing conflicting status is broken and wrong.  It's probably easiest to choose an annotation key per api version
+	// and convert to and from in conversion to avoid any conflicts.
+	if val, ok := meta.Annotations[key]; ok {
+		return val
+	}
+
 	for _, mappedKey := range annotationMap[key] {
 		if val, ok := meta.Annotations[mappedKey]; ok {
 			return val
 		}
-	}
-	if val, ok := meta.Annotations[key]; ok {
-		return val
 	}
 	return ""
 }


### PR DESCRIPTION
The deployment controller is broken because it's setting a new status annotation, but looking at an old one to determine status.  This results in the controller getting stuck with deployments in running state:
```
I0629 09:37:41.983165   24673 controller.go:122] Failing deployment "example/database-2" because its deployer pod "database-2-deploy" disappeared
I0629 09:37:41.994724   24673 controller.go:192] Updated deployment example/database-2 status from Running to Failed
I0629 09:37:41.995724   24673 replication_controller.go:351] Finished syncing controller "example/database-2" (172.139µs)
I0629 09:37:41.997417   24673 controller.go:122] Failing deployment "example/database-2" because its deployer pod "database-2-deploy" disappeared
I0629 09:37:42.005396   24673 controller.go:192] Updated deployment example/database-2 status from Running to Failed
I0629 09:37:42.005548   24673 replication_controller.go:351] Finished syncing controller "example/database-2" (169.6µs)
I0629 09:37:42.008878   24673 controller.go:122] Failing deployment "example/database-2" because its deployer pod "database-2-deploy" disappeared
I0629 09:37:42.016921   24673 replication_controller.go:351] Finished syncing controller "example/database-2" (176.462µs)
I0629 09:37:42.018667   24673 controller.go:192] Updated deployment example/database-2 status from Running to Failed
I0629 09:37:42.020571   24673 controller.go:122] Failing deployment "example/database-2" because its deployer pod "database-2-deploy" disappeared
I0629 09:37:42.031217   24673 replication_controller.go:351] Finished syncing controller "example/database-2" (171.829µs)
I0629 09:37:42.032111   24673 controller.go:192] Updated deployment example/database-2 status from Running to Failed
I0629 09:37:42.034617   24673 controller.go:122] Failing deployment "example/database-2" because its deployer pod "database-2-deploy" disappeared
I0629 09:37:42.046573   24673 replication_controller.go:351] Finished syncing controller "example/database-2" (164.056µs)
I0629 09:37:42.047847   24673 controller.go:192] Updated deployment example/database-2 status from Running to Failed
```

We should probably fix the deployment code to have an internal annotation and external serialization of that annotation for each version.  That would allow internal code to be agnostic of external serialization and still allow cross-talk between controllers running at different versions.

@ironcladlou 