### PR TITLE
Preserve permissions during image build copy

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -33,21 +33,21 @@ echo " image:   $(basename ${OS_IMAGE_RELEASE_TAR})"
 imagedir="_output/imagecontext"
 rm -rf "${imagedir}"
 mkdir -p "${imagedir}"
-tar xzf "${OS_PRIMARY_RELEASE_TAR}" -C "${imagedir}"
-tar xzf "${OS_IMAGE_RELEASE_TAR}" -C "${imagedir}"
+tar xzpf "${OS_PRIMARY_RELEASE_TAR}" -C "${imagedir}"
+tar xzpf "${OS_IMAGE_RELEASE_TAR}" -C "${imagedir}"
 
 # Copy primary binaries to the appropriate locations.
-cp -f "${imagedir}/openshift" images/origin/bin
-cp -f "${imagedir}/openshift" images/router/haproxy/bin
-cp -f "${imagedir}/openshift" images/ipfailover/keepalived/bin
-cp -f "${imagedir}/openshift" images/router/f5/bin
+cp -pf "${imagedir}/openshift" images/origin/bin
+cp -pf "${imagedir}/openshift" images/router/haproxy/bin
+cp -pf "${imagedir}/openshift" images/ipfailover/keepalived/bin
+cp -pf "${imagedir}/openshift" images/router/f5/bin
 
 # Copy image binaries to the appropriate locations.
-cp -f "${imagedir}/pod" images/pod/bin
-cp -f "${imagedir}/hello-openshift" examples/hello-openshift/bin
-cp -f "${imagedir}/deployment"      examples/deployment/bin
-cp -f "${imagedir}/gitserver"       examples/gitserver/bin
-cp -f "${imagedir}/dockerregistry"  images/dockerregistry/bin
+cp -pf "${imagedir}/pod" images/pod/bin
+cp -pf "${imagedir}/hello-openshift" examples/hello-openshift/bin
+cp -pf "${imagedir}/deployment"      examples/deployment/bin
+cp -pf "${imagedir}/gitserver"       examples/gitserver/bin
+cp -pf "${imagedir}/dockerregistry"  images/dockerregistry/bin
 
 # builds an image and tags it two ways - with latest, and with the release tag
 function image {


### PR DESCRIPTION
When running as non-root, it's possible that permissions won't get 
changed as the user copies binaries.  Use -p to ensure that it happens
on tar and cp (it will fail if permissions can't be copied).

Extracted from #4421