### PR TITLE
Fix unit test for Retry service account update when adding token reference

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller.go
@@ -30,9 +30,12 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/registry/secret"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util/wait"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
 	"github.com/golang/glog"
 )
+
+const NumServiceAccountRemoveReferenceRetries = 10
 
 // TokensControllerOptions contains options for the TokensController
 type TokensControllerOptions struct {
@@ -238,8 +241,16 @@ func (e *TokensController) secretDeleted(obj interface{}) {
 		return
 	}
 
-	if _, err := e.removeSecretReferenceIfNeeded(serviceAccount, secret.Name); err != nil {
-		glog.Error(err)
+	for i := 1; i <= NumServiceAccountRemoveReferenceRetries; i++ {
+		if _, err := e.removeSecretReferenceIfNeeded(serviceAccount, secret.Name); err != nil {
+			if apierrors.IsConflict(err) && i < NumServiceAccountRemoveReferenceRetries {
+				time.Sleep(wait.Jitter(100*time.Millisecond, 0.0))
+				continue
+			}
+			glog.Error(err)
+			break
+		}
+		break
 	}
 }
 
@@ -273,6 +284,21 @@ func (e *TokensController) createSecretIfNeeded(serviceAccount *api.ServiceAccou
 
 // createSecret creates a secret of type ServiceAccountToken for the given ServiceAccount
 func (e *TokensController) createSecret(serviceAccount *api.ServiceAccount) error {
+	// We don't want to update the cache's copy of the service account
+	// so add the secret to a freshly retrieved copy of the service account
+	serviceAccounts := e.client.ServiceAccounts(serviceAccount.Namespace)
+	liveServiceAccount, err := serviceAccounts.Get(serviceAccount.Name)
+	if err != nil {
+		return err
+	}
+	if liveServiceAccount.ResourceVersion != serviceAccount.ResourceVersion {
+		// our view of the service account is not up to date
+		// we'll get notified of an update event later and get to try again
+		// this only prevent interactions between successive runs of this controller's event handlers, but that is useful
+		glog.V(2).Infof("View of ServiceAccount %s/%s is not up to date, skipping token creation", serviceAccount.Namespace, serviceAccount.Name)
+		return nil
+	}
+
 	// Build the secret
 	secret := &api.Secret{
 		ObjectMeta: api.ObjectMeta{
@@ -302,16 +328,9 @@ func (e *TokensController) createSecret(serviceAccount *api.ServiceAccount) erro
 		return err
 	}
 
-	// We don't want to update the cache's copy of the service account
-	// so add the secret to a freshly retrieved copy of the service account
-	serviceAccounts := e.client.ServiceAccounts(serviceAccount.Namespace)
-	serviceAccount, err = serviceAccounts.Get(serviceAccount.Name)
-	if err != nil {
-		return err
-	}
-	serviceAccount.Secrets = append(serviceAccount.Secrets, api.ObjectReference{Name: secret.Name})
+	liveServiceAccount.Secrets = append(liveServiceAccount.Secrets, api.ObjectReference{Name: secret.Name})
 
-	_, err = serviceAccounts.Update(serviceAccount)
+	_, err = serviceAccounts.Update(liveServiceAccount)
 	if err != nil {
 		// we weren't able to use the token, try to clean it up.
 		glog.V(2).Infof("Deleting secret %s/%s because reference couldn't be added (%v)", secret.Namespace, secret.Name, err)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/tokens_controller_test.go
@@ -77,6 +77,13 @@ func serviceAccount(secretRefs []api.ObjectReference) *api.ServiceAccount {
 	}
 }
 
+// updatedServiceAccount returns a service account with the resource version modified
+func updatedServiceAccount(secretRefs []api.ObjectReference) *api.ServiceAccount {
+	sa := serviceAccount(secretRefs)
+	sa.ResourceVersion = "2"
+	return sa
+}
+
 // opaqueSecret returns a persisted non-ServiceAccountToken secret named "regular-secret-1"
 func opaqueSecret() *api.Secret {
 	return &api.Secret{
@@ -163,8 +170,8 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
 			},
 		},
@@ -175,8 +182,8 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
 			},
 		},
@@ -185,8 +192,8 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(missingSecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(missingSecretReferences()))},
 			},
 		},
@@ -203,8 +210,8 @@ func TestTokenCreation(t *testing.T) {
 
 			AddedServiceAccount: serviceAccount(regularSecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(regularSecretReferences()))},
 			},
 		},
@@ -215,14 +222,22 @@ func TestTokenCreation(t *testing.T) {
 			AddedServiceAccount: serviceAccount(tokenSecretReferences()),
 			ExpectedActions:     []testclient.FakeAction{},
 		},
+		"new serviceaccount with no secrets with resource conflict": {
+			ClientObjects: []runtime.Object{updatedServiceAccount(emptySecretReferences()), createdTokenSecret()},
+
+			AddedServiceAccount: serviceAccount(emptySecretReferences()),
+			ExpectedActions: []testclient.FakeAction{
+				{Action: "get-serviceaccount", Value: "default"},
+			},
+		},
 
 		"updated serviceaccount with no secrets": {
 			ClientObjects: []runtime.Object{serviceAccount(emptySecretReferences()), createdTokenSecret()},
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
 			},
 		},
@@ -233,8 +248,8 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(emptySecretReferences()))},
 			},
 		},
@@ -243,8 +258,8 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(missingSecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(missingSecretReferences()))},
 			},
 		},
@@ -261,8 +276,8 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(regularSecretReferences()),
 			ExpectedActions: []testclient.FakeAction{
-				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "get-serviceaccount", Value: "default"},
+				{Action: "create-secret", Value: createdTokenSecret()},
 				{Action: "update-serviceaccount", Value: serviceAccount(addTokenSecretReference(regularSecretReferences()))},
 			},
 		},
@@ -271,6 +286,14 @@ func TestTokenCreation(t *testing.T) {
 
 			UpdatedServiceAccount: serviceAccount(tokenSecretReferences()),
 			ExpectedActions:       []testclient.FakeAction{},
+		},
+		"updated serviceaccount with no secrets with resource conflict": {
+			ClientObjects: []runtime.Object{updatedServiceAccount(emptySecretReferences()), createdTokenSecret()},
+
+			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
+			ExpectedActions: []testclient.FakeAction{
+				{Action: "get-serviceaccount", Value: "default"},
+			},
 		},
 
 		"deleted serviceaccount with no secrets": {


### PR DESCRIPTION
ServiceAccount unit test fix-up.

```
[deads@deads-dev-01 origin]$ hack/test-go.sh ./Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount
ok  	github.com/openshift/origin/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount	0.263s
```

@pmorie as per your request.