### PR TITLE
Disable builds for atomic

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/selector.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/selector.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resource
 
 import (
-	"github.com/golang/glog"
+	"fmt"
 
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
@@ -50,11 +50,10 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 	if err != nil {
 		if errors.IsBadRequest(err) || errors.IsNotFound(err) {
 			if r.Selector.Empty() {
-				glog.V(2).Infof("Unable to list %q: %v", r.Mapping.Resource, err)
+				return fmt.Errorf("Unable to list %q: %v", r.Mapping.Resource, err)
 			} else {
-				glog.V(2).Infof("Unable to find %q that match the selector %q: %v", r.Mapping.Resource, r.Selector, err)
+				return fmt.Errorf("Unable to find %q that match the selector %q: %v", r.Mapping.Resource, r.Selector, err)
 			}
-			return nil
 		}
 		return err
 	}

--- a/pkg/cmd/server/api/util.go
+++ b/pkg/cmd/server/api/util.go
@@ -1,0 +1,6 @@
+package api
+
+// IsBuildDisabled returns true if the builder feature is disabled.
+func IsBuildEnabled(config *MasterConfig) bool {
+	return !config.DisabledFeatures.Has(FeatureBuilder)
+}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -400,13 +400,6 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	)
 
 	storage := map[string]rest.Storage{
-		"builds":                   buildStorage,
-		"buildConfigs":             buildConfigStorage,
-		"buildConfigs/webhooks":    buildConfigWebHooks,
-		"builds/clone":             buildclonestorage.NewStorage(buildGenerator),
-		"buildConfigs/instantiate": buildinstantiatestorage.NewStorage(buildGenerator),
-		"builds/log":               buildlogregistry.NewREST(buildRegistry, c.BuildLogClient(), kubeletClient),
-
 		"images":              imageStorage,
 		"imageStreams":        imageStreamStorage,
 		"imageStreams/status": imageStreamStatusStorage,
@@ -452,6 +445,15 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"clusterPolicyBindings": clusterPolicyBindingStorage,
 		"clusterRoleBindings":   clusterRoleBindingStorage,
 		"clusterRoles":          clusterRoleStorage,
+	}
+
+	if configapi.IsBuildEnabled(&c.Options) {
+		storage["builds"] = buildStorage
+		storage["buildConfigs"] = buildConfigStorage
+		storage["buildConfigs/webhooks"] = buildConfigWebHooks
+		storage["builds/clone"] = buildclonestorage.NewStorage(buildGenerator)
+		storage["buildConfigs/instantiate"] = buildinstantiatestorage.NewStorage(buildGenerator)
+		storage["builds/log"] = buildlogregistry.NewREST(buildRegistry, c.BuildLogClient(), kubeletClient)
 	}
 
 	return storage

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -470,11 +470,13 @@ func StartControllers(openshiftConfig *origin.MasterConfig, kubeMasterConfig *ku
 		kubeMasterConfig.RunPersistentVolumeClaimRecycler(openshiftConfig.ImageFor("deployer"))
 	}
 
-	// no special order
-	openshiftConfig.RunBuildController()
-	openshiftConfig.RunBuildPodController()
-	openshiftConfig.RunBuildConfigChangeController()
-	openshiftConfig.RunBuildImageChangeTriggerController()
+	// no special order\
+	if configapi.IsBuildEnabled(&openshiftConfig.Options) {
+		openshiftConfig.RunBuildController()
+		openshiftConfig.RunBuildPodController()
+		openshiftConfig.RunBuildConfigChangeController()
+		openshiftConfig.RunBuildImageChangeTriggerController()
+	}
 	openshiftConfig.RunDeploymentController()
 	openshiftConfig.RunDeployerPodController()
 	openshiftConfig.RunDeploymentConfigController()


### PR DESCRIPTION
@smarterclayton @ashcrow - this builds on Steve's WIP to disable builders completely in admission.  Please take a look and let me know what you think of the approach.  This is in addition to not starting the controllers, etc.

```
----------- using atomic-enterprise
[vagrant@openshiftdev sample-app]$ oc get templates
NAME                     DESCRIPTION                                                                        PARAMETERS        OBJECTS
ruby-helloworld-sample   This example shows how to create a simple ruby application in openshift origi...   5 (4 generated)   8
[vagrant@openshiftdev sample-app]$ oc new-app ruby-helloworld-sample
services/frontend
routes/route-edge
imagestreams/origin-ruby-sample
imagestreams/ruby-20-centos7
Error: BuildConfig "ruby-sample-build" is forbidden: Builders are disabled
deploymentconfigs/frontend
services/database
deploymentconfigs/database



------- using openshift
[vagrant@openshiftdev sample-app]$ oc create -f application-template-stibuild.json
template "ruby-helloworld-sample" created
[vagrant@openshiftdev sample-app]$ oc new-app ruby-helloworld-sample
services/frontend
routes/route-edge
imagestreams/origin-ruby-sample
imagestreams/ruby-20-centos7
buildconfigs/ruby-sample-build
deploymentconfigs/frontend
services/database
deploymentconfigs/database
Service "frontend" created at 172.30.75.87 with port mappings 5432->8080.
A build was created - you can run `oc start-build ruby-sample-build` to start it.
Service "database" created at 172.30.120.70 with port mappings 5434->3306.
Run 'oc status' to view your app.
```