### PR TITLE
Removing whitespaces in project describe

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -574,7 +574,6 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 		formatString(out, "Description", project.Annotations[projectapi.ProjectDescription])
 		formatString(out, "Status", project.Status.Phase)
 		formatString(out, "Node Selector", nodeSelector)
-		fmt.Fprintf(out, "\n")
 		if len(resourceQuotaList.Items) == 0 {
 			formatString(out, "Quota", "")
 		} else {
@@ -600,7 +599,6 @@ func (d *ProjectDescriber) Describe(namespace, name string) (string, error) {
 				}
 			}
 		}
-		fmt.Fprintf(out, "\n")
 		if len(limitRangeList.Items) == 0 {
 			formatString(out, "Resource limits", "")
 		} else {


### PR DESCRIPTION
@fabianofranz I've removed the two newlines, but I could not find where we are adding the two extra lines at the end of the describe. I see that describe command generally has this issue, not just the `project` resource

Based on: https://github.com/openshift/origin/issues/4089