### PR TITLE
[RPMs] Fix requirements between node and tuned profiles

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -60,7 +60,7 @@ Requires(postun): systemd
 Summary:        %{product_name} Node
 Requires:       %{name} = %{version}-%{release}
 Requires:       docker-io >= %{docker_version}
-Requires:       tuned-profiles-%{name}-node
+Requires:       tuned-profiles-%{name}-node = %{version}-%{release}
 Requires:       util-linux
 Requires:       socat
 Requires:       nfs-utils
@@ -74,7 +74,6 @@ Requires(postun): systemd
 %package -n tuned-profiles-%{name}-node
 Summary:        Tuned profiles for %{product_name} Node hosts
 Requires:       tuned >= %{tuned_version}
-Requires:       %{name} = %{version}-%{release}
 
 %description -n tuned-profiles-%{name}-node
 %{summary}


### PR DESCRIPTION
While testing upgrade paths I found that it's impossible to install an older version of origin-node because it depends on tuned-profiles-origin-node which depends on origin-node of a matching version. Yum selects the latest version of tuned-profiles-origin-node to install and dependency resolution fails at that point.

The example below is based on OSE equivalent packages.
```
Running transaction check
---> Package openshift-node.x86_64 0:3.0.0.0-0.git.25.235b0e7.el7ose will be installed
--> Processing Dependency: openshift = 3.0.0.0-0.git.
25.235b0e7.el7ose for package: openshift-node-3.0.0.0-0.git.25.235b0e7.el7ose.x86_64
--> Processing Dependency: docker-io >= 1.6.2 for package: openshift-node-3.0.0.0-0.git.25.235b0e7.el7ose.x86_64
--> Processing Dependency: tuned-profiles-openshift-node for package: openshift-node-3.0.0.0-0.git.25.235b0e7.el7ose.x86_64
--> Running transaction check
---> Package docker.x86_64 0:1.7.1-108.el7 will be installed
--> Processing Dependency: docker-selinux >= 1.7.1-108.el7 for package: docker-1.7.1-108.el7.x86_64
---> Package openshift.x86_64 0:3.0.0.0-0.git.25.235b0e7.el7ose will be installed
---> Package tuned-profiles-openshift-node.x86_64 0:3.0.1.0-1.git.529.dcab62c.el7ose will be installed
--> Processing Dependency: openshift = 3.0.1.0-1.git.529.dcab62c.el7ose for package: tuned-profiles-openshift-node-3.0.1.0-1.git.529.dcab62c.el7ose.x86_64
--> Running transaction check\n---> Package docker-selinux.x86_64 0:1.7.1-108.el7 will be installed
---> Package openshift.x86_64 0:3.0.0.0-0.git.25.235b0e7.el7ose will be installed
--> Processing Dependency: openshift = 3.0
.0.0-0.git.25.235b0e7.el7ose for package: openshift-node-3.0.0.0-0.git.25.235b0e7.el7ose.x86_64
---> Package openshift.x86_64 0:3.0.1.0-1.git.529.dcab62c.el7ose will be installed
--> Finished Dependency Resolution
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest"]}

msg: Error: Package: openshift-node-3.0.0.0-0.git.25.235b0e7.el7ose.x86_64 (rhel-7-server-ose-3.0-rpms)
           Requires: openshift = 3.0.0.0-0.git.25.235b0e7.el7ose
           Available: openshift-3.0.0.0-0.git.25.235b0e7.el7ose.x86_64 (rhel-7-server-ose-3.0-rpms)
               openshift = 3.0.0.0-0.git.25.235b0e7.el7ose
           Available: openshift-3.0.0.1-1.git.4.eab4c86.el7ose.x86_64 (rhel-7-server-ose-3.0-rpms)
               openshift = 3.0.0.1-1.git.4.eab4c86.el7ose
           Available: openshift-3.0.1.0-1.git.525.eddc479.el7ose.x86_64 (rhel-7-server-ose-3.0-rpms)
               openshift = 3.0.1.0-1.git.525.eddc479.el7ose
           Available: openshift-3.0.1.0-1.git.527.f8d5fed.el7ose.x86_64 (rhel-7-server-ose-3.0-rpms)
               openshift = 3.0.1.0-1.git.527.f8d5fed.el7ose
           Installing: openshift-3.0.1.0-1.git.529.dcab62c.el7ose.x86_64 (rhel-7-server-ose-3.0-rpms)
               openshift = 3.0.1.0-1.git.529.dcab62c.el7ose
```

The profiles should not depend on the origin nor origin-node so I've also removed the dependency there.