### PR TITLE
UPSTREAM: <carry>: Correct v1 deep_copy_generated.go

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1376,6 +1376,10 @@ func deepCopy_v1_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error {
 	} else {
 		out.ImagePullSecrets = nil
 	}
+
+	// Carry copy
+	out.DeprecatedHost = in.DeprecatedHost
+	out.DeprecatedServiceAccount = in.DeprecatedServiceAccount
 	return nil
 }
 
@@ -2025,6 +2029,9 @@ func deepCopy_v1_ServiceSpec(in ServiceSpec, out *ServiceSpec, c *conversion.Clo
 		out.DeprecatedPublicIPs = nil
 	}
 	out.SessionAffinity = in.SessionAffinity
+
+	// Carry copy
+	out.DeprecatedPortalIP = in.DeprecatedPortalIP
 	return nil
 }
 


### PR DESCRIPTION
@deads2k @liggitt @smarterclayton 

This was missed in https://github.com/openshift/origin/commit/31d30984203f8db8c7eea0e05d132db1b312db78