### PR TITLE
[RPMs] Add nfs-utils to openshift-node requires

### DIFF
--- a/openshift.spec
+++ b/openshift.spec
@@ -51,6 +51,7 @@ Requires:       docker-io >= 1.6.2
 Requires:       tuned-profiles-openshift-node
 Requires:       util-linux
 Requires:       socat
+Requires:       nfs-utils
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd


### PR DESCRIPTION
Not all nodes will require NFS mounts but this adds only 4MiB on top of a
minimal RHEL7.1 installation.

Fixes Bug 1238565