### PR TITLE
Disable duplicate routes in the router

### DIFF
--- a/pkg/client/cache/eventqueue.go
+++ b/pkg/client/cache/eventqueue.go
@@ -326,10 +326,22 @@ func (eq *EventQueue) Replace(objects []interface{}) error {
 	return nil
 }
 
-// NewEventQueue returns a new EventQueue ready for action.
+// NewEventQueue returns a new EventQueue.
 func NewEventQueue(keyFn kcache.KeyFunc) *EventQueue {
 	q := &EventQueue{
 		store:  kcache.NewStore(keyFn),
+		events: map[string]watch.EventType{},
+		queue:  []string{},
+		keyFn:  keyFn,
+	}
+	q.cond.L = &q.lock
+	return q
+}
+
+// NewEventQueueForStore returns a new EventQueue that uses the provided store.
+func NewEventQueueForStore(keyFn kcache.KeyFunc, store kcache.Store) *EventQueue {
+	q := &EventQueue{
+		store:  store,
 		events: map[string]watch.EventType{},
 		queue:  []string{},
 		keyFn:  keyFn,

--- a/plugins/router/template/plugin.go
+++ b/plugins/router/template/plugin.go
@@ -17,8 +17,23 @@ import (
 // TemplatePlugin implements the router.Plugin interface to provide
 // a template based, backend-agnostic router.
 type TemplatePlugin struct {
-	Router router
+	Router       router
+	HostForRoute func(*routeapi.Route) string
+	hostToRoute  HostToRouteMap
+	routeToHost  RouteToHostMap
 }
+
+func newDefaultTemplatePlugin(router router) *TemplatePlugin {
+	return &TemplatePlugin{
+		Router:       router,
+		HostForRoute: defaultHostForRoute,
+		hostToRoute:  make(HostToRouteMap),
+		routeToHost:  make(RouteToHostMap),
+	}
+}
+
+type HostToRouteMap map[string]*routeapi.Route
+type RouteToHostMap map[string]string
 
 type TemplatePluginConfig struct {
 	WorkingDir         string
@@ -49,9 +64,9 @@ type router interface {
 	// DeleteEndpoints deletes the endpoints for the frontend with the given id.
 	DeleteEndpoints(id string)
 
-	// AddRoute adds a route for the given id.  Returns true if a change was made
-	// and the state should be stored with Commit().
-	AddRoute(id string, route *routeapi.Route) bool
+	// AddRoute adds a route for the given id and the calculated host.  Returns true if a
+	// change was made and the state should be stored with Commit().
+	AddRoute(id string, route *routeapi.Route, host string) bool
 	// RemoveRoute removes the given route for the given id.
 	RemoveRoute(id string, route *routeapi.Route)
 
@@ -92,12 +107,12 @@ func NewTemplatePlugin(cfg TemplatePluginConfig) (*TemplatePlugin, error) {
 		peerEndpointsKey:   peerKey,
 	}
 	router, err := newTemplateRouter(templateRouterCfg)
-	return &TemplatePlugin{router}, err
+	return newDefaultTemplatePlugin(router), err
 }
 
 // HandleEndpoints processes watch events on the Endpoints resource.
 func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
-	key := endpointsKey(*endpoints)
+	key := endpointsKey(endpoints)
 
 	glog.V(4).Infof("Processing %d Endpoints for Name: %v (%v)", len(endpoints.Subsets), endpoints.Name, eventType)
 
@@ -113,7 +128,7 @@ func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *k
 	case watch.Added, watch.Modified:
 		glog.V(4).Infof("Modifying endpoints for %s", key)
 		routerEndpoints := createRouterEndpoints(endpoints)
-		key := endpointsKey(*endpoints)
+		key := endpointsKey(endpoints)
 		commit := p.Router.AddEndpoints(key, routerEndpoints)
 		if commit {
 			return p.Router.Commit()
@@ -125,34 +140,77 @@ func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *k
 
 // HandleRoute processes watch events on the Route resource.
 func (p *TemplatePlugin) HandleRoute(eventType watch.EventType, route *routeapi.Route) error {
-	key := routeKey(*route)
-	if _, ok := p.Router.FindServiceUnit(key); !ok {
-		glog.V(4).Infof("Creating new frontend for key: %v", key)
-		p.Router.CreateServiceUnit(key)
+	key := routeKey(route)
+	routeName := routeNameKey(route)
+
+	host := p.HostForRoute(route)
+	if len(host) == 0 {
+		return nil
+	}
+
+	// ensure hosts can only be claimed by one route at a time
+	// TODO: this could be abstracted above this layer?
+	if old, ok := p.hostToRoute[host]; ok {
+		if old.CreationTimestamp.Before(route.CreationTimestamp) {
+			glog.V(4).Infof("Route %s cannot take %s from %s", routeName, host, routeNameKey(old))
+			return fmt.Errorf("route %s holds %s and is older than %s", routeNameKey(old), host, key)
+		}
+		glog.V(4).Infof("Route %s is reclaiming %s from %s", routeName, host, routeNameKey(old))
+		p.Router.RemoveRoute(routeKey(old), old)
+		p.hostToRoute[host] = route
+	} else {
+		glog.V(4).Infof("Route %s claims %s", key, host)
+		p.hostToRoute[host] = route
 	}
 
 	switch eventType {
 	case watch.Added, watch.Modified:
+		// TODO: this could be abstracted above this layer?
+		if old, ok := p.routeToHost[routeName]; ok {
+			if old != host {
+				glog.V(4).Infof("Route %s changed from serving host %s to host %s", key, old, host)
+				delete(p.hostToRoute, old)
+			}
+		}
+		p.routeToHost[routeName] = host
+
+		if _, ok := p.Router.FindServiceUnit(key); !ok {
+			glog.V(4).Infof("Creating new frontend for key: %v", key)
+			p.Router.CreateServiceUnit(key)
+		}
+
 		glog.V(4).Infof("Modifying routes for %s", key)
-		commit := p.Router.AddRoute(key, route)
+		commit := p.Router.AddRoute(key, route, host)
 		if commit {
 			return p.Router.Commit()
 		}
 	case watch.Deleted:
 		glog.V(4).Infof("Deleting routes for %s", key)
+		delete(p.hostToRoute, host)
+		delete(p.routeToHost, routeName)
 		p.Router.RemoveRoute(key, route)
 		return p.Router.Commit()
 	}
 	return nil
 }
 
+// defaultHostForRoute return the host based on the string value on a route.
+func defaultHostForRoute(route *routeapi.Route) string {
+	return route.Host
+}
+
 // routeKey returns the internal router key to use for the given Route.
-func routeKey(route routeapi.Route) string {
+func routeKey(route *routeapi.Route) string {
 	return fmt.Sprintf("%s/%s", route.Namespace, route.ServiceName)
 }
 
+// routeNameKey returns a unique name for a given route
+func routeNameKey(route *routeapi.Route) string {
+	return fmt.Sprintf("%s/%s", route.Namespace, route.Name)
+}
+
 // endpointsKey returns the internal router key to use for the given Endpoints.
-func endpointsKey(endpoints kapi.Endpoints) string {
+func endpointsKey(endpoints *kapi.Endpoints) string {
 	return fmt.Sprintf("%s/%s", endpoints.Namespace, endpoints.Name)
 }
 

--- a/plugins/router/template/plugin_test.go
+++ b/plugins/router/template/plugin_test.go
@@ -267,7 +267,7 @@ func TestHandleRoute(t *testing.T) {
 	if _, ok := router.FindServiceUnit("foo/TestService2"); ok {
 		t.Fatalf("unexpected second unit: %#v", router)
 	}
-	if r, ok := plugin.hostToRoute["www.example.com"]; !ok || r.Name != "test" {
+	if r, ok := plugin.hostToRoute["www.example.com"]; !ok || r[0].Name != "test" {
 		t.Fatalf("unexpected claimed routes: %#v", r)
 	}
 
@@ -281,7 +281,7 @@ func TestHandleRoute(t *testing.T) {
 	if _, ok := router.FindServiceUnit("foo/TestService"); !ok {
 		t.Fatalf("unexpected first unit: %#v", router)
 	}
-	if r, ok := plugin.hostToRoute["www.example.com"]; !ok || r.Name != "test" {
+	if r, ok := plugin.hostToRoute["www.example.com"]; !ok || r[0].Name != "test" {
 		t.Fatalf("unexpected claimed routes: %#v", r)
 	}
 

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -117,7 +117,7 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 		dir:                    dir,
 		templates:              cfg.templates,
 		reloadScriptPath:       cfg.reloadScriptPath,
-		state:                  map[string]ServiceUnit{},
+		state:                  make(map[string]ServiceUnit),
 		certManager:            certManager,
 		defaultCertificate:     cfg.defaultCertificate,
 		defaultCertificatePath: "",
@@ -299,7 +299,7 @@ func (r *templateRouter) DeleteEndpoints(id string) {
 	}
 }
 
-// routeKey generates route key in form of Namespace-Name.  This is NOT the normal key structure of ns/name because
+// routeKey generates route key in form of Namespace_Name.  This is NOT the normal key structure of ns/name because
 // it is not safe to use / in names of router config files.  This allows templates to use this key without having
 // to create (or provide) a separate method
 func (r *templateRouter) routeKey(route *routeapi.Route) string {
@@ -315,13 +315,13 @@ func (r *templateRouter) routeKey(route *routeapi.Route) string {
 }
 
 // AddRoute adds a route for the given id
-func (r *templateRouter) AddRoute(id string, route *routeapi.Route) bool {
+func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string) bool {
 	frontend, _ := r.FindServiceUnit(id)
 
 	backendKey := r.routeKey(route)
 
 	config := ServiceAliasConfig{
-		Host: route.Host,
+		Host: host,
 		Path: route.Path,
 	}
 

--- a/plugins/router/template/router_test.go
+++ b/plugins/router/template/router_test.go
@@ -256,7 +256,7 @@ func TestRouteKey(t *testing.T) {
 		}
 
 		// add route always returns true
-		added := router.AddRoute(suKey, route)
+		added := router.AddRoute(suKey, route, route.Host)
 		if !added {
 			t.Fatalf("expected AddRoute to return true but got false")
 		}
@@ -298,7 +298,7 @@ func TestAddRoute(t *testing.T) {
 	router.CreateServiceUnit(suKey)
 
 	// add route always returns true
-	added := router.AddRoute(suKey, route)
+	added := router.AddRoute(suKey, route, route.Host)
 	if !added {
 		t.Fatalf("expected AddRoute to return true but got false")
 	}
@@ -374,8 +374,8 @@ func TestRemoveRoute(t *testing.T) {
 	suKey := "test"
 
 	router.CreateServiceUnit(suKey)
-	router.AddRoute(suKey, route)
-	router.AddRoute(suKey, route2)
+	router.AddRoute(suKey, route, route.Host)
+	router.AddRoute(suKey, route2, route2.Host)
 
 	su, ok := router.FindServiceUnit(suKey)
 	if !ok {
@@ -543,18 +543,18 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 
 	// setup the router
 	router := newFakeTemplateRouter()
-	routeWithBadServiceKey := routeKey(*routeWithBadService)
+	routeWithBadServiceKey := routeKey(routeWithBadService)
 	routeWithBadServiceCfgKey := router.routeKey(routeWithBadService)
-	routeWithGoodServiceKey := routeKey(*routeWithGoodService)
+	routeWithGoodServiceKey := routeKey(routeWithGoodService)
 	routeWithGoodServiceCfgKey := router.routeKey(routeWithGoodService)
-	routeWithGoodServiceDifferentNamespaceKey := routeKey(*routeWithGoodServiceDifferentNamespace)
+	routeWithGoodServiceDifferentNamespaceKey := routeKey(routeWithGoodServiceDifferentNamespace)
 	routeWithGoodServiceDifferentNamespaceCfgKey := router.routeKey(routeWithGoodServiceDifferentNamespace)
 	router.CreateServiceUnit(routeWithBadServiceKey)
 	router.CreateServiceUnit(routeWithGoodServiceKey)
 	router.CreateServiceUnit(routeWithGoodServiceDifferentNamespaceKey)
 
 	// add the route with the bad service name, it should add fine
-	router.AddRoute(routeWithBadServiceKey, routeWithBadService)
+	router.AddRoute(routeWithBadServiceKey, routeWithBadService, routeWithBadService.Host)
 	route, ok := router.FindServiceUnit(routeWithBadServiceKey)
 
 	if !ok {
@@ -567,7 +567,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 
 	// now add the same route with a modified service name, it should exists under the new service
 	// and no longer exist under the old service
-	router.AddRoute(routeWithGoodServiceKey, routeWithGoodService)
+	router.AddRoute(routeWithGoodServiceKey, routeWithGoodService, routeWithGoodService.Host)
 	route, ok = router.FindServiceUnit(routeWithGoodServiceKey)
 	if !ok {
 		t.Fatalf("unable to find route %s after adding", routeWithGoodServiceKey)
@@ -587,7 +587,7 @@ func TestRouteExistsUnderOneServiceOnly(t *testing.T) {
 	}
 
 	// add a route with the same name but under a different namespace.
-	router.AddRoute(routeWithGoodServiceDifferentNamespaceKey, routeWithGoodServiceDifferentNamespace)
+	router.AddRoute(routeWithGoodServiceDifferentNamespaceKey, routeWithGoodServiceDifferentNamespace, routeWithGoodServiceDifferentNamespace.Host)
 	route, ok = router.FindServiceUnit(routeWithGoodServiceDifferentNamespaceKey)
 	if !ok {
 		t.Fatalf("unable to find route %s after adding", routeWithGoodServiceDifferentNamespaceKey)

--- a/test/integration/router/router_http_server.go
+++ b/test/integration/router/router_http_server.go
@@ -37,19 +37,21 @@ func NewTestHttpService() *TestHttpService {
 
 	masterHttpAddr := fmt.Sprintf("%s:8080", addr)
 	podHttpAddr := fmt.Sprintf("%s:8888", addr)
+	alternatePodHttpAddr := fmt.Sprintf("%s:8889", addr)
 	podHttpsAddr := fmt.Sprintf("%s:8443", addr)
 
 	return &TestHttpService{
-		MasterHttpAddr:   masterHttpAddr,
-		PodHttpAddr:      podHttpAddr,
-		PodHttpsAddr:     podHttpsAddr,
-		PodWebSocketPath: "echo",
-		PodTestPath:      "test",
-		PodHttpsCert:     []byte(Example2Cert),
-		PodHttpsKey:      []byte(Example2Key),
-		PodHttpsCaCert:   []byte(ExampleCACert),
-		EndpointChannel:  endpointChannel,
-		RouteChannel:     routeChannel,
+		MasterHttpAddr:       masterHttpAddr,
+		PodHttpAddr:          podHttpAddr,
+		AlternatePodHttpAddr: alternatePodHttpAddr,
+		PodHttpsAddr:         podHttpsAddr,
+		PodWebSocketPath:     "echo",
+		PodTestPath:          "test",
+		PodHttpsCert:         []byte(Example2Cert),
+		PodHttpsKey:          []byte(Example2Key),
+		PodHttpsCaCert:       []byte(ExampleCACert),
+		EndpointChannel:      endpointChannel,
+		RouteChannel:         routeChannel,
 	}
 }
 
@@ -62,23 +64,25 @@ func NewTestHttpService() *TestHttpService {
 //
 // List events will return empty data for all calls.
 type TestHttpService struct {
-	MasterHttpAddr   string
-	PodHttpAddr      string
-	PodHttpsAddr     string
-	PodHttpsCert     []byte
-	PodHttpsKey      []byte
-	PodHttpsCaCert   []byte
-	PodWebSocketPath string
-	PodTestPath      string
-	EndpointChannel  chan string
-	RouteChannel     chan string
+	MasterHttpAddr       string
+	PodHttpAddr          string
+	AlternatePodHttpAddr string
+	PodHttpsAddr         string
+	PodHttpsCert         []byte
+	PodHttpsKey          []byte
+	PodHttpsCaCert       []byte
+	PodWebSocketPath     string
+	PodTestPath          string
+	EndpointChannel      chan string
+	RouteChannel         chan string
 
 	listeners []net.Listener
 }
 
 const (
 	// HelloPod is the expected response to a call to PodHttpAddr (usually called through a route)
-	HelloPod = "Hello Pod!"
+	HelloPod          = "Hello Pod!"
+	HelloPodAlternate = "Alternate Hello Pod!"
 	// HelloPod is the expected response to a call to PodHttpAddr (usually called through a route)
 	HelloPodPath = "Hello Pod Path!"
 	// HelloPodSecure is the expected response to a call to PodHttpsAddr (usually called through a route)
@@ -90,6 +94,11 @@ const (
 // handleHelloPod handles calls to PodHttpAddr (usually called through a route)
 func (s *TestHttpService) handleHelloPod(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, HelloPod)
+}
+
+// handleHelloPod handles calls to PodHttpAddr (usually called through a route)
+func (s *TestHttpService) handleHelloPod2(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, HelloPodAlternate)
 }
 
 // handleHelloPodTest handles calls to PodHttpAddr (usually called through a route) with the /test/ path
@@ -192,6 +201,14 @@ func (s *TestHttpService) startPod() error {
 	unsecurePodServer.Handle("/"+s.PodWebSocketPath, websocket.Handler(s.handleWebSocket))
 
 	if err := s.startServing(s.PodHttpAddr, unsecurePodServer); err != nil {
+		return err
+	}
+
+	alternatePodServer := http.NewServeMux()
+	alternatePodServer.HandleFunc("/", s.handleHelloPod2)
+	alternatePodServer.HandleFunc("/"+s.PodTestPath, s.handleHelloPod2)
+
+	if err := s.startServing(s.AlternatePodHttpAddr, alternatePodServer); err != nil {
 		return err
 	}
 

--- a/test/integration/router/router_http_server.go
+++ b/test/integration/router/router_http_server.go
@@ -89,22 +89,22 @@ const (
 
 // handleHelloPod handles calls to PodHttpAddr (usually called through a route)
 func (s *TestHttpService) handleHelloPod(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, HelloPod)
+	fmt.Fprint(w, HelloPod)
 }
 
 // handleHelloPodTest handles calls to PodHttpAddr (usually called through a route) with the /test/ path
 func (s *TestHttpService) handleHelloPodTest(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, HelloPodPath)
+	fmt.Fprint(w, HelloPodPath)
 }
 
 // handleHelloPodSecure handles calls to PodHttpsAddr (usually called through a route)
 func (s *TestHttpService) handleHelloPodSecure(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, HelloPodSecure)
+	fmt.Fprint(w, HelloPodSecure)
 }
 
 // handleHelloPodTestSecure handles calls to PodHttpsAddr (usually called through a route) with the /test/ path
 func (s *TestHttpService) handleHelloPodTestSecure(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, HelloPodPathSecure)
+	fmt.Fprint(w, HelloPodPathSecure)
 }
 
 // handleRouteWatch handles calls to /osapi/v1beta1/watch/routes and uses the route channel to simulate watch events
@@ -114,7 +114,7 @@ func (s *TestHttpService) handleRouteWatch(w http.ResponseWriter, r *http.Reques
 
 // handleRouteList handles calls to /osapi/v1beta1/routes and always returns empty data
 func (s *TestHttpService) handleRouteList(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, "{}")
+	fmt.Fprint(w, "{}")
 }
 
 // handleEndpointWatch handles calls to /api/v1beta1/watch/endpoints and uses the endpoint channel to simulate watch events
@@ -124,7 +124,7 @@ func (s *TestHttpService) handleEndpointWatch(w http.ResponseWriter, r *http.Req
 
 // handleEndpointList handles calls to /api/v1beta1/endpoints and always returns empty data
 func (s *TestHttpService) handleEndpointList(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, "{}")
+	fmt.Fprint(w, "{}")
 }
 
 // handleWebSocket copies whatever is written to the web socket back to the socket


### PR DESCRIPTION
Only the oldest route for a given hostname is used.

Explore some alternative options for implementation.

@pweil- @ramr

Added one commit on top of #4421