### PR TITLE
Fix incorrect ENV["VAGRANT_LIBVIRT_URI"] if statement

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -226,7 +226,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       libvirt.memory      = vagrant_openshift_config['memory'].to_i
       libvirt.cpus        = vagrant_openshift_config['cpus'].to_i
       # run on libvirt somewhere other than default:
-      libvirt.uri         = ENV["VAGRANT_LIBVIRT_URI"] if defined? ENV["VAGRANT_LIBVIRT_URI"] 
+      libvirt.uri         = ENV["VAGRANT_LIBVIRT_URI"] if ENV["VAGRANT_LIBVIRT_URI"]
       full_provision(override.vm)
     end if vagrant_openshift_config['libvirt']
 


### PR DESCRIPTION
 which causes "Mssing required arguments: libvirt_uri (ArgumentError)" if the env is undefined.