### PR TITLE
Typo in https proxy debug output

### DIFF
--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -166,7 +166,7 @@ func (d *DockerBuilder) fetchSource(dir string) error {
 		setHttps = true
 	}
 	if len(d.build.Spec.Source.Git.HTTPProxy) != 0 {
-		glog.V(2).Infof("Setting http proxy variables for Git to %s", d.build.Spec.Source.Git.HTTPSProxy)
+		glog.V(2).Infof("Setting http proxy variables for Git to %s", d.build.Spec.Source.Git.HTTPProxy)
 		origProxy["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")
 		origProxy["http_proxy"] = os.Getenv("http_proxy")
 		os.Setenv("HTTP_PROXY", d.build.Spec.Source.Git.HTTPProxy)

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -110,7 +110,7 @@ func (s *STIBuilder) Build() error {
 		setHttps = true
 	}
 	if len(s.build.Spec.Source.Git.HTTPProxy) != 0 {
-		glog.V(2).Infof("Setting http proxy variables for Git to %s", s.build.Spec.Source.Git.HTTPSProxy)
+		glog.V(2).Infof("Setting http proxy variables for Git to %s", s.build.Spec.Source.Git.HTTPProxy)
 		origProxy["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")
 		origProxy["http_proxy"] = os.Getenv("http_proxy")
 		os.Setenv("HTTP_PROXY", s.build.Spec.Source.Git.HTTPProxy)


### PR DESCRIPTION
My first ever pull request on GitHub, so be nice if I'm doing it wrong... :-)

The "Setting http proxy variables for Git" builder debug message outputs the name of httpsProxy rather than httpProxy. You would never notice this unless you are using different proxies for each. 