### PR TITLE
Overwriting a volume claim with --claim-name not working

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -107,6 +107,12 @@ function test_privileges {
   set -e
 }
 
+# tryuntil loops up to 60 seconds to redo this action
+function tryuntil {
+  timeout=$(($(date +%s) + 60))
+  until eval "${@}" || [[ $(date +%s) -gt $timeout ]]; do :; done
+}
+
 # wait_for_command executes a command and waits for it to
 # complete or times out after max_wait.
 #

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -4,10 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function tryuntil {
-  timeout=$(($(date +%s) + 60))
-  until eval "${@}" || [[ $(date +%s) -gt $timeout ]]; do :; done
-}
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # Cleanup cluster resources created by this test
 (

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates basic resource retrieval and command interaction
 
 # Test resource builder filtering of files with expected extensions inside directories, and individual files without expected extensions
@@ -23,7 +27,7 @@ oc delete pods hello-openshift
 echo "pods: ok"
 
 oc create -f examples/hello-openshift/hello-pod.json
-oc label pod/hello-openshift acustom=label
+tryuntil oc label pod/hello-openshift acustom=label # can race against scheduling and status updates
 [ "$(oc describe pod/hello-openshift | grep 'acustom=label')" ]
 oc delete pods -l acustom=label
 [ ! "$(oc get pod/hello-openshift)" ]

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 url=":${API_PORT:-8443}"
 project="$(oc project -q)"
 

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -4,10 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function tryuntil {
-  timeout=$(($(date +%s) + 60))
-  until eval "${@}" || [[ $(date +%s) -gt $timeout ]]; do :; done
-}
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # This test validates deployments
 

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates the edit command
 
 oc create -f examples/hello-openshift/hello-pod.json

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates the export command
 
 oc new-app -f examples/sample-app/application-template-stibuild.json --name=sample

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates the help commands and output text
 
 # verify some default commands

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -4,10 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function tryuntil {
-  timeout=$(($(date +%s) + 60))
-  until eval "${@}" || [[ $(date +%s) -gt $timeout ]]; do :; done
-}
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # Cleanup cluster resources created by this test
 (

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -4,10 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-function tryuntil {
-  timeout=$(($(date +%s) + 60))
-  until eval "${@}" || [[ $(date +%s) -gt $timeout ]]; do :; done
-}
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # This test validates the new-app command
 

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates user level policy
 
 oc policy add-role-to-group cluster-admin system:unauthenticated

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates secret interaction
 
 oc secrets new-dockercfg dockercfg --docker-username=sample-user --docker-password=sample-password --docker-email=fake@example.org

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates template commands
 
 oc get templates

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -4,12 +4,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
+
 # This test validates the 'volume' command
 
 oc create -f test/integration/fixtures/test-deployment-config.json
 
 [ "$(oc volume dc/test-deployment-config --list | grep vol1)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol2 -m /opt)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol0 -m /opt5)" ]
+[ "$(oc volume dc/test-deployment-config --add --name=vol2 --type=emptydir -m /opt)" ]
 [ "$(oc volume dc/test-deployment-config --add --name=vol1 --type=secret --secret-name='$ecret' -m /data 2>&1 | grep overwrite)" ]
 [ "$(oc volume dc/test-deployment-config --add --name=vol1 --type=emptyDir -m /data --overwrite)" ]
 [ "$(oc volume dc/test-deployment-config --add -m /opt 2>&1 | grep exists)" ]


### PR DESCRIPTION
Persistent volume claims weren't correctly overwriting the type when
they were implicitly specified.

--type is now correctly required if --claim-name or --claim-size aren't
provided by the user. The default emptydir isn't terribly useful and
users can always add it if they want it.

[test]

@fabianofranz