### PR TITLE
Make "default" an admin namespace in multitenant

### DIFF
--- a/plugins/osdn/multitenant/multitenant.go
+++ b/plugins/osdn/multitenant/multitenant.go
@@ -31,6 +31,7 @@ func Master(osClient *osclient.Client, kClient *kclient.Client, clusterNetwork s
 	if err != nil {
 		glog.Fatalf("SDN initialization failed: %v", err)
 	}
+	kc.AdminNamespaces = append(kc.AdminNamespaces, "default")
 	err = kc.StartMaster(false, clusterNetwork, clusterNetworkLength, serviceNetwork)
 	if err != nil {
 		glog.Fatalf("SDN initialization failed: %v", err)


### PR DESCRIPTION
#4370 had more admin namespace handling stuff, but that didn't get merged. Meanwhile, even "default" isn't being treated as an admin namespace. So let's fix at least that.
@pravisankar 