### PR TITLE
Show last three builds by default in the UI

### DIFF
--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -17,6 +17,8 @@ angular.module('openshiftConsole')
     $scope.emptyMessage = "Loading...";
     // Expand builds on load if there's a hash that might link to a hidden build.
     $scope.expanded = !!$location.hash();
+    // Show only 3 builds for each build config by default.
+    $scope.defaultBuildLimit = 3;
 
     $scope.buildsByBuildConfig = {};
 

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -237,4 +237,16 @@ angular.module('openshiftConsole')
 
       return id.replace(/^sha256:/, "");
     };
+  })
+  // Like limitTo, except if the limit is undefined, return all items instead of none.
+  // TODO: Remove when we upgrade Angular since you can pass undefined to limitTo in newer versions.
+  //       See https://github.com/angular/angular.js/pull/10510
+  .filter("limitToOrAll", function(limitToFilter) {
+    return function(input, limit) {
+      if (isNaN(limit)) {
+        return input;
+      }
+
+      return limitToFilter(input, limit);
+    };
   });

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -140,7 +140,8 @@
             </dl>
           </div>
         </div>
-        <div ng-show="$first || expanded" ng-repeat="build in buildsByBuildConfig[buildConfigName] | orderObjectsByDate : true" ng-attr-id="build-{{build.metadata.name}}" class="well build-well">
+        <!-- When expanded, pass undefined to limitToOrAll to show all builds. -->
+        <div ng-repeat="build in buildsByBuildConfig[buildConfigName] | orderObjectsByDate : true | limitToOrAll: (expanded ? undefined : defaultBuildLimit)" class="well build-well">
           <div class="row">
             <div class="col-md-7 col-sm-7 col-xs-7">
               <h3>{{build.metadata.name}}</h3>
@@ -212,7 +213,7 @@
             </div><!-- /.col -->
           </div><!-- /.row -->
         </div><!-- /build .well -->
-        <div ng-hide="expanded || (buildsByBuildConfig[buildConfigName] | hashSize) <= 1"><a href="" ng-click="expanded = true">Show older builds</a></div>
+        <div ng-hide="expanded || (buildsByBuildConfig[buildConfigName] | hashSize) <= defaultBuildLimit"><a href="" ng-click="expanded = true">Show older builds</a></div>
       </div><!-- /buildConfig .tile -->
 
       <!-- render any builds whose build configs no longer exist -->


### PR DESCRIPTION
Show the last three builds on the browse builds page instead of only the latest. This is less confusing when new builds start because you have more context.

Fixes #4045