### PR TITLE
add masterCA to SA token controller

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -103,6 +103,7 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.KubernetesMasterConfig.SchedulerConfigFile)
 	}
 
+	refs = append(refs, &config.ServiceAccountConfig.MasterCA)
 	refs = append(refs, &config.ServiceAccountConfig.PrivateKeyFile)
 	for i := range config.ServiceAccountConfig.PublicKeyFiles {
 		refs = append(refs, &config.ServiceAccountConfig.PublicKeyFiles[i])

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -346,6 +346,10 @@ type ServiceAccountConfig struct {
 	// Each key is tried in order until the list is exhausted or verification succeeds.
 	// If no keys are specified, no service account authentication will be available.
 	PublicKeyFiles []string
+
+	// MasterCA is the CA for verifying the TLS connection back to the master.  The service account controller will automatically
+	// inject the contents of this file into pods so they can verify connections to the master.
+	MasterCA string
 }
 
 type TokenConfig struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -337,6 +337,10 @@ type ServiceAccountConfig struct {
 	// Each key is tried in order until the list is exhausted or verification succeeds.
 	// If no keys are specified, no service account authentication will be available.
 	PublicKeyFiles []string `json:"publicKeyFiles"`
+
+	// MasterCA is the CA for verifying the TLS connection back to the master.  The service account controller will automatically
+	// inject the contents of this file into pods so they can verify connections to the master.
+	MasterCA string `json:"masterCA"`
 }
 
 type TokenConfig struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -213,6 +213,7 @@ routingConfig:
   subdomain: ""
 serviceAccountConfig:
   managedNames: null
+  masterCA: ""
   privateKeyFile: ""
   publicKeyFiles: null
 servingInfo:

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -228,6 +228,12 @@ func ValidateServiceAccountConfig(config api.ServiceAccountConfig, builtInKubern
 		}
 	}
 
+	if len(config.MasterCA) > 0 {
+		validationResults.AddErrors(ValidateFile(config.MasterCA, "masterCA")...)
+	} else if builtInKubernetes {
+		validationResults.AddWarnings(fielderrors.NewFieldInvalid("masterCA", "", "master CA information will not be automatically injected into pods, which will prevent verification of the API server from inside a pod"))
+	}
+
 	return validationResults
 }
 

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -254,6 +254,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		if builtInKubernetes {
 			config.KubeletClientInfo.CA = admin.DefaultRootCAFile(args.ConfigDir.Value())
 			config.KubeletClientInfo.ClientCert = kubeletClientInfo.CertLocation
+			config.ServiceAccountConfig.MasterCA = admin.DefaultRootCAFile(args.ConfigDir.Value())
 		}
 
 		// Only set up ca/cert info for etcd connections if we're self-hosting etcd


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3579

This plumbs a `masterCA` element for `serviceAccountConfig` through the system.  It does not address two additional problems that I discovered:
 1. If we have a external kube and a private key for SA tokens, we don't error or warn in the config validation.  I think we should error, because crazy stuff can happen and there doesn't seem to be a significant upside.
 1. Adding a `masterCA` will not affect SA tokens that already exist, so those will still be unable to verify the api server.