### PR TITLE
show RCs for services in oc status

### DIFF
--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -97,6 +97,22 @@ func TestProjectStatus(t *testing.T) {
 				"To see more, use",
 			},
 		},
+		"service with RC": {
+			Path: "../../../../test/fixtures/app-scenarios/k8s-unserviced-rc.json",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example\n",
+				"service database-rc",
+				"rc/database-rc-1 runs mysql",
+				"0/1 pods growing to 1",
+				"To see more, use",
+			},
+		},
 		"unstarted build": {
 			Path: "../../../../test/fixtures/app-scenarios/new-project-no-build.yaml",
 			Extra: []runtime.Object{

--- a/pkg/deploy/graph/edges.go
+++ b/pkg/deploy/graph/edges.go
@@ -59,7 +59,7 @@ func AddAllTriggerEdges(g osgraph.MutableUniqueGraph) {
 func AddDeploymentEdges(g osgraph.MutableUniqueGraph, node *deploygraph.DeploymentConfigNode) *deploygraph.DeploymentConfigNode {
 	for _, n := range g.(graph.Graph).NodeList() {
 		if rcNode, ok := n.(*kubegraph.ReplicationControllerNode); ok {
-			if belongsToDeploymentConfig(node.DeploymentConfig, rcNode.ReplicationController) {
+			if BelongsToDeploymentConfig(node.DeploymentConfig, rcNode.ReplicationController) {
 				g.AddEdge(node, rcNode, DeploymentEdgeKind)
 			}
 		}

--- a/pkg/deploy/graph/helpers.go
+++ b/pkg/deploy/graph/helpers.go
@@ -34,7 +34,7 @@ func RelevantDeployments(g osgraph.Graph, dcNode *deploygraph.DeploymentConfigNo
 	return nil, allDeployments
 }
 
-func belongsToDeploymentConfig(config *deployapi.DeploymentConfig, b *kapi.ReplicationController) bool {
+func BelongsToDeploymentConfig(config *deployapi.DeploymentConfig, b *kapi.ReplicationController) bool {
 	if b.Annotations != nil {
 		return config.Name == deployutil.DeploymentConfigNameFor(b)
 	}


### PR DESCRIPTION
RCs that create pods that fulfill a service selector are displayed, but only if they have not already been displayed by an associated DC.  Standalone RCs are **not** displayed, but we could add that without much trouble.

```
[deads@deads-dev-01 origin]$ oc status
In project foo

service ruby-hello-world - 172.30.96.162:8080
  ruby-hello-world deploys ruby-hello-world:latest <- docker build of https://github.com/openshift/ruby-hello-world 
    #1 deployed 11 minutes ago - 1 pod
  rc/my-rc runs 172.30.192.209:5000/foo/ruby-hello-world@sha256:871e183b8b415f8aa9e74b882765287e34f7d9bbbdf1bf1c85e3007814f3c703
    rc/my-rc created 11 minutes ago - 1 pod

To see more, use 'oc describe service <name>' or 'oc describe dc <name>'.
You can use 'oc get all' to see a list of other objects.
```

@fabianofranz ptal