### PR TITLE
get: Fix imageStream tag clutter

### DIFF
--- a/pkg/image/api/sort.go
+++ b/pkg/image/api/sort.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"sort"
+
+	"k8s.io/kubernetes/pkg/util"
+)
+
+type tag struct {
+	Name    string
+	Created util.Time
+}
+
+type byCreationTimestamp []tag
+
+func (t byCreationTimestamp) Len() int {
+	return len(t)
+}
+
+func (t byCreationTimestamp) Less(i, j int) bool {
+	return t[i].Created.Time.After(t[j].Created.Time)
+}
+
+func (t byCreationTimestamp) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+// SortStatusTags sorts the status tags of an image stream based on
+// the latest created
+func SortStatusTags(tags map[string]TagEventList) []string {
+	tagSlice := make([]tag, len(tags))
+	index := 0
+	for tag, list := range tags {
+		tagSlice[index].Name = tag
+		if len(list.Items) > 0 {
+			tagSlice[index].Created = list.Items[0].Created
+		}
+		index++
+	}
+
+	sort.Sort(byCreationTimestamp(tagSlice))
+
+	actual := make([]string, len(tagSlice))
+	for i, tag := range tagSlice {
+		actual[i] = tag.Name
+	}
+
+	return actual
+}

--- a/pkg/image/api/sort_test.go
+++ b/pkg/image/api/sort_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	kutil "k8s.io/kubernetes/pkg/util"
+
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSortStatusTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     map[string]TagEventList
+		expected []string
+	}{
+		{
+			name: "all timestamps here",
+			tags: map[string]TagEventList{
+				"other": {
+					Items: []TagEvent{
+						{
+							DockerImageReference: "other-ref",
+							Created:              kutil.Date(2015, 9, 4, 13, 52, 0, 0, time.UTC),
+							Image:                "other-image",
+						},
+					},
+				},
+				"latest": {
+					Items: []TagEvent{
+						{
+							DockerImageReference: "latest-ref",
+							Created:              kutil.Date(2015, 9, 4, 13, 53, 0, 0, time.UTC),
+							Image:                "latest-image",
+						},
+					},
+				},
+				"third": {
+					Items: []TagEvent{
+						{
+							DockerImageReference: "third-ref",
+							Created:              kutil.Date(2015, 9, 4, 13, 54, 0, 0, time.UTC),
+							Image:                "third-image",
+						},
+					},
+				},
+			},
+			expected: []string{"third", "latest", "other"},
+		},
+	}
+
+	for _, test := range tests {
+		got := SortStatusTags(test.tags)
+		if !reflect.DeepEqual(test.expected, got) {
+			t.Errorf("%s: tags mismatch: expected %v, got %v", test.name, test.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
If an image stream is full of tags, getting it doesn't give the best output in the world
```
[vagrant@openshiftdev sample-app]$ oc get is
NAME         DOCKER REPO                          TAGS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              UPDATED
python       library/python                       2,2-onbuild,2-slim,2-wheezy,2.7,2.7-onbuild,2.7-slim,2.7-wheezy,2.7.10,2.7.10-onbuild,2.7.10-slim,2.7.10-wheezy,2.7.9,2.7.9-onbuild,2.7.9-slim,2.7.9-wheezy,3,3-onbuild,3-slim,3-wheezy,3.2,3.2-onbuild,3.2-slim,3.2-wheezy,3.2.6,3.2.6-onbuild,3.2.6-slim,3.2.6-wheezy,3.3,3.3-onbuild,3.3-slim,3.3-wheezy,3.3.6,3.3.6-onbuild,3.3.6-slim,3.3.6-wheezy,3.4,3.4-onbuild,3.4-slim,3.4-wheezy,3.4.3,3.4.3-onbuild,3.4.3-slim,3.4.3-wheezy,3.5,3.5-onbuild,3.5-slim,3.5.0,3.5.0-onbuild,3.5.0-slim,3.5.0b3,3.5.0b3-onbuild,3.5.0b3-slim,latest,onbuild,slim,wheezy   13 minutes ago
sti-python   172.30.232.91:5000/test/sti-python  
```

Instead let's print up to a number of the most recent tags (3 in the case of this PR but I can change it)
```
[vagrant@openshiftdev sample-app]$ oc get is
NAME         DOCKER REPO                          TAGS                            UPDATED
python       library/python                       wheezy,slim,onbuild + 54 more...   39 minutes ago
sti-python   172.30.232.91:5000/test/sti-python   
```

Something similar already happens with endpoints when describing services: https://github.com/kubernetes/kubernetes/pull/8778


Found in #4519 

@ncdc 