### PR TITLE
Restore failed initial deployment events

### DIFF
--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -7,6 +7,7 @@ import (
 
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kerrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/record"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
@@ -22,6 +23,8 @@ type DeploymentConfigChangeController struct {
 	changeStrategy changeStrategy
 	// decodeConfig knows how to decode the deploymentConfig from a deployment's annotations.
 	decodeConfig func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error)
+	// recorder records events.
+	recorder record.EventRecorder
 }
 
 // fatalError is an error which can't be retried.
@@ -52,9 +55,7 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 			if kerrors.IsConflict(err) {
 				return fatalError(fmt.Sprintf("DeploymentConfig %s updated since retrieval; aborting trigger: %v", deployutil.LabelForDeploymentConfig(config), err))
 			}
-			// TODO: This needs handled by setting some state within the API so
-			// users know why the trigger isn't doing anything.
-			// https://github.com/openshift/origin/issues/3526
+			c.recorder.Eventf(config, "failedCreate", "Couldn't create initial deployment: %v", err)
 			return nil
 		}
 		glog.V(4).Infof("Created initial Deployment for DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))

--- a/pkg/deploy/controller/configchange/factory.go
+++ b/pkg/deploy/controller/configchange/factory.go
@@ -61,6 +61,7 @@ func (factory *DeploymentConfigChangeControllerFactory) Create() controller.Runn
 		decodeConfig: func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
 			return deployutil.DecodeDeploymentConfig(deployment, factory.Codec)
 		},
+		recorder: eventBroadcaster.NewRecorder(kapi.EventSource{Component: "deployer"}),
 	}
 
 	return &controller.RetryController{


### PR DESCRIPTION
Restore event writing for failed initial deployments, but remove server
logging for those failures. The event writing was erroneously removed due
to miscommunication: it's the server log spam which is an issue, not
duplicated events.

Closes #3492 (again).
Reverts #3527.
