### PR TITLE
removed docker-registry endpoint validation

### DIFF
--- a/hack/test-extended/default/run.sh
+++ b/hack/test-extended/default/run.sh
@@ -43,8 +43,6 @@ install_router_extended
 
 install_registry_extended
 
-wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=/tmp/openshift-extended-tests/openshift.local.config/master/admin.kubeconfig || echo "0")" != "0" ]]' $((5*TIME_MIN))
-
 create_image_streams_extended
 
 echo "[INFO] MASTER IP - ${MASTER_ADDR}"

--- a/hack/test-extended/forcepull/run.sh
+++ b/hack/test-extended/forcepull/run.sh
@@ -45,9 +45,6 @@ install_router_extended
 
 install_registry_extended
 
-# I've seen this hang, even though when I run it manually concurrently it works ... simply bypassing this check has simply accelerated the test ... so far, not seeing value in this verification ... the registry seems to come up consistently
-#wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=/tmp/openshift-extended-tests/openshift.local.config/master/admin.kubeconfig || echo "0")" != "0" ]]' $((5*TIME_MIN))
-
 create_image_streams_extended
 
 echo "[INFO] MASTER IP - ${MASTER_ADDR}"


### PR DESCRIPTION
This check inside of the extended test suite is a constant head-ache for me. Apparently @gabemontero thought so as well, his comment was : 
>  I've seen this hang, even though when I run it manually concurrently it works ... simply bypassing this check has simply accelerated the test ... so far, not seeing value in this verification ... the registry seems to come up consistently

I think removing it saves us headaches, makes the test faster, and doesn't have downsides. I haven't seen the registry fail to come online ever.

@mfojtik @deads2k @liggitt PTAL