### PR TITLE
changed check logic for new go versions

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -8,8 +8,8 @@ set -o pipefail
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping gofmt."
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4?(\.[0-9]+)') ]]; then
+  echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 0
 fi
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -11,8 +11,8 @@ fi
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping golint."
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4?(\.[0-9]+)') ]]; then
+  echo "Unknown go version '${GO_VERSION[2]}', skipping golint."
   exit 0
 fi
 

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -5,8 +5,8 @@ set -o pipefail
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping go vet."
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4?(\.[0-9]+)') ]]; then
+  echo "Unknown go version '${GO_VERSION[2]}', skipping go vet."
   exit 0
 fi
 


### PR DESCRIPTION
@liggitt 
This allows for `go version` of `go1.4` and any sub-versions `go.1.4.x(xx)`