### PR TITLE
UPSTREAM: 12498: Re-add timeouts for kubelet 

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/server.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/server.go
@@ -65,6 +65,8 @@ func ListenAndServeKubeletServer(host HostInterface, address net.IP, port uint, 
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
+		ReadTimeout:    60 * time.Minute,
+		WriteTimeout:   60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	if tlsOptions != nil {
@@ -84,6 +86,8 @@ func ListenAndServeKubeletReadOnlyServer(host HostInterface, address net.IP, por
 	server := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &s,
+		ReadTimeout:    60 * time.Minute,
+		WriteTimeout:   60 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Fatal(server.ListenAndServe())


### PR DESCRIPTION
Re-add timeouts for kubelet which is not in the upstream PR.

Ref: https://github.com/GoogleCloudPlatform/kubernetes/pull/10656/files#r36634728 pending open question about this change.

@liggitt - I did not see this timeout in the configuration options for the kubelet unless I missed it.  The only timeout option seemed to be for the port forwarding/exec streaming connections

Fixes https://github.com/openshift/origin/issues/4090#event-378276506