### PR TITLE
bump(github.com/RangelReale/osin): c07b3bd1ee57089f63e6325c0ea035ceed2e905c

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -45,7 +45,7 @@
 		},
 		{
 			"ImportPath": "github.com/RangelReale/osin",
-			"Rev": "a9958a122a90a3b069389d394284283c19d58913"
+			"Rev": "c07b3bd1ee57089f63e6325c0ea035ceed2e905c"
 		},
 		{
 			"ImportPath": "github.com/RangelReale/osincli",

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/README.md
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/README.md
@@ -11,10 +11,6 @@ Using it, you can build your own OAuth2 authentication service.
 
 The library implements the majority of the specification, like authorization and token endpoints, and authorization code, implicit, resource owner and client credentials grant types.
 
-### Dependencies
-
-* go-uuid (http://code.google.com/p/go-uuid)
-
 ### Example Server
 
 ````go
@@ -27,7 +23,7 @@ server := osin.NewServer(osin.NewServerConfig(), &TestStorage{})
 http.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
 	resp := server.NewResponse()
 	defer resp.Close()
-	
+
 	if ar := server.HandleAuthorizeRequest(resp, r); ar != nil {
 
 		// HANDLE LOGIN PAGE HERE
@@ -42,7 +38,7 @@ http.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
 http.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
 	resp := server.NewResponse()
 	defer resp.Close()
-	
+
 	if ar := server.HandleAccessRequest(resp, r); ar != nil {
 		ar.Authorized = true
 		server.FinishAccessRequest(resp, r, ar)
@@ -79,7 +75,7 @@ rangelreale@gmail.com
 	  that need to clone / close in each connection (mgo)
 	- Client was changed to be an interface instead of an struct. Because of that,
 	  the Storage interface also had to change, as interface is already a pointer.
-	
+
 	- HOW TO FIX YOUR CODE:
 		+ In your Storage, add a Clone function returning itself, and a do nothing Close.
 		+ In your Storage, replace all *osin.Client with osin.Client (remove the pointer reference)
@@ -88,6 +84,6 @@ rangelreale@gmail.com
 		+ Change all accesses using osin.Client to use the methods instead of the fields directly.
 		+ You MUST defer Response.Close in all your http handlers, otherwise some
 		  Storages may not clean correctly.
-		
+
 				resp := server.NewResponse()
 				defer resp.Close()

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/access_test.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/access_test.go
@@ -193,3 +193,26 @@ func TestAccessClientCredentials(t *testing.T) {
 		t.Fatalf("Refresh token should not be generated: %s", d)
 	}
 }
+
+func TestExtraScopes(t *testing.T) {
+	if extraScopes("", "") == true {
+		t.Fatalf("extraScopes returned true with empty scopes")
+	}
+
+	if extraScopes("a", "") == true {
+		t.Fatalf("extraScopes returned true with less scopes")
+	}
+
+	if extraScopes("a,b", "b,a") == true {
+		t.Fatalf("extraScopes returned true with matching scopes")
+	}
+
+	if extraScopes("a,b", "b,a,c") == false {
+		t.Fatalf("extraScopes returned false with extra scopes")
+	}
+
+	if extraScopes("", "a") == false {
+		t.Fatalf("extraScopes returned false with extra scopes")
+	}
+
+}

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/authorize.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/authorize.go
@@ -11,7 +11,7 @@ type AuthorizeRequestType string
 
 const (
 	CODE  AuthorizeRequestType = "code"
-	TOKEN                      = "token"
+	TOKEN AuthorizeRequestType = "token"
 )
 
 // Authorize request information
@@ -88,115 +88,67 @@ type AuthorizeTokenGen interface {
 func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *AuthorizeRequest {
 	r.ParseForm()
 
+	// create the authorization request
+	unescapedUri, err := url.QueryUnescape(r.Form.Get("redirect_uri"))
+	if err != nil {
+		w.SetErrorState(E_INVALID_REQUEST, "", "")
+		w.InternalError = err
+		return nil
+	}
+
+	ret := &AuthorizeRequest{
+		State:       r.Form.Get("state"),
+		Scope:       r.Form.Get("scope"),
+		RedirectUri: unescapedUri,
+		Authorized:  false,
+		HttpRequest: r,
+	}
+
+	// must have a valid client
+	ret.Client, err = w.Storage.GetClient(r.Form.Get("client_id"))
+	if err != nil {
+		w.SetErrorState(E_SERVER_ERROR, "", ret.State)
+		w.InternalError = err
+		return nil
+	}
+	if ret.Client == nil {
+		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "", ret.State)
+		return nil
+	}
+	if ret.Client.GetRedirectUri() == "" {
+		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "", ret.State)
+		return nil
+	}
+
+	// check redirect uri, if there are multiple client redirect uri's
+	// don't set the uri
+	if ret.RedirectUri == "" && FirstUri(ret.Client.GetRedirectUri(), s.Config.RedirectUriSeparator) == ret.Client.GetRedirectUri() {
+		ret.RedirectUri = FirstUri(ret.Client.GetRedirectUri(), s.Config.RedirectUriSeparator)
+	}
+
+	if err = ValidateUriList(ret.Client.GetRedirectUri(), ret.RedirectUri, s.Config.RedirectUriSeparator); err != nil {
+		w.SetErrorState(E_INVALID_REQUEST, "", ret.State)
+		w.InternalError = err
+		return nil
+	}
+
+	w.SetRedirect(ret.RedirectUri)
+
 	requestType := AuthorizeRequestType(r.Form.Get("response_type"))
 	if s.Config.AllowedAuthorizeTypes.Exists(requestType) {
 		switch requestType {
 		case CODE:
-			return s.handleCodeRequest(w, r)
+			ret.Type = CODE
+			ret.Expiration = s.Config.AuthorizationExpiration
 		case TOKEN:
-			return s.handleTokenRequest(w, r)
+			ret.Type = TOKEN
+			ret.Expiration = s.Config.AccessExpiration
 		}
+		return ret
 	}
 
-	w.SetError(E_UNSUPPORTED_RESPONSE_TYPE, "")
+	w.SetErrorState(E_UNSUPPORTED_RESPONSE_TYPE, "", ret.State)
 	return nil
-}
-
-func (s *Server) handleCodeRequest(w *Response, r *http.Request) *AuthorizeRequest {
-	// create the authorization request
-	unescapedUri, err := url.QueryUnescape(r.Form.Get("redirect_uri"))
-	if err != nil {
-		unescapedUri = ""
-	}
-	ret := &AuthorizeRequest{
-		Type:        CODE,
-		State:       r.Form.Get("state"),
-		Scope:       r.Form.Get("scope"),
-		RedirectUri: unescapedUri,
-		Authorized:  false,
-		Expiration:  s.Config.AuthorizationExpiration,
-		HttpRequest: r,
-	}
-
-	// must have a valid client
-	ret.Client, err = w.Storage.GetClient(r.Form.Get("client_id"))
-	if err != nil {
-		w.SetErrorState(E_SERVER_ERROR, "", ret.State)
-		w.InternalError = err
-		return nil
-	}
-	if ret.Client == nil {
-		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "", ret.State)
-		return nil
-	}
-	if ret.Client.GetRedirectUri() == "" {
-		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "", ret.State)
-		return nil
-	}
-
-	// force redirect response to client redirecturl first
-	w.SetRedirect(FirstUri(ret.Client.GetRedirectUri(), s.Config.RedirectUriSeparator))
-
-	// check redirect uri
-	if ret.RedirectUri == "" {
-		ret.RedirectUri = FirstUri(ret.Client.GetRedirectUri(), s.Config.RedirectUriSeparator)
-	}
-	if err = ValidateUriList(ret.Client.GetRedirectUri(), ret.RedirectUri, s.Config.RedirectUriSeparator); err != nil {
-		w.SetErrorState(E_INVALID_REQUEST, "", ret.State)
-		w.InternalError = err
-		return nil
-	}
-
-	return ret
-}
-
-func (s *Server) handleTokenRequest(w *Response, r *http.Request) *AuthorizeRequest {
-	// create the authorization request
-	unescapedUri, err := url.QueryUnescape(r.Form.Get("redirect_uri"))
-	if err != nil {
-		unescapedUri = ""
-	}
-	ret := &AuthorizeRequest{
-		Type:        TOKEN,
-		State:       r.Form.Get("state"),
-		Scope:       r.Form.Get("scope"),
-		RedirectUri: unescapedUri,
-		Authorized:  false,
-		// this type will generate a token directly, use access token expiration instead.
-		Expiration:  s.Config.AccessExpiration,
-		HttpRequest: r,
-	}
-
-	// must have a valid client
-	ret.Client, err = w.Storage.GetClient(r.Form.Get("client_id"))
-	if err != nil {
-		w.SetErrorState(E_SERVER_ERROR, "", ret.State)
-		w.InternalError = err
-		return nil
-	}
-	if ret.Client == nil {
-		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "", ret.State)
-		return nil
-	}
-	if ret.Client.GetRedirectUri() == "" {
-		w.SetErrorState(E_UNAUTHORIZED_CLIENT, "", ret.State)
-		return nil
-	}
-
-	// force redirect response to client redirecturl first
-	w.SetRedirect(FirstUri(ret.Client.GetRedirectUri(), s.Config.RedirectUriSeparator))
-
-	// check redirect uri
-	if ret.RedirectUri == "" {
-		ret.RedirectUri = FirstUri(ret.Client.GetRedirectUri(), s.Config.RedirectUriSeparator)
-	}
-	if err = ValidateUriList(ret.Client.GetRedirectUri(), ret.RedirectUri, s.Config.RedirectUriSeparator); err != nil {
-		w.SetErrorState(E_INVALID_REQUEST, "", ret.State)
-		w.InternalError = err
-		return nil
-	}
-
-	return ret
 }
 
 func (s *Server) FinishAuthorizeRequest(w *Response, r *http.Request, ar *AuthorizeRequest) {

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/config.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/config.go
@@ -64,7 +64,7 @@ func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
 		AuthorizationExpiration:   250,
 		AccessExpiration:          3600,
-		TokenType:                 "bearer",
+		TokenType:                 "Bearer",
 		AllowedAuthorizeTypes:     AllowedAuthorizeType{CODE},
 		AllowedAccessTypes:        AllowedAccessType{AUTHORIZATION_CODE},
 		ErrorStatusCode:           200,

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/response.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/response.go
@@ -28,6 +28,7 @@ type Response struct {
 	Output             ResponseData
 	Headers            http.Header
 	IsError            bool
+	ErrorId            string
 	InternalError      error
 	RedirectInFragment bool
 
@@ -75,6 +76,7 @@ func (r *Response) SetErrorUri(id string, description string, uri string, state 
 
 	// set error parameters
 	r.IsError = true
+	r.ErrorId = id
 	r.StatusCode = r.ErrorStatusCode
 	if r.StatusCode != 200 {
 		r.StatusText = description

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/response_json.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/response_json.go
@@ -23,8 +23,10 @@ func OutputJSON(rs *Response, w http.ResponseWriter, r *http.Request) error {
 		w.Header().Add("Location", u)
 		w.WriteHeader(302)
 	} else {
-		// Output json
-		w.Header().Add("Content-Type", "application/json")
+		// set content type if the response doesn't already have one associated with it
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
 		w.WriteHeader(rs.StatusCode)
 
 		encoder := json.NewEncoder(w)

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/tokengen.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/tokengen.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"strings"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 )
 
 // AuthorizeTokenGenDefault is the default authorization token generator

--- a/Godeps/_workspace/src/github.com/RangelReale/osin/urivalidate_test.go
+++ b/Godeps/_workspace/src/github.com/RangelReale/osin/urivalidate_test.go
@@ -5,24 +5,95 @@ import (
 )
 
 func TestURIValidate(t *testing.T) {
-	// V1
-	if err := ValidateUri("http://localhost:14000/appauth", "http://localhost:14000/appauth"); err != nil {
-		t.Errorf("V1: %s", err)
+	valid := [][]string{
+		{
+			// Exact match
+			"http://localhost:14000/appauth",
+			"http://localhost:14000/appauth",
+		},
+		{
+			// Trailing slash
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/",
+		},
+		{
+			// Exact match with trailing slash
+			"http://www.google.com/myapp/",
+			"http://www.google.com/myapp/",
+		},
+		{
+			// Subpath
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/interface/implementation",
+		},
+		{
+			// Subpath with trailing slash
+			"http://www.google.com/myapp/",
+			"http://www.google.com/myapp/interface/implementation",
+		},
+		{
+			// Subpath with things that are close to path traversals, but aren't
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/.../..implementation../...",
+		},
+		{
+			// If the allowed basepath contains path traversals, allow them?
+			"http://www.google.com/traversal/../allowed",
+			"http://www.google.com/traversal/../allowed/with/subpath",
+		},
+	}
+	for _, v := range valid {
+		if err := ValidateUri(v[0], v[1]); err != nil {
+			t.Errorf("Expected ValidateUri(%s, %s) to succeed, got %v", v[0], v[1], err)
+		}
 	}
 
-	// V2
-	if err := ValidateUri("http://localhost:14000/appauth", "http://localhost:14000/app"); err == nil {
-		t.Error("V2 should have failed")
+	invalid := [][]string{
+		{
+			// Doesn't satisfy base path
+			"http://localhost:14000/appauth",
+			"http://localhost:14000/app",
+		},
+		{
+			// Doesn't satisfy base path
+			"http://localhost:14000/app/",
+			"http://localhost:14000/app",
+		},
+		{
+			// Not a subpath of base path
+			"http://localhost:14000/appauth",
+			"http://localhost:14000/appauthmodifiedpath",
+		},
+		{
+			// Host mismatch
+			"http://www.google.com/myapp",
+			"http://www2.google.com/myapp",
+		},
+		{
+			// Scheme mismatch
+			"http://www.google.com/myapp",
+			"https://www.google.com/myapp",
+		},
+		{
+			// Path traversal
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/..",
+		},
+		{
+			// Embedded path traversal
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/../test",
+		},
+		{
+			// Not a subpath
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp../test",
+		},
 	}
-
-	// V3
-	if err := ValidateUri("http://www.google.com/myapp", "http://www.google.com/myapp/interface/implementation"); err != nil {
-		t.Errorf("V3: %s", err)
-	}
-
-	// V4
-	if err := ValidateUri("http://www.google.com/myapp", "http://www2.google.com/myapp"); err == nil {
-		t.Error("V4 should have failed")
+	for _, v := range invalid {
+		if err := ValidateUri(v[0], v[1]); err == nil {
+			t.Errorf("Expected ValidateUri(%s, %s) to fail", v[0], v[1])
+		}
 	}
 }
 

--- a/assets/app/scripts/services/login.js
+++ b/assets/app/scripts/services/login.js
@@ -86,7 +86,7 @@ angular.module('openshiftConsole')
         }
 
         // Handle an access_token response
-        if (fragmentParams.access_token && fragmentParams.token_type === "bearer") {
+        if (fragmentParams.access_token && (fragmentParams.token_type || "").toLowerCase() === "bearer") {
           var deferred = $q.defer();
           deferred.resolve({
             token: fragmentParams.access_token,

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -232,13 +232,17 @@ func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddre
 			// Update the existing resource version
 			currClient.ResourceVersion = existing.ResourceVersion
 
-			// Add in any redirects from the existing one
-			// This preserves any additional customized redirects in the default clients
-			redirects := util.NewStringSet(currClient.RedirectURIs...)
-			for _, redirect := range existing.RedirectURIs {
-				if !redirects.Has(redirect) {
-					currClient.RedirectURIs = append(currClient.RedirectURIs, redirect)
-					redirects.Insert(redirect)
+			// Preserve redirects for clients other than the CLI client
+			// The CLI client doesn't care about the redirect URL, just the token or error fragment
+			if currClient.Name != OSCliClientBase.Name {
+				// Add in any redirects from the existing one
+				// This preserves any additional customized redirects in the default clients
+				redirects := util.NewStringSet(currClient.RedirectURIs...)
+				for _, redirect := range existing.RedirectURIs {
+					if !redirects.Has(redirect) {
+						currClient.RedirectURIs = append(currClient.RedirectURIs, redirect)
+						redirects.Insert(redirect)
+					}
 				}
 			}
 


### PR DESCRIPTION
Updated to latest version to pick up improvements:
1. Made spec compliant (if multiple redirect_uris are registered, client must provide one) (ensured our CLI client only has a single redirect_uri registered, for that reason)
2. redirect_uris are validated against traversal attacks
3. requested scopes are validated against granted scopes by osin