### PR TITLE
Bug 1256303: prune images: Tolerate missing bc/build errors for AEP

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -235,6 +235,12 @@ oc new-project project-foo --display-name="my project" --description="boring pro
 oc logout
 [ -z "$(oc get pods | grep 'system:anonymous')" ]
 
+# log in as an image-pruner and test that oadm prune images works against the atomic binary
+oadm policy add-cluster-role-to-user system:image-pruner pruner --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+oc login --server=${KUBERNETES_MASTER}/ --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u pruner -p anything
+# this shouldn't fail but instead output "Dry run enabled - no modifications will be made. Add --confirm to remove images"
+oadm prune images
+
 # log in and set project to use from now on
 oc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
 oc get projects

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/prune"
+	oserrors "github.com/openshift/origin/pkg/util/errors"
 	"github.com/spf13/cobra"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client"
@@ -70,9 +71,13 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 			cmdutil.CheckErr(err)
 
 			allBCs, err := osClient.BuildConfigs(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())
+			// We need to tolerate 'not found' errors for buildConfigs since they may be disabled in Atomic
+			err = oserrors.TolerateNotFoundError(err)
 			cmdutil.CheckErr(err)
 
 			allBuilds, err := osClient.Builds(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())
+			// We need to tolerate 'not found' errors for builds since they may be disabled in Atomic
+			err = oserrors.TolerateNotFoundError(err)
 			cmdutil.CheckErr(err)
 
 			allDCs, err := osClient.DeploymentConfigs(kapi.NamespaceAll).List(labels.Everything(), fields.Everything())

--- a/pkg/util/errors/doc.go
+++ b/pkg/util/errors/doc.go
@@ -1,0 +1,2 @@
+// Package errors provides utility functions for various errors
+package errors

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -1,0 +1,11 @@
+package errors
+
+import kapierrors "k8s.io/kubernetes/pkg/api/errors"
+
+// TolerateNotFoundError tolerates 'not found' errors
+func TolerateNotFoundError(err error) error {
+	if kapierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
Cherry pick of the bugfix commit from https://github.com/openshift/origin/pull/4451