### PR TITLE
Fix osc-key-value control silently eating duplicate keys in web console.

### DIFF
--- a/assets/app/scripts/directives/oscKeyValues.js
+++ b/assets/app/scripts/directives/oscKeyValues.js
@@ -21,6 +21,7 @@ angular.module("openshiftConsole")
   })
   .controller("KeyValuesController", function($scope){
     var added = {};
+    $scope.canAdd = false;
     $scope.allowDelete = function(value){
       if($scope.deletePolicy === "never") {
         return false;
@@ -32,25 +33,33 @@ angular.module("openshiftConsole")
     };
     $scope.addEntry = function() {
       if($scope.key && $scope.value){
-       var readonly = $scope.readonlyKeys.split(",");
-       if(readonly.indexOf($scope.key) !== -1){
-         return;
-       }
-       added[$scope.key] = "";
-       $scope.entries[$scope.key] = $scope.value;
-       $scope.key = null;
-       $scope.value = null;
-       $scope.form.$setPristine();
-       $scope.form.$setUntouched();
-       $scope.form.$setValidity();
+        added[$scope.key] = "";
+        $scope.entries[$scope.key] = $scope.value;
+        $scope.key = null;
+        $scope.value = null;
+        $scope.form.$setPristine();
+        $scope.form.$setUntouched();
+        $scope.form.$setValidity();
       }
-     };
-     $scope.deleteEntry = function(key) {
+    };
+    $scope.deleteEntry = function(key) {
        if ($scope.entries[key]) {
          delete $scope.entries[key];
          delete added[key];
        }
-     };
+    };
+    $scope.toggleAdd = function() {
+      var key = $scope.key;
+      var val = $scope.value;
+      var readonly = $scope.readonlyKeys.split(",");
+      var entries = $scope.entries;
+      var keyExists = _.has($scope.entries, key) || _.contains(readonly, key);
+      if(!key || !val || keyExists) {
+        $scope.canAdd = false;
+      } else {
+        $scope.canAdd = true;
+      }
+    };
   })
   .directive("oscInputValidator", function(){
 

--- a/assets/app/views/directives/osc-key-values.html
+++ b/assets/app/views/directives/osc-key-values.html
@@ -2,18 +2,27 @@
     <div class="form-inline labels-edit" ng-show="editable">
       <form class="edit-label" name="form" novalidate>
         <div class='form-group' ng-class="{'has-error': form.key.$error.oscKeyValid}">
-          <input class="form-control" type="text" name="key" placeholder="{{keyTitle}}" ng-model="key" 
+          <input class="form-control"
+                 type="text"
+                 name="key"
+                 placeholder="{{keyTitle}}"
+                 ng-model="key"
+                 ng-keyup="toggleAdd()"
                  osc-input-validator="key">
         </div>
         <div class="form-group" ng-class="{'has-error': form.value.$error.oscValueValid}">
-          <input class="form-control" 
+          <input class="form-control"
                  type="text"
-                 name="value" 
+                 name="value"
                  placeholder="Value"
-                 ng-model="value" 
+                 ng-model="value"
+                 ng-keyup="toggleAdd()"
                  osc-input-validator="value">
         </div>
-        <button class="btn btn-default" ng-click="addEntry()" ng-disabled="form.key.$error.oscKeyValid || form.value.$error.oscValueValid">Add</button>
+        <button
+          class="btn btn-default"
+          ng-click="addEntry()"
+          ng-disabled="(!canAdd) || form.key.$error.oscKeyValid || form.value.$error.oscValueValid">Add</button>
         <div class="has-error" ng-show="form.key.$error.oscKeyValid">
           <span class="help-block">Please enter a valid key
             <span class="help action-inline" ng-if="keyValidationTooltip">
@@ -23,7 +32,7 @@
               </a>
             </span>
           </span>
-        </div>      
+        </div>
         <div class="has-error" ng-show="form.value.$error.oscValueValid">
           <span class="help-block">Please enter a valid value
             <span class="help action-inline" ng-if="keyValidationTooltip">
@@ -33,7 +42,7 @@
               </a>
             </span>
           </span>
-        </div>      
+        </div>
       </form>
       <ul class="list-unstyled label-list">
         <li ng-repeat="(key,value) in entries | valuesIn:readonlyKeys">


### PR DESCRIPTION
Re #3436 fixes the issue by toggling the button state as the user enters values in the inputs.  

@liggitt or @jwforres 