### PR TITLE
fedora 21 Vagrant provisioning fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -239,6 +239,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       override.vm.box     = vagrant_openshift_config['libvirt']['box_name']
       override.vm.box_url = vagrant_openshift_config['libvirt']['box_url']
       override.ssh.insert_key = vagrant_openshift_config['insert_key']
+      override.vm.synced_folder ".", "/vagrant", type: 'nfs'
       libvirt.driver      = 'kvm'
       libvirt.memory      = vagrant_openshift_config['memory'].to_i
       libvirt.cpus        = vagrant_openshift_config['cpus'].to_i

--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -20,7 +20,7 @@ if [ ! -d etcd ]; then
   pushd etcd >/dev/null
 
   curl -s -L https://github.com/coreos/etcd/tarball/${etcd_version} | \
-    tar xz --strip-components 1 2>/dev/null
+    tar xz --strip-components 1 --no-same-owner 2>/dev/null
 
   if [ "$?" != "0" ]; then
     echo "Failed to download coreos/etcd."

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -9,9 +9,13 @@ NETWORK_PLUGIN=$(os::util::get-network-plugin ${6:-""})
 
 if [ "${FIXUP_NET_UDEV}" == "true" ]; then
   NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-  sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
-
-  systemctl restart network
+  rm -f ${NETWORK_CONF_PATH}ifcfg-enp*
+  if [[ -f "${NETWORK_CONF_PATH}ifcfg-eth1" ]]; then
+    sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+    nmcli con reload
+    nmcli dev disconnect eth1
+    nmcli dev connect eth1
+  fi
 fi
 
 # Setup hosts file to ensure name resolution to each member of the cluster

--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -8,9 +8,13 @@ FIXUP_NET_UDEV=$7
 
 if [ "${FIXUP_NET_UDEV}" == "true" ]; then
   NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-  sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
-
-  systemctl restart network
+  rm -f ${NETWORK_CONF_PATH}ifcfg-enp*
+  if [[ -f "${NETWORK_CONF_PATH}ifcfg-eth1" ]]; then
+    sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+    nmcli con reload
+    nmcli dev disconnect eth1
+    nmcli dev connect eth1
+  fi
 fi
 
 # get the minion name, index is 1-based


### PR DESCRIPTION
1) Because udev renames network devices from their original enpXsY to
eth0 (since they are virtual and not hardware), the dracut-created
ifcfg-enp0s3 ifcfg file does not have a corresponding interface.  This
makes 'service network restart' or 'systemctl restart network' angry
and those commands terminate with an error.  Since the interface will
be automatically handled by NetworkManager anyway, we don't need the
ifcfg file so delete it.  Also, use nmcli to selectively start/stop
the 'eth1' interface since NetworkManager is handling it anyway.

2) Forces NFS shared directories when using libvirt, because it seems that
vagrant or vagrant-libvirt default to rsync for some reason, which of course
means that the OpenShift master generated certificates are not available for
the minions to use (since rsync is one-way).  This does mean that you need
to ensure that firewalld on your host lets NFS through:
    sudo firewall-cmd --permanent --add-service=nfs
    sudo firewall-cmd --permanent --add-service=rpc-bind
    sudo firewall-cmd --permanent --add-service=mountd
    sudo firewall-cmd --restart
See: http://nts.strzibny.name/vagrant-nfs-exports-on-fedora-21/

Also make sure you have this patch to vagrant-libvirt:

https://github.com/pradels/vagrant-libvirt/commit/d107b899c8a3d0d22a9f8f7803f1e5753e4872e4

3) Finally, due to use of NFS, we need to ensure that hack/install-etcd.sh
doesn't try to use the owner from the original tarball (which is who-knows-what)
but instead uses the owner of the mounted NFS share.  This should be safe
for non-NFS and other Vagrant providers too.