### PR TITLE
New-app: set name of image stream with --name argument

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -452,10 +452,8 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 		glog.V(2).Infof("found group: %#v", group)
 		common := app.PipelineGroup{}
 		for _, ref := range group {
-			if !ref.Input().ResolvedMatch.IsImage() {
-				continue
-			}
 			var pipeline *app.Pipeline
+			var name string
 			if ref.Input().ExpectToBuild {
 				glog.V(2).Infof("will use %q as the base image for a source build of %q", ref, ref.Input().Uses)
 				input, err := app.InputImageFromMatch(ref.Input().ResolvedMatch)
@@ -470,15 +468,20 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 					return nil, fmt.Errorf("can't build %q: %v", ref.Input(), err)
 				}
 				// Override resource names from the cli
-				if len(c.Name) > 0 {
-					source.Name = c.Name
-				}
-				if name, ok := (app.NameSuggestions{source, input}).SuggestName(); ok {
-					source.Name, err = ensureValidUniqueName(names, name)
-					if err != nil {
-						return nil, err
+				name = c.Name
+				if len(name) == 0 {
+					var ok bool
+					name, ok = (app.NameSuggestions{source, input}).SuggestName()
+					if !ok {
+						return nil, fmt.Errorf("can't suggest a valid name, please specify a name with --name")
 					}
 				}
+				name, err = ensureValidUniqueName(names, name)
+				source.Name = name
+				if err != nil {
+					return nil, err
+				}
+
 				// Append any exposed ports from Dockerfile to input image
 				if ref.Input().Uses.IsDockerBuild() {
 					exposed, ok := ref.Input().Uses.Info().Dockerfile.GetDirective("EXPOSE")
@@ -503,17 +506,24 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 				if err != nil {
 					return nil, fmt.Errorf("can't include %q: %v", ref.Input(), err)
 				}
-				if name, ok := input.SuggestName(); ok {
-					input.ObjectName, err = ensureValidUniqueName(names, name)
-					if err != nil {
-						return nil, err
+				name = c.Name
+				if len(name) == 0 {
+					var ok bool
+					name, ok = input.SuggestName()
+					if !ok {
+						return nil, fmt.Errorf("can't suggest a valid name, please specify a name with --name")
 					}
 				}
+				name, err = ensureValidUniqueName(names, name)
+				if err != nil {
+					return nil, err
+				}
+				input.ObjectName = name
 				if pipeline, err = app.NewImagePipeline(ref.Input().String(), input); err != nil {
 					return nil, fmt.Errorf("can't include %q: %v", ref.Input(), err)
 				}
 			}
-			if err := pipeline.NeedsDeployment(environment, c.Name); err != nil {
+			if err := pipeline.NeedsDeployment(environment, name); err != nil {
 				return nil, fmt.Errorf("can't set up a deployment for %q: %v", ref.Input(), err)
 			}
 			common = append(common, pipeline)
@@ -532,10 +542,6 @@ func (c *AppConfig) buildTemplates(components app.ComponentReferences, environme
 	objects := []runtime.Object{}
 
 	for _, ref := range components {
-		if !ref.Input().ResolvedMatch.IsTemplate() {
-			continue
-		}
-
 		tpl := ref.Input().ResolvedMatch.Template
 
 		glog.V(4).Infof("processing template %s/%s", c.originNamespace, tpl.Name)
@@ -746,7 +752,11 @@ func (c *AppConfig) run(out, errOut io.Writer, acceptors app.Acceptors) (*AppRes
 		return nil, ErrNoInputs
 	}
 
-	pipelines, err := c.buildPipelines(components, app.Environment(environment))
+	if len(components.ImageComponentRefs()) > 1 && len(c.Name) > 0 {
+		return nil, fmt.Errorf("only one component or source repository can be used when specifying a name")
+	}
+
+	pipelines, err := c.buildPipelines(components.ImageComponentRefs(), app.Environment(environment))
 	if err != nil {
 		return nil, err
 	}
@@ -770,7 +780,7 @@ func (c *AppConfig) run(out, errOut io.Writer, acceptors app.Acceptors) (*AppRes
 
 	objects = app.AddServices(objects, false)
 
-	templateObjects, err := c.buildTemplates(components, app.Environment(parameters))
+	templateObjects, err := c.buildTemplates(components.TemplateComponentRefs(), app.Environment(parameters))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -681,6 +681,44 @@ func TestRunAll(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			name: "custom name",
+			config: &AppConfig{
+				DockerImages: util.StringList{"mysql"},
+				dockerSearcher: app.DockerClientSearcher{
+					Client: &dockertools.FakeDockerClient{
+						Images: []docker.APIImages{{RepoTags: []string{"mysql"}}},
+						Image: &docker.Image{
+							Config: &docker.Config{
+								ExposedPorts: map[docker.Port]struct{}{
+									"8080/tcp": {},
+								},
+							},
+						},
+					},
+				},
+				imageStreamSearcher: app.ImageStreamSearcher{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				templateSearcher: app.TemplateSearcher{
+					Client: &client.Fake{},
+					TemplateConfigsNamespacer: &client.Fake{},
+					Namespaces:                []string{"openshift", "default"},
+				},
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+				Name:            "custom",
+			},
+			expected: map[string][]string{
+				"imageStream":      {"custom"},
+				"deploymentConfig": {"custom"},
+				"service":          {"custom"},
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -57,14 +57,35 @@ type ComponentReference interface {
 // ComponentReferences is a set of components
 type ComponentReferences []ComponentReference
 
-// NeedsSource returns all the components that need source code in order to build
-func (r ComponentReferences) NeedsSource() (refs ComponentReferences) {
+func (r ComponentReferences) filter(filterFunc func(ref ComponentReference) bool) ComponentReferences {
+	refs := ComponentReferences{}
 	for _, ref := range r {
-		if ref.NeedsSource() {
+		if filterFunc(ref) {
 			refs = append(refs, ref)
 		}
 	}
-	return
+	return refs
+}
+
+// NeedsSource returns all the components that need source code in order to build
+func (r ComponentReferences) NeedsSource() (refs ComponentReferences) {
+	return r.filter(func(ref ComponentReference) bool {
+		return ref.NeedsSource()
+	})
+}
+
+// ImageComponentRefs returns the list of component references to images
+func (r ComponentReferences) ImageComponentRefs() (refs ComponentReferences) {
+	return r.filter(func(ref ComponentReference) bool {
+		return ref.Input() != nil && ref.Input().ResolvedMatch != nil && ref.Input().ResolvedMatch.IsImage()
+	})
+}
+
+// TemplateComponentRefs returns the list of component references to templates
+func (r ComponentReferences) TemplateComponentRefs() (refs ComponentReferences) {
+	return r.filter(func(ref ComponentReference) bool {
+		return ref.Input() != nil && ref.Input().ResolvedMatch != nil && ref.Input().ResolvedMatch.IsTemplate()
+	})
 }
 
 func (r ComponentReferences) String() string {


### PR DESCRIPTION
Changes current behavior to set name of the image stream when creating a component from an image or source. Also displays error if --name is set when specifying multiple images or source repositories.

Fixes https://github.com/openshift/origin/issues/3770