### PR TITLE
Avoid flicker on overview page when scaling

### DIFF
--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -84,7 +84,8 @@
     <div class="component-label">
       Pods
       <span ng-if="rc.status.replicas === rc.spec.replicas" class="component-label-details">({{rc.status.replicas}})</span>
-      <span ng-if="rc.status.replicas !== rc.spec.replicas" class="component-label-details">({{rc.status.replicas}} current, {{rc.spec.replicas || 0}} desired)</span>
+      <!-- TODO: Change default from 0 to 1 when updating to API version v1. -->
+      <span ng-if="rc.status.replicas !== rc.spec.replicas" class="component-label-details">(scaling to {{rc.spec.replicas || 0}})</span>
     </div>
 
     <pods pods="pods"></pods>


### PR DESCRIPTION
Show a simple "scaling to n" message when expected replicas doesn't
match actual.

Fixes #3362