### PR TITLE
Add support for docker-in-docker dev cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_output
 /_tools
 /openshift.local.*
+/third-party
 /.project
 /.vagrant
 /cpu.pprof

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,7 +155,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         minion_ip = minion_ips[n]
         minion.vm.box = kube_box[kube_os]["name"]
         minion.vm.box_url = kube_box[kube_os]["box_url"]
-        minion.vm.provision "shell", inline: "/vagrant/vagrant/provision-minion.sh #{master_ip} #{num_minion} #{minion_ips_str} #{minion_ip} #{minion_index} #{ENV['OPENSHIFT_SDN']}"
+        minion.vm.provision "shell", inline: "/vagrant/vagrant/provision-minion.sh #{master_ip} #{num_minion} #{minion_ips_str} #{minion_ip} #{minion_index}"
         minion.vm.network "private_network", ip: "#{minion_ip}"
         minion.vm.hostname = "openshift-minion-#{minion_index}"
       end

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+# WARNING: The script modifies the host on which it is run.  It loads
+# the openvwitch and br_netfilter modules, sets
+# net.bridge.bridge-nf-call-iptables=0, and creates 2 loopback devices
+# for each non-master node.  Consider creating dind clusters in a VM
+# if this modification is undesirable:
+#
+#   OPENSHIFT_DIND_DEV_CLUSTER=1 vagrant up'
+#
+# Overview
+# ========
+#
+# This script manages the lifecycle of an openshift dev cluster
+# deployed to docker-in-docker containers.  Once 'start' has been used
+# to successfully create a dind cluster, 'docker exec' can be used to
+# access the created containers (named
+# openshift-{master,node-1,node-2}) as if they were VMs.
+#
+# Dependencies
+# ------------
+#
+# This script has been tested on Fedora 22, but should work on any
+# release.  Docker is assumed to be installed.  At this time,
+# boot2docker is not supported.
+#
+# SELinux
+# -------
+#
+# Docker-in-docker's use of volumes is not compatible with selinux set
+# to enforcing mode.  Set selinux to permissive or disable it
+# entirely.
+#
+# Vagrant Dev Cluster
+# -------------------
+#
+# At present the dind setup uses the same config (./openshift.local.*)
+# as a vagrant-deployed cluster, so it is not possible to run both a
+# vm-based dev cluster and a dind-based dev cluster from a given repo
+# clone.  Until this is fixed, it is necessary to run only a vm or
+# dind-based cluster at a time, or run them from separate repos.
+#
+# Bash Aliases
+# ------------
+#
+# The following bash aliases are available in the cluster containers:
+#
+# oc-create-hello - create the 'hello' example app
+# oc-less-log - invoke 'less' on the openshift daemon log (will target
+#               the master or node log depending on the type of node)
+# oc-tail-log - invoke tail on the openshift daemon log
+#
+# Process Management
+# ------------------
+#
+# Due to docker-in-docker conflicting with systemd when running in a
+# container, supervisord is used instead.  The 'supervisorctl' command
+# is the equivalent of 'systemctl' and logs for managed processes can
+# be found in /var/log/supervisor.
+#
+# Loopback Devices
+# ----------------
+#
+# Due to the way docker-in-docker daemons interact with loopback
+# devices, it is important to invoke 'dind-cluster.sh stop' on a
+# running cluster instead of manually stopping the containers.  This
+# ensures that the containerized docker daemons are gracefully
+# shutdown and allowed to release their loopback devices before
+# container shutdown.  If the daemons are not stopped before container
+# shutdown, the associated loopback devices will be effectively
+# unusable ('leaked') until a subsequent host reboot.  If enough
+# loopback devices are leaked, cluster boot may not be possible since
+# each openshift node running in a container depends on a docker
+# daemon requiring 2 loopback devices.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE}")/dind/init.sh
+
+function check-selinux() {
+  if [ "$(getenforce)" = "Enforcing" ]; then
+    >&2 echo "Error: This script is not compatible with SELinux enforcing mode."
+    exit 1
+  fi
+}
+
+function build-image() {
+  local build_root=$1
+  local image_name=$2
+
+  pushd "${build_root}"
+  ${DOCKER_CMD} build -t "${image_name}" .
+  popd
+}
+
+function get-docker-ip() {
+  local cid=$1
+
+  ${DOCKER_CMD} inspect --format '{{ .NetworkSettings.IPAddress }}' "${cid}"
+}
+
+# Ensure sufficient available loopback devices to support the
+# indicated number of dind nodes.  Since it's not possible to create
+# device nodes inside a container, this function needs to be called
+# before launching a container that will run dind.
+function ensure-loopback-for-dind() {
+  local node_count=$1
+
+  # Ensure extra loopback devices to minimize the potential for
+  # contention.  Sometimes docker restarts during deployment don't
+  # properly release the devices.
+  local extra_loopback=4
+  local loopback_per_node=2
+  local required_free_loopback=$(( ( ${node_count} * ${loopback_per_node} ) + \
+    ${extra_loopback} ))
+
+  # Find the maximum index of existing loopback devices.
+  local max_index=$(losetup | grep '/dev/loop' | tail -n 1 |
+    sed -e 's|^/dev/loop\([0-9]\{1,\}\).*|\1|')
+  if [ -z "${max_index}" ]; then
+    max_index=0
+  fi
+
+  local requested_max_index=$(( ${max_index} + ${required_free_loopback} - 1))
+  for i in $(eval echo "{${max_index}..${requested_max_index}}"); do
+    if [ ! -e "/dev/loop${i}" ]; then
+      sudo mknod "/dev/loop${i}" b 7 "${i}"
+    fi
+  done
+}
+
+function start() {
+  # docker-in-docker's use of volumes is not compatible with SELinux
+  check-selinux
+
+  echo "Ensuring compatible host configuration"
+  sudo modprobe openvswitch
+  sudo modprobe br_netfilter || true
+  sudo sysctl -w net.bridge.bridge-nf-call-iptables=0
+  ensure-loopback-for-dind "${NUM_NODES}"
+
+  echo "Building containers"
+  local master_image="openshift/dind-master"
+  local node_image="openshift/dind-node"
+  build-image "${ORIGIN_ROOT}/images/dind/master" "${master_image}"
+  build-image "${ORIGIN_ROOT}/images/dind/node" "${node_image}"
+
+  ## Create containers
+  echo "Launching containers"
+  local deployed_root="/data"
+  local base_run_cmd="${DOCKER_CMD} run -dt -v ${ORIGIN_ROOT}:${deployed_root}"
+
+  # Ensure the deployed root is usable in the container
+  sudo chcon -Rt svirt_sandbox_file_t $(pwd)
+
+  local master_cid=$(${base_run_cmd} --name="${MASTER_NAME}" \
+    --hostname="${MASTER_NAME}" "${master_image}")
+  local master_ip=$(get-docker-ip "${master_cid}")
+
+  local node_cids=()
+  local node_ips=()
+  for name in "${NODE_NAMES[@]}"; do
+    local cid=$(${base_run_cmd} --privileged --name="${name}" \
+      --hostname="${name}" "${node_image}")
+    node_cids+=( "${cid}" )
+    node_ips+=( $(get-docker-ip "${cid}") )
+  done
+  node_ips=$(os::util::join , ${node_ips[@]})
+
+  ## Provision containers
+  local script_root="${deployed_root}/hack/dind"
+  echo "Provisioning ${MASTER_NAME}"
+  ${DOCKER_CMD} exec -t "${master_cid}" bash -c "\
+    ${script_root}/provision-master.sh \
+    ${master_ip} ${NUM_NODES} ${node_ips} ${MASTER_NAME} ${NETWORK_PLUGIN}"
+
+  for (( i=0; i < ${#node_cids[@]}; i++ )); do
+    local cid="${node_cids[$i]}"
+    local name="${NODE_NAMES[$i]}"
+    echo "Provisioning ${name}"
+    ${DOCKER_CMD} exec "${cid}" bash -c "\
+      ${script_root}/provision-node.sh \
+      ${master_ip} ${NUM_NODES} ${node_ips} ${name}"
+  done
+}
+
+function stop() {
+  echo "Cleaning up docker-in-docker containers"
+  local master_cid=$(${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}")
+  if [[ "${master_cid}" ]]; then
+    ${DOCKER_CMD} rm -f "${master_cid}"
+  fi
+
+  local node_cids=$(${DOCKER_CMD} ps -qa --filter "name=${NODE_PREFIX}")
+  if [[ "${node_cids}" ]]; then
+    node_cids=(${node_cids//\n/ })
+    for cid in "${node_cids[@]}"; do
+      local is_running=$(${DOCKER_CMD} inspect -f {{.State.Running}} "${cid}")
+      if [ "${is_running}" = "true" ]; then
+        # Make sure to ensure that the the docker daemon has stopped
+        # before container removal so associated loopback devices are
+        # released.
+        #
+        # See: https://github.com/jpetazzo/dind/issues/19
+        #
+        local exec_cmd="${DOCKER_CMD} exec -t ${cid}"
+        if ${exec_cmd} supervisorctl status docker | grep -q 'RUNNING'; then
+          ${exec_cmd} supervisorctl stop docker
+        fi
+      fi
+      ${DOCKER_CMD} rm -f "${cid}"
+    done
+  fi
+
+  # Volume cleanup is not compatible with SELinux
+  check-selinux
+
+  # Cleanup orphaned volumes
+  #
+  # See: https://github.com/jpetazzo/dind#important-warning-about-disk-usage
+  #
+  echo "Cleaning up volumes used by docker-in-docker daemons"
+  ${DOCKER_CMD} run -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes
+
+}
+
+function wipe-config() {
+  rm -rf "${ORIGIN_ROOT}/openshift.local.*"
+}
+
+case "${1:-""}" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  wipe)
+    wipe-config
+    ;;
+  wipe-restart)
+    stop
+    wipe-config
+    start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|wipe|wipe-restart}"
+    exit 2
+esac

--- a/hack/dind/init.sh
+++ b/hack/dind/init.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE}")/../../vagrant/provision-config.sh
+
+NUM_NODES=${NUM_MINIONS:-2}
+NODE_IPS=(${MINION_IPS//,/ })
+HOST_NAME=${4:-""}
+NETWORK_PLUGIN=${5:-${OPENSHIFT_SDN:-""}}
+
+NODE_PREFIX="${INSTANCE_PREFIX}-node-"
+NODE_NAMES=( $(eval echo ${NODE_PREFIX}{1..${NUM_NODES}}) )
+
+DOCKER_CMD=${DOCKER_CMD:-"sudo docker"}
+
+os::dind::set-dind-env() {
+  # Set up the KUBECONFIG environment variable for use by oc
+  local deployed_root=$1
+  # Target .bashrc by default instead of .bash_profile because a
+  # 'docker exec' invocation will not run .bash_profile
+  local target=${2:-"/root/.bashrc"}
+
+  local log_target='/var/log/supervisor/openshift-*-stderr-*'
+  os::util::set-oc-env "${deployed_root}" "${target}"
+  cat <<EOF >> "${target}"
+alias oc-less-log="less ${log_target}"
+alias oc-tail-log="tail -f ${log_target}"
+alias oc-create-hello="oc create -f ${deployed_root}/examples/hello-openshift/hello-pod.json"
+EOF
+}

--- a/hack/dind/provision-master.sh
+++ b/hack/dind/provision-master.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE}")/init.sh
+
+NETWORK_PLUGIN=$(os::util::get-network-plugin "${NETWORK_PLUGIN}")
+
+os::util::setup-hosts-file "${MASTER_NAME}" "${MASTER_IP}" NODE_NAMES NODE_IPS
+
+echo "Building and installing openshift"
+${ORIGIN_ROOT}/hack/build-go.sh
+os::util::install-cmds "${ORIGIN_ROOT}"
+${ORIGIN_ROOT}/hack/install-etcd.sh
+os::util::install-sdn "${ORIGIN_ROOT}"
+
+os::util::init-certs "${ORIGIN_ROOT}" "${NETWORK_PLUGIN}" "${MASTER_NAME}" \
+  "${MASTER_IP}" NODE_NAMES NODE_IPS
+
+NODE_NAME_LIST=$(os::util::join , ${NODE_NAMES[@]})
+cat <<EOF >> /etc/supervisord.conf
+
+[program:openshift-master]
+command=/usr/bin/openshift start master --loglevel=5 --master=https://${MASTER_IP}:8443 --nodes=${NODE_NAME_LIST} --network-plugin=${NETWORK_PLUGIN}
+directory=${ORIGIN_ROOT}
+priority=10
+startsecs=20
+stderr_events_enabled=true
+stdout_events_enabled=true
+EOF
+
+# Start openshift
+supervisorctl update
+
+os::dind::set-dind-env "${ORIGIN_ROOT}"

--- a/hack/dind/provision-node.sh
+++ b/hack/dind/provision-node.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE}")/init.sh
+
+os::util::setup-hosts-file ${MASTER_NAME} ${MASTER_IP} NODE_NAMES NODE_IPS
+
+echo "Installing openshift"
+os::util::install-cmds "${ORIGIN_ROOT}"
+os::util::install-sdn "${ORIGIN_ROOT}"
+
+SUPERVISORD_CONF="/etc/supervisord.conf"
+cat <<EOF >> "${SUPERVISORD_CONF}"
+
+[program:openshift-node]
+command=/usr/bin/openshift start node --loglevel=5 --config=/${ORIGIN_ROOT}/openshift.local.config/node-${HOST_NAME}/node-config.yaml
+priority=20
+startsecs=20
+stderr_events_enabled=true
+stdout_events_enabled=true
+EOF
+
+# Start openshift
+supervisorctl update
+
+# Ensure that openshift-sdn has written configuration for docker
+# before triggering a docker restart.
+while grep 'DOCKER_DAEMON_ARGS=\"\"' "${SUPERVISORD_CONF}" > /dev/null; do
+  sleep 1
+done
+
+# Restart docker
+supervisorctl update
+
+os::dind::set-dind-env "${ORIGIN_ROOT}"

--- a/images/dind/master/Dockerfile
+++ b/images/dind/master/Dockerfile
@@ -1,0 +1,15 @@
+#
+# This image is used for running a master node of an openshift dev cluster.
+#
+# The standard name for this image is openshift/dind-master
+#
+
+FROM fedora:22
+
+RUN dnf -y update && dnf -y install supervisor git golang hg tar make \
+    hostname bind-utils iproute iputils which procps-ng \
+    && dnf clean all
+
+ADD supervisord.conf /etc/supervisord.conf
+
+CMD [ "/usr/bin/supervisord" ]

--- a/images/dind/master/supervisord.conf
+++ b/images/dind/master/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+logfile = /var/log/supervisor/supervisord.log
+logfile_maxbytes = 200KB
+logfile_backups = 1
+pidfile = /var/run/supervisord.pid
+childlogdir = /var/log/supervisor
+
+[unix_http_server]
+file = /var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///var/run/supervisor.sock

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -1,0 +1,20 @@
+#
+# This image is used for running a node of an openshift dev cluster.
+#
+# The standard name for this image is openshift/dind-node
+#
+
+FROM openshift/dind-master
+
+RUN dnf -y update && dnf -y install docker openvswitch bridge-utils ethtool \
+    && dnf clean all
+
+ENV DIND_COMMIT e253b43366abf618475237e15633c43dc2ad40e6
+RUN curl -fL "https://raw.githubusercontent.com/jpetazzo/dind/${DIND_COMMIT}/wrapdocker" \
+    -o /usr/local/bin/wrapdocker && chmod +x /usr/local/bin/wrapdocker
+
+VOLUME /var/lib/docker
+
+ADD supervisord.conf /etc/supervisord.conf
+
+CMD [ "/usr/bin/supervisord" ]

--- a/images/dind/node/supervisord.conf
+++ b/images/dind/node/supervisord.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /var/log/supervisor/supervisord.log
+logfile_maxbytes = 200KB
+logfile_backups = 1
+pidfile = /var/run/supervisord.pid
+childlogdir = /var/log/supervisor
+
+[unix_http_server]
+file = /var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///var/run/supervisor.sock
+
+[program:docker]
+command=/usr/local/bin/wrapdocker
+priority=10
+startsecs=10
+stderr_events_enabled=true
+stdout_events_enabled=true
+environment=PORT="4444",DOCKER_DAEMON_ARGS=""
+
+[program:openvswitch]
+command=/usr/share/openvswitch/scripts/ovs-ctl start --system-id=random
+priority=10
+startsecs=0
+# The fedora control script exits after starting the ovs daemons.
+autorestart=false

--- a/vagrant/provision-config.sh
+++ b/vagrant/provision-config.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
-set -e
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ORIGIN_ROOT=$(
+  unset CDPATH
+  origin_root=$(dirname "${BASH_SOURCE}")/..
+  cd "${origin_root}"
+  pwd
+)
+source ${ORIGIN_ROOT}/vagrant/provision-util.sh
 
 # Passed as arguments to provisioning from Vagrantfile
-MASTER_IP=$1
-NUM_MINIONS=$2
-MINION_IPS=$3
+MASTER_IP=${1:-""}
+NUM_MINIONS=${2:-""}
+MINION_IPS=${3:-""}
 
 INSTANCE_PREFIX=openshift
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/vagrant/provision-master.sh
+++ b/vagrant/provision-master.sh
@@ -3,86 +3,38 @@
 set -ex
 source $(dirname $0)/provision-config.sh
 
-OPENSHIFT_SDN=$4
-if [ "${OPENSHIFT_SDN}" == "redhat/openshift-ovs-multitenant" ] || [ "${OPENSHIFT_SDN}" == "redhat/openshift-ovs-subnet" ] || [ "${OPENSHIFT_SDN}" == "" ]; then
-	OPENSHIFT_SDN_PLUGIN=${OPENSHIFT_SDN}
-fi
-OPENSHIFT_SDN_PLUGIN=${OPENSHIFT_SDN_PLUGIN:-redhat/openshift-ovs-subnet}
+NETWORK_PLUGIN=$(os::util::get-network-plugin ${4:-""})
 
 NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
 sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
 
 systemctl restart network
 
-# Setup hosts file to support ping by hostname to each minion in the cluster from apiserver
-node_list=""
+# Setup hosts file to ensure name resolution to each member of the cluster
 minion_ip_array=(${MINION_IPS//,/ })
-for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
-  minion=${MINION_NAMES[$i]}
-  node_list="${node_list},${minion}"
-  ip=${minion_ip_array[$i]}
-  if [ ! "$(cat /etc/hosts | grep $minion)" ]; then
-    echo "Adding $minion to hosts file"
-    echo "$ip $minion" >> /etc/hosts
-  fi
-done
-if ! grep ${MASTER_IP} /etc/hosts; then
-  echo "${MASTER_IP} ${MASTER_NAME}" >> /etc/hosts
-fi
-node_list=${node_list:1}
+os::util::setup-hosts-file "${MASTER_NAME}" "${MASTER_IP}" MINION_NAMES \
+  minion_ip_array
 
 # Install the required packages
 yum install -y docker-io git golang e2fsprogs hg net-tools bridge-utils which
 
 # Build openshift
 echo "Building openshift"
-pushd /vagrant
+pushd "${ORIGIN_ROOT}"
   ./hack/build-go.sh
-  cp _output/local/go/bin/openshift /usr/bin
+  os::util::install-cmds "${ORIGIN_ROOT}"
   ./hack/install-etcd.sh
 popd
 
-# Initialize certificates
-echo "Generating certs"
-pushd /vagrant
-  SERVER_CONFIG_DIR="`pwd`/openshift.local.config"
-  VOLUMES_DIR="/var/lib/openshift.local.volumes"
-  MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
-  CERT_DIR="${MASTER_CONFIG_DIR}"
-
-  # Master certs
-  /usr/bin/openshift admin ca create-master-certs \
-    --overwrite=false \
-    --cert-dir=${CERT_DIR} \
-    --master=https://${MASTER_IP}:8443 \
-    --hostnames=${MASTER_IP},${MASTER_NAME}
-
-  # Certs for nodes
-  for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
-    minion=${MINION_NAMES[$i]}
-    ip=${minion_ip_array[$i]}
-
-    /usr/bin/openshift admin create-node-config \
-      --node-dir="${SERVER_CONFIG_DIR}/node-${minion}" \
-      --node="${minion}" \
-      --hostnames="${minion},${ip}" \
-      --master="https://${MASTER_IP}:8443" \
-      --network-plugin="${OPENSHIFT_SDN_PLUGIN}" \
-      --node-client-certificate-authority="${CERT_DIR}/ca.crt" \
-      --certificate-authority="${CERT_DIR}/ca.crt" \
-      --signer-cert="${CERT_DIR}/ca.crt" \
-      --signer-key="${CERT_DIR}/ca.key" \
-      --signer-serial="${CERT_DIR}/ca.serial.txt" \
-      --volume-dir="${VOLUMES_DIR}"
-  done
-
-popd
+os::util::init-certs "${ORIGIN_ROOT}" "${NETWORK_PLUGIN}" "${MASTER_NAME}" \
+  "${MASTER_IP}" MINION_NAMES minion_ip_array
 
 # Start docker
 systemctl enable docker.service
 systemctl start docker.service
 
 # Create systemd service
+node_list=$(os::util::join , ${MINION_NAMES[@]})
 cat <<EOF > /usr/lib/systemd/system/openshift-master.service
 [Unit]
 Description=OpenShift Master
@@ -90,8 +42,8 @@ Requires=docker.service network.service
 After=network.service
 
 [Service]
-ExecStart=/usr/bin/openshift start master --master=https://${MASTER_IP}:8443 --nodes=${node_list} --network-plugin=${OPENSHIFT_SDN_PLUGIN}
-WorkingDirectory=/vagrant/
+ExecStart=/usr/bin/openshift start master --master=https://${MASTER_IP}:8443 --nodes=${node_list} --network-plugin=${NETWORK_PLUGIN}
+WorkingDirectory=${ORIGIN_ROOT}/
 
 [Install]
 WantedBy=multi-user.target
@@ -102,8 +54,8 @@ systemctl daemon-reload
 systemctl start openshift-master.service
 
 # setup SDN
-$(dirname $0)/provision-sdn.sh $@
+$(dirname $0)/provision-sdn.sh
 
 # Set up the KUBECONFIG environment variable for use by oc
-echo 'export KUBECONFIG=/vagrant/openshift.local.config/master/admin.kubeconfig' >> /root/.bash_profile
-echo 'export KUBECONFIG=/vagrant/openshift.local.config/master/admin.kubeconfig' >> /home/vagrant/.bash_profile
+os::util::set-oc-env "${ORIGIN_ROOT}" "/root/.bash_profile"
+os::util::set-oc-env "${ORIGIN_ROOT}" "/home/vagrant/.bash_profile"

--- a/vagrant/provision-minion.sh
+++ b/vagrant/provision-minion.sh
@@ -3,7 +3,6 @@ set -ex
 source $(dirname $0)/provision-config.sh
 
 MINION_IP=$4
-OPENSHIFT_SDN=$6
 MINION_INDEX=$5
 
 NETWORK_CONF_PATH=/etc/sysconfig/network-scripts/
@@ -14,44 +13,29 @@ systemctl restart network
 # get the minion name, index is 1-based
 minion_name=${MINION_NAMES[$MINION_INDEX-1]}
 
-# Setup hosts file to support ping by hostname to master
-if [ ! "$(cat /etc/hosts | grep $MASTER_NAME)" ]; then
-  echo "Adding $MASTER_NAME to hosts file"
-  echo "$MASTER_IP $MASTER_NAME" >> /etc/hosts
-fi
-
-# Setup hosts file to support ping by hostname to each minion in the cluster
+# Setup hosts file to ensure name resolution to each member of the cluster
 minion_ip_array=(${MINION_IPS//,/ })
-for (( i=0; i<${#MINION_NAMES[@]}; i++)); do
-  minion=${MINION_NAMES[$i]}
-  ip=${minion_ip_array[$i]}  
-  if [ ! "$(cat /etc/hosts | grep $minion)" ]; then
-    echo "Adding $minion to hosts file"
-    echo "$ip $minion" >> /etc/hosts
-  fi
-done
-if ! grep ${MINION_IP} /etc/hosts; then
-  echo "${MINION_IP} ${minion_name}" >> /etc/hosts
-fi
+os::util::setup-hosts-file "${MASTER_NAME}" "${MASTER_IP}" MINION_NAMES \
+  minion_ip_array
 
 # Install the required packages
 yum install -y docker-io git golang e2fsprogs hg openvswitch net-tools bridge-utils which ethtool
 
 # Build openshift
 echo "Building openshift"
-pushd /vagrant
+pushd "${ORIGIN_ROOT}"
   ./hack/build-go.sh
-  cp _output/local/go/bin/openshift /usr/bin
+  os::util::install-cmds "${ORIGIN_ROOT}"
 popd
 
 # Copy over the certificates directory
-cp -r /vagrant/openshift.local.config /
+cp -r "${ORIGIN_ROOT}/openshift.local.config" /
 chown -R vagrant.vagrant /openshift.local.config
 
 mkdir -p /openshift.local.volumes
 
 # Setup SDN
-$(dirname $0)/provision-sdn.sh $@
+$(dirname $0)/provision-sdn.sh
 
 # Create systemd service
 cat <<EOF > /usr/lib/systemd/system/openshift-node.service
@@ -75,8 +59,8 @@ systemctl enable openshift-node.service
 systemctl start openshift-node.service
 
 # Set up the KUBECONFIG environment variable for use by the client
-echo 'export KUBECONFIG=/openshift.local.config/master/admin.kubeconfig' >> /root/.bash_profile
-echo 'export KUBECONFIG=/openshift.local.config/master/admin.kubeconfig' >> /home/vagrant/.bash_profile
+os::util::set-oc-env / "/root/.bash_profile"
+os::util::set-oc-env / "/home/vagrant/.bash_profile"
 
 # Register with the master
 #curl -X POST -H 'Accept: application/json' -d "{\"kind\":\"Minion\", \"id\":"${MINION_IP}", \"apiVersion\":\"v1beta1\", \"hostIP\":"${MINION_IP}" }" http://${MASTER_IP}:8080/api/v1beta1/minions

--- a/vagrant/provision-sdn.sh
+++ b/vagrant/provision-sdn.sh
@@ -2,24 +2,12 @@
 set -ex
 source $(dirname $0)/provision-config.sh
 
-pushd $HOME
-# build openshift-sdn
-if [ -d openshift-sdn ]; then
-    cd openshift-sdn
-    git fetch origin
-    git reset --hard origin/master
-    git checkout -b multitenant
-else
-    git clone https://github.com/openshift/openshift-sdn -b multitenant
-    cd openshift-sdn
+os::util::install-sdn "${ORIGIN_ROOT}"
+
+# Only start openvswitch if it has been installed (only minions).
+if rpm -qa | grep -q openvswitch; then
+  systemctl enable openvswitch
+  systemctl start openvswitch
 fi
-
-make clean
-make
-make install
-popd
-
-systemctl enable openvswitch
-systemctl start openvswitch
 
 # no need to start openshift-sdn, as it is integrated with openshift binary


### PR DESCRIPTION
This change adds support for running an openshift cluster in containers via docker-in-docker.  This is intended to make it possible to run multinode tests on a single CI node.

The control script for a dind cluster is:

     hack/dind-cluster.sh

The script includes inline documentation that should be reviewed before use.