### PR TITLE
Add missing rolling hook conversions

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -218,6 +218,28 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 				params.TimeoutSeconds = randInt64()
 				params.IntervalSeconds = randInt64()
 				params.UpdatePeriodSeconds = randInt64()
+
+				policyTypes := []deploy.LifecycleHookFailurePolicy{
+					deploy.LifecycleHookFailurePolicyRetry,
+					deploy.LifecycleHookFailurePolicyAbort,
+					deploy.LifecycleHookFailurePolicyIgnore,
+				}
+				if c.RandBool() {
+					params.Pre = &deploy.LifecycleHook{
+						FailurePolicy: policyTypes[c.Rand.Intn(len(policyTypes))],
+						ExecNewPod: &deploy.ExecNewPodHook{
+							ContainerName: c.RandString(),
+						},
+					}
+				}
+				if c.RandBool() {
+					params.Post = &deploy.LifecycleHook{
+						FailurePolicy: policyTypes[c.Rand.Intn(len(policyTypes))],
+						ExecNewPod: &deploy.ExecNewPodHook{
+							ContainerName: c.RandString(),
+						},
+					}
+				}
 				if c.RandBool() {
 					params.MaxUnavailable = util.NewIntOrStringFromInt(int(c.RandUint64()))
 					params.MaxSurge = util.NewIntOrStringFromInt(int(c.RandUint64()))

--- a/pkg/deploy/api/v1/conversion.go
+++ b/pkg/deploy/api/v1/conversion.go
@@ -204,6 +204,17 @@ func convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategy
 	out.TimeoutSeconds = in.TimeoutSeconds
 	out.UpdatePercent = in.UpdatePercent
 
+	if in.Pre != nil {
+		if err := s.Convert(&in.Pre, &out.Pre, 0); err != nil {
+			return err
+		}
+	}
+	if in.Post != nil {
+		if err := s.Convert(&in.Post, &out.Post, 0); err != nil {
+			return err
+		}
+	}
+
 	if in.UpdatePercent != nil {
 		pct := kutil.NewIntOrStringFromString(fmt.Sprintf("%d%%", int(math.Abs(float64(*in.UpdatePercent)))))
 		if *in.UpdatePercent > 0 {
@@ -227,6 +238,17 @@ func convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategy
 	out.IntervalSeconds = in.IntervalSeconds
 	out.TimeoutSeconds = in.TimeoutSeconds
 	out.UpdatePercent = in.UpdatePercent
+
+	if in.Pre != nil {
+		if err := s.Convert(&in.Pre, &out.Pre, 0); err != nil {
+			return err
+		}
+	}
+	if in.Post != nil {
+		if err := s.Convert(&in.Post, &out.Post, 0); err != nil {
+			return err
+		}
+	}
 
 	if out.MaxUnavailable == nil {
 		out.MaxUnavailable = &kutil.IntOrString{}

--- a/pkg/deploy/api/v1/conversion_test.go
+++ b/pkg/deploy/api/v1/conversion_test.go
@@ -43,6 +43,12 @@ func Test_convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStr
 				IntervalSeconds:     newInt64(6),
 				TimeoutSeconds:      newInt64(7),
 				UpdatePercent:       newInt(-25),
+				Pre: &LifecycleHook{
+					FailurePolicy: LifecycleHookFailurePolicyIgnore,
+				},
+				Post: &LifecycleHook{
+					FailurePolicy: LifecycleHookFailurePolicyAbort,
+				},
 			},
 			out: &newer.RollingDeploymentStrategyParams{
 				UpdatePeriodSeconds: newInt64(5),
@@ -51,6 +57,12 @@ func Test_convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStr
 				UpdatePercent:       newInt(-25),
 				MaxSurge:            util.NewIntOrStringFromInt(0),
 				MaxUnavailable:      util.NewIntOrStringFromString("25%"),
+				Pre: &newer.LifecycleHook{
+					FailurePolicy: newer.LifecycleHookFailurePolicyIgnore,
+				},
+				Post: &newer.LifecycleHook{
+					FailurePolicy: newer.LifecycleHookFailurePolicyAbort,
+				},
 			},
 		},
 		{

--- a/pkg/deploy/api/v1beta3/conversion.go
+++ b/pkg/deploy/api/v1beta3/conversion.go
@@ -204,6 +204,17 @@ func convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStr
 	out.TimeoutSeconds = in.TimeoutSeconds
 	out.UpdatePercent = in.UpdatePercent
 
+	if in.Pre != nil {
+		if err := s.Convert(&in.Pre, &out.Pre, 0); err != nil {
+			return err
+		}
+	}
+	if in.Post != nil {
+		if err := s.Convert(&in.Post, &out.Post, 0); err != nil {
+			return err
+		}
+	}
+
 	if in.UpdatePercent != nil {
 		pct := kutil.NewIntOrStringFromString(fmt.Sprintf("%d%%", int(math.Abs(float64(*in.UpdatePercent)))))
 		if *in.UpdatePercent > 0 {
@@ -227,6 +238,17 @@ func convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStr
 	out.IntervalSeconds = in.IntervalSeconds
 	out.TimeoutSeconds = in.TimeoutSeconds
 	out.UpdatePercent = in.UpdatePercent
+
+	if in.Pre != nil {
+		if err := s.Convert(&in.Pre, &out.Pre, 0); err != nil {
+			return err
+		}
+	}
+	if in.Post != nil {
+		if err := s.Convert(&in.Post, &out.Post, 0); err != nil {
+			return err
+		}
+	}
 
 	if out.MaxUnavailable == nil {
 		out.MaxUnavailable = &kutil.IntOrString{}

--- a/pkg/deploy/api/v1beta3/conversion_test.go
+++ b/pkg/deploy/api/v1beta3/conversion_test.go
@@ -43,6 +43,12 @@ func Test_convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeployme
 				IntervalSeconds:     newInt64(6),
 				TimeoutSeconds:      newInt64(7),
 				UpdatePercent:       newInt(-25),
+				Pre: &LifecycleHook{
+					FailurePolicy: LifecycleHookFailurePolicyIgnore,
+				},
+				Post: &LifecycleHook{
+					FailurePolicy: LifecycleHookFailurePolicyAbort,
+				},
 			},
 			out: &newer.RollingDeploymentStrategyParams{
 				UpdatePeriodSeconds: newInt64(5),
@@ -51,6 +57,12 @@ func Test_convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeployme
 				UpdatePercent:       newInt(-25),
 				MaxSurge:            util.NewIntOrStringFromInt(0),
 				MaxUnavailable:      util.NewIntOrStringFromString("25%"),
+				Pre: &newer.LifecycleHook{
+					FailurePolicy: newer.LifecycleHookFailurePolicyIgnore,
+				},
+				Post: &newer.LifecycleHook{
+					FailurePolicy: newer.LifecycleHookFailurePolicyAbort,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Rolling deployment param hook conversions got lost in a previous
refactor, preventing hooks from being converted/persisted. Add the
conversions so hooks can be persisted.