### PR TITLE
return if SCCs can't be listed

### DIFF
--- a/pkg/cmd/server/origin/ensure.go
+++ b/pkg/cmd/server/origin/ensure.go
@@ -152,7 +152,8 @@ func (c *MasterConfig) ensureDefaultNamespaceServiceAccountRoles() {
 func (c *MasterConfig) ensureDefaultSecurityContextConstraints() {
 	sccList, err := c.KubeClient().SecurityContextConstraints().List(labels.Everything(), fields.Everything())
 	if err != nil {
-		glog.Errorf("Unable to initialize security context constraints: %v", err)
+		glog.Errorf("Unable to initialize security context constraints: %v.  This may prevent the creation of pods", err)
+		return
 	}
 	if len(sccList.Items) > 0 {
 		return


### PR DESCRIPTION
No need to try and create if there is an error listing