### PR TITLE
make oc status output describeable

### DIFF
--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -42,6 +42,9 @@ func NewSimpleFake(objects ...runtime.Object) *Fake {
 // Invokes registers the passed fake action and reacts on it if a ReactFn
 // has been defined
 func (c *Fake) Invokes(action FakeAction, obj runtime.Object) (runtime.Object, error) {
+	c.Lock.Lock()
+	defer c.Lock.Unlock()
+
 	c.Actions = append(c.Actions, action)
 	if c.ReactFn != nil {
 		return c.ReactFn(ktestclient.FakeAction(action))

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -61,7 +61,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service empty-service",
+				"service/empty-service",
 				"<initializing>:5432",
 				"To see more, use",
 			},
@@ -76,7 +76,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service database-rc",
+				"service/database-rc",
 				"rc/database-rc-1 runs mysql",
 				"0/1 pods growing to 1",
 				"To see more, use",
@@ -122,7 +122,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service frontend-app",
+				"service/frontend-app",
 				"pod/frontend-app-1-bjwh8 runs openshift/ruby-hello-world",
 				"To see more, use",
 			},
@@ -151,7 +151,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service sinatra-example-2 - 172.30.17.48:8080",
+				"service/sinatra-example-2 - 172.30.17.48:8080",
 				"builds git://github.com",
 				"with docker.io/openshift/ruby-20-centos7:latest",
 				"not built yet",
@@ -193,7 +193,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service sinatra-example-1 - 172.30.17.47:8080",
+				"service/sinatra-example-1 - 172.30.17.47:8080",
 				"builds git://github.com",
 				"with docker.io/openshift/ruby-20-centos7:latest",
 				"build 1 running for about a minute",
@@ -212,7 +212,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service sinatra-app-example - 172.30.17.49:8080",
+				"service/sinatra-app-example - 172.30.17.49:8080",
 				"sinatra-app-example-a deploys",
 				"sinatra-app-example-b deploys",
 				"with docker.io/openshift/ruby-20-centos7:latest",
@@ -232,8 +232,8 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example\n",
-				"service database - 172.30.17.240:5434 -> 3306",
-				"service frontend - 172.30.17.154:5432 -> 8080",
+				"service/database - 172.30.17.240:5434 -> 3306",
+				"service/frontend - 172.30.17.154:5432 -> 8080",
 				"database deploys",
 				"frontend deploys",
 				"with docker.io/openshift/ruby-20-centos7:latest",


### PR DESCRIPTION
Updates `oc status` output to make it possible to copy and paste names directly into `oc describe`.  This way, if a new user wants more details, `oc describe` arguments can be directly copied and pasted.

It also makes the connections between different types very clear to advanced users.  "Is this a bc, dc, or is?" will never be an issue.

```
In project foo

service/ruby-hello-world - 172.30.1.102:8080
  dc/ruby-hello-world deploys istag/ruby-hello-world:latest <-
    docker build of https://github.com/openshift/ruby-hello-world through bc/ruby-hello-world 
      build 1 failed 2 days ago (can't push to image)
    #1 deployment waiting on image or update

Warning: Some of your builds are pointing to image streams, but the administrator has not configured the integrated Docker registry (oadm registry).
To see more, use 'oc describe <resource>/<name>'.
You can use 'oc get all' to see a list of other objects.
```