### PR TITLE
add group commands

### DIFF
--- a/docs/generated/oadm_by_example_content.adoc
+++ b/docs/generated/oadm_by_example_content.adoc
@@ -107,6 +107,49 @@ displays Merged kubeconfig settings or a specified kubeconfig file.
 ====
 
 
+== oadm groups add-users
+Add users to a group
+
+====
+
+[options="nowrap"]
+----
+  // Add user1 and user2 to my-group
+  $ openshift admin groups add-users my-group user1 user2
+----
+====
+
+
+== oadm groups new
+Create a new group
+
+====
+
+[options="nowrap"]
+----
+  // Add a group with no users
+  $ openshift admin groups new my-group
+
+  // Add a group with two users
+  $ openshift admin groups new my-group user1 user2
+----
+====
+
+
+== oadm groups remove-users
+Remove users from a group
+
+====
+
+[options="nowrap"]
+----
+  // Add user1 and user2 to my-group
+  $   // Remove user1 and user2 from my-group
+  $ %[1]s my-group user1 user2 my-group user1 user2
+----
+====
+
+
 == oadm ipfailover
 Install an IP failover group to a set of nodes
 

--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/admin/cert"
+	"github.com/openshift/origin/pkg/cmd/admin/groups"
 	"github.com/openshift/origin/pkg/cmd/admin/node"
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/admin/project"
@@ -46,6 +47,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 			Commands: []*cobra.Command{
 				project.NewCmdNewProject(project.NewProjectRecommendedName, fullName+" "+project.NewProjectRecommendedName, f, out),
 				policy.NewCmdPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out),
+				groups.NewCmdGroups(groups.GroupsRecommendedName, fullName+" "+groups.GroupsRecommendedName, f, out),
 			},
 		},
 		{

--- a/pkg/cmd/admin/groups/changemembership.go
+++ b/pkg/cmd/admin/groups/changemembership.go
@@ -1,0 +1,142 @@
+package groups
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	AddRecommendedName = "add-users"
+	addLong            = `
+Add users to a group.
+
+This command will append unique users to the list of members for a group.`
+
+	addExample = `  // Add user1 and user2 to my-group
+  $ %[1]s my-group user1 user2`
+)
+
+const (
+	RemoveRecommendedName = "remove-users"
+	removeLong            = `
+Remove users from a group.
+
+This command will remove users from the list of members for a group.`
+
+	removeExample = `  // Remove user1 and user2 from my-group
+  $ %[1]s my-group user1 user2`
+)
+
+type GroupModificationOptions struct {
+	GroupClient client.GroupInterface
+
+	Group string
+	Users []string
+}
+
+func NewCmdAddUsers(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &GroupModificationOptions{}
+
+	cmd := &cobra.Command{
+		Use:     name + " GROUP USER [USER ...]",
+		Short:   "Add users to a group",
+		Long:    addLong,
+		Example: fmt.Sprintf(addExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Complete(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			kcmdutil.CheckErr(options.AddUsers())
+		},
+	}
+
+	return cmd
+}
+
+func NewCmdRemoveUsers(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &GroupModificationOptions{}
+
+	cmd := &cobra.Command{
+		Use:     name + " GROUP USER [USER ...]",
+		Short:   "Remove users from a group",
+		Long:    removeLong,
+		Example: fmt.Sprintf(addExample, removeExample),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Complete(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			kcmdutil.CheckErr(options.RemoveUsers())
+		},
+	}
+
+	return cmd
+}
+
+func (o *GroupModificationOptions) Complete(f *clientcmd.Factory, args []string) error {
+	if len(args) < 2 {
+		return errors.New("You must specify at least two arguments: GROUP USER [USER ...]")
+	}
+
+	o.Group = args[0]
+	o.Users = append(o.Users, args[1:]...)
+
+	osClient, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+
+	o.GroupClient = osClient.Groups()
+
+	return nil
+}
+
+func (o *GroupModificationOptions) AddUsers() error {
+	group, err := o.GroupClient.Get(o.Group)
+	if err != nil {
+		return err
+	}
+
+	existingUsers := util.NewStringSet(group.Users...)
+	for _, user := range o.Users {
+		if existingUsers.Has(user) {
+			continue
+		}
+
+		group.Users = append(group.Users, user)
+	}
+
+	_, err = o.GroupClient.Update(group)
+	return err
+}
+
+func (o *GroupModificationOptions) RemoveUsers() error {
+	group, err := o.GroupClient.Get(o.Group)
+	if err != nil {
+		return err
+	}
+
+	toDelete := util.NewStringSet(o.Users...)
+	newUsers := []string{}
+	for _, user := range group.Users {
+		if toDelete.Has(user) {
+			continue
+		}
+
+		newUsers = append(newUsers, user)
+	}
+	group.Users = newUsers
+
+	_, err = o.GroupClient.Update(group)
+	return err
+}

--- a/pkg/cmd/admin/groups/groups.go
+++ b/pkg/cmd/admin/groups/groups.go
@@ -1,0 +1,35 @@
+package groups
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const GroupsRecommendedName = "groups"
+
+const (
+	groupLong = `
+Manage groups in your cluster
+
+Groups are sets of users that can be used when describing policy.`
+)
+
+func NewCmdGroups(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   name,
+		Short: "Manage groups",
+		Long:  groupLong,
+		Run:   cmdutil.DefaultSubCommandRun(out),
+	}
+
+	cmds.AddCommand(NewCmdNewGroup(NewGroupRecommendedName, fullName+" "+NewGroupRecommendedName, f, out))
+	cmds.AddCommand(NewCmdAddUsers(AddRecommendedName, fullName+" "+AddRecommendedName, f, out))
+	cmds.AddCommand(NewCmdRemoveUsers(RemoveRecommendedName, fullName+" "+RemoveRecommendedName, f, out))
+
+	return cmds
+}

--- a/pkg/cmd/admin/groups/new.go
+++ b/pkg/cmd/admin/groups/new.go
@@ -1,0 +1,94 @@
+package groups
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	kcmdutil "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+const (
+	NewGroupRecommendedName = "new"
+	newLong                 = `
+Create a new group.
+
+This command will create a new group with an optional list of users.`
+
+	newExample = `  // Add a group with no users
+  $ %[1]s my-group
+
+  // Add a group with two users
+  $ %[1]s my-group user1 user2`
+)
+
+type NewGroupOptions struct {
+	GroupClient client.GroupInterface
+
+	Group string
+	Users []string
+}
+
+func NewCmdNewGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &NewGroupOptions{}
+
+	cmd := &cobra.Command{
+		Use:     name + " GROUP [USER ...]",
+		Short:   "Create a new group",
+		Long:    newLong,
+		Example: fmt.Sprintf(newExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Complete(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			kcmdutil.CheckErr(options.AddGroup())
+		},
+	}
+
+	return cmd
+}
+
+func (o *NewGroupOptions) Complete(f *clientcmd.Factory, args []string) error {
+	if len(args) < 1 {
+		return errors.New("You must specify at least one argument: GROUP [USER ...]")
+	}
+
+	o.Group = args[0]
+	if len(args) > 1 {
+		o.Users = append(o.Users, args[1:]...)
+	}
+
+	osClient, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+
+	o.GroupClient = osClient.Groups()
+	return nil
+}
+
+func (o *NewGroupOptions) AddGroup() error {
+	group := &userapi.Group{}
+	group.Name = o.Group
+
+	usedNames := util.StringSet{}
+	for _, user := range o.Users {
+		if usedNames.Has(user) {
+			continue
+		}
+		usedNames.Insert(user)
+
+		group.Users = append(group.Users, user)
+	}
+
+	_, err := o.GroupClient.Create(group)
+	return err
+}

--- a/rel-eng/completions/bash/oadm
+++ b/rel-eng/completions/bash/oadm
@@ -423,6 +423,77 @@ _oadm_policy()
     must_have_one_noun=()
 }
 
+_oadm_groups_new()
+{
+    last_command="oadm_groups_new"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_oadm_groups_add-users()
+{
+    last_command="oadm_groups_add-users"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_oadm_groups_remove-users()
+{
+    last_command="oadm_groups_remove-users"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_oadm_groups()
+{
+    last_command="oadm_groups"
+    commands=()
+    commands+=("new")
+    commands+=("add-users")
+    commands+=("remove-users")
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oadm_router()
 {
     last_command="oadm_router"
@@ -1200,6 +1271,7 @@ _oadm()
     commands=()
     commands+=("new-project")
     commands+=("policy")
+    commands+=("groups")
     commands+=("router")
     commands+=("ipfailover")
     commands+=("registry")

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -801,6 +801,77 @@ _openshift_admin_policy()
     must_have_one_noun=()
 }
 
+_openshift_admin_groups_new()
+{
+    last_command="openshift_admin_groups_new"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_admin_groups_add-users()
+{
+    last_command="openshift_admin_groups_add-users"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_admin_groups_remove-users()
+{
+    last_command="openshift_admin_groups_remove-users"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_admin_groups()
+{
+    last_command="openshift_admin_groups"
+    commands=()
+    commands+=("new")
+    commands+=("add-users")
+    commands+=("remove-users")
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_admin_router()
 {
     last_command="openshift_admin_router"
@@ -1578,6 +1649,7 @@ _openshift_admin()
     commands=()
     commands+=("new-project")
     commands+=("policy")
+    commands+=("groups")
     commands+=("router")
     commands+=("ipfailover")
     commands+=("registry")

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -35,6 +35,14 @@ oc create -f examples/hello-openshift/hello-pod.json
 oc delete pods hello-openshift
 echo "manage-node: ok"
 
+oadm groups new group1 foo bar
+oc get groups/group1 --no-headers | grep -q "foo, bar"
+oadm groups add-users group1 baz
+oc get groups/group1 --no-headers | grep -q "baz"
+oadm groups remove-users group1 bar
+[ ! "$(oc get groups/group1 --no-headers | grep -q "bar")" ]
+echo "groups: ok"
+
 oadm policy who-can get pods
 oadm policy who-can get pods -n default
 oadm policy who-can get pods --all-namespaces


### PR DESCRIPTION
Adds
```
oadm groups new GROUP [USER ...]
oadm groups add-users GROUP USER [USER ...]
oadm groups remove-users GROUP USER [USER ...]
```

to manage groups without having to resort to json.

@fabianofranz ptal
@smarterclayton any object in general?  I'd really like a set of pretty `oc new <subcommand for resource> [resource appropriate args]` commands, but we don't have those yet.