### PR TITLE
Hotfix Go Vet Errors

### DIFF
--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -394,7 +394,7 @@ func WaitForBuildComplete(c osclient.BuildInterface, name string) error {
 				return nil
 			}
 			if name != list.Items[i].Name || isFailed(&list.Items[i]) {
-				return fmt.Errorf("The build %s/%s status is %q", &list.Items[i].Namespace, list.Items[i].Name, &list.Items[i].Status.Phase)
+				return fmt.Errorf("the build %s/%s status is %q", list.Items[i].Namespace, list.Items[i].Name, &list.Items[i].Status.Phase)
 			}
 		}
 

--- a/pkg/generate/app/app_test.go
+++ b/pkg/generate/app/app_test.go
@@ -314,7 +314,7 @@ func TestSourceRefBuildSourceURI(t *testing.T) {
 	}
 }
 
-func ExampleGenerateSimpleDockerApp() {
+func TestGenerateSimpleDockerApp(t *testing.T) {
 	// TODO: determine if the repo is secured prior to fetching
 	// TODO: determine whether we want to clone this repo, or use it directly. Using it directly would require setting hooks
 	// if we have source, assume we are going to go into a build flow.


### PR DESCRIPTION
@deads2k @liggitt @smarterclayton 

This is a fix for two `go vet` errors in `master/HEAD` right now. 
The error fixed in https://github.com/openshift/origin/commit/5272d726dd09eacfa03ade038fd3e3cffb6873c5 was created by Travis upgrading to a new version of `go vet`. We need to version-lock tools like `go vet` to ensure this doesn't happen again.
The error fixed in https://github.com/openshift/origin/commit/edc5a463ad80807f4e9a4f5c3a3e219b7be920b6 was introduced in https://github.com/openshift/origin/pull/4572 and did *not* cause that PR to fail tests. We need to investigate why this did not fail tests then, and continues to not fail tests on some machines (on @csrwng machine, no error. On mine, error)