### PR TITLE
added go vet testing 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ check-test: export KUBE_RACE=  -race
 check-test: build check
 check-test:
 	hack/verify-gofmt.sh
+	hack/verify-govet.sh
 	hack/verify-generated-deep-copies.sh
 	hack/verify-generated-conversions.sh
 	hack/verify-generated-completions.sh
@@ -89,6 +90,7 @@ test: build check
 endif
 test:
 	hack/verify-gofmt.sh
+	hack/verify-govet.sh
 	hack/verify-generated-deep-copies.sh
 	hack/verify-generated-conversions.sh
 	hack/verify-generated-completions.sh

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -8,4 +8,4 @@ source "${OS_ROOT}/hack/common.sh"
 GO_VERSION=($(go version))
 echo "Detected go version: $(go version)"
 
-go get golang.org/x/tools/cmd/cover github.com/tools/godep
+go get golang.org/x/tools/cmd/cover github.com/tools/godep golang.org/x/tools/cmd/vet

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -547,3 +547,19 @@ os::log::status() {
     echo "    $message"
   done
 }
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './.*' \
+        -o -wholename './release' \
+        -o -wholename './pkg/assets/bindata.go' \
+        -o -wholename './pkg/assets/*/bindata.go' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/Godeps/*' \
+      \) -prune \
+    \) -name '*.go' | sort -u
+}

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -8,8 +8,6 @@ set -o pipefail
 
 GO_VERSION=($(go version))
 
-GO_VERSION=($(go version))
-
 if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
   echo "Unknown go version '${GO_VERSION}', skipping gofmt."
   exit 0
@@ -17,24 +15,9 @@ fi
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
 
 cd "${OS_ROOT}"
-
-find_files() {
-  find . -not \( \
-      \( \
-        -wholename './output' \
-        -o -wholename './_output' \
-        -o -wholename './.git' \
-        -o -wholename './release' \
-        -o -wholename './pkg/assets/bindata.go' \
-        -o -wholename './pkg/assets/*/bindata.go' \
-        -o -wholename './target' \
-        -o -wholename '*/third_party/*' \
-        -o -wholename '*/Godeps/*' \
-      \) -prune \
-    \) -name '*.go'
-}
 
 bad_files=$(find_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,6 +18,7 @@ fi
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
 
 cd "${OS_ROOT}"
 
@@ -37,21 +38,11 @@ if [ "$arg" == "-m" ]; then
   fi
   set -e
 else
-  find_files() {
-    find . -not \( \
-      \( \
-        -wholename './Godeps' \
-        -o -wholename './release' \
-        -o -wholename './target' \
-        -o -wholename './test' \
-        -o -wholename './pkg/assets/bindata.go' \
-        -o -wholename '*/Godeps/*' \
-        -o -wholename '*/third_party/*' \
-        -o -wholename '*/_output/*' \
-      \) -prune \
-    \) -name '*.go' | sort -u | sed 's/^.{2}//' | xargs -n1 printf "${GOPATH}/src/${OS_GO_PACKAGE}/%s\n"
-  }
-  bad_files=$(find_files | xargs -n1 golint)
+  bad_files=$(find_files | 
+                sort -u | 
+                sed 's/^.{2}//' | 
+                xargs -n1 printf "${GOPATH}/src/${OS_GO_PACKAGE}/%s\n" | 
+                xargs -n1 golint)
 fi
 
 if [[ -n "${bad_files}" ]]; then

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+GO_VERSION=($(go version))
+
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
+  echo "Unknown go version '${GO_VERSION}', skipping go vet."
+  exit 0
+fi
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+
+cd "${OS_ROOT}"
+mkdir -p _output/govet
+
+FAILURE=false
+test_dirs=$(find_files | cut --delimiter=/ --fields=1-2 | sort -u)
+for test_dir in $test_dirs
+do
+  go tool vet -printf=false \
+              -methods=false \
+              -structtags=false \
+              -composites=false \
+              -buildtags=false \
+              -unreachable=false \
+              -shadow=false \
+              -unusedresult=false \
+              $test_dir 2>&1 | sed '/exit status/d'
+  if [ "$?" -ne 0 ]
+  then 
+    FAILURE=true
+  fi
+done
+
+# We don't want to exit on the first failure of go vet, so just keep track of 
+# whether a failure occured or not.
+if $FAILURE
+then
+  echo "FAILURE: go vet failed!"
+  exit 1
+else
+  echo "SUCCESS: go vet succeded!"
+  exit 0
+fi


### PR DESCRIPTION
@liggitt 

This PR adds the `go vet` tests that currently do not fail. I will add new PRs that enable the failing tests and fix their issues:
- [x] `printf` (#4162)
- [x] `methods` (#4155)
- [x] `structtags` (#4156)
- [x] `composites` (#4163)
- [x] `buildtags` (#4154)
- [x] `unreachable` (#4159)
- [ ] `shadow`
- [x] `unusedresult` (#4158)