### PR TITLE
Fix manual deployment

### DIFF
--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"sort"
@@ -99,7 +100,7 @@ func TestCmdDeploy_latestLookupError(t *testing.T) {
 	kubeClient.ReactFn = func(action ktc.Action) (runtime.Object, error) {
 		switch action.(type) {
 		case ktc.GetAction:
-			return nil, kerrors.NewNotFound("name", "not found")
+			return nil, kerrors.NewInternalError(fmt.Errorf("internal error"))
 		}
 		t.Fatalf("unexpected action: %+v", action)
 		return nil, nil


### PR DESCRIPTION
Fix the manual deployment command (--latest) so that new deployments
can be started any time there's no conflict with an existing deployment.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1259153