### PR TITLE
Fix for https://github.com/openshift/origin/issues/3446, by make pods…

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -64,6 +64,9 @@
         /* Switch to vertical layout at small sizes */
         .flex-direction(@direction: column);
       }
+      &.pod-container {
+        .flex-direction(@direction: row);
+      }
       &.pod-template-container {
         margin-top: 5px;
       }
@@ -215,9 +218,9 @@
     }
     .pod {
       .osc-object-highlight();
-      .flex(@columns: 1 1 auto);
+      .flex(@columns: 1 1 0);
       max-width: 450px;
-      min-width: 90px;
+      min-width: 120px;
       background-size: 20px 20px;
       border-radius: @border-radius-md;
       border: 1px solid transparent;


### PR DESCRIPTION
… align vertically and horizontally at all times.

Make pod width consistent (120px) so alignment is correct with any amount of pods and text width.
Since pods are set width no need for them to be a single column at mobile sizes so set pod-container to flex row at <768px

![screen shot 2015-06-29 at 4 37 15 pm](https://cloud.githubusercontent.com/assets/1874151/8418318/55ab7d06-1e80-11e5-8671-2f02dd638c1a.png)
