### PR TITLE
Minor tweak to hack/install-assets.sh for the RHEL AMI

### DIFF
--- a/hack/install-assets.sh
+++ b/hack/install-assets.sh
@@ -52,7 +52,7 @@ if ! which grunt > /dev/null 2>&1 ; then
 fi
 
 pushd ${OS_ROOT}/assets > /dev/null
-  cmd "npm install"
+  cmd "npm install --unsafe-perm"
   cmd "node_modules/protractor/bin/webdriver-manager update"
   
   # In case upstream components change things without incrementing versions


### PR DESCRIPTION
Since the vagrant test function logs in to the RHEL AMI as root we need this
flag to prevent npm from dropping permissions and being unable to write the
protractor config.