### PR TITLE
Trim clients size, create clients-redistributable

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -42,6 +42,7 @@ ExclusiveArch:  x86_64
 Source0:        https://%{import_path}/archive/%{commit}/%{name}-%{version}.tar.gz
 BuildRequires:  systemd
 BuildRequires:  golang >= 1.4
+Requires:       %{name}-clients = %{version}-%{release}
 Obsoletes:      openshift < 1.0.6
 
 %description
@@ -83,12 +84,19 @@ Obsoletes:      tuned-profiles-openshift-node < 1.0.6
 %{summary}
 
 %package clients
-Summary:        %{product_name} Client binaries for Linux, Mac OSX, and Windows
-BuildRequires:  golang-pkg-darwin-amd64
-BuildRequires:  golang-pkg-windows-386
+Summary:        %{product_name} Client binaries for Linux
 Obsoletes:      openshift-clients < 1.0.6
 
 %description clients
+%{summary}
+
+%package clients-redistributable
+Summary:        %{product_name} Client binaries for Linux, Mac OSX, and Windows
+BuildRequires:  golang-pkg-darwin-amd64
+BuildRequires:  golang-pkg-windows-386
+Obsoletes:      openshift-clients-redistributable < 1.0.6
+
+%description clients-redistributable
 %{summary}
 
 %package dockerregistry
@@ -141,15 +149,14 @@ pushd _thirdpartyhacks
 popd
 export GOPATH=$(pwd)/_build:$(pwd)/_thirdpartyhacks:%{buildroot}%{gopath}:%{gopath}
 # Build all linux components we care about
-for cmd in openshift dockerregistry
+for cmd in oc openshift dockerregistry
 do
         go install -ldflags "%{ldflags}" %{import_path}/cmd/${cmd}
 done
 
 # Build clients for other platforms
-# TODO: build cmd/oc instead of openshift
-GOOS=windows GOARCH=386 go install -ldflags "%{ldflags}" %{import_path}/cmd/openshift
-GOOS=darwin GOARCH=amd64 go install -ldflags "%{ldflags}" %{import_path}/cmd/openshift
+GOOS=windows GOARCH=386 go install -ldflags "%{ldflags}" %{import_path}/cmd/oc
+GOOS=darwin GOARCH=amd64 go install -ldflags "%{ldflags}" %{import_path}/cmd/oc
 
 #Build our pod
 pushd images/pod/
@@ -161,7 +168,7 @@ popd
 install -d %{buildroot}%{_bindir}
 
 # Install linux components
-for bin in openshift dockerregistry
+for bin in oc openshift dockerregistry
 do
   echo "+++ INSTALLING ${bin}"
   install -p -m 755 _build/bin/${bin} %{buildroot}%{_bindir}/${bin}
@@ -169,9 +176,9 @@ done
 
 # Install client executable for windows and mac
 install -d %{buildroot}%{_datadir}/%{name}/{linux,macosx,windows}
-install -p -m 755 _build/bin/openshift %{buildroot}%{_datadir}/%{name}/linux/oc
-install -p -m 755 _build/bin/darwin_amd64/openshift %{buildroot}/%{_datadir}/%{name}/macosx/oc
-install -p -m 755 _build/bin/windows_386/openshift.exe %{buildroot}/%{_datadir}/%{name}/windows/oc.exe
+install -p -m 755 _build/bin/oc %{buildroot}%{_datadir}/%{name}/linux/oc
+install -p -m 755 _build/bin/darwin_amd64/oc %{buildroot}/%{_datadir}/%{name}/macosx/oc
+install -p -m 755 _build/bin/windows_386/oc.exe %{buildroot}/%{_datadir}/%{name}/windows/oc.exe
 
 #Install pod
 install -p -m 755 images/pod/pod %{buildroot}%{_bindir}/
@@ -180,10 +187,12 @@ install -d -m 0755 %{buildroot}%{_unitdir}
 
 mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
 
-for cmd in oc openshift-router openshift-deploy openshift-sti-build openshift-docker-build origin atomic-enterprise \
-  oadm kubectl kubernetes kubelet kube-proxy kube-apiserver kube-controller-manager kube-scheduler ; do
+for cmd in openshift-router openshift-deploy openshift-sti-build openshift-docker-build origin atomic-enterprise \
+  oadm kubernetes kubelet kube-proxy kube-apiserver kube-controller-manager kube-scheduler ; do
     ln -s %{_bindir}/openshift %{buildroot}%{_bindir}/$cmd
 done
+
+ln -s %{_bindir}/oc %{buildroot}%{_bindir}/kubectl
 
 install -d -m 0755 %{buildroot}%{_sysconfdir}/origin/{master,node}
 
@@ -226,7 +235,6 @@ install -p -m 644 rel-eng/completions/bash/* %{buildroot}%{_sysconfdir}/bash_com
 %files
 %defattr(-,root,root,-)
 %doc README.md LICENSE
-%{_bindir}/oc
 %{_bindir}/openshift
 %{_bindir}/openshift-router
 %{_bindir}/openshift-deploy
@@ -235,7 +243,6 @@ install -p -m 644 rel-eng/completions/bash/* %{buildroot}%{_sysconfdir}/bash_com
 %{_bindir}/origin
 %{_bindir}/atomic-enterprise
 %{_bindir}/oadm
-%{_bindir}/kubectl
 %{_bindir}/kubernetes
 %{_bindir}/kubelet
 %{_bindir}/kube-proxy
@@ -365,6 +372,10 @@ if [ "$1" = 0 ]; then
 fi
 
 %files clients
+%{_bindir}/oc
+%{_bindir}/kubectl
+
+%files clients-redistributable
 %{_datadir}/%{name}/linux/oc
 %{_datadir}/%{name}/macosx/oc
 %{_datadir}/%{name}/windows/oc.exe


### PR DESCRIPTION
Build oc by itself, instead of linking to openshift. (Cut size by 60%)
Move oc binary to openshift-clients (not in basic openshift package anymore)
Link kubectl to oc binary
Move kubectl link to openshift-clients (not in basic openshift package anymore)
Move windows and apple binaries to openshift-clients-redistributable.

RPM Size Changes:
Original
43M - openshift-clients
With this change
5M - openshift-clients
17M - openshift-clients-other
