### PR TITLE
Change build-go to generate binaries to _output/local/bin/${platform}

### DIFF
--- a/hack/build-assets.sh
+++ b/hack/build-assets.sh
@@ -6,6 +6,8 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 pushd "${OS_ROOT}/assets" > /dev/null
   grunt build

--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -11,6 +11,8 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # Go to the top of the tree.
 cd "${OS_ROOT}"

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -8,6 +8,8 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # Build the primary client/server for all platforms
 OS_BUILD_PLATFORMS=("${OS_CROSS_COMPILE_PLATFORMS[@]}")
@@ -22,12 +24,10 @@ CGO_ENABLED=0 OS_GOFLAGS="-a -installsuffix cgo" os::build::build_binaries "${OS
 
 # Make the primary client/server release.
 OS_RELEASE_ARCHIVE="openshift-origin"
-OS_RELEASE_PLATFORMS=("${OS_CROSS_COMPILE_PLATFORMS[@]}")
-OS_RELEASE_BINARIES=("${OS_CROSS_COMPILE_BINARIES[@]}")
-os::build::place_bins
+OS_BUILD_PLATFORMS=("${OS_CROSS_COMPILE_PLATFORMS[@]}")
+os::build::place_bins "${OS_CROSS_COMPILE_BINARIES[@]}"
 
 # Make the image binaries release.
 OS_RELEASE_ARCHIVE="openshift-origin-image"
-OS_RELEASE_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
-OS_RELEASE_BINARIES=("${OS_IMAGE_COMPILE_BINARIES[@]}")
-os::build::place_bins
+OS_BUILD_PLATFORMS=("${OS_IMAGE_COMPILE_PLATFORMS[@]-}")
+os::build::place_bins "${OS_IMAGE_COMPILE_BINARIES[@]}"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -8,7 +8,9 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 os::build::build_binaries "$@"
-os::build::place_bins
+os::build::place_bins "$@"
 os::build::make_openshift_binary_symlinks

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -13,6 +13,8 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # Go to the top of the tree.
 cd "${OS_ROOT}"

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -11,6 +11,8 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+os::log::install_errexit
 
 # Go to the top of the tree.
 cd "${OS_ROOT}"
@@ -19,7 +21,6 @@ context="${OS_ROOT}/_output/buildenv-context"
 
 # Clean existing output.
 rm -rf "${OS_LOCAL_RELEASEPATH}"
-rm -rf "${OS_LOCAL_BINPATH}"
 rm -rf "${context}"
 mkdir -p "${context}"
 mkdir -p "${OS_OUTPUT}"

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -17,8 +17,8 @@ cd "${OS_ROOT}"
 # TODO: support different OS's?
 os::build::detect_local_release_tars "linux-amd64"
 
-mkdir -p "${OS_LOCAL_BINPATH}"
-tar mxzf "${OS_PRIMARY_RELEASE_TAR}" -C "${OS_LOCAL_BINPATH}"
-tar mxzf "${OS_IMAGE_RELEASE_TAR}" -C "${OS_LOCAL_BINPATH}"
+mkdir -p "${OS_OUTPUT_BINPATH}/linux/amd64"
+tar mxzf "${OS_PRIMARY_RELEASE_TAR}" -C "${OS_OUTPUT_BINPATH}/linux/amd64"
+tar mxzf "${OS_IMAGE_RELEASE_TAR}" -C "${OS_OUTPUT_BINPATH}/linux/amd64"
 
 os::build::make_openshift_binary_symlinks

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -21,7 +21,7 @@ function cleanup()
     if [ $out -ne 0 ]; then
         echo "[FAIL] !!!!! Test Failed !!!!"
         echo
-        cat "${TEMP_DIR}/openshift.log"
+        cat "${LOG_DIR}/openshift.log"
         echo
         echo -------------------------------------
         echo
@@ -30,7 +30,7 @@ function cleanup()
           echo
           echo "pprof: top output"
           echo
-          go tool pprof -text ./_output/local/go/bin/openshift cpu.pprof
+          go tool pprof -text ./_output/local/bin/$(os::util::host_platform)/openshift cpu.pprof
         fi
 
         echo
@@ -50,41 +50,25 @@ function find_tests {
 }
 tests=( $(find_tests ${1:-test/cmd}) )
 
-# Prevent user environment from colliding with the test setup
-unset KUBECONFIG
+# Setup environment
 
-# Use either the latest release built images, or latest.
-if [[ -z "${USE_IMAGES-}" ]]; then
-  tag="latest"
-  if [[ -e "${OS_ROOT}/_output/local/releases/.commit" ]]; then
-    COMMIT="$(cat "${OS_ROOT}/_output/local/releases/.commit")"
-    tag="${COMMIT}"
-  fi
-  USE_IMAGES="openshift/origin-\${component}:${tag}"
-fi
-export USE_IMAGES
+# test-cmd specific defaults
+BASETMPDIR=${USE_TEMP:-$(mkdir -p /tmp/openshift-cmd && mktemp -d /tmp/openshift-cmd/XXXX)}
+API_HOST=${API_HOST:-127.0.0.1}
+export API_PORT=${API_PORT:-28443}
+
+setup_env_vars
+mkdir -p "${ETCD_DATA_DIR}" "${VOLUME_DIR}" "${FAKE_HOME_DIR}" "${MASTER_CONFIG_DIR}" "${NODE_CONFIG_DIR}" "${LOG_DIR}"
 
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-24001}
 ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
-API_SCHEME=${API_SCHEME:-https}
-export API_PORT=${API_PORT:-28443}
-API_HOST=${API_HOST:-127.0.0.1}
 MASTER_ADDR="${API_SCHEME}://${API_HOST}:${API_PORT}"
 PUBLIC_MASTER_HOST="${PUBLIC_MASTER_HOST:-${API_HOST}}"
-KUBELET_SCHEME=${KUBELET_SCHEME:-https}
-KUBELET_HOST=${KUBELET_HOST:-127.0.0.1}
-KUBELET_PORT=${KUBELET_PORT:-10250}
 
-TEMP_DIR=${USE_TEMP:-$(mkdir -p /tmp/openshift-cmd && mktemp -d /tmp/openshift-cmd/XXXX)}
-ETCD_DATA_DIR="${TEMP_DIR}/etcd"
-VOLUME_DIR="${TEMP_DIR}/volumes"
-FAKE_HOME_DIR="${TEMP_DIR}/openshift.local.home"
-SERVER_CONFIG_DIR="${TEMP_DIR}/openshift.local.config"
-MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
-NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-${KUBELET_HOST}"
-CONFIG_DIR="${TEMP_DIR}/configs"
-mkdir -p "${ETCD_DATA_DIR}" "${VOLUME_DIR}" "${FAKE_HOME_DIR}" "${MASTER_CONFIG_DIR}" "${NODE_CONFIG_DIR}" "${CONFIG_DIR}"
+# Prevent user environment from colliding with the test setup
+unset KUBECONFIG
+
 
 # handle profiling defaults
 profile="${OPENSHIFT_PROFILE-}"
@@ -98,10 +82,6 @@ if [[ -n "${profile}" ]]; then
 else
   export WEB_PROFILE=cpu
 fi
-
-# set path so OpenShift is available
-GO_OUT="${OS_ROOT}/_output/local/go/bin"
-export PATH="${GO_OUT}:${PATH}"
 
 # Check openshift version
 out=$(openshift version)
@@ -151,24 +131,24 @@ openshift start \
 [ "$(openshift ex validate master-config ${MASTER_CONFIG_DIR}/master-config.yaml 2>&1 | grep SUCCESS)" ]
 [ "$(openshift ex validate node-config ${NODE_CONFIG_DIR}/node-config.yaml 2>&1 | grep SUCCESS)" ]
 # breaking the config fails the validation check
-cp ${MASTER_CONFIG_DIR}/master-config.yaml ${TEMP_DIR}/master-config-broken.yaml
-sed -i '5,10d' ${TEMP_DIR}/master-config-broken.yaml
-[ "$(openshift ex validate master-config ${TEMP_DIR}/master-config-broken.yaml 2>&1 | grep error)" ]
+cp ${MASTER_CONFIG_DIR}/master-config.yaml ${BASETMPDIR}/master-config-broken.yaml
+sed -i '5,10d' ${BASETMPDIR}/master-config-broken.yaml
+[ "$(openshift ex validate master-config ${BASETMPDIR}/master-config-broken.yaml 2>&1 | grep error)" ]
 
-cp ${NODE_CONFIG_DIR}/node-config.yaml ${TEMP_DIR}/node-config-broken.yaml
-sed -i '5,10d' ${TEMP_DIR}/node-config-broken.yaml
-[ "$(openshift ex validate node-config ${TEMP_DIR}/node-config-broken.yaml 2>&1 | grep ERROR)" ]
+cp ${NODE_CONFIG_DIR}/node-config.yaml ${BASETMPDIR}/node-config-broken.yaml
+sed -i '5,10d' ${BASETMPDIR}/node-config-broken.yaml
+[ "$(openshift ex validate node-config ${BASETMPDIR}/node-config-broken.yaml 2>&1 | grep ERROR)" ]
 echo "validation: ok"
 
 # Don't try this at home.  We don't have flags for setting etcd ports in the config, but we want deconflicted ones.  Use sed to replace defaults in a completely unsafe way
-sed -i "s/:4001$/:${ETCD_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
-sed -i "s/:7001$/:${ETCD_PEER_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
+os::util::sed "s/:4001$/:${ETCD_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
+os::util::sed "s/:7001$/:${ETCD_PEER_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
 
 # Start openshift
 OPENSHIFT_ON_PANIC=crash openshift start master \
   --config=${MASTER_CONFIG_DIR}/master-config.yaml \
   --loglevel=4 \
-  1>&2 2>"${TEMP_DIR}/openshift.log" &
+  1>&2 2>"${LOG_DIR}/openshift.log" &
 OS_PID=$!
 
 if [[ "${API_SCHEME}" == "https" ]]; then
@@ -176,9 +156,6 @@ if [[ "${API_SCHEME}" == "https" ]]; then
     export CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
     export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
 fi
-
-# set the home directory so we don't pick up the users .config
-export HOME="${FAKE_HOME_DIR}"
 
 wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
 wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz/ready" "apiserver(ready): " 0.25 80
@@ -192,7 +169,7 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 
 # create master config as atomic-enterprise just to test it works
 atomic-enterprise start \
-  --write-config=$TEMP_DIR/atomic.local.config \
+  --write-config="${BASETMPDIR}/atomic.local.config" \
   --create-certs=true \
   --master="${API_SCHEME}://${API_HOST}:${API_PORT}" \
   --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" \
@@ -204,7 +181,7 @@ atomic-enterprise start \
 # ensure that DisabledFeatures aren't written to config files
 ! grep -i '\<disabledFeatures\>' \
 	"${MASTER_CONFIG_DIR}/master-config.yaml" \
-	"$TEMP_DIR/atomic.local.config/master/master-config.yaml" \
+	"${BASETMPDIR}/atomic.local.config/master/master-config.yaml" \
 	"${NODE_CONFIG_DIR}/node-config.yaml"
 
 # test client not configured

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -18,7 +18,7 @@ fi
 "${OS_ROOT}/hack/build-go.sh" cmd/genbashcomp
 
 # Find binary
-genbashcomp=$( (ls -t _output/local/go/bin/genbashcomp) 2>/dev/null || true | head -1 )
+genbashcomp=$( (ls -t _output/local/bin/${platform}/genbashcomp) 2>/dev/null || true | head -1 )
 
 if [[ ! "$genbashcomp" ]]; then
   {

--- a/hack/update-generated-docs.sh
+++ b/hack/update-generated-docs.sh
@@ -12,9 +12,9 @@ source "${OS_ROOT}/hack/common.sh"
 "${OS_ROOT}/hack/build-go.sh" cmd/gendocs
 
 # Find binary
-gendocs=$( (ls -t _output/local/go/bin/gendocs) 2>/dev/null || true | head -1 )
+gendocs=$( (ls -t _output/local/bin/$(os::build::host_platform)/gendocs) 2>/dev/null || true | head -1 )
 
-if [[ ! "$gendocs" ]]; then
+if [[ -z "$gendocs" ]]; then
   {
     echo "It looks as if you don't have a compiled gendocs binary"
     echo

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -8,7 +8,6 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/util.sh"
-
 os::log::install_errexit
 
 function cleanup()
@@ -43,7 +42,7 @@ SWAGGER_API_PATH="${HOST}/swaggerapi/"
 # Prevent user environment from colliding with the test setup
 unset KUBECONFIG
 
-openshift=$(cd "${OS_ROOT}"; echo "$(pwd)/_output/local/go/bin/openshift")
+openshift=$(cd "${OS_ROOT}"; echo "$(pwd)/_output/local/bin/$(os::util::host_platform)/openshift")
 
 if [[ ! -e "${openshift}" ]]; then
   {

--- a/hack/verify-generated-conversions.sh
+++ b/hack/verify-generated-conversions.sh
@@ -20,7 +20,7 @@ else
   echo "$buildout" | sed 's/^/   /'
 fi
 
-genconversion="${OS_ROOT}/_output/local/go/bin/genconversion"
+genconversion="${OS_ROOT}/_output/local/bin/$(os::build::host_platform)/genconversion"
 
 echo "   Verifying genconversion binary..."
 if [[ ! -x "$genconversion" ]]; then

--- a/hack/verify-generated-deep-copies.sh
+++ b/hack/verify-generated-deep-copies.sh
@@ -20,7 +20,7 @@ else
   echo "$buildout" | sed 's/^/   /'
 fi
 
-gendeepcopy="${OS_ROOT}/_output/local/go/bin/gendeepcopy"
+gendeepcopy="${OS_ROOT}/_output/local/bin/$(os::build::host_platform)/gendeepcopy"
 
 echo "   Verifying gendeepcopy binary..."
 if [[ ! -x "$gendeepcopy" ]]; then

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -21,6 +21,7 @@ if ! output=`${OS_ROOT}/hack/update-generated-docs.sh ${TMP_GENERATED_DOCS_ROOT_
 then
 	echo "FAILURE: Generation of fresh docs failed:"
 	echo "$output"
+  exit 1
 fi
 
 echo "Diffing current docs against freshly generated docs"

--- a/test/old-start-configs/v1.0.0/test-end-to-end.sh
+++ b/test/old-start-configs/v1.0.0/test-end-to-end.sh
@@ -89,7 +89,7 @@ CONTAINER_ACCESSIBLE_API_HOST="${CONTAINER_ACCESSIBLE_API_HOST:-172.17.42.1}"
 STI_CONFIG_FILE="${LOG_DIR}/stiAppConfig.json"
 DOCKER_CONFIG_FILE="${LOG_DIR}/dockerAppConfig.json"
 CUSTOM_CONFIG_FILE="${LOG_DIR}/customAppConfig.json"
-GO_OUT="${OS_ROOT}/_output/local/go/bin"
+GO_OUT="${OS_ROOT}/_output/local/bin/$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 
 # set path so OpenShift is available
 export PATH="${GO_OUT}:${PATH}"

--- a/vagrant/provision-full.sh
+++ b/vagrant/provision-full.sh
@@ -25,7 +25,7 @@ function set_env {
   if [[ $(grep GOPATH $USER_DIR/.bash_profile) = "" ]]; then
     touch $USER_DIR/.bash_profile
     echo "export GOPATH=/data" >> $USER_DIR/.bash_profile
-    echo "export PATH=\$GOPATH/src/github.com/openshift/origin/_output/local/go/bin:\$GOPATH/bin:\$PATH" >> $USER_DIR/.bash_profile
+    echo "export PATH=\$GOPATH/src/github.com/openshift/origin/_output/local/bin/linux/amd64:\$GOPATH/bin:\$PATH" >> $USER_DIR/.bash_profile
     echo "cd \$GOPATH/src/github.com/openshift/origin" >> $USER_DIR/.bash_profile
 
     echo "bind '\"\e[A\":history-search-backward'" >> $USER_DIR/.bashrc

--- a/vagrant/provision-util.sh
+++ b/vagrant/provision-util.sh
@@ -10,7 +10,7 @@ os::util::join() {
 os::util::install-cmds() {
   local deployed_root=$1
 
-  cp ${deployed_root}/_output/local/go/bin/{openshift,oc,osadm} /usr/bin
+  cp ${deployed_root}/_output/local/bin/linux/amd64/{openshift,oc,osadm} /usr/bin
 }
 
 os::util::add-to-hosts-file() {


### PR DESCRIPTION
This allows multiplatform compilation on a shared drive which simplifies
Windows and Mac vbox development. The output binaries will be moved
into

     _output/local/bin/linux/amd64/*

and the symlinks will be created there.  Any built binary will not be in `_output/local/go/bin` 

@deads2k your sed in hack/test-cmd.sh doesn't work on Macs - can you
suggest something that will?