### PR TITLE
show build context in oc status

### DIFF
--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -406,7 +406,8 @@ func describeAdditionalBuildDetail(build *buildgraph.BuildConfigNode, lastSucces
 		lastTime = passTime
 	}
 
-	if lastSuccessfulBuild != nil && includeSuccess {
+	// display the last successful build if specifically requested or we're going to display an active build for context
+	if lastSuccessfulBuild != nil && (includeSuccess || len(activeBuilds) > 0) {
 		out = append(out, describeBuildPhase(lastSuccessfulBuild.Build, &passTime, build.BuildConfig.Name, pushTargetResolved))
 	}
 	if passTime.Before(failTime) {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4194

```
[deads@deads-dev-01 origin]$ oc status
In project foo

service/ruby-hello-world - 172.30.113.128:8080
  dc/ruby-hello-world deploys istag/ruby-hello-world:latest <-
    docker build of https://github.com/openshift/ruby-hello-world through bc/ruby-hello-world 
      #2 build running for 1 seconds
      #1 build succeeded 22 seconds ago
    #1 deployed 30 seconds ago - 1 pod

To see more, use 'oc describe <resource>/<name>'.
You can use 'oc get all' to see a list of other objects.
```

@fabianofranz ptal