### PR TITLE
Add a cluster diagnostic to check if master is also running as a node.

### DIFF
--- a/pkg/cmd/experimental/diagnostics/cluster.go
+++ b/pkg/cmd/experimental/diagnostics/cluster.go
@@ -20,7 +20,7 @@ import (
 var (
 	// availableClusterDiagnostics contains the names of cluster diagnostics that can be executed
 	// during a single run of diagnostics. Add more diagnostics to the list as they are defined.
-	availableClusterDiagnostics = sets.NewString(clustdiags.NodeDefinitionsName, clustdiags.ClusterRegistryName, clustdiags.ClusterRouterName, clustdiags.ClusterRolesName, clustdiags.ClusterRoleBindingsName)
+	availableClusterDiagnostics = sets.NewString(clustdiags.NodeDefinitionsName, clustdiags.ClusterRegistryName, clustdiags.ClusterRouterName, clustdiags.ClusterRolesName, clustdiags.ClusterRoleBindingsName, clustdiags.MasterNodeName)
 )
 
 // buildClusterDiagnostics builds cluster Diagnostic objects if a cluster-admin client can be extracted from the rawConfig passed in.
@@ -36,7 +36,7 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 		kclusterClient *kclient.Client
 	)
 
-	clusterClient, kclusterClient, found, err := o.findClusterClients(rawConfig)
+	clusterClient, kclusterClient, found, serverUrl, err := o.findClusterClients(rawConfig)
 	if !found {
 		o.Logger.Notice("CED1002", "No cluster-admin client config found; skipping cluster diagnostics.")
 		return nil, true, err
@@ -47,6 +47,8 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 		switch diagnosticName {
 		case clustdiags.NodeDefinitionsName:
 			diagnostics = append(diagnostics, &clustdiags.NodeDefinitions{KubeClient: kclusterClient, OsClient: clusterClient})
+		case clustdiags.MasterNodeName:
+			diagnostics = append(diagnostics, &clustdiags.MasterNode{KubeClient: kclusterClient, OsClient: clusterClient, ServerUrl: serverUrl, MasterConfigFile: o.MasterConfigLocation})
 		case clustdiags.ClusterRegistryName:
 			diagnostics = append(diagnostics, &clustdiags.ClusterRegistry{KubeClient: kclusterClient, OsClient: clusterClient})
 		case clustdiags.ClusterRouterName:
@@ -64,50 +66,51 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 }
 
 // attempts to find which context in the config might be a cluster-admin for the server in the current context.
-func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (*client.Client, *kclient.Client, bool, error) {
+func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (*client.Client, *kclient.Client, bool, string, error) {
 	if o.ClientClusterContext != "" { // user has specified cluster context to use
 		if context, exists := rawConfig.Contexts[o.ClientClusterContext]; exists {
 			configErr := fmt.Errorf("Specified '%s' as cluster-admin context, but it was not found in your client configuration.", o.ClientClusterContext)
 			o.Logger.Error("CED1003", configErr.Error())
-			return nil, nil, false, configErr
-		} else if os, kube, found, err := o.makeClusterClients(rawConfig, o.ClientClusterContext, context); found {
-			return os, kube, true, err
+			return nil, nil, false, "", configErr
+		} else if os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, o.ClientClusterContext, context); found {
+			return os, kube, true, serverUrl, err
 		} else {
-			return nil, nil, false, err
+			return nil, nil, false, "", err
 		}
 	}
 	currentContext, exists := rawConfig.Contexts[rawConfig.CurrentContext]
 	if !exists { // config specified cluster admin context that doesn't exist; complain and quit
 		configErr := fmt.Errorf("Current context '%s' not found in client configuration; will not attempt cluster diagnostics.", rawConfig.CurrentContext)
 		o.Logger.Error("CED1004", configErr.Error())
-		return nil, nil, false, configErr
+		return nil, nil, false, "", configErr
 	}
 	// check if current context is already cluster admin
-	if os, kube, found, err := o.makeClusterClients(rawConfig, rawConfig.CurrentContext, currentContext); found {
-		return os, kube, true, err
+	if os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, rawConfig.CurrentContext, currentContext); found {
+		return os, kube, true, serverUrl, err
 	}
 	// otherwise, for convenience, search for a context with the same server but with the system:admin user
 	for name, context := range rawConfig.Contexts {
 		if context.Cluster == currentContext.Cluster && name != rawConfig.CurrentContext && strings.HasPrefix(context.AuthInfo, "system:admin/") {
-			if os, kube, found, err := o.makeClusterClients(rawConfig, name, context); found {
-				return os, kube, true, err
+			if os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, name, context); found {
+				return os, kube, true, serverUrl, err
 			} else {
-				return nil, nil, false, err // don't try more than one such context, they'll probably fail the same
+				return nil, nil, false, "", err // don't try more than one such context, they'll probably fail the same
 			}
 		}
 	}
-	return nil, nil, false, nil
+	return nil, nil, false, "", nil
 }
 
 // makes the client from the specified context and determines whether it is a cluster-admin.
-func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (*client.Client, *kclient.Client, bool, error) {
+func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (*client.Client, *kclient.Client, bool, string, error) {
 	overrides := &clientcmd.ConfigOverrides{Context: *context}
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, overrides)
+	serverUrl := rawConfig.Clusters[context.Cluster].Server
 	factory := osclientcmd.NewFactory(clientConfig)
 	o.Logger.Debug("CED1005", fmt.Sprintf("Checking if context is cluster-admin: '%s'", contextName))
 	if osClient, kubeClient, err := factory.Clients(); err != nil {
 		o.Logger.Debug("CED1006", fmt.Sprintf("Error creating client for context '%s':\n%v", contextName, err))
-		return nil, nil, false, nil
+		return nil, nil, false, "", nil
 	} else {
 		subjectAccessReview := authorizationapi.SubjectAccessReview{Action: authorizationapi.AuthorizationAttributes{
 			// if you can do everything, you're the cluster admin.
@@ -117,16 +120,16 @@ func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, c
 		if resp, err := osClient.SubjectAccessReviews().Create(&subjectAccessReview); err != nil {
 			if regexp.MustCompile(`User "[\w:]+" cannot create \w+ at the cluster scope`).MatchString(err.Error()) {
 				o.Logger.Debug("CED1007", fmt.Sprintf("Context '%s' does not have cluster-admin access:\n%v", contextName, err))
-				return nil, nil, false, nil
+				return nil, nil, false, "", nil
 			} else {
 				o.Logger.Error("CED1008", fmt.Sprintf("Unknown error testing cluster-admin access for context '%s':\n%v", contextName, err))
-				return nil, nil, false, err
+				return nil, nil, false, "", err
 			}
 		} else if resp.Allowed {
 			o.Logger.Info("CED1009", fmt.Sprintf("Using context for cluster-admin access: '%s'", contextName))
-			return osClient, kubeClient, true, nil
+			return osClient, kubeClient, true, serverUrl, nil
 		}
 	}
 	o.Logger.Debug("CED1010", fmt.Sprintf("Context does not have cluster-admin access: '%s'", contextName))
-	return nil, nil, false, nil
+	return nil, nil, false, "", nil
 }

--- a/pkg/cmd/experimental/diagnostics/diagnostics.go
+++ b/pkg/cmd/experimental/diagnostics/diagnostics.go
@@ -45,6 +45,12 @@ type DiagnosticsOptions struct {
 	Logger *log.Logger
 }
 
+const (
+	// Standard locations for the host config files OpenShift uses.
+	StandardMasterConfigPath string = "/etc/openshift/master/master-config.yaml"
+	StandardNodeConfigPath   string = "/etc/openshift/node/node-config.yaml"
+)
+
 const longDescription = `
 This utility helps troubleshoot and diagnose known problems. It runs
 diagnostics using a client and/or the state of a running master /
@@ -148,6 +154,19 @@ only these are available:
 The list of all possible is:
     {{.available}}
 		`, log.Hash{"requested": o.RequestedDiagnostics, "common": common.List(), "available": AvailableDiagnostics.List()}))
+	}
+
+	// If not given master/client config file locations, check if the defaults exist
+	// and adjust the options accordingly:
+	if len(o.MasterConfigLocation) == 0 {
+		if _, err := os.Stat(StandardMasterConfigPath); !os.IsNotExist(err) {
+			o.MasterConfigLocation = StandardMasterConfigPath
+		}
+	}
+	if len(o.NodeConfigLocation) == 0 {
+		if _, err := os.Stat(StandardNodeConfigPath); !os.IsNotExist(err) {
+			o.NodeConfigLocation = StandardNodeConfigPath
+		}
 	}
 
 	func() { // don't trust discovery/build of diagnostics; wrap panic nicely in case of developer error

--- a/pkg/cmd/experimental/diagnostics/host.go
+++ b/pkg/cmd/experimental/diagnostics/host.go
@@ -2,19 +2,12 @@ package diagnostics
 
 import (
 	"fmt"
-	"os"
 
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	hostdiags "github.com/openshift/origin/pkg/diagnostics/host"
 	systemddiags "github.com/openshift/origin/pkg/diagnostics/systemd"
 	"github.com/openshift/origin/pkg/diagnostics/types"
-)
-
-const (
-	// Standard locations for the host config files OpenShift uses.
-	StandardMasterConfigPath string = "/etc/openshift/master/master-config.yaml"
-	StandardNodeConfigPath   string = "/etc/openshift/node/node-config.yaml"
 )
 
 var (
@@ -31,21 +24,7 @@ func (o DiagnosticsOptions) buildHostDiagnostics() ([]types.Diagnostic, bool, er
 		return nil, true, nil // don't waste time on discovery
 	}
 	isHost := o.IsHost
-	// check for standard host config paths if not given
-	if len(o.MasterConfigLocation) == 0 {
-		if _, err := os.Stat(StandardMasterConfigPath); !os.IsNotExist(err) {
-			o.MasterConfigLocation = StandardMasterConfigPath
-			isHost = true
-		}
-	} else {
-		isHost = true
-	}
-	if len(o.NodeConfigLocation) == 0 {
-		if _, err := os.Stat(StandardNodeConfigPath); !os.IsNotExist(err) {
-			o.NodeConfigLocation = StandardNodeConfigPath
-			isHost = true
-		}
-	} else {
+	if len(o.MasterConfigLocation) > 0 || len(o.NodeConfigLocation) > 0 {
 		isHost = true
 	}
 

--- a/pkg/diagnostics/cluster/master_node.go
+++ b/pkg/diagnostics/cluster/master_node.go
@@ -1,0 +1,178 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	osclient "github.com/openshift/origin/pkg/client"
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	"k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+
+	"github.com/openshift/origin/pkg/diagnostics/types"
+)
+
+const masterNotRunningAsANode = `Unable to find a node matching the cluster server IP.
+This may indicate the master is not also running a node, and is unable
+to proxy to pods over the Open vSwitch SDN.
+`
+
+const ovsSubnetPluginName = "redhat/openshift-ovs-subnet"
+const ovsMultiTenantPluginName = "redhat/openshift-ovs-multitenant"
+
+// MasterNode is a Diagnostic for checking that the OpenShift master is also running as node.
+// This is currently required to have the master on the Open vSwitch SDN and able to communicate
+// with other nodes.
+type MasterNode struct {
+	KubeClient       *kclient.Client
+	OsClient         *osclient.Client
+	ServerUrl        string
+	MasterConfigFile string // may often be empty if not being run on the host
+}
+
+const MasterNodeName = "MasterNode"
+
+func (d *MasterNode) Name() string {
+	return MasterNodeName
+}
+
+func (d *MasterNode) Description() string {
+	return "Check if master is also running node (for Open vSwitch)"
+}
+
+func (d *MasterNode) CanRun() (bool, error) {
+	if d.KubeClient == nil || d.OsClient == nil {
+		return false, errors.New("must have kube and os client")
+	}
+	if d.ServerUrl == "" {
+		return false, errors.New("must have a server URL")
+	}
+
+	// If there is a master config file available, we'll perform an additional
+	// check to see if an OVS network plugin is in use. If no master config,
+	// we assume this is the case for now and let the check run anyhow.
+	if len(d.MasterConfigFile) > 0 {
+		// Parse the master config and check the network plugin name:
+		masterCfg, masterErr := configapilatest.ReadAndResolveMasterConfig(d.MasterConfigFile)
+		if masterErr != nil {
+			return false, types.DiagnosticError{ID: "DClu3008",
+				LogMessage: fmt.Sprintf("Master config provided but unable to parse: %s", masterErr), Cause: masterErr}
+		}
+		networkPluginName := masterCfg.NetworkConfig.NetworkPluginName
+
+		// Make sure this is an OVS network plugin:
+		ovsNetworkPlugins := [2]string{ovsSubnetPluginName, ovsMultiTenantPluginName}
+		usingOvsNetworkPlugin := false
+		for _, plugin := range ovsNetworkPlugins {
+			if plugin == networkPluginName {
+				usingOvsNetworkPlugin = true
+			}
+		}
+		if !usingOvsNetworkPlugin {
+			return false, errors.New(fmt.Sprintf("Network plugin does not require master to also run node: %s", networkPluginName))
+		}
+	}
+
+	can, err := userCan(d.OsClient, authorizationapi.AuthorizationAttributes{
+		Verb:     "list",
+		Resource: "nodes",
+	})
+	if err != nil {
+		return false, types.DiagnosticError{ID: "DClu3000", LogMessage: fmt.Sprintf(clientErrorGettingNodes, err), Cause: err}
+	} else if !can {
+		return false, types.DiagnosticError{ID: "DClu3001", LogMessage: "Client does not have access to see node status", Cause: err}
+	}
+	return true, nil
+}
+
+func (d *MasterNode) Check() types.DiagnosticResult {
+	r := types.NewDiagnosticResult(MasterNodeName)
+
+	nodes, err := d.KubeClient.Nodes().List(labels.LabelSelector{}, fields.Everything())
+	if err != nil {
+		r.Error("DClu3002", err, fmt.Sprintf(clientErrorGettingNodes, err))
+		return r
+	}
+
+	// Provide the actual net.LookupHost as the DNS resolver:
+	serverIps, err := resolveServerIP(d.ServerUrl, net.LookupHost)
+	if err != nil {
+		r.Error("DClu3007", err, "Error resolving servers IP")
+		return r
+	}
+
+	return searchNodesForIP(nodes.Items, serverIps)
+}
+
+// Define a resolve callback function type, use to swap in a dummy implementation
+// in tests and avoid actual DNS calls.
+type dnsResolver func(string) ([]string, error)
+
+// resolveServerIP extracts the hostname portion of the API server URL passed in,
+// and attempts dns resolution. It also attempts to catch server URL's that already
+// contain both IPv4 and IPv6 addresses.
+func resolveServerIP(serverUrl string, fn dnsResolver) ([]string, error) {
+	// Extract the hostname from the API server URL:
+	u, err := url.Parse(serverUrl)
+	if err != nil || u.Host == "" {
+		return nil, errors.New(fmt.Sprintf("Unable to parse hostname from URL: %s", serverUrl))
+	}
+
+	// Trim the port, if one exists, and watchout for IPv6 URLs.
+	if strings.Count(u.Host, ":") > 1 {
+		// Check if this is an IPv6 address as is to avoid problems with splitting
+		// off the port:
+		ipv6 := net.ParseIP(u.Host)
+		if ipv6 != nil {
+			return []string{ipv6.String()}, nil
+		}
+	}
+	hostname, _, err := net.SplitHostPort(u.Host)
+	if err != nil && hostname == "" {
+		// Likely didn't have a port, carry on:
+		hostname = u.Host
+	}
+
+	// Check if the hostname already looks like an IPv4 or IPv6 address:
+	goIp := net.ParseIP(hostname)
+	if goIp != nil {
+		return []string{goIp.String()}, nil
+	}
+
+	// If not, attempt a DNS lookup. We may get multiple addresses for the hostname,
+	// we'll return them all and search for any match in Kube nodes:
+	ips, err := fn(hostname)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Unable to perform DNS lookup for: %s", hostname))
+	}
+	return ips, nil
+}
+
+func searchNodesForIP(nodes []api.Node, ips []string) types.DiagnosticResult {
+	r := types.NewDiagnosticResult(MasterNodeName)
+	r.Debug("DClu3005", fmt.Sprintf("Seaching for a node with master IP: %s", ips))
+
+	// Loops = # of nodes * number of IPs per node (2 commonly) * # of IPs the
+	// server hostname resolves to. (should usually be 1)
+	for _, node := range nodes {
+		for _, address := range node.Status.Addresses {
+			for _, ipAddress := range ips {
+				r.Debug("DClu3006", fmt.Sprintf("Checking node %s address %s",
+					node.ObjectMeta.Name, address.Address))
+				if address.Address == ipAddress {
+					r.Info("DClu3003", fmt.Sprintf("Found a node with same IP as master: %s",
+						node.ObjectMeta.Name))
+					return r
+				}
+			}
+		}
+	}
+	r.Warn("DClu3004", nil, masterNotRunningAsANode)
+	return r
+}

--- a/pkg/diagnostics/cluster/master_node_test.go
+++ b/pkg/diagnostics/cluster/master_node_test.go
@@ -1,0 +1,187 @@
+package cluster
+
+import (
+	"errors"
+	"k8s.io/kubernetes/pkg/api"
+	"testing"
+)
+
+// Used as a stub for golang's net.LookupIP to avoid actual DNS lookups in tests.
+func dummyDnsResolver(hostname string) ([]string, error) {
+	// This method should not end up getting called for actual IPs, so we only
+	// need to map out the hostnames we'll be "resolving":
+	domains := map[string][]string{
+		"something.example.com":    {"192.168.1.1"},
+		"multiaddress.example.com": {"192.168.1.2", "10.0.1.1"},
+		"localhost":                {"127.0.0.1"},
+	}
+	ip, ok := domains[hostname]
+	if !ok {
+		return nil, errors.New("Dummy DNS lookup error")
+	}
+
+	return ip, nil
+}
+
+func ipTester(t *testing.T, serverUrl string, expectedIps ...string) {
+	hostnames, err := resolveServerIP(serverUrl, dummyDnsResolver)
+
+	// If given no expected IPs we assume the caller wanted an error to occur:
+	if len(expectedIps) == 0 || expectedIps == nil {
+		if err == nil {
+			t.Errorf("No expected IPs given, error expected but none occurred. Got hostnames: %s", hostnames)
+			return
+		}
+		return
+	}
+
+	if err != nil || len(hostnames) == 0 {
+		t.Errorf("Unable to resolve IP from: %s, error: %s", serverUrl, err)
+		return
+	}
+	if len(hostnames) != len(expectedIps) {
+		t.Errorf("Expected %d IPs, got: %d", len(expectedIps), len(hostnames))
+		return
+	}
+	for _, expectedIp := range expectedIps {
+		found := false
+		for _, hostResult := range hostnames {
+			if hostResult == expectedIp {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Errorf("Missing expected IP: %s, got: %s", expectedIp, hostnames)
+			return
+		}
+	}
+}
+
+func TestServerResolve(t *testing.T) {
+	ipTester(t, "https://something.example.com:8443/api/", "192.168.1.1")
+}
+
+func TestServerResolveFails(t *testing.T) {
+	// Our dummy DNS resolver function doesn't know this host:
+	ipTester(t, "https://somethingelse.example.com:8443/api/")
+}
+
+func TestServerResolveMultiAddress(t *testing.T) {
+	ipTester(t, "https://multiaddress.example.com:8443/api/", "192.168.1.2", "10.0.1.1")
+}
+
+func TestServerResolveNoPort(t *testing.T) {
+	ipTester(t, "https://something.example.com/api/", "192.168.1.1")
+}
+
+func TestServerResolveNoPortNoPath(t *testing.T) {
+	ipTester(t, "https://something.example.com", "192.168.1.1")
+}
+
+func TestServerResolveNoPath(t *testing.T) {
+	ipTester(t, "https://something.example.com:8443", "192.168.1.1")
+}
+
+func TestServerResolveLocalhost(t *testing.T) {
+	ipTester(t, "https://localhost:8443/api/", "127.0.0.1")
+}
+
+func TestServerResolveIP(t *testing.T) {
+	ipTester(t, "https://192.168.1.1:8443/api/", "192.168.1.1")
+}
+
+func TestServerResolveIPNoPort(t *testing.T) {
+	ipTester(t, "https://192.168.1.1/api/", "192.168.1.1")
+}
+
+func TestServerResolveIPNoPortNoPath(t *testing.T) {
+	ipTester(t, "https://192.168.1.1", "192.168.1.1")
+}
+
+func TestServerResolveIPNoPath(t *testing.T) {
+	ipTester(t, "https://192.168.1.1:8443", "192.168.1.1")
+}
+
+func TestServerResolveIPv6(t *testing.T) {
+	ipTester(t, "https://[2001:4860:0:2001::6]:8443/api/", "2001:4860:0:2001::6")
+}
+
+func TestServerResolveIPv6UpperCaseFull(t *testing.T) {
+	// net.IP normalizes to lowercase and shortens:
+	ipTester(t, "https://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:8443/api/",
+		"fe80::202:b3ff:fe1e:8329")
+}
+
+func TestServerResolveIPv6NoPort(t *testing.T) {
+	ipTester(t, "https://2001:4860:0:2001::6/api/", "2001:4860:0:2001::6")
+}
+
+func TestServerResolveIPv6BracesNoPort(t *testing.T) {
+	// Technically bad syntax so expect an error:
+	ipTester(t, "https://[2001:4860:0:2001::6]/api/")
+}
+
+func TestServerResolveIPv6NoPortNoPath(t *testing.T) {
+	ipTester(t, "https://2001:4860:0:2001::6", "2001:4860:0:2001::6")
+}
+
+func TestServerResolveIPv6NoPath(t *testing.T) {
+	ipTester(t, "https://[2001:4860:0:2001::6]:8443", "2001:4860:0:2001::6")
+}
+
+func TestServerResolveIPv6BadBraces(t *testing.T) {
+	ipTester(t, "https://[[2001:4860:0:2001::6]:8443")
+	ipTester(t, "https://[[2001:4860:0:2001::6]]:8443")
+	ipTester(t, "https://2001:4860:0:2001::6]]:8443")
+}
+
+func TestServerResolveBadURL(t *testing.T) {
+	ipTester(t, "thisdoesntlooklikeaurl")
+}
+
+// createNode creates a dummy Kubernetes Node object with the IP addresses we request.
+func createNode(name string, ipAddresses []string) api.Node {
+
+	// Create a Kube NodeAddress for each given IP address string:
+	addresses := make([]api.NodeAddress, len(ipAddresses))
+	for _, addr := range ipAddresses {
+		// We don't really care what the type is, we check them all looking for any match:
+		addresses = append(addresses, api.NodeAddress{Type: api.NodeExternalIP, Address: addr})
+	}
+
+	status := api.NodeStatus{Addresses: addresses}
+	node := api.Node{ObjectMeta: api.ObjectMeta{Name: name}, Status: status}
+	return node
+}
+
+func TestScanNodesMatchFound(t *testing.T) {
+	nodes := make([]api.Node, 3)
+	nodes = append(nodes, createNode("node1", []string{"192.168.1.1", "10.0.0.1", "24.222.0.1"}))
+	nodes = append(nodes, createNode("node2", []string{"192.168.1.2", "10.0.0.2", "24.222.0.2"}))
+	nodes = append(nodes, createNode("node3", []string{"192.168.1.3", "10.0.0.3", "24.222.0.3"}))
+
+	r := searchNodesForIP(nodes, []string{"24.222.0.3"})
+	if len(r.Errors()) > 0 {
+		t.Error("Unexpected error attempting to locate node with IP")
+	}
+	if len(r.Warnings()) > 0 {
+		t.Error("Unexpected warning attempting to locate node with IP")
+	}
+}
+
+func TestScanNodesAnyIPv6MatchFound(t *testing.T) {
+	nodes := make([]api.Node, 3)
+	nodes = append(nodes, createNode("node1", []string{"2001:4860:0:2001::6"}))
+	nodes = append(nodes, createNode("node2", []string{"3001:4860:0:2001::6"}))
+	nodes = append(nodes, createNode("node3", []string{"4001:4860:0:2001::6"}))
+
+	// First server IP won't match, second will:
+	r := searchNodesForIP(nodes, []string{"10.0.55.55", "2001:4860:0:2001::6"})
+	if len(r.Errors()) > 0 {
+		t.Error("Unexpected error attempting to locate node with IP")
+	}
+	if len(r.Warnings()) > 0 {
+		t.Error("Unexpected warning attempting to locate node with IP")
+	}
+}


### PR DESCRIPTION
This is currently a requirement for Open vSwitch to ensure the master
is on the SDN and can communicate with other nodes.

Diagnostic uses the configured server URL in the kube config to perform a DNS
lookup for the IP(s) of the master. Care is taken to handle both IPv4 and IPv6
addresses being directly in the server URL already.

Once we've got a list of server IPs to check we scan the nodes via the
Kubernetes API, and check all of their reported IP addresses to look for a
match. No DNS lookup is done on the nodes, the IP addresses are already known.

If no node reports the IP of the master server, we warn the user that something
may be amiss and why.

NOTE: Technically speaking I have not actually tested the IPv6 bits outside of the unit tests. (if we even support such deployments today). If we can assume that Kube node addresses will contain strings formatted as golang's net.IP.String() would format them, there's a reasonable chance this will work. Worst case scenario is an inaccurate diagnostic warning.