### PR TITLE
add kubectl patch

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -494,6 +494,19 @@ Request a new project
 ====
 
 
+== oc patch
+Update field(s) of a resource by stdin.
+
+====
+
+[options="nowrap"]
+----
+  // Partially update a node using strategic merge patch
+  $ openshift cli patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
+----
+====
+
+
 == oc port-forward
 Forward one or more local ports to a pod.
 
@@ -581,11 +594,14 @@ Replace a resource by filename or stdin.
 
 [options="nowrap"]
 ----
-  // Update a pod using the data in pod.json.
-  $ openshift cli update -f pod.json
+  // Replace a pod using the data in pod.json.
+  $ openshift cli replace -f pod.json
 
-  // Update a pod based on the JSON passed into stdin.
-  $ cat pod.json | openshift cli update -f -
+  // Replace a pod based on the JSON passed into stdin.
+  $ cat pod.json | openshift cli replace -f -
+
+  // Force replace, delete and then re-create the resource
+  $ openshift cli replace --force -f pod.json
 ----
 ====
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -318,6 +318,8 @@ echo "templates: ok"
 [ "$(openshift help start master 2>&1 | grep 'Start an OpenShift master')" ]
 [ "$(openshift help start node 2>&1 | grep 'Start an OpenShift node')" ]
 [ "$(openshift cli help update 2>&1 | grep 'openshift')" ]
+[ "$(openshift cli help replace 2>&1 | grep 'openshift')" ]
+[ "$(openshift cli help patch 2>&1 | grep 'openshift')" ]
 
 # runnable commands with required flags must error consistently
 [ "$(oc get 2>&1 | grep 'Required resource not specified')" ]

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -117,7 +117,8 @@ func NewCommandCLI(name, fullName string) *cobra.Command {
 			Message: "Advanced Commands:",
 			Commands: []*cobra.Command{
 				cmd.NewCmdCreate(fullName, f, out),
-				cmd.NewCmdUpdate(fullName, f, out),
+				cmd.NewCmdReplace(fullName, f, out),
+				cmd.NewCmdPatch(fullName, f, out),
 				cmd.NewCmdProcess(fullName, f, out),
 				cmd.NewCmdExport(fullName, f, os.Stdin, out),
 				policy.NewCmdPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out),

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -54,22 +54,42 @@ func NewCmdGet(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Comm
 }
 
 const (
-	updateLong = `Update a resource by filename or stdin.
+	replaceLong = `Replace a resource by filename or stdin.
 
 JSON and YAML formats are accepted.`
 
-	updateExample = `  // Update a pod using the data in pod.json.
-  $ %[1]s update -f pod.json
+	replaceExample = `  // Replace a pod using the data in pod.json.
+  $ %[1]s replace -f pod.json
 
-  // Update a pod based on the JSON passed into stdin.
-  $ cat pod.json | %[1]s update -f -`
+  // Replace a pod based on the JSON passed into stdin.
+  $ cat pod.json | %[1]s replace -f -
+
+  // Force replace, delete and then re-create the resource
+  $ %[1]s replace --force -f pod.json`
 )
 
-// NewCmdUpdate is a wrapper for the Kubernetes cli update command
-func NewCmdUpdate(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+// NewCmdReplace is a wrapper for the Kubernetes cli replace command
+func NewCmdReplace(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdReplace(f.Factory, out)
-	cmd.Long = updateLong
-	cmd.Example = fmt.Sprintf(updateExample, fullName)
+	cmd.Long = replaceLong
+	cmd.Example = fmt.Sprintf(replaceExample, fullName)
+	return cmd
+}
+
+const (
+	patchLong = `Update field(s) of a resource using strategic merge patch
+
+JSON and YAML formats are accepted.`
+
+	patchExample = `  // Partially update a node using strategic merge patch
+  $ %[1]s patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'`
+)
+
+// NewCmdPatch is a wrapper for the Kubernetes cli patch command
+func NewCmdPatch(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	cmd := kcmd.NewCmdPatch(f.Factory, out)
+	cmd.Long = patchLong
+	cmd.Example = fmt.Sprintf(patchExample, fullName)
 	return cmd
 }
 

--- a/rel-eng/completions/bash/oc
+++ b/rel-eng/completions/bash/oc
@@ -1061,6 +1061,27 @@ _oc_replace()
     must_have_one_noun=()
 }
 
+_oc_patch()
+{
+    last_command="oc_patch"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--patch=")
+    two_word_flags+=("-p")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--patch=")
+    must_have_one_flag+=("-p")
+    must_have_one_noun=()
+}
+
 _oc_process()
 {
     last_command="oc_process"
@@ -1618,6 +1639,7 @@ _oc()
     commands+=("proxy")
     commands+=("create")
     commands+=("replace")
+    commands+=("patch")
     commands+=("process")
     commands+=("export")
     commands+=("policy")

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -2436,6 +2436,27 @@ _openshift_cli_replace()
     must_have_one_noun=()
 }
 
+_openshift_cli_patch()
+{
+    last_command="openshift_cli_patch"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--patch=")
+    two_word_flags+=("-p")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--patch=")
+    must_have_one_flag+=("-p")
+    must_have_one_noun=()
+}
+
 _openshift_cli_process()
 {
     last_command="openshift_cli_process"
@@ -2993,6 +3014,7 @@ _openshift_cli()
     commands+=("proxy")
     commands+=("create")
     commands+=("replace")
+    commands+=("patch")
     commands+=("process")
     commands+=("export")
     commands+=("policy")


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3581

Adds patch and fixes our `oc replace` example.

@bparees This is related to what you asked for

```
[deads@deads-dev-01 origin]$ oc update --help
Replace a resource by filename or stdin.

JSON and YAML formats are accepted.

Usage:
  oc replace -f FILENAME [options]

Examples:
  // Replace a pod using the data in pod.json.
  $ oc replace -f pod.json

  // Replace a pod based on the JSON passed into stdin.
  $ cat pod.json | oc replace -f -

  // Force replace, delete and then re-create the resource
  $ oc replace --force -f pod.json

Options:
      --cascade=false: Only relevant during a force replace. If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.
  -f, --filename=[]: Filename, directory, or URL to file to use to replace the resource.
      --force=false: Delete and re-create the specified resource
      --grace-period=-1: Only relevant during a force replace. Period of time in seconds given to the old resource to terminate gracefully. Ignored if negative.
      --timeout=0: Only relevant during a force replace. The length of time to wait before giving up on a delete of the old resource, zero means determine a timeout from the size of the object

Use "oc --help" for a list of all commands available in oc.
Use "oc options" for a list of global command-line options (applies to all commands).
```