### PR TITLE
Remove selection highlighting when sidebar hidden

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -32,10 +32,12 @@
         top:1px;
       }
     }
-    .osc-object-active {
-      .connector {
-        i {
-          color: @osc-object-active-color;
+    @media (min-width: @screen-sm-min) {
+      .osc-object-active {
+        .connector {
+          i {
+            color: @osc-object-active-color;
+          }
         }
       }
     }

--- a/assets/app/styles/_mixins.less
+++ b/assets/app/styles/_mixins.less
@@ -8,14 +8,16 @@
 
 
 .osc-object-highlight() {
+  @media (min-width: @screen-sm-min) {
     &.osc-object {
-    &.osc-object-hover {
-      cursor: pointer;
-      border-color: @osc-object-hover-color;
+      &.osc-object-hover {
+        cursor: pointer;
+        border-color: @osc-object-hover-color;
+      }
+      &.osc-object-active {
+        border-color: @osc-object-active-color;
+      }
     }
-    &.osc-object-active {
-      border-color: @osc-object-active-color;
-    } 
   }
 }
 


### PR DESCRIPTION
Remove the active object and hover styles on the overview page when you
can't click to see details because the sidebar is hidden.

Fixes #2214