### PR TITLE
fix integration tests

### DIFF
--- a/hack/test-integration-docker.sh
+++ b/hack/test-integration-docker.sh
@@ -9,4 +9,4 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 # Go to the top of the tree.
 cd "${OS_ROOT}"
 
-OS_TEST_TAGS="integration docker" hack/test-integration.sh $@
+OS_TEST_TAGS="integration docker etcd" hack/test-integration.sh $@

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -24,7 +24,7 @@ function cleanup()
 }
 
 package="${OS_TEST_PACKAGE:-test/integration}"
-tags="${OS_TEST_TAGS:-integration !docker}"
+tags="${OS_TEST_TAGS:-integration !docker etcd}"
 
 export GOMAXPROCS="$(grep "processor" -c /proc/cpuinfo 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || 1)"
 TMPDIR=${TMPDIR:-/tmp}


### PR DESCRIPTION
The etcd tag is missing from the integration tests, so very few are running.  Looks like it was https://github.com/openshift/origin/pull/4154.

```
[deads@deads-dev-01 origin]$ hack/test-integration.sh 

Test test/integration -tags='integration !docker' ...

etcd: etcd 0.4.6
{"action":"set","node":{"key":"/_test","value":"","modifiedIndex":3,"createdIndex":3}}
ok      TestAccessDisabledWebConsole
ok      TestAccessOriginWebConsole
ok      TestRegistryClientConnect
ok      TestRegistryClientConnectPulpRegistry
ok      TestRegistryClientImage
ok      TestRegistryClientQuayIOImage
ok      TestRegistryClientRegistryNotFound

real	0m16.416s
user	0m16.934s
sys	0m0.611s
```

@liggitt what joker merged that? :)