### PR TITLE
testclient: Wrap Kubernetes testclient

### DIFF
--- a/pkg/client/testclient/fake_buildconfigs.go
+++ b/pkg/client/testclient/fake_buildconfigs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -20,12 +21,12 @@ type FakeBuildConfigs struct {
 }
 
 func (c *FakeBuildConfigs) List(label labels.Selector, field fields.Selector) (*buildapi.BuildConfigList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-buildconfig"}, &buildapi.BuildConfigList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-buildconfig"}, &buildapi.BuildConfigList{})
 	return obj.(*buildapi.BuildConfigList), err
 }
 
 func (c *FakeBuildConfigs) Get(name string) (*buildapi.BuildConfig, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-buildconfig", Value: name}, &buildapi.BuildConfig{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-buildconfig", Value: name}, &buildapi.BuildConfig{})
 	return obj.(*buildapi.BuildConfig), err
 }
 
@@ -41,26 +42,26 @@ func (c *FakeBuildConfigs) WebHookURL(name string, trigger *buildapi.BuildTrigge
 }
 
 func (c *FakeBuildConfigs) Create(config *buildapi.BuildConfig) (*buildapi.BuildConfig, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-buildconfig"}, &buildapi.BuildConfig{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-buildconfig"}, &buildapi.BuildConfig{})
 	return obj.(*buildapi.BuildConfig), err
 }
 
 func (c *FakeBuildConfigs) Update(config *buildapi.BuildConfig) (*buildapi.BuildConfig, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-buildconfig"}, &buildapi.BuildConfig{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-buildconfig"}, &buildapi.BuildConfig{})
 	return obj.(*buildapi.BuildConfig), err
 }
 
 func (c *FakeBuildConfigs) Delete(name string) error {
-	_, err := c.Fake.Invokes(FakeAction{Action: "delete-buildconfig", Value: name}, &buildapi.BuildConfig{})
+	_, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "delete-buildconfig", Value: name}, &buildapi.BuildConfig{})
 	return err
 }
 
 func (c *FakeBuildConfigs) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-buildconfigs"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-buildconfigs"})
 	return nil, nil
 }
 
 func (c *FakeBuildConfigs) Instantiate(request *buildapi.BuildRequest) (result *buildapi.Build, err error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "instantiate-buildconfig", Value: request}, &buildapi.Build{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "instantiate-buildconfig", Value: request}, &buildapi.Build{})
 	return obj.(*buildapi.Build), err
 }

--- a/pkg/client/testclient/fake_buildlogs.go
+++ b/pkg/client/testclient/fake_buildlogs.go
@@ -2,6 +2,7 @@ package testclient
 
 import (
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 
 	"github.com/openshift/origin/pkg/build/api"
 )
@@ -15,6 +16,6 @@ type FakeBuildLogs struct {
 
 // Get builds and returns a buildLog request
 func (c *FakeBuildLogs) Get(name string, opt api.BuildLogOptions) *kclient.Request {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "proxy"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "proxy"})
 	return &kclient.Request{}
 }

--- a/pkg/client/testclient/fake_builds.go
+++ b/pkg/client/testclient/fake_builds.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -16,36 +17,36 @@ type FakeBuilds struct {
 }
 
 func (c *FakeBuilds) List(label labels.Selector, field fields.Selector) (*buildapi.BuildList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-builds"}, &buildapi.BuildList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-builds"}, &buildapi.BuildList{})
 	return obj.(*buildapi.BuildList), err
 }
 
 func (c *FakeBuilds) Get(name string) (*buildapi.Build, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-build"}, &buildapi.Build{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-build"}, &buildapi.Build{})
 	return obj.(*buildapi.Build), err
 }
 
 func (c *FakeBuilds) Create(build *buildapi.Build) (*buildapi.Build, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-build", Value: build}, &buildapi.Build{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-build", Value: build}, &buildapi.Build{})
 	return obj.(*buildapi.Build), err
 }
 
 func (c *FakeBuilds) Update(build *buildapi.Build) (*buildapi.Build, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-build"}, &buildapi.Build{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-build"}, &buildapi.Build{})
 	return obj.(*buildapi.Build), err
 }
 
 func (c *FakeBuilds) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-build", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-build", Value: name})
 	return nil
 }
 
 func (c *FakeBuilds) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-builds"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-builds"})
 	return nil, nil
 }
 
 func (c *FakeBuilds) Clone(request *buildapi.BuildRequest) (result *buildapi.Build, err error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "clone-build"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "clone-build"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_clusternetwork.go
+++ b/pkg/client/testclient/fake_clusternetwork.go
@@ -1,6 +1,8 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
@@ -11,11 +13,11 @@ type FakeClusterNetwork struct {
 }
 
 func (c *FakeClusterNetwork) Get(name string) (*sdnapi.ClusterNetwork, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-network"}, &sdnapi.ClusterNetwork{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-network"}, &sdnapi.ClusterNetwork{})
 	return obj.(*sdnapi.ClusterNetwork), err
 }
 
 func (c *FakeClusterNetwork) Create(sdn *sdnapi.ClusterNetwork) (*sdnapi.ClusterNetwork, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-network"}, &sdnapi.ClusterNetwork{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-network"}, &sdnapi.ClusterNetwork{})
 	return obj.(*sdnapi.ClusterNetwork), err
 }

--- a/pkg/client/testclient/fake_clusterpolicies.go
+++ b/pkg/client/testclient/fake_clusterpolicies.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -15,21 +16,21 @@ type FakeClusterPolicies struct {
 }
 
 func (c *FakeClusterPolicies) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterPolicies"}, &authorizationapi.ClusterPolicyList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-clusterPolicies"}, &authorizationapi.ClusterPolicyList{})
 	return obj.(*authorizationapi.ClusterPolicyList), err
 }
 
 func (c *FakeClusterPolicies) Get(name string) (*authorizationapi.ClusterPolicy, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterPolicy"}, &authorizationapi.ClusterPolicy{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-clusterPolicy"}, &authorizationapi.ClusterPolicy{})
 	return obj.(*authorizationapi.ClusterPolicy), err
 }
 
 func (c *FakeClusterPolicies) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterPolicy", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-clusterPolicy", Value: name})
 	return nil
 }
 
 func (c *FakeClusterPolicies) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-clusterPolicy"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-clusterPolicy"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_clusterpolicybindings.go
+++ b/pkg/client/testclient/fake_clusterpolicybindings.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -15,26 +16,26 @@ type FakeClusterPolicyBindings struct {
 }
 
 func (c *FakeClusterPolicyBindings) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterPolicyBindingList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterPolicyBindings"}, &authorizationapi.ClusterPolicyBindingList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-clusterPolicyBindings"}, &authorizationapi.ClusterPolicyBindingList{})
 	return obj.(*authorizationapi.ClusterPolicyBindingList), err
 }
 
 func (c *FakeClusterPolicyBindings) Get(name string) (*authorizationapi.ClusterPolicyBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterPolicyBinding"}, &authorizationapi.ClusterPolicyBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-clusterPolicyBinding"}, &authorizationapi.ClusterPolicyBinding{})
 	return obj.(*authorizationapi.ClusterPolicyBinding), err
 }
 
 func (c *FakeClusterPolicyBindings) Create(policyBinding *authorizationapi.ClusterPolicyBinding) (*authorizationapi.ClusterPolicyBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-clusterPolicyBinding", Value: policyBinding}, &authorizationapi.ClusterPolicyBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-clusterPolicyBinding", Value: policyBinding}, &authorizationapi.ClusterPolicyBinding{})
 	return obj.(*authorizationapi.ClusterPolicyBinding), err
 }
 
 func (c *FakeClusterPolicyBindings) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterPolicyBinding", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-clusterPolicyBinding", Value: name})
 	return nil
 }
 
 func (c *FakeClusterPolicyBindings) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-clusterPolicyBinding"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-clusterPolicyBinding"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_clusterrolebindings.go
+++ b/pkg/client/testclient/fake_clusterrolebindings.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -14,26 +15,26 @@ type FakeClusterRoleBindings struct {
 }
 
 func (c *FakeClusterRoleBindings) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterRoleBindingList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterRoleBindings"}, &authorizationapi.ClusterRoleBindingList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-clusterRoleBindings"}, &authorizationapi.ClusterRoleBindingList{})
 	return obj.(*authorizationapi.ClusterRoleBindingList), err
 }
 
 func (c *FakeClusterRoleBindings) Get(name string) (*authorizationapi.ClusterRoleBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterRoleBinding"}, &authorizationapi.ClusterRoleBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-clusterRoleBinding"}, &authorizationapi.ClusterRoleBinding{})
 	return obj.(*authorizationapi.ClusterRoleBinding), err
 }
 
 func (c *FakeClusterRoleBindings) Create(roleBinding *authorizationapi.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-clusterRoleBinding", Value: roleBinding}, &authorizationapi.ClusterRoleBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-clusterRoleBinding", Value: roleBinding}, &authorizationapi.ClusterRoleBinding{})
 	return obj.(*authorizationapi.ClusterRoleBinding), err
 }
 
 func (c *FakeClusterRoleBindings) Update(roleBinding *authorizationapi.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-clusterRoleBinding"}, &authorizationapi.ClusterRoleBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-clusterRoleBinding"}, &authorizationapi.ClusterRoleBinding{})
 	return obj.(*authorizationapi.ClusterRoleBinding), err
 }
 
 func (c *FakeClusterRoleBindings) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterRoleBinding", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-clusterRoleBinding", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_clusterroles.go
+++ b/pkg/client/testclient/fake_clusterroles.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -14,26 +15,26 @@ type FakeClusterRoles struct {
 }
 
 func (c *FakeClusterRoles) List(label labels.Selector, field fields.Selector) (*authorizationapi.ClusterRoleList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-clusterRoles"}, &authorizationapi.ClusterRoleList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-clusterRoles"}, &authorizationapi.ClusterRoleList{})
 	return obj.(*authorizationapi.ClusterRoleList), err
 }
 
 func (c *FakeClusterRoles) Get(name string) (*authorizationapi.ClusterRole, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-clusterRole"}, &authorizationapi.ClusterRole{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-clusterRole"}, &authorizationapi.ClusterRole{})
 	return obj.(*authorizationapi.ClusterRole), err
 }
 
 func (c *FakeClusterRoles) Create(role *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-clusterRole", Value: role}, &authorizationapi.ClusterRole{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-clusterRole", Value: role}, &authorizationapi.ClusterRole{})
 	return obj.(*authorizationapi.ClusterRole), err
 }
 
 func (c *FakeClusterRoles) Update(role *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-clusterRole"}, &authorizationapi.ClusterRole{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-clusterRole"}, &authorizationapi.ClusterRole{})
 	return obj.(*authorizationapi.ClusterRole), err
 }
 
 func (c *FakeClusterRoles) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-clusterRole", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-clusterRole", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_deploymentconfigs.go
+++ b/pkg/client/testclient/fake_deploymentconfigs.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -16,41 +17,41 @@ type FakeDeploymentConfigs struct {
 }
 
 func (c *FakeDeploymentConfigs) List(label labels.Selector, field fields.Selector) (*deployapi.DeploymentConfigList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-deploymentconfig"}, &deployapi.DeploymentConfigList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-deploymentconfig"}, &deployapi.DeploymentConfigList{})
 	return obj.(*deployapi.DeploymentConfigList), err
 }
 
 func (c *FakeDeploymentConfigs) Get(name string) (*deployapi.DeploymentConfig, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-deploymentconfig"}, &deployapi.DeploymentConfig{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-deploymentconfig"}, &deployapi.DeploymentConfig{})
 	return obj.(*deployapi.DeploymentConfig), err
 }
 
 func (c *FakeDeploymentConfigs) Create(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-deploymentconfig"}, &deployapi.DeploymentConfig{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-deploymentconfig"}, &deployapi.DeploymentConfig{})
 	return obj.(*deployapi.DeploymentConfig), err
 }
 
 func (c *FakeDeploymentConfigs) Update(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-deploymentconfig"}, &deployapi.DeploymentConfig{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-deploymentconfig"}, &deployapi.DeploymentConfig{})
 	return obj.(*deployapi.DeploymentConfig), err
 }
 
 func (c *FakeDeploymentConfigs) Delete(name string) error {
-	_, err := c.Fake.Invokes(FakeAction{Action: "delete-deploymentconfig"}, nil)
+	_, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "delete-deploymentconfig"}, nil)
 	return err
 }
 
 func (c *FakeDeploymentConfigs) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-deploymentconfig"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-deploymentconfig"})
 	return nil, nil
 }
 
 func (c *FakeDeploymentConfigs) Generate(name string) (*deployapi.DeploymentConfig, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "generate-deploymentconfig"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "generate-deploymentconfig"})
 	return nil, nil
 }
 
 func (c *FakeDeploymentConfigs) Rollback(config *deployapi.DeploymentConfigRollback) (result *deployapi.DeploymentConfig, err error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "rollback"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "rollback"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_hostsubnets.go
+++ b/pkg/client/testclient/fake_hostsubnets.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/api"
@@ -13,26 +14,26 @@ type FakeHostSubnet struct {
 }
 
 func (c *FakeHostSubnet) List() (*sdnapi.HostSubnetList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-subnets"}, &sdnapi.HostSubnetList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-subnets"}, &sdnapi.HostSubnetList{})
 	return obj.(*sdnapi.HostSubnetList), err
 }
 
 func (c *FakeHostSubnet) Get(name string) (*sdnapi.HostSubnet, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-subnets"}, &sdnapi.HostSubnet{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-subnets"}, &sdnapi.HostSubnet{})
 	return obj.(*sdnapi.HostSubnet), err
 }
 
 func (c *FakeHostSubnet) Create(sdn *sdnapi.HostSubnet) (*sdnapi.HostSubnet, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-subnet"}, &sdnapi.HostSubnet{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-subnet"}, &sdnapi.HostSubnet{})
 	return obj.(*sdnapi.HostSubnet), err
 }
 
 func (c *FakeHostSubnet) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-subnet"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-subnet"})
 	return nil
 }
 
 func (c *FakeHostSubnet) Watch(resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-subnets"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-subnets"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_identities.go
+++ b/pkg/client/testclient/fake_identities.go
@@ -1,8 +1,10 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
@@ -13,21 +15,21 @@ type FakeIdentities struct {
 }
 
 func (c *FakeIdentities) List(label labels.Selector, field fields.Selector) (*userapi.IdentityList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-identities"}, &userapi.IdentityList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-identities"}, &userapi.IdentityList{})
 	return obj.(*userapi.IdentityList), err
 }
 
 func (c *FakeIdentities) Get(name string) (*userapi.Identity, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-identity", Value: name}, &userapi.Identity{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-identity", Value: name}, &userapi.Identity{})
 	return obj.(*userapi.Identity), err
 }
 
 func (c *FakeIdentities) Create(identity *userapi.Identity) (*userapi.Identity, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-identity", Value: identity}, &userapi.Identity{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-identity", Value: identity}, &userapi.Identity{})
 	return obj.(*userapi.Identity), err
 }
 
 func (c *FakeIdentities) Update(identity *userapi.Identity) (*userapi.Identity, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-identity", Value: identity}, &userapi.Identity{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-identity", Value: identity}, &userapi.Identity{})
 	return obj.(*userapi.Identity), err
 }

--- a/pkg/client/testclient/fake_images.go
+++ b/pkg/client/testclient/fake_images.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -18,21 +19,21 @@ type FakeImages struct {
 var _ client.ImageInterface = &FakeImages{}
 
 func (c *FakeImages) List(label labels.Selector, field fields.Selector) (*imageapi.ImageList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-images"}, &imageapi.ImageList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-images"}, &imageapi.ImageList{})
 	return obj.(*imageapi.ImageList), err
 }
 
 func (c *FakeImages) Get(name string) (*imageapi.Image, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-image", Value: name}, &imageapi.Image{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-image", Value: name}, &imageapi.Image{})
 	return obj.(*imageapi.Image), err
 }
 
 func (c *FakeImages) Create(image *imageapi.Image) (*imageapi.Image, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-image"}, &imageapi.Image{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-image"}, &imageapi.Image{})
 	return obj.(*imageapi.Image), err
 }
 
 func (c *FakeImages) Delete(name string) error {
-	_, err := c.Fake.Invokes(FakeAction{Action: "delete-image", Value: name}, nil)
+	_, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "delete-image", Value: name}, nil)
 	return err
 }

--- a/pkg/client/testclient/fake_imagestreamimages.go
+++ b/pkg/client/testclient/fake_imagestreamimages.go
@@ -3,6 +3,8 @@ package testclient
 import (
 	"fmt"
 
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -18,6 +20,6 @@ type FakeImageStreamImages struct {
 var _ client.ImageStreamImageInterface = &FakeImageStreamImages{}
 
 func (c *FakeImageStreamImages) Get(name, id string) (*imageapi.ImageStreamImage, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-imagestream-image", Value: fmt.Sprintf("%s@%s", name, id)}, &imageapi.ImageStreamImage{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-imagestream-image", Value: fmt.Sprintf("%s@%s", name, id)}, &imageapi.ImageStreamImage{})
 	return obj.(*imageapi.ImageStreamImage), err
 }

--- a/pkg/client/testclient/fake_imagestreammappings.go
+++ b/pkg/client/testclient/fake_imagestreammappings.go
@@ -1,6 +1,8 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -16,6 +18,6 @@ type FakeImageStreamMappings struct {
 var _ client.ImageStreamMappingInterface = &FakeImageStreamMappings{}
 
 func (c *FakeImageStreamMappings) Create(mapping *imageapi.ImageStreamMapping) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "create-imagestream-mapping"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "create-imagestream-mapping"})
 	return nil
 }

--- a/pkg/client/testclient/fake_imagestreams.go
+++ b/pkg/client/testclient/fake_imagestreams.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -20,36 +21,36 @@ type FakeImageStreams struct {
 var _ client.ImageStreamInterface = &FakeImageStreams{}
 
 func (c *FakeImageStreams) List(label labels.Selector, field fields.Selector) (*imageapi.ImageStreamList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-imagestreams"}, &imageapi.ImageStreamList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-imagestreams"}, &imageapi.ImageStreamList{})
 	return obj.(*imageapi.ImageStreamList), err
 }
 
 func (c *FakeImageStreams) Get(name string) (*imageapi.ImageStream, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-imagestream", Value: name}, &imageapi.ImageStream{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-imagestream", Value: name}, &imageapi.ImageStream{})
 	return obj.(*imageapi.ImageStream), err
 }
 
 func (c *FakeImageStreams) Create(stream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-imagestream"}, &imageapi.ImageStream{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-imagestream"}, &imageapi.ImageStream{})
 	return obj.(*imageapi.ImageStream), err
 }
 
 func (c *FakeImageStreams) Update(stream *imageapi.ImageStream) (*imageapi.ImageStream, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-imagestream", Value: stream}, stream)
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-imagestream", Value: stream}, stream)
 	return obj.(*imageapi.ImageStream), err
 }
 
 func (c *FakeImageStreams) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-imagestream", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-imagestream", Value: name})
 	return nil
 }
 
 func (c *FakeImageStreams) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-imagestreams"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-imagestreams"})
 	return nil, nil
 }
 
 func (c *FakeImageStreams) UpdateStatus(stream *imageapi.ImageStream) (result *imageapi.ImageStream, err error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-status-imagestream", Value: stream}, stream)
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-status-imagestream", Value: stream}, stream)
 	return obj.(*imageapi.ImageStream), err
 }

--- a/pkg/client/testclient/fake_imagestreamtags.go
+++ b/pkg/client/testclient/fake_imagestreamtags.go
@@ -3,6 +3,8 @@ package testclient
 import (
 	"fmt"
 
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -18,11 +20,11 @@ type FakeImageStreamTags struct {
 var _ client.ImageStreamTagInterface = &FakeImageStreamTags{}
 
 func (c *FakeImageStreamTags) Get(name, tag string) (result *imageapi.ImageStreamTag, err error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "get-imagestream-tag", Value: fmt.Sprintf("%s:%s", name, tag)})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "get-imagestream-tag", Value: fmt.Sprintf("%s:%s", name, tag)})
 	return &imageapi.ImageStreamTag{}, nil
 }
 
 func (c *FakeImageStreamTags) Delete(name, tag string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-imagestream-tag", Value: fmt.Sprintf("%s:%s", name, tag)})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-imagestream-tag", Value: fmt.Sprintf("%s:%s", name, tag)})
 	return nil
 }

--- a/pkg/client/testclient/fake_oauthaccesstoken.go
+++ b/pkg/client/testclient/fake_oauthaccesstoken.go
@@ -1,5 +1,9 @@
 package testclient
 
+import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+)
+
 // FakeOAuthAccessTokens implements OAuthAccessTokenInterface. Meant to be embedded into a struct to get a default
 // implementation. This makes faking out just the methods you want to test easier.
 type FakeOAuthAccessTokens struct {
@@ -8,6 +12,6 @@ type FakeOAuthAccessTokens struct {
 
 // Delete mocks deleting an OAuthAccessToken
 func (c *FakeOAuthAccessTokens) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-oauthaccesstoken", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-oauthaccesstoken", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_policies.go
+++ b/pkg/client/testclient/fake_policies.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -15,21 +16,21 @@ type FakePolicies struct {
 }
 
 func (c *FakePolicies) List(label labels.Selector, field fields.Selector) (*authorizationapi.PolicyList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-policies"}, &authorizationapi.PolicyList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-policies"}, &authorizationapi.PolicyList{})
 	return obj.(*authorizationapi.PolicyList), err
 }
 
 func (c *FakePolicies) Get(name string) (*authorizationapi.Policy, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-policy"}, &authorizationapi.Policy{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-policy"}, &authorizationapi.Policy{})
 	return obj.(*authorizationapi.Policy), err
 }
 
 func (c *FakePolicies) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-policy", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-policy", Value: name})
 	return nil
 }
 
 func (c *FakePolicies) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-policy"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-policy"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_policybindings.go
+++ b/pkg/client/testclient/fake_policybindings.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -15,26 +16,26 @@ type FakePolicyBindings struct {
 }
 
 func (c *FakePolicyBindings) List(label labels.Selector, field fields.Selector) (*authorizationapi.PolicyBindingList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-policyBindings"}, &authorizationapi.PolicyBindingList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-policyBindings"}, &authorizationapi.PolicyBindingList{})
 	return obj.(*authorizationapi.PolicyBindingList), err
 }
 
 func (c *FakePolicyBindings) Get(name string) (*authorizationapi.PolicyBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-policyBinding"}, &authorizationapi.PolicyBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-policyBinding"}, &authorizationapi.PolicyBinding{})
 	return obj.(*authorizationapi.PolicyBinding), err
 }
 
 func (c *FakePolicyBindings) Create(policyBinding *authorizationapi.PolicyBinding) (*authorizationapi.PolicyBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-policyBinding", Value: policyBinding}, &authorizationapi.PolicyBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-policyBinding", Value: policyBinding}, &authorizationapi.PolicyBinding{})
 	return obj.(*authorizationapi.PolicyBinding), err
 }
 
 func (c *FakePolicyBindings) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-policyBinding", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-policyBinding", Value: name})
 	return nil
 }
 
 func (c *FakePolicyBindings) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-policyBinding"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-policyBinding"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_projectrequests.go
+++ b/pkg/client/testclient/fake_projectrequests.go
@@ -2,6 +2,7 @@ package testclient
 
 import (
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -15,11 +16,11 @@ type FakeProjectRequests struct {
 }
 
 func (c *FakeProjectRequests) Create(project *projectapi.ProjectRequest) (*projectapi.Project, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-newProject", Value: project}, &projectapi.ProjectRequest{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-newProject", Value: project}, &projectapi.ProjectRequest{})
 	return obj.(*projectapi.Project), err
 }
 
 func (c *FakeProjectRequests) List(label labels.Selector, field fields.Selector) (*kapi.Status, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-newProject"}, &kapi.Status{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-newProject"}, &kapi.Status{})
 	return obj.(*kapi.Status), err
 }

--- a/pkg/client/testclient/fake_projects.go
+++ b/pkg/client/testclient/fake_projects.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -14,26 +15,26 @@ type FakeProjects struct {
 }
 
 func (c *FakeProjects) List(label labels.Selector, field fields.Selector) (*projectapi.ProjectList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-projects"}, &projectapi.ProjectList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-projects"}, &projectapi.ProjectList{})
 	return obj.(*projectapi.ProjectList), err
 }
 
 func (c *FakeProjects) Get(name string) (*projectapi.Project, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-project"}, &projectapi.Project{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-project"}, &projectapi.Project{})
 	return obj.(*projectapi.Project), err
 }
 
 func (c *FakeProjects) Create(project *projectapi.Project) (*projectapi.Project, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-project", Value: project}, &projectapi.Project{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-project", Value: project}, &projectapi.Project{})
 	return obj.(*projectapi.Project), err
 }
 
 func (c *FakeProjects) Update(project *projectapi.Project) (*projectapi.Project, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-project"}, &projectapi.Project{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-project"}, &projectapi.Project{})
 	return obj.(*projectapi.Project), err
 }
 
 func (c *FakeProjects) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-project", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-project", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_resourceaccessreview.go
+++ b/pkg/client/testclient/fake_resourceaccessreview.go
@@ -1,6 +1,8 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
@@ -11,7 +13,7 @@ type FakeResourceAccessReviews struct {
 }
 
 func (c *FakeResourceAccessReviews) Create(resourceAccessReview *authorizationapi.ResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-resourceAccessReview", Value: resourceAccessReview}, &authorizationapi.ResourceAccessReviewResponse{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-resourceAccessReview", Value: resourceAccessReview}, &authorizationapi.ResourceAccessReviewResponse{})
 	return obj.(*authorizationapi.ResourceAccessReviewResponse), err
 }
 
@@ -20,6 +22,6 @@ type FakeClusterResourceAccessReviews struct {
 }
 
 func (c *FakeClusterResourceAccessReviews) Create(resourceAccessReview *authorizationapi.ResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-cluster-resourceAccessReview", Value: resourceAccessReview}, &authorizationapi.ResourceAccessReviewResponse{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-cluster-resourceAccessReview", Value: resourceAccessReview}, &authorizationapi.ResourceAccessReviewResponse{})
 	return obj.(*authorizationapi.ResourceAccessReviewResponse), err
 }

--- a/pkg/client/testclient/fake_rolebindings.go
+++ b/pkg/client/testclient/fake_rolebindings.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -14,26 +15,26 @@ type FakeRoleBindings struct {
 }
 
 func (c *FakeRoleBindings) List(label labels.Selector, field fields.Selector) (*authorizationapi.RoleBindingList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-roleBinding"}, &authorizationapi.RoleBindingList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-roleBinding"}, &authorizationapi.RoleBindingList{})
 	return obj.(*authorizationapi.RoleBindingList), err
 }
 
 func (c *FakeRoleBindings) Get(name string) (*authorizationapi.RoleBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-roleBinding"}, &authorizationapi.RoleBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-roleBinding"}, &authorizationapi.RoleBinding{})
 	return obj.(*authorizationapi.RoleBinding), err
 }
 
 func (c *FakeRoleBindings) Create(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-roleBinding", Value: roleBinding}, &authorizationapi.RoleBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-roleBinding", Value: roleBinding}, &authorizationapi.RoleBinding{})
 	return obj.(*authorizationapi.RoleBinding), err
 }
 
 func (c *FakeRoleBindings) Update(roleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-roleBinding"}, &authorizationapi.RoleBinding{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-roleBinding"}, &authorizationapi.RoleBinding{})
 	return obj.(*authorizationapi.RoleBinding), err
 }
 
 func (c *FakeRoleBindings) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-roleBinding", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-roleBinding", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_roles.go
+++ b/pkg/client/testclient/fake_roles.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 
@@ -14,26 +15,26 @@ type FakeRoles struct {
 }
 
 func (c *FakeRoles) List(label labels.Selector, field fields.Selector) (*authorizationapi.RoleList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-role"}, &authorizationapi.RoleList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-role"}, &authorizationapi.RoleList{})
 	return obj.(*authorizationapi.RoleList), err
 }
 
 func (c *FakeRoles) Get(name string) (*authorizationapi.Role, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-role"}, &authorizationapi.Role{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-role"}, &authorizationapi.Role{})
 	return obj.(*authorizationapi.Role), err
 }
 
 func (c *FakeRoles) Create(role *authorizationapi.Role) (*authorizationapi.Role, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-role", Value: role}, &authorizationapi.Role{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-role", Value: role}, &authorizationapi.Role{})
 	return obj.(*authorizationapi.Role), err
 }
 
 func (c *FakeRoles) Update(role *authorizationapi.Role) (*authorizationapi.Role, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-role"}, &authorizationapi.Role{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-role"}, &authorizationapi.Role{})
 	return obj.(*authorizationapi.Role), err
 }
 
 func (c *FakeRoles) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-role", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-role", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_routes.go
+++ b/pkg/client/testclient/fake_routes.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -16,31 +17,31 @@ type FakeRoutes struct {
 }
 
 func (c *FakeRoutes) List(label labels.Selector, field fields.Selector) (*routeapi.RouteList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-routes"}, &routeapi.RouteList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-routes"}, &routeapi.RouteList{})
 	return obj.(*routeapi.RouteList), err
 }
 
 func (c *FakeRoutes) Get(name string) (*routeapi.Route, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-route"}, &routeapi.Route{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-route"}, &routeapi.Route{})
 	return obj.(*routeapi.Route), err
 }
 
 func (c *FakeRoutes) Create(route *routeapi.Route) (*routeapi.Route, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-route"}, &routeapi.Route{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-route"}, &routeapi.Route{})
 	return obj.(*routeapi.Route), err
 }
 
 func (c *FakeRoutes) Update(route *routeapi.Route) (*routeapi.Route, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-route"}, &routeapi.Route{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-route"}, &routeapi.Route{})
 	return obj.(*routeapi.Route), err
 }
 
 func (c *FakeRoutes) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-route"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-route"})
 	return nil
 }
 
 func (c *FakeRoutes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-routes"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-routes"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_subjectaccessreview.go
+++ b/pkg/client/testclient/fake_subjectaccessreview.go
@@ -1,6 +1,8 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
@@ -11,7 +13,7 @@ type FakeSubjectAccessReviews struct {
 }
 
 func (c *FakeSubjectAccessReviews) Create(subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-subjectAccessReview", Value: subjectAccessReview}, &authorizationapi.SubjectAccessReviewResponse{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-subjectAccessReview", Value: subjectAccessReview}, &authorizationapi.SubjectAccessReviewResponse{})
 	return obj.(*authorizationapi.SubjectAccessReviewResponse), err
 }
 
@@ -23,6 +25,6 @@ type FakeClusterSubjectAccessReviews struct {
 }
 
 func (c *FakeClusterSubjectAccessReviews) Create(resourceAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-cluster-subjectAccessReview", Value: resourceAccessReview}, &authorizationapi.SubjectAccessReviewResponse{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-cluster-subjectAccessReview", Value: resourceAccessReview}, &authorizationapi.SubjectAccessReviewResponse{})
 	return obj.(*authorizationapi.SubjectAccessReviewResponse), err
 }

--- a/pkg/client/testclient/fake_template_configs.go
+++ b/pkg/client/testclient/fake_template_configs.go
@@ -1,6 +1,8 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	templateapi "github.com/openshift/origin/pkg/template/api"
 )
 
@@ -12,6 +14,6 @@ type FakeTemplateConfigs struct {
 }
 
 func (c *FakeTemplateConfigs) Create(template *templateapi.Template) (*templateapi.Template, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-template-config", Value: template}, &templateapi.Template{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-template-config", Value: template}, &templateapi.Template{})
 	return obj.(*templateapi.Template), err
 }

--- a/pkg/client/testclient/fake_templates.go
+++ b/pkg/client/testclient/fake_templates.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -16,31 +17,31 @@ type FakeTemplates struct {
 }
 
 func (c *FakeTemplates) List(label labels.Selector, field fields.Selector) (*templateapi.TemplateList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-templates"}, &templateapi.TemplateList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-templates"}, &templateapi.TemplateList{})
 	return obj.(*templateapi.TemplateList), err
 }
 
 func (c *FakeTemplates) Get(name string) (*templateapi.Template, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-template"}, &templateapi.Template{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-template"}, &templateapi.Template{})
 	return obj.(*templateapi.Template), err
 }
 
 func (c *FakeTemplates) Create(template *templateapi.Template) (*templateapi.Template, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-template", Value: template}, &templateapi.Template{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-template", Value: template}, &templateapi.Template{})
 	return obj.(*templateapi.Template), err
 }
 
 func (c *FakeTemplates) Update(template *templateapi.Template) (*templateapi.Template, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-template"}, &templateapi.Template{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-template"}, &templateapi.Template{})
 	return obj.(*templateapi.Template), err
 }
 
 func (c *FakeTemplates) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-template", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-template", Value: name})
 	return nil
 }
 
 func (c *FakeTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "watch-templates"})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "watch-templates"})
 	return nil, nil
 }

--- a/pkg/client/testclient/fake_useridentitymappings.go
+++ b/pkg/client/testclient/fake_useridentitymappings.go
@@ -1,6 +1,8 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
+
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
@@ -11,21 +13,21 @@ type FakeUserIdentityMappings struct {
 }
 
 func (c *FakeUserIdentityMappings) Get(name string) (*userapi.UserIdentityMapping, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-useridentitymapping", Value: name}, &userapi.UserIdentityMapping{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-useridentitymapping", Value: name}, &userapi.UserIdentityMapping{})
 	return obj.(*userapi.UserIdentityMapping), err
 }
 
 func (c *FakeUserIdentityMappings) Create(mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-useridentitymapping", Value: mapping}, &userapi.UserIdentityMapping{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-useridentitymapping", Value: mapping}, &userapi.UserIdentityMapping{})
 	return obj.(*userapi.UserIdentityMapping), err
 }
 
 func (c *FakeUserIdentityMappings) Update(mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-useridentitymapping", Value: mapping}, &userapi.UserIdentityMapping{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-useridentitymapping", Value: mapping}, &userapi.UserIdentityMapping{})
 	return obj.(*userapi.UserIdentityMapping), err
 }
 
 func (c *FakeUserIdentityMappings) Delete(name string) error {
-	c.Fake.Actions = append(c.Fake.Actions, FakeAction{Action: "delete-useridentitymapping", Value: name})
+	c.Fake.Actions = append(c.Fake.Actions, ktestclient.FakeAction{Action: "delete-useridentitymapping", Value: name})
 	return nil
 }

--- a/pkg/client/testclient/fake_users.go
+++ b/pkg/client/testclient/fake_users.go
@@ -1,8 +1,10 @@
 package testclient
 
 import (
+	ktestclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
@@ -13,21 +15,21 @@ type FakeUsers struct {
 }
 
 func (c *FakeUsers) List(label labels.Selector, field fields.Selector) (*userapi.UserList, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "list-users"}, &userapi.UserList{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "list-users"}, &userapi.UserList{})
 	return obj.(*userapi.UserList), err
 }
 
 func (c *FakeUsers) Get(name string) (*userapi.User, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "get-user", Value: name}, &userapi.User{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "get-user", Value: name}, &userapi.User{})
 	return obj.(*userapi.User), err
 }
 
 func (c *FakeUsers) Create(user *userapi.User) (*userapi.User, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "create-user", Value: user}, &userapi.User{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "create-user", Value: user}, &userapi.User{})
 	return obj.(*userapi.User), err
 }
 
 func (c *FakeUsers) Update(user *userapi.User) (*userapi.User, error) {
-	obj, err := c.Fake.Invokes(FakeAction{Action: "update-user", Value: user}, &userapi.User{})
+	obj, err := c.Fake.Invokes(ktestclient.FakeAction{Action: "update-user", Value: user}, &userapi.User{})
 	return obj.(*userapi.User), err
 }

--- a/pkg/image/controller/controller_test.go
+++ b/pkg/image/controller/controller_test.go
@@ -305,6 +305,7 @@ func TestControllerWithSpecTags(t *testing.T) {
 		if test.expectUpdate {
 			if len(fake.Actions) != 2 {
 				t.Errorf("%s: expected an update action: %#v", name, fake.Actions)
+				continue
 			}
 			if e, a := "create-imagestream-mapping", fake.Actions[0].Action; e != a {
 				t.Errorf("%s: expected %s, got %s", name, e, a)
@@ -315,6 +316,7 @@ func TestControllerWithSpecTags(t *testing.T) {
 		} else {
 			if len(fake.Actions) != 1 {
 				t.Errorf("%s: expected no update action: %#v", name, fake.Actions)
+				continue
 			}
 			if e, a := "update-imagestream", fake.Actions[0].Action; e != a {
 				t.Errorf("%s: expected %s, got %s", name, e, a)


### PR DESCRIPTION
Useful for having a unified call stack when testing involves calls from both Kubernetes and OpenShift APIs.

@liggitt @ironcladlou fyi