### PR TITLE
Add port table to browse services page

### DIFF
--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -535,4 +535,14 @@ angular.module('openshiftConsole')
 
       return rc.spec.replicas;
     };
+  })
+  .filter('serviceImplicitDNSName', function() {
+    return function(service) {
+      if (!service || !service.metadata || !service.metadata.name || !service.metadata.namespace) {
+        return '';
+      }
+
+      // cluster.local suffix is customizable, so leave it off. <name>.<namespace>.svc resolves.
+      return service.metadata.name + '.' + service.metadata.namespace + '.svc';
+    };
   });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -356,10 +356,10 @@ code {
   }
 }
 @media (max-width: @screen-xs-max) {
-  .table-events, thead, tbody, th, td, tr {
-    display: block;
-  }
   .table-events {
+    thead, tbody, th, td, tr {
+      display: block;
+    }
     thead tr {
       /* Hide table headers (but not display: none;, for accessibility) */
       .sr-only();

--- a/assets/app/styles/_tile.less
+++ b/assets/app/styles/_tile.less
@@ -14,9 +14,17 @@
   h1, h2, h3 {
     margin: (@line-height-computed / 2) 0px;
   }
-  .tile-details {
+  h3 .tile-timestamp {
+    .text-muted;
+    .small;
     @media (min-width: @screen-sm-min) {
       .pull-right();
+    }
+    @media (max-width: @screen-sm-min) {
+      &:before {
+        // em dash and non-breaking space
+        content: '\2014\00a0'
+      }
     }
   }
   .tile-table {
@@ -55,6 +63,24 @@
       font-size: inherit;
     }
 
+  }
+  .table-responsive {
+    border: 0;
+    margin: 10px 0 5px;
+    table {
+      .table;
+      .table-condensed;
+      .text-center;
+      .small;
+      margin-bottom: 0;
+      thead {
+        background-color: white;
+        background-image: none;
+        tr th {
+          .text-center;
+        }
+      }
+    }
   }
 }
 .tile.tile-template {

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -41,7 +41,7 @@
 
             <div class="component-block">
               <div class="component">
-                <div class="component-label">
+                <div ng-attr-title="{{service | serviceImplicitDNSName}}" class="component-label">
                   <!-- "service" class is present for e2e tests to check   -->
                   Service <span ng-if="displayRouteByService[serviceId]">: <span class="service">{{serviceId}}</span></span>
                 </div>
@@ -72,9 +72,6 @@
               </div>
 
               <div class="component meta-data">
-                <span ng-if="service.spec.clusterIP && service.spec.clusterIP !== 'None'">
-                  routing traffic on {{service.spec.clusterIP}}
-                </span>
                 <div ng-if="numPorts">
                   <!--
                   Show only the first two ports if there are many since we don't have much space here.
@@ -82,7 +79,8 @@
                   -->
                   <span ng-repeat="portMapping in service.spec.ports | orderBy:'port' | limitTo:2" class="nowrap">
                     <!-- Group port mappings and allow multiple mappings to stack if needed -->
-                    <span class="port-mappings">port {{portMapping.port}}&#8201;&#8594;&#8201;{{portMapping.targetPort}}
+                    <span class="port-mappings">
+                      {{portMapping.port}}&#8201;&#8594;&#8201;{{portMapping.targetPort}}
                       ({{portMapping.protocol}})<span ng-if="$index < (numPorts - 1)">, </span></span>
                   </span>
                   <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
@@ -92,7 +90,6 @@
               </div>
             </div>
           </div>
-
 
           <!--
           Iterate over deploymentConfigs for this service.

--- a/assets/app/views/services.html
+++ b/assets/app/views/services.html
@@ -11,29 +11,50 @@
         </div>
       </div>
       <div ng-repeat="service in services" class="tile">
-        <h3 id="service-{{service.metadata.name}}">{{service.metadata.name}}</h3>
-        <div>Created: <relative-timestamp timestamp="service.metadata.creationTimestamp"></relative-timestamp></div>
-        <div>IP:
-          <span ng-if="service.spec.clusterIP == 'None'"><em>none</em></span>
-          <span ng-if="service.spec.clusterIP != 'None'">{{service.spec.clusterIP}}</span>
-        </div>
-        <div>Ports:
-          <span ng-if="!service.spec.ports.length"><em>none</em></span>
-          <ul ng-if="service.spec.ports.length">
-            <li ng-repeat="portMapping in service.spec.ports | orderBy:'port'">
-              {{portMapping.port}} &#8594; {{portMapping.targetPort}} ({{portMapping.protocol}})
-            </li>
-          </ul>
-        </div>
+        <h3 id="service-{{service.metadata.name}}">
+          {{service.metadata.name}}
+          <span class="tile-timestamp">Created <relative-timestamp timestamp="service.metadata.creationTimestamp"></relative-timestamp></span>
+        </h3>
         <div>Selectors: <span ng-if="!service.spec.selector"><em>none</em></span>
             <span ng-repeat="(selectorLabel, selectorValue) in service.spec.selector"> {{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></span>
         </div>
+        <div>Type: {{service.spec.type}}</div>
         <div>Routes: <span ng-if="(routesByService[service.metadata.name] | hashSize) == 0"><em>none</em></span>
             <span ng-repeat="(routeName, route) in routesByService[service.metadata.name]">
                 <span ng-if="route | isWebRoute"><a href="{{route | routeWebURL}}">{{route | routeLabel}}</a></span>
                 <span ng-if="!(route | isWebRoute)">{{route | routeLabel}}</span>
                 <span ng-show="!$last">, </span>
             </span>
+        </div>
+        <div class="table-responsive">
+          <table ng-if="service.spec.ports.length" style="max-width: 650px;">
+            <thead>
+              <tr>
+                <th>Node Port</th>
+                <th role="presentation"></th>
+                <th>
+                  Service Port
+                  <!-- Show cluster IP in column header instead of table body at small screen widths to save space. -->
+                  <span class="visible-xs">({{service.spec.clusterIP}})</span>
+                </th>
+                <th role="presentation"></th>
+                <th>Target Port</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr ng-repeat="portMapping in service.spec.ports | orderBy:'port'">
+                <td>
+                  <span ng-if="portMapping.nodePort">{{portMapping.nodePort}}</span>
+                  <span ng-if="!portMapping.nodePort" class="text-muted">none</span>
+                </td>
+                <td role="presentation" class="text-muted">&#8594;</td>
+                <td><span ng-if="service.spec.clusterIP && service.spec.clusterIP !== 'None'">
+                    <span class="hidden-xs">{{service.spec.clusterIP}}:</span></span>{{portMapping.port}}</td>
+                <td role="presentation" class="text-muted">&#8594;</td>
+                <td>{{portMapping.targetPort}}&nbsp;({{portMapping.protocol}})</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #3662

Mobile:

<img width="325" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/9204008/9256aa2c-4028-11e5-8fcb-fe1cbcdb2052.png">

Full:

<img width="603" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/9204014/9af6f54c-4028-11e5-9e24-1a395cec8f7b.png">

Overview, removed wordy routing traffic message with not-so-useful IP.

<img width="536" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/9204020/a9761382-4028-11e5-8119-ca343e5b0d8c.png">
