### PR TITLE
Split oc and gitserver into their own binaries

### DIFF
--- a/cmd/gitserver/gitserver.go
+++ b/cmd/gitserver/gitserver.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/openshift/origin/pkg/cmd/infra/gitserver"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+)
+
+func main() {
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	basename := filepath.Base(os.Args[0])
+	command := gitserver.NewCommandGitServer(basename)
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/openshift/origin/pkg/cmd/cli"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+)
+
+func main() {
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	basename := filepath.Base(os.Args[0])
+	command := cli.CommandFor(basename)
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -30,6 +30,7 @@ readonly OS_IMAGE_COMPILE_PLATFORMS=(
 readonly OS_IMAGE_COMPILE_TARGETS=(
   images/pod
   cmd/dockerregistry
+  cmd/gitserver
 )
 readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS=(
   examples/hello-openshift
@@ -43,6 +44,7 @@ readonly OS_CROSS_COMPILE_PLATFORMS=(
 )
 readonly OS_CROSS_COMPILE_TARGETS=(
   cmd/openshift
+  cmd/oc
 )
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")
 
@@ -57,9 +59,7 @@ readonly OPENSHIFT_BINARY_SYMLINKS=(
   openshift-deploy
   openshift-sti-build
   openshift-docker-build
-  openshift-gitserver
   origin
-  oc
   osc
   oadm
   osadm

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -14,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/cli/policy"
 	"github.com/openshift/origin/pkg/cmd/cli/secrets"
+	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -166,6 +169,34 @@ func NewCmdKubectl(name string, out io.Writer) *cobra.Command {
 	templates.ActsAsRootCommand(cmds)
 	cmds.AddCommand(cmd.NewCmdOptions(out))
 	return cmds
+}
+
+// CommandFor returns the appropriate command for this base name,
+// or the OpenShift CLI command.
+func CommandFor(basename string) *cobra.Command {
+	var cmd *cobra.Command
+
+	out := os.Stdout
+
+	// Make case-insensitive and strip executable suffix if present
+	if runtime.GOOS == "windows" {
+		basename = strings.ToLower(basename)
+		basename = strings.TrimSuffix(basename, ".exe")
+	}
+
+	switch basename {
+	case "kubectl":
+		cmd = NewCmdKubectl(basename, out)
+	default:
+		cmd = NewCommandCLI(basename, basename)
+	}
+
+	if cmd.UsageFunc() == nil {
+		templates.ActsAsRootCommand(cmd)
+	}
+	flagtypes.GLog(cmd.PersistentFlags())
+
+	return cmd
 }
 
 // applyToCreate injects the deprecation notice about for 'apply' command into

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/infra/builder"
 	"github.com/openshift/origin/pkg/cmd/infra/deployer"
-	"github.com/openshift/origin/pkg/cmd/infra/gitserver"
 	irouter "github.com/openshift/origin/pkg/cmd/infra/router"
 	"github.com/openshift/origin/pkg/cmd/server/start"
 	"github.com/openshift/origin/pkg/cmd/server/start/kubernetes"
@@ -57,8 +56,6 @@ func CommandFor(basename string) *cobra.Command {
 		cmd = builder.NewCommandSTIBuilder(basename)
 	case "openshift-docker-build":
 		cmd = builder.NewCommandDockerBuilder(basename)
-	case "openshift-gitserver":
-		cmd = gitserver.NewCommandGitServer(basename)
 	case "oc", "osc":
 		cmd = cli.NewCommandCLI(basename, basename)
 	case "oadm", "osadm":
@@ -121,7 +118,6 @@ func NewCommandOpenShift(name string) *cobra.Command {
 		deployer.NewCommandDeployer("deploy"),
 		builder.NewCommandSTIBuilder("sti-build"),
 		builder.NewCommandDockerBuilder("docker-build"),
-		gitserver.NewCommandGitServer("git-server"),
 	)
 	root.AddCommand(infra)
 

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -4231,23 +4231,6 @@ _openshift_infra_docker-build()
     must_have_one_noun=()
 }
 
-_openshift_infra_git-server()
-{
-    last_command="openshift_infra_git-server"
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-}
-
 _openshift_infra()
 {
     last_command="openshift_infra"
@@ -4256,7 +4239,6 @@ _openshift_infra()
     commands+=("deploy")
     commands+=("sti-build")
     commands+=("docker-build")
-    commands+=("git-server")
 
     flags=()
     two_word_flags=()


### PR DESCRIPTION
This begins to provide a separate oc binary which can be smaller
than the origin binary.

[test]

@fabianofranz review