### PR TITLE
Add --commit option to start-build

### DIFF
--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -59,6 +59,7 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 		},
 	}
 	cmd.Flags().String("from-build", "", "Specify the name of a build which should be re-run")
+	cmd.Flags().String("commit", "", "Specify the commit hash the build should be run from")
 	cmd.Flags().Bool("follow", false, "Start a build and watch its logs until it completes or fails")
 	cmd.Flags().Var(&webhooks, "list-webhooks", "List the webhooks for the specified BuildConfig or build; accepts 'all', 'generic', or 'github'")
 	cmd.Flags().String("from-webhook", "", "Specify a webhook URL for an existing BuildConfig to trigger")
@@ -72,6 +73,7 @@ func RunStartBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args
 	webhook := cmdutil.GetFlagString(cmd, "from-webhook")
 	buildName := cmdutil.GetFlagString(cmd, "from-build")
 	follow := cmdutil.GetFlagBool(cmd, "follow")
+	commit := cmdutil.GetFlagString(cmd, "commit")
 
 	switch {
 	case len(webhook) > 0:
@@ -109,6 +111,14 @@ func RunStartBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args
 
 	request := &buildapi.BuildRequest{
 		ObjectMeta: kapi.ObjectMeta{Name: name},
+	}
+	if len(commit) > 0 {
+		request.Revision = &buildapi.SourceRevision{
+			Type: buildapi.BuildSourceGit,
+			Git: &buildapi.GitSourceRevision{
+				Commit: commit,
+			},
+		}
 	}
 	var newBuild *buildapi.Build
 	if isBuild {

--- a/rel-eng/completions/bash/oc
+++ b/rel-eng/completions/bash/oc
@@ -377,6 +377,7 @@ _oc_start-build()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--commit=")
     flags+=("--follow")
     flags+=("--from-build=")
     flags+=("--from-webhook=")

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -1952,6 +1952,7 @@ _openshift_cli_start-build()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--commit=")
     flags+=("--follow")
     flags+=("--from-build=")
     flags+=("--from-webhook=")


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/4208

@deads2k you're wishes become true! This allow to specify the commit hash when starting a build:

```console
$ oc start-build sample-app --commit=f497b20 --follow
Note: checking out 'f497b20'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at f497b20... Test commit
I0908 08:49:18.406199       1 sti.go:406] ---> Installing application source ...
```

@gabemontero @bparees this is needed for the Jenkins work (being able to specify the current $COMMIT_ID when starting a build in OpenShift.