### PR TITLE
Allow origin api controllers to be run independently in the master

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -42,7 +42,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	}
 
 	// Connect and setup etcd interfaces
-	etcdClient, err := etcd.GetAndTestEtcdClient(options.EtcdClientInfo)
+	etcdClient, err := etcd.EtcdClient(options.EtcdClientInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/origin/auth_config.go
+++ b/pkg/cmd/server/origin/auth_config.go
@@ -35,7 +35,7 @@ type AuthConfig struct {
 }
 
 func BuildAuthConfig(options configapi.MasterConfig) (*AuthConfig, error) {
-	client, err := etcd.GetAndTestEtcdClient(options.EtcdClientInfo)
+	client, err := etcd.EtcdClient(options.EtcdClientInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -125,7 +125,7 @@ type MasterConfig struct {
 }
 
 func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
-	client, err := etcd.GetAndTestEtcdClient(options.EtcdClientInfo)
+	client, err := etcd.EtcdClient(options.EtcdClientInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/start/command_test.go
+++ b/pkg/cmd/server/start/command_test.go
@@ -271,5 +271,5 @@ func executeAllInOneCommandWithConfigs(args []string) (*MasterArgs, *configapi.M
 	if nodeCfg == nil && nodeErr == nil {
 		nodeErr = errors.New("did not find node config")
 	}
-	return cfg.MasterArgs, masterCfg, masterErr, cfg.NodeArgs, nodeCfg, nodeErr
+	return cfg.MasterOptions.MasterArgs, masterCfg, masterErr, cfg.NodeArgs, nodeCfg, nodeErr
 }

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -44,6 +44,12 @@ type MasterArgs struct {
 	// or URL). Defaults to same as --master.
 	MasterPublicAddr flagtypes.Addr
 
+	// StartAPI controls whether the API component of the master is started (to support the API role)
+	// TODO: once we implement bastion role and kube/os controller role, revisit
+	StartAPI bool
+	// StartControllers controls whether the controller component of the master is started (to support
+	// the controller role)
+	StartControllers bool
 	PauseControllers bool
 
 	// DNSBindAddr exposed for integration tests to set

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -20,22 +20,18 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/pkg/cmd/server/admin"
-	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/start/kubernetes"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
 type AllInOneOptions struct {
-	MasterArgs *MasterArgs
-	NodeArgs   *NodeArgs
+	MasterOptions *MasterOptions
 
-	CreateCerts      bool
-	ConfigDir        util.StringFlag
-	MasterConfigFile string
-	NodeConfigFile   string
-	PrintIP          bool
-	Output           io.Writer
-	DisabledFeatures []string
+	NodeArgs *NodeArgs
+
+	ConfigDir      util.StringFlag
+	NodeConfigFile string
+	PrintIP        bool
 }
 
 const allInOneLong = `
@@ -60,25 +56,21 @@ You may also pass --etcd=<address> to connect to an external etcd server.
 You may also pass --kubeconfig=<path> to connect to an external Kubernetes cluster.`
 
 // NewCommandStartAllInOne provides a CLI handler for 'start' command
-func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *AllInOneOptions) {
-	options := &AllInOneOptions{Output: out}
-
-	switch fullName {
-	case "atomic-enterprise":
-		options.DisabledFeatures = configapi.AtomicDisabledFeatures
-	}
+func NewCommandStartAllInOne(basename string, out io.Writer) (*cobra.Command, *AllInOneOptions) {
+	options := &AllInOneOptions{MasterOptions: &MasterOptions{Output: out}}
+	options.MasterOptions.DefaultsFromName(basename)
 
 	cmds := &cobra.Command{
 		Use:   "start",
 		Short: "Launch all-in-one server",
-		Long:  fmt.Sprintf(allInOneLong, fullName),
+		Long:  fmt.Sprintf(allInOneLong, basename),
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Complete(); err != nil {
-				fmt.Println(kcmdutil.UsageError(c, err.Error()))
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, err.Error()))
 				return
 			}
 			if err := options.Validate(args); err != nil {
-				fmt.Println(kcmdutil.UsageError(c, err.Error()))
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, err.Error()))
 				return
 			}
 
@@ -103,13 +95,13 @@ func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *A
 	flags := cmds.Flags()
 
 	flags.Var(&options.ConfigDir, "write-config", "Directory to write an initial config into.  After writing, exit without starting the server.")
-	flags.StringVar(&options.MasterConfigFile, "master-config", "", "Location of the master configuration file to run from. When running from configuration files, all other command-line arguments are ignored.")
+	flags.StringVar(&options.MasterOptions.ConfigFile, "master-config", "", "Location of the master configuration file to run from. When running from configuration files, all other command-line arguments are ignored.")
 	flags.StringVar(&options.NodeConfigFile, "node-config", "", "Location of the node configuration file to run from. When running from configuration files, all other command-line arguments are ignored.")
-	flags.BoolVar(&options.CreateCerts, "create-certs", true, "Indicates whether missing certs should be created.")
+	flags.BoolVar(&options.MasterOptions.CreateCertificates, "create-certs", true, "Indicates whether missing certs should be created.")
 	flags.BoolVar(&options.PrintIP, "print-ip", false, "Print the IP that would be used if no master IP is specified and exit.")
 
 	masterArgs, nodeArgs, listenArg, imageFormatArgs, _ := GetAllInOneArgs()
-	options.MasterArgs, options.NodeArgs = masterArgs, nodeArgs
+	options.MasterOptions.MasterArgs, options.NodeArgs = masterArgs, nodeArgs
 	// by default, all-in-ones all disabled docker.  Set it here so that if we allow it to be bound later, bindings take precedence
 	options.NodeArgs.AllowDisabledDocker = true
 
@@ -118,12 +110,12 @@ func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *A
 	BindListenArg(listenArg, flags, "")
 	BindImageFormatArgs(imageFormatArgs, flags, "")
 
-	startMaster, _ := NewCommandStartMaster(fullName, out)
-	startNode, _ := NewCommandStartNode(fullName, out)
+	startMaster, _ := NewCommandStartMaster(basename, out)
+	startNode, _ := NewCommandStartNode(basename, out)
 	cmds.AddCommand(startMaster)
 	cmds.AddCommand(startNode)
 
-	startKube := kubernetes.NewCommand("kubernetes", fullName, out)
+	startKube := kubernetes.NewCommand("kubernetes", basename, out)
 	cmds.AddCommand(startKube)
 
 	// autocompletion hints
@@ -137,6 +129,8 @@ func NewCommandStartAllInOne(fullName string, out io.Writer) (*cobra.Command, *A
 // GetAllInOneArgs makes sure that the node and master args that should be shared, are shared
 func GetAllInOneArgs() (*MasterArgs, *NodeArgs, *ListenArg, *ImageFormatArgs, *KubeConnectionArgs) {
 	masterArgs := NewDefaultMasterArgs()
+	masterArgs.StartAPI = true
+	masterArgs.StartControllers = true
 	nodeArgs := NewDefaultNodeArgs()
 
 	listenArg := NewDefaultListenArg()
@@ -159,7 +153,7 @@ func (o AllInOneOptions) Validate(args []string) error {
 		return errors.New("no arguments are supported for start")
 	}
 
-	if (len(o.MasterConfigFile) == 0) != (len(o.NodeConfigFile) == 0) {
+	if (len(o.MasterOptions.ConfigFile) == 0) != (len(o.NodeConfigFile) == 0) {
 		return errors.New("--master-config and --node-config must both be specified or both be unspecified")
 	}
 
@@ -173,7 +167,7 @@ func (o AllInOneOptions) Validate(args []string) error {
 
 	// if we are not starting up using a config file, run the argument validation
 	if !o.IsRunFromConfig() {
-		if err := o.MasterArgs.Validate(); err != nil {
+		if err := o.MasterOptions.MasterArgs.Validate(); err != nil {
 			return err
 		}
 
@@ -183,7 +177,7 @@ func (o AllInOneOptions) Validate(args []string) error {
 
 	}
 
-	if len(o.MasterArgs.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath) != 0 {
+	if len(o.MasterOptions.MasterArgs.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath) != 0 {
 		return errors.New("all-in-one cannot start with a remote Kubernetes server, start the master instead")
 	}
 
@@ -192,31 +186,31 @@ func (o AllInOneOptions) Validate(args []string) error {
 
 func (o *AllInOneOptions) Complete() error {
 	if o.ConfigDir.Provided() {
-		o.MasterArgs.ConfigDir.Set(path.Join(o.ConfigDir.Value(), "master"))
+		o.MasterOptions.MasterArgs.ConfigDir.Set(path.Join(o.ConfigDir.Value(), "master"))
 		o.NodeArgs.ConfigDir.Set(path.Join(o.ConfigDir.Value(), admin.DefaultNodeDir(o.NodeArgs.NodeName)))
 	} else {
 		o.ConfigDir.Default("openshift.local.config")
-		o.MasterArgs.ConfigDir.Default(path.Join(o.ConfigDir.Value(), "master"))
+		o.MasterOptions.MasterArgs.ConfigDir.Default(path.Join(o.ConfigDir.Value(), "master"))
 		o.NodeArgs.ConfigDir.Default(path.Join(o.ConfigDir.Value(), admin.DefaultNodeDir(o.NodeArgs.NodeName)))
 	}
 
 	nodeList := util.NewStringSet(strings.ToLower(o.NodeArgs.NodeName))
 	// take everything toLower
-	for _, s := range o.MasterArgs.NodeList {
+	for _, s := range o.MasterOptions.MasterArgs.NodeList {
 		nodeList.Insert(strings.ToLower(s))
 	}
-	o.MasterArgs.NodeList = nodeList.List()
+	o.MasterOptions.MasterArgs.NodeList = nodeList.List()
 
-	o.MasterArgs.NetworkArgs.NetworkPluginName = o.NodeArgs.NetworkPluginName
+	o.MasterOptions.MasterArgs.NetworkArgs.NetworkPluginName = o.NodeArgs.NetworkPluginName
 
-	masterAddr, err := o.MasterArgs.GetMasterAddress()
+	masterAddr, err := o.MasterOptions.MasterArgs.GetMasterAddress()
 	if err != nil {
 		return err
 	}
 	// in the all-in-one, default kubernetes URL to the master's address
 	o.NodeArgs.DefaultKubernetesURL = masterAddr
 	o.NodeArgs.NodeName = strings.ToLower(o.NodeArgs.NodeName)
-	o.NodeArgs.MasterCertDir = o.MasterArgs.ConfigDir.Value()
+	o.NodeArgs.MasterCertDir = o.MasterOptions.MasterArgs.ConfigDir.Value()
 
 	// in the all-in-one, default ClusterDNS to the master's address
 	if host, _, err := net.SplitHostPort(masterAddr.Host); err == nil {
@@ -240,15 +234,15 @@ func (o AllInOneOptions) StartAllInOne() error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(o.Output, "%s\n", host)
+		fmt.Fprintf(o.MasterOptions.Output, "%s\n", host)
 		return nil
 	}
-	masterOptions := MasterOptions{o.MasterArgs, o.CreateCerts, o.MasterConfigFile, o.Output, o.DisabledFeatures}
+	masterOptions := *o.MasterOptions
 	if err := masterOptions.RunMaster(); err != nil {
 		return err
 	}
 
-	nodeOptions := NodeOptions{o.NodeArgs, o.NodeConfigFile, o.Output}
+	nodeOptions := NodeOptions{o.NodeArgs, o.NodeConfigFile, o.MasterOptions.Output}
 	if err := nodeOptions.RunNode(); err != nil {
 		return err
 	}
@@ -277,5 +271,5 @@ func (o AllInOneOptions) IsWriteConfigOnly() bool {
 }
 
 func (o AllInOneOptions) IsRunFromConfig() bool {
-	return (len(o.MasterConfigFile) > 0) && (len(o.NodeConfigFile) > 0)
+	return (len(o.MasterOptions.ConfigFile) > 0) && (len(o.NodeConfigFile) > 0)
 }

--- a/pkg/cmd/server/start/start_api.go
+++ b/pkg/cmd/server/start/start_api.go
@@ -1,0 +1,77 @@
+package start
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+const apiLong = `Start the master API
+
+This command starts the master API.  Running
+
+  $ %[1]s start master %[2]s
+
+will start the server listening for incoming API requests. The server
+will run in the foreground until you terminate the process.`
+
+// NewCommandStartMasterAPI starts only the APIserver
+func NewCommandStartMasterAPI(name, basename string, out io.Writer) (*cobra.Command, *MasterOptions) {
+	options := &MasterOptions{Output: out}
+	options.DefaultsFromName(basename)
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Launch master API",
+		Long:  fmt.Sprintf(apiLong, basename, name),
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Complete(); err != nil {
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, err.Error()))
+				return
+			}
+
+			if len(options.ConfigFile) == 0 {
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, "--config is required for this command"))
+				return
+			}
+
+			if err := options.Validate(args); err != nil {
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, err.Error()))
+				return
+			}
+
+			startProfiler()
+
+			if err := options.StartMaster(); err != nil {
+				if kerrors.IsInvalid(err) {
+					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
+						fmt.Fprintf(c.Out(), "Invalid %s %s\n", details.Kind, details.Name)
+						for _, cause := range details.Causes {
+							fmt.Fprintf(c.Out(), "  %s: %s\n", cause.Field, cause.Message)
+						}
+						os.Exit(255)
+					}
+				}
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	options.MasterArgs = NewDefaultMasterArgs()
+	options.MasterArgs.StartAPI = true
+
+	flags := cmd.Flags()
+	// This command only supports reading from config and the listen argument
+	flags.StringVar(&options.ConfigFile, "config", "", "Location of the master configuration file to run from. Required")
+	cmd.MarkFlagFilename("config", "yaml", "yml")
+	// TODO: add health and metrics endpoints on this listen argument
+	BindListenArg(options.MasterArgs.ListenArg, flags, "")
+
+	return cmd, options
+}

--- a/pkg/cmd/server/start/start_controllers.go
+++ b/pkg/cmd/server/start/start_controllers.go
@@ -1,0 +1,77 @@
+package start
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+const controllersLong = `Start the master controllers
+
+This command starts the controllers for the master.  Running
+
+  $ %[1]s start master %[2]s
+
+will start the controllers that manage the master state, including the scheduler. The controllers
+will run in the foreground until you terminate the process.`
+
+// NewCommandStartMasterControllers starts only the controllers
+func NewCommandStartMasterControllers(name, basename string, out io.Writer) (*cobra.Command, *MasterOptions) {
+	options := &MasterOptions{Output: out}
+	options.DefaultsFromName(basename)
+
+	cmd := &cobra.Command{
+		Use:   "controllers",
+		Short: "Launch master controllers",
+		Long:  fmt.Sprintf(controllersLong, basename, name),
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Complete(); err != nil {
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, err.Error()))
+				return
+			}
+
+			if len(options.ConfigFile) == 0 {
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, "--config is required for this command"))
+				return
+			}
+
+			if err := options.Validate(args); err != nil {
+				fmt.Fprintln(c.Out(), kcmdutil.UsageError(c, err.Error()))
+				return
+			}
+
+			startProfiler()
+
+			if err := options.StartMaster(); err != nil {
+				if kerrors.IsInvalid(err) {
+					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
+						fmt.Fprintf(c.Out(), "Invalid %s %s\n", details.Kind, details.Name)
+						for _, cause := range details.Causes {
+							fmt.Fprintf(c.Out(), "  %s: %s\n", cause.Field, cause.Message)
+						}
+						os.Exit(255)
+					}
+				}
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	options.MasterArgs = NewDefaultMasterArgs()
+	options.MasterArgs.StartControllers = true
+
+	flags := cmd.Flags()
+	// This command only supports reading from config and the listen argument
+	flags.StringVar(&options.ConfigFile, "config", "", "Location of the master configuration file to run from. Required")
+	cmd.MarkFlagFilename("config", "yaml", "yml")
+	// TODO: add health and metrics endpoints on this listen argument
+	BindListenArg(options.MasterArgs.ListenArg, flags, "")
+
+	return cmd, options
+}

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -156,10 +156,54 @@ __handle_word()
     __handle_word
 }
 
+_openshift_start_master_api()
+{
+    last_command="openshift_start_master_api"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("__handle_filename_extension_flag yaml|yml")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--listen=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_start_master_controllers()
+{
+    last_command="openshift_start_master_controllers"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("__handle_filename_extension_flag yaml|yml")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--listen=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_start_master()
 {
     last_command="openshift_start_master"
     commands=()
+    commands+=("api")
+    commands+=("controllers")
 
     flags=()
     two_word_flags=()

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -201,18 +201,18 @@ func CreateNodeCerts(nodeArgs *start.NodeArgs) error {
 
 func DefaultAllInOneOptions() (*configapi.MasterConfig, *configapi.NodeConfig, error) {
 	startOptions := start.AllInOneOptions{}
-	startOptions.MasterArgs, startOptions.NodeArgs, _, _, _ = setupStartOptions()
-	startOptions.MasterArgs.NodeList = nil
+	startOptions.MasterOptions.MasterArgs, startOptions.NodeArgs, _, _, _ = setupStartOptions()
+	startOptions.MasterOptions.MasterArgs.NodeList = nil
 	startOptions.NodeArgs.AllowDisabledDocker = true
 	startOptions.Complete()
-	startOptions.MasterArgs.ConfigDir.Default(path.Join(GetBaseDir(), "openshift.local.config", "master"))
+	startOptions.MasterOptions.MasterArgs.ConfigDir.Default(path.Join(GetBaseDir(), "openshift.local.config", "master"))
 	startOptions.NodeArgs.ConfigDir.Default(path.Join(GetBaseDir(), "openshift.local.config", admin.DefaultNodeDir(startOptions.NodeArgs.NodeName)))
-	startOptions.NodeArgs.MasterCertDir = startOptions.MasterArgs.ConfigDir.Value()
+	startOptions.NodeArgs.MasterCertDir = startOptions.MasterOptions.MasterArgs.ConfigDir.Value()
 
-	if err := CreateMasterCerts(startOptions.MasterArgs); err != nil {
+	if err := CreateMasterCerts(startOptions.MasterOptions.MasterArgs); err != nil {
 		return nil, nil, err
 	}
-	if err := CreateBootstrapPolicy(startOptions.MasterArgs); err != nil {
+	if err := CreateBootstrapPolicy(startOptions.MasterOptions.MasterArgs); err != nil {
 		return nil, nil, err
 	}
 
@@ -220,7 +220,7 @@ func DefaultAllInOneOptions() (*configapi.MasterConfig, *configapi.NodeConfig, e
 		return nil, nil, err
 	}
 
-	masterOptions, err := startOptions.MasterArgs.BuildSerializeableMasterConfig()
+	masterOptions, err := startOptions.MasterOptions.MasterArgs.BuildSerializeableMasterConfig()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
First step to HA.

Run `openshift start master api --config=...` to run just the apiserver.  Run `openshift start master controllers --config=...` to run just the controllers.

Known gaps:
* [ ] no health check or metrics available, need to abstract the code for that
* [ ] no test cases yet