### PR TITLE
Added unit testing for handler chain

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/master/master.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/master/master.go
@@ -366,7 +366,6 @@ func New(c *Config) *Master {
 	m.muxHelper = &apiserver.MuxHelper{m.mux, []string{}}
 
 	m.init(c)
-
 	return m
 }
 

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -590,27 +590,3 @@ func (redirectSuccessHandler) AuthenticationSucceeded(user kuser.Info, then stri
 	http.Redirect(w, req, then, http.StatusFound)
 	return true, nil
 }
-
-// authenticationHandlerFilter creates a filter object that will enforce authentication directly
-func authenticationHandlerFilter(handler http.Handler, authenticator authenticator.Request, contextMapper kapi.RequestContextMapper) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		user, ok, err := authenticator.AuthenticateRequest(req)
-		if err != nil || !ok {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		ctx, ok := contextMapper.Get(req)
-		if !ok {
-			http.Error(w, "Unable to find request context", http.StatusInternalServerError)
-			return
-		}
-		if err := contextMapper.Update(req, kapi.WithUser(ctx, user)); err != nil {
-			glog.V(4).Infof("Error setting authenticated context: %v", err)
-			http.Error(w, "Unable to set authenticated request context", http.StatusInternalServerError)
-			return
-		}
-
-		handler.ServeHTTP(w, req)
-	})
-}

--- a/pkg/cmd/server/origin/handler_installation.go
+++ b/pkg/cmd/server/origin/handler_installation.go
@@ -1,0 +1,187 @@
+package origin
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/emicklei/go-restful"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/auth/authenticator"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+// HandlerPrepender prepends handlers to the end of a chain
+type HandlerPrepender interface {
+	PrependHandler(http.Handler, HandlerPrependSpecifier) http.Handler
+}
+
+func NewHandlerPrepender() HandlerPrepender {
+	return &defaultHandlerPrepender{}
+}
+
+type defaultHandlerPrepender struct{}
+
+func (ha *defaultHandlerPrepender) PrependHandler(parent http.Handler, prepender HandlerPrependSpecifier) http.Handler {
+	return prepender.Prepend(parent)
+}
+
+// HandlerPrependSpecifier is an interface for objects that can specify how to prepend a handler
+type HandlerPrependSpecifier interface {
+	// Prepend prepends the child handler to the parent handler
+	Prepend(parent http.Handler) (child http.Handler)
+}
+
+// InsecureContainerConfig is the HandlerPrependSpecifier that prepeds an InsecureContainer
+type InsecureContainerConfig struct {
+	insecureContainer *restful.Container
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending an InsecureContainer
+// This implementation is different from others in that we want the resulting handlers to be prepended
+// to not only the parent Handler given but also any WebServices on the Container, so we add the Parent
+// handler to handle paths from `/` on the Container, and then return the Handler for the Container
+// which will choose when to route requests to WebServices and when to route them to the Parent
+func (i *InsecureContainerConfig) Prepend(parent http.Handler) http.Handler {
+	i.insecureContainer.Handle("/", parent)
+	return &InsecureContainer{
+		parent: http.Handler(i.insecureContainer),
+	}
+}
+
+// AuthorizationFilterConfig is the HandlerPrependSpecifier that prepends an AuthorizationFilter
+type AuthorizationFilterConfig struct {
+	attributeBuilder authorizer.AuthorizationAttributeBuilder
+	contextMapper    kapi.RequestContextMapper
+	authorizer       authorizer.Authorizer
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending an AuthorizationFilter
+func (f *AuthorizationFilterConfig) Prepend(parent http.Handler) http.Handler {
+	return &AuthorizationFilter{
+		attributeBuilder: f.attributeBuilder,
+		contextMapper:    f.contextMapper,
+		authorizer:       f.authorizer,
+		parent:           parent,
+	}
+}
+
+// AuthenticationFilterConfig is the HandlerPrependSpecifier that prepends an AuthenticationFilter
+type AuthenticationFilterConfig struct {
+	authenticator authenticator.Request
+	contextMapper kapi.RequestContextMapper
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending an AuthenticationFilter
+func (f *AuthenticationFilterConfig) Prepend(parent http.Handler) http.Handler {
+	return &AuthenticationFilter{
+		authenticator: f.authenticator,
+		contextMapper: f.contextMapper,
+		parent:        parent,
+	}
+}
+
+// NamespacingFilterConfig is the HandlerPrependSpecifier that prepends a NamepsacingFilter
+type NamespacingFilterConfig struct {
+	contextMapper kapi.RequestContextMapper
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending an NamespacingFilter
+func (n *NamespacingFilterConfig) Prepend(parent http.Handler) http.Handler {
+	return &NamespacingFilter{
+		infoResolver: apiserver.APIRequestInfoResolver{
+			util.NewStringSet("api", "osapi", "oapi"),
+			latest.RESTMapper,
+		},
+		contextMapper: n.contextMapper,
+		parent:        parent,
+	}
+}
+
+// CacheControlFilterConfig is the HandlerPrependSpecifier that prepends the CacheControlFilter
+type CacheControlFilterConfig struct {
+	headerSetting string
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending an CacheControlFilter
+func (c *CacheControlFilterConfig) Prepend(parent http.Handler) http.Handler {
+	return &CacheControlFilter{
+		headerSetting: c.headerSetting,
+		parent:        parent,
+	}
+}
+
+// APIPathIndexerConfig is the HandlerPrependSpecifier that prepends the APIPathIndexer
+type APIPathIndexerConfig struct{}
+
+// Prepend implements HandlerPrependSpecifier for prepending an APIPathIndexer
+func (a *APIPathIndexerConfig) Prepend(parent http.Handler) http.Handler {
+	return &APIPathIndexer{
+		parent: parent,
+	}
+}
+
+// CORSFilterConfig is the HandlerPrependSpecifier that prepends the CORSFilter
+type CORSFilterConfig struct {
+	origins          []*regexp.Regexp
+	allowedMethods   []string
+	allowedHeaders   []string
+	allowCredentials string
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending a CORSFilter
+func (c *CORSFilterConfig) Prepend(parent http.Handler) http.Handler {
+	corsHandler := apiserver.CORS(parent, c.origins, c.allowedMethods, c.allowedHeaders, c.allowCredentials)
+	return &CORSFilter{
+		handler: corsHandler,
+	}
+}
+
+// AssetServerRedirecterConfig is the HandlerPrependSpecifier that prepends the AssetServerRedirecter
+type AssetServerRedirecterConfig struct {
+	headerSetting string
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending an AssetServerRedirecter
+func (a *AssetServerRedirecterConfig) Prepend(parent http.Handler) http.Handler {
+	return &AssetServerRedirecter{
+		assetPublicURL: a.assetPublicURL,
+		parent:         parent,
+	}
+}
+
+// RequestContextFilterConfig is the HandlerPrependSpecifier that prepends the RequestContextFilter
+type RequestContextFilterConfig struct {
+	contextMapper kapi.RequestContextMapper
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending a RequestContextFilter
+func (r *RequestContextFilterConfig) Prepend(parent http.Handler) http.Handler {
+	contextFilter, err := kapi.NewRequestContextFilter(r.contextMapper, parent)
+	if err != nil {
+		glog.Fatalf("Error setting up request context filter: %v", err)
+		return parent
+	}
+	return &RequestContextFilter{
+		handler: contextFilter,
+	}
+}
+
+// MaxInFlightLimitFilterConfig is the HandlerPrependSpecifier that prepends the MaxInFlightLimitFilter
+type MaxInFlightLimitFilterConfig struct {
+	channel                 chan bool
+	longRunningRequestRegex *regexp.Regexp
+}
+
+// Prepend implements HandlerPrependSpecifier for prepending a MaxInFlightLimitFilter
+func (m *MaxInFlightLimitFilterConfig) Prepend(parent http.Handler) http.Handler {
+	maxInFlightLimitHandler := apiserver.MaxInFlightLimit(m.channel, m.longRunningRequestRegex, parent)
+	return &MaxInFlightLimitFilter{
+		handler: maxInFlightLimitHandler,
+	}
+}

--- a/pkg/cmd/server/origin/handler_installation.go
+++ b/pkg/cmd/server/origin/handler_installation.go
@@ -144,7 +144,7 @@ func (c *CORSFilterConfig) Prepend(parent http.Handler) http.Handler {
 
 // AssetServerRedirecterConfig is the HandlerPrependSpecifier that prepends the AssetServerRedirecter
 type AssetServerRedirecterConfig struct {
-	headerSetting string
+	assetPublicURL string
 }
 
 // Prepend implements HandlerPrependSpecifier for prepending an AssetServerRedirecter

--- a/pkg/cmd/server/origin/handlers.go
+++ b/pkg/cmd/server/origin/handlers.go
@@ -6,140 +6,238 @@ import (
 
 	"bitbucket.org/ww/goautoneg"
 
-	restful "github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful"
+	"github.com/golang/glog"
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
-	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/auth/authenticator"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
 )
+
+// InsecureContainer is a http.Handler that delegates requests to routes held in the container
+type InsecureContainer struct {
+	parent http.Handler
+}
+
+// ServeHTTP allows InsecureContainer to implement http.Handler - it delegates calls to the Container
+func (i *InsecureContainer) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	i.parent.ServeHTTP(responseWriter, request)
+}
+
+// AuthorizationFilter is a http.Handler that enforces authorization rules
+type AuthorizationFilter struct {
+	attributeBuilder authorizer.AuthorizationAttributeBuilder
+	contextMapper    kapi.RequestContextMapper
+	authorizer       authorizer.Authorizer
+	parent           http.Handler
+}
+
+// ServeHTTP allows the AuthorizationFilter to impement http.Handler
+func (a AuthorizationFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	attributes, err := a.attributeBuilder.GetAttributes(request)
+	if err != nil {
+		forbidden(err.Error(), "", responseWriter, request)
+		return
+	}
+	if attributes == nil {
+		forbidden("No attributes", "", responseWriter, request)
+		return
+	}
+
+	ctx, exists := a.contextMapper.Get(request)
+	if !exists {
+		forbidden("context not found", attributes.GetAPIVersion(), responseWriter, request)
+		return
+	}
+
+	allowed, reason, err := a.authorizer.Authorize(ctx, attributes)
+	if err != nil {
+		forbidden(err.Error(), attributes.GetAPIVersion(), responseWriter, request)
+		return
+	}
+	if !allowed {
+		forbidden(reason, attributes.GetAPIVersion(), responseWriter, request)
+		return
+	}
+
+	a.parent.ServeHTTP(responseWriter, request)
+}
+
+// AuthenticationFilter is a http.Handler that enforces authentication rules
+type AuthenticationFilter struct {
+	authenticator authenticator.Request
+	contextMapper kapi.RequestContextMapper
+	parent        http.Handler
+}
+
+// ServeHTTP allows the AuthenticationFilter to impement http.Handler
+func (a AuthenticationFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	user, ok, err := a.authenticator.AuthenticateRequest(request)
+	if err != nil || !ok {
+		http.Error(responseWriter, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	ctx, ok := a.contextMapper.Get(request)
+	if !ok {
+		http.Error(responseWriter, "Unable to find request context", http.StatusInternalServerError)
+		return
+	}
+	if err := a.contextMapper.Update(request, kapi.WithUser(ctx, user)); err != nil {
+		glog.V(4).Infof("Error setting authenticated context: %v", err)
+		http.Error(responseWriter, "Unable to set authenticated request context", http.StatusInternalServerError)
+		return
+	}
+
+	a.parent.ServeHTTP(responseWriter, request)
+}
+
+// NamespacingFilter is a http.Handler that enforces namespacing rules:
+// NamespacingFilter adds a filter that adds the namespace of the request to the context.
+// Not all requests will have namespaces, but any that do will have the appropriate value added.
+type NamespacingFilter struct {
+	infoResolver  apiserver.APIRequestInfoResolver
+	contextMapper kapi.RequestContextMapper
+	parent        http.Handler
+}
+
+// ServeHTTP allows the NamespacingFilter to impement http.Handler
+func (n NamespacingFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	ctx, ok := n.contextMapper.Get(request)
+	if !ok {
+		http.Error(responseWriter, "Unable to find request context", http.StatusInternalServerError)
+		return
+	}
+
+	if _, exists := kapi.NamespaceFrom(ctx); !exists {
+		if requestInfo, err := n.infoResolver.GetAPIRequestInfo(request); err == nil {
+			// only set the namespace if the apiRequestInfo was resolved
+			// keep in mind that GetAPIRequestInfo will fail on non-api requests, so don't fail the entire http request on that
+			// kind of failure.
+
+			// TODO reconsider special casing this.  Having the special case hereallow us to fully share the kube
+			// APIRequestInfoResolver without any modification or customization.
+			namespace := requestInfo.Namespace
+			if (requestInfo.Resource == "projects") && (len(requestInfo.Name) > 0) {
+				namespace = requestInfo.Name
+			}
+
+			ctx = kapi.WithNamespace(ctx, namespace)
+			n.contextMapper.Update(request, ctx)
+		}
+	}
+
+	n.parent.ServeHTTP(responseWriter, request)
+}
+
+// CacheControlFilter is a http.Handler that enforces caching rules:
+// The CacheControlFilter sets the Cache-Control header to the specified value.
+type CacheControlFilter struct {
+	headerSetting string
+	parent        http.Handler
+}
+
+// ServeHTTP allows the CacheControlFilter to impement http.Handler
+func (c CacheControlFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	responseWriter.Header().Set("Cache-Control", c.headerSetting)
+	c.parent.ServeHTTP(responseWriter, request)
+}
 
 // TODO We would like to use the IndexHandler from k8s but we do not yet have a
 // MuxHelper to track all registered paths
-func indexAPIPaths(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == "/" {
-			// TODO once we have a MuxHelper we will not need to hardcode this list of paths
-			object := kapi.RootPaths{Paths: []string{
-				"/api",
-				"/api/v1beta3",
-				"/api/v1",
-				"/controllers",
-				"/healthz",
-				"/healthz/ping",
-				"/logs/",
-				"/metrics",
-				"/ready",
-				"/osapi",
-				"/osapi/v1beta3",
-				"/oapi",
-				"/oapi/v1",
-				"/swaggerapi/",
-			}}
-			// TODO it would be nice if apiserver.writeRawJSON was not private
-			output, err := json.MarshalIndent(object, "", "  ")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			w.Header().Set("Content-Type", restful.MIME_JSON)
-			w.WriteHeader(http.StatusOK)
-			w.Write(output)
-		} else {
-			handler.ServeHTTP(w, req)
-		}
-	})
+// APIPathIndexer is a http.Handler that handles requests to the root with a response containing API paths
+type APIPathIndexer struct {
+	parent http.Handler
 }
 
-func (c *MasterConfig) authorizationFilter(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		attributes, err := c.AuthorizationAttributeBuilder.GetAttributes(req)
+// ServeHTTP allows the APIPathIndexer to impement http.Handler
+func (a APIPathIndexer) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	if request.URL.Path == "/" {
+		// TODO once we have a MuxHelper we will not need to hardcode this list of paths
+		object := kapi.RootPaths{Paths: []string{
+			"/api",
+			"/api/v1beta3",
+			"/api/v1",
+			"/controllers",
+			"/healthz",
+			"/healthz/ping",
+			"/logs/",
+			"/metrics",
+			"/ready",
+			"/osapi",
+			"/osapi/v1beta3",
+			"/oapi",
+			"/oapi/v1",
+			"/swaggerapi/",
+		}}
+		// TODO it would be nice if apiserver.writeRawJSON was not private
+		output, err := json.MarshalIndent(object, "", "  ")
 		if err != nil {
-			forbidden(err.Error(), "", w, req)
+			http.Error(responseWriter, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		if attributes == nil {
-			forbidden("No attributes", "", w, req)
-			return
-		}
-
-		ctx, exists := c.RequestContextMapper.Get(req)
-		if !exists {
-			forbidden("context not found", attributes.GetAPIVersion(), w, req)
-			return
-		}
-
-		allowed, reason, err := c.Authorizer.Authorize(ctx, attributes)
-		if err != nil {
-			forbidden(err.Error(), attributes.GetAPIVersion(), w, req)
-			return
-		}
-		if !allowed {
-			forbidden(reason, attributes.GetAPIVersion(), w, req)
-			return
-		}
-
-		handler.ServeHTTP(w, req)
-	})
+		responseWriter.Header().Set("Content-Type", restful.MIME_JSON)
+		responseWriter.WriteHeader(http.StatusOK)
+		responseWriter.Write(output)
+	} else {
+		a.parent.ServeHTTP(responseWriter, request)
+	}
 }
 
-// cacheControlFilter sets the Cache-Control header to the specified value.
-func cacheControlFilter(handler http.Handler, value string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Cache-Control", value)
-		handler.ServeHTTP(w, req)
-	})
+// CORSFilter is a http.Handler that wraps the CORSFilter given by the Kubernetes Apiserver in order to
+// strongly type this filter for identification
+type CORSFilter struct {
+	handler http.Handler
 }
 
-// namespacingFilter adds a filter that adds the namespace of the request to the context.  Not all requests will have namespaces,
-// but any that do will have the appropriate value added.
-func namespacingFilter(handler http.Handler, contextMapper kapi.RequestContextMapper) http.Handler {
-	infoResolver := &apiserver.APIRequestInfoResolver{util.NewStringSet("api", "osapi", "oapi"), latest.RESTMapper}
-
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ctx, ok := contextMapper.Get(req)
-		if !ok {
-			http.Error(w, "Unable to find request context", http.StatusInternalServerError)
-			return
-		}
-
-		if _, exists := kapi.NamespaceFrom(ctx); !exists {
-			if requestInfo, err := infoResolver.GetAPIRequestInfo(req); err == nil {
-				// only set the namespace if the apiRequestInfo was resolved
-				// keep in mind that GetAPIRequestInfo will fail on non-api requests, so don't fail the entire http request on that
-				// kind of failure.
-
-				// TODO reconsider special casing this.  Having the special case hereallow us to fully share the kube
-				// APIRequestInfoResolver without any modification or customization.
-				namespace := requestInfo.Namespace
-				if (requestInfo.Resource == "projects") && (len(requestInfo.Name) > 0) {
-					namespace = requestInfo.Name
-				}
-
-				ctx = kapi.WithNamespace(ctx, namespace)
-				contextMapper.Update(req, ctx)
-			}
-		}
-
-		handler.ServeHTTP(w, req)
-	})
+// ServeHTTP allows the CORSFilter to implement http.Handler - it delegates to the internal handler from the CORSFilter
+func (c CORSFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	c.handler.ServeHTTP(responseWriter, request)
 }
 
+// AssetServerRedirecter is a http.Handler that allows for asset server redirection:
 // If we know the location of the asset server, redirect to it when / is requested
 // and the Accept header supports text/html
-func assetServerRedirect(handler http.Handler, assetPublicURL string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == "/" {
-			accepts := goautoneg.ParseAccept(req.Header.Get("Accept"))
-			for _, accept := range accepts {
-				if accept.Type == "text" && accept.SubType == "html" {
-					http.Redirect(w, req, assetPublicURL, http.StatusFound)
-					return
-				}
+type AssetServerRedirecter struct {
+	assetPublicURL string
+	parent         http.Handler
+}
+
+// ServeHTTP allows the AssetServerRedirecter to impement http.Handler
+func (a AssetServerRedirecter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	if request.URL.Path == "/" {
+		accepts := goautoneg.ParseAccept(request.Header.Get("Accept"))
+		for _, accept := range accepts {
+			if accept.Type == "text" && accept.SubType == "html" {
+				http.Redirect(responseWriter, request, a.assetPublicURL, http.StatusFound)
+				return
 			}
 		}
-		// Dispatch to the next handler
-		handler.ServeHTTP(w, req)
-	})
+	}
+	// Dispatch to the next handler
+	a.parent.ServeHTTP(responseWriter, request)
+}
+
+// RequestContextFilter is a http.Handler that wraps the RequestContextFilter given by the Kubernetes api in order to
+// strongly type this filter for identification
+type RequestContextFilter struct {
+	handler http.Handler
+}
+
+// ServeHTTP allows the RequestContextFilter to implement http.Handler - it delegates to the internal handler from the RequestContextFilter
+func (c RequestContextFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	c.handler.ServeHTTP(responseWriter, request)
+}
+
+// MaxInFlightLimitFilter is a http.Handler that wraps the MaxInFlightLimitFilter given by the Kubernetes api in order to
+// strongly type this filter for identification
+type MaxInFlightLimitFilter struct {
+	handler http.Handler
+}
+
+// ServeHTTP allows the MaxInFlightLimitFilter to implement http.Handler - it delegates to the internal handler from the MaxInFlightLimitFilter
+func (c MaxInFlightLimitFilter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	c.handler.ServeHTTP(responseWriter, request)
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -186,75 +186,7 @@ func (c *MasterConfig) CreateServer(protected, unprotected []APIInstaller) (*htt
 		extra = append(extra, i.InstallAPI(open)...)
 	}
 
-	authorizationFilterConfig := &AuthorizationFilterConfig{
-		attributeBuilder: c.AuthorizationAttributeBuilder,
-		contextMapper:    c.getRequestContextMapper(),
-		authorizer:       c.Authorizer,
-	}
-
-	authenticationFilterConfig := &AuthenticationFilterConfig{
-		authenticator: c.Authenticator,
-		contextMapper: c.getRequestContextMapper(),
-	}
-
-	namespacingFilterConfig := &NamespacingFilterConfig{
-		contextMapper: c.getRequestContextMapper(),
-	}
-
-	cacheControlFilterConfig := &CacheControlFilterConfig{
-		headerSetting: "no-store", // protected endpoints should not be cached
-	}
-
-	apiPathIndexerConfig := &APIPathIndexerConfig{}
-
-	insecureContainerConfig := &InsecureContainerConfig{
-		insecureContainer: open,
-	}
-
-	requestContextFilterConfig := &RequestContextFilterConfig{
-		contextMapper: c.getRequestContextMapper(),
-	}
-
-	handlerPrepender := NewHandlerPrepender()
-	handler := handlerPrepender.PrependHandler(safe, authorizationFilterConfig)
-	handler = handlerPrepender.PrependHandler(handler, authenticationFilterConfig)
-	handler = handlerPrepender.PrependHandler(handler, namespacingFilterConfig)
-	handler = handlerPrepender.PrependHandler(handler, cacheControlFilterConfig)
-	handler = handlerPrepender.PrependHandler(handler, apiPathIndexerConfig)
-
-	// allow for following prepend calls to prepend to the handler of the insecure container
-	handler = handlerPrepender.PrependHandler(handler, insecureContainerConfig)
-
-	// add CORS support
-	if len(c.ensureCORSAllowedOrigins()) != 0 {
-		corsFilterConfig := &CORSFilterConfig{
-			origins:          c.ensureCORSAllowedOrigins(),
-			allowedMethods:   nil, // use default set of methods
-			allowedHeaders:   nil, // use default set of headers
-			allowCredentials: "true",
-		}
-		handler = handlerPrepender.PrependHandler(handler, corsFilterConfig)
-	}
-
-	if c.Options.AssetConfig != nil {
-		assetServerRedirecterConfig := &AssetServerRedirecterConfig{
-			assetPublicURL: c.Options.AssetConfig.PublicURL,
-		}
-		handler = handlerPrepender.PrependHandler(handler, assetServerRedirecterConfig)
-	}
-
-	// Make the outermost filter the requestContextMapper to ensure all components share the same context
-	handler = handlerPrepender.PrependHandler(handler, requestContextFilterConfig)
-
-	// TODO: MaxRequestsInFlight should be subdivided by intent, type of behavior, and speed of
-	// execution - updates vs reads, long reads vs short reads, fat reads vs skinny reads.
-	if c.Options.ServingInfo.MaxRequestsInFlight > 0 {
-		maxInFlightLimitFilterConfig := &MaxInFlightLimitFilterConfig{
-			channel:                 make(chan bool, c.Options.ServingInfo.MaxRequestsInFlight),
-			longRunningRequestRegex: longRunningRE,
-		}
-		handler = handlerPrepender.PrependHandler(handler, maxInFlightLimitFilterConfig)
-	}
+	handler := c.assembleHandlers(safe, open)
 
 	// install swagger
 	swaggerConfig := swagger.Config{

--- a/pkg/cmd/server/origin/master_test.go
+++ b/pkg/cmd/server/origin/master_test.go
@@ -1,7 +1,14 @@
 package origin
 
 import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
 	"testing"
+
+	kmaster "github.com/GoogleCloudPlatform/kubernetes/pkg/master"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 
 	"github.com/emicklei/go-restful"
 )
@@ -29,4 +36,177 @@ func contains(list []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func TestPrependHandlers(t *testing.T) {
+	tests := []struct {
+		testName        string
+		config          MasterConfig
+		desiredHandlers []string
+	}{
+		{
+			testName: "allHandlers",
+			config: MasterConfig{
+				Options: configapi.MasterConfig{
+					AssetConfig: &configapi.AssetConfig{
+						PublicURL: "http://localhost", // allow asset server redirects
+					},
+					ServingInfo: configapi.HTTPServingInfo{
+						MaxRequestsInFlight: 1, // allow max-in-flight filter
+					},
+					CORSAllowedOrigins: []string{
+						"origin", // allow CORS support
+					},
+				},
+			},
+			desiredHandlers: []string{
+				"MaxInFlightLimitFilter",
+				"RequestContextFilter",
+				"AssetServerRedirecter",
+				"CORSFilter",
+				"InsecureContainer", // contains unprotected WebServices - asset & auth servers
+				"APIPathIndexer",
+				"CacheControlFilter",
+				"NamespacingFilter",
+				"AuthenticationFilter",
+				"AuthorizationFilter",
+				"Container", // contains protected WebServices - API, controllers, health&readiness, etc
+			},
+		},
+		{
+			testName: "noCORS",
+			config: MasterConfig{
+				Options: configapi.MasterConfig{
+					AssetConfig: &configapi.AssetConfig{
+						PublicURL: "http://localhost", // allow asset server redirects
+					},
+					ServingInfo: configapi.HTTPServingInfo{
+						MaxRequestsInFlight: 1, // allow max-in-flight filter
+					},
+				},
+			},
+			desiredHandlers: []string{
+				"MaxInFlightLimitFilter",
+				"RequestContextFilter",
+				"AssetServerRedirecter",
+				"InsecureContainer", // contains unprotected WebServices - asset & auth servers
+				"APIPathIndexer",
+				"CacheControlFilter",
+				"NamespacingFilter",
+				"AuthenticationFilter",
+				"AuthorizationFilter",
+				"Container", // contains protected WebServices - API, controllers, health&readiness, etc
+			},
+		},
+		{
+			testName: "noMaxInFlight",
+			config: MasterConfig{
+				Options: configapi.MasterConfig{
+					AssetConfig: &configapi.AssetConfig{
+						PublicURL: "http://localhost", // allow asset server redirects
+					},
+					CORSAllowedOrigins: []string{
+						"origin", // allow CORS support
+					},
+				},
+			},
+			desiredHandlers: []string{
+				"RequestContextFilter",
+				"AssetServerRedirecter",
+				"CORSFilter",
+				"InsecureContainer", // contains unprotected WebServices - asset & auth servers
+				"APIPathIndexer",
+				"CacheControlFilter",
+				"NamespacingFilter",
+				"AuthenticationFilter",
+				"AuthorizationFilter",
+				"Container", // contains protected WebServices - API, controllers, health&readiness, etc
+			},
+		},
+		{
+			testName: "noAssetServerRedirect",
+			config: MasterConfig{
+				Options: configapi.MasterConfig{
+					ServingInfo: configapi.HTTPServingInfo{
+						MaxRequestsInFlight: 1, // allow max-in-flight filter
+					},
+					CORSAllowedOrigins: []string{
+						"origin", // allow CORS support
+					},
+				},
+			},
+			desiredHandlers: []string{
+				"MaxInFlightLimitFilter",
+				"RequestContextFilter",
+				"CORSFilter",
+				"InsecureContainer", // contains unprotected WebServices - asset & auth servers
+				"APIPathIndexer",
+				"CacheControlFilter",
+				"NamespacingFilter",
+				"AuthenticationFilter",
+				"AuthorizationFilter",
+				"Container", // contains protected WebServices - API, controllers, health&readiness, etc
+			},
+		},
+	}
+
+	for _, test := range tests {
+		handlerPrepender := &testHandlerPrepender{
+			prependedHandlers: make(map[reflect.Type]reflect.Type),
+		}
+		secureContainer := kmaster.NewHandlerContainer(http.NewServeMux())
+		insecureContainer := kmaster.NewHandlerContainer(http.NewServeMux())
+
+		test.config.assembleHandlersUsingPrepender(secureContainer, insecureContainer, handlerPrepender)
+
+		actualHandlers := handlerPrepender.GetHandlerChain()
+
+		if !reflect.DeepEqual(actualHandlers, test.desiredHandlers) {
+			t.Fatalf("test %v failed: got handlers: %v, wanted: %v", test.testName, actualHandlers, test.desiredHandlers)
+		}
+	}
+}
+
+type testHandlerPrepender struct {
+	firstHandlerPrepended reflect.Type
+	prependedHandlers     map[reflect.Type]reflect.Type
+}
+
+// PrependHandler prepends a child onto the given parent using the given HandlerPrependFunc and records
+// that this prepending happened internally.
+func (hi *testHandlerPrepender) PrependHandler(parent http.Handler, prependSpec HandlerPrependSpecifier) http.Handler {
+	child := prependSpec.Prepend(parent)
+
+	parentType := reflect.TypeOf(parent)
+	childType := reflect.TypeOf(child)
+
+	if parentType != childType { // if the two are the same, the prependSpec encountered an error and skipped addition
+		hi.prependedHandlers[parentType] = childType
+		if hi.firstHandlerPrepended == nil {
+			hi.firstHandlerPrepended = parentType
+		}
+	}
+
+	return child
+}
+
+// GetHandlerChain returns the longest handler chain that was built from the first prepended handler
+// This implementation will not be sufficient if handler prepending is ever not one-to-one (e.g. multiple children)
+func (hi *testHandlerPrepender) GetHandlerChain() []string {
+	handlerChain := []string{}
+
+	var currentHandler reflect.Type
+	currentHandler = hi.firstHandlerPrepended
+
+	for {
+		fullHandlerType := fmt.Sprintf("%v", currentHandler)
+		handlerType := strings.Split(fullHandlerType, ".")[1]
+		handlerChain = append([]string{handlerType}, handlerChain...)
+		nextHandler, ok := hi.prependedHandlers[currentHandler]
+		if !ok {
+			break
+		}
+		currentHandler = nextHandler
+	}
+	return handlerChain
 }


### PR DESCRIPTION
In order to enable a soon-to-be PR for refactoring the flow of `Run()` in `master.go`, I am implementing unit testing for the order of handler chaining for the API server as we discussed.

This change should ideally be testing the code already in `master.go` to ensure it passes with no other changes. However, that's not possible, so I broke this up into atomic commits to better document what changes I made to the codebase in order to implement the test so that we can convince ourselves nothing about the flow of `master.go` changed and the test *is* testing the existing code.
@deads2k  @liggitt  PTAL