### PR TITLE
enable SA secret ref limitting per SA.  Default to insecure

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -44,8 +43,8 @@ func nameIndexFunc(obj interface{}) ([]string, error) {
 
 // ServiceAccountsControllerOptions contains options for running a ServiceAccountsController
 type ServiceAccountsControllerOptions struct {
-	// Names is the set of service account names to ensure exist in every namespace
-	Names util.StringSet
+	// ServiceAccounts is the list of service accounts to ensure exist in every namespace
+	ServiceAccounts []api.ServiceAccount
 
 	// ServiceAccountResync is the interval between full resyncs of ServiceAccounts.
 	// If non-zero, all service accounts will be re-listed this often.
@@ -59,20 +58,24 @@ type ServiceAccountsControllerOptions struct {
 }
 
 func DefaultServiceAccountsControllerOptions() ServiceAccountsControllerOptions {
-	return ServiceAccountsControllerOptions{Names: util.NewStringSet("default")}
+	return ServiceAccountsControllerOptions{
+		ServiceAccounts: []api.ServiceAccount{
+			{ObjectMeta: api.ObjectMeta{Name: "default"}},
+		},
+	}
 }
 
 // NewServiceAccountsController returns a new *ServiceAccountsController.
 func NewServiceAccountsController(cl client.Interface, options ServiceAccountsControllerOptions) *ServiceAccountsController {
 	e := &ServiceAccountsController{
-		client: cl,
-		names:  options.Names,
+		client:                  cl,
+		serviceAccountsToEnsure: options.ServiceAccounts,
 	}
 
 	accountSelector := fields.Everything()
-	if len(options.Names) == 1 {
+	if len(options.ServiceAccounts) == 1 {
 		// If we're maintaining a single account, we can scope the accounts we watch to just that name
-		accountSelector = fields.SelectorFromSet(map[string]string{client.ObjectNameField: options.Names.List()[0]})
+		accountSelector = fields.SelectorFromSet(map[string]string{client.ObjectNameField: options.ServiceAccounts[0].Name})
 	}
 	e.serviceAccounts, e.serviceAccountController = framework.NewIndexerInformer(
 		&cache.ListWatch{
@@ -116,8 +119,8 @@ func NewServiceAccountsController(cl client.Interface, options ServiceAccountsCo
 type ServiceAccountsController struct {
 	stopChan chan struct{}
 
-	client client.Interface
-	names  util.StringSet
+	client                  client.Interface
+	serviceAccountsToEnsure []api.ServiceAccount
 
 	serviceAccounts cache.Indexer
 	namespaces      cache.Indexer
@@ -153,24 +156,26 @@ func (e *ServiceAccountsController) serviceAccountDeleted(obj interface{}) {
 		return
 	}
 	// If the deleted service account is one we're maintaining, recreate it
-	if e.names.Has(serviceAccount.Name) {
-		e.createServiceAccountIfNeeded(serviceAccount.Name, serviceAccount.Namespace)
+	for _, sa := range e.serviceAccountsToEnsure {
+		if sa.Name == serviceAccount.Name {
+			e.createServiceAccountIfNeeded(sa, serviceAccount.Namespace)
+		}
 	}
 }
 
 // namespaceAdded reacts to a Namespace creation by creating a default ServiceAccount object
 func (e *ServiceAccountsController) namespaceAdded(obj interface{}) {
 	namespace := obj.(*api.Namespace)
-	for _, name := range e.names.List() {
-		e.createServiceAccountIfNeeded(name, namespace.Name)
+	for _, sa := range e.serviceAccountsToEnsure {
+		e.createServiceAccountIfNeeded(sa, namespace.Name)
 	}
 }
 
 // namespaceUpdated reacts to a Namespace update (or re-list) by creating a default ServiceAccount in the namespace if needed
 func (e *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj interface{}) {
 	newNamespace := newObj.(*api.Namespace)
-	for _, name := range e.names.List() {
-		e.createServiceAccountIfNeeded(name, newNamespace.Name)
+	for _, sa := range e.serviceAccountsToEnsure {
+		e.createServiceAccountIfNeeded(sa, newNamespace.Name)
 	}
 }
 
@@ -178,13 +183,13 @@ func (e *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj 
 // * the named ServiceAccount does not already exist
 // * the specified namespace exists
 // * the specified namespace is in the ACTIVE phase
-func (e *ServiceAccountsController) createServiceAccountIfNeeded(name, namespace string) {
-	serviceAccount, err := e.getServiceAccount(name, namespace)
+func (e *ServiceAccountsController) createServiceAccountIfNeeded(sa api.ServiceAccount, namespace string) {
+	existingServiceAccount, err := e.getServiceAccount(sa.Name, namespace)
 	if err != nil {
 		glog.Error(err)
 		return
 	}
-	if serviceAccount != nil {
+	if existingServiceAccount != nil {
 		// If service account already exists, it doesn't need to be created
 		return
 	}
@@ -203,20 +208,18 @@ func (e *ServiceAccountsController) createServiceAccountIfNeeded(name, namespace
 		return
 	}
 
-	e.createServiceAccount(name, namespace)
+	e.createServiceAccount(sa, namespace)
 }
 
 // createDefaultServiceAccount creates a default ServiceAccount in the specified namespace
-func (e *ServiceAccountsController) createServiceAccount(name, namespace string) {
-	serviceAccount := &api.ServiceAccount{}
-	serviceAccount.Name = name
-	serviceAccount.Namespace = namespace
-	if _, err := e.client.ServiceAccounts(namespace).Create(serviceAccount); err != nil {
+func (e *ServiceAccountsController) createServiceAccount(sa api.ServiceAccount, namespace string) {
+	sa.Namespace = namespace
+	if _, err := e.client.ServiceAccounts(namespace).Create(&sa); err != nil {
 		glog.Error(err)
 	}
 }
 
-// getDefaultServiceAccount returns the ServiceAccount with the given name for the given namespace
+// getServiceAccount returns the ServiceAccount with the given name for the given namespace
 func (e *ServiceAccountsController) getServiceAccount(name, namespace string) (*api.ServiceAccount, error) {
 	key := &api.ServiceAccount{ObjectMeta: api.ObjectMeta{Namespace: namespace}}
 	accounts, err := e.serviceAccounts.Index("namespace", key)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -170,7 +170,10 @@ func TestServiceAccountCreation(t *testing.T) {
 	for k, tc := range testcases {
 		client := testclient.NewSimpleFake(defaultServiceAccount, managedServiceAccount)
 		options := DefaultServiceAccountsControllerOptions()
-		options.Names = util.NewStringSet(defaultName, managedName)
+		options.ServiceAccounts = []api.ServiceAccount{
+			{ObjectMeta: api.ObjectMeta{Name: defaultName}},
+			{ObjectMeta: api.ObjectMeta{Name: managedName}},
+		}
 		controller := NewServiceAccountsController(client, options)
 
 		if tc.ExistingNamespace != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/serviceaccount/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/serviceaccount/admission.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"strconv"
 	"time"
 
 	"k8s.io/kubernetes/pkg/admission"
@@ -38,12 +39,19 @@ import (
 // DefaultServiceAccountName is the name of the default service account to set on pods which do not specify a service account
 const DefaultServiceAccountName = "default"
 
+// EnforceMountableSecretsAnnotation is a default annotation that indicates that a service account should enforce mountable secrets.
+// The value must be true to have this annotation take effect
+const EnforceMountableSecretsAnnotation = "kubernetes.io/enforce-mountable-secrets"
+
 // DefaultAPITokenMountPath is the path that ServiceAccountToken secrets are automounted to.
 // The token file would then be accessible at /var/run/secrets/kubernetes.io/serviceaccount
 const DefaultAPITokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 
+// PluginName is the name of this admission plugin
+const PluginName = "ServiceAccount"
+
 func init() {
-	admission.RegisterPlugin("ServiceAccount", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+	admission.RegisterPlugin(PluginName, func(client client.Interface, config io.Reader) (admission.Interface, error) {
 		serviceAccountAdmission := NewServiceAccount(client)
 		serviceAccountAdmission.Run()
 		return serviceAccountAdmission, nil
@@ -180,7 +188,7 @@ func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
 		return admission.NewForbidden(a, fmt.Errorf("service account %s/%s was not found, retry after the service account is created", a.GetNamespace(), pod.Spec.ServiceAccountName))
 	}
 
-	if s.LimitSecretReferences {
+	if s.enforceMountableSecrets(serviceAccount) {
 		if err := s.limitSecretReferences(serviceAccount, pod); err != nil {
 			return admission.NewForbidden(a, err)
 		}
@@ -198,6 +206,21 @@ func (s *serviceAccount) Admit(a admission.Attributes) (err error) {
 	}
 
 	return nil
+}
+
+// enforceMountableSecrets indicates whether mountable secrets should be enforced for a particular service account
+// A global setting of true will override any flag set on the individual service account
+func (s *serviceAccount) enforceMountableSecrets(serviceAccount *api.ServiceAccount) bool {
+	if s.LimitSecretReferences {
+		return true
+	}
+
+	if value, ok := serviceAccount.Annotations[EnforceMountableSecretsAnnotation]; ok {
+		enforceMountableSecretCheck, _ := strconv.ParseBool(value)
+		return enforceMountableSecretCheck
+	}
+
+	return false
 }
 
 // getServiceAccount returns the ServiceAccount for the given namespace and name if it exists

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -363,6 +363,10 @@ type ServiceAccountConfig struct {
 	// If no names are specified, the ServiceAccountsController will not be started.
 	ManagedNames []string
 
+	// LimitSecretReferences controls whether or not to allow a service account to reference any secret in a namespace
+	// without explicitly referencing them
+	LimitSecretReferences bool
+
 	// PrivateKeyFile is a file containing a PEM-encoded private RSA key, used to sign service account tokens.
 	// If no private key is specified, the service account TokensController will not be started.
 	PrivateKeyFile string

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -346,6 +346,10 @@ type ServiceAccountConfig struct {
 	// If no names are specified, the ServiceAccountsController will not be started.
 	ManagedNames []string `json:"managedNames"`
 
+	// LimitSecretReferences controls whether or not to allow a service account to reference any secret in a namespace
+	// without explicitly referencing them
+	LimitSecretReferences bool `json:"limitSecretReferences"`
+
 	// PrivateKeyFile is a file containing a PEM-encoded private RSA key, used to sign service account tokens.
 	// If no private key is specified, the service account TokensController will not be started.
 	PrivateKeyFile string `json:"privateKeyFile"`

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -237,6 +237,7 @@ projectConfig:
 routingConfig:
   subdomain: ""
 serviceAccountConfig:
+  limitSecretReferences: false
   managedNames: null
   masterCA: ""
   privateKeyFile: ""

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -68,7 +68,15 @@ func (c *MasterConfig) RunServiceAccountsController() {
 		return
 	}
 	options := serviceaccount.DefaultServiceAccountsControllerOptions()
-	options.Names = util.NewStringSet(c.Options.ServiceAccountConfig.ManagedNames...)
+	options.ServiceAccounts = []kapi.ServiceAccount{}
+
+	for _, saName := range c.Options.ServiceAccountConfig.ManagedNames {
+		sa := kapi.ServiceAccount{}
+		sa.Name = saName
+
+		options.ServiceAccounts = append(options.ServiceAccounts, sa)
+	}
+
 	serviceaccount.NewServiceAccountsController(c.KubeClient(), options).Run()
 	glog.Infof("Started Service Account Manager")
 }

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/wait"
 	serviceaccountadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
@@ -224,9 +226,20 @@ func getServiceAccountToken(client *kclient.Client, ns, name string) (string, er
 	}
 	for _, secret := range secrets.Items {
 		if secret.Type == api.SecretTypeServiceAccountToken && secret.Annotations[api.ServiceAccountNameKey] == name {
-			return string(secret.Data[api.ServiceAccountTokenKey]), nil
+			sa, err := client.ServiceAccounts(ns).Get(name)
+			if err != nil {
+				return "", err
+			}
+
+			for _, ref := range sa.Secrets {
+				if ref.Name == secret.Name {
+					return string(secret.Data[api.ServiceAccountTokenKey]), nil
+				}
+			}
+
 		}
 	}
+
 	return "", nil
 }
 
@@ -287,4 +300,98 @@ func getServiceAccountPullSecret(client *kclient.Client, ns, name string) (strin
 		}
 	}
 	return "", nil
+}
+
+func TestEnforcingServiceAccount(t *testing.T) {
+	masterConfig, err := testutil.DefaultMasterOptions()
+	masterConfig.ServiceAccountConfig.LimitSecretReferences = false
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminConfig, err := testutil.StartConfiguredMaster(masterConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Get a service account token
+	saToken, err := waitForServiceAccountToken(clusterAdminKubeClient, api.NamespaceDefault, serviceaccountadmission.DefaultServiceAccountName, 20, time.Second)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(saToken) == 0 {
+		t.Errorf("token was not created")
+	}
+
+	pod := &api.Pod{}
+	pod.Name = "foo"
+	pod.Namespace = api.NamespaceDefault
+	pod.Spec.ServiceAccountName = serviceaccountadmission.DefaultServiceAccountName
+
+	container := api.Container{}
+	container.Name = "foo"
+	container.Image = "openshift/hello-openshift"
+	pod.Spec.Containers = []api.Container{container}
+
+	secretVolume := api.Volume{}
+	secretVolume.Name = "bar-vol"
+	secretVolume.Secret = &api.SecretVolumeSource{}
+	secretVolume.Secret.SecretName = "bar"
+	pod.Spec.Volumes = []api.Volume{secretVolume}
+
+	err = wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		if _, err := clusterAdminKubeClient.Pods(api.NamespaceDefault).Create(pod); err != nil {
+			// The SA admission controller cache seems to take forever to update.  This check comes after the limit check, so until we get it sorted out
+			// check if we're getting this particular error
+			if strings.Contains(err.Error(), "no API token found for service account") {
+				return true, nil
+			}
+
+			t.Log(err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	clusterAdminKubeClient.Pods(api.NamespaceDefault).Delete(pod.Name, nil)
+
+	sa, err := clusterAdminKubeClient.ServiceAccounts(api.NamespaceDefault).Get(bootstrappolicy.DeployerServiceAccountName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sa.Annotations == nil {
+		sa.Annotations = map[string]string{}
+	}
+	sa.Annotations[serviceaccountadmission.EnforceMountableSecretsAnnotation] = "true"
+
+	time.Sleep(5)
+
+	_, err = clusterAdminKubeClient.ServiceAccounts(api.NamespaceDefault).Update(sa)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedMessage := "is not allowed because service account deployer does not reference that secret"
+	pod.Spec.ServiceAccountName = bootstrappolicy.DeployerServiceAccountName
+
+	err = wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		if _, err := clusterAdminKubeClient.Pods(api.NamespaceDefault).Create(pod); err == nil || !strings.Contains(err.Error(), expectedMessage) {
+			clusterAdminKubeClient.Pods(api.NamespaceDefault).Delete(pod.Name, nil)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 }

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -119,7 +119,14 @@ func DefaultMasterOptions() (*configapi.MasterConfig, error) {
 		return nil, err
 	}
 
-	return startOptions.MasterArgs.BuildSerializeableMasterConfig()
+	masterConfig, err := startOptions.MasterArgs.BuildSerializeableMasterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// force strict handling of service account secret references by default, so that all our examples and controllers will handle it.
+	masterConfig.ServiceAccountConfig.LimitSecretReferences = true
+	return masterConfig, nil
 }
 
 func CreateBootstrapPolicy(masterArgs *start.MasterArgs) error {


### PR DESCRIPTION
Upstream https://github.com/GoogleCloudPlatform/kubernetes/pull/11827

1. allows a particular service account to be enforcing and require references to a secret to be in the mountable list.  
1. provides config values to say which service accounts should be enforcing by default
1. provides a config value to disable the (default)permissive mode for the entire cluster

@smarterclayton Before I take this upstream, does it do what you want?
@liggitt Did you have something else in mind?  This doesn't require any API changes and leave the cluster admin in control as to whether he wants to allow a project admin to do this.