### PR TITLE
Add standard vars to hook pod environment

### DIFF
--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -122,6 +122,8 @@ func makeHookPod(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationCont
 	for k, v := range envMap {
 		mergedEnv = append(mergedEnv, kapi.EnvVar{Name: k, Value: v})
 	}
+	mergedEnv = append(mergedEnv, kapi.EnvVar{Name: "OPENSHIFT_DEPLOYMENT_NAME", Value: deployment.Name})
+	mergedEnv = append(mergedEnv, kapi.EnvVar{Name: "OPENSHIFT_DEPLOYMENT_NAMESPACE", Value: deployment.Namespace})
 
 	// Inherit resources from the base container
 	resources := kapi.ResourceRequirements{}

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -202,6 +202,8 @@ func TestHookExecutor_makeHookPodOk(t *testing.T) {
 	expectedEnv := map[string]string{
 		"name": "value",
 		"ENV1": "overridden",
+		"OPENSHIFT_DEPLOYMENT_NAME":      deployment.Name,
+		"OPENSHIFT_DEPLOYMENT_NAMESPACE": deployment.Namespace,
 	}
 
 	for k, v := range expectedEnv {


### PR DESCRIPTION
Hook containers should have access to OPENSHIFT_DEPLOYMENT_NAME
and OPENSHIFT_DEPLOYMENT_NAMESPACE just like the deployer pod.

Fixes #3969