### PR TITLE
Bug 1248464 - fixes message about builds created by new-app

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -185,7 +185,7 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 			}
 			fmt.Fprintf(c.Out(), "Service %q created at %s%s\n", t.Name, t.Spec.ClusterIP, portMappings)
 		case *buildapi.BuildConfig:
-			fmt.Fprintf(c.Out(), "A build was created - you can run `%s start-build %s` to start it.\n", fullName, t.Name)
+			fmt.Fprintf(c.Out(), "Build %q created and started - you can run `%s status` to check the progress.\n", t.Name, fullName)
 		case *imageapi.ImageStream:
 			if len(t.Status.DockerImageRepository) == 0 {
 				if hasMissingRepo {


### PR DESCRIPTION
The build now starts automatically and user does not have to run the suggested command. If user runs the suggested command, a second build is started.
@smarterclayton ptal