### PR TITLE
expose: Default to the service generator when not exposing services

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -312,7 +312,7 @@ Expose a replicated application as a service or route
   $ openshift cli expose service nginx --hostname=www.example.com
 
   // Expose a deployment configuration as a service and use the specified port
-  $ openshift cli expose dc ruby-hello-world --port=8080 --generator=service/v1
+  $ openshift cli expose dc ruby-hello-world --port=8080
 ----
 ====
 

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -200,7 +200,7 @@ OpenShift, through labels and deployment configurations, can support multiple si
 
 4.  Create a service that uses the common label:
 
-        $ oc expose dc/ab-example-a --name=ab-example --selector=ab-example=true --generator=service/v1
+        $ oc expose dc/ab-example-a --name=ab-example --selector=ab-example=true
 
     If you have the router installed, make the application available via a route (or use the service IP directly)
 

--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -32,7 +32,7 @@ labels from the object it exposes.`
   $ %[1]s expose service nginx --hostname=www.example.com
 
   // Expose a deployment configuration as a service and use the specified port
-  $ %[1]s expose dc ruby-hello-world --port=8080 --generator=service/v1`
+  $ %[1]s expose dc ruby-hello-world --port=8080`
 )
 
 // NewCmdExpose is a wrapper for the Kubernetes cli expose command
@@ -41,9 +41,15 @@ func NewCmdExpose(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 	cmd.Short = "Expose a replicated application as a service or route"
 	cmd.Long = exposeLong
 	cmd.Example = fmt.Sprintf(exposeExample, fullName)
-	cmd.Flags().Set("generator", "route/v1")
-	cmd.Flag("generator").Usage = "The name of the API generator to use. Default is 'route/v1'."
-	cmd.Flag("generator").DefValue = "route/v1"
+	// Default generator to an empty string so we can get more flexibility
+	// when setting defaults based on input resources
+	cmd.Flags().Set("generator", "")
+	cmd.Flag("generator").Usage = "The name of the API generator to use."
+	cmd.Flag("generator").DefValue = ""
+	// Default protocol to an empty string so we can get more flexibility
+	// when validating the use of it (invalid for routes)
+	cmd.Flags().Set("protocol", "")
+	cmd.Flag("protocol").DefValue = ""
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		err := validate(cmd, f, args)
 		cmdutil.CheckErr(err)
@@ -55,19 +61,8 @@ func NewCmdExpose(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 }
 
 // validate adds one layer of validation prior to calling the upstream
-// expose command. Used only for validating services that are about
-// to be exposed as routes.
+// expose command.
 func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
-	if cmdutil.GetFlagString(cmd, "generator") != "route/v1" {
-		if len(cmdutil.GetFlagString(cmd, "hostname")) > 0 {
-			return fmt.Errorf("cannot use --hostname without generating a route")
-		}
-		return nil
-	}
-	if err := validateFlags(cmd); err != nil {
-		return err
-	}
-
 	namespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err
@@ -102,55 +97,96 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 	}
 	info := infos[0]
 
+	generator := cmdutil.GetFlagString(cmd, "generator")
 	switch mapping.Kind {
 	case "Service":
-		svc, err := kc.Services(info.Namespace).Get(info.Name)
-		if err != nil {
-			return err
-		}
+		switch generator {
+		case "service/v1":
+			// Set default protocol back for generating services
+			if len(cmdutil.GetFlagString(cmd, "protocol")) == 0 {
+				cmd.Flags().Set("protocol", "TCP")
+			}
+			return validateFlags(cmd, "service/v1")
+		case "":
+			// Default exposing services as a route
+			cmd.Flags().Set("generator", "route/v1")
+			fallthrough
+		case "route/v1":
+			// We need to validate services exposed as routes
+			if err := validateFlags(cmd, "route/v1"); err != nil {
+				return err
+			}
+			svc, err := kc.Services(info.Namespace).Get(info.Name)
+			if err != nil {
+				return err
+			}
 
-		supportsTCP := false
-		for _, port := range svc.Spec.Ports {
-			if port.Protocol == kapi.ProtocolTCP {
-				supportsTCP = true
-				break
+			supportsTCP := false
+			for _, port := range svc.Spec.Ports {
+				if port.Protocol == kapi.ProtocolTCP {
+					supportsTCP = true
+					break
+				}
+			}
+			if !supportsTCP {
+				return fmt.Errorf("service %s doesn't support TCP", info.Name)
 			}
 		}
-		if !supportsTCP {
-			return fmt.Errorf("service %s doesn't support TCP", info.Name)
-		}
+
 	default:
-		return fmt.Errorf("cannot expose a %s as a route", mapping.Kind)
+		switch generator {
+		case "route/v1":
+			return fmt.Errorf("cannot expose a %s as a route", mapping.Kind)
+		case "":
+			// Default exposing everything except services as a service
+			cmd.Flags().Set("generator", "service/v1")
+			fallthrough
+		case "service/v1":
+			// Set default protocol back for generating services
+			if len(cmdutil.GetFlagString(cmd, "protocol")) == 0 {
+				cmd.Flags().Set("protocol", "TCP")
+			}
+			return validateFlags(cmd, "service/v1")
+		}
 	}
 
 	return nil
 }
 
 // validateFlags filters out flags that are not supposed to be used
-// when generating a route
-func validateFlags(cmd *cobra.Command) error {
+// when exposing a resource; depends on the provided generator
+func validateFlags(cmd *cobra.Command, generator string) error {
 	invalidFlags := []string{}
 
-	if len(cmdutil.GetFlagString(cmd, "type")) != 0 {
-		invalidFlags = append(invalidFlags, "--type")
-	}
-	if len(cmdutil.GetFlagString(cmd, "selector")) != 0 {
-		invalidFlags = append(invalidFlags, "--selector")
-	}
-	if len(cmdutil.GetFlagString(cmd, "container-port")) != 0 {
-		invalidFlags = append(invalidFlags, "--container-port")
-	}
-	if len(cmdutil.GetFlagString(cmd, "target-port")) != 0 {
-		invalidFlags = append(invalidFlags, "--target-port")
-	}
-	if len(cmdutil.GetFlagString(cmd, "public-ip")) != 0 {
-		invalidFlags = append(invalidFlags, "--public-ip")
-	}
-	if cmdutil.GetFlagInt(cmd, "port") != -1 {
-		invalidFlags = append(invalidFlags, "--port")
-	}
-	if cmdutil.GetFlagBool(cmd, "create-external-load-balancer") {
-		invalidFlags = append(invalidFlags, "--create-external-load-balancer")
+	if generator == "service/v1" {
+		if len(cmdutil.GetFlagString(cmd, "hostname")) != 0 {
+			invalidFlags = append(invalidFlags, "--hostname")
+		}
+	} else if generator == "route/v1" {
+		if len(cmdutil.GetFlagString(cmd, "protocol")) != 0 {
+			invalidFlags = append(invalidFlags, "--protocol")
+		}
+		if len(cmdutil.GetFlagString(cmd, "type")) != 0 {
+			invalidFlags = append(invalidFlags, "--type")
+		}
+		if len(cmdutil.GetFlagString(cmd, "selector")) != 0 {
+			invalidFlags = append(invalidFlags, "--selector")
+		}
+		if len(cmdutil.GetFlagString(cmd, "container-port")) != 0 {
+			invalidFlags = append(invalidFlags, "--container-port")
+		}
+		if len(cmdutil.GetFlagString(cmd, "target-port")) != 0 {
+			invalidFlags = append(invalidFlags, "--target-port")
+		}
+		if len(cmdutil.GetFlagString(cmd, "public-ip")) != 0 {
+			invalidFlags = append(invalidFlags, "--public-ip")
+		}
+		if cmdutil.GetFlagInt(cmd, "port") != -1 {
+			invalidFlags = append(invalidFlags, "--port")
+		}
+		if cmdutil.GetFlagBool(cmd, "create-external-load-balancer") {
+			invalidFlags = append(invalidFlags, "--create-external-load-balancer")
+		}
 	}
 
 	msg := ""
@@ -163,8 +199,8 @@ func validateFlags(cmd *cobra.Command) error {
 
 	default:
 		commaSeparated, last := invalidFlags[:len(invalidFlags)-1], invalidFlags[len(invalidFlags)-1]
-		msg = fmt.Sprintf("%s or %s", strings.Join(commaSeparated, ","), last)
+		msg = fmt.Sprintf("%s or %s", strings.Join(commaSeparated, ", "), last)
 	}
 
-	return fmt.Errorf("cannot use %s when generating a route", msg)
+	return fmt.Errorf("cannot use %s when generating a %s", msg, strings.Split(generator, "/")[0])
 }


### PR DESCRIPTION
Routes should be generated only out of services. Make this explicit and default to the appropriate generator based on the input resource we want to expose.

Also, validate --protocol by unsetting its default value, checking its use - invalid when generating a route - and setting its default value for exposing services back.

Fixes #3778

@smarterclayton PTAL