### PR TITLE
parallel resource lists for status

### DIFF
--- a/pkg/api/graph/graphview/dc_pipeline.go
+++ b/pkg/api/graph/graphview/dc_pipeline.go
@@ -4,13 +4,18 @@ import (
 	"sort"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 	deployedges "github.com/openshift/origin/pkg/deploy/graph"
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
 )
 
 type DeploymentConfigPipeline struct {
 	Deployment *deploygraph.DeploymentConfigNode
-	Images     []ImagePipeline
+
+	ActiveDeployment    *kubegraph.ReplicationControllerNode
+	InactiveDeployments []*kubegraph.ReplicationControllerNode
+
+	Images []ImagePipeline
 }
 
 // AllDeploymentConfigPipelines returns all the DCPipelines that aren't in the excludes set and the set of covered NodeIDs
@@ -55,6 +60,8 @@ func NewDeploymentConfigPipeline(g osgraph.Graph, dcNode *deploygraph.Deployment
 		covered.Insert(covers.List()...)
 		dcPipeline.Images = append(dcPipeline.Images, imagePipeline)
 	}
+
+	dcPipeline.ActiveDeployment, dcPipeline.InactiveDeployments = deployedges.RelevantDeployments(g, dcNode)
 
 	return dcPipeline, covered
 }

--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -20,8 +20,6 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployedges "github.com/openshift/origin/pkg/deploy/graph"
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
-	imageapi "github.com/openshift/origin/pkg/image/api"
-	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
 )
 
 func TestServiceGroup(t *testing.T) {
@@ -166,8 +164,11 @@ func TestGraph(t *testing.T) {
 			},
 		},
 	}
+	for i := range builds {
+		buildgraph.EnsureBuildNode(g, &builds[i])
+	}
 
-	bc1Node := buildgraph.EnsureBuildConfigNode(g, &buildapi.BuildConfig{
+	buildgraph.EnsureBuildConfigNode(g, &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Namespace: "default", Name: "build1"},
 		Spec: buildapi.BuildConfigSpec{
 			Triggers: []buildapi.BuildTriggerPolicy{
@@ -188,7 +189,6 @@ func TestGraph(t *testing.T) {
 			},
 		},
 	})
-	buildedges.JoinBuilds(bc1Node, builds)
 	bcTestNode := buildgraph.EnsureBuildConfigNode(g, &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Namespace: "default", Name: "test"},
 		Spec: buildapi.BuildConfigSpec{
@@ -298,36 +298,12 @@ func TestGraph(t *testing.T) {
 
 	kubeedges.AddAllExposedPodTemplateSpecEdges(g)
 	buildedges.AddAllInputOutputEdges(g)
+	buildedges.AddAllBuildEdges(g)
 	deployedges.AddAllTriggerEdges(g)
+	deployedges.AddAllDeploymentEdges(g)
 
 	t.Log(g)
 
-	ist, dc, bc, other := 0, 0, 0, 0
-	for _, node := range g.NodeList() {
-		switch g.Object(node).(type) {
-		case *deployapi.DeploymentConfig:
-			if g.Kind(node) != deploygraph.DeploymentConfigNodeKind {
-				t.Fatalf("unexpected kind: %v", g.Kind(node))
-			}
-			dc++
-		case *buildapi.BuildConfig:
-			if g.Kind(node) != buildgraph.BuildConfigNodeKind {
-				t.Fatalf("unexpected kind: %v", g.Kind(node))
-			}
-			bc++
-		case *imageapi.ImageStreamTag:
-			if g.Kind(node) != imagegraph.ImageStreamTagNodeKind {
-				t.Fatalf("unexpected kind: %v", g.Kind(node))
-			}
-			ist++
-		default:
-			other++
-		}
-	}
-
-	if dc != 2 || bc != 3 || ist != 3 || other != 12 {
-		t.Errorf("unexpected nodes: %d %d %d %d", dc, bc, ist, other)
-	}
 	for _, edge := range g.EdgeList() {
 		if g.EdgeKind(edge) == osgraph.UnknownEdgeKind {
 			t.Errorf("edge reported unknown kind: %#v", edge)
@@ -395,13 +371,13 @@ func TestGraph(t *testing.T) {
 			for _, image := range deployment.Images {
 				t.Logf("%s  image %s", indent, image.Image.ImageSpec())
 				if image.Build != nil {
-					if image.Build.LastSuccessfulBuild != nil {
-						t.Logf("%s    built at %s", indent, image.Build.LastSuccessfulBuild.CreationTimestamp)
-					} else if image.Build.LastUnsuccessfulBuild != nil {
-						t.Logf("%s    build %s at %s", indent, image.Build.LastUnsuccessfulBuild.Status, image.Build.LastSuccessfulBuild.CreationTimestamp)
+					if image.LastSuccessfulBuild != nil {
+						t.Logf("%s    built at %s", indent, image.LastSuccessfulBuild.Build.CreationTimestamp)
+					} else if image.LastUnsuccessfulBuild != nil {
+						t.Logf("%s    build %s at %s", indent, image.LastUnsuccessfulBuild.Build.Status, image.LastUnsuccessfulBuild.Build.CreationTimestamp)
 					}
-					for _, b := range image.Build.ActiveBuilds {
-						t.Logf("%s    build %s %s", indent, b.Name, b.Status)
+					for _, b := range image.ActiveBuilds {
+						t.Logf("%s    build %s %s", indent, b.Build.Name, b.Build.Status)
 					}
 				}
 			}

--- a/pkg/build/graph/helpers.go
+++ b/pkg/build/graph/helpers.go
@@ -1,0 +1,75 @@
+package graph
+
+import (
+	"sort"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildgraph "github.com/openshift/origin/pkg/build/graph/nodes"
+)
+
+// RelevantBuilds returns the lastSuccessful build, lastUnsuccesful build, and a list of active builds
+func RelevantBuilds(g osgraph.Graph, bcNode *buildgraph.BuildConfigNode) (*buildgraph.BuildNode, *buildgraph.BuildNode, []*buildgraph.BuildNode) {
+	var (
+		lastSuccessfulBuild   *buildgraph.BuildNode
+		lastUnsuccessfulBuild *buildgraph.BuildNode
+	)
+	activeBuilds := []*buildgraph.BuildNode{}
+	allBuilds := []*buildgraph.BuildNode{}
+	uncastBuilds := g.SuccessorNodesByEdgeKind(bcNode, BuildEdgeKind)
+
+	for i := range uncastBuilds {
+		buildNode := uncastBuilds[i].(*buildgraph.BuildNode)
+		if belongsToBuildConfig(bcNode.BuildConfig, buildNode.Build) {
+			allBuilds = append(allBuilds, buildNode)
+		}
+	}
+
+	if len(allBuilds) == 0 {
+		return nil, nil, []*buildgraph.BuildNode{}
+	}
+
+	sort.Sort(RecentBuildReferences(allBuilds))
+
+	for i := range allBuilds {
+		switch allBuilds[i].Build.Status.Phase {
+		case buildapi.BuildPhaseComplete:
+			if lastSuccessfulBuild == nil {
+				lastSuccessfulBuild = allBuilds[i]
+			}
+		case buildapi.BuildPhaseFailed, buildapi.BuildPhaseCancelled, buildapi.BuildPhaseError:
+			if lastUnsuccessfulBuild == nil {
+				lastUnsuccessfulBuild = allBuilds[i]
+			}
+		default:
+			activeBuilds = append(activeBuilds, allBuilds[i])
+		}
+	}
+
+	return lastSuccessfulBuild, lastUnsuccessfulBuild, activeBuilds
+}
+
+func belongsToBuildConfig(config *buildapi.BuildConfig, b *buildapi.Build) bool {
+	if b.Labels == nil {
+		return false
+	}
+	if b.Labels[buildapi.BuildConfigLabel] == config.Name {
+		return true
+	}
+	return false
+}
+
+type RecentBuildReferences []*buildgraph.BuildNode
+
+func (m RecentBuildReferences) Len() int      { return len(m) }
+func (m RecentBuildReferences) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m RecentBuildReferences) Less(i, j int) bool {
+	return m[i].Build.CreationTimestamp.After(m[j].Build.CreationTimestamp.Time)
+}
+
+func defaultNamespace(value, defaultValue string) string {
+	if len(value) == 0 {
+		return defaultValue
+	}
+	return value
+}

--- a/pkg/build/graph/nodes/types.go
+++ b/pkg/build/graph/nodes/types.go
@@ -23,10 +23,6 @@ func BuildConfigNodeName(o *buildapi.BuildConfig) osgraph.UniqueName {
 type BuildConfigNode struct {
 	osgraph.Node
 	*buildapi.BuildConfig
-
-	LastSuccessfulBuild   *buildapi.Build
-	LastUnsuccessfulBuild *buildapi.Build
-	ActiveBuilds          []buildapi.Build
 }
 
 func (n BuildConfigNode) Object() interface{} {

--- a/pkg/deploy/graph/helpers.go
+++ b/pkg/deploy/graph/helpers.go
@@ -1,12 +1,38 @@
 package graph
 
 import (
+	"sort"
+
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
+
+// RelevantDeployments returns the active deployment and a list of inactive deployments (in order from newest to oldest)
+func RelevantDeployments(g osgraph.Graph, dcNode *deploygraph.DeploymentConfigNode) (*kubegraph.ReplicationControllerNode, []*kubegraph.ReplicationControllerNode) {
+	allDeployments := []*kubegraph.ReplicationControllerNode{}
+	uncastDeployments := g.SuccessorNodesByEdgeKind(dcNode, DeploymentEdgeKind)
+	if len(uncastDeployments) == 0 {
+		return nil, []*kubegraph.ReplicationControllerNode{}
+	}
+
+	for i := range uncastDeployments {
+		allDeployments = append(allDeployments, uncastDeployments[i].(*kubegraph.ReplicationControllerNode))
+	}
+
+	sort.Sort(RecentDeploymentReferences(allDeployments))
+
+	if dcNode.DeploymentConfig.LatestVersion == deployutil.DeploymentVersionFor(allDeployments[0]) {
+		return allDeployments[0], allDeployments[1:]
+	}
+
+	return nil, allDeployments
+}
 
 func belongsToDeploymentConfig(config *deployapi.DeploymentConfig, b *kapi.ReplicationController) bool {
 	if b.Annotations != nil {
@@ -15,12 +41,12 @@ func belongsToDeploymentConfig(config *deployapi.DeploymentConfig, b *kapi.Repli
 	return false
 }
 
-type RecentDeploymentReferences []*kapi.ReplicationController
+type RecentDeploymentReferences []*kubegraph.ReplicationControllerNode
 
 func (m RecentDeploymentReferences) Len() int      { return len(m) }
 func (m RecentDeploymentReferences) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
 func (m RecentDeploymentReferences) Less(i, j int) bool {
-	return deployutil.DeploymentVersionFor(m[i]) > deployutil.DeploymentVersionFor(m[j])
+	return deployutil.DeploymentVersionFor(m[i].ReplicationController) > deployutil.DeploymentVersionFor(m[j].ReplicationController)
 }
 
 // TODO: move to deploy/api/helpers.go

--- a/pkg/deploy/graph/nodes/types.go
+++ b/pkg/deploy/graph/nodes/types.go
@@ -3,8 +3,6 @@ package nodes
 import (
 	"reflect"
 
-	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 )
@@ -20,9 +18,6 @@ func DeploymentConfigNodeName(o *deployapi.DeploymentConfig) osgraph.UniqueName 
 type DeploymentConfigNode struct {
 	osgraph.Node
 	*deployapi.DeploymentConfig
-
-	ActiveDeployment *kapi.ReplicationController
-	Deployments      []*kapi.ReplicationController
 }
 
 func (n DeploymentConfigNode) Object() interface{} {


### PR DESCRIPTION
This a shuffle.  It does all the `List` and `EnsureNode` operations for `oc status` in parallel.  The BC and DC nodes were cleaned up to bring them inline with all the other nodes.  They contain only their own `runtime.Object` and all relationships are expressed via edges.  Helpers were added to reduce the edge navigation load.

@liggitt 