### PR TITLE
Improve dind cluster management

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -86,6 +86,19 @@ function check-selinux() {
   fi
 }
 
+IMAGE_REPO="${OS_DIND_IMAGE_REPO:-}"
+IMAGE_TAG="${OS_DIND_IMAGE_TAG:-}"
+function get-image-name() {
+  local name=$1
+
+  echo "${IMAGE_REPO}openshift/dind-${name}${IMAGE_TAG}"
+}
+
+BASE_IMAGE=$(get-image-name base)
+MASTER_IMAGE=$(get-image-name master)
+NODE_IMAGE=$(get-image-name node)
+BUILD_IMAGES="${OS_DIND_BUILD_IMAGES:-1}"
+
 function build-image() {
   local build_root=$1
   local image_name=$2
@@ -93,6 +106,32 @@ function build-image() {
   pushd "${build_root}"
   ${DOCKER_CMD} build -t "${image_name}" .
   popd
+}
+
+function build-images() {
+  # Building images is done by default but can be disabled to allow
+  # separation of image build from cluster creation.
+  if [ "${BUILD_IMAGES}" = "1" ]; then
+    echo "Building container images"
+    if [ "${IMAGE_REPO}" != "" ]; then
+      # Failure to cache is assumed to not be worth failing the build.
+      ${DOCKER_CMD} pull "${BASE_IMAGE}" || true
+      ${DOCKER_CMD} pull "${MASTER_IMAGE}" || true
+      ${DOCKER_CMD} pull "${NODE_IMAGE}" || true
+    fi
+    build-image "${ORIGIN_ROOT}/images/dind/base" "${BASE_IMAGE}"
+    if [ "${IMAGE_REPO}" != "" ]; then
+      # Tag the base image for use by master and node image builds
+      ${DOCKER_CMD} tag "${BASE_IMAGE}" "openshift/dind-base" || true
+    fi
+    build-image "${ORIGIN_ROOT}/images/dind/master" "${MASTER_IMAGE}"
+    build-image "${ORIGIN_ROOT}/images/dind/node" "${NODE_IMAGE}"
+    if [ "${IMAGE_REPO}" != "" ]; then
+      ${DOCKER_CMD} push "${BASE_IMAGE}" || true
+      ${DOCKER_CMD} push "${MASTER_IMAGE}" || true
+      ${DOCKER_CMD} push "${NODE_IMAGE}" || true
+    fi
+  fi
 }
 
 function get-docker-ip() {
@@ -141,28 +180,21 @@ function start() {
   sudo sysctl -w net.bridge.bridge-nf-call-iptables=0
   ensure-loopback-for-dind "${NUM_NODES}"
 
-  echo "Building containers"
-  local master_image="openshift/dind-master"
-  local node_image="openshift/dind-node"
-  build-image "${ORIGIN_ROOT}/images/dind/master" "${master_image}"
-  build-image "${ORIGIN_ROOT}/images/dind/node" "${node_image}"
+  build-images
 
   ## Create containers
   echo "Launching containers"
   local base_run_cmd="${DOCKER_CMD} run -dt -v ${ORIGIN_ROOT}:${DEPLOYED_ROOT}"
 
-  # Ensure the deployed root is usable in the container
-  sudo chcon -Rt svirt_sandbox_file_t $(pwd)
-
   local master_cid=$(${base_run_cmd} --name="${MASTER_NAME}" \
-    --hostname="${MASTER_NAME}" "${master_image}")
+    --hostname="${MASTER_NAME}" "${MASTER_IMAGE}")
   local master_ip=$(get-docker-ip "${master_cid}")
 
   local node_cids=()
   local node_ips=()
   for name in "${NODE_NAMES[@]}"; do
     local cid=$(${base_run_cmd} --privileged --name="${name}" \
-      --hostname="${name}" "${node_image}")
+      --hostname="${name}" "${NODE_IMAGE}")
     node_cids+=( "${cid}" )
     node_ips+=( $(get-docker-ip "${cid}") )
   done
@@ -237,6 +269,10 @@ case "${1:-""}" in
     stop
     start
     ;;
+  build-images)
+    BUILD_IMAGES=1
+    build-images
+    ;;
   wipe)
     wipe-config
     ;;
@@ -246,6 +282,6 @@ case "${1:-""}" in
     start
     ;;
   *)
-    echo "Usage: $0 {start|stop|restart|wipe|wipe-restart}"
+    echo "Usage: $0 {start|stop|restart|build-images|wipe|wipe-restart}"
     exit 2
 esac

--- a/hack/dind/init.sh
+++ b/hack/dind/init.sh
@@ -16,6 +16,9 @@ NODE_NAMES=( $(eval echo ${NODE_PREFIX}{1..${NUM_NODES}}) )
 
 DOCKER_CMD=${DOCKER_CMD:-"sudo docker"}
 
+DEPLOYED_ROOT="/data"
+SCRIPT_ROOT="${DEPLOYED_ROOT}/hack/dind"
+
 os::dind::set-dind-env() {
   # Set up the KUBECONFIG environment variable for use by oc
   local deployed_root=$1

--- a/hack/dind/kill-docker.sh
+++ b/hack/dind/kill-docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Ensure that docker is gracefully killed.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+pid_file=/var/run/docker.pid
+pid=$(cat "${pid_file}")
+if [ -f "${pid_file}" ]; then
+  kill "${pid}"
+  echo "Waiting for docker daemon to exit"
+  COUNTER=0
+  TIMEOUT=60
+  while [ -d "/proc/${pid}" ]; do
+    if [[ "${COUNTER}" -lt "${TIMEOUT}" ]]; then
+      COUNTER=$((COUNTER + 1))
+      echo -n '.'
+      sleep 1
+    else
+      echo -e "\nError: Timeout waiting for the docker daemon to exit"
+      exit 1
+    fi
+  done
+  echo -e '\nDone'
+fi

--- a/images/dind/base/Dockerfile
+++ b/images/dind/base/Dockerfile
@@ -1,0 +1,11 @@
+#
+# This is the base image for an openshift docker-in-docker dev cluster.
+#
+# The standard name for this image is openshift/dind-base
+#
+
+FROM fedora:22
+
+RUN dnf -y update && dnf -y install supervisor git golang hg tar make \
+    hostname bind-utils iproute iputils which procps-ng \
+    && dnf clean all

--- a/images/dind/master/Dockerfile
+++ b/images/dind/master/Dockerfile
@@ -4,11 +4,7 @@
 # The standard name for this image is openshift/dind-master
 #
 
-FROM fedora:22
-
-RUN dnf -y update && dnf -y install supervisor git golang hg tar make \
-    hostname bind-utils iproute iputils which procps-ng \
-    && dnf clean all
+FROM openshift/dind-base
 
 ADD supervisord.conf /etc/supervisord.conf
 

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -4,7 +4,7 @@
 # The standard name for this image is openshift/dind-node
 #
 
-FROM openshift/dind-master
+FROM openshift/dind-base
 
 RUN dnf -y update && dnf -y install docker openvswitch bridge-utils ethtool \
     && dnf clean all

--- a/images/dind/node/supervisord.conf
+++ b/images/dind/node/supervisord.conf
@@ -22,6 +22,7 @@ startsecs=10
 stderr_events_enabled=true
 stdout_events_enabled=true
 environment=PORT="4444",DOCKER_DAEMON_ARGS=""
+autorestart=false
 
 [program:openvswitch]
 command=/usr/share/openvswitch/scripts/ovs-ctl start --system-id=random


### PR DESCRIPTION
Experience running ci jobs against dind clusters suggested the addition of image caching to speed up builds and better handling of docker-in-docker daemon shutdown.