### PR TITLE
add layout.attrs to web console

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -16,6 +16,7 @@
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/messenger/build/css/messenger-theme-flat.css" />
     <link rel="stylesheet" href="bower_components/kubernetes-label-selector/labelFilter.css" />
+    <link rel="stylesheet" href="bower_components/layout.attrs/dist/layout.attrs.css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -26,7 +26,8 @@
     "zeroclipboard": "2.2.0",
     "messenger": "1.4.1",
     "kubernetes-label-selector": "0.0.5",
-    "openshift-object-describer": "1.1.0"
+    "openshift-object-describer": "1.1.0",
+    "layout.attrs": "1.1.2"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",
@@ -43,6 +44,11 @@
     "selectize": {
       "main": [
         "dist/js/selectize.js"
+      ]
+    },
+    "layout.attrs" : {
+      "main": [
+        "dist/layout.attrs.css"
       ]
     }
   }


### PR DESCRIPTION
Adds a small library to the web console that provides a clear system for doing flexbox layouts.  This PR only adds the library to the project to test compatibility, it is not used for anything in particular yet.

We should run this through QE to ensure there are no compatibility issues with current CSS libraries (primarily bootstrap).  

