### PR TITLE
Duplicate serials were being handed out because objects were copied

### DIFF
--- a/pkg/cmd/server/admin/create_client.go
+++ b/pkg/cmd/server/admin/create_client.go
@@ -17,7 +17,7 @@ import (
 const CreateClientCommandName = "create-api-client-config"
 
 type CreateClientOptions struct {
-	GetSignerCertOptions *GetSignerCertOptions
+	SignerCertOptions *SignerCertOptions
 
 	ClientDir string
 	BaseName  string
@@ -40,7 +40,7 @@ master as the provided user.
 `
 
 func NewCommandCreateClient(commandName string, fullName string, out io.Writer) *cobra.Command {
-	options := &CreateClientOptions{GetSignerCertOptions: &GetSignerCertOptions{}, Output: out}
+	options := &CreateClientOptions{SignerCertOptions: &SignerCertOptions{}, Output: out}
 
 	cmd := &cobra.Command{
 		Use:   commandName,
@@ -59,7 +59,7 @@ func NewCommandCreateClient(commandName string, fullName string, out io.Writer) 
 
 	flags := cmd.Flags()
 
-	BindGetSignerCertOptions(options.GetSignerCertOptions, flags, "")
+	BindSignerCertOptions(options.SignerCertOptions, flags, "")
 
 	flags.StringVar(&options.ClientDir, "client-dir", "", "The client data directory.")
 	flags.StringVar(&options.BaseName, "basename", "", "The base filename to use for the .crt, .key, and .kubeconfig files. Defaults to the username.")
@@ -95,10 +95,10 @@ func (o CreateClientOptions) Validate(args []string) error {
 		return errors.New("certificate-authority must be provided")
 	}
 
-	if o.GetSignerCertOptions == nil {
+	if o.SignerCertOptions == nil {
 		return errors.New("signer options are required")
 	}
-	if err := o.GetSignerCertOptions.Validate(); err != nil {
+	if err := o.SignerCertOptions.Validate(); err != nil {
 		return err
 	}
 
@@ -118,9 +118,9 @@ func (o CreateClientOptions) CreateClientFolder() error {
 	kubeConfigFile := DefaultKubeConfigFilename(o.ClientDir, baseName)
 
 	createClientCertOptions := CreateClientCertOptions{
-		GetSignerCertOptions: o.GetSignerCertOptions,
-		CertFile:             clientCertFile,
-		KeyFile:              clientKeyFile,
+		SignerCertOptions: o.SignerCertOptions,
+		CertFile:          clientCertFile,
+		KeyFile:           clientKeyFile,
 
 		User:      o.User,
 		Groups:    o.Groups,

--- a/pkg/cmd/server/admin/create_clientcert.go
+++ b/pkg/cmd/server/admin/create_clientcert.go
@@ -13,7 +13,7 @@ import (
 )
 
 type CreateClientCertOptions struct {
-	GetSignerCertOptions *GetSignerCertOptions
+	SignerCertOptions *SignerCertOptions
 
 	CertFile string
 	KeyFile  string
@@ -39,10 +39,10 @@ func (o CreateClientCertOptions) Validate(args []string) error {
 		return errors.New("user must be provided")
 	}
 
-	if o.GetSignerCertOptions == nil {
+	if o.SignerCertOptions == nil {
 		return errors.New("signer options are required")
 	}
-	if err := o.GetSignerCertOptions.Validate(); err != nil {
+	if err := o.SignerCertOptions.Validate(); err != nil {
 		return err
 	}
 
@@ -50,9 +50,9 @@ func (o CreateClientCertOptions) Validate(args []string) error {
 }
 
 func (o CreateClientCertOptions) CreateClientCert() (*crypto.TLSCertificateConfig, error) {
-	glog.V(4).Infof("Creating a client cert with: %#v and %#v", o, o.GetSignerCertOptions)
+	glog.V(4).Infof("Creating a client cert with: %#v and %#v", o, o.SignerCertOptions)
 
-	signerCert, err := o.GetSignerCertOptions.GetSignerCert()
+	signerCert, err := o.SignerCertOptions.CA()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -149,7 +149,7 @@ func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 		return err
 	}
 	// once we've minted the signer, don't overwrite it
-	getSignerCertOptions := GetSignerCertOptions{
+	getSignerCertOptions := SignerCertOptions{
 		CertFile:   DefaultCertFilename(o.CertDir, CAFilePrefix),
 		KeyFile:    DefaultKeyFilename(o.CertDir, CAFilePrefix),
 		SerialFile: DefaultSerialFilename(o.CertDir, CAFilePrefix),
@@ -165,7 +165,7 @@ func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 	return utilerrors.NewAggregate(errs)
 }
 
-func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *GetSignerCertOptions) error {
+func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *SignerCertOptions) error {
 	for _, clientCertInfo := range DefaultAPIClientCerts(o.CertDir) {
 		if err := o.createClientCert(clientCertInfo, getSignerCertOptions); err != nil {
 			return err
@@ -194,7 +194,7 @@ func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *GetSign
 	return nil
 }
 
-func (o CreateMasterCertsOptions) createEtcdClientCerts(getSignerCertOptions *GetSignerCertOptions) error {
+func (o CreateMasterCertsOptions) createEtcdClientCerts(getSignerCertOptions *SignerCertOptions) error {
 	for _, clientCertInfo := range DefaultEtcdClientCerts(o.CertDir) {
 		if err := o.createClientCert(clientCertInfo, getSignerCertOptions); err != nil {
 			return err
@@ -203,7 +203,7 @@ func (o CreateMasterCertsOptions) createEtcdClientCerts(getSignerCertOptions *Ge
 	return nil
 }
 
-func (o CreateMasterCertsOptions) createKubeletClientCerts(getSignerCertOptions *GetSignerCertOptions) error {
+func (o CreateMasterCertsOptions) createKubeletClientCerts(getSignerCertOptions *SignerCertOptions) error {
 	for _, clientCertInfo := range DefaultKubeletClientCerts(o.CertDir) {
 		if err := o.createClientCert(clientCertInfo, getSignerCertOptions); err != nil {
 			return err
@@ -212,9 +212,9 @@ func (o CreateMasterCertsOptions) createKubeletClientCerts(getSignerCertOptions 
 	return nil
 }
 
-func (o CreateMasterCertsOptions) createClientCert(clientCertInfo ClientCertInfo, getSignerCertOptions *GetSignerCertOptions) error {
+func (o CreateMasterCertsOptions) createClientCert(clientCertInfo ClientCertInfo, getSignerCertOptions *SignerCertOptions) error {
 	clientCertOptions := CreateClientCertOptions{
-		GetSignerCertOptions: getSignerCertOptions,
+		SignerCertOptions: getSignerCertOptions,
 
 		CertFile: clientCertInfo.CertLocation.CertFile,
 		KeyFile:  clientCertInfo.CertLocation.KeyFile,
@@ -230,10 +230,10 @@ func (o CreateMasterCertsOptions) createClientCert(clientCertInfo ClientCertInfo
 	return nil
 }
 
-func (o CreateMasterCertsOptions) createServerCerts(getSignerCertOptions *GetSignerCertOptions) error {
+func (o CreateMasterCertsOptions) createServerCerts(getSignerCertOptions *SignerCertOptions) error {
 	for _, serverCertInfo := range DefaultServerCerts(o.CertDir) {
 		serverCertOptions := CreateServerCertOptions{
-			GetSignerCertOptions: getSignerCertOptions,
+			SignerCertOptions: getSignerCertOptions,
 
 			CertFile: serverCertInfo.CertFile,
 			KeyFile:  serverCertInfo.KeyFile,

--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -29,7 +29,7 @@ import (
 const NodeConfigCommandName = "create-node-config"
 
 type CreateNodeConfigOptions struct {
-	GetSignerCertOptions *GetSignerCertOptions
+	SignerCertOptions *SignerCertOptions
 
 	NodeConfigDir string
 
@@ -73,7 +73,7 @@ func NewCommandNodeConfig(commandName string, fullName string, out io.Writer) *c
 
 	flags := cmd.Flags()
 
-	BindGetSignerCertOptions(options.GetSignerCertOptions, flags, "")
+	BindSignerCertOptions(options.SignerCertOptions, flags, "")
 
 	flags.StringVar(&options.NodeConfigDir, "node-dir", "", "The client data directory.")
 
@@ -110,7 +110,7 @@ func NewCommandNodeConfig(commandName string, fullName string, out io.Writer) *c
 }
 
 func NewDefaultCreateNodeConfigOptions() *CreateNodeConfigOptions {
-	options := &CreateNodeConfigOptions{GetSignerCertOptions: &GetSignerCertOptions{}}
+	options := &CreateNodeConfigOptions{SignerCertOptions: &SignerCertOptions{}}
 	options.VolumeDir = "openshift.local.volumes"
 	// TODO: replace me with a proper round trip of config options through decode
 	options.DNSDomain = "cluster.local"
@@ -179,13 +179,13 @@ func (o CreateNodeConfigOptions) Validate(args []string) error {
 	}
 
 	if o.IsCreateClientCertificate() || o.IsCreateServerCertificate() {
-		if len(o.GetSignerCertOptions.KeyFile) == 0 {
+		if len(o.SignerCertOptions.KeyFile) == 0 {
 			return errors.New("signer-key must be provided to create certificates")
 		}
-		if len(o.GetSignerCertOptions.CertFile) == 0 {
+		if len(o.SignerCertOptions.CertFile) == 0 {
 			return errors.New("signer-cert must be provided to create certificates")
 		}
-		if len(o.GetSignerCertOptions.SerialFile) == 0 {
+		if len(o.SignerCertOptions.SerialFile) == 0 {
 			return errors.New("signer-serial must be provided to create certificates")
 		}
 	}
@@ -256,7 +256,7 @@ func (o CreateNodeConfigOptions) CreateNodeFolder() error {
 func (o CreateNodeConfigOptions) MakeClientCert(clientCertFile, clientKeyFile string) error {
 	if o.IsCreateClientCertificate() {
 		createNodeClientCert := CreateClientCertOptions{
-			GetSignerCertOptions: o.GetSignerCertOptions,
+			SignerCertOptions: o.SignerCertOptions,
 
 			CertFile: clientCertFile,
 			KeyFile:  clientKeyFile,
@@ -288,7 +288,7 @@ func (o CreateNodeConfigOptions) MakeClientCert(clientCertFile, clientKeyFile st
 func (o CreateNodeConfigOptions) MakeServerCert(serverCertFile, serverKeyFile string) error {
 	if o.IsCreateServerCertificate() {
 		nodeServerCertOptions := CreateServerCertOptions{
-			GetSignerCertOptions: o.GetSignerCertOptions,
+			SignerCertOptions: o.SignerCertOptions,
 
 			CertFile: serverCertFile,
 			KeyFile:  serverKeyFile,

--- a/pkg/cmd/server/admin/create_servercert.go
+++ b/pkg/cmd/server/admin/create_servercert.go
@@ -17,7 +17,7 @@ import (
 const CreateServerCertCommandName = "create-server-cert"
 
 type CreateServerCertOptions struct {
-	GetSignerCertOptions *GetSignerCertOptions
+	SignerCertOptions *SignerCertOptions
 
 	CertFile string
 	KeyFile  string
@@ -45,7 +45,7 @@ Example: Creating a secure router certificate.
 `
 
 func NewCommandCreateServerCert(commandName string, fullName string, out io.Writer) *cobra.Command {
-	options := &CreateServerCertOptions{GetSignerCertOptions: &GetSignerCertOptions{}, Output: out}
+	options := &CreateServerCertOptions{SignerCertOptions: &SignerCertOptions{}, Output: out}
 
 	cmd := &cobra.Command{
 		Use:   commandName,
@@ -63,7 +63,7 @@ func NewCommandCreateServerCert(commandName string, fullName string, out io.Writ
 	}
 
 	flags := cmd.Flags()
-	BindGetSignerCertOptions(options.GetSignerCertOptions, flags, "")
+	BindSignerCertOptions(options.SignerCertOptions, flags, "")
 
 	flags.StringVar(&options.CertFile, "cert", "", "The certificate file. Choose a name that indicates what the service is.")
 	flags.StringVar(&options.KeyFile, "key", "", "The key file. Choose a name that indicates what the service is.")
@@ -92,10 +92,10 @@ func (o CreateServerCertOptions) Validate(args []string) error {
 		return errors.New("key must be provided")
 	}
 
-	if o.GetSignerCertOptions == nil {
+	if o.SignerCertOptions == nil {
 		return errors.New("signer options are required")
 	}
-	if err := o.GetSignerCertOptions.Validate(); err != nil {
+	if err := o.SignerCertOptions.Validate(); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func (o CreateServerCertOptions) Validate(args []string) error {
 func (o CreateServerCertOptions) CreateServerCert() (*crypto.TLSCertificateConfig, error) {
 	glog.V(4).Infof("Creating a server cert with: %#v", o)
 
-	signerCert, err := o.GetSignerCertOptions.GetSignerCert()
+	signerCert, err := o.SignerCertOptions.CA()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/admin/create_signercert.go
+++ b/pkg/cmd/server/admin/create_signercert.go
@@ -25,7 +25,7 @@ type CreateSignerCertOptions struct {
 	Overwrite bool
 }
 
-func BindSignerCertOptions(options *CreateSignerCertOptions, flags *pflag.FlagSet, prefix string) {
+func BindCreateSignerCertOptions(options *CreateSignerCertOptions, flags *pflag.FlagSet, prefix string) {
 	flags.StringVar(&options.CertFile, prefix+"cert", "openshift.local.config/master/ca.crt", "The certificate file.")
 	flags.StringVar(&options.KeyFile, prefix+"key", "openshift.local.config/master/ca.key", "The key file.")
 	flags.StringVar(&options.SerialFile, prefix+"serial", "openshift.local.config/master/ca.serial.txt", "The serial file that keeps track of how many certs have been signed.")
@@ -67,7 +67,7 @@ func NewCommandCreateSignerCert(commandName string, fullName string, out io.Writ
 		},
 	}
 
-	BindSignerCertOptions(options, cmd.Flags(), "")
+	BindCreateSignerCertOptions(options, cmd.Flags(), "")
 
 	return cmd
 }

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -183,7 +183,7 @@ func (o NodeOptions) RunNode() error {
 }
 
 func (o NodeOptions) CreateNodeConfig() error {
-	getSignerOptions := &admin.GetSignerCertOptions{
+	getSignerOptions := &admin.SignerCertOptions{
 		CertFile:   admin.DefaultCertFilename(o.NodeArgs.MasterCertDir, "ca"),
 		KeyFile:    admin.DefaultKeyFilename(o.NodeArgs.MasterCertDir, "ca"),
 		SerialFile: admin.DefaultSerialFilename(o.NodeArgs.MasterCertDir, "ca"),
@@ -201,7 +201,7 @@ func (o NodeOptions) CreateNodeConfig() error {
 
 	nodeConfigDir := o.NodeArgs.ConfigDir.Value()
 	createNodeConfigOptions := admin.CreateNodeConfigOptions{
-		GetSignerCertOptions: getSignerOptions,
+		SignerCertOptions: getSignerOptions,
 
 		NodeConfigDir: nodeConfigDir,
 

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -178,14 +178,14 @@ func CreateMasterCerts(masterArgs *start.MasterArgs) error {
 }
 
 func CreateNodeCerts(nodeArgs *start.NodeArgs) error {
-	getSignerOptions := &admin.GetSignerCertOptions{
+	getSignerOptions := &admin.SignerCertOptions{
 		CertFile:   admin.DefaultCertFilename(nodeArgs.MasterCertDir, "ca"),
 		KeyFile:    admin.DefaultKeyFilename(nodeArgs.MasterCertDir, "ca"),
 		SerialFile: admin.DefaultSerialFilename(nodeArgs.MasterCertDir, "ca"),
 	}
 
 	createNodeConfig := admin.NewDefaultCreateNodeConfigOptions()
-	createNodeConfig.GetSignerCertOptions = getSignerOptions
+	createNodeConfig.SignerCertOptions = getSignerOptions
 	createNodeConfig.NodeConfigDir = nodeArgs.ConfigDir.Value()
 	createNodeConfig.NodeName = nodeArgs.NodeName
 	createNodeConfig.Hostnames = []string{nodeArgs.NodeName}


### PR DESCRIPTION
Hand out one CA per process.

Fixes #3594