### PR TITLE
Allow viewers to use oc status

### DIFF
--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -306,6 +306,10 @@ wait_for_url_timed "http://${DOCKER_REGISTRY}/healthz" "[INFO] Docker registry s
 echo "[INFO] Logging in as a regular user (e2e-user:pass) with project 'test'..."
 oc login -u e2e-user -p pass
 [ "$(oc whoami | grep 'e2e-user')" ]
+ 
+# make sure viewers can see oc status
+oc status -n default
+
 oc project cache
 token=$(oc config view --flatten -o template -t '{{with index .users 0}}{{.user.token}}{{end}}')
 [[ -n ${token} ]]

--- a/pkg/api/graph/interfaces.go
+++ b/pkg/api/graph/interfaces.go
@@ -84,6 +84,9 @@ func (m ByNodeID) Less(i, j int) bool {
 	if m[i].Node == nil {
 		return true
 	}
+	if m[j].Node == nil {
+		return false
+	}
 	return m[i].Node.ID() < m[j].Node.ID()
 }
 

--- a/pkg/cmd/server/origin/handlers.go
+++ b/pkg/cmd/server/origin/handlers.go
@@ -124,7 +124,7 @@ func forbidden(reason string, attributes authorizer.AuthorizationAttributes, w h
 	if err != nil {
 		fmt.Fprintf(formatted, "%s", forbiddenError.Error())
 	} else {
-		_ = json.Indent(formatted, output, "", "  ")
+		json.Indent(formatted, output, "", "  ")
 	}
 
 	w.Header().Set("Content-Type", restful.MIME_JSON)


### PR DESCRIPTION
Viewers don't have rights to view secrets, so the list from oc status fails.  This pull makes us tolerate forbidden listings and keep track of which types weren't retrieved.

Later, we'll be able to cull the list of warnings based on nodes we weren't able to retrieve.

@ironcladlou @fabianofranz ptal