### PR TITLE
Add --env flag to the new-build to

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -541,6 +541,9 @@ Create a new build configuration
 
   // Create a build config from a remote repository using its beta2 branch
   $ openshift cli new-build https://github.com/openshift/ruby-hello-world#beta2
+
+  // Create a build config from a remote repository and add custom environment variables into resulting image
+  $ openshift cli new-build https://github.com/openshift/ruby-hello-world --env=RACK_ENV=development
 ----
 ====
 

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -35,7 +35,10 @@ Once the build configuration is created you may need to run a build with 'start-
   $ %[1]s new-build openshift/nodejs-010-centos7~https://bitbucket.com/user/nodejs-app
 
   // Create a build config from a remote repository using its beta2 branch
-  $ %[1]s new-build https://github.com/openshift/ruby-hello-world#beta2`
+  $ %[1]s new-build https://github.com/openshift/ruby-hello-world#beta2
+
+  // Create a build config from a remote repository and add custom environment variables into resulting image
+  $ %[1]s new-build https://github.com/openshift/ruby-hello-world --env=RACK_ENV=development`
 )
 
 // NewCmdNewBuild implements the OpenShift cli new-build command
@@ -50,6 +53,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 		Long:    newBuildLong,
 		Example: fmt.Sprintf(newBuildExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
+			config.AddEnvironmentToBuild = true
 			err := RunNewBuild(fullName, f, out, c, args, config)
 			if err == errExit {
 				os.Exit(1)
@@ -62,6 +66,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	cmd.Flags().VarP(&config.ImageStreams, "image", "i", "Name of an image stream to to use as a builder.")
 	cmd.Flags().Var(&config.DockerImages, "docker-image", "Name of a Docker image to use as a builder.")
 	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated build artifacts")
+	cmd.Flags().VarP(&config.Environment, "env", "e", "Specify key value pairs of environment variables to set into resulting image.")
 	cmd.Flags().StringVar(&config.Strategy, "strategy", "", "Specify the build strategy to use if you don't want to detect (docker|source).")
 	cmd.Flags().BoolVar(&config.OutputDocker, "to-docker", false, "Have the build output push to a Docker repository.")
 	cmd.Flags().StringP("labels", "l", "", "Label to set in all generated resources.")

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -45,6 +45,8 @@ type AppConfig struct {
 	Environment        util.StringList
 	Labels             map[string]string
 
+	AddEnvironmentToBuild bool
+
 	Name             string
 	Strategy         string
 	InsecureRegistry bool
@@ -511,7 +513,7 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 						}
 					}
 				}
-				if pipeline, err = app.NewBuildPipeline(ref.Input().String(), input, c.OutputDocker, strategy, source); err != nil {
+				if pipeline, err = app.NewBuildPipeline(ref.Input().String(), input, c.OutputDocker, strategy, c.GetBuildEnvironment(environment), source); err != nil {
 					return nil, fmt.Errorf("can't build %q: %v", ref.Input(), err)
 				}
 			} else {
@@ -855,4 +857,11 @@ func (c *AppConfig) HasArguments() bool {
 		len(c.DockerImages) > 0 ||
 		len(c.Templates) > 0 ||
 		len(c.TemplateFiles) > 0
+}
+
+func (c *AppConfig) GetBuildEnvironment(environment app.Environment) app.Environment {
+	if c.AddEnvironmentToBuild {
+		return environment
+	}
+	return app.Environment{}
 }

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -40,7 +40,7 @@ func NewImagePipeline(from string, image *ImageRef) (*Pipeline, error) {
 
 // NewBuildPipeline creates a new pipeline with components that are
 // expected to be built
-func NewBuildPipeline(from string, input *ImageRef, outputDocker bool, strategy *BuildStrategyRef, source *SourceRef) (*Pipeline, error) {
+func NewBuildPipeline(from string, input *ImageRef, outputDocker bool, strategy *BuildStrategyRef, env Environment, source *SourceRef) (*Pipeline, error) {
 	name, ok := NameSuggestions{source, input}.SuggestName()
 	if !ok {
 		name = fmt.Sprintf("app%d", rand.Intn(10000))
@@ -66,6 +66,7 @@ func NewBuildPipeline(from string, input *ImageRef, outputDocker bool, strategy 
 		Input:    input,
 		Strategy: strategy,
 		Output:   output,
+		Env:      env,
 	}
 
 	return &Pipeline{

--- a/rel-eng/completions/bash/oc
+++ b/rel-eng/completions/bash/oc
@@ -471,6 +471,8 @@ _oc_new-build()
 
     flags+=("--code=")
     flags+=("--docker-image=")
+    flags+=("--env=")
+    two_word_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     flags+=("--image=")

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -2028,6 +2028,8 @@ _openshift_cli_new-build()
 
     flags+=("--code=")
     flags+=("--docker-image=")
+    flags+=("--env=")
+    two_word_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     flags+=("--image=")


### PR DESCRIPTION
`new-build` command will now take `--env` flag to pass custom envVars. Basically the use-case is the case as in `new-app`, so user can add envVars by:
- `oc new-build ... A=B` 
- `oc new-build ... --env=A=B`

@csrwng @smarterclayton PTAL