### PR TITLE
Fix for issue #4437 - restarting the haproxy router still dispatches to a downed backend

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -165,6 +165,7 @@ backend be_http_{{$cfgIdx}}
 backend be_edge_http_{{$cfgIdx}}
                 {{ end }}
   mode http
+  option redispatch
   balance leastconn
   timeout check 5000ms
   {{ if (eq $cfg.TLSTermination "") }}
@@ -190,6 +191,7 @@ backend be_tcp_{{$cfgIdx}}
             {{ if eq $cfg.TLSTermination "reencrypt" }}
 backend be_secure_{{$cfgIdx}}
   mode http
+  option redispatch
   balance leastconn
   timeout check 5000ms
   cookie OPENSHIFT_REENCRYPT_{{$cfgIdx}}_SERVERID insert indirect nocache httponly secure


### PR DESCRIPTION
@rajatchopra / @smarterclayton  PTAL 

The only way I could sort of reproduce the issue was with 1 second timeouts  and a downed backend (:9999 and cookie pointing to it) - where response codes back were 000/503 - very timing sensitive. Test at:  https://gist.github.com/ramr/c0f2c55bcbeb65555175