### PR TITLE
v1.0.0 k8s data migration

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/conversion_generated.go
@@ -1592,6 +1592,11 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	} else {
 		out.ImagePullSecrets = nil
 	}
+
+	// Carry conversion
+	out.DeprecatedServiceAccount = in.ServiceAccountName
+	out.DeprecatedHost = in.NodeName
+
 	return nil
 }
 
@@ -2305,6 +2310,10 @@ func convert_api_ServiceSpec_To_v1_ServiceSpec(in *api.ServiceSpec, out *Service
 		out.DeprecatedPublicIPs = nil
 	}
 	out.SessionAffinity = ServiceAffinity(in.SessionAffinity)
+
+	// Carry conversion
+	out.DeprecatedPortalIP = in.ClusterIP
+
 	return nil
 }
 

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/defaults.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/defaults.go
@@ -55,6 +55,14 @@ func addDefaultingFuncs() {
 			if obj.Protocol == "" {
 				obj.Protocol = ProtocolTCP
 			}
+
+			// Carry conversion to make port case valid
+			switch strings.ToUpper(string(obj.Protocol)) {
+			case string(ProtocolTCP):
+				obj.Protocol = ProtocolTCP
+			case string(ProtocolUDP):
+				obj.Protocol = ProtocolUDP
+			}
 		},
 		func(obj *Container) {
 			if obj.ImagePullPolicy == "" {
@@ -87,6 +95,20 @@ func addDefaultingFuncs() {
 					sp.TargetPort = util.NewIntOrStringFromInt(sp.Port)
 				}
 			}
+
+			// Carry conversion
+			if len(obj.ClusterIP) == 0 && len(obj.DeprecatedPortalIP) > 0 {
+				obj.ClusterIP = obj.DeprecatedPortalIP
+			}
+		},
+		func(obj *ServicePort) {
+			// Carry conversion to make port case valid
+			switch strings.ToUpper(string(obj.Protocol)) {
+			case string(ProtocolTCP):
+				obj.Protocol = ProtocolTCP
+			case string(ProtocolUDP):
+				obj.Protocol = ProtocolUDP
+			}
 		},
 		func(obj *PodSpec) {
 			if obj.DNSPolicy == "" {
@@ -97,6 +119,15 @@ func addDefaultingFuncs() {
 			}
 			if obj.HostNetwork {
 				defaultHostNetworkPorts(&obj.Containers)
+			}
+
+			// Carry migration from serviceAccount to serviceAccountName
+			if len(obj.ServiceAccountName) == 0 && len(obj.DeprecatedServiceAccount) > 0 {
+				obj.ServiceAccountName = obj.DeprecatedServiceAccount
+			}
+			// Carry migration from host to nodeName
+			if len(obj.NodeName) == 0 && len(obj.DeprecatedHost) > 0 {
+				obj.NodeName = obj.DeprecatedHost
 			}
 		},
 		func(obj *Probe) {
@@ -131,6 +162,15 @@ func addDefaultingFuncs() {
 						ep.Protocol = ProtocolTCP
 					}
 				}
+			}
+		},
+		func(obj *EndpointPort) {
+			// Carry conversion to make port case valid
+			switch strings.ToUpper(string(obj.Protocol)) {
+			case string(ProtocolTCP):
+				obj.Protocol = ProtocolTCP
+			case string(ProtocolUDP):
+				obj.Protocol = ProtocolUDP
 			}
 		},
 		func(obj *HTTPGetAction) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/types.go
@@ -896,6 +896,11 @@ type PodSpec struct {
 	// NodeSelector is a selector which must be true for the pod to fit on a node
 	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"selector which must match a node's labels for the pod to be scheduled on that node"`
 
+	// DeprecatedServiceAccount is the name of the ServiceAccount to use to run this pod
+	DeprecatedServiceAccount string `json:"serviceAccount,omitempty" description:"deprecated, use serviceAccountName instead."`
+	// DeprecatedHost is a request to schedule this pod onto a specific node
+	DeprecatedHost string `json:"host,omitempty" description:"deprecated, use nodeName instead"`
+
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod
 	ServiceAccountName string `json:"serviceAccountName,omitempty" description:"name of the ServiceAccount to use to run this pod"`
 
@@ -1104,6 +1109,9 @@ type ServiceSpec struct {
 
 	// This service will route traffic to pods having labels matching this selector. If null, no endpoints will be automatically created. If empty, all pods will be selected.
 	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified"`
+
+	// DeprecatedPortalIP
+	DeprecatedPortalIP string `json:"portalIP,omitempty" description:"deprecated, use clusterIP instead"`
 
 	// ClusterIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can

--- a/pkg/api/compatibility_test.go
+++ b/pkg/api/compatibility_test.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/validation"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/fielderrors"
+)
+
+func TestCompatibility_v1_Pod(t *testing.T) {
+	// Test "spec.host" -> "spec.nodeName"
+	expectedHost := "my-host"
+	// Test "spec.serviceAccount" -> "spec.serviceAccountName"
+	expectedServiceAccount := "my-service-account"
+	// Test "tcp" protocol gets converted to "TCP" and validated
+	originalProtocol := "tcp"
+	expectedProtocol := "TCP"
+
+	input := []byte(fmt.Sprintf(`
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"host":"%s",
+		"serviceAccount":"%s",
+		"containers":[{
+			"name":"my-container-name",
+			"image":"my-container-image",
+			"ports":[{"containerPort":1,"protocol":"%s"}]
+		}]
+	}
+}
+`, expectedHost, expectedServiceAccount, originalProtocol))
+
+	t.Log("Testing 1.0.0 v1 migration added in PR #3592")
+	testCompatibility(
+		t, "v1", input,
+		func(obj runtime.Object) fielderrors.ValidationErrorList {
+			return validation.ValidatePod(obj.(*api.Pod))
+		},
+		map[string]string{
+			"spec.host":     expectedHost,
+			"spec.nodeName": expectedHost,
+
+			"spec.serviceAccount":     expectedServiceAccount,
+			"spec.serviceAccountName": expectedServiceAccount,
+
+			"spec.containers[0].ports[0].protocol": expectedProtocol,
+		},
+	)
+}
+
+func TestCompatibility_v1_Service(t *testing.T) {
+	// Test "spec.portalIP" -> "spec.clusterIP"
+	expectedIP := "1.2.3.4"
+	// Test "tcp" protocol gets converted to "TCP" and validated
+	originalProtocol := "tcp"
+	expectedProtocol := "TCP"
+
+	input := []byte(fmt.Sprintf(`
+{
+	"kind":"Service",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-service-name", "namespace":"my-service-namespace"},
+	"spec": {
+		"portalIP":"%s",
+		"ports":[{"port":1,"protocol":"%s"}]
+	}
+}
+`, expectedIP, originalProtocol))
+
+	t.Log("Testing 1.0.0 v1 migration added in PR #3592")
+	testCompatibility(
+		t, "v1", input,
+		func(obj runtime.Object) fielderrors.ValidationErrorList {
+			return validation.ValidateService(obj.(*api.Service))
+		},
+		map[string]string{
+			"spec.portalIP":          expectedIP,
+			"spec.clusterIP":         expectedIP,
+			"spec.ports[0].protocol": expectedProtocol,
+		},
+	)
+}
+
+func TestCompatibility_v1_Endpoints(t *testing.T) {
+	// Test "tcp" protocol gets converted to "TCP" and validated
+	originalProtocol := "tcp"
+	expectedProtocol := "TCP"
+
+	input := []byte(fmt.Sprintf(`
+{
+	"kind":"Endpoints",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-endpoints-name", "namespace":"my-endpoints-namespace"},
+	"subsets": [{
+		"addresses":[{"ip":"1.2.3.4"}],
+		"ports": [{"port":1,"targetPort":1,"protocol":"%s"}]
+	}]
+}
+`, originalProtocol))
+
+	t.Log("Testing 1.0.0 v1 migration added in PR #3592")
+	testCompatibility(
+		t, "v1", input,
+		func(obj runtime.Object) fielderrors.ValidationErrorList {
+			return validation.ValidateEndpoints(obj.(*api.Endpoints))
+		},
+		map[string]string{
+			"subsets[0].ports[0].protocol": expectedProtocol,
+		},
+	)
+}
+
+func testCompatibility(
+	t *testing.T,
+	version string,
+	input []byte,
+	validator func(obj runtime.Object) fielderrors.ValidationErrorList,
+	serialized map[string]string,
+) {
+
+	// Decode
+	codec := runtime.CodecFor(api.Scheme, version)
+	obj, err := codec.Decode(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Validate
+	errs := validator(obj)
+	if len(errs) != 0 {
+		t.Fatalf("Unexpected errors: %v", errs)
+	}
+
+	// Encode
+	output, err := codec.Encode(obj)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Validate old and new fields are encoded
+	generic := map[string]interface{}{}
+	if err := json.Unmarshal(output, &generic); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	for k, expectedValue := range serialized {
+		keys := strings.Split(k, ".")
+		if actualValue, ok, err := getJSONValue(generic, keys...); err != nil || !ok {
+			t.Errorf("Unexpected error for %s: %v", k, err)
+		} else if !reflect.DeepEqual(expectedValue, actualValue) {
+			t.Errorf("Expected %v, got %v", expectedValue, actualValue)
+		}
+	}
+}
+
+func getJSONValue(data map[string]interface{}, keys ...string) (interface{}, bool, error) {
+	// No keys, current value is it
+	if len(keys) == 0 {
+		return data, true, nil
+	}
+
+	// Get the key (and optional index)
+	key := keys[0]
+	index := -1
+	if matches := regexp.MustCompile(`^(.*)\[(\d+)\]$`).FindStringSubmatch(key); len(matches) > 0 {
+		key = matches[1]
+		index, _ = strconv.Atoi(matches[2])
+	}
+
+	// Look up the value
+	value, ok := data[key]
+	if !ok {
+		return nil, false, fmt.Errorf("No key %s found", key)
+	}
+
+	// Get the indexed value if an index is specified
+	if index >= 0 {
+		valueSlice, ok := value.([]interface{})
+		if !ok {
+			return nil, false, fmt.Errorf("Key %s did not hold a slice", key)
+		}
+		if index >= len(valueSlice) {
+			return nil, false, fmt.Errorf("Index %d out of bounds for slice at key", index, key)
+		}
+		value = valueSlice[index]
+	}
+
+	if len(keys) == 1 {
+		return value, true, nil
+	}
+
+	childData, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("Key %s did not hold a map", keys[0])
+	}
+	return getJSONValue(childData, keys[1:]...)
+}


### PR DESCRIPTION
Fixes #3520
Related to #3331
No upstream PR, since this is something we're carrying for compatibility with our 1.0.0 release

- [x] Migrates data in these fields (while preserving the 1.0.0 fields as deprecated fields):

    origin 1.0.0 v1 | kubernetes v1
    -----------|-------------------
    PodSpec.serviceAccount | PodSpec.serviceAccountName
    PodSpec.host | PodSpec.nodeName
    ServiceSpec.portalIP | ServiceSpec.clusterIP

- [x] Upper-cases TCP/UDP port protocols in {Container,Endpoint,Service}Port objects in order to validate