### PR TITLE
make localsubjectaccessreview

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,3 +19,8 @@ when that change will happen.
 1. The `pauseControllers` field in `master-config.yaml` is deprecated as of Origin 1.0.4 and will
   no longer be supported in Origin 1.1. After that, a warning will be printed on startup if it
   is set to true.
+
+1. The `/ns/namespace-name/subjectaccessreview` endpoint is deprecated, use `/subjectaccessreview` 
+(with the `namespace` field set) or `/ns/namespace-name/localsubjectaccessreview`.  In 
+Origin 1.y / OSE 3.y, support for `/ns/namespace-name/subjectaccessreview` wil be removed.
+At that time, the openshift docker registry image must be upgraded in order to continue functioning.

--- a/api/definitions/v1.localresourceaccessreview/description.adoc
+++ b/api/definitions/v1.localresourceaccessreview/description.adoc
@@ -1,0 +1,1 @@
+Local Resource Access Reviews are objects that allow you to determine which users and groups can perform a given action in a given namespace.

--- a/api/definitions/v1.localsubjectaccessreview/description.adoc
+++ b/api/definitions/v1.localsubjectaccessreview/description.adoc
@@ -1,0 +1,1 @@
+Local Subject Access Reviews are objects that allow you to determine whether a given user or group can perform a particular action in a given namespace.  Leaving `user` and `groups` empty allows you determine whether the identity making the request can perform the action.

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -6837,6 +6837,194 @@
     ]
    },
    {
+    "path": "/oapi/v1/namespaces/{namespace}/localresourceaccessreviews",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.LocalResourceAccessReview",
+      "method": "POST",
+      "summary": "create a LocalResourceAccessReview",
+      "nickname": "createNamespacedLocalResourceAccessReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.LocalResourceAccessReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.LocalResourceAccessReview"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/localresourceaccessreviews",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.LocalResourceAccessReview",
+      "method": "POST",
+      "summary": "create a LocalResourceAccessReview",
+      "nickname": "createLocalResourceAccessReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.LocalResourceAccessReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.LocalResourceAccessReview"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/namespaces/{namespace}/localsubjectaccessreviews",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.LocalSubjectAccessReview",
+      "method": "POST",
+      "summary": "create a LocalSubjectAccessReview",
+      "nickname": "createNamespacedLocalSubjectAccessReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.LocalSubjectAccessReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.LocalSubjectAccessReview"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/localsubjectaccessreviews",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.LocalSubjectAccessReview",
+      "method": "POST",
+      "summary": "create a LocalSubjectAccessReview",
+      "nickname": "createLocalSubjectAccessReview",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.LocalSubjectAccessReview",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.LocalSubjectAccessReview"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/netnamespaces",
     "description": "OpenShift REST API, version v1",
     "operations": [
@@ -16111,6 +16299,97 @@
      }
     }
    },
+   "v1.LocalResourceAccessReview": {
+    "id": "v1.LocalResourceAccessReview",
+    "required": [
+     "namespace",
+     "verb",
+     "resource",
+     "resourceName"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the action being requested"
+     },
+     "verb": {
+      "type": "string",
+      "description": "one of get, list, watch, create, update, delete"
+     },
+     "resource": {
+      "type": "string",
+      "description": "one of the existing resource types"
+     },
+     "resourceName": {
+      "type": "string",
+      "description": "name of the resource being requested for a get or delete"
+     },
+     "content": {
+      "type": "string",
+      "description": "actual content of the request for create and update"
+     }
+    }
+   },
+   "v1.LocalSubjectAccessReview": {
+    "id": "v1.LocalSubjectAccessReview",
+    "required": [
+     "namespace",
+     "verb",
+     "resource",
+     "resourceName",
+     "user",
+     "groups"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the action being requested"
+     },
+     "verb": {
+      "type": "string",
+      "description": "one of get, list, watch, create, update, delete"
+     },
+     "resource": {
+      "type": "string",
+      "description": "one of the existing resource types"
+     },
+     "resourceName": {
+      "type": "string",
+      "description": "name of the resource being requested for a get or delete"
+     },
+     "content": {
+      "type": "string",
+      "description": "actual content of the request for create and update"
+     },
+     "user": {
+      "type": "string",
+      "description": "optional, if both user and groups are empty, the current authenticated user is used"
+     },
+     "groups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "optional, list of groups to which the user belongs"
+     }
+    }
+   },
    "v1.NetNamespaceList": {
     "id": "v1.NetNamespaceList",
     "required": [
@@ -16835,8 +17114,10 @@
    "v1.ResourceAccessReview": {
     "id": "v1.ResourceAccessReview",
     "required": [
+     "namespace",
      "verb",
-     "resource"
+     "resource",
+     "resourceName"
     ],
     "properties": {
      "kind": {
@@ -16847,6 +17128,10 @@
       "type": "string",
       "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the action being requested"
+     },
      "verb": {
       "type": "string",
       "description": "one of get, list, watch, create, update, delete"
@@ -16855,13 +17140,13 @@
       "type": "string",
       "description": "one of the existing resource types"
      },
-     "content": {
-      "type": "string",
-      "description": "actual content of the request for a create or update"
-     },
      "resourceName": {
       "type": "string",
-      "description": "name of the resource being requested for a get or delete operation"
+      "description": "name of the resource being requested for a get or delete"
+     },
+     "content": {
+      "type": "string",
+      "description": "actual content of the request for create and update"
      }
     }
    },
@@ -17002,11 +17287,12 @@
    "v1.SubjectAccessReview": {
     "id": "v1.SubjectAccessReview",
     "required": [
+     "namespace",
      "verb",
      "resource",
+     "resourceName",
      "user",
-     "groups",
-     "resourceName"
+     "groups"
     ],
     "properties": {
      "kind": {
@@ -17017,6 +17303,10 @@
       "type": "string",
       "description": "version of the schema the object should have; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
      },
+     "namespace": {
+      "type": "string",
+      "description": "namespace of the action being requested"
+     },
      "verb": {
       "type": "string",
       "description": "one of get, list, watch, create, update, delete"
@@ -17024,6 +17314,14 @@
      "resource": {
       "type": "string",
       "description": "one of the existing resource types"
+     },
+     "resourceName": {
+      "type": "string",
+      "description": "name of the resource being requested for a get or delete"
+     },
+     "content": {
+      "type": "string",
+      "description": "actual content of the request for create and update"
      },
      "user": {
       "type": "string",
@@ -17035,14 +17333,6 @@
        "type": "string"
       },
       "description": "optional, list of groups to which the user belongs"
-     },
-     "content": {
-      "type": "string",
-      "description": "actual content of the request for create and update"
-     },
-     "resourceName": {
-      "type": "string",
-      "description": "name of the resource being requested for a get or delete"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -18,6 +18,19 @@ import (
 	util "k8s.io/kubernetes/pkg/util"
 )
 
+func deepCopy_api_AuthorizationAttributes(in api.AuthorizationAttributes, out *api.AuthorizationAttributes, c *conversion.Cloner) error {
+	out.Namespace = in.Namespace
+	out.Verb = in.Verb
+	out.Resource = in.Resource
+	out.ResourceName = in.ResourceName
+	if newVal, err := c.DeepCopy(in.Content); err != nil {
+		return err
+	} else {
+		out.Content = newVal.(runtime.EmbeddedObject)
+	}
+	return nil
+}
+
 func deepCopy_api_ClusterPolicy(in api.ClusterPolicy, out *api.ClusterPolicy, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -257,6 +270,43 @@ func deepCopy_api_IsPersonalSubjectAccessReview(in api.IsPersonalSubjectAccessRe
 	return nil
 }
 
+func deepCopy_api_LocalResourceAccessReview(in api.LocalResourceAccessReview, out *api.LocalResourceAccessReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(pkgapi.TypeMeta)
+	}
+	if err := deepCopy_api_AuthorizationAttributes(in.Action, &out.Action, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_api_LocalSubjectAccessReview(in api.LocalSubjectAccessReview, out *api.LocalSubjectAccessReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(pkgapi.TypeMeta)
+	}
+	if err := deepCopy_api_AuthorizationAttributes(in.Action, &out.Action, c); err != nil {
+		return err
+	}
+	out.User = in.User
+	if in.Groups != nil {
+		out.Groups = make(util.StringSet)
+		for key, val := range in.Groups {
+			if newVal, err := c.DeepCopy(val); err != nil {
+				return err
+			} else {
+				out.Groups[key] = newVal.(util.Empty)
+			}
+		}
+	} else {
+		out.Groups = nil
+	}
+	return nil
+}
+
 func deepCopy_api_Policy(in api.Policy, out *api.Policy, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -435,14 +485,9 @@ func deepCopy_api_ResourceAccessReview(in api.ResourceAccessReview, out *api.Res
 	} else {
 		out.TypeMeta = newVal.(pkgapi.TypeMeta)
 	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if newVal, err := c.DeepCopy(in.Content); err != nil {
+	if err := deepCopy_api_AuthorizationAttributes(in.Action, &out.Action, c); err != nil {
 		return err
-	} else {
-		out.Content = newVal.(runtime.EmbeddedObject)
 	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -601,8 +646,9 @@ func deepCopy_api_SubjectAccessReview(in api.SubjectAccessReview, out *api.Subje
 	} else {
 		out.TypeMeta = newVal.(pkgapi.TypeMeta)
 	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
+	if err := deepCopy_api_AuthorizationAttributes(in.Action, &out.Action, c); err != nil {
+		return err
+	}
 	out.User = in.User
 	if in.Groups != nil {
 		out.Groups = make(util.StringSet)
@@ -616,12 +662,6 @@ func deepCopy_api_SubjectAccessReview(in api.SubjectAccessReview, out *api.Subje
 	} else {
 		out.Groups = nil
 	}
-	if newVal, err := c.DeepCopy(in.Content); err != nil {
-		return err
-	} else {
-		out.Content = newVal.(runtime.EmbeddedObject)
-	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -2549,6 +2589,7 @@ func deepCopy_api_UserList(in userapi.UserList, out *userapi.UserList, c *conver
 
 func init() {
 	err := pkgapi.Scheme.AddGeneratedDeepCopyFuncs(
+		deepCopy_api_AuthorizationAttributes,
 		deepCopy_api_ClusterPolicy,
 		deepCopy_api_ClusterPolicyBinding,
 		deepCopy_api_ClusterPolicyBindingList,
@@ -2558,6 +2599,8 @@ func init() {
 		deepCopy_api_ClusterRoleBindingList,
 		deepCopy_api_ClusterRoleList,
 		deepCopy_api_IsPersonalSubjectAccessReview,
+		deepCopy_api_LocalResourceAccessReview,
+		deepCopy_api_LocalSubjectAccessReview,
 		deepCopy_api_Policy,
 		deepCopy_api_PolicyBinding,
 		deepCopy_api_PolicyBindingList,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -200,22 +200,6 @@ func convert_api_PolicyList_To_v1_PolicyList(in *api.PolicyList, out *v1.PolicyL
 	return nil
 }
 
-func convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *api.ResourceAccessReview, out *v1.ResourceAccessReview, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*api.ResourceAccessReview))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if err := s.Convert(&in.Content, &out.Content, 0); err != nil {
-		return err
-	}
-	out.ResourceName = in.ResourceName
-	return nil
-}
-
 func convert_api_Role_To_v1_Role(in *api.Role, out *v1.Role, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Role))(in)
@@ -466,22 +450,6 @@ func convert_v1_PolicyList_To_api_PolicyList(in *v1.PolicyList, out *api.PolicyL
 	} else {
 		out.Items = nil
 	}
-	return nil
-}
-
-func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *v1.ResourceAccessReview, out *api.ResourceAccessReview, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*v1.ResourceAccessReview))(in)
-	}
-	if err := convert_v1_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if err := s.Convert(&in.Content, &out.Content, 0); err != nil {
-		return err
-	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -3196,7 +3164,6 @@ func init() {
 		convert_api_ProjectSpec_To_v1_ProjectSpec,
 		convert_api_ProjectStatus_To_v1_ProjectStatus,
 		convert_api_Project_To_v1_Project,
-		convert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
 		convert_api_ResourceRequirements_To_v1_ResourceRequirements,
 		convert_api_RoleBindingList_To_v1_RoleBindingList,
 		convert_api_RoleList_To_v1_RoleList,
@@ -3274,7 +3241,6 @@ func init() {
 		convert_v1_ProjectSpec_To_api_ProjectSpec,
 		convert_v1_ProjectStatus_To_api_ProjectStatus,
 		convert_v1_Project_To_api_Project,
-		convert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
 		convert_v1_ResourceRequirements_To_api_ResourceRequirements,
 		convert_v1_RoleBindingList_To_api_RoleBindingList,
 		convert_v1_RoleList_To_api_RoleList,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -19,6 +19,19 @@ import (
 	util "k8s.io/kubernetes/pkg/util"
 )
 
+func deepCopy_v1_AuthorizationAttributes(in v1.AuthorizationAttributes, out *v1.AuthorizationAttributes, c *conversion.Cloner) error {
+	out.Namespace = in.Namespace
+	out.Verb = in.Verb
+	out.Resource = in.Resource
+	out.ResourceName = in.ResourceName
+	if newVal, err := c.DeepCopy(in.Content); err != nil {
+		return err
+	} else {
+		out.Content = newVal.(runtime.RawExtension)
+	}
+	return nil
+}
+
 func deepCopy_v1_ClusterPolicy(in v1.ClusterPolicy, out *v1.ClusterPolicy, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -246,6 +259,39 @@ func deepCopy_v1_IsPersonalSubjectAccessReview(in v1.IsPersonalSubjectAccessRevi
 	return nil
 }
 
+func deepCopy_v1_LocalResourceAccessReview(in v1.LocalResourceAccessReview, out *v1.LocalResourceAccessReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(pkgapiv1.TypeMeta)
+	}
+	if err := deepCopy_v1_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_v1_LocalSubjectAccessReview(in v1.LocalSubjectAccessReview, out *v1.LocalSubjectAccessReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(pkgapiv1.TypeMeta)
+	}
+	if err := deepCopy_v1_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
+		return err
+	}
+	out.User = in.User
+	if in.GroupsSlice != nil {
+		out.GroupsSlice = make([]string, len(in.GroupsSlice))
+		for i := range in.GroupsSlice {
+			out.GroupsSlice[i] = in.GroupsSlice[i]
+		}
+	} else {
+		out.GroupsSlice = nil
+	}
+	return nil
+}
+
 func deepCopy_v1_NamedClusterRole(in v1.NamedClusterRole, out *v1.NamedClusterRole, c *conversion.Cloner) error {
 	out.Name = in.Name
 	if err := deepCopy_v1_ClusterRole(in.Role, &out.Role, c); err != nil {
@@ -436,14 +482,9 @@ func deepCopy_v1_ResourceAccessReview(in v1.ResourceAccessReview, out *v1.Resour
 	} else {
 		out.TypeMeta = newVal.(pkgapiv1.TypeMeta)
 	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if newVal, err := c.DeepCopy(in.Content); err != nil {
+	if err := deepCopy_v1_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
 		return err
-	} else {
-		out.Content = newVal.(runtime.RawExtension)
 	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -586,8 +627,9 @@ func deepCopy_v1_SubjectAccessReview(in v1.SubjectAccessReview, out *v1.SubjectA
 	} else {
 		out.TypeMeta = newVal.(pkgapiv1.TypeMeta)
 	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
+	if err := deepCopy_v1_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
+		return err
+	}
 	out.User = in.User
 	if in.GroupsSlice != nil {
 		out.GroupsSlice = make([]string, len(in.GroupsSlice))
@@ -597,12 +639,6 @@ func deepCopy_v1_SubjectAccessReview(in v1.SubjectAccessReview, out *v1.SubjectA
 	} else {
 		out.GroupsSlice = nil
 	}
-	if newVal, err := c.DeepCopy(in.Content); err != nil {
-		return err
-	} else {
-		out.Content = newVal.(runtime.RawExtension)
-	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -2426,6 +2462,7 @@ func deepCopy_v1_UserList(in userapiv1.UserList, out *userapiv1.UserList, c *con
 
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
+		deepCopy_v1_AuthorizationAttributes,
 		deepCopy_v1_ClusterPolicy,
 		deepCopy_v1_ClusterPolicyBinding,
 		deepCopy_v1_ClusterPolicyBindingList,
@@ -2435,6 +2472,8 @@ func init() {
 		deepCopy_v1_ClusterRoleBindingList,
 		deepCopy_v1_ClusterRoleList,
 		deepCopy_v1_IsPersonalSubjectAccessReview,
+		deepCopy_v1_LocalResourceAccessReview,
+		deepCopy_v1_LocalSubjectAccessReview,
 		deepCopy_v1_NamedClusterRole,
 		deepCopy_v1_NamedClusterRoleBinding,
 		deepCopy_v1_NamedRole,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -219,22 +219,6 @@ func convert_api_PolicyList_To_v1beta3_PolicyList(in *api.PolicyList, out *v1bet
 	return nil
 }
 
-func convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *api.ResourceAccessReview, out *v1beta3.ResourceAccessReview, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*api.ResourceAccessReview))(in)
-	}
-	if err := convert_api_TypeMeta_To_v1beta3_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if err := s.Convert(&in.Content, &out.Content, 0); err != nil {
-		return err
-	}
-	out.ResourceName = in.ResourceName
-	return nil
-}
-
 func convert_api_Role_To_v1beta3_Role(in *api.Role, out *v1beta3.Role, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.Role))(in)
@@ -504,22 +488,6 @@ func convert_v1beta3_PolicyList_To_api_PolicyList(in *v1beta3.PolicyList, out *a
 	} else {
 		out.Items = nil
 	}
-	return nil
-}
-
-func convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *v1beta3.ResourceAccessReview, out *api.ResourceAccessReview, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*v1beta3.ResourceAccessReview))(in)
-	}
-	if err := convert_v1beta3_TypeMeta_To_api_TypeMeta(&in.TypeMeta, &out.TypeMeta, s); err != nil {
-		return err
-	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if err := s.Convert(&in.Content, &out.Content, 0); err != nil {
-		return err
-	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -3130,7 +3098,6 @@ func init() {
 		convert_api_ProjectSpec_To_v1beta3_ProjectSpec,
 		convert_api_ProjectStatus_To_v1beta3_ProjectStatus,
 		convert_api_Project_To_v1beta3_Project,
-		convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
 		convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements,
 		convert_api_RoleBindingList_To_v1beta3_RoleBindingList,
 		convert_api_RoleList_To_v1beta3_RoleList,
@@ -3206,7 +3173,6 @@ func init() {
 		convert_v1beta3_ProjectSpec_To_api_ProjectSpec,
 		convert_v1beta3_ProjectStatus_To_api_ProjectStatus,
 		convert_v1beta3_Project_To_api_Project,
-		convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
 		convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements,
 		convert_v1beta3_RoleBindingList_To_api_RoleBindingList,
 		convert_v1beta3_RoleList_To_api_RoleList,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -19,6 +19,19 @@ import (
 	util "k8s.io/kubernetes/pkg/util"
 )
 
+func deepCopy_v1beta3_AuthorizationAttributes(in v1beta3.AuthorizationAttributes, out *v1beta3.AuthorizationAttributes, c *conversion.Cloner) error {
+	out.Namespace = in.Namespace
+	out.Verb = in.Verb
+	out.Resource = in.Resource
+	out.ResourceName = in.ResourceName
+	if newVal, err := c.DeepCopy(in.Content); err != nil {
+		return err
+	} else {
+		out.Content = newVal.(runtime.RawExtension)
+	}
+	return nil
+}
+
 func deepCopy_v1beta3_ClusterPolicy(in v1beta3.ClusterPolicy, out *v1beta3.ClusterPolicy, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -246,6 +259,39 @@ func deepCopy_v1beta3_IsPersonalSubjectAccessReview(in v1beta3.IsPersonalSubject
 	return nil
 }
 
+func deepCopy_v1beta3_LocalResourceAccessReview(in v1beta3.LocalResourceAccessReview, out *v1beta3.LocalResourceAccessReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(pkgapiv1beta3.TypeMeta)
+	}
+	if err := deepCopy_v1beta3_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_LocalSubjectAccessReview(in v1beta3.LocalSubjectAccessReview, out *v1beta3.LocalSubjectAccessReview, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
+		return err
+	} else {
+		out.TypeMeta = newVal.(pkgapiv1beta3.TypeMeta)
+	}
+	if err := deepCopy_v1beta3_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
+		return err
+	}
+	out.User = in.User
+	if in.GroupsSlice != nil {
+		out.GroupsSlice = make([]string, len(in.GroupsSlice))
+		for i := range in.GroupsSlice {
+			out.GroupsSlice[i] = in.GroupsSlice[i]
+		}
+	} else {
+		out.GroupsSlice = nil
+	}
+	return nil
+}
+
 func deepCopy_v1beta3_NamedClusterRole(in v1beta3.NamedClusterRole, out *v1beta3.NamedClusterRole, c *conversion.Cloner) error {
 	out.Name = in.Name
 	if err := deepCopy_v1beta3_ClusterRole(in.Role, &out.Role, c); err != nil {
@@ -444,14 +490,9 @@ func deepCopy_v1beta3_ResourceAccessReview(in v1beta3.ResourceAccessReview, out 
 	} else {
 		out.TypeMeta = newVal.(pkgapiv1beta3.TypeMeta)
 	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
-	if newVal, err := c.DeepCopy(in.Content); err != nil {
+	if err := deepCopy_v1beta3_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
 		return err
-	} else {
-		out.Content = newVal.(runtime.RawExtension)
 	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -594,8 +635,9 @@ func deepCopy_v1beta3_SubjectAccessReview(in v1beta3.SubjectAccessReview, out *v
 	} else {
 		out.TypeMeta = newVal.(pkgapiv1beta3.TypeMeta)
 	}
-	out.Verb = in.Verb
-	out.Resource = in.Resource
+	if err := deepCopy_v1beta3_AuthorizationAttributes(in.AuthorizationAttributes, &out.AuthorizationAttributes, c); err != nil {
+		return err
+	}
 	out.User = in.User
 	if in.GroupsSlice != nil {
 		out.GroupsSlice = make([]string, len(in.GroupsSlice))
@@ -605,12 +647,6 @@ func deepCopy_v1beta3_SubjectAccessReview(in v1beta3.SubjectAccessReview, out *v
 	} else {
 		out.GroupsSlice = nil
 	}
-	if newVal, err := c.DeepCopy(in.Content); err != nil {
-		return err
-	} else {
-		out.Content = newVal.(runtime.RawExtension)
-	}
-	out.ResourceName = in.ResourceName
 	return nil
 }
 
@@ -2416,6 +2452,7 @@ func deepCopy_v1beta3_UserList(in userapiv1beta3.UserList, out *userapiv1beta3.U
 
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
+		deepCopy_v1beta3_AuthorizationAttributes,
 		deepCopy_v1beta3_ClusterPolicy,
 		deepCopy_v1beta3_ClusterPolicyBinding,
 		deepCopy_v1beta3_ClusterPolicyBindingList,
@@ -2425,6 +2462,8 @@ func init() {
 		deepCopy_v1beta3_ClusterRoleBindingList,
 		deepCopy_v1beta3_ClusterRoleList,
 		deepCopy_v1beta3_IsPersonalSubjectAccessReview,
+		deepCopy_v1beta3_LocalResourceAccessReview,
+		deepCopy_v1beta3_LocalSubjectAccessReview,
 		deepCopy_v1beta3_NamedClusterRole,
 		deepCopy_v1beta3_NamedClusterRoleBinding,
 		deepCopy_v1beta3_NamedRole,

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -27,6 +27,8 @@ import (
 func init() {
 	Validator.Register(&authorizationapi.SubjectAccessReview{}, authorizationvalidation.ValidateSubjectAccessReview, nil)
 	Validator.Register(&authorizationapi.ResourceAccessReview{}, authorizationvalidation.ValidateResourceAccessReview, nil)
+	Validator.Register(&authorizationapi.LocalSubjectAccessReview{}, authorizationvalidation.ValidateLocalSubjectAccessReview, nil)
+	Validator.Register(&authorizationapi.LocalResourceAccessReview{}, authorizationvalidation.ValidateLocalResourceAccessReview, nil)
 
 	Validator.Register(&authorizationapi.Policy{}, authorizationvalidation.ValidateLocalPolicy, authorizationvalidation.ValidateLocalPolicyUpdate)
 	Validator.Register(&authorizationapi.PolicyBinding{}, authorizationvalidation.ValidateLocalPolicyBinding, authorizationvalidation.ValidateLocalPolicyBindingUpdate)

--- a/pkg/authorization/api/register.go
+++ b/pkg/authorization/api/register.go
@@ -10,15 +10,17 @@ func init() {
 		&RoleBinding{},
 		&Policy{},
 		&PolicyBinding{},
-		&ResourceAccessReview{},
-		&SubjectAccessReview{},
-		&ResourceAccessReviewResponse{},
-		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
 		&RoleBindingList{},
 		&RoleList{},
 
+		&ResourceAccessReview{},
+		&SubjectAccessReview{},
+		&LocalResourceAccessReview{},
+		&LocalSubjectAccessReview{},
+		&ResourceAccessReviewResponse{},
+		&SubjectAccessReviewResponse{},
 		&IsPersonalSubjectAccessReview{},
 
 		&ClusterRole{},
@@ -41,17 +43,19 @@ func (*ClusterPolicyBindingList) IsAnAPIObject() {}
 func (*ClusterRoleBindingList) IsAnAPIObject()   {}
 func (*ClusterRoleList) IsAnAPIObject()          {}
 
-func (*Role) IsAnAPIObject()                         {}
-func (*Policy) IsAnAPIObject()                       {}
-func (*PolicyBinding) IsAnAPIObject()                {}
-func (*RoleBinding) IsAnAPIObject()                  {}
-func (*ResourceAccessReview) IsAnAPIObject()         {}
-func (*SubjectAccessReview) IsAnAPIObject()          {}
-func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
-func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
-func (*PolicyList) IsAnAPIObject()                   {}
-func (*PolicyBindingList) IsAnAPIObject()            {}
-func (*RoleBindingList) IsAnAPIObject()              {}
-func (*RoleList) IsAnAPIObject()                     {}
+func (*Role) IsAnAPIObject()              {}
+func (*Policy) IsAnAPIObject()            {}
+func (*PolicyBinding) IsAnAPIObject()     {}
+func (*RoleBinding) IsAnAPIObject()       {}
+func (*PolicyList) IsAnAPIObject()        {}
+func (*PolicyBindingList) IsAnAPIObject() {}
+func (*RoleBindingList) IsAnAPIObject()   {}
+func (*RoleList) IsAnAPIObject()          {}
 
+func (*ResourceAccessReview) IsAnAPIObject()          {}
+func (*SubjectAccessReview) IsAnAPIObject()           {}
+func (*LocalResourceAccessReview) IsAnAPIObject()     {}
+func (*LocalSubjectAccessReview) IsAnAPIObject()      {}
+func (*ResourceAccessReviewResponse) IsAnAPIObject()  {}
+func (*SubjectAccessReviewResponse) IsAnAPIObject()   {}
 func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -10,8 +10,55 @@ import (
 	newer "github.com/openshift/origin/pkg/authorization/api"
 )
 
+func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convert_api_ResourceAccessReview_To_v1_ResourceAccessReview(in *newer.ResourceAccessReview, out *ResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *LocalResourceAccessReview, out *newer.LocalResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview(in *newer.LocalResourceAccessReview, out *LocalResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func convert_v1_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 
@@ -22,6 +69,35 @@ func convert_v1_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccess
 
 func convert_api_SubjectAccessReview_To_v1_SubjectAccessReview(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.GroupsSlice = in.Groups.List()
+
+	return nil
+}
+
+func convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *LocalSubjectAccessReview, out *newer.LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.Groups = util.NewStringSet(in.GroupsSlice...)
+
+	return nil
+}
+
+func convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview(in *newer.LocalSubjectAccessReview, out *LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 
@@ -312,6 +388,12 @@ func init() {
 
 		convert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
 		convert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
+		convert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
+		convert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview,
+		convert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
+		convert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
+		convert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
+		convert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview,
 		convert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
 		convert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse,
 		convert_v1_PolicyRule_To_api_PolicyRule,

--- a/pkg/authorization/api/v1/register.go
+++ b/pkg/authorization/api/v1/register.go
@@ -10,15 +10,17 @@ func init() {
 		&RoleBinding{},
 		&Policy{},
 		&PolicyBinding{},
-		&ResourceAccessReview{},
-		&SubjectAccessReview{},
-		&ResourceAccessReviewResponse{},
-		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
 		&RoleBindingList{},
 		&RoleList{},
 
+		&ResourceAccessReview{},
+		&SubjectAccessReview{},
+		&LocalResourceAccessReview{},
+		&LocalSubjectAccessReview{},
+		&ResourceAccessReviewResponse{},
+		&SubjectAccessReviewResponse{},
 		&IsPersonalSubjectAccessReview{},
 
 		&ClusterRole{},
@@ -41,17 +43,19 @@ func (*ClusterPolicyBindingList) IsAnAPIObject() {}
 func (*ClusterRoleBindingList) IsAnAPIObject()   {}
 func (*ClusterRoleList) IsAnAPIObject()          {}
 
-func (*Role) IsAnAPIObject()                         {}
-func (*Policy) IsAnAPIObject()                       {}
-func (*PolicyBinding) IsAnAPIObject()                {}
-func (*RoleBinding) IsAnAPIObject()                  {}
-func (*ResourceAccessReview) IsAnAPIObject()         {}
-func (*SubjectAccessReview) IsAnAPIObject()          {}
-func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
-func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
-func (*PolicyList) IsAnAPIObject()                   {}
-func (*PolicyBindingList) IsAnAPIObject()            {}
-func (*RoleBindingList) IsAnAPIObject()              {}
-func (*RoleList) IsAnAPIObject()                     {}
+func (*Role) IsAnAPIObject()              {}
+func (*Policy) IsAnAPIObject()            {}
+func (*PolicyBinding) IsAnAPIObject()     {}
+func (*RoleBinding) IsAnAPIObject()       {}
+func (*PolicyList) IsAnAPIObject()        {}
+func (*PolicyBindingList) IsAnAPIObject() {}
+func (*RoleBindingList) IsAnAPIObject()   {}
+func (*RoleList) IsAnAPIObject()          {}
 
+func (*ResourceAccessReview) IsAnAPIObject()          {}
+func (*SubjectAccessReview) IsAnAPIObject()           {}
+func (*LocalResourceAccessReview) IsAnAPIObject()     {}
+func (*LocalSubjectAccessReview) IsAnAPIObject()      {}
+func (*ResourceAccessReviewResponse) IsAnAPIObject()  {}
+func (*SubjectAccessReviewResponse) IsAnAPIObject()   {}
 func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -90,6 +90,16 @@ type PolicyBinding struct {
 	RoleBindings []NamedRoleBinding `json:"roleBindings" description:"all roleBindings held by this policyBinding"`
 }
 
+type NamedRole struct {
+	Name string `json:"name" description:"name of the role"`
+	Role Role   `json:"role" description:"the role"`
+}
+
+type NamedRoleBinding struct {
+	Name        string      `json:"name" description:"name of the roleBinding"`
+	RoleBinding RoleBinding `json:"roleBinding" description:"the roleBinding"`
+}
+
 // ResourceAccessReviewResponse describes who can perform the action
 type ResourceAccessReviewResponse struct {
 	kapi.TypeMeta `json:",inline"`
@@ -107,24 +117,8 @@ type ResourceAccessReviewResponse struct {
 type ResourceAccessReview struct {
 	kapi.TypeMeta `json:",inline"`
 
-	// Verb is one of: get, list, watch, create, update, delete
-	Verb string `json:"verb" description:"one of get, list, watch, create, update, delete"`
-	// Resource is one of the existing resource types
-	Resource string `json:"resource" description:"one of the existing resource types"`
-	// Content is the actual content of the request for create and update
-	Content kruntime.RawExtension `json:"content,omitempty" description:"actual content of the request for a create or update"`
-	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
-	ResourceName string `json:"resourceName,omitempty" description:"name of the resource being requested for a get or delete operation"`
-}
-
-type NamedRole struct {
-	Name string `json:"name" description:"name of the role"`
-	Role Role   `json:"role" description:"the role"`
-}
-
-type NamedRoleBinding struct {
-	Name        string      `json:"name" description:"name of the roleBinding"`
-	RoleBinding RoleBinding `json:"roleBinding" description:"the roleBinding"`
+	// AuthorizationAttributes describes the action being tested.
+	AuthorizationAttributes `json:",inline" description:"the action being tested"`
 }
 
 // SubjectAccessReviewResponse describes whether or not a user or group can perform an action
@@ -143,18 +137,45 @@ type SubjectAccessReviewResponse struct {
 type SubjectAccessReview struct {
 	kapi.TypeMeta `json:",inline"`
 
-	// Verb is one of: get, list, watch, create, update, delete
-	Verb string `json:"verb" description:"one of get, list, watch, create, update, delete"`
-	// Resource is one of the existing resource types
-	Resource string `json:"resource" description:"one of the existing resource types"`
+	// AuthorizationAttributes describes the action being tested.
+	AuthorizationAttributes `json:",inline" description:"the action being tested"`
 	// User is optional. If both User and Groups are empty, the current authenticated user is used.
 	User string `json:"user" description:"optional, if both user and groups are empty, the current authenticated user is used"`
 	// GroupsSlice is optional. Groups is the list of groups to which the User belongs.
 	GroupsSlice []string `json:"groups" description:"optional, list of groups to which the user belongs"`
-	// Content is the actual content of the request for create and update
-	Content kruntime.RawExtension `json:"content,omitempty" description:"actual content of the request for create and update"`
+}
+
+// LocalResourceAccessReview is a means to request a list of which users and groups are authorized to perform the action specified by spec in a particular namespace
+type LocalResourceAccessReview struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// AuthorizationAttributes describes the action being tested.  The Namespace element is FORCED to the current namespace.
+	AuthorizationAttributes `json:",inline" description:"the action being tested"`
+}
+
+// LocalSubjectAccessReview is an object for requesting information about whether a user or group can perform an action in a particular namespace
+type LocalSubjectAccessReview struct {
+	kapi.TypeMeta
+
+	// AuthorizationAttributes describes the action being tested.  The Namespace element is FORCED to the current namespace.
+	AuthorizationAttributes `json:",inline" description:"the action being tested"`
+	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
+	User string `json:"user" description:"optional, if both user and groups are empty, the current authenticated user is used"`
+	// Groups is optional.  Groups is the list of groups to which the User belongs.
+	GroupsSlice []string `json:"groups" description:"optional, list of groups to which the user belongs"`
+}
+
+type AuthorizationAttributes struct {
+	// Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces
+	Namespace string `json:"namespace" description:"namespace of the action being requested"`
+	// Verb is one of: get, list, watch, create, update, delete
+	Verb string `json:"verb" description:"one of get, list, watch, create, update, delete"`
+	// Resource is one of the existing resource types
+	Resource string `json:"resource" description:"one of the existing resource types"`
 	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
 	ResourceName string `json:"resourceName" description:"name of the resource being requested for a get or delete"`
+	// Content is the actual content of the request for create and update
+	Content kruntime.RawExtension `json:"content,omitempty" description:"actual content of the request for create and update"`
 }
 
 // PolicyList is a collection of Policies

--- a/pkg/authorization/api/v1beta3/conversion.go
+++ b/pkg/authorization/api/v1beta3/conversion.go
@@ -10,8 +10,55 @@ import (
 	newer "github.com/openshift/origin/pkg/authorization/api"
 )
 
+func convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview(in *newer.ResourceAccessReview, out *ResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview(in *LocalResourceAccessReview, out *newer.LocalResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview(in *newer.LocalResourceAccessReview, out *LocalResourceAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 
@@ -22,6 +69,35 @@ func convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview(in *SubjectA
 
 func convert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview(in *newer.SubjectAccessReview, out *SubjectAccessReview, s conversion.Scope) error {
 	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.GroupsSlice = in.Groups.List()
+
+	return nil
+}
+
+func convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview(in *LocalSubjectAccessReview, out *newer.LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.AuthorizationAttributes, &out.Action, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+
+	out.Groups = util.NewStringSet(in.GroupsSlice...)
+
+	return nil
+}
+
+func convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview(in *newer.LocalSubjectAccessReview, out *LocalSubjectAccessReview, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	if err := s.DefaultConvert(&in.Action, &out.AuthorizationAttributes, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 
@@ -186,6 +262,12 @@ func init() {
 	err := api.Scheme.AddConversionFuncs(
 		convert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview,
 		convert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview,
+		convert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
+		convert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview,
+		convert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
+		convert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
+		convert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
+		convert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview,
 		convert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
 		convert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewResponse,
 		convert_v1beta3_PolicyRule_To_api_PolicyRule,

--- a/pkg/authorization/api/v1beta3/register.go
+++ b/pkg/authorization/api/v1beta3/register.go
@@ -10,15 +10,17 @@ func init() {
 		&RoleBinding{},
 		&Policy{},
 		&PolicyBinding{},
-		&ResourceAccessReview{},
-		&SubjectAccessReview{},
-		&ResourceAccessReviewResponse{},
-		&SubjectAccessReviewResponse{},
 		&PolicyList{},
 		&PolicyBindingList{},
 		&RoleBindingList{},
 		&RoleList{},
 
+		&ResourceAccessReview{},
+		&SubjectAccessReview{},
+		&LocalResourceAccessReview{},
+		&LocalSubjectAccessReview{},
+		&ResourceAccessReviewResponse{},
+		&SubjectAccessReviewResponse{},
 		&IsPersonalSubjectAccessReview{},
 
 		&ClusterRole{},
@@ -41,17 +43,19 @@ func (*ClusterPolicyBindingList) IsAnAPIObject() {}
 func (*ClusterRoleBindingList) IsAnAPIObject()   {}
 func (*ClusterRoleList) IsAnAPIObject()          {}
 
-func (*Role) IsAnAPIObject()                         {}
-func (*Policy) IsAnAPIObject()                       {}
-func (*PolicyBinding) IsAnAPIObject()                {}
-func (*RoleBinding) IsAnAPIObject()                  {}
-func (*ResourceAccessReview) IsAnAPIObject()         {}
-func (*SubjectAccessReview) IsAnAPIObject()          {}
-func (*ResourceAccessReviewResponse) IsAnAPIObject() {}
-func (*SubjectAccessReviewResponse) IsAnAPIObject()  {}
-func (*PolicyList) IsAnAPIObject()                   {}
-func (*PolicyBindingList) IsAnAPIObject()            {}
-func (*RoleBindingList) IsAnAPIObject()              {}
-func (*RoleList) IsAnAPIObject()                     {}
+func (*Role) IsAnAPIObject()              {}
+func (*Policy) IsAnAPIObject()            {}
+func (*PolicyBinding) IsAnAPIObject()     {}
+func (*RoleBinding) IsAnAPIObject()       {}
+func (*PolicyList) IsAnAPIObject()        {}
+func (*PolicyBindingList) IsAnAPIObject() {}
+func (*RoleBindingList) IsAnAPIObject()   {}
+func (*RoleList) IsAnAPIObject()          {}
 
+func (*ResourceAccessReview) IsAnAPIObject()          {}
+func (*SubjectAccessReview) IsAnAPIObject()           {}
+func (*LocalResourceAccessReview) IsAnAPIObject()     {}
+func (*LocalSubjectAccessReview) IsAnAPIObject()      {}
+func (*ResourceAccessReviewResponse) IsAnAPIObject()  {}
+func (*SubjectAccessReviewResponse) IsAnAPIObject()   {}
 func (*IsPersonalSubjectAccessReview) IsAnAPIObject() {}

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -93,6 +93,16 @@ type PolicyBinding struct {
 	RoleBindings []NamedRoleBinding `json:"roleBindings"`
 }
 
+type NamedRole struct {
+	Name string `json:"name"`
+	Role Role   `json:"role"`
+}
+
+type NamedRoleBinding struct {
+	Name        string      `json:"name"`
+	RoleBinding RoleBinding `json:"roleBinding"`
+}
+
 // ResourceAccessReviewResponse describes who can perform the action
 type ResourceAccessReviewResponse struct {
 	kapi.TypeMeta `json:",inline"`
@@ -110,24 +120,8 @@ type ResourceAccessReviewResponse struct {
 type ResourceAccessReview struct {
 	kapi.TypeMeta `json:",inline"`
 
-	// Verb is one of: get, list, watch, create, update, delete
-	Verb string `json:"verb"`
-	// Resource is one of the existing resource types
-	Resource string `json:"resource"`
-	// Content is the actual content of the request for create and update
-	Content kruntime.RawExtension `json:"content,omitempty"`
-	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
-	ResourceName string `json:"resourceName,omitempty"`
-}
-
-type NamedRole struct {
-	Name string `json:"name"`
-	Role Role   `json:"role"`
-}
-
-type NamedRoleBinding struct {
-	Name        string      `json:"name"`
-	RoleBinding RoleBinding `json:"roleBinding"`
+	// AuthorizationAttributes describes the action being tested
+	AuthorizationAttributes `json:",inline"`
 }
 
 // SubjectAccessReviewResponse describes whether or not a user or group can perform an action
@@ -146,18 +140,45 @@ type SubjectAccessReviewResponse struct {
 type SubjectAccessReview struct {
 	kapi.TypeMeta `json:",inline"`
 
-	// Verb is one of: get, list, watch, create, update, delete
-	Verb string `json:"verb"`
-	// Resource is one of the existing resource types
-	Resource string `json:"resource"`
+	// AuthorizationAttributes describes the action being tested
+	AuthorizationAttributes `json:",inline"`
 	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
 	User string `json:"user"`
 	// Groups is optional.  Groups is the list of groups to which the User belongs.
 	GroupsSlice []string `json:"groups"`
-	// Content is the actual content of the request for create and update
-	Content kruntime.RawExtension `json:"content,omitempty"`
+}
+
+// LocalResourceAccessReview is a means to request a list of which users and groups are authorized to perform the action specified by spec in a particular namespace
+type LocalResourceAccessReview struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// AuthorizationAttributes describes the action being tested.  The Namespace element is FORCED to the current namespace.
+	AuthorizationAttributes `json:",inline"`
+}
+
+// LocalSubjectAccessReview is an object for requesting information about whether a user or group can perform an action in a particular namespace
+type LocalSubjectAccessReview struct {
+	kapi.TypeMeta `json:",inline"`
+
+	// AuthorizationAttributes describes the action being tested.  The Namespace element is FORCED to the current namespace.
+	AuthorizationAttributes `json:",inline"`
+	// User is optional.  If both User and Groups are empty, the current authenticated user is used.
+	User string `json:"user"`
+	// Groups is optional.  Groups is the list of groups to which the User belongs.
+	GroupsSlice []string `json:"groups"`
+}
+
+type AuthorizationAttributes struct {
+	// Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces
+	Namespace string `json:"namespace"`
+	// Verb is one of: get, list, watch, create, update, delete
+	Verb string `json:"verb"`
+	// Resource is one of the existing resource types
+	Resource string `json:"resource"`
 	// ResourceName is the name of the resource being requested for a "get" or deleted for a "delete"
 	ResourceName string `json:"resourceName"`
+	// Content is the actual content of the request for create and update
+	Content kruntime.RawExtension `json:"content,omitempty"`
 }
 
 // PolicyList is a collection of Policies

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -12,10 +12,10 @@ import (
 func ValidateSubjectAccessReview(review *authorizationapi.SubjectAccessReview) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
-	if len(review.Verb) == 0 {
+	if len(review.Action.Verb) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("verb"))
 	}
-	if len(review.Resource) == 0 {
+	if len(review.Action.Resource) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("resource"))
 	}
 
@@ -25,10 +25,36 @@ func ValidateSubjectAccessReview(review *authorizationapi.SubjectAccessReview) f
 func ValidateResourceAccessReview(review *authorizationapi.ResourceAccessReview) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
-	if len(review.Verb) == 0 {
+	if len(review.Action.Verb) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("verb"))
 	}
-	if len(review.Resource) == 0 {
+	if len(review.Action.Resource) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("resource"))
+	}
+
+	return allErrs
+}
+
+func ValidateLocalSubjectAccessReview(review *authorizationapi.LocalSubjectAccessReview) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(review.Action.Verb) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("verb"))
+	}
+	if len(review.Action.Resource) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("resource"))
+	}
+
+	return allErrs
+}
+
+func ValidateLocalResourceAccessReview(review *authorizationapi.LocalResourceAccessReview) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(review.Action.Verb) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("verb"))
+	}
+	if len(review.Action.Resource) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("resource"))
 	}
 

--- a/pkg/authorization/authorizer/attributes.go
+++ b/pkg/authorization/authorizer/attributes.go
@@ -20,6 +20,16 @@ type DefaultAuthorizationAttributes struct {
 	URL               string
 }
 
+// ToDefaultAuthorizationAttributes coerces AuthorizationAttributes to DefaultAuthorizationAttributes.  Namespace is not included
+// because the authorizer takes that information on the context
+func ToDefaultAuthorizationAttributes(in authorizationapi.AuthorizationAttributes) DefaultAuthorizationAttributes {
+	return DefaultAuthorizationAttributes{
+		Verb:         in.Verb,
+		Resource:     in.Resource,
+		ResourceName: in.ResourceName,
+	}
+}
+
 func (a DefaultAuthorizationAttributes) RuleMatches(rule authorizationapi.PolicyRule) (bool, error) {
 	if a.IsNonResourceURL() {
 		if a.nonResourceMatches(rule) {

--- a/pkg/authorization/registry/localresourceaccessreview/registry.go
+++ b/pkg/authorization/registry/localresourceaccessreview/registry.go
@@ -1,0 +1,31 @@
+package localresourceaccessreview
+
+import (
+	api "github.com/openshift/origin/pkg/authorization/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type Registry interface {
+	CreateLocalResourceAccessReview(ctx kapi.Context, resourceAccessReview *api.LocalResourceAccessReview) (*api.ResourceAccessReviewResponse, error)
+}
+
+type Storage interface {
+	Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error)
+}
+
+type storage struct {
+	Storage
+}
+
+func NewRegistry(s Storage) Registry {
+	return &storage{s}
+}
+
+func (s *storage) CreateLocalResourceAccessReview(ctx kapi.Context, resourceAccessReview *api.LocalResourceAccessReview) (*api.ResourceAccessReviewResponse, error) {
+	obj, err := s.Create(ctx, resourceAccessReview)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceAccessReviewResponse), nil
+}

--- a/pkg/authorization/registry/localresourceaccessreview/rest.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest.go
@@ -1,0 +1,53 @@
+package localresourceaccessreview
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/runtime"
+	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationvalidation "github.com/openshift/origin/pkg/authorization/api/validation"
+	"github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	clusterRARRegistry resourceaccessreview.Registry
+}
+
+func NewREST(clusterRARRegistry resourceaccessreview.Registry) *REST {
+	return &REST{clusterRARRegistry}
+}
+
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.LocalResourceAccessReview{}
+}
+
+// Create transforms a LocalRAR into an ClusterRAR that is requesting a namespace.  That collapses the code paths.
+// LocalResourceAccessReview exists to allow clean expression of policy.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	localRAR, ok := obj.(*authorizationapi.LocalResourceAccessReview)
+	if !ok {
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a localResourceAccessReview: %#v", obj))
+	}
+	if err := kutilerrors.NewAggregate(authorizationvalidation.ValidateLocalResourceAccessReview(localRAR)); err != nil {
+		return nil, err
+	}
+	if namespace := kapi.NamespaceValue(ctx); len(namespace) == 0 {
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("namespace is required on this type: %v", namespace))
+	} else if (len(localRAR.Action.Namespace) > 0) && (namespace != localRAR.Action.Namespace) {
+		return nil, fielderrors.NewFieldInvalid("namespace", localRAR.Action.Namespace, fmt.Sprintf("namespace must be: %v", namespace))
+	}
+
+	// transform this into a ResourceAccessReview
+	clusterRAR := &authorizationapi.ResourceAccessReview{
+		Action: localRAR.Action,
+	}
+	clusterRAR.Action.Namespace = kapi.NamespaceValue(ctx)
+
+	return r.clusterRARRegistry.CreateResourceAccessReview(kapi.WithNamespace(ctx, ""), clusterRAR)
+}

--- a/pkg/authorization/registry/localsubjectaccessreview/registry.go
+++ b/pkg/authorization/registry/localsubjectaccessreview/registry.go
@@ -1,0 +1,31 @@
+package localsubjectaccessreview
+
+import (
+	api "github.com/openshift/origin/pkg/authorization/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type Registry interface {
+	CreateLocalSubjectAccessReview(ctx kapi.Context, subjectAccessReview *api.LocalSubjectAccessReview) (*api.SubjectAccessReviewResponse, error)
+}
+
+type Storage interface {
+	Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error)
+}
+
+type storage struct {
+	Storage
+}
+
+func NewRegistry(s Storage) Registry {
+	return &storage{s}
+}
+
+func (s *storage) CreateLocalSubjectAccessReview(ctx kapi.Context, subjectAccessReview *api.LocalSubjectAccessReview) (*api.SubjectAccessReviewResponse, error) {
+	obj, err := s.Create(ctx, subjectAccessReview)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.SubjectAccessReviewResponse), nil
+}

--- a/pkg/authorization/registry/localsubjectaccessreview/rest.go
+++ b/pkg/authorization/registry/localsubjectaccessreview/rest.go
@@ -1,0 +1,55 @@
+package localsubjectaccessreview
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/runtime"
+	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	authorizationvalidation "github.com/openshift/origin/pkg/authorization/api/validation"
+	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
+)
+
+// REST implements the RESTStorage interface in terms of an Registry.
+type REST struct {
+	clusterSARRegistry subjectaccessreview.Registry
+}
+
+func NewREST(clusterSARRegistry subjectaccessreview.Registry) *REST {
+	return &REST{clusterSARRegistry}
+}
+
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.LocalSubjectAccessReview{}
+}
+
+// Create transforms a LocalSAR into an ClusterSAR that is requesting a namespace.  That collapses the code paths.
+// LocalSubjectAccessReview exists to allow clean expression of policy.
+func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
+	localSAR, ok := obj.(*authorizationapi.LocalSubjectAccessReview)
+	if !ok {
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a localSubjectAccessReview: %#v", obj))
+	}
+	if err := kutilerrors.NewAggregate(authorizationvalidation.ValidateLocalSubjectAccessReview(localSAR)); err != nil {
+		return nil, err
+	}
+	if namespace := kapi.NamespaceValue(ctx); len(namespace) == 0 {
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("namespace is required on this type: %v", namespace))
+	} else if (len(localSAR.Action.Namespace) > 0) && (namespace != localSAR.Action.Namespace) {
+		return nil, fielderrors.NewFieldInvalid("namespace", localSAR.Action.Namespace, fmt.Sprintf("namespace must be: %v", namespace))
+	}
+
+	// transform this into a SubjectAccessReview
+	clusterSAR := &authorizationapi.SubjectAccessReview{
+		Action: localSAR.Action,
+		User:   localSAR.User,
+		Groups: localSAR.Groups,
+	}
+	clusterSAR.Action.Namespace = kapi.NamespaceValue(ctx)
+
+	return r.clusterSARRegistry.CreateSubjectAccessReview(kapi.WithNamespace(ctx, ""), clusterSAR)
+}

--- a/pkg/authorization/registry/resourceaccessreview/registry.go
+++ b/pkg/authorization/registry/resourceaccessreview/registry.go
@@ -1,0 +1,31 @@
+package resourceaccessreview
+
+import (
+	api "github.com/openshift/origin/pkg/authorization/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type Registry interface {
+	CreateResourceAccessReview(ctx kapi.Context, resourceAccessReview *api.ResourceAccessReview) (*api.ResourceAccessReviewResponse, error)
+}
+
+type Storage interface {
+	Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error)
+}
+
+type storage struct {
+	Storage
+}
+
+func NewRegistry(s Storage) Registry {
+	return &storage{s}
+}
+
+func (s *storage) CreateResourceAccessReview(ctx kapi.Context, resourceAccessReview *api.ResourceAccessReview) (*api.ResourceAccessReviewResponse, error) {
+	obj, err := s.Create(ctx, resourceAccessReview)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceAccessReviewResponse), nil
+}

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -1,10 +1,11 @@
 package resourceaccessreview
 
 import (
+	"errors"
 	"fmt"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/errors"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/runtime"
 	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
 
@@ -32,29 +33,53 @@ func (r *REST) New() runtime.Object {
 func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
 	resourceAccessReview, ok := obj.(*authorizationapi.ResourceAccessReview)
 	if !ok {
-		return nil, errors.NewBadRequest(fmt.Sprintf("not a resourceAccessReview: %#v", obj))
+		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a resourceAccessReview: %#v", obj))
 	}
 	if err := kutilerrors.NewAggregate(authorizationvalidation.ValidateResourceAccessReview(resourceAccessReview)); err != nil {
 		return nil, err
 	}
-
-	namespace := kapi.NamespaceValue(ctx)
-
-	attributes := &authorizer.DefaultAuthorizationAttributes{
-		Verb:     resourceAccessReview.Verb,
-		Resource: resourceAccessReview.Resource,
+	// if a namespace is present on the request, then the namespace on the on the RAR is overwritten.
+	// This is to support backwards compatibility.  To have gotten here in this state, it means that
+	// the authorizer decided that a user could run an RAR against this namespace
+	if namespace := kapi.NamespaceValue(ctx); len(namespace) > 0 {
+		resourceAccessReview.Action.Namespace = namespace
+	}
+	if err := r.isAllowed(ctx, resourceAccessReview); err != nil {
+		return nil, err
 	}
 
-	users, groups, err := r.authorizer.GetAllowedSubjects(ctx, attributes)
+	requestContext := kapi.WithNamespace(ctx, resourceAccessReview.Action.Namespace)
+	attributes := authorizer.ToDefaultAuthorizationAttributes(resourceAccessReview.Action)
+	users, groups, err := r.authorizer.GetAllowedSubjects(requestContext, attributes)
 	if err != nil {
 		return nil, err
 	}
 
 	response := &authorizationapi.ResourceAccessReviewResponse{
-		Namespace: namespace,
+		Namespace: resourceAccessReview.Action.Namespace,
 		Users:     users,
 		Groups:    groups,
 	}
 
 	return response, nil
+}
+
+// isAllowed checks to see if the current user has rights to issue a LocalSubjectAccessReview on the namespace they're attempting to access
+func (r *REST) isAllowed(ctx kapi.Context, rar *authorizationapi.ResourceAccessReview) error {
+	localRARAttributes := authorizer.DefaultAuthorizationAttributes{
+		Verb:     "create",
+		Resource: "localresourceaccessreviews",
+	}
+	allowed, reason, err := r.authorizer.Authorize(kapi.WithNamespace(ctx, rar.Action.Namespace), localRARAttributes)
+
+	if err != nil {
+		return kapierrors.NewForbidden(localRARAttributes.GetResource(), localRARAttributes.GetResourceName(), err)
+	}
+	if !allowed {
+		forbiddenError, _ := kapierrors.NewForbidden(localRARAttributes.GetResource(), localRARAttributes.GetResourceName(), errors.New("") /*discarded*/).(*kapierrors.StatusError)
+		forbiddenError.ErrStatus.Message = reason
+		return forbiddenError
+	}
+
+	return nil
 }

--- a/pkg/build/admission/admission.go
+++ b/pkg/build/admission/admission.go
@@ -84,26 +84,30 @@ func resourceName(objectMeta kapi.ObjectMeta) string {
 
 func (a *buildByStrategy) checkBuildAuthorization(build *buildapi.Build, attr admission.Attributes) error {
 	strategyType := build.Spec.Strategy.Type
-	subjectAccessReview := &authorizationapi.SubjectAccessReview{
-		Verb:         "create",
-		Resource:     resourceForStrategyType(strategyType),
-		User:         attr.GetUserInfo().GetName(),
-		Groups:       util.NewStringSet(attr.GetUserInfo().GetGroups()...),
-		Content:      runtime.EmbeddedObject{Object: build},
-		ResourceName: resourceName(build.ObjectMeta),
+	subjectAccessReview := &authorizationapi.LocalSubjectAccessReview{
+		Action: authorizationapi.AuthorizationAttributes{
+			Verb:         "create",
+			Resource:     resourceForStrategyType(strategyType),
+			Content:      runtime.EmbeddedObject{Object: build},
+			ResourceName: resourceName(build.ObjectMeta),
+		},
+		User:   attr.GetUserInfo().GetName(),
+		Groups: util.NewStringSet(attr.GetUserInfo().GetGroups()...),
 	}
 	return a.checkAccess(strategyType, subjectAccessReview, attr)
 }
 
 func (a *buildByStrategy) checkBuildConfigAuthorization(buildConfig *buildapi.BuildConfig, attr admission.Attributes) error {
 	strategyType := buildConfig.Spec.Strategy.Type
-	subjectAccessReview := &authorizationapi.SubjectAccessReview{
-		Verb:         "create",
-		Resource:     resourceForStrategyType(strategyType),
-		User:         attr.GetUserInfo().GetName(),
-		Groups:       util.NewStringSet(attr.GetUserInfo().GetGroups()...),
-		Content:      runtime.EmbeddedObject{Object: buildConfig},
-		ResourceName: resourceName(buildConfig.ObjectMeta),
+	subjectAccessReview := &authorizationapi.LocalSubjectAccessReview{
+		Action: authorizationapi.AuthorizationAttributes{
+			Verb:         "create",
+			Resource:     resourceForStrategyType(strategyType),
+			Content:      runtime.EmbeddedObject{Object: buildConfig},
+			ResourceName: resourceName(buildConfig.ObjectMeta),
+		},
+		User:   attr.GetUserInfo().GetName(),
+		Groups: util.NewStringSet(attr.GetUserInfo().GetGroups()...),
 	}
 	return a.checkAccess(strategyType, subjectAccessReview, attr)
 }
@@ -127,8 +131,8 @@ func (a *buildByStrategy) checkBuildRequestAuthorization(req *buildapi.BuildRequ
 	}
 }
 
-func (a *buildByStrategy) checkAccess(strategyType buildapi.BuildStrategyType, subjectAccessReview *authorizationapi.SubjectAccessReview, attr admission.Attributes) error {
-	resp, err := a.client.SubjectAccessReviews(attr.GetNamespace()).Create(subjectAccessReview)
+func (a *buildByStrategy) checkAccess(strategyType buildapi.BuildStrategyType, subjectAccessReview *authorizationapi.LocalSubjectAccessReview, attr admission.Attributes) error {
+	resp, err := a.client.LocalSubjectAccessReviews(attr.GetNamespace()).Create(subjectAccessReview)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/admission/admission_test.go
+++ b/pkg/build/admission/admission_test.go
@@ -156,14 +156,14 @@ func fakeClient(expectedResource string, reviewResponse *authorizationapi.Subjec
 	return &testclient.Fake{
 		ReactFn: func(action ktestclient.Action) (runtime.Object, error) {
 			switch {
-			case action.Matches("create", "subjectaccessreviews"):
-				review, ok := action.(ktestclient.CreateAction).GetObject().(*authorizationapi.SubjectAccessReview)
+			case action.Matches("create", "localsubjectaccessreviews"):
+				review, ok := action.(ktestclient.CreateAction).GetObject().(*authorizationapi.LocalSubjectAccessReview)
 				if !ok {
 					return emptyResponse, fmt.Errorf("unexpected object received: %#v", review)
 				}
-				if review.Resource != expectedResource {
+				if review.Action.Resource != expectedResource {
 					return emptyResponse, fmt.Errorf("unexpected resource received: %s. expected: %s",
-						review.Resource, expectedResource)
+						review.Action.Resource, expectedResource)
 				}
 				return reviewResponse, nil
 			case action.Matches("get", "buildconfigs"):

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -113,7 +113,7 @@ func validateBuildSpec(spec *buildapi.BuildSpec) fielderrors.ValidationErrorList
 	allErrs = append(allErrs, validateOutput(&spec.Output).Prefix("output")...)
 	allErrs = append(allErrs, validateStrategy(&spec.Strategy).Prefix("strategy")...)
 
-	// TODO: validate resource requirements (prereq: https://github.com/GoogleCloudPlatform/kubernetes/pull/7059)
+	// TODO: validate resource requirements (prereq: https://k8s.io/kubernetes/pull/7059)
 	return allErrs
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,11 +34,12 @@ type Interface interface {
 	UserIdentityMappingsInterface
 	ProjectsInterface
 	ProjectRequestsInterface
-	ResourceAccessReviewsNamespacer
-	ClusterResourceAccessReviews
-	SubjectAccessReviewsNamespacer
+	LocalSubjectAccessReviewsImpersonator
 	SubjectAccessReviewsImpersonator
-	ClusterSubjectAccessReviews
+	LocalResourceAccessReviewsNamespacer
+	ResourceAccessReviews
+	SubjectAccessReviews
+	LocalSubjectAccessReviewsNamespacer
 	TemplatesNamespacer
 	TemplateConfigsNamespacer
 	OAuthAccessTokensInterface
@@ -177,29 +178,34 @@ func (c *Client) RoleBindings(namespace string) RoleBindingInterface {
 	return newRoleBindings(c, namespace)
 }
 
-// ResourceAccessReviews provides a REST client for ResourceAccessReviews
-func (c *Client) ResourceAccessReviews(namespace string) ResourceAccessReviewInterface {
-	return newResourceAccessReviews(c, namespace)
+// LocalResourceAccessReviews provides a REST client for LocalResourceAccessReviews
+func (c *Client) LocalResourceAccessReviews(namespace string) LocalResourceAccessReviewInterface {
+	return newLocalResourceAccessReviews(c, namespace)
 }
 
 // ClusterResourceAccessReviews provides a REST client for ClusterResourceAccessReviews
-func (c *Client) ClusterResourceAccessReviews() ResourceAccessReviewInterface {
-	return newClusterResourceAccessReviews(c)
-}
-
-// SubjectAccessReviews provides a REST client for SubjectAccessReviews
-func (c *Client) SubjectAccessReviews(namespace string) SubjectAccessReviewInterface {
-	return newSubjectAccessReviews(c, namespace, "")
+func (c *Client) ResourceAccessReviews() ResourceAccessReviewInterface {
+	return newResourceAccessReviews(c)
 }
 
 // ImpersonateSubjectAccessReviews provides a REST client for SubjectAccessReviews
-func (c *Client) ImpersonateSubjectAccessReviews(namespace, token string) SubjectAccessReviewInterface {
-	return newSubjectAccessReviews(c, namespace, token)
+func (c *Client) ImpersonateSubjectAccessReviews(token string) SubjectAccessReviewInterface {
+	return newImpersonatingSubjectAccessReviews(c, token)
 }
 
-// ClusterSubjectAccessReviews provides a REST client for SubjectAccessReviews
-func (c *Client) ClusterSubjectAccessReviews() SubjectAccessReviewInterface {
-	return newClusterSubjectAccessReviews(c)
+// ImpersonateLocalSubjectAccessReviews provides a REST client for SubjectAccessReviews
+func (c *Client) ImpersonateLocalSubjectAccessReviews(namespace, token string) LocalSubjectAccessReviewInterface {
+	return newImpersonatingLocalSubjectAccessReviews(c, namespace, token)
+}
+
+// LocalSubjectAccessReviews provides a REST client for LocalSubjectAccessReviews
+func (c *Client) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
+	return newLocalSubjectAccessReviews(c, namespace)
+}
+
+// SubjectAccessReviews provides a REST client for SubjectAccessReviews
+func (c *Client) SubjectAccessReviews() SubjectAccessReviewInterface {
+	return newSubjectAccessReviews(c)
 }
 
 // OAuthAccessTokens provides a REST client for OAuthAccessTokens

--- a/pkg/client/localresourceaccessreview.go
+++ b/pkg/client/localresourceaccessreview.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+// LocalResourceAccessReviewsNamespacer has methods to work with LocalResourceAccessReview resources in a namespace
+type LocalResourceAccessReviewsNamespacer interface {
+	LocalResourceAccessReviews(namespace string) LocalResourceAccessReviewInterface
+}
+
+// LocalResourceAccessReviewInterface exposes methods on LocalResourceAccessReview resources.
+type LocalResourceAccessReviewInterface interface {
+	Create(policy *authorizationapi.LocalResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error)
+}
+
+// localResourceAccessReviews implements ResourceAccessReviewsNamespacer interface
+type localResourceAccessReviews struct {
+	r  *Client
+	ns string
+}
+
+// newLocalResourceAccessReviews returns a localLocalResourceAccessReviews
+func newLocalResourceAccessReviews(c *Client, namespace string) *localResourceAccessReviews {
+	return &localResourceAccessReviews{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+func (c *localResourceAccessReviews) Create(rar *authorizationapi.LocalResourceAccessReview) (result *authorizationapi.ResourceAccessReviewResponse, err error) {
+	result = &authorizationapi.ResourceAccessReviewResponse{}
+	err = c.r.Post().Namespace(c.ns).Resource("localResourceAccessReviews").Body(rar).Do().Into(result)
+
+	// if we get one of these failures, we may be talking to an older openshift.  In that case, we need to try hitting ns/namespace-name/subjectaccessreview
+	if kapierrors.IsForbidden(err) || kapierrors.IsNotFound(err) {
+		deprecatedRAR := &authorizationapi.ResourceAccessReview{
+			Action: rar.Action,
+		}
+		deprecatedResponse := &authorizationapi.ResourceAccessReviewResponse{}
+		deprecatedAttemptErr := c.r.Post().Namespace(c.ns).Resource("resourceAccessReviews").Body(deprecatedRAR).Do().Into(deprecatedResponse)
+		if deprecatedAttemptErr == nil {
+			err = nil
+			result = deprecatedResponse
+		}
+	}
+
+	return
+}

--- a/pkg/client/localsubjectaccessreview.go
+++ b/pkg/client/localsubjectaccessreview.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type LocalSubjectAccessReviewsImpersonator interface {
+	ImpersonateLocalSubjectAccessReviews(namespace, token string) LocalSubjectAccessReviewInterface
+}
+
+// LocalSubjectAccessReviewsNamespacer has methods to work with LocalSubjectAccessReview resources in a namespace
+type LocalSubjectAccessReviewsNamespacer interface {
+	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface
+}
+
+// LocalSubjectAccessReviewInterface exposes methods on LocalSubjectAccessReview resources.
+type LocalSubjectAccessReviewInterface interface {
+	Create(policy *authorizationapi.LocalSubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error)
+}
+
+// localSubjectAccessReviews implements LocalSubjectAccessReviewsNamespacer interface
+type localSubjectAccessReviews struct {
+	r     *Client
+	ns    string
+	token string
+}
+
+// newImpersonatingLocalSubjectAccessReviews returns a subjectAccessReviews
+func newImpersonatingLocalSubjectAccessReviews(c *Client, namespace, token string) *localSubjectAccessReviews {
+	return &localSubjectAccessReviews{
+		r:     c,
+		ns:    namespace,
+		token: token,
+	}
+}
+
+// newLocalSubjectAccessReviews returns a localSubjectAccessReviews
+func newLocalSubjectAccessReviews(c *Client, namespace string) *localSubjectAccessReviews {
+	return &localSubjectAccessReviews{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+func (c *localSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
+	result = &authorizationapi.SubjectAccessReviewResponse{}
+	err = overrideAuth(c.token, c.r.Post().Namespace(c.ns).Resource("localSubjectAccessReviews")).Body(sar).Do().Into(result)
+
+	// if we get one of these failures, we may be talking to an older openshift.  In that case, we need to try hitting ns/namespace-name/subjectaccessreview
+	if kapierrors.IsForbidden(err) || kapierrors.IsNotFound(err) {
+		deprecatedSAR := &authorizationapi.SubjectAccessReview{
+			Action: sar.Action,
+			User:   sar.User,
+			Groups: sar.Groups,
+		}
+		deprecatedResponse := &authorizationapi.SubjectAccessReviewResponse{}
+		deprecatedAttemptErr := overrideAuth(c.token, c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews")).Body(deprecatedSAR).Do().Into(deprecatedResponse)
+		if deprecatedAttemptErr == nil {
+			err = nil
+			result = deprecatedResponse
+		}
+	}
+
+	return
+}

--- a/pkg/client/subjectaccessreview.go
+++ b/pkg/client/subjectaccessreview.go
@@ -3,23 +3,19 @@ package client
 import (
 	"fmt"
 
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/client"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
-// SubjectAccessReviewsNamespacer has methods to work with SubjectAccessReview resources in a namespace
-type SubjectAccessReviewsNamespacer interface {
-	SubjectAccessReviews(namespace string) SubjectAccessReviewInterface
-}
-
 type SubjectAccessReviewsImpersonator interface {
-	ImpersonateSubjectAccessReviews(namespace, token string) SubjectAccessReviewInterface
+	ImpersonateSubjectAccessReviews(token string) SubjectAccessReviewInterface
 }
 
-// ClusterSubjectAccessReviews has methods to work with SubjectAccessReview resources in the cluster scope
-type ClusterSubjectAccessReviews interface {
-	ClusterSubjectAccessReviews() SubjectAccessReviewInterface
+// SubjectAccessReviews has methods to work with SubjectAccessReview resources in the cluster scope
+type SubjectAccessReviews interface {
+	SubjectAccessReviews() SubjectAccessReviewInterface
 }
 
 // SubjectAccessReviewInterface exposes methods on SubjectAccessReview resources.
@@ -27,45 +23,56 @@ type SubjectAccessReviewInterface interface {
 	Create(policy *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error)
 }
 
-// subjectAccessReviews implements SubjectAccessReviewsNamespacer interface
+// subjectAccessReviews implements SubjectAccessReviews interface
 type subjectAccessReviews struct {
 	r     *Client
-	ns    string
 	token string
 }
 
-// newSubjectAccessReviews returns a subjectAccessReviews
-func newSubjectAccessReviews(c *Client, namespace, token string) *subjectAccessReviews {
+// newImpersonatingSubjectAccessReviews returns a subjectAccessReviews
+func newImpersonatingSubjectAccessReviews(c *Client, token string) *subjectAccessReviews {
 	return &subjectAccessReviews{
 		r:     c,
-		ns:    namespace,
 		token: token,
 	}
 }
 
-// Create creates new policy. Returns the server's representation of the policy and error if one occurs.
-func (c *subjectAccessReviews) Create(policy *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
-	result = &authorizationapi.SubjectAccessReviewResponse{}
-	err = overrideAuth(c.token, c.r.Post().Namespace(c.ns).Resource("subjectAccessReviews")).Body(policy).Do().Into(result)
-	return
-}
-
-// clusterSubjectAccessReviews implements ClusterSubjectAccessReviews interface
-type clusterSubjectAccessReviews struct {
-	r *Client
-}
-
-// newClusterSubjectAccessReviews returns a clusterSubjectAccessReviews
-func newClusterSubjectAccessReviews(c *Client) *clusterSubjectAccessReviews {
-	return &clusterSubjectAccessReviews{
+// newSubjectAccessReviews returns a subjectAccessReviews
+func newSubjectAccessReviews(c *Client) *subjectAccessReviews {
+	return &subjectAccessReviews{
 		r: c,
 	}
 }
 
-// Create creates new policy. Returns the server's representation of the policy and error if one occurs.
-func (c *clusterSubjectAccessReviews) Create(policy *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
+func (c *subjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReviewResponse, err error) {
 	result = &authorizationapi.SubjectAccessReviewResponse{}
-	err = c.r.Post().Resource("subjectAccessReviews").Body(policy).Do().Into(result)
+
+	// if this a cluster SAR, then no special handling
+	if len(sar.Action.Namespace) == 0 {
+		err = overrideAuth(c.token, c.r.Post().Resource("subjectAccessReviews")).Body(sar).Do().Into(result)
+		return
+	}
+
+	err = c.r.Post().Resource("subjectAccessReviews").Body(sar).Do().Into(result)
+
+	// if the namespace values don't match then we definitely hit an old server.  If we got a forbidden, then we might have hit an old server
+	// and should try the old endpoint
+	if (sar.Action.Namespace != result.Namespace) || kapierrors.IsForbidden(err) {
+		deprecatedResponse := &authorizationapi.SubjectAccessReviewResponse{}
+		deprecatedAttemptErr := overrideAuth(c.token, c.r.Post().Namespace(sar.Action.Namespace).Resource("subjectAccessReviews")).Body(sar).Do().Into(deprecatedResponse)
+
+		// if we definitely hit an old server, then return the error and result you get from the older server.
+		if sar.Action.Namespace != result.Namespace {
+			return deprecatedResponse, deprecatedAttemptErr
+		}
+
+		// if we're not certain it was an old server, success overwrites the previous error, but failure doesn't overwrite the previous error
+		if deprecatedAttemptErr == nil {
+			err = nil
+			result = deprecatedResponse
+		}
+	}
+
 	return
 }
 

--- a/pkg/client/testclient/fake.go
+++ b/pkg/client/testclient/fake.go
@@ -211,24 +211,24 @@ func (c *Fake) PolicyBindings(namespace string) client.PolicyBindingInterface {
 	return &FakePolicyBindings{Fake: c, Namespace: namespace}
 }
 
-// ResourceAccessReviews provides a fake REST client for ResourceAccessReviews
-func (c *Fake) ResourceAccessReviews(namespace string) client.ResourceAccessReviewInterface {
-	return &FakeResourceAccessReviews{Fake: c, Namespace: namespace}
+// LocalResourceAccessReviews provides a fake REST client for ResourceAccessReviews
+func (c *Fake) LocalResourceAccessReviews(namespace string) client.LocalResourceAccessReviewInterface {
+	return &FakeLocalResourceAccessReviews{Fake: c}
 }
 
-// ClusterResourceAccessReviews provides a fake REST client for ClusterResourceAccessReviews
-func (c *Fake) ClusterResourceAccessReviews() client.ResourceAccessReviewInterface {
+// ResourceAccessReviews provides a fake REST client for ClusterResourceAccessReviews
+func (c *Fake) ResourceAccessReviews() client.ResourceAccessReviewInterface {
 	return &FakeClusterResourceAccessReviews{Fake: c}
 }
 
-// SubjectAccessReviews provides a fake REST client for SubjectAccessReviews
-func (c *Fake) SubjectAccessReviews(namespace string) client.SubjectAccessReviewInterface {
-	return &FakeSubjectAccessReviews{Fake: c, Namespace: namespace}
+// ImpersonateSubjectAccessReviews provides a fake REST client for SubjectAccessReviews
+func (c *Fake) ImpersonateSubjectAccessReviews(token string) client.SubjectAccessReviewInterface {
+	return &FakeClusterSubjectAccessReviews{Fake: c}
 }
 
 // ImpersonateSubjectAccessReviews provides a fake REST client for SubjectAccessReviews
-func (c *Fake) ImpersonateSubjectAccessReviews(token, namespace string) client.SubjectAccessReviewInterface {
-	return &FakeSubjectAccessReviews{Fake: c, Namespace: namespace}
+func (c *Fake) ImpersonateLocalSubjectAccessReviews(namespace, token string) client.LocalSubjectAccessReviewInterface {
+	return &FakeLocalSubjectAccessReviews{Fake: c, Namespace: namespace}
 }
 
 // OAuthAccessTokens provides a fake REST client for OAuthAccessTokens
@@ -236,8 +236,13 @@ func (c *Fake) OAuthAccessTokens() client.OAuthAccessTokenInterface {
 	return &FakeOAuthAccessTokens{Fake: c}
 }
 
-// ClusterSubjectAccessReviews provides a fake REST client for ClusterSubjectAccessReviews
-func (c *Fake) ClusterSubjectAccessReviews() client.SubjectAccessReviewInterface {
+// LocalSubjectAccessReviews provides a fake REST client for SubjectAccessReviews
+func (c *Fake) LocalSubjectAccessReviews(namespace string) client.LocalSubjectAccessReviewInterface {
+	return &FakeLocalSubjectAccessReviews{Fake: c}
+}
+
+// SubjectAccessReviews provides a fake REST client for ClusterSubjectAccessReviews
+func (c *Fake) SubjectAccessReviews() client.SubjectAccessReviewInterface {
 	return &FakeClusterSubjectAccessReviews{Fake: c}
 }
 

--- a/pkg/client/testclient/fake_localresourceaccessreview.go
+++ b/pkg/client/testclient/fake_localresourceaccessreview.go
@@ -1,0 +1,20 @@
+package testclient
+
+import (
+	ktestclient "k8s.io/kubernetes/pkg/client/testclient"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeLocalResourceAccessReviews struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeLocalResourceAccessReviews) Create(inObj *authorizationapi.LocalResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewCreateAction("localresourceaccessreviews", c.Namespace, inObj), &authorizationapi.ResourceAccessReviewResponse{})
+	if cast, ok := obj.(*authorizationapi.ResourceAccessReviewResponse); ok {
+		return cast, err
+	}
+	return nil, err
+}

--- a/pkg/client/testclient/fake_localsubjectaccessreview.go
+++ b/pkg/client/testclient/fake_localsubjectaccessreview.go
@@ -1,0 +1,20 @@
+package testclient
+
+import (
+	ktestclient "k8s.io/kubernetes/pkg/client/testclient"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+type FakeLocalSubjectAccessReviews struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeLocalSubjectAccessReviews) Create(inObj *authorizationapi.LocalSubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewCreateAction("localsubjectaccessreviews", c.Namespace, inObj), &authorizationapi.SubjectAccessReviewResponse{})
+	if cast, ok := obj.(*authorizationapi.SubjectAccessReviewResponse); ok {
+		return cast, err
+	}
+	return nil, err
+}

--- a/pkg/client/testclient/fake_resourceaccessreview.go
+++ b/pkg/client/testclient/fake_resourceaccessreview.go
@@ -6,31 +6,14 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
-// FakeResourceAccessReviews implements ResourceAccessReviewInterface. Meant to be embedded into a struct to get a default
-// implementation. This makes faking out just the methods you want to test easier.
-type FakeResourceAccessReviews struct {
-	Fake      *Fake
-	Namespace string
-}
-
-func (c *FakeResourceAccessReviews) Create(inObj *authorizationapi.ResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(ktestclient.NewCreateAction("resourceaccessreviews", c.Namespace, inObj), inObj)
-	if obj == nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.ResourceAccessReviewResponse), err
-}
-
 type FakeClusterResourceAccessReviews struct {
 	Fake *Fake
 }
 
 func (c *FakeClusterResourceAccessReviews) Create(inObj *authorizationapi.ResourceAccessReview) (*authorizationapi.ResourceAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("resourceaccessreviews", inObj), inObj)
-	if obj == nil {
-		return nil, err
+	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("resourceaccessreviews", inObj), &authorizationapi.ResourceAccessReviewResponse{})
+	if cast, ok := obj.(*authorizationapi.ResourceAccessReviewResponse); ok {
+		return cast, err
 	}
-
-	return obj.(*authorizationapi.ResourceAccessReviewResponse), err
+	return nil, err
 }

--- a/pkg/client/testclient/fake_subjectaccessreview.go
+++ b/pkg/client/testclient/fake_subjectaccessreview.go
@@ -6,22 +6,6 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
 
-// FakeSubjectAccessReviews implements SubjectAccessReviewInterface. Meant to be embedded into a struct to get a default
-// implementation. This makes faking out just the methods you want to test easier.
-type FakeSubjectAccessReviews struct {
-	Fake      *Fake
-	Namespace string
-}
-
-func (c *FakeSubjectAccessReviews) Create(inObj *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(ktestclient.NewCreateAction("subjectaccessreviews", c.Namespace, inObj), inObj)
-	if obj == nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.SubjectAccessReviewResponse), err
-}
-
 // FakeClusterSubjectAccessReviews implements the ClusterSubjectAccessReviews interface.
 // Meant to be embedded into a struct to get a default implementation.
 // This makes faking out just the methods you want to test easier.
@@ -30,10 +14,9 @@ type FakeClusterSubjectAccessReviews struct {
 }
 
 func (c *FakeClusterSubjectAccessReviews) Create(inObj *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
-	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("subjectaccessreviews", inObj), inObj)
-	if obj == nil {
-		return nil, err
+	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("subjectaccessreviews", inObj), &authorizationapi.SubjectAccessReviewResponse{})
+	if cast, ok := obj.(*authorizationapi.SubjectAccessReviewResponse); ok {
+		return cast, err
 	}
-
-	return obj.(*authorizationapi.SubjectAccessReviewResponse), err
+	return nil, err
 }

--- a/pkg/cmd/cli/cmd/config.go
+++ b/pkg/cmd/cli/cmd/config.go
@@ -21,7 +21,7 @@ The client stores configuration in the current user's home directory (under the 
 config). When you login the first time, a new config file is created, and subsequent project changes with the
 'project' command will set the current context. These subcommands allow you to manage the config directly.
 
-Reference: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubeconfig-file.md`
+Reference: https://k8s.io/kubernetes/blob/master/docs/kubeconfig-file.md`
 
 	configExample = `  // Change the config context to use
   %[1]s %[2]s use-context my-context

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -45,6 +45,14 @@ var DescriberCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&deployapi.DeploymentConfigRollback{}),             // normal users don't ever look at these
 	reflect.TypeOf(&projectapi.ProjectRequest{}),                      // normal users don't ever look at these
 	reflect.TypeOf(&authorizationapi.IsPersonalSubjectAccessReview{}), // not a top level resource
+
+	// these resources can't be "GET"ed, so you can't make a describer for them
+	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
+	reflect.TypeOf(&authorizationapi.LocalSubjectAccessReview{}),
+	reflect.TypeOf(&authorizationapi.LocalResourceAccessReview{}),
 }
 
 // MissingDescriberCoverageExceptions is the list of types that were missing describer methods when I started
@@ -52,10 +60,6 @@ var DescriberCoverageExceptions = []reflect.Type{
 // TODO describers should be added for these types
 var MissingDescriberCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&imageapi.ImageStreamMapping{}),
-	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
-	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
-	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
-	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
 	reflect.TypeOf(&oauthapi.OAuthClient{}),
 	reflect.TypeOf(&sdnapi.ClusterNetwork{}),
 	reflect.TypeOf(&sdnapi.HostSubnet{}),

--- a/pkg/cmd/cli/describe/printer_test.go
+++ b/pkg/cmd/cli/describe/printer_test.go
@@ -22,16 +22,20 @@ import (
 var PrinterCoverageExceptions = []reflect.Type{
 	reflect.TypeOf(&imageapi.DockerImage{}), // not a top level resource
 	reflect.TypeOf(&buildapi.BuildLog{}),    // just a marker type
+
+	// these resources can't be "GET"ed, so we probably don't need a printer for them
+	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
+	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
+	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
+	reflect.TypeOf(&authorizationapi.LocalSubjectAccessReview{}),
+	reflect.TypeOf(&authorizationapi.LocalResourceAccessReview{}),
 }
 
 // MissingPrinterCoverageExceptions is the list of types that were missing printer methods when I started
 // You should never add to this list
 // TODO printers should be added for these types
 var MissingPrinterCoverageExceptions = []reflect.Type{
-	reflect.TypeOf(&authorizationapi.SubjectAccessReviewResponse{}),
-	reflect.TypeOf(&authorizationapi.ResourceAccessReviewResponse{}),
-	reflect.TypeOf(&authorizationapi.SubjectAccessReview{}),
-	reflect.TypeOf(&authorizationapi.ResourceAccessReview{}),
 	reflect.TypeOf(&deployapi.DeploymentConfigRollback{}),
 	reflect.TypeOf(&imageapi.ImageStreamMapping{}),
 	reflect.TypeOf(&buildapi.BuildLogOptions{}),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -125,7 +125,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{Verbs: util.NewStringSet("list"), Resources: util.NewStringSet("projectrequests")},
 				{Verbs: util.NewStringSet("list", "get"), Resources: util.NewStringSet("clusterroles")},
 				{Verbs: util.NewStringSet("list"), Resources: util.NewStringSet("projects")},
-				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("subjectaccessreviews"), AttributeRestrictions: runtime.EmbeddedObject{Object: &authorizationapi.IsPersonalSubjectAccessReview{}}},
+				{Verbs: util.NewStringSet("create"), Resources: util.NewStringSet("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: runtime.EmbeddedObject{Object: &authorizationapi.IsPersonalSubjectAccessReview{}}},
 			},
 		},
 		{

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -77,11 +77,13 @@ import (
 	clusterpolicybindingstorage "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding/etcd"
 	clusterrolestorage "github.com/openshift/origin/pkg/authorization/registry/clusterrole/proxy"
 	clusterrolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding/proxy"
+	"github.com/openshift/origin/pkg/authorization/registry/localresourceaccessreview"
+	"github.com/openshift/origin/pkg/authorization/registry/localsubjectaccessreview"
 	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
 	policyetcd "github.com/openshift/origin/pkg/authorization/registry/policy/etcd"
 	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
 	policybindingetcd "github.com/openshift/origin/pkg/authorization/registry/policybinding/etcd"
-	resourceaccessreviewregistry "github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
+	"github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
 	rolestorage "github.com/openshift/origin/pkg/authorization/registry/role/policybased"
 	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
@@ -359,6 +361,10 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 
 	subjectAccessReviewStorage := subjectaccessreview.NewREST(c.Authorizer)
 	subjectAccessReviewRegistry := subjectaccessreview.NewRegistry(subjectAccessReviewStorage)
+	localSubjectAccessReviewStorage := localsubjectaccessreview.NewREST(subjectAccessReviewRegistry)
+	resourceAccessReviewStorage := resourceaccessreview.NewREST(c.Authorizer)
+	resourceAccessReviewRegistry := resourceaccessreview.NewRegistry(resourceAccessReviewStorage)
+	localResourceAccessReviewStorage := localresourceaccessreview.NewREST(resourceAccessReviewRegistry)
 
 	imageStorage := imageetcd.NewREST(c.EtcdHelper)
 	imageRegistry := image.NewRegistry(imageStorage)
@@ -455,8 +461,10 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"oAuthClients":              clientetcd.NewREST(c.EtcdHelper),
 		"oAuthClientAuthorizations": clientauthetcd.NewREST(c.EtcdHelper),
 
-		"resourceAccessReviews": resourceaccessreviewregistry.NewREST(c.Authorizer),
-		"subjectAccessReviews":  subjectAccessReviewStorage,
+		"resourceAccessReviews":      resourceAccessReviewStorage,
+		"subjectAccessReviews":       subjectAccessReviewStorage,
+		"localSubjectAccessReviews":  localSubjectAccessReviewStorage,
+		"localResourceAccessReviews": localResourceAccessReviewStorage,
 
 		"policies":       policyStorage,
 		"policyBindings": policyBindingStorage,

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -87,7 +87,7 @@ func validateDeploymentStrategy(strategy *deployapi.DeploymentStrategy) fielderr
 		}
 	}
 
-	// TODO: validate resource requirements (prereq: https://github.com/GoogleCloudPlatform/kubernetes/pull/7059)
+	// TODO: validate resource requirements (prereq: https://k8s.io/kubernetes/pull/7059)
 
 	return errs
 }

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -20,7 +20,7 @@ import (
 )
 
 // TODO: This should perhaps be made public upstream. See:
-// https://github.com/GoogleCloudPlatform/kubernetes/issues/7851
+// https://k8s.io/kubernetes/issues/7851
 const sourceIdAnnotation = "kubectl.kubernetes.io/update-source-id"
 
 // RollingDeploymentStrategy is a Strategy which implements rolling
@@ -35,8 +35,8 @@ const sourceIdAnnotation = "kubectl.kubernetes.io/update-source-id"
 // These caveats can be resolved with future upstream refactorings to
 // RollingUpdater[1][2].
 //
-// [1] https://github.com/GoogleCloudPlatform/kubernetes/pull/7183
-// [2] https://github.com/GoogleCloudPlatform/kubernetes/issues/7851
+// [1] https://k8s.io/kubernetes/pull/7183
+// [2] https://k8s.io/kubernetes/issues/7851
 type RollingDeploymentStrategy struct {
 	// initialStrategy is used when there are no prior deployments.
 	initialStrategy acceptingDeploymentStrategy
@@ -56,7 +56,7 @@ type RollingDeploymentStrategy struct {
 // acceptingDeploymentStrategy is a DeploymentStrategy which accepts an
 // injected UpdateAcceptor as part of the deploy function. This is a hack to
 // support using the Recreate strategy for initial deployments and should be
-// removed when https://github.com/GoogleCloudPlatform/kubernetes/pull/7183 is
+// removed when https://k8s.io/kubernetes/pull/7183 is
 // fixed.
 type acceptingDeploymentStrategy interface {
 	DeployWithAcceptor(from *kapi.ReplicationController, to *kapi.ReplicationController, desiredReplicas int, updateAcceptor kubectl.UpdateAcceptor) error
@@ -174,7 +174,7 @@ func (s *RollingDeploymentStrategy) Deploy(from *kapi.ReplicationController, to 
 	// unless it already exists on the deployment.
 	//
 	// Related upstream issue:
-	// https://github.com/GoogleCloudPlatform/kubernetes/pull/7183
+	// https://k8s.io/kubernetes/pull/7183
 	to, err = s.client.GetReplicationController(to.Namespace, to.Name)
 	if err != nil {
 		return fmt.Errorf("couldn't look up deployment %s: %s", deployutil.LabelForDeployment(to), err)
@@ -194,7 +194,7 @@ func (s *RollingDeploymentStrategy) Deploy(from *kapi.ReplicationController, to 
 	// on the RC. For now, fake it out by just setting replicas to 1.
 	//
 	// Related upstream issue:
-	// https://github.com/GoogleCloudPlatform/kubernetes/pull/7183
+	// https://k8s.io/kubernetes/pull/7183
 	to.Spec.Replicas = 1
 
 	// Perform a rolling update.

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -174,9 +174,9 @@ func TestAccessController(t *testing.T) {
 			openshiftResponses: []response{
 				{500, "Uh oh"},
 			},
-			expectedError:     errors.New("an error on the server has prevented the request from succeeding (post subjectAccessReviews)"),
+			expectedError:     errors.New("an error on the server has prevented the request from succeeding (post localSubjectAccessReviews)"),
 			expectedChallenge: false,
-			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/subjectaccessreviews"},
+			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews"},
 		},
 		"valid openshift token but token not scoped for the given repo operation": {
 			access: []auth.Access{{
@@ -192,7 +192,7 @@ func TestAccessController(t *testing.T) {
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
-			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/subjectaccessreviews"},
+			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews"},
 		},
 		"partially valid openshift token": {
 			// Check all the different resource-type/verb combinations we allow to make sure they validate and continue to validate remaining Resource requests
@@ -212,10 +212,10 @@ func TestAccessController(t *testing.T) {
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
 			expectedActions: []string{
-				"POST /oapi/v1/namespaces/foo/subjectaccessreviews",
-				"POST /oapi/v1/namespaces/bar/subjectaccessreviews",
+				"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews",
+				"POST /oapi/v1/namespaces/bar/localsubjectaccessreviews",
 				"POST /oapi/v1/subjectaccessreviews",
-				"POST /oapi/v1/namespaces/baz/subjectaccessreviews",
+				"POST /oapi/v1/namespaces/baz/localsubjectaccessreviews",
 			},
 		},
 		"valid openshift token": {
@@ -232,7 +232,7 @@ func TestAccessController(t *testing.T) {
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
-			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/subjectaccessreviews"},
+			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews"},
 		},
 		"pruning": {
 			access: []auth.Access{

--- a/pkg/gitserver/gitserver.go
+++ b/pkg/gitserver/gitserver.go
@@ -200,17 +200,19 @@ func NewEnviromentConfig() (*Config, error) {
 			if !info.Push && allowAnonymousGet {
 				return true, nil
 			}
-			req := &authapi.SubjectAccessReview{
-				Verb:     "get",
-				Resource: "pods",
+			req := &authapi.LocalSubjectAccessReview{
+				Action: authapi.AuthorizationAttributes{
+					Verb:     "get",
+					Resource: "pods",
+				},
 			}
 			if info.Push {
 				if !config.AllowPush {
 					return false, nil
 				}
-				req.Verb = "create"
+				req.Action.Verb = "create"
 			}
-			res, err := osc.ImpersonateSubjectAccessReviews(namespace, info.Password).Create(req)
+			res, err := osc.ImpersonateLocalSubjectAccessReviews(namespace, info.Password).Create(req)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -309,11 +309,13 @@ func (v *TagVerifier) Verify(old, stream *api.ImageStream, user user.Info) field
 		}
 
 		subjectAccessReview := authorizationapi.SubjectAccessReview{
-			Verb:         "get",
-			Resource:     "imagestreams",
-			User:         user.GetName(),
-			Groups:       util.NewStringSet(user.GetGroups()...),
-			ResourceName: streamName,
+			Action: authorizationapi.AuthorizationAttributes{
+				Verb:         "get",
+				Resource:     "imagestreams",
+				ResourceName: streamName,
+			},
+			User:   user.GetName(),
+			Groups: util.NewStringSet(user.GetGroups()...),
 		}
 		ctx := kapi.WithNamespace(kapi.NewContext(), tagRef.From.Namespace)
 		glog.V(1).Infof("Performing SubjectAccessReview for user=%s, groups=%v to %s/%s", user.GetName(), user.GetGroups(), tagRef.From.Namespace, streamName)

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -282,11 +282,13 @@ func TestTagVerifier(t *testing.T) {
 				t.Errorf("%s: sar namespace: expected %v, got %v", name, e, a)
 			}
 			expectedSar := &authorizationapi.SubjectAccessReview{
-				Verb:         "get",
-				Resource:     "imagestreams",
-				User:         "user",
-				Groups:       util.NewStringSet("group1"),
-				ResourceName: "otherstream",
+				Action: authorizationapi.AuthorizationAttributes{
+					Verb:         "get",
+					Resource:     "imagestreams",
+					ResourceName: "otherstream",
+				},
+				User:   "user",
+				Groups: util.NewStringSet("group1"),
 			}
 			if e, a := expectedSar, sar.request; !reflect.DeepEqual(e, a) {
 				t.Errorf("%s: unexpected SAR request: %s", name, util.ObjectDiff(e, a))

--- a/pkg/project/auth/reviewer.go
+++ b/pkg/project/auth/reviewer.go
@@ -32,11 +32,11 @@ type Reviewer interface {
 
 // reviewer performs access reviews for a project by name
 type reviewer struct {
-	resourceAccessReviewsNamespacer client.ResourceAccessReviewsNamespacer
+	resourceAccessReviewsNamespacer client.LocalResourceAccessReviewsNamespacer
 }
 
 // NewReviewer knows how to make access control reviews for a resource by name
-func NewReviewer(resourceAccessReviewsNamespacer client.ResourceAccessReviewsNamespacer) Reviewer {
+func NewReviewer(resourceAccessReviewsNamespacer client.LocalResourceAccessReviewsNamespacer) Reviewer {
 	return &reviewer{
 		resourceAccessReviewsNamespacer: resourceAccessReviewsNamespacer,
 	}
@@ -44,13 +44,15 @@ func NewReviewer(resourceAccessReviewsNamespacer client.ResourceAccessReviewsNam
 
 // Review performs a resource access review for the given resource by name
 func (r *reviewer) Review(name string) (Review, error) {
-	resourceAccessReview := &authorizationapi.ResourceAccessReview{
-		Verb:         "get",
-		Resource:     "namespaces",
-		ResourceName: name,
+	resourceAccessReview := &authorizationapi.LocalResourceAccessReview{
+		Action: authorizationapi.AuthorizationAttributes{
+			Verb:         "get",
+			Resource:     "namespaces",
+			ResourceName: name,
+		},
 	}
 
-	response, err := r.resourceAccessReviewsNamespacer.ResourceAccessReviews(name).Create(resourceAccessReview)
+	response, err := r.resourceAccessReviewsNamespacer.LocalResourceAccessReviews(name).Create(resourceAccessReview)
 
 	if err != nil {
 		return nil, err

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -154,12 +154,14 @@ func (r *REST) List(ctx kapi.Context, label labels.Selector, field fields.Select
 	// the caller might not have permission to run a subject access review (he has it by default, but it could have been removed).
 	// So we'll escalate for the subject access review to determine rights
 	accessReview := &authorizationapi.SubjectAccessReview{
-		Verb:     "create",
-		Resource: "projectrequests",
-		User:     userInfo.GetName(),
-		Groups:   util.NewStringSet(userInfo.GetGroups()...),
+		Action: authorizationapi.AuthorizationAttributes{
+			Verb:     "create",
+			Resource: "projectrequests",
+		},
+		User:   userInfo.GetName(),
+		Groups: util.NewStringSet(userInfo.GetGroups()...),
 	}
-	accessReviewResponse, err := r.openshiftClient.ClusterSubjectAccessReviews().Create(accessReview)
+	accessReviewResponse, err := r.openshiftClient.SubjectAccessReviews().Create(accessReview)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -159,10 +159,12 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 	}
 
 	// can I get a subjectaccessreview on myself even if I have no rights to do it generally
-	askCanICreatePolicyBindings := &authorizationapi.SubjectAccessReview{Verb: "create", Resource: "policybindings"}
+	askCanICreatePolicyBindings := &authorizationapi.LocalSubjectAccessReview{
+		Action: authorizationapi.AuthorizationAttributes{Verb: "create", Resource: "policybindings"},
+	}
 	subjectAccessReviewTest{
-		clientInterface: valerieOpenshiftClient.SubjectAccessReviews("openshift"),
-		review:          askCanICreatePolicyBindings,
+		localInterface: valerieOpenshiftClient.LocalSubjectAccessReviews("openshift"),
+		localReview:    askCanICreatePolicyBindings,
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   false,
 			Reason:    `User "valerie" cannot create policybindings in project "openshift"`,
@@ -171,11 +173,14 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 	}.run(t)
 
 	// I shouldn't be allowed to ask whether someone else can perform an action
-	askCanClusterAdminsCreateProject := &authorizationapi.SubjectAccessReview{Groups: util.NewStringSet("system:cluster-admins"), Verb: "create", Resource: "projects"}
+	askCanClusterAdminsCreateProject := &authorizationapi.LocalSubjectAccessReview{
+		Groups: util.NewStringSet("system:cluster-admins"),
+		Action: authorizationapi.AuthorizationAttributes{Verb: "create", Resource: "projects"},
+	}
 	subjectAccessReviewTest{
-		clientInterface: valerieOpenshiftClient.SubjectAccessReviews("openshift"),
-		review:          askCanClusterAdminsCreateProject,
-		err:             `User "valerie" cannot create subjectaccessreviews in project "openshift"`,
+		localInterface: valerieOpenshiftClient.LocalSubjectAccessReviews("openshift"),
+		localReview:    askCanClusterAdminsCreateProject,
+		err:            `User "valerie" cannot create localsubjectaccessreviews in project "openshift"`,
 	}.run(t)
 
 }

--- a/test/util/policy.go
+++ b/test/util/policy.go
@@ -17,9 +17,9 @@ const (
 // WaitForPolicyUpdate checks if the given client can perform the named verb and action.
 // If PolicyCachePollTimeout is reached without the expected condition matching, an error is returned
 func WaitForPolicyUpdate(c *client.Client, namespace, verb, resource string, allowed bool) error {
-	review := &authorizationapi.SubjectAccessReview{Verb: verb, Resource: resource}
+	review := &authorizationapi.LocalSubjectAccessReview{Action: authorizationapi.AuthorizationAttributes{Verb: verb, Resource: resource}}
 	err := wait.Poll(PolicyCachePollInterval, PolicyCachePollTimeout, func() (bool, error) {
-		response, err := c.SubjectAccessReviews(namespace).Create(review)
+		response, err := c.LocalSubjectAccessReviews(namespace).Create(review)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3668

 1. collapses authorization attributes under a type for de-duplication.  Keeping this serialized as `inline` keeps us backwards compatible
 1. creates new LocalSAR  and LocalRAR types
 1. removes old clients and eliminates internal usages
 1. adds a fallback to the docker registry so that new docker registries can communicate with old openshift masters
 1. updates `UPDATES.md` with information about the change.


@smarterclayton I think this is probably you.