### PR TITLE
UPSTREAM: 10647 (carry until 10656): increase Kubelet timeouts to 1 hour

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/server.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/server.go
@@ -65,8 +65,8 @@ func ListenAndServeKubeletServer(host HostInterface, address net.IP, port uint, 
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
-		ReadTimeout:    5 * time.Minute,
-		WriteTimeout:   5 * time.Minute,
+		ReadTimeout:    60 * time.Minute,
+		WriteTimeout:   60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	if tlsOptions != nil {


### PR DESCRIPTION
This makes the Kubelet's read and write timeouts match the master.

10647 isn't going to be merged. Instead, 10656 will finer-grained
timeouts based on the type of request, but it's not merged upstream yet.
Once 10656 is merged, we can drop this patch.