### PR TITLE
display standalone rcs

### DIFF
--- a/pkg/api/graph/graphview/dc_pipeline.go
+++ b/pkg/api/graph/graphview/dc_pipeline.go
@@ -62,6 +62,12 @@ func NewDeploymentConfigPipeline(g osgraph.Graph, dcNode *deploygraph.Deployment
 	}
 
 	dcPipeline.ActiveDeployment, dcPipeline.InactiveDeployments = deployedges.RelevantDeployments(g, dcNode)
+	for _, rc := range dcPipeline.InactiveDeployments {
+		covered.Insert(rc.ID())
+	}
+	if dcPipeline.ActiveDeployment != nil {
+		covered.Insert(dcPipeline.ActiveDeployment.ID())
+	}
 
 	return dcPipeline, covered
 }

--- a/pkg/api/graph/graphview/rc.go
+++ b/pkg/api/graph/graphview/rc.go
@@ -1,0 +1,72 @@
+package graphview
+
+import (
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubeedges "github.com/openshift/origin/pkg/api/kubegraph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+)
+
+type ReplicationController struct {
+	RC *kubegraph.ReplicationControllerNode
+
+	OwnedPods   []*kubegraph.PodNode
+	CreatedPods []*kubegraph.PodNode
+
+	ConflictingRCs        []*kubegraph.ReplicationControllerNode
+	ConflictingRCIDToPods map[int][]*kubegraph.PodNode
+}
+
+// AllReplicationControllers returns all the ReplicationControllers that aren't in the excludes set and the set of covered NodeIDs
+func AllReplicationControllers(g osgraph.Graph, excludeNodeIDs IntSet) ([]ReplicationController, IntSet) {
+	covered := IntSet{}
+	rcViews := []ReplicationController{}
+
+	for _, uncastNode := range g.NodesByKind(kubegraph.ReplicationControllerNodeKind) {
+		if excludeNodeIDs.Has(uncastNode.ID()) {
+			continue
+		}
+
+		rcView, covers := NewReplicationController(g, uncastNode.(*kubegraph.ReplicationControllerNode))
+		covered.Insert(covers.List()...)
+		rcViews = append(rcViews, rcView)
+	}
+
+	return rcViews, covered
+}
+
+// NewReplicationController returns the ReplicationController and a set of all the NodeIDs covered by the ReplicationController
+func NewReplicationController(g osgraph.Graph, rcNode *kubegraph.ReplicationControllerNode) (ReplicationController, IntSet) {
+	covered := IntSet{}
+	covered.Insert(rcNode.ID())
+
+	rcView := ReplicationController{}
+	rcView.RC = rcNode
+
+	for _, uncastPodNode := range g.PredecessorNodesByEdgeKind(rcNode, kubeedges.ManagedByRCEdgeKind) {
+		podNode := uncastPodNode.(*kubegraph.PodNode)
+		covered.Insert(podNode.ID())
+		rcView.OwnedPods = append(rcView.OwnedPods, podNode)
+
+		// check to see if this pod is managed by more than one RC
+		uncastOwningRCs := g.SuccessorNodesByEdgeKind(podNode, kubeedges.ManagedByRCEdgeKind)
+		if len(uncastOwningRCs) > 1 {
+			for _, uncastOwningRC := range uncastOwningRCs {
+				if uncastOwningRC.ID() == rcNode.ID() {
+					continue
+				}
+
+				conflictingRC := uncastOwningRC.(*kubegraph.ReplicationControllerNode)
+				rcView.ConflictingRCs = append(rcView.ConflictingRCs, conflictingRC)
+
+				conflictingPods, ok := rcView.ConflictingRCIDToPods[conflictingRC.ID()]
+				if !ok {
+					conflictingPods = []*kubegraph.PodNode{}
+				}
+				conflictingPods = append(conflictingPods, podNode)
+				rcView.ConflictingRCIDToPods[conflictingRC.ID()] = conflictingPods
+			}
+		}
+	}
+
+	return rcView, covered
+}

--- a/pkg/api/graph/graphview/service_group.go
+++ b/pkg/api/graph/graphview/service_group.go
@@ -18,6 +18,7 @@ type ServiceGroup struct {
 	Service *kubegraph.ServiceNode
 
 	DeploymentConfigPipelines []DeploymentConfigPipeline
+	ReplicationControllers    []ReplicationController
 
 	FulfillingDCs  []*deploygraph.DeploymentConfigNode
 	FulfillingRCs  []*kubegraph.ReplicationControllerNode
@@ -73,6 +74,13 @@ func NewServiceGroup(g osgraph.Graph, serviceNode *kubegraph.ServiceNode) (Servi
 
 		covered.Insert(dcCovers.List()...)
 		service.DeploymentConfigPipelines = append(service.DeploymentConfigPipelines, dcPipeline)
+	}
+
+	for _, fulfillingRC := range service.FulfillingRCs {
+		rcView, rcCovers := NewReplicationController(g, fulfillingRC)
+
+		covered.Insert(rcCovers.List()...)
+		service.ReplicationControllers = append(service.ReplicationControllers, rcView)
 	}
 
 	return service, covered

--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -61,6 +61,32 @@ func TestServiceGroup(t *testing.T) {
 	}
 }
 
+func TestBareRCGroup(t *testing.T) {
+	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/bare-rc.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kubeedges.AddAllExposedPodTemplateSpecEdges(g)
+	kubeedges.AddAllExposedPodEdges(g)
+	kubeedges.AddAllManagedByRCPodEdges(g)
+
+	coveredNodes := IntSet{}
+
+	serviceGroups, coveredByServiceGroups := AllServiceGroups(g, coveredNodes)
+	coveredNodes.Insert(coveredByServiceGroups.List()...)
+
+	bareRCs, coveredByRCs := AllReplicationControllers(g, coveredNodes)
+	coveredNodes.Insert(coveredByRCs.List()...)
+
+	if e, a := 1, len(serviceGroups); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 1, len(bareRCs); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
 func TestBareDCGroup(t *testing.T) {
 	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/bare-dc.yaml")
 	if err != nil {

--- a/pkg/api/graph/test/bare-rc.yaml
+++ b/pkg/api/graph/test/bare-rc.yaml
@@ -1,0 +1,439 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    annotations:
+      openshift.io/deployment-config.latest-version: "1"
+      openshift.io/deployment-config.name: database
+      openshift.io/deployment.phase: Complete
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"database","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/database","uid":"4725b5d3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"271","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ConfigChange"}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"database"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld-database","image":"openshift/mysql-55-centos7","ports":[{"containerPort":3306,"protocol":"TCP"}],"env":[{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"database","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ConfigChange"}]}}'
+      pod: deploy-database-19m1he
+    creationTimestamp: 2015-07-14T14:31:01Z
+    generation: 1
+    labels:
+      template: application-template-stibuild
+    name: database-1
+    namespace: example
+    resourceVersion: "2791"
+    selfLink: /api/v1/namespaces/example/replicationcontrollers/database-1
+    uid: f33231fb-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    replicas: 1
+    selector:
+      deployment: database-1
+      deploymentconfig: database
+      name: database
+    template:
+      metadata:
+        annotations:
+          openshift.io/deployment-config.latest-version: "1"
+          openshift.io/deployment-config.name: database
+          openshift.io/deployment.name: database-1
+        creationTimestamp: null
+        labels:
+          deployment: database-1
+          deploymentconfig: database
+          name: database
+          template: application-template-stibuild
+      spec:
+        containers:
+        - env:
+          - name: MYSQL_USER
+            value: user1CY
+          - name: MYSQL_PASSWORD
+            value: FfyXmsGG
+          - name: MYSQL_DATABASE
+            value: root
+          image: openshift/mysql-55-centos7
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld-database
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+  status:
+    observedGeneration: 1
+    replicas: 1
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    creationTimestamp: 2015-07-14T14:31:00Z
+    generation: 1
+    labels:
+      template: ruby-helloworld-sample
+    name: frontend-rc-1
+    namespace: example
+    resourceVersion: "2754"
+    selfLink: /api/v1/namespaces/example/replicationcontrollers/frontend-rc-1
+    uid: f2c6e6ed-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    replicas: 3
+    selector:
+      deconflict: frontend.rc
+      name: frontend
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deconflict: frontend.rc
+          name: frontend
+          template: ruby-helloworld-sample
+      spec:
+        containers:
+        - env:
+          - name: ADMIN_USERNAME
+            value: admin6TM
+          - name: ADMIN_PASSWORD
+            value: xImx1tHR
+          - name: MYSQL_ROOT_PASSWORD
+            value: rQHfVnTo
+          - name: MYSQL_DATABASE
+            value: root
+          image: openshift/ruby-hello-world
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+  status:
+    observedGeneration: 1
+    replicas: 3
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-07-14T14:31:01Z
+    labels:
+      template: application-template-stibuild
+    name: database
+    namespace: example
+    resourceVersion: "2800"
+    selfLink: /api/v1/namespaces/example/services/database
+    uid: f3abfe9c-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    clusterIP: 172.30.17.240
+    portalIP: 172.30.17.240
+    ports:
+    - nodePort: 0
+      port: 5434
+      protocol: TCP
+      targetPort: 3306
+    selector:
+      name: database
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"example","name":"database-1","uid":"f33231fb-2a34-11e5-a0e9-28d2447dc82b","apiVersion":"v1","resourceVersion":"2757"}}'
+      openshift.io/deployment-config.latest-version: "1"
+      openshift.io/deployment-config.name: database
+      openshift.io/deployment.name: database-1
+      openshift.io/scc: restricted
+    creationTimestamp: 2015-07-14T14:31:01Z
+    generateName: database-1-
+    labels:
+      deployment: database-1
+      deploymentconfig: database
+      name: database
+      template: application-template-stibuild
+    name: database-1-z3y1m
+    namespace: example
+    resourceVersion: "2790"
+    selfLink: /api/v1/namespaces/example/pods/database-1-z3y1m
+    uid: f356014e-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    containers:
+    - env:
+      - name: MYSQL_USER
+        value: user1CY
+      - name: MYSQL_PASSWORD
+        value: FfyXmsGG
+      - name: MYSQL_DATABASE
+        value: root
+      image: openshift/mysql-55-centos7
+      imagePullPolicy: IfNotPresent
+      name: ruby-helloworld-database
+      ports:
+      - containerPort: 3306
+        protocol: TCP
+      resources: {}
+      securityContext:
+        capabilities: {}
+        privileged: false
+        runAsUser: 1000040000
+        seLinuxOptions:
+          level: s0:c6,c5
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-sxmef
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: deads-dev-01
+    imagePullSecrets:
+    - name: default-dockercfg-53ijy
+    nodeName: deads-dev-01
+    restartPolicy: Always
+    serviceAccount: default
+    serviceAccountName: default
+    volumes:
+    - name: default-token-sxmef
+      secret:
+        secretName: default-token-sxmef
+  status:
+    conditions:
+    - status: "False"
+      type: Ready
+    containerStatuses:
+    - image: openshift/mysql-55-centos7
+      imageID: ""
+      lastState: {}
+      name: ruby-helloworld-database
+      ready: false
+      restartCount: 0
+      state:
+        waiting:
+          reason: 'Image: openshift/mysql-55-centos7 is ready, container is creating'
+    phase: Pending
+    startTime: 2015-07-14T14:31:01Z
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"example","name":"frontend-rc-1","uid":"f2c6e6ed-2a34-11e5-a0e9-28d2447dc82b","apiVersion":"v1","resourceVersion":"2717"}}'
+      openshift.io/scc: restricted
+    creationTimestamp: 2015-07-14T14:31:00Z
+    generateName: frontend-rc-1-
+    labels:
+      deconflict: frontend.rc
+      name: frontend
+      template: ruby-helloworld-sample
+    name: frontend-rc-1-b9pm8
+    namespace: example
+    resourceVersion: "2756"
+    selfLink: /api/v1/namespaces/example/pods/frontend-rc-1-b9pm8
+    uid: f2dc8661-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    containers:
+    - env:
+      - name: ADMIN_USERNAME
+        value: admin6TM
+      - name: ADMIN_PASSWORD
+        value: xImx1tHR
+      - name: MYSQL_ROOT_PASSWORD
+        value: rQHfVnTo
+      - name: MYSQL_DATABASE
+        value: root
+      image: openshift/ruby-hello-world
+      imagePullPolicy: IfNotPresent
+      name: ruby-helloworld
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+      resources: {}
+      securityContext:
+        capabilities: {}
+        privileged: false
+        runAsUser: 1000040000
+        seLinuxOptions:
+          level: s0:c6,c5
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-sxmef
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: deads-dev-01
+    imagePullSecrets:
+    - name: default-dockercfg-53ijy
+    nodeName: deads-dev-01
+    restartPolicy: Always
+    serviceAccount: default
+    serviceAccountName: default
+    volumes:
+    - name: default-token-sxmef
+      secret:
+        secretName: default-token-sxmef
+  status:
+    conditions:
+    - status: "False"
+      type: Ready
+    containerStatuses:
+    - image: openshift/ruby-hello-world
+      imageID: ""
+      lastState: {}
+      name: ruby-helloworld
+      ready: false
+      restartCount: 0
+      state:
+        waiting:
+          reason: 'Image: openshift/ruby-hello-world is not ready on the node'
+    phase: Pending
+    startTime: 2015-07-14T14:31:00Z
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"example","name":"frontend-rc-1","uid":"f2c6e6ed-2a34-11e5-a0e9-28d2447dc82b","apiVersion":"v1","resourceVersion":"2717"}}'
+      openshift.io/scc: restricted
+    creationTimestamp: 2015-07-14T14:31:00Z
+    generateName: frontend-rc-1-
+    labels:
+      deconflict: frontend.rc
+      name: frontend
+      template: ruby-helloworld-sample
+    name: frontend-rc-1-rs910
+    namespace: example
+    resourceVersion: "2751"
+    selfLink: /api/v1/namespaces/example/pods/frontend-rc-1-rs910
+    uid: f2d541c4-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    containers:
+    - env:
+      - name: ADMIN_USERNAME
+        value: admin6TM
+      - name: ADMIN_PASSWORD
+        value: xImx1tHR
+      - name: MYSQL_ROOT_PASSWORD
+        value: rQHfVnTo
+      - name: MYSQL_DATABASE
+        value: root
+      image: openshift/ruby-hello-world
+      imagePullPolicy: IfNotPresent
+      name: ruby-helloworld
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+      resources: {}
+      securityContext:
+        capabilities: {}
+        privileged: false
+        runAsUser: 1000040000
+        seLinuxOptions:
+          level: s0:c6,c5
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-sxmef
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: deads-dev-01
+    imagePullSecrets:
+    - name: default-dockercfg-53ijy
+    nodeName: deads-dev-01
+    restartPolicy: Always
+    serviceAccount: default
+    serviceAccountName: default
+    volumes:
+    - name: default-token-sxmef
+      secret:
+        secretName: default-token-sxmef
+  status:
+    conditions:
+    - status: "False"
+      type: Ready
+    containerStatuses:
+    - image: openshift/ruby-hello-world
+      imageID: ""
+      lastState: {}
+      name: ruby-helloworld
+      ready: false
+      restartCount: 0
+      state:
+        waiting:
+          reason: 'Image: openshift/ruby-hello-world is not ready on the node'
+    phase: Pending
+    startTime: 2015-07-14T14:31:00Z
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: '{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"example","name":"frontend-rc-1","uid":"f2c6e6ed-2a34-11e5-a0e9-28d2447dc82b","apiVersion":"v1","resourceVersion":"2717"}}'
+      openshift.io/scc: restricted
+    creationTimestamp: 2015-07-14T14:31:00Z
+    generateName: frontend-rc-1-
+    labels:
+      deconflict: frontend.rc
+      name: frontend
+      template: ruby-helloworld-sample
+    name: frontend-rc-1-wr3ll
+    namespace: example
+    resourceVersion: "2766"
+    selfLink: /api/v1/namespaces/example/pods/frontend-rc-1-wr3ll
+    uid: f2e959cb-2a34-11e5-a0e9-28d2447dc82b
+  spec:
+    containers:
+    - env:
+      - name: ADMIN_USERNAME
+        value: admin6TM
+      - name: ADMIN_PASSWORD
+        value: xImx1tHR
+      - name: MYSQL_ROOT_PASSWORD
+        value: rQHfVnTo
+      - name: MYSQL_DATABASE
+        value: root
+      image: openshift/ruby-hello-world
+      imagePullPolicy: IfNotPresent
+      name: ruby-helloworld
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+      resources: {}
+      securityContext:
+        capabilities: {}
+        privileged: false
+        runAsUser: 1000040000
+        seLinuxOptions:
+          level: s0:c6,c5
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-sxmef
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: deads-dev-01
+    imagePullSecrets:
+    - name: default-dockercfg-53ijy
+    nodeName: deads-dev-01
+    restartPolicy: Always
+    serviceAccount: default
+    serviceAccountName: default
+    volumes:
+    - name: default-token-sxmef
+      secret:
+        secretName: default-token-sxmef
+  status:
+    conditions:
+    - status: "False"
+      type: Ready
+    containerStatuses:
+    - image: openshift/ruby-hello-world
+      imageID: ""
+      lastState: {}
+      name: ruby-helloworld
+      ready: false
+      restartCount: 0
+      state:
+        waiting:
+          reason: 'Image: openshift/ruby-hello-world is not ready on the node'
+    phase: Pending
+    startTime: 2015-07-14T14:31:00Z
+kind: List
+metadata: {}

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -95,6 +95,9 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 	standaloneDCs, coveredByDCs := graphview.AllDeploymentConfigPipelines(g, coveredNodes)
 	coveredNodes.Insert(coveredByDCs.List()...)
 
+	standaloneRCs, coveredByRCs := graphview.AllReplicationControllers(g, coveredNodes)
+	coveredNodes.Insert(coveredByRCs.List()...)
+
 	standaloneImages, coveredByImages := graphview.AllImagePipelinesFromBuildConfig(g, coveredNodes)
 	coveredNodes.Insert(coveredByImages.List()...)
 
@@ -141,6 +144,11 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 			fmt.Fprintln(out)
 			printLines(out, indent, 0, describeStandaloneBuildGroup(standaloneImage, namespace)...)
 			printLines(out, indent, 1, describeAdditionalBuildDetail(standaloneImage.Build, standaloneImage.LastSuccessfulBuild, standaloneImage.LastUnsuccessfulBuild, standaloneImage.ActiveBuilds, standaloneImage.DestinationResolved, true)...)
+		}
+
+		for _, standaloneRC := range standaloneRCs {
+			fmt.Fprintln(out)
+			printLines(out, indent, 0, describeRCInServiceGroup(standaloneRC.RC)...)
 		}
 
 		if (len(services) == 0) && (len(standaloneDCs) == 0) && (len(standaloneImages) == 0) {

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -128,6 +128,20 @@ func TestProjectStatus(t *testing.T) {
 				"To see more, use",
 			},
 		},
+		"standalone rc": {
+			Path: "../../../../pkg/api/graph/test/bare-rc.yaml",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example\n",
+				"  rc/database-1 runs openshift/mysql-55-centos7",
+				"rc/frontend-rc-1 runs openshift/ruby-hello-world",
+			},
+		},
 		"unstarted build": {
 			Path: "../../../../test/fixtures/app-scenarios/new-project-no-build.yaml",
 			Extra: []runtime.Object{


### PR DESCRIPTION
Makes oc status show standalone RCs.  RCs that are not contained by a DC or covered by a Service.

```
In project example

service database - 172.30.17.240:5434 -> 3306
  rc/database-1 runs openshift/mysql-55-centos7
    rc/database-1 created 2 hours ago - 1 pod

rc/frontend-rc-1 runs openshift/ruby-hello-world
  rc/frontend-rc-1 created 2 hours ago - 3 pods

To see more, use 'oc describe service <name>' or 'oc describe dc <name>'.
You can use 'oc get all' to see a list of other objects.
```

@ironcladlou 