### PR TITLE
deploy: Remove extra newline when describing deployments

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -196,7 +196,7 @@ func (o DeployOptions) RunDeploy() error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(o.out, desc)
+		fmt.Fprint(o.out, desc)
 	}
 
 	return err


### PR DESCRIPTION
Fixes #3357 

@smarterclayton fyi