### PR TITLE
Remove default backend from the mix + add info on how to enable custom 503 messages 

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -141,7 +141,11 @@ backend openshift_default
   option forwardfor
   #option http-keep-alive
   option http-pretend-keepalive
-  server openshift_backend 127.0.0.1:8080
+  # To configure custom default errors, you can either uncomment the
+  # line below (server ... 127.0.0.1:8080) and point it to your custom
+  # backend service or alternatively, you can send a custom 503 error.
+  #server openshift_backend 127.0.0.1:8080
+  #errorfile 503 /path/to/custom-503-page.html
 
 ##-------------- app level backends ----------------
 {{/*


### PR DESCRIPTION
Fixes issue #4215  - remove the default backend and add some info on how to enable it/custom 503 messages.

Currently, haproxy returns incorrect info if something is serving on port 8080. The second bit is if nothing is running on port 8080, the cost to return a 503 is high. 

And if someone wishes to add custom 503 messages, they can always add a custom backend or use the errorfile 503 /path/to/page directive in a custom template.

Timing info for a non-existent host is now : 
```
time curl -H "Host: ramr.org" http://$routerip  
... &lt;h1;&gt; 503 Service Unavailable&lt;h1;&gt;  
No server is available to handle this request.  
...

real	0m0.160s  
user	0m0.003s  
sys	0m0.004s  
```  

And about the same if a custom 503 page is used  - wall clock time ```0m0.158s```. 
However if the default backend is configured (```server ... 127.0.0.1:8080```) and nothing is serving on port 8080, it is a lot slower, wall clock time is ```real	0m3.167s```.

@rajatchopra PTAL