### PR TITLE
Line up breadcrumbs and content on create from template page

### DIFF
--- a/assets/app/views/newfromtemplate.html
+++ b/assets/app/views/newfromtemplate.html
@@ -1,12 +1,10 @@
 <div ng-controller="ProjectController">
   <div ng-controller="NewFromTemplateController" class="container">
-    <div class="container">
-      <ol class="breadcrumb">
-        <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
-        <li><a href="project/{{projectName}}/create">Add to Project</a></li>
-        <li class="active"><strong>{{template | displayName}}</strong></li>
-      </ol>
-    </div>
+    <ol class="breadcrumb">
+      <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
+      <li><a href="project/{{projectName}}/create">Add to Project</a></li>
+      <li class="active"><strong>{{template | displayName}}</strong></li>
+    </ol>
     <div class="row">
       <div class="col-md-12">
         <div class="create-from-template">


### PR DESCRIPTION
Small screen widths:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/8781182/95869328-2edb-11e5-86cc-3d1eb47e7b65.png)

Medium and large screen widths:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/8781189/9acf999c-2edb-11e5-9e70-8c2879254675.png)

Fixes #3482