### PR TITLE
enable docker registry wait in forcepull bucket

### DIFF
--- a/hack/test-extended/forcepull/run.sh
+++ b/hack/test-extended/forcepull/run.sh
@@ -45,8 +45,7 @@ install_router_extended
 
 install_registry_extended
 
-# I've seen this hang, even though when I run it manually concurrently it works ... simply bypassing this check has simply accelerated the test ... so far, not seeing value in this verification ... the registry seems to come up consistently
-#wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=/tmp/openshift-extended-tests/openshift.local.config/master/admin.kubeconfig || echo "0")" != "0" ]]' $((5*TIME_MIN))
+wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=/tmp/openshift-extended-tests/openshift.local.config/master/admin.kubeconfig || echo "0")" != "0" ]]' $((5*TIME_MIN))
 
 create_image_streams_extended
 


### PR DESCRIPTION
The wait times seem to be under control. @gabemontero fyi 

@liggitt  PTAL

Fixes #4507