### PR TITLE
Making the regex in ./test/cmd/admin.sh a little more flexible for do…

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -121,7 +121,7 @@ echo "router: ok"
 
 # Test running a registry
 [ ! "$(oadm registry --dry-run | grep 'does not exist')"]
-[ "$(oadm registry -o yaml --credentials="${KUBECONFIG}" | grep 'openshift/origin-docker-registry')" ]
+[ "$(oadm registry -o yaml --credentials="${KUBECONFIG}" | egrep 'image:.*-docker-registry')" ]
 oadm registry --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
 [ "$(oadm registry | grep 'service exists')" ]
 echo "registry: ok"


### PR DESCRIPTION
…wnstream

Even though the build process is building them with 'origin' in the name
downstream has changed their default for --images to be non-origin.