### PR TITLE
update policy for pods/exec

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/exec.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/exec.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/remotecommand"
 	cmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
@@ -176,5 +177,29 @@ func RunExec(f *cmdutil.Factory, cmd *cobra.Command, cmdIn io.Reader, cmdOut, cm
 		SubResource("exec").
 		Param("container", containerName)
 
-	return re.Execute(req, config, args, stdin, cmdOut, cmdErr, tty)
+	postErr := re.Execute(req, config, args, stdin, cmdOut, cmdErr, tty)
+
+	// if we don't have an error, return.  If we did get an error, try a GET because v3.0.0 shipped with exec running as a GET.
+	if postErr == nil {
+		return nil
+	}
+
+	// only try the get if the error is either a forbidden or method not supported, otherwise trying with a GET probably won't help
+	if !apierrors.IsForbidden(postErr) && !apierrors.IsMethodNotSupported(postErr) {
+		return postErr
+	}
+
+	getReq := client.RESTClient.Get().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", containerName)
+	getErr := re.Execute(getReq, config, args, stdin, cmdOut, cmdErr, tty)
+	if getErr == nil {
+		return nil
+	}
+
+	// if we got a getErr, return the postErr because it's more likely to be correct.  GET is legacy
+	return postErr
 }

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy/roundtripper.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream/spdy/roundtripper.go
@@ -25,6 +25,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	apierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/httpstream"
 	"github.com/GoogleCloudPlatform/kubernetes/third_party/golang/netutil"
 )
@@ -137,6 +139,11 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 		if err != nil {
 			responseError = "Unable to read error from server response"
 		} else {
+			if obj, err := api.Scheme.Decode(responseErrorBytes); err == nil {
+				if status, ok := obj.(*api.Status); ok {
+					return nil, &apierrors.StatusError{*status}
+				}
+			}
 			responseError = string(responseErrorBytes)
 		}
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -335,7 +335,9 @@ oc process -n docker -f examples/sample-app/application-template-dockerbuild.jso
 oc process -n custom -f examples/sample-app/application-template-custombuild.json > "${CUSTOM_CONFIG_FILE}"
 
 echo "[INFO] Back to 'test' context with 'e2e-user' user"
+oc login -u e2e-user
 oc project test
+oc whoami
 
 echo "[INFO] Applying STI application config"
 oc create -f "${STI_CONFIG_FILE}"
@@ -345,6 +347,20 @@ echo "[INFO] Starting build from ${STI_CONFIG_FILE} and streaming its logs..."
 #oc start-build -n test ruby-sample-build --follow
 wait_for_build "test"
 wait_for_app "test"
+
+# Remote command execution
+echo "[INFO] Validating exec"
+frontend_pod=$(oc get pod -l deploymentconfig=frontend -t '{{(index .items 0).metadata.name}}')
+# when running as a restricted pod the registry will run with a pre-allocated
+# user in the neighborhood of 1000000+.  Look for a substring of the pre-allocated uid range
+oc exec -p ${frontend_pod} id | grep 10
+
+# Port forwarding
+echo "[INFO] Validating port-forward"
+oc port-forward -p ${frontend_pod} 10080:8080  &> "${LOG_DIR}/port-forward.log" &
+wait_for_url_timed "http://localhost:10080" "[INFO] Frontend says: " $((10*TIME_SEC))
+
+
 
 #echo "[INFO] Applying Docker application config"
 #oc create -n docker -f "${DOCKER_CONFIG_FILE}"
@@ -370,18 +386,6 @@ wait_for_command '[[ "$(oc get endpoints router --output-version=v1beta3 -t "{{ 
 echo "[INFO] Validating routed app response..."
 validate_response "-s -k --resolve www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST} https://www.example.com" "Hello from OpenShift" 0.2 50
 
-# Remote command execution
-echo "[INFO] Validating exec"
-registry_pod=$(oc get pod -l deploymentconfig=docker-registry -t '{{(index .items 0).metadata.name}}')
-# when running as a restricted pod the registry will run with a pre-allocated
-# user in the neighborhood of 1000000+.  Look for a substring of the pre-allocated uid range
-oc exec -p ${registry_pod} id | grep 10
-
-# Port forwarding
-echo "[INFO] Validating port-forward"
-oc port-forward -p ${registry_pod} 5001:5000  &> "${LOG_DIR}/port-forward.log" &
-wait_for_url_timed "http://localhost:5001/healthz" "[INFO] Docker registry says: " $((10*TIME_SEC))
-
 # Image pruning
 echo "[INFO] Validating image pruning"
 docker pull busybox
@@ -401,6 +405,7 @@ docker tag -f gcr.io/google_containers/pause ${DOCKER_REGISTRY}/cache/prune
 docker push ${DOCKER_REGISTRY}/cache/prune
 
 # record the storage before pruning
+registry_pod=$(oc get pod -l deploymentconfig=docker-registry -t '{{(index .items 0).metadata.name}}')
 oc exec -p ${registry_pod} du /registry > ${LOG_DIR}/prune-images.before.txt
 
 # set up pruner user

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -72,11 +72,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "delete"),
-					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/proxy", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
+					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
 				},
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch"),
-					Resources: util.NewStringSet(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "pods/exec", "pods/portforward"),
+					Resources: util.NewStringSet(authorizationapi.PolicyOwnerGroupName, authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName),
 				},
 				{
 					Verbs: util.NewStringSet("get", "update"),
@@ -92,11 +92,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			Rules: []authorizationapi.PolicyRule{
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "delete"),
-					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/proxy", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
+					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
 				},
 				{
 					Verbs:     util.NewStringSet("get", "list", "watch"),
-					Resources: util.NewStringSet(authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects", "pods/exec", "pods/portforward"),
+					Resources: util.NewStringSet(authorizationapi.KubeAllGroupName, authorizationapi.OpenshiftStatusGroupName, authorizationapi.KubeStatusGroupName, "projects"),
 				},
 				{
 					Verbs: util.NewStringSet("get", "update"),


### PR DESCRIPTION
Upstream pull: https://github.com/GoogleCloudPlatform/kubernetes/pull/11333

Reacts to upstream changes for https://github.com/GoogleCloudPlatform/kubernetes/pull/10654.  Also refactors the test to make sure that project admins are able to run `pods/exec` by default.