### PR TITLE
fix help typo

### DIFF
--- a/docs/generated/oadm_by_example_content.adoc
+++ b/docs/generated/oadm_by_example_content.adoc
@@ -143,7 +143,7 @@ Remove users from a group
 
 [options="nowrap"]
 ----
-  // Add user1 and user2 to my-group
+  // Remove user1 and user2 from my-group
   $ openshift admin groups remove-users my-group user1 user2
 ----
 ====

--- a/pkg/cmd/admin/groups/changemembership.go
+++ b/pkg/cmd/admin/groups/changemembership.go
@@ -70,7 +70,7 @@ func NewCmdRemoveUsers(name, fullName string, f *clientcmd.Factory, out io.Write
 		Use:     name + " GROUP USER [USER ...]",
 		Short:   "Remove users from a group",
 		Long:    removeLong,
-		Example: fmt.Sprintf(addExample, fullName),
+		Example: fmt.Sprintf(removeExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))


### PR DESCRIPTION
Fixes help text to say "remove".

[merge]