### PR TITLE
Make output directory symlinks relative links

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -336,7 +336,7 @@ os::build::place_bins() {
 os::build::make_openshift_binary_symlinks() {
   if [[ -f "${OS_LOCAL_BINPATH}/openshift" ]]; then
     for linkname in "${OPENSHIFT_BINARY_SYMLINKS[@]}"; do
-      ln -sf "${OS_LOCAL_BINPATH}/openshift" "${OS_LOCAL_BINPATH}/${linkname}"
+      ln -sf openshift "${OS_LOCAL_BINPATH}/${linkname}"
     done
   fi
 }


### PR DESCRIPTION
When these links contain the full paths of the source directory
then they are not relocatable. They should just refer to
the openshift binary in the same directory.

The most obvious case of this is when the directory that
openshift is built doesn't match the directory inside the
openshift-dev vagrant vm.