### PR TITLE
added extended test for openldap image and fixtures

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/origin/pkg/api/latest"
 	"github.com/openshift/origin/pkg/api/validation"
+	buildapi "github.com/openshift/origin/pkg/build/api"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
@@ -87,6 +88,13 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"mysql-ephemeral-template":       &templateapi.Template{},
 			"postgresql-ephemeral-template":  &templateapi.Template{},
 			"mongodb-ephemeral-template":     &templateapi.Template{},
+		},
+		"../test/extended/fixtures/ldap": {
+			"ldapserver-buildconfig":         &buildapi.BuildConfig{},
+			"ldapserver-deploymentconfig":    &deployapi.DeploymentConfig{},
+			"ldapserver-imagestream":         &imageapi.ImageStream{},
+			"ldapserver-imagestream-testenv": &imageapi.ImageStream{},
+			"ldapserver-service":             &kapi.Service{},
 		},
 		"../test/integration/fixtures": {
 			"test-deployment-config":    &deployapi.DeploymentConfig{},

--- a/hack/test-extended/authentication/run.sh
+++ b/hack/test-extended/authentication/run.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# This scripts starts the OpenShift server with a default configuration.
+# The OpenShift Docker registry and router are installed.
+# It will start all 'default_*_test.go' test cases.
+
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../../..
+cd "${OS_ROOT}"
+
+source ${OS_ROOT}/hack/util.sh
+source ${OS_ROOT}/hack/common.sh
+
+
+set -e
+ensure_ginkgo_or_die
+set +e
+
+os::build::extended
+
+ensure_iptables_or_die
+
+function cleanup()
+{
+	out=$?
+	cleanup_openshift
+	echo "[INFO] Exiting"
+	exit $out
+}
+
+echo "[INFO] Starting 'authentication' extended tests"
+
+trap "exit" INT TERM
+trap "cleanup" EXIT
+
+export TMPDIR="${TMPDIR:-"/tmp"}"
+export BASETMPDIR="${TMPDIR}/openshift-extended-tests/authentication"
+setup_env_vars
+reset_tmp_dir 
+configure_os_server
+start_os_server
+
+install_registry
+wait_for_registry
+
+# Run the tests
+pushd ${OS_ROOT}/test/extended >/dev/null
+export KUBECONFIG="${ADMIN_KUBECONFIG}"
+export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
+TMPDIR=${BASETMPDIR} ginkgo -progress -stream -v -focus="authentication:" -p ${OS_OUTPUT_BINPATH}/extended.test
+popd >/dev/null
+

--- a/test/extended/authentication/ldap_fixtures.go
+++ b/test/extended/authentication/ldap_fixtures.go
@@ -1,0 +1,77 @@
+package authentication
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("authentication: OpenLDAP build and deployment", func() {
+	defer g.GinkgoRecover()
+	var (
+		imageStreamFixture       = exutil.FixturePath("fixtures", "ldap", "ldapserver-imagestream.json")
+		imageStreamTargetFixture = exutil.FixturePath("fixtures", "ldap", "ldapserver-imagestream-testenv.json")
+		buildConfigFixture       = exutil.FixturePath("fixtures", "ldap", "ldapserver-buildconfig.json")
+		deploymentConfigFixture  = exutil.FixturePath("fixtures", "ldap", "ldapserver-deploymentconfig.json")
+		serviceConfigFixture     = exutil.FixturePath("fixtures", "ldap", "ldapserver-service.json")
+		oc                       = exutil.NewCLI("openldap", exutil.KubeConfigPath())
+	)
+
+	g.Describe("Building and deploying an OpenLDAP server", func() {
+		g.It(fmt.Sprintf("should create a image from %s template and run it in a pod", buildConfigFixture), func() {
+			nameRegex := regexp.MustCompile(`"[A-Za-z0-9\-]+"`)
+			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+			g.By(fmt.Sprintf("calling oc create -f %s", imageStreamFixture))
+			imageStreamMessage, err := oc.Run("create").Args("-f", imageStreamFixture).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			imageStreamName := strings.Trim(nameRegex.FindString(imageStreamMessage), `"`)
+			g.By("expecting the imagestream to fetch and tag the latest image")
+			err = exutil.WaitForAnImageStream(oc.REST().ImageStreams(oc.Namespace()), imageStreamName,
+				exutil.CheckImageStreamLatestTagPopulatedFunc, exutil.CheckImageStreamTagNotFoundFunc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %s", imageStreamTargetFixture))
+			err = oc.Run("create").Args("-f", imageStreamTargetFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %s", buildConfigFixture))
+			buildConfigMessage, err := oc.Run("create").Args("-f", buildConfigFixture).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			buildConfigName := strings.Trim(nameRegex.FindString(buildConfigMessage), `"`)
+			g.By(fmt.Sprintf("calling oc start-build %s", buildConfigName))
+			buildName, err := oc.Run("start-build").Args(buildConfigName).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting the build to be in Complete phase")
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName,
+				exutil.CheckBuildSuccessFunc, exutil.CheckBuildFailedFunc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %s", deploymentConfigFixture))
+			deploymentConfigMessage, err := oc.Run("create").Args("-f", deploymentConfigFixture).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			deploymentConfigName := strings.Trim(nameRegex.FindString(deploymentConfigMessage), `"`)
+			g.By(fmt.Sprintf("calling oc deploy %s", deploymentConfigName))
+			err = oc.Run("deploy").Args(deploymentConfigName).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting the deployment to be in Complete phase")
+			err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), deploymentConfigName,
+				exutil.CheckDeploymentCompletedFunc, exutil.CheckDeploymentFailedFunc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc create -f %s", serviceConfigFixture))
+			err = oc.Run("create").Args("-f", serviceConfigFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+	})
+})

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientcmd"
 	"k8s.io/kubernetes/test/e2e"
 
+	_ "github.com/openshift/origin/test/extended/authentication"
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/images"
 	_ "github.com/openshift/origin/test/extended/router"

--- a/test/extended/fixtures/ldap/ldapserver-buildconfig.json
+++ b/test/extended/fixtures/ldap/ldapserver-buildconfig.json
@@ -1,0 +1,40 @@
+{
+  "kind": "BuildConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "openldap",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "openldap"
+    }
+  },
+  "spec": {
+    "source": {
+      "type": "Git",
+      "git": {
+        "uri": "git://github.com/openshift/origin.git",
+        "ref": "master"
+      },
+      "contextDir": "images/openldap"
+    },
+    "strategy": {
+      "type": "Docker",
+      "dockerStrategy": {
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "openldap:latest"
+        }
+      }
+    },
+    "output": {
+      "to": {
+        "kind": "ImageStreamTag",
+        "name": "openldap-testenv:latest"
+      }
+    },
+    "resources": {}
+  },
+  "status": {
+    "lastVersion": 0
+  }
+}

--- a/test/extended/fixtures/ldap/ldapserver-deploymentconfig.json
+++ b/test/extended/fixtures/ldap/ldapserver-deploymentconfig.json
@@ -1,0 +1,71 @@
+{
+  "kind": "DeploymentConfig",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "openldap-server",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "strategy": {
+      "type": "Recreate",
+      "resources": {}
+    },
+    "triggers": [
+      {
+        "type": "ImageChange",
+        "imageChangeParams": {
+          "automatic": true,
+          "containerNames": [
+            "openldap-server"
+          ],
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "openldap-testenv:latest"
+          },
+          "lastTriggeredImage": ""
+        }
+      },
+      {
+        "type": "ConfigChange"
+      }
+    ],
+    "replicas": 1,
+    "selector": {
+      "name": "openldap-server"
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "name": "openldap-server"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "openldap-server",
+            "image": "openldap-testenv",
+            "ports": [
+              {
+                "containerPort": 389,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "IfNotPresent",
+            "capabilities": {},
+            "securityContext": {
+              "capabilities": {},
+              "privileged": false
+            }
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccount": ""
+      }
+    }
+  },
+  "status": {}
+}

--- a/test/extended/fixtures/ldap/ldapserver-imagestream-testenv.json
+++ b/test/extended/fixtures/ldap/ldapserver-imagestream-testenv.json
@@ -1,0 +1,12 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "openldap-testenv",
+    "creationTimestamp": null
+  },
+  "spec": {},
+  "status": {
+    "dockerImageRepository": ""
+  }
+}

--- a/test/extended/fixtures/ldap/ldapserver-imagestream.json
+++ b/test/extended/fixtures/ldap/ldapserver-imagestream.json
@@ -1,0 +1,25 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "openldap",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "dockerImageRepository": "openshift/openldap-2441-centos7",
+    "tags": [
+      {
+        "tag": "latest",
+        "annotations": {
+          "description": "Provides OpenLDAP v2.4.41",
+          "iconClass": "fa-server",
+          "tags": "server,openldap",
+          "version": "2.4.41"
+        }
+      }
+    ]
+  },
+  "status": {
+    "dockerImageRepository": ""
+  }
+}

--- a/test/extended/fixtures/ldap/ldapserver-service.json
+++ b/test/extended/fixtures/ldap/ldapserver-service.json
@@ -1,0 +1,28 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "openldap-server",
+    "creationTimestamp": null
+  },
+  "spec": {
+    "ports": [
+      {
+        "name": "ldap",
+        "protocol": "TCP",
+        "port": 389,
+        "targetPort": 389,
+        "nodePort": 0
+      }
+    ],
+    "selector": {
+      "name": "openldap-server"
+    },
+    "portalIP": "",
+    "type": "ClusterIP",
+    "sessionAffinity": "None"
+  },
+  "status": {
+    "loadBalancer": {}
+  }
+}


### PR DESCRIPTION
@deads2k @liggitt This PR will hold the fixtures and respective test. This needs https://github.com/openshift/origin/pull/4129 to merge so the `buildConfig` in this PR can access those artifacts from github.