### PR TITLE
Fix for issue #4035 - internally generated router keys are not unique.

### DIFF
--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -301,7 +301,15 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 // it is not safe to use / in names of router config files.  This allows templates to use this key without having
 // to create (or provide) a separate method
 func (r *templateRouter) routeKey(route *routeapi.Route) string {
-	return fmt.Sprintf("%s-%s", route.Namespace, route.Name)
+	// Namespace can contain dashes, so ${namespace}-${name} is not
+	// unique, use an underscore instead - ${namespace}_${name} akin
+	// to the way domain keys/service records use it ala
+	// _$service.$proto.$name.
+	// Note here that underscore (_) is not a valid DNS character and
+	// is just used for the key name and not for the record/route name.
+	// This also helps the use case for the key used as a router config
+	// file name.
+	return fmt.Sprintf("%s_%s", route.Namespace, route.Name)
 }
 
 // AddRoute adds a route for the given id


### PR DESCRIPTION
Change how internal router keys are generated so that there's no name collisions.
Fix for issue #4035 

@rajatchopra  PTAL

@liggitt  fyi