### PR TITLE
Newapp: Use labels for deployment config and service selectors

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -148,13 +148,14 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 
 		return printHumanReadableSearchResult(result, out, fullName)
 	}
-
+	if err := setAppConfigLabels(c, config); err != nil {
+		return err
+	}
 	result, err := config.RunAll(out, c.Out())
 	if err != nil {
 		return handleRunError(c, err)
 	}
-
-	if err := setLabels(c, result); err != nil {
+	if err := setLabels(config.Labels, result); err != nil {
 		return err
 	}
 	if len(cmdutil.GetFlagString(c, "output")) != 0 {
@@ -190,6 +191,18 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 	return nil
 }
 
+func setAppConfigLabels(c *cobra.Command, config *newcmd.AppConfig) error {
+	labelStr := cmdutil.GetFlagString(c, "labels")
+	if len(labelStr) != 0 {
+		var err error
+		config.Labels, err = ctl.ParseLabels(labelStr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func setupAppConfig(f *clientcmd.Factory, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
 	namespace, _, err := f.DefaultNamespace()
 	if err != nil {
@@ -220,21 +233,16 @@ func setupAppConfig(f *clientcmd.Factory, c *cobra.Command, args []string, confi
 	return nil
 }
 
-func setLabels(c *cobra.Command, result *newcmd.AppResult) error {
-	label := cmdutil.GetFlagString(c, "labels")
-	if len(label) != 0 {
-		lbl, err := ctl.ParseLabels(label)
+func setLabels(labels map[string]string, result *newcmd.AppResult) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	for _, object := range result.List.Items {
+		err := util.AddObjectLabels(object, labels)
 		if err != nil {
 			return err
 		}
-		for _, object := range result.List.Items {
-			err = util.AddObjectLabels(object, lbl)
-			if err != nil {
-				return err
-			}
-		}
 	}
-
 	return nil
 }
 

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -75,6 +75,9 @@ func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, c *cobra.
 		return err
 	}
 
+	if err := setAppConfigLabels(c, config); err != nil {
+		return err
+	}
 	result, err := config.RunBuilds(out, c.Out())
 	if err != nil {
 		if errs, ok := err.(errors.Aggregate); ok {
@@ -88,8 +91,7 @@ func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, c *cobra.
 		}
 		return err
 	}
-
-	if err := setLabels(c, result); err != nil {
+	if err := setLabels(config.Labels, result); err != nil {
 		return err
 	}
 	if len(cmdutil.GetFlagString(c, "output")) != 0 {

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -246,11 +246,12 @@ func TestBuildTemplates(t *testing.T) {
 
 func TestEnsureHasSource(t *testing.T) {
 	tests := []struct {
-		name         string
-		cfg          AppConfig
-		components   app.ComponentReferences
-		repositories []*app.SourceRepository
-		expectedErr  string
+		name              string
+		cfg               AppConfig
+		components        app.ComponentReferences
+		repositories      []*app.SourceRepository
+		expectedErr       string
+		dontExpectToBuild bool
 	}{
 		{
 			name: "One requiresSource, multiple repositories",
@@ -282,8 +283,9 @@ func TestEnsureHasSource(t *testing.T) {
 					ExpectToBuild: true,
 				}),
 			},
-			repositories: []*app.SourceRepository{},
-			expectedErr:  "you must specify a repository via --code",
+			repositories:      []*app.SourceRepository{},
+			expectedErr:       "",
+			dontExpectToBuild: true,
 		},
 		{
 			name: "Multiple requiresSource, no repositories",
@@ -295,8 +297,9 @@ func TestEnsureHasSource(t *testing.T) {
 					ExpectToBuild: true,
 				}),
 			},
-			repositories: []*app.SourceRepository{},
-			expectedErr:  "you must provide at least one source code repository",
+			repositories:      []*app.SourceRepository{},
+			expectedErr:       "",
+			dontExpectToBuild: true,
 		},
 		{
 			name: "Successful - one repository",
@@ -328,6 +331,13 @@ func TestEnsureHasSource(t *testing.T) {
 			}
 		} else if len(test.expectedErr) != 0 {
 			t.Errorf("%s: Expected %s error but got none", test.name, test.expectedErr)
+		}
+		if test.dontExpectToBuild {
+			for _, comp := range test.components {
+				if comp.NeedsSource() {
+					t.Errorf("%s: expected component reference to not require source.", test.name)
+				}
+			}
 		}
 	}
 }
@@ -448,6 +458,15 @@ func TestDetectSource(t *testing.T) {
 	}
 }
 
+func mapContains(a, b map[string]string) bool {
+	for k, v := range a {
+		if v2, exists := b[k]; !exists || v != v2 {
+			return false
+		}
+	}
+	return true
+}
+
 func TestRunAll(t *testing.T) {
 	dockerSearcher := app.DockerRegistrySearcher{
 		Client: dockerregistry.NewClient(),
@@ -486,6 +505,42 @@ func TestRunAll(t *testing.T) {
 				typer:           kapi.Scheme,
 				osclient:        &client.Fake{},
 				originNamespace: "default",
+			},
+			expected: map[string][]string{
+				"imageStream":      {"ruby-hello-world", "ruby"},
+				"buildConfig":      {"ruby-hello-world"},
+				"deploymentConfig": {"ruby-hello-world"},
+				"service":          {"ruby-hello-world"},
+			},
+			expectedVolumes: nil,
+			expectedErr:     nil,
+		},
+		{
+			name: "successful ruby app generation with labels",
+			config: &AppConfig{
+				SourceRepositories: util.StringList{"https://github.com/openshift/ruby-hello-world"},
+
+				dockerSearcher: fakeDockerSearcher(),
+				imageStreamSearcher: app.ImageStreamSearcher{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				Strategy:                        "source",
+				imageStreamByAnnotationSearcher: app.NewImageStreamByAnnotationSearcher(&client.Fake{}, &client.Fake{}, []string{"default"}),
+				templateSearcher: app.TemplateSearcher{
+					Client: &client.Fake{},
+					TemplateConfigsNamespacer: &client.Fake{},
+					Namespaces:                []string{"openshift", "default"},
+				},
+				detector: app.SourceRepositoryEnumerator{
+					Detectors: source.DefaultDetectors,
+					Tester:    dockerfile.NewTester(),
+				},
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+				Labels:          map[string]string{"label1": "value1", "label2": "value2"},
 			},
 			expected: map[string][]string{
 				"imageStream":      {"ruby-hello-world", "ruby"},
@@ -746,6 +801,12 @@ func TestRunAll(t *testing.T) {
 						t.Errorf("%s: did not get expected port in service. Expected: %d. Got %d\n", expectedPort, tp.Spec.Ports[0].Port)
 					}
 				}
+				if test.config.Labels != nil {
+					if !mapContains(test.config.Labels, tp.Spec.Selector) {
+						t.Errorf("%s: did not get expected service selector. Expected: %v. Got: %v",
+							test.name, test.config.Labels, tp.Spec.Selector)
+					}
+				}
 				got["service"] = append(got["service"], tp.Name)
 			case *imageapi.ImageStream:
 				got["imageStream"] = append(got["imageStream"], tp.Name)
@@ -764,6 +825,12 @@ func TestRunAll(t *testing.T) {
 						for _, volumeMount := range container.VolumeMounts {
 							got["volumeMounts"] = append(got["volumeMounts"], volumeMount.Name)
 						}
+					}
+				}
+				if test.config.Labels != nil {
+					if !mapContains(test.config.Labels, tp.Template.ControllerTemplate.Selector) {
+						t.Errorf("%s: did not get expected deployment config rc selector. Expected: %v. Got: %v",
+							test.name, test.config.Labels, tp.Template.ControllerTemplate.Selector)
 					}
 				}
 			}

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -26,6 +26,7 @@ type Pipeline struct {
 	Build      *BuildRef
 	Image      *ImageRef
 	Deployment *DeploymentConfigRef
+	Labels     map[string]string
 }
 
 // NewImagePipeline creates a new pipeline with components that are not
@@ -76,7 +77,7 @@ func NewBuildPipeline(from string, input *ImageRef, outputDocker bool, strategy 
 }
 
 // NeedsDeployment sets the pipeline for deployment
-func (p *Pipeline) NeedsDeployment(env Environment, name string) error {
+func (p *Pipeline) NeedsDeployment(env Environment, labels map[string]string, name string) error {
 	if p.Deployment != nil {
 		return nil
 	}
@@ -85,7 +86,8 @@ func (p *Pipeline) NeedsDeployment(env Environment, name string) error {
 		Images: []*ImageRef{
 			p.Image,
 		},
-		Env: env,
+		Env:    env,
+		Labels: labels,
 	}
 	return nil
 }


### PR DESCRIPTION
Use labels, when specified, for service and deployment config selectors
Does not fail when an image is specified and it's detected as a builder -- this is to allow you to do new-app on images that have been created by a source build (they are detected as builder images)

Fixes #3776 