### PR TITLE
If Vagrant sets a hostname that doesn't resolve it breaks containerized installs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -178,8 +178,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     # define settings for the single VM being created.
     config.vm.define "#{VM_NAME_PREFIX}openshiftdev", primary: true do |config|
-      config.vm.hostname = "openshiftdev.local"
-
       if vagrant_openshift_config['rebuild_yum_cache']
         config.vm.provision "shell", inline: "yum clean all && yum makecache"
       end


### PR DESCRIPTION
Currently if you launch a Fedora devenv in AWS this code wasn't even working.
Something silently fails and you end up with a hostname like ip-172-18-6-152.
However on RHEL7 it was working and openshiftdev.local didn't resolve from
within Docker containers.  This breaks the hack/test-end-to-end-docker.sh.

You get an error message like:

-----------
[INFO] Installing the registry
deploymentconfigs/docker-registry
services/docker-registry
[INFO] Verifying the docker-registry is up at 172.30.129.104
ERROR: gave up waiting for http://172.30.129.104:5000/healthz

[FAIL] !!!!! Test Failed !!!!
-----------

The reason it failed is because the Nodes can't find the Master to register
themselves.