### PR TITLE
always show markers is oc status

### DIFF
--- a/pkg/api/graph/test/bad_secret_with_just_rc.yaml
+++ b/pkg/api/graph/test/bad_secret_with_just_rc.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  data:
+    content: IyBVcGdyYWRpbmcKClRoaXMgZG9jdW1lbnQgZGVzY3JpYmVzIGZ1dHVyZSBjaGFuZ2VzIHRoYXQgd2lsbCBhZmZlY3QgeW91ciBjdXJyZW50IHJlc291cmNlcyB1c2VkCmluc2lkZSBvZiBPcGVuU2hpZnQuIEVhY2ggY2hhbmdlIGNvbnRhaW5zIGRlc2NyaXB0aW9uIG9mIHRoZSBjaGFuZ2UgYW5kIGluZm9ybWF0aW9uCndoZW4gdGhhdCBjaGFuZ2Ugd2lsbCBoYXBwZW4uCgoKIyMgT3JpZ2luIDEuMC54IC8gT1NFIDMuMC54CgoqIEN1cnJlbnRseSBhbGwgYnVpbGQgcG9kcyBoYXZlIGEgbGFiZWwgbmFtZWQgYGJ1aWxkYC4gVGhpcyBsYWJlbCBpcyBiZWluZyBkZXByZWNhdGVkCiAgaW4gZmF2b3Igb2YgYG9wZW5zaGlmdC5pby9idWlsZC5uYW1lYCBpbiBPcmlnaW4gMS4wLnggLyBPU0UgMy4xLnggYXQgd2hpY2ggcG9pbnQgYm90aAogIGxhYmVscyB3aWxsIGJlIHN1cHBvcnRlZC4gQWxsIHRoZSBuZXdseSBjcmVhdGVkIGJ1aWxkcyB3aWxsIGhhdmUganVzdCB0aGUgbmV3IGxhYmVsLgogIEluIE9yaWdpbiAxLnkgLyBPU0UgMy55IHRoZSBzdXBwb3J0IGZvciB0aGUgb2xkIGxhYmVsIChgYnVpbGRgKSB3aWxsIGJlIHJlbW92ZWQgZW50aXJlbHkuCiAgU2VlICMzNTAyLgo=
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: existing-secret
+  type: Opaque
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    creationTimestamp: null
+    generation: 1
+    labels:
+      name: my-rc
+    name: my-rc
+  spec:
+    replicas: 1
+    selector:
+      name: my-rc
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          name: my-rc
+      spec:
+        containers:
+        - image: openshift/mysql-55-centos7
+          imagePullPolicy: IfNotPresent
+          name: ruby-helloworld-database
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: unmountable-secret-volume
+          secret:
+            secretName: existing-secret
+        - name: missing-secret-volume
+          secret:
+            secretName: dne
+  status:
+    replicas: 0
+kind: List
+metadata: {}

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -113,6 +113,22 @@ func TestProjectStatus(t *testing.T) {
 				"To see more, use",
 			},
 		},
+		"rc with unmountable and missing secrets": {
+			Path: "../../../../pkg/api/graph/test/bad_secret_with_just_rc.yaml",
+			Extra: []runtime.Object{
+				&projectapi.Project{
+					ObjectMeta: kapi.ObjectMeta{Name: "example", Namespace: ""},
+				},
+			},
+			ErrFn: func(err error) bool { return err == nil },
+			Contains: []string{
+				"In project example\n",
+				"rc/my-rc runs openshift/mysql-55-centos7",
+				"0/1 pods growing to 1",
+				"is not allowed to mount secret/existing-secret",
+				"these missing secrets secret/dne",
+			},
+		},
 		"service with pod": {
 			Path: "../../../../pkg/api/graph/test/service-with-pod.yaml",
 			Extra: []runtime.Object{


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1243769

Previously, warnings were only displayed if certain resource types were available.  This simply moves warning output to always be displayed, regardless of available resources.

@fabianofranz or @liggitt ptal.