### PR TITLE
Allow metadata on images to be edited after creation

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -5754,6 +5754,98 @@
       ]
      },
      {
+      "type": "v1.Image",
+      "method": "PUT",
+      "summary": "replace the specified Image",
+      "nickname": "replaceNamespacedImage",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.Image",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Image",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Image"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Image",
+      "method": "PATCH",
+      "summary": "partially update the specified Image",
+      "nickname": "patchNamespacedImage",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "api.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Image",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Image"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     },
+     {
       "type": "v1.Status",
       "method": "DELETE",
       "summary": "delete a Image",

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -47,7 +47,7 @@ func init() {
 	Validator.Register(&deployapi.DeploymentConfig{}, deployvalidation.ValidateDeploymentConfig, deployvalidation.ValidateDeploymentConfigUpdate)
 	Validator.Register(&deployapi.DeploymentConfigRollback{}, deployvalidation.ValidateDeploymentConfigRollback, nil)
 
-	Validator.Register(&imageapi.Image{}, imagevalidation.ValidateImage, nil)
+	Validator.Register(&imageapi.Image{}, imagevalidation.ValidateImage, imagevalidation.ValidateImageUpdate)
 	Validator.Register(&imageapi.ImageStream{}, imagevalidation.ValidateImageStream, imagevalidation.ValidateImageStreamUpdate)
 	Validator.Register(&imageapi.ImageStreamMapping{}, imagevalidation.ValidateImageStreamMapping, nil)
 

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -42,6 +42,15 @@ func ValidateImage(image *api.Image) fielderrors.ValidationErrorList {
 	return result
 }
 
+func ValidateImageUpdate(newImage, oldImage *api.Image) fielderrors.ValidationErrorList {
+	result := fielderrors.ValidationErrorList{}
+
+	result = append(result, validation.ValidateObjectMetaUpdate(&newImage.ObjectMeta, &oldImage.ObjectMeta).Prefix("metadata")...)
+	result = append(result, ValidateImage(newImage)...)
+
+	return result
+}
+
 // ValidateImageStream tests required fields for an ImageStream.
 func ValidateImageStream(stream *api.ImageStream) fielderrors.ValidationErrorList {
 	result := fielderrors.ValidationErrorList{}

--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -39,6 +39,7 @@ func NewREST(s storage.Interface) *REST {
 		EndpointName: "image",
 
 		CreateStrategy: image.Strategy,
+		UpdateStrategy: image.Strategy,
 
 		ReturnDeletedObject: false,
 
@@ -78,6 +79,11 @@ func (r *REST) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 // Create creates an image based on a specification.
 func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, error) {
 	return r.store.Create(ctx, obj)
+}
+
+// Update alters an existing image.
+func (r *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, obj)
 }
 
 // Delete deletes an existing image specified by its ID.

--- a/pkg/image/registry/image/strategy.go
+++ b/pkg/image/registry/image/strategy.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
+	errs "k8s.io/kubernetes/pkg/util/fielderrors"
 
 	"github.com/openshift/origin/pkg/image/api"
 	"github.com/openshift/origin/pkg/image/api/validation"
@@ -42,6 +43,25 @@ func (imageStrategy) Validate(ctx kapi.Context, obj runtime.Object) fielderrors.
 // AllowCreateOnUpdate is false for images.
 func (imageStrategy) AllowCreateOnUpdate() bool {
 	return false
+}
+
+func (imageStrategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
+func (imageStrategy) PrepareForUpdate(obj, old runtime.Object) {
+	newImage := obj.(*api.Image)
+	oldImage := old.(*api.Image)
+	// image metadata cannot be altered
+	newImage.DockerImageMetadata = oldImage.DockerImageMetadata
+	newImage.DockerImageManifest = oldImage.DockerImageManifest
+	newImage.DockerImageMetadataVersion = oldImage.DockerImageMetadataVersion
+}
+
+// ValidateUpdate is the default update validation for an end user.
+func (imageStrategy) ValidateUpdate(ctx kapi.Context, obj, old runtime.Object) errs.ValidationErrorList {
+	return validation.ValidateImageUpdate(old.(*api.Image), obj.(*api.Image))
 }
 
 // MatchImage returns a generic matcher for a given label and field selector.


### PR DESCRIPTION
Enable editable metadata on images (labels, annotations). Need to add some more tests, but fyi

@miminar @ncdc