### PR TITLE
Generate the same labels in the UI as the CLI

### DIFF
--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -43,6 +43,7 @@ angular.module("openshiftConsole")
         include: true
       };
       scope.labels = {};
+      scope.annotations = {};
       scope.scaling = {
         replicas: 1
       };

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -67,8 +67,8 @@ angular.module("openshiftConsole")
       }
 
       //augment labels
-      input.labels.name = input.name;
-      input.labels.generatedby = "OpenShiftWebConsole";
+      input.labels.app = input.name;
+      input.annotations["openshift.io/generatedby"] = "OpenShiftWebConsole";
 
       var imageSpec;
       if(input.buildConfig.sourceUrl !== null){
@@ -101,7 +101,8 @@ angular.module("openshiftConsole")
         apiVersion: osApiVersion,
         metadata: {
           name: name,
-          labels: input.labels
+          labels: input.labels,
+          annotations: input.annotations
         },
         spec: {
           to: {
@@ -112,20 +113,21 @@ angular.module("openshiftConsole")
       };
     };
 
-    scope._generateDeploymentConfig = function(input, imageSpec, ports, labels){
+    scope._generateDeploymentConfig = function(input, imageSpec, ports){
       var env = [];
       angular.forEach(input.deploymentConfig.envVars, function(value, key){
         env.push({name: key, value: value});
       });
-      labels = angular.copy(labels);
-      labels.deploymentconfig = input.name;
+      var templateLabels = angular.copy(input.labels);
+      templateLabels.deploymentconfig = input.name;
 
       var deploymentConfig = {
         apiVersion: osApiVersion,
         kind: "DeploymentConfig",
         metadata: {
           name: input.name,
-          labels: labels
+          labels: input.labels,
+          annotations: input.annotations
         },
         spec: {
           replicas: input.scaling.replicas,
@@ -135,7 +137,7 @@ angular.module("openshiftConsole")
           triggers: [],
           template: {
             metadata: {
-              labels: labels
+              labels: templateLabels
             },
             spec: {
               containers: [
@@ -173,7 +175,7 @@ angular.module("openshiftConsole")
       return deploymentConfig;
     };
 
-    scope._generateBuildConfig = function(input, imageSpec, labels){
+    scope._generateBuildConfig = function(input, imageSpec){
       var triggers = [
         {
           generic: {
@@ -202,7 +204,8 @@ angular.module("openshiftConsole")
         kind: "BuildConfig",
         metadata: {
           name: input.name,
-          labels: labels
+          labels: input.labels,
+          annotations: input.annotations
         },
         spec: {
           output: {
@@ -239,7 +242,8 @@ angular.module("openshiftConsole")
         kind: "ImageStream",
         metadata: {
           name: input.name,
-          labels: input.labels
+          labels: input.labels,
+          annotations: input.annotations
         }
       };
     };
@@ -253,7 +257,8 @@ angular.module("openshiftConsole")
         apiVersion: k8sApiVersion,
         metadata: {
           name: serviceName,
-          labels: input.labels
+          labels: input.labels,
+          annotations: input.annotations
         },
         spec: {
           selector: {

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -43,6 +43,7 @@ describe("ApplicationGenerator", function(){
         foo: "bar",
         abc: "xyz"
       },
+      annotations: {},
       scaling: {
         replicas: 1
       },
@@ -142,8 +143,13 @@ describe("ApplicationGenerator", function(){
       expect(ApplicationGenerator._generateRoute(input, input.name, "theServiceName")).toBe(null);
     });
 
-    it("should generate an unsecure Route when routing is required", function(){
-      var route = ApplicationGenerator._generateRoute(input, input.name, "theServiceName");
+    it("should generate an insecure Route when routing is required", function(){
+      // Add the same labels and annotations as application generator `generate()`
+      var routeInput = angular.copy(input);
+      routeInput.labels.app = input.name;
+      routeInput.annotations["openshift.io/generatedby"] = "OpenShiftWebConsole";
+
+      var route = ApplicationGenerator._generateRoute(routeInput, routeInput.name, "theServiceName");
       expect(route).toEqual({
         kind: "Route",
         apiVersion: 'v1beta3',
@@ -151,7 +157,11 @@ describe("ApplicationGenerator", function(){
           name: "ruby-hello-world",
           labels : {
             "foo" : "bar",
-            "abc" : "xyz"
+            "abc" : "xyz",
+            "app": "ruby-hello-world"
+          },
+          annotations: {
+            "openshift.io/generatedby": "OpenShiftWebConsole"
           }
         },
         spec: {
@@ -180,8 +190,10 @@ describe("ApplicationGenerator", function(){
                 "labels": {
                   "foo" : "bar",
                   "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby": "OpenShiftWebConsole"
+                  "app": "ruby-hello-world"
+                },
+                "annotations": {
+                  "openshift.io/generatedby": "OpenShiftWebConsole"
                 }
             },
             "spec": {
@@ -240,8 +252,10 @@ describe("ApplicationGenerator", function(){
               labels : {
                 "foo" : "bar",
                 "abc" : "xyz",
-                "name": "ruby-hello-world",
-                "generatedby": "OpenShiftWebConsole"
+                "app" : "ruby-hello-world",
+              },
+              "annotations": {
+                "openshift.io/generatedby": "OpenShiftWebConsole"
               }
           }
         }
@@ -258,8 +272,10 @@ describe("ApplicationGenerator", function(){
                 "labels" : {
                   "foo" : "bar",
                   "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby": "OpenShiftWebConsole"
+                  "app" : "ruby-hello-world"
+                },
+                "annotations": {
+                  "openshift.io/generatedby": "OpenShiftWebConsole"
                 }
             },
             "spec": {
@@ -287,9 +303,10 @@ describe("ApplicationGenerator", function(){
             "labels": {
               "foo" : "bar",
               "abc" : "xyz",
-              "name": "ruby-hello-world",
-              "generatedby" : "OpenShiftWebConsole",
-              "deploymentconfig": "ruby-hello-world"
+              "app" : "ruby-hello-world"
+            },
+            "annotations": {
+              "openshift.io/generatedby": "OpenShiftWebConsole"
             }
           },
           "spec": {
@@ -320,8 +337,7 @@ describe("ApplicationGenerator", function(){
                 "labels": {
                   "foo" : "bar",
                   "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby" : "OpenShiftWebConsole",
+                  "app" : "ruby-hello-world",
                   "deploymentconfig": "ruby-hello-world"
                 }
               },
@@ -391,8 +407,10 @@ describe("ApplicationGenerator", function(){
                 "labels" : {
                   "foo" : "bar",
                   "abc" : "xyz",
-                  "name": "ruby-hello-world",
-                  "generatedby": "OpenShiftWebConsole"
+                  "app" : "ruby-hello-world"
+                },
+                "annotations": {
+                  "openshift.io/generatedby": "OpenShiftWebConsole"
                 }
             },
             "spec": {


### PR DESCRIPTION
In the create from source flow, generate labels that are consistent with the CLI.

- Use `app` instead of `name`.
- Don't add a `deploymentconfig` label on the deployment config itself, only the template.
- Change the `generatedby` label to a prefixed annotation.

Fixes #3966 