### PR TITLE
Follow up on #4660: new app error msg

### DIFF
--- a/pkg/generate/app/templatelookup.go
+++ b/pkg/generate/app/templatelookup.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -117,6 +118,9 @@ func (r *TemplateFileSearcher) Search(precise bool, terms ...string) (ComponentM
 			case strings.Contains(err.Error(), "does not exist") && strings.Contains(err.Error(), "the path"):
 				continue
 			default:
+				if syntaxErr, ok := err.(*json.SyntaxError); ok {
+					err = fmt.Errorf("at offset %d: %v", syntaxErr.Offset, err)
+				}
 				errs = append(errs, fmt.Errorf("unable to load template file %q: %v", term, err))
 				continue
 			}

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -163,7 +163,7 @@ os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-worl
 os::cmd::expect_success 'oc delete all -l app=ruby'
 # check for error when template JSON file has errors
 jsonfile="${OS_ROOT}/test/fixtures/invalid.json"
-os::cmd::expect_failure_and_text "oc new-app '${jsonfile}'" "error: unable to load template file \"${jsonfile}\": invalid character '}' after object key"
+os::cmd::expect_failure_and_text "oc new-app '${jsonfile}'" "error: unable to load template file \"${jsonfile}\": at offset 8: invalid character '}' after object key"
 
 # check new-build
 os::cmd::expect_failure_and_text 'oc new-build mysql -o yaml' 'you must specify at least one source repository URL'


### PR DESCRIPTION
Given a JSON template with invalid syntax:

``` 
$ cat bad-template.json
{
"there should not be a trailing comma": "here",
}
```

Before #4660, `oc new-app` produced this error message:

```
$ oc new-app bad-template.json
error: no image or template matched "bad-template.json"
```

After:

```
$ oc new-app bad-template.json
error: invalid character '}' looking for beginning of object key string
```

But @smarterclayton [commented](https://github.com/openshift/origin/pull/4660#discussion_r39747207) that the implementation was leaking an abstraction, thus, this follow up.