### PR TITLE
allow self SARs using old policy:

### DIFF
--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -43,8 +43,10 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	// the authorizer decided that a user could run an RAR against this namespace
 	if namespace := kapi.NamespaceValue(ctx); len(namespace) > 0 {
 		resourceAccessReview.Action.Namespace = namespace
-	}
-	if err := r.isAllowed(ctx, resourceAccessReview); err != nil {
+
+	} else if err := r.isAllowed(ctx, resourceAccessReview); err != nil {
+		// this check is mutually exclusive to the condition above.  localSAR and localRAR both clear the namespace before delegating their calls
+		// We only need to check if the RAR is allowed **again** if the authorizer didn't already approve the request for a legacy call.
 		return nil, err
 	}
 

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -44,9 +44,12 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	// the authorizer decided that a user could run an SAR against this namespace
 	if namespace := kapi.NamespaceValue(ctx); len(namespace) > 0 {
 		subjectAccessReview.Action.Namespace = namespace
-	}
-	if err := r.isAllowed(ctx, subjectAccessReview); err != nil {
+
+	} else if err := r.isAllowed(ctx, subjectAccessReview); err != nil {
+		// this check is mutually exclusive to the condition above.  localSAR and localRAR both clear the namespace before delegating their calls
+		// We only need to check if the SAR is allowed **again** if the authorizer didn't already approve the request for a legacy call.
 		return nil, err
+
 	}
 
 	var userToCheck user.Info


### PR DESCRIPTION
Backwards compatibility without policy updates is broken without this fix.  Without this fix, old registry images against new openshift servers running with old policy (before `oadm policy reconcile-cluster-roles`), will suddenly start failing

There's an extra check in an SAR to ensure that the user can run an SAR against the namespace he's requesting.  This is done via an authorization check against the localSAR resource for that namespace.  That check should only happen for requests that weren't already authorized via the authorizer before being assigned to a go-restful route.

The integration test was broken because the server starts up with new policy instead of old policy.  A new test was added to cover this case.

@sdodson @brenton please evaluate for patch to OSE.