### PR TITLE
fix process kill in old e2e.sh

### DIFF
--- a/hack/test-extended/config-compatibility/run.sh
+++ b/hack/test-extended/config-compatibility/run.sh
@@ -13,7 +13,7 @@ trap "exit" INT TERM
 trap "cleanup_extended" EXIT
 
 TMPDIR="${TMPDIR:-"/tmp"}"
-BASETMPDIR="${TMPDIR}/openshift-extended-test/config-compatibility"
+BASETMPDIR="${TMPDIR}/openshift-extended-tests/config-compatibility"
 
 # run the end-to-end using the old config from each release
 V1_TMPDIR=${BASETMPDIR}/v1.0.0

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -382,9 +382,9 @@ function kill_all_processes()
   fi
 
   pids=($(jobs -pr))
-  for i in ${pids[@]}; do
+  for i in ${pids[@]-}; do
     ps --ppid=${i} | xargs $sudo kill &> /dev/null
-    $sudo kill ${i} &> /dev/null &> /dev/null
+    $sudo kill ${i} &> /dev/null
   done
 }
 

--- a/test/old-start-configs/v1.0.0/test-end-to-end.sh
+++ b/test/old-start-configs/v1.0.0/test-end-to-end.sh
@@ -124,17 +124,13 @@ function cleanup()
 	echo
 
 	if [[ -z "${SKIP_TEARDOWN-}" ]]; then
-		echo "[INFO] Deleting test constructs"
-		oc delete -n test all --all
-		oc delete -n docker all --all
-		oc delete -n custom all --all
-		oc delete -n cache all --all
-		oc delete -n default all --all
-
 		echo "[INFO] Tearing down test"
 		pids="$(jobs -pr)"
 		echo "[INFO] Children: ${pids}"
-		sudo kill ${pids}
+		for i in ${pids[@]-}; do
+			ps --ppid=${i} | xargs sudo kill &> /dev/null
+			sudo kill ${i} &> /dev/null
+		done
 		sudo ps f
 		set +u
 		echo "[INFO] Stopping k8s docker containers"; docker ps | awk 'index($NF,"k8s_")==1 { print $1 }' | xargs -l -r docker stop


### PR DESCRIPTION
The process kill in the old e2e.sh that we used in v1.0.0 was broken.  It left the openshift process running.  That causes the later tests to fail.  This copies the new kill.  We can't use the new kill directly because we need e2e to cleanup after itself for future compatibility tests and we can't depend on a different version `util.sh` for the compat test.

@liggitt or @mfojtik This fixes the https://ci.openshift.redhat.com/jenkins/job/origin_extended/ job. (I think)