### PR TITLE
[WIP] - Show service ports table in UI overview

### DIFF
--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -521,4 +521,14 @@ angular.module('openshiftConsole')
         return [];
       }
     };
+  })
+  .filter('serviceImplicitDNSName', function() {
+    return function(service) {
+      if (!service || !service.metadata || !service.metadata.name || !service.metadata.namespace) {
+        return '';
+      }
+
+      // cluster.local suffix is customizable, so leave it off. <name>.<namespace>.svc resolves.
+      return service.metadata.name + '.' + service.metadata.namespace + '.svc';
+    };
   });

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -2,6 +2,8 @@
 // Overview page components
 // --------------------------------------------------
 
+@components-small-font-size: 11px;
+
 .components {
   border-left: 3px solid #ccc;
   border-left-style: dotted;
@@ -49,7 +51,7 @@
     .osc-object-highlight();
     .component-label {
       text-transform: uppercase;
-      font-size: 11px;
+      font-size: @components-small-font-size;
       color: @gray-light;
       + span {
         margin-left: 5px;
@@ -92,6 +94,7 @@
             // assign flex properties when >768 for proper layout then .component divs will stack at mobile by default
             .flex(@columns: 1);
           }
+          font-size: @components-small-font-size;
           text-align: right;
           line-height: 1.3em;
           .align-self(@align: left);
@@ -121,6 +124,32 @@
       .osc-object-highlight();
       &.none {
         background-color: transparent;
+      }
+      .meta-data {
+        // a little margin above the ports table
+        margin-bottom: 5px;
+        .fa {
+          margin-left: 5px;
+          font-size: 15px;
+        }
+      }
+      .table-responsive {
+        border: 0;
+        margin-bottom: 0;
+      }
+      .port-table {
+        .table;
+        .table-condensed;
+        .text-center;
+        font-size: @components-small-font-size;
+        margin-bottom: 0;
+        thead {
+          background-color: white;
+          background-image: none;
+          tr th {
+            .text-center;
+          }
+        }
       }
     }
     &.deployment-block {
@@ -294,7 +323,7 @@
       }
       .pod-text {
         font-family: @font-family-base;
-        font-size: 11px;
+        font-size: @components-small-font-size;
       }
     }
   }

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -131,6 +131,10 @@ html, body {
   }
 }
 
+.clickable {
+  cursor: pointer;
+}
+
 .separator {
   border-top: 1px solid rgba(0, 0, 0, 0.15);
 }

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -37,17 +37,17 @@
         <!-- TODO handle multiple services mapping to the same deploymentConfig/deployment/pod -->
         <section ng-repeat="(serviceId, service) in services" class="components components-group">
 
-          <div class="osc-object components-panel service" ng-init="numPorts = service.spec.ports.length" kind="Service" resource="service">
-
+          <div class="osc-object components-panel service" kind="Service" resource="service">
             <div class="component-block">
               <div class="component">
-                <div class="component-label">
+                <div ng-attr-title="{{service | serviceImplicitDNSName}}" class="component-label">
                   <!-- "service" class is present for e2e tests to check   -->
                   Service <span ng-if="displayRouteByService[serviceId]">: <span class="service">{{serviceId}}</span></span>
                 </div>
 
                 <!-- Show the route if present -->
-                <h2 ng-if="displayRouteByService[serviceId]" ng-init="otherRoutes = (routesByService[serviceId] | hashSize) - 1">
+                <h2 ng-if="displayRouteByService[serviceId]"
+                    ng-init="otherRoutes = (routesByService[serviceId] | hashSize) - 1">
                   <span ng-if="(displayRouteByService[serviceId] | isWebRoute)">
                     <!-- "route" class is present for e2e tests to check -->
                     <a href="{{displayRouteByService[serviceId] | routeWebURL}}" class="route">{{displayRouteByService[serviceId] | routeLabel}}</a>
@@ -66,33 +66,51 @@
 
                 <!-- If no route is present, show the service name large -->
                 <!-- "service" class is present for e2e tests to check   -->
-                <h2 class="service" ng-if="!displayRouteByService[serviceId]">
+                <h2 class="service" ng-if="!displayRouteByService[serviceId]" ng-attr-title="{{service | serviceImplicitDNSName}}">
                   {{serviceId}}
                 </h2>
               </div>
 
               <div class="component meta-data">
-                <span ng-if="service.spec.portalIP && service.spec.portalIP !== 'None'">
-                  routing traffic on {{service.spec.portalIP}}
+                <span ng-click="expanded = !expanded" class="clickable" title="Show service ports">
+                  <span ng-if="service.spec.type">{{service.spec.type}}</span>
+                  <i ng-show="!expanded" class="fa fa-caret-down"></i>
+                  <i ng-show="expanded" class="fa fa-caret-up"></i>
                 </span>
-                <div ng-if="numPorts">
-                  <!--
-                  Show only the first two ports if there are many since we don't have much space here.
-                  The full list is visible elsewhere.
-                  -->
-                  <span ng-repeat="portMapping in service.spec.ports | orderBy:'port' | limitTo:2" class="nowrap">
-                    <!-- Group port mappings and allow multiple mappings to stack if needed -->
-                    <span class="port-mappings">port {{portMapping.port}}&#8201;&#8594;&#8201;{{portMapping.targetPort}}
-                      ({{portMapping.protocol}})<span ng-if="$index < (numPorts - 1)">, </span></span>
-                  </span>
-                  <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
-                    and {{numRemaining}} {{numRemaining == 1 ? "other" : "others"}}
-                  </span>
-                </div>
               </div>
             </div>
+            <div ng-show="expanded" class="table-responsive">
+              <table ng-if="service.spec.ports.length" class="port-table">
+                <thead>
+                  <tr>
+                    <th>Node Port</th>
+                    <th role="presentation"></th>
+                    <th>
+                      Service Port
+                      <!-- Show portal IP in column header instead of table body at small screen
+                      widths to save space. -->
+                      <span class="visible-xs">({{service.spec.portalIP}})</span>
+                    </th>
+                    <th role="presentation"></th>
+                    <th>Target Port</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr ng-repeat="portMapping in service.spec.ports | orderBy:'port'">
+                    <td>
+                      <span ng-if="portMapping.nodePort">{{portMapping.nodePort}}</span>
+                      <span ng-if="!portMapping.nodePort" class="text-muted">none</span>
+                    </td>
+                    <td role="presentation" class="text-muted">&#8594;</td>
+                    <td><span ng-if="service.spec.portalIP && service.spec.portalIP !== 'None'">
+                        <span class="hidden-xs">{{service.spec.portalIP}}:</span></span>{{portMapping.port}}</td>
+                    <td role="presentation" class="text-muted">&#8594;</td>
+                    <td>{{portMapping.targetPort}}&nbsp;({{portMapping.protocol}})</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
-
 
           <!--
           Iterate over deploymentConfigs for this service.


### PR DESCRIPTION
Add a ports table for services displaying

   node port -> service port -> container port.

<img width="570" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/8752659/ab04447a-2c83-11e5-9228-a158d450191d.png">

<img width="574" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/8752662/ae706dd2-2c83-11e5-9ca3-90ef004cff90.png">

Fixes #3662

