### PR TITLE
add cli display coverage tests

### DIFF
--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -1,6 +1,7 @@
 package describe
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -11,12 +12,17 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	kutil "github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployapitest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 )
 
 type describeClient struct {
@@ -26,17 +32,63 @@ type describeClient struct {
 	*testclient.Fake
 }
 
-func TestDescribeFor(t *testing.T) {
+// DescriberCoverageExceptions is the list of API types that do NOT have corresponding describers
+// If you add something to this list, explain why it doesn't need validation.  waaaa is not a valid
+// reason.
+var DescriberCoverageExceptions = []reflect.Type{
+	reflect.TypeOf(&buildapi.BuildLogOptions{}),                       // normal users don't ever look at these
+	reflect.TypeOf(&buildapi.BuildRequest{}),                          // normal users don't ever look at these
+	reflect.TypeOf(&imageapi.DockerImage{}),                           // not a top level resource
+	reflect.TypeOf(&oauthapi.OAuthAccessToken{}),                      // normal users don't ever look at these
+	reflect.TypeOf(&oauthapi.OAuthAuthorizeToken{}),                   // normal users don't ever look at these
+	reflect.TypeOf(&oauthapi.OAuthClientAuthorization{}),              // normal users don't ever look at these
+	reflect.TypeOf(&deployapi.DeploymentConfigRollback{}),             // normal users don't ever look at these
+	reflect.TypeOf(&projectapi.ProjectRequest{}),                      // normal users don't ever look at these
+	reflect.TypeOf(&authorizationapi.IsPersonalSubjectAccessReview{}), // not a top level resource
+}
+
+// MissingDescriberCoverageExceptions is the list of types that were missing describer methods when I started
+// You should never add to this list
+// TODO describers should be added for these types
+var MissingDescriberCoverageExceptions = []reflect.Type{
+	reflect.TypeOf(&imageapi.ImageStreamMapping{}),
+	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
+	reflect.TypeOf(&oauthapi.OAuthClient{}),
+	reflect.TypeOf(&sdnapi.ClusterNetwork{}),
+	reflect.TypeOf(&sdnapi.HostSubnet{}),
+}
+
+func TestDescriberCoverage(t *testing.T) {
 	c := &client.Client{}
-	testTypesList := []string{
-		"Build", "BuildConfig", "BuildLog", "DeploymentConfig",
-		"Image", "ImageStream", "ImageStreamTag", "ImageStreamImage",
-		"Route", "Project",
-	}
-	for _, o := range testTypesList {
-		_, ok := DescriberFor(o, c, &ktestclient.Fake{}, "")
+
+main:
+	for _, apiType := range kapi.Scheme.KnownTypes("") {
+		if !strings.Contains(apiType.PkgPath(), "openshift/origin") {
+			continue
+		}
+		// we don't describe lists
+		if strings.HasSuffix(apiType.Name(), "List") {
+			continue
+		}
+
+		ptrType := reflect.PtrTo(apiType)
+		for _, exception := range DescriberCoverageExceptions {
+			if ptrType == exception {
+				continue main
+			}
+		}
+		for _, exception := range MissingDescriberCoverageExceptions {
+			if ptrType == exception {
+				continue main
+			}
+		}
+
+		_, ok := DescriberFor(apiType.Name(), c, &ktestclient.Fake{}, "")
 		if !ok {
-			t.Errorf("Unable to obtain describer for %s", o)
+			t.Errorf("missing printer for %v.  Check pkg/cmd/cli/describe/describer.go", apiType)
 		}
 	}
 }

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -205,7 +205,13 @@ func printBuildConfig(bc *buildapi.BuildConfig, w io.Writer, withNamespace, wide
 		_, err := fmt.Fprintf(w, "%s\t%v\t%s\n", bc.Name, describeStrategy(bc.Spec.Strategy.Type), bc.Spec.Strategy.CustomStrategy.From.Name)
 		return err
 	}
-	_, err := fmt.Fprintf(w, "%s\t%v\t%s\n", bc.Name, describeStrategy(bc.Spec.Strategy.Type), bc.Spec.Source.Git.URI)
+
+	uri := "MISSING"
+	if bc.Spec.Source.Git != nil {
+		uri = bc.Spec.Source.Git.URI
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%v\t%s\n", bc.Name, describeStrategy(bc.Spec.Strategy.Type), uri)
 	return err
 }
 

--- a/pkg/cmd/cli/describe/printer_test.go
+++ b/pkg/cmd/cli/describe/printer_test.go
@@ -1,0 +1,70 @@
+package describe
+
+import (
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	projectapi "github.com/openshift/origin/pkg/project/api"
+)
+
+// PrinterCoverageExceptions is the list of API types that do NOT have corresponding printers
+// If you add something to this list, explain why it doesn't need validation.  waaaa is not a valid
+// reason.
+var PrinterCoverageExceptions = []reflect.Type{
+	reflect.TypeOf(&imageapi.DockerImage{}), // not a top level resource
+	reflect.TypeOf(&buildapi.BuildLog{}),    // just a marker type
+}
+
+// MissingPrinterCoverageExceptions is the list of types that were missing printer methods when I started
+// You should never add to this list
+// TODO printers should be added for these types
+var MissingPrinterCoverageExceptions = []reflect.Type{
+	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
+	reflect.TypeOf(&deployapi.DeploymentConfigRollback{}),
+	reflect.TypeOf(&imageapi.ImageStreamMapping{}),
+	reflect.TypeOf(&buildapi.BuildLogOptions{}),
+	reflect.TypeOf(&buildapi.BuildRequest{}),
+	reflect.TypeOf(&projectapi.ProjectRequest{}),
+}
+
+func TestPrinterCoverage(t *testing.T) {
+	printer := NewHumanReadablePrinter(false, false, false, []string{})
+
+main:
+	for _, apiType := range kapi.Scheme.KnownTypes("") {
+		if !strings.Contains(apiType.PkgPath(), "openshift/origin") {
+			continue
+		}
+
+		ptrType := reflect.PtrTo(apiType)
+		for _, exception := range PrinterCoverageExceptions {
+			if ptrType == exception {
+				continue main
+			}
+		}
+		for _, exception := range MissingPrinterCoverageExceptions {
+			if ptrType == exception {
+				continue main
+			}
+		}
+
+		newStructValue := reflect.New(apiType)
+		newStruct := newStructValue.Interface()
+
+		if err := printer.PrintObj(newStruct.(runtime.Object), ioutil.Discard); (err != nil) && strings.Contains(err.Error(), "error: unknown type ") {
+			t.Errorf("missing printer for %v.  Check pkg/cmd/cli/describe/printer.go", apiType)
+		}
+	}
+}


### PR DESCRIPTION
Whenever an API object is added, we should be adding describers and printers.  If we choose not to, the choice should be made consciously.  This forces people to think about it.

@fabianofranz ptal

When this is added to the merge queue, I'll open issues for adding printers and describers for missing objects.  