### PR TITLE
Added --openshift-enabled boolean flag to OpenShift daemon

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -86,6 +86,8 @@ const (
 type MasterConfig struct {
 	api.TypeMeta
 
+	// If Openshift is enabled
+	OpenshiftEnabled bool
 	// ServingInfo describes how to start serving
 	ServingInfo HTTPServingInfo
 

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -76,6 +76,9 @@ const (
 type MasterConfig struct {
 	v1.TypeMeta `json:",inline"`
 
+	// If Openshift is enabled
+	OpenshiftEnabled bool `json:"openshiftEnabled"`
+
 	// ServingInfo describes how to start serving
 	ServingInfo HTTPServingInfo `json:"servingInfo"`
 

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -216,6 +216,7 @@ oauthConfig:
   tokenConfig:
     accessTokenMaxAgeSeconds: 0
     authorizeTokenMaxAgeSeconds: 0
+openshiftEnabled: false
 policyConfig:
   bootstrapPolicyFile: ""
   openshiftInfrastructureNamespace: ""

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -62,6 +62,7 @@ const (
 type MasterConfig struct {
 	Options configapi.MasterConfig
 
+	OpenshiftEnabled              bool
 	Authenticator                 authenticator.Request
 	Authorizer                    authorizer.Authorizer
 	AuthorizationAttributeBuilder authorizer.AuthorizationAttributeBuilder
@@ -162,8 +163,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 	}
 
 	config := &MasterConfig{
-		Options: options,
-
+		Options:                       options,
+		OpenshiftEnabled:              options.OpenshiftEnabled,
 		Authenticator:                 newAuthenticator(options, etcdHelper, serviceAccountTokenGetter, apiClientCAs),
 		Authorizer:                    newAuthorizer(policyClient, options.ProjectConfig.ProjectRequestMessage),
 		AuthorizationAttributeBuilder: newAuthorizationAttributeBuilder(requestContextMapper),

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -40,8 +40,8 @@ type MasterArgs struct {
 	// with any IP ranges assigned to nodes for pods.
 	PortalNet flagtypes.IPNet
 
-	// MasterPublicAddr is the master address for use by public clients, if different (host, host:port,
-	// or URL). Defaults to same as --master.
+	OpenshiftEnabled bool
+	// addresses for external clients
 	MasterPublicAddr flagtypes.Addr
 
 	PauseControllers bool
@@ -75,6 +75,7 @@ type MasterArgs struct {
 func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 	flags.Var(&args.MasterAddr, prefix+"master", "The master address for use by OpenShift components (host, host:port, or URL). Scheme and port default to the --listen scheme and port. When unset, attempt to use the first public IPv4 non-loopback address registered on this host.")
 	flags.Var(&args.MasterPublicAddr, prefix+"public-master", "The master address for use by public clients, if different (host, host:port, or URL). Defaults to same as --master.")
+	flags.BoolVar(&args.OpenshiftEnabled, prefix+"openshift-enabled", false, "Controls if openshift additions are enabled or not.")
 	flags.Var(&args.EtcdAddr, prefix+"etcd", "The address of the etcd server (host, host:port, or URL). If specified, no built-in etcd will be started.")
 	flags.Var(&args.PortalNet, prefix+"portal-net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
 	flags.Var(&args.DNSBindAddr, prefix+"dns", "The address to listen for DNS requests on.")
@@ -93,6 +94,7 @@ func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 func NewDefaultMasterArgs() *MasterArgs {
 	config := &MasterArgs{
 		MasterAddr:       flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),
+		OpenshiftEnabled: false,
 		EtcdAddr:         flagtypes.Addr{Value: "0.0.0.0:4001", DefaultScheme: "https", DefaultPort: 4001}.Default(),
 		PortalNet:        flagtypes.DefaultIPNet("172.30.0.0/16"),
 		MasterPublicAddr: flagtypes.Addr{Value: "localhost:8443", DefaultScheme: "https", DefaultPort: 8443, AllowPrefix: true}.Default(),

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -40,8 +40,11 @@ type MasterArgs struct {
 	// with any IP ranges assigned to nodes for pods.
 	PortalNet flagtypes.IPNet
 
+	// Enable OpenShift Enterprise features
 	OpenshiftEnabled bool
-	// addresses for external clients
+
+	// MasterPublicAddr is the master address for use by public clients, if different (host, host:port,
+	// or URL). Defaults to same as --master.
 	MasterPublicAddr flagtypes.Addr
 
 	PauseControllers bool
@@ -75,7 +78,7 @@ type MasterArgs struct {
 func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
 	flags.Var(&args.MasterAddr, prefix+"master", "The master address for use by OpenShift components (host, host:port, or URL). Scheme and port default to the --listen scheme and port. When unset, attempt to use the first public IPv4 non-loopback address registered on this host.")
 	flags.Var(&args.MasterPublicAddr, prefix+"public-master", "The master address for use by public clients, if different (host, host:port, or URL). Defaults to same as --master.")
-	flags.BoolVar(&args.OpenshiftEnabled, prefix+"openshift-enabled", false, "Controls if openshift additions are enabled or not.")
+	flags.BoolVar(&args.OpenshiftEnabled, prefix+"openshift-enabled", false, "Controls if OpenShift additions are enabled or not.")
 	flags.Var(&args.EtcdAddr, prefix+"etcd", "The address of the etcd server (host, host:port, or URL). If specified, no built-in etcd will be started.")
 	flags.Var(&args.PortalNet, prefix+"portal-net", "A CIDR notation IP range from which to assign portal IPs. This must not overlap with any IP ranges assigned to nodes for pods.")
 	flags.Var(&args.DNSBindAddr, prefix+"dns", "The address to listen for DNS requests on.")


### PR DESCRIPTION
This starts AE enablement work within OpenShift.

The boolean will enable OpenShift Enterprise features like S2I builds and UI at runtime.

It will also affect console output (help messages won't refer to disabled features).

I believe it makes sense to make the flag hidden. WDYT?