### PR TITLE
[DO NOT MERGE] Build lifecycle hooks

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -323,6 +323,8 @@ type ExecNewPodHook struct {
 	Command []string
 	// Env is a set of environment variables to supply to the hook pod's container.
 	Env []kapi.EnvVar
+	// Image is a reference to a DockerImage or ImageStreamTag, used to run the hook pod's container.
+	Image kapi.ObjectReference
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -243,6 +243,10 @@ type CustomBuildStrategy struct {
 	// inside the Docker container.
 	// TODO: Allow admins to enforce 'false' for this option
 	ExposeDockerSocket bool
+
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all build logic.
+	Post *LifecycleHook
 }
 
 // DockerBuildStrategy defines input parameters specific to Docker build.
@@ -263,6 +267,10 @@ type DockerBuildStrategy struct {
 
 	// Env contains additional environment variables you want to pass into a builder container
 	Env []kapi.EnvVar
+
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all build logic.
+	Post *LifecycleHook
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.
@@ -284,6 +292,37 @@ type SourceBuildStrategy struct {
 
 	// Incremental flag forces the Source build to do incremental builds if true.
 	Incremental bool
+
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all build logic.
+	Post *LifecycleHook
+}
+
+// LifecycleHook defines a specific build lifecycle action.
+type LifecycleHook struct {
+	// FailurePolicy specifies what action to take if the hook fails.
+	FailurePolicy LifecycleHookFailurePolicy
+	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
+	ExecNewPod *ExecNewPodHook
+}
+
+// LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
+type LifecycleHookFailurePolicy string
+
+const (
+	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
+	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
+	// LifecycleHookFailurePolicyIgnore means ignore hook execution failure.
+	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
+)
+
+// ExecNewPodHook is a hook implementation which runs a command in a new pod
+// based on the image built by the BuildConfig.
+type ExecNewPodHook struct {
+	// Command is the action command and its arguments.
+	Command []string
+	// Env is a set of environment variables to supply to the hook pod's container.
+	Env []kapi.EnvVar
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -312,6 +312,8 @@ type ExecNewPodHook struct {
 	Command []string `json:"command" description:"the hook command and its arguments"`
 	// Env is a set of environment variables to supply to the hook pod's container.
 	Env []kapi.EnvVar `json:"env,omitempty" description:"environment variables provided to the hook container"`
+	// Image is a reference to a DockerImage or ImageStreamTag, used to run the hook pod's container.
+	Image kapi.ObjectReference `json:"image" description:"reference to a DockerImage or ImageStreamTag, used for the hook container"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -232,6 +232,10 @@ type CustomBuildStrategy struct {
 	// inside the Docker container.
 	// TODO: Allow admins to enforce 'false' for this option
 	ExposeDockerSocket bool `json:"exposeDockerSocket,omitempty" description:"allow running Docker commands (and build Docker images) from inside the container"`
+
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all build logic.
+	Post *LifecycleHook `json:"post,omitempty" description:"a hook executed after the strategy finishes the build"`
 }
 
 // DockerBuildStrategy defines input parameters specific to Docker build.
@@ -252,6 +256,10 @@ type DockerBuildStrategy struct {
 
 	// Env contains additional environment variables you want to pass into a builder container
 	Env []kapi.EnvVar `json:"env,omitempty" description:"additional environment variables you want to pass into a builder container"`
+
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all build logic.
+	Post *LifecycleHook `json:"post,omitempty" description:"a hook executed after the strategy finishes the build"`
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.
@@ -273,6 +281,37 @@ type SourceBuildStrategy struct {
 
 	// Incremental flag forces the Source build to do incremental builds if true.
 	Incremental bool `json:"incremental,omitempty" description:"forces the source build to do incremental builds if true"`
+
+	// Post is a lifecycle hook which is executed after the strategy has
+	// finished all build logic.
+	Post *LifecycleHook `json:"post,omitempty" description:"a hook executed after the strategy finishes the build"`
+}
+
+// LifecycleHook defines a specific build lifecycle action.
+type LifecycleHook struct {
+	// FailurePolicy specifies what action to take if the hook fails.
+	FailurePolicy LifecycleHookFailurePolicy `json:"failurePolicy" description:"what action to take if the hook fails"`
+	// ExecNewPod specifies the options for a lifecycle hook backed by a pod.
+	ExecNewPod *ExecNewPodHook `json:"execNewPod,omitempty" description:"options for an ExecNewPodHook"`
+}
+
+// LifecycleHookFailurePolicy describes possibles actions to take if a hook fails.
+type LifecycleHookFailurePolicy string
+
+const (
+	// LifecycleHookFailurePolicyRetry means retry the hook until it succeeds.
+	LifecycleHookFailurePolicyRetry LifecycleHookFailurePolicy = "Retry"
+	// LifecycleHookFailurePolicyIgnore means ignore hook execution failure.
+	LifecycleHookFailurePolicyIgnore LifecycleHookFailurePolicy = "Ignore"
+)
+
+// ExecNewPodHook is a hook implementation which runs a command in a new pod
+// based on the image built by the BuildConfig.
+type ExecNewPodHook struct {
+	// Command is the action command and its arguments.
+	Command []string `json:"command" description:"the hook command and its arguments"`
+	// Env is a set of environment variables to supply to the hook pod's container.
+	Env []kapi.EnvVar `json:"env,omitempty" description:"environment variables provided to the hook container"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy


### PR DESCRIPTION
Add lifecycle hooks to builds, similar to existing Deployment lifecycle hooks.

* Supported build strategies:
  - Source
  - Docker
  - Custom (not supported in DCs, forcing the strategy implementer define his own hooks, if desired, probably via env vars)

* Supported hooks:
  - Post
  - ~~Pre~~: not supported because there is no Docker image to run the hook before a successful build

* Supported failure policies:
  - Ignore
  - Retry
  - ~~Abort~~: not supported because cannot abort a build that has been completed