### PR TITLE
Make unknown trigger types to be warning not error

### DIFF
--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 
+	"github.com/golang/glog"
 	oapi "github.com/openshift/origin/pkg/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildutil "github.com/openshift/origin/pkg/build/util"
@@ -348,9 +349,9 @@ func validateTrigger(trigger *buildapi.BuildTriggerPolicy) fielderrors.Validatio
 		}
 		allErrs = append(allErrs, validateFromImageReference(trigger.ImageChange.From).Prefix("from")...)
 	case buildapi.ConfigChangeBuildTriggerType:
-		// doesn't reuqire additional validation
+		// doesn't require additional validation
 	default:
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("type", trigger.Type, "invalid trigger type"))
+		glog.Warningf("Unknown trigger type: '%s'", trigger.Type)
 	}
 	return allErrs
 }

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -994,11 +994,10 @@ func TestValidateTrigger(t *testing.T) {
 			trigger:  buildapi.BuildTriggerPolicy{},
 			expected: []*fielderrors.ValidationError{fielderrors.NewFieldRequired("type")},
 		},
-		"trigger with unknown type": {
+		"trigger with unknown type is valid, but ignored": {
 			trigger: buildapi.BuildTriggerPolicy{
 				Type: "UnknownTriggerType",
 			},
-			expected: []*fielderrors.ValidationError{fielderrors.NewFieldInvalid("type", "", "")},
 		},
 		"GitHub type with no github webhook": {
 			trigger:  buildapi.BuildTriggerPolicy{Type: buildapi.GitHubWebHookBuildTriggerType},


### PR DESCRIPTION
This allow us to introduce new trigger types in the future without
breaking older versions of the OpenShift server.

Part of #4447
Related to:
- https://bugzilla.redhat.com/show_bug.cgi?id=1257576
- https://bugzilla.redhat.com/show_bug.cgi?id=1259263

@bparees PTAL