### PR TITLE
Support prefixed deploymentConfig name

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -126,7 +126,16 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 	o.out = out
 
 	if len(args) > 0 {
-		o.deploymentConfigName = args[0]
+		name := args[0]
+		// Strip out any existing resource prefix.
+		// TODO: consider switching to using a resource.Builder.
+		i := strings.Index(name, "/")
+		if i >= 0 {
+			i++
+		} else {
+			i = 0
+		}
+		o.deploymentConfigName = name[i:]
 	}
 
 	return nil


### PR DESCRIPTION
Support prefixed deploymentConfig name references to allow command
chaining.

Fixes #4182