### PR TITLE
Allow cancellation of unscheduled deployments

### DIFF
--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -127,12 +127,7 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 			}
 		}
 
-		// If the deployment is cancelled, terminate any deployer/hook pods.
-		// NOTE: Do not mark the deployment as Failed just yet.
-		// The deployment will be marked as Failed by the deployer pod controller
-		// when the deployer pod failure state is picked up
-		// Also, it will scale down the failed deployment and scale back up
-		// the last successful completed deployment
+		// Handle deployment cancellation.
 		if deployutil.IsDeploymentCancelled(deployment) {
 			deployerPods, err := c.podClient.getDeployerPodsFor(deployment.Namespace, deployment.Name)
 			if err != nil {
@@ -141,14 +136,34 @@ func (c *DeploymentController) Handle(deployment *kapi.ReplicationController) er
 			glog.V(4).Infof("Cancelling %d deployer pods for deployment %s", len(deployerPods), deployutil.LabelForDeployment(deployment))
 			zeroDelay := int64(1)
 			for _, deployerPod := range deployerPods {
-				// Set the ActiveDeadlineSeconds on the pod so it's terminated very soon.
-				if deployerPod.Spec.ActiveDeadlineSeconds == nil || *deployerPod.Spec.ActiveDeadlineSeconds != zeroDelay {
-					deployerPod.Spec.ActiveDeadlineSeconds = &zeroDelay
-					if _, err := c.podClient.updatePod(deployerPod.Namespace, &deployerPod); err != nil {
-						c.recorder.Eventf(deployment, "failedCancellation", "Error cancelling deployer pod %s for deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
-						return fmt.Errorf("couldn't cancel deployer pod %s for deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
+				if deployerPod.Status.Phase == kapi.PodPending {
+					// If the pod hasn't yet been scheduled, just delete it.
+					err := c.podClient.deletePod(deployerPod.Namespace, deployerPod.Name)
+					if err != nil {
+						c.recorder.Eventf(deployment, "failedCancellation", "Error deleting deployer pod %s while cancelling deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
+						return fmt.Errorf("couldn't delete deployer pod %s while cancelling deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
 					}
-					glog.V(4).Infof("Cancelled deployer pod %s for deployment %s", deployerPod.Name, deployutil.LabelForDeployment(deployment))
+					// If we deleted the unscheduled primary deployer pod, just
+					// transition to failed immediately, since the DeployerPodController
+					// has no cleanup to do as the deployment never executed.
+					if deployerPod.Name == deployutil.DeployerPodNameForDeployment(deployment.Name) {
+						nextStatus = deployapi.DeploymentStatusFailed
+					}
+					glog.V(4).Infof("Deleted deployer pod %s while cancelling deployment %s", deployerPod.Name, deployutil.LabelForDeployment(deployment))
+				} else {
+					// Since the deployer pod is already running, set
+					// ActiveDeadlineSeconds on the pod so it's terminated very soon. If
+					// the primary deployer pod has a deadline and doesn't get deleted,
+					// the DeployerPodController will handle failing the deployment and
+					// perfoming any other cleanup.
+					if deployerPod.Spec.ActiveDeadlineSeconds == nil || *deployerPod.Spec.ActiveDeadlineSeconds != zeroDelay {
+						deployerPod.Spec.ActiveDeadlineSeconds = &zeroDelay
+						if _, err := c.podClient.updatePod(deployerPod.Namespace, &deployerPod); err != nil {
+							c.recorder.Eventf(deployment, "failedCancellation", "Error cancelling deployer pod %s for deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
+							return fmt.Errorf("couldn't cancel deployer pod %s for deployment %s: %v", deployerPod.Name, deployutil.LabelForDeployment(deployment), err)
+						}
+						glog.V(4).Infof("Cancelled deployer pod %s for deployment %s", deployerPod.Name, deployutil.LabelForDeployment(deployment))
+					}
 				}
 			}
 			c.recorder.Eventf(deployment, "cancelled", "Cancelled deployment")


### PR DESCRIPTION
Improve the deployment cancellation support by adding the ability to
delete unscheduled/pending deployer pods and fail the deployment. Prior
to this change, deployments with deployer pods could hang forever and
not be cancelled because of the reliance on ActiveDeadlineSeconds (which
only applies to scheduled pods.)

Fixes #4329