### PR TITLE
Replace FatalErr with ginkgos Fail

### DIFF
--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -281,6 +281,5 @@ func trimmedOutput(stdout io.Writer) string {
 
 // FatalErr exits the test in case a fatal error has occured.
 func FatalErr(msg interface{}) {
-	fmt.Printf("ERROR: %v\n", msg)
-	os.Exit(1)
+	Failf("%v", msg)
 }


### PR DESCRIPTION
wasnt sure if we wanna just replace the logic by not exiting the whole test suit when the error occurs or 
we wanna a separate function for that.
@mfojtik @mnagy PTAL