### PR TITLE
switch integration tests to non-default ports

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -13,15 +13,34 @@ cd "${OS_ROOT}"
 
 os::build::setup_env
 
-function cleanup()
-{
-  [ ! -z "${ETCD_STARTED-}" ] && return
-  set +e
-  kill ${ETCD_PID} 1>&2 2>/dev/null
-  rm -rf ${ETCD_DIR} 1>&2 2>/dev/null
-  echo
-  echo "Complete"
+export ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+export ETCD_PORT=${ETCD_PORT:-44001}
+export ETCD_PEER_PORT=${ETCD_PEER_PORT:-47001}
+
+
+set +e
+
+if [ "$(which etcd 2>/dev/null)" == "" ]; then
+	if [[ ! -f ${OS_ROOT}/_tools/etcd/bin/etcd ]]; then
+		echo "etcd must be in your PATH or installed in _tools/etcd/bin/ with hack/install-etcd.sh"
+		exit 1
+	fi
+	export PATH="${OS_ROOT}/_tools/etcd/bin:$PATH"
+fi
+
+# Stop on any failures
+set -e
+
+
+
+function cleanup() {
+	set +e
+	kill "${ETCD_PID}" 1>&2 2>/dev/null
+	echo
+	echo "Complete"
 }
+
+
 
 package="${OS_TEST_PACKAGE:-test/integration}"
 tags="${OS_TEST_TAGS:-integration !docker etcd}"
@@ -29,6 +48,9 @@ tags="${OS_TEST_TAGS:-integration !docker etcd}"
 export GOMAXPROCS="$(grep "processor" -c /proc/cpuinfo 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || 1)"
 TMPDIR=${TMPDIR:-/tmp}
 export BASETMPDIR=${BASETMPDIR:-${TMPDIR}/openshift-integration}
+rm -rf ${BASETMPDIR} | true
+mkdir -p ${BASETMPDIR}
+
 
 echo
 echo "Test ${package} -tags='${tags}' ..."
@@ -45,36 +67,53 @@ pushd "${testdir}" 2>&1 >/dev/null
 CGO_ENABLED=0 go test -c -tags="${tags}" "${OS_GO_PACKAGE}/${package}"
 popd 2>&1 >/dev/null
 
-start_etcd
+
+# Start etcd
+export ETCD_DIR=${BASETMPDIR}/etcd
+etcd -name test -data-dir ${ETCD_DIR} \
+ --listen-peer-urls http://${ETCD_HOST}:${ETCD_PEER_PORT} \
+ --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} \
+ --initial-advertise-peer-urls http://${ETCD_HOST}:${ETCD_PEER_PORT} \
+ --initial-cluster test=http://${ETCD_HOST}:${ETCD_PEER_PORT} \
+ --advertise-client-urls http://${ETCD_HOST}:${ETCD_PORT} \
+ >/dev/null 2>/dev/null &
+export ETCD_PID=$!
+
+wait_for_url "http://${ETCD_HOST}:${ETCD_PORT}/version" "etcd: " 0.25 80
+curl -X PUT	"http://${ETCD_HOST}:${ETCD_PORT}/v2/keys/_test"
+echo
+
+
+
 trap cleanup EXIT SIGINT
 
 function exectest() {
-  echo "Running $1..."
+	echo "Running $1..."
 
-  result=1
-  if [ -n "${VERBOSE-}" ]; then
-    "${testexec}" -test.v -test.run="^$1$" "${@:2}" 2>&1
-    result=$?
-  else
-    out=$("${testexec}" -test.run="^$1$" "${@:2}" 2>&1)
-    result=$?
-  fi
+	result=1
+	if [ -n "${VERBOSE-}" ]; then
+		ETCD_PORT=${ETCD_PORT} "${testexec}" -test.v -test.run="^$1$" "${@:2}" 2>&1
+		result=$?
+	else
+		out=$(ETCD_PORT=${ETCD_PORT} "${testexec}" -test.run="^$1$" "${@:2}" 2>&1)
+		result=$?
+	fi
 
-  tput cuu 1 # Move up one line
-  tput el    # Clear "running" line
+	tput cuu 1 # Move up one line
+	tput el		# Clear "running" line
 
-  if [[ ${result} -eq 0 ]]; then
-    tput setaf 2 # green
-    echo "ok      $1"
-    tput sgr0    # reset
-    exit 0
-  else
-    tput setaf 1 # red
-    echo "failed  $1"
-    tput sgr0    # reset
-    echo "${out}"
-    exit 1
-  fi
+	if [[ ${result} -eq 0 ]]; then
+		tput setaf 2 # green
+		echo "ok			$1"
+		tput sgr0		# reset
+		exit 0
+	else
+		tput setaf 1 # red
+		echo "failed	$1"
+		tput sgr0		# reset
+		echo "${out}"
+		exit 1
+	fi
 }
 
 export -f exectest
@@ -93,6 +132,6 @@ export childargs
 # run each test as its own process
 pushd "./${package}" 2>&1 >/dev/null
 time go run "${OS_ROOT}/hack/listtests.go" -prefix="${OS_GO_PACKAGE}/${package}.Test" "${testdir}" \
-  | grep --color=never -E "${1-Test}" \
-  | xargs -I {} -n 1 bash -c "exectest {} ${@:2}" # "${testexec}" -test.run="^{}$" "${@:2}"
+	| grep --color=never -E "${1-Test}" \
+	| xargs -I {} -n 1 bash -c "exectest {} ${@:2}" # "${testexec}" -test.run="^{}$" "${@:2}"
 popd 2>&1 >/dev/null


### PR DESCRIPTION
Change the integration test etcd server to a non-default port to make it easier to run them in parallel with other tests.

@liggitt 