### PR TITLE
Add Subjects []kapi.ObjectReference to rolebindings

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14618,6 +14618,7 @@
     "required": [
      "userNames",
      "groupNames",
+     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -14645,6 +14646,13 @@
        "type": "string"
       },
       "description": "all the groups directly bound to the role"
+     },
+     "subjects": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ObjectReference"
+      },
+      "description": "references to subjects bound to the role.  Only User, Group, SystemUser, SystemGroup, and ServiceAccount are allowed."
      },
      "roleRef": {
       "$ref": "v1.ObjectReference",
@@ -16900,6 +16908,7 @@
     "required": [
      "userNames",
      "groupNames",
+     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -16927,6 +16936,13 @@
        "type": "string"
       },
       "description": "all the groups directly bound to the role"
+     },
+     "subjects": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ObjectReference"
+      },
+      "description": "references to subjects bound to the role.  Only User, Group, SystemUser, SystemGroup, and ServiceAccount are allowed."
      },
      "roleRef": {
       "$ref": "v1.ObjectReference",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -181,29 +181,17 @@ func deepCopy_api_ClusterRoleBinding(in api.ClusterRoleBinding, out *api.Cluster
 	} else {
 		out.ObjectMeta = newVal.(pkgapi.ObjectMeta)
 	}
-	if in.Users != nil {
-		out.Users = make(util.StringSet)
-		for key, val := range in.Users {
-			if newVal, err := c.DeepCopy(val); err != nil {
+	if in.Subjects != nil {
+		out.Subjects = make([]pkgapi.ObjectReference, len(in.Subjects))
+		for i := range in.Subjects {
+			if newVal, err := c.DeepCopy(in.Subjects[i]); err != nil {
 				return err
 			} else {
-				out.Users[key] = newVal.(util.Empty)
+				out.Subjects[i] = newVal.(pkgapi.ObjectReference)
 			}
 		}
 	} else {
-		out.Users = nil
-	}
-	if in.Groups != nil {
-		out.Groups = make(util.StringSet)
-		for key, val := range in.Groups {
-			if newVal, err := c.DeepCopy(val); err != nil {
-				return err
-			} else {
-				out.Groups[key] = newVal.(util.Empty)
-			}
-		}
-	} else {
-		out.Groups = nil
+		out.Subjects = nil
 	}
 	if newVal, err := c.DeepCopy(in.RoleRef); err != nil {
 		return err
@@ -560,29 +548,17 @@ func deepCopy_api_RoleBinding(in api.RoleBinding, out *api.RoleBinding, c *conve
 	} else {
 		out.ObjectMeta = newVal.(pkgapi.ObjectMeta)
 	}
-	if in.Users != nil {
-		out.Users = make(util.StringSet)
-		for key, val := range in.Users {
-			if newVal, err := c.DeepCopy(val); err != nil {
+	if in.Subjects != nil {
+		out.Subjects = make([]pkgapi.ObjectReference, len(in.Subjects))
+		for i := range in.Subjects {
+			if newVal, err := c.DeepCopy(in.Subjects[i]); err != nil {
 				return err
 			} else {
-				out.Users[key] = newVal.(util.Empty)
+				out.Subjects[i] = newVal.(pkgapi.ObjectReference)
 			}
 		}
 	} else {
-		out.Users = nil
-	}
-	if in.Groups != nil {
-		out.Groups = make(util.StringSet)
-		for key, val := range in.Groups {
-			if newVal, err := c.DeepCopy(val); err != nil {
-				return err
-			} else {
-				out.Groups[key] = newVal.(util.Empty)
-			}
-		}
-	} else {
-		out.Groups = nil
+		out.Subjects = nil
 	}
 	if newVal, err := c.DeepCopy(in.RoleRef); err != nil {
 		return err

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -11,8 +12,10 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 
 	osapi "github.com/openshift/origin/pkg/api"
@@ -24,6 +27,7 @@ import (
 	deploy "github.com/openshift/origin/pkg/deploy/api"
 	image "github.com/openshift/origin/pkg/image/api"
 	template "github.com/openshift/origin/pkg/template/api"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
 func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, seed int64) runtime.Object {
@@ -41,6 +45,82 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 		},
 		func(j *authorizationapi.ClusterPolicyBinding, c fuzz.Continue) {
 			j.RoleBindings = make(map[string]*authorizationapi.ClusterRoleBinding)
+		},
+		func(j *authorizationapi.RoleBinding, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			for i := range j.Subjects {
+				kinds := []string{authorizationapi.UserKind, authorizationapi.SystemUserKind, authorizationapi.GroupKind, authorizationapi.SystemGroupKind, authorizationapi.ServiceAccountKind}
+				j.Subjects[i].Kind = kinds[c.Intn(len(kinds))]
+				switch j.Subjects[i].Kind {
+				case authorizationapi.UserKind:
+					j.Subjects[i].Namespace = ""
+					if valid, _ := uservalidation.ValidateUserName(j.Subjects[i].Name, false); !valid {
+						j.Subjects[i].Name = fmt.Sprintf("validusername%d", i)
+					}
+
+				case authorizationapi.GroupKind:
+					j.Subjects[i].Namespace = ""
+					if valid, _ := uservalidation.ValidateGroupName(j.Subjects[i].Name, false); !valid {
+						j.Subjects[i].Name = fmt.Sprintf("validgroupname%d", i)
+					}
+
+				case authorizationapi.ServiceAccountKind:
+					if valid, _ := validation.ValidateNamespaceName(j.Subjects[i].Namespace, false); !valid {
+						j.Subjects[i].Namespace = fmt.Sprintf("sanamespacehere%d", i)
+					}
+					if valid, _ := validation.ValidateServiceAccountName(j.Subjects[i].Name, false); !valid {
+						j.Subjects[i].Name = fmt.Sprintf("sanamehere%d", i)
+					}
+
+				case authorizationapi.SystemUserKind, authorizationapi.SystemGroupKind:
+					j.Subjects[i].Namespace = ""
+					j.Subjects[i].Name = ":" + j.Subjects[i].Name
+
+				}
+
+				j.Subjects[i].UID = types.UID("")
+				j.Subjects[i].APIVersion = ""
+				j.Subjects[i].ResourceVersion = ""
+				j.Subjects[i].FieldPath = ""
+			}
+		},
+		func(j *authorizationapi.ClusterRoleBinding, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			for i := range j.Subjects {
+				kinds := []string{authorizationapi.UserKind, authorizationapi.SystemUserKind, authorizationapi.GroupKind, authorizationapi.SystemGroupKind, authorizationapi.ServiceAccountKind}
+				j.Subjects[i].Kind = kinds[c.Intn(len(kinds))]
+				switch j.Subjects[i].Kind {
+				case authorizationapi.UserKind:
+					j.Subjects[i].Namespace = ""
+					if valid, _ := uservalidation.ValidateUserName(j.Subjects[i].Name, false); !valid {
+						j.Subjects[i].Name = fmt.Sprintf("validusername%d", i)
+					}
+
+				case authorizationapi.GroupKind:
+					j.Subjects[i].Namespace = ""
+					if valid, _ := uservalidation.ValidateGroupName(j.Subjects[i].Name, false); !valid {
+						j.Subjects[i].Name = fmt.Sprintf("validgroupname%d", i)
+					}
+
+				case authorizationapi.ServiceAccountKind:
+					if valid, _ := validation.ValidateNamespaceName(j.Subjects[i].Namespace, false); !valid {
+						j.Subjects[i].Namespace = fmt.Sprintf("sanamespacehere%d", i)
+					}
+					if valid, _ := validation.ValidateServiceAccountName(j.Subjects[i].Name, false); !valid {
+						j.Subjects[i].Name = fmt.Sprintf("sanamehere%d", i)
+					}
+
+				case authorizationapi.SystemUserKind, authorizationapi.SystemGroupKind:
+					j.Subjects[i].Namespace = ""
+					j.Subjects[i].Name = ":" + j.Subjects[i].Name
+
+				}
+
+				j.Subjects[i].UID = types.UID("")
+				j.Subjects[i].APIVersion = ""
+				j.Subjects[i].ResourceVersion = ""
+				j.Subjects[i].FieldPath = ""
+			}
 		},
 		func(j *template.Template, c fuzz.Continue) {
 			c.Fuzz(&j.ObjectMeta)

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -194,6 +194,18 @@ func deepCopy_v1_ClusterRoleBinding(in v1.ClusterRoleBinding, out *v1.ClusterRol
 	} else {
 		out.GroupNames = nil
 	}
+	if in.Subjects != nil {
+		out.Subjects = make([]pkgapiv1.ObjectReference, len(in.Subjects))
+		for i := range in.Subjects {
+			if newVal, err := c.DeepCopy(in.Subjects[i]); err != nil {
+				return err
+			} else {
+				out.Subjects[i] = newVal.(pkgapiv1.ObjectReference)
+			}
+		}
+	} else {
+		out.Subjects = nil
+	}
 	if newVal, err := c.DeepCopy(in.RoleRef); err != nil {
 		return err
 	} else {
@@ -564,6 +576,18 @@ func deepCopy_v1_RoleBinding(in v1.RoleBinding, out *v1.RoleBinding, c *conversi
 		}
 	} else {
 		out.GroupNames = nil
+	}
+	if in.Subjects != nil {
+		out.Subjects = make([]pkgapiv1.ObjectReference, len(in.Subjects))
+		for i := range in.Subjects {
+			if newVal, err := c.DeepCopy(in.Subjects[i]); err != nil {
+				return err
+			} else {
+				out.Subjects[i] = newVal.(pkgapiv1.ObjectReference)
+			}
+		}
+	} else {
+		out.Subjects = nil
 	}
 	if newVal, err := c.DeepCopy(in.RoleRef); err != nil {
 		return err

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -194,6 +194,18 @@ func deepCopy_v1beta3_ClusterRoleBinding(in v1beta3.ClusterRoleBinding, out *v1b
 	} else {
 		out.GroupNames = nil
 	}
+	if in.Subjects != nil {
+		out.Subjects = make([]pkgapiv1beta3.ObjectReference, len(in.Subjects))
+		for i := range in.Subjects {
+			if newVal, err := c.DeepCopy(in.Subjects[i]); err != nil {
+				return err
+			} else {
+				out.Subjects[i] = newVal.(pkgapiv1beta3.ObjectReference)
+			}
+		}
+	} else {
+		out.Subjects = nil
+	}
 	if newVal, err := c.DeepCopy(in.RoleRef); err != nil {
 		return err
 	} else {
@@ -572,6 +584,18 @@ func deepCopy_v1beta3_RoleBinding(in v1beta3.RoleBinding, out *v1beta3.RoleBindi
 		}
 	} else {
 		out.GroupNames = nil
+	}
+	if in.Subjects != nil {
+		out.Subjects = make([]pkgapiv1beta3.ObjectReference, len(in.Subjects))
+		for i := range in.Subjects {
+			if newVal, err := c.DeepCopy(in.Subjects[i]); err != nil {
+				return err
+			} else {
+				out.Subjects[i] = newVal.(pkgapiv1beta3.ObjectReference)
+			}
+		}
+	} else {
+		out.Subjects = nil
 	}
 	if newVal, err := c.DeepCopy(in.RoleRef); err != nil {
 		return err

--- a/pkg/authorization/api/casts.go
+++ b/pkg/authorization/api/casts.go
@@ -167,8 +167,7 @@ func ToRoleBinding(in *ClusterRoleBinding) *RoleBinding {
 
 	ret := &RoleBinding{}
 	ret.ObjectMeta = in.ObjectMeta
-	ret.Users = in.Users
-	ret.Groups = in.Groups
+	ret.Subjects = in.Subjects
 	ret.RoleRef = ToRoleRef(in.RoleRef)
 	return ret
 }
@@ -235,8 +234,7 @@ func ToClusterRoleBinding(in *RoleBinding) *ClusterRoleBinding {
 
 	ret := &ClusterRoleBinding{}
 	ret.ObjectMeta = in.ObjectMeta
-	ret.Users = in.Users
-	ret.Groups = in.Groups
+	ret.Subjects = in.Subjects
 	ret.RoleRef = ToClusterRoleRef(in.RoleRef)
 
 	return ret

--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -5,7 +5,12 @@ import (
 	"sort"
 	"strings"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/controller/serviceaccount"
 	kutil "k8s.io/kubernetes/pkg/util"
+
+	// uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
 func ExpandResources(rawResources kutil.StringSet) kutil.StringSet {
@@ -85,3 +90,91 @@ func GetPolicyBindingName(policyRefNamespace string) string {
 }
 
 var ClusterPolicyBindingName = GetPolicyBindingName("")
+
+func BuildSubjects(users, groups []string, userNameValidator, groupNameValidator validation.ValidateNameFunc) []kapi.ObjectReference {
+	subjects := []kapi.ObjectReference{}
+
+	for _, user := range users {
+		saNamespace, saName, err := serviceaccount.SplitUsername(user)
+		if err == nil {
+			subjects = append(subjects, kapi.ObjectReference{Kind: ServiceAccountKind, Namespace: saNamespace, Name: saName})
+			continue
+		}
+
+		kind := UserKind
+		if valid, _ := userNameValidator(user, false); !valid {
+			kind = SystemUserKind
+		}
+
+		subjects = append(subjects, kapi.ObjectReference{Kind: kind, Name: user})
+	}
+
+	for _, group := range groups {
+		kind := GroupKind
+		if valid, _ := groupNameValidator(group, false); !valid {
+			kind = SystemGroupKind
+		}
+
+		subjects = append(subjects, kapi.ObjectReference{Kind: kind, Name: group})
+	}
+
+	return subjects
+}
+
+// StringSubjectsFor returns users and groups for comparison against user.Info.  currentNamespace is used to
+// to create usernames for service accounts where namespace=="".
+func StringSubjectsFor(currentNamespace string, subjects []kapi.ObjectReference) ([]string, []string) {
+	users := []string{}
+	groups := []string{}
+
+	for _, subject := range subjects {
+		switch subject.Kind {
+		case ServiceAccountKind:
+			namespace := currentNamespace
+			if len(subject.Namespace) > 0 {
+				namespace = subject.Namespace
+			}
+			users = append(users, serviceaccount.MakeUsername(namespace, subject.Name))
+
+		case UserKind, SystemUserKind:
+			users = append(users, subject.Name)
+
+		case GroupKind, SystemGroupKind:
+			groups = append(groups, subject.Name)
+		}
+	}
+
+	return users, groups
+}
+
+// SubjectsStrings returns users, groups, serviceaccounts, unknown for display purposes.  currentNamespace is used to
+// hide the subject.Namespace for ServiceAccounts in the currentNamespace
+func SubjectsStrings(currentNamespace string, subjects []kapi.ObjectReference) ([]string, []string, []string, []string) {
+	users := []string{}
+	groups := []string{}
+	sas := []string{}
+	others := []string{}
+
+	for _, subject := range subjects {
+		switch subject.Kind {
+		case ServiceAccountKind:
+			if len(subject.Namespace) > 0 && currentNamespace != subject.Namespace {
+				sas = append(sas, subject.Namespace+"/"+subject.Name)
+			} else {
+				sas = append(sas, subject.Name)
+			}
+
+		case UserKind, SystemUserKind:
+			users = append(users, subject.Name)
+
+		case GroupKind, SystemGroupKind:
+			groups = append(groups, subject.Name)
+
+		default:
+			others = append(others, fmt.Sprintf("%s/%s/%s", subject.Kind, subject.Namespace, subject.Name))
+
+		}
+	}
+
+	return users, groups, sas, others
+}

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -19,6 +19,12 @@ const (
 	ResourceAll    = "*"
 	VerbAll        = "*"
 	NonResourceAll = "*"
+
+	UserKind           = "User"
+	GroupKind          = "Group"
+	ServiceAccountKind = "ServiceAccount"
+	SystemUserKind     = "SystemUser"
+	SystemGroupKind    = "SystemGroup"
 )
 
 const (
@@ -142,10 +148,8 @@ type RoleBinding struct {
 	kapi.TypeMeta
 	kapi.ObjectMeta
 
-	// Users holds all the usernames directly bound to the role
-	Users util.StringSet
-	// Groups holds all the groups directly bound to the role
-	Groups util.StringSet
+	// Subjects hold object references of to authorize with this rule
+	Subjects []kapi.ObjectReference
 
 	// RoleRef can only reference the current namespace and the global namespace
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
@@ -311,10 +315,8 @@ type ClusterRoleBinding struct {
 	kapi.TypeMeta
 	kapi.ObjectMeta
 
-	// Users holds all the usernames directly bound to the role
-	Users util.StringSet
-	// GroupNames holds all the groups directly bound to the role
-	Groups util.StringSet
+	// Subjects hold object references of to authorize with this rule
+	Subjects []kapi.ObjectReference
 
 	// RoleRef can only reference the current namespace and the global namespace
 	// If the ClusterRoleRef cannot be resolved, the Authorizer must return an error.

--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 
 	newer "github.com/openshift/origin/pkg/authorization/api"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
 func convert_v1_ResourceAccessReview_To_api_ResourceAccessReview(in *ResourceAccessReview, out *newer.ResourceAccessReview, s conversion.Scope) error {
@@ -181,8 +182,12 @@ func convert_v1_RoleBinding_To_api_RoleBinding(in *RoleBinding, out *newer.RoleB
 		return err
 	}
 
-	out.Users = util.NewStringSet(in.UserNames...)
-	out.Groups = util.NewStringSet(in.GroupNames...)
+	// if the users and groups fields are cleared, then respect only subjects.  The field was set in the DefaultConvert above
+	if in.UserNames == nil && in.GroupNames == nil {
+		return nil
+	}
+
+	out.Subjects = newer.BuildSubjects(in.UserNames, in.GroupNames, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
 
 	return nil
 }
@@ -192,8 +197,7 @@ func convert_api_RoleBinding_To_v1_RoleBinding(in *newer.RoleBinding, out *RoleB
 		return err
 	}
 
-	out.UserNames = in.Users.List()
-	out.GroupNames = in.Groups.List()
+	out.UserNames, out.GroupNames = newer.StringSubjectsFor(in.Namespace, in.Subjects)
 
 	return nil
 }
@@ -228,8 +232,12 @@ func convert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding(in *ClusterRoleBind
 		return err
 	}
 
-	out.Users = util.NewStringSet(in.UserNames...)
-	out.Groups = util.NewStringSet(in.GroupNames...)
+	// if the users and groups fields are cleared, then respect only subjects.  The field was set in the DefaultConvert above
+	if in.UserNames == nil && in.GroupNames == nil {
+		return nil
+	}
+
+	out.Subjects = newer.BuildSubjects(in.UserNames, in.GroupNames, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
 
 	return nil
 }
@@ -239,8 +247,7 @@ func convert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *newer.ClusterRo
 		return err
 	}
 
-	out.UserNames = in.Users.List()
-	out.GroupNames = in.Groups.List()
+	out.UserNames, out.GroupNames = newer.StringSubjectsFor(in.Namespace, in.Subjects)
 
 	return nil
 }

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -55,6 +55,8 @@ type RoleBinding struct {
 	UserNames []string `json:"userNames" description:"all the usernames directly bound to the role"`
 	// GroupNames holds all the groups directly bound to the role
 	GroupNames []string `json:"groupNames" description:"all the groups directly bound to the role"`
+	// Subjects hold object references to authorize with this rule
+	Subjects []kapi.ObjectReference `json:"subjects" description:"references to subjects bound to the role.  Only User, Group, SystemUser, SystemGroup, and ServiceAccount are allowed."`
 
 	// RoleRef can only reference the current namespace and the global namespace
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
@@ -234,6 +236,8 @@ type ClusterRoleBinding struct {
 	UserNames []string `json:"userNames" description:"all user names directly bound to the role"`
 	// GroupNames holds all the groups directly bound to the role
 	GroupNames []string `json:"groupNames" description:"all the groups directly bound to the role"`
+	// Subjects hold object references to authorize with this rule
+	Subjects []kapi.ObjectReference `json:"subjects" description:"references to subjects bound to the role.  Only User, Group, SystemUser, SystemGroup, and ServiceAccount are allowed."`
 
 	// RoleRef can only reference the current namespace and the global namespace
 	// If the ClusterRoleRef cannot be resolved, the Authorizer must return an error.

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -58,6 +58,8 @@ type RoleBinding struct {
 	UserNames []string `json:"userNames"`
 	// GroupNames holds all the groups directly bound to the role
 	GroupNames []string `json:"groupNames"`
+	// Subjects hold object references to authorize with this rule
+	Subjects []kapi.ObjectReference `json:"subjects"`
 
 	// Since Policy is a singleton, this is sufficient knowledge to locate a role
 	// RoleRefs can only reference the current namespace and the global namespace
@@ -229,6 +231,8 @@ type ClusterRoleBinding struct {
 	UserNames []string `json:"userNames"`
 	// GroupNames holds all the groups directly bound to the role
 	GroupNames []string `json:"groupNames"`
+	// Subjects hold object references to authorize with this rule
+	Subjects []kapi.ObjectReference `json:"subjects"`
 
 	// Since Policy is a singleton, this is sufficient knowledge to locate a role
 	// ClusterRoleRefs can only reference the current namespace and the global namespace

--- a/pkg/authorization/api/validation/validation.go
+++ b/pkg/authorization/api/validation/validation.go
@@ -1,12 +1,16 @@
 package validation
 
 import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
 func ValidateSubjectAccessReview(review *authorizationapi.SubjectAccessReview) fielderrors.ValidationErrorList {
@@ -246,6 +250,67 @@ func ValidateRoleBinding(roleBinding *authorizationapi.RoleBinding, isNamespaced
 		if valid, err := oapi.MinimalNameRequirements(roleBinding.RoleRef.Name, false); !valid {
 			allErrs = append(allErrs, fielderrors.NewFieldInvalid("roleRef.name", roleBinding.RoleRef.Name, err))
 		}
+	}
+
+	for i, subject := range roleBinding.Subjects {
+		allErrs = append(allErrs, ValidateRoleBindingSubject(subject, isNamespaced).Prefix(fmt.Sprintf("subjects[%d]", i))...)
+	}
+
+	return allErrs
+}
+
+func ValidateRoleBindingSubject(subject kapi.ObjectReference, isNamespaced bool) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(subject.Name) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("name"))
+	}
+	if len(subject.UID) != 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldForbidden("uid", subject.UID))
+	}
+	if len(subject.APIVersion) != 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldForbidden("apiVersion", subject.APIVersion))
+	}
+	if len(subject.ResourceVersion) != 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldForbidden("resourceVersion", subject.ResourceVersion))
+	}
+	if len(subject.FieldPath) != 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldForbidden("fieldPath", subject.FieldPath))
+	}
+
+	switch subject.Kind {
+	case authorizationapi.ServiceAccountKind:
+		if valid, reason := validation.ValidateServiceAccountName(subject.Name, false); len(subject.Name) > 0 && !valid {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("name", subject.Name, reason))
+		}
+		if !isNamespaced && len(subject.Namespace) == 0 {
+			allErrs = append(allErrs, fielderrors.NewFieldRequired("namespace"))
+		}
+
+	case authorizationapi.UserKind:
+		if valid, reason := uservalidation.ValidateUserName(subject.Name, false); len(subject.Name) > 0 && !valid {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("name", subject.Name, reason))
+		}
+
+	case authorizationapi.GroupKind:
+		if valid, reason := uservalidation.ValidateGroupName(subject.Name, false); len(subject.Name) > 0 && !valid {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("name", subject.Name, reason))
+		}
+
+	case authorizationapi.SystemUserKind:
+		isValidSAName, _ := validation.ValidateServiceAccountName(subject.Name, false)
+		isValidUserName, _ := uservalidation.ValidateUserName(subject.Name, false)
+		if isValidSAName || isValidUserName {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("name", subject.Name, "conforms to User.name or ServiceAccount.name restrictions"))
+		}
+
+	case authorizationapi.SystemGroupKind:
+		if valid, _ := uservalidation.ValidateGroupName(subject.Name, false); len(subject.Name) > 0 && valid {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("name", subject.Name, "conforms to Group.name restrictions"))
+		}
+
+	default:
+		allErrs = append(allErrs, fielderrors.NewFieldValueNotSupported("kind", subject.Kind, []string{authorizationapi.ServiceAccountKind, authorizationapi.UserKind, authorizationapi.GroupKind, authorizationapi.SystemGroupKind, authorizationapi.SystemUserKind}))
 	}
 
 	return allErrs

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -463,7 +463,7 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 					RoleRef: kapi.ObjectReference{
 						Name: bootstrappolicy.AdminRoleName,
 					},
-					Users: util.NewStringSet("Matthew"),
+					Subjects: []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "Matthew"}},
 				},
 				"viewers": {
 					ObjectMeta: kapi.ObjectMeta{
@@ -473,7 +473,7 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 					RoleRef: kapi.ObjectReference{
 						Name: bootstrappolicy.ViewRoleName,
 					},
-					Users: util.NewStringSet("Victor"),
+					Subjects: []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "Victor"}},
 				},
 				"editors": {
 					ObjectMeta: kapi.ObjectMeta{
@@ -483,7 +483,7 @@ func newMalletBindings() []authorizationapi.PolicyBinding {
 					RoleRef: kapi.ObjectReference{
 						Name: bootstrappolicy.EditRoleName,
 					},
-					Users: util.NewStringSet("Edgar"),
+					Subjects: []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "Edgar"}},
 				},
 			},
 		},
@@ -534,7 +534,7 @@ func newInvalidExtensionBindings() []authorizationapi.PolicyBinding {
 						Name:      "badExtension",
 						Namespace: "mallet",
 					},
-					Users: util.NewStringSet("Brad"),
+					Subjects: []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "Brad"}},
 				},
 			},
 		},

--- a/pkg/authorization/authorizer/subjects_test.go
+++ b/pkg/authorization/authorizer/subjects_test.go
@@ -34,7 +34,7 @@ func TestSubjects(t *testing.T) {
 			Verb:     "get",
 			Resource: "pods",
 		},
-		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie"),
+		expectedUsers:  util.NewStringSet("Anna", "ClusterAdmin", "Ellen", "Valerie", "system:serviceaccount:adze:second", "system:serviceaccount:foo:default", "system:serviceaccount:other:first"),
 		expectedGroups: util.NewStringSet("RootUsers", "system:cluster-admins", "system:cluster-readers", "system:masters", "system:nodes"),
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()

--- a/pkg/authorization/interfaces/interfaces.go
+++ b/pkg/authorization/interfaces/interfaces.go
@@ -208,10 +208,15 @@ func (a RoleBindingAdapter) RoleRef() kapi.ObjectReference {
 }
 
 func (a RoleBindingAdapter) Users() util.StringSet {
-	return a.roleBinding.Users
+	users, _ := authorizationapi.StringSubjectsFor(a.roleBinding.Namespace, a.roleBinding.Subjects)
+
+	return util.NewStringSet(users...)
 }
+
 func (a RoleBindingAdapter) Groups() util.StringSet {
-	return a.roleBinding.Groups
+	_, groups := authorizationapi.StringSubjectsFor(a.roleBinding.Namespace, a.roleBinding.Subjects)
+
+	return util.NewStringSet(groups...)
 }
 
 type ClusterPolicyBindingAdapter struct {
@@ -260,8 +265,12 @@ func (a ClusterRoleBindingAdapter) RoleRef() kapi.ObjectReference {
 }
 
 func (a ClusterRoleBindingAdapter) Users() util.StringSet {
-	return a.roleBinding.Users
+	users, _ := authorizationapi.StringSubjectsFor(a.roleBinding.Namespace, a.roleBinding.Subjects)
+
+	return util.NewStringSet(users...)
 }
 func (a ClusterRoleBindingAdapter) Groups() util.StringSet {
-	return a.roleBinding.Groups
+	_, groups := authorizationapi.StringSubjectsFor(a.roleBinding.Namespace, a.roleBinding.Subjects)
+
+	return util.NewStringSet(groups...)
 }

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
@@ -44,7 +44,7 @@ func testNewClusterBindings() []authorizationapi.ClusterPolicyBinding {
 				"cluster-admins": {
 					ObjectMeta: kapi.ObjectMeta{Name: "cluster-admins"},
 					RoleRef:    kapi.ObjectReference{Name: "cluster-admin"},
-					Users:      util.NewStringSet("system:admin"),
+					Subjects:   []kapi.ObjectReference{{Kind: authorizationapi.SystemUserKind, Name: "system:admin"}},
 				},
 			},
 		},

--- a/pkg/cmd/admin/policy/remove_from_project.go
+++ b/pkg/cmd/admin/policy/remove_from_project.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/fields"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/labels"
@@ -15,6 +16,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 )
 
 const (
@@ -103,20 +105,25 @@ func (o *RemoveFromProjectOptions) Run() error {
 
 	usersRemoved := util.StringSet{}
 	groupsRemoved := util.StringSet{}
+	sasRemoved := util.StringSet{}
+	othersRemoved := util.StringSet{}
+
+	subjectsToRemove := authorizationapi.BuildSubjects(o.Users, o.Groups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
 
 	for _, currPolicyBinding := range bindingList.Items {
 		for _, currBinding := range authorizationapi.SortRoleBindings(currPolicyBinding.RoleBindings, true) {
-			bindingHasGroups := len(o.Groups) > 0 && currBinding.Groups.HasAny(o.Groups...)
-			bindingHasUsers := len(o.Users) > 0 && currBinding.Users.HasAny(o.Users...)
-			if !bindingHasGroups && !bindingHasUsers {
+			originalSubjects := make([]kapi.ObjectReference, len(currBinding.Subjects))
+			copy(originalSubjects, currBinding.Subjects)
+			oldUsers, oldGroups, oldSAs, oldOthers := authorizationapi.SubjectsStrings(currBinding.Namespace, originalSubjects)
+			oldUsersSet, oldGroupsSet, oldSAsSet, oldOtherSet := util.NewStringSet(oldUsers...), util.NewStringSet(oldGroups...), util.NewStringSet(oldSAs...), util.NewStringSet(oldOthers...)
+
+			currBinding.Subjects = removeSubjects(currBinding.Subjects, subjectsToRemove)
+			newUsers, newGroups, newSAs, newOthers := authorizationapi.SubjectsStrings(currBinding.Namespace, currBinding.Subjects)
+			newUsersSet, newGroupsSet, newSAsSet, newOtherSet := util.NewStringSet(newUsers...), util.NewStringSet(newGroups...), util.NewStringSet(newSAs...), util.NewStringSet(newOthers...)
+
+			if len(currBinding.Subjects) == len(originalSubjects) {
 				continue
 			}
-
-			existingGroups := util.NewStringSet(currBinding.Groups.List()...)
-			existingUsers := util.NewStringSet(currBinding.Users.List()...)
-
-			currBinding.Groups.Delete(o.Groups...)
-			currBinding.Users.Delete(o.Users...)
 
 			_, err = o.Client.RoleBindings(o.BindingNamespace).Update(currBinding)
 			if err != nil {
@@ -127,22 +134,31 @@ func (o *RemoveFromProjectOptions) Run() error {
 			if len(currBinding.RoleRef.Namespace) == 0 {
 				roleDisplayName = currBinding.RoleRef.Name
 			}
-			if diff := existingGroups.Difference(currBinding.Groups); len(diff) != 0 {
+
+			if diff := oldUsersSet.Difference(newUsersSet); len(diff) != 0 {
+				fmt.Fprintf(o.Out, "Removing %s from users %v in project %s.\n", roleDisplayName, diff.List(), o.BindingNamespace)
+				usersRemoved.Insert(diff.List()...)
+			}
+			if diff := oldGroupsSet.Difference(newGroupsSet); len(diff) != 0 {
 				fmt.Fprintf(o.Out, "Removing %s from groups %v in project %s.\n", roleDisplayName, diff.List(), o.BindingNamespace)
 				groupsRemoved.Insert(diff.List()...)
 			}
-			if diff := existingUsers.Difference(currBinding.Users); len(diff) != 0 {
-				fmt.Fprintf(o.Out, "Removing %s from users %v in project %s.\n", roleDisplayName, diff.List(), o.BindingNamespace)
-				usersRemoved.Insert(diff.List()...)
+			if diff := oldSAsSet.Difference(newSAsSet); len(diff) != 0 {
+				fmt.Fprintf(o.Out, "Removing %s from serviceaccounts %v in project %s.\n", roleDisplayName, diff.List(), o.BindingNamespace)
+				sasRemoved.Insert(diff.List()...)
+			}
+			if diff := oldOtherSet.Difference(newOtherSet); len(diff) != 0 {
+				fmt.Fprintf(o.Out, "Removing %s from subjects %v in project %s.\n", roleDisplayName, diff.List(), o.BindingNamespace)
+				othersRemoved.Insert(diff.List()...)
 			}
 		}
 	}
 
-	if diff := util.NewStringSet(o.Groups...).Difference(groupsRemoved); len(diff) != 0 {
-		fmt.Fprintf(o.Out, "Groups %v were not bound to roles in project %s.\n", diff.List(), o.BindingNamespace)
-	}
 	if diff := util.NewStringSet(o.Users...).Difference(usersRemoved); len(diff) != 0 {
 		fmt.Fprintf(o.Out, "Users %v were not bound to roles in project %s.\n", diff.List(), o.BindingNamespace)
+	}
+	if diff := util.NewStringSet(o.Groups...).Difference(groupsRemoved); len(diff) != 0 {
+		fmt.Fprintf(o.Out, "Groups %v were not bound to roles in project %s.\n", diff.List(), o.BindingNamespace)
 	}
 
 	return nil

--- a/pkg/cmd/admin/project/new_project.go
+++ b/pkg/cmd/admin/project/new_project.go
@@ -128,8 +128,7 @@ func (o *NewProjectOptions) Run(useNodeSelector bool) error {
 			RoleName:            binding.RoleRef.Name,
 			RoleNamespace:       binding.RoleRef.Namespace,
 			RoleBindingAccessor: policy.NewLocalRoleBindingAccessor(o.ProjectName, o.Client),
-			Users:               binding.Users.List(),
-			Groups:              binding.Groups.List(),
+			Subjects:            binding.Subjects,
 		}
 		if err := addRole.AddRole(); err != nil {
 			fmt.Printf("Could not add service accounts to the %v role: %v\n", binding.RoleRef.Name, err)

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -39,7 +39,7 @@ var (
 	templateColumns         = []string{"NAME", "DESCRIPTION", "PARAMETERS", "OBJECTS"}
 	policyColumns           = []string{"NAME", "ROLES", "LAST MODIFIED"}
 	policyBindingColumns    = []string{"NAME", "ROLE BINDINGS", "LAST MODIFIED"}
-	roleBindingColumns      = []string{"NAME", "ROLE", "USERS", "GROUPS"}
+	roleBindingColumns      = []string{"NAME", "ROLE", "USERS", "GROUPS", "SERVICE ACCOUNTS", "SUBJECTS"}
 	roleColumns             = []string{"NAME"}
 
 	oauthClientColumns              = []string{"NAME", "SECRET", "WWW-CHALLENGE", "REDIRECT URIS"}
@@ -512,7 +512,9 @@ func printRoleBinding(roleBinding *authorizationapi.RoleBinding, w io.Writer, wi
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%v\t%v\n", roleBinding.Name, roleBinding.RoleRef.Namespace+"/"+roleBinding.RoleRef.Name, roleBinding.Users.List(), roleBinding.Groups.List())
+	users, groups, sas, others := authorizationapi.SubjectsStrings(roleBinding.Namespace, roleBinding.Subjects)
+
+	_, err := fmt.Fprintf(w, "%s\t%s\t%v\t%v\t%v\t%v\n", roleBinding.Name, roleBinding.RoleRef.Namespace+"/"+roleBinding.RoleRef.Name, strings.Join(users, ", "), strings.Join(groups, ", "), strings.Join(sas, ", "), strings.Join(others, ", "))
 	return err
 }
 

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -518,7 +518,7 @@ func GetBootstrapOpenshiftRoleBindings(openshiftNamespace string) []authorizatio
 				Name:      OpenshiftSharedResourceViewRoleName,
 				Namespace: openshiftNamespace,
 			},
-			Groups: util.NewStringSet(AuthenticatedGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
 		},
 	}
 }
@@ -532,7 +532,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: MasterRoleName,
 			},
-			Groups: util.NewStringSet(MastersGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: MastersGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -541,7 +541,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: ClusterAdminRoleName,
 			},
-			Groups: util.NewStringSet(ClusterAdminGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: ClusterAdminGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -550,7 +550,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: ClusterReaderRoleName,
 			},
-			Groups: util.NewStringSet(ClusterReaderGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: ClusterReaderGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -559,7 +559,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: BasicUserRoleName,
 			},
-			Groups: util.NewStringSet(AuthenticatedGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -568,7 +568,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: SelfProvisionerRoleName,
 			},
-			Groups: util.NewStringSet(AuthenticatedGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -577,7 +577,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: OAuthTokenDeleterRoleName,
 			},
-			Groups: util.NewStringSet(AuthenticatedGroup, UnauthenticatedGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}, {Kind: authorizationapi.SystemGroupKind, Name: UnauthenticatedGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -586,7 +586,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: StatusCheckerRoleName,
 			},
-			Groups: util.NewStringSet(AuthenticatedGroup, UnauthenticatedGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}, {Kind: authorizationapi.SystemGroupKind, Name: UnauthenticatedGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -595,7 +595,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: RouterRoleName,
 			},
-			Groups: util.NewStringSet(RouterGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: RouterGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -604,7 +604,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: RegistryRoleName,
 			},
-			Groups: util.NewStringSet(RegistryGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: RegistryGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -613,7 +613,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: NodeRoleName,
 			},
-			Groups: util.NewStringSet(NodesGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: NodesGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -623,7 +623,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 				Name: NodeProxierRoleName,
 			},
 			// Allow node identities to run node proxies
-			Groups: util.NewStringSet(NodesGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: NodesGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -633,7 +633,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 				Name: SDNReaderRoleName,
 			},
 			// Allow node identities to run SDN plugins
-			Groups: util.NewStringSet(NodesGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: NodesGroup}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -642,7 +642,7 @@ func GetBootstrapClusterRoleBindings() []authorizationapi.ClusterRoleBinding {
 			RoleRef: kapi.ObjectReference{
 				Name: WebHooksRoleName,
 			},
-			Groups: util.NewStringSet(AuthenticatedGroup, UnauthenticatedGroup),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: AuthenticatedGroup}, {Kind: authorizationapi.SystemGroupKind, Name: UnauthenticatedGroup}},
 		},
 	}
 }

--- a/pkg/cmd/server/bootstrappolicy/project_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/project_policy.go
@@ -3,7 +3,6 @@ package bootstrappolicy
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/controller/serviceaccount"
-	"k8s.io/kubernetes/pkg/util"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 )
@@ -18,7 +17,7 @@ func GetBootstrapServiceAccountProjectRoleBindings(namespace string) []authoriza
 			RoleRef: kapi.ObjectReference{
 				Name: ImagePullerRoleName,
 			},
-			Groups: util.NewStringSet(serviceaccount.MakeNamespaceGroupName(namespace)),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.SystemGroupKind, Name: serviceaccount.MakeNamespaceGroupName(namespace)}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -28,7 +27,7 @@ func GetBootstrapServiceAccountProjectRoleBindings(namespace string) []authoriza
 			RoleRef: kapi.ObjectReference{
 				Name: ImageBuilderRoleName,
 			},
-			Users: util.NewStringSet(serviceaccount.MakeUsername(namespace, BuilderServiceAccountName)),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.ServiceAccountKind, Name: BuilderServiceAccountName}},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
@@ -38,7 +37,7 @@ func GetBootstrapServiceAccountProjectRoleBindings(namespace string) []authoriza
 			RoleRef: kapi.ObjectReference{
 				Name: DeployerRoleName,
 			},
-			Users: util.NewStringSet(serviceaccount.MakeUsername(namespace, DeployerServiceAccountName)),
+			Subjects: []kapi.ObjectReference{{Kind: authorizationapi.ServiceAccountKind, Name: DeployerServiceAccountName}},
 		},
 	}
 }

--- a/pkg/cmd/server/origin/ensure.go
+++ b/pkg/cmd/server/origin/ensure.go
@@ -56,22 +56,22 @@ func (c *MasterConfig) ensureOpenShiftInfraNamespace() {
 	}
 
 	// Ensure service account cluster role bindings exist
-	clusterRolesToUsernames := map[string][]string{
-		bootstrappolicy.BuildControllerRoleName:       {serviceaccount.MakeUsername(ns, c.BuildControllerServiceAccount)},
-		bootstrappolicy.DeploymentControllerRoleName:  {serviceaccount.MakeUsername(ns, c.DeploymentControllerServiceAccount)},
-		bootstrappolicy.ReplicationControllerRoleName: {serviceaccount.MakeUsername(ns, c.ReplicationControllerServiceAccount)},
+	clusterRolesToSubjects := map[string][]kapi.ObjectReference{
+		bootstrappolicy.BuildControllerRoleName:       {{Namespace: ns, Name: c.BuildControllerServiceAccount, Kind: "ServiceAccount"}},
+		bootstrappolicy.DeploymentControllerRoleName:  {{Namespace: ns, Name: c.DeploymentControllerServiceAccount, Kind: "ServiceAccount"}},
+		bootstrappolicy.ReplicationControllerRoleName: {{Namespace: ns, Name: c.ReplicationControllerServiceAccount, Kind: "ServiceAccount"}},
 	}
 	roleAccessor := policy.NewClusterRoleBindingAccessor(c.ServiceAccountRoleBindingClient())
-	for clusterRole, usernames := range clusterRolesToUsernames {
+	for clusterRole, subjects := range clusterRolesToSubjects {
 		addRole := &policy.RoleModificationOptions{
 			RoleName:            clusterRole,
 			RoleBindingAccessor: roleAccessor,
-			Users:               usernames,
+			Subjects:            subjects,
 		}
 		if err := addRole.AddRole(); err != nil {
-			glog.Errorf("Could not add %v users to the %v cluster role: %v\n", usernames, clusterRole, err)
+			glog.Errorf("Could not add %v subjects to the %v cluster role: %v\n", subjects, clusterRole, err)
 		} else {
-			glog.V(2).Infof("Added %v users to the %v cluster role: %v\n", usernames, clusterRole, err)
+			glog.V(2).Infof("Added %v subjects to the %v cluster role: %v\n", subjects, clusterRole, err)
 		}
 	}
 }
@@ -128,8 +128,7 @@ func (c *MasterConfig) ensureDefaultNamespaceServiceAccountRoles() {
 			RoleName:            binding.RoleRef.Name,
 			RoleNamespace:       binding.RoleRef.Namespace,
 			RoleBindingAccessor: policy.NewLocalRoleBindingAccessor(kapi.NamespaceDefault, c.ServiceAccountRoleBindingClient()),
-			Users:               binding.Users.List(),
-			Groups:              binding.Groups.List(),
+			Subjects:            binding.Subjects,
 		}
 		if err := addRole.AddRole(); err != nil {
 			glog.Errorf("Could not add service accounts to the %v role in the %v namespace: %v\n", binding.RoleRef.Name, kapi.NamespaceDefault, err)

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -1,7 +1,7 @@
 package delegated
 
 import (
-	"k8s.io/kubernetes/pkg/util"
+	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -39,7 +39,7 @@ func DefaultTemplate() *templateapi.Template {
 	binding := &authorizationapi.RoleBinding{}
 	binding.Name = "admins"
 	binding.Namespace = ns
-	binding.Users = util.NewStringSet("${" + ProjectAdminUserParam + "}")
+	binding.Subjects = []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "${" + ProjectAdminUserParam + "}"}}
 	binding.RoleRef.Name = bootstrappolicy.AdminRoleName
 	ret.Objects = append(ret.Objects, binding)
 

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -8,17 +8,20 @@ set -o pipefail
 
 oc policy add-role-to-group cluster-admin system:unauthenticated
 oc policy add-role-to-user cluster-admin system:no-user
+oc get rolebinding/cluster-admin --no-headers
 oc get rolebinding/cluster-admin --no-headers | grep -q "system:no-user"
 
 oc policy add-role-to-user cluster-admin -z=one,two --serviceaccount=three,four
-oc get rolebinding/cluster-admin --no-headers | grep -q "system:serviceaccount:cmd-policy:one"
-oc get rolebinding/cluster-admin --no-headers | grep -q "system:serviceaccount:cmd-policy:four"
+oc get rolebinding/cluster-admin --no-headers
+oc get rolebinding/cluster-admin --no-headers | grep -q "one"
+oc get rolebinding/cluster-admin --no-headers | grep -q "four"
 
 oc policy remove-role-from-group cluster-admin system:unauthenticated
 
 oc policy remove-role-from-user cluster-admin system:no-user
 oc policy remove-role-from-user cluster-admin -z=one,two --serviceaccount=three,four
-[ ! "$(oc get rolebinding/cluster-admin --no-headers | grep -q "system:serviceaccount:cmd-policy:four")" ]
+oc get rolebinding/cluster-admin --no-headers
+[ ! "$(oc get rolebinding/cluster-admin --no-headers | grep -q "four")" ]
 
 oc policy remove-group system:unauthenticated
 oc policy remove-user system:no-user

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -6,12 +6,11 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/util"
-
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	groupscmd "github.com/openshift/origin/pkg/cmd/admin/groups"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
 	testutil "github.com/openshift/origin/test/util"
 )
 
@@ -85,7 +84,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 	roleBinding := &authorizationapi.RoleBinding{}
 	roleBinding.Name = "admins"
 	roleBinding.RoleRef.Name = "admin"
-	roleBinding.Groups = util.NewStringSet(valerieGroups...)
+	roleBinding.Subjects = authorizationapi.BuildSubjects([]string{}, valerieGroups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
 	_, err = clusterAdminClient.RoleBindings("empty").Create(roleBinding)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -145,7 +144,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 	roleBinding := &authorizationapi.RoleBinding{}
 	roleBinding.Name = "admins"
 	roleBinding.RoleRef.Name = "admin"
-	roleBinding.Groups = util.NewStringSet(theGroup.Name)
+	roleBinding.Subjects = authorizationapi.BuildSubjects([]string{}, []string{theGroup.Name}, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
 	_, err = clusterAdminClient.RoleBindings("empty").Create(roleBinding)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -8,6 +8,7 @@ import (
 
 	testutil "github.com/openshift/origin/test/util"
 
+	authorizationinterfaces "github.com/openshift/origin/pkg/authorization/interfaces"
 	policy "github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
@@ -50,11 +51,12 @@ func TestPolicyCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !viewers.Users.Has("valerie") {
-		t.Errorf("expected valerie in users: %v", viewers.Users)
+	binding := authorizationinterfaces.NewLocalRoleBindingAdapter(viewers)
+	if !binding.Users().Has("valerie") {
+		t.Errorf("expected valerie in users: %v", binding.Users())
 	}
-	if !viewers.Groups.Has("my-group") {
-		t.Errorf("expected my-group in groups: %v", viewers.Groups)
+	if !binding.Groups().Has("my-group") {
+		t.Errorf("expected my-group in groups: %v", binding.Groups())
 	}
 
 	removeValerie := policy.RemoveFromProjectOptions{
@@ -71,11 +73,12 @@ func TestPolicyCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if viewers.Users.Has("valerie") {
-		t.Errorf("unexpected valerie in users: %v", viewers.Users)
+	binding = authorizationinterfaces.NewLocalRoleBindingAdapter(viewers)
+	if binding.Users().Has("valerie") {
+		t.Errorf("unexpected valerie in users: %v", binding.Users())
 	}
-	if !viewers.Groups.Has("my-group") {
-		t.Errorf("expected my-group in groups: %v", viewers.Groups)
+	if !binding.Groups().Has("my-group") {
+		t.Errorf("expected my-group in groups: %v", binding.Groups())
 	}
 
 	removeMyGroup := policy.RemoveFromProjectOptions{
@@ -92,11 +95,12 @@ func TestPolicyCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if viewers.Users.Has("valerie") {
-		t.Errorf("unexpected valerie in users: %v", viewers.Users)
+	binding = authorizationinterfaces.NewLocalRoleBindingAdapter(viewers)
+	if binding.Users().Has("valerie") {
+		t.Errorf("unexpected valerie in users: %v", binding.Users())
 	}
-	if viewers.Groups.Has("my-group") {
-		t.Errorf("unexpected my-group in groups: %v", viewers.Groups)
+	if binding.Groups().Has("my-group") {
+		t.Errorf("unexpected my-group in groups: %v", binding.Groups())
 	}
 
 }


### PR DESCRIPTION
This adds a `Subjects []kapi.ObjectReference` field to rolebindings.  It allows easy binding of service accounts to roles inside of a template.  For now, the `users` and `groups` fields remain and only `Subjects` with `Kind=="ServiceAccount"` are allowed.

@liggitt @smarterclayton