### PR TITLE
Allow customization of login page

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -81,6 +81,7 @@ func NewCommandAdmin(name, fullName string, out io.Writer) *cobra.Command {
 			Commands: []*cobra.Command{
 				admin.NewCommandCreateBootstrapProjectTemplate(f, admin.CreateBootstrapProjectTemplateCommand, fullName+" "+admin.CreateBootstrapProjectTemplateCommand, out),
 				admin.NewCommandCreateBootstrapPolicyFile(admin.CreateBootstrapPolicyFileCommand, fullName+" "+admin.CreateBootstrapPolicyFileCommand, out),
+				admin.NewCommandCreateLoginTemplate(f, admin.CreateLoginTemplateCommand, fullName+" "+admin.CreateLoginTemplateCommand, out),
 				admin.NewCommandOverwriteBootstrapPolicy(admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.CreateBootstrapPolicyFileCommand, out),
 				admin.NewCommandNodeConfig(admin.NodeConfigCommandName, fullName+" "+admin.NodeConfigCommandName, out),
 				cert.NewCmdCert(cert.CertRecommendedName, fullName+" "+cert.CertRecommendedName, out),

--- a/pkg/cmd/server/admin/create_login_template.go
+++ b/pkg/cmd/server/admin/create_login_template.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/auth/server/login"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	CreateLoginTemplateCommand = "create-login-template"
+	longDescription            = `
+Create a template for customizing the login page
+
+This command creates a basic template to use as a starting point for
+customizing the login page. Save the output to a file and edit the template to
+change the look and feel or add content. Be careful not to remove any parameter
+values inside curly braces.
+
+To use the template, set oauthConfig.templates.login in the master
+configuration to point to the template file. For example,
+
+    oauthConfig:
+      templates:
+        login: templates/login.html
+`
+)
+
+type CreateLoginTemplateOptions struct{}
+
+func NewCommandCreateLoginTemplate(f *clientcmd.Factory, commandName string, fullName string, out io.Writer) *cobra.Command {
+	options := &CreateLoginTemplateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   commandName,
+		Short: "Create a login template",
+		Long:  longDescription,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Validate(args); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
+			}
+
+			_, err := io.WriteString(out, login.LoginTemplateExample)
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	return cmd
+}
+
+func (o CreateLoginTemplateOptions) Validate(args []string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+
+	return nil
+}

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -159,6 +159,10 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 
 			}
 		}
+
+		if config.OAuthConfig.Templates != nil {
+			refs = append(refs, &config.OAuthConfig.Templates.Login)
+		}
 	}
 
 	if config.AssetConfig != nil {

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -381,6 +381,15 @@ type OAuthConfig struct {
 	SessionConfig *SessionConfig
 
 	TokenConfig TokenConfig
+
+	// Templates allow you to customize pages like the login page.
+	Templates *OAuthTemplates
+}
+
+type OAuthTemplates struct {
+	// Login is a path to a file containing a go template used to render the login page.
+	// If unspecified, the default login page is used.
+	Login string
 }
 
 type ServiceAccountConfig struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -367,6 +367,15 @@ type OAuthConfig struct {
 	SessionConfig *SessionConfig `json:"sessionConfig"`
 
 	TokenConfig TokenConfig `json:"tokenConfig"`
+
+	// Templates allow you to customize pages like the login page.
+	Templates *OAuthTemplates `json:"templates"`
+}
+
+type OAuthTemplates struct {
+	// Login is a path to a file containing a go template used to render the login page.
+	// If unspecified, the default login page is used.
+	Login string `json:"login"`
 }
 
 type ServiceAccountConfig struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -230,6 +230,7 @@ oauthConfig:
     sessionMaxAgeSeconds: 0
     sessionName: ""
     sessionSecretsFile: ""
+  templates: null
   tokenConfig:
     accessTokenMaxAgeSeconds: 0
     authorizeTokenMaxAgeSeconds: 0

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -343,7 +343,17 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 
 				// Since we're redirecting to a local login page, we don't need to force absolute URL resolution
 				redirectors["login-"+identityProvider.Name+"-redirect"] = redirector.NewRedirector(nil, OpenShiftLoginPrefix+"?then=${url}")
-				login := login.NewLogin(c.getCSRF(), &callbackPasswordAuthenticator{passwordAuth, passwordSuccessHandler}, login.DefaultLoginFormRenderer)
+
+				var loginTemplateFile string
+				if c.Options.Templates != nil {
+					loginTemplateFile = c.Options.Templates.Login
+				}
+				loginFormRenderer, err := login.NewLoginFormRenderer(loginTemplateFile)
+				if err != nil {
+					return nil, err
+				}
+
+				login := login.NewLogin(c.getCSRF(), &callbackPasswordAuthenticator{passwordAuth, passwordSuccessHandler}, loginFormRenderer)
 				login.Install(mux, OpenShiftLoginPrefix)
 			}
 			if identityProvider.UseAsChallenger {

--- a/rel-eng/completions/bash/oadm
+++ b/rel-eng/completions/bash/oadm
@@ -1044,6 +1044,23 @@ _oadm_create-bootstrap-policy-file()
     must_have_one_noun=()
 }
 
+_oadm_create-login-template()
+{
+    last_command="oadm_create-login-template"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oadm_overwrite-policy()
 {
     last_command="oadm_overwrite-policy"
@@ -1296,6 +1313,7 @@ _oadm()
     commands+=("create-api-client-config")
     commands+=("create-bootstrap-project-template")
     commands+=("create-bootstrap-policy-file")
+    commands+=("create-login-template")
     commands+=("overwrite-policy")
     commands+=("create-node-config")
     commands+=("ca")

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -1477,6 +1477,23 @@ _openshift_admin_create-bootstrap-policy-file()
     must_have_one_noun=()
 }
 
+_openshift_admin_create-login-template()
+{
+    last_command="openshift_admin_create-login-template"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_admin_overwrite-policy()
 {
     last_command="openshift_admin_overwrite-policy"
@@ -1729,6 +1746,7 @@ _openshift_admin()
     commands+=("create-api-client-config")
     commands+=("create-bootstrap-project-template")
     commands+=("create-bootstrap-policy-file")
+    commands+=("create-login-template")
     commands+=("overwrite-policy")
     commands+=("create-node-config")
     commands+=("ca")


### PR DESCRIPTION
Adds a `login-template.html` file that can be modified and used as a login page through master configuration parameter `oauthConfg.loginTemplateFile`.

Fixes #3494

TODO:
- [x] Fix _output/local/go/src/github.com/openshift/origin/pkg/auth/server/login/login_test.go:143: undefined: DefaultLoginFormRenderer
- [x] Update ValidateLoginTemplate func to accept `[]byte` and return `[]error`
- [x] Add ValidateLoginTemplate unit tests
- [x] Add some basic styles to login-template.html
- [x] Add command to generate login-template.html
- [x] Add generated completions to commit.
- [x] Open docs and ansible issues for new config options.