### PR TITLE
oc project suggest oc status when new stanza created

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -166,6 +166,8 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 			}
 		}
 	}
+	fmt.Fprintf(c.Out(), "Run '%s status' to view your app.\n", fullName)
+
 	return nil
 }
 


### PR DESCRIPTION
When a new context  stanza is created in `~/.kube/config` using `oc project` (or derivatives like `oc new-project`), the output suggests using `oc status` to take a look at your project.  

`oc new-app` ends with a suggestion to look at `oc status` to see your app.

Hopefully these will help people find `oc status` which will also help them figure out when their builds or deployments aren't working how they want.

```
[deads@deads-dev-01 origin]$ oc new-project bar
Now using project "bar" on server "https://localhost:8443".
See more about your project using `oc status`.
```

```
[deads@deads-dev-01 origin]$ oc new-app https://github.com/openshift/ruby-hello-world -l app=ruby
imagestreams/ruby-20-centos7
imagestreams/ruby-hello-world
buildconfigs/ruby-hello-world
deploymentconfigs/ruby-hello-world
services/ruby-hello-world
A build was created - you can run `oc start-build ruby-hello-world` to start it.
Service "ruby-hello-world" created at 172.30.212.160 with port mappings 8080.
Run 'oc status' to view your app.
```

@ncdc 