### PR TITLE
Support additional source secret files in builds

### DIFF
--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	bld "github.com/openshift/origin/pkg/build/builder"
 	"github.com/openshift/origin/pkg/build/builder/cmd/scmauth"
 	dockerutil "github.com/openshift/origin/pkg/cmd/util/docker"
+	"github.com/openshift/origin/pkg/generate/git"
 )
 
 type builder interface {
@@ -26,7 +28,7 @@ type factoryFunc func(
 
 // run is responsible for preparing environment for actual build.
 // It accepts factoryFunc and an ordered array of SCMAuths.
-func run(builderFactory factoryFunc, scmAuths []scmauth.SCMAuth) {
+func run(builderFactory factoryFunc) {
 	client, endpoint, err := dockerutil.NewHelper().GetClient()
 	if err != nil {
 		glog.Fatalf("Error obtaining docker client: %v", err)
@@ -38,6 +40,11 @@ func run(builderFactory factoryFunc, scmAuths []scmauth.SCMAuth) {
 		glog.Fatalf("Unable to parse build: %v", err)
 	}
 	if build.Spec.Source.SourceSecret != nil {
+		sourceURL, err := git.ParseRepository(build.Spec.Source.Git.URI)
+		if err != nil {
+			glog.Fatalf("Cannot parse build URL: %s", build.Spec.Source.Git.URI)
+		}
+		scmAuths := auths(sourceURL)
 		if err := setupSourceSecret(build.Spec.Source.SourceSecret.Name, scmAuths); err != nil {
 			glog.Fatalf("Cannot setup secret file for accessing private repository: %v", err)
 		}
@@ -85,51 +92,55 @@ func setupSourceSecret(sourceSecretName string, scmAuths []scmauth.SCMAuth) erro
 	if err != nil {
 		return err
 	}
-	found := false
 
-SCMAuthLoop:
-	for _, scmAuth := range scmAuths {
-		glog.V(3).Infof("Checking for '%s' in secret '%s'", scmAuth.Name(), sourceSecretName)
-		for _, file := range files {
-			if file.Name() == scmAuth.Name() {
-				glog.Infof("Using '%s' from secret '%s'", scmAuth.Name(), sourceSecretName)
-				if err := scmAuth.Setup(sourceSecretDir); err != nil {
-					glog.Warningf("Error setting up '%s': %v", scmAuth.Name(), err)
-					continue
-				}
-				found = true
-				break SCMAuthLoop
+	// Filter the list of SCMAuths based on the secret files that are present
+	scmAuthsPresent := map[string]scmauth.SCMAuth{}
+	for _, file := range files {
+		glog.V(3).Infof("Finding auth for %q in secret %q", file.Name(), sourceSecretName)
+		for _, scmAuth := range scmAuths {
+			if scmAuth.Handles(file.Name()) {
+				glog.V(3).Infof("Found SCMAuth %q to handle %q", scmAuth.Name(), file.Name())
+				scmAuthsPresent[scmAuth.Name()] = scmAuth
 			}
 		}
 	}
-	if !found {
-		return fmt.Errorf("the provided secret '%s' did not have any of the supported keys %v",
-			sourceSecretName, getSCMNames(scmAuths))
+
+	if len(scmAuthsPresent) == 0 {
+		return fmt.Errorf("no auth handler was found for the provided secret %q",
+			sourceSecretName)
 	}
+
+	for name, auth := range scmAuthsPresent {
+		glog.V(3).Infof("Setting up SCMAuth %q", name)
+		if err := auth.Setup(sourceSecretDir); err != nil {
+			// If an error occurs during setup, fail the build
+			return fmt.Errorf("cannot set up source authentication method %q: %v", name, err)
+		}
+	}
+
 	return nil
 }
 
-func getSCMNames(scmAuths []scmauth.SCMAuth) string {
-	var names string
-	for _, scmAuth := range scmAuths {
-		if len(names) > 0 {
-			names += ", "
-		}
-		names += scmAuth.Name()
+func auths(sourceURL *url.URL) []scmauth.SCMAuth {
+	auths := []scmauth.SCMAuth{
+		&scmauth.SSHPrivateKey{},
+		&scmauth.UsernamePassword{SourceURL: *sourceURL},
+		&scmauth.CACert{SourceURL: *sourceURL},
+		&scmauth.GitConfig{},
 	}
-	return names
+	return auths
 }
 
 // RunDockerBuild creates a docker builder and runs its build
 func RunDockerBuild() {
 	run(func(client bld.DockerClient, sock string, build *api.Build) builder {
 		return bld.NewDockerBuilder(client, build)
-	}, []scmauth.SCMAuth{&scmauth.SSHPrivateKey{}})
+	})
 }
 
 // RunSTIBuild creates a STI builder and runs its build
 func RunSTIBuild() {
 	run(func(client bld.DockerClient, sock string, build *api.Build) builder {
 		return bld.NewSTIBuilder(client, sock, build)
-	}, []scmauth.SCMAuth{&scmauth.SSHPrivateKey{}})
+	})
 }

--- a/pkg/build/builder/cmd/scmauth/cacert.go
+++ b/pkg/build/builder/cmd/scmauth/cacert.go
@@ -1,0 +1,46 @@
+package scmauth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	CACertName   = "ca.crt"
+	CACertConfig = `# SSL cert
+[http]
+   sslCAInfo = %[1]s
+`
+)
+
+// CACert implements SCMAuth interface for using a custom certificate authority
+type CACert struct {
+	SourceURL url.URL
+}
+
+// Setup creates a .gitconfig fragment that points to the given ca.crt
+func (s CACert) Setup(baseDir string) error {
+	if strings.ToLower(s.SourceURL.Scheme) != "https" {
+		return nil
+	}
+	gitconfig, err := ioutil.TempFile("", "ca.crt.")
+	if err != nil {
+		return err
+	}
+	defer gitconfig.Close()
+	gitconfig.WriteString(fmt.Sprintf(CACertConfig, filepath.Join(baseDir, CACertName)))
+	return ensureGitConfigIncludes(gitconfig.Name())
+}
+
+// Name returns the name of this auth method.
+func (_ CACert) Name() string {
+	return CACertName
+}
+
+// Handles returns true if the secret is a CA certificate
+func (_ CACert) Handles(name string) bool {
+	return name == CACertName
+}

--- a/pkg/build/builder/cmd/scmauth/gitconfig.go
+++ b/pkg/build/builder/cmd/scmauth/gitconfig.go
@@ -1,0 +1,25 @@
+package scmauth
+
+import (
+	"path/filepath"
+)
+
+const GitConfigName = "gitconfig"
+
+// GitConfig implements SCMAuth interface for using a custom .gitconfig file
+type GitConfig struct{}
+
+// Setup adds the secret .gitconfig as an include to the .gitconfig file to be used in the build
+func (_ GitConfig) Setup(baseDir string) error {
+	return ensureGitConfigIncludes(filepath.Join(baseDir, GitConfigName))
+}
+
+// Name returns the name of this auth method.
+func (_ GitConfig) Name() string {
+	return GitConfigName
+}
+
+// Handles returns true if the secret file is a gitconfig
+func (_ GitConfig) Handles(name string) bool {
+	return name == GitConfigName
+}

--- a/pkg/build/builder/cmd/scmauth/password.go
+++ b/pkg/build/builder/cmd/scmauth/password.go
@@ -1,0 +1,121 @@
+package scmauth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/origin/pkg/util/file"
+)
+
+const (
+	DefaultUsername      = "builder"
+	UsernamePasswordName = "password"
+	UsernameSecret       = "username"
+	PasswordSecret       = "password"
+	TokenSecret          = "token"
+	UserPassGitConfig    = `# credential git config
+[credential]
+   helper = store --file=%s
+`
+)
+
+// UsernamePassword implements SCMAuth interface for using Username and Password credentials
+type UsernamePassword struct {
+	SourceURL url.URL
+}
+
+// Setup creates a gitconfig fragment that includes a substitution URL with the username/password
+// included in the URL
+func (u UsernamePassword) Setup(baseDir string) error {
+
+	// Only apply to https and http URLs
+	if scheme := strings.ToLower(u.SourceURL.Scheme); scheme != "http" && scheme != "https" {
+		return nil
+	}
+
+	// Determine username
+	// 1. Look for a username secret
+	username, err := readSecret(baseDir, UsernameSecret)
+	if err != nil {
+		return err
+	}
+	// 2. If not provided, look at the username in the URL
+	if username == "" && u.SourceURL.User != nil {
+		username = u.SourceURL.User.Username()
+	}
+	// 3. If still not found, use a default username
+	if username == "" {
+		username = DefaultUsername
+	}
+
+	// Determine password
+	// 1. Look for a token secret
+	password, err := readSecret(baseDir, TokenSecret)
+	if err != nil {
+		return err
+	}
+	// 2. Look for a password secret
+	if password == "" {
+		password, err = readSecret(baseDir, PasswordSecret)
+		if err != nil {
+			return err
+		}
+	}
+	// 3. Look for a password in the URL
+	if password == "" && u.SourceURL.User != nil {
+		password, _ = u.SourceURL.User.Password()
+	}
+
+	gitcredentials, err := ioutil.TempFile("", "gitcredentials.")
+	if err != nil {
+		return err
+	}
+	defer gitcredentials.Close()
+	gitconfig, err := ioutil.TempFile("", "gitcredentialscfg.")
+	if err != nil {
+		return err
+	}
+	defer gitconfig.Close()
+
+	usernamePasswordURL := u.SourceURL
+	usernamePasswordURL.User = url.UserPassword(username, password)
+	fmt.Fprintf(gitconfig, UserPassGitConfig, gitcredentials.Name())
+	fmt.Fprintf(gitcredentials, usernamePasswordURL.String())
+
+	return ensureGitConfigIncludes(gitconfig.Name())
+}
+
+// Name returns the name of this auth method.
+func (_ UsernamePassword) Name() string {
+	return UsernamePasswordName
+}
+
+// Handles returns true if a username, password or token secret is present
+func (_ UsernamePassword) Handles(name string) bool {
+	switch name {
+	case UsernameSecret, PasswordSecret, TokenSecret:
+		return true
+	}
+	return false
+}
+
+// readSecret reads the contents of a secret file
+func readSecret(baseDir, fileName string) (string, error) {
+	path := filepath.Join(baseDir, fileName)
+	lines, err := file.ReadLines(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	// If the file is empty, simply return empty string
+	if len(lines) == 0 {
+		return "", nil
+	}
+	return lines[0], nil
+}

--- a/pkg/build/builder/cmd/scmauth/scmauth.go
+++ b/pkg/build/builder/cmd/scmauth/scmauth.go
@@ -4,6 +4,12 @@ package scmauth
 // which are responsible for setting up the credentials to be used when accessing
 // private repository.
 type SCMAuth interface {
+	// Name is the name of the authentication method for use in log and error messages
 	Name() string
+
+	// Handles returns true if this authentication method handles a file with the given name
+	Handles(name string) bool
+
+	// Setup lays down the required files for this authentication method to work
 	Setup(baseDir string) error
 }

--- a/pkg/build/builder/cmd/scmauth/sshkey.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey.go
@@ -38,3 +38,8 @@ func (_ SSHPrivateKey) Setup(baseDir string) error {
 func (_ SSHPrivateKey) Name() string {
 	return SSHPrivateKeyMethodName
 }
+
+// Handles returns true if the file is an SSH private key
+func (_ SSHPrivateKey) Handles(name string) bool {
+	return name == SSHPrivateKeyMethodName
+}

--- a/pkg/build/builder/cmd/scmauth/util.go
+++ b/pkg/build/builder/cmd/scmauth/util.go
@@ -1,0 +1,54 @@
+package scmauth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/origin/pkg/util/file"
+)
+
+func createGitConfig(includePath string) error {
+	tempDir, err := ioutil.TempDir("", "git")
+	if err != nil {
+		return err
+	}
+	gitconfig := filepath.Join(tempDir, ".gitconfig")
+	content := fmt.Sprintf("[include]\npath = %s\n", includePath)
+	if err := ioutil.WriteFile(gitconfig, []byte(content), 0600); err != nil {
+		return err
+	}
+	// The GIT_CONFIG variable won't affect regular git operation
+	// therefore the HOME variable needs to be set so git can pick up
+	// .gitconfig from that location. The GIT_CONFIG variable is still used
+	// to track the location of the GIT_CONFIG for multiple SCMAuth objects.
+	os.Setenv("HOME", tempDir)
+	os.Setenv("GIT_CONFIG", gitconfig)
+	return nil
+}
+
+// ensureGitConfigIncludes ensures that the OS env var GIT_CONFIG is set and
+// that it points to a file that has an include statement for the given path
+func ensureGitConfigIncludes(path string) error {
+	gitconfig := os.Getenv("GIT_CONFIG")
+	if gitconfig == "" {
+		return createGitConfig(path)
+	}
+
+	lines, err := file.ReadLines(gitconfig)
+	if err != nil {
+		return err
+	}
+	for _, line := range lines {
+		// If include already exists, return with no error
+		if line == fmt.Sprintf("path = %s", path) {
+			return nil
+		}
+	}
+
+	lines = append(lines, fmt.Sprintf("path = %s", path))
+	content := []byte(strings.Join(lines, "\n"))
+	return ioutil.WriteFile(gitconfig, content, 0644)
+}

--- a/pkg/util/file/doc.go
+++ b/pkg/util/file/doc.go
@@ -1,0 +1,2 @@
+// Package file implements utility functions used to work with arbitrary files.
+package file

--- a/pkg/util/file/fileutil.go
+++ b/pkg/util/file/fileutil.go
@@ -1,0 +1,22 @@
+package file
+
+import (
+	"bufio"
+	"os"
+)
+
+// ReadLines reads the content of the given file into a string slice
+func ReadLines(fileName string) ([]string, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}


### PR DESCRIPTION
Adds support for the following keys inside a source secret:

```
ssh-privatekey - private ssh key (existing)
username - git username
password - git password
token - git password (overrides password)
ca.crt - CA cert
gitconfig - user's own gitconfig
```

For each of:
- user name/password/token
- ca.crt 
- gitconfig 

a partial .gitconfig will be generated and included in a larger .gitconfig. If the user also supplies their own .gitconfig, then it will be merged with the fragments generated for password and ssl-cert. The larger gitconfig will simply include the other files:

```
[include]
path = [path to password fragment]
path = [path to ssl-cert fragment]
path = [path to user-supplied gitconfig]
```