### PR TITLE
Allow origin clientcmd to use kubeconfig

### DIFF
--- a/pkg/cmd/util/clientcmd/clientcmd.go
+++ b/pkg/cmd/util/clientcmd/clientcmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client"
+	"k8s.io/kubernetes/pkg/client/clientcmd"
 
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
@@ -26,6 +27,12 @@ type Config struct {
 	KubernetesAddr flagtypes.Addr
 	// CommonConfig is the shared base config for both the OpenShift config and Kubernetes config
 	CommonConfig kclient.Config
+	// Namespace is the namespace to act in
+	Namespace string
+
+	// If set, allow kubeconfig file loading
+	FromFile     bool
+	clientConfig clientcmd.ClientConfig
 }
 
 // NewConfig returns a new configuration
@@ -51,7 +58,11 @@ func (cfg *Config) Bind(flags *pflag.FlagSet) {
 	flags.Var(&cfg.MasterAddr, "master", "The address the master can be reached on (host, host:port, or URL).")
 	flags.Var(&cfg.KubernetesAddr, "kubernetes", "The address of the Kubernetes server (host, host:port, or URL). If omitted defaults to the master.")
 
-	BindClientConfigSecurityFlags(&cfg.CommonConfig, flags)
+	if cfg.FromFile {
+		cfg.clientConfig = DefaultClientConfig(flags)
+	} else {
+		BindClientConfigSecurityFlags(&cfg.CommonConfig, flags)
+	}
 }
 
 func EnvVars(host string, caData []byte, insecure bool, bearerTokenFile string) []api.EnvVar {
@@ -76,6 +87,30 @@ func EnvVars(host string, caData []byte, insecure bool, bearerTokenFile string) 
 func (cfg *Config) bindEnv() error {
 	var err error
 
+	// callers may not use the config file if they have specified a master directly
+	_, masterSet := util.GetEnv("OPENSHIFT_MASTER")
+	specifiedMaster := masterSet || cfg.MasterAddr.Provided
+
+	if cfg.clientConfig != nil && !specifiedMaster {
+		clientConfig, err := cfg.clientConfig.ClientConfig()
+		if err != nil {
+			return err
+		}
+		cfg.CommonConfig = *clientConfig
+		cfg.Namespace, _, err = cfg.clientConfig.Namespace()
+		if err != nil {
+			return err
+		}
+		if !cfg.MasterAddr.Provided {
+			cfg.MasterAddr.Set(cfg.CommonConfig.Host)
+		}
+		if !cfg.KubernetesAddr.Provided {
+			cfg.KubernetesAddr.Set(cfg.CommonConfig.Host)
+		}
+		return nil
+	}
+
+	// Legacy path - preserve env vars set on pods that previously were honored.
 	if value, ok := util.GetEnv("KUBERNETES_MASTER"); ok && !cfg.KubernetesAddr.Provided {
 		cfg.KubernetesAddr.Set(value)
 	}


### PR DESCRIPTION
Enables commands that use the old syntax to switch over to using
a kubeconfig (or in-cluster kubeconfig) behavior.

Extracted from #4421