### PR TITLE
Bump min Docker version in docs

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -45,7 +45,7 @@ Here's how to get set up:
 1. For Go, Git and optionally also Docker, follow the links below to get to installation information for these tools: +
 ** http://golang.org/doc/install[Installing Go]. You must install Go 1.4 and NOT use $HOME/go directory for Go installation.
 ** http://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Installing Git]
-** https://docs.docker.com/installation/[Installing Docker]. NOTE: OpenShift requires Docker 1.6 or higher or 1.6.2 on CentOS/RHEL.
+** https://docs.docker.com/installation/[Installing Docker]. NOTE: OpenShift requires Docker 1.7.1 or higher.
 2. Next, create a Go workspace directory: +
 +
 ----

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the [security documentation](https://docs.openshift.org/latest/admin_guide/m
 
 Getting Started
 ---------------
-The easiest way to run Origin is in a Docker container (Origin requires Docker 1.6.2 or higher).
+The easiest way to run Origin is in a Docker container (Origin requires Docker 1.7.1 or higher).
 If you'd like to get started with Atomic Enterprise please refer to the [quickstart guide](docs/atomic-quick-start-tutorial.adoc).
 
 You'll need to configure the Docker daemon on your host to trust the Docker registry service you'll be starting.


### PR DESCRIPTION
Update contributing and readme to require at least Docker 1.7.1.

Closes #4581