### PR TITLE
Surface ConfigChange trigger in new app, render in build page

### DIFF
--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -31,7 +31,8 @@ angular.module("openshiftConsole")
       scope.buildConfig = {
         sourceUrl: $routeParams.sourceURL,
         buildOnSourceChange: true,
-        buildOnImageChange: true
+        buildOnImageChange: true,
+        buildOnConfigChange: true
       };
       scope.deploymentConfig = {
         deployOnNewImage: true,

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -182,12 +182,9 @@ angular.module("openshiftConsole")
             secret: scope._generateSecret()
           },
           type: "Generic"
-        },
-        {
-          type: "ConfigChange"
         }
       ];
-      if(input.buildConfig.buildOnSourceChange){
+      if (input.buildConfig.buildOnSourceChange) {
         triggers.push({
             github: {
               secret: scope._generateSecret()
@@ -196,10 +193,15 @@ angular.module("openshiftConsole")
           }
         );
       }
-      if(input.buildConfig.buildOnImageChange){
+      if (input.buildConfig.buildOnImageChange) {
         triggers.push({
           imageChange: {},
           type: "ImageChange"
+        });
+      }
+      if (input.buildConfig.buildOnConfigChange) {
+        triggers.push({
+          type: "ConfigChange"
         });
       }
 

--- a/assets/app/views/builds.html
+++ b/assets/app/views/builds.html
@@ -78,41 +78,40 @@
                   </div>
                   <div ng-switch-when="ImageChange">
                     <div ng-switch="buildConfig.spec.strategy.type">
-                      <div ng-switch-when="Source">
-                        <dl class="dl-horizontal" ng-if="buildConfig.spec.strategy.sourceStrategy.from && buildConfig.spec.strategy.sourceStrategy.from.kind!='ImageStreamImage'">
-                          <dt>
-                            New image for:
-                          </dt>
-                          <dd>
-                            Image stream {{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                          </dd>
-                        </dl>
+                      <div ng-switch-when="Source" ng-if="buildConfig.spec.strategy.sourceStrategy.from && buildConfig.spec.strategy.sourceStrategy.from.kind!='ImageStreamImage'">
+                        <dt>
+                          New image for:
+                        </dt>
+                        <dd>
+                          Image stream {{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                        </dd>
                       </div>
-                      <div ng-switch-when="Docker">
-                        <dl class="dl-horizontal" ng-if="buildConfig.spec.strategy.dockerStrategy.from && buildConfig.spec.strategy.dockerStrategy.from.kind!='ImageStreamImage'">
-                          <dt>
-                            New image for:
-                          </dt>
-                          <dd>
-                            Image stream {{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                          </dd>
-                          <br>
-                        </dl>
+                      <div ng-switch-when="Docker" ng-if="buildConfig.spec.strategy.dockerStrategy.from && buildConfig.spec.strategy.dockerStrategy.from.kind!='ImageStreamImage'">
+                        <dt>
+                          New image for:
+                        </dt>
+                        <dd>
+                          Image stream {{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                        </dd>
                       </div>
-                      <div ng-switch-when="Custom">
-                        <dl class="dl-horizontal" ng-if="buildConfig.spec.strategy.customStrategy.from && buildConfig.spec.strategy.customStrategy.from.kind!='ImageStreamImage'">
-                          <dt>
-                            New image for:
-                          </dt>
-                          <dd>
-                            Image stream {{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                          </dd>
-                           <br>
-                        </dl>
+                      <div ng-switch-when="Custom" ng-if="buildConfig.spec.strategy.customStrategy.from && buildConfig.spec.strategy.customStrategy.from.kind!='ImageStreamImage'">
+                        <dt>
+                          New image for:
+                        </dt>
+                        <dd>
+                          Image stream {{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                        </dd>
                       </div>
                     </div>
                   </div>
-                  <div ng-switch-default>{{trigger.type}}</div>
+                  <div ng-switch-when="ConfigChange">
+                    <dt>Config change for:</dt>
+                    <dd>Build config {{buildConfig.metadata.name}}</dd>
+                  </div>
+                  <div ng-switch-default>
+                    <dt>Other trigger:</dt>
+                    <dd>{{trigger.type}}</dd>
+                  </div>
                 </div>
               </div>
             </dl>

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -162,12 +162,16 @@
                       <span>{{buildConfig.sourceUrl | defaultIfBlank: "Not Specified"}}</span>
                     </div>
                     <div>
-                      <label>Automatically build new image when code changes: </label>
+                      <label>Configure a webhook build trigger: </label>
                       <span>{{buildConfig.buildOnSourceChange | yesNo}}</span>
                     </div>
                     <div>
-                      <label>Automatically build new image when builder image changes: </label>
+                      <label>Automatically build a new image when builder image changes: </label>
                       <span>{{buildConfig.buildOnImageChange | yesNo}}</span>
+                    </div>
+                    <div>
+                      <label>Automatically build a new image when build configuration changes: </label>
+                      <span>{{buildConfig.buildOnConfigChange | yesNo}}</span>
                     </div>
                   </div>
                   <div class="animate-drawer" ng-show="$parent.expand">
@@ -178,7 +182,7 @@
                     <div>
                       <label class="checkbox">
                         <input type="checkbox" ng-model="buildConfig.buildOnSourceChange"/>
-                        Configure webhook build trigger 
+                        Configure a webhook build trigger 
                         <span class="help action-inline">
                           <a href data-toggle="tooltip" data-placement="right" 
                              data-original-title="The source repository must be configured to use the webhook to trigger a build when source is committed.">
@@ -190,12 +194,18 @@
                     <div>
                       <label class="checkbox">
                         <input type="checkbox" ng-model="buildConfig.buildOnImageChange"/>
-                        Automatically build new image when the builder image changes
+                        Automatically build a new image when the builder image changes
                         <span class="help action-inline">
                           <a href data-toggle="tooltip" data-placement="right" data-original-title="Automatically building a new image when the builder image changes allows your code to always run on the latest updates.">
                           <i class="pficon pficon-help"></i> 
                           </a>
                         </span>
+                      </label>
+                    </div>
+                    <div>
+                      <label class="checkbox">
+                        <input type="checkbox" ng-model="buildConfig.buildOnConfigChange"/>
+                        Automatically build a new image when the build configuration changes
                       </label>
                     </div>
                   </div>

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -27,7 +27,8 @@ describe("ApplicationGenerator", function(){
       buildConfig: {
         sourceUrl: "https://github.com/openshift/ruby-hello-world.git",
         buildOnSourceChange: true,
-        buildOnImageChange: true
+        buildOnImageChange: true,
+        buildOnConfigChange: true
       },
       deploymentConfig: {
         deployOnConfigChange: true,
@@ -227,9 +228,6 @@ describe("ApplicationGenerator", function(){
                         "type": "Generic"
                     },
                     {
-                        "type": "ConfigChange"
-                    },
-                    {
                         "github": {
                             "secret": "secret101"
                         },
@@ -238,6 +236,9 @@ describe("ApplicationGenerator", function(){
                     {
                       "imageChange" : {},
                       "type" : "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
                     }
                 ]
             }


### PR DESCRIPTION
Fixes #4546

- [x] Reorder triggers to put ConfigChange last
- [x] Surface checkbox in new app wizard to allow toggling it
- [x] Render ConfigChange trigger better on builds page