### PR TITLE
Docker registry client: handle [registry]/[name] specs

### DIFF
--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -30,6 +30,16 @@ func parseRepositoryTag(repos string) (string, string, string) {
 	return repos, "", ""
 }
 
+func isRegistryName(str string) bool {
+	switch {
+	case strings.Contains(str, ":"),
+		strings.Contains(str, "."),
+		str == "localhost":
+		return true
+	}
+	return false
+}
+
 // ParseDockerImageReference parses a Docker pull spec string into a
 // DockerImageReference.
 func ParseDockerImageReference(spec string) (DockerImageReference, error) {
@@ -42,7 +52,7 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 	repoParts := strings.Split(stream, "/")
 	switch len(repoParts) {
 	case 2:
-		if strings.Contains(repoParts[0], ":") {
+		if isRegistryName(repoParts[0]) {
 			// registry/name
 			ref.Registry = repoParts[0]
 			// TODO: default this in all cases where Namespace ends up as ""?

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -93,6 +93,18 @@ func TestParseDockerImageReference(t *testing.T) {
 			Name:      "baz",
 			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
+		{
+			From:      "myregistry.io/foo",
+			Registry:  "myregistry.io",
+			Namespace: "library",
+			Name:      "foo",
+		},
+		{
+			From:      "localhost/bar",
+			Registry:  "localhost",
+			Namespace: "library",
+			Name:      "bar",
+		},
 		// TODO: test cases if ParseDockerImageReference validates segment length and allowed chars
 		//
 		// {


### PR DESCRIPTION
Allows the registry client to handle names like docker.io/rhel7 or localhost/myimage 