### PR TITLE
Give cap_sys_net_bind to openshift binary

### DIFF
--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -17,7 +17,8 @@ RUN ln -s /usr/bin/openshift /usr/bin/oc && \
     ln -s /usr/bin/openshift /usr/bin/openshift-deploy && \
     ln -s /usr/bin/openshift /usr/bin/openshift-docker-build && \
     ln -s /usr/bin/openshift /usr/bin/openshift-sti-build && \
-    ln -s /usr/bin/openshift /usr/bin/openshift-router
+    ln -s /usr/bin/openshift /usr/bin/openshift-router && \
+    setcap 'cap_net_bind_service=ep' /usr/bin/openshift
 
 ADD scripts/recycler.sh /usr/share/openshift/scripts/volumes/recycler.sh
 


### PR DESCRIPTION
Allows DNS to be bound to port 53 when running a standalone master

[merge]