### PR TITLE
Wait for the builder service account to get registry secrets in extended tests

### DIFF
--- a/test/extended/builds/forcepull.go
+++ b/test/extended/builds/forcepull.go
@@ -14,8 +14,9 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	exutil "github.com/openshift/origin/test/extended/util"
 	"time"
+
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var (
@@ -55,6 +56,7 @@ var _ = g.BeforeSuite(func() {
 
 var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)", func() {
 	defer g.GinkgoRecover()
+	var oc = exutil.NewCLI("force-pull-s2i", exutil.KubeConfigPath())
 
 	g.Describe("\n FORCE PULL TEST:  Force pull and s2i builder", func() {
 		// corrupt the s2i builder image
@@ -66,10 +68,14 @@ var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)
 			exutil.ResetImage(resetData)
 		})
 
+		g.JustBeforeEach(func() {
+			g.By("waiting for builder service account")
+			err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
 		g.Context("\n FORCE PULL TEST:  when s2i force pull is false and the image is bad", func() {
-			var (
-				oc = exutil.NewCLI("force-pull-s2i-false-env", exutil.KubeConfigPath())
-			)
+
 			g.It("\n FORCE PULL TEST s2i false", func() {
 				fpFalseS2I := exutil.FixturePath("fixtures", "forcepull-false-s2i.json")
 				g.By(fmt.Sprintf("\n%s FORCE PULL TEST s2i false:  calling create on %s", time.Now().Format(time.RFC850), fpFalseS2I))
@@ -83,9 +89,6 @@ var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)
 		})
 
 		g.Context("\n FORCE PULL TEST:  when s2i force pull is true and the image is bad", func() {
-			var (
-				oc = exutil.NewCLI("force-pull-s2i-true-env", exutil.KubeConfigPath())
-			)
 			g.It("\n FORCE PULL TEST s2i true", func() {
 				fpTrueS2I := exutil.FixturePath("fixtures", "forcepull-true-s2i.json")
 				g.By(fmt.Sprintf("\n%s FORCE PULL TEST s2i true:  calling create on %s", time.Now().Format(time.RFC850), fpTrueS2I))
@@ -109,9 +112,6 @@ var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)
 		})
 
 		g.Context("\n FORCE PULL TEST:  when docker force pull is false and the image is bad", func() {
-			var (
-				oc = exutil.NewCLI("force-pull-dock-false-env", exutil.KubeConfigPath())
-			)
 			g.It("\n FORCE PULL TEST dock false", func() {
 				fpFalseDock := exutil.FixturePath("fixtures", "forcepull-false-dock.json")
 				g.By(fmt.Sprintf("\n%s FORCE PULL TEST dock false:  calling create on %s", time.Now().Format(time.RFC850), fpFalseDock))
@@ -125,9 +125,6 @@ var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)
 		})
 
 		g.Context("\n FORCE PULL TEST:  docker when force pull is true and the image is bad", func() {
-			var (
-				oc = exutil.NewCLI("force-pull-dock-true-env", exutil.KubeConfigPath())
-			)
 			g.It("\n FORCE PULL TEST dock true", func() {
 				fpTrueDock := exutil.FixturePath("fixtures", "forcepull-true-dock.json")
 				g.By(fmt.Sprintf("\n%s FORCE PULL TEST dock true:  calling create on %s", time.Now().Format(time.RFC850), fpTrueDock))
@@ -152,9 +149,6 @@ var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)
 		})
 
 		g.Context("\n FORCE PULL TEST:  when custom force pull is false and the image is bad", func() {
-			var (
-				oc = exutil.NewCLI("force-pull-cust-false-env", exutil.KubeConfigPath())
-			)
 			g.It("\nFORCE PULL TEST cust false", func() {
 				fpFalseCust := exutil.FixturePath("fixtures", "forcepull-false-cust.json")
 				g.By(fmt.Sprintf("\n%s FORCE PULL TEST cust false:  calling create on %s", time.Now().Format(time.RFC850), fpFalseCust))
@@ -169,9 +163,6 @@ var _ = g.Describe("forcepull: ForcePull from OpenShift induced builds (vs. sti)
 		})
 
 		g.Context("\n FORCE PULL TEST:  when custom force pull is true and the image is bad", func() {
-			var (
-				oc = exutil.NewCLI("force-pull-cust-true-env", exutil.KubeConfigPath())
-			)
 			g.It("\n FORCE PULL TEST cust true", func() {
 				fpTrueCust := exutil.FixturePath("fixtures", "forcepull-true-cust.json")
 				g.By(fmt.Sprintf("\n%s FORCE PULL TEST cust true:  calling create on %s", time.Now().Format(time.RFC850), fpTrueCust))

--- a/test/extended/builds/sti_env.go
+++ b/test/extended/builds/sti_env.go
@@ -22,6 +22,12 @@ var _ = g.Describe("default: STI build with .sti/environment file", func() {
 		oc                 = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
 	)
 
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
 	g.Describe("Building from a template", func() {
 		g.It(fmt.Sprintf("should create a image from %q template and run it in a pod", stiEnvBuildFixture), func() {
 			oc.SetOutputDir(exutil.TestContext.OutputDir)

--- a/test/extended/fixtures/test-sti-build.json
+++ b/test/extended/fixtures/test-sti-build.json
@@ -18,6 +18,12 @@
     },
     "strategy":{
       "type":"Source",
+      "env": [
+        {
+          "name": "BUILD_LOGLEVEL",
+          "value": "5"
+        }
+      ],
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",


### PR DESCRIPTION
@bparees FYI I hope that this should fix the authentication error when pushing to internal Docker registry. Andy pointed me to end-to-end test where we are doing the same (but using `oc` command ;-).

@ncdc PTAL