### PR TITLE
allow multiple edges of different kinds between nodes

### DIFF
--- a/pkg/api/graph/graph_test.go
+++ b/pkg/api/graph/graph_test.go
@@ -1,0 +1,23 @@
+package graph
+
+import (
+	"testing"
+)
+
+func TestMultipleEdgeKindsBetweenTheSameNodes(t *testing.T) {
+	g := New()
+
+	fooNode := makeTestNode(g, "foo")
+	barNode := makeTestNode(g, "bar")
+
+	g.AddEdge(fooNode, barNode, "first")
+	g.AddEdge(fooNode, barNode, "second")
+
+	edge := g.EdgeBetween(fooNode, barNode)
+	if !g.EdgeKinds(edge).Has("first") {
+		t.Errorf("expected first, got %v", edge)
+	}
+	if !g.EdgeKinds(edge).Has("second") {
+		t.Errorf("expected second, got %v", edge)
+	}
+}

--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -331,7 +331,7 @@ func TestGraph(t *testing.T) {
 	t.Log(g)
 
 	for _, edge := range g.EdgeList() {
-		if g.EdgeKind(edge) == osgraph.UnknownEdgeKind {
+		if g.EdgeKinds(edge).Has(osgraph.UnknownEdgeKind) {
 			t.Errorf("edge reported unknown kind: %#v", edge)
 		}
 	}

--- a/pkg/api/graph/types.go
+++ b/pkg/api/graph/types.go
@@ -64,7 +64,7 @@ func GetContainingNode(g Graph, containedNode graph.Node) graph.Node {
 	for _, node := range g.Predecessors(containedNode) {
 		edge := g.EdgeBetween(node, containedNode)
 
-		if g.EdgeKind(edge) == ContainsEdgeKind {
+		if g.EdgeKinds(edge).Has(ContainsEdgeKind) {
 			return node
 		}
 	}

--- a/pkg/api/kubegraph/edge_test.go
+++ b/pkg/api/kubegraph/edge_test.go
@@ -35,8 +35,8 @@ func TestSecretEdges(t *testing.T) {
 	if edge := g.EdgeBetween(saNode, secretNode); edge == nil {
 		t.Errorf("edge missing")
 	} else {
-		if edgeKind := g.EdgeKind(edge); edgeKind != MountableSecretEdgeKind {
-			t.Errorf("expected %v, got %v", MountableSecretEdgeKind, edgeKind)
+		if !g.EdgeKinds(edge).Has(MountableSecretEdgeKind) {
+			t.Errorf("expected %v, got %v", MountableSecretEdgeKind, edge)
 		}
 	}
 
@@ -48,8 +48,8 @@ func TestSecretEdges(t *testing.T) {
 	if edge := g.EdgeBetween(podSpecNodes[0], secretNode); edge == nil {
 		t.Errorf("edge missing")
 	} else {
-		if edgeKind := g.EdgeKind(edge); edgeKind != MountedSecretEdgeKind {
-			t.Errorf("expected %v, got %v", MountedSecretEdgeKind, edgeKind)
+		if !g.EdgeKinds(edge).Has(MountedSecretEdgeKind) {
+			t.Errorf("expected %v, got %v", MountedSecretEdgeKind, edge)
 		}
 	}
 }

--- a/pkg/api/kubegraph/nodes/nodes_test.go
+++ b/pkg/api/kubegraph/nodes/nodes_test.go
@@ -27,8 +27,8 @@ func TestPodSpecNode(t *testing.T) {
 	}
 
 	edge := g.EdgeList()[0]
-	if g.EdgeKind(edge) != osgraph.ContainsEdgeKind {
-		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, g.EdgeKind(edge))
+	if !g.EdgeKinds(edge).Has(osgraph.ContainsEdgeKind) {
+		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, g.EdgeKinds(edge))
 	}
 	if edge.Head().ID() != podNode.ID() {
 		t.Errorf("expected %v, got %v", podNode.ID(), edge.Head())
@@ -57,7 +57,7 @@ func TestReplicationControllerSpecNode(t *testing.T) {
 	if len(rcEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %v", rcEdges)
 	}
-	if g.EdgeKind(rcEdges[0]) != osgraph.ContainsEdgeKind {
+	if !g.EdgeKinds(rcEdges[0]).Has(osgraph.ContainsEdgeKind) {
 		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, rcEdges[0])
 	}
 
@@ -70,7 +70,7 @@ func TestReplicationControllerSpecNode(t *testing.T) {
 	if len(rcSpecEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %v", rcSpecEdges)
 	}
-	if g.EdgeKind(rcSpecEdges[0]) != osgraph.ContainsEdgeKind {
+	if !g.EdgeKinds(rcSpecEdges[0]).Has(osgraph.ContainsEdgeKind) {
 		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, rcSpecEdges[0])
 	}
 
@@ -83,7 +83,7 @@ func TestReplicationControllerSpecNode(t *testing.T) {
 	if len(ptSpecEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %v", ptSpecEdges)
 	}
-	if g.EdgeKind(ptSpecEdges[0]) != osgraph.ContainsEdgeKind {
+	if !g.EdgeKinds(ptSpecEdges[0]).Has(osgraph.ContainsEdgeKind) {
 		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, ptSpecEdges[0])
 	}
 

--- a/pkg/deploy/graph/nodes/nodes_test.go
+++ b/pkg/deploy/graph/nodes/nodes_test.go
@@ -25,8 +25,8 @@ func TestDCRCSpecNode(t *testing.T) {
 	}
 
 	edge := g.EdgeList()[0]
-	if g.EdgeKind(edge) != osgraph.ContainsEdgeKind {
-		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, g.EdgeKind(edge))
+	if !g.EdgeKinds(edge).Has(osgraph.ContainsEdgeKind) {
+		t.Errorf("expected %v, got %v", osgraph.ContainsEdgeKind, g.EdgeKinds(edge))
 	}
 	if edge.Head().ID() != dcNode.ID() {
 		t.Errorf("expected %v, got %v", dcNode.ID(), edge.Head())

--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -350,7 +350,7 @@ func addImageStreamsToGraph(g graph.Graph, streams *imageapi.ImageStreamList, al
 				}
 
 				glog.V(4).Infof("Checking for existing strong reference from stream %s/%s to image %s", stream.Namespace, stream.Name, imageNode.Image.Name)
-				if edge := g.EdgeBetween(imageStreamNode, imageNode); edge != nil && g.EdgeKind(edge) == ReferencedImageEdgeKind {
+				if edge := g.EdgeBetween(imageStreamNode, imageNode); edge != nil && g.EdgeKinds(edge).Has(ReferencedImageEdgeKind) {
 					glog.V(4).Infof("Strong reference found")
 					continue
 				}
@@ -548,8 +548,8 @@ func getImageNodes(nodes []gonum.Node) []*imagegraph.ImageNode {
 // edgeKind returns true if the edge from "from" to "to" is of the desired kind.
 func edgeKind(g graph.Graph, from, to gonum.Node, desiredKind string) bool {
 	edge := g.EdgeBetween(from, to)
-	kind := g.EdgeKind(edge)
-	return kind == desiredKind
+	kinds := g.EdgeKinds(edge)
+	return kinds.Has(desiredKind)
 }
 
 // imageIsPrunable returns true iff the image node only has weak references
@@ -599,7 +599,7 @@ func subgraphWithoutPrunableImages(g graph.Graph, prunableImageIDs graph.NodeSet
 		func(g graph.Interface, node gonum.Node) bool {
 			return !prunableImageIDs.Has(node.ID())
 		},
-		func(g graph.Interface, head, tail gonum.Node, edgeKind string) bool {
+		func(g graph.Interface, head, tail gonum.Node, edgeKinds util.StringSet) bool {
 			if prunableImageIDs.Has(head.ID()) {
 				return false
 			}


### PR DESCRIPTION
This allows us to handle cases where we want to have multiple edges between nodeA and nodeB with different kinds.  The need comes up when you're trying to build relationships like: 
 1. SA to pull secrets, mountable secrets, and automounted secrets
 1. BC to all builds, lastSuccessfulBuild, and lastUnsuccessfulBuild
 1. DC to all deployments, active deployment
 1. Pod to owning RC, creating RC

Since the parent graph library doesn't support multiple edges between the same nodes, this muxes the kinds together in a `StringSet` and leaves demuxing them to callers.  

@smarterclayton @ironcladlou ptal.   If we don't do it like this, I'll need an alternate suggestion for supporting those use-cases.  1 and 4 are particularly important to me.