### PR TITLE
Build from a Dockerfile directly

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -13908,7 +13908,7 @@
      },
      "dockerfile": {
       "type": "string",
-      "description": "the contents of a Dockerfile to build; FROM and ENV may be overriden if you have specified 'from' and 'env' on the build strategy"
+      "description": "the contents of a Dockerfile to build; FROM may be overridden by your strategy source, and additional ENV from your strategy will be placed before the rest of the Dockerfile stanzas"
      },
      "git": {
       "$ref": "v1.GitBuildSource",

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -13906,6 +13906,10 @@
       "type": "string",
       "description": "type of source control management system"
      },
+     "dockerfile": {
+      "type": "string",
+      "description": "the contents of a Dockerfile to build; FROM and ENV may be overriden if you have specified 'from' and 'env' on the build strategy"
+     },
      "git": {
       "$ref": "v1.GitBuildSource",
       "description": "optional information about git build source"

--- a/cmd/genbashcomp/gen_openshift_bash_comp.go
+++ b/cmd/genbashcomp/gen_openshift_bash_comp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -50,7 +51,7 @@ func main() {
 
 	outFile_osc := outDir + "oc"
 	out := os.Stdout
-	oc := cli.NewCommandCLI("oc", "openshift cli", out)
+	oc := cli.NewCommandCLI("oc", "openshift cli", &bytes.Buffer{}, out, ioutil.Discard)
 	oc.GenBashCompletionFile(outFile_osc)
 
 	outFile_osadm := outDir + "oadm"

--- a/cmd/gendocs/gen_openshift_docs.go
+++ b/cmd/gendocs/gen_openshift_docs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -46,7 +47,7 @@ func main() {
 
 	outFile := outDir + "oc_by_example_content.adoc"
 	out := os.Stdout
-	cmd := cli.NewCommandCLI("oc", "openshift cli", out)
+	cmd := cli.NewCommandCLI("oc", "openshift cli", &bytes.Buffer{}, out, ioutil.Discard)
 	gendocs.GenDocs(cmd, outFile)
 
 	outFile = outDir + "oadm_by_example_content.adoc"

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -542,6 +542,9 @@ Create a new build configuration
   // Create a build config from a remote repository using its beta2 branch
   $ openshift cli new-build https://github.com/openshift/ruby-hello-world#beta2
 
+  // Create a build config using a Dockerfile specified as an argument
+  $ openshift cli new-build -D $'FROM centos7\nRUN yum install -y apache'
+
   // Create a build config from a remote repository and add custom environment variables into resulting image
   $ openshift cli new-build https://github.com/openshift/ruby-hello-world --env=RACK_ENV=development
 ----

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -858,6 +858,12 @@ func deepCopy_api_BuildRequest(in buildapi.BuildRequest, out *buildapi.BuildRequ
 
 func deepCopy_api_BuildSource(in buildapi.BuildSource, out *buildapi.BuildSource, c *conversion.Cloner) error {
 	out.Type = in.Type
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(buildapi.GitBuildSource)
 		if err := deepCopy_api_GitBuildSource(*in.Git, out.Git, c); err != nil {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -720,6 +720,12 @@ func convert_api_BuildSource_To_v1_BuildSource(in *buildapi.BuildSource, out *ap
 		defaulting.(func(*buildapi.BuildSource))(in)
 	}
 	out.Type = apiv1.BuildSourceType(in.Type)
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(apiv1.GitBuildSource)
 		if err := convert_api_GitBuildSource_To_v1_GitBuildSource(in.Git, out.Git, s); err != nil {
@@ -1101,6 +1107,12 @@ func convert_v1_BuildSource_To_api_BuildSource(in *apiv1.BuildSource, out *build
 		defaulting.(func(*apiv1.BuildSource))(in)
 	}
 	out.Type = buildapi.BuildSourceType(in.Type)
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(buildapi.GitBuildSource)
 		if err := convert_v1_GitBuildSource_To_api_GitBuildSource(in.Git, out.Git, s); err != nil {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -883,6 +883,12 @@ func deepCopy_v1_BuildRequest(in apiv1.BuildRequest, out *apiv1.BuildRequest, c 
 
 func deepCopy_v1_BuildSource(in apiv1.BuildSource, out *apiv1.BuildSource, c *conversion.Cloner) error {
 	out.Type = in.Type
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(apiv1.GitBuildSource)
 		if err := deepCopy_v1_GitBuildSource(*in.Git, out.Git, c); err != nil {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -758,6 +758,12 @@ func convert_api_BuildSource_To_v1beta3_BuildSource(in *buildapi.BuildSource, ou
 		defaulting.(func(*buildapi.BuildSource))(in)
 	}
 	out.Type = apiv1beta3.BuildSourceType(in.Type)
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(apiv1beta3.GitBuildSource)
 		if err := convert_api_GitBuildSource_To_v1beta3_GitBuildSource(in.Git, out.Git, s); err != nil {
@@ -1139,6 +1145,12 @@ func convert_v1beta3_BuildSource_To_api_BuildSource(in *apiv1beta3.BuildSource, 
 		defaulting.(func(*apiv1beta3.BuildSource))(in)
 	}
 	out.Type = buildapi.BuildSourceType(in.Type)
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(buildapi.GitBuildSource)
 		if err := convert_v1beta3_GitBuildSource_To_api_GitBuildSource(in.Git, out.Git, s); err != nil {

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -891,6 +891,12 @@ func deepCopy_v1beta3_BuildRequest(in apiv1beta3.BuildRequest, out *apiv1beta3.B
 
 func deepCopy_v1beta3_BuildSource(in apiv1beta3.BuildSource, out *apiv1beta3.BuildSource, c *conversion.Cloner) error {
 	out.Type = in.Type
+	if in.Dockerfile != nil {
+		out.Dockerfile = new(string)
+		*out.Dockerfile = *in.Dockerfile
+	} else {
+		out.Dockerfile = nil
+	}
 	if in.Git != nil {
 		out.Git = new(apiv1beta3.GitBuildSource)
 		if err := deepCopy_v1beta3_GitBuildSource(*in.Git, out.Git, c); err != nil {

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -121,12 +121,18 @@ type BuildSourceType string
 const (
 	//BuildSourceGit is a Git SCM
 	BuildSourceGit BuildSourceType = "Git"
+	// bulidSourceDockerfile is an embedded dockerfile
+	BuildSourceDockerfile BuildSourceType = "Dockerfile"
 )
 
-// BuildSource is the SCM used for the build
+// BuildSource is the input used for the build
 type BuildSource struct {
-	// Type of source control management system
+	// Type of build inputsystem
 	Type BuildSourceType
+
+	// Dockerfile is the raw contents of a Dockerfile which should be built. When this option is
+	// specified, the From and Env on the Docker build strategy are applied on top of this file.
+	Dockerfile *string
 
 	// Git contains optional information about git build source
 	Git *GitBuildSource

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -131,7 +131,11 @@ type BuildSource struct {
 	Type BuildSourceType
 
 	// Dockerfile is the raw contents of a Dockerfile which should be built. When this option is
-	// specified, the From and Env on the Docker build strategy are applied on top of this file.
+	// specified, the FROM may be modified based on your strategy base image and additional ENV
+	// stanzas from your strategy environment will be added after the FROM, but before the rest
+	// of your Dockerfile stanzas. The Dockerfile source type may be used with other options like
+	// git - in those cases the Git repo will have any innate Dockerfile replaced in the context
+	// dir.
 	Dockerfile *string
 
 	// Git contains optional information about git build source

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -108,12 +108,20 @@ type BuildSourceType string
 const (
 	//BuildSourceGit is a Git SCM
 	BuildSourceGit BuildSourceType = "Git"
+	// bulidSourceDockerfile is an embedded dockerfile
+	BuildSourceDockerfile BuildSourceType = "Dockerfile"
 )
 
 // BuildSource is the SCM used for the build
 type BuildSource struct {
 	// Type of source control management system
 	Type BuildSourceType `json:"type" description:"type of source control management system"`
+
+	// Dockerfile is the raw contents of a Dockerfile which should be built. When this option is
+	// specified, the From and Env on the Docker build strategy are applied on top of this file.
+	// The Dockerfile source type may be used with other options like .git - in those cases the
+	// Git repo will have any innate Dockerfile replaced in the context dir.
+	Dockerfile *string `json:"dockerfile,omitempty" description:"the contents of a Dockerfile to build; FROM and ENV may be overridden if you have specified 'from' and 'env' on the build strategy"`
 
 	// Git contains optional information about git build source
 	Git *GitBuildSource `json:"git,omitempty" description:"optional information about git build source"`

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -118,10 +118,12 @@ type BuildSource struct {
 	Type BuildSourceType `json:"type" description:"type of source control management system"`
 
 	// Dockerfile is the raw contents of a Dockerfile which should be built. When this option is
-	// specified, the From and Env on the Docker build strategy are applied on top of this file.
-	// The Dockerfile source type may be used with other options like .git - in those cases the
-	// Git repo will have any innate Dockerfile replaced in the context dir.
-	Dockerfile *string `json:"dockerfile,omitempty" description:"the contents of a Dockerfile to build; FROM and ENV may be overridden if you have specified 'from' and 'env' on the build strategy"`
+	// specified, the FROM may be modified based on your strategy base image and additional ENV
+	// stanzas from your strategy environment will be added after the FROM, but before the rest
+	// of your Dockerfile stanzas. The Dockerfile source type may be used with other options like
+	// git - in those cases the Git repo will have any innate Dockerfile replaced in the context
+	// dir.
+	Dockerfile *string `json:"dockerfile,omitempty" description:"the contents of a Dockerfile to build; FROM may be overridden by your strategy source, and additional ENV from your strategy will be placed before the rest of the Dockerfile stanzas"`
 
 	// Git contains optional information about git build source
 	Git *GitBuildSource `json:"git,omitempty" description:"optional information about git build source"`

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -108,12 +108,20 @@ type BuildSourceType string
 const (
 	//BuildSourceGit is a Git SCM
 	BuildSourceGit BuildSourceType = "Git"
+	// bulidSourceDockerfile is an embedded dockerfile
+	BuildSourceDockerfile BuildSourceType = "Dockerfile"
 )
 
 // BuildSource is the SCM used for the build
 type BuildSource struct {
 	Type BuildSourceType `json:"type"`
-	Git  *GitBuildSource `json:"git,omitempty"`
+
+	// Dockerfile is the raw contents of a Dockerfile which should be built. When this option is
+	// specified, the From and Env on the Docker build strategy are applied on top of this file.
+	Dockerfile *string `json:"dockerfile,omitempty" description="the contents of a Dockerfile to build; FROM and ENV may be overridden if you have specified 'from' and 'env' on the build strategy"`
+
+	// Git contains optional information about git build source
+	Git *GitBuildSource `json:"git,omitempty"`
 
 	// Specify the sub-directory where the source code for the application exists.
 	// This allows to have buildable sources in directory other than root of

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -134,6 +134,8 @@ func validateBuildSpec(spec *buildapi.BuildSpec) fielderrors.ValidationErrorList
 	return allErrs
 }
 
+const maxDockerfileLengthBytes = 60 * 1000
+
 func validateSource(input *buildapi.BuildSource) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 	switch input.Type {
@@ -150,8 +152,8 @@ func validateSource(input *buildapi.BuildSource) fielderrors.ValidationErrorList
 		if input.Dockerfile == nil {
 			allErrs = append(allErrs, fielderrors.NewFieldRequired("dockerfile"))
 		} else {
-			if len(*input.Dockerfile) > 60*1000 {
-				allErrs = append(allErrs, fielderrors.NewFieldInvalid("dockerfile", "", "must be smaller than 60Kb"))
+			if len(*input.Dockerfile) > maxDockerfileLengthBytes {
+				allErrs = append(allErrs, fielderrors.NewFieldInvalid("dockerfile", "", fmt.Sprintf("must be smaller than %d bytes", maxDockerfileLengthBytes)))
 			}
 		}
 		if input.Git != nil {

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -20,13 +20,15 @@ func buildInfo(build *api.Build) []KeyValue {
 	kv := []KeyValue{
 		{"OPENSHIFT_BUILD_NAME", build.Name},
 		{"OPENSHIFT_BUILD_NAMESPACE", build.Namespace},
-		{"OPENSHIFT_BUILD_SOURCE", build.Spec.Source.Git.URI},
 	}
-	if build.Spec.Source.Git.Ref != "" {
-		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_REFERENCE", build.Spec.Source.Git.Ref})
-	}
-	if build.Spec.Revision != nil && build.Spec.Revision.Git != nil && build.Spec.Revision.Git.Commit != "" {
-		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_COMMIT", build.Spec.Revision.Git.Commit})
+	if build.Spec.Source.Git != nil {
+		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_SOURCE", build.Spec.Source.Git.URI})
+		if build.Spec.Source.Git.Ref != "" {
+			kv = append(kv, KeyValue{"OPENSHIFT_BUILD_REFERENCE", build.Spec.Source.Git.Ref})
+		}
+		if build.Spec.Revision != nil && build.Spec.Revision.Git != nil && build.Spec.Revision.Git.Commit != "" {
+			kv = append(kv, KeyValue{"OPENSHIFT_BUILD_COMMIT", build.Spec.Revision.Git.Commit})
+		}
 	}
 	if build.Spec.Strategy.Type == api.SourceBuildStrategyType {
 		env := build.Spec.Strategy.SourceStrategy.Env

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -269,11 +269,9 @@ func (d *DockerBuilder) buildLabels(dir string) []dockerfile.KeyValue {
 		sourceInfo.ContextDir = d.build.Spec.Source.ContextDir
 	}
 	labels = util.GenerateLabelsFromSourceInfo(labels, sourceInfo, api.DefaultDockerLabelNamespace)
-	kv := make([]dockerfile.KeyValue, len(labels))
-	i := 0
+	kv := make([]dockerfile.KeyValue, 0, len(labels))
 	for k, v := range labels {
-		kv[i] = dockerfile.KeyValue{Key: k, Value: v}
-		i++
+		kv = append(kv, dockerfile.KeyValue{Key: k, Value: v})
 	}
 	return kv
 }
@@ -342,6 +340,9 @@ func appendEnv(node *parser.Node, m []dockerfile.KeyValue) error {
 // appendLabel appends a LABEL Dockerfile instruction as the last child of node
 // with keys and values from m.
 func appendLabel(node *parser.Node, m []dockerfile.KeyValue) error {
+	if len(m) == 0 {
+		return nil
+	}
 	return appendKeyValueInstruction(dockerfile.Label, node, m)
 }
 

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -132,11 +132,14 @@ func setupSourceSecrets(pod *kapi.Pod, sourceSecret *kapi.LocalObjectReference) 
 // addSourceEnvVars adds environment variables related to the source code
 // repository to builder container
 func addSourceEnvVars(source buildapi.BuildSource, output *[]kapi.EnvVar) {
-	sourceVars := []kapi.EnvVar{{Name: "SOURCE_REPOSITORY", Value: source.Git.URI}}
+	sourceVars := []kapi.EnvVar{}
+	if source.Git != nil {
+		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_REPOSITORY", Value: source.Git.URI})
+	}
 	if len(source.ContextDir) > 0 {
 		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_CONTEXT_DIR", Value: source.ContextDir})
 	}
-	if len(source.Git.Ref) > 0 {
+	if source.Git != nil && len(source.Git.Ref) > 0 {
 		sourceVars = append(sourceVars, kapi.EnvVar{Name: "SOURCE_REF", Value: source.Git.Ref})
 	}
 	*output = append(*output, sourceVars...)

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -51,10 +51,7 @@ created for you.
 
 You can easily switch between multiple projects using '%[1]s project <projectname>'.`
 
-func NewCommandCLI(name, fullName string, out io.Writer) *cobra.Command {
-	in := os.Stdin
-	errout := os.Stderr
-
+func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *cobra.Command {
 	// Main command
 	cmds := &cobra.Command{
 		Use:   name,
@@ -183,7 +180,7 @@ support for application lifecycles.`
 func CommandFor(basename string) *cobra.Command {
 	var cmd *cobra.Command
 
-	out := os.Stdout
+	in, out, errout := os.Stdin, os.Stdout, os.Stderr
 
 	// Make case-insensitive and strip executable suffix if present
 	if runtime.GOOS == "windows" {
@@ -195,7 +192,7 @@ func CommandFor(basename string) *cobra.Command {
 	case "kubectl":
 		cmd = NewCmdKubectl(basename, out)
 	default:
-		cmd = NewCommandCLI(basename, basename, out)
+		cmd = NewCommandCLI(basename, basename, in, out, errout)
 	}
 
 	if cmd.UsageFunc() == nil {

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -86,7 +86,7 @@ func NewCommandCLI(name, fullName string, out io.Writer) *cobra.Command {
 				cmd.NewCmdBuildLogs(fullName, f, out),
 				cmd.NewCmdDeploy(fullName, f, out),
 				cmd.NewCmdRollback(fullName, f, out),
-				cmd.NewCmdNewBuild(fullName, f, out),
+				cmd.NewCmdNewBuild(fullName, f, in, out),
 				cmd.NewCmdCancelBuild(fullName, f, out),
 				cmd.NewCmdImportImage(fullName, f, out),
 				cmd.NewCmdScale(fullName, f, out),

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -39,7 +39,7 @@ Once the build configuration is created you may need to run a build with 'start-
   $ %[1]s new-build https://github.com/openshift/ruby-hello-world#beta2
 
   // Create a build config using a Dockerfile specified as an argument
-  $ %[1]s new-build -D $'FROM centos7\nRUN yum install apache'
+  $ %[1]s new-build -D $'FROM centos7\nRUN yum install -y apache'
 
   // Create a build config from a remote repository and add custom environment variables into resulting image
   $ %[1]s new-build https://github.com/openshift/ruby-hello-world --env=RACK_ENV=development`

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,12 +38,15 @@ Once the build configuration is created you may need to run a build with 'start-
   // Create a build config from a remote repository using its beta2 branch
   $ %[1]s new-build https://github.com/openshift/ruby-hello-world#beta2
 
+  // Create a build config using a Dockerfile specified as an argument
+  $ %[1]s new-build -D $'FROM centos7\nRUN yum install apache'
+
   // Create a build config from a remote repository and add custom environment variables into resulting image
   $ %[1]s new-build https://github.com/openshift/ruby-hello-world --env=RACK_ENV=development`
 )
 
 // NewCmdNewBuild implements the OpenShift cli new-build command
-func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdNewBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
 	mapper, typer := f.Object()
 	clientMapper := f.ClientMapperForCommand()
 	config := newcmd.NewAppConfig(typer, mapper, clientMapper)
@@ -54,7 +58,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 		Example: fmt.Sprintf(newBuildExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			config.AddEnvironmentToBuild = true
-			err := RunNewBuild(fullName, f, out, c, args, config)
+			err := RunNewBuild(fullName, f, out, in, c, args, config)
 			if err == errExit {
 				os.Exit(1)
 			}
@@ -68,6 +72,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated build artifacts")
 	cmd.Flags().VarP(&config.Environment, "env", "e", "Specify key value pairs of environment variables to set into resulting image.")
 	cmd.Flags().StringVar(&config.Strategy, "strategy", "", "Specify the build strategy to use if you don't want to detect (docker|source).")
+	cmd.Flags().StringVarP(&config.Dockerfile, "dockerfile", "D", "", "Specify the contents of a Dockerfile to build directly, implies --strategy=docker. Pass '-' to read from STDIN.")
 	cmd.Flags().BoolVar(&config.OutputDocker, "to-docker", false, "Have the build output push to a Docker repository.")
 	cmd.Flags().StringP("labels", "l", "", "Label to set in all generated resources.")
 	cmdutil.AddPrinterFlags(cmd)
@@ -76,7 +81,15 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 }
 
 // RunNewBuild contains all the necessary functionality for the OpenShift cli new-build command
-func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
+func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, in io.Reader, c *cobra.Command, args []string, config *newcmd.AppConfig) error {
+	if config.Dockerfile == "-" {
+		data, err := ioutil.ReadAll(in)
+		if err != nil {
+			return err
+		}
+		config.Dockerfile = string(data)
+	}
+
 	if err := setupAppConfig(f, c, args, config); err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -68,10 +68,13 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, out io.Writer) *cob
 	}
 	cmd.Flags().String("from-build", "", "Specify the name of a build which should be re-run")
 	cmd.Flags().String("commit", "", "Specify the commit hash the build should be run from")
+
 	cmd.Flags().Bool("follow", false, "Start a build and watch its logs until it completes or fails")
 	cmd.Flags().Bool("wait", false, "Wait for a build to complete and exit with a non-zero return code if the build fails")
+
 	cmd.Flags().Var(&webhooks, "list-webhooks", "List the webhooks for the specified BuildConfig or build; accepts 'all', 'generic', or 'github'")
 	cmd.Flags().String("from-webhook", "", "Specify a webhook URL for an existing BuildConfig to trigger")
+
 	cmd.Flags().String("git-post-receive", "", "The contents of the post-receive hook to trigger a build")
 	cmd.Flags().String("git-repository", "", "The path to the git repository for post-receive; defaults to the current directory")
 	return cmd

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -535,6 +535,8 @@ func buildTimestamp(build *buildapi.Build) util.Time {
 
 func describeSourceInPipeline(source *buildapi.BuildSource) (string, bool) {
 	switch source.Type {
+	case buildapi.BuildSourceDockerfile:
+		return "Dockerfile", true
 	case buildapi.BuildSourceGit:
 		if len(source.Git.Ref) == 0 {
 			return source.Git.URI, true

--- a/pkg/cmd/cli/kubectl_compat_test.go
+++ b/pkg/cmd/cli/kubectl_compat_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -24,7 +25,7 @@ var WhitelistedCommands = util.NewStringSet()
 func TestKubectlCompatibility(t *testing.T) {
 	f := clientcmd.New(pflag.NewFlagSet("name", pflag.ContinueOnError))
 
-	oc := NewCommandCLI("oc", "oc", ioutil.Discard)
+	oc := NewCommandCLI("oc", "oc", &bytes.Buffer{}, ioutil.Discard, ioutil.Discard)
 	kubectl := kcmd.NewKubectlCommand(f.Factory, nil, ioutil.Discard, ioutil.Discard)
 
 kubectlLoop:

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -40,7 +40,7 @@ Docker containers. To start an all-in-one server with the default configuration,
 func CommandFor(basename string) *cobra.Command {
 	var cmd *cobra.Command
 
-	out := os.Stdout
+	in, out, errout := os.Stdin, os.Stdout, os.Stderr
 
 	// Make case-insensitive and strip executable suffix if present
 	if runtime.GOOS == "windows" {
@@ -60,7 +60,7 @@ func CommandFor(basename string) *cobra.Command {
 	case "openshift-docker-build":
 		cmd = builder.NewCommandDockerBuilder(basename)
 	case "oc", "osc":
-		cmd = cli.NewCommandCLI(basename, basename, out)
+		cmd = cli.NewCommandCLI(basename, basename, in, out, errout)
 	case "oadm", "osadm":
 		cmd = admin.NewCommandAdmin(basename, basename, out)
 	case "kubectl":
@@ -93,7 +93,7 @@ func CommandFor(basename string) *cobra.Command {
 
 // NewCommandOpenShift creates the standard OpenShift command
 func NewCommandOpenShift(name string) *cobra.Command {
-	out := os.Stdout
+	in, out, errout := os.Stdin, os.Stdout, os.Stderr
 
 	product := "Origin"
 	switch name {
@@ -113,7 +113,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 	startAllInOne, _ := start.NewCommandStartAllInOne(name, out)
 	root.AddCommand(startAllInOne)
 	root.AddCommand(admin.NewCommandAdmin("admin", name+" admin", out))
-	root.AddCommand(cli.NewCommandCLI("cli", name+" cli", out))
+	root.AddCommand(cli.NewCommandCLI("cli", name+" cli", in, out, errout))
 	root.AddCommand(cli.NewCmdKubectl("kube", out))
 	root.AddCommand(newExperimentalCommand("ex", name+" ex"))
 	root.AddCommand(version.NewVersionCommand(name))

--- a/pkg/cmd/server/start/start_api.go
+++ b/pkg/cmd/server/start/start_api.go
@@ -67,7 +67,7 @@ func NewCommandStartMasterAPI(name, basename string, out io.Writer) (*cobra.Comm
 		},
 	}
 
-	// allow the master IP address to be overriden on a per process basis
+	// allow the master IP address to be overridden on a per process basis
 	masterAddr := flagtypes.Addr{
 		Value:         "127.0.0.1:8443",
 		DefaultScheme: "https",
@@ -75,7 +75,7 @@ func NewCommandStartMasterAPI(name, basename string, out io.Writer) (*cobra.Comm
 		AllowPrefix:   true,
 	}.Default()
 
-	// allow the listen address to be overriden on a per process basis
+	// allow the listen address to be overridden on a per process basis
 	listenArg := &ListenArg{
 		ListenAddr: flagtypes.Addr{
 			Value:         "127.0.0.1:8444",

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -99,6 +99,8 @@ type SourceRef struct {
 	Dir        string
 	Name       string
 	ContextDir string
+
+	DockerfileContents string
 }
 
 func urlWithoutRef(url url.URL) string {
@@ -111,32 +113,46 @@ func (r *SourceRef) SuggestName() (string, bool) {
 	if len(r.Name) > 0 {
 		return r.Name, true
 	}
-	return nameFromGitURL(r.URL)
+	if r.URL != nil {
+		return nameFromGitURL(r.URL)
+	}
+	return "", false
 }
 
 // BuildSource returns an OpenShift BuildSource from the SourceRef
 func (r *SourceRef) BuildSource() (*buildapi.BuildSource, []buildapi.BuildTriggerPolicy) {
-	return &buildapi.BuildSource{
+	triggers := []buildapi.BuildTriggerPolicy{
+		{
+			Type: buildapi.GitHubWebHookBuildTriggerType,
+			GitHubWebHook: &buildapi.WebHookTrigger{
+				Secret: generateSecret(20),
+			},
+		},
+		{
+			Type: buildapi.GenericWebHookBuildTriggerType,
+			GenericWebHook: &buildapi.WebHookTrigger{
+				Secret: generateSecret(20),
+			},
+		},
+	}
+	var source *buildapi.BuildSource
+	switch {
+	case r.URL != nil:
+		source = &buildapi.BuildSource{
 			Type: buildapi.BuildSourceGit,
 			Git: &buildapi.GitBuildSource{
 				URI: urlWithoutRef(*r.URL),
 				Ref: r.Ref,
 			},
 			ContextDir: r.ContextDir,
-		}, []buildapi.BuildTriggerPolicy{
-			{
-				Type: buildapi.GitHubWebHookBuildTriggerType,
-				GitHubWebHook: &buildapi.WebHookTrigger{
-					Secret: generateSecret(20),
-				},
-			},
-			{
-				Type: buildapi.GenericWebHookBuildTriggerType,
-				GenericWebHook: &buildapi.WebHookTrigger{
-					Secret: generateSecret(20),
-				},
-			},
 		}
+	case len(r.DockerfileContents) != 0:
+		source = &buildapi.BuildSource{
+			Type:       buildapi.BuildSourceDockerfile,
+			Dockerfile: &r.DockerfileContents,
+		}
+	}
+	return source, triggers
 }
 
 // BuildStrategyRef is a reference to a build strategy
@@ -385,10 +401,13 @@ func (r *BuildRef) BuildConfig() (*buildapi.BuildConfig, error) {
 	if !ok {
 		return nil, fmt.Errorf("unable to suggest a name for this BuildConfig from %q", r.Source.URL)
 	}
-	source := &buildapi.BuildSource{}
+	var source *buildapi.BuildSource
 	sourceTriggers := []buildapi.BuildTriggerPolicy{}
 	if r.Source != nil {
 		source, sourceTriggers = r.Source.BuildSource()
+	}
+	if source == nil {
+		source = &buildapi.BuildSource{}
 	}
 	strategy := &buildapi.BuildStrategy{}
 	strategyTriggers := []buildapi.BuildTriggerPolicy{}

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -53,6 +53,8 @@ type AppConfig struct {
 
 	AddEnvironmentToBuild bool
 
+	Dockerfile string
+
 	Name             string
 	Strategy         string
 	InsecureRegistry bool
@@ -189,6 +191,18 @@ func (c *AppConfig) individualSourceRepositories() (app.SourceRepositories, erro
 			first = false
 		}
 	}
+	if len(c.Dockerfile) > 0 {
+		switch {
+		case c.Strategy == "docker", len(c.Strategy) == 0:
+		default:
+			return nil, fmt.Errorf("when directly referencing a Dockerfile, the strategy must must be 'docker'")
+		}
+		repo, err := app.NewSourceRepositoryForDockerfile(c.Dockerfile)
+		if err != nil {
+			return nil, fmt.Errorf("provided Dockerfile is not valid: %v", err)
+		}
+		c.refBuilder.AddExistingSourceRepository(repo)
+	}
 	_, repos, errs := c.refBuilder.Result()
 	return repos, errors.NewAggregate(errs)
 }
@@ -258,7 +272,7 @@ func (c *AppConfig) validate() (app.ComponentReferences, app.SourceRepositories,
 	b.AddGroups(c.Groups)
 	refs, repos, errs := b.Result()
 
-	if len(repos) > 0 {
+	if len(c.ContextDir) > 0 && len(repos) > 0 {
 		repos[0].SetContextDir(c.ContextDir)
 		if len(repos) > 1 {
 			glog.Warningf("You have specified more than one source repository and a context directory. "+
@@ -298,7 +312,13 @@ func (c *AppConfig) componentsForRepos(repositories app.SourceRepositories) (app
 			errs = append(errs, fmt.Errorf("source not detected for repository %q", repo))
 			continue
 		case info.Dockerfile != nil && (len(c.Strategy) == 0 || c.Strategy == "docker"):
-			dockerFrom, ok := info.Dockerfile.GetDirective("FROM")
+			df, err := info.Dockerfile.Dockerfile()
+			if err != nil {
+				// an unparseable docker file should not terminate the entire create - it may be valid to Docker but not to us
+				glog.V(1).Infof("The Dockerfile for the repository %q could not be parsed - no image stream can be created for the FROM", info.Path)
+				continue
+			}
+			dockerFrom, ok := df.GetDirective("FROM")
 			if !ok || len(dockerFrom) > 1 {
 				errs = append(errs, fmt.Errorf("invalid FROM directive in Dockerfile in repository %q", repo))
 			}
@@ -506,16 +526,18 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 
 				// Append any exposed ports from Dockerfile to input image
 				if ref.Input().Uses.IsDockerBuild() {
-					exposed, ok := ref.Input().Uses.Info().Dockerfile.GetDirective("EXPOSE")
-					if ok {
-						if input.Info == nil {
-							input.Info = &imageapi.DockerImage{
-								Config: &imageapi.DockerConfig{},
+					if df, err := ref.Input().Uses.Info().Dockerfile.Dockerfile(); err == nil {
+						exposed, ok := df.GetDirective("EXPOSE")
+						if ok {
+							if input.Info == nil {
+								input.Info = &imageapi.DockerImage{
+									Config: &imageapi.DockerConfig{},
+								}
 							}
-						}
-						input.Info.Config.ExposedPorts = map[string]struct{}{}
-						for _, p := range exposed {
-							input.Info.Config.ExposedPorts[p] = struct{}{}
+							input.Info.Config.ExposedPorts = map[string]struct{}{}
+							for _, p := range exposed {
+								input.Info.Config.ExposedPorts[p] = struct{}{}
+							}
 						}
 					}
 				}

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -908,7 +908,7 @@ func TestRunBuild(t *testing.T) {
 		name        string
 		config      *AppConfig
 		expected    map[string][]string
-		expectedErr error
+		expectedErr func(error) bool
 	}{
 		{
 			name: "successful ruby app generation",
@@ -946,15 +946,66 @@ func TestRunBuild(t *testing.T) {
 				"buildConfig": {"ruby-hello-world"},
 				"imageStream": {"ruby-20-centos7"},
 			},
-			expectedErr: nil,
+		},
+		{
+			name: "successful build from dockerfile",
+			config: &AppConfig{
+				Dockerfile: "FROM openshift/origin-base\nUSER foo",
+
+				dockerSearcher: dockerSearcher,
+				imageStreamSearcher: app.ImageStreamSearcher{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				imageStreamByAnnotationSearcher: &app.ImageStreamByAnnotationSearcher{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				templateSearcher: app.TemplateSearcher{
+					Client: &client.Fake{},
+					TemplateConfigsNamespacer: &client.Fake{},
+					Namespaces:                []string{"openshift", "default"},
+				},
+
+				detector: app.SourceRepositoryEnumerator{
+					Detectors: source.DefaultDetectors,
+					Tester:    dockerfile.NewTester(),
+				},
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+			},
+			expected: map[string][]string{
+				"buildConfig": {"origin-base"},
+				"imageStream": {"origin-base"},
+			},
+		},
+		{
+			name: "unsuccessful build from dockerfile due to strategy conflict",
+			config: &AppConfig{
+				Dockerfile: "FROM openshift/origin-base\nUSER foo",
+				Strategy:   "source",
+
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+			},
+			expectedErr: func(err error) bool {
+				return err.Error() == "when directly referencing a Dockerfile, the strategy must must be 'docker'"
+			},
 		},
 	}
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
 		res, err := test.config.RunBuilds(os.Stdout, os.Stderr)
-		if err != test.expectedErr {
-			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
+		if (test.expectedErr == nil && err != nil) || (test.expectedErr != nil && !test.expectedErr(err)) {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+			continue
+		}
+		if err != nil {
 			continue
 		}
 		got := map[string][]string{}
@@ -1167,10 +1218,7 @@ tests:
 // Make sure that buildPipelines defaults DockerImage.Config if needed to
 // avoid a nil panic.
 func TestBuildPipelinesWithUnresolvedImage(t *testing.T) {
-	dockerParser := dockerfile.NewParser()
-
-	dockerFileInput := strings.NewReader("EXPOSE 1234\nEXPOSE 4567")
-	dockerFile, err := dockerParser.Parse(dockerFileInput)
+	dockerFile, err := app.NewDockerfile("EXPOSE 1234\nEXPOSE 4567")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -206,6 +206,10 @@ func (r *ReferenceBuilder) AddSourceRepository(input string) (*SourceRepository,
 	return source, true
 }
 
+func (r *ReferenceBuilder) AddExistingSourceRepository(source *SourceRepository) {
+	r.repos = append(r.repos, source)
+}
+
 // Result returns the result of the config conversion to object references
 func (r *ReferenceBuilder) Result() (ComponentReferences, SourceRepositories, []error) {
 	return r.refs, r.repos, r.errs

--- a/rel-eng/completions/bash/oc
+++ b/rel-eng/completions/bash/oc
@@ -466,6 +466,8 @@ _oc_new-build()
 
     flags+=("--code=")
     flags+=("--docker-image=")
+    flags+=("--dockerfile=")
+    two_word_flags+=("-D")
     flags+=("--env=")
     two_word_flags+=("-e")
     flags+=("--image=")

--- a/rel-eng/completions/bash/openshift
+++ b/rel-eng/completions/bash/openshift
@@ -1922,6 +1922,8 @@ _openshift_cli_new-build()
 
     flags+=("--code=")
     flags+=("--docker-image=")
+    flags+=("--dockerfile=")
+    two_word_flags+=("-D")
     flags+=("--env=")
     two_word_flags+=("-e")
     flags+=("--image=")

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -13,6 +13,14 @@ project="$(oc project -q)"
 
 # This test validates builds and build related commands
 
+oc new-build openshift/ruby-20-centos7 https://github.com/openshift/ruby-hello-world.git
+oc get bc/ruby-hello-world
+cat "${OS_ROOT}/Dockerfile" | oc new-build -D - --name=test
+oc get bc/test
+oc new-build --dockerfile=$'FROM centos\nRUN yum install -y apache'
+oc get bc/centos
+oc delete all --all
+
 oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -
 oc get buildConfigs
 oc get bc

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -1,0 +1,59 @@
+package builds
+
+import (
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: parallel: Dockerfile input", func() {
+	defer g.GinkgoRecover()
+	var (
+		imageStreamFixture = exutil.FixturePath("..", "integration", "fixtures", "test-image-stream.json")
+		oc                 = exutil.NewCLI("build-dockerfile-env", exutil.KubeConfigPath())
+		testDockerfile     = `
+FROM openshift/origin-base
+USER 1001
+`
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.Describe("being created from new-app", func() {
+		g.It("should create a image via new-build", func() {
+			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+			g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
+			err := oc.Run("create").Args("-f", imageStreamFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("calling oc new-app with Dockerfile"))
+			err = oc.Run("new-build").Args("-D", "-").InputString(testDockerfile).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a test build")
+			bc, err := oc.REST().BuildConfigs(oc.Namespace()).Get("origin-base")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(bc.Spec.Source.Git).To(o.BeNil())
+			o.Expect(bc.Spec.Source.Dockerfile).NotTo(o.BeNil())
+			o.Expect(*bc.Spec.Source.Dockerfile).To(o.Equal(testDockerfile))
+			buildName := "origin-base-1"
+
+			g.By("expecting the Dockerfile build is in Complete phase")
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFunc, exutil.CheckBuildFailedFunc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("getting the Docker image reference from ImageStream")
+			image, err := oc.REST().ImageStreamTags(oc.Namespace()).Get("test", "latest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
+		})
+	})
+})

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -33,7 +33,9 @@ type CLI struct {
 	globalArgs      []string
 	commandArgs     []string
 	finalArgs       []string
+	stdin           *bytes.Buffer
 	stdout          io.Writer
+	stderr          io.Writer
 	verbose         bool
 	cmd             *cobra.Command
 	kubeFramework   *e2e.Framework
@@ -174,8 +176,7 @@ func (c *CLI) Namespace() string {
 }
 
 // SetOutput allows to override the default command output
-func (c *CLI) SetOutput(out io.Writer) *CLI {
-	c.stdout = out
+func (c *CLI) setOutput(out io.Writer) *CLI {
 	for _, subCmd := range c.cmd.Commands() {
 		subCmd.SetOutput(c.stdout)
 	}
@@ -187,7 +188,8 @@ func (c *CLI) SetOutput(out io.Writer) *CLI {
 // This function also override the default 'stdout' to redirect all output
 // to a buffer and prepare the global flags such as namespace and config path.
 func (c *CLI) Run(verb string) *CLI {
-	out := new(bytes.Buffer)
+
+	in, out, errout := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
 	nc := &CLI{
 		verb:            verb,
 		kubeFramework:   c.KubeFramework(),
@@ -195,14 +197,15 @@ func (c *CLI) Run(verb string) *CLI {
 		configPath:      c.configPath,
 		username:        c.username,
 		outputDir:       c.outputDir,
-		cmd:             cli.NewCommandCLI("oc", "openshift", out),
+		cmd:             cli.NewCommandCLI("oc", "openshift", in, out, errout),
 		globalArgs: []string{
 			verb,
 			fmt.Sprintf("--namespace=%s", c.Namespace()),
 			fmt.Sprintf("--config=%s", c.configPath),
 		},
 	}
-	return nc.SetOutput(out)
+	nc.stdin, nc.stdout, nc.stderr = in, out, errout
+	return nc.setOutput(c.stdout)
 }
 
 // Template sets a Go template for the OpenShift CLI command.
@@ -215,6 +218,12 @@ func (c *CLI) Template(t string) *CLI {
 	commandArgs := append(c.commandArgs, templateArgs...)
 	c.finalArgs = append(c.globalArgs, commandArgs...)
 	c.cmd.SetArgs(c.finalArgs)
+	return c
+}
+
+// InputString adds expected input to the command
+func (c *CLI) InputString(input string) *CLI {
+	c.stdin.WriteString(input)
 	return c
 }
 


### PR DESCRIPTION
Support a new --dockerfile option on oc new-build that performs a
docker build based on the contents of a dockerfile, and support
Dockerfile as a source type on builds. Fix lots of NPEs in the build
code where .Git != nil is assumed. If you specify Git and Dockerfile
during a Docker build, the Dockerfile will overwrite whatever is in
the git repo in the context dir.

    oc new-build -D $'FROM centos7\nRUN yum install -y apache'
    oc new-build --dockerfile="$(cat ../Dockerfile)"

@bparees @mfojtik, still needs e2e tests.  Also @jwforres because this
breaks the assumption that code has that there is only ever one source
type, or that there is just one source type (Docker build allows Dockerfile
and git repo).