### PR TITLE
SCC hostNetwork/hostPort support

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/deep_copy_generated.go
@@ -1835,6 +1835,8 @@ func deepCopy_api_SecurityContextConstraints(in SecurityContextConstraints, out 
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := deepCopy_api_SELinuxContextStrategyOptions(in.SELinuxContext, &out.SELinuxContext, c); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/types.go
@@ -2162,45 +2162,49 @@ type RangeAllocation struct {
 // SecurityContextConstraints governs the ability to make requests that affect the SecurityContext
 // that will be applied to a container.
 type SecurityContextConstraints struct {
-	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty"`
+	TypeMeta
+	ObjectMeta
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
-	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer,omitempty" description:"allow containers to run as privileged"`
+	AllowPrivilegedContainer bool
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
-	AllowedCapabilities []Capability `json:"allowedCapabilities,omitempty" description:"capabilities that are allowed to be added"`
+	AllowedCapabilities []Capability
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
-	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin,omitempty" description:"allow the use of the host dir volume plugin"`
+	AllowHostDirVolumePlugin bool
+	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+	AllowHostNetwork bool
+	// AllowHostPorts determines if the policy allows host ports in the containers.
+	AllowHostPorts bool
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
-	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
+	SELinuxContext SELinuxContextStrategyOptions
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
-	RunAsUser RunAsUserStrategyOptions `json:"runAsUser,omitempty" description:"strategy used to generate RunAsUser"`
+	RunAsUser RunAsUserStrategyOptions
 
 	// The users who have permissions to use this security context constraints
-	Users []string `json:"users,omitempty" description:"users allowed to use this SecurityContextConstraints"`
+	Users []string
 	// The groups that have permission to use this security context constraints
-	Groups []string `json:"groups,omitempty" description:"groups allowed to use this SecurityContextConstraints"`
+	Groups []string
 }
 
 // SELinuxContextStrategyOptions defines the strategy type and any options used to create the strategy.
 type SELinuxContextStrategyOptions struct {
 	// Type is the strategy that will dictate what SELinux context is used in the SecurityContext.
-	Type SELinuxContextStrategyType `json:"type,omitempty" description:"strategy used to generate the SELinux context"`
+	Type SELinuxContextStrategyType
 	// seLinuxOptions required to run as; required for MustRunAs
-	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty" description:"seLinuxOptions required to run as; required for MustRunAs"`
+	SELinuxOptions *SELinuxOptions
 }
 
 // RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.
 type RunAsUserStrategyOptions struct {
 	// Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.
-	Type RunAsUserStrategyType `json:"type,omitempty" description:"strategy used to generate RunAsUser"`
+	Type RunAsUserStrategyType
 	// UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using
 	// namespace/service account allocated uids.
-	UID *int64 `json:"uid,omitempty" description:"the uid to always run as; required for MustRunAs"`
+	UID *int64
 	// UIDRangeMin defines the min value for a strategy that allocates by range.
-	UIDRangeMin *int64 `json:"uidRangeMin,omitempty" description:"min value for range based allocators"`
+	UIDRangeMin *int64
 	// UIDRangeMax defines the max value for a strategy that allocates by range.
-	UIDRangeMax *int64 `json:"uidRangeMax,omitempty" description:"max value for range based allocators"`
+	UIDRangeMax *int64
 }
 
 // SELinuxContextStrategyType denotes strategy types for generating SELinux options for a

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2104,6 +2104,8 @@ func convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in 
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := convert_api_SELinuxContextStrategyOptions_To_v1_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}
@@ -4608,6 +4610,8 @@ func convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in 
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := convert_v1_SELinuxContextStrategyOptions_To_api_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1843,6 +1843,8 @@ func deepCopy_v1_SecurityContextConstraints(in SecurityContextConstraints, out *
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := deepCopy_v1_SELinuxContextStrategyOptions(in.SELinuxContext, &out.SELinuxContext, c); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/types.go
@@ -2025,11 +2025,15 @@ type SecurityContextConstraints struct {
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
-	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer,omitempty" description:"allow containers to run as privileged"`
+	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer" description:"allow containers to run as privileged"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
-	AllowedCapabilities []Capability `json:"allowedCapabilities,omitempty" description:"capabilities that are allowed to be added"`
+	AllowedCapabilities []Capability `json:"allowedCapabilities" description:"capabilities that are allowed to be added"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
-	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin,omitempty" description:"allow the use of the host dir volume plugin"`
+	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" description:"allow the use of the host dir volume plugin"`
+	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+	AllowHostNetwork bool `json:"allowHostNetwork" description:"allow the use of the hostNetwork in the pod spec"`
+	// AllowHostPorts determines if the policy allows host ports in the containers.
+	AllowHostPorts bool `json:"allowHostPorts" description:"allow the use of the host ports in the containers"`
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -1895,6 +1895,8 @@ func convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraint
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := convert_api_SELinuxContextStrategyOptions_To_v1beta3_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}
@@ -4125,6 +4127,8 @@ func convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraint
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := convert_v1beta3_SELinuxContextStrategyOptions_To_api_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
@@ -1847,6 +1847,8 @@ func deepCopy_v1beta3_SecurityContextConstraints(in SecurityContextConstraints, 
 		out.AllowedCapabilities = nil
 	}
 	out.AllowHostDirVolumePlugin = in.AllowHostDirVolumePlugin
+	out.AllowHostNetwork = in.AllowHostNetwork
+	out.AllowHostPorts = in.AllowHostPorts
 	if err := deepCopy_v1beta3_SELinuxContextStrategyOptions(in.SELinuxContext, &out.SELinuxContext, c); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta3/types.go
@@ -2023,11 +2023,15 @@ type SecurityContextConstraints struct {
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
-	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer,omitempty" description:"allow containers to run as privileged"`
+	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer" description:"allow containers to run as privileged"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
-	AllowedCapabilities []Capability `json:"allowedCapabilities,omitempty" description:"capabilities that are allowed to be added"`
+	AllowedCapabilities []Capability `json:"allowedCapabilities" description:"capabilities that are allowed to be added"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
-	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin,omitempty" description:"allow the use of the host dir volume plugin"`
+	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" description:"allow the use of the host dir volume plugin"`
+	// AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+	AllowHostNetwork bool `json:"allowHostNetwork" description:"allow the use of the hostNetwork in the pod spec"`
+	// AllowHostPorts determines if the policy allows host ports in the containers.
+	AllowHostPorts bool `json:"allowHostPorts" description:"allow the use of the host ports in the containers"`
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.

--- a/examples/hello-openshift/hello-pod.json
+++ b/examples/hello-openshift/hello-pod.json
@@ -15,7 +15,6 @@
         "image": "openshift/hello-openshift",
         "ports": [
           {
-            "hostPort": 6061,
             "containerPort": 8080,
             "protocol": "TCP"
           }

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -678,8 +678,10 @@ echo "new-project: ok"
 
 # Test running a router
 [ ! "$(oadm router --dry-run | grep 'does not exist')" ]
-[ "$(oadm router -o yaml --credentials="${KUBECONFIG}" | grep 'openshift/origin-haproxy-')" ]
-oadm router --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
+echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' | oc create -f -
+oc get scc privileged -o json | sed '/\"users\"/a \"system:serviceaccount:default:router\",' | oc replace scc privileged -f -
+[ "$(oadm router -o yaml --credentials="${KUBECONFIG}" --service-account=router | grep 'openshift/origin-haproxy-')" ]
+oadm router --credentials="${KUBECONFIG}" --images="${USE_IMAGES}" --service-account=router
 [ "$(oadm router | grep 'service exists')" ]
 echo "router: ok"
 

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -165,7 +165,9 @@ wait_for_url "https://localhost:8443/healthz/ready" "apiserver(ready): " 0.25 16
 
 # install the router
 echo "[INFO] Installing the router"
-sudo docker exec origin openshift admin router --create --credentials="./openshift.local.config/master/openshift-router.kubeconfig" --images="${USE_IMAGES}"
+sudo docker exec origin bash -c "echo '{\"kind\":\"ServiceAccount\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"router\"}}' | openshift cli create -f -"
+sudo docker exec origin bash -c "openshift cli get scc privileged -o json | sed '/\"users\"/a \"system:serviceaccount:default:router\",' | openshift cli replace scc privileged -f -"
+sudo docker exec origin openshift admin router --create --credentials="./openshift.local.config/master/openshift-router.kubeconfig" --images="${USE_IMAGES}" --service-account=router
 
 # install the registry. The --mount-host option is provided to reuse local storage.
 echo "[INFO] Installing the registry"

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -276,7 +276,9 @@ echo "Log in as 'e2e-user' to see the 'test' project."
 
 # install the router
 echo "[INFO] Installing the router"
-openshift admin router --create --credentials="${MASTER_CONFIG_DIR}/openshift-router.kubeconfig" --images="${USE_IMAGES}"
+echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' | oc create -f -
+oc get scc privileged -o json | sed '/\"users\"/a \"system:serviceaccount:default:router\",' | oc replace scc privileged -f -
+openshift admin router --create --credentials="${MASTER_CONFIG_DIR}/openshift-router.kubeconfig" --images="${USE_IMAGES}" --service-account=router
 
 # install the registry. The --mount-host option is provided to reuse local storage.
 echo "[INFO] Installing the registry"

--- a/images/ipfailover/keepalived/conf/hello-openshift-template.json
+++ b/images/ipfailover/keepalived/conf/hello-openshift-template.json
@@ -59,7 +59,6 @@
                 "image": "openshift/hello-openshift",
                 "ports": [
                   {
-                    "hostPort": 6061,
                     "containerPort": 8080,
                     "protocol": "TCP"
                   }

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -9,21 +9,26 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	kclientcmd "github.com/GoogleCloudPlatform/kubernetes/pkg/client/clientcmd"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount"
 	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
-	"github.com/golang/glog"
-	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	dapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/generate/app"
+	"github.com/openshift/origin/pkg/security/admission"
 )
 
 const (
@@ -225,6 +230,15 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			return fmt.Errorf("router %q does not exist (no service)", name)
 		}
 
+		if len(cfg.ServiceAccount) == 0 {
+			return fmt.Errorf("router could not be created; you must specify a service account with --service-account")
+		}
+
+		err := validateServiceAccount(kClient, namespace, cfg.ServiceAccount)
+		if err != nil {
+			return fmt.Errorf("router could not be created; %v", err)
+		}
+
 		// create new router
 		if len(cfg.Credentials) == 0 {
 			return fmt.Errorf("router could not be created; you must specify a .kubeconfig file path containing credentials for connecting the router to the master with --credentials")
@@ -353,4 +367,24 @@ func generateStatsPassword() string {
 		password = append(password, string(char))
 	}
 	return strings.Join(password, "")
+}
+
+func validateServiceAccount(kClient *kclient.Client, ns string, sa string) error {
+	// get cluster sccs
+	sccList, err := kClient.SecurityContextConstraints().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return fmt.Errorf("unable to validate service account %v", err)
+	}
+
+	// get set of sccs applicable to the service account
+	userInfo := serviceaccount.UserInfo(ns, sa, "")
+	for _, scc := range sccList.Items {
+		if admission.ConstraintAppliesTo(&scc, userInfo) {
+			if scc.AllowHostPorts {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("unable to validate service account, host ports are forbidden")
 }

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -21,6 +21,8 @@ func GetBootstrapSecurityContextConstraints(buildControllerUsername string) []ka
 			},
 			AllowPrivilegedContainer: true,
 			AllowHostDirVolumePlugin: true,
+			AllowHostNetwork:         true,
+			AllowHostPorts:           true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				Type: kapi.SELinuxStrategyRunAsAny,
 			},

--- a/pkg/security/admission/admission.go
+++ b/pkg/security/admission/admission.go
@@ -262,7 +262,7 @@ func getMatchingSecurityContextConstraints(store cache.Store, userInfo user.Info
 		if !ok {
 			return nil, errors.NewInternalError(fmt.Errorf("error converting object from store to a security context constraint: %v", c))
 		}
-		if constraintAppliesTo(constraint, userInfo) {
+		if ConstraintAppliesTo(constraint, userInfo) {
 			matchedConstraints = append(matchedConstraints, constraint)
 		}
 	}
@@ -272,7 +272,7 @@ func getMatchingSecurityContextConstraints(store cache.Store, userInfo user.Info
 
 // constraintAppliesTo inspects the constraint's users and groups against the userInfo to determine
 // if it is usable by the userInfo.
-func constraintAppliesTo(constraint *kapi.SecurityContextConstraints, userInfo user.Info) bool {
+func ConstraintAppliesTo(constraint *kapi.SecurityContextConstraints, userInfo user.Info) bool {
 	for _, user := range constraint.Users {
 		if userInfo.GetName() == user {
 			return true

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -124,6 +124,12 @@ func TestAdmit(t *testing.T) {
 		Level: "s0:c1,c0",
 	}
 
+	requestsHostNetwork := goodPod()
+	requestsHostNetwork.Spec.HostNetwork = true
+
+	requestsHostPorts := goodPod()
+	requestsHostPorts.Spec.Containers[0].Ports = []kapi.ContainerPort{{HostPort: 1}}
+
 	testCases := map[string]struct {
 		pod           *kapi.Pod
 		shouldAdmit   bool
@@ -154,6 +160,14 @@ func TestAdmit(t *testing.T) {
 			shouldAdmit:   true,
 			expectedUID:   1,
 			expectedLevel: specifyLabels.Spec.Containers[0].SecurityContext.SELinuxOptions.Level,
+		},
+		"requestsHostNetwork": {
+			pod:         requestsHostNetwork,
+			shouldAdmit: false,
+		},
+		"requestsHostPorts": {
+			pod:         requestsHostPorts,
+			shouldAdmit: false,
 		},
 	}
 
@@ -192,6 +206,8 @@ func TestAdmit(t *testing.T) {
 			Name: "scc-admin",
 		},
 		AllowPrivilegedContainer: true,
+		AllowHostNetwork:         true,
+		AllowHostPorts:           true,
 		RunAsUser: kapi.RunAsUserStrategyOptions{
 			Type: kapi.RunAsUserStrategyRunAsAny,
 		},


### PR DESCRIPTION
upstream: https://github.com/GoogleCloudPlatform/kubernetes/pull/7893

Allow controlling `hostNetwork` and `hostPort` with an SCC.  

Note: this still works with `HostNetworkSources` defined in `capabilities.go`.  If the pod source is not allowed by `HostNetworkSources` then the kubelet check in `canRunPod` will fail even if the SCC allows the request.  I think it is probably best to leave the kubelet check in place for now.  In the future I think it's reasonable to remove `HostNetworkSources` and allow the kubelet to assume that admission has performed the necessary checks and restricting sources becomes allocating permissions to users/groups in the SCC.


@liggitt @pmorie @smarterclayton 