### PR TITLE
Disable unsecured CAdvisor and kubelet healthz ports

### DIFF
--- a/hack/verify-open-ports.sh
+++ b/hack/verify-open-ports.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Script to create latest swagger spec.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/util.sh"
+
+os::log::install_errexit
+
+# Open port scanning
+echo "[INFO] Checking open ports ('sudo openshift start' should already be running)"
+
+# 53 (DNS)
+# 4001,7001 (etcd)
+# 8443 (master, api, web)
+# 10250 (kubelet)
+expected_ports=(53 4001 7001 8443 10250 single-high-port-for-kubelet-api-proxy)
+
+open_ports=($(pgrep -f 'openshift|_output/local' | \
+  while read pid; do
+    sudo netstat -tulpn 2>/dev/null | grep $pid | \
+    while read listening; do
+      echo "$listening" | awk '{print $4}' | awk -F: '{print $NF}'
+    done
+  done | sort -n -u))
+
+if [[ "${expected_ports[@]}" == "${open_ports[@]}" ]]; then
+    echo "Found expected ports open (${expected_ports[@]})"
+else
+    echo "Expected: ${expected_ports[@]}"
+    echo "Open:     ${open_ports[@]}"
+    exit 1
+fi

--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -108,6 +108,8 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 	server.Address = kubeAddress
 	server.Port = uint(kubePort)
 	server.ReadOnlyPort = 0 // no read only access
+	server.CadvisorPort = 0 // no unsecured cadvisor access
+	server.HealthzPort = 0  // no unsecured healthz access
 	server.ClusterDNS = dnsIP
 	server.ClusterDomain = options.DNSDomain
 	server.NetworkPluginName = options.NetworkPluginName


### PR DESCRIPTION
Fixes #4143

Added a helper script to check open ports so we can make sure no more sneak in accidentally. Eventually I'll get that running as part of the builds, but I need a way to configure the port range for the kubelet proxy first, to nail down the random high port.