### PR TITLE
fix colliding serial numbers in certs

### DIFF
--- a/pkg/cmd/server/admin/signer_cert_args.go
+++ b/pkg/cmd/server/admin/signer_cert_args.go
@@ -30,7 +30,7 @@ func BindSignerCertOptions(options *SignerCertOptions, flags *pflag.FlagSet, pre
 	cobra.MarkFlagFilename(flags, prefix+"signer-serial")
 }
 
-func (o SignerCertOptions) Validate() error {
+func (o *SignerCertOptions) Validate() error {
 	if len(o.CertFile) == 0 {
 		return errors.New("signer-cert must be provided")
 	}
@@ -44,7 +44,7 @@ func (o SignerCertOptions) Validate() error {
 	return nil
 }
 
-func (o SignerCertOptions) CA() (*crypto.CA, error) {
+func (o *SignerCertOptions) CA() (*crypto.CA, error) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	if o.ca != nil {


### PR DESCRIPTION
The method receiver was "by value", resulting in a copy of the mutex, so it didn't correctly lock.

Fixes:
```
curl: (35) You are attempting to import a cert with the same issuer/serial as an existing cert, but that is not the same cert.
```

@bparees or @smarterclayton ptal