### PR TITLE
Support prefixed deploymentConfig name

### DIFF
--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -14,7 +14,7 @@ import (
 	kclient "k8s.io/kubernetes/pkg/client"
 	"k8s.io/kubernetes/pkg/fields"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
@@ -25,8 +25,9 @@ import (
 
 type DeployOptions struct {
 	out             io.Writer
-	osClient        *client.Client
-	kubeClient      *kclient.Client
+	osClient        client.Interface
+	kubeClient      kclient.Interface
+	builder         *resource.Builder
 	namespace       string
 	baseCommandName string
 
@@ -123,16 +124,23 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 		return err
 	}
 
+	mapper, typer := f.Object()
+	o.builder = resource.NewBuilder(mapper, typer, f.ClientMapperForCommand())
+
 	o.out = out
 
 	if len(args) > 0 {
-		o.deploymentConfigName = args[0]
+		name := args[0]
+		if strings.Index(name, "/") == -1 {
+			name = fmt.Sprintf("dc/%s", name)
+		}
+		o.deploymentConfigName = name
 	}
 
 	return nil
 }
 
-func (o DeployOptions) Validate(args []string) error {
+func (o *DeployOptions) Validate(args []string) error {
 	if len(args) == 0 || len(args[0]) == 0 {
 		return errors.New("a DeploymentConfig name is required.")
 	}
@@ -158,60 +166,33 @@ func (o DeployOptions) Validate(args []string) error {
 	return nil
 }
 
-func (o DeployOptions) RunDeploy() error {
-	config, err := o.osClient.DeploymentConfigs(o.namespace).Get(o.deploymentConfigName)
+func (o *DeployOptions) RunDeploy() error {
+	r := o.builder.
+		NamespaceParam(o.namespace).
+		ResourceTypeOrNameArgs(false, o.deploymentConfigName).
+		SingleResourceType().
+		Do()
+	if r.Err() != nil {
+		return r.Err()
+	}
+	resultObj, err := r.Object()
 	if err != nil {
 		return err
 	}
-
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-			return o.kubeClient.ReplicationControllers(namespace).Get(name)
-		},
-		ListDeploymentsForConfigFn: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
-			list, err := o.kubeClient.ReplicationControllers(namespace).List(deployutil.ConfigSelector(configName))
-			if err != nil {
-				return nil, err
-			}
-			return list, nil
-		},
-
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			return o.osClient.DeploymentConfigs(config.Namespace).Update(config)
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			return o.kubeClient.ReplicationControllers(deployment.Namespace).Update(deployment)
-		},
-
-		ListDeployerPodsForFn: func(namespace, deploymentName string) (*kapi.PodList, error) {
-			selector, err := labels.Parse(fmt.Sprintf("%s=%s", deployapi.DeployerPodForDeploymentLabel, deploymentName))
-			if err != nil {
-				return nil, err
-			}
-			return o.kubeClient.Pods(namespace).List(selector, fields.Everything())
-		},
-		DeletePodFn: func(pod *kapi.Pod) error {
-			return o.kubeClient.Pods(pod.Namespace).Delete(pod.Name, nil)
-		},
+	config, ok := resultObj.(*deployapi.DeploymentConfig)
+	if !ok {
+		return fmt.Errorf("%s is not a valid deploymentconfig", o.deploymentConfigName)
 	}
 
 	switch {
 	case o.deployLatest:
-		c := &deployLatestCommand{client: commandClient}
-		err = c.deploy(config, o.out)
+		err = o.deploy(config, o.out)
 	case o.retryDeploy:
-		c := &retryDeploymentCommand{client: commandClient}
-		err = c.retry(config, o.out)
+		err = o.retry(config, o.out)
 	case o.cancelDeploy:
-		c := &cancelDeploymentCommand{client: commandClient}
-		err = c.cancel(config, o.out)
+		err = o.cancel(config, o.out)
 	case o.enableTriggers:
-		t := &triggerEnabler{
-			updateConfig: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-				return o.osClient.DeploymentConfigs(namespace).Update(config)
-			},
-		}
-		err = t.enableTriggers(config, o.out)
+		err = o.reenableTriggers(config, o.out)
 	default:
 		describer := describe.NewLatestDeploymentsDescriber(o.osClient, o.kubeClient, -1)
 		desc, err := describer.Describe(config.Namespace, config.Name)
@@ -224,31 +205,16 @@ func (o DeployOptions) RunDeploy() error {
 	return err
 }
 
-// deployCommandClient abstracts access to the API server.
-type deployCommandClient interface {
-	GetDeployment(namespace, name string) (*kapi.ReplicationController, error)
-	ListDeploymentsForConfig(namespace, configName string) (*kapi.ReplicationControllerList, error)
-	UpdateDeploymentConfig(*deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-	UpdateDeployment(*kapi.ReplicationController) (*kapi.ReplicationController, error)
-
-	ListDeployerPodsFor(namespace, deploymentName string) (*kapi.PodList, error)
-	DeletePod(pod *kapi.Pod) error
-}
-
-// deployLatestCommand can launch new deployments.
-type deployLatestCommand struct {
-	client deployCommandClient
-}
-
 // deploy launches a new deployment unless there's already a deployment
 // process in progress for config.
-func (c *deployLatestCommand) deploy(config *deployapi.DeploymentConfig, out io.Writer) error {
+func (o *DeployOptions) deploy(config *deployapi.DeploymentConfig, out io.Writer) error {
 	deploymentName := deployutil.LatestDeploymentNameForConfig(config)
-	deployment, err := c.client.GetDeployment(config.Namespace, deploymentName)
+	deployment, err := o.kubeClient.ReplicationControllers(config.Namespace).Get(deploymentName)
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return err
+		if kerrors.IsNotFound(err) {
+			return fmt.Errorf("couldn't find deployment %q", deploymentName)
 		}
+		return err
 	} else {
 		// Reject attempts to start a concurrent deployment.
 		status := deployutil.DeploymentStatusFor(deployment)
@@ -258,27 +224,22 @@ func (c *deployLatestCommand) deploy(config *deployapi.DeploymentConfig, out io.
 	}
 
 	config.LatestVersion++
-	_, err = c.client.UpdateDeploymentConfig(config)
+	_, err = o.osClient.DeploymentConfigs(config.Namespace).Update(config)
 	if err == nil {
 		fmt.Fprintf(out, "Started deployment #%d\n", config.LatestVersion)
 	}
 	return err
 }
 
-// retryDeploymentCommand can retry failed deployments.
-type retryDeploymentCommand struct {
-	client deployCommandClient
-}
-
 // retry resets the status of the latest deployment to New, which will cause
 // the deployment to be retried. An error is returned if the deployment is not
 // currently in a failed state.
-func (c *retryDeploymentCommand) retry(config *deployapi.DeploymentConfig, out io.Writer) error {
+func (o *DeployOptions) retry(config *deployapi.DeploymentConfig, out io.Writer) error {
 	if config.LatestVersion == 0 {
 		return fmt.Errorf("no deployments found for %s/%s", config.Namespace, config.Name)
 	}
 	deploymentName := deployutil.LatestDeploymentNameForConfig(config)
-	deployment, err := c.client.GetDeployment(config.Namespace, deploymentName)
+	deployment, err := o.kubeClient.ReplicationControllers(config.Namespace).Get(deploymentName)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return fmt.Errorf("Unable to find the latest deployment (#%d).\nYou can start a new deployment using the --latest option.", config.LatestVersion)
@@ -298,12 +259,12 @@ func (c *retryDeploymentCommand) retry(config *deployapi.DeploymentConfig, out i
 	}
 
 	// Delete the deployer pod as well as the deployment hooks pods, if any
-	pods, err := c.client.ListDeployerPodsFor(config.Namespace, deploymentName)
+	pods, err := o.kubeClient.Pods(config.Namespace).List(deployutil.DeployerPodSelector(deploymentName), fields.Everything())
 	if err != nil {
 		return fmt.Errorf("Failed to list deployer/hook pods for deployment #%d: %v", config.LatestVersion, err)
 	}
 	for _, pod := range pods.Items {
-		err := c.client.DeletePod(&pod)
+		err := o.kubeClient.Pods(pod.Namespace).Delete(pod.Name, kapi.NewDeleteOptions(0))
 		if err != nil {
 			return fmt.Errorf("Failed to delete deployer/hook pod %s for deployment #%d: %v", pod.Name, config.LatestVersion, err)
 		}
@@ -313,21 +274,16 @@ func (c *retryDeploymentCommand) retry(config *deployapi.DeploymentConfig, out i
 	// clear out the cancellation flag as well as any previous status-reason annotation
 	delete(deployment.Annotations, deployapi.DeploymentStatusReasonAnnotation)
 	delete(deployment.Annotations, deployapi.DeploymentCancelledAnnotation)
-	_, err = c.client.UpdateDeployment(deployment)
+	_, err = o.kubeClient.ReplicationControllers(deployment.Namespace).Update(deployment)
 	if err == nil {
 		fmt.Fprintf(out, "retried #%d\n", config.LatestVersion)
 	}
 	return err
 }
 
-// cancelDeploymentCommand cancels the in-progress deployments.
-type cancelDeploymentCommand struct {
-	client deployCommandClient
-}
-
 // cancel cancels any deployment process in progress for config.
-func (c *cancelDeploymentCommand) cancel(config *deployapi.DeploymentConfig, out io.Writer) error {
-	deployments, err := c.client.ListDeploymentsForConfig(config.Namespace, config.Name)
+func (o *DeployOptions) cancel(config *deployapi.DeploymentConfig, out io.Writer) error {
+	deployments, err := o.kubeClient.ReplicationControllers(config.Namespace).List(deployutil.ConfigSelector(config.Name))
 	if err != nil {
 		return err
 	}
@@ -351,7 +307,7 @@ func (c *cancelDeploymentCommand) cancel(config *deployapi.DeploymentConfig, out
 
 			deployment.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
 			deployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledByUser
-			_, err := c.client.UpdateDeployment(&deployment)
+			_, err := o.kubeClient.ReplicationControllers(deployment.Namespace).Update(&deployment)
 			if err == nil {
 				fmt.Fprintf(out, "cancelled deployment #%d\n", config.LatestVersion)
 				anyCancelled = true
@@ -370,14 +326,8 @@ func (c *cancelDeploymentCommand) cancel(config *deployapi.DeploymentConfig, out
 	return nil
 }
 
-// triggerEnabler can enable image triggers for a config.
-type triggerEnabler struct {
-	// updateConfig persists config.
-	updateConfig func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-}
-
-// enableTriggers enables all image triggers and then persists config.
-func (t *triggerEnabler) enableTriggers(config *deployapi.DeploymentConfig, out io.Writer) error {
+// reenableTriggers enables all image triggers and then persists config.
+func (o *DeployOptions) reenableTriggers(config *deployapi.DeploymentConfig, out io.Writer) error {
 	enabled := []string{}
 	for _, trigger := range config.Triggers {
 		if trigger.Type == deployapi.DeploymentTriggerOnImageChange {
@@ -389,45 +339,10 @@ func (t *triggerEnabler) enableTriggers(config *deployapi.DeploymentConfig, out 
 		fmt.Fprintln(out, "no image triggers found to enable")
 		return nil
 	}
-	_, err := t.updateConfig(config.Namespace, config)
+	_, err := o.osClient.DeploymentConfigs(config.Namespace).Update(config)
 	if err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "enabled image triggers: %s\n", strings.Join(enabled, ","))
 	return nil
-}
-
-// deployCommandClientImpl is a pluggable deployCommandClient.
-type deployCommandClientImpl struct {
-	GetDeploymentFn            func(namespace, name string) (*kapi.ReplicationController, error)
-	ListDeploymentsForConfigFn func(namespace, configName string) (*kapi.ReplicationControllerList, error)
-	UpdateDeploymentConfigFn   func(*deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error)
-	UpdateDeploymentFn         func(*kapi.ReplicationController) (*kapi.ReplicationController, error)
-
-	ListDeployerPodsForFn func(namespace, deploymentName string) (*kapi.PodList, error)
-	DeletePodFn           func(pod *kapi.Pod) error
-}
-
-func (c *deployCommandClientImpl) GetDeployment(namespace, name string) (*kapi.ReplicationController, error) {
-	return c.GetDeploymentFn(namespace, name)
-}
-
-func (c *deployCommandClientImpl) ListDeploymentsForConfig(namespace, configName string) (*kapi.ReplicationControllerList, error) {
-	return c.ListDeploymentsForConfigFn(namespace, configName)
-}
-
-func (c *deployCommandClientImpl) UpdateDeploymentConfig(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-	return c.UpdateDeploymentConfigFn(config)
-}
-
-func (c *deployCommandClientImpl) UpdateDeployment(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-	return c.UpdateDeploymentFn(deployment)
-}
-
-func (c *deployCommandClientImpl) ListDeployerPodsFor(namespace, deploymentName string) (*kapi.PodList, error) {
-	return c.ListDeployerPodsForFn(namespace, deploymentName)
-}
-
-func (c *deployCommandClientImpl) DeletePod(pod *kapi.Pod) error {
-	return c.DeletePodFn(pod)
 }

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -172,9 +172,6 @@ func (o *DeployOptions) RunDeploy() error {
 		ResourceTypeOrNameArgs(false, o.deploymentConfigName).
 		SingleResourceType().
 		Do()
-	if r.Err() != nil {
-		return r.Err()
-	}
 	resultObj, err := r.Object()
 	if err != nil {
 		return err
@@ -215,12 +212,11 @@ func (o *DeployOptions) deploy(config *deployapi.DeploymentConfig, out io.Writer
 			return fmt.Errorf("couldn't find deployment %q", deploymentName)
 		}
 		return err
-	} else {
-		// Reject attempts to start a concurrent deployment.
-		status := deployutil.DeploymentStatusFor(deployment)
-		if status != deployapi.DeploymentStatusComplete && status != deployapi.DeploymentStatusFailed {
-			return fmt.Errorf("#%d is already in progress (%s).\nOptionally, you can cancel this deployment using the --cancel option.", config.LatestVersion, status)
-		}
+	}
+	// Reject attempts to start a concurrent deployment.
+	status := deployutil.DeploymentStatusFor(deployment)
+	if status != deployapi.DeploymentStatusComplete && status != deployapi.DeploymentStatusFailed {
+		return fmt.Errorf("#%d is already in progress (%s).\nOptionally, you can cancel this deployment using the --cancel option.", config.LatestVersion, status)
 	}
 
 	config.LatestVersion++

--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -1,15 +1,18 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"sort"
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	ktc "k8s.io/kubernetes/pkg/client/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
 
 	api "github.com/openshift/origin/pkg/api/latest"
+	tc "github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
@@ -24,34 +27,35 @@ func deploymentFor(config *deployapi.DeploymentConfig, status deployapi.Deployme
 // TestCmdDeploy_latestOk ensures that attempts to start a new deployment
 // succeeds given an existing deployment in a terminal state.
 func TestCmdDeploy_latestOk(t *testing.T) {
-	var existingDeployment *kapi.ReplicationController
-	var updatedConfig *deployapi.DeploymentConfig
-
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-			return existingDeployment, nil
-		},
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			updatedConfig = config
-			return config, nil
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			t.Fatalf("unexpected call to UpdateDeployment for %s/%s", deployment.Namespace, deployment.Name)
-			return nil, nil
-		},
-	}
-
-	c := &deployLatestCommand{client: commandClient}
-
 	validStatusList := []deployapi.DeploymentStatus{
 		deployapi.DeploymentStatusComplete,
 		deployapi.DeploymentStatusFailed,
 	}
-
 	for _, status := range validStatusList {
 		config := deploytest.OkDeploymentConfig(1)
-		existingDeployment = deploymentFor(config, status)
-		err := c.deploy(config, ioutil.Discard)
+		var updatedConfig *deployapi.DeploymentConfig
+		osClient := &tc.Fake{}
+		osClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
+			switch a := action.(type) {
+			case ktc.GetAction:
+				return deploymentFor(config, status), nil
+			case ktc.UpdateAction:
+				updatedConfig = a.GetObject().(*deployapi.DeploymentConfig)
+				return updatedConfig, nil
+			}
+			return nil, nil
+		}
+		kubeClient := &ktc.Fake{}
+		kubeClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
+			switch action.(type) {
+			case ktc.GetAction:
+				return deploymentFor(config, status), nil
+			}
+			return nil, nil
+		}
+
+		o := &DeployOptions{osClient: osClient, kubeClient: kubeClient}
+		err := o.deploy(config, ioutil.Discard)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -69,24 +73,6 @@ func TestCmdDeploy_latestOk(t *testing.T) {
 // TestCmdDeploy_latestConcurrentRejection ensures that attempts to start a
 // deployment concurrent with a running deployment are rejected.
 func TestCmdDeploy_latestConcurrentRejection(t *testing.T) {
-	var existingDeployment *kapi.ReplicationController
-
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-			return existingDeployment, nil
-		},
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			t.Fatalf("unexpected call to UpdateDeploymentConfig")
-			return nil, nil
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			t.Fatalf("unexpected call to UpdateDeployment for %s/%s", deployment.Namespace, deployment.Name)
-			return nil, nil
-		},
-	}
-
-	c := &deployLatestCommand{client: commandClient}
-
 	invalidStatusList := []deployapi.DeploymentStatus{
 		deployapi.DeploymentStatusNew,
 		deployapi.DeploymentStatusPending,
@@ -95,8 +81,11 @@ func TestCmdDeploy_latestConcurrentRejection(t *testing.T) {
 
 	for _, status := range invalidStatusList {
 		config := deploytest.OkDeploymentConfig(1)
-		existingDeployment = deploymentFor(config, status)
-		err := c.deploy(config, ioutil.Discard)
+		existingDeployment := deploymentFor(config, status)
+		kubeClient := ktc.NewSimpleFake(existingDeployment)
+		o := &DeployOptions{kubeClient: kubeClient}
+
+		err := o.deploy(config, ioutil.Discard)
 		if err == nil {
 			t.Errorf("expected an error starting deployment with existing status %s", status)
 		}
@@ -106,26 +95,22 @@ func TestCmdDeploy_latestConcurrentRejection(t *testing.T) {
 // TestCmdDeploy_latestLookupError ensures that an error is thrown when
 // existing deployments can't be looked up due to some fatal server error.
 func TestCmdDeploy_latestLookupError(t *testing.T) {
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-			return nil, fmt.Errorf("fatal GetDeployment error")
-		},
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			t.Fatalf("unexpected call to UpdateDeploymentConfig")
-			return nil, nil
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			t.Fatalf("unexpected call to UpdateDeployment for %s/%s", deployment.Namespace, deployment.Name)
-			return nil, nil
-		},
+	kubeClient := &ktc.Fake{}
+	kubeClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
+		switch action.(type) {
+		case ktc.GetAction:
+			return nil, kerrors.NewNotFound("name", "not found")
+		}
+		t.Fatalf("unexpected action: %+v", action)
+		return nil, nil
 	}
 
 	config := deploytest.OkDeploymentConfig(1)
-	c := &deployLatestCommand{client: commandClient}
-	err := c.deploy(config, ioutil.Discard)
+	o := &DeployOptions{kubeClient: kubeClient}
+	err := o.deploy(config, ioutil.Discard)
 
 	if err == nil {
-		t.Fatal("expected an error error")
+		t.Fatal("expected an error")
 	}
 }
 
@@ -134,6 +119,7 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 	deletedPods := []string{}
 	config := deploytest.OkDeploymentConfig(1)
 
+	var updatedDeployment *kapi.ReplicationController
 	existingDeployment := deploymentFor(config, deployapi.DeploymentStatusFailed)
 	existingDeployment.Annotations[deployapi.DeploymentCancelledAnnotation] = deployapi.DeploymentCancelledAnnotationValue
 	existingDeployment.Annotations[deployapi.DeploymentStatusReasonAnnotation] = deployapi.DeploymentCancelledByUser
@@ -144,30 +130,26 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 		{ObjectMeta: kapi.ObjectMeta{Name: "deployerpod"}},
 	}
 
-	var updatedDeployment *kapi.ReplicationController
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
+	kubeClient := &ktc.Fake{}
+	kubeClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
+		switch a := action.(type) {
+		case ktc.GetActionImpl:
 			return existingDeployment, nil
-		},
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			t.Fatalf("unexpected call to UpdateDeploymentConfig")
-			return nil, nil
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			updatedDeployment = deployment
-			return deployment, nil
-		},
-		ListDeployerPodsForFn: func(namespace, name string) (*kapi.PodList, error) {
+		case ktc.UpdateActionImpl:
+			updatedDeployment = a.GetObject().(*kapi.ReplicationController)
+			return updatedDeployment, nil
+		case ktc.ListActionImpl:
 			return &kapi.PodList{Items: existingDeployerPods}, nil
-		},
-		DeletePodFn: func(pod *kapi.Pod) error {
-			deletedPods = append(deletedPods, pod.Name)
-			return nil
-		},
+		case ktc.DeleteActionImpl:
+			deletedPods = append(deletedPods, a.GetName())
+			return nil, nil
+		}
+		t.Fatalf("unexpected action: %+v", action)
+		return nil, nil
 	}
 
-	c := &retryDeploymentCommand{client: commandClient}
-	err := c.retry(config, ioutil.Discard)
+	o := &DeployOptions{kubeClient: kubeClient}
+	err := o.retry(config, ioutil.Discard)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -186,8 +168,9 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 	}
 
 	sort.Strings(deletedPods)
-	if !reflect.DeepEqual(deletedPods, []string{"deployerpod", "posthook", "prehook"}) {
-		t.Fatalf("Not all deployer pods for the failed deployment were deleted")
+	expectedDeletions := []string{"deployerpod", "posthook", "prehook"}
+	if e, a := expectedDeletions, deletedPods; !reflect.DeepEqual(e, a) {
+		t.Fatalf("Not all deployer pods for the failed deployment were deleted.\nEXPECTED: %v\nACTUAL: %v", e, a)
 	}
 
 	if e, a := deployapi.DeploymentStatusNew, deployutil.DeploymentStatusFor(updatedDeployment); e != a {
@@ -198,32 +181,6 @@ func TestCmdDeploy_retryOk(t *testing.T) {
 // TestCmdDeploy_retryRejectNonFailed ensures that attempts to retry a non-
 // failed deployment are rejected.
 func TestCmdDeploy_retryRejectNonFailed(t *testing.T) {
-	var existingDeployment *kapi.ReplicationController
-
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-			return existingDeployment, nil
-		},
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			t.Fatalf("unexpected call to UpdateDeploymentConfig")
-			return nil, nil
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			t.Fatalf("unexpected call to UpdateDeployment")
-			return nil, nil
-		},
-		ListDeployerPodsForFn: func(namespace, deploymentName string) (*kapi.PodList, error) {
-			t.Fatalf("unexpected call to ListDeployerPodsFor")
-			return nil, nil
-		},
-		DeletePodFn: func(pod *kapi.Pod) error {
-			t.Fatalf("unexpected call to DeletePod")
-			return nil
-		},
-	}
-
-	c := &retryDeploymentCommand{client: commandClient}
-
 	invalidStatusList := []deployapi.DeploymentStatus{
 		deployapi.DeploymentStatusNew,
 		deployapi.DeploymentStatusPending,
@@ -233,8 +190,10 @@ func TestCmdDeploy_retryRejectNonFailed(t *testing.T) {
 
 	for _, status := range invalidStatusList {
 		config := deploytest.OkDeploymentConfig(1)
-		existingDeployment = deploymentFor(config, status)
-		err := c.retry(config, ioutil.Discard)
+		existingDeployment := deploymentFor(config, status)
+		kubeClient := ktc.NewSimpleFake(existingDeployment)
+		o := &DeployOptions{kubeClient: kubeClient}
+		err := o.retry(config, ioutil.Discard)
 		if err == nil {
 			t.Errorf("expected an error retrying deployment with status %s", status)
 		}
@@ -245,30 +204,6 @@ func TestCmdDeploy_retryRejectNonFailed(t *testing.T) {
 // for a config result in cancelling all in-progress deployments
 // and none of the completed/faild ones.
 func TestCmdDeploy_cancelOk(t *testing.T) {
-	var (
-		config              *deployapi.DeploymentConfig
-		existingDeployments *kapi.ReplicationControllerList
-		updatedDeployments  []kapi.ReplicationController
-	)
-
-	commandClient := &deployCommandClientImpl{
-		GetDeploymentFn: func(namespace, name string) (*kapi.ReplicationController, error) {
-			t.Fatalf("unexpected call to GetDeployment: %s", name)
-			return nil, nil
-		},
-		ListDeploymentsForConfigFn: func(namespace, configName string) (*kapi.ReplicationControllerList, error) {
-			return existingDeployments, nil
-		},
-		UpdateDeploymentConfigFn: func(config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			t.Fatalf("unexpected call to UpdateDeploymentConfig")
-			return nil, nil
-		},
-		UpdateDeploymentFn: func(deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-			updatedDeployments = append(updatedDeployments, *deployment)
-			return deployment, nil
-		},
-	}
-
 	type existing struct {
 		version      int
 		status       deployapi.DeploymentStatus
@@ -298,18 +233,33 @@ func TestCmdDeploy_cancelOk(t *testing.T) {
 		{3, []existing{{3, deployapi.DeploymentStatusNew, true}, {2, deployapi.DeploymentStatusRunning, true}, {1, deployapi.DeploymentStatusFailed, false}}},
 	}
 
-	c := &cancelDeploymentCommand{client: commandClient}
 	for _, scenario := range scenarios {
-		updatedDeployments = []kapi.ReplicationController{}
-		config = deploytest.OkDeploymentConfig(scenario.version)
-		existingDeployments = &kapi.ReplicationControllerList{}
+		updatedDeployments := []kapi.ReplicationController{}
+		config := deploytest.OkDeploymentConfig(scenario.version)
+		existingDeployments := &kapi.ReplicationControllerList{}
 		for _, e := range scenario.existing {
 			d, _ := deployutil.MakeDeployment(deploytest.OkDeploymentConfig(e.version), api.Codec)
 			d.Annotations[deployapi.DeploymentStatusAnnotation] = string(e.status)
 			existingDeployments.Items = append(existingDeployments.Items, *d)
 		}
 
-		err := c.cancel(config, ioutil.Discard)
+		kubeClient := &ktc.Fake{}
+		kubeClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
+			switch a := action.(type) {
+			case ktc.UpdateActionImpl:
+				updated := a.GetObject().(*kapi.ReplicationController)
+				updatedDeployments = append(updatedDeployments, *updated)
+				return updated, nil
+			case ktc.ListActionImpl:
+				return existingDeployments, nil
+			}
+			t.Fatalf("unexpected action: %+v", action)
+			return nil, nil
+		}
+
+		o := &DeployOptions{kubeClient: kubeClient}
+
+		err := o.cancel(config, ioutil.Discard)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -333,29 +283,35 @@ func TestCmdDeploy_cancelOk(t *testing.T) {
 	}
 }
 
-func TestDeploy_triggerEnable(t *testing.T) {
-	var updated *deployapi.DeploymentConfig
-	triggerEnabler := &triggerEnabler{
-		updateConfig: func(namespace string, config *deployapi.DeploymentConfig) (*deployapi.DeploymentConfig, error) {
-			updated = config
-			return config, nil
-		},
-	}
-
+func TestDeploy_reenableTriggers(t *testing.T) {
 	mktrigger := func() deployapi.DeploymentTriggerPolicy {
 		t := deploytest.OkImageChangeTrigger()
 		t.ImageChangeParams.Automatic = false
 		return t
 	}
-	count := 3
+
+	var updated *deployapi.DeploymentConfig
+
+	osClient := &tc.Fake{}
+	osClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
+		switch a := action.(type) {
+		case ktc.UpdateActionImpl:
+			updated = a.GetObject().(*deployapi.DeploymentConfig)
+			return updated, nil
+		}
+		t.Fatalf("unexpected action: %+v", action)
+		return nil, nil
+	}
 
 	config := deploytest.OkDeploymentConfig(1)
 	config.Triggers = []deployapi.DeploymentTriggerPolicy{}
+	count := 3
 	for i := 0; i < count; i++ {
 		config.Triggers = append(config.Triggers, mktrigger())
 	}
 
-	err := triggerEnabler.enableTriggers(config, ioutil.Discard)
+	o := &DeployOptions{osClient: osClient}
+	err := o.reenableTriggers(config, ioutil.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Support prefixed deploymentConfig name references to allow command
chaining. Refactor the code to use client interfaces. Update all tests
to use fake clients.

Fixes #4182