### PR TITLE
show unresolved references in status

### DIFF
--- a/pkg/api/graph/graph.go
+++ b/pkg/api/graph/graph.go
@@ -158,7 +158,7 @@ func (g Graph) SyntheticNodes() []graph.Node {
 	sort.Sort(SortedNodeList(nodeList))
 	for _, node := range nodeList {
 		if potentiallySyntheticNode, ok := node.(ExistenceChecker); ok {
-			if potentiallySyntheticNode.Found() {
+			if !potentiallySyntheticNode.Found() {
 				ret = append(ret, node)
 			}
 		}

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/gonum/graph"
+
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kclient "github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
@@ -153,12 +155,43 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 				fmt.Fprintln(out, "Warning: Some of your builds are pointing to image streams, but the administrator has not configured the integrated Docker registry (oadm registry).")
 
 			}
+			if syntheticNodes := g.SyntheticNodes(); len(syntheticNodes) > 0 {
+				fmt.Fprintln(out, strings.Join(describeMissingResources(g, syntheticNodes), "\n"))
+			}
+
 			fmt.Fprintln(out, "To see more, use 'oc describe service <name>' or 'oc describe dc <name>'.")
 			fmt.Fprintln(out, "You can use 'oc get all' to see a list of other objects.")
 		}
 
 		return nil
 	})
+}
+
+func describeMissingResources(g osgraph.Graph, missingNodes []graph.Node) []string {
+	ret := []string{"Warning: some references could not be resolved:"}
+
+	for _, node := range missingNodes {
+		predecessorNames := []string{}
+		for _, predecessor := range g.Predecessors(node) {
+			predecessorNames = append(predecessorNames, g.GraphDescriber.Name(predecessor))
+		}
+
+		successorNames := []string{}
+		for _, successor := range g.Successors(node) {
+			successorNames = append(successorNames, g.GraphDescriber.Name(successor))
+		}
+
+		switch {
+		case len(predecessorNames) > 0 && len(successorNames) > 0:
+			ret = append(ret, fmt.Sprintf("\t%s used by %s referencing %s was not found", g.GraphDescriber.Name(node), strings.Join(predecessorNames, ","), strings.Join(successorNames, ",")))
+		case len(predecessorNames) > 0:
+			ret = append(ret, fmt.Sprintf("\t%s used by %s was not found", g.GraphDescriber.Name(node), strings.Join(predecessorNames, ",")))
+		case len(successorNames) > 0:
+			ret = append(ret, fmt.Sprintf("\t%s referencing %s was not found", g.GraphDescriber.Name(node), strings.Join(successorNames, ",")))
+		}
+	}
+
+	return ret
 }
 
 // hasUnresolvedImageStreamTag checks all build configs that will output to an IST backed by an ImageStream and checks to make sure their builds can push.


### PR DESCRIPTION
This adds the display of missing resources.  It looks like this:

```
[deads@deads-dev-01 origin]$ oc status
In project foo

service ruby-hello-world - 172.30.170.224:8080
  ruby-hello-world deploys ruby-hello-world:latest <- docker build of https://github.com/openshift/ruby-hello-world 
    build 1 pending for 21 hours
    #1 deployment waiting on image or update

Warning: some references could not be resolved:
	ImageStreamTag|foo/ruby-hello-world:latest used by BuildConfig|foo/ruby-hello-world referencing DeploymentConfig|foo/ruby-hello-world,ImageStream|foo/ruby-hello-world was not found
To see more, use 'oc describe service <name>' or 'oc describe dc <name>'.
You can use 'oc get all' to see a list of other objects.
```

And I know @smarterclayton doesn't like this.  One option is to add a description map of some sort for edge types so we can display them better, but I'm open to suggestions.

@smarterclayton @ncdc 