### PR TITLE
Issue 3423: jshint wired into build-assets, lots of jshint errors

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -3,7 +3,7 @@
   "browser": true,
   "esnext": true,
   "bitwise": true,
-  "camelcase": true,
+  "camelcase": false,
   "curly": true,
   "eqeqeq": true,
   "immed": true,
@@ -13,15 +13,21 @@
   "noarg": true,
   "regexp": true,
   "undef": true,
-  "unused": true,
+  "unused": false,
   "strict": true,
   "trailing": true,
   "smarttabs": true,
   "globals": {
     "angular": false,
-    "$": false,
-    "URI": false,
+    "hawtioPluginLoader": false,
+    "HawtioCore": false,
+    "Logger" : false,
+    "LabelSelector": false,
     "moment": false,
-    "hawtioPluginLoader": false
+    "Messenger" : false,
+    "URI": false,
+    "ZeroClipboard": false,
+    "$": false,
+    "_" : false
   }
 }

--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -1,5 +1,6 @@
 // Generated on 2014-09-12 using generator-angular 0.9.8
 'use strict';
+/* jshint unused: false, camelcase: false */
 
 // # Globbing
 // for performance reasons we're only matching one level down:
@@ -51,7 +52,7 @@ module.exports = function (grunt) {
       css: {
         files: '<%= yeoman.app %>/styles/*.less',
         tasks: ['less']
-      },      
+      },
       gruntfile: {
         files: ['Gruntfile.js']
       },
@@ -261,7 +262,7 @@ module.exports = function (grunt) {
                     beautify: {
                       beautify: true,
                       indent_level: 0, // Don't waste characters indenting
-                      space_colon: false, // Don't waste characters 
+                      space_colon: false, // Don't waste characters
                       width: 1000,
                     },
                   };
@@ -414,13 +415,13 @@ module.exports = function (grunt) {
           cwd: 'bower_components/patternfly/components/font-awesome',
           src: 'fonts/*',
           dest: '<%= yeoman.dist %>/styles'
-        }, 
+        },
         {
           expand: true,
           cwd: 'bower_components/zeroclipboard/dist',
           src: 'ZeroClipboard.swf',
           dest: '<%= yeoman.dist %>/scripts'
-        }, 
+        },
 
         // Copy separate components
         {
@@ -479,21 +480,21 @@ module.exports = function (grunt) {
 
     protractor: {
       options: {
-        configFile: "test/protractor.conf.js", // Default config file 
-        keepAlive: false, // If false, the grunt process stops when the test fails. 
-        noColor: false, // If true, protractor will not use colors in its output. 
+        configFile: "test/protractor.conf.js", // Default config file
+        keepAlive: false, // If false, the grunt process stops when the test fails.
+        noColor: false, // If true, protractor will not use colors in its output.
         args: {
-          // Arguments passed to the command 
+          // Arguments passed to the command
         }
       },
       phantomjs: {},
       chrome: {
         options: {
-          configFile: "test/protractor-chrome.conf.js", // Target-specific config file 
-          args: {} // Target-specific arguments 
+          configFile: "test/protractor-chrome.conf.js", // Target-specific config file
+          args: {} // Target-specific arguments
         }
       }
-    },    
+    },
 
     // Settings for grunt-istanbul-coverage
     // NOTE: coverage task is currently not in use
@@ -508,7 +509,7 @@ module.exports = function (grunt) {
         dir: 'coverage',
         root: 'test'
       }
-    }    
+    }
   });
 
 
@@ -554,7 +555,7 @@ module.exports = function (grunt) {
     'connect:test',
     'protractor:phantomjs',
     'clean:server'
-  ]);  
+  ]);
 
   grunt.registerTask('test-e2e-chrome', [
     'clean:server',
@@ -563,10 +564,11 @@ module.exports = function (grunt) {
     'connect:test',
     'protractor:chrome',
     'clean:server'
-  ]);  
+  ]);
 
   grunt.registerTask('build', [
     'clean:dist',
+    'newer:jshint',
     'htmlhint',
     'wiredep',
     'useminPrepare',

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false, camelcase: false */
 
 /**
  * @ngdoc overview
@@ -48,7 +49,7 @@ angular
           }
         }
         return "project/:project/" + path;
-      }
+      };
     };
 
     var templatePath = "views";

--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false, sub:true */
 
 /**
  * @ngdoc function
@@ -21,6 +22,7 @@ angular.module('openshiftConsole')
     var watches = [];
 
     watches.push(DataService.watch("builds", $scope, function(builds, action, build) {
+
       $scope.unfilteredBuilds = builds.by("metadata.name");
       LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuilds, $scope.labelSuggestions);
       LabelFilter.setLabelSuggestions($scope.labelSuggestions);
@@ -29,9 +31,11 @@ angular.module('openshiftConsole')
       associateBuildsToBuildConfig();
       updateFilterWarning();
 
+      var buildConfigName;
+      var buildName;
       if (build) {
-        var buildConfigName = build.metadata.labels.buildconfig;
-        var buildName = build.metadata.name;
+        buildConfigName = build.metadata.labels.buildconfig;
+        buildName = build.metadata.name;
       }
       if (!action) {
         // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
@@ -80,7 +84,7 @@ angular.module('openshiftConsole')
         });
       });
       return buildConfigBuildsInProgress;
-    };
+    }
 
     function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.builds) && !$.isEmptyObject($scope.unfilteredBuilds)) {
@@ -92,7 +96,7 @@ angular.module('openshiftConsole')
       else {
         delete $scope.alerts["builds"];
       }
-    };
+    }
 
     // Function which will 'instantiate' new build from given buildConfigName
     $scope.startBuild = function(buildConfigName) {

--- a/assets/app/scripts/controllers/create.js
+++ b/assets/app/scripts/controllers/create.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint camelcase: false */
 
 /**
  * @ngdoc function
@@ -13,11 +14,11 @@ angular.module('openshiftConsole')
     var openshiftTemplates;
 
     // Templates with the `instant-apps` tag.
-    $scope.instantApps;
+    $scope.instantApps = undefined;
 
     // All templates from the shared or project namespace that aren't instant apps.
     // This is displayed in the "Other Templates" section.
-    $scope.otherTemplates;
+    // $scope.otherTemplates;
 
     // Set to true when shared templates and project templates have finished loading.
     $scope.templatesLoaded = false;

--- a/assets/app/scripts/controllers/deployments.js
+++ b/assets/app/scripts/controllers/deployments.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint sub: true */
 
 /**
  * @ngdoc function
@@ -28,7 +29,7 @@ angular.module('openshiftConsole')
       angular.forEach($scope.deployments, function(deployment, deploymentId){
         $scope.podTemplates[deploymentId] = deployment.spec.template;
       });
-    };
+    }
 
     watches.push(DataService.watch("replicationcontrollers", $scope, function(deployments) {
       $scope.unfilteredDeployments = deployments.by("metadata.name");
@@ -36,7 +37,7 @@ angular.module('openshiftConsole')
       LabelFilter.setLabelSuggestions($scope.labelSuggestions);
       $scope.deployments = LabelFilter.getLabelSelector().select($scope.unfilteredDeployments);
       extractPodTemplates();
-      ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);      
+      ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
       $scope.emptyMessage = "No deployments to show";
       associateDeploymentsToDeploymentConfig();
       updateFilterWarning();
@@ -83,7 +84,7 @@ angular.module('openshiftConsole')
       else {
         delete $scope.alerts["deployments"];
       }
-    };
+    }
 
     LabelFilter.onActiveFiltersChanged(function(labelSelector) {
       // trigger a digest loop

--- a/assets/app/scripts/controllers/images.js
+++ b/assets/app/scripts/controllers/images.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint sub: true */
 
 /**
  * @ngdoc function
@@ -37,7 +38,7 @@ angular.module('openshiftConsole')
       else {
         delete $scope.alerts["imageStreams"];
       }
-    };
+    }
 
     LabelFilter.onActiveFiltersChanged(function(labelSelector) {
       // trigger a digest loop

--- a/assets/app/scripts/controllers/newfromtemplate.js
+++ b/assets/app/scripts/controllers/newfromtemplate.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 /**
  * @ngdoc function

--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint sub: true */
 
 /**
  * @ngdoc function
@@ -157,7 +158,7 @@ angular.module('openshiftConsole')
             }
           }
         });
-        if (deployments.length == 0 && services.length == 0 && showMonopod(pod)) {
+        if (deployments.length === 0 && services.length === 0 && showMonopod(pod)) {
           $scope.monopodsByService[""][name] = pod;
         }
       });
@@ -165,7 +166,7 @@ angular.module('openshiftConsole')
       Logger.log("podsByDeployment", $scope.podsByDeployment);
       Logger.log("podsByService", $scope.podsByService);
       Logger.log("monopodsByService", $scope.monopodsByService);
-    };
+    }
 
     // Filter out monopods we know we don't want to see
     function showMonopod(pod) {
@@ -212,7 +213,7 @@ angular.module('openshiftConsole')
           $scope.deploymentConfigsByService[""][depName] = deploymentConfig;
         }
       });
-    };
+    }
 
     function deploymentsByService() {
       var bySvc = $scope.deploymentsByService = {"": {}};
@@ -243,7 +244,7 @@ angular.module('openshiftConsole')
           bySvcByDepCfg[""][depConfigName][depName] = deployment;
         }
       });
-    };
+    }
 
     // Sets up subscription for deployments
     watches.push(DataService.watch("replicationcontrollers", $scope, function(deployments, action, deployment) {
@@ -303,7 +304,7 @@ angular.module('openshiftConsole')
           trigger.builds[build.metadata.name] = build;
         }
       }
-    };
+    }
 
     // Sets up subscription for deploymentConfigs, associates builds to triggers on deploymentConfigs
     watches.push(DataService.watch("deploymentconfigs", $scope, function(deploymentConfigs, action, deploymentConfig) {
@@ -371,7 +372,7 @@ angular.module('openshiftConsole')
       else {
         delete $scope.alerts["services"];
       }
-    };
+    }
 
     function isGeneratedHost(route) {
       return annotationFilter(route, "openshift.io/host.generated") === "true";

--- a/assets/app/scripts/controllers/pods.js
+++ b/assets/app/scripts/controllers/pods.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint sub: true */
 
 /**
  * @ngdoc function
@@ -54,7 +55,7 @@ angular.module('openshiftConsole')
       else {
         delete $scope.alerts["pods"];
       }
-    };
+    }
 
     LabelFilter.onActiveFiltersChanged(function(labelSelector) {
       // trigger a digest loop

--- a/assets/app/scripts/controllers/project.js
+++ b/assets/app/scripts/controllers/project.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint sub: true, eqeqeq: false */
 
 /**
  * @ngdoc function
@@ -31,9 +32,9 @@ angular.module('openshiftConsole')
         function(e) {
           $scope.projectPromise.reject(e);
           if (e.status == 403 || e.status == 404) {
-            var message = e.status == 403 ? 
+            var message = e.status == 403 ?
               ("The project " + $scope.projectName + " does not exist or you are not authorized to view it.") :
-              ("The project " + $scope.projectName + " does not exist.")
+              ("The project " + $scope.projectName + " does not exist.");
             var redirect = URI('error').query({
               "error_description": message,
               "error" : e.status == 403 ? 'access_denied' : 'not_found'

--- a/assets/app/scripts/controllers/services.js
+++ b/assets/app/scripts/controllers/services.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint sub: true */
 
 /**
  * @ngdoc function
@@ -42,7 +43,7 @@ angular.module('openshiftConsole')
           }
         });
         return routeMap;
-    };
+    }
 
     function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.services)  && !$.isEmptyObject($scope.unfilteredServices)) {
@@ -54,7 +55,7 @@ angular.module('openshiftConsole')
       else {
         delete $scope.alerts["services"];
       }
-    };
+    }
 
     LabelFilter.onActiveFiltersChanged(function(labelSelector) {
       // trigger a digest loop

--- a/assets/app/scripts/controllers/settings.js
+++ b/assets/app/scripts/controllers/settings.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 /**
  * @ngdoc function

--- a/assets/app/scripts/directives/alerts.js
+++ b/assets/app/scripts/directives/alerts.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('openshiftConsole')
   .directive('alerts', function() {
     return {

--- a/assets/app/scripts/directives/catalog.js
+++ b/assets/app/scripts/directives/catalog.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 angular.module('openshiftConsole')
   .directive('catalogTemplate', function($location) {

--- a/assets/app/scripts/directives/date.js
+++ b/assets/app/scripts/directives/date.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('openshiftConsole')
   .directive("relativeTimestamp", function() {
     return {

--- a/assets/app/scripts/directives/nav.js
+++ b/assets/app/scripts/directives/nav.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 angular.module('openshiftConsole')
   .directive('sidebar', function(HawtioNav) {
@@ -60,7 +61,7 @@ angular.module('openshiftConsole')
           angular.forEach(sortedProjects, function(project) {
             $('<option>')
               .attr("value", project.metadata.name)
-              .attr("selected", project.metadata.name == projectName)
+              .attr("selected", project.metadata.name === projectName)
               .text($filter('displayName')(project))
               .appendTo(select);
           });

--- a/assets/app/scripts/directives/oscFileInput.js
+++ b/assets/app/scripts/directives/oscFileInput.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 angular.module('openshiftConsole')
   .directive('oscFileInput', function(Logger) {

--- a/assets/app/scripts/directives/oscFormSection.js
+++ b/assets/app/scripts/directives/oscFormSection.js
@@ -14,7 +14,9 @@ angular.module("openshiftConsole")
       },
       templateUrl: "views/directives/osc-form-section.html",
       link: function(scope, element, attrs){
-        if(!attrs.editText) attrs.editText="Edit";
+        if(!attrs.editText) {
+          attrs.editText="Edit";
+        }
         scope.expand = attrs.expand ? true : false;
         scope.toggle = function(){
           scope.expand = !scope.expand;

--- a/assets/app/scripts/directives/oscGitLink.js
+++ b/assets/app/scripts/directives/oscGitLink.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('openshiftConsole')
 .directive('oscGitLink', function() {
   return {
@@ -9,4 +11,4 @@ angular.module('openshiftConsole')
     transclude: true,
     template: '<a ng-href="{{uri | githubLink : commit}}" ng-transclude></a>'
   };
-})
+});

--- a/assets/app/scripts/directives/oscKeyValues.js
+++ b/assets/app/scripts/directives/oscKeyValues.js
@@ -1,4 +1,5 @@
 "use strict";
+/* jshint unused: false */
 
 angular.module("openshiftConsole")
   .controller("KeyValuesEntryController", function($scope){
@@ -21,7 +22,9 @@ angular.module("openshiftConsole")
   .controller("KeyValuesController", function($scope){
     var added = {};
     $scope.allowDelete = function(value){
-      if($scope.deletePolicy === "never") return false;
+      if($scope.deletePolicy === "never") {
+        return false;
+      }
       if($scope.deletePolicy === "added"){
         return added[value] !== undefined;
       }
@@ -57,8 +60,9 @@ angular.module("openshiftConsole")
       },
       env: function(modelValue, viewValue){
         var C_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/i;
-        if(modelValue === undefined || modelValue === null || modelValue.trim().length === 0) 
+        if(modelValue === undefined || modelValue === null || modelValue.trim().length === 0) {
           return true;
+        }
         return C_IDENTIFIER_RE.test(viewValue);
       },
       label: function(modelValue, viewValue) {

--- a/assets/app/scripts/directives/oscObjectDescriber.js
+++ b/assets/app/scripts/directives/oscObjectDescriber.js
@@ -1,3 +1,6 @@
+'use strict';
+/* jshint unused: false, eqeqeq: false */
+
 angular.module('openshiftConsole')
   .directive('oscObjectDescriber', function(ObjectDescriber) {
     return {
@@ -51,7 +54,7 @@ angular.module('openshiftConsole')
           if (scope.resource) {
             $(this).removeClass("osc-object-hover");
           }
-        }); 
+        });
 
         // TODO can we be more efficient about this to reduce the number of listeners
         var resourceChangeCallback = ObjectDescriber.onResourceChanged(function(resource, kind) {
@@ -78,7 +81,7 @@ angular.module('openshiftConsole')
         });
       }
     };
-  })  
+  })
   .service("ObjectDescriber", function($timeout){
     function ObjectDescriber() {
       this.resource = null;

--- a/assets/app/scripts/directives/popups.js
+++ b/assets/app/scripts/directives/popups.js
@@ -1,8 +1,10 @@
+'use strict';
+
 angular.module('openshiftConsole')
   // This triggers when an element has either a toggle or data-toggle attribute set on it
   .directive('toggle', function() {
     return {
-      restrict: 'A', 
+      restrict: 'A',
       link: function($scope, element, attrs) {
         if (attrs) {
           switch(attrs.toggle) {

--- a/assets/app/scripts/directives/resources.js
+++ b/assets/app/scripts/directives/resources.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused:false */
 
 angular.module('openshiftConsole')
   .directive('overviewDeployment', function() {

--- a/assets/app/scripts/directives/truncate.js
+++ b/assets/app/scripts/directives/truncate.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 angular.module('openshiftConsole')
   // Truncates text to a length, adding a tooltip and an ellipsis if truncated.

--- a/assets/app/scripts/directives/util.js
+++ b/assets/app/scripts/directives/util.js
@@ -1,7 +1,10 @@
+'use strict';
+/* jshint unused: false */
+
 angular.module('openshiftConsole')
   .directive('selectOnFocus', function() {
     return {
-      restrict: 'A', 
+      restrict: 'A',
       link: function($scope, element, attrs) {
         $(element).focus(function () {
           $(this).select();
@@ -11,7 +14,7 @@ angular.module('openshiftConsole')
   })
   .directive('tileClick', function() {
     return {
-      restrict: 'AC', 
+      restrict: 'AC',
       link: function($scope, element, attrs) {
         $(element).click(function (evt) {
           var t = $(evt.target);
@@ -55,7 +58,7 @@ angular.module('openshiftConsole')
           $("#global-zeroclipboard-html-bridge").tooltip({title: "Copy to clipboard", placement: 'bottom'});
         }
       }
-    }
+    };
   })
   .directive('shortId', function() {
     return {
@@ -64,7 +67,7 @@ angular.module('openshiftConsole')
         id: '@'
       },
       template: '<code class="short-id" title="{{id}}">{{id.substring(0, 6)}}</code>'
-    }
+    };
   })
   .directive('customIcon', function() {
     return {
@@ -80,7 +83,7 @@ angular.module('openshiftConsole')
         } else {
           $scope.icon = $filter('annotation')($scope.resource, "icon");
         }
-        $scope.isDataIcon = $scope.icon && $scope.icon.indexOf("data:") == 0;
+        $scope.isDataIcon = $scope.icon && ($scope.icon.indexOf("data:") === 0);
         if (!$scope.isDataIcon) {
           // The icon class filter will at worst return the default icon for the given kind
           if ($scope.tag) {
@@ -91,5 +94,5 @@ angular.module('openshiftConsole')
         }
       },
       templateUrl: 'views/directives/_custom-icon.html'
-    }
+    };
   });

--- a/assets/app/scripts/extensions/javaLink.js
+++ b/assets/app/scripts/extensions/javaLink.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint newcap: false */
 
 /**
  * @ngdoc function

--- a/assets/app/scripts/filters/date.js
+++ b/assets/app/scripts/filters/date.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('openshiftConsole')
   .filter('dateRelative', function() {
     return function(timestamp) {
@@ -43,7 +45,7 @@ angular.module('openshiftConsole')
       add(minutes, "minute", "minutes");
       add(seconds, "second", "seconds");
 
-      if (humanizedDuration.length == 0) {
+      if (humanizedDuration.length === 0) {
         humanizedDuration.push("0 seconds");
       }
 
@@ -58,7 +60,7 @@ angular.module('openshiftConsole')
     // ex:  amt = 5  and unit = 'minutes'
     return function(timestamp, amt, unit) {
       return moment().subtract(amt, unit).diff(moment(timestamp)) < 0;
-    }
+    };
   })
   .filter('orderObjectsByDate', function() {
     return function(items, reverse) {
@@ -72,7 +74,9 @@ angular.module('openshiftConsole')
         }
         return moment(a.metadata.creationTimestamp).diff(moment(b.metadata.creationTimestamp));
       });
-      if(reverse) filtered.reverse();
+      if(reverse) {
+        filtered.reverse();
+      }
       return filtered;
-    }
+    };
   });

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint unused: false */
 
 angular.module('openshiftConsole')
   // this filter is intended for use with the "track by" in an ng-repeat
@@ -11,7 +12,7 @@ angular.module('openshiftConsole')
       else {
         return resource;
       }
-    }
+    };
   })
   .filter('annotation', function() {
     // This maps an annotation key to all known synonymous keys to insulate
@@ -30,7 +31,7 @@ angular.module('openshiftConsole')
       if (resource && resource.metadata && resource.metadata.annotations) {
         // If the key's already in the annotation map, return it.
         if (resource.metadata.annotations[key] !== undefined) {
-          return resource.metadata.annotations[key]
+          return resource.metadata.annotations[key];
         }
         // Try and return a value for a mapped key.
         var mappings = annotationMap[key] || [];
@@ -157,7 +158,7 @@ angular.module('openshiftConsole')
       }
 
       return image.split(":")[1];
-    }
+    };
   })
   .filter('imageStreamName', function() {
     return function(image) {
@@ -167,7 +168,7 @@ angular.module('openshiftConsole')
       // TODO move this parsing method into a utility method
 
       // remove @sha256:....
-      var imageWithoutID = image.split("@")[0]
+      var imageWithoutID = image.split("@")[0];
 
       var slashSplit = imageWithoutID.split("/");
       var semiColonSplit;
@@ -197,7 +198,7 @@ angular.module('openshiftConsole')
       }
       return null;
     };
-  })  
+  })
   .filter('buildForImage', function() {
     return function(image, builds) {
       // TODO concerned that this gets called anytime any data is changed on the scope,
@@ -452,6 +453,7 @@ angular.module('openshiftConsole')
           return ageLessThanFilter(timestamp, 1, 'minutes');
         case 'Failed':
         case 'Error':
+          /* falls through */
         default:
           return ageLessThanFilter(timestamp, 5, 'minutes');
       }
@@ -463,7 +465,7 @@ angular.module('openshiftConsole')
         return [];
       }
 
-      var configJson = annotationFilter(deployment, 'encodedDeploymentConfig')
+      var configJson = annotationFilter(deployment, 'encodedDeploymentConfig');
       if (!configJson) {
         return [];
       }

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -12,7 +12,9 @@ angular.module('openshiftConsole')
   })
   .filter("defaultIfBlank", function(){
     return function(input, defaultValue){
-      if(input === null) return defaultValue;
+      if(input === null) {
+        return defaultValue;
+      }
       if(typeof input !== "string"){
         input = String(input);
       }
@@ -40,10 +42,10 @@ angular.module('openshiftConsole')
       }
       var number = split[1];
       if (number.indexOf(".") >= 0) {
-        var number = parseFloat(number);
+        number = parseFloat(number);
       }
       else {
-        var number =  parseInt(split[1]);
+        number = parseInt(split[1]);
       }
       var siSuffix = split[2];
       var multiplier = 1;
@@ -172,7 +174,7 @@ angular.module('openshiftConsole')
   })
   /**
    * Filter a hash of values
-   * 
+   *
    * @param {Hash} entries  A Hash to filter
    * @param {String} keys    A comma delimited string of keys to evaluate against
    * @returns {Hash} A filtered set where the keys of those in keys
@@ -191,7 +193,7 @@ angular.module('openshiftConsole')
   })
     /**
    * Filter a hash of values
-   * 
+   *
    * @param {Hash} entries  A Hash to filter
    * @param {String} keys    A comma delimited string of keys to evaluate against
    * @returns {Hash} A filtered set where the keys of those not in keys

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -92,7 +92,9 @@ angular.module("openshiftConsole")
     };
 
     scope._generateRoute = function(input, name, serviceName){
-      if(!input.routing.include) return null;
+      if(!input.routing.include) {
+        return null;
+      }
       return {
         kind: "Route",
         apiVersion: osApiVersion,
@@ -241,7 +243,9 @@ angular.module("openshiftConsole")
     };
 
     scope._generateService  = function(input, serviceName, port){
-      if(port === 'None') return null;
+      if(port === 'None') {
+        return null;
+      }
       var service = {
         kind: "Service",
         apiVersion: k8sApiVersion,

--- a/assets/app/scripts/services/auth.js
+++ b/assets/app/scripts/services/auth.js
@@ -1,3 +1,6 @@
+'use strict';
+/* jshint sub:true, camelcase: false */
+
 angular.module('openshiftConsole')
 // In a config step, set the desired user store and login service. For example:
 //   AuthServiceProvider.setUserStore('LocalStorageUserStore')
@@ -108,7 +111,8 @@ angular.module('openshiftConsole')
 
         var oldName = oldUser && oldUser.metadata && oldUser.metadata.name;
         var newName = user    && user.metadata    && user.metadata.name;
-        if (oldName != newName) {
+
+        if (oldName !== newName) {
           authLogger.log('AuthService.setUser(), user changed', oldUser, user);
           _userChangedCallbacks.fire(user);
         }
@@ -136,7 +140,7 @@ angular.module('openshiftConsole')
         }
 
         // Handle web socket requests with a parameter
-        if (config.method == 'WATCH') {
+        if (config.method === 'WATCH') {
           config.url = URI(config.url).addQuery({access_token: token}).toString();
           authLogger.log('AuthService.addAuthToRequest(), added token param', config.url);
         } else {
@@ -202,7 +206,7 @@ angular.module('openshiftConsole')
       onUserChanged: function(callback) {
         _userChangedCallbacks.add(callback);
       }
-    }
+    };
   };
 })
 // register the interceptor as a service
@@ -274,4 +278,4 @@ angular.module('openshiftConsole')
       }
     }
   };
-}])
+}]);

--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint eqeqeq: false, unused: false */
 
 angular.module('openshiftConsole')
 .factory('DataService', function($http, $ws, $rootScope, $q, API_CFG, Notification, Logger) {
@@ -75,14 +76,15 @@ angular.module('openshiftConsole')
   };
 
   var normalizeType = function(type) {
-     if (!type) return type;
-     var lower = type.toLowerCase();
-     if (type !== lower) {
-       Logger.warn('Non-lower case type "' + type + '"');
-     }
-
-     return lower;
-  }
+    if (!type) {
+      return type;
+    }
+    var lower = type.toLowerCase();
+    if (type !== lower) {
+      Logger.warn('Non-lower case type "' + type + '"');
+    }
+    return lower;
+  };
 
   function DataService() {
     this._listCallbacksMap = {};
@@ -298,7 +300,7 @@ angular.module('openshiftConsole')
           if (opts.errorNotification !== false) {
             var msg = "Failed to get " + type + "/" + name;
             if (status !== 0) {
-              msg += " (" + status + ")"
+              msg += " (" + status + ")";
             }
             Notification.error(msg);
           }
@@ -351,6 +353,7 @@ angular.module('openshiftConsole')
     }
 
     var existingWatchOpts = this._watchOptions(type, context);
+
     if (existingWatchOpts) {
       // Check any options for compatibility with existing watch
       if (existingWatchOpts.poll != opts.poll) {
@@ -541,7 +544,9 @@ angular.module('openshiftConsole')
     // connection is not succeeding. This check is necessary if connection
     // timeouts take longer than 6 seconds.
     for (var i = events.length - maxConsecutiveCloseEvents; i < events.length; i++) {
-      if (events[i].type !== 'close') return false;
+      if (events[i].type !== 'close') {
+        return false;
+      }
     }
 
     return true;
@@ -588,7 +593,7 @@ angular.module('openshiftConsole')
         }).error(function(data, status, headers, config) {
           var msg = "Failed to list " + type;
           if (status !== 0) {
-            msg += " (" + status + ")"
+            msg += " (" + status + ")";
           }
           // TODO would like to make this optional with an errorNotification option, see get for an example
           Notification.error(msg);
@@ -604,7 +609,7 @@ angular.module('openshiftConsole')
       }).error(function(data, status, headers, config) {
         var msg = "Failed to list " + type;
         if (status !== 0) {
-          msg += " (" + status + ")"
+          msg += " (" + status + ")";
         }
         // TODO would like to make this optional with an errorNotification option, see get for an example
         Notification.error(msg);
@@ -839,17 +844,19 @@ angular.module('openshiftConsole')
   };
 
   DataService.prototype._urlForType = function(type, id, context, isWebsocket, params) {
+    var subresource;
+    var typeWithSubresource;
 
     // Parse the type parameter for type itself and subresource. Example: 'buildconfigs/instantiate'
     if(type.indexOf('/') !== -1){
-      var typeWithSubresource = type.split("/");
-      var type = typeWithSubresource[0];
-      var subresource = typeWithSubresource[1];
+      typeWithSubresource = type.split("/");
+      type = typeWithSubresource[0];
+      subresource = typeWithSubresource[1];
     }
 
     var typeInfo = SERVER_TYPE_MAP[type];
     if (!typeInfo) {
-    	Logger.error("_urlForType called with unknown type", type, arguments)
+    	Logger.error("_urlForType called with unknown type", type, arguments);
     	return null;
     }
 

--- a/assets/app/scripts/services/imageStreamResolver.js
+++ b/assets/app/scripts/services/imageStreamResolver.js
@@ -32,7 +32,7 @@ angular.module('openshiftConsole')
         });
         promises.push(imageStreamImagePromise);
       });
-    })
+    });
     return $q.all(promises);
   };
 

--- a/assets/app/scripts/services/login.js
+++ b/assets/app/scripts/services/login.js
@@ -1,3 +1,7 @@
+'use strict';
+/* jshint unused: false, camelcase: false */
+/* TODO (bpeterse): fix these jshint issues later */
+
 // Login strategies
 angular.module('openshiftConsole')
 .provider('RedirectLoginService', function() {
@@ -30,14 +34,14 @@ angular.module('openshiftConsole')
     return {
       // Returns a promise that resolves with {user:{...}, token:'...', ttl:X}, or rejects with {error:'...'[,error_description:'...',error_uri:'...']}
       login: function() {
-        if (_oauth_client_id == "") {
-          return $q.reject({error:'invalid_request', error_description:'RedirectLoginServiceProvider.OAuthClientID() not set'}); 
+        if (_oauth_client_id === "") {
+          return $q.reject({error:'invalid_request', error_description:'RedirectLoginServiceProvider.OAuthClientID() not set'});
         }
-        if (_oauth_authorize_uri == "") {
-          return $q.reject({error:'invalid_request', error_description:'RedirectLoginServiceProvider.OAuthAuthorizeURI() not set'}); 
+        if (_oauth_authorize_uri === "") {
+          return $q.reject({error:'invalid_request', error_description:'RedirectLoginServiceProvider.OAuthAuthorizeURI() not set'});
         }
-        if (_oauth_redirect_uri == "") {
-          return $q.reject({error:'invalid_request', error_description:'RedirectLoginServiceProvider.OAuthRedirectURI not set'}); 
+        if (_oauth_redirect_uri === "") {
+          return $q.reject({error:'invalid_request', error_description:'RedirectLoginServiceProvider.OAuthRedirectURI not set'});
         }
 
         var deferred = $q.defer();
@@ -66,7 +70,7 @@ angular.module('openshiftConsole')
 
         // Read params
         var queryParams = u.query(true);
-        var fragmentParams = new URI("?" + u.fragment()).query(true); 
+        var fragmentParams = new URI("?" + u.fragment()).query(true);
         authLogger.log("RedirectLoginService.finish()", queryParams, fragmentParams);
 
        // Error codes can come in query params or fragment params
@@ -84,7 +88,7 @@ angular.module('openshiftConsole')
         }
 
         // Handle an access_token response
-        if (fragmentParams.access_token && fragmentParams.token_type == "bearer") {
+        if (fragmentParams.access_token && fragmentParams.token_type === "bearer") {
           var deferred = $q.defer();
           deferred.resolve({
             token: fragmentParams.access_token,

--- a/assets/app/scripts/services/logout.js
+++ b/assets/app/scripts/services/logout.js
@@ -1,8 +1,8 @@
+'use strict';
+
 // Logout strategies
 angular.module('openshiftConsole')
 .provider('DeleteTokenLogoutService', function() {
-
-  var debug = true;
 
   this.$get = function($q, $injector, Logger) {
     var authLogger = Logger.get("auth");

--- a/assets/app/scripts/services/navigate.js
+++ b/assets/app/scripts/services/navigate.js
@@ -1,11 +1,12 @@
 "use strict";
+/* jshint camelcase: false */
 
 angular.module("openshiftConsole")
   .service("Navigate", function($location){
     return {
       /**
        * Navigate and display the error page.
-       * 
+       *
        * @param {type} message    The message to display to the user
        * @param {type} errorCode  An optional error code to display
        * @returns {undefined}
@@ -19,7 +20,7 @@ angular.module("openshiftConsole")
       },
       /**
        * Navigate and display the project overview page.
-       * 
+       *
        * @param {type} projectName  the projedt name
        * @returns {undefined}
        */
@@ -29,7 +30,7 @@ angular.module("openshiftConsole")
 
       /**
        * Return the URL for the project overview
-       * 
+       *
        * @param {type}     projectName
        * @returns {String} a URL string for the project overview
        */

--- a/assets/app/scripts/services/notification.js
+++ b/assets/app/scripts/services/notification.js
@@ -1,4 +1,5 @@
 'use strict';
+/* jshint newcap: false */
 
 angular.module('openshiftConsole')
 .factory('Notification', function($rootScope) {
@@ -11,9 +12,8 @@ angular.module('openshiftConsole')
         hideAfter: 10
       }
     });
-
     var self = this;
-    $rootScope.$on( "$routeChangeStart", function(event, next, current) {
+    $rootScope.$on( "$routeChangeStart", function() {
       self.clear();
     });
   }
@@ -41,7 +41,7 @@ angular.module('openshiftConsole')
 
   Notification.prototype.info = function(message, opts) {
     this.notify("info", message, opts);
-  };  
+  };
 
   Notification.prototype.error = function(message, opts) {
     this.notify("error", message, opts);
@@ -55,5 +55,5 @@ angular.module('openshiftConsole')
     this.messenger.hideAll();
   };
 
-  return new Notification();;
+  return new Notification();
 });

--- a/assets/app/scripts/services/tasks.js
+++ b/assets/app/scripts/services/tasks.js
@@ -21,9 +21,6 @@ angular.module('openshiftConsole')
   // Maximum amount of time that a successful task will hang around after completion
   var TASK_TIMEOUT = 30*1000;
 
-  // How often the task list will be checked
-  var TASK_REFRESH_INTERVAL = 100;
-
   function TaskList() {
     this.tasks = [];
   }

--- a/assets/app/scripts/services/userstore.js
+++ b/assets/app/scripts/services/userstore.js
@@ -1,3 +1,6 @@
+'use strict';
+/* jshint unused: false */
+
 // UserStore objects able to remember user and tokens for the current user
 angular.module('openshiftConsole')
 .provider('MemoryUserStore', function() {
@@ -27,7 +30,7 @@ angular.module('openshiftConsole')
         authLogger.log("MemoryUserStore.setToken", token);
         _token = token;
       }
-    }
+    };
   };
 })
 .provider('SessionStorageUserStore', function() {
@@ -38,11 +41,11 @@ angular.module('openshiftConsole')
     return {
       available: function() {
         try {
-          var x = new Date().getTime();
+          var x = String(Date.now());
           sessionStorage['SessionStorageUserStore.test'] = x;
           var y = sessionStorage['SessionStorageUserStore.test'];
           sessionStorage.removeItem('SessionStorageUserStore.test');
-          return x == y;
+          return x === y;
         } catch(e) {
           return false;
         }
@@ -87,7 +90,7 @@ angular.module('openshiftConsole')
           sessionStorage.removeItem(tokenkey);
         }
       }
-    }
+    };
   };
 })
 .provider('LocalStorageUserStore', function() {
@@ -122,11 +125,11 @@ angular.module('openshiftConsole')
     return {
       available: function() {
         try {
-          var x = new Date().getTime();
+          var x = String(Date.now());
           localStorage['LocalStorageUserStore.test'] = x;
           var y = localStorage['LocalStorageUserStore.test'];
           localStorage.removeItem('LocalStorageUserStore.test');
-          return x == y;
+          return x === y;
         } catch(e) {
           return false;
         }
@@ -185,6 +188,6 @@ angular.module('openshiftConsole')
           setTTL(tokenkey, null);
         }
       }
-    }
+    };
   };
 });

--- a/assets/app/scripts/services/ws.js
+++ b/assets/app/scripts/services/ws.js
@@ -1,3 +1,4 @@
+'use strict';
 // Provide a websocket implementation that behaves like $http
 // Methods:
 //   $ws({
@@ -10,8 +11,6 @@
 //   returns true if WebSockets are available to use
 angular.module('openshiftConsole')
 .provider('$ws', function($httpProvider) {
-
-  var debug = false;
 
   // $get method is called to build the $ws service
   this.$get = function($q, $injector, Logger) {
@@ -75,4 +74,4 @@ angular.module('openshiftConsole')
 
     return $ws;
   };
-})
+});

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-cssmin": "0.9.0",
     "grunt-contrib-htmlmin": "0.4.0",
     "grunt-contrib-imagemin": "0.8.1",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "~0.11.0",
     "grunt-contrib-less": "1.0.0",
     "grunt-contrib-uglify": "0.4.1",
     "grunt-contrib-watch": "0.6.1",

--- a/assets/test/.jshintrc
+++ b/assets/test/.jshintrc
@@ -30,7 +30,18 @@
     "inject": false,
     "it": false,
     "jasmine": false,
-    "spyOn": false
+    "spyOn": false,
+    "hawtioPluginLoader": false,
+    "HawtioCore": false,
+    "Logger" : false,
+    "LabelSelector": false,
+    "moment": false,
+    "Messenger" : false,
+    "URI": false,
+    "ZeroClipboard": false,
+    "$": false,
+    "_" : false
+
   }
 }
 

--- a/assets/test/spec/controllers/create.js
+++ b/assets/test/spec/controllers/create.js
@@ -1,6 +1,7 @@
-"use strict";
+'use strict';
+/* jshint unused: false */
 
-describe("CreateController", function(){
+describe('CreateController', function(){
   var controller, form;
   var $scope = {
     projectTemplates: {},
@@ -11,7 +12,7 @@ describe("CreateController", function(){
   beforeEach(function(){
     inject(function(_$controller_){
       // The injector unwraps the underscores (_) from around the parameter names when matching
-      controller = _$controller_("CreateController", {
+      controller = _$controller_('CreateController', {
         $scope: $scope,
         DataService: {
           list: function(templates){}
@@ -21,59 +22,59 @@ describe("CreateController", function(){
   });
 
 
-  it("valid http URL", function(){
-    var match = 'http://example.com/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid http URL', function(){
+    var match = 'http://example.com/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("valid http URL, without http part", function(){
-    var match = 'example.com/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid http URL, without http part', function(){
+    var match = 'example.com/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
 
-  it("valid http URL with user and password", function(){
-    var match = 'http://user:pass@example.com/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid http URL with user and password', function(){
+    var match = 'http://user:pass@example.com/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("invalid http URL with user and password containing space", function(){
-    var match = 'http://user:pa ss@example.com/dir1/dir2'.match($scope.sourceURLPattern)
+  it('invalid http URL with user and password containing space', function(){
+    var match = 'http://user:pa ss@example.com/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).toBeNull();
   });
 
-  it("valid http URL with user and password with special characters", function(){
-    var match = 'https://user:my!password@example.com/gerrit/p/myrepo.git'.match($scope.sourceURLPattern)
+  it('valid http URL with user and password with special characters', function(){
+    var match = 'https://user:my!password@example.com/gerrit/p/myrepo.git'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("valid http URL with port", function(){
-    var match = 'http://example.com:8080/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid http URL with port', function(){
+    var match = 'http://example.com:8080/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("valid http URL with port, user and password", function(){
-    var match = 'http://user:pass@example.com:8080/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid http URL with port, user and password', function(){
+    var match = 'http://user:pass@example.com:8080/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("valid https URL", function(){
-    var match = 'https://example.com/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid https URL', function(){
+    var match = 'https://example.com/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("valid ftp URL", function(){
-    var match = 'ftp://example.com/dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid ftp URL', function(){
+    var match = 'ftp://example.com/dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("valid git+ssh URL", function(){
-    var match = 'git@example.com:dir1/dir2'.match($scope.sourceURLPattern)
+  it('valid git+ssh URL', function(){
+    var match = 'git@example.com:dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).not.toBeNull();
   });
 
-  it("invalid git+ssh URL (double @@)", function(){
-    var match = 'git@@example.com:dir1/dir2'.match($scope.sourceURLPattern)
+  it('invalid git+ssh URL (double @@)', function(){
+    var match = 'git@@example.com:dir1/dir2'.match($scope.sourceURLPattern);
     expect(match).toBeNull();
   });
 

--- a/assets/test/spec/controllers/project.js
+++ b/assets/test/spec/controllers/project.js
@@ -1,11 +1,12 @@
 'use strict';
+/* jshint unused: false */
 
 describe('Controller: ProjectController', function () {
 
   // Angular is refusing to recognize the HawtioNav stuff
   // when testing even though its being loaded
    beforeEach(module(function ($provide) {
-    $provide.provider("HawtioNavBuilder", function() {
+    $provide.provider('HawtioNavBuilder', function() {
       function Mocked() {}
       this.create = function() {return this;};
       this.id = function() {return this;};
@@ -16,18 +17,18 @@ describe('Controller: ProjectController', function () {
       this.page = function() {return this;};
       this.subPath = function() {return this;};
       this.build = function() {return this;};
-      this.join = function() {return "";};
+      this.join = function() {return '';};
       this.$get = function() {return new Mocked();};
     });
 
-    $provide.factory("HawtioNav", function(){
+    $provide.factory('HawtioNav', function(){
       return {add: function() {}};
     });
   }));
 
   // Make sure a base location exists in the generated test html
   if (!$('head base').length) {
-    $('head').append($('<base href="/">'))
+    $('head').append($('<base href="/">'));
   }
 
   angular.module('openshiftConsole').config(function(AuthServiceProvider) {
@@ -44,15 +45,15 @@ describe('Controller: ProjectController', function () {
   // Initialize the controller and a mock scope
   beforeEach(inject(function ($controller, $rootScope, $q, $timeout, MemoryUserStore) {
     // Set up a stub user
-    MemoryUserStore.setToken("myToken");
-    MemoryUserStore.setUser({metadata: {name: "My User"}});
+    MemoryUserStore.setToken('myToken');
+    MemoryUserStore.setUser({metadata: {name: 'My User'}});
 
     scope = $rootScope.$new();
     timeout = $timeout;
 
     ProjectController = $controller('ProjectController', {
       $scope: scope,
-      $routeParams: {project: "foo"},
+      $routeParams: {project: 'foo'},
       DataService: {
         get: function(type, id, context, opts) {
           // TODO return mocked project data
@@ -78,12 +79,12 @@ describe('Controller: ProjectController', function () {
   it('should set the projectName', function () {
     // Flush async withUser and DataService calls
     timeout.flush();
-    expect(scope.projectName).toBe("foo");
+    expect(scope.projectName).toBe('foo');
   });
 
   it('should set up the promise and resolve it when project is returned', function () {
     // Flush async withUser and DataService calls
     timeout.flush();
-    expect(scope.projectPromise.state()).toBe("resolved");
+    expect(scope.projectPromise.state()).toBe('resolved');
   });
 });

--- a/assets/test/spec/controllers/projects.js
+++ b/assets/test/spec/controllers/projects.js
@@ -1,11 +1,12 @@
 'use strict';
+/* jshint unused: false */
 
 describe('Controller: ProjectsController', function () {
 
   // Angular is refusing to recognize the HawtioNav stuff
   // when testing even though its being loaded
    beforeEach(module(function ($provide) {
-    $provide.provider("HawtioNavBuilder", function() {
+    $provide.provider('HawtioNavBuilder', function() {
       function Mocked() {}
       this.create = function() {return this;};
       this.id = function() {return this;};
@@ -16,18 +17,18 @@ describe('Controller: ProjectsController', function () {
       this.page = function() {return this;};
       this.subPath = function() {return this;};
       this.build = function() {return this;};
-      this.join = function() {return "";};
+      this.join = function() {return '';};
       this.$get = function() {return new Mocked();};
     });
 
-    $provide.factory("HawtioNav", function(){
+    $provide.factory('HawtioNav', function(){
       return {add: function() {}};
     });
   }));
 
   // Make sure a base location exists in the generated test html
   if (!$('head base').length) {
-    $('head').append($('<base href="/">'))
+    $('head').append($('<base href='/'>'));
   }
 
   angular.module('openshiftConsole').config(function(AuthServiceProvider) {
@@ -44,8 +45,8 @@ describe('Controller: ProjectsController', function () {
   // Initialize the controller and a mock scope
   beforeEach(inject(function ($controller, $timeout, $rootScope, $q, MemoryUserStore) {
     // Set up a stub user
-    MemoryUserStore.setToken("myToken");
-    MemoryUserStore.setUser({metadata: {name: "My User"}});
+    MemoryUserStore.setToken('myToken');
+    MemoryUserStore.setUser({metadata: {name: 'My User'}});
 
     scope = $rootScope.$new();
     timeout = $timeout;
@@ -56,7 +57,7 @@ describe('Controller: ProjectsController', function () {
       DataService: {
         list: function(type, context, callback, opts) {
           // TODO return mocked project data
-          callback({by: function(){return {}}});
+          callback({by:function(){ return {};}});
         },
         get: function(type, name, context, opts) {
           var deferred = $q.defer();

--- a/assets/test/spec/directives/oscKeyValuesSpec.js
+++ b/assets/test/spec/directives/oscKeyValuesSpec.js
@@ -1,122 +1,122 @@
-"use strict";
+'use strict';
 
-describe("KeyValuesEntryController", function(){
+describe('KeyValuesEntryController', function(){
     var scope, controller;
     beforeEach(function(){
       scope = {
-        value: "foo"
+        value: 'foo'
       };
       inject(function(_$controller_){
         // The injector unwraps the underscores (_) from around the parameter names when matching
-       controller = _$controller_("KeyValuesEntryController", {$scope: scope});
+       controller = _$controller_('KeyValuesEntryController', {$scope: scope});
       });
     });
-    
-    describe("#edit", function(){
-      it("should copy the original value", function(){
+
+    describe('#edit', function(){
+      it('should copy the original value', function(){
         scope.edit();
         expect(scope.value).toEqual(scope.originalValue);
         expect(scope.editing).toEqual(true);
       });
     });
-    
-    describe("#cancel", function(){
-      it("should reset value to the original value", function(){
-        scope.originalValue = "bar";
+
+    describe('#cancel', function(){
+      it('should reset value to the original value', function(){
+        scope.originalValue = 'bar';
         scope.cancel();
-        expect(scope.value).toEqual("bar");
+        expect(scope.value).toEqual('bar');
         expect(scope.editing).toEqual(false);
       });
     });
-    
-    describe("#update", function(){
-      var entries = { foo: "abc"};
-      it("should update the entries for the key when the value is not empty", function(){
-        scope.update("foo", "bar", entries);
-        expect(entries["foo"]).toEqual("bar");
+
+    describe('#update', function(){
+      var entries = { foo: 'abc'};
+      it('should update the entries for the key when the value is not empty', function(){
+        scope.update('foo', 'bar', entries);
+        expect(entries.foo).toEqual('bar');
         expect(scope.editing).toEqual(false);
       });
     });
 });
 
-describe("KeyValuesController", function(){
+describe('KeyValuesController', function(){
   var scope, controller;
 
   beforeEach(function(){
-    scope = { 
-      entries: { "foo": "bar"},
+    scope = {
+      entries: { 'foo': 'bar'},
       form: {
         $setPristine: function(){},
         $setUntouched: function(){},
         $setValidity: function(){},
       },
-      readonlyKeys: ""
+      readonlyKeys: ''
     };
     inject(function(_$controller_){
       // The injector unwraps the underscores (_) from around the parameter names when matching
-     controller = _$controller_("KeyValuesController", {$scope: scope});
-    });
-    
-  });
-  
-  describe("#allowDelete", function(){
-
-    it("should when the deletePolicy equals always", function(){
-      expect(scope.allowDelete("foo")).toBe(true);
-    });
-    
-    it("should not when the deletePolicy equals never", function(){
-      scope.deletePolicy = "never";
-      expect(scope.allowDelete("foo")).toBe(false);
-    });
-    
-    it("should when the deletePolicy equals added and the entry was not originally in entries", function(){
-      scope.deletePolicy = "added";
-      scope.key = "abc";
-      scope.value = "def";
-      scope.addEntry();
-      expect(scope.allowDelete("abc")).toBe(true);
-    });
-
-    it("should not when the deletePolicy equals added and the entry was originally in entries", function(){
-      scope.deletePolicy = "added";
-      expect(scope.allowDelete("foo")).toBe(false);
+     controller = _$controller_('KeyValuesController', {$scope: scope});
     });
 
   });
 
-  describe("#addEntry", function(){
-    it("should not add the entry if the key is in the readonly list", function(){
-      scope.readonlyKeys = "abc";
-      scope.key = "abc";
-      scope.value = "xyz";
-      scope.addEntry();
-      expect(scope.entries["abc"]).toBe(undefined);
-      expect(scope.key).toEqual("abc");
-      expect(scope.value).toEqual("xyz");
+  describe('#allowDelete', function(){
+
+    it('should when the deletePolicy equals always', function(){
+      expect(scope.allowDelete('foo')).toBe(true);
     });
-    
-    it("should add the key/value to the scope", function(){
-      scope.key = "foo";
-      scope.value = "bar";
+
+    it('should not when the deletePolicy equals never', function(){
+      scope.deletePolicy = 'never';
+      expect(scope.allowDelete('foo')).toBe(false);
+    });
+
+    it('should when the deletePolicy equals added and the entry was not originally in entries', function(){
+      scope.deletePolicy = 'added';
+      scope.key = 'abc';
+      scope.value = 'def';
       scope.addEntry();
-      scope.key = "abc";
-      scope.value = "def";
+      expect(scope.allowDelete('abc')).toBe(true);
+    });
+
+    it('should not when the deletePolicy equals added and the entry was originally in entries', function(){
+      scope.deletePolicy = 'added';
+      expect(scope.allowDelete('foo')).toBe(false);
+    });
+
+  });
+
+  describe('#addEntry', function(){
+    it('should not add the entry if the key is in the readonly list', function(){
+      scope.readonlyKeys = 'abc';
+      scope.key = 'abc';
+      scope.value = 'xyz';
       scope.addEntry();
-      expect(scope.entries["foo"]).toEqual("bar");
-      expect(scope.entries["abc"]).toEqual("def");
+      expect(scope.entries.abc).toBe(undefined);
+      expect(scope.key).toEqual('abc');
+      expect(scope.value).toEqual('xyz');
+    });
+
+    it('should add the key/value to the scope', function(){
+      scope.key = 'foo';
+      scope.value = 'bar';
+      scope.addEntry();
+      scope.key = 'abc';
+      scope.value = 'def';
+      scope.addEntry();
+      expect(scope.entries.foo).toEqual('bar');
+      expect(scope.entries.abc).toEqual('def');
       expect(scope.key).toEqual(null);
       expect(scope.value).toEqual(null);
     });
-      
+
   });
-  
-  describe("#deleteEntry", function(){
+
+  describe('#deleteEntry', function(){
     //TODO add test for nonrecognized key?
-    
-    it("should delete the key/value from the scope", function(){
-      scope.deleteEntry("foo");
-      expect(scope.entries["foo"]).toBe(undefined);
+
+    it('should delete the key/value from the scope', function(){
+      scope.deleteEntry('foo');
+      expect(scope.entries.foo).toBe(undefined);
     });
   });
 });

--- a/assets/test/spec/filters/defaultIfEmptySpec.js
+++ b/assets/test/spec/filters/defaultIfEmptySpec.js
@@ -1,32 +1,32 @@
-"use strict";
+'use strict';
 
-describe("defaultIfBlankFilter", function(){
+describe('defaultIfBlankFilter', function(){
   var defaultIfBlank;
-  
+
   beforeEach(
     inject(function(defaultIfBlankFilter){
       defaultIfBlank = defaultIfBlankFilter;
     })
   );
 
-  it("should return the value if a non-string", function(){
-    expect(defaultIfBlank(1, "foo")).toBe("1");
+  it('should return the value if a non-string', function(){
+    expect(defaultIfBlank(1, 'foo')).toBe('1');
   });
-  
-  it("should return the value if a non empty string", function(){
-    expect(defaultIfBlank("theValue", "foo")).toBe("theValue");
+
+  it('should return the value if a non empty string', function(){
+    expect(defaultIfBlank('theValue', 'foo')).toBe('theValue');
   });
-  
-  it("should return the default if a null string", function(){
-    expect(defaultIfBlank(null, "foo")).toBe("foo");
+
+  it('should return the default if a null string', function(){
+    expect(defaultIfBlank(null, 'foo')).toBe('foo');
   });
-  
-  it("should return the default if an empty string", function(){
-    expect(defaultIfBlank("", "foo")).toBe("foo");
+
+  it('should return the default if an empty string', function(){
+    expect(defaultIfBlank('', 'foo')).toBe('foo');
   });
-  
-  it("should return the default if a blank string", function(){
-    expect(defaultIfBlank("  ", "foo")).toBe("foo");
+
+  it('should return the default if a blank string', function(){
+    expect(defaultIfBlank('  ', 'foo')).toBe('foo');
   });
-  
+
 });

--- a/assets/test/spec/filters/httpHttpsSpec.js
+++ b/assets/test/spec/filters/httpHttpsSpec.js
@@ -1,17 +1,17 @@
-"use strict";
+'use strict';
 
-describe("httpHttpsFilter", function(){
+describe('httpHttpsFilter', function(){
 
-  it("should return https:// when true", function(){
+  it('should return https:// when true', function(){
     inject(function(httpHttpsFilter){
-      expect(httpHttpsFilter(true)).toBe("https://");
-    })
+      expect(httpHttpsFilter(true)).toBe('https://');
+    });
   });
 
-  it("should return http:// when false", function(){
+  it('should return http:// when false', function(){
     inject(function(httpHttpsFilter){
-      expect(httpHttpsFilter(false)).toBe("http://");
-    })
+      expect(httpHttpsFilter(false)).toBe('http://');
+    });
   });
 });
 

--- a/assets/test/spec/filters/valuesInSpec.js
+++ b/assets/test/spec/filters/valuesInSpec.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict';
 
-describe("valuesInFilter", function(){
+describe('valuesInFilter', function(){
   var filter;
   var entries = {
-    foo: "bar",
-    abc: "xyz",
-    another: "value"
+    foo: 'bar',
+    abc: 'xyz',
+    another: 'value'
   };
   beforeEach(function(){
     inject(function(valuesInFilter){
       filter = valuesInFilter;
     });
   });
-  
-  it("should return a subset of the entries", function(){
-    var results = filter(entries,"foo,another");
-    delete entries["abc"];
+
+  it('should return a subset of the entries', function(){
+    var results = filter(entries,'foo,another');
+    delete entries.abc;
     expect(results).toEqual(entries);
   });
 });
-  
+

--- a/assets/test/spec/filters/valuesNotInSpec.js
+++ b/assets/test/spec/filters/valuesNotInSpec.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict';
 
-describe("valuesNotInFilter", function(){
+describe('valuesNotInFilter', function(){
   var filter;
   var entries = {
-    foo: "bar",
-    abc: "xyz",
-    another: "value"
+    foo: 'bar',
+    abc: 'xyz',
+    another: 'value'
   };
   beforeEach(function(){
     inject(function(valuesNotInFilter){
       filter = valuesNotInFilter;
     });
   });
-  
-  it("should return a subset of the entries", function(){
-    var results = filter(entries,"foo,another");
-    delete entries["foo"];
-    delete entries["another"];
+
+  it('should return a subset of the entries', function(){
+    var results = filter(entries,'foo,another');
+    delete entries.foo;
+    delete entries.another;
     expect(results).toEqual(entries);
   });
 });
-  
+

--- a/assets/test/spec/filters/yesNoSpec.js
+++ b/assets/test/spec/filters/yesNoSpec.js
@@ -1,17 +1,17 @@
-"use strict";
+'use strict';
 
-describe("yesNoFilter", function(){
+describe('yesNoFilter', function(){
 
-  it("should return Yes when true", function(){
+  it('should return Yes when true', function(){
     inject(function(yesNoFilter){
-      expect(yesNoFilter(true)).toBe("Yes");
-    })
+      expect(yesNoFilter(true)).toBe('Yes');
+    });
   });
 
-  it("should return No when false", function(){
+  it('should return No when false', function(){
     inject(function(yesNoFilter){
-      expect(yesNoFilter(false)).toBe("No");
-    })
+      expect(yesNoFilter(false)).toBe('No');
+    });
   });
 });
 

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -1,31 +1,31 @@
-"use strict";
+'use strict';
 
-describe("ApplicationGenerator", function(){
+describe('ApplicationGenerator', function(){
   var ApplicationGenerator;
   var input;
 
   beforeEach(function(){
     module('openshiftConsole', function($provide){
-      $provide.value("DataService",{
-        osApiVersion: "v1beta3",
-        k8sApiVersion: "v1beta3"
+      $provide.value('DataService',{
+        osApiVersion: 'v1beta3',
+        k8sApiVersion: 'v1beta3'
       });
     });
 
     inject(function(_ApplicationGenerator_){
       ApplicationGenerator = _ApplicationGenerator_;
       ApplicationGenerator._generateSecret = function(){
-        return "secret101";
+        return 'secret101';
       };
     });
 
     input = {
-      name: "ruby-hello-world",
+      name: 'ruby-hello-world',
       routing: {
         include: true
       },
       buildConfig: {
-        sourceUrl: "https://github.com/openshift/ruby-hello-world.git",
+        sourceUrl: 'https://github.com/openshift/ruby-hello-world.git',
         buildOnSourceChange: true,
         buildOnImageChange: true
       },
@@ -33,50 +33,50 @@ describe("ApplicationGenerator", function(){
         deployOnConfigChange: true,
         deployOnNewImage: true,
         envVars: {
-          "ADMIN_USERNAME" : "adminEME",
-          "ADMIN_PASSWORD" : "xFSkebip",
-          "MYSQL_ROOT_PASSWORD" : "qX6JGmjX",
-          "MYSQL_DATABASE" : "root"
+          'ADMIN_USERNAME' : 'adminEME',
+          'ADMIN_PASSWORD' : 'xFSkebip',
+          'MYSQL_ROOT_PASSWORD' : 'qX6JGmjX',
+          'MYSQL_DATABASE' : 'root'
         }
       },
       labels : {
-        foo: "bar",
-        abc: "xyz"
+        foo: 'bar',
+        abc: 'xyz'
       },
       scaling: {
         replicas: 1
       },
-      imageName: "origin-ruby-sample",
-      imageTag: "latest",
+      imageName: 'origin-ruby-sample',
+      imageTag: 'latest',
       imageRepo: {
-        "kind": "ImageStream",
-        "apiVersion": "v1beta3",
-        "metadata": {
-          "name": "origin-ruby-sample",
-          "namespace": "test",
-          "selfLink": "/osapi/v1beta3/test/imagestreams/origin-ruby-sample",
-          "uid": "ea1d67fc-c358-11e4-90e6-080027c5bfa9",
-          "resourceVersion": "150",
-          "creationTimestamp": "2015-03-05T16:58:58Z"
+        'kind': 'ImageStream',
+        'apiVersion': 'v1beta3',
+        'metadata': {
+          'name': 'origin-ruby-sample',
+          'namespace': 'test',
+          'selfLink': '/osapi/v1beta3/test/imagestreams/origin-ruby-sample',
+          'uid': 'ea1d67fc-c358-11e4-90e6-080027c5bfa9',
+          'resourceVersion': '150',
+          'creationTimestamp': '2015-03-05T16:58:58Z'
         },
-        "spec": {
-          "dockerImageRepository": "openshift/origin-ruby-sample",
-          "tags": [
+        'spec': {
+          'dockerImageRepository': 'openshift/origin-ruby-sample',
+          'tags': [
             {
-              "name": "latest"
+              'name': 'latest'
             }
           ]
         },
-        "status": {
-          "dockerImageRepository": "openshift/origin-ruby-sample",
-          "tags": [
+        'status': {
+          'dockerImageRepository': 'openshift/origin-ruby-sample',
+          'tags': [
             {
-              "name": "latest",
-              "items": [
+              'name': 'latest',
+              'items': [
                 {
-                  "created": "2015-06-01T18:54:14Z",
-                  "dockerImageReference": "openshift/origin-ruby-sample:latest",
-                  "image": "f4589d5a40dc3ddcea72d58f51ec0a5c3915494f1f5a6b4964212120494880b6"
+                  'created': '2015-06-01T18:54:14Z',
+                  'dockerImageReference': 'openshift/origin-ruby-sample:latest',
+                  'image': 'f4589d5a40dc3ddcea72d58f51ec0a5c3915494f1f5a6b4964212120494880b6'
                 }
               ]
             }
@@ -84,18 +84,18 @@ describe("ApplicationGenerator", function(){
         }
       },
       image: {
-        "kind" : "Image",
-        "metadata" : {
-          "name" : "ea15999fd97b2f1bafffd615697ef8c14abdfd9ab17ff4ed67cf5857fec8d6c0"
+        'kind' : 'Image',
+        'metadata' : {
+          'name' : 'ea15999fd97b2f1bafffd615697ef8c14abdfd9ab17ff4ed67cf5857fec8d6c0'
         },
-        "dockerImageMetadata" : {
-          "ContainerConfig" : {
-            "ExposedPorts": {
-              "443/tcp": {},
-              "80/tcp": {}
+        'dockerImageMetadata' : {
+          'ContainerConfig' : {
+            'ExposedPorts': {
+              '443/tcp': {},
+              '80/tcp': {}
             },
-            "Env": [
-              "STI_SCRIPTS_URL"
+            'Env': [
+              'STI_SCRIPTS_URL'
             ]
           }
         }
@@ -103,125 +103,125 @@ describe("ApplicationGenerator", function(){
     };
   });
 
-  describe("#_generateService", function(){
+  describe('#_generateService', function(){
 
-    it("should not generate a service if no ports are exposed", function(){
-      var service = ApplicationGenerator._generateService(input, "theServiceName", "None");
+    it('should not generate a service if no ports are exposed', function(){
+      var service = ApplicationGenerator._generateService(input, 'theServiceName', 'None');
       expect(service).toEqual(null);
     });
 
     //TODO - add in when server supports headless services without a port spec
-//    it("should generate a headless service when no ports are exposed", function(){
+//    it('should generate a headless service when no ports are exposed', function(){
 //      var copy = angular.copy(input);
 //      copy.image.dockerImageMetadata.ContainerConfig.ExposedPorts = {};
-//      var service = ApplicationGenerator._generateService(copy, "theServiceName", "None");
+//      var service = ApplicationGenerator._generateService(copy, 'theServiceName', 'None');
 //      expect(service).toEqual(
 //        {
-//            "kind": "Service",
-//            "apiVersion": "v1beta3",
-//            "metadata": {
-//                "name": "theServiceName",
-//                "labels" : {
-//                  "foo" : "bar",
-//                  "abc" : "xyz"                }
+//            'kind': 'Service',
+//            'apiVersion': 'v1beta3',
+//            'metadata': {
+//                'name': 'theServiceName',
+//                'labels' : {
+//                  'foo' : 'bar',
+//                  'abc' : 'xyz'                }
 //            },
-//            "spec": {
-//                "portalIP" : "None",
-//                "selector": {
-//                    "deploymentconfig": "ruby-hello-world"
+//            'spec': {
+//                'portalIP' : 'None',
+//                'selector': {
+//                    'deploymentconfig': 'ruby-hello-world'
 //                }
 //            }
 //        });
 //    });
   });
 
-  describe("#_generateRoute", function(){
+  describe('#_generateRoute', function(){
 
-    it("should generate nothing if routing is not required", function(){
+    it('should generate nothing if routing is not required', function(){
       input.routing.include = false;
-      expect(ApplicationGenerator._generateRoute(input, input.name, "theServiceName")).toBe(null);
+      expect(ApplicationGenerator._generateRoute(input, input.name, 'theServiceName')).toBe(null);
     });
 
-    it("should generate an unsecure Route when routing is required", function(){
-      var route = ApplicationGenerator._generateRoute(input, input.name, "theServiceName");
+    it('should generate an unsecure Route when routing is required', function(){
+      var route = ApplicationGenerator._generateRoute(input, input.name, 'theServiceName');
       expect(route).toEqual({
-        kind: "Route",
+        kind: 'Route',
         apiVersion: 'v1beta3',
         metadata: {
-          name: "ruby-hello-world",
+          name: 'ruby-hello-world',
           labels : {
-            "foo" : "bar",
-            "abc" : "xyz"
+            'foo' : 'bar',
+            'abc' : 'xyz'
           }
         },
         spec: {
           to: {
-            kind: "Service",
-            name: "theServiceName"
+            kind: 'Service',
+            name: 'theServiceName'
           }
         }
       });
     });
   });
 
-  describe("generating applications from image that includes source", function(){
+  describe('generating applications from image that includes source', function(){
     var resources;
     beforeEach(function(){
       resources = ApplicationGenerator.generate(input);
     });
 
-    it("should generate a BuildConfig for the source", function(){
+    it('should generate a BuildConfig for the source', function(){
       expect(resources.buildConfig).toEqual(
         {
-            "apiVersion": "v1beta3",
-            "kind": "BuildConfig",
-            "metadata": {
-                "name": "ruby-hello-world",
-                "labels": {
-                  "foo" : "bar",
-                  "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby": "OpenShiftWebConsole"
+            'apiVersion': 'v1beta3',
+            'kind': 'BuildConfig',
+            'metadata': {
+                'name': 'ruby-hello-world',
+                'labels': {
+                  'foo' : 'bar',
+                  'abc' : 'xyz',
+                  'name': 'ruby-hello-world',
+                  'generatedby': 'OpenShiftWebConsole'
                 }
             },
-            "spec": {
-                "output": {
-                    "to": {
-                        "name": "ruby-hello-world"
+            'spec': {
+                'output': {
+                    'to': {
+                        'name': 'ruby-hello-world'
                     }
                 },
-                "source": {
-                    "git": {
-                        "ref": "master",
-                        "uri": "https://github.com/openshift/ruby-hello-world.git"
+                'source': {
+                    'git': {
+                        'ref': 'master',
+                        'uri': 'https://github.com/openshift/ruby-hello-world.git'
                     },
-                    "type": "Git"
+                    'type': 'Git'
                 },
-                "strategy": {
-                    "type": "Source",
-                    "sourceStrategy" : {
-                      "from": {
-                        "kind": "ImageStreamTag",
-                        "name": "origin-ruby-sample:latest"
+                'strategy': {
+                    'type': 'Source',
+                    'sourceStrategy' : {
+                      'from': {
+                        'kind': 'ImageStreamTag',
+                        'name': 'origin-ruby-sample:latest'
                       }
                     }
                 },
-                "triggers": [
+                'triggers': [
                     {
-                        "generic": {
-                            "secret": "secret101"
+                        'generic': {
+                            'secret': 'secret101'
                         },
-                        "type": "generic"
+                        'type': 'generic'
                     },
                     {
-                        "github": {
-                            "secret": "secret101"
+                        'github': {
+                            'secret': 'secret101'
                         },
-                        "type": "github"
+                        'type': 'github'
                     },
                     {
-                      "imageChange" : {},
-                      "type" : "imageChange"
+                      'imageChange' : {},
+                      'type' : 'imageChange'
                     }
                 ]
             }
@@ -229,134 +229,137 @@ describe("ApplicationGenerator", function(){
       );
     });
 
-    it("should generate an ImageStream for the build output", function(){
+    it('should generate an ImageStream for the build output', function(){
       expect(resources.imageStream).toEqual(
         {
-          "apiVersion": "v1beta3",
-          "kind": "ImageStream",
-          "metadata": {
-              "name": "ruby-hello-world",
+          'apiVersion': 'v1beta3',
+          'kind': 'ImageStream',
+          'metadata': {
+              'name': 'ruby-hello-world',
               labels : {
-                "foo" : "bar",
-                "abc" : "xyz",
-                "name": "ruby-hello-world",
-                "generatedby": "OpenShiftWebConsole"
+                'foo' : 'bar',
+                'abc' : 'xyz',
+                'name': 'ruby-hello-world',
+                'generatedby': 'OpenShiftWebConsole'
               }
           }
         }
       );
     });
 
-    it("should generate a Service for the build output", function(){
+    it('should generate a Service for the build output', function(){
       expect(resources.service).toEqual(
         {
-            "kind": "Service",
-            "apiVersion": "v1beta3",
-            "metadata": {
-                "name": "ruby-hello-world",
-                "labels" : {
-                  "foo" : "bar",
-                  "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby": "OpenShiftWebConsole"
+            'kind': 'Service',
+            'apiVersion': 'v1beta3',
+            'metadata': {
+                'name': 'ruby-hello-world',
+                'labels' : {
+                  'foo' : 'bar',
+                  'abc' : 'xyz',
+                  'name': 'ruby-hello-world',
+                  'generatedby': 'OpenShiftWebConsole'
                 }
             },
-            "spec": {
-                "ports": [{
-                  "port": 80,
-                  "targetPort" : 80,
-                  "protocol": "TCP"
+            'spec': {
+                'ports': [{
+                  'port': 80,
+                  'targetPort' : 80,
+                  'protocol': 'TCP'
                 }],
-                "selector": {
-                    "deploymentconfig": "ruby-hello-world"
+                'selector': {
+                    'deploymentconfig': 'ruby-hello-world'
                 }
             }
         }
       );
     });
 
-    it("should generate a DeploymentConfig for the BuildConfig output image", function(){
+    it('should generate a DeploymentConfig for the BuildConfig output image', function(){
       var resources = ApplicationGenerator.generate(input);
       expect(resources.deploymentConfig).toEqual(
         {
-          "apiVersion": "v1beta3",
-          "kind": "DeploymentConfig",
-          "metadata": {
-            "name": "ruby-hello-world",
-            "labels": {
-              "foo" : "bar",
-              "abc" : "xyz",
-              "name": "ruby-hello-world",
-              "generatedby" : "OpenShiftWebConsole",
-              "deploymentconfig": "ruby-hello-world"
+          'apiVersion': 'v1beta3',
+          'kind': 'DeploymentConfig',
+          'metadata': {
+            'name': 'ruby-hello-world',
+            'labels': {
+              'foo' : 'bar',
+              'abc' : 'xyz',
+              'name': 'ruby-hello-world',
+              'generatedby' : 'OpenShiftWebConsole',
+              'deploymentconfig': 'ruby-hello-world'
             }
           },
-          "spec": {
-            "replicas": 1,
-            "selector": {
-              "deploymentconfig": "ruby-hello-world"
+          'spec': {
+            'strategy': {
+              'type': 'Recreate'
             },
-            "triggers": [
+            'replicas': 1,
+            'selector': {
+              'deploymentconfig': 'ruby-hello-world'
+            },
+            'triggers': [
               {
-                "type": "ImageChange",
-                "imageChangeParams": {
-                  "automatic": true,
-                  "containerNames": [
-                    "ruby-hello-world"
+                'type': 'ImageChange',
+                'imageChangeParams': {
+                  'automatic': true,
+                  'containerNames': [
+                    'ruby-hello-world'
                   ],
-                  "from": {
-                    "kind": "ImageStreamTag",
-                    "name": "ruby-hello-world:latest"
+                  'from': {
+                    'kind': 'ImageStreamTag',
+                    'name': 'ruby-hello-world:latest'
                   }
                 }
               },
               {
-                "type": "ConfigChange"
+                'type': 'ConfigChange'
               }
             ],
-            "template": {
-              "metadata": {
-                "labels": {
-                  "foo" : "bar",
-                  "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby" : "OpenShiftWebConsole",
-                  "deploymentconfig": "ruby-hello-world"
+            'template': {
+              'metadata': {
+                'labels': {
+                  'foo' : 'bar',
+                  'abc' : 'xyz',
+                  'name': 'ruby-hello-world',
+                  'generatedby' : 'OpenShiftWebConsole',
+                  'deploymentconfig': 'ruby-hello-world'
                 }
               },
-              "spec": {
-                "containers": [
+              'spec': {
+                'containers': [
                   {
-                    "image": "ruby-hello-world:latest",
-                    "name": "ruby-hello-world",
-                    "ports": [
+                    'image': 'ruby-hello-world:latest',
+                    'name': 'ruby-hello-world',
+                    'ports': [
                       {
-                        "containerPort": 443,
-                        "name": "ruby-hello-world-tcp-443",
-                        "protocol": "TCP"
+                        'containerPort': 443,
+                        'name': 'ruby-hello-world-tcp-443',
+                        'protocol': 'TCP'
                       },
                       {
-                        "containerPort": 80,
-                        "name": "ruby-hello-world-tcp-80",
-                        "protocol": "TCP"
+                        'containerPort': 80,
+                        'name': 'ruby-hello-world-tcp-80',
+                        'protocol': 'TCP'
                       }
                     ],
-                    "env" : [
+                    'env' : [
                       {
-                        "name": "ADMIN_USERNAME",
-                        "value": "adminEME"
+                        'name': 'ADMIN_USERNAME',
+                        'value': 'adminEME'
                       },
                       {
-                        "name": "ADMIN_PASSWORD",
-                        "value": "xFSkebip"
+                        'name': 'ADMIN_PASSWORD',
+                        'value': 'xFSkebip'
                       },
                       {
-                        "name": "MYSQL_ROOT_PASSWORD",
-                        "value": "qX6JGmjX"
+                        'name': 'MYSQL_ROOT_PASSWORD',
+                        'value': 'qX6JGmjX'
                       },
                       {
-                        "name": "MYSQL_DATABASE",
-                        "value": "root"
+                        'name': 'MYSQL_DATABASE',
+                        'value': 'root'
                       }
                     ]
                   }
@@ -370,40 +373,40 @@ describe("ApplicationGenerator", function(){
 
   });
 
-  describe("generating service where the ports are defined on the image config block", function(){
+  describe('generating service where the ports are defined on the image config block', function(){
     var resources;
     beforeEach(function(){
       input.image.dockerImageMetadata.Config = {
-        "ExposedPorts": {
-          "999/tcp": {},
-          "777/tcp": {}
+        'ExposedPorts': {
+          '999/tcp': {},
+          '777/tcp': {}
         }
       };
       resources = ApplicationGenerator.generate(input);
     });
 
-    it("should use the first port found from the config block for the service ports", function(){
+    it('should use the first port found from the config block for the service ports', function(){
         expect(resources.service).toEqual(
         {
-            "kind": "Service",
-            "apiVersion": "v1beta3",
-            "metadata": {
-                "name": "ruby-hello-world",
-                "labels" : {
-                  "foo" : "bar",
-                  "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby": "OpenShiftWebConsole"
+            'kind': 'Service',
+            'apiVersion': 'v1beta3',
+            'metadata': {
+                'name': 'ruby-hello-world',
+                'labels' : {
+                  'foo' : 'bar',
+                  'abc' : 'xyz',
+                  'name': 'ruby-hello-world',
+                  'generatedby': 'OpenShiftWebConsole'
                 }
             },
-            "spec": {
-                "ports": [{
-                  "port": 777,
-                  "targetPort" : 777,
-                  "protocol": "TCP"
+            'spec': {
+                'ports': [{
+                  'port': 777,
+                  'targetPort' : 777,
+                  'protocol': 'TCP'
                 }],
-                "selector": {
-                    "deploymentconfig": "ruby-hello-world"
+                'selector': {
+                    'deploymentconfig': 'ruby-hello-world'
                 }
             }
         }

--- a/assets/test/spec/services/dataServiceSpec.js
+++ b/assets/test/spec/services/dataServiceSpec.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
-describe("DataService", function(){
+describe('DataService', function(){
   var DataService;
-  
+
   beforeEach(function(){
     inject(function(_DataService_){
       DataService = _DataService_;
     });
   });
-  
-  describe("#url", function(){
-    
+
+  describe('#url', function(){
+
     var tc = [
       // Empty tests
       [null,           null],
@@ -21,46 +21,44 @@ describe("DataService", function(){
       [{type:'bogus'}, null],
 
       // Type normalization
-      [{type:'users'},             "http://localhost:8443/osapi/v1beta3/users"],
-      [{type:'Users'},             "http://localhost:8443/osapi/v1beta3/users"],
-      [{type:'oauthaccesstokens'}, "http://localhost:8443/osapi/v1beta3/oauthaccesstokens"],
-      [{type:'OAuthAccessTokens'}, "http://localhost:8443/osapi/v1beta3/oauthaccesstokens"],
-      [{type:'pods'},              "http://localhost:8443/api/v1beta3/pods"],
-      [{type:'Pods'},              "http://localhost:8443/api/v1beta3/pods"],
+      [{type:'users'},             'http://localhost:8443/osapi/v1beta3/users'],
+      [{type:'Users'},             'http://localhost:8443/osapi/v1beta3/users'],
+      [{type:'oauthaccesstokens'}, 'http://localhost:8443/osapi/v1beta3/oauthaccesstokens'],
+      [{type:'OAuthAccessTokens'}, 'http://localhost:8443/osapi/v1beta3/oauthaccesstokens'],
+      [{type:'pods'},              'http://localhost:8443/api/v1beta3/pods'],
+      [{type:'Pods'},              'http://localhost:8443/api/v1beta3/pods'],
 
       // Openshift type
-      [{type:'builds'                           }, "http://localhost:8443/osapi/v1beta3/builds"],
-      [{type:'builds', namespace:"foo"          }, "http://localhost:8443/osapi/v1beta3/namespaces/foo/builds"],
-      [{type:'builds',                  id:"bar"}, "http://localhost:8443/osapi/v1beta3/builds/bar"],
-      [{type:'builds', namespace:"foo", id:"bar"}, "http://localhost:8443/osapi/v1beta3/namespaces/foo/builds/bar"],
+      [{type:'builds'                           }, 'http://localhost:8443/osapi/v1beta3/builds'],
+      [{type:'builds', namespace:'foo'          }, 'http://localhost:8443/osapi/v1beta3/namespaces/foo/builds'],
+      [{type:'builds',                  id:'bar'}, 'http://localhost:8443/osapi/v1beta3/builds/bar'],
+      [{type:'builds', namespace:'foo', id:'bar'}, 'http://localhost:8443/osapi/v1beta3/namespaces/foo/builds/bar'],
 
       // k8s type
-      [{type:'replicationcontrollers'                           }, "http://localhost:8443/api/v1beta3/replicationcontrollers"],
-      [{type:'replicationcontrollers', namespace:"foo"          }, "http://localhost:8443/api/v1beta3/namespaces/foo/replicationcontrollers"],
-      [{type:'replicationcontrollers',                  id:"bar"}, "http://localhost:8443/api/v1beta3/replicationcontrollers/bar"],
-      [{type:'replicationcontrollers', namespace:"foo", id:"bar"}, "http://localhost:8443/api/v1beta3/namespaces/foo/replicationcontrollers/bar"],
+      [{type:'replicationcontrollers'                           }, 'http://localhost:8443/api/v1beta3/replicationcontrollers'],
+      [{type:'replicationcontrollers', namespace:'foo'          }, 'http://localhost:8443/api/v1beta3/namespaces/foo/replicationcontrollers'],
+      [{type:'replicationcontrollers',                  id:'bar'}, 'http://localhost:8443/api/v1beta3/replicationcontrollers/bar'],
+      [{type:'replicationcontrollers', namespace:'foo', id:'bar'}, 'http://localhost:8443/api/v1beta3/namespaces/foo/replicationcontrollers/bar'],
 
       // Subresources and webhooks
-      [{type:'builds/clone',             id:"mybuild", namespace:"foo"                                 }, "http://localhost:8443/osapi/v1beta3/namespaces/foo/builds/mybuild/clone"],
-      [{type:'buildconfigs/instantiate', id:"mycfg",   namespace:"foo"                                 }, "http://localhost:8443/osapi/v1beta3/namespaces/foo/buildconfigs/mycfg/instantiate"],
-      [{type:'buildconfigs/webhooks',    id:"mycfg",   namespace:"foo", hookType:"github", secret:"123"}, "http://localhost:8443/osapi/v1beta3/namespaces/foo/buildconfigs/mycfg/webhooks/123/github"],
+      [{type:'builds/clone',             id:'mybuild', namespace:'foo'                                 }, 'http://localhost:8443/osapi/v1beta3/namespaces/foo/builds/mybuild/clone'],
+      [{type:'buildconfigs/instantiate', id:'mycfg',   namespace:'foo'                                 }, 'http://localhost:8443/osapi/v1beta3/namespaces/foo/buildconfigs/mycfg/instantiate'],
+      [{type:'buildconfigs/webhooks',    id:'mycfg',   namespace:'foo', hookType:'github', secret:'123'}, 'http://localhost:8443/osapi/v1beta3/namespaces/foo/buildconfigs/mycfg/webhooks/123/github'],
 
       // Watch
-      [{type:'pods', namespace:"foo", isWebsocket:true                     }, "ws://localhost:8443/api/v1beta3/watch/namespaces/foo/pods"],
-      [{type:'pods', namespace:"foo", isWebsocket:true, resourceVersion:"5"}, "ws://localhost:8443/api/v1beta3/watch/namespaces/foo/pods?resourceVersion=5"],
+      [{type:'pods', namespace:'foo', isWebsocket:true                     }, 'ws://localhost:8443/api/v1beta3/watch/namespaces/foo/pods'],
+      [{type:'pods', namespace:'foo', isWebsocket:true, resourceVersion:'5'}, 'ws://localhost:8443/api/v1beta3/watch/namespaces/foo/pods?resourceVersion=5'],
 
       // Namespaced subresource with params
-      [{type:'pods/proxy', id:"mypod", namespace:"myns", myparam1:"myvalue"}, "http://localhost:8443/api/v1beta3/namespaces/myns/pods/mypod/proxy?myparam1=myvalue"],
+      [{type:'pods/proxy', id:'mypod', namespace:'myns', myparam1:'myvalue'}, 'http://localhost:8443/api/v1beta3/namespaces/myns/pods/mypod/proxy?myparam1=myvalue'],
     ];
-    
-    for (var i=0; i < tc.length; i++) {
-      it("should generate a correct URL for " + JSON.stringify(tc[i][0]), function(tc){
-      	return function() {
-          expect(DataService.url(tc[0])).toEqual(tc[1]);
-        };
-      }(tc[i]));
-    }
-    
+
+    _.each(tc, function(item) {
+      it('should generate a correct URL for ' + JSON.stringify(item[0]), function() {
+        expect(DataService.url(item[0])).toEqual(item[1]);
+      });
+    });
+
   });
-  
+
 });

--- a/assets/test/spec/services/nameGeneratorSpec.js
+++ b/assets/test/spec/services/nameGeneratorSpec.js
@@ -1,31 +1,32 @@
-"use strict";
+'use strict';
+/* jshint unused: false */
 
-describe("NameGenerator", function(){
+describe('NameGenerator', function(){
   var NameGenerator;
-  
+
   beforeEach(function($provide){
-    
+
     inject(function(_NameGenerator_){
       NameGenerator = _NameGenerator_;
     });
   });
-  
-  describe("#suggestFromSourceUrl", function(){
-    
-    var sourceUrl = "git@github.com:openshift/ruby-hello-world.git";
-    
-    it("should suggest a name based on git source url ending with 'git'", function(){
+
+  describe('#suggestFromSourceUrl', function(){
+
+    var sourceUrl = 'git@github.com:openshift/ruby-hello-world.git';
+
+    it('should suggest a name based on git source url ending with \'git\'', function(){
       var result = NameGenerator.suggestFromSourceUrl(sourceUrl);
-      expect(result).toEqual("ruby-hello-world");
+      expect(result).toEqual('ruby-hello-world');
     });
-    
-    it("should suggest a name based on git source url not ending with 'git'", function(){
-      
-      sourceUrl = "git@github.com:openshift/ruby-hello-world";
+
+    it('should suggest a name based on git source url not ending with \'git\'', function(){
+
+      sourceUrl = 'git@github.com:openshift/ruby-hello-world';
       var result = NameGenerator.suggestFromSourceUrl(sourceUrl);
-      expect(result).toEqual("ruby-hello-world");
+      expect(result).toEqual('ruby-hello-world');
     });
-    
+
   });
-  
+
 });

--- a/assets/test/spec/spec-helper.js
+++ b/assets/test/spec/spec-helper.js
@@ -1,8 +1,9 @@
-"use strict";
+'use strict';
+
 // Angular is refusing to recognize the HawtioNav stuff
 // when testing even though its being loaded
  beforeEach(module(function ($provide) {
-  $provide.provider("HawtioNavBuilder", function() {
+  $provide.provider('HawtioNavBuilder', function() {
     function Mocked() {}
     this.create = function() {return this;};
     this.id = function() {return this;};
@@ -13,20 +14,20 @@
     this.page = function() {return this;};
     this.subPath = function() {return this;};
     this.build = function() {return this;};
-    this.join = function() {return "";};
+    this.join = function() {return '';};
     this.$get = function() {return new Mocked();};
   });
-  
-  $provide.factory("HawtioNav", function(){
+
+  $provide.factory('HawtioNav', function(){
     return {add: function() {}};
   });
 
-  $provide.factory("HawtioExtension", function() {
+  $provide.factory('HawtioExtension', function() {
     return {
       add: function() {}
     };
   });
-  
+
 }));
 
 // Make sure a base location exists in the generated test html
@@ -37,6 +38,6 @@
  angular.module('openshiftConsole').config(function(AuthServiceProvider) {
    AuthServiceProvider.UserStore('MemoryUserStore');
  });
- 
+
  //load the module
 beforeEach(module('openshiftConsole'));


### PR DESCRIPTION
This pull request touches on a number of files and my strategy changed mid-stream.  Sorry about that.  I began by submitting one file per commit & fixing all the problems jshint reported.  This was time consuming, so about half way through I switched & fixed all of a particular type of issue across multiple files & committed.  The last commit is a sweeping commit updating all the assets/test/* files.

A few things to note:
- I left comments on the [original ticket](https://github.com/openshift/origin/issues/3423) illustrating a few items that are tricky to address.  The most common one is swapping == for === in some cases where it was hard for me to trigger the function.  This is the common issue of 12345 == '12345', but 12345 === '12345' is not true. I didn't want to cause a break with a fix.
- Some of the issues I just silenced with inline `/* jshint */` comments. The issue is not severe but the fix would be rather time consuming or stylistic.  We can probably keep an eye out for these and update the next time we touch the files.  Ideally we wouldn't have any `/* jshint */`comments and everything would pass naturally.  Examples would be dot syntax vs bracket, camelCase vs snake_case variables.
- A number of jshint features are deprecated and transferred to the [JSCS project](http://jscs.info/).  I'll open a ticket where we can discuss adding JSCS to our grunt tasks.

@liggitt @spadgett @sg00dwin 
 

