### PR TITLE
Remove dot imports from extended tests

### DIFF
--- a/test/extended/builds/sti_env.go
+++ b/test/extended/builds/sti_env.go
@@ -5,39 +5,40 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "k8s.io/kubernetes/test/e2e"
+	"k8s.io/kubernetes/test/e2e"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = Describe("default: STI build with .sti/environment file", func() {
-	defer GinkgoRecover()
+var _ = g.Describe("default: STI build with .sti/environment file", func() {
+	defer g.GinkgoRecover()
 	var (
 		imageStreamFixture = exutil.FixturePath("..", "integration", "fixtures", "test-image-stream.json")
 		stiEnvBuildFixture = exutil.FixturePath("fixtures", "test-env-build.json")
 		oc                 = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
 	)
 
-	Describe("Building from a template", func() {
-		It(fmt.Sprintf("should create a image from %q template and run it in a pod", stiEnvBuildFixture), func() {
+	g.Describe("Building from a template", func() {
+		g.It(fmt.Sprintf("should create a image from %q template and run it in a pod", stiEnvBuildFixture), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
-			By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
+			g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 			err := oc.Run("create").Args("-f", imageStreamFixture).Execute()
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By(fmt.Sprintf("calling oc create -f %q", stiEnvBuildFixture))
+			g.By(fmt.Sprintf("calling oc create -f %q", stiEnvBuildFixture))
 			err = oc.Run("create").Args("-f", stiEnvBuildFixture).Execute()
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("starting a test build")
+			g.By("starting a test build")
 			buildName, err := oc.Run("start-build").Args("test").Output()
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("expecting the build is in Complete phase")
+			g.By("expecting the build is in Complete phase")
 			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName,
 				// The build passed
 				func(b *buildapi.Build) bool {
@@ -51,32 +52,32 @@ var _ = Describe("default: STI build with .sti/environment file", func() {
 					return b.Status.Phase == buildapi.BuildPhaseFailed || b.Status.Phase == buildapi.BuildPhaseError
 				},
 			)
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("getting the Docker image reference from ImageStream")
+			g.By("getting the Docker image reference from ImageStream")
 			imageName, err := exutil.GetDockerImageReference(oc.REST().ImageStreams(oc.Namespace()), "test", "latest")
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("writing the pod defintion to a file")
+			g.By("writing the pod defintion to a file")
 			outputPath := filepath.Join(exutil.TestContext.OutputDir, oc.Namespace()+"-sample-pod.json")
 			pod := exutil.CreatePodForImage(imageName)
 			err = exutil.WriteObjectToFile(pod, outputPath)
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By(fmt.Sprintf("calling oc create -f %q", outputPath))
+			g.By(fmt.Sprintf("calling oc create -f %q", outputPath))
 			err = oc.Run("create").Args("-f", outputPath).Execute()
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("expecting the pod to be running")
+			g.By("expecting the pod to be running")
 			err = oc.KubeFramework().WaitForPodRunning(pod.Name)
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("expecting the pod container has TEST_ENV variable set")
+			g.By("expecting the pod container has TEST_ENV variable set")
 			out, err := oc.Run("exec").Args("-p", pod.Name, "--", "curl", "http://0.0.0.0:8080").Output()
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
 			if !strings.Contains(out, "success") {
-				Failf("Pod %q contains does not contain expected variable: %q", pod.Name, out)
+				e2e.Failf("Pod %q contains does not contain expected variable: %q", pod.Name, out)
 			}
 		})
 	})

--- a/test/extended/images/mysql_ephemeral.go
+++ b/test/extended/images/mysql_ephemeral.go
@@ -3,33 +3,33 @@ package images
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = Describe("default: MySQL ephemeral template", func() {
-	defer GinkgoRecover()
+var _ = g.Describe("default: MySQL ephemeral template", func() {
+	defer g.GinkgoRecover()
 	var (
 		templatePath = exutil.FixturePath("..", "..", "examples", "db-templates", "mysql-ephemeral-template.json")
 		oc           = exutil.NewCLI("mysql-create", exutil.KubeConfigPath())
 	)
-	Describe("Creating from a template", func() {
-		It(fmt.Sprintf("should process and create the %q template", templatePath), func() {
+	g.Describe("Creating from a template", func() {
+		g.It(fmt.Sprintf("should process and create the %q template", templatePath), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
-			By(fmt.Sprintf("calling oc process -f %q", templatePath))
+			g.By(fmt.Sprintf("calling oc process -f %q", templatePath))
 			configFile, err := oc.Run("process").Args("-f", templatePath).OutputToFile("config.json")
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By(fmt.Sprintf("calling oc create -f %q", configFile))
+			g.By(fmt.Sprintf("calling oc create -f %q", configFile))
 			err = oc.Run("create").Args("-f", configFile).Execute()
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			By("expecting the mysql service get endpoints")
+			g.By("expecting the mysql service get endpoints")
 			err = oc.KubeFramework().WaitForAnEndpoint("mysql")
-			Expect(err).NotTo(HaveOccurred())
+			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 	})
 

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -19,7 +19,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client"
 	clientcmd "k8s.io/kubernetes/pkg/client/clientcmd"
-	. "k8s.io/kubernetes/test/e2e"
+	"k8s.io/kubernetes/test/e2e"
 )
 
 // CLI provides function to call the OpenShift CLI and Kubernetes and OpenShift
@@ -36,7 +36,7 @@ type CLI struct {
 	stdout          io.Writer
 	verbose         bool
 	cmd             *cobra.Command
-	kubeFramework   *Framework
+	kubeFramework   *e2e.Framework
 }
 
 // NewCLI initialize the upstream E2E framework and set the namespace to match
@@ -44,7 +44,7 @@ type CLI struct {
 // role bindings for the namespace.
 func NewCLI(project, adminConfigPath string) *CLI {
 	client := &CLI{}
-	client.kubeFramework = InitializeFramework(project, client.SetupProject)
+	client.kubeFramework = e2e.InitializeFramework(project, client.SetupProject)
 	client.outputDir = os.TempDir()
 	client.username = "admin"
 	if len(adminConfigPath) == 0 {
@@ -56,7 +56,7 @@ func NewCLI(project, adminConfigPath string) *CLI {
 
 // KubeFramework returns Kubernetes framework which contains helper functions
 // specific for Kubernetes resources
-func (c *CLI) KubeFramework() *Framework {
+func (c *CLI) KubeFramework() *e2e.Framework {
 	return c.kubeFramework
 }
 
@@ -117,14 +117,14 @@ func (c *CLI) SetOutputDir(dir string) *CLI {
 func (c *CLI) SetupProject(name string, kubeClient *kclient.Client) (*kapi.Namespace, error) {
 	newNamespace := kapi.SimpleNameGenerator.GenerateName(fmt.Sprintf("extended-test-%s-", name))
 	c.SetNamespace(newNamespace).ChangeUser(fmt.Sprintf("%s-user", c.Namespace()))
-	Logf("The user is now %q", c.Username())
+	e2e.Logf("The user is now %q", c.Username())
 
 	projectOpts := cmdapi.NewProjectOptions{
 		ProjectName: c.Namespace(),
 		Client:      c.REST(),
 		Out:         c.stdout,
 	}
-	Logf("Creating project %q", c.Namespace())
+	e2e.Logf("Creating project %q", c.Namespace())
 	return c.kubeFramework.Namespace, projectOpts.Run()
 }
 
@@ -281,5 +281,5 @@ func trimmedOutput(stdout io.Writer) string {
 
 // FatalErr exits the test in case a fatal error has occured.
 func FatalErr(msg interface{}) {
-	Failf("%v", msg)
+	e2e.Failf("%v", msg)
 }


### PR DESCRIPTION
@stevekuznetsov FYI

This will:

* Remove dot imports (you now do `g.Describe` and `o.Expect`)
* Support `FOCUS='-focus="default:" -focus="ldap:"'` (you can control what test group is executed by setting  `FOCUS` var. This allows to re-use the 'default' launcher entirely and just override the default FOCUS.)
* Minor tweaks to the launcher itself to be more friendly when:
  * You don't have `openshift` binary for some reason
  * Print what test group is executed
  * Fix cleanup script when no openshift is running (there is no PID)
  * Add `require_ginkgo_or_die`, `compile_extended_tests` and `run_extended_tests`  into util.sh