### PR TITLE
UPSTREAM: 11820: Reuse round tripper for identical TLS configurations

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/helper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/helper.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	gruntime "runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -329,6 +330,56 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 	return client, nil
 }
 
+var (
+	// tlsTransports stores reusable round trippers with custom TLSClientConfig options
+	tlsTransports = map[string]*http.Transport{}
+
+	// tlsTransportLock protects retrieval and storage of round trippers into the tlsTransports map
+	tlsTransportLock sync.Mutex
+)
+
+// tlsTransportFor returns a http.RoundTripper for the given config, or an error
+// The same RoundTripper will be returned for configs with identical TLS options
+// If the config has no custom TLS options, http.DefaultTransport is returned
+func tlsTransportFor(config *Config) (http.RoundTripper, error) {
+	// Get a unique key for the TLS options in the config
+	key, err := tlsConfigKey(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure we only create a single transport for the given TLS options
+	tlsTransportLock.Lock()
+	defer tlsTransportLock.Unlock()
+
+	// See if we already have a custom transport for this config
+	if cachedTransport, ok := tlsTransports[key]; ok {
+		return cachedTransport, nil
+	}
+
+	// Get the TLS options for this client config
+	tlsConfig, err := TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+	// The options didn't require a custom TLS config
+	if tlsConfig == nil {
+		return http.DefaultTransport, nil
+	}
+
+	// Cache a single transport for these options
+	tlsTransports[key] = &http.Transport{
+		TLSClientConfig: tlsConfig,
+		Proxy:           http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return tlsTransports[key], nil
+}
+
 // TransportFor returns an http.RoundTripper that will provide the authentication
 // or transport level security defined by the provided Config. Will return the
 // default http.DefaultTransport if no special case behavior is needed.
@@ -341,28 +392,23 @@ func TransportFor(config *Config) (http.RoundTripper, error) {
 		return nil, fmt.Errorf("using a custom transport with TLS certificate options or the insecure flag is not allowed")
 	}
 
-	tlsConfig, err := TLSConfigFor(config)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		transport http.RoundTripper
+		err       error
+	)
 
-	var transport http.RoundTripper
 	if config.Transport != nil {
 		transport = config.Transport
 	} else {
-		if tlsConfig != nil {
-			transport = &http.Transport{
-				TLSClientConfig: tlsConfig,
-				Proxy:           http.ProxyFromEnvironment,
-				Dial: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).Dial,
-				TLSHandshakeTimeout: 10 * time.Second,
-			}
-		} else {
-			transport = http.DefaultTransport
+		transport, err = tlsTransportFor(config)
+		if err != nil {
+			return nil, err
 		}
+	}
+
+	// Call wrap prior to adding debugging wrappers
+	if config.WrapTransport != nil {
+		transport = config.WrapTransport(transport)
 	}
 
 	switch {
@@ -374,10 +420,6 @@ func TransportFor(config *Config) (http.RoundTripper, error) {
 		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, ResponseStatus)
 	case bool(glog.V(6)):
 		transport = NewDebuggingRoundTripper(transport, URLTiming)
-	}
-
-	if config.WrapTransport != nil {
-		transport = config.WrapTransport(transport)
 	}
 
 	transport, err = HTTPWrappersForConfig(config, transport)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/transport.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/transport.go
@@ -117,6 +117,16 @@ func TLSConfigFor(config *Config) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// tlsConfigKey returns a unique key for tls.Config objects returned from TLSConfigFor
+func tlsConfigKey(config *Config) (string, error) {
+	// Make sure ca/key/cert content is loaded
+	if err := LoadTLSFiles(config); err != nil {
+		return "", err
+	}
+	// Only include the things that actually affect the tls.Config
+	return fmt.Sprintf("%v/%x/%x/%x", config.Insecure, config.CAData, config.CertData, config.KeyData), nil
+}
+
 // LoadTLSFiles copies the data from the CertFile, KeyFile, and CAFile fields into the CertData,
 // KeyData, and CAFile fields, or returns an error. If no error is returned, all three fields are
 // either populated or were empty to start.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/transport_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/transport_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/base64"
 	"net/http"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/latest"
 )
 
 func TestUnsecuredTLSTransport(t *testing.T) {
@@ -97,5 +99,76 @@ func TestUserAgentRoundTripper(t *testing.T) {
 	}
 	if rt.Request.Header.Get("User-Agent") != "test" {
 		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+}
+
+func TestTLSConfigKey(t *testing.T) {
+	// Make sure config fields that don't affect the tls config don't affect the cache key
+	identicalConfigurations := map[string]*Config{
+		"empty":          {},
+		"host":           {Host: "foo"},
+		"prefix":         {Prefix: "foo"},
+		"version":        {Version: "foo"},
+		"codec":          {Codec: latest.Codec},
+		"basic":          {Username: "bob", Password: "password"},
+		"bearer":         {BearerToken: "token"},
+		"user agent":     {UserAgent: "useragent"},
+		"transport":      {Transport: http.DefaultTransport},
+		"wrap transport": {WrapTransport: func(http.RoundTripper) http.RoundTripper { return nil }},
+		"qps/burst":      {QPS: 1.0, Burst: 10},
+	}
+	for nameA, valueA := range identicalConfigurations {
+		for nameB, valueB := range identicalConfigurations {
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA != keyB {
+				t.Errorf("Expected identical cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
+	}
+
+	// Make sure config fields that affect the tls config affect the cache key
+	uniqueConfigurations := map[string]*Config{
+		"no tls":                  {},
+		"insecure":                {Insecure: true},
+		"cadata 1":                {TLSClientConfig: TLSClientConfig{CAData: []byte{1}}},
+		"cadata 2":                {TLSClientConfig: TLSClientConfig{CAData: []byte{2}}},
+		"cert 1, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{1}}},
+		"cert 1, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{2}}},
+		"cert 2, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{1}}},
+		"cert 2, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{2}}},
+		"cadata 1, cert 1, key 1": {TLSClientConfig: TLSClientConfig{CAData: []byte{1}, CertData: []byte{1}, KeyData: []byte{1}}},
+	}
+	for nameA, valueA := range uniqueConfigurations {
+		for nameB, valueB := range uniqueConfigurations {
+			// Don't compare to ourselves
+			if nameA == nameB {
+				continue
+			}
+
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA == keyB {
+				t.Errorf("Expected unique cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes unbounded connection growth in #3569 
Upstream PR at https://github.com/GoogleCloudPlatform/kubernetes/pull/11820

I'm seeing "leaked" idle connections when part of the system repeatedly constructs clients for short-term use. The connections are in the `http.Transport` idle pool, which holds connections open until the server times out. The options I see to improve this are:

1. Set `Transport.DisableKeepAlives=true` when setting up the transport (bad for places where we want to make several requests before discarding the client, which is pretty much everywhere)
2. Call `Transport.CloseIdleConnections` after we're done with a client (hard to plumb through access after the transport has been wrapped 4-5 times (for debugging, custom wrapping, bearer/basic auth, and user agent header-setting), sometimes hard to know when we're done with a client
3. Avoid constructing lots of identical `http.Transport` objects. If lots of clients are built with different TLS options, we can still see growth, but this will drastically help the "client per use" case

This PR implements option 3 by building a key around all the unique inputs to the constructed transport. Ideally, a combination of 2 and 3 would be possible, but if we start collecting the constructed `http.Transport` objects in one place, that gives us a potential way to sweep them and call `CloseIdleConnections` occasionally.