### PR TITLE
Prune blobs from registry even w/o stream refs

### DIFF
--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -17,7 +17,6 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -33,16 +32,16 @@ const PruneImagesRecommendedName = "images"
 type pruneImagesConfig struct {
 	Confirm             bool
 	KeepYoungerThan     time.Duration
-	TagRevisionsToKeep  int
+	KeepTagRevisions    int
 	CABundle            string
 	RegistryUrlOverride string
 }
 
 func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
 	cfg := &pruneImagesConfig{
-		Confirm:            false,
-		KeepYoungerThan:    60 * time.Minute,
-		TagRevisionsToKeep: 3,
+		Confirm:          false,
+		KeepYoungerThan:  60 * time.Minute,
+		KeepTagRevisions: 3,
 	}
 
 	cmd := &cobra.Command{
@@ -79,123 +78,217 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 			allDCs, err := osClient.DeploymentConfigs(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())
 			cmdutil.CheckErr(err)
 
-			pruner := prune.NewImagePruner(
-				cfg.KeepYoungerThan,
-				cfg.TagRevisionsToKeep,
-				allImages,
-				allStreams,
-				allPods,
-				allRCs,
-				allBCs,
-				allBuilds,
-				allDCs,
-			)
+			dryRun := cfg.Confirm == false
 
+			options := prune.ImageRegistryPrunerOptions{
+				KeepYoungerThan:  cfg.KeepYoungerThan,
+				KeepTagRevisions: cfg.KeepTagRevisions,
+				Images:           allImages,
+				Streams:          allStreams,
+				Pods:             allPods,
+				RCs:              allRCs,
+				BCs:              allBCs,
+				Builds:           allBuilds,
+				DCs:              allDCs,
+				DryRun:           dryRun,
+				RegistryClient:   registryClient,
+				RegistryURL:      cfg.RegistryUrlOverride,
+			}
+			pruner := prune.NewImageRegistryPruner(options)
+
+			// this tabwriter is used by the describing*Pruners below for their output
 			w := tabwriter.NewWriter(out, 10, 4, 3, ' ', 0)
 			defer w.Flush()
 
-			var streams util.StringSet
-			printImageHeader := true
-			describingImagePruneFunc := func(image *imageapi.Image) error {
-				if printImageHeader {
-					printImageHeader = false
-					fmt.Fprintf(w, "IMAGE\tSTREAMS")
-				}
-
-				if streams.Len() > 0 {
-					fmt.Fprintf(w, strings.Join(streams.List(), ", "))
-				}
-
-				fmt.Fprintf(w, "\n%s\t", image.Name)
-				streams = util.NewStringSet()
-
-				return nil
-			}
-
-			describingImageStreamPruneFunc := func(stream *imageapi.ImageStream, image *imageapi.Image) (*imageapi.ImageStream, error) {
-				streams.Insert(stream.Status.DockerImageRepository)
-				return stream, nil
-			}
-
-			printLayerHeader := true
-			describingLayerPruneFunc := func(registryURL, repo, layer string) error {
-				if printLayerHeader {
-					printLayerHeader = false
-					// need to print the remaining streams for the last image
-					if streams.Len() > 0 {
-						fmt.Fprintf(w, strings.Join(streams.List(), ", "))
-					}
-					fmt.Fprintf(w, "\n\nREGISTRY\tSTREAM\tLAYER\n")
-				}
-				fmt.Fprintf(w, "%s\t%s\t%s\n", registryURL, repo, layer)
-				return nil
-			}
-
-			var (
-				imagePruneFunc       prune.ImagePruneFunc
-				imageStreamPruneFunc prune.ImageStreamPruneFunc
-				layerPruneFunc       prune.LayerPruneFunc
-				blobPruneFunc        prune.BlobPruneFunc
-				manifestPruneFunc    prune.ManifestPruneFunc
-			)
+			imagePruner := &describingImagePruner{w: w}
+			imageStreamPruner := &describingImageStreamPruner{w: w}
+			layerPruner := &describingLayerPruner{w: w}
+			blobPruner := &describingBlobPruner{w: w}
+			manifestPruner := &describingManifestPruner{w: w}
 
 			switch cfg.Confirm {
 			case true:
-				imagePruneFunc = func(image *imageapi.Image) error {
-					describingImagePruneFunc(image)
-					return prune.DeletingImagePruneFunc(osClient.Images())(image)
-				}
-				imageStreamPruneFunc = func(stream *imageapi.ImageStream, image *imageapi.Image) (*imageapi.ImageStream, error) {
-					describingImageStreamPruneFunc(stream, image)
-					return prune.DeletingImageStreamPruneFunc(osClient)(stream, image)
-				}
-				layerPruneFunc = func(registryURL, repo, layer string) error {
-					describingLayerPruneFunc(registryURL, repo, layer)
-					return prune.DeletingLayerPruneFunc(registryClient)(registryURL, repo, layer)
-				}
-				blobPruneFunc = prune.DeletingBlobPruneFunc(registryClient)
-				manifestPruneFunc = prune.DeletingManifestPruneFunc(registryClient)
+				imagePruner.delegate = prune.NewDeletingImagePruner(osClient.Images())
+				imageStreamPruner.delegate = prune.NewDeletingImageStreamPruner(osClient)
+				layerPruner.delegate = prune.NewDeletingLayerPruner()
+				blobPruner.delegate = prune.NewDeletingBlobPruner()
+				manifestPruner.delegate = prune.NewDeletingManifestPruner()
 			default:
 				fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made. Add --confirm to remove images")
-				imagePruneFunc = describingImagePruneFunc
-				imageStreamPruneFunc = describingImageStreamPruneFunc
-				layerPruneFunc = describingLayerPruneFunc
-				blobPruneFunc = func(registryURL, blob string) error {
-					return nil
-				}
-				manifestPruneFunc = func(registryURL, repo, manifest string) error {
-					return nil
-				}
 			}
 
-			if len(cfg.RegistryUrlOverride) > 0 {
-				originalLayerPruneFunc := layerPruneFunc
-				layerPruneFunc = func(registryURL, repo, layer string) error {
-					return originalLayerPruneFunc(cfg.RegistryUrlOverride, repo, layer)
-				}
-				originalBlobPruneFunc := blobPruneFunc
-				blobPruneFunc = func(registryURL, blob string) error {
-					return originalBlobPruneFunc(cfg.RegistryUrlOverride, blob)
-				}
-				originalManifestPruneFunc := manifestPruneFunc
-				manifestPruneFunc = func(registryURL, repo, manifest string) error {
-					return originalManifestPruneFunc(cfg.RegistryUrlOverride, repo, manifest)
-				}
-			}
-
-			pruner.Run(imagePruneFunc, imageStreamPruneFunc, layerPruneFunc, blobPruneFunc, manifestPruneFunc)
+			err = pruner.Prune(imagePruner, imageStreamPruner, layerPruner, blobPruner, manifestPruner)
+			cmdutil.CheckErr(err)
 		},
 	}
 
 	cmd.Flags().BoolVar(&cfg.Confirm, "confirm", cfg.Confirm, "Specify that image pruning should proceed. Defaults to false, displaying what would be deleted but not actually deleting anything.")
 	cmd.Flags().DurationVar(&cfg.KeepYoungerThan, "keep-younger-than", cfg.KeepYoungerThan, "Specify the minimum age of a build for it to be considered a candidate for pruning.")
-	cmd.Flags().IntVar(&cfg.TagRevisionsToKeep, "keep-tag-revisions", cfg.TagRevisionsToKeep, "Specify the number of image revisions for a tag in an image stream that will be preserved.")
+	cmd.Flags().IntVar(&cfg.KeepTagRevisions, "keep-tag-revisions", cfg.KeepTagRevisions, "Specify the number of image revisions for a tag in an image stream that will be preserved.")
 	cmd.Flags().StringVar(&cfg.CABundle, "certificate-authority", cfg.CABundle, "The path to a certificate authority bundle to use when communicating with the OpenShift-managed registries. Defaults to the certificate authority data from the current user's config file.")
 	cmd.Flags().StringVar(&cfg.RegistryUrlOverride, "registry-url", cfg.RegistryUrlOverride, "The address to use when contacting the registry, instead of using the default value. This is useful if you can't resolve or reach the registry (e.g.; the default is a cluster-internal URL) but you do have an alternative route that works.")
 
 	return cmd
 }
 
+// describingImageStreamPruner prints information about each image stream update.
+// If a delegate exists, its PruneImageStream function is invoked prior to returning.
+type describingImageStreamPruner struct {
+	w             io.Writer
+	delegate      prune.ImageStreamPruner
+	headerPrinted bool
+}
+
+var _ prune.ImageStreamPruner = &describingImageStreamPruner{}
+
+func (p *describingImageStreamPruner) PruneImageStream(stream *imageapi.ImageStream, image *imageapi.Image, updatedTags []string) (*imageapi.ImageStream, error) {
+	if !p.headerPrinted {
+		p.headerPrinted = true
+		fmt.Fprintln(p.w, "Deleting references from image streams to images ...")
+		fmt.Fprintln(p.w, "STREAM\tIMAGE\tTAGS")
+	}
+
+	fmt.Fprintf(p.w, "%s/%s\t%s\t%s\n", stream.Namespace, stream.Name, image.Name, strings.Join(updatedTags, ", "))
+
+	if p.delegate == nil {
+		return stream, nil
+	}
+
+	updatedStream, err := p.delegate.PruneImageStream(stream, image, updatedTags)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error updating image stream %s/%s to remove references to image %s: %v\n", stream.Namespace, stream.Name, image.Name, err)
+	}
+
+	return updatedStream, err
+}
+
+// describingImagePruner prints information about each image being deleted.
+// If a delegate exists, its PruneImage function is invoked prior to returning.
+type describingImagePruner struct {
+	w             io.Writer
+	delegate      prune.ImagePruner
+	headerPrinted bool
+}
+
+var _ prune.ImagePruner = &describingImagePruner{}
+
+func (p *describingImagePruner) PruneImage(image *imageapi.Image) error {
+	if !p.headerPrinted {
+		p.headerPrinted = true
+		fmt.Fprintln(p.w, "\nDeleting images from OpenShift ...")
+		fmt.Fprintln(p.w, "IMAGE")
+	}
+
+	fmt.Fprintf(p.w, "%s\n", image.Name)
+
+	if p.delegate == nil {
+		return nil
+	}
+
+	err := p.delegate.PruneImage(image)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error deleting image %s from OpenShift: %v\n", image.Name, err)
+	}
+
+	return err
+}
+
+// describingLayerPruner prints information about each repo layer link being
+// deleted. If a delegate exists, its PruneLayer function is invoked prior to
+// returning.
+type describingLayerPruner struct {
+	w             io.Writer
+	delegate      prune.LayerPruner
+	headerPrinted bool
+}
+
+var _ prune.LayerPruner = &describingLayerPruner{}
+
+func (p *describingLayerPruner) PruneLayer(registryClient *http.Client, registryURL, repo, layer string) error {
+	if !p.headerPrinted {
+		p.headerPrinted = true
+		fmt.Fprintln(p.w, "\nDeleting registry repository layer links ...")
+		fmt.Fprintln(p.w, "REPO\tLAYER")
+	}
+
+	fmt.Fprintf(p.w, "%s\t%s\n", repo, layer)
+
+	if p.delegate == nil {
+		return nil
+	}
+
+	err := p.delegate.PruneLayer(registryClient, registryURL, repo, layer)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error deleting repository %s layer link %s from the registry: %v\n", repo, layer, err)
+	}
+
+	return err
+}
+
+// describingBlobPruner prints information about each blob being deleted. If a
+// delegate exists, its PruneBlob function is invoked prior to returning.
+type describingBlobPruner struct {
+	w             io.Writer
+	delegate      prune.BlobPruner
+	headerPrinted bool
+}
+
+var _ prune.BlobPruner = &describingBlobPruner{}
+
+func (p *describingBlobPruner) PruneBlob(registryClient *http.Client, registryURL, layer string) error {
+	if !p.headerPrinted {
+		p.headerPrinted = true
+		fmt.Fprintln(p.w, "\nDeleting registry layer blobs ...")
+		fmt.Fprintln(p.w, "BLOB")
+	}
+
+	fmt.Fprintf(p.w, "%s\n", layer)
+
+	if p.delegate == nil {
+		return nil
+	}
+
+	err := p.delegate.PruneBlob(registryClient, registryURL, layer)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error deleting blob %s from the registry: %v\n", layer, err)
+	}
+
+	return err
+}
+
+// describingManifestPruner prints information about each repo manifest being
+// deleted. If a delegate exists, its PruneManifest function is invoked prior
+// to returning.
+type describingManifestPruner struct {
+	w             io.Writer
+	delegate      prune.ManifestPruner
+	headerPrinted bool
+}
+
+var _ prune.ManifestPruner = &describingManifestPruner{}
+
+func (p *describingManifestPruner) PruneManifest(registryClient *http.Client, registryURL, repo, manifest string) error {
+	if !p.headerPrinted {
+		p.headerPrinted = true
+		fmt.Fprintln(p.w, "\nDeleting registry repository manifest data ...")
+		fmt.Fprintln(p.w, "REPO\tIMAGE")
+	}
+
+	fmt.Fprintf(p.w, "%s\t%s\n", repo, manifest)
+
+	if p.delegate == nil {
+		return nil
+	}
+
+	err := p.delegate.PruneManifest(registryClient, registryURL, repo, manifest)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error deleting data for repository %s image manifest %s from the registry: %v\n", repo, manifest, err)
+	}
+
+	return err
+}
+
+// getClients returns a Kube client, OpenShift client, and registry client.
 func getClients(f *clientcmd.Factory, cfg *pruneImagesConfig) (*client.Client, *kclient.Client, *http.Client, error) {
 	clientConfig, err := f.OpenShiftClientConfig.ClientConfig()
 	if err != nil {

--- a/pkg/dockerregistry/server/admin.go
+++ b/pkg/dockerregistry/server/admin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/handlers"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	gorillahandlers "github.com/gorilla/handlers"
 )
 
@@ -46,9 +47,12 @@ func (bh *blobHandler) Delete(w http.ResponseWriter, req *http.Request) {
 
 	err := bh.Registry().Blobs().Delete(bh.Digest)
 	if err != nil {
-		bh.Errors.PushErr(fmt.Errorf("error deleting blob %q: %v", bh.Digest, err))
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		// Ignore PathNotFoundError
+		if _, ok := err.(storagedriver.PathNotFoundError); !ok {
+			bh.Errors.PushErr(fmt.Errorf("error deleting blob %q: %v", bh.Digest, err))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 	}
 
 	w.WriteHeader(http.StatusNoContent)
@@ -89,9 +93,12 @@ func (lh *layerHandler) Delete(w http.ResponseWriter, req *http.Request) {
 
 	err := lh.Repository.Layers().Delete(lh.Digest)
 	if err != nil {
-		lh.Errors.PushErr(fmt.Errorf("error unlinking layer %q from repo %q: %v", lh.Digest, lh.Repository.Name(), err))
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		// Ignore PathNotFoundError
+		if _, ok := err.(storagedriver.PathNotFoundError); !ok {
+			lh.Errors.PushErr(fmt.Errorf("error unlinking layer %q from repo %q: %v", lh.Digest, lh.Repository.Name(), err))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 	}
 
 	w.WriteHeader(http.StatusNoContent)
@@ -133,9 +140,12 @@ func (mh *manifestHandler) Delete(w http.ResponseWriter, req *http.Request) {
 
 	err := mh.Repository.Manifests().Delete(mh.Context, mh.Digest)
 	if err != nil {
-		mh.Errors.PushErr(fmt.Errorf("error deleting repo %q, manifest %q: %v", mh.Repository.Name(), mh.Digest, err))
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		// Ignore PathNotFoundError
+		if _, ok := err.(storagedriver.PathNotFoundError); !ok {
+			mh.Errors.PushErr(fmt.Errorf("error deleting repo %q, manifest %q: %v", mh.Repository.Name(), mh.Digest, err))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 	}
 
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
Update layer pruning to always delete blobs from the registry, even if
the image stream(s) that referenced the layer no longer exists. In the
event that there aren't any image streams referencing the layer any
more, we'll be able to delete the blob, but not the registry image
repository layer link files.

Fixes bug 1237271

Replaces #3514