### PR TITLE
Rolling updater enhancements

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/rollingupdate.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/rollingupdate.go
@@ -105,7 +105,7 @@ func validateArguments(cmd *cobra.Command, args []string) (deploymentKey, filena
 }
 
 func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
-	if os.Args[1] == "rollingupdate" {
+	if len(os.Args) > 1 && os.Args[1] == "rollingupdate" {
 		printDeprecationWarning("rolling-update", "rollingupdate")
 	}
 	deploymentKey, filename, image, oldName, err := validateArguments(cmd, args)
@@ -258,13 +258,14 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		updateCleanupPolicy = kubectl.RenameRollingUpdateCleanupPolicy
 	}
 	config := &kubectl.RollingUpdaterConfig{
-		Out:           out,
-		OldRc:         oldRc,
-		NewRc:         newRc,
-		UpdatePeriod:  period,
-		Interval:      interval,
-		Timeout:       timeout,
-		CleanupPolicy: updateCleanupPolicy,
+		Out:            out,
+		OldRc:          oldRc,
+		NewRc:          newRc,
+		UpdatePeriod:   period,
+		Interval:       interval,
+		Timeout:        timeout,
+		CleanupPolicy:  updateCleanupPolicy,
+		UpdateAcceptor: kubectl.DefaultUpdateAcceptor,
 	}
 	if cmdutil.GetFlagBool(cmd, "rollback") {
 		kubectl.AbortRollingUpdate(config)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/rolling_updater.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/rolling_updater.go
@@ -20,6 +20,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -39,7 +40,13 @@ type RollingUpdater struct {
 	c RollingUpdaterClient
 	// Namespace for resources
 	ns string
+	// scaleAndWait scales a controller and returns its updated state.
+	scaleAndWait scaleAndWait
 }
+
+// scaleAndWait scales rc and returns its updated state. This typedef is to
+// abstract away the use of a Scaler to ease testing.
+type scaleAndWait func(rc *api.ReplicationController, retry *RetryParams, wait *RetryParams) (*api.ReplicationController, error)
 
 // RollingUpdaterConfig is the configuration for a rolling deployment process.
 type RollingUpdaterConfig struct {
@@ -60,6 +67,16 @@ type RollingUpdaterConfig struct {
 	// CleanupPolicy defines the cleanup action to take after the deployment is
 	// complete.
 	CleanupPolicy RollingUpdaterCleanupPolicy
+	// UpdateAcceptor is given a chance to accept the new controller after each
+	// scale-up operation. If the controller is accepted, updates continue; if
+	// the controller is rejected, the update will fail immediately.
+	UpdateAcceptor UpdateAcceptor
+	// UpdatePercent is optional; if specified, the amount of replicas scaled up
+	// and down each interval will be computed as a percentage of the desired
+	// replicas for the new RC. If UpdatePercent is nil, one replica will be
+	// scaled up and down each interval. If UpdatePercent is negative, the order
+	// of scaling will be down/up instead of up/down.
+	UpdatePercent *int
 }
 
 // RollingUpdaterCleanupPolicy is a cleanup action to take after the
@@ -75,6 +92,26 @@ const (
 	// the new controller to the name of the old controller.
 	RenameRollingUpdateCleanupPolicy RollingUpdaterCleanupPolicy = "Rename"
 )
+
+// UpdateAcceptor is given a chance to accept or reject the new controller
+// during a deployment each time the controller is scaled up.
+//
+// After the successful scale-up of the controller, the controller is given to
+// the UpdateAcceptor. If the UpdateAcceptor rejects the controller, the
+// deployment is stopped with an error.
+type UpdateAcceptor interface {
+	// Accept returns nil if the controller is okay, otherwise returns an error.
+	Accept(*api.ReplicationController) error
+}
+
+// AlwaysAccept is an UpdateAcceptor which always accepts the controller.
+type AlwaysAccept struct{}
+
+// Accept implements UpdateAcceptor.
+func (a *AlwaysAccept) Accept(*api.ReplicationController) error { return nil }
+
+// DefaultUpdaterAcceptor always accepts controllers.
+var DefaultUpdateAcceptor UpdateAcceptor = &AlwaysAccept{}
 
 func LoadExistingNextReplicationController(c *client.Client, namespace, newName string) (*api.ReplicationController, error) {
 	if len(newName) == 0 {
@@ -121,10 +158,12 @@ func CreateNewControllerFromCurrentController(c *client.Client, namespace, oldNa
 }
 
 // NewRollingUpdater creates a RollingUpdater from a client
-func NewRollingUpdater(namespace string, c RollingUpdaterClient) *RollingUpdater {
+func NewRollingUpdater(namespace string, client RollingUpdaterClient) *RollingUpdater {
 	return &RollingUpdater{
-		c,
-		namespace,
+		c:  client,
+		ns: namespace,
+		// Use a real scaleAndWait implementation.
+		scaleAndWait: scalerScaleAndWait(client, namespace),
 	}
 }
 
@@ -172,6 +211,21 @@ func UpdateExistingReplicationController(c client.Interface, oldRc *api.Replicat
 		// If we didn't need to update the controller for the deployment key, we still need to write
 		// the "next" controller.
 		return c.ReplicationControllers(namespace).Update(oldRc)
+	}
+}
+
+// scalerScaleAndWait returns a scaleAndWait function which scales a
+// controller using a Scaler and a real client.
+func scalerScaleAndWait(client RollingUpdaterClient, namespace string) scaleAndWait {
+	scaler, err := ScalerFor("ReplicationController", client)
+	return func(rc *api.ReplicationController, retry *RetryParams, wait *RetryParams) (*api.ReplicationController, error) {
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't make scaler: %s", err)
+		}
+		if err := scaler.Scale(rc.Namespace, rc.Name, uint(rc.Spec.Replicas), &ScalePrecondition{-1, ""}, retry, wait); err != nil {
+			return nil, err
+		}
+		return client.GetReplicationController(namespace, rc.ObjectMeta.Name)
 	}
 }
 
@@ -297,9 +351,13 @@ func FindSourceController(r RollingUpdaterClient, namespace, name string) (*api.
 }
 
 // Update all pods for a ReplicationController (oldRc) by creating a new
-// controller (newRc) with 0 replicas, and synchronously scaling oldRc,newRc
-// by 1 until oldRc has 0 replicas and newRc has the original # of desired
+// controller (newRc) with 0 replicas, and synchronously scaling oldRc and
+// newRc until oldRc has 0 replicas and newRc has the original # of desired
 // replicas. Cleanup occurs based on a RollingUpdaterCleanupPolicy.
+//
+// The scaling amount each interval is either 1 or based on a percent of the
+// desired replicas. If a percentage is used and the percentage is negative,
+// the scaling order is inverted to down/up instead of the default up/down.
 //
 // If an update from newRc to oldRc is already in progress, we attempt to
 // drive it to completion. If an error occurs at any step of the update, the
@@ -353,51 +411,50 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 		}
 	}
 
-	// +1, -1 on oldRc, newRc until newRc has desired number of replicas or oldRc has 0 replicas
-	for newRc.Spec.Replicas < desired && oldRc.Spec.Replicas != 0 {
-		newRc.Spec.Replicas += 1
-		oldRc.Spec.Replicas -= 1
-		fmt.Printf("At beginning of loop: %s replicas: %d, %s replicas: %d\n",
-			oldName, oldRc.Spec.Replicas,
-			newName, newRc.Spec.Replicas)
-		fmt.Fprintf(out, "Updating %s replicas: %d, %s replicas: %d\n",
-			oldName, oldRc.Spec.Replicas,
-			newName, newRc.Spec.Replicas)
+	// Compute the scale amount based on a percentage of the new desired count.
+	// A negative percentage indicates our scale direction should be down-first.
+	scaleAmount := 1
+	skipFirstUp := false
+	if config.UpdatePercent != nil {
+		scaleAmount = int(math.Ceil(float64(desired) * (math.Abs(float64(*config.UpdatePercent)) / 100)))
+		if *config.UpdatePercent < 0 {
+			skipFirstUp = true
+		}
+	}
+	// Helpful output about what we're about to do.
+	direction := "up"
+	if skipFirstUp {
+		direction = "down"
+	}
+	fmt.Fprintf(out, "Scaling up %s from %d to %d, scaling down %s from %d to 0 (scale %s first by %d each interval)\n",
+		newRc.Name, newRc.Spec.Replicas, desired, oldRc.Name, oldRc.Spec.Replicas, direction, scaleAmount)
 
-		newRc, err = r.scaleAndWait(newRc, retry, waitForReplicas)
+	// Scale newRc and oldRc until newRc has the desired number of replicas and
+	// oldRc has 0 replicas.
+	for newRc.Spec.Replicas != desired || oldRc.Spec.Replicas != 0 {
+		// Choose up/down vs. down/up scaling direction.
+		if !skipFirstUp {
+			scaledRc, err := r.scaleUp(newRc, oldRc, desired, scaleAmount, retry, waitForReplicas, out, config)
+			if err != nil {
+				return err
+			}
+			newRc = scaledRc
+			time.Sleep(updatePeriod)
+			skipFirstUp = true
+		}
+		scaledRc, err := r.scaleDown(newRc, oldRc, desired, scaleAmount, retry, waitForReplicas, out, config)
 		if err != nil {
 			return err
 		}
+		rc = scaledRc
 		time.Sleep(updatePeriod)
-		oldRc, err = r.scaleAndWait(oldRc, retry, waitForReplicas)
+		scaledRc, err = r.scaleUp(newRc, oldRc, desired, scaleAmount, retry, waitForReplicas, out, config)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("At end of loop: %s replicas: %d, %s replicas: %d\n",
-			oldName, oldRc.Spec.Replicas,
-			newName, newRc.Spec.Replicas)
+		newRc = scaledRc
 	}
-	// delete remaining replicas on oldRc
-	if oldRc.Spec.Replicas != 0 {
-		fmt.Fprintf(out, "Stopping %s replicas: %d -> %d\n",
-			oldName, oldRc.Spec.Replicas, 0)
-		oldRc.Spec.Replicas = 0
-		oldRc, err = r.scaleAndWait(oldRc, retry, waitForReplicas)
-		// oldRc, err = r.scaleAndWait(oldRc, interval, timeout)
-		if err != nil {
-			return err
-		}
-	}
-	// add remaining replicas on newRc
-	if newRc.Spec.Replicas != desired {
-		fmt.Fprintf(out, "Scaling %s replicas: %d -> %d\n",
-			newName, newRc.Spec.Replicas, desired)
-		newRc.Spec.Replicas = desired
-		newRc, err = r.scaleAndWait(newRc, retry, waitForReplicas)
-		if err != nil {
-			return err
-		}
-	}
+
 	// Clean up annotations
 	if newRc, err = r.c.GetReplicationController(r.ns, newName); err != nil {
 		return err
@@ -429,6 +486,50 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 	}
 }
 
+// scaleUp scales up newRc to desired by scaleAmount. It accounts for
+// fencepost conditions. If newRc is already scaled to desired, scaleUp does
+// nothing. If the oldRc is already scaled to 0, newRc is scaled to desired
+// immediately regardless of scale count.
+func (r *RollingUpdater) scaleUp(newRc, oldRc *api.ReplicationController, desired, scaleAmount int, retry, wait *RetryParams, out io.Writer, config *RollingUpdaterConfig) (*api.ReplicationController, error) {
+	if newRc.Spec.Replicas == desired {
+		return newRc, nil
+	}
+	newRc.Spec.Replicas += scaleAmount
+	if newRc.Spec.Replicas > desired || oldRc.Spec.Replicas == 0 {
+		newRc.Spec.Replicas = desired
+	}
+	fmt.Fprintf(out, "Scaling %s up to %d\n", newRc.Name, newRc.Spec.Replicas)
+	scaledRc, err := r.scaleAndWait(newRc, retry, wait)
+	if err != nil {
+		return nil, err
+	}
+	err = config.UpdateAcceptor.Accept(scaledRc)
+	if err != nil {
+		return nil, fmt.Errorf("update rejected for %s: %v", scaledRc.Name, err)
+	}
+	return scaledRc, nil
+}
+
+// scaleDown scales down oldRc to 0 by scaleAmount. It accounts for fencepost
+// conditions. If oldRc is already scaled to 0, scaleDown does nothing. If
+// newRc is already scaled to desired, oldRc is scaled to 0 immediately
+// regardless of scaleAmount.
+func (r *RollingUpdater) scaleDown(newRc, oldRc *api.ReplicationController, desired, scaleAmount int, retry, wait *RetryParams, out io.Writer, config *RollingUpdaterConfig) (*api.ReplicationController, error) {
+	if oldRc.Spec.Replicas == 0 {
+		return oldRc, nil
+	}
+	oldRc.Spec.Replicas -= scaleAmount
+	if oldRc.Spec.Replicas < 0 || newRc.Spec.Replicas == desired {
+		oldRc.Spec.Replicas = 0
+	}
+	fmt.Fprintf(out, "Scaling %s down to %d\n", oldRc.Name, oldRc.Spec.Replicas)
+	scaledRc, err := r.scaleAndWait(oldRc, retry, wait)
+	if err != nil {
+		return nil, err
+	}
+	return scaledRc, nil
+}
+
 func (r *RollingUpdater) getExistingNewRc(sourceId, name string) (rc *api.ReplicationController, existing bool, err error) {
 	if rc, err = r.c.GetReplicationController(r.ns, name); err == nil {
 		existing = true
@@ -442,17 +543,6 @@ func (r *RollingUpdater) getExistingNewRc(sourceId, name string) (rc *api.Replic
 	}
 	err = nil
 	return
-}
-
-func (r *RollingUpdater) scaleAndWait(rc *api.ReplicationController, retry *RetryParams, wait *RetryParams) (*api.ReplicationController, error) {
-	scaler, err := ScalerFor("ReplicationController", r.c)
-	if err != nil {
-		return nil, err
-	}
-	if err := scaler.Scale(rc.Namespace, rc.Name, uint(rc.Spec.Replicas), &ScalePrecondition{-1, ""}, retry, wait); err != nil {
-		return nil, err
-	}
-	return r.c.GetReplicationController(r.ns, rc.ObjectMeta.Name)
 }
 
 func (r *RollingUpdater) updateAndWait(rc *api.ReplicationController, interval, timeout time.Duration) (*api.ReplicationController, error) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/rolling_updater.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/rolling_updater.go
@@ -60,9 +60,6 @@ type RollingUpdaterConfig struct {
 	// CleanupPolicy defines the cleanup action to take after the deployment is
 	// complete.
 	CleanupPolicy RollingUpdaterCleanupPolicy
-	// UpdateAcceptor is optional and drives acceptance of the first controller
-	// during scale-up. If nil, controllers are always accepted.
-	UpdateAcceptor UpdateAcceptor
 }
 
 // RollingUpdaterCleanupPolicy is a cleanup action to take after the
@@ -78,20 +75,6 @@ const (
 	// the new controller to the name of the old controller.
 	RenameRollingUpdateCleanupPolicy RollingUpdaterCleanupPolicy = "Rename"
 )
-
-// UpdateAcceptor is given a chance to accept or reject the first controller
-// during a deployment.
-//
-// After the successful scale-up of the first replica, the replica is given
-// the the UpdateAcceptor. If the UpdateAcceptor rejects the replica, the
-// deployment is stopped with an error.
-//
-// Only the first replica scaled up during the deployment is checked for
-// acceptance.
-type UpdateAcceptor interface {
-	// Accept returns nil if the controller is okay, otherwise returns an error.
-	Accept(*api.ReplicationController) error
-}
 
 func LoadExistingNextReplicationController(c *client.Client, namespace, newName string) (*api.ReplicationController, error) {
 	if len(newName) == 0 {
@@ -371,7 +354,6 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 	}
 
 	// +1, -1 on oldRc, newRc until newRc has desired number of replicas or oldRc has 0 replicas
-	updateAccepted := false
 	for newRc.Spec.Replicas < desired && oldRc.Spec.Replicas != 0 {
 		newRc.Spec.Replicas += 1
 		oldRc.Spec.Replicas -= 1
@@ -385,14 +367,6 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 		newRc, err = r.scaleAndWait(newRc, retry, waitForReplicas)
 		if err != nil {
 			return err
-		}
-		// Perform the update acceptance check exactly once.
-		if config.UpdateAcceptor != nil && !updateAccepted {
-			err := config.UpdateAcceptor.Accept(newRc)
-			if err != nil {
-				return fmt.Errorf("Update rejected for %s: %v", newRc.Name, err)
-			}
-			updateAccepted = true
 		}
 		time.Sleep(updatePeriod)
 		oldRc, err = r.scaleAndWait(oldRc, retry, waitForReplicas)

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1420,6 +1420,12 @@ func deepCopy_api_RollingDeploymentStrategyParams(in deployapi.RollingDeployment
 	} else {
 		out.TimeoutSeconds = nil
 	}
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
 	if in.Pre != nil {
 		out.Pre = new(deployapi.LifecycleHook)
 		if err := deepCopy_api_LifecycleHook(*in.Pre, out.Pre, c); err != nil {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1422,6 +1422,12 @@ func deepCopy_v1_RollingDeploymentStrategyParams(in deployapiv1.RollingDeploymen
 	} else {
 		out.TimeoutSeconds = nil
 	}
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
 	if in.Pre != nil {
 		out.Pre = new(deployapiv1.LifecycleHook)
 		if err := deepCopy_v1_LifecycleHook(*in.Pre, out.Pre, c); err != nil {

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1430,6 +1430,12 @@ func deepCopy_v1beta3_RollingDeploymentStrategyParams(in deployapiv1beta3.Rollin
 	} else {
 		out.TimeoutSeconds = nil
 	}
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
 	if in.Pre != nil {
 		out.Pre = new(deployapiv1beta3.LifecycleHook)
 		if err := deepCopy_v1beta3_LifecycleHook(*in.Pre, out.Pre, c); err != nil {

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -115,6 +115,9 @@ type RollingDeploymentStrategyParams struct {
 	// TimeoutSeconds is the time to wait for updates before giving up. If the
 	// value is nil, a default will be used.
 	TimeoutSeconds *int64
+	// UpdatePercent is the percentage of replicas to scale up or down each
+	// interval. If nil, one replica will be scaled up and down each interval.
+	UpdatePercent *int
 	// Pre is a lifecycle hook which is executed before the deployment process
 	// begins. All LifecycleHookFailurePolicy values are supported.
 	Pre *LifecycleHook

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -115,6 +115,10 @@ type RollingDeploymentStrategyParams struct {
 	// TimeoutSeconds is the time to wait for updates before giving up. If the
 	// value is nil, a default will be used.
 	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty" description:"the time to wait for updates before giving up"`
+	// UpdatePercent is the percentage of replicas to scale up or down each
+	// interval. If nil, one replica will be scaled up and down each interval.
+	// If negative, the scale order will be down/up instead of up/down.
+	UpdatePercent *int `json:"updatePercent,omitempty" description:"the percentage of replicas to scale up or down each interval (negative value switches scale order to down/up instead of up/down)"`
 	// Pre is a lifecycle hook which is executed before the deployment process
 	// begins. All LifecycleHookFailurePolicy values are supported.
 	Pre *LifecycleHook `json:"pre,omitempty" description:"a hook executed before the strategy starts the deployment"`

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -115,6 +115,10 @@ type RollingDeploymentStrategyParams struct {
 	// TimeoutSeconds is the time to wait for updates before giving up. If the
 	// value is nil, a default will be used.
 	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty" description:"the time to wait for updates before giving up"`
+	// UpdatePercent is the percentage of replicas to scale up or down each
+	// interval. If nil, one replica will be scaled up and down each interval.
+	// If negative, the scale order will be down/up instead of up/down.
+	UpdatePercent *int `json:"updatePercent,omitempty" description:"the percentage of replicas to scale up or down each interval (negative value switches scale order to down/up instead of up/down)"`
 	// Pre is a lifecycle hook which is executed before the deployment process
 	// begins. All LifecycleHookFailurePolicy values are supported.
 	Pre *LifecycleHook `json:"pre,omitempty" description:"a hook executed before the strategy starts the deployment"`

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -180,6 +180,13 @@ func validateRollingParams(params *deployapi.RollingDeploymentStrategyParams) fi
 		errs = append(errs, fielderrors.NewFieldInvalid("timeoutSeconds", *params.TimeoutSeconds, "must be >0"))
 	}
 
+	if params.UpdatePercent != nil {
+		p := *params.UpdatePercent
+		if p == 0 || p < -100 || p > 100 {
+			errs = append(errs, fielderrors.NewFieldInvalid("updatePercent", *params.UpdatePercent, "must be between 1 and 100 or between -1 and -100 (inclusive)"))
+		}
+	}
+
 	if params.Pre != nil {
 		errs = append(errs, validateLifecycleHook(params.Pre).Prefix("pre")...)
 	}

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -109,14 +109,14 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 		// If an UpdateAcceptor is provided, scale up to 1 and validate the replica,
 		// aborting if the replica isn't acceptable.
 		if updateAcceptor != nil {
-			glog.Infof("Scaling %s to 1 before validating first replica", deployutil.LabelForDeployment(to))
+			glog.Infof("Scaling %s to 1 before performing acceptance check", deployutil.LabelForDeployment(to))
 			updatedTo, err := s.scaleAndWait(to, 1, retryParams, waitParams)
 			if err != nil {
 				return fmt.Errorf("couldn't scale %s to 1: %v", deployutil.LabelForDeployment(to), err)
 			}
-			glog.Infof("Validating first replica of %s", deployutil.LabelForDeployment(to))
+			glog.Infof("Performing acceptance check of %s", deployutil.LabelForDeployment(to))
 			if err := updateAcceptor.Accept(updatedTo); err != nil {
-				return fmt.Errorf("first replica rejected for %s: %v", to.Name, err)
+				return fmt.Errorf("update acceptor rejected %s: %v", deployutil.LabelForDeployment(to), err)
 			}
 			to = updatedTo
 		}


### PR DESCRIPTION
Integrate with upstream rolling update enhancements.
    
* Tweak the update acceptor to support being invoked on every update
      interval for a deployment.
* Update rolling params API to support updatePercent passed through
      to the upstream rolling updater.

Integrates deployments with https://github.com/GoogleCloudPlatform/kubernetes/pull/10062.

Closes #2828.
Fixes #3313.