### PR TITLE
shorted SAR response

### DIFF
--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -1,8 +1,6 @@
 package authorizer
 
 import (
-	"fmt"
-
 	kapi "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/auth/user"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
@@ -129,10 +127,11 @@ func (a *openshiftAuthorizer) authorizeWithNamespaceRules(ctx kapi.Context, pass
 			return false, "", err
 		}
 		if matches {
-			if len(kapi.NamespaceValue(ctx)) == 0 {
-				return true, fmt.Sprintf("allowed by cluster rule: %#v", rule), nil
+			namespace := kapi.NamespaceValue(ctx)
+			if len(namespace) == 0 {
+				return true, "allowed by cluster rule", nil
 			}
-			return true, fmt.Sprintf("allowed by rule in %v: %#v", kapi.NamespaceValue(ctx), rule), nil
+			return true, "allowed by rule in " + namespace, nil
 		}
 	}
 

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -461,7 +461,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		review:          askCanClusterAdminsCreateProject,
 		response: authorizationapi.SubjectAccessReviewResponse{
 			Allowed:   true,
-			Reason:    "allowed by cluster rule:",
+			Reason:    "allowed by cluster rule",
 			Namespace: "",
 		},
 	}.run(t)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/3889.

Produces 
```
{"kind":"SubjectAccessReviewResponse","apiVersion":"v1beta3","namespace":"foo","allowed":true,"reason":"allowed by rule in foo"}
```

@smarterclayton  is the message acceptable?  the actual rule isn't as important as where it came from.