### PR TITLE
Extended test fixtures

### DIFF
--- a/test/extended/fixtures/test-build-app/Dockerfile
+++ b/test/extended/fixtures/test-build-app/Dockerfile
@@ -1,0 +1,10 @@
+FROM openshift/ruby-20-centos7
+USER default
+EXPOSE 8080
+ENV RACK_ENV production
+ENV RAILS_ENV production
+COPY . /opt/app-root/src/
+RUN scl enable ror40 "bundle install"
+CMD ["scl", "enable", "ror40", "./run.sh"]
+
+USER default

--- a/test/extended/fixtures/test-build-app/Gemfile
+++ b/test/extended/fixtures/test-build-app/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rack"

--- a/test/extended/fixtures/test-build-app/config.ru
+++ b/test/extended/fixtures/test-build-app/config.ru
@@ -1,0 +1,1 @@
+run Proc.new {|env| [200, {"Content-Type" => "text/html"}, [ENV['TEST_ENV']]]}


### PR DESCRIPTION
In order to pass the extended-tests for the https://github.com/openshift/origin/pull/4079 the `test-build-app` fixtures have to be available in the origin/master so the testing build can obtain the source of the app that will be build.
@mfojtik PTAL