### PR TITLE
Add namespace flag when reporting rollback trigger enablement instructions

### DIFF
--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -255,7 +255,7 @@ func (o *RollbackOptions) Run() error {
 			disabled = append(disabled, trigger.ImageChangeParams.From.Name)
 		}
 		if len(disabled) > 0 {
-			reenable := fmt.Sprintf("oc deploy %s --enable-triggers", rolledback.Name)
+			reenable := fmt.Sprintf("oc deploy %s --enable-triggers -n %s", rolledback.Name, o.Namespace)
 			fmt.Fprintf(o.out, "Warning: the following images triggers were disabled: %s\n  You can re-enable them with: %s\n", strings.Join(disabled, ","), reenable)
 		}
 	}


### PR DESCRIPTION
Report the namespace flag when describing trigger re-enablement
instructions during rollback. If the triggers are outside the current
contextual namespace, the reported command will fail without -n.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1253317