### PR TITLE
Vagrantfile: Don't forward port 8080

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -202,7 +202,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       else
         config.vm.network "forwarded_port", guest: 80, host: 1080
         config.vm.network "forwarded_port", guest: 443, host: 1443
-        config.vm.network "forwarded_port", guest: 8080, host: 8080
         config.vm.network "forwarded_port", guest: 8443, host: 8443
       end
     end


### PR DESCRIPTION
openshift doesn't listen on port 8080, and this unneccesarily prevents local use of port 8080 on the machine hosting vagrant.