### PR TITLE
create SCCExecRestriction admission plugin

### DIFF
--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -28,7 +28,7 @@ import (
 )
 
 // AdmissionPlugins is the full list of admission control plugins to enable in the order they must run
-var AdmissionPlugins = []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "ResourceQuota", "DenyExecOnPrivileged"}
+var AdmissionPlugins = []string{"NamespaceExists", "NamespaceLifecycle", "OriginPodNodeEnvironment", "LimitRanger", "ServiceAccount", "SecurityContextConstraint", "ResourceQuota", "SCCExecRestrictions"}
 
 // MasterConfig defines the required values to start a Kubernetes master
 type MasterConfig struct {

--- a/pkg/cmd/server/start/admission_sync_test.go
+++ b/pkg/cmd/server/start/admission_sync_test.go
@@ -18,6 +18,7 @@ var admissionPluginsNotUsedByKube = util.NewStringSet(
 	"AlwaysDeny",             // from kube, no need for this by default
 	"NamespaceAutoProvision", // from kube, it creates a namespace if a resource is created in a non-existent namespace.  We don't want this behavior
 	"SecurityContextDeny",    // from kube, it denies pods that want to use SCC capabilities.  We have different rules to allow this in openshift.
+	"DenyExecOnPrivileged",   // from kube, it denies exec to pods that have certain privileges.  This is superceded in origin by SCCExecRestrictions that checks against SCC rules.
 
 	"BuildByStrategy",          // from origin, only needed for managing builds, not kubernetes resources
 	"OriginNamespaceLifecycle", // from origin, only needed for rejecting openshift resources, so not needed by kube

--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"io"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/client"
+)
+
+func init() {
+	admission.RegisterPlugin("SCCExecRestrictions", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		return NewSCCExecRestrictions(client), nil
+	})
+}
+
+// sccExecRestrictions is an implementation of admission.Interface which says no to a pod/exec on
+// a pod that the user would not be allowed to create
+type sccExecRestrictions struct {
+	*admission.Handler
+	constraintAdmission *constraint
+	client              client.Interface
+}
+
+func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
+	if a.GetOperation() != admission.Connect {
+		return nil
+	}
+	if a.GetResource() != "pods" {
+		return nil
+	}
+	if a.GetSubresource() != "attach" && a.GetSubresource() != "exec" {
+		return nil
+	}
+
+	pod, err := d.client.Pods(a.GetNamespace()).Get(a.GetName())
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+
+	// create a synthentic admission attribute to check SCC admission status for this pod
+	// clear the SA name, so that any permissions MUST be based on your user's power, not the SAs power.
+	pod.Spec.ServiceAccountName = ""
+	createAttributes := admission.NewAttributesRecord(pod, "pods", a.GetNamespace(), a.GetName(), a.GetResource(), a.GetSubresource(), admission.Create, a.GetUserInfo())
+	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
+		return admission.NewForbidden(a, err)
+	}
+
+	return nil
+}
+
+// NewSCCExecRestrictions creates a new admission controller that denies an exec operation on a privileged pod
+func NewSCCExecRestrictions(client client.Interface) admission.Interface {
+	return &sccExecRestrictions{
+		Handler:             admission.NewHandler(admission.Connect),
+		constraintAdmission: NewConstraint(client).(*constraint),
+		client:              client,
+	}
+}

--- a/pkg/security/admission/scc_exec_test.go
+++ b/pkg/security/admission/scc_exec_test.go
@@ -1,0 +1,117 @@
+package admission
+
+import (
+	"testing"
+
+	kadmission "k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/client/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// scc exec is a pass through to *constraint, so we only need to test that
+// it correctly limits its actions to certain conditions
+func TestExecAdmit(t *testing.T) {
+
+	goodPod := func() *kapi.Pod {
+		return &kapi.Pod{
+			Spec: kapi.PodSpec{
+				ServiceAccountName: "default",
+				Containers: []kapi.Container{
+					{
+						SecurityContext: &kapi.SecurityContext{},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := map[string]struct {
+		operation   kadmission.Operation
+		resource    string
+		subresource string
+
+		pod                    *kapi.Pod
+		shouldAdmit            bool
+		shouldHaveClientAction bool
+	}{
+		"unchecked operation": {
+			operation:              kadmission.Create,
+			resource:               string(kapi.ResourcePods),
+			subresource:            "exec",
+			pod:                    goodPod(),
+			shouldAdmit:            true,
+			shouldHaveClientAction: false,
+		},
+		"unchecked resource": {
+			operation:              kadmission.Connect,
+			resource:               string(kapi.ResourceSecrets),
+			subresource:            "exec",
+			pod:                    goodPod(),
+			shouldAdmit:            true,
+			shouldHaveClientAction: false,
+		},
+		"unchecked subresource": {
+			operation:              kadmission.Connect,
+			resource:               string(kapi.ResourcePods),
+			subresource:            "not-exec",
+			pod:                    goodPod(),
+			shouldAdmit:            true,
+			shouldHaveClientAction: false,
+		},
+		"attach check": {
+			operation:              kadmission.Connect,
+			resource:               string(kapi.ResourcePods),
+			subresource:            "attach",
+			pod:                    goodPod(),
+			shouldAdmit:            false,
+			shouldHaveClientAction: true,
+		},
+		"exec check": {
+			operation:              kadmission.Connect,
+			resource:               string(kapi.ResourcePods),
+			subresource:            "exec",
+			pod:                    goodPod(),
+			shouldAdmit:            false,
+			shouldHaveClientAction: true,
+		},
+	}
+
+	for k, v := range testCases {
+		tc := testclient.NewSimpleFake()
+		tc.ReactFn = func(a testclient.Action) (runtime.Object, error) {
+			if a.Matches("get", "pods") {
+				return v.pod, nil
+			}
+
+			return nil, nil
+		}
+
+		// create the admission plugin
+		p := NewSCCExecRestrictions(tc)
+
+		attrs := kadmission.NewAttributesRecord(v.pod, "Pod", "namespace", "", v.resource, v.subresource, v.operation, &user.DefaultInfo{})
+		err := p.Admit(attrs)
+
+		if v.shouldAdmit && err != nil {
+			t.Errorf("%s: expected no errors but received %v", k, err)
+		}
+		if !v.shouldAdmit && err == nil {
+			t.Errorf("%s: expected errors but received none", k)
+		}
+
+		if !v.shouldHaveClientAction && (len(tc.Actions()) > 0) {
+			t.Errorf("%s: unexpected actions: %v", k, tc.Actions())
+		}
+		if v.shouldHaveClientAction && (len(tc.Actions()) == 0) {
+			t.Errorf("%s: no actions found", k)
+		}
+
+		if v.shouldHaveClientAction {
+			if len(v.pod.Spec.ServiceAccountName) != 0 {
+				t.Errorf("%s: sa name should have been cleared: %v", k, v.pod.Spec.ServiceAccountName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This allows users who can create privileged pods to exec into privileged pods.  It seems to make sense to relax this restriction.

If SCC moves into origin, then this should change to be our own controller that we include instead of modifying an existing one.

@pweil- is this keeping with you thoughts on SCC?