### PR TITLE
Allow the bind network to be configured rather than inferred

### DIFF
--- a/Godeps/_workspace/src/github.com/skynetservices/skydns/server/config.go
+++ b/Godeps/_workspace/src/github.com/skynetservices/skydns/server/config.go
@@ -24,6 +24,8 @@ const (
 type Config struct {
 	// The ip:port SkyDNS should be listening on for incoming DNS requests.
 	DnsAddr string `json:"dns_addr,omitempty"`
+	// The network used to bind DNS - can be 'ip' (both ipv4 and ipv6), 'ipv4', or 'ipv6', defaults to 'ip'
+	BindNetwork string `json:"bind_network,omitempty"`
 	// bind to port(s) activated by systemd. If set to true, this overrides DnsAddr.
 	Systemd bool `json:"systemd,omitempty"`
 	// The domain SkyDNS is authoritative for, defaults to skydns.local.
@@ -79,6 +81,9 @@ func SetDefaults(config *Config) error {
 	if config.DnsAddr == "" {
 		config.DnsAddr = "127.0.0.1:53"
 	}
+	if config.BindNetwork == "" {
+		config.BindNetwork = "ip"
+	}
 	if config.Domain == "" {
 		config.Domain = "skydns.local."
 	}
@@ -108,6 +113,12 @@ func SetDefaults(config *Config) error {
 	}
 	if config.Ndots <= 0 {
 		config.Ndots = 2
+	}
+
+	switch config.BindNetwork {
+	case "ip", "ipv4", "ipv6":
+	default:
+		return fmt.Errorf("%s is not an accepted value for BindNetwork", config.BindNetwork)
 	}
 
 	if len(config.Nameservers) == 0 {

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -282,6 +282,9 @@ type EtcdStorageConfig struct {
 type ServingInfo struct {
 	// BindAddress is the ip:port to serve on
 	BindAddress string
+	// BindNetwork is the type of network to bind to - defaults to "tcp4", accepts "tcp",
+	// "tcp4", and "tcp6"
+	BindNetwork string
 	// ServerCert is the TLS cert info for serving secure traffic
 	ServerCert CertInfo
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
@@ -307,6 +310,9 @@ type MasterClients struct {
 type DNSConfig struct {
 	// BindAddress is the ip:port to serve DNS on
 	BindAddress string
+	// BindNetwork is the type of network to bind to - defaults to "tcp4", accepts "tcp",
+	// "tcp4", and "tcp6"
+	BindNetwork string
 }
 
 type AssetConfig struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -62,6 +62,16 @@ func init() {
 				obj.ExecHandlerName = DockerExecHandlerNative
 			}
 		},
+		func(obj *ServingInfo) {
+			if len(obj.BindNetwork) == 0 {
+				obj.BindNetwork = "tcp4"
+			}
+		},
+		func(obj *DNSConfig) {
+			if len(obj.BindNetwork) == 0 {
+				obj.BindNetwork = "tcp4"
+			}
+		},
 		func(obj *SecurityAllocator) {
 			if len(obj.UIDAllocatorRange) == 0 {
 				obj.UIDAllocatorRange = "1000000000-1999999999/10000"
@@ -81,6 +91,7 @@ func init() {
 	err = newer.Scheme.AddConversionFuncs(
 		func(in *ServingInfo, out *newer.ServingInfo, s conversion.Scope) error {
 			out.BindAddress = in.BindAddress
+			out.BindNetwork = in.BindNetwork
 			out.ClientCA = in.ClientCA
 			out.ServerCert.CertFile = in.CertFile
 			out.ServerCert.KeyFile = in.KeyFile
@@ -88,6 +99,7 @@ func init() {
 		},
 		func(in *newer.ServingInfo, out *ServingInfo, s conversion.Scope) error {
 			out.BindAddress = in.BindAddress
+			out.BindNetwork = in.BindNetwork
 			out.ClientCA = in.ClientCA
 			out.CertFile = in.ServerCert.CertFile
 			out.KeyFile = in.ServerCert.KeyFile

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -266,6 +266,9 @@ type EtcdStorageConfig struct {
 type ServingInfo struct {
 	// BindAddress is the ip:port to serve on
 	BindAddress string `json:"bindAddress"`
+	// BindNetwork is the type of network to bind to - defaults to "tcp4", accepts "tcp",
+	// "tcp4", and "tcp6"
+	BindNetwork string `json:"bindNetwork"`
 	// CertInfo is the TLS cert info for serving secure traffic.
 	// this is anonymous so that we can inline it for serialization
 	CertInfo `json:",inline"`
@@ -292,6 +295,9 @@ type MasterClients struct {
 type DNSConfig struct {
 	// BindAddress is the ip:port to serve DNS on
 	BindAddress string `json:"bindAddress"`
+	// BindNetwork is the type of network to bind to - defaults to "tcp4", accepts "tcp",
+	// "tcp4", and "tcp6"
+	BindNetwork string `json:"bindNetwork"`
 }
 
 type AssetConfig struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -33,6 +33,7 @@ podManifestConfig:
   path: ""
 servingInfo:
   bindAddress: ""
+  bindNetwork: ""
   certFile: ""
   clientCA: ""
   keyFile: ""
@@ -52,6 +53,7 @@ assetConfig:
   publicURL: ""
   servingInfo:
     bindAddress: ""
+    bindNetwork: ""
     certFile: ""
     clientCA: ""
     keyFile: ""
@@ -60,6 +62,7 @@ assetConfig:
 corsAllowedOrigins: null
 dnsConfig:
   bindAddress: ""
+  bindNetwork: ""
 etcdClientInfo:
   ca: ""
   certFile: ""
@@ -70,11 +73,13 @@ etcdConfig:
   peerAddress: ""
   peerServingInfo:
     bindAddress: ""
+    bindNetwork: ""
     certFile: ""
     clientCA: ""
     keyFile: ""
   servingInfo:
     bindAddress: ""
+    bindNetwork: ""
     certFile: ""
     clientCA: ""
     keyFile: ""
@@ -234,6 +239,7 @@ serviceAccountConfig:
   publicKeyFiles: null
 servingInfo:
   bindAddress: ""
+  bindNetwork: ""
   certFile: ""
   clientCA: ""
   keyFile: ""

--- a/pkg/cmd/server/api/validation/etcd.go
+++ b/pkg/cmd/server/api/validation/etcd.go
@@ -60,7 +60,13 @@ func ValidateEtcdConfig(config *api.EtcdConfig) fielderrors.ValidationErrorList 
 	allErrs := fielderrors.ValidationErrorList{}
 
 	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	if config.ServingInfo.BindNetwork == "tcp6" {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("servingInfo.bindNetwork", config.ServingInfo.BindNetwork, "tcp6 is not a valid bindNetwork for etcd, must be tcp or tcp4"))
+	}
 	allErrs = append(allErrs, ValidateServingInfo(config.PeerServingInfo).Prefix("peerServingInfo")...)
+	if config.ServingInfo.BindNetwork == "tcp6" {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("peerServingInfo.bindNetwork", config.ServingInfo.BindNetwork, "tcp6 is not a valid bindNetwork for etcd peers, must be tcp or tcp4"))
+	}
 
 	allErrs = append(allErrs, ValidateHostPort(config.Address, "address")...)
 	allErrs = append(allErrs, ValidateHostPort(config.PeerAddress, "peerAddress")...)

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -88,6 +88,11 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 
 	if config.DNSConfig != nil {
 		validationResults.AddErrors(ValidateHostPort(config.DNSConfig.BindAddress, "bindAddress").Prefix("dnsConfig")...)
+		switch config.DNSConfig.BindNetwork {
+		case "tcp", "tcp4", "tcp6":
+		default:
+			validationResults.AddErrors(fielderrors.NewFieldInvalid("dnsConfig.bindNetwork", config.DNSConfig.BindNetwork, "must be 'tcp', 'tcp4', or 'tcp6'"))
+		}
 	}
 
 	if config.EtcdConfig != nil {

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -18,6 +18,9 @@ func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList 
 	}
 
 	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	if config.ServingInfo.BindNetwork == "tcp6" {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("servingInfo.bindNetwork", config.ServingInfo.BindNetwork, "tcp6 is not a valid bindNetwork for nodes, must be tcp or tcp4"))
+	}
 	allErrs = append(allErrs, ValidateKubeConfig(config.MasterKubeConfig, "masterKubeConfig")...)
 
 	if len(config.DNSIP) > 0 {

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -58,6 +58,12 @@ func ValidateServingInfo(info api.ServingInfo) fielderrors.ValidationErrorList {
 	allErrs = append(allErrs, ValidateHostPort(info.BindAddress, "bindAddress")...)
 	allErrs = append(allErrs, ValidateCertInfo(info.ServerCert, false)...)
 
+	switch info.BindNetwork {
+	case "tcp", "tcp4", "tcp6":
+	default:
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("bindNetwork", info.BindNetwork, "must be 'tcp', 'tcp4', or 'tcp6'"))
+	}
+
 	if len(info.ServerCert.CertFile) > 0 {
 		if len(info.ClientCA) > 0 {
 			allErrs = append(allErrs, ValidateFile(info.ClientCA, "clientCA")...)

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -80,7 +80,7 @@ func (c *AssetConfig) Run() {
 				MinVersion: tls.VersionTLS10,
 			}
 			glog.Infof("Web console listening at https://%s", c.Options.ServingInfo.BindAddress)
-			glog.Fatal(server.ListenAndServeTLS(c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))
+			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))
 		} else {
 			glog.Infof("Web console listening at http://%s", c.Options.ServingInfo.BindAddress)
 			glog.Fatal(server.ListenAndServe())
@@ -88,7 +88,7 @@ func (c *AssetConfig) Run() {
 	}, 0)
 
 	// Attempt to verify the server came up for 20 seconds (100 tries * 100ms, 100ms timeout per try)
-	cmdutil.WaitForSuccessfulDial(isTLS, "tcp", c.Options.ServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
+	cmdutil.WaitForSuccessfulDial(isTLS, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
 
 	glog.Infof("Web console available at %s", c.Options.PublicURL)
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -214,14 +214,14 @@ func (c *MasterConfig) Run(protected []APIInstaller, unprotected []APIInstaller)
 				ClientAuth: tls.RequestClientCert,
 				ClientCAs:  c.ClientCAs,
 			}
-			glog.Fatal(server.ListenAndServeTLS(c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))
+			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))
 		} else {
 			glog.Fatal(server.ListenAndServe())
 		}
 	}, 0)
 
 	// Attempt to verify the server came up for 20 seconds (100 tries * 100ms, 100ms timeout per try)
-	cmdutil.WaitForSuccessfulDial(c.TLS, "tcp", c.Options.ServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
+	cmdutil.WaitForSuccessfulDial(c.TLS, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
 
 	// Create required policy rules if needed
 	c.ensureComponentAuthorizationRules()

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -138,6 +138,14 @@ func (c *MasterConfig) RunDNSServer() {
 	if err != nil {
 		glog.Fatalf("Could not start DNS: %v", err)
 	}
+	switch c.Options.DNSConfig.BindNetwork {
+	case "tcp":
+		config.BindNetwork = "ip"
+	case "tcp4":
+		config.BindNetwork = "ipv4"
+	case "tcp6":
+		config.BindNetwork = "ipv6"
+	}
 	config.DnsAddr = c.Options.DNSConfig.BindAddress
 	config.NoRec = true // do not want to deploy an open resolver
 
@@ -149,7 +157,7 @@ func (c *MasterConfig) RunDNSServer() {
 		glog.Warningf("Binding DNS on port %v instead of 53 (you may need to run as root and update your config), using %s which will not resolve from all locations", port, c.Options.DNSConfig.BindAddress)
 	}
 
-	if ok, err := cmdutil.TryListen(c.Options.DNSConfig.BindAddress); !ok {
+	if ok, err := cmdutil.TryListen(c.Options.DNSConfig.BindNetwork, c.Options.DNSConfig.BindAddress); !ok {
 		glog.Warningf("Could not start DNS: %v", err)
 		return
 	}

--- a/pkg/cmd/server/start/config_test.go
+++ b/pkg/cmd/server/start/config_test.go
@@ -76,19 +76,6 @@ func TestAssetPublicAddressDefaulting(t *testing.T) {
 	}
 }
 
-func TestAssetBindAddressDefaulting(t *testing.T) {
-	bind := "1.2.3.4:9011"
-	expected := "1.2.3.4:9011"
-
-	masterArgs := NewDefaultMasterArgs()
-	masterArgs.ListenArg.ListenAddr.Set(bind)
-
-	actual := masterArgs.GetAssetBindAddress()
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
 func TestKubernetesAddressDefaulting(t *testing.T) {
 	expected := "http://example.com:9012"
 

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -288,12 +288,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		config.ServiceAccountConfig.PublicKeyFiles = []string{}
 	}
 
-	// Roundtrip the config to v1 and back to ensure proper defaults are set.
-	ext, err := configapi.Scheme.ConvertToVersion(config, "v1")
-	if err != nil {
-		return nil, err
-	}
-	internal, err := configapi.Scheme.ConvertToVersion(ext, "")
+	internal, err := applyDefaults(config, "v1")
 	if err != nil {
 		return nil, err
 	}
@@ -647,4 +642,13 @@ func getPort(theURL url.URL) int {
 
 	intport, _ := strconv.Atoi(port)
 	return intport
+}
+
+// applyDefaults roundtrips the config to v1 and back to ensure proper defaults are set.
+func applyDefaults(config runtime.Object, version string) (runtime.Object, error) {
+	ext, err := configapi.Scheme.ConvertToVersion(config, version)
+	if err != nil {
+		return nil, err
+	}
+	return configapi.Scheme.ConvertToVersion(ext, "")
 }

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -138,12 +138,7 @@ func (args NodeArgs) BuildSerializeableNodeConfig() (*configapi.NodeConfig, erro
 		config.ServingInfo.ClientCA = admin.DefaultKubeletClientCAFile(args.MasterCertDir)
 	}
 
-	// Roundtrip the config to v1 and back to ensure proper defaults are set.
-	ext, err := configapi.Scheme.ConvertToVersion(config, "v1")
-	if err != nil {
-		return nil, err
-	}
-	internal, err := configapi.Scheme.ConvertToVersion(ext, "")
+	internal, err := applyDefaults(config, "v1")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -87,7 +87,7 @@ func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *A
 			if err := options.StartAllInOne(); err != nil {
 				if kerrors.IsInvalid(err) {
 					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
-						fmt.Fprintf(c.Out(), "Invalid %s %s\n", details.Kind, details.Name)
+						fmt.Fprintf(c.Out(), "error: Invalid %s %s\n", details.Kind, details.Name)
 						for _, cause := range details.Causes {
 							fmt.Fprintf(c.Out(), "  %s: %s\n", cause.Field, cause.Message)
 						}


### PR DESCRIPTION
Allows listen on IPv4 or IPv6 only

Fixes #3689

Prevents DNS from being reached on IPv6 to prevent AAAA records from being returned (which aren't accessible).