### PR TITLE
add sample repo annotation to imagestreams

### DIFF
--- a/examples/image-streams/image-streams-centos7.json
+++ b/examples/image-streams/image-streams-centos7.json
@@ -23,7 +23,8 @@
               "iconClass": "icon-ruby",
               "tags": "builder,ruby",
               "supports": "ruby:2.0,ruby",
-              "version": "2.0"
+              "version": "2.0",
+              "sampleRepo": "http://github.com/openshift/ruby-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -53,7 +54,8 @@
               "iconClass": "icon-nodejs",
               "tags": "builder,nodejs",
               "supports":"nodejs:0.10,nodejs:0.1,nodejs",
-              "version": "0.10"
+              "version": "0.10",
+              "sampleRepo": "http://github.com/openshift/nodejs-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -83,7 +85,8 @@
               "iconClass": "icon-perl",
               "tags": "builder,perl",
               "supports":"perl:5.16,perl",
-              "version": "5.16"
+              "version": "5.16",
+              "sampleRepo": "http://github.com/openshift/dancer-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -113,7 +116,8 @@
               "iconClass": "icon-php",
               "tags": "builder,php",
               "supports":"php:5.5,php",
-              "version": "5.5"
+              "version": "5.5",
+              "sampleRepo": "http://github.com/openshift/cakephp-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -143,7 +147,8 @@
               "iconClass": "icon-python",
               "tags": "builder,python",
               "supports":"python:3.3,python",
-              "version": "3.3"
+              "version": "3.3",
+              "sampleRepo": "http://github.com/openshift/django-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -173,7 +178,8 @@
               "iconClass": "icon-wildfly",
               "tags": "builder,wildfly,java",
               "supports":"wildfly:8.1,jee,java",
-              "version": "8.1"
+              "version": "8.1",
+              "sampleRepo": "http://github.com/bparees/openshift-jee-sample.git"
             },
             "from": {
               "Kind": "ImageStreamTag",

--- a/examples/image-streams/image-streams-rhel7.json
+++ b/examples/image-streams/image-streams-rhel7.json
@@ -23,7 +23,8 @@
               "iconClass": "icon-ruby",
               "tags": "builder,ruby",
               "supports": "ruby:2.0,ruby",
-              "version": "2.0"
+              "version": "2.0",
+              "sampleRepo": "http://github.com/openshift/ruby-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -53,7 +54,8 @@
               "iconClass": "icon-nodejs",
               "tags": "builder,nodejs",
               "supports":"nodejs:0.10,nodejs:0.1,nodejs",
-              "version": "0.10"
+              "version": "0.10",
+              "sampleRepo": "http://github.com/openshift/nodejs-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -83,7 +85,8 @@
               "iconClass": "icon-perl",
               "tags": "builder,perl",
               "supports":"perl:5.16,perl",
-              "version": "5.16"
+              "version": "5.16",
+              "sampleRepo": "http://github.com/openshift/dancer-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -113,7 +116,8 @@
               "iconClass": "icon-php",
               "tags": "builder,php",
               "supports":"php:5.5,php",
-              "version": "5.5"
+              "version": "5.5",
+              "sampleRepo": "http://github.com/openshift/cakephp-ex.git"              
             },
             "from": {
               "Kind": "ImageStreamTag",
@@ -143,7 +147,8 @@
               "iconClass": "icon-python",
               "tags": "builder,python",
               "supports":"python:3.3,python",
-              "version": "3.3"
+              "version": "3.3",
+              "sampleRepo": "http://github.com/openshift/django-ex.git"
             },
             "from": {
               "Kind": "ImageStreamTag",


### PR DESCRIPTION
add a sampleRepo annotation to builder imagestreamtags so the UI can offer it as a suggested repo to use when someone is experimenting with the builder image.
