### PR TITLE
Refactored the use of restful.Container.Handle() method

### DIFF
--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -32,8 +32,7 @@ func (c *AssetConfig) InstallAPI(container *restful.Container) []string {
 		glog.Fatal(err)
 	}
 
-	mux := container.ServeMux
-	mux.Handle(publicURL.Path, http.StripPrefix(publicURL.Path, assetHandler))
+	container.Handle(publicURL.Path, http.StripPrefix(publicURL.Path, assetHandler))
 
 	return []string{fmt.Sprintf("Started OpenShift UI %%s%s", publicURL.Path)}
 }


### PR DESCRIPTION
@liggitt your original implementation made an un-necessary literal call to the `ServeMux` inside of the container. `restful.Container` [delegates](https://github.com/openshift/origin/blob/master/Godeps/_workspace/src/github.com/emicklei/go-restful/container.go#L238-241) the `Handle` call.