### PR TITLE
bump(openshift/source-to-image) a737bdd101de4a013758ad01f4bdd1c8d2f912b3

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -633,47 +633,47 @@
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/git",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
 			"Comment": "v1.0.1-50-g2e52377",
-			"Rev": "2e52377338d425a290e74192ba8d53bb22965b0d"
+			"Rev": "a737bdd101de4a013758ad01f4bdd1c8d2f912b3"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker.go
@@ -404,8 +404,8 @@ func runContainerDockerRun(container *docker.Container, d *stiDocker, image stri
 	cleanupDone := make(chan bool)
 	signal.Notify(signalChan, os.Interrupt)
 	go func() {
-		for range signalChan {
-			glog.V(2).Info("\nReceived an interrupt, stopping services...\n")
+		for signal := range signalChan {
+			glog.V(2).Info("\nReceived signal %s, stopping services...\n", signal)
 			cleanupDone <- true
 		}
 	}()


### PR DESCRIPTION
@bparees @gabemontero PTAL
I know that its just a minor change but the `make release` was failing in vagrant without this fix.