### PR TITLE
Customize the events table layout and styles for better readability on mobile devices.

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -331,6 +331,57 @@ code {
   overflow-x: auto; // remove when we update to latest patternfly with twbs 3.3.4
 }
 
+.table-events {
+  background-color: #fff;
+  > tbody {
+    + tbody {
+      border-top-width: 1px;
+    }
+  }
+  tr {
+    @media (min-width: @screen-md-min) {
+      td.event-time {
+        white-space: nowrap;
+      }
+    }
+  }
+}
+@media (max-width: @screen-xs-max) {
+  .table-events, thead, tbody, th, td, tr {
+    display: block;
+  }
+  .table-events {
+    thead tr {
+      /* Hide table headers (but not display: none;, for accessibility) */
+      .sr-only();
+    }
+    > tbody {
+      > tr {
+        > td {
+           /* Behave like a row */
+          border: none;
+          border-bottom: 1px solid #eee;
+          padding: 3px 6px 2px 35%;
+          position: relative;
+          &:last-child {
+            border-bottom: none;
+          }
+          &:before {
+            /* Act as mobile table header */
+            content: attr(data-title);
+            position: absolute;
+            top: 3px;
+            left: 6px;
+            width: 35%; 
+            padding-right: 10px; 
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+  }
+}
+
 .gutter-top-bottom {
   padding: @grid-gutter-width / 2 0;
   &.gutter-top-bottom-2x {

--- a/assets/app/views/events.html
+++ b/assets/app/views/events.html
@@ -10,32 +10,38 @@
           <em>{{emptyMessage}}</em>
         </div>
       </div>
-      <div class="table-responsive">
-        <table ng-if="(events | hashSize) !== 0" class="table table-bordered table-condensed">
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Name</th>
-              <th>Kind</th>
-              <th>Reason</th>
-              <th>Message</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr ng-repeat="event in events | toArray | orderBy:'-lastTimestamp'">
-              <td class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
-              <td>{{event.involvedObject.name}}</td>
-              <td>{{event.involvedObject.kind}}</td>
-              <td class="nowrap">{{event.reason}}</td>
-              <td class="break-word">{{event.message}}
-                <span class="text-muted small" ng-if="event.count > 1">
-                  ({{event.count}} times in the last
-                    {{event.firstTimestamp | duration:event.lastTimestamp:true}})
-                </span></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <table ng-if="(events | hashSize) !== 0" class="table table-bordered table-condensed table-events">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Kind and </span>Name</th>
+            <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Kind</span></th>
+            <th class="hidden-sm hidden-md"><span class="visible-lg-inline">Reason</span></th>
+            <th><span class="hidden-xs-inline visible-sm-inline visible-md-inline hidden-lg-inline">Reason and </span>Message</th>
+          </tr>
+        </thead>
+        <tbody ng-repeat="event in events | toArray | orderBy:'-lastTimestamp'">
+          <tr>
+            <td data-title="Time" class="nowrap">{{event.lastTimestamp | date:'mediumTime'}}</td>
+            <td data-title="Name" class="event-time">
+              <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">
+              {{event.involvedObject.kind}}</div>
+              {{event.involvedObject.name}}</td>
+            <td class="hidden-sm hidden-md" data-title="Kind">
+              {{event.involvedObject.kind}}</td>
+            <td class="hidden-sm hidden-md" data-title="Reason">
+              {{event.reason}}</td>
+            <td data-title="Message" class="break-word">
+              <div class="hidden-xs-block visible-sm-block visible-md-block hidden-lg-block">{{event.reason}}</div>
+              {{event.message}}
+              <span class="text-muted small" ng-if="event.count > 1">
+                ({{event.count}} times in the last
+                  {{event.firstTimestamp | duration:event.lastTimestamp:true}})
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </project-page>
 </div>


### PR DESCRIPTION
At < 992px the "Reason and Message" columns are combined into one, so that the columns aren't squished.
At < 767px the data switches to a 2 column layout - table headings are on the left and their values are on the right. This enable the content to compress down to 320px and without triggering a horizontal scrollbar.

Display at multiple viewport widths.

1200px and wider
![screen shot 2015-07-20 at 4 09 41 pm](https://cloud.githubusercontent.com/assets/1874151/8786766/2143ae74-2efe-11e5-9d7a-e429f82a3365.png)

800px
![screen shot 2015-07-20 at 4 10 19 pm](https://cloud.githubusercontent.com/assets/1874151/8786705/bf1a1896-2efd-11e5-9d2c-42cbc198766a.png)

580px
![screen shot 2015-07-20 at 4 10 46 pm](https://cloud.githubusercontent.com/assets/1874151/8786735/e2a38c20-2efd-11e5-9f83-4e91db11dad7.png)

320px
![screen shot 2015-07-20 at 3 47 01 pm](https://cloud.githubusercontent.com/assets/1874151/8786738/eb096e8e-2efd-11e5-959b-000125aa4f4e.png)

