### PR TITLE
Show pods

### DIFF
--- a/pkg/api/graph/test/service-with-pod.yaml
+++ b/pkg/api/graph/test/service-with-pod.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-07-13T19:36:04Z
+    labels:
+      template: ruby-helloworld-sample
+    name: frontend-app
+    namespace: example
+    resourceVersion: "32433"
+    selfLink: /api/v1/namespaces/example/services/frontend-app
+    uid: 667e1293-2996-11e5-b9e2-28d2447dc82b
+  spec:
+    clusterIP: 172.30.197.115
+    portalIP: 172.30.197.115
+    ports:
+    - nodePort: 0
+      port: 5432
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: frontend
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"example","name":"frontend-app-1","uid":"666e12d7-2996-11e5-b9e2-28d2447dc82b","apiVersion":"v1","resourceVersion":"32416"}}'
+      openshift.io/scc: restricted
+    creationTimestamp: 2015-07-13T19:36:04Z
+    generateName: frontend-app-1-
+    labels:
+      deconflict: frontend.app
+      name: frontend
+      template: ruby-helloworld-sample
+    name: frontend-app-1-bjwh8
+    namespace: example
+    resourceVersion: "32467"
+    selfLink: /api/v1/namespaces/example/pods/frontend-app-1-bjwh8
+    uid: 669a3b5d-2996-11e5-b9e2-28d2447dc82b
+  spec:
+    containers:
+    - env:
+      - name: ADMIN_USERNAME
+        value: admin6TM
+      - name: ADMIN_PASSWORD
+        value: xImx1tHR
+      - name: MYSQL_ROOT_PASSWORD
+        value: rQHfVnTo
+      - name: MYSQL_DATABASE
+        value: root
+      image: openshift/ruby-hello-world
+      imagePullPolicy: IfNotPresent
+      name: ruby-helloworld
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+      resources: {}
+      securityContext:
+        capabilities: {}
+        privileged: false
+        runAsUser: 1000060000
+        seLinuxOptions:
+          level: s0:c8,c2
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-mmv27
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: deads-dev-01
+    imagePullSecrets:
+    - name: default-dockercfg-yr2e3
+    nodeName: deads-dev-01
+    restartPolicy: Always
+    serviceAccount: default
+    serviceAccountName: default
+    volumes:
+    - name: default-token-mmv27
+      secret:
+        secretName: default-token-mmv27
+  status:
+    conditions:
+    - status: "False"
+      type: Ready
+    containerStatuses:
+    - image: openshift/ruby-hello-world
+      imageID: ""
+      lastState: {}
+      name: ruby-helloworld
+      ready: false
+      restartCount: 0
+      state:
+        waiting:
+          reason: 'Image: openshift/ruby-hello-world is not ready on the node'
+    phase: Pending
+    startTime: 2015-07-13T19:36:05Z
+kind: List
+metadata: {}

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -113,6 +113,21 @@ func TestProjectStatus(t *testing.T) {
 				"To see more, use",
 			},
 		},
+		"service with pod": {
+			Path: "../../../../pkg/api/graph/test/service-with-pod.yaml",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example\n",
+				"service frontend-app",
+				"pod/frontend-app-1-bjwh8 runs openshift/ruby-hello-world",
+				"To see more, use",
+			},
+		},
 		"unstarted build": {
 			Path: "../../../../test/fixtures/app-scenarios/new-project-no-build.yaml",
 			Extra: []runtime.Object{


### PR DESCRIPTION
Shows the pods that back a service if they aren't covered by RCs or DCs.  I did this to ease myself into dueling RCs.  The require edges are the same and this output was easy.

```
service frontend-app - 172.30.197.115:5432 -> 8080
  frontend deploys origin-ruby-sample:latest <-
    builds git://github.com/openshift/ruby-hello-world.git with docker.io/openshift/ruby-20-centos7:latest 
    #3 deployment pending 56 seconds ago
    #2 deployment failed 56 seconds ago: unable to contact server - 1 pod
    #1 deployed 56 seconds ago - 1 pod
  rc/frontend-rc-1 runs openshift/ruby-hello-world
    rc/frontend-rc-1 created 57 seconds ago - 3 pods
  pod/frontend-app-1-bjwh8 runs openshift/ruby-hello-world
  pod/frontend-app-1-rk4fb runs openshift/ruby-hello-world
  pod/frontend-app-1-f1xxu runs openshift/ruby-hello-world
```

@derekwaynecarr you asked for this
@ironcladlou ptal