### PR TITLE
Fix registry file descriptor leaks

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,6 +37,7 @@ type Interface interface {
 	SubjectAccessReviewsNamespacer
 	SubjectAccessReviewsImpersonator
 	ClusterSubjectAccessReviews
+	ClusterSubjectAccessReviewsImpersonator
 	TemplatesNamespacer
 	TemplateConfigsNamespacer
 	OAuthAccessTokensInterface
@@ -187,7 +188,12 @@ func (c *Client) ImpersonateSubjectAccessReviews(namespace, token string) Subjec
 
 // ClusterSubjectAccessReviews provides a REST client for SubjectAccessReviews
 func (c *Client) ClusterSubjectAccessReviews() SubjectAccessReviewInterface {
-	return newClusterSubjectAccessReviews(c)
+	return newClusterSubjectAccessReviews(c, "")
+}
+
+// ImpersonateClusterSubjectAccessReviews provides a REST client for SubjectAccessReviews
+func (c *Client) ImpersonateClusterSubjectAccessReviews(token string) SubjectAccessReviewInterface {
+	return newClusterSubjectAccessReviews(c, token)
 }
 
 // OAuthAccessTokens provides a REST client for OAuthAccessTokens

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,6 +35,7 @@ type Interface interface {
 	ResourceAccessReviewsNamespacer
 	ClusterResourceAccessReviews
 	SubjectAccessReviewsNamespacer
+	SubjectAccessReviewsImpersonator
 	ClusterSubjectAccessReviews
 	TemplatesNamespacer
 	TemplateConfigsNamespacer
@@ -176,7 +177,12 @@ func (c *Client) ClusterResourceAccessReviews() ResourceAccessReviewInterface {
 
 // SubjectAccessReviews provides a REST client for SubjectAccessReviews
 func (c *Client) SubjectAccessReviews(namespace string) SubjectAccessReviewInterface {
-	return newSubjectAccessReviews(c, namespace)
+	return newSubjectAccessReviews(c, namespace, "")
+}
+
+// ImpersonateSubjectAccessReviews provides a REST client for SubjectAccessReviews
+func (c *Client) ImpersonateSubjectAccessReviews(namespace, token string) SubjectAccessReviewInterface {
+	return newSubjectAccessReviews(c, namespace, token)
 }
 
 // ClusterSubjectAccessReviews provides a REST client for SubjectAccessReviews

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,7 @@ type Interface interface {
 	BuildLogsNamespacer
 	ImagesInterfacer
 	ImageStreamsNamespacer
+	ImageStreamsImpersonator
 	ImageStreamMappingsNamespacer
 	ImageStreamTagsNamespacer
 	ImageStreamImagesNamespacer
@@ -29,6 +30,7 @@ type Interface interface {
 	ClusterNetworkingInterface
 	IdentitiesInterface
 	UsersInterface
+	UsersImpersonator
 	UserIdentityMappingsInterface
 	ProjectsInterface
 	ProjectRequestsInterface
@@ -73,7 +75,12 @@ func (c *Client) Images() ImageInterface {
 
 // ImageStreams provides a REST client for ImageStream
 func (c *Client) ImageStreams(namespace string) ImageStreamInterface {
-	return newImageStreams(c, namespace)
+	return newImageStreams(c, namespace, "")
+}
+
+// ImpersonateImageStreams provides a REST client for ImageStream
+func (c *Client) ImpersonateImageStreams(namespace, token string) ImageStreamInterface {
+	return newImageStreams(c, namespace, token)
 }
 
 // ImageStreamMappings provides a REST client for ImageStreamMapping
@@ -113,7 +120,12 @@ func (c *Client) ClusterNetwork() ClusterNetworkInterface {
 
 // Users provides a REST client for User
 func (c *Client) Users() UserInterface {
-	return newUsers(c)
+	return newUsers(c, "")
+}
+
+// ImpersonateUsers provides a REST client for User
+func (c *Client) ImpersonateUsers(token string) UserInterface {
+	return newUsers(c, token)
 }
 
 // Identities provides a REST client for Identity

--- a/pkg/client/subjectaccessreview.go
+++ b/pkg/client/subjectaccessreview.go
@@ -1,12 +1,20 @@
 package client
 
 import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
+
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
 // SubjectAccessReviewsNamespacer has methods to work with SubjectAccessReview resources in a namespace
 type SubjectAccessReviewsNamespacer interface {
 	SubjectAccessReviews(namespace string) SubjectAccessReviewInterface
+}
+
+type SubjectAccessReviewsImpersonator interface {
+	ImpersonateSubjectAccessReviews(namespace, token string) SubjectAccessReviewInterface
 }
 
 // ClusterSubjectAccessReviews has methods to work with SubjectAccessReview resources in the cluster scope
@@ -21,22 +29,24 @@ type SubjectAccessReviewInterface interface {
 
 // subjectAccessReviews implements SubjectAccessReviewsNamespacer interface
 type subjectAccessReviews struct {
-	r  *Client
-	ns string
+	r     *Client
+	ns    string
+	token string
 }
 
 // newSubjectAccessReviews returns a subjectAccessReviews
-func newSubjectAccessReviews(c *Client, namespace string) *subjectAccessReviews {
+func newSubjectAccessReviews(c *Client, namespace, token string) *subjectAccessReviews {
 	return &subjectAccessReviews{
-		r:  c,
-		ns: namespace,
+		r:     c,
+		ns:    namespace,
+		token: token,
 	}
 }
 
 // Create creates new policy. Returns the server's representation of the policy and error if one occurs.
 func (c *subjectAccessReviews) Create(policy *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
 	result = &authorizationapi.SubjectAccessReviewResponse{}
-	err = c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews").Body(policy).Do().Into(result)
+	err = overrideAuth(c.token, c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews")).Body(policy).Do().Into(result)
 	return
 }
 
@@ -57,4 +67,11 @@ func (c *clusterSubjectAccessReviews) Create(policy *authorizationapi.SubjectAcc
 	result = &authorizationapi.SubjectAccessReviewResponse{}
 	err = c.r.Post().Resource("subjectAccessReviews").Body(policy).Do().Into(result)
 	return
+}
+
+func overrideAuth(token string, req *client.Request) *client.Request {
+	if len(token) > 0 {
+		req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+	return req
 }

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -184,6 +184,11 @@ func (c *Fake) SubjectAccessReviews(namespace string) client.SubjectAccessReview
 	return &FakeSubjectAccessReviews{Fake: c}
 }
 
+// ImpersonateSubjectAccessReviews provides a fake REST client for SubjectAccessReviews
+func (c *Fake) ImpersonateSubjectAccessReviews(namespace, token string) client.SubjectAccessReviewInterface {
+	return &FakeSubjectAccessReviews{Fake: c}
+}
+
 // OAuthAccessTokens provides a fake REST client for OAuthAccessTokens
 func (c *Fake) OAuthAccessTokens() client.OAuthAccessTokenInterface {
 	return &FakeOAuthAccessTokens{Fake: c}
@@ -191,6 +196,11 @@ func (c *Fake) OAuthAccessTokens() client.OAuthAccessTokenInterface {
 
 // ClusterSubjectAccessReviews provides a fake REST client for ClusterSubjectAccessReviews
 func (c *Fake) ClusterSubjectAccessReviews() client.SubjectAccessReviewInterface {
+	return &FakeClusterSubjectAccessReviews{Fake: c}
+}
+
+// ImpersonateClusterSubjectAccessReviews provides a fake REST client for ClusterSubjectAccessReviews
+func (c *Fake) ImpersonateClusterSubjectAccessReviews(token string) client.SubjectAccessReviewInterface {
 	return &FakeClusterSubjectAccessReviews{Fake: c}
 }
 

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -79,6 +79,11 @@ func (c *Fake) ImageStreams(namespace string) client.ImageStreamInterface {
 	return &FakeImageStreams{Fake: c, Namespace: namespace}
 }
 
+// ImpersonateImageStreams provides a fake REST client for ImageStreams
+func (c *Fake) ImpersonateImageStreams(namespace, token string) client.ImageStreamInterface {
+	return &FakeImageStreams{Fake: c, Namespace: namespace}
+}
+
 // ImageStreamMappings provides a fake REST client for ImageStreamMappings
 func (c *Fake) ImageStreamMappings(namespace string) client.ImageStreamMappingInterface {
 	return &FakeImageStreamMappings{Fake: c, Namespace: namespace}
@@ -131,6 +136,11 @@ func (c *Fake) Identities() client.IdentityInterface {
 
 // Users provides a fake REST client for Users
 func (c *Fake) Users() client.UserInterface {
+	return &FakeUsers{Fake: c}
+}
+
+// ImpersonateUsers provides a fake REST client for Users
+func (c *Fake) ImpersonateUsers(token string) client.UserInterface {
 	return &FakeUsers{Fake: c}
 }
 

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -42,6 +42,10 @@ func Execute(configFile io.Reader) {
 
 	app := handlers.NewApp(ctx, *config)
 
+	if err := server.NewRegistryOpenShiftClient(); err != nil {
+		log.Fatalf("Error creating OpenShift client: %v", err)
+	}
+
 	// register OpenShift routes
 	// TODO: change this to an anonymous Access record
 	app.RegisterRoute(app.NewRoute().Path("/healthz"), server.HealthzHandler, handlers.NameNotRequired, handlers.NoCustomAccessRecords)

--- a/pkg/dockerregistry/server/openshiftclient.go
+++ b/pkg/dockerregistry/server/openshiftclient.go
@@ -22,28 +22,31 @@ func NewUserOpenShiftClient(bearerToken string) (*osclient.Client, error) {
 	return client, nil
 }
 
-func NewRegistryOpenShiftClient() (*osclient.Client, error) {
+var registryClient *osclient.Client
+
+func NewRegistryOpenShiftClient() error {
 	config, err := openShiftClientConfig()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if !config.Insecure {
 		certData := os.Getenv("OPENSHIFT_CERT_DATA")
 		if len(certData) == 0 {
-			return nil, errors.New("OPENSHIFT_CERT_DATA is required")
+			return errors.New("OPENSHIFT_CERT_DATA is required")
 		}
 		certKeyData := os.Getenv("OPENSHIFT_KEY_DATA")
 		if len(certKeyData) == 0 {
-			return nil, errors.New("OPENSHIFT_KEY_DATA is required")
+			return errors.New("OPENSHIFT_KEY_DATA is required")
 		}
 		config.TLSClientConfig.CertData = []byte(certData)
 		config.TLSClientConfig.KeyData = []byte(certKeyData)
 	}
 	client, err := osclient.New(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating OpenShift client: %s", err)
+		return fmt.Errorf("error creating OpenShift client: %s", err)
 	}
-	return client, nil
+	registryClient = client
+	return nil
 }
 
 func openShiftClientConfig() (*kclient.Config, error) {


### PR DESCRIPTION
Use token impersonation whenever the registry talks to OpenShift so there's ever only a single Client created, instead of 2 per request.

Fixes #3569 