### PR TITLE
Sync the upstream e2e framework with extended tests

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/core.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/core.go
@@ -60,7 +60,7 @@ func CoreDump(dir string) {
 	// I wish there was a better way to get the master IP...
 	config, err := loadConfig()
 	if err != nil {
-		fmt.Printf("Error loading config: %v")
+		fmt.Printf("Error loading config: %v", err)
 	}
 	ix := strings.LastIndex(config.Host, "/")
 	master := net.JoinHostPort(config.Host[ix+1:], "22")

--- a/hack/test-extended/default/run.sh
+++ b/hack/test-extended/default/run.sh
@@ -32,6 +32,16 @@ cleanup() {
 	exit $out
 }
 
+# Check if we have ginkgo command
+set -e
+which ginkgo &>/dev/null || (echo 'Run: "go get github.com/onsi/ginkgo/ginkgo"' && exit 1)
+set +e
+
+# Compile the extended tests first to avoid waiting for OpenShift server to
+# start and fail sooner on compilation errors.
+GOPATH="${OS_ROOT}/Godeps/_workspace:${GOPATH}" \
+  ginkgo build -r ./test/extended 
+
 test_privileges
 
 echo "[INFO] Starting 'default' extended tests"
@@ -140,6 +150,6 @@ echo "[INFO] Starting extended tests ..."
 echo "[INFO] MASTER IP - ${MASTER_ADDR}"
 echo "[INFO] SERVER CONFIG PATH - ${SERVER_CONFIG_DIR}"
 
+# Run the tests
 KUBECONFIG="${ADMIN_KUBECONFIG}" \
-	GOPATH="${OS_ROOT}/Godeps/_workspace:${GOPATH}" \
-	go test -v -tags=default ./test/extended
+  ginkgo -progress -focus="default:" -p ./test/extended/extended.test

--- a/test/extended/default_builds_test.go
+++ b/test/extended/default_builds_test.go
@@ -1,5 +1,3 @@
-// +build default
-
 package extended
 
 import (
@@ -15,7 +13,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = Describe("STI build with .sti/environment file", func() {
+var _ = Describe("default: STI build with .sti/environment file", func() {
 	defer GinkgoRecover()
 	var (
 		imageStreamFixture = filepath.Join("..", "integration", "fixtures", "test-image-stream.json")

--- a/test/extended/default_mysql_test.go
+++ b/test/extended/default_mysql_test.go
@@ -1,5 +1,3 @@
-// +build default
-
 package extended
 
 import (
@@ -12,7 +10,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = Describe("MySQL ephemeral template", func() {
+var _ = Describe("default: MySQL ephemeral template", func() {
 	defer GinkgoRecover()
 	var (
 		templatePath = filepath.Join("..", "..", "examples", "db-templates", "mysql-ephemeral-template.json")

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -44,7 +44,7 @@ type CLI struct {
 // role bindings for the namespace.
 func NewCLI(project, adminConfigPath string) *CLI {
 	client := &CLI{}
-	client.kubeFramework = NewCustomFramework(project, client.SetupProject)
+	client.kubeFramework = InitializeFramework(project, client.SetupProject)
 	client.outputDir = os.TempDir()
 	client.username = "admin"
 	if len(adminConfigPath) == 0 {


### PR DESCRIPTION
Having the tests definitions (the files that contains "var _ = Describe") causes that when launching extended tests, all upstream tests are ran as well ;-)

Also there are few tweaks that are not (yet) part of upstream, namely:

* NewCustomFramework()
* rc.go has some helpers we need, but also has "var _ = Describe" which we don't want... 

This PR will make the extended tests work again.

@deads2k FYI 