### PR TITLE
Ignore 404 on list of resources during delete

### DIFF
--- a/pkg/project/controller/controller.go
+++ b/pkg/project/controller/controller.go
@@ -213,6 +213,9 @@ func deleteDeploymentConfigs(client osclient.Interface, ns string) error {
 func deleteBuilds(client osclient.Interface, ns string) error {
 	items, err := client.Builds(ns).List(labels.Everything(), fields.Everything())
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	for i := range items.Items {
@@ -227,6 +230,9 @@ func deleteBuilds(client osclient.Interface, ns string) error {
 func deleteBuildConfigs(client osclient.Interface, ns string) error {
 	items, err := client.BuildConfigs(ns).List(labels.Everything(), fields.Everything())
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	for i := range items.Items {


### PR DESCRIPTION
When running as Atomic Enterprise, we never terminated a namespace because we got an error for not found when trying to list resources not in Atomic Enterprise.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1256277

cc @smarterclayton @liggitt  