### PR TITLE
enable patch verb for policy

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers.go
@@ -485,6 +485,8 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 			requestInfo.Verb = "get"
 		case "PUT":
 			requestInfo.Verb = "update"
+		case "PATCH":
+			requestInfo.Verb = "patch"
 		case "DELETE":
 			requestInfo.Verb = "delete"
 		}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -263,6 +263,7 @@ echo "config files: ok"
 
 # from this point every command will use config from the KUBECONFIG env var
 export KUBECONFIG="${HOME}/.kube/non-default-config"
+export CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template -t '{{index . "current-context"}}')
 
 
 # NOTE: Do not add tests here, add them to test/cmd/*.
@@ -272,6 +273,9 @@ for test in "${tests[@]}"; do
   echo
   echo "++ ${test}"
   name=$(basename ${test} .sh)
+
+  # switch back to a standard identity. This prevents individual tests from changing contexts and messing up other tests
+  oc project ${CLUSTER_ADMIN_CONTEXT}
   oc new-project "cmd-${name}"
   ${test}
   oc delete project "cmd-${name}"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -71,7 +71,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "delete"),
+					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "patch", "delete"),
 					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.PermissionGrantingGroupName, authorizationapi.KubeExposedGroupName, "projects", "secrets", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
 				},
 				{
@@ -91,7 +91,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "delete"),
+					Verbs:     util.NewStringSet("get", "list", "watch", "create", "update", "patch", "delete"),
 					Resources: util.NewStringSet(authorizationapi.OpenshiftExposedGroupName, authorizationapi.KubeExposedGroupName, "secrets", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward", authorizationapi.DockerBuildResource, authorizationapi.SourceBuildResource, authorizationapi.CustomBuildResource),
 				},
 				{

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -65,6 +65,10 @@ echo "expose: ok"
 
 oc delete all --all
 
+# switch to test user to be sure that default project admin policy works properly
+oc policy add-role-to-user admin test-user
+oc login -u test-user -p anything
+
 oc run --image=openshift/hello-openshift test
 oc run --image=openshift/hello-openshift --generator=run-controller/v1 test2
 oc run --image=openshift/hello-openshift --restart=Never test3
@@ -74,6 +78,11 @@ oc process -f examples/sample-app/application-template-stibuild.json -l name=myt
 oc delete all -l name=mytemplate
 oc new-app https://github.com/openshift/ruby-hello-world
 [ "$(oc get dc/ruby-hello-world)" ]
+
+oc get dc/ruby-hello-world -t '{{ .spec.replicas }}' | grep -q 1
+oc patch dc/ruby-hello-world -p '{"spec": {"replicas": 2}}'
+oc get dc/ruby-hello-world -t '{{ .spec.replicas }}' | grep -q 2
+
 oc delete all -l app=ruby-hello-world
 [ ! "$(oc get dc/ruby-hello-world)" ]
 echo "delete all: ok"


### PR DESCRIPTION
Fixes #4744 

This allows project admins and editors to use `oc patch`.

@liggitt @thoraxe 
