### PR TITLE
HA active-passive leader election of controllers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,11 +8,14 @@ when that change will happen.
 ## Origin 1.0.x / OSE 3.0.x
 
 1. Currently all build pods have a label named `build`. This label is being deprecated
-  in favor of `openshift.io/build.name` in Origin 1.0.x / OSE 3.1.x at which point both
-  labels will be supported. All the newly created builds will have just the new label.
-  In Origin 1.y / OSE 3.y the support for the old label (`build`) will be removed entirely.
+  in favor of `openshift.io/build.name` in Origin 1.0.x (OSE 3.0.x) - both are supported.
+  In Origin 1.1 we will only set the new label and remove support for the old label.
   See #3502.
 
 1. Currently `oc exec` will attempt to `POST` to `pods/podname/exec`, if that fails it will
-fallback to a `GET` to match older policy roles.  In Origin 1.y/ OSE 3.y the support for the
-old `oc exec` endpoint via `GET` will be removed.
+  fallback to a `GET` to match older policy roles.  In Origin 1.1 (OSE 3.1) the support for the
+  old `oc exec` endpoint via `GET` will be removed.
+
+1. The `pauseControllers` field in `master-config.yaml` is deprecated as of Origin 1.0.4 and will
+  no longer be supported in Origin 1.1. After that, a warning will be printed on startup if it
+  is set to true.

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -116,7 +116,14 @@ type MasterConfig struct {
 	Controllers string
 	// PauseControllers instructs the master to not automatically start controllers, but instead
 	// to wait until a notification to the server is received before launching them.
+	// TODO: will be disabled in function for 1.1.
 	PauseControllers bool
+	// ControllerLeaseTTL enables controller election, instructing the master to attempt to acquire
+	// a lease before controllers start and renewing it within a number of seconds defined by this value.
+	// Setting this value non-negative forces pauseControllers=true. This value defaults off (0, or
+	// omitted) and controller election can be disabled with -1.
+	ControllerLeaseTTL int
+	// TODO: the next field added to controllers must be added to a new controllers struct
 
 	// Allow to disable OpenShift components
 	DisabledFeatures FeatureList

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -99,6 +99,11 @@ type MasterConfig struct {
 	// PauseControllers instructs the master to not automatically start controllers, but instead
 	// to wait until a notification to the server is received before launching them.
 	PauseControllers bool `json:"pauseControllers,omitempty"`
+	// ControllerLeaseTTL enables controller election, instructing the master to attempt to acquire
+	// a lease before controllers start and renewing it within a number of seconds defined by this value.
+	// Setting this value non-negative forces pauseControllers=true. This value defaults off (0, or
+	// omitted) and controller election can be disabled with -1.
+	ControllerLeaseTTL int `json:"controllerLeaseTTL,omitempty"`
 
 	// DisabledFeatures is a list of features that should not be started.  We
 	// omitempty here because its very unlikely that anyone will want to

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -95,20 +95,20 @@ type MasterConfig struct {
 	// will start automatically. The default value is "*" which will start all controllers. When
 	// using "*", you may exclude controllers by prepending a "-" in front of their name. No other
 	// values are recognized at this time.
-	Controllers string `json:"controllers,omitempty"`
+	Controllers string `json:"controllers"`
 	// PauseControllers instructs the master to not automatically start controllers, but instead
 	// to wait until a notification to the server is received before launching them.
-	PauseControllers bool `json:"pauseControllers,omitempty"`
+	PauseControllers bool `json:"pauseControllers"`
 	// ControllerLeaseTTL enables controller election, instructing the master to attempt to acquire
 	// a lease before controllers start and renewing it within a number of seconds defined by this value.
 	// Setting this value non-negative forces pauseControllers=true. This value defaults off (0, or
 	// omitted) and controller election can be disabled with -1.
-	ControllerLeaseTTL int `json:"controllerLeaseTTL,omitempty"`
+	ControllerLeaseTTL int `json:"controllerLeaseTTL"`
 
 	// DisabledFeatures is a list of features that should not be started.  We
 	// omitempty here because its very unlikely that anyone will want to
 	// manually disable features and we don't want to encourage it.
-	DisabledFeatures FeatureList `json:"disabledFeatures,omitempty"`
+	DisabledFeatures FeatureList `json:"disabledFeatures"`
 
 	// EtcdStorageConfig contains information about how API resources are
 	// stored in Etcd. These values are only relevant when etcd is the

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -59,7 +59,10 @@ assetConfig:
     keyFile: ""
     maxRequestsInFlight: 0
     requestTimeoutSeconds: 0
+controllerLeaseTTL: 0
+controllers: ""
 corsAllowedOrigins: null
+disabledFeatures: null
 dnsConfig:
   bindAddress: ""
   bindNetwork: ""
@@ -221,6 +224,7 @@ oauthConfig:
   tokenConfig:
     accessTokenMaxAgeSeconds: 0
     authorizeTokenMaxAgeSeconds: 0
+pauseControllers: false
 policyConfig:
   bootstrapPolicyFile: ""
   openshiftInfrastructureNamespace: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -61,6 +61,13 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 		validationResults.AddErrors(urlErrs...)
 	}
 
+	switch {
+	case config.ControllerLeaseTTL > 300,
+		config.ControllerLeaseTTL < -1,
+		config.ControllerLeaseTTL > 0 && config.ControllerLeaseTTL < 10:
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("controllerLeaseTTL", config.ControllerLeaseTTL, "TTL must be -1 (disabled), 0 (default), or between 10 and 300 seconds"))
+	}
+
 	validationResults.AddErrors(ValidateDisabledFeatures(config.DisabledFeatures, "disabledFeatures")...)
 
 	if config.AssetConfig != nil {

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -75,6 +75,8 @@ type MasterArgs struct {
 	SchedulerConfigFile string
 
 	NetworkArgs *NetworkArgs
+
+	OverrideConfig func(config *configapi.MasterConfig) error
 }
 
 // BindMasterArgs binds the options to the flags with prefix + default flag names

--- a/pkg/cmd/server/start/start_api.go
+++ b/pkg/cmd/server/start/start_api.go
@@ -70,7 +70,6 @@ func NewCommandStartMasterAPI(name, basename string, out io.Writer) (*cobra.Comm
 	// This command only supports reading from config and the listen argument
 	flags.StringVar(&options.ConfigFile, "config", "", "Location of the master configuration file to run from. Required")
 	cmd.MarkFlagFilename("config", "yaml", "yml")
-	// TODO: add health and metrics endpoints on this listen argument
 	BindListenArg(options.MasterArgs.ListenArg, flags, "")
 
 	return cmd, options

--- a/pkg/cmd/server/start/start_api.go
+++ b/pkg/cmd/server/start/start_api.go
@@ -70,7 +70,6 @@ func NewCommandStartMasterAPI(name, basename string, out io.Writer) (*cobra.Comm
 	// This command only supports reading from config and the listen argument
 	flags.StringVar(&options.ConfigFile, "config", "", "Location of the master configuration file to run from. Required")
 	cmd.MarkFlagFilename("config", "yaml", "yml")
-	BindListenArg(options.MasterArgs.ListenArg, flags, "")
 
 	return cmd, options
 }

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -277,7 +277,7 @@ func (o MasterOptions) RunMaster() error {
 		masterConfig.Controllers = configapi.ControllersDisabled
 	}
 
-	m := &master{
+	m := &Master{
 		config:      masterConfig,
 		api:         o.MasterArgs.StartAPI,
 		controllers: o.MasterArgs.StartControllers,
@@ -335,16 +335,25 @@ func buildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kuberne
 	return kubeConfig, err
 }
 
-// master encapsulates starting the components of the master
-type master struct {
+// Master encapsulates starting the components of the master
+type Master struct {
 	config      *configapi.MasterConfig
 	controllers bool
 	api         bool
 }
 
+// NewMaster create a master launcher
+func NewMaster(config *configapi.MasterConfig, controllers, api bool) *Master {
+	return &Master{
+		config:      config,
+		controllers: controllers,
+		api:         api,
+	}
+}
+
 // Start launches a master. It will error if possible, but some background processes may still
 // be running and the process should exit after it finishes.
-func (m *master) Start() error {
+func (m *Master) Start() error {
 	// Allow privileged containers
 	// TODO: make this configurable and not the default https://github.com/openshift/origin/issues/662
 	capabilities.Initialize(capabilities.Capabilities{

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -437,12 +437,16 @@ func StartControllers(openshiftConfig *origin.MasterConfig, kubeMasterConfig *ku
 	}
 
 	go func() {
+		openshiftConfig.ControllerPlugStart()
+		// when a manual shutdown (DELETE /controllers) or lease lost occurs, the process should exit
+		// this ensures no code is still running as a controller, and allows a process manager to reset
+		// the controller to come back into a candidate state and compete for the lease
 		openshiftConfig.ControllerPlug.WaitForStop()
-		glog.Fatalf("Master shutdown requested")
+		glog.Fatalf("Controller shutdown requested")
 	}()
 
 	openshiftConfig.ControllerPlug.WaitForStart()
-	glog.Infof("Master controllers starting (%s)", openshiftConfig.Options.Controllers)
+	glog.Infof("Controllers starting (%s)", openshiftConfig.Options.Controllers)
 
 	// Start these first, because they provide credentials for other controllers' clients
 	openshiftConfig.RunServiceAccountsController()

--- a/pkg/cmd/util/plug/plug.go
+++ b/pkg/cmd/util/plug/plug.go
@@ -4,14 +4,26 @@ import (
 	"sync"
 )
 
+// Plug represents a synchronization primitive that holds and releases
+// execution for other objects.
 type Plug interface {
+	// Begins operation of the plug and unblocks WaitForStart().
+	// May be invoked multiple times but only the first invocation has
+	// an effect.
 	Start()
+	// Ends operation of the plug and unblocks WaitForStop()
+	// May be invoked multiple times but only the first invocation has
+	// an effect. Calling Stop() before Start() is undefined.
 	Stop()
+	// Blocks until Start() is invoked
 	WaitForStart()
+	// Blocks until Stop() is invoked
 	WaitForStop()
+	// Returns true if Start() has been invoked
 	IsStarted() bool
 }
 
+// plug is the default implementation of Plug
 type plug struct {
 	start   sync.Once
 	stop    sync.Once
@@ -19,7 +31,8 @@ type plug struct {
 	stopCh  chan struct{}
 }
 
-func NewPlug(started bool) Plug {
+// New returns a new plug that can begin in the Started state.
+func New(started bool) Plug {
 	p := &plug{
 		startCh: make(chan struct{}),
 		stopCh:  make(chan struct{}),
@@ -53,4 +66,53 @@ func (p *plug) WaitForStart() {
 
 func (p *plug) WaitForStop() {
 	<-p.stopCh
+}
+
+// Leaser controls access to a lease
+type Leaser interface {
+	// AcquireAndHold tries to acquire the lease and hold it until it expires, the lease is deleted,
+	// or we observe another party take the lease. The notify channel will be sent a value
+	// when the lease is held, and closed when the lease is lost.
+	AcquireAndHold(chan struct{})
+	Release()
+}
+
+// leased uses a Leaser to control Start and Stop on a Plug
+type Leased struct {
+	Plug
+
+	leaser Leaser
+}
+
+var _ Plug = &Leased{}
+
+// NewLeased creates a Plug that starts when a lease is acquired
+// and stops when it is lost.
+func NewLeased(leaser Leaser) *Leased {
+	return &Leased{
+		Plug:   New(false),
+		leaser: leaser,
+	}
+}
+
+// Stop releases the acquired lease
+func (l *Leased) Stop() {
+	l.leaser.Release()
+	l.Plug.Stop()
+}
+
+// Run tries to acquire and hold a lease, invoking Start()
+// when the lease is held and invoking Stop() when the lease
+// is lost.
+func (l *Leased) Run() {
+	ch := make(chan struct{}, 1)
+	go l.leaser.AcquireAndHold(ch)
+	defer l.Stop()
+	for {
+		_, ok := <-ch
+		if !ok {
+			return
+		}
+		l.Start()
+	}
 }

--- a/pkg/util/leaderlease/leaderlease.go
+++ b/pkg/util/leaderlease/leaderlease.go
@@ -1,0 +1,286 @@
+package leaderlease
+
+import (
+	"fmt"
+	"time"
+
+	etcdclient "github.com/coreos/go-etcd/etcd"
+	"github.com/golang/glog"
+	storage "k8s.io/kubernetes/pkg/storage/etcd"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+// Leaser allows a caller to acquire a lease and be notified when it is lost.
+type Leaser interface {
+	// AcquireAndHold tries to acquire the lease and hold it until it expires, the lease is lost,
+	// or we observe another party take the lease. The provided function will be invoked when the
+	// lease is acquired, and the provided channel will be closed when the lease is lost. If the
+	// function returns true, the lease will be released on exit. If the function returns false,
+	// the lease will be held.
+	AcquireAndHold(chan struct{})
+	// Release returns any active leases
+	Release()
+}
+
+// Etcd takes and holds a leader lease until it can no longer confirm it owns
+// the lease, then returns.
+type Etcd struct {
+	client *etcdclient.Client
+	key    string
+	value  string
+	ttl    uint64
+
+	// the fraction of the ttl to wait before trying to renew - for instance, 0.75 with TTL 20
+	// will wait 15 seconds before attempting to renew the lease, then retry over the next 5
+	// seconds in the event of an error no more than maxRetries times.
+	waitFraction float32
+	// the interval to wait when an error occurs acquiring the lease
+	pauseInterval time.Duration
+	// the maximum retries when releasing or renewing the lease
+	maxRetries int
+	// the shortest time between attempts to renew the lease
+	minimumRetryInterval time.Duration
+}
+
+// NewEtcd creates a Lease in etcd, storing value at key with expiration ttl
+// and continues to refresh it until the key is lost, expires, or another
+// client takes it.
+func NewEtcd(client *etcdclient.Client, key, value string, ttl uint64) Leaser {
+	return &Etcd{
+		client: client,
+		key:    key,
+		value:  value,
+		ttl:    ttl,
+
+		waitFraction:         0.75,
+		pauseInterval:        time.Second,
+		maxRetries:           10,
+		minimumRetryInterval: 100 * time.Millisecond,
+	}
+}
+
+// AcquireAndHold implements an acquire and release of a lease.
+func (e *Etcd) AcquireAndHold(notify chan struct{}) {
+	for {
+		ok, ttl, index, err := e.tryAcquire()
+		if err != nil {
+			util.HandleError(err)
+			time.Sleep(e.pauseInterval)
+			continue
+		}
+		if !ok {
+			time.Sleep(e.pauseInterval)
+			continue
+		}
+
+		// notify
+		notify <- struct{}{}
+		defer close(notify)
+
+		// hold the lease
+		if err := e.tryHold(ttl, index); err != nil {
+			util.HandleError(err)
+		}
+		break
+	}
+}
+
+// tryAcquire tries to create the lease key in etcd, or if it already exists
+// and belongs to another user, to wait until the lease expires or is deleted.
+// It returns true if the lease was acquired, the current TTL, the nextIndex
+// to watch from, or an error.
+func (e *Etcd) tryAcquire() (ok bool, ttl uint64, nextIndex uint64, err error) {
+	ttl = e.ttl
+
+	resp, err := e.client.Create(e.key, e.value, ttl)
+	if err == nil {
+		// we hold the lease
+		glog.V(4).Infof("Lease %s acquired, ttl %d seconds", e.key, e.ttl)
+		return true, ttl, resp.EtcdIndex + 1, nil
+	}
+
+	if !storage.IsEtcdNodeExist(err) {
+		return false, 0, 0, fmt.Errorf("unable to check lease %s: %v", e.key, err)
+	}
+
+	latest, err := e.client.Get(e.key, false, false)
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("unable to retrieve lease %s: %v", e.key, err)
+	}
+
+	nextIndex = eventIndexFor(latest)
+	if latest.Node.TTL > 0 {
+		ttl = uint64(latest.Node.TTL)
+	}
+
+	if latest.Node.Value != e.value {
+		glog.V(4).Infof("Lease %s owned by %s, waiting for expiration", e.key, latest.Node.Value)
+		// waits until the lease expires or changes to us.
+		// TODO: it's possible we were given the lease during the watch, but we just expect to go
+		//   through this loop again and let this condition check
+		if _, err := e.waitForExpiration(false, nextIndex, nil); err != nil {
+			return false, 0, 0, fmt.Errorf("unable to wait for lease expiration %s: %v", e.key, err)
+		}
+		return false, 0, 0, nil
+	}
+
+	glog.V(4).Infof("Lease %s already held, expires in %d seconds", e.key, ttl)
+	return true, ttl, nextIndex, nil
+}
+
+// Release tries to delete the leader lock.
+func (e *Etcd) Release() {
+	for i := 0; i < e.maxRetries; i++ {
+		_, err := e.client.CompareAndDelete(e.key, e.value, 0)
+		if err == nil {
+			break
+		}
+		// If the value has changed, we don't hold the lease. If the key is missing we don't
+		// hold the lease.
+		if storage.IsEtcdTestFailed(err) || storage.IsEtcdNotFound(err) {
+			break
+		}
+		util.HandleError(fmt.Errorf("unable to release %s: %v", e.key, err))
+	}
+}
+
+// tryHold attempts to hold on to the lease by repeatedly refreshing its TTL.
+// If the lease hold fails, is deleted, or changed to another user. The provided
+// index is used to watch from.
+// TODO: currently if we miss the watch window, we will error and try to recreate
+//   the lock. It's likely we will lose the lease due to that.
+func (e *Etcd) tryHold(ttl, index uint64) error {
+	// watch for termination
+	stop := make(chan struct{})
+	lost := make(chan struct{})
+	watchIndex := index
+	go util.Until(func() {
+		index, err := e.waitForExpiration(true, watchIndex, stop)
+		watchIndex = index
+		if err != nil {
+			util.HandleError(fmt.Errorf("error watching for lease expiration %s: %v", e.key, err))
+			return
+		}
+		glog.V(4).Infof("Lease %s lost due to deletion", e.key)
+		close(lost)
+	}, 100*time.Millisecond, stop)
+	defer close(stop)
+
+	duration := time.Duration(ttl) * time.Second
+	after := time.Duration(float32(duration) * e.waitFraction)
+	last := duration - after
+	interval := last / time.Duration(e.maxRetries)
+	if interval < e.minimumRetryInterval {
+		interval = e.minimumRetryInterval
+	}
+
+	// as long as we can renew the lease, loop
+	for {
+		select {
+		case <-time.After(after):
+			err := wait.Poll(interval, last, func() (bool, error) {
+				glog.V(4).Infof("Renewing lease %s", e.key)
+				resp, err := e.client.CompareAndSwap(e.key, e.value, e.ttl, e.value, index-1)
+				switch {
+				case err == nil:
+					index = eventIndexFor(resp)
+					return true, nil
+				case storage.IsEtcdTestFailed(err):
+					return false, fmt.Errorf("another client has taken the lease %s: %v", e.key, err)
+				case storage.IsEtcdNotFound(err):
+					return false, fmt.Errorf("another client has revoked the lease %s", e.key)
+				default:
+					util.HandleError(fmt.Errorf("unexpected error renewing lease %s: %v", e.key, err))
+					index = etcdIndexFor(err, index)
+					// try again
+					return false, nil
+				}
+			})
+
+			switch err {
+			case nil:
+				// wait again
+				glog.V(4).Infof("Lease %s renewed", e.key)
+			case wait.ErrWaitTimeout:
+				return fmt.Errorf("unable to renew lease %s: %v", e.key, err)
+			default:
+				return fmt.Errorf("lost lease %s: %v", e.key, err)
+			}
+
+		case <-lost:
+			return fmt.Errorf("the lease has been lost %s", e.key)
+		}
+	}
+}
+
+// waitForExpiration waits until the lease value changes in etcd through deletion, expiration,
+// or explicit change. Held indicates whether the current process owns the lease. The appropriate
+// next watch index is returned.
+func (e *Etcd) waitForExpiration(held bool, from uint64, stop chan struct{}) (uint64, error) {
+	for {
+		lost, index, err := e.waitExpiration(held, from, stop)
+		if err != nil {
+			return index, err
+		}
+		if lost {
+			return index, nil
+		}
+	}
+}
+
+// waitExpiration watches etcd until the lease is deleted, expired, or changed. If the lease is
+// held and a change to the value no longer matches the local value, the lease will be considered
+// to be lost. If the lease is not held, and the value changes to match our value, we'll consider
+// the existing lease to be lost and we are a candidate to acquire it. The appropriate next watch
+// index is returned.
+func (e *Etcd) waitExpiration(held bool, from uint64, stop chan struct{}) (bool, uint64, error) {
+	for {
+		select {
+		case <-stop:
+			return false, from, nil
+		default:
+		}
+		resp, err := e.client.Watch(e.key, from, false, nil, nil)
+		if err != nil {
+			return false, etcdIndexFor(err, from), err
+		}
+
+		index := eventIndexFor(resp)
+
+		if resp.Action == "delete" || resp.Action == "compareAndDelete" || resp.Action == "expire" {
+			// the lease has expired
+			return true, index, nil
+		}
+
+		switch {
+		case resp.Node == nil:
+		case resp.Node.Value == e.value && !held:
+			// given to us
+			return true, index, nil
+		case resp.Node.Value != e.value && held:
+			// taken away from us
+			return true, index, nil
+		}
+	}
+}
+
+// eventIndexFor returns the next etcd index to watch based on a response
+func eventIndexFor(resp *etcdclient.Response) uint64 {
+	if resp.Node != nil {
+		return resp.Node.ModifiedIndex + 1
+	}
+	if resp.PrevNode != nil {
+		return resp.PrevNode.ModifiedIndex + 1
+	}
+	return resp.EtcdIndex
+}
+
+// etcdIndexFor returns index, or if err is an EtcdError, the current
+// etcd index.
+func etcdIndexFor(err error, index uint64) uint64 {
+	if etcderr, ok := err.(*etcdclient.EtcdError); ok {
+		return etcderr.Index
+	}
+	return index
+}

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -171,7 +171,6 @@ _openshift_start_master_api()
     flags_completion+=("__handle_filename_extension_flag yaml|yml")
     flags+=("--help")
     flags+=("-h")
-    flags+=("--listen=")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/test/integration/leaderlease_test.go
+++ b/test/integration/leaderlease_test.go
@@ -1,0 +1,152 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/util/leaderlease"
+	"github.com/openshift/origin/test/util"
+)
+
+func TestLeaderLeaseAcquire(t *testing.T) {
+	util.DeleteAllEtcdKeys()
+	client := util.NewEtcdClient()
+
+	key := "/random/key"
+	held := make(chan struct{})
+	go func() {
+		<-held
+		if _, err := client.Delete(key, false); err != nil {
+			t.Fatal(err)
+		}
+		glog.Infof("Deleted key")
+	}()
+
+	lease := leaderlease.NewEtcd(client, key, "holder", 10)
+	ch := make(chan struct{})
+	go lease.AcquireAndHold(ch)
+
+	<-ch
+	glog.Infof("Lease acquired")
+	close(held)
+	<-ch
+	glog.Infof("Lease lost")
+
+	select {
+	case _, ok := <-held:
+		if ok {
+			t.Error("did not acquire the lease")
+		}
+	default:
+		t.Error("lease is still open")
+	}
+}
+
+func TestLeaderLeaseWait(t *testing.T) {
+	util.DeleteAllEtcdKeys()
+	client := util.NewEtcdClient()
+	key := "/random/key"
+
+	if _, err := client.Create(key, "other", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	held := make(chan struct{})
+	go func() {
+		<-held
+		if _, err := client.Delete(key, false); err != nil {
+			t.Fatal(err)
+		}
+		glog.Infof("Deleted key")
+	}()
+
+	lease := leaderlease.NewEtcd(client, key, "holder", 10)
+	ch := make(chan struct{})
+	go lease.AcquireAndHold(ch)
+
+	<-ch
+	glog.Infof("Lease acquired")
+	close(held)
+	<-ch
+	glog.Infof("Lease lost")
+
+	select {
+	case _, ok := <-held:
+		if ok {
+			t.Error("did not acquire the lease")
+		}
+	default:
+		t.Error("lease is still open")
+	}
+}
+
+func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
+	util.DeleteAllEtcdKeys()
+	client := util.NewEtcdClient()
+	key := "/random/key"
+
+	if _, err := client.Create(key, "holder", 10); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(time.Second)
+		if _, err := client.Set(key, "other", 10); err != nil {
+			t.Fatal(err)
+		}
+		glog.Infof("Changed key ownership")
+	}()
+
+	lease := leaderlease.NewEtcd(client, key, "other", 10)
+	ch := make(chan struct{})
+	go lease.AcquireAndHold(ch)
+
+	<-ch
+	glog.Infof("Lease acquired")
+	lease.Release()
+	<-ch
+	glog.Infof("Lease gone")
+}
+
+func TestLeaderLeaseReacquire(t *testing.T) {
+	util.DeleteAllEtcdKeys()
+	client := util.NewEtcdClient()
+	key := "/random/key"
+
+	if _, err := client.Create(key, "holder", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	held := make(chan struct{})
+	go func() {
+		<-held
+		if _, err := client.Delete(key, false); err != nil {
+			t.Fatal(err)
+		}
+		glog.Infof("Deleted key")
+	}()
+
+	lease := leaderlease.NewEtcd(client, key, "holder", 1)
+	ch := make(chan struct{})
+	go lease.AcquireAndHold(ch)
+
+	<-ch
+	glog.Infof("Lease acquired")
+	time.Sleep(2 * time.Second)
+	close(held)
+	<-ch
+	glog.Infof("Lease lost")
+
+	select {
+	case _, ok := <-held:
+		if ok {
+			t.Error("did not acquire the lease")
+		}
+	default:
+		t.Error("lease is still open")
+	}
+}

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -273,7 +273,7 @@ func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig, test
 		DeleteAllEtcdKeys()
 	}
 
-	if err := start.StartMaster(masterConfig); err != nil {
+	if err := start.NewMaster(masterConfig, true, true).Start(); err != nil {
 		return "", err
 	}
 	adminKubeConfigFile := KubeConfigPath()


### PR DESCRIPTION
This pull request allows the controller processes in the master to be configured in an innate HA fashion.  Controllers, when the config value `controllerLeaseTTL` is set to a non-negative integer, will attempt to acquire a lease via etcd. If the lease expires (because the controller process cannot talk to etcd, or because another client delete or alters the leas) then the controller will terminate itself (and under systemd or process manager, be restarted).