### PR TITLE
Make the docker registry client loggable

### DIFF
--- a/pkg/dockerregistry/client.go
+++ b/pkg/dockerregistry/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
+	kclient "k8s.io/kubernetes/pkg/client"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
@@ -35,7 +36,7 @@ type Image struct {
 // Client includes methods for accessing a Docker registry by name.
 type Client interface {
 	// Connect to a Docker registry by name. Pass "" for the Docker Hub
-	Connect(registry string, allowInsecure, disableV2 bool) (Connection, error)
+	Connect(registry string, allowInsecure bool) (Connection, error)
 }
 
 // Connection allows you to retrieve data from a Docker V1 registry.
@@ -51,8 +52,14 @@ type Connection interface {
 	ImageByTag(namespace, name, tag string) (*Image, error)
 }
 
+// client implements the Client interface
+type client struct {
+	connections map[string]*connection
+}
+
 // NewClient returns a client object which allows public access to
-// a Docker registry.
+// a Docker registry. enableV2 allows a client to prefer V1 registry
+// API connections.
 // TODO: accept a docker auth config
 func NewClient() Client {
 	return &client{
@@ -60,17 +67,10 @@ func NewClient() Client {
 	}
 }
 
-// client implements the Client interface
-type client struct {
-	connections map[string]*connection
-}
-
 // Connect accepts the name of a registry in the common form Docker provides and will
 // create a connection to the registry. Callers may provide a host, a host:port, or
 // a fully qualified URL. When not providing a URL, the default scheme will be "https"
-// disableV2 allows a client to prefer V1 registry API connections for a particular
-// server.
-func (c *client) Connect(name string, allowInsecure, disableV2 bool) (Connection, error) {
+func (c *client) Connect(name string, allowInsecure bool) (Connection, error) {
 	target, err := normalizeRegistryName(name)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (c *client) Connect(name string, allowInsecure, disableV2 bool) (Connection
 	if conn, ok := c.connections[prefix]; ok && conn.allowInsecure == allowInsecure {
 		return conn, nil
 	}
-	conn := newConnection(*target, allowInsecure, disableV2)
+	conn := newConnection(*target, allowInsecure, true)
 	c.connections[prefix] = conn
 	return conn, nil
 }
@@ -156,18 +156,16 @@ type connection struct {
 }
 
 // newConnection creates a new connection
-func newConnection(url url.URL, allowInsecure, disableV2 bool) *connection {
-	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Jar: jar}
-
+func newConnection(url url.URL, allowInsecure, enableV2 bool) *connection {
 	var isV2 *bool
-	if disableV2 {
+	if !enableV2 {
 		v2 := false
 		isV2 = &v2
 	}
 
+	var transport http.RoundTripper
 	if allowInsecure {
-		client.Transport = &http.Transport{
+		transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			Proxy:           http.ProxyFromEnvironment,
 			Dial: (&net.Dialer{
@@ -176,7 +174,23 @@ func newConnection(url url.URL, allowInsecure, disableV2 bool) *connection {
 			}).Dial,
 			TLSHandshakeTimeout: 10 * time.Second,
 		}
+	} else {
+		transport = http.DefaultTransport
 	}
+
+	switch {
+	case bool(glog.V(9)):
+		transport = kclient.NewDebuggingRoundTripper(transport, kclient.CurlCommand, kclient.URLTiming, kclient.ResponseHeaders)
+	case bool(glog.V(8)):
+		transport = kclient.NewDebuggingRoundTripper(transport, kclient.JustURL, kclient.RequestHeaders, kclient.ResponseStatus, kclient.ResponseHeaders)
+	case bool(glog.V(7)):
+		transport = kclient.NewDebuggingRoundTripper(transport, kclient.JustURL, kclient.RequestHeaders, kclient.ResponseStatus)
+	case bool(glog.V(6)):
+		transport = kclient.NewDebuggingRoundTripper(transport, kclient.URLTiming)
+	}
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar, Transport: transport}
 	return &connection{
 		url:    url,
 		client: client,
@@ -280,7 +294,8 @@ func (c *connection) getCachedRepository(name string) (repository, error) {
 // https://docs.docker.com/registry/spec/api/
 func (c *connection) checkV2() (bool, error) {
 	base := c.url
-	base.Path = path.Join(base.Path, "v2")
+	base.Host = normalizeDockerHubHost(base.Host, true)
+	base.Path = path.Join(base.Path, "v2") + "/"
 	req, err := http.NewRequest("GET", base.String(), nil)
 	if err != nil {
 		return false, fmt.Errorf("error creating request: %v", err)
@@ -298,11 +313,12 @@ func (c *connection) checkV2() (bool, error) {
 	defer resp.Body.Close()
 
 	switch code := resp.StatusCode; {
-	case code >= 300 || resp.StatusCode < 200:
-		return false, nil
 	case code == http.StatusUnauthorized:
 		// handle auth challenges on individual repositories
+	case code >= 300 || resp.StatusCode < 200:
+		return false, nil
 	}
+	glog.V(5).Infof("Found registry v2 API at %s", base.String())
 	// TODO: check Docker-Distribution-API-Version?
 	return true, nil
 }

--- a/pkg/dockerregistry/client_test.go
+++ b/pkg/dockerregistry/client_test.go
@@ -24,10 +24,12 @@ func TestHTTPFallback(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	uri, _ = url.Parse(server.URL)
-	conn, err := NewClient().Connect(uri.Host, true, true)
+	conn, err := NewClient().Connect(uri.Host, true)
 	if err != nil {
 		t.Fatal(err)
 	}
+	v2 := false
+	conn.(*connection).isV2 = &v2
 	if _, err := conn.ImageTags("foo", "bar"); !IsRepositoryNotFound(err) {
 		t.Error(err)
 	}
@@ -40,7 +42,7 @@ func TestV2Check(t *testing.T) {
 	var uri *url.URL
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called <- struct{}{}
-		if strings.HasSuffix(r.URL.Path, "/v2") {
+		if strings.HasSuffix(r.URL.Path, "/v2/") {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -52,7 +54,7 @@ func TestV2Check(t *testing.T) {
 		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.RequestURI())
 	}))
 	uri, _ = url.Parse(server.URL)
-	conn, err := NewClient().Connect(uri.Host, true, false)
+	conn, err := NewClient().Connect(uri.Host, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,10 +86,12 @@ func TestInsecureHTTPS(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	uri, _ = url.Parse(server.URL)
-	conn, err := NewClient().Connect(uri.Host, true, true)
+	conn, err := NewClient().Connect(uri.Host, true)
 	if err != nil {
 		t.Fatal(err)
 	}
+	v2 := false
+	conn.(*connection).isV2 = &v2
 	if _, err := conn.ImageTags("foo", "bar"); !IsRepositoryNotFound(err) {
 		t.Error(err)
 	}
@@ -138,11 +142,12 @@ func TestTokenExpiration(t *testing.T) {
 	}))
 
 	uri, _ = url.Parse(server.URL)
-	conn, err := NewClient().Connect(uri.Host, true, true)
+	conn, err := NewClient().Connect(uri.Host, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	v2 := false
+	conn.(*connection).isV2 = &v2
 	if _, err := conn.ImageTags("foo", "bar"); err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +202,7 @@ func TestGetTagFallback(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	uri, _ = url.Parse(server.URL)
-	conn, err := NewClient().Connect(uri.Host, true, true)
+	conn, err := NewClient().Connect(uri.Host, true)
 	c := conn.(*connection)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -136,7 +136,7 @@ func (r DockerRegistrySearcher) Search(terms ...string) (ComponentMatches, error
 		}
 
 		glog.V(4).Infof("checking Docker registry for %q", ref.String())
-		connection, err := r.Client.Connect(ref.Registry, r.AllowInsecure, false)
+		connection, err := r.Client.Connect(ref.Registry, r.AllowInsecure)
 		if err != nil {
 			if dockerregistry.IsRegistryNotFound(err) {
 				return nil, ErrNoMatch{value: term}

--- a/pkg/image/controller/controller.go
+++ b/pkg/image/controller/controller.go
@@ -58,7 +58,7 @@ func (c *ImportController) Next(stream *api.ImageStream) error {
 	if client == nil {
 		client = dockerregistry.NewClient()
 	}
-	conn, err := client.Connect(ref.Registry, insecure, false)
+	conn, err := client.Connect(ref.Registry, insecure)
 	if err != nil {
 		return err
 	}

--- a/pkg/image/controller/controller_test.go
+++ b/pkg/image/controller/controller_test.go
@@ -32,7 +32,7 @@ type fakeDockerRegistryClient struct {
 	Images []expectedImage
 }
 
-func (f *fakeDockerRegistryClient) Connect(registry string, insecure, disableV2 bool) (dockerregistry.Connection, error) {
+func (f *fakeDockerRegistryClient) Connect(registry string, insecure bool) (dockerregistry.Connection, error) {
 	f.Registry = registry
 	f.Insecure = insecure
 	return f, nil


### PR DESCRIPTION
Tweak the URLs we use to connect to the server to avoid redirects and
remove the "disableV2" flag for now.  Add a test for an apparent failing
endpoint on the v2 docker hub.