### PR TITLE
WIP: Extended tests for start-build [CLI]

### DIFF
--- a/test/extended/builds/start_build.go
+++ b/test/extended/builds/start_build.go
@@ -1,0 +1,90 @@
+package builds
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: parallel: oc start-build", func() {
+	defer g.GinkgoRecover()
+	var (
+		buildFixture = exutil.FixturePath("..", "extended", "fixtures", "test-build.json")
+		oc           = exutil.NewCLI("cli-start-build", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.Run("create").Args("-f", buildFixture).Execute()
+	})
+
+	g.Describe("oc start-build --wait", func() {
+		g.It("should start a build and wait for the build to complete", func() {
+			g.By("starting the build with --wait flag")
+			out, err := oc.Run("start-build").Args("sample-build", "--wait").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("verifying the build %q status", out))
+			build, err := oc.REST().Builds(oc.Namespace()).Get(out)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseComplete))
+
+		})
+
+		g.It("should start a build and wait for the build to fail", func() {
+			g.By("starting the build with --wait flag but wrong --commit")
+			out, err := oc.Run("start-build").
+				Args("sample-build", "--wait", "--commit", "fffffff").
+				Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(out).Should(o.ContainSubstring(`status is "Failed"`))
+		})
+	})
+
+	g.Describe("cancelling build started by oc start-build --wait", func() {
+		g.It("should start a build and wait for the build to cancel", func() {
+			g.By("starting the build with --wait flag")
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer g.GinkgoRecover()
+				out, err := oc.Run("start-build").Args("sample-build", "--wait").Output()
+				defer wg.Done()
+				o.Expect(err).To(o.HaveOccurred())
+				o.Expect(out).Should(o.ContainSubstring(`status is "Cancelled"`))
+			}()
+
+			g.By("getting the build name")
+			var buildName string
+			wait.Poll(time.Duration(100*time.Millisecond), time.Duration(60*time.Second), func() (bool, error) {
+				out, err := oc.Run("get").
+					Args("build", "-t", "{{ (index .items 0).metadata.name }}").Output()
+				// Give it second chance in case the build resource was not created yet
+				if err != nil || len(out) == 0 {
+					return false, nil
+				}
+				buildName = out
+				return true, nil
+			})
+
+			o.Expect(buildName).ToNot(o.BeEmpty())
+
+			g.By(fmt.Sprintf("cancelling the build %q", buildName))
+			err := oc.Run("cancel-build").Args(buildName).Execute()
+			o.Expect(err).ToNot(o.HaveOccurred())
+			wg.Wait()
+		})
+
+	})
+
+})

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -98,5 +98,3 @@ echo "[INFO] Running extended tests"
 
 # Run the tests
 TMPDIR=${BASETMPDIR} ginkgo -progress -stream -v -p "-skip=${SKIP}" "$@" ${OS_OUTPUT_BINPATH}/extended.test
-
-

--- a/test/extended/fixtures/test-build.json
+++ b/test/extended/fixtures/test-build.json
@@ -1,0 +1,54 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "origin-ruby-sample",
+        "creationTimestamp": null
+      },
+      "spec": {},
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "sample-build",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "imageChange",
+            "imageChange": {}
+          }
+        ],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          }
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/ruby-20-centos7"
+            }
+          }
+        },
+        "resources": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
@bparees the two cases I have here works (thanks to the BehaviorOnFatal() in k8s). However, I don't think I can make the 'cancel' build work here without a lot of hacking.

The problem I have is that the `start-build --wait` hangs till the build either fails or succeed, which is what we want. The problem is that this command also returns the name of the build that it created, which is not that good when you want to background it and then trigger subsequent `cancel-build`. IOW. you don't know what build to cancel.

We can add another option to `start-build` (like `--build-name-file` or something where we write the name of the build we started). But I dunno if it is worth the effort as the only use-case I see here is to have the test case for cancel build :-)