### PR TITLE
Prohibit passthrough route with path

### DIFF
--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -31,6 +31,11 @@ func ValidateRoute(route *routeapi.Route) fielderrors.ValidationErrorList {
 		result = append(result, fielderrors.NewFieldInvalid("path", route.Path, "path must begin with /"))
 	}
 
+	if len(route.Path) > 0 && route.TLS != nil &&
+		route.TLS.Termination == routeapi.TLSTerminationPassthrough {
+		result = append(result, fielderrors.NewFieldInvalid("path", route.Path, "paththrough termination does not support paths"))
+	}
+
 	if len(route.ServiceName) == 0 {
 		result = append(result, fielderrors.NewFieldRequired("serviceName"))
 	}

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -109,6 +109,22 @@ func TestValidateRoute(t *testing.T) {
 			},
 			expectedErrors: 1,
 		},
+		{
+			name: "Passthrough route with path",
+			route: &api.Route{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Host:        "www.example.com",
+				Path:        "/test",
+				ServiceName: "serviceName",
+				TLS: &api.TLSConfig{
+					Termination: api.TLSTerminationPassthrough,
+				},
+			},
+			expectedErrors: 1,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
It is impossible to support paths with passthrough termination because the router cannot determine the path in the request without decrypting the connection.

@ramr, does this look OK?