### PR TITLE
Filter topology correctly and refactor relations

### DIFF
--- a/assets/app/styles/_topology.less
+++ b/assets/app/styles/_topology.less
@@ -16,9 +16,10 @@ kubernetes-topology-graph {
     font-size: 21px;
   }
 
-  // These links are rendered dotted
+  // These links are rendered dotted, where relationship incidental
   line.ServiceReplicationController,
   line.ServiceDeploymentConfig,
+  line.DeploymentConfigReplicationController,
   line.ReplicationControllerPod {
     stroke-dasharray: 1, 3;
     strake-linecap: round;


### PR DESCRIPTION
Refactor the updateTopology code that generates the nodes
and vertices in the topology graph. We now respect the filter
and link things correctly and consistently.

Fixes #4681