### PR TITLE
Set expanded property on ng-repeat child scope for tasks

### DIFF
--- a/assets/app/scripts/controllers/tasks.js
+++ b/assets/app/scripts/controllers/tasks.js
@@ -15,8 +15,4 @@ angular.module('openshiftConsole')
     $scope.delete = function(task) {
       TaskList.deleteTask(task);
     };
-    $scope.expanded = false;
-    $scope.toggleExpand = function() {
-      $scope.expanded = !$scope.expanded;
-    };
   });

--- a/assets/app/views/_tasks.html
+++ b/assets/app/views/_tasks.html
@@ -19,7 +19,7 @@
             </ul>
           </div>
           <div ng-show="task.hasErrors">
-            <a href="javascript:;" ng-click="toggleExpand()">
+            <a href="javascript:;" ng-click="expanded = !expanded">
               <span ng-hide="expanded">Show details</span>
               <span ng-show="expanded">Hide details</span>
             </a>


### PR DESCRIPTION
Don't set the `expanded` property on the parent scope as it will apply
to all displayed tasks.

Fixes #2523