### PR TITLE
Fix reencrypt routes and add path based support

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -38,10 +38,10 @@ frontend public
   tcp-request content accept if HTTP
 
   # map to http backend
+  # Search from most specific to general path (host case).
+  # Note: If no match, haproxy uses the default_backend, no other
+  #       use_backend directives below this will be processed.
   use_backend be_http_%[base,map_beg(/var/lib/haproxy/conf/os_http_be.map)]
-
-  # if a specific path based lookup was not found then revert to a host header lookup
-  use_backend be_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_http_be.map)] if TRUE
 
   default_backend openshift_default
 
@@ -84,15 +84,17 @@ frontend fe_sni
   bind 127.0.0.1:10444 ssl {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} crt /var/lib/containers/router/certs accept-proxy
   mode http
 
-  # re-ssl?
-  acl reencrypt hdr(host),map(/var/lib/haproxy/conf/os_reencrypt.map) -m found
-  use_backend be_secure_%[hdr(host),map(/var/lib/haproxy/conf/os_tcp_be.map)] if reencrypt
+  # check re-encrypt backends first - from most specific to general path.
+  acl reencrypt base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map) -m found
+
+  # Search from most specific to general path (host case).
+  use_backend be_secure_%[base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map)] if reencrypt
 
   # map to http backend
+  # Search from most specific to general path (host case).
+  # Note: If no match, haproxy uses the default_backend, no other
+  #       use_backend directives below this will be processed.
   use_backend be_edge_http_%[base,map_beg(/var/lib/haproxy/conf/os_edge_http_be.map)]
-
-  # if a specific path based lookup was not found then revert to a host header lookup
-  use_backend be_edge_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_edge_http_be.map)] if TRUE
 
   default_backend openshift_default
 
@@ -116,15 +118,17 @@ frontend fe_no_sni
   bind 127.0.0.1:10443 ssl {{ if (len .DefaultCertificate) gt 0 }}crt {{.DefaultCertificate}}{{ else }}crt /var/lib/haproxy/conf/default_pub_keys.pem{{ end }} accept-proxy
   mode http
 
-  # re-ssl?
-  acl reencrypt hdr(host),map(/var/lib/haproxy/conf/os_reencrypt.map) -m found
-  use_backend be_secure_%[hdr(host),map(/var/lib/haproxy/conf/os_tcp_be.map)] if reencrypt
+  # check re-encrypt backends first - path or host based.
+  acl reencrypt base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map) -m found
+
+  # Search from most specific to general path (host case).
+  use_backend be_secure_%[base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map)] if reencrypt
 
   # map to http backend
+  # Search from most specific to general path (host case).
+  # Note: If no match, haproxy uses the default_backend, no other
+  #       use_backend directives below this will be processed.
   use_backend be_edge_http_%[base,map_beg(/var/lib/haproxy/conf/os_edge_http_be.map)]
-
-  # if a specific path based lookup was not found then revert to a host header lookup
-  use_backend be_edge_http_%[hdr(host),map_beg(/var/lib/haproxy/conf/os_edge_http_be.map)] if TRUE
 
   default_backend openshift_default
 
@@ -260,9 +264,9 @@ backend be_secure_{{$cfgIdx}}
 {{ define "/var/lib/haproxy/conf/os_reencrypt.map" }}
 {{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "reencrypt") }}
-{{$cfg.Host}} 1
+{{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "reencrypt") }}
+{{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
 {{   end }}
-{{ end }}{{/* end sni passthrough map template */}}
+{{ end }}{{/* end reencrypt passthrough map template */}}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -59,7 +59,7 @@ frontend public_ssl
   use_backend be_tcp_%[req.ssl_sni,map(/var/lib/haproxy/conf/os_tcp_be.map)] if sni sni_passthrough
 
   # if the route is SNI and NOT passthrough enter the termination flow
-  use_backend be_sni if { req.ssl_sni -m found }
+  use_backend be_sni if sni
 
   # non SNI requests should enter a default termination backend rather than the custom cert SNI backend since it
   # will not be able to match a cert to an SNI host

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -3,12 +3,12 @@
 config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
 old_pid=""
-path_map_file=/var/lib/haproxy/conf/os_http_be.map
-edge_path_map_file=/var/lib/haproxy/conf/os_edge_http_be.map
+haproxy_conf_dir=/var/lib/haproxy/conf
 
 # sort the path based map files for the haproxy map_beg function
-sort -r $path_map_file -o $path_map_file
-sort -r $edge_path_map_file -o $edge_path_map_file
+for mapfile in "$haproxy_conf_dir"/*.map; do
+  sort -r "$mapfile" -o "$mapfile"
+done
 
 if [ -f $pid_file ]; then
   old_pid=$(<$pid_file)

--- a/test/integration/router/router_http_server.go
+++ b/test/integration/router/router_http_server.go
@@ -65,6 +65,8 @@ const (
 	HelloPodPath = "Hello Pod Path!"
 	// HelloPodSecure is the expected response to a call to PodHttpsAddr (usually called through a route)
 	HelloPodSecure = "Hello Pod Secure!"
+	// HelloPodPathSecure is the expected response to a call to PodHttpsAddr (usually called through a route)
+	HelloPodPathSecure = "Hello Pod Path Secure!"
 )
 
 // handleHelloMaster handles calls to MasterHttpAddr
@@ -85,6 +87,11 @@ func (s *TestHttpService) handleHelloPodTest(w http.ResponseWriter, r *http.Requ
 // handleHelloPodSecure handles calls to PodHttpsAddr (usually called through a route)
 func (s *TestHttpService) handleHelloPodSecure(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, HelloPodSecure)
+}
+
+// handleHelloPodTestSecure handles calls to PodHttpsAddr (usually called through a route) with the /test/ path
+func (s *TestHttpService) handleHelloPodTestSecure(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, HelloPodPathSecure)
 }
 
 // handleRouteWatch handles calls to /osapi/v1beta1/watch/routes and uses the route channel to simulate watch events
@@ -179,6 +186,7 @@ func (s *TestHttpService) startPod() error {
 
 	securePodServer := http.NewServeMux()
 	securePodServer.HandleFunc("/", s.handleHelloPodSecure)
+	securePodServer.HandleFunc("/"+s.PodTestPath, s.handleHelloPodTestSecure)
 	securePodServer.Handle("/"+s.PodWebSocketPath, websocket.Handler(s.handleWebSocket))
 	if err := s.startServingTLS(s.PodHttpsAddr, s.PodHttpsCert, s.PodHttpsKey, s.PodHttpsCaCert, securePodServer); err != nil {
 		return err


### PR DESCRIPTION
Get reencrypt routes working + add support for path based reencrypt routes - similar to the other http/edge path based checks. This is the same functionality #4097 was going to fix.
This fixes issue #4011

Whilst testing this, I did find some issues with ACLs (```map_beg``` doesn't seem to work inside an ACL), so I inlined the ACL code to get it to work and then it further got optimized because the check/condition in  
```use_backend be_secure_%[base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map)] if { base,map_beg(/var/lib/haproxy/conf/os_reencrypt.map) -m found }``` was redundant and so it morphed into its current form. LMK if that's outta whack - it does work fine.

Test with:  
```
function test_uris() {  
   local verbosity=""   #  "-vvv"  
   local rip="10.245.2.3"  # "10.0.2.15"
   for uri in https://www.example2.com/test/ https://www.example2.com/; do   
     echo "uri: $uri -> $(curl -s -w "%{http_code}" --resolve www.example2.com:443:$rip --cacert _qatests/hello-nginx-docker/certs/mypersonalca/certs/ca.pem $verbosity "$uri")"  
  done  
}   
  
oc create -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/nginx-pod.json  
oc create -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/service_secure.json  
test_uris  
  
oc create -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/route_reencrypt-path.json  
test_uris  
  
oc create -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/route_reencrypt.json  
test_uris  
  
oc delete -f https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/reencrypt/route_reencrypt-path.json  
test_uris  
```

@pweil- @rajatchopra  PTAL Thx