### PR TITLE
allow local access reviews while namespace is terminating

### DIFF
--- a/pkg/project/admission/lifecycle/admission.go
+++ b/pkg/project/admission/lifecycle/admission.go
@@ -52,7 +52,7 @@ type lifecycle struct {
 	creatableResources util.StringSet
 }
 
-var recommendedCreatableResources = util.NewStringSet("subjectaccessreviews", "resourceaccessreviews")
+var recommendedCreatableResources = util.NewStringSet("subjectaccessreviews", "resourceaccessreviews", "localsubjectaccessreviews", "localresourceaccessreviews")
 
 // Admit enforces that a namespace must exist in order to associate content with it.
 // Admit enforces that a namespace that is terminating cannot accept new content being associated with it.


### PR DESCRIPTION
@liggitt oversight you mentioned at lunch.  This simply maintains intent from before the access review refactoring.