### PR TITLE
improve nodeconfig validation

### DIFF
--- a/pkg/cmd/server/admin/create_client.go
+++ b/pkg/cmd/server/admin/create_client.go
@@ -40,7 +40,7 @@ master as the provided user.
 `
 
 func NewCommandCreateClient(commandName string, fullName string, out io.Writer) *cobra.Command {
-	options := &CreateClientOptions{SignerCertOptions: &SignerCertOptions{}, Output: out}
+	options := &CreateClientOptions{SignerCertOptions: NewDefaultSignerCertOptions(), Output: out}
 
 	cmd := &cobra.Command{
 		Use:   commandName,

--- a/pkg/cmd/server/admin/create_nodeconfig.go
+++ b/pkg/cmd/server/admin/create_nodeconfig.go
@@ -110,7 +110,7 @@ func NewCommandNodeConfig(commandName string, fullName string, out io.Writer) *c
 }
 
 func NewDefaultCreateNodeConfigOptions() *CreateNodeConfigOptions {
-	options := &CreateNodeConfigOptions{SignerCertOptions: &SignerCertOptions{}}
+	options := &CreateNodeConfigOptions{SignerCertOptions: NewDefaultSignerCertOptions()}
 	options.VolumeDir = "openshift.local.volumes"
 	// TODO: replace me with a proper round trip of config options through decode
 	options.DNSDomain = "cluster.local"
@@ -147,16 +147,16 @@ func (o CreateNodeConfigOptions) Validate(args []string) error {
 		return errors.New("no arguments are supported")
 	}
 	if len(o.NodeConfigDir) == 0 {
-		return errors.New("node-dir must be provided")
+		return errors.New("--node-dir must be provided")
 	}
 	if len(o.NodeName) == 0 {
-		return errors.New("node must be provided")
+		return errors.New("--node must be provided")
 	}
 	if len(o.APIServerURL) == 0 {
-		return errors.New("master must be provided")
+		return errors.New("--master must be provided")
 	}
-	if len(o.APIServerCAFile) == 0 {
-		return errors.New("certificate-authority must be provided")
+	if _, err := os.Stat(o.APIServerCAFile); len(o.APIServerCAFile) == 0 || err != nil {
+		return fmt.Errorf("--certificate-authority, %q must be a valid certificate file", cmdutil.GetDisplayFilename(o.APIServerCAFile))
 	}
 	if len(o.Hostnames) == 0 {
 		return errors.New("at least one hostname must be provided")
@@ -164,29 +164,29 @@ func (o CreateNodeConfigOptions) Validate(args []string) error {
 
 	if len(o.ClientCertFile) != 0 {
 		if len(o.ClientKeyFile) == 0 {
-			return errors.New("client-key must be provided if client-certificate is provided")
+			return errors.New("--client-key must be provided if --client-certificate is provided")
 		}
 	} else if len(o.ClientKeyFile) != 0 {
-		return errors.New("client-certificate must be provided if client-key is provided")
+		return errors.New("--client-certificate must be provided if --client-key is provided")
 	}
 
 	if len(o.ServerCertFile) != 0 {
 		if len(o.ServerKeyFile) == 0 {
-			return errors.New("server-key must be provided if server-certificate is provided")
+			return errors.New("--server-key must be provided if --server-certificate is provided")
 		}
 	} else if len(o.ServerKeyFile) != 0 {
-		return errors.New("server-certificate must be provided if server-key is provided")
+		return errors.New("--server-certificate must be provided if --server-key is provided")
 	}
 
 	if o.IsCreateClientCertificate() || o.IsCreateServerCertificate() {
 		if len(o.SignerCertOptions.KeyFile) == 0 {
-			return errors.New("signer-key must be provided to create certificates")
+			return errors.New("--signer-key must be provided to create certificates")
 		}
 		if len(o.SignerCertOptions.CertFile) == 0 {
-			return errors.New("signer-cert must be provided to create certificates")
+			return errors.New("--signer-cert must be provided to create certificates")
 		}
 		if len(o.SignerCertOptions.SerialFile) == 0 {
-			return errors.New("signer-serial must be provided to create certificates")
+			return errors.New("--signer-serial must be provided to create certificates")
 		}
 	}
 

--- a/pkg/cmd/server/admin/create_servercert.go
+++ b/pkg/cmd/server/admin/create_servercert.go
@@ -45,7 +45,7 @@ Example: Creating a secure router certificate.
 `
 
 func NewCommandCreateServerCert(commandName string, fullName string, out io.Writer) *cobra.Command {
-	options := &CreateServerCertOptions{SignerCertOptions: &SignerCertOptions{}, Output: out}
+	options := &CreateServerCertOptions{SignerCertOptions: NewDefaultSignerCertOptions(), Output: out}
 
 	cmd := &cobra.Command{
 		Use:   commandName,

--- a/pkg/cmd/server/admin/signer_cert_args.go
+++ b/pkg/cmd/server/admin/signer_cert_args.go
@@ -1,13 +1,15 @@
 package admin
 
 import (
-	"errors"
+	"fmt"
+	"os"
 	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
 type SignerCertOptions struct {
@@ -20,9 +22,9 @@ type SignerCertOptions struct {
 }
 
 func BindSignerCertOptions(options *SignerCertOptions, flags *pflag.FlagSet, prefix string) {
-	flags.StringVar(&options.CertFile, prefix+"signer-cert", "openshift.local.config/master/ca.crt", "The certificate file.")
-	flags.StringVar(&options.KeyFile, prefix+"signer-key", "openshift.local.config/master/ca.key", "The key file.")
-	flags.StringVar(&options.SerialFile, prefix+"signer-serial", "openshift.local.config/master/ca.serial.txt", "The serial file that keeps track of how many certs have been signed.")
+	flags.StringVar(&options.CertFile, prefix+"signer-cert", options.CertFile, "The certificate file.")
+	flags.StringVar(&options.KeyFile, prefix+"signer-key", options.KeyFile, "The key file.")
+	flags.StringVar(&options.SerialFile, prefix+"signer-serial", options.SerialFile, "The serial file that keeps track of how many certs have been signed.")
 
 	// autocompletion hints
 	cobra.MarkFlagFilename(flags, prefix+"signer-cert")
@@ -30,15 +32,24 @@ func BindSignerCertOptions(options *SignerCertOptions, flags *pflag.FlagSet, pre
 	cobra.MarkFlagFilename(flags, prefix+"signer-serial")
 }
 
+func NewDefaultSignerCertOptions() *SignerCertOptions {
+	options := &SignerCertOptions{}
+	options.CertFile = "openshift.local.config/master/ca.crt"
+	options.KeyFile = "openshift.local.config/master/ca.key"
+	options.SerialFile = "openshift.local.config/master/ca.serial.txt"
+
+	return options
+}
+
 func (o *SignerCertOptions) Validate() error {
-	if len(o.CertFile) == 0 {
-		return errors.New("signer-cert must be provided")
+	if _, err := os.Stat(o.CertFile); len(o.CertFile) == 0 || err != nil {
+		return fmt.Errorf("--signer-cert, %q must be a valid certificate file", cmdutil.GetDisplayFilename(o.CertFile))
 	}
-	if len(o.KeyFile) == 0 {
-		return errors.New("signer-key must be provided")
+	if _, err := os.Stat(o.KeyFile); len(o.KeyFile) == 0 || err != nil {
+		return fmt.Errorf("--signer-key, %q must be a valid key file", cmdutil.GetDisplayFilename(o.KeyFile))
 	}
-	if len(o.SerialFile) == 0 {
-		return errors.New("signer-serial must be provided")
+	if _, err := os.Stat(o.SerialFile); len(o.SerialFile) == 0 || err != nil {
+		return fmt.Errorf("--signer-serial, %q must be a valid file", cmdutil.GetDisplayFilename(o.SerialFile))
 	}
 
 	return nil

--- a/pkg/cmd/util/cmd.go
+++ b/pkg/cmd/util/cmd.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,4 +21,13 @@ func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
 
 		c.Help()
 	}
+}
+
+// GetDisplayFilename returns the absolute path of the filename as long as there was no error, otherwise it returns the filename as-is
+func GetDisplayFilename(filename string) string {
+	if absName, err := filepath.Abs(filename); err == nil {
+		return absName
+	}
+
+	return filename
 }


### PR DESCRIPTION
Adds an additional check to node config and signer cert validation to give better messages when information is missing.  Previously, a reference to a missing file produced an esoteric message about a missing file that the user may even have forgotten to specify.  Now if the referenced signer information doesn't exist, then command will fail with a message indicating which parameter is bad.

If you'd prefer, I can eliminate the default values, but that's sometimes a pain.  I did go ahead and plumb a way for individual commands to decide about the default values.

@csrwng you complained about this before too.  ptal.