### PR TITLE
Improve systemd detection for diagnostics.

### DIFF
--- a/pkg/diagnostics/systemd/unit_status.go
+++ b/pkg/diagnostics/systemd/unit_status.go
@@ -3,8 +3,6 @@ package systemd
 import (
 	"errors"
 	"fmt"
-	"os/exec"
-	"runtime"
 
 	"github.com/openshift/origin/pkg/diagnostics/types"
 )
@@ -24,13 +22,10 @@ func (d UnitStatus) Description() string {
 	return "Check status for related systemd units"
 }
 func (d UnitStatus) CanRun() (bool, error) {
-	if runtime.GOOS == "linux" {
-		if _, err := exec.LookPath("systemctl"); err == nil {
-			return true, nil
-		}
+	if HasSystemctl() {
+		return true, nil
 	}
-
-	return false, errors.New("systemd is not present on this host")
+	return false, errors.New("systemd is not present/functional on this host")
 }
 func (d UnitStatus) Check() types.DiagnosticResult {
 	r := types.NewDiagnosticResult(UnitStatusName)


### PR DESCRIPTION
Previous code assumed that if systemctl exists, we can check unit status. However in a containerized deployment systemctl may be in the container but non-functional, resulting in multiple false errors checking unit status.                  
                                                                                                                                  
Fixed by checking that systemctl is actually usable before we proceed with checking unit status.
                                                                                                                                  
Additionally added a check that journalctl is usable in the AnalyzeLogs CanRun() method, resulting in slightly more accurate output in a container indicating that the check was skipped entirely.

WARNING: first openshift PR, first golang, feedback welcomed

## Relevant sample output from a master only container:

### Before

[Note] Performing systemd discovery

ERROR: [DS1004 from controller openshift/origin/pkg/diagnostics/systemd/locate_units.go]
       Error running `systemctl show openshift`: exit status 1
       Cannot analyze systemd units.

[SNIP: Above error repeated for all systemd units we care about]

[Note] Running diagnostic: AnalyzeLogs
       Description: Check for recent problems in systemd service logs

### After 

[Note] Systemd not available, skipping unit discovery.

[Note] Skipping diagnostic: AnalyzeLogs
       Description: Check for recent problems in systemd service logs
       Because: journalctl is not present/functional on this host

[Note] Skipping diagnostic: UnitStatus
       Description: Check status for related systemd units
       Because: systemd is not present/functional on this host

## Relevant sample output from an all-in-one container:

### Before
[Note] Performing systemd discovery

[Note] Running diagnostic: AnalyzeLogs
       Description: Check for recent problems in systemd service logs

Info:  Checking journalctl logs for 'docker' service

### After

[Note] Skipping diagnostic: AnalyzeLogs
       Description: Check for recent problems in systemd service logs
       Because: journalctl is not present/functional on this host
       

I have also tested minimally on a regular non-containerized host and systemd related diagnostics appear to trigger correctly there as well.
