### PR TITLE
honor new group resources in authorizer

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/index.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/index.go
@@ -30,18 +30,33 @@ type Indexer interface {
 	Index(indexName string, obj interface{}) ([]interface{}, error)
 	// ListIndexFuncValues returns the list of generated values of an Index func
 	ListIndexFuncValues(indexName string) []string
+	// ByIndex lists object that match on the named indexing function with the exact key
+	ByIndex(indexName, indexKey string) ([]interface{}, error)
 }
 
 // IndexFunc knows how to provide an indexed value for an object.
-type IndexFunc func(obj interface{}) (string, error)
+type IndexFunc func(obj interface{}) ([]string, error)
+
+func IndexFuncToKeyFuncAdapter(indexFunc IndexFunc) KeyFunc {
+	return func(obj interface{}) (string, error) {
+		indexKeys, err := indexFunc(obj)
+		if err != nil {
+			return "", err
+		}
+		if len(indexKeys) > 1 {
+			return "", fmt.Errorf("too many keys: %v", indexKeys)
+		}
+		return indexKeys[0], nil
+	}
+}
 
 // MetaNamespaceIndexFunc is a default index function that indexes based on an object's namespace
-func MetaNamespaceIndexFunc(obj interface{}) (string, error) {
+func MetaNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	meta, err := meta.Accessor(obj)
 	if err != nil {
-		return "", fmt.Errorf("object has no meta: %v", err)
+		return []string{""}, fmt.Errorf("object has no meta: %v", err)
 	}
-	return meta.Namespace(), nil
+	return []string{meta.Namespace()}, nil
 }
 
 // Index maps the indexed value to a set of keys in the store that match on that value

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/index.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/index.go
@@ -28,6 +28,8 @@ type Indexer interface {
 	Store
 	// Retrieve list of objects that match on the named indexing function
 	Index(indexName string, obj interface{}) ([]interface{}, error)
+	// ListIndexFuncValues returns the list of generated values of an Index func
+	ListIndexFuncValues(indexName string) []string
 }
 
 // IndexFunc knows how to provide an indexed value for an object.

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/index_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/index_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"testing"
+)
+
+func testIndexFunc(obj interface{}) (string, error) {
+	pod := obj.(*api.Pod)
+	return pod.Labels["foo"], nil
+}
+
+func TestGetIndexFuncValues(t *testing.T) {
+	index := NewIndexer(MetaNamespaceKeyFunc, Indexers{"testmodes": testIndexFunc})
+
+	pod1 := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "one", Labels: map[string]string{"foo": "bar"}}}
+	pod2 := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "two", Labels: map[string]string{"foo": "bar"}}}
+	pod3 := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "tre", Labels: map[string]string{"foo": "biz"}}}
+
+	index.Add(pod1)
+	index.Add(pod2)
+	index.Add(pod3)
+
+	keys := index.ListIndexFuncValues("testmodes")
+	if len(keys) != 2 {
+		t.Errorf("Expected 2 keys but got %v", len(keys))
+	}
+
+	for _, key := range keys {
+		if key != "bar" && key != "biz" {
+			t.Errorf("Expected only 'bar' or 'biz' but got %s", key)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/store.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/store.go
@@ -164,6 +164,11 @@ func (c *cache) Index(indexName string, obj interface{}) ([]interface{}, error) 
 	return c.cacheStorage.Index(indexName, obj)
 }
 
+// ListIndexFuncValues returns the list of generated values of an Index func
+func (c *cache) ListIndexFuncValues(indexName string) []string {
+	return c.cacheStorage.ListIndexFuncValues(indexName)
+}
+
 // Get returns the requested item, or sets exists=false.
 // Get is completely threadsafe as long as you treat all items as immutable.
 func (c *cache) Get(obj interface{}) (item interface{}, exists bool, err error) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/store.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/store.go
@@ -169,6 +169,10 @@ func (c *cache) ListIndexFuncValues(indexName string) []string {
 	return c.cacheStorage.ListIndexFuncValues(indexName)
 }
 
+func (c *cache) ByIndex(indexName, indexKey string) ([]interface{}, error) {
+	return c.cacheStorage.ByIndex(indexName, indexKey)
+}
+
 // Get returns the requested item, or sets exists=false.
 // Get is completely threadsafe as long as you treat all items as immutable.
 func (c *cache) Get(obj interface{}) (item interface{}, exists bool, err error) {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/store_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/store_test.go
@@ -123,8 +123,8 @@ func testStoreKeyFunc(obj interface{}) (string, error) {
 	return obj.(testStoreObject).id, nil
 }
 
-func testStoreIndexFunc(obj interface{}) (string, error) {
-	return obj.(testStoreObject).val, nil
+func testStoreIndexFunc(obj interface{}) ([]string, error) {
+	return []string{obj.(testStoreObject).val}, nil
 }
 
 func testStoreIndexers() Indexers {

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/thread_safe_store.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/thread_safe_store.go
@@ -43,6 +43,7 @@ type ThreadSafeStore interface {
 	ListKeys() []string
 	Replace(map[string]interface{})
 	Index(indexName string, obj interface{}) ([]interface{}, error)
+	ListIndexFuncValues(name string) []string
 }
 
 // threadSafeMap implements ThreadSafeStore
@@ -144,6 +145,15 @@ func (c *threadSafeMap) Index(indexName string, obj interface{}) ([]interface{},
 		list = append(list, c.items[key])
 	}
 	return list, nil
+}
+
+func (c *threadSafeMap) ListIndexFuncValues(indexName string) []string {
+	index := c.indices[indexName]
+	names := make([]string, 0, len(index))
+	for key := range index {
+		names = append(names, key)
+	}
+	return names
 }
 
 // updateIndices modifies the objects location in the managed indexes, if this is an update, you must provide an oldObj

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/thread_safe_store.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache/thread_safe_store.go
@@ -44,6 +44,7 @@ type ThreadSafeStore interface {
 	Replace(map[string]interface{})
 	Index(indexName string, obj interface{}) ([]interface{}, error)
 	ListIndexFuncValues(name string) []string
+	ByIndex(indexName, indexKey string) ([]interface{}, error)
 }
 
 // threadSafeMap implements ThreadSafeStore
@@ -134,16 +135,46 @@ func (c *threadSafeMap) Index(indexName string, obj interface{}) ([]interface{},
 		return nil, fmt.Errorf("Index with name %s does not exist", indexName)
 	}
 
-	indexKey, err := indexFunc(obj)
+	indexKeys, err := indexFunc(obj)
 	if err != nil {
 		return nil, err
 	}
 	index := c.indices[indexName]
+
+	// need to de-dupe the return list.  Since multiple keys are allowed, this can happen.
+	returnKeySet := util.StringSet{}
+	for _, indexKey := range indexKeys {
+		set := index[indexKey]
+		for _, key := range set.List() {
+			returnKeySet.Insert(key)
+		}
+	}
+
+	list := []interface{}{}
+	for absoluteKey := range returnKeySet {
+		list = append(list, c.items[absoluteKey])
+	}
+	return list, nil
+}
+
+// ByIndex returns a list of items that match an exact value on the index function
+func (c *threadSafeMap) ByIndex(indexName, indexKey string) ([]interface{}, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	indexFunc := c.indexers[indexName]
+	if indexFunc == nil {
+		return nil, fmt.Errorf("Index with name %s does not exist", indexName)
+	}
+
+	index := c.indices[indexName]
+
 	set := index[indexKey]
 	list := make([]interface{}, 0, set.Len())
 	for _, key := range set.List() {
 		list = append(list, c.items[key])
 	}
+
 	return list, nil
 }
 
@@ -164,7 +195,7 @@ func (c *threadSafeMap) updateIndices(oldObj interface{}, newObj interface{}, ke
 		c.deleteFromIndices(oldObj, key)
 	}
 	for name, indexFunc := range c.indexers {
-		indexValue, err := indexFunc(newObj)
+		indexValues, err := indexFunc(newObj)
 		if err != nil {
 			return err
 		}
@@ -173,12 +204,15 @@ func (c *threadSafeMap) updateIndices(oldObj interface{}, newObj interface{}, ke
 			index = Index{}
 			c.indices[name] = index
 		}
-		set := index[indexValue]
-		if set == nil {
-			set = util.StringSet{}
-			index[indexValue] = set
+
+		for _, indexValue := range indexValues {
+			set := index[indexValue]
+			if set == nil {
+				set = util.StringSet{}
+				index[indexValue] = set
+			}
+			set.Insert(key)
 		}
-		set.Insert(key)
 	}
 	return nil
 }
@@ -187,15 +221,18 @@ func (c *threadSafeMap) updateIndices(oldObj interface{}, newObj interface{}, ke
 // it is intended to be called from a function that already has a lock on the cache
 func (c *threadSafeMap) deleteFromIndices(obj interface{}, key string) error {
 	for name, indexFunc := range c.indexers {
-		indexValue, err := indexFunc(obj)
+		indexValues, err := indexFunc(obj)
 		if err != nil {
 			return err
 		}
+
 		index := c.indices[name]
-		if index != nil {
-			set := index[indexValue]
-			if set != nil {
-				set.Delete(key)
+		for _, indexValue := range indexValues {
+			if index != nil {
+				set := index[indexValue]
+				if set != nil {
+					set.Delete(key)
+				}
 			}
 		}
 	}

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/serviceaccounts_controller.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/serviceaccount/serviceaccounts_controller.go
@@ -34,12 +34,12 @@ import (
 )
 
 // nameIndexFunc is an index function that indexes based on an object's name
-func nameIndexFunc(obj interface{}) (string, error) {
+func nameIndexFunc(obj interface{}) ([]string, error) {
 	meta, err := meta.Accessor(obj)
 	if err != nil {
-		return "", fmt.Errorf("object has no meta: %v", err)
+		return []string{""}, fmt.Errorf("object has no meta: %v", err)
 	}
-	return meta.Name(), nil
+	return []string{meta.Name()}, nil
 }
 
 // ServiceAccountsControllerOptions contains options for running a ServiceAccountsController

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volumeclaimbinder/types.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/volumeclaimbinder/types.go
@@ -40,12 +40,12 @@ func NewPersistentVolumeOrderedIndex() *persistentVolumeOrderedIndex {
 }
 
 // accessModesIndexFunc is an indexing function that returns a persistent volume's AccessModes as a string
-func accessModesIndexFunc(obj interface{}) (string, error) {
+func accessModesIndexFunc(obj interface{}) ([]string, error) {
 	if pv, ok := obj.(*api.PersistentVolume); ok {
 		modes := volume.GetAccessModesAsString(pv.Spec.AccessModes)
-		return modes, nil
+		return []string{modes}, nil
 	}
-	return "", fmt.Errorf("object is not a persistent volume: %v", obj)
+	return []string{""}, fmt.Errorf("object is not a persistent volume: %v", obj)
 }
 
 // ListByAccessModes returns all volumes with the given set of AccessModeTypes *in order* of their storage capacity (low to high)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -17,13 +17,24 @@ limitations under the License.
 package lifecycle
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/admission"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/testclient"
 )
+
+// TODO this is what the code used to do.  This should actually be using the same mechanism as NewLifecycle
+func metaNamespaceIndexAsKeyFunc(obj interface{}) (string, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return "", fmt.Errorf("object has no meta: %v", err)
+	}
+	return meta.Namespace(), nil
+}
 
 // TestAdmission
 func TestAdmission(t *testing.T) {
@@ -36,7 +47,7 @@ func TestAdmission(t *testing.T) {
 			Phase: api.NamespaceActive,
 		},
 	}
-	store := cache.NewStore(cache.MetaNamespaceIndexFunc)
+	store := cache.NewStore(metaNamespaceIndexAsKeyFunc)
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
 	lfhandler := NewLifecycle(mockClient).(*lifecycle)

--- a/pkg/auth/oauth/registry/registry_test.go
+++ b/pkg/auth/oauth/registry/registry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/openshift/origin/pkg/auth/api"
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
+	"github.com/openshift/origin/pkg/auth/userregistry/identitymapper"
 	oapi "github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/test"
 	"github.com/openshift/origin/pkg/oauth/server/osinserver"
@@ -248,7 +249,7 @@ func TestRegistryAndServer(t *testing.T) {
 func TestAuthenticateTokenNotFound(t *testing.T) {
 	tokenRegistry := &test.AccessTokenRegistry{Err: apierrs.NewNotFound("AccessToken", "token")}
 	userRegistry := usertest.NewUserRegistry()
-	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry)
+	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry, identitymapper.NoopGroupMapper{})
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
 	if found {
@@ -267,7 +268,7 @@ func TestAuthenticateTokenNotFound(t *testing.T) {
 func TestAuthenticateTokenOtherGetError(t *testing.T) {
 	tokenRegistry := &test.AccessTokenRegistry{Err: errors.New("get error")}
 	userRegistry := usertest.NewUserRegistry()
-	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry)
+	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry, identitymapper.NoopGroupMapper{})
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
 	if found {
@@ -292,7 +293,7 @@ func TestAuthenticateTokenExpired(t *testing.T) {
 		},
 	}
 	userRegistry := usertest.NewUserRegistry()
-	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry)
+	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry, identitymapper.NoopGroupMapper{})
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
 	if found {
@@ -318,7 +319,7 @@ func TestAuthenticateTokenValidated(t *testing.T) {
 	userRegistry := usertest.NewUserRegistry()
 	userRegistry.Get["foo"] = &userapi.User{ObjectMeta: kapi.ObjectMeta{UID: "bar"}}
 
-	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry)
+	tokenAuthenticator := NewTokenAuthenticator(tokenRegistry, userRegistry, identitymapper.NoopGroupMapper{})
 
 	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
 	if !found {

--- a/pkg/auth/oauth/registry/tokenauthenticator.go
+++ b/pkg/auth/oauth/registry/tokenauthenticator.go
@@ -7,21 +7,24 @@ import (
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	kuser "github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
+	"github.com/openshift/origin/pkg/auth/userregistry/identitymapper"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	"github.com/openshift/origin/pkg/user/registry/user"
 )
 
 type TokenAuthenticator struct {
-	tokens oauthaccesstoken.Registry
-	users  user.Registry
+	tokens      oauthaccesstoken.Registry
+	users       user.Registry
+	groupMapper identitymapper.UserToGroupMapper
 }
 
 var ErrExpired = errors.New("Token is expired")
 
-func NewTokenAuthenticator(tokens oauthaccesstoken.Registry, users user.Registry) *TokenAuthenticator {
+func NewTokenAuthenticator(tokens oauthaccesstoken.Registry, users user.Registry, groupMapper identitymapper.UserToGroupMapper) *TokenAuthenticator {
 	return &TokenAuthenticator{
-		tokens: tokens,
-		users:  users,
+		tokens:      tokens,
+		users:       users,
+		groupMapper: groupMapper,
 	}
 }
 
@@ -44,9 +47,19 @@ func (a *TokenAuthenticator) AuthenticateToken(value string) (kuser.Info, bool, 
 		return nil, false, fmt.Errorf("user.UID (%s) does not match token.userUID (%s)", u.UID, token.UserUID)
 	}
 
+	groups, err := a.groupMapper.GroupsFor(u.Name)
+	if err != nil {
+		return nil, false, err
+	}
+	groupNames := []string{}
+	for _, group := range groups {
+		groupNames = append(groupNames, group.Name)
+	}
+	groupNames = append(groupNames, u.Groups...)
+
 	return &kuser.DefaultInfo{
 		Name:   u.Name,
 		UID:    string(u.UID),
-		Groups: u.Groups,
+		Groups: groupNames,
 	}, true, nil
 }

--- a/pkg/auth/userregistry/identitymapper/interfaces.go
+++ b/pkg/auth/userregistry/identitymapper/interfaces.go
@@ -1,0 +1,15 @@
+package identitymapper
+
+import (
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+type UserToGroupMapper interface {
+	GroupsFor(username string) ([]*userapi.Group, error)
+}
+
+type NoopGroupMapper struct{}
+
+func (n NoopGroupMapper) GroupsFor(username string) ([]*userapi.Group, error) {
+	return []*userapi.Group{}, nil
+}

--- a/pkg/build/prune/data.go
+++ b/pkg/build/prune/data.go
@@ -15,7 +15,7 @@ import (
 func BuildByBuildConfigIndexFunc(obj interface{}) ([]string, error) {
 	build, ok := obj.(*buildapi.Build)
 	if !ok {
-		return []string{""}, fmt.Errorf("not a build: %v", build)
+		return nil, fmt.Errorf("not a build: %v", build)
 	}
 	config := build.Status.Config
 	if config == nil {

--- a/pkg/build/prune/data.go
+++ b/pkg/build/prune/data.go
@@ -12,16 +12,16 @@ import (
 )
 
 // BuildByBuildConfigIndexFunc indexes Build items by their associated BuildConfig, if none, index with key "orphan"
-func BuildByBuildConfigIndexFunc(obj interface{}) (string, error) {
+func BuildByBuildConfigIndexFunc(obj interface{}) ([]string, error) {
 	build, ok := obj.(*buildapi.Build)
 	if !ok {
-		return "", fmt.Errorf("not a build: %v", build)
+		return []string{""}, fmt.Errorf("not a build: %v", build)
 	}
 	config := build.Status.Config
 	if config == nil {
-		return "orphan", nil
+		return []string{"orphan"}, nil
 	}
-	return config.Namespace + "/" + config.Name, nil
+	return []string{config.Namespace + "/" + config.Name}, nil
 }
 
 // Filter filters the set of objects

--- a/pkg/build/prune/data_test.go
+++ b/pkg/build/prune/data_test.go
@@ -1,6 +1,7 @@
 package prune
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -49,17 +50,17 @@ func TestBuildByBuildConfigIndexFunc(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	expectedKey := buildWithConfig.Status.Config.Namespace + "/" + buildWithConfig.Status.Config.Name
-	if actualKey != expectedKey {
-		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
+	expectedKey := []string{buildWithConfig.Status.Config.Namespace + "/" + buildWithConfig.Status.Config.Name}
+	if !reflect.DeepEqual(actualKey, expectedKey) {
+		t.Errorf("expected %#v, actual %#v", expectedKey, actualKey)
 	}
 	buildWithNoConfig := &buildapi.Build{}
 	actualKey, err = BuildByBuildConfigIndexFunc(buildWithNoConfig)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	expectedKey = "orphan"
-	if actualKey != expectedKey {
+	expectedKey = []string{"orphan"}
+	if !reflect.DeepEqual(actualKey, expectedKey) {
 		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
 	}
 }

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -363,3 +363,8 @@ func (c *MasterConfig) RunSecurityAllocationController() {
 	controller := factory.Create()
 	controller.Run()
 }
+
+// RunGroupCache starts the group cache
+func (c *MasterConfig) RunGroupCache() {
+	c.GroupCache.Run()
+}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -330,6 +330,7 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 	}()
 
 	// Must start policy caching immediately
+	openshiftConfig.RunGroupCache()
 	openshiftConfig.RunPolicyCache()
 	openshiftConfig.RunProjectCache()
 

--- a/pkg/deploy/prune/data.go
+++ b/pkg/deploy/prune/data.go
@@ -13,16 +13,16 @@ import (
 )
 
 // DeploymentByDeploymentConfigIndexFunc indexes Deployment items by their associated DeploymentConfig, if none, index with key "orphan"
-func DeploymentByDeploymentConfigIndexFunc(obj interface{}) (string, error) {
+func DeploymentByDeploymentConfigIndexFunc(obj interface{}) ([]string, error) {
 	controller, ok := obj.(*kapi.ReplicationController)
 	if !ok {
-		return "", fmt.Errorf("not a replication controller: %v", obj)
+		return []string{""}, fmt.Errorf("not a replication controller: %v", obj)
 	}
 	name := deployutil.DeploymentConfigNameFor(controller)
 	if len(name) == 0 {
-		return "orphan", nil
+		return []string{"orphan"}, nil
 	}
-	return controller.Namespace + "/" + name, nil
+	return []string{controller.Namespace + "/" + name}, nil
 }
 
 // Filter filters the set of objects

--- a/pkg/deploy/prune/data.go
+++ b/pkg/deploy/prune/data.go
@@ -16,7 +16,7 @@ import (
 func DeploymentByDeploymentConfigIndexFunc(obj interface{}) ([]string, error) {
 	controller, ok := obj.(*kapi.ReplicationController)
 	if !ok {
-		return []string{""}, fmt.Errorf("not a replication controller: %v", obj)
+		return nil, fmt.Errorf("not a replication controller: %v", obj)
 	}
 	name := deployutil.DeploymentConfigNameFor(controller)
 	if len(name) == 0 {

--- a/pkg/deploy/prune/data_test.go
+++ b/pkg/deploy/prune/data_test.go
@@ -1,6 +1,7 @@
 package prune
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -46,8 +47,8 @@ func TestDeploymentByDeploymentConfigIndexFunc(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	expectedKey := "a/b"
-	if actualKey != expectedKey {
+	expectedKey := []string{"a/b"}
+	if !reflect.DeepEqual(actualKey, expectedKey) {
 		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
 	}
 	deploymentWithNoConfig := &kapi.ReplicationController{}
@@ -55,8 +56,8 @@ func TestDeploymentByDeploymentConfigIndexFunc(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	expectedKey = "orphan"
-	if actualKey != expectedKey {
+	expectedKey = []string{"orphan"}
+	if !reflect.DeepEqual(actualKey, expectedKey) {
 		t.Errorf("expected %v, actual %v", expectedKey, actualKey)
 	}
 }

--- a/pkg/dns/serviceaccessor.go
+++ b/pkg/dns/serviceaccessor.go
@@ -65,8 +65,8 @@ func (a *cachedServiceAccessor) ServiceByPortalIP(ip string) (*api.Service, erro
 
 // indexServiceByPortalIP creates an index between a portalIP and the service that
 // uses it.
-func indexServiceByPortalIP(obj interface{}) (string, error) {
-	return obj.(*api.Service).Spec.ClusterIP, nil
+func indexServiceByPortalIP(obj interface{}) ([]string, error) {
+	return []string{obj.(*api.Service).Spec.ClusterIP}, nil
 }
 
 func (a *cachedServiceAccessor) Services(namespace string) client.ServiceInterface {

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -81,7 +81,7 @@ func TestAdmissionLifecycle(t *testing.T) {
 			Phase: kapi.NamespaceActive,
 		},
 	}
-	store := cache.NewStore(cache.MetaNamespaceIndexFunc)
+	store := cache.NewStore(cache.IndexFuncToKeyFuncAdapter(cache.MetaNamespaceIndexFunc))
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
 	projectcache.FakeProjectCache(mockClient, store, "")

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -21,7 +21,7 @@ func TestPodAdmission(t *testing.T) {
 			Namespace: "",
 		},
 	}
-	projectStore := cache.NewStore(cache.MetaNamespaceIndexFunc)
+	projectStore := cache.NewStore(cache.IndexFuncToKeyFuncAdapter(cache.MetaNamespaceIndexFunc))
 	projectStore.Add(project)
 
 	handler := &podNodeEnvironment{client: mockClient}

--- a/pkg/user/cache/groups.go
+++ b/pkg/user/cache/groups.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"fmt"
+	"time"
+
+	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/fields"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
+
+	userapi "github.com/openshift/origin/pkg/user/api"
+	groupregistry "github.com/openshift/origin/pkg/user/registry/group"
+)
+
+type GroupCache struct {
+	indexer   cache.Indexer
+	reflector *cache.Reflector
+}
+
+const byUserIndexName = "ByUser"
+
+// ByUserIndexKeys is cache.IndexFunc for Groups that will index groups by User, so that a direct cache lookup
+// using a User.Name will return all Groups that User is a member of
+func ByUserIndexKeys(obj interface{}) ([]string, error) {
+	group, ok := obj.(*userapi.Group)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type: %v", obj)
+	}
+
+	return group.Users, nil
+}
+
+func NewGroupCache(groupRegistry groupregistry.Registry) *GroupCache {
+	allNamespaceContext := kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceAll)
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{byUserIndexName: ByUserIndexKeys})
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return groupRegistry.ListGroups(allNamespaceContext, labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return groupRegistry.WatchGroups(allNamespaceContext, labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&userapi.Group{},
+		indexer,
+		// TODO this was chosen via copy/paste.  If or when we choose to standardize these in some way, be sure to update this.
+		2*time.Minute,
+	)
+
+	return &GroupCache{
+		indexer:   indexer,
+		reflector: reflector,
+	}
+}
+
+// Run begins watching and synchronizing the cache
+func (c *GroupCache) Run() {
+	c.reflector.Run()
+}
+
+// RunUntil starts a watch and handles watch events. Will restart the watch if it is closed.
+// RunUntil starts a goroutine and returns immediately. It will exit when stopCh is closed.
+func (c *GroupCache) RunUntil(stopChannel <-chan struct{}) {
+	c.reflector.RunUntil(stopChannel)
+}
+
+func (c *GroupCache) GroupsFor(username string) ([]*userapi.Group, error) {
+	objs, err := c.indexer.ByIndex(byUserIndexName, username)
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make([]*userapi.Group, len(objs))
+	for i := range objs {
+		groups[i] = objs[i].(*userapi.Group)
+	}
+
+	return groups, nil
+}


### PR DESCRIPTION
Upstream https://github.com/GoogleCloudPlatform/kubernetes/pull/11925

1. updates indexer to support indexing by multiple keys
1. index groups by their constituent users
1. update etcd token authenticator to lookup groups in the cache for the user

@smarterclayton suggestion for reviewer?  This hits authentication and authorization.