### PR TITLE
hack: Support usage of docker via sudo too

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -50,8 +50,8 @@ cp -f "${imagedir}/dockerregistry"  images/dockerregistry/bin
 # builds an image and tags it two ways - with latest, and with the release tag
 function image {
   echo "--- $1 ---"
-  docker build -t $1:latest $2
-  docker tag -f $1:latest $1:${OS_RELEASE_COMMIT}
+  os::docker build -t $1:latest $2
+  os::docker tag -f $1:latest $1:${OS_RELEASE_COMMIT}
 }
 
 # images that depend on scratch
@@ -76,4 +76,4 @@ docker build --no-cache -t openshift/deployment-example:v1 examples/deployment
 docker build --no-cache -t openshift/deployment-example:v2 -f examples/deployment/Dockerfile.v2 examples/deployment
 
 echo "++ Active images"
-docker images | grep openshift/
+os::docker images | grep openshift/

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -36,8 +36,11 @@ tar -rf "${context}/archive.tar" -C "${context}" os-version-defs
 gzip -f "${context}/archive.tar"
 
 # Perform the build and release in Docker.
-cat "${context}/archive.tar.gz" | docker run -i --cidfile="${context}/cid" openshift/origin-release
-docker cp $(cat ${context}/cid):/go/src/github.com/openshift/origin/_output/local/releases "${OS_OUTPUT}"
+cat "${context}/archive.tar.gz" | os::docker run -i --cidfile="${context}/cid" openshift/origin-release
+os::docker cp $(cat ${context}/cid):/go/src/github.com/openshift/origin/_output/local/releases "${OS_OUTPUT}"
+if os::docker_needs_sudo; then
+    sudo chown -R -h ${USER}:${USER} "${OS_OUTPUT}"
+fi
 echo "${OS_GIT_COMMIT}" > "${OS_LOCAL_RELEASEPATH}/.commit"
 
 # Copy the linux release archives release back to the local _output/local/go/bin directory.

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -500,6 +500,23 @@ os::build::gen-docs() {
   find "${tmpdir}" -exec rsync -pt {} "${dest}" \; >/dev/null
   #cleanup
   rm -rf "${tmpdir}"
-
   echo "Assets generated in ${dest}"
+}
+
+# While upstream docker supports a `docker` group, in Project Atomic
+# we decided to discourage its use; see https://lists.projectatomic.io/projectatomic-archives/atomic-devel/2015-January/msg00034.html
+# If the docker socket isn't writable, try sudo.
+os::docker_needs_sudo() {
+    if test -w /run/docker.sock; then
+	return 1
+    else
+	return 0
+    fi
+}
+os::docker() {
+    if os::docker_needs_sudo; then
+	sudo docker "$@"
+    else
+	docker "$@"
+    fi
 }


### PR DESCRIPTION
From @cgwalters:

"While upstream docker supports a `docker` group, in Project Atomic we
decided to discourage its use; see
https://lists.projectatomic.io/projectatomic-archives/atomic-devel/2015-January/msg00034.html

If the docker socket isn't writable, try sudo."
