### PR TITLE
Add --wait option to start-build

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -784,14 +784,19 @@ Starts a new build
 [options="nowrap"]
 ----
   // Starts build from BuildConfig matching the name "3bd2ug53b"
-  $ openshift cli start-build 3bd2ug53b
+  $ openshift cli start-build sample-build
 
-  // Starts build from build matching the name "3bd2ug53b"
-  $ openshift cli start-build --from-build=3bd2ug53b
+  // Starts build from build matching the name "sample-build-1"
+  $ openshift cli start-build --from-build=sample-build-1
 
-  // Starts build from BuildConfig matching the name "3bd2ug53b" and watches the logs until the build
-  // completes or fails
-  $ openshift cli start-build 3bd2ug53b --follow
+  // Starts build from BuildConfig matching the name "sample-build" and watches
+	// the logs until the build completes or fails
+  $ openshift cli start-build sample-build --follow
+
+  // Starts build from BuildConfig matching the name "sample-build" and wait until
+	// the build completes. It exits with a non-zero return code if the build
+	// fails. 
+  $ openshift cli start-build sample-build --wait
 ----
 ====
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -196,6 +196,11 @@ wait_for_build_start "test"
 wait_for_build "test"
 wait_for_app "test"
 
+echo "[INFO] Starting build from ${STI_CONFIG_FILE} with non-existing commit..."
+set +e
+oc start-build test --commit=fffffff --wait && echo "The build was supposed to fail, but it succeeded." && exit 1
+set -e
+
 # Remote command execution
 echo "[INFO] Validating exec"
 frontend_pod=$(oc get pod -l deploymentconfig=frontend -t '{{(index .items 0).metadata.name}}')

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -10,13 +10,16 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client"
+	"k8s.io/kubernetes/pkg/fields"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -33,14 +36,19 @@ This command starts a build for the provided BuildConfig or re-runs an existing 
 --from-build=<name>. You may pass the --follow flag to see output from the build.`
 
 	startBuildExample = `  // Starts build from BuildConfig matching the name "3bd2ug53b"
-  $ %[1]s start-build 3bd2ug53b
+  $ %[1]s start-build sample-build
 
-  // Starts build from build matching the name "3bd2ug53b"
-  $ %[1]s start-build --from-build=3bd2ug53b
+  // Starts build from build matching the name "sample-build-1"
+  $ %[1]s start-build --from-build=sample-build-1
 
-  // Starts build from BuildConfig matching the name "3bd2ug53b" and watches the logs until the build
-  // completes or fails
-  $ %[1]s start-build 3bd2ug53b --follow`
+  // Starts build from BuildConfig matching the name "sample-build" and watches
+	// the logs until the build completes or fails
+  $ %[1]s start-build sample-build --follow
+
+  // Starts build from BuildConfig matching the name "sample-build" and wait until
+	// the build completes. It exits with a non-zero return code if the build
+	// fails. 
+  $ %[1]s start-build sample-build --wait`
 )
 
 // NewCmdStartBuild implements the OpenShift cli start-build command
@@ -61,6 +69,7 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 	cmd.Flags().String("from-build", "", "Specify the name of a build which should be re-run")
 	cmd.Flags().String("commit", "", "Specify the commit hash the build should be run from")
 	cmd.Flags().Bool("follow", false, "Start a build and watch its logs until it completes or fails")
+	cmd.Flags().Bool("wait", false, "Wait for a build to complete and exit with a non-zero return code if the build fails")
 	cmd.Flags().Var(&webhooks, "list-webhooks", "List the webhooks for the specified BuildConfig or build; accepts 'all', 'generic', or 'github'")
 	cmd.Flags().String("from-webhook", "", "Specify a webhook URL for an existing BuildConfig to trigger")
 	cmd.Flags().String("git-post-receive", "", "The contents of the post-receive hook to trigger a build")
@@ -74,6 +83,7 @@ func RunStartBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args
 	buildName := cmdutil.GetFlagString(cmd, "from-build")
 	follow := cmdutil.GetFlagBool(cmd, "follow")
 	commit := cmdutil.GetFlagString(cmd, "commit")
+	waitForComplete := cmdutil.GetFlagBool(cmd, "wait")
 
 	switch {
 	case len(webhook) > 0:
@@ -132,21 +142,49 @@ func RunStartBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args
 	}
 	fmt.Fprintf(out, "%s\n", newBuild.Name)
 
-	if follow {
-		opts := buildapi.BuildLogOptions{
-			Follow: true,
-			NoWait: false,
-		}
-		rd, err := client.BuildLogs(namespace).Get(newBuild.Name, opts).Stream()
-		if err != nil {
-			return fmt.Errorf("error getting logs: %v", err)
-		}
-		defer rd.Close()
-		_, err = io.Copy(out, rd)
-		if err != nil {
-			return fmt.Errorf("error streaming logs: %v", err)
-		}
+	var (
+		wg      sync.WaitGroup
+		exitErr error
+	)
+
+	// Wait for the build to complete
+	if waitForComplete {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			exitErr = WaitForBuildComplete(client.Builds(namespace), newBuild.Name)
+		}()
 	}
+
+	// Stream the logs from the build
+	if follow {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			opts := buildapi.BuildLogOptions{
+				Follow: true,
+				NoWait: false,
+			}
+			rd, err := client.BuildLogs(namespace).Get(newBuild.Name, opts).Stream()
+			if err != nil {
+				fmt.Fprintf(cmd.Out(), "error getting logs: %v\n", err)
+				return
+			}
+			defer rd.Close()
+			if _, err = io.Copy(out, rd); err != nil {
+				fmt.Fprintf(cmd.Out(), "error streaming logs: %v\n", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	// When waiting for the build to complete and the build fail, exit with 1 so the
+	// scripts can read this and treat the build as a failed.
+	if exitErr != nil {
+		fmt.Fprintf(cmd.Out(), "%v\n", exitErr)
+		os.Exit(1)
+	}
+
 	return nil
 }
 
@@ -336,4 +374,53 @@ func gitRefInfo(repo git.Repository, dir, ref string) (buildapi.GitRefInfo, erro
 	info.Committer.Email = lines[3]
 	info.Message = lines[4]
 	return info, nil
+}
+
+// WaitForBuildComplete waits for a build identified by the name to complete
+func WaitForBuildComplete(c osclient.BuildInterface, name string) error {
+	isOK := func(b *buildapi.Build) bool {
+		return b.Status.Phase == buildapi.BuildPhaseComplete
+	}
+	isFailed := func(b *buildapi.Build) bool {
+		return b.Status.Phase == buildapi.BuildPhaseFailed ||
+			b.Status.Phase == buildapi.BuildPhaseCancelled ||
+			b.Status.Phase == buildapi.BuildPhaseError
+	}
+	for {
+		list, err := c.List(labels.Everything(), fields.Set{"name": name}.AsSelector())
+		if err != nil {
+			return err
+		}
+		for i := range list.Items {
+			if name == list.Items[i].Name && isOK(&list.Items[i]) {
+				return nil
+			}
+			if name != list.Items[i].Name || isFailed(&list.Items[i]) {
+				return fmt.Errorf("The build %s/%s status is %q", &list.Items[i].Namespace, list.Items[i].Name, &list.Items[i].Status.Phase)
+			}
+		}
+
+		rv := list.ResourceVersion
+		w, err := c.Watch(labels.Everything(), fields.Set{"name": name}.AsSelector(), rv)
+		if err != nil {
+			return err
+		}
+		defer w.Stop()
+
+		for {
+			val, ok := <-w.ResultChan()
+			if !ok {
+				// reget and re-watch
+				break
+			}
+			if e, ok := val.Object.(*buildapi.Build); ok {
+				if name == e.Name && isOK(e) {
+					return nil
+				}
+				if name != e.Name || isFailed(e) {
+					return fmt.Errorf("The build %s/%s status is %q", e.Namespace, name, e.Status.Phase)
+				}
+			}
+		}
+	}
 }

--- a/rel-eng/completions/bash/oc
+++ b/rel-eng/completions/bash/oc
@@ -386,6 +386,7 @@ _oc_start-build()
     flags+=("--help")
     flags+=("-h")
     flags+=("--list-webhooks=")
+    flags+=("--wait")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -1961,6 +1961,7 @@ _openshift_cli_start-build()
     flags+=("--help")
     flags+=("-h")
     flags+=("--list-webhooks=")
+    flags+=("--wait")
 
     must_have_one_flag=()
     must_have_one_noun=()


### PR DESCRIPTION
This will add support for `oc start-build foo --wait`. In that case, the `start-build` command will start the build and waits till the build is complete. If this is true, the command exits with 0, if the build failed or the Phase is not Complete, this command will exit with 1.

Note that you can still specify the `--follow` option which will stream the logs. Together with `--wait` it will get the behavior I described above.

Usage:
```
# This will stream the logs to console, but exit always with 0
$ oc start-build sample-app --follow

# This will wait for the build to complete and stream the logs to console. 
# It exists with 1 if the build failed
$ oc start-build sample-app --follow --wait

# This will wait for the build to complete and exit 1 when the build failed
$ oc start-build sample-app --wait
```

Sample error output:
```
$ oc start-build sample-app --wait ; echo $?
sample-app-6
The build dev/sample-app-6 status is "Failed"
1
```