### PR TITLE
Port consistency in route creating example

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -181,7 +181,7 @@ service.json
           {
             "protocol": "TCP",
             "port": 27017,
-            "targetPort": 0,
+            "targetPort": 8080,
             "nodePort": 0
           }
         ],


### PR DESCRIPTION
`targetPort` in `service.json` should be the same as `containerPort` in pod.json.