### PR TITLE
Add Cache-Control header to assets

### DIFF
--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -73,6 +73,8 @@ func CacheControlHandler(version string, h http.Handler) http.Handler {
 			return
 		}
 
+		// Clients must revalidate their cached copy every time.
+		w.Header().Add("Cache-Control", "public, max-age=0, must-revalidate")
 		w.Header().Add("ETag", etag)
 		h.ServeHTTP(w, r)
 


### PR DESCRIPTION
Fixes #3007

`Cache-Control: no-cache` forces clients to revalidate ETags using `If-None-Match` each time the Web Console is loaded.

<img width="551" alt="openshift_web_console_and_comparing_openshift_master___spadgett_no-cache_ _openshift_origin" src="https://cloud.githubusercontent.com/assets/1167259/8835296/956c06ea-3087-11e5-9535-06232b77ea50.png">

First load:

<img width="1041" alt="openshift_web_console_and_openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/8835224/19602338-3087-11e5-8050-3b330c091ecf.png">

Second load:

<img width="1033" alt="openshift_web_console_and_openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/8835231/2522de4a-3087-11e5-9aa3-e60f8f060562.png">

I've verified that after a new commit and build, the client gets the new version.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1

> no-cache
> If the no-cache directive does not specify a field-name, then a cache MUST NOT use the response to satisfy a subsequent request without successful revalidation with the origin server.
