### PR TITLE
display the host in 'oc status'

### DIFF
--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -63,12 +63,17 @@ func RunStatus(f *clientcmd.Factory, out io.Writer) error {
 		return err
 	}
 
+	config, err := f.OpenShiftClientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+
 	namespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	describer := &describe.ProjectStatusDescriber{K: kclient, C: client}
+	describer := &describe.ProjectStatusDescriber{K: kclient, C: client, Server: config.Host}
 	s, err := describer.Describe(namespace, "")
 	if err != nil {
 		return err
@@ -85,12 +90,17 @@ func RunGraph(f *clientcmd.Factory, out io.Writer) error {
 		return err
 	}
 
+	config, err := f.OpenShiftClientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+
 	namespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	describer := &describe.ProjectStatusDescriber{K: kclient, C: client}
+	describer := &describe.ProjectStatusDescriber{K: kclient, C: client, Server: config.Host}
 	g, _, err := describer.MakeGraph(namespace)
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -40,8 +40,9 @@ const ForbiddenListWarning = "Forbidden"
 
 // ProjectStatusDescriber generates extended information about a Project
 type ProjectStatusDescriber struct {
-	K kclient.Interface
-	C client.Interface
+	K      kclient.Interface
+	C      client.Interface
+	Server string
 }
 
 func (d *ProjectStatusDescriber) MakeGraph(namespace string) (osgraph.Graph, util.StringSet, error) {
@@ -131,7 +132,7 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		indent := "  "
-		fmt.Fprintf(out, "In project %s\n", projectapi.DisplayNameAndNameForProject(project))
+		fmt.Fprintf(out, describeProjectAndServer(project, d.Server))
 
 		for _, service := range services {
 			fmt.Fprintln(out)
@@ -258,6 +259,14 @@ func indentLines(indent string, lines ...string) []string {
 	}
 
 	return ret
+}
+
+func describeProjectAndServer(project *projectapi.Project, server string) string {
+	if server != "" {
+		return fmt.Sprintf("In project %s on server %s\n", projectapi.DisplayNameAndNameForProject(project), server)
+	} else {
+		return fmt.Sprintf("In project %s\n", projectapi.DisplayNameAndNameForProject(project))
+	}
 }
 
 func describeDeploymentInServiceGroup(deploy graphview.DeploymentConfigPipeline) []string {

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -47,7 +47,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project Test (example)\n",
+				"In project Test (example) on server https://example.com:8443\n",
 				"You have no services, deployment configs, or build configs.",
 			},
 		},
@@ -60,7 +60,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/empty-service",
 				"<initializing>:5432",
 				"To see more, use",
@@ -75,7 +75,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/database-rc",
 				"rc/database-rc-1 runs mysql",
 				"0/1 pods growing to 1",
@@ -91,7 +91,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"rc/my-rc runs openshift/mysql-55-centos7",
 				"0/1 pods growing to 1",
 				"rc/my-rc is attempting to mount a secret secret/existing-secret disallowed by sa/default",
@@ -121,7 +121,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/frontend-app",
 				"pod/frontend-app-1-bjwh8 runs openshift/ruby-hello-world",
 				"To see more, use",
@@ -136,7 +136,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"  rc/database-1 runs openshift/mysql-55-centos7",
 				"rc/frontend-rc-1 runs openshift/ruby-hello-world",
 			},
@@ -150,7 +150,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/sinatra-example-2 - 172.30.17.48:8080",
 				"builds git://github.com",
 				"with docker.io/openshift/ruby-20-centos7:latest",
@@ -192,7 +192,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/sinatra-example-1 - 172.30.17.47:8080",
 				"builds git://github.com",
 				"with docker.io/openshift/ruby-20-centos7:latest",
@@ -211,7 +211,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/sinatra-app-example - 172.30.17.49:8080",
 				"sinatra-app-example-a deploys",
 				"sinatra-app-example-b deploys",
@@ -231,7 +231,7 @@ func TestProjectStatus(t *testing.T) {
 			},
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
-				"In project example\n",
+				"In project example on server https://example.com:8443\n",
 				"service/database - 172.30.17.240:5434 -> 3306",
 				"service/frontend - 172.30.17.154:5432 -> 8080",
 				"database deploys",
@@ -265,7 +265,7 @@ func TestProjectStatus(t *testing.T) {
 			o.Add(obj)
 		}
 		oc, kc := testclient.NewFixtureClients(o)
-		d := ProjectStatusDescriber{C: oc, K: kc}
+		d := ProjectStatusDescriber{C: oc, K: kc, Server: "https://example.com:8443"}
 		out, err := d.Describe("example", "")
 		if !test.ErrFn(err) {
 			t.Errorf("%s: unexpected error: %v", k, err)


### PR DESCRIPTION
When using more than 1 openshift instance, it is not easy to see which one we are currently using.
I just added the host from the config in the 'oc status' output for that purpose.