### PR TITLE
bump(go-ldap/ldap): c265aaa27b1c60c66f6d4695c6f33eb8b28989ad

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -385,7 +385,7 @@
 		{
 			"ImportPath": "github.com/go-ldap/ldap",
 			"Comment": "v1-19-g83e6542",
-			"Rev": "83e65426fd1c06626e88aa8a085e5bfed0208e29"
+			"Rev": "c265aaa27b1c60c66f6d4695c6f33eb8b28989ad"
 		},
 		{
 			"ImportPath": "github.com/godbus/dbus",

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/conn.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/conn.go
@@ -176,7 +176,7 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 		ber.PrintPacket(packet)
 	}
 
-	if packet.Children[1].Children[0].Value.(int64) == 0 {
+	if packet.Children[1].Children[0].Value.(int64) == LDAPResultSuccess {
 		conn := tls.Client(l.conn, config)
 
 		if err := conn.Handshake(); err != nil {
@@ -186,6 +186,12 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 
 		l.isTLS = true
 		l.conn = conn
+	} else {
+		// https://tools.ietf.org/html/rfc4511#section-4.1.9
+		// Children[1].Children[2] is the diagnosticMessage which is guaranteed to exist.
+		return NewError(
+			uint8(packet.Children[1].Children[0].Value.(int64)),
+			fmt.Errorf("ldap: cannot StartTLS (%s)", packet.Children[1].Children[2].Value.(string)))
 	}
 	go l.reader()
 


### PR DESCRIPTION
Update go-ldap/ldap to return an error when StartTLS was not successful