### PR TITLE
Bug 1250291 - labels must be applied to templates in deploymentconfigs

### DIFF
--- a/pkg/util/labels_test.go
+++ b/pkg/util/labels_test.go
@@ -111,7 +111,7 @@ func TestAddConfigLabels(t *testing.T) {
 					ControllerTemplate: kapi.ReplicationControllerSpec{
 						Template: &kapi.PodTemplateSpec{
 							ObjectMeta: kapi.ObjectMeta{
-								Labels: map[string]string{},
+								Labels: map[string]string{"foo": "first value"},
 							},
 						},
 					},
@@ -155,7 +155,7 @@ func TestAddConfigLabels(t *testing.T) {
 				t.Errorf("Unexpected labels on testCase[%v]. Expected: %#v, got: %#v.", i, e, a)
 			}
 		case *deployapi.DeploymentConfig:
-			if e, a := map[string]string{}, objType.Template.ControllerTemplate.Template.Labels; !reflect.DeepEqual(e, a) {
+			if e, a := test.expectedLabels, objType.Template.ControllerTemplate.Template.Labels; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected labels on testCase[%v]. Expected: %#v, got: %#v.", i, e, a)
 			}
 		}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1250291

This addresses an inconsistency between the CLI and the web console - when creating from `oc new-app` the `app=` label does not propagate to pods, while they do when creating from the web console. 

In CLI, the template element in deployment configs must contain all proposed labels, including `app=`.