### PR TITLE
Stop adding user to 'docker' group

### DIFF
--- a/vagrant/provision-full.sh
+++ b/vagrant/provision-full.sh
@@ -41,8 +41,6 @@ set_env /root
 systemctl enable docker
 systemctl start docker
 
-usermod -a -G docker $USERNAME
-
 echo To install etcd, run hack/install-etcd.sh
 
 sed -i s/^Defaults.*requiretty/\#Defaults\ requiretty/g /etc/sudoers


### PR DESCRIPTION
The 'docker' group is no longer created by default on Fedora >= 21, and
trying to add a user to a non-existent group will fail provisioning.

#2135 was closed, seemingly without resolution, so if nothing else this 
is an opportunity to revisit the issue and document whether this fix is
appropriate.