### PR TITLE
examples/sample-app: Use the registry kubeconfig, not master

### DIFF
--- a/examples/sample-app/container-setup.md
+++ b/examples/sample-app/container-setup.md
@@ -65,7 +65,7 @@ step #3.
 
 ## Deploy the private docker registry
 
-    $ oadm registry --create --credentials="${KUBECONFIG}"
+    $ oadm registry --create --credentials=$(pwd)/openshift.local.config/master/openshift-registry.kubeconfig
     $ cd examples/sample-app
 
 For more information on this step, see [Application Build, Deploy, and Update


### PR DESCRIPTION
I'm guessing at some point the container build changed to generate a
separate registry config, which is what the Ansible code does too -
this works for me.