### PR TITLE
kill all child processes

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -16,6 +16,8 @@ function cleanup()
 {
     out=$?
     pkill -P $$
+    set +e
+    kill_all_processes
 
     if [ $out -ne 0 ]; then
         echo "[FAIL] !!!!! Test Failed !!!!"
@@ -29,7 +31,6 @@ function cleanup()
           echo
           echo "pprof: top output"
           echo
-          set +e
           go tool pprof -text ./_output/local/go/bin/openshift cpu.pprof
         fi
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -89,10 +89,8 @@ function cleanup()
 		oc delete -n default all --all
 
 		echo "[INFO] Tearing down test"
-		pids="$(jobs -pr)"
-		echo "[INFO] Children: ${pids}"
-		sudo kill ${pids}
-		sudo ps f
+		kill_all_processes
+
 		set +u
 		echo "[INFO] Stopping k8s docker containers"; docker ps | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker stop
 		if [[ -z "${SKIP_IMAGE_CLEANUP-}" ]]; then
@@ -152,7 +150,6 @@ function wait_for_build() {
 }
 
 # Setup
-stop_openshift_server
 echo "[INFO] `openshift version`"
 echo "[INFO] Server logs will be at:    ${LOG_DIR}/openshift.log"
 echo "[INFO] Test artifacts will be in: ${ARTIFACT_DIR}"

--- a/hack/test-extended.sh
+++ b/hack/test-extended.sh
@@ -29,7 +29,7 @@ for BUCKET in ${EXTENDED_BUCKETS[@]}; do
 	fi
 	
     echo "[INFO] Starting extended test ${BUCKET}"
-	(exec hack/test-extended/${BUCKET}/run.sh)
+	hack/test-extended/${BUCKET}/run.sh
 done
 
 echo "[INFO] Finished extended tests"


### PR DESCRIPTION
The OS server has to be started without sudo or else the the cleanup wont be able shut the server down, since sudo will spawn a new subshell. When trying to kill the OS server, only the subshell will be killed and the OS server will become a orphan process and then needs to be killed manually.

This fix counts with the case that we are running our tests as sudo/root
@deads2k thoughts ?