### PR TITLE
Fix missing port error when validating source url

### DIFF
--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -127,7 +127,7 @@ func (d *DockerBuilder) checkSourceURI(testConnection bool) error {
 	if !d.git.ValidCloneSpec(rawurl) {
 		return fmt.Errorf("Invalid git source url: %s", rawurl)
 	}
-	if strings.HasPrefix(rawurl, "git@") {
+	if strings.HasPrefix(rawurl, "git@") || strings.HasPrefix(rawurl, "git://") {
 		return nil
 	}
 	srcURL, err := url.Parse(rawurl)


### PR DESCRIPTION
This fixes following error when the source use the "Git protocol" (git://) in the Source URL:

```
[builder.go:47] Build error: dial tcp: missing port in address github.com
```

This protocol is read-only and while it uses the URL schema I don't want to replace the `git://` with `http://` to check the validation. Also I'm unsure if you can specify the "port" as part of the URL with the GIT schema, so probably the best is to leave the validation to the builder.