### PR TITLE
Use server side resource list in the client

### DIFF
--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -88,6 +88,30 @@ var UserResources = []string{
 	"pods",
 }
 
+// RemoveFromUserResources removes types from the user facing resource list.  This is used
+// to allow the client to find which types are supported by the server when making calls
+// to the alias "all".
+func RemoveFromUserResources(types ...string) {
+	newUserResources := []string{}
+	for _, r := range UserResources {
+		if excludeUserResource(r, types...) {
+			continue
+		}
+		newUserResources = append(newUserResources, r)
+	}
+	UserResources = newUserResources
+}
+
+// excludeUserResource returns true if resource is in exclusions.
+func excludeUserResource(resource string, exclusions ...string) bool {
+	for _, e := range exclusions {
+		if resource == e {
+			return true
+		}
+	}
+	return false
+}
+
 // OriginKind returns true if OpenShift owns the kind described in a given apiVersion.
 func OriginKind(kind, apiVersion string) bool {
 	return originTypes.Has(kind)

--- a/pkg/cmd/server/origin/handlers.go
+++ b/pkg/cmd/server/origin/handlers.go
@@ -42,6 +42,7 @@ func indexAPIPaths(handler http.Handler) http.Handler {
 				"/oapi",
 				"/oapi/v1",
 				"/swaggerapi/",
+				"/userresources",
 			}}
 			// TODO it would be nice if apiserver.writeRawJSON was not private
 			output, err := json.MarshalIndent(object, "", "  ")

--- a/pkg/cmd/util/userresources.go
+++ b/pkg/cmd/util/userresources.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/openshift/origin/pkg/client"
+)
+
+// GetUserResources queries the server for user resources.
+func GetUserResources(c *client.Client) ([]string, error) {
+	result := c.RESTClient.Get().AbsPath("/userresources").Do()
+	if result.Error() != nil {
+		return []string{}, result.Error()
+	}
+	raw, _ := result.Raw()
+	resourceString := string(raw)
+	return strings.Split(resourceString, ","), nil
+}
+
+// IsBuildEnabled returns true if both builds and buildConfigs are enabled in the resources slice.
+func IsBuildEnabled(resources []string) bool {
+	builds := false
+	buildConfigs := false
+
+	for _, s := range resources {
+		if s == "builds" {
+			builds = true
+		}
+		if s == "buildConfigs" {
+			buildConfigs = true
+		}
+	}
+
+	return builds && buildConfigs
+}


### PR DESCRIPTION
to determine what builders to use in the graph and what types the "all" alias should include.

@liggitt - if this looks reasonable then I'll write up tests for the new methods.

```
# openshift server
[vagrant@openshiftdev origin]$ oc get all
NAME                TYPE      SOURCE
ruby-sample-build   Docker    git://github.com/openshift/ruby-hello-world.git
NAME                  TYPE      STATUS    POD
ruby-sample-build-1   Docker    New       ruby-sample-build-1-build
NAME                 DOCKER REPO                 TAGS      UPDATED
origin-ruby-sample                                         
ruby-20-centos7      openshift/ruby-20-centos7   latest    33 minutes ago
NAME       TRIGGERS                    LATEST VERSION
database   ConfigChange                1
frontend   ConfigChange, ImageChange   0
CONTROLLER   CONTAINER(S)               IMAGE(S)                     SELECTOR                                                        REPLICAS   AGE
database-1   ruby-helloworld-database   openshift/mysql-55-centos7   deployment=database-1,deploymentconfig=database,name=database   1          33m
NAME         HOST/PORT         PATH      SERVICE    LABELS                                      TLS TERMINATION
route-edge   www.example.com             frontend   template=application-template-dockerbuild   edge
NAME         CLUSTER_IP     EXTERNAL_IP   PORT(S)    SELECTOR        AGE
database     172.30.31.56   <none>        5434/TCP   name=database   33m
frontend     172.30.2.166   <none>        5432/TCP   name=frontend   33m
kubernetes   172.30.0.1     <none>        443/TCP    <none>          21h
NAME               READY     STATUS    RESTARTS   AGE
database-1-tps0t   1/1       Running   0          33m

# aes server
[vagrant@openshiftdev origin]$ oc get all
NAME                 DOCKER REPO                 TAGS      UPDATED
origin-ruby-sample                                         
ruby-20-centos7      openshift/ruby-20-centos7   latest    33 minutes ago
NAME       TRIGGERS                    LATEST VERSION
database   ConfigChange                1
frontend   ConfigChange, ImageChange   0
CONTROLLER   CONTAINER(S)               IMAGE(S)                     SELECTOR                                                        REPLICAS   AGE
database-1   ruby-helloworld-database   openshift/mysql-55-centos7   deployment=database-1,deploymentconfig=database,name=database   1          33m
NAME         HOST/PORT         PATH      SERVICE    LABELS                                      TLS TERMINATION
route-edge   www.example.com             frontend   template=application-template-dockerbuild   edge
NAME         CLUSTER_IP     EXTERNAL_IP   PORT(S)    SELECTOR        AGE
database     172.30.31.56   <none>        5434/TCP   name=database   33m
frontend     172.30.2.166   <none>        5432/TCP   name=frontend   33m
kubernetes   172.30.0.1     <none>        443/TCP    <none>          21h
NAME               READY     STATUS    RESTARTS   AGE
database-1-tps0t   1/1       Running   0          33m
```