### PR TITLE
Use <name>-<namespace> instead of <name>.<namespace> in routes

### DIFF
--- a/plugins/route/allocation/simple/plugin.go
+++ b/plugins/route/allocation/simple/plugin.go
@@ -3,7 +3,6 @@ package simple
 import (
 	"fmt"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/util"
 
@@ -37,8 +36,8 @@ func NewSimpleAllocationPlugin(suffix string) (*SimpleAllocationPlugin, error) {
 
 // Allocate a router shard for the given route. This plugin always returns
 // the "global" router shard.
+// TODO: replace with per router allocation
 func (p *SimpleAllocationPlugin) Allocate(route *routeapi.Route) (*routeapi.RouterShard, error) {
-
 	glog.V(4).Infof("Allocating global shard *.%s to Route: %s", p.DNSSuffix, route.ServiceName)
 
 	return &routeapi.RouterShard{ShardName: "global", DNSSuffix: p.DNSSuffix}, nil
@@ -46,25 +45,10 @@ func (p *SimpleAllocationPlugin) Allocate(route *routeapi.Route) (*routeapi.Rout
 
 // GenerateHostname generates a host name for a route - using the service name,
 // namespace (if provided) and the router shard dns suffix.
+// TODO: move to router code, and have the routers set this back on the route status.
 func (p *SimpleAllocationPlugin) GenerateHostname(route *routeapi.Route, shard *routeapi.RouterShard) string {
-
-	name := route.Name
-	if len(name) == 0 {
-		name = route.ServiceName
+	if len(route.Name) == 0 || len(route.Namespace) == 0 {
+		return ""
 	}
-	if len(name) == 0 {
-		name = uuid.NewUUID().String()
-		glog.V(4).Infof("No service name passed, using generated name: %s", name)
-	}
-
-	s := ""
-	if len(route.Namespace) == 0 {
-		s = fmt.Sprintf("%s.%s", name, shard.DNSSuffix)
-	} else {
-		s = fmt.Sprintf("%s.%s.%s", name, route.Namespace, shard.DNSSuffix)
-	}
-
-	glog.V(4).Infof("Generated hostname=%s for Route: %s", s, route.Name)
-
-	return s
+	return fmt.Sprintf("%s-%s.%s", route.Name, route.Namespace, shard.DNSSuffix)
 }


### PR DESCRIPTION
Fixes TLS wildcarding issues.  This is now safe because duplicate names
are rejected by routers.

Fixes #4015