### PR TITLE
[WIP] DataService.get() digest error fix

### DIFF
--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -2,7 +2,7 @@
 /* jshint eqeqeq: false, unused: false */
 
 angular.module('openshiftConsole')
-.factory('DataService', function($http, $ws, $rootScope, $q, API_CFG, Notification, Logger) {
+.factory('DataService', function($http, $q, $rootScope, $timeout, $ws, API_CFG, Logger, Notification) {
 
   function Data(array) {
     this._data = {};
@@ -275,12 +275,12 @@ angular.module('openshiftConsole')
     else if (!force && this._watchInFlight(type, context) && this._resourceVersion(type, context)) {
       var obj = existingData.by('metadata.name')[name];
       if (obj) {
-        $rootScope.$apply(function(){
+        $timeout(function(){
           deferred.resolve(obj);
         });
       }
       else {
-        $rootScope.$apply(function(){
+        $timeout(function(){
           // simulation of API object not found
           deferred.reject({
             data: {},


### PR DESCRIPTION
Fix digest error in DataService.get() by replacing $rootScope.$apply with $timeout.

See [issue 4247](https://github.com/openshift/origin/issues/4247) for the discussion prompting this PR.  This fix rectifies an issue that limits promise usage.