### PR TITLE
Load UI extensions outside the OpenShift binary

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -53,6 +53,10 @@ module.exports = function (grunt) {
         files: '<%= yeoman.app %>/styles/*.less',
         tasks: ['less']
       },
+      extensions: {
+        files: ['extensions/extensions.js', 'extensions/extensions.css'],
+        tasks: ['copy:extensions']
+      },
       gruntfile: {
         files: ['Gruntfile.js']
       },
@@ -63,6 +67,7 @@ module.exports = function (grunt) {
         files: [
           '<%= yeoman.app %>/{,*/}*.html',
           '.tmp/styles/{,*/}*.css',
+          '.tmp/scripts/extensions.js',
           '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
         ]
       }
@@ -456,6 +461,20 @@ module.exports = function (grunt) {
           src: 'fonts/*',
           dest: '.tmp/styles'
         }]
+      },
+      // Copy files in the extensions dir for development, but not distribution.
+      extensions: {
+        files: [{
+          expand: true,
+          cwd: 'extensions',
+          src: 'extensions.js',
+          dest: '.tmp/scripts'
+        }, {
+          expand: true,
+          cwd: 'extensions',
+          src: 'extensions.css',
+          dest: '.tmp/styles'
+        }]
       }
     },
 
@@ -463,7 +482,8 @@ module.exports = function (grunt) {
     concurrent: {
       server: [
         'less:development',
-        'copy:styles'
+        'copy:styles',
+        'copy:extensions'
       ],
       test: [
         'less:development'

--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -22,6 +22,7 @@
     <!-- build:css(.tmp) styles/main.css -->
     <link rel="stylesheet" type="text/css" href="styles/main.css">
     <!-- endbuild -->
+    <link rel="stylesheet" type="text/css" href="styles/extensions.css">
      <style type="text/css">
 
 
@@ -180,5 +181,9 @@
         <script src="scripts/filters/util.js"></script>
         <script src="scripts/extensions/javaLink.js"></script>
         <!-- endbuild -->
+
+    <!-- Load any extensions last. -->
+    <script src="scripts/extensions.js"></script>
+
 </body>
 </html>

--- a/assets/extensions/extensions.css
+++ b/assets/extensions/extensions.css
@@ -1,0 +1,12 @@
+/*
+ * This is an empty extensions stylesheet file. Extensions stylesheets are
+ * loaded by the Web Console when set in assetConfig in master-config.yaml.
+ * For example,
+ *
+ * assetConfig:
+ *  extensionStylesheets:
+ *   - "/home/vagrant/extensions/extension1/css/ext1.css"
+ *   - "/home/vagrant/extensions/extension2/css/ext2.css"
+ *
+ * You can modify this file to test extensions in a development environment.
+ */

--- a/assets/extensions/extensions.js
+++ b/assets/extensions/extensions.js
@@ -1,0 +1,11 @@
+/*
+ * This is an empty extensions script file. Extensions scripts are loaded by
+ * the Web Console when set in assetConfig in master-config.yaml. For example,
+ *
+ * assetConfig:
+ *  extensionScripts:
+ *   - "/home/vagrant/extensions/java/js/javaLink.js"
+ *   - "/home/vagrant/extensions/extension2/js/ext2.js"
+ *
+ * You can modify this file to test extensions in a development environment.
+ */

--- a/pkg/assets/extensions.go
+++ b/pkg/assets/extensions.go
@@ -1,0 +1,191 @@
+package assets
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// ExtensionScriptsHandler concatenates and serves extension JavaScript files as one HTTP response.
+func ExtensionScriptsHandler(files []string, developmentMode bool) (http.Handler, error) {
+	return concatHandler(files, developmentMode, "text/javascript", ";\n")
+}
+
+// ExtensionStylesheetsHandler concatenates and serves extension stylesheets as one HTTP response.
+func ExtensionStylesheetsHandler(files []string, developmentMode bool) (http.Handler, error) {
+	return concatHandler(files, developmentMode, "text/css", "\n")
+}
+
+func concatHandler(files []string, developmentMode bool, mediaType, separator string) (http.Handler, error) {
+	// Read the files for each request if development mode is enabled.
+	if developmentMode {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			bytes, err := concatAll(files, separator)
+			if err != nil {
+				util.HandleError(fmt.Errorf("Error serving extension content: %v", err))
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+			}
+			serve(w, r, bytes, mediaType, "")
+		}), nil
+	}
+
+	// Otherwise, read the files once on server startup.
+	bytes, err := concatAll(files, separator)
+	if err != nil {
+		return nil, err
+	}
+	hash := calculateMD5(bytes)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serve(w, r, bytes, mediaType, hash)
+	}), nil
+}
+
+func concatAll(files []string, separator string) ([]byte, error) {
+	var buffer bytes.Buffer
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		_, err = buffer.ReadFrom(f)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = buffer.WriteString(separator)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func calculateMD5(bytes []byte) string {
+	hasher := md5.New()
+	hasher.Write(bytes)
+	sum := hasher.Sum(nil)
+
+	return hex.EncodeToString(sum)
+}
+
+func generateETag(w http.ResponseWriter, r *http.Request, hash string) string {
+	vary := w.Header().Get("Vary")
+	varyHeaders := []string{}
+	if vary != "" {
+		varyHeaders = varyHeaderRegexp.Split(vary, -1)
+	}
+
+	varyHeaderValues := ""
+	for _, varyHeader := range varyHeaders {
+		varyHeaderValues += r.Header.Get(varyHeader)
+	}
+
+	return fmt.Sprintf("W/\"%s_%s\"", hash, hex.EncodeToString([]byte(varyHeaderValues)))
+}
+
+func serve(w http.ResponseWriter, r *http.Request, bytes []byte, mediaType, hash string) {
+	if len(bytes) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if len(hash) > 0 {
+		etag := generateETag(w, r, hash)
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Cache-Control", "public, max-age=0, must-revalidate")
+	} else {
+		w.Header().Add("Cache-Control", "no-cache, no-store")
+	}
+
+	w.Header().Set("Content-Type", mediaType)
+	_, err := w.Write(bytes)
+	if err != nil {
+		util.HandleError(fmt.Errorf("Error serving extension content: %v", err))
+	}
+}
+
+// AssetExtensionHandler serves extension files from sourceDir. context is the URL context for this
+// extension.
+func AssetExtensionHandler(sourceDir, context string, html5Mode bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveExtensionFile(w, r, sourceDir, context, html5Mode)
+	})
+}
+
+// Injects the HTML <base> into the file and serves it.
+func serveIndex(w http.ResponseWriter, r *http.Request, path, base string) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Make sure the base always ends in a trailing slash.
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	content = bytes.Replace(content, []byte(`<base href="/">`), []byte(fmt.Sprintf(`<base href="%s">`, base)), 1)
+
+	w.Header().Add("Cache-Control", "no-cache, no-store")
+	w.Header().Set("Content-Type", "text/html")
+
+	w.Write(content)
+}
+
+func serveFile(w http.ResponseWriter, r *http.Request, path, base string, html5Mode bool) {
+	_, name := filepath.Split(path)
+	if html5Mode && name == "index.html" {
+		// Inject the correct base for Angular apps if the file is index.html.
+		serveIndex(w, r, path, base)
+	} else {
+		// Otherwise just serve the file.
+		http.ServeFile(w, r, path)
+	}
+}
+
+// Serve the extension file under dir matching the path from the request URI.
+func serveExtensionFile(w http.ResponseWriter, r *http.Request, sourceDir, context string, html5Mode bool) {
+	// The path to the requested file on the filesystem.
+	file := filepath.Join(sourceDir, r.URL.Path)
+
+	if html5Mode {
+		// Check if the file exists.
+		fileInfo, err := os.Stat(file)
+		if err != nil {
+			if os.IsNotExist(err) {
+				index := filepath.Join(sourceDir, "index.html")
+				serveFile(w, r, index, context, html5Mode)
+				return
+			}
+
+			util.HandleError(fmt.Errorf("Error serving extension file: %v", err))
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		if fileInfo.IsDir() {
+			index := filepath.Join(sourceDir, "index.html")
+			serveFile(w, r, index, context, html5Mode)
+			return
+		}
+	}
+
+	serveFile(w, r, file, context, html5Mode)
+}

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -182,16 +182,19 @@ type WebConsoleConfig struct {
 	LogoutURI string
 }
 
-func GeneratedConfigHandler(config WebConsoleConfig, h http.Handler) http.Handler {
+func GeneratedConfigHandler(config WebConsoleConfig) (http.Handler, error) {
+	var buffer bytes.Buffer
+	if err := configTemplate.Execute(&buffer, config); err != nil {
+		return nil, err
+	}
+	content := buffer.Bytes()
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.TrimPrefix(r.URL.Path, "/") == "config.js" {
-			w.Header().Add("Cache-Control", "no-cache, no-store")
-			w.Header().Add("Content-Type", "application/json")
-			if err := configTemplate.Execute(w, config); err != nil {
-				util.HandleError(fmt.Errorf("unable to render config template: %v", err))
-			}
-			return
+		w.Header().Add("Cache-Control", "no-cache, no-store")
+		w.Header().Add("Content-Type", "application/json")
+		_, err := w.Write(content)
+		if err != nil {
+			util.HandleError(fmt.Errorf("Error serving Web Console configuration: %v", err))
 		}
-		h.ServeHTTP(w, r)
-	})
+	}), nil
 }

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -165,6 +165,15 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.AssetConfig.ServingInfo.ServerCert.CertFile)
 		refs = append(refs, &config.AssetConfig.ServingInfo.ServerCert.KeyFile)
 		refs = append(refs, &config.AssetConfig.ServingInfo.ClientCA)
+		for i := range config.AssetConfig.ExtensionScripts {
+			refs = append(refs, &config.AssetConfig.ExtensionScripts[i])
+		}
+		for i := range config.AssetConfig.ExtensionStylesheets {
+			refs = append(refs, &config.AssetConfig.ExtensionStylesheets[i])
+		}
+		for i := range config.AssetConfig.Extensions {
+			refs = append(refs, &config.AssetConfig.Extensions[i].SourceDirectory)
+		}
 	}
 
 	if config.KubernetesMasterConfig != nil {

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -335,6 +335,22 @@ type AssetConfig struct {
 
 	// MasterPublicURL is how the web console can access the OpenShift api server
 	MasterPublicURL string
+
+	// ExtensionScripts are file paths on the asset server files to load as scripts when the Web
+	// Console loads
+	ExtensionScripts []string
+
+	// ExtensionStylesheets are file paths on the asset server files to load as stylesheets when
+	// the Web Console loads
+	ExtensionStylesheets []string
+
+	// Extensions are files to serve from the asset server filesystem under a subcontext
+	Extensions []AssetExtensionsConfig
+
+	// ExtensionDevelopment when true tells the asset server to reload extension scripts and
+	// stylesheets for every request rather than only at startup. It lets you develop extensions
+	// without having to restart the server for every change.
+	ExtensionDevelopment bool
 }
 
 type OAuthConfig struct {
@@ -645,4 +661,17 @@ type PodManifestConfig struct {
 	// FileCheckIntervalSeconds is the interval in seconds for checking the manifest file(s) for new data
 	// The interval needs to be a positive value
 	FileCheckIntervalSeconds int64
+}
+
+type AssetExtensionsConfig struct {
+	// Name is the path under /<context>/extensions/ to serve files from SourceDirectory
+	Name string
+	// SourceDirectory is a directory on the asset server to serve files under Name in the Web
+	// Console. It may have nested folders.
+	SourceDirectory string
+	// HTML5Mode determines whether to redirect to the root index.html when a file is not found.
+	// This is needed for apps that use the HTML5 history API like AngularJS apps with HTML5
+	// mode enabled. If HTML5Mode is true, also rewrite the base element in index.html with the
+	// Web Console's context root. Defaults to false.
+	HTML5Mode bool
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -318,6 +318,22 @@ type AssetConfig struct {
 
 	// MasterPublicURL is how the web console can access the OpenShift v1 server
 	MasterPublicURL string `json:"masterPublicURL"`
+
+	// ExtensionScripts are file paths on the asset server files to load as scripts when the Web
+	// Console loads
+	ExtensionScripts []string `json:"extensionScripts"`
+
+	// ExtensionStylesheets are file paths on the asset server files to load as stylesheets when
+	// the Web Console loads
+	ExtensionStylesheets []string `json:"extensionStylesheets"`
+
+	// Extensions are files to serve from the asset server filesystem under a subcontext
+	Extensions []AssetExtensionsConfig `json:"extensions"`
+
+	// ExtensionDevelopment when true tells the asset server to reload extension scripts and
+	// stylesheets for every request rather than only at startup. It lets you develop extensions
+	// without having to restart the server for every change.
+	ExtensionDevelopment bool `json:"extensionDevelopment"`
 }
 
 type OAuthConfig struct {
@@ -626,4 +642,17 @@ type PodManifestConfig struct {
 	// FileCheckIntervalSeconds is the interval in seconds for checking the manifest file(s) for new data
 	// The interval needs to be a positive value
 	FileCheckIntervalSeconds int64 `json:"fileCheckIntervalSeconds"`
+}
+
+type AssetExtensionsConfig struct {
+	// SubContext is the path under /<context>/extensions/ to serve files from SourceDirectory
+	Name string `json:"name"`
+	// SourceDirectory is a directory on the asset server to serve files under Name in the Web
+	// Console. It may have nested folders.
+	SourceDirectory string `json:"sourceDirectory"`
+	// HTML5Mode determines whether to redirect to the root index.html when a file is not found.
+	// This is needed for apps that use the HTML5 history API like AngularJS apps with HTML5
+	// mode enabled. If HTML5Mode is true, also rewrite the base element in index.html with the
+	// Web Console's context root. Defaults to false.
+	HTML5Mode bool `json:"html5Mode"`
 }

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -48,6 +48,10 @@ volumeDirectory: ""
 	expectedSerializedMasterConfig = `apiLevels: null
 apiVersion: v1
 assetConfig:
+  extensionDevelopment: false
+  extensionScripts: null
+  extensionStylesheets: null
+  extensions: null
   logoutURL: ""
   masterPublicURL: ""
   publicURL: ""

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -209,6 +209,22 @@ func ValidateFile(path string, field string) fielderrors.ValidationErrorList {
 	return allErrs
 }
 
+func ValidateDir(path string, field string) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+	if len(path) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired(field))
+	} else {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid(field, path, "could not read info"))
+		} else if !fileInfo.IsDir() {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid(field, path, "not a directory"))
+		}
+	}
+
+	return allErrs
+}
+
 func ValidateExtendedArguments(config api.ExtendedArguments, flagFunc func(*pflag.FlagSet)) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 

--- a/test/integration/extensions_test.go
+++ b/test/integration/extensions_test.go
@@ -1,0 +1,264 @@
+// +build integration,etcd
+
+package integration
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	testutil "github.com/openshift/origin/test/util"
+)
+
+func TestExtensions(t *testing.T) {
+	// Create a temporary directory.
+	tmpDir, err := ioutil.TempDir("", "extensions")
+	if err != nil {
+		t.Fatalf("Could not create tmp dir for extensions: %v", err)
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create extension files.
+	var testData = map[string]string{
+		"script1.js":                       script1,
+		"script2.js":                       script2,
+		"stylesheet1.css":                  stylesheet1,
+		"stylesheet2.css":                  stylesheet2,
+		"extension1/index.html":            index,
+		"extension2/index.html":            index,
+		"extension1/files/shakespeare.txt": plaintext,
+	}
+
+	for path, content := range testData {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(tmpDir, path)), 0755); err != nil {
+			t.Fatalf("Failed creating directory for %s: %v", path, err)
+			return
+		}
+		if err := ioutil.WriteFile(filepath.Join(tmpDir, path), []byte(content), 0755); err != nil {
+			t.Fatalf("Failed creating file %s: %v", path, err)
+			return
+		}
+	}
+
+	// Build master config.
+	masterOptions, err := testutil.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("Failed creating master configuration: %v", err)
+		return
+	}
+	masterOptions.AssetConfig.ExtensionScripts = []string{
+		filepath.Join(tmpDir, "script1.js"),
+		filepath.Join(tmpDir, "script2.js"),
+	}
+	masterOptions.AssetConfig.ExtensionStylesheets = []string{
+		filepath.Join(tmpDir, "stylesheet1.css"),
+		filepath.Join(tmpDir, "stylesheet2.css"),
+	}
+	masterOptions.AssetConfig.Extensions = []configapi.AssetExtensionsConfig{
+		{
+			Name:            "extension1",
+			SourceDirectory: filepath.Join(tmpDir, "extension1"),
+			HTML5Mode:       true,
+		},
+		{
+			Name:            "extension2",
+			SourceDirectory: filepath.Join(tmpDir, "extension2"),
+			HTML5Mode:       false,
+		},
+	}
+
+	// Start server.
+	_, err = testutil.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("Unexpected error starting server: %v", err)
+		return
+	}
+
+	// Inject the base into index.html to test HTML5Mode
+	publicURL, err := url.Parse(masterOptions.AssetConfig.PublicURL)
+	if err != nil {
+		t.Fatalf("Unexpected error parsing PublicURL %q: %v", masterOptions.AssetConfig.PublicURL, err)
+		return
+	}
+	baseInjected := injectBase(index, "extension1", publicURL)
+
+	// TODO: Add tests for caching.
+
+	testcases := map[string]struct {
+		URL              string
+		Status           int
+		Type             string
+		Content          []byte
+		RedirectLocation string
+	}{
+		"extension scripts": {
+			URL:     "scripts/extensions.js",
+			Status:  http.StatusOK,
+			Type:    "text/javascript",
+			Content: []byte(script1 + ";\n" + script2 + ";\n"),
+		},
+		"extension css": {
+			URL:     "styles/extensions.css",
+			Status:  http.StatusOK,
+			Type:    "text/css",
+			Content: []byte(stylesheet1 + "\n" + stylesheet2 + "\n"),
+		},
+		"extension index.html (html5Mode on)": {
+			URL:     "extensions/extension1/",
+			Status:  http.StatusOK,
+			Type:    "text/html",
+			Content: baseInjected,
+		},
+		"extension index.html (html5Mode off)": {
+			URL:     "extensions/extension2/",
+			Status:  http.StatusOK,
+			Type:    "text/html",
+			Content: []byte(index),
+		},
+		"extension no trailing slash (html5Mode on)": {
+			URL:              "extensions/extension1",
+			Status:           http.StatusMovedPermanently,
+			RedirectLocation: "extensions/extension1/",
+		},
+		"extension missing file (html5Mode on)": {
+			URL:     "extensions/extension1/does-not-exist/",
+			Status:  http.StatusOK,
+			Type:    "text/html",
+			Content: baseInjected,
+		},
+		"extension missing file (html5Mode on, no trailing slash)": {
+			URL:     "extensions/extension1/does-not-exist",
+			Status:  http.StatusOK,
+			Type:    "text/html",
+			Content: baseInjected,
+		},
+		"extension missing file (html5Mode off)": {
+			URL:    "extensions/extension2/does-not-exist/",
+			Status: http.StatusNotFound,
+		},
+		"extension missing file (html5Mode off, no trailing slash)": {
+			URL:    "extensions/extension2/does-not-exist",
+			Status: http.StatusNotFound,
+		},
+		"extension file in subdir": {
+			URL:     "extensions/extension1/files/shakespeare.txt",
+			Status:  http.StatusOK,
+			Type:    "text/plain",
+			Content: []byte(plaintext),
+		},
+		"extension file from other extension": {
+			URL:    "extensions/extension2/files/shakespeare.txt",
+			Status: http.StatusNotFound,
+		},
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	for k, tc := range testcases {
+		testURL := masterOptions.AssetConfig.PublicURL + tc.URL
+		req, err := http.NewRequest("GET", testURL, nil)
+		if err != nil {
+			t.Errorf("%s: Unexpected error creating request for %q: %v", k, testURL, err)
+			continue
+		}
+
+		resp, err := transport.RoundTrip(req)
+		if err != nil {
+			t.Errorf("%s: Unexpected error while accessing %q: %v", k, testURL, err)
+			continue
+		}
+
+		if resp.StatusCode != tc.Status {
+			t.Errorf("%s: Expected status %d for %q, got %d", k, tc.Status, testURL, resp.StatusCode)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			actualType := strings.Split(resp.Header.Get("Content-Type"), ";")[0]
+			if actualType != tc.Type {
+				t.Errorf("%s: Expected type %q for %q, got %s", k, tc.Type, testURL, actualType)
+				continue
+			}
+
+			defer resp.Body.Close()
+			actualContent, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("%s: Unexpected error while reading body of %q: %v", k, testURL, err)
+				continue
+			}
+			if !bytes.Equal(actualContent, []byte(tc.Content)) {
+				t.Errorf("%s: Response body for %q did not match expected, actual:\n%s\nexpected:\n%s", k, testURL, actualContent, tc.Content)
+				continue
+			}
+		}
+
+		if len(tc.RedirectLocation) > 0 {
+			actualLocation := resp.Header.Get("Location")
+			expectedLocation := publicURL.Path + tc.RedirectLocation
+			if actualLocation != expectedLocation {
+				t.Errorf("%s: Expected response header Location %q for %q, got %q", k, expectedLocation, testURL, actualLocation)
+				continue
+			}
+		}
+	}
+}
+
+func injectBase(content, extensionName string, publicURL *url.URL) []byte {
+	base := path.Join(publicURL.Path, "extensions", extensionName) + "/"
+	return bytes.Replace([]byte(content), []byte(`<base href="/">`), []byte(fmt.Sprintf(`<base href="%s">`, base)), 1)
+}
+
+const (
+	script1 = `$(document).ready(function(){$("body").hide().fadeIn(1000);})`
+
+	script2 = `$(document).ready(function() {
+	$('#openshift-logo img').attr('src', 'http://example.com/images/my-logo.png');
+})`
+
+	stylesheet1 = `html {
+	font-family: Gill Sans Extrabold, sans-serif;
+	font-size: 14px;
+}
+`
+
+	stylesheet2 = `.navbar-header {
+	background-color: red;
+	border-bottom: 1px solid white;
+}
+
+.btn-primary {
+	background-color: green;
+	background-image: none;
+}
+`
+
+	index = `<!DOCTYPE html>
+<html>
+<head>
+	<title>Hello</title>
+	<base href="/">
+</head>
+<body>
+	<h1>Hello</h1>
+	<p>Hello, OpenShift!</p>
+</body>
+</html>
+`
+
+	plaintext = `Conscience does make cowards of us all, and thus the native hue of resolution is sicklied o'er with the pale cast of thought.
+`
+)


### PR DESCRIPTION
@smarterclayton @liggitt 

Load JS and CSS files when the Web Console loads and serve extension files under a sub context without needing to rebuild the OpenShift binary.

Example configuration:

```yaml
assetConfig:
  extensionScripts:
   - "/home/vagrant/extensions/java/js/javaLink.js"
   - "/home/vagrant/extensions/extension1/js/ext1.js"
  extensionStylesheets:
   - "/home/vagrant/extensions/extension1/css/ext1.css"
  extensions:
   - sourceDirectory: "/home/vagrant/extensions/java/files/"
     name: "java"
     html5Mode: true
   - sourceDirectory: "/home/vagrant/extensions/extension1/files/"
     name: "ext1"
```

**What's left:**

- [x] Handle HTTP cache headers
- [x] Flat mux instead of chaining handlers
- [x] Rewrite `<base>` element in HTML files if set to `/`
- [x] Separate configuration stanzas for each extension
- [x] Generate different ETags based on Vary headers
- [x] Generate asset configuration only once
- [x] Handle relative paths for extension files
- [x] Add a development mode for writing extensions
- [x] Gruntfile updates, dummy extension files
- [x] Add cache headers for index.html
- [x] Update configuration property names
- [x] Check that no two extensions have the same name/subcontext
