### PR TITLE
Drop BuildConfig triggers of unknown type

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -389,6 +389,14 @@ type BuildTriggerPolicy struct {
 // BuildTriggerType refers to a specific BuildTriggerPolicy implementation.
 type BuildTriggerType string
 
+//NOTE: Adding a new trigger type requires adding the type to KnownTriggerTypes
+var KnownTriggerTypes = util.NewStringSet(
+	string(GitHubWebHookBuildTriggerType),
+	string(GenericWebHookBuildTriggerType),
+	string(ImageChangeBuildTriggerType),
+	string(ConfigChangeBuildTriggerType),
+)
+
 const (
 	// GitHubWebHookBuildTriggerType represents a trigger that launches builds on
 	// GitHub webhook invocations

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 
-	"github.com/golang/glog"
 	oapi "github.com/openshift/origin/pkg/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildutil "github.com/openshift/origin/pkg/build/util"
@@ -81,7 +80,7 @@ func ValidateBuildConfig(config *buildapi.BuildConfig) fielderrors.ValidationErr
 	strategy := config.Spec.BuildSpec.Strategy
 	if strategy.Type == buildapi.DockerBuildStrategyType && strategy.DockerStrategy.From == nil {
 		for _, trigger := range config.Spec.Triggers {
-			if trigger.Type == buildapi.ImageChangeBuildTriggerType && trigger.ImageChange.From == nil {
+			if trigger.Type == buildapi.ImageChangeBuildTriggerType && (trigger.ImageChange == nil || trigger.ImageChange.From == nil) {
 				allErrs = append(allErrs, fielderrors.NewFieldRequired("imageChange.from"))
 			}
 		}
@@ -362,7 +361,7 @@ func validateTrigger(trigger *buildapi.BuildTriggerPolicy) fielderrors.Validatio
 	case buildapi.ConfigChangeBuildTriggerType:
 		// doesn't require additional validation
 	default:
-		glog.Warningf("Unknown trigger type: '%s'", trigger.Type)
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("type", trigger.Type, "invalid trigger type"))
 	}
 	return allErrs
 }

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -1008,10 +1008,11 @@ func TestValidateTrigger(t *testing.T) {
 			trigger:  buildapi.BuildTriggerPolicy{},
 			expected: []*fielderrors.ValidationError{fielderrors.NewFieldRequired("type")},
 		},
-		"trigger with unknown type is valid, but ignored": {
+		"trigger with unknown type": {
 			trigger: buildapi.BuildTriggerPolicy{
 				Type: "UnknownTriggerType",
 			},
+			expected: []*fielderrors.ValidationError{fielderrors.NewFieldInvalid("type", "", "")},
 		},
 		"GitHub type with no github webhook": {
 			trigger:  buildapi.BuildTriggerPolicy{Type: buildapi.GitHubWebHookBuildTriggerType},

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -19,6 +19,15 @@ func TestBuildConfigStrategy(t *testing.T) {
 	buildConfig := &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "config-id", Namespace: "namespace"},
 		Spec: buildapi.BuildConfigSpec{
+			Triggers: []buildapi.BuildTriggerPolicy{
+				{
+					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},
+					Type:          buildapi.GitHubWebHookBuildTriggerType,
+				},
+				{
+					Type: "unknown",
+				},
+			},
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
 					Type: buildapi.BuildSourceGit,


### PR DESCRIPTION
Drops BuildConfig triggers of unknown types in conversion and restores validation error for unknown trigger type