### PR TITLE
Make push retries more intelligent

### DIFF
--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/kubernetes/pkg/util"
@@ -15,9 +16,9 @@ import (
 var (
 	// DefaultPushRetryCount is the number of retries of pushing the built Docker image
 	// into a configured repository
-	DefaultPushRetryCount = 2
+	DefaultPushRetryCount = 6
 	// DefaultPushRetryDelay is the time to wait before triggering a push retry
-	DefaultPushRetryDelay = 10 * time.Second
+	DefaultPushRetryDelay = 5 * time.Second
 )
 
 // DockerClient is an interface to the Docker client that contains
@@ -28,7 +29,11 @@ type DockerClient interface {
 	RemoveImage(name string) error
 }
 
-// pushImage pushes a docker image to the registry specified in its tag
+// pushImage pushes a docker image to the registry specified in its tag.
+// The method will retry to push the image when following scenarios occur:
+// - Docker registry is down temporarily or permanently
+// - other image is being pushed to the registry
+// If any other scenario the push will fail, without retries.
 func pushImage(client DockerClient, name string, authConfig docker.AuthConfiguration) error {
 	repository, tag := docker.ParseRepositoryTag(name)
 	opts := docker.PushImageOptions{
@@ -39,15 +44,19 @@ func pushImage(client DockerClient, name string, authConfig docker.AuthConfigura
 		opts.OutputStream = os.Stderr
 	}
 	var err error
+
 	for retries := 0; retries <= DefaultPushRetryCount; retries++ {
 		err = client.PushImage(opts, authConfig)
 		if err == nil {
 			return nil
 		}
-		if retries == DefaultPushRetryCount {
+
+		errMsg := fmt.Sprintf("%s", err)
+		if !strings.Contains(errMsg, "ping attempt failed with error") || !strings.Contains(errMsg, "is already in progress") {
 			return err
 		}
-		util.HandleError(fmt.Errorf("push for image %s failed, will retry in %s ...", name, DefaultPushRetryDelay))
+
+		util.HandleError(fmt.Errorf("push for image %s failed, will retry in %s seconds ...", name, DefaultPushRetryDelay))
 		glog.Flush()
 		time.Sleep(DefaultPushRetryDelay)
 	}


### PR DESCRIPTION
So currently there are three situation that the can detect upon the image push to Docker registry and react accordingly:
- registry is down permanently
- registry is down temporarily
- multiple image are tried to be pushed into registry.

For the first two we will just do two retries. For the simultaneous image push, the number of retries will be 20. Not really sure if the 20 retries is the ideal number, but there is no way how to distinguish how long shall the build take, so its kinda hard to pick the amount of retries (or the delay between retries).

@mfojtik I know that you have been working on the retry logic. PTAL  