### PR TITLE
Prune blobs from registry even w/o stream refs

### DIFF
--- a/pkg/image/prune/imagepruner_test.go
+++ b/pkg/image/prune/imagepruner_test.go
@@ -722,6 +722,22 @@ func TestRegistryPruning(t *testing.T) {
 			expectedBlobDeletions:     util.NewStringSet(),
 			expectedManifestDeletions: util.NewStringSet(),
 		},
+		"blobs pruned when streams have already been deleted": {
+			images: imageList(
+				imageWithLayers("id1", "registry1/foo/bar@id1", "layer1", "layer2", "layer3", "layer4"),
+				imageWithLayers("id2", "registry1/foo/bar@id2", "layer3", "layer4", "layer5", "layer6"),
+			),
+			expectedLayerDeletions: util.NewStringSet(),
+			expectedBlobDeletions: util.NewStringSet(
+				"registry1|layer1",
+				"registry1|layer2",
+				"registry1|layer3",
+				"registry1|layer4",
+				"registry1|layer5",
+				"registry1|layer6",
+			),
+			expectedManifestDeletions: util.NewStringSet(),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Update layer pruning to always delete blobs from the registry, even if
the image stream(s) that referenced the layer no longer exists. In the
event that there aren't any image streams referencing the layer any
more, we'll be able to delete the blob, but not the registry image
repository layer link files.

Fixes bug 1235148