### PR TITLE
Add build config change trigger to start a build when a BuildConfig is created

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14004,6 +14004,11 @@
      "from": {
       "$ref": "v1.ObjectReference",
       "description": "ImageStreamTag that triggered this build"
+     },
+     "lastVersion": {
+      "type": "integer",
+      "format": "int32",
+      "description": "LastVersion of the BuildConfig that triggered this build"
      }
     }
    },

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -182,6 +182,9 @@ angular.module("openshiftConsole")
             secret: scope._generateSecret()
           },
           type: "Generic"
+        },
+        {
+          type: "ConfigChange"
         }
       ];
       if(input.buildConfig.buildOnSourceChange){

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -227,6 +227,9 @@ describe("ApplicationGenerator", function(){
                         "type": "Generic"
                     },
                     {
+                        "type": "ConfigChange"
+                    },
+                    {
                         "github": {
                             "secret": "secret101"
                         },

--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -112,6 +112,9 @@
           {
             "type": "imageChange",
             "imageChange": {}
+          },
+          {
+            "type": "ConfigChange"
           }
         ],
         "source": {

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -112,6 +112,9 @@
           {
             "type": "imageChange",
             "imageChange": {}
+          },
+          {
+            "type": "ConfigChange"
           }
         ],
         "source": {

--- a/examples/sample-app/application-template-pullspecbuild.json
+++ b/examples/sample-app/application-template-pullspecbuild.json
@@ -110,6 +110,9 @@
             "generic": {
               "secret": "secret101"
             }
+          },
+          {
+            "type": "ConfigChange"
           }
         ],
         "source": {

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -114,6 +114,9 @@
           {
             "type": "ImageChange",
             "imageChange": {}
+          },
+          {
+            "type": "ConfigChange"
           }
         ],
         "source": {

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -831,6 +831,12 @@ func deepCopy_api_BuildRequest(in buildapi.BuildRequest, out *buildapi.BuildRequ
 	} else {
 		out.From = nil
 	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -738,6 +738,12 @@ func convert_api_BuildRequest_To_v1_BuildRequest(in *buildapi.BuildRequest, out 
 	} else {
 		out.From = nil
 	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
+	}
 	return nil
 }
 
@@ -1101,6 +1107,12 @@ func convert_v1_BuildRequest_To_api_BuildRequest(in *apiv1.BuildRequest, out *bu
 		}
 	} else {
 		out.From = nil
+	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
 	}
 	return nil
 }

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -812,6 +812,12 @@ func deepCopy_v1_BuildRequest(in apiv1.BuildRequest, out *apiv1.BuildRequest, c 
 	} else {
 		out.From = nil
 	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -776,6 +776,12 @@ func convert_api_BuildRequest_To_v1beta3_BuildRequest(in *buildapi.BuildRequest,
 	} else {
 		out.From = nil
 	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
+	}
 	return nil
 }
 
@@ -1139,6 +1145,12 @@ func convert_v1beta3_BuildRequest_To_api_BuildRequest(in *apiv1beta3.BuildReques
 		}
 	} else {
 		out.From = nil
+	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
 	}
 	return nil
 }

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -820,6 +820,12 @@ func deepCopy_v1beta3_BuildRequest(in apiv1beta3.BuildRequest, out *apiv1beta3.B
 	} else {
 		out.From = nil
 	}
+	if in.LastVersion != nil {
+		out.LastVersion = new(int)
+		*out.LastVersion = *in.LastVersion
+	} else {
+		out.LastVersion = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -397,6 +397,10 @@ const (
 	// availability of a new version of an image
 	ImageChangeBuildTriggerType           BuildTriggerType = "ImageChange"
 	ImageChangeBuildTriggerTypeDeprecated BuildTriggerType = "imageChange"
+
+	// ConfigChangeBuildTriggerType will trigger a build on an initial build config creation
+	// WARNING: In the future the behavior will change to trigger a build on any config change
+	ConfigChangeBuildTriggerType BuildTriggerType = "ConfigChange"
 )
 
 // BuildList is a collection of Builds.
@@ -462,6 +466,11 @@ type BuildRequest struct {
 
 	// From is the reference to the ImageStreamTag that triggered the build.
 	From *kapi.ObjectReference
+
+	// LastVersion (optional) is the LastVersion of the BuildConfig that was used
+	// to generate the build. If the BuildConfig in the generator doesn't match, a build will
+	// not be generated.
+	LastVersion *int
 }
 
 // BuildLogOptions is the REST options for a build log

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -382,6 +382,10 @@ const (
 	// availability of a new version of an image
 	ImageChangeBuildTriggerType           BuildTriggerType = "ImageChange"
 	ImageChangeBuildTriggerTypeDeprecated BuildTriggerType = "imageChange"
+
+	// ConfigChangeBuildTriggerType will trigger a build on an initial build config creation
+	// WARNING: In the future the behavior will change to trigger a build on any config change
+	ConfigChangeBuildTriggerType BuildTriggerType = "ConfigChange"
 )
 
 // BuildList is a collection of Builds.
@@ -436,6 +440,11 @@ type BuildRequest struct {
 
 	// From is the reference to the ImageStreamTag that triggered the build.
 	From *kapi.ObjectReference `json:"from,omitempty" description:"ImageStreamTag that triggered this build"`
+
+	// LastVersion (optional) is the LastVersion of the BuildConfig that was used
+	// to generate the build. If the BuildConfig in the generator doesn't match, a build will
+	// not be generated.
+	LastVersion *int `json:"lastVersion,omitempty" description:"LastVersion of the BuildConfig that triggered this build"`
 }
 
 // BuildLogOptions is the REST options for a build log

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -368,6 +368,10 @@ const (
 	// ImageChangeBuildTriggerType represents a trigger that launches builds on
 	// availability of a new version of an image
 	ImageChangeBuildTriggerType BuildTriggerType = "imageChange"
+
+	// ConfigChangeBuildTriggerType will trigger a build on an initial build config creation
+	// WARNING: In the future the behavior will change to trigger a build on any config change
+	ConfigChangeBuildTriggerType BuildTriggerType = "ConfigChange"
 )
 
 // BuildList is a collection of Builds.
@@ -418,6 +422,11 @@ type BuildRequest struct {
 
 	// From is the reference to the ImageStreamTag that triggered the build.
 	From *kapi.ObjectReference `json:"from,omitempty" description:"ImageStreamTag that triggered this build"`
+
+	// LastVersion (optional) is the LastVersion of the BuildConfig that was used
+	// to generate the build. If the BuildConfig in the generator doesn't match, a build will
+	// not be generated.
+	LastVersion *int `json:"lastVersion,omitempty" description:"LastVersion of the BuildConfig that triggered this build"`
 }
 
 // BuildLogOptions is the REST options for a build log

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -347,6 +347,8 @@ func validateTrigger(trigger *buildapi.BuildTriggerPolicy) fielderrors.Validatio
 			break
 		}
 		allErrs = append(allErrs, validateFromImageReference(trigger.ImageChange.From).Prefix("from")...)
+	case buildapi.ConfigChangeBuildTriggerType:
+		// doesn't reuqire additional validation
 	default:
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("type", trigger.Type, "invalid trigger type"))
 	}

--- a/pkg/build/controller/config_controller.go
+++ b/pkg/build/controller/config_controller.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildclient "github.com/openshift/origin/pkg/build/client"
+)
+
+type BuildConfigController struct {
+	BuildConfigInstantiator buildclient.BuildConfigInstantiator
+}
+
+func (c *BuildConfigController) HandleBuildConfig(bc *buildapi.BuildConfig) error {
+	glog.V(4).Infof("Handling BuildConfig %s/%s", bc.Namespace, bc.Name)
+
+	hasChangeTrigger := false
+	for _, trigger := range bc.Spec.Triggers {
+		if trigger.Type == buildapi.ConfigChangeBuildTriggerType {
+			hasChangeTrigger = true
+			break
+		}
+	}
+
+	if !hasChangeTrigger {
+		return nil
+	}
+
+	if bc.Status.LastVersion > 0 {
+		return nil
+	}
+
+	glog.V(4).Infof("Running build for BuildConfig %s/%s", bc.Namespace, bc.Name)
+	// instantiate new build
+	lastVersion := 0
+	request := &buildapi.BuildRequest{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      bc.Name,
+			Namespace: bc.Namespace,
+		},
+		LastVersion: &lastVersion,
+	}
+	if _, err := c.BuildConfigInstantiator.Instantiate(bc.Namespace, request); err != nil {
+		var instantiateErr error
+		if kerrors.IsConflict(err) {
+			instantiateErr = fmt.Errorf("unable to instantiate Build for BuildConfig %s/%s due to a conflicting update: %v", bc.Namespace, bc.Name, err)
+			util.HandleError(instantiateErr)
+		} else {
+			instantiateErr = fmt.Errorf("error instantiating Build from BuildConfig %s/%s: %v", bc.Namespace, bc.Name, err)
+			util.HandleError(instantiateErr)
+		}
+		return instantiateErr
+	}
+	return nil
+}

--- a/pkg/build/controller/config_controller_test.go
+++ b/pkg/build/controller/config_controller_test.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+func TestHandleBuildConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		bc                *buildapi.BuildConfig
+		expectBuild       bool
+		instantiatorError bool
+		expectErr         bool
+	}{
+		{
+			name:        "build config with no config change trigger",
+			bc:          baseBuildConfig(),
+			expectBuild: false,
+		},
+		{
+			name:        "build config with non-zero last version",
+			bc:          buildConfigWithNonZeroLastVersion(),
+			expectBuild: false,
+		},
+		{
+			name:        "build config with config change trigger",
+			bc:          buildConfigWithConfigChangeTrigger(),
+			expectBuild: true,
+		},
+		{
+			name:              "instantiator error",
+			bc:                buildConfigWithConfigChangeTrigger(),
+			instantiatorError: true,
+			expectErr:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		instantiator := &testInstantiator{
+			err: tc.instantiatorError,
+		}
+		controller := &BuildConfigController{
+			BuildConfigInstantiator: instantiator,
+		}
+		err := controller.HandleBuildConfig(tc.bc)
+		if err != nil {
+			if !tc.expectErr {
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			}
+			continue
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("%s: expected error, but got none", tc.name)
+			continue
+		}
+		if tc.expectBuild && len(instantiator.requestName) == 0 {
+			t.Errorf("%s: expected a build to be started.", tc.name)
+		}
+		if !tc.expectBuild && len(instantiator.requestName) > 0 {
+			t.Errorf("%s: did not expect a build to be started.", tc.name)
+		}
+	}
+
+}
+
+type testInstantiator struct {
+	requestName string
+	err         bool
+}
+
+func (i *testInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
+	i.requestName = request.Name
+	if i.err {
+		return nil, fmt.Errorf("error")
+	}
+	return &buildapi.Build{}, nil
+}
+
+func baseBuildConfig() *buildapi.BuildConfig {
+	bc := &buildapi.BuildConfig{}
+	bc.Name = "testBuildConfig"
+	bc.Spec.BuildSpec.Strategy.Type = buildapi.SourceBuildStrategyType
+	bc.Spec.BuildSpec.Strategy.SourceStrategy = &buildapi.SourceBuildStrategy{}
+	bc.Spec.BuildSpec.Strategy.SourceStrategy.From.Name = "builderimage:latest"
+	bc.Spec.BuildSpec.Strategy.SourceStrategy.From.Kind = "ImageStreamTag"
+	return bc
+}
+
+func buildConfigWithConfigChangeTrigger() *buildapi.BuildConfig {
+	bc := baseBuildConfig()
+	configChangeTrigger := buildapi.BuildTriggerPolicy{}
+	configChangeTrigger.Type = buildapi.ConfigChangeBuildTriggerType
+	bc.Spec.Triggers = append(bc.Spec.Triggers, configChangeTrigger)
+	return bc
+}
+
+func buildConfigWithNonZeroLastVersion() *buildapi.BuildConfig {
+	bc := buildConfigWithConfigChangeTrigger()
+	bc.Status.LastVersion = 1
+	return bc
+}

--- a/pkg/build/controller/factory/factory_test.go
+++ b/pkg/build/controller/factory/factory_test.go
@@ -2,13 +2,16 @@ package factory
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+	kutil "k8s.io/kubernetes/pkg/util"
+
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	controller "github.com/openshift/origin/pkg/controller"
-	kutil "k8s.io/kubernetes/pkg/util"
 )
 
 type buildUpdater struct {
@@ -54,5 +57,65 @@ func TestLimitedLogAndRetryProcessing(t *testing.T) {
 	}
 	if updater.Build != nil {
 		t.Fatal("BuildUpdater shouldn't be called!")
+	}
+}
+
+func TestControllerRetryFunc(t *testing.T) {
+	obj := &kapi.Pod{}
+	obj.Name = "testpod"
+	obj.Namespace = "testNS"
+
+	testErr := fmt.Errorf("test error")
+	tests := []struct {
+		name       string
+		retryCount int
+		isFatal    func(err error) bool
+		err        error
+		expect     bool
+	}{
+		{
+			name:       "maxRetries-1 retries",
+			retryCount: maxRetries - 1,
+			err:        testErr,
+			expect:     true,
+		},
+		{
+			name:       "maxRetries+1 retries",
+			retryCount: maxRetries + 1,
+			err:        testErr,
+			expect:     false,
+		},
+		{
+			name:       "isFatal returns true",
+			retryCount: 0,
+			err:        testErr,
+			isFatal: func(err error) bool {
+				if err != testErr {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				return true
+			},
+			expect: false,
+		},
+		{
+			name:       "isFatal returns false",
+			retryCount: 0,
+			err:        testErr,
+			isFatal: func(err error) bool {
+				if err != testErr {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				return false
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range tests {
+		f := retryFunc("test kind", tc.isFatal)
+		result := f(obj, tc.err, controller.Retry{Count: tc.retryCount})
+		if result != tc.expect {
+			t.Errorf("%s: unexpected result. Expected: %v. Got: %v", tc.name, tc.expect, result)
+		}
 	}
 }

--- a/pkg/build/controller/image_change_controller.go
+++ b/pkg/build/controller/image_change_controller.go
@@ -33,8 +33,6 @@ func (e ImageChangeControllerFatalError) Error() string {
 type ImageChangeController struct {
 	BuildConfigStore        cache.Store
 	BuildConfigInstantiator buildclient.BuildConfigInstantiator
-	// Stop is an optional channel that controls when the controller exits
-	Stop <-chan struct{}
 }
 
 // getImageStreamNameFromReference strips off the :tag or @id suffix

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -393,6 +393,11 @@ func (c *MasterConfig) BuildImageChangeTriggerControllerClients() (*osclient.Cli
 	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
 }
 
+// BuildConfigChangeControllerClients returns the build config change controller client objects
+func (c *MasterConfig) BuildConfigChangeControllerClients() (*osclient.Client, *kclient.Client) {
+	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClient
+}
+
 // ImageChangeControllerClient returns the openshift client object
 func (c *MasterConfig) ImageChangeControllerClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -232,6 +232,14 @@ func (c *MasterConfig) RunBuildImageChangeTriggerController() {
 	factory.Create().Run()
 }
 
+// RunBuildConfigChangeController starts the build config change trigger controller process.
+func (c *MasterConfig) RunBuildConfigChangeController() {
+	bcClient, _ := c.BuildConfigChangeControllerClients()
+	bcInstantiator := buildclient.NewOSClientBuildConfigInstantiatorClient(bcClient)
+	factory := buildcontrollerfactory.BuildConfigControllerFactory{Client: bcClient, BuildConfigInstantiator: bcInstantiator}
+	factory.Create().Run()
+}
+
 // RunDeploymentController starts the deployment controller process.
 func (c *MasterConfig) RunDeploymentController() {
 	_, kclient := c.DeploymentControllerClients()

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -438,6 +438,7 @@ func StartMaster(openshiftMasterConfig *configapi.MasterConfig) error {
 			// no special order
 			openshiftConfig.RunBuildController()
 			openshiftConfig.RunBuildPodController()
+			openshiftConfig.RunBuildConfigChangeController()
 			openshiftConfig.RunBuildImageChangeTriggerController()
 			openshiftConfig.RunDeploymentController()
 			openshiftConfig.RunDeployerPodController()

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -394,12 +394,19 @@ func (r *BuildRef) BuildConfig() (*buildapi.BuildConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	configChangeTrigger := buildapi.BuildTriggerPolicy{
+		Type: buildapi.ConfigChangeBuildTriggerType,
+	}
+
+	triggers := append(sourceTriggers, configChangeTrigger)
+	triggers = append(triggers, strategyTriggers...)
+
 	return &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: name,
 		},
 		Spec: buildapi.BuildConfigSpec{
-			Triggers: append(sourceTriggers, strategyTriggers...),
+			Triggers: triggers,
 			BuildSpec: buildapi.BuildSpec{
 				Source:   *source,
 				Strategy: *strategy,

--- a/pkg/generate/app/app_test.go
+++ b/pkg/generate/app/app_test.go
@@ -115,7 +115,7 @@ func TestBuildConfigOutput(t *testing.T) {
 		if config.Spec.Output.To.Name != "origin:latest" || config.Spec.Output.To.Kind != test.expectedKind {
 			t.Errorf("(%d) unexpected output image: %s/%s", i, config.Spec.Output.To.Kind, config.Spec.Output.To.Name)
 		}
-		if len(config.Spec.Triggers) != 3 {
+		if len(config.Spec.Triggers) != 4 {
 			t.Errorf("(%d) unexpected number of triggers %d: %#v\n", i, len(config.Spec.Triggers), config.Spec.Triggers)
 		}
 		imageChangeTrigger := false

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -34,6 +34,15 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
 	runTest(t, "SimpleImageChangeBuildTriggerFromImageStreamTagSTI", clusterAdminClient, imageStream, imageStreamMapping, config, tag)
 }
 
+func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *testing.T) {
+	clusterAdminClient := setup(t)
+	imageStream := mockImageStream2(tag)
+	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
+	strategy := stiStrategy("ImageStreamTag", streamName+":"+tag)
+	config := imageChangeBuildConfigWithConfigChange("sti-imagestreamtag", strategy)
+	runTest(t, "SimpleImageChangeBuildTriggerFromImageStreamTagSTI", clusterAdminClient, imageStream, imageStreamMapping, config, tag)
+}
+
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
 	clusterAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
@@ -43,12 +52,30 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
 	runTest(t, "SimpleImageChangeBuildTriggerFromImageStreamTagDocker", clusterAdminClient, imageStream, imageStreamMapping, config, tag)
 }
 
+func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t *testing.T) {
+	clusterAdminClient := setup(t)
+	imageStream := mockImageStream2(tag)
+	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
+	strategy := dockerStrategy("ImageStreamTag", streamName+":"+tag)
+	config := imageChangeBuildConfigWithConfigChange("docker-imagestreamtag", strategy)
+	runTest(t, "SimpleImageChangeBuildTriggerFromImageStreamTagDocker", clusterAdminClient, imageStream, imageStreamMapping, config, tag)
+}
+
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
 	clusterAdminClient := setup(t)
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
 	strategy := customStrategy("ImageStreamTag", streamName+":"+tag)
 	config := imageChangeBuildConfig("custom-imagestreamtag", strategy)
+	runTest(t, "SimpleImageChangeBuildTriggerFromImageStreamTagCustom", clusterAdminClient, imageStream, imageStreamMapping, config, tag)
+}
+
+func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange(t *testing.T) {
+	clusterAdminClient := setup(t)
+	imageStream := mockImageStream2(tag)
+	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
+	strategy := customStrategy("ImageStreamTag", streamName+":"+tag)
+	config := imageChangeBuildConfigWithConfigChange("custom-imagestreamtag", strategy)
 	runTest(t, "SimpleImageChangeBuildTriggerFromImageStreamTagCustom", clusterAdminClient, imageStream, imageStreamMapping, config, tag)
 }
 
@@ -118,6 +145,11 @@ func imageChangeBuildConfig(name string, strategy buildapi.BuildStrategy) *build
 			},
 		},
 	}
+}
+func imageChangeBuildConfigWithConfigChange(name string, strategy buildapi.BuildStrategy) *buildapi.BuildConfig {
+	bc := imageChangeBuildConfig(name, strategy)
+	bc.Spec.Triggers = append(bc.Spec.Triggers, buildapi.BuildTriggerPolicy{Type: buildapi.ConfigChangeBuildTriggerType})
+	return bc
 }
 
 func mockImageStream2(tag string) *imageapi.ImageStream {


### PR DESCRIPTION
Introduces new build trigger type which, when present causes a new build to be kicked off as soon as a BuildConfig is added. 
Fixes existing build controllers to use the Stop channel
Adds the new trigger by default to build configs generated by new-app and the web console