### PR TITLE
Add run label to Dockerfile and document usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,13 @@ RUN go get github.com/openshift/origin && \
     cp _output/local/bin/linux/amd64/* /usr/bin/ && \
     mkdir -p /var/lib/openshift
 
+LABEL RUN docker run -d --name "origin" \
+          --privileged --net=host \
+          -v /:/rootfs:ro -v /var/run:/var/run:rw \
+          -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
+          -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
+          IMAGE start
+
 EXPOSE 8080 8443
 WORKDIR /var/lib/openshift
 ENTRYPOINT ["/usr/bin/openshift"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The easiest way to run OpenShift Origin is in a Docker container (OpenShift requ
 
 **Important!**: Docker on non-RedHat distributions (Ubuntu, Debian, boot2docker) has mount propagation PRIVATE, which [breaks](https://github.com/openshift/origin/issues/3072) running OpenShift inside a container. Please use the [Vagrant](CONTRIBUTING.adoc#develop-on-virtual-machine-using-vagrant) or binary installation paths on those distributions.
 
-**Option 1**: Red Hat-based distributions (Fedora, CentOs, RHEL)
+**Option 1**: Red Hat-based distributions (Fedora, CentOS, RHEL)
 
     $ sudo atomic run openshift/origin
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,29 @@ For questions or feedback, reach us on [IRC on #openshift-dev](https://botbot.me
 Getting Started
 ---------------
 
+The easiest way to run OpenShift Origin is in a Docker container (OpenShift requires Docker 1.6.2 or higher):
+
+**Important!**: Docker on non-RedHat distributions (Ubuntu, Debian, boot2docker) has mount propagation PRIVATE, which [breaks](https://github.com/openshift/origin/issues/3072) running OpenShift inside a container. Please use the [Vagrant](CONTRIBUTING.adoc#develop-on-virtual-machine-using-vagrant) or binary installation paths on those distributions.
+
+**Option 1**: Red Hat-based distributions (Fedora, CentOs, RHEL)
+
+    $ sudo atomic run openshift/origin
+
+**Option 2**: non-Red Hat-based distributions (Ubuntu, Debian, boot2docker)
+
+    $ sudo docker run -d --name "origin" \
+        --privileged --net=host \
+        -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
+        -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
+        openshift/origin start
+
+**Security!** Why do we need to mount your host, run privileged, and get access to your Docker directory? OpenShift runs as a host agent (like Docker)
+and starts and stops Docker containers, mounts remote volumes, and monitors the system (/sys) to report performance and health info. You can strip all of these options off and OpenShift will still start, but you won't be able to run pods (which is kind of the point).
+
+Once the container is started, you can jump into a console inside the container and run the CLI.
+
+    $ sudo docker exec -it origin bash
+
 ### Installation
 
 * For a quick install of Origin, see the [Getting Started Install guide](https://docs.openshift.org/latest/getting_started/administrators.html).

--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -27,4 +27,9 @@ ENV OPENSHIFT_CONTAINERIZED true
 ENV KUBECONFIG /var/lib/openshift/openshift.local.config/master/admin.kubeconfig
 WORKDIR /var/lib/openshift
 EXPOSE 8443 53
+LABEL RUN docker run -d --name "origin" \
+          --privileged --net=host \
+          -v /:/rootfs:ro -v /var/run:/var/run:rw \
+          -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
+          -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/opens
 ENTRYPOINT ["/usr/bin/openshift"]


### PR DESCRIPTION
Standard container LABELs have been documented[1]. Tools
such as the atomic CLI use these to identify how an image
is designed to be used. This simplifies the user experience
and provides a more reliable way to run a container.

[1] https://github.com/projectatomic/ContainerApplicationGenericLabels