### PR TITLE
UPSTREAM: 844: Fix cadvisor bug with advancing clocks

### DIFF
--- a/Godeps/_workspace/src/github.com/google/cadvisor/manager/container.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/manager/container.go
@@ -416,6 +416,8 @@ func (c *containerData) housekeeping() {
 		// Schedule the next housekeeping. Sleep until that time.
 		if time.Now().Before(next) {
 			time.Sleep(next.Sub(time.Now()))
+		} else {
+			next = time.Now()
 		}
 		lastHousekeeping = next
 	}


### PR DESCRIPTION
Upstream PR is https://github.com/google/cadvisor/pull/844

Fixes #1370

k8s is already on a newer version of cadvisor with this fix included, but we should cherrypick until we rebase