### PR TITLE
do not remove output image when doing s2i build

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -95,7 +95,7 @@ func (s *STIBuilder) Build() error {
 	if err != nil {
 		return err
 	}
-	defer removeImage(s.dockerClient, tag)
+
 	glog.V(4).Infof("Starting S2I build from %s/%s BuildConfig ...", s.build.Namespace, s.build.Name)
 
 	origProxy := make(map[string]string)


### PR DESCRIPTION
not sure why we were doing this (save disk space maybe?) but it messes up incremental builds and the problem of removing old images from the local docker registry (to address disk space usage) should be handled more generically.

This is part of the solution to https://github.com/openshift/origin/issues/4127.  Doing this will at least ensure people doing incremental builds on a single node system can get incremental behavior (multinode setups are still broken unless you did the build on the same node since the pull fails due to missing credentials)

@csrwng @soltysh @jhadvig ptal.
