### PR TITLE
Renaming osc to oc in cmd code

### DIFF
--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -45,7 +45,7 @@ After logging out, if you want to log back into the server use '%[1]s'.`
 )
 
 // NewCmdLogout implements the OpenShift cli logout command
-func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
+func NewCmdLogout(name, fullName, ocLoginFullCommand string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
 	options := &LogoutOptions{
 		Out: out,
 	}
@@ -53,7 +53,7 @@ func NewCmdLogout(name, fullName, oscLoginFullCommand string, f *osclientcmd.Fac
 	cmds := &cobra.Command{
 		Use:     name,
 		Short:   "End the current server session",
-		Long:    fmt.Sprintf(logoutLong, oscLoginFullCommand),
+		Long:    fmt.Sprintf(logoutLong, ocLoginFullCommand),
 		Example: fmt.Sprintf(logoutExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, cmd, args); err != nil {

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -45,14 +45,14 @@ After your project is created it will be made your default project in your confi
   $ %[1]s web-team-dev --display-name="Web Team Development" --description="Development project for the web team."`
 )
 
-func NewCmdRequestProject(name, fullName, oscLoginName, oscProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRequestProject(name, fullName, ocLoginName, ocProjectName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	options := &NewProjectOptions{}
 	options.Out = out
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
 		Short:   "Request a new project",
-		Long:    fmt.Sprintf(requestProjectLong, oscLoginName, oscProjectName),
+		Long:    fmt.Sprintf(requestProjectLong, ocLoginName, ocProjectName),
 		Example: fmt.Sprintf(requestProjectExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.complete(cmd, f); err != nil {


### PR DESCRIPTION
Just minor cosmetic update, since the vars names where raising exceptions in my head while reading the code :no_entry: