### PR TITLE
Skip second validation in when creating dockercfg secret

### DIFF
--- a/pkg/cmd/cli/secrets/dockercfg.go
+++ b/pkg/cmd/cli/secrets/dockercfg.go
@@ -116,10 +116,6 @@ func (o CreateDockerConfigOptions) CreateDockerSecret() error {
 }
 
 func (o CreateDockerConfigOptions) MakeDockerSecret() (*api.Secret, error) {
-	if err := o.Validate(); err != nil {
-		return nil, err
-	}
-
 	dockercfgAuth := credentialprovider.DockerConfigEntry{
 		Username: o.Username,
 		Password: o.Password,


### PR DESCRIPTION
While working on the new source secret I've noticed that we are doing the validation multiple times in a row. Is that needed ?
@deads2k 