### PR TITLE
Diff whole template for deployment config changes

### DIFF
--- a/pkg/deploy/controller/configchange/controller_test.go
+++ b/pkg/deploy/controller/configchange/controller_test.go
@@ -89,93 +89,84 @@ func TestHandle_newConfigTriggers(t *testing.T) {
 // config with a config change trigger results in a version bump and cause
 // update.
 func TestHandle_changeWithTemplateDiff(t *testing.T) {
-	var updated *deployapi.DeploymentConfig
-
-	controller := &DeploymentConfigChangeController{
-		decodeConfig: func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
-			return deployutil.DecodeDeploymentConfig(deployment, api.Codec)
-		},
-		changeStrategy: &changeStrategyImpl{
-			generateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
-				return deployapitest.OkDeploymentConfig(2), nil
-			},
-			updateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-				updated = config
-				return config, nil
-			},
-			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				deployment, _ := deployutil.MakeDeployment(deployapitest.OkDeploymentConfig(1), kapi.Codec)
-				return deployment, nil
+	scenarios := []struct {
+		name           string
+		modify         func(*deployapi.DeploymentConfig)
+		changeExpected bool
+	}{
+		{
+			name:           "container name change",
+			changeExpected: true,
+			modify: func(config *deployapi.DeploymentConfig) {
+				config.Template.ControllerTemplate.Template.Spec.Containers[1].Name = "modified"
 			},
 		},
-	}
-
-	config := deployapitest.OkDeploymentConfig(1)
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
-	config.Template.ControllerTemplate.Template.Spec.Containers[1].Name = "modified"
-	err := controller.Handle(config)
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if updated == nil {
-		t.Fatalf("expected config to be updated")
-	}
-
-	if e, a := 2, updated.LatestVersion; e != a {
-		t.Fatalf("expected update to latestversion=%d, got %d", e, a)
-	}
-
-	if updated.Details == nil {
-		t.Fatalf("expected config change details to be set")
-	} else if updated.Details.Causes == nil {
-		t.Fatalf("expected config change causes to be set")
-	} else if updated.Details.Causes[0].Type != deployapi.DeploymentTriggerOnConfigChange {
-		t.Fatalf("expected config change cause to be set to config change trigger, got %s", updated.Details.Causes[0].Type)
-	}
-}
-
-// TestHandle_changeWithoutTemplateDiff ensures that an updated config with no
-// pod template diff results in the config version remaining the same.
-func TestHandle_changeWithoutTemplateDiff(t *testing.T) {
-	config := deployapitest.OkDeploymentConfig(1)
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
-
-	generated := false
-	updated := false
-
-	controller := &DeploymentConfigChangeController{
-		decodeConfig: func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
-			return deployutil.DecodeDeploymentConfig(deployment, api.Codec)
+		{
+			name:           "template label change",
+			changeExpected: true,
+			modify: func(config *deployapi.DeploymentConfig) {
+				config.Template.ControllerTemplate.Template.Labels["newkey"] = "value"
+			},
 		},
-		changeStrategy: &changeStrategyImpl{
-			generateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
-				generated = true
-				return config, nil
-			},
-			updateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-				updated = true
-				return config, nil
-			},
-			getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
-				deployment, _ := deployutil.MakeDeployment(deployapitest.OkDeploymentConfig(1), kapi.Codec)
-				return deployment, nil
-			},
+		{
+			name:           "no diff",
+			changeExpected: false,
+			modify:         func(config *deployapi.DeploymentConfig) {},
 		},
 	}
 
-	err := controller.Handle(config)
+	for _, s := range scenarios {
+		t.Logf("running scenario: %s", s.name)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+		config := deployapitest.OkDeploymentConfig(1)
+		config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
+		deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
+		var updated *deployapi.DeploymentConfig
 
-	if generated {
-		t.Error("Unexpected generation of deploymentConfig")
-	}
+		controller := &DeploymentConfigChangeController{
+			decodeConfig: func(deployment *kapi.ReplicationController) (*deployapi.DeploymentConfig, error) {
+				return deployutil.DecodeDeploymentConfig(deployment, api.Codec)
+			},
+			changeStrategy: &changeStrategyImpl{
+				generateDeploymentConfigFunc: func(namespace, name string) (*deployapi.DeploymentConfig, error) {
+					return deployapitest.OkDeploymentConfig(2), nil
+				},
+				updateDeploymentConfigFunc: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
+					updated = config
+					return config, nil
+				},
+				getDeploymentFunc: func(namespace, name string) (*kapi.ReplicationController, error) {
+					return deployment, nil
+				},
+			},
+		}
 
-	if updated {
-		t.Error("Unexpected update of deploymentConfig")
+		s.modify(config)
+		err := controller.Handle(config)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if s.changeExpected {
+			if updated == nil {
+				t.Errorf("expected config to be updated")
+				continue
+			}
+			if e, a := 2, updated.LatestVersion; e != a {
+				t.Errorf("expected update to latestversion=%d, got %d", e, a)
+			}
+
+			if updated.Details == nil {
+				t.Errorf("expected config change details to be set")
+			} else if updated.Details.Causes == nil {
+				t.Errorf("expected config change causes to be set")
+			} else if updated.Details.Causes[0].Type != deployapi.DeploymentTriggerOnConfigChange {
+				t.Errorf("expected config change cause to be set to config change trigger, got %s", updated.Details.Causes[0].Type)
+			}
+		} else {
+			if updated != nil {
+				t.Errorf("unexpected update to version %d", updated.LatestVersion)
+			}
+		}
 	}
 }


### PR DESCRIPTION
When detecting triggered deployment config changes, diff the entire
pod template instead of just the spec contained in the template. This
is so that changes to labels and other ObjectMeta on the template will
result in a new deployment.

Fixes #3780