### PR TITLE
Making the regex in hack/test-cmd.sh a little more flexible for downs…

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -95,7 +95,7 @@ echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' 
 oc get scc privileged -o yaml | sed '/users:/ a\
 - system:serviceaccount:default:router\
 ' | oc replace scc privileged -f -
-[ "$(oadm router -o yaml --credentials="${KUBECONFIG}" --service-account=router -n default | grep 'openshift/origin-haproxy-')" ]
+[ "$(oadm router -o yaml --credentials="${KUBECONFIG}" --service-account=router -n default | egrep 'image:.*-haproxy-router:')" ]
 oadm router --credentials="${KUBECONFIG}" --images="${USE_IMAGES}" --service-account=router -n default
 [ "$(oadm router -n default | grep 'service exists')" ]
 echo "router: ok"


### PR DESCRIPTION
…tream

Even though the build process is building them with 'origin' in the name
downstream has changed their default for --images to be non-origin.