### PR TITLE
Bug 1260948 - Remove index.html from Java console URL

### DIFF
--- a/assets/app/scripts/extensions/javaLink.js
+++ b/assets/app/scripts/extensions/javaLink.js
@@ -53,8 +53,7 @@ angular.module('openshiftConsoleExtensions', ['openshiftConsole'])
         var title = container.name || 'Untitled Container';
         var token = AuthService.UserStore().getToken() || '';
         var targetURI = new URI().path(BaseHref)
-                                 .segment('java')
-                                 .segment('index.html')
+                                 .segment('java/') // Must have a trailing slash to avoid runtime errors in Safari
                                  .hash(token)
                                  .query({
                                    jolokiaUrl: jolokiaUrl,


### PR DESCRIPTION
Using `/java/index.html` instead of `/java/` prevents reading the token from the hash in Safari.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1260948