### PR TITLE
Bug 1260948 - Update to openshift-jvm 1.0.22

### DIFF
--- a/hack/install-assets.sh
+++ b/hack/install-assets.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-OPENSHIFT_JVM_VERSION=v1.0.20
+OPENSHIFT_JVM_VERSION=v1.0.22
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"


### PR DESCRIPTION
Updates some icon URLs to relative urls, should hopefully fix some missing icons spotted in https://bugzilla.redhat.com/show_bug.cgi?id=1260948