### PR TITLE
UPSTREAM: tweak CheckErr for openshift specific advice

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -86,7 +86,7 @@ func checkErr(err error, handleErr func(string)) {
 
 	// handle multiline errors
 	if clientcmd.IsConfigurationInvalid(err) {
-		handleErr(MultilineError("Error in configuration: ", err))
+		handleErr(MultilineError("Error in connection configuration.  Create a configuration file using 'oc login'.\n", err))
 	}
 	if agg, ok := err.(utilerrors.Aggregate); ok && len(agg.Errors()) > 0 {
 		handleErr(MultipleErrors("", agg.Errors()))
@@ -138,7 +138,7 @@ func checkCustomErr(customPrefix string, err error, handleErr func(string)) {
 
 	// handle multiline errors
 	if clientcmd.IsConfigurationInvalid(err) {
-		handleErr(MultilineError("Error in configuration: ", err))
+		handleErr(MultilineError("Error in connection configuration.  Create a configuration file using 'oc login'.\n", err))
 	}
 	if agg, ok := err.(utilerrors.Aggregate); ok && len(agg.Errors()) > 0 {
 		handleErr(MultipleErrors("", agg.Errors()))

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -174,8 +174,8 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 # Begin tests
 #
 
-# test client not configured
-[ "$(oc get services 2>&1 | grep 'Error in configuration')" ]
+# test client not configured.  See "UPSTREAM: tweak CheckErr for openshift specific advice" (https://github.com/openshift/origin/pull/3518) if this fails.
+[ "$(oc get services 2>&1 | grep 'Error in connection configuration.  Create a configuration file using ')" ]
 
 # Set KUBERNETES_MASTER for oc from now on
 export KUBERNETES_MASTER="${API_SCHEME}://${API_HOST}:${API_PORT}"


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/1643.

This changes the message to say:
```
[deads@deads-dev-01 origin]$ oc get pods
Error in connection configuration.  Create a configuration file using 'oc login'.
default cluster has no server defined
```

We'll have to carry this patch until kube opens up to accept new changes for a proper refactor.