### PR TITLE
do not use vagrant shared dir for volumes

### DIFF
--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -42,7 +42,7 @@ popd
 echo "Generating certs"
 pushd /vagrant
   SERVER_CONFIG_DIR="`pwd`/openshift.local.config"
-  VOLUMES_DIR="`pwd`/openshift.local.volumes"
+  VOLUMES_DIR="/openshift.local.volumes"
   MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
   CERT_DIR="${MASTER_CONFIG_DIR}"
 
@@ -69,7 +69,7 @@ pushd /vagrant
       --signer-cert="${CERT_DIR}/ca.crt" \
       --signer-key="${CERT_DIR}/ca.key" \
       --signer-serial="${CERT_DIR}/ca.serial.txt" \
-      --volume-dir="${VOLUMES_DIR}_${minion}"
+      --volume-dir="${VOLUMES_DIR}"
   done
 
 popd

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -42,7 +42,7 @@ popd
 echo "Generating certs"
 pushd /vagrant
   SERVER_CONFIG_DIR="`pwd`/openshift.local.config"
-  VOLUMES_DIR="/openshift.local.volumes"
+  VOLUMES_DIR="/var/lib/openshift.local.volumes"
   MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
   CERT_DIR="${MASTER_CONFIG_DIR}"
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3435

@jwhonce - now that `empty_dir.go` is trying to chmod volume directories to support arbitrary users running containers we're running into an issue with the volumes being located inside the shared directory.  It manifests itself in the kubelet as:

```
Jun 30 14:26:19 openshift-minion-1 openshift[3090]: E0630 14:26:19.351398    3090 empty_dir.go:322] Expected directory "/vagrant/openshift.local.volumes_openshift-minion-1/pods/f96e07f5-1f33-11e5-94a9-080027c5bfa9/volumes/kubernetes.io~empty-dir/tmp" permissions to be: -rwxrwxrwx; got: -rwxrwxr-x
Jun 30 14:26:19 openshift-minion-1 openshift[3090]: E0630 14:26:19.351767    3090 kubelet.go:1119] Unable to mount volumes for pod "hello-openshift_default": operation not supported; skipping pod
Jun 30 14:26:19 openshift-minion-1 openshift[3090]: E0630 14:26:19.354067    3090 pod_workers.go:108] Error syncing pod f96e07f5-1f33-11e5-94a9-080027c5bfa9, skipping: operation not supported
Jun 30 14:26:29 openshift-minion-1 openshift[3090]: E0630 14:26:29.350041    3090 empty_dir.go:322] Expected directory "/vagrant/openshift.local.volumes_openshift-minion-1/pods/f96e07f5-1f33-11e5-94a9-080027c5bfa9/volumes/kubernetes.io~empty-dir/tmp" permissions to be: -rwxrwxrwx; got: -rwxrwxr-x
Jun 30 14:26:29 openshift-minion-1 openshift[3090]: E0630 14:26:29.350579    3090 kubelet.go:1119] Unable to mount volumes for pod "hello-openshift_default": operation not supported; skipping pod
Jun 30 14:26:29 openshift-minion-1 openshift[3090]: E0630 14:26:29.352949    3090 pod_workers.go:108] Error syncing pod f96e07f5-1f33-11e5-94a9-080027c5bfa9, skipping: operation not supported
```

This change proposes using a volume directory in the root directory.  PTAL