### PR TITLE
make sure we don't accidentally drop admission plugins

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -27,6 +27,9 @@ import (
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 )
 
+// AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
+var AdmissionPlugins = []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "ResourceQuota", "DenyExecOnPrivileged"}
+
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {
 	Options    configapi.KubernetesMasterConfig
@@ -84,9 +87,7 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	server.EventTTL = 2 * time.Hour
 	server.ServiceClusterIPRange = net.IPNet(flagtypes.DefaultIPNet(options.KubernetesMasterConfig.ServicesSubnet))
 	server.ServiceNodePortRange = *portRange
-	server.AdmissionControl = strings.Join([]string{
-		"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "ResourceQuota", "DenyExecOnPrivileged",
-	}, ",")
+	server.AdmissionControl = strings.Join(AdmissionPlugins, ",")
 
 	// resolve extended arguments
 	// TODO: this should be done in config validation (along with the above) so we can provide

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -1,0 +1,42 @@
+package start
+
+import (
+	"testing"
+
+	// this package has imports for all the admission controllers used in the kube api server
+	// it causes all the admission plugins to be registered, giving us a full listing.
+	_ "k8s.io/kubernetes/cmd/kube-apiserver/app"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
+)
+
+var admissionPluginsNotUsedByKube = util.NewStringSet(
+	"AlwaysAdmit",            // from kube, no need for this by default
+	"AlwaysDeny",             // from kube, no need for this by default
+	"NamespaceAutoProvision", // from kube, it creates a namespace if a resource is created in a non-existent namespace.  We don't want this behavior
+	"SecurityContextDeny",    // from kube, it denies pods that want to use SCC capabilities.  We have different rules to allow this in openshift.
+
+	"BuildByStrategy",          // from origin, only needed for managing builds, not kubernetes resources
+	"OriginNamespaceLifecycle", // from origin, only needed for rejecting openshift resources, so not needed by kube
+)
+
+func TestKubeAdmissionControllerUsage(t *testing.T) {
+	registeredKubePlugins := util.NewStringSet(admission.GetPlugins()...)
+
+	usedAdmissionPlugins := util.NewStringSet(kubernetes.AdmissionPlugins...)
+
+	if missingPlugins := usedAdmissionPlugins.Difference(registeredKubePlugins); len(missingPlugins) != 0 {
+		t.Errorf("%v not found", missingPlugins.List())
+	}
+
+	if notUsed := registeredKubePlugins.Difference(usedAdmissionPlugins); len(notUsed) != 0 {
+		for pluginName := range notUsed {
+			if !admissionPluginsNotUsedByKube.Has(pluginName) {
+				t.Errorf("%v not used", pluginName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4265

Adds a unit test that checks all registered admission controllers against those we apply for starting kube.



@csrwng ptal