### PR TITLE
allow regex test identifiers for docker integration tests

### DIFF
--- a/hack/test-integration-docker.sh
+++ b/hack/test-integration-docker.sh
@@ -9,4 +9,4 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 # Go to the top of the tree.
 cd "${OS_ROOT}"
 
-OS_TEST_TAGS="integration docker" hack/test-integration.sh
+OS_TEST_TAGS="integration docker" hack/test-integration.sh $@


### PR DESCRIPTION
Allows for users to pass in regex to `hack/test-integration-docker.sh` in the same manner as they do to `hack/test-integration.sh`

@smarterclayton PTAL