### PR TITLE
Add project service, refactor projectNav in web console

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -85,7 +85,7 @@
     <!-- endbuild -->
 
     <!-- build:js(.) scripts/vendor.js -->
-    <script src="bower_components/es5-dom-shim/__COMPILE/a.js"></script>    
+    <script src="bower_components/es5-dom-shim/__COMPILE/a.js"></script>
     <!-- bower:js -->
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
@@ -128,6 +128,7 @@
         <script src="scripts/services/userstore.js"></script>
         <script src="scripts/services/auth.js"></script>
         <script src="scripts/services/data.js"></script>
+        <script src="scripts/services/project.js"></script>
         <script src="scripts/services/applicationGenerator.js"></script>
         <script src="scripts/services/login.js"></script>
         <script src="scripts/services/logout.js"></script>

--- a/assets/app/scripts/controllers/project.js
+++ b/assets/app/scripts/controllers/project.js
@@ -9,7 +9,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('ProjectController', function ($scope, $routeParams, DataService, AuthService, $filter, LabelFilter, $location, Logger) {
+  .controller('ProjectController', function ($scope, $routeParams, DataService, AuthService, $filter, LabelFilter, $location) {
 
     $scope.projectName = $routeParams.project;
     $scope.project = {};
@@ -51,11 +51,5 @@ angular.module('openshiftConsole')
           }
         }
       );
-
-      DataService.list("projects", $scope, function(projects) {
-        $scope.projects = projects.by("metadata.name");
-        Logger.log("projects", $scope.projects);
-      });
-
     });
   });

--- a/assets/app/scripts/services/project.js
+++ b/assets/app/scripts/services/project.js
@@ -1,0 +1,40 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('project', [
+    '$q',
+    '$routeParams',
+    'AuthService',
+    'DataService',
+    function($q, $routeParams, AuthService, DataService) {
+      var context = {
+        // TODO: swap $.Deferred() for $q.defer()
+        projectPromise: $.Deferred()
+      };
+
+      return {
+        get: function(projectName) {
+          return  AuthService
+                    .withUser()
+                    .then(function() {
+                      context.projectName = projectName;
+                      return DataService
+                              .get('projects', context.projectName, context, {errorNotification: false})
+                              .then(function(project) {
+                                context.projectPromise.resolve(project);
+                                // TODO: ideally would just return project, but DataService expects
+                                // context.projectPromise as a separate Deferred at this point.
+                                return [project, context];
+                              }, function(e) {
+                                context.projectPromise.reject(e);
+                              });
+                    });
+          }
+        };
+    }
+  ]);
+
+
+
+
+


### PR DESCRIPTION
Previously 2 [WIP] PRs (for comment references):
- [here](https://github.com/openshift/origin/pull/4418)
- [and here](https://github.com/openshift/origin/pull/4419)

This PR consists of two small steps towards simplifying controllers.  

Project service eliminates the need for ProjectController & DOM heirarchy to make requests & lets us do all requests in one place:

```javascript
project
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
             return $q.all([DataService.get('other', context), DataService.get('stuff', context)])
        })
        .then(_.spread(function(other, stuff) {
             angular.extend($scope, { other: other, stuff: stuff });
        }));
```
ProjectNav now handles it's own watch on projects, decoupling from controllers:

```javascript
 DataService.list("projects", $scope, function(items) {
      projects = items.by("metadata.name");
      updateOptions();
 });
```