### PR TITLE
Fix openshift-sdn repo management

### DIFF
--- a/vagrant/provision-sdn.sh
+++ b/vagrant/provision-sdn.sh
@@ -8,9 +8,9 @@ if [ -d openshift-sdn ]; then
     cd openshift-sdn
     git fetch origin
     git reset --hard origin/master
-    git checkout -b multitenant
+    git checkout
 else
-    git clone https://github.com/openshift/openshift-sdn -b multitenant
+    git clone https://github.com/openshift/openshift-sdn
     cd openshift-sdn
 fi
 


### PR DESCRIPTION
A previous commit added a branch qualifier to git commands for
openshift-sdn.  This was unintentional - master should be used.