### PR TITLE
buildchain: Fix resource shortcut

### DIFF
--- a/pkg/cmd/experimental/buildchain/buildchain.go
+++ b/pkg/cmd/experimental/buildchain/buildchain.go
@@ -185,7 +185,7 @@ func buildChainInput(input string) (string, string, error) {
 	case 1:
 	case 2:
 		resourceType := resource[0]
-		if resourceType != "ist" && resourceType != "imagestreamtag" {
+		if resourceType != "istag" && resourceType != "imagestreamtag" {
 			return "", "", fmt.Errorf("invalid resource type %q", resourceType)
 		}
 	default:


### PR DESCRIPTION
Conforms to our shortcut for imagestreamtag (https://github.com/openshift/origin/blob/4ab3ac0715f557f9504786daaeaf45bffb64fe6c/pkg/cmd/util/clientcmd/factory.go#L250)