### PR TITLE
Issue 4365 - example github url as a link is really confusing

### DIFF
--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -27,9 +27,9 @@
                       ng-disabled="from_source_form.$invalid" value="">Next</button>
                   </span>
                 </div>
-                <div id="from_source_help" class="help-block">For example,
+                <div id="from_source_help" class="help-block">For example, https://github.com/openshift/nodejs-ex#master
                   <a href="#" ng-click="from_source_url = 'https://github.com/openshift/nodejs-ex#master'"
-                    >https://github.com/openshift/nodejs-ex#master</a></div>
+                    style="margin-left: 3px;">Try it out!<i class="fa fa-level-up" style="margin-left: 3px; font-size: 17px;"></i></a></div>
                 <span class="text-warning" ng-if="from_source_form.from_source_url.$dirty && !sourceURLPattern.test(from_source_url)">Source repository should be a URL</span>
               </div>
             </div>


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4365

![20150908_160623_](https://cloud.githubusercontent.com/assets/1467629/9746073/99a0502c-5643-11e5-902c-23cf87763d66.png)
