### PR TITLE
Add commas between pod template ports in UI

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -167,9 +167,6 @@
     .font-icon-block {
       margin-right: 8px;
     }
-    .port-number {
-      display: inline-block;
-    }
   }
 }
 

--- a/assets/app/views/_pod-template.html
+++ b/assets/app/views/_pod-template.html
@@ -55,9 +55,9 @@
           <span data-icon="" aria-hidden="true" class="font-icon"></span>
           <span data-icon="" aria-hidden="true" class="font-icon"></span>
         </div>Ports:
-        <div ng-repeat="port in container.ports" class="port-number">
-          <span>{{port.containerPort}} ({{port.protocol}})<span ng-if="port.hostPort"> <span class="port-icon">&#10230;</span> {{port.hostPort}}</span></span>
-        </div>
+        <span ng-repeat="port in container.ports | orderBy: 'containerPort'">
+          <span class="nowrap">{{port.containerPort}}&thinsp;({{port.protocol}})<span ng-if="port.hostPort">&thinsp;<span class="port-icon">&#8594;</span>&thinsp;{{port.hostPort}}</span></span><span ng-if="!$last">, </span>
+        </span>
       </div> 
 
       <div hawtio-extension name="container-links"></div>


### PR DESCRIPTION
Fixes #3991 

<img width="422" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/9139248/027d123a-3cf7-11e5-8d35-cd9d602b2b33.png">
