### PR TITLE
Deploy, rollback, retry and cancel deployments from the web console

### DIFF
--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -136,6 +136,30 @@ angular.module('openshiftConsole')
       );
     };
 
+    $scope.cancelBuild = function(build, buildConfigName) {
+      var canceledBuild = angular.copy(build);
+      canceledBuild.status.cancelled = true;
+      DataService.update("builds", canceledBuild.metadata.name, canceledBuild, $scope).then(
+        function() {
+            $scope.alerts = [
+            {
+              type: "success",
+              message: "Cancelling build " + build.metadata.name + " of " + buildConfigName + ".",
+            }
+          ];
+        },
+        function(result) {
+          $scope.alerts = [
+            {
+              type: "error",
+              message: "An error occurred cancelling the build.",
+              details: $filter('getErrorDetails')(result)
+            }
+          ];
+        }
+      );
+    };
+
     // Function which will 'clone' build from given buildName
     $scope.cloneBuild = function(buildName) {
       var req = {

--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -129,7 +129,7 @@ angular.module('openshiftConsole')
             {
               type: "error",
               message: "An error occurred while starting the build.",
-              details: getErrorDetails(result)
+              details: $filter('getErrorDetails')(result)
             }
           ];
         }
@@ -159,7 +159,7 @@ angular.module('openshiftConsole')
             {
               type: "error",
               message: "An error occurred while rerunning the build.",
-              details: getErrorDetails(result)
+              details: $filter('getErrorDetails')(result)
             }
           ];
         }
@@ -174,20 +174,6 @@ angular.module('openshiftConsole')
         updateFilterWarning();
       });
     });
-
-    function getErrorDetails(result) {
-      var error = result.data || {};
-      if (error.message) {
-        return error.message;
-      }
-
-      var status = result.status || error.status;
-      if (status) {
-        return "Status: " + status;
-      }
-
-      return "";
-    }
 
     $scope.$on('$destroy', function(){
       DataService.unwatchAll(watches);

--- a/assets/app/scripts/controllers/deployments.js
+++ b/assets/app/scripts/controllers/deployments.js
@@ -30,7 +30,7 @@ angular.module('openshiftConsole')
       });
     }
 
-    watches.push(DataService.watch("replicationcontrollers", $scope, function(deployments) {
+    watches.push(DataService.watch("replicationcontrollers", $scope, function(deployments, action, deployment) {
       $scope.unfilteredDeployments = deployments.by("metadata.name");
       LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredDeployments, $scope.labelSuggestions);
       LabelFilter.setLabelSuggestions($scope.labelSuggestions);
@@ -40,6 +40,27 @@ angular.module('openshiftConsole')
       $scope.emptyMessage = "No deployments to show";
       associateDeploymentsToDeploymentConfig();
       updateFilterWarning();
+
+      var deploymentConfigName;
+      var deploymentName;
+      if (deployment) {
+        deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');
+        deploymentName = deployment.metadata.name;
+      }
+      if (!action) {
+        // Loading of the page that will create deploymentConfigDeploymentsInProgress structure, which will associate running deployment to his deploymentConfig.
+        $scope.deploymentConfigDeploymentsInProgress = associateRunningDeploymentToDeploymentConfig($scope.deploymentsByDeploymentConfig);
+      } else if (action === 'ADDED' || (action === 'MODIFIED' && ['New', 'Pending', 'Running'].indexOf($scope.deploymentStatus(deployment)) > -1)) {
+        // When new deployment id instantiated/cloned, or in case of a retry, associate him to his deploymentConfig and add him into deploymentConfigDeploymentsInProgress structure.
+        $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] = $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] || {};
+        $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName] = deployment;
+      } else if (action === 'MODIFIED') {
+        // After the deployment ends remove him from the deploymentConfigDeploymentsInProgress structure.
+        var deploymentStatus = $scope.deploymentStatus(deployment);
+        if (deploymentStatus === "Complete" || deploymentStatus === "Failed"){
+          delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
+        }
+      }
 
       Logger.log("deployments (subscribe)", $scope.deployments);
     }));
@@ -73,6 +94,20 @@ angular.module('openshiftConsole')
       });
     }
 
+    function associateRunningDeploymentToDeploymentConfig(deploymentsByDeploymentConfig) {
+      var deploymentConfigDeploymentsInProgress = {};
+      angular.forEach(deploymentsByDeploymentConfig, function(deploymentConfigDeployments, deploymentConfigName) {
+        deploymentConfigDeploymentsInProgress[deploymentConfigName] = {};
+        angular.forEach(deploymentConfigDeployments, function(deployment, deploymentName) {
+          var deploymentStatus = $scope.deploymentStatus(deployment);
+          if (deploymentStatus === "New" || deploymentStatus === "Pending" || deploymentStatus === "Running") {
+            deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName] = deployment;
+          }
+        });
+      });
+      return deploymentConfigDeploymentsInProgress;
+    }
+
     function updateFilterWarning() {
       if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.deployments) && !$.isEmptyObject($scope.unfilteredDeployments)) {
         $scope.alerts["deployments"] = {
@@ -84,6 +119,201 @@ angular.module('openshiftConsole')
         delete $scope.alerts["deployments"];
       }
     }
+
+    $scope.startLatestDeployment = function(deploymentConfigName) {
+      var deploymentConfig = $scope.deploymentConfigs[deploymentConfigName];
+
+      // increase latest version by one so starts new deployment based on latest
+      var req = {
+        kind: "DeploymentConfig",
+        apiVersion: "v1",
+        metadata: deploymentConfig.metadata,
+        spec: deploymentConfig.spec,
+        status: deploymentConfig.status
+      };
+      if (!req.status.latestVersion) {
+        req.status.latestVersion = 0;
+      }
+      req.status.latestVersion++;
+
+      // update the deployment config
+      DataService.update("deploymentconfigs", deploymentConfigName, req, $scope).then(
+        function() {
+            $scope.alerts = [
+            {
+              type: "success",
+              message: "Deployment #" + req.status.latestVersion + " of " + deploymentConfigName + " has started.",
+            }
+          ];
+        },
+        function(result) {
+          $scope.alerts = [
+            {
+              type: "error",
+              message: "An error occurred while starting the deployment.",
+              details: $filter('getErrorDetails')(result)
+            }
+          ];
+        }
+      );
+    };
+
+    $scope.retryFailedDeployment = function(deploymentConfigName, deploymentName) {
+      var deployment = $scope.deploymentsByDeploymentConfig[deploymentConfigName][deploymentName];
+      var req = deployment;
+
+      // delete the deployer pod as well as the deployment hooks pods, if any
+      DataService.list("pods", $scope, function(list) {
+        var pods = list.by("metadata.name");
+        var deleteDeployerPod = function(pod) {
+          var deployerPodForAnnotation = $filter('annotationName')('deployerPodFor');
+          if (pod.metadata.labels[deployerPodForAnnotation] === deploymentName) {
+            DataService.delete("pods", pod.metadata.name, $scope).then(
+              function() {
+                Logger.info("Deployer pod " + pod.metadata.name + " deleted");
+              },
+              function(result) {
+                $scope.alerts = [
+                  {
+                    type: "error",
+                    message: "An error occurred while deleting the deployer pod.",
+                    details: $filter('getErrorDetails')(result)
+                  }
+                ];
+              }
+            );
+          }
+        };
+        angular.forEach(pods, deleteDeployerPod);
+      });
+
+      // set deployment to "New" and remove statuses so we can retry
+      var deploymentStatusAnnotation = $filter('annotationName')('deploymentStatus');
+      var deploymentStatusReasonAnnotation = $filter('annotationName')('deploymentStatusReason');
+      var deploymentCancelledAnnotation = $filter('annotationName')('deploymentCancelled');
+      req.metadata.annotations[deploymentStatusAnnotation] = "New";
+      delete req.metadata.annotations[deploymentStatusReasonAnnotation];
+      delete req.metadata.annotations[deploymentCancelledAnnotation];
+
+      // update the deployment
+      DataService.update("replicationcontrollers", deploymentName, req, $scope).then(
+        function() {
+            $scope.alerts = [
+            {
+              type: "success",
+              message: "Retrying deployment " + deploymentName + " of " + deploymentConfigName + ".",
+            }
+          ];
+        },
+        function(result) {
+          $scope.alerts = [
+            {
+              type: "error",
+              message: "An error occurred while retrying the deployment.",
+              details: $filter('getErrorDetails')(result)
+            }
+          ];
+        }
+      );
+    };
+
+    $scope.rollbackToDeployment = function(deploymentConfigName, deploymentName, changeScaleSettings, changeStrategy, changeTriggers) {
+      // put together a new rollback request
+      var req = {
+        kind: "DeploymentConfigRollback",
+        apiVersion: "v1",
+        spec: {
+          from: {
+            name: deploymentName
+          },
+          includeTemplate: true,
+          includeReplicationMeta: changeScaleSettings,
+          includeStrategy: changeStrategy,
+          includeTriggers: changeTriggers
+        }
+      };
+
+      // create the deployment config rollback 
+      DataService.create("deploymentconfigrollbacks", null, req, $scope).then(
+        function(newDeploymentConfig) {
+          // update the deployment config based on the one returned by the rollback
+          DataService.update("deploymentconfigs", deploymentConfigName, newDeploymentConfig, $scope).then(
+            function(rolledBackDeploymentConfig) {
+                $scope.alerts = [
+                {
+                  type: "success",
+                  message: "Deployment #" + rolledBackDeploymentConfig.status.latestVersion + " is rolling back " + deploymentConfigName + " to " + deploymentName + ".",
+                }
+              ];
+            },
+            function(result) {
+              $scope.alerts = [
+                {
+                  type: "error",
+                  message: "An error occurred while rolling back the deployment.",
+                  details: $filter('getErrorDetails')(result)
+                }
+              ];
+            }
+          );
+        },
+        function(result) {
+          $scope.alerts = [
+            {
+              type: "error",
+              message: "An error occurred while rolling back the deployment.",
+              details: $filter('getErrorDetails')(result)
+            }
+          ];
+        }
+      );
+    };
+
+    $scope.cancelRunningDeployment = function(deploymentConfigName, deploymentName) {
+      var deployment = $scope.deploymentsByDeploymentConfig[deploymentConfigName][deploymentName];
+      var req = deployment;
+
+      // set the cancellation annotations
+      var deploymentCancelledAnnotation = $filter('annotationName')('deploymentCancelled');
+      var deploymentStatusReasonAnnotation = $filter('annotationName')('deploymentStatusReason');
+      req.metadata.annotations[deploymentCancelledAnnotation] = "true";
+      req.metadata.annotations[deploymentStatusReasonAnnotation] = "The deployment was cancelled by the user";
+
+      // update the deployment with cancellation annotations
+      DataService.update("replicationcontrollers", deploymentName, req, $scope).then(
+        function() {
+            $scope.alerts = [
+            {
+              type: "success",
+              message: "Cancelling deployment " + deploymentName + " of " + deploymentConfigName + ".",
+            }
+          ];
+        },
+        function(result) {
+          $scope.alerts = [
+            {
+              type: "error",
+              message: "An error occurred while cancelling the deployment.",
+              details: $filter('getErrorDetails')(result)
+            }
+          ];
+        }
+      );
+    };
+
+    $scope.deploymentIsLatest = function(deploymentConfig, deployment) {
+      var deploymentVersion = parseInt($filter('annotation')(deployment, 'deploymentVersion'));
+      var deploymentConfigVersion = deploymentConfig.status.latestVersion;
+      return deploymentVersion === deploymentConfigVersion;
+    };
+
+    $scope.deploymentStatus = function(deployment) {
+      return $filter('annotation')(deployment, 'deploymentStatus');
+    };
+
+    $scope.deploymentIsInProgress = function(deployment) {
+      return ['New', 'Pending', 'Running'].indexOf($scope.deploymentStatus(deployment)) > -1;
+    };
 
     LabelFilter.onActiveFiltersChanged(function(labelSelector) {
       // trigger a digest loop

--- a/assets/app/scripts/controllers/deployments.js
+++ b/assets/app/scripts/controllers/deployments.js
@@ -162,6 +162,8 @@ angular.module('openshiftConsole')
       var deployment = $scope.deploymentsByDeploymentConfig[deploymentConfigName][deploymentName];
       var req = deployment;
 
+      // TODO: we need a "retry" api endpoint so we don't have to do this manually
+
       // delete the deployer pod as well as the deployment hooks pods, if any
       DataService.list("pods", $scope, function(list) {
         var pods = list.by("metadata.name");
@@ -233,6 +235,8 @@ angular.module('openshiftConsole')
         }
       };
 
+      // TODO: we need a "rollback" api endpoint so we don't have to do this manually
+
       // create the deployment config rollback 
       DataService.create("deploymentconfigrollbacks", null, req, $scope).then(
         function(newDeploymentConfig) {
@@ -272,6 +276,8 @@ angular.module('openshiftConsole')
     $scope.cancelRunningDeployment = function(deploymentConfigName, deploymentName) {
       var deployment = $scope.deploymentsByDeploymentConfig[deploymentConfigName][deploymentName];
       var req = deployment;
+
+      // TODO: we need a "cancel" api endpoint so we don't have to do this manually
 
       // set the cancellation annotations
       var deploymentCancelledAnnotation = $filter('annotationName')('deploymentCancelled');

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -14,20 +14,28 @@ angular.module('openshiftConsole')
       }
     };
   })
-  .filter('annotation', function() {
-    // This maps an annotation key to all known synonymous keys to insulate
-    // the referring code from key renames across API versions.
-    var annotationMap = {
-      "deploymentConfig": ["openshift.io/deployment-config.name"],
-      "deployment": ["openshift.io/deployment.name"],
-      "pod": ["openshift.io/deployer-pod.name"],
-      "deploymentStatus": ["openshift.io/deployment.phase"],
-      "encodedDeploymentConfig": ["openshift.io/encoded-deployment-config"],
-      "deploymentVersion": ["openshift.io/deployment-config.latest-version"],
-      "displayName": ["openshift.io/display-name"],
-      "description": ["openshift.io/description"],
-      "buildNumber": ["openshift.io/build.number"]
+  .filter('annotationName', function() {
+    return function(annotationKey) {
+      // This maps an annotation key to all known synonymous keys to insulate
+      // the referring code from key renames across API versions.
+      var annotationMap = {
+        "deploymentConfig":         ["openshift.io/deployment-config.name"],
+        "deployment":               ["openshift.io/deployment.name"],
+        "pod":                      ["openshift.io/deployer-pod.name"],
+        "deployerPodFor":           ["openshift.io/deployer-pod-for.name"],
+        "deploymentStatus":         ["openshift.io/deployment.phase"],
+        "deploymentStatusReason":   ["openshift.io/deployment.status-reason"],
+        "deploymentCancelled":      ["openshift.io/deployment.cancelled"],
+        "encodedDeploymentConfig":  ["openshift.io/encoded-deployment-config"],
+        "deploymentVersion":        ["openshift.io/deployment-config.latest-version"],
+        "displayName":              ["openshift.io/display-name"],
+        "description":              ["openshift.io/description"],
+        "buildNumber":              ["openshift.io/build.number"]
+      };
+      return annotationMap[annotationKey] || null;
     };
+  })
+  .filter('annotation', function(annotationNameFilter) {
     return function(resource, key) {
       if (resource && resource.metadata && resource.metadata.annotations) {
         // If the key's already in the annotation map, return it.
@@ -35,7 +43,7 @@ angular.module('openshiftConsole')
           return resource.metadata.annotations[key];
         }
         // Try and return a value for a mapped key.
-        var mappings = annotationMap[key] || [];
+        var mappings = annotationNameFilter(key) || [];
         for (var i=0; i < mappings.length; i++) {
           var mappedKey = mappings[i];
           if (resource.metadata.annotations[mappedKey] !== undefined) {

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -249,4 +249,19 @@ angular.module('openshiftConsole')
 
       return limitToFilter(input, limit);
     };
+  })
+  .filter("getErrorDetails", function() {
+    return function(result) {
+      var error = result.data || {};
+      if (error.message) {
+        return error.message;
+      }
+
+      var status = result.status || error.status;
+      if (status) {
+        return "Status: " + status;
+      }
+
+      return "";
+    };
   });

--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -167,6 +167,38 @@ angular.module('openshiftConsole')
   };
 
 // resource:  API resource (e.g. "pods")
+// name:      API name, the unique name for the object
+// object:    API object data(eg. { kind: "Build", parameters: { ... } } )
+// context:   API context (e.g. {project: "..."})
+// opts:      http - options to pass to the inner $http call
+// Returns a promise resolved with response data or rejected with {data:..., status:..., headers:..., config:...} when the delete call completes.
+  DataService.prototype.update = function(resource, name, object, context, opts) {
+    resource = normalizeResource(resource);
+    opts = opts || {};
+    var deferred = $q.defer();
+    var self = this;
+    this._getNamespace(resource, context, opts).then(function(ns){
+      $http(angular.extend({
+        method: 'PUT',
+        data: object,
+        url: self._urlForResource(resource, name, object.apiVersion, context, false, ns)
+      }, opts.http || {}))
+      .success(function(data, status, headerFunc, config, statusText) {
+        deferred.resolve(data);
+      })
+      .error(function(data, status, headers, config) {
+        deferred.reject({
+          data: data,
+          status: status,
+          headers: headers,
+          config: config
+        });
+      });
+    });
+    return deferred.promise;
+  };
+
+// resource:  API resource (e.g. "pods")
 // name:      API name, the unique name for the object.
 //            In case the name of the Object is provided, expected format of 'resource' parameter is 'resource/subresource', eg: 'buildconfigs/instantiate'.
 // object:    API object data(eg. { kind: "Build", parameters: { ... } } )

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -329,18 +329,50 @@
   }
 }
 
+.deployment-well {
+  &:not(.active) {
+    background-color: white;
+  }
+  &:not(.detailed) {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    .deployment-summary {
+      h3 {
+        margin-bottom: 5px;
+        text-transform: lowercase;
+      }
+      .deployment-summary-status {
+        font-size: 90%;
+        margin-left: 7px;
+      }
+      .deployment-summary-toggler {
+        float: right !important;
+        font-size: 80%;
+      }
+    }
+    .deployment-details {
+      display: none;
+    }
+  }
+  &.detailed {
+    .deployment-summary-status, .deployment-summary-toggler {
+      display: none;
+    }
+  }
+}
+
 .popover {
   min-width: 300px;
   font-size: 13px;
   line-height: 1.66667;
 }
 
-.build-well, .pod-well {
+.build-well, .pod-well, .deployment-well {
   overflow: hidden;
   margin-bottom: 10px;
-  .build-detail, .pod-detail {
+  .build-detail, .pod-detail, .deployment-detail {
     margin-bottom: 3px;
-    .build-detail-label, .pod-detail-label {
+    .build-detail-label, .pod-detail-label, .deployment-detail-label {
       margin-right: 10px;
     }
   }

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -376,6 +376,9 @@
       margin-right: 10px;
     }
   }
+  .build-status-button {
+    margin-left: 7px;
+  }
 }
 
 .animate-repeat.ng-move,

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -142,20 +142,12 @@
         <!-- When expanded, pass undefined to limitToOrAll to show all builds. -->
         <div ng-repeat="build in buildsByBuildConfig[buildConfigName] | orderObjectsByDate : true | limitToOrAll: (expanded ? undefined : defaultBuildLimit)" class="well build-well">
           <div class="row">
-            <div class="col-md-7 col-sm-7 col-xs-7">
+            <div class="col-md-12 col-sm-12 col-xs-12">
               <h3>{{build.metadata.name}}</h3>
-            </div>
-            <div class="col-md-4 col-sm-4 col-xs-offset-1 col-xs-4 text-right">
-              <div>
-                <button class="btn btn-default" ng-click="cloneBuild(build.metadata.name)" ng-disabled="(buildConfigBuildsInProgress[buildConfigName] | hashSize) > 0">Rebuild</button>
-              </div>
             </div>
           </div><!-- /.row -->
           <div class="row">
             <div class="col-md-6">
-              <div class="build-detail">
-                <span class="build-detail-label">Created:</span><relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp>
-              </div>
               <div class="build-detail">
                 <span class="build-detail-label">Status:</span>
                 <span ng-switch="build.status.phase" class="hide-ng-leave">
@@ -167,6 +159,12 @@
                   <span ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
                 </span>
                 {{build.status.phase}}
+
+                <button class="btn btn-default build-status-button btn-primary" ng-click="cancelBuild(build, buildConfigName)" ng-if="build | isIncompleteBuild">Cancel</button>
+                <button class="btn btn-default build-status-button" ng-click="cloneBuild(build.metadata.name)" ng-hide="build | isIncompleteBuild" ng-disabled="(buildConfigBuildsInProgress[buildConfigName] | hashSize) !== 0">Rebuild</button>
+              </div>
+              <div class="build-detail">
+                <span class="build-detail-label">Created:</span><relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp>
               </div>
               <div class="build-detail">
                 <span class="build-detail-label">Duration:</span>
@@ -182,7 +180,7 @@
                   </span>
                 </span>
               </div>
-            </div><!-- .col -->        
+            </div><!-- .col -->
             <div class="col-md-6">
               <div class="build-detail" ng-if="buildConfig.spec.strategy.type != build.spec.strategy.type">
                 <span class="build-detail-label">Build strategy:</span>{{build.spec.strategy.type}}

--- a/assets/app/views/deployments.html
+++ b/assets/app/views/deployments.html
@@ -45,14 +45,14 @@
 
             <div>
               <h3>Triggers:</h3>
-                <!---<dl class="dl-horizontal left indent">
+                <dl class="dl-horizontal left indent">
                 <dt>Manual:</dt>
                 <dd>
                   <span>
-                    <button class="btn btn-primary" ng-click="startLatestDeployment(deploymentConfigName)" ng-disabled="">Start Deployment</button>
-                  <span>
+                    <button class="btn btn-primary" ng-click="startLatestDeployment(deploymentConfigName)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0">Start Deployment</button>
+                  </span>
                 </dd>
-              </dl>-->
+              </dl>
 
               <dl class="dl-horizontal left indent">
                 <dt>Manual (CLI):
@@ -82,68 +82,115 @@
                 </div>
               </dl>
             </div>
-          
-            <div class="well" ng-repeat="deployment in deploymentsByDeploymentConfig[deploymentConfigName] | orderObjectsByDate : true">
-              <h3>
-                {{deployment.metadata.name}}
-                <span ng-if="(deployment | annotation:'deploymentVersion') == deploymentConfig.status.latestVersion">(latest)</span>
-              </h3>
-              <div>
-                <dt>Created:</dt>
-                <dd><relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></dd>
-              </div>
-              <div>
-                <span>
-                  <dt>Status:</dt>
-                  <dd>
-                    <span>{{deployment | annotation:'deploymentStatus'}}</span>
-                    <span ng-switch="deployment | annotation:'deploymentStatus'" class="hide-ng-leave">
-                      <span ng-switch-when="Running"> for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
-                      <span ng-switch-when="New"> for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
-                      <span ng-switch-when="Pending"> for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
-                    </span>
-                    <span ng-switch="deployment | annotation:'deploymentStatus'" class="hide-ng-leave">
-                      <span style="margin-left: 5px;" ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
-                      <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
-                      <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
-                    </span>
-                  </dd>
-                </span>
-              </div>
-              <div>
-                <dt>Labels:</dt>
-                <dd>
-                  <span ng-if="!deployment.metadata.labels">none</span>
-                  <span ng-repeat="(labelKey, labelValue) in deployment.metadata.labels">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
-                </dd>
-              </div>
-              <div>
-                <dt>Selectors:</dt>
-                <dd>
-                  <span ng-if="!deployment.spec.selector">none</span>
-                  <span ng-repeat="(labelKey, labelValue) in deployment.spec.selector">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
-                </dd>
-              </div>
-              <div>
-                <dt>Replicas:</dt>
-                <dd>{{deployment.status.replicas}} current / {{deployment.spec.replicas}} desired</dd>
-              </div>
-              <div style="padding-top:10px;" ng-if="deployment.spec.template">
-                <dt>Pod Template:</dt>
-                <dd>
-                  <pod-template
-                    pod-template="deployment.spec.template" 
-                    images-by-docker-reference="imagesByDockerReference"
-                    builds="builds"></pod-template>
-                </dd>
-              </div>
-            </div>
-
-            <!--<div ng-if="(deploymentsByDeploymentConfig[deploymentConfigName] | hashSize) > 1">
-              <button class="btn btn-default" ng-click="" data-toggle="button">Show older deployments</button>
-            </div>-->
           </dl>
         </div>
+          
+        <div ng-show="expanded || $index < 3 || deploymentIsLatest(deploymentConfig, deployment)" ng-repeat="deployment in deploymentsByDeploymentConfig[deploymentConfigName] | orderObjectsByDate : true" class="well deployment-well" ng-class="{active: deploymentIsLatest(deploymentConfig, deployment), detailed: (detailed || deploymentIsLatest(deploymentConfig, deployment))}">
+          <div class="row deployment-summary">
+            <div class="col-md-12 col-sm-12 col-xs-12">
+              <h3>
+                {{deployment.metadata.name}}
+                <span ng-if="deploymentIsLatest(deploymentConfig, deployment)">(active)</span>
+                <span class="text-muted deployment-summary-status">
+                  <span ng-switch="deploymentStatus(deployment)" class="hide-ng-leave">
+                    <span ng-switch-when="Failed">
+                      failed <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp><span ng-if="deployment | annotation:'deploymentStatusReason'">: {{deployment | annotation:'deploymentStatusReason'}}</span>
+                    </span>
+                    <span ng-switch-when="Complete">deployed <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></span>
+                    <span ng-switch-default>{{deploymentStatus(deployment)}} since <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></span>
+                  </span>
+                </span>
+                <span class="deployment-summary-toggler"><a href="" ng-click="detailed = true">details</a></span>
+              </h3>
+            </div>
+            <!-- disabled until we have view logs and metrics 
+            <div class="btn-group">
+              <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                View <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li><a href="#">Logs</a></li>
+                <li><a href="#">Metrics</a></li>
+              </ul>
+            </div>-->
+          </div><!-- /.row -->
+          <div class="row deployment-details">
+            <div class="col-md-12">
+              <div class="deployment-detail" style="margin-bottom:15px;">
+                <span class="deployment-detail-label">Status:</span>
+                <span ng-switch="deploymentStatus(deployment)" class="hide-ng-leave">
+                  <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
+                  <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
+                  <span ng-switch-when="New" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
+                  <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
+                  <span ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
+                </span>
+                {{deploymentStatus(deployment)}}
+                <span style="margin-left: 7px;">
+                  <button ng-show="!rollBackCollapsed && deploymentStatus(deployment) == 'Complete' && !deploymentIsLatest(deploymentConfig, deployment)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" type="button" class="btn btn-primary" ng-click="rollBackCollapsed = !rollBackCollapsed">Roll Back</button>
+                  <div ng-show="rollBackCollapsed" class="well well-sm">
+                    Use the following settings from {{deployment.metadata.name}}: 
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox" ng-model="changeScaleSettings" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> replica count and selector
+                      </label>
+                    </div>
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox" ng-model="changeStrategy" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> deployment strategy
+                      </label>
+                    </div>
+                    <div class="checkbox">
+                      <label>
+                        <input type="checkbox" ng-model="changeTriggers" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> deployment trigger
+                      </label>
+                    </div>
+                    <button type="button" ng-click="rollbackToDeployment(deploymentConfigName, deployment.metadata.name, changeScaleSettings, changeStrategy, changeTriggers)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-primary">Roll Back</button>
+                  </div> 
+                  <button ng-show="deploymentStatus(deployment) == 'Failed'" type="button" ng-click="retryFailedDeployment(deploymentConfigName, deployment.metadata.name)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-primary" ng-if="deploymentIsLatest(deploymentConfig, deployment)">Retry</button>
+                  <button ng-show="deploymentIsInProgress(deployment)" type="button" ng-click="cancelRunningDeployment(deploymentConfigName, deployment.metadata.name)" class="btn btn-primary">Cancel</button>
+                </span>                
+              </div>
+              <div class="deployment-detail">
+                <span class="deployment-detail-label">Created:</span><relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp>
+              </div>
+              <div class="deployment-detail" ng-if="deployment | annotation:'deploymentStatusReason'">
+                <span class="deployment-detail-label">Status reason:</span>
+                {{deployment | annotation:'deploymentStatusReason'}}
+              </div>
+              <div class="deployment-detail" ng-if="deploymentIsInProgress(deployment)">
+                <span class="deployment-detail-label">Duration:</span>
+                <span ng-switch="deploymentStatus(deployment)" class="hide-ng-leave">
+                  <span ng-switch-when="Running">running for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
+                  <span ng-switch-default>waiting for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
+                </span>
+              </div>
+              <div class="deployment-detail">
+                <span class="deployment-detail-label">Labels:</span>
+                <span ng-if="!deployment.metadata.labels">none</span>
+                <span ng-repeat="(labelKey, labelValue) in deployment.metadata.labels">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
+              </div>
+              <div class="deployment-detail">
+                <span class="deployment-detail-label">Selectors:</span>
+                <span ng-if="!deployment.spec.selector">none</span>
+                <span ng-repeat="(labelKey, labelValue) in deployment.spec.selector">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
+              </div>
+              <div class="deployment-detail">
+                <span class="deployment-detail-label">Replicas:</span>
+                {{deployment.status.replicas}} current / {{deployment.spec.replicas}} desired
+              </div>
+              <div class="deployment-detail">
+                <span>Pod template:</span>
+                <pod-template
+                  pod-template="deployment.spec.template" 
+                  images-by-docker-reference="imagesByDockerReference"
+                  builds="builds"></pod-template>
+              </div>
+            </div><!-- .col -->
+          </div>    
+        </div>
+
+        <div ng-hide="expanded || (deploymentsByDeploymentConfig[deploymentConfigName] | hashSize) <= 3"><a href="" ng-click="expanded = true">Show older deployments</a></div>
       </div>
 
       <!-- render any deployments whose deployment configs no longer exist -->
@@ -167,7 +214,7 @@
             </span>
           </h2>
           <dl class="dl-horizontal left indent">
-            <div class="well" ng-repeat="deployment in deployments | orderObjectsByDate : true">
+            <div ng-repeat="deployment in deployments | orderObjectsByDate : true" class="well deployment-well">
               <h3>
                 {{deployment.metadata.name}}
               </h3>
@@ -179,13 +226,13 @@
                 <span>
                   <dt>Status:</dt>
                   <dd>
-                    <span>{{deployment | annotation:'deploymentStatus'}}</span>
-                    <span ng-switch="deployment | annotation:'deploymentStatus'" class="hide-ng-leave">
+                    <span>{{deploymentStatus(deployment)}}</span>
+                    <span ng-switch="deploymentStatus(deployment)" class="hide-ng-leave">
                       <span ng-switch-when="Running"> for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
                       <span ng-switch-when="New"> for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
                       <span ng-switch-when="Pending"> for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
                     </span>
-                    <span ng-switch="deployment | annotation:'deploymentStatus'" class="hide-ng-leave">
+                    <span ng-switch="deploymentStatus(deployment)" class="hide-ng-leave">
                       <span style="margin-left: 5px;" ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
                       <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
                       <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
@@ -213,7 +260,6 @@
               </div>
               <div style="padding-top:10px;" ng-if="deployment.spec.template">
                 <dt>Pod Template:</dt>
-
                 <dd>
                   <pod-template
                     pod-template="deployment.spec.template" 

--- a/assets/app/views/deployments.html
+++ b/assets/app/views/deployments.html
@@ -129,7 +129,7 @@
                 <span style="margin-left: 7px;">
                   <button ng-show="!rollBackCollapsed && deploymentStatus(deployment) == 'Complete' && !deploymentIsLatest(deploymentConfig, deployment)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" type="button" class="btn btn-primary" ng-click="rollBackCollapsed = !rollBackCollapsed">Roll Back</button>
                   <div ng-show="rollBackCollapsed" class="well well-sm">
-                    Use the following settings from {{deployment.metadata.name}}: 
+                    Use the following settings from {{deployment.metadata.name}} when rolling back: 
                     <div class="checkbox">
                       <label>
                         <input type="checkbox" ng-model="changeScaleSettings" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0"> replica count and selector
@@ -146,8 +146,10 @@
                       </label>
                     </div>
                     <button type="button" ng-click="rollbackToDeployment(deploymentConfigName, deployment.metadata.name, changeScaleSettings, changeStrategy, changeTriggers)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-primary">Roll Back</button>
-                  </div> 
+                  </div>
+                  <!-- disabled until we have an api endpoint for retry
                   <button ng-show="deploymentStatus(deployment) == 'Failed'" type="button" ng-click="retryFailedDeployment(deploymentConfigName, deployment.metadata.name)" ng-disabled="(deploymentConfigDeploymentsInProgress[deploymentConfigName] | hashSize) > 0" class="btn btn-primary" ng-if="deploymentIsLatest(deploymentConfig, deployment)">Retry</button>
+                  -->
                   <button ng-show="deploymentIsInProgress(deployment)" type="button" ng-click="cancelRunningDeployment(deploymentConfigName, deployment.metadata.name)" class="btn btn-primary">Cancel</button>
                 </span>                
               </div>


### PR DESCRIPTION
This adds buttons to the "Deployments" page on the web console to "Start Deployment" (based on the latest config), "Retry" a failed deployment, "Cancel" a running one or "Rollback" to a previous successful deployment.

TODO: rollback with parameters like in the CLI.

Screenshots (1. collapsed view, 2. expanded view):

![collapsed](https://cloud.githubusercontent.com/assets/158611/9285586/bef1186e-42bd-11e5-8a9a-e9b49e387e9a.png)

![expanded](https://cloud.githubusercontent.com/assets/158611/9285589/c983c7ae-42bd-11e5-83f4-4fc50867bd92.png)
