### PR TITLE
Output emptyDir notice to standard error

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -122,7 +122,7 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 		return err
 	}
 
-	result, err := config.RunAll(out)
+	result, err := config.RunAll(out, c.Out())
 	if err != nil {
 		if errs, ok := err.(errors.Aggregate); ok {
 			if len(errs.Errors()) == 1 {

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -75,7 +75,7 @@ func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, c *cobra.
 		return err
 	}
 
-	result, err := config.RunBuilds(out)
+	result, err := config.RunBuilds(out, c.Out())
 	if err != nil {
 		if errs, ok := err.(errors.Aggregate); ok {
 			if len(errs.Errors()) == 1 {

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -523,14 +523,14 @@ type AppResult struct {
 }
 
 // RunAll executes the provided config to generate all objects.
-func (c *AppConfig) RunAll(out io.Writer) (*AppResult, error) {
-	return c.run(out, app.Acceptors{app.NewAcceptUnique(c.typer), app.AcceptNew})
+func (c *AppConfig) RunAll(out, errOut io.Writer) (*AppResult, error) {
+	return c.run(out, errOut, app.Acceptors{app.NewAcceptUnique(c.typer), app.AcceptNew})
 }
 
 // RunBuilds executes the provided config to generate just builds.
-func (c *AppConfig) RunBuilds(out io.Writer) (*AppResult, error) {
+func (c *AppConfig) RunBuilds(out, errOut io.Writer) (*AppResult, error) {
 	bcAcceptor := app.NewAcceptBuildConfigs(c.typer)
-	result, err := c.run(out, app.Acceptors{bcAcceptor, app.NewAcceptUnique(c.typer), app.AcceptNew})
+	result, err := c.run(out, errOut, app.Acceptors{bcAcceptor, app.NewAcceptUnique(c.typer), app.AcceptNew})
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func makeImageStreamKey(ref kapi.ObjectReference) string {
 }
 
 // run executes the provided config applying provided acceptors.
-func (c *AppConfig) run(out io.Writer, acceptors app.Acceptors) (*AppResult, error) {
+func (c *AppConfig) run(out, errOut io.Writer, acceptors app.Acceptors) (*AppResult, error) {
 	c.ensureDockerResolver()
 	repositories, err := c.individualSourceRepositories()
 	if err != nil {
@@ -641,7 +641,7 @@ func (c *AppConfig) run(out io.Writer, acceptors app.Acceptors) (*AppResult, err
 		}
 		if p.Image != nil && p.Image.HasEmptyDir {
 			if _, ok := warned[p.Image.Name]; !ok {
-				fmt.Fprintf(out, "NOTICE: Image %q uses an EmptyDir volume. Data in EmptyDir volumes is not persisted across deployments.\n", p.Image.Name)
+				fmt.Fprintf(errOut, "NOTICE: Image %q uses an EmptyDir volume. Data in EmptyDir volumes is not persisted across deployments.\n", p.Image.Name)
 				warned[p.Image.Name] = struct{}{}
 			}
 		}

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -681,7 +681,7 @@ func TestRunAll(t *testing.T) {
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
-		res, err := test.config.RunAll(os.Stdout)
+		res, err := test.config.RunAll(os.Stdout, os.Stderr)
 		if err != test.expectedErr {
 			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
 			continue
@@ -830,7 +830,7 @@ func TestRunBuild(t *testing.T) {
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
-		res, err := test.config.RunBuilds(os.Stdout)
+		res, err := test.config.RunBuilds(os.Stdout, os.Stderr)
 		if err != test.expectedErr {
 			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
 			continue


### PR DESCRIPTION
This will make sure the NOTICE doesn't get mixed up with e.g. json when
invoking new-app with -o.

Fixes #3547