### PR TITLE
Update headers and breadcrumbs to match button text

### DIFF
--- a/assets/app/views/catalog/images.html
+++ b/assets/app/views/catalog/images.html
@@ -3,7 +3,7 @@
     <div class="container">
       <ol class="breadcrumb">
         <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
-        <li><a href="project/{{projectName}}/create">Create</a></li>
+        <li><a href="project/{{projectName}}/create">Add to Project</a></li>
         <li class="active"><strong>Select Image</strong></li>
       </ol>
       <h1>Select a builder image</h1>

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -3,7 +3,7 @@
     <div class="container">
       <ol class="breadcrumb">
         <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
-        <li class="active"><strong>Create</strong></li>
+        <li class="active"><strong>Add to Project</strong></li>
       </ol>
       <div class="row">
         <div class="col-md-12">

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -2,7 +2,7 @@
   <div ng-controller="CreateFromImageController" class="container">
     <ol class="breadcrumb">
       <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
-      <li><a href="project/{{projectName}}/create">Create</a></li>
+      <li><a href="project/{{projectName}}/create">Add to Project</a></li>
       <li class="active"><strong>{{imageName}}</strong></li>
     </ol>
     <div class="row">

--- a/assets/app/views/createProject.html
+++ b/assets/app/views/createProject.html
@@ -1,7 +1,7 @@
 <div ng-controller="CreateProjectController">
   <div class="container">
     <div class="col-md-12">
-      <h1>Create Project</h1>
+      <h1>New Project</h1>
       <form name="createProjectForm">
         <div class="form-group">
           <label for="name">Name *</label>

--- a/assets/app/views/newfromtemplate.html
+++ b/assets/app/views/newfromtemplate.html
@@ -3,7 +3,7 @@
     <div class="container">
       <ol class="breadcrumb">
         <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
-        <li><a href="project/{{projectName}}/create">Create</a></li>
+        <li><a href="project/{{projectName}}/create">Add to Project</a></li>
         <li class="active"><strong>{{template | displayName}}</strong></li>
       </ol>
     </div>

--- a/assets/test/e2e/test.js
+++ b/assets/test/e2e/test.js
@@ -76,7 +76,7 @@ describe('', function() {
 
     it('should be able to show the create project page', function() {
       browser.get('/createProject');
-      expect(element(by.cssContainingText("h1","Create Project")).isPresent()).toBe(true);
+      expect(element(by.cssContainingText("h1","New Project")).isPresent()).toBe(true);
       // TODO: attempt creating a project with a taken name
       // TODO: attempt creating a new project, ensure all three fields are honored
     });


### PR DESCRIPTION
We inconsistently use "add," "new," and "create" in a few places now.

Follow on to #3491 

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/8577709/8d18056c-2578-11e5-8283-7bda893651c1.png)

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/8577728/a3c02902-2578-11e5-86a3-36a70a7434a2.png)
