### PR TITLE
Make network fixup during provision conditional

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "rebuild_yum_cache" => false,
     "cpus"              => ENV['OPENSHIFT_NUM_CPUS'] || 2,
     "memory"            => ENV['OPENSHIFT_MEMORY'] || 2048,
+    "fixup_net_udev"    => ENV['OPENSHIFT_FIXUP_NET_UDEV'] || true,
     "sync_folders_type" => nil,
     "master_ip"         => ENV['OPENSHIFT_MASTER_IP'] || "10.245.2.2",
     "minion_ip_base"    => ENV['OPENSHIFT_MINION_IP_BASE'] || "10.245.2.",
@@ -152,11 +153,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     minion_ips = num_minion.times.collect { |n| minion_ip_base + "#{n+3}" }
     minion_ips_str = minion_ips.join(",")
 
+    fixup_net_udev = vagrant_openshift_config['fixup_net_udev']
+
     # OpenShift master
     config.vm.define "#{VM_NAME_PREFIX}master" do |config|
       config.vm.box = kube_box[kube_os]["name"]
       config.vm.box_url = kube_box[kube_os]["box_url"]
-      config.vm.provision "shell", inline: "/vagrant/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{ENV['OPENSHIFT_SDN']}"
+      config.vm.provision "shell", inline: "/vagrant/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{fixup_net_udev} #{ENV['OPENSHIFT_SDN']}"
       config.vm.network "private_network", ip: "#{master_ip}"
       config.vm.hostname = "openshift-master"
       config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']
@@ -169,7 +172,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         minion_ip = minion_ips[n]
         minion.vm.box = kube_box[kube_os]["name"]
         minion.vm.box_url = kube_box[kube_os]["box_url"]
-        minion.vm.provision "shell", inline: "/vagrant/vagrant/provision-minion.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{minion_ip} #{minion_index}"
+        minion.vm.provision "shell", inline: "/vagrant/vagrant/provision-minion.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{minion_ip} #{minion_index} #{fixup_net_udev}"
         minion.vm.network "private_network", ip: "#{minion_ip}"
         minion.vm.hostname = "openshift-minion-#{minion_index}"
         config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -3,12 +3,16 @@
 set -ex
 source $(dirname $0)/provision-config.sh
 
-NETWORK_PLUGIN=$(os::util::get-network-plugin ${5:-""})
+FIXUP_NET_UDEV=$5
 
-NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+NETWORK_PLUGIN=$(os::util::get-network-plugin ${6:-""})
 
-systemctl restart network
+if [ "${FIXUP_NET_UDEV}" == "true" ]; then
+  NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
+  sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+
+  systemctl restart network
+fi
 
 # Setup hosts file to ensure name resolution to each member of the cluster
 minion_ip_array=(${MINION_IPS//,/ })

--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -4,11 +4,14 @@ source $(dirname $0)/provision-config.sh
 
 MINION_IP=$5
 MINION_INDEX=$6
+FIXUP_NET_UDEV=$7
 
-NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
-sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
+if [ "${FIXUP_NET_UDEV}" == "true" ]; then
+  NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
+  sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
 
-systemctl restart network
+  systemctl restart network
+fi
 
 # get the minion name, index is 1-based
 minion_name=${MINION_NAMES[$MINION_INDEX-1]}


### PR DESCRIPTION
The networking fixup performed by the provision-master.sh and
provision-minion.sh scripts may be required by the default images, but
may not apply to custom images.  This change continues to perform fixup
by default but allows it to be skipped by setting the 'fixup_net_udev'
value in the configuration file or OPENSHIFT_FIXUP_NET_UDEV to something
other than true.