### PR TITLE
make test-cmd RCs non-conflicting

### DIFF
--- a/test/fixtures/app-scenarios/k8s-sample-app.json
+++ b/test/fixtures/app-scenarios/k8s-sample-app.json
@@ -16,14 +16,16 @@
       "spec": {
         "replicas": 1,
         "selector": {
-          "name": "database"
+          "name": "database",
+          "deconflict": "database.app"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
               "name": "database",
-              "template": "ruby-helloworld-sample"
+              "template": "ruby-helloworld-sample",
+              "deconflict": "database.app"
             }
           },
           "spec": {
@@ -79,14 +81,16 @@
       "spec": {
         "replicas": 3,
         "selector": {
-          "name": "frontend"
+          "name": "frontend",
+          "deconflict": "frontend.app"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
               "name": "frontend",
-              "template": "ruby-helloworld-sample"
+              "template": "ruby-helloworld-sample",
+              "deconflict": "frontend.app"
             }
           },
           "spec": {

--- a/test/fixtures/app-scenarios/k8s-unserviced-rc.json
+++ b/test/fixtures/app-scenarios/k8s-unserviced-rc.json
@@ -16,14 +16,16 @@
       "spec": {
         "replicas": 1,
         "selector": {
-          "name": "database"
+          "name": "database",
+          "deconflict": "database.rc"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
               "name": "database",
-              "template": "ruby-helloworld-sample"
+              "template": "ruby-helloworld-sample",
+              "deconflict": "database.rc"
             }
           },
           "spec": {
@@ -79,14 +81,16 @@
       "spec": {
         "replicas": 3,
         "selector": {
-          "name": "frontend"
+          "name": "frontend",
+          "deconflict": "frontend.rc"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
               "name": "frontend",
-              "template": "ruby-helloworld-sample"
+              "template": "ruby-helloworld-sample",
+              "deconflict": "frontend.rc"
             }
           },
           "spec": {


### PR DESCRIPTION
Since https://github.com/GoogleCloudPlatform/kubernetes/pull/10477 is going to take a while and this is jamming up our merge queue, these RCs can be changed avoid conflicting with each other.

Fixes https://github.com/openshift/origin/issues/2295

@liggitt 