### PR TITLE
Reconcile roles

### DIFF
--- a/docs/generated/oadm_by_example_content.adoc
+++ b/docs/generated/oadm_by_example_content.adoc
@@ -168,6 +168,22 @@ Manage nodes - list pods, evacuate, or mark ready
 ====
 
 
+== oadm policy reconcile-cluster-roles
+Replace cluster roles to match the recommended bootstrap policy
+
+====
+
+[options="nowrap"]
+----
+  // Display the cluster roles that would be modified
+  $ openshift admin policy reconcile-cluster-roles
+
+  // Replace cluster roles that don't match the current defaults
+  $ openshift admin policy reconcile-cluster-roles --confirm
+----
+====
+
+
 == oadm registry
 Install the OpenShift Docker registry
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -701,6 +701,12 @@ oadm policy add-cluster-role-to-group cluster-admin system:unauthenticated
 oadm policy remove-cluster-role-from-group cluster-admin system:unauthenticated
 oadm policy add-cluster-role-to-user cluster-admin system:no-user
 oadm policy remove-cluster-role-from-user cluster-admin system:no-user
+oc delete clusterrole/cluster-status
+[ ! "$(oc get clusterrole/cluster-status)" ]
+oadm policy reconcile-cluster-roles
+[ ! "$(oc get clusterrole/cluster-status)" ]
+oadm policy reconcile-cluster-roles --confirm
+oc get clusterrole/cluster-status
 
 oc policy add-role-to-group cluster-admin system:unauthenticated
 oc policy add-role-to-user cluster-admin system:no-user

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -43,6 +43,7 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	cmds.AddCommand(NewCmdRemoveClusterRoleFromUser(RemoveClusterRoleFromUserRecommendedName, fullName+" "+RemoveClusterRoleFromUserRecommendedName, f, out))
 	cmds.AddCommand(NewCmdAddClusterRoleToGroup(AddClusterRoleToGroupRecommendedName, fullName+" "+AddClusterRoleToGroupRecommendedName, f, out))
 	cmds.AddCommand(NewCmdRemoveClusterRoleFromGroup(RemoveClusterRoleFromGroupRecommendedName, fullName+" "+RemoveClusterRoleFromGroupRecommendedName, f, out))
+	cmds.AddCommand(NewCmdReconcileClusterRoles(ReconcileClusterRolesRecommendedName, fullName+" "+ReconcileClusterRolesRecommendedName, f, out))
 
 	return cmds
 }

--- a/pkg/cmd/admin/policy/reconcile_clusterroles.go
+++ b/pkg/cmd/admin/policy/reconcile_clusterroles.go
@@ -1,0 +1,156 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	kapierrors "github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const ReconcileClusterRolesRecommendedName = "reconcile-cluster-roles"
+
+type reconcileClusterOptions struct {
+	Confirmed bool
+
+	Out io.Writer
+
+	RoleClient client.ClusterRoleInterface
+}
+
+const (
+	reconcileLong = `
+Replace cluster roles to match the recommended bootstrap policy
+
+This command will inspect the cluster roles against the recommended bootstrap policy.  Any cluster role
+that does not match will be replaced by the recommended bootstrap role.  This command will not remove
+any additional cluster role.
+
+You can see which cluster role have recommended changed by choosing an output type.`
+
+	reconcileExample = `  // Display the cluster roles that would be modified
+  $ %[1]s
+
+  // Replace cluster roles that don't match the current defaults
+  $ %[1]s --confirm`
+)
+
+// NewCmdReconcileClusterRoles implements the OpenShift cli reconcile-cluster-roles command
+func NewCmdReconcileClusterRoles(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	o := &reconcileClusterOptions{Out: out}
+
+	cmd := &cobra.Command{
+		Use:     name,
+		Short:   "Replace cluster roles to match the recommended bootstrap policy",
+		Long:    reconcileLong,
+		Example: fmt.Sprintf(reconcileExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := o.Complete(cmd, f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			changedClusterRoles, err := o.ChangedClusterRoles()
+			kcmdutil.CheckErr(err)
+
+			if len(changedClusterRoles) == 0 {
+				return
+			}
+
+			if (len(kcmdutil.GetFlagString(cmd, "output")) != 0) && !o.Confirmed {
+				list := &kapi.List{}
+				for _, item := range changedClusterRoles {
+					list.Items = append(list.Items, item)
+				}
+
+				kcmdutil.CheckErr(f.Factory.PrintObject(cmd, list, out))
+			}
+
+			if o.Confirmed {
+				kcmdutil.CheckErr(o.ReplaceChangedRoles(changedClusterRoles))
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&o.Confirmed, "confirm", o.Confirmed, "Specify that cluster roles should be modified. Defaults to false, displaying what would be replaced but not actually replacing anything.")
+	kcmdutil.AddPrinterFlags(cmd)
+	cmd.Flags().Lookup("output").DefValue = "yaml"
+	cmd.Flags().Lookup("output").Value.Set("yaml")
+
+	return cmd
+}
+
+func (o *reconcileClusterOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+	if len(args) != 0 {
+		return errors.New("No arguments are allowed")
+	}
+
+	oclient, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	o.RoleClient = oclient.ClusterRoles()
+
+	return nil
+}
+
+func (o *reconcileClusterOptions) ReplaceChangedRoles(changedRoles []*authorizationapi.ClusterRole) error {
+	for i := range changedRoles {
+		role, err := o.RoleClient.Get(changedRoles[i].Name)
+		if err != nil && !kapierrors.IsNotFound(err) {
+			return err
+		}
+
+		if kapierrors.IsNotFound(err) {
+			createdRole, err := o.RoleClient.Create(changedRoles[i])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(o.Out, "clusterrole/%s\n", createdRole.Name)
+			continue
+		}
+
+		role.Rules = changedRoles[i].Rules
+		updatedRole, err := o.RoleClient.Update(role)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(o.Out, "clusterrole/%s\n", updatedRole.Name)
+	}
+
+	return nil
+}
+
+func (o *reconcileClusterOptions) ChangedClusterRoles() ([]*authorizationapi.ClusterRole, error) {
+	changedRoles := []*authorizationapi.ClusterRole{}
+
+	bootstrapClusterRoles := bootstrappolicy.GetBootstrapClusterRoles()
+	for i := range bootstrapClusterRoles {
+		expectedClusterRole := &bootstrapClusterRoles[i]
+
+		actualClusterRole, err := o.RoleClient.Get(expectedClusterRole.Name)
+		if kapierrors.IsNotFound(err) {
+			changedRoles = append(changedRoles, expectedClusterRole)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if !kapi.Semantic.DeepEqual(expectedClusterRole.Rules, actualClusterRole.Rules) {
+			changedRoles = append(changedRoles, expectedClusterRole)
+		}
+	}
+
+	return changedRoles, nil
+}

--- a/rel-eng/completions/bash/oadm
+++ b/rel-eng/completions/bash/oadm
@@ -370,6 +370,30 @@ _oadm_policy_remove-cluster-role-from-group()
     must_have_one_noun=()
 }
 
+_oadm_policy_reconcile-cluster-roles()
+{
+    last_command="oadm_policy_reconcile-cluster-roles"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--confirm")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--no-headers")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--output-version=")
+    flags+=("--template=")
+    two_word_flags+=("-t")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oadm_policy()
 {
     last_command="oadm_policy"
@@ -385,6 +409,7 @@ _oadm_policy()
     commands+=("remove-cluster-role-from-user")
     commands+=("add-cluster-role-to-group")
     commands+=("remove-cluster-role-from-group")
+    commands+=("reconcile-cluster-roles")
 
     flags=()
     two_word_flags=()

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -748,6 +748,30 @@ _openshift_admin_policy_remove-cluster-role-from-group()
     must_have_one_noun=()
 }
 
+_openshift_admin_policy_reconcile-cluster-roles()
+{
+    last_command="openshift_admin_policy_reconcile-cluster-roles"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--confirm")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--no-headers")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--output-version=")
+    flags+=("--template=")
+    two_word_flags+=("-t")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_admin_policy()
 {
     last_command="openshift_admin_policy"
@@ -763,6 +787,7 @@ _openshift_admin_policy()
     commands+=("remove-cluster-role-from-user")
     commands+=("add-cluster-role-to-group")
     commands+=("remove-cluster-role-from-group")
+    commands+=("reconcile-cluster-roles")
 
     flags=()
     two_word_flags=()


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3802.

This adds `oadm policy reconcile-cluster-roles`.  This command ensures that every recommended bootstrap cluster role exists with the correct ruleset.  You can pass an `-o yaml|json` to output what would be changed instead of actually  making the changes.  That list can then be passed to `oc replace --force` to make the changes.