### PR TITLE
Node IP can be passed as node config option

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -34,6 +34,10 @@ type NodeConfig struct {
 	// If you're describing a set of static nodes to the master, this value must match one of the values in the list
 	NodeName string
 
+	// Node may have multiple IPs, specify the IP to use for pod traffic routing
+	// If not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
+	NodeIP string
+
 	// ServingInfo describes how to start serving
 	ServingInfo ServingInfo
 

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -15,6 +15,10 @@ type NodeConfig struct {
 	// If you're describing a set of static nodes to the master, this value must match one of the values in the list
 	NodeName string `json:"nodeName"`
 
+	// Node may have multiple IPs, specify the IP to use for pod traffic routing
+	// If not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
+	NodeIP string `json:"nodeIP"`
+
 	// ServingInfo describes how to start serving
 	ServingInfo ServingInfo `json:"servingInfo"`
 

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -29,6 +29,7 @@ masterKubeConfig: ""
 networkConfig:
   mtu: 0
   networkPluginName: ""
+nodeIP: ""
 nodeName: ""
 podManifestConfig:
   fileCheckIntervalSeconds: 0

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -16,6 +16,9 @@ func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList 
 	if len(config.NodeName) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldRequired("nodeName"))
 	}
+	if len(config.NodeIP) > 0 {
+		allErrs = append(allErrs, ValidateSpecifiedIP(config.NodeIP, "nodeIP")...)
+	}
 
 	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
 	if config.ServingInfo.BindNetwork == "tcp6" {

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -249,13 +249,13 @@ func RunSDNController(config *kubernetes.NodeConfig, nodeConfig configapi.NodeCo
 	case flatsdn.NetworkPluginName():
 		ch := make(chan struct{})
 		config.KubeletConfig.StartUpdates = ch
-		go flatsdn.Node(oclient, config.Client, nodeConfig.NodeName, "", ch, nodeConfig.NetworkConfig.MTU)
+		go flatsdn.Node(oclient, config.Client, nodeConfig.NodeName, nodeConfig.NodeIP, ch, nodeConfig.NetworkConfig.MTU)
 	case multitenant.NetworkPluginName():
 		ch := make(chan struct{})
 		config.KubeletConfig.StartUpdates = ch
 		plugin := multitenant.GetKubeNetworkPlugin()
 		config.KubeletConfig.NetworkPlugins = append(config.KubeletConfig.NetworkPlugins, plugin)
-		go multitenant.Node(oclient, config.Client, nodeConfig.NodeName, "", ch, plugin, nodeConfig.NetworkConfig.MTU)
+		go multitenant.Node(oclient, config.Client, nodeConfig.NodeName, nodeConfig.NodeIP, ch, plugin, nodeConfig.NetworkConfig.MTU)
 	}
 }
 


### PR DESCRIPTION
If 'nodeIP' option is provided, this IP will be used
for pod traffic communication, Otherwise we will do
network parse/lookup on the node name to fetch the IP
address and in case of multiple IP addresses, the first
non loopback IP address is used.

closes: https://github.com/openshift/openshift-sdn/issues/84