### PR TITLE
Support deployment hook volume inheritance

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -15162,6 +15162,13 @@
      "containerName": {
       "type": "string",
       "description": "the name of a container from the pod template whose image will be used for the hook container"
+     },
+     "volumes": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "the names of volumes from the pod template which should be included in the hook pod; an empty list means no volumes will be copied, and names not found in the pod spec will be ignored"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1436,6 +1436,14 @@ func deepCopy_api_ExecNewPodHook(in deployapi.ExecNewPodHook, out *deployapi.Exe
 		out.Env = nil
 	}
 	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1481,6 +1481,14 @@ func deepCopy_v1_ExecNewPodHook(in deployapiv1.ExecNewPodHook, out *deployapiv1.
 		out.Env = nil
 	}
 	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1489,6 +1489,14 @@ func deepCopy_v1beta3_ExecNewPodHook(in deployapiv1beta3.ExecNewPodHook, out *de
 		out.Env = nil
 	}
 	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
 	return nil
 }
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -102,6 +102,9 @@ type ExecNewPodHook struct {
 	// ContainerName is the name of a container in the deployment pod template
 	// whose Docker image will be used for the hook pod's container.
 	ContainerName string
+	// Volumes is a list of named volumes from the pod template which should be
+	// copied to the hook pod.
+	Volumes []string
 }
 
 // RollingDeploymentStrategyParams are the input to the Rolling deployment

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -102,6 +102,10 @@ type ExecNewPodHook struct {
 	// ContainerName is the name of a container in the deployment pod template
 	// whose Docker image will be used for the hook pod's container.
 	ContainerName string `json:"containerName" description:"the name of a container from the pod template whose image will be used for the hook container"`
+	// Volumes is a list of named volumes from the pod template which should be
+	// copied to the hook pod. Volumes names not found in pod spec are ignored.
+	// An empty list means no volumes will be copied.
+	Volumes []string `json:"volumes,omitempty" description:"the names of volumes from the pod template which should be included in the hook pod; an empty list means no volumes will be copied, and names not found in the pod spec will be ignored"`
 }
 
 // RollingDeploymentStrategyParams are the input to the Rolling deployment

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -102,6 +102,10 @@ type ExecNewPodHook struct {
 	// ContainerName is the name of a container in the deployment pod template
 	// whose Docker image will be used for the hook pod's container.
 	ContainerName string `json:"containerName" description:"the name of a container from the pod template whose image will be used for the hook container"`
+	// Volumes is a list of named volumes from the pod template which should be
+	// copied to the hook pod. Volumes names not found in pod spec are ignored.
+	// An empty list means no volumes will be copied.
+	Volumes []string `json:"volumes,omitempty" description:"the names of volumes from the pod template which should be included in the hook pod; an empty list means no volumes will be copied, and names not found in the pod spec will be ignored"`
 }
 
 // RollingDeploymentStrategyParams are the input to the Rolling deployment

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -149,6 +149,8 @@ func validateExecNewPod(hook *deployapi.ExecNewPodHook) fielderrors.ValidationEr
 		errs = append(errs, validateEnv(hook.Env).Prefix("env")...)
 	}
 
+	errs = append(errs, validateHookVolumes(hook.Volumes).Prefix("volumes")...)
+
 	return errs
 }
 
@@ -166,6 +168,18 @@ func validateEnv(vars []kapi.EnvVar) fielderrors.ValidationErrorList {
 		allErrs = append(allErrs, vErrs.PrefixIndex(i)...)
 	}
 	return allErrs
+}
+
+func validateHookVolumes(volumes []string) fielderrors.ValidationErrorList {
+	errs := fielderrors.ValidationErrorList{}
+	for i, vol := range volumes {
+		vErrs := fielderrors.ValidationErrorList{}
+		if len(vol) == 0 {
+			vErrs = append(vErrs, fielderrors.NewFieldInvalid("", "", "must not be empty"))
+		}
+		errs = append(errs, vErrs.PrefixIndex(i)...)
+	}
+	return errs
 }
 
 func validateRollingParams(params *deployapi.RollingDeploymentStrategyParams) fielderrors.ValidationErrorList {

--- a/pkg/deploy/api/validation/validation_test.go
+++ b/pkg/deploy/api/validation/validation_test.go
@@ -324,6 +324,29 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			fielderrors.ValidationErrorTypeRequired,
 			"template.strategy.recreateParams.pre.execNewPod.containerName",
 		},
+		"invalid template.strategy.recreateParams.pre.execNewPod.volumes": {
+			api.DeploymentConfig{
+				ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "bar"},
+				Template: api.DeploymentTemplate{
+					Strategy: api.DeploymentStrategy{
+						Type: api.DeploymentStrategyTypeRecreate,
+						RecreateParams: &api.RecreateDeploymentStrategyParams{
+							Pre: &api.LifecycleHook{
+								FailurePolicy: api.LifecycleHookFailurePolicyRetry,
+								ExecNewPod: &api.ExecNewPodHook{
+									ContainerName: "container",
+									Command:       []string{"cmd"},
+									Volumes:       []string{"good", ""},
+								},
+							},
+						},
+					},
+					ControllerTemplate: test.OkControllerTemplate(),
+				},
+			},
+			fielderrors.ValidationErrorTypeInvalid,
+			"template.strategy.recreateParams.pre.execNewPod.volumes[1]",
+		},
 		"invalid template.strategy.rollingParams.intervalSeconds": {
 			rollingConfig(-20, 1, 1),
 			fielderrors.ValidationErrorTypeInvalid,

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -3,12 +3,14 @@ package support
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/client/cache"
+	kutil "k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -141,114 +143,155 @@ func TestHookExecutor_makeHookPodInvalidContainerRef(t *testing.T) {
 	t.Logf("got expected error: %s", err)
 }
 
-func TestHookExecutor_makeHookPodOk(t *testing.T) {
-	hook := &deployapi.LifecycleHook{
-		FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
-		ExecNewPod: &deployapi.ExecNewPodHook{
-			ContainerName: "container1",
-			Command:       []string{"overridden"},
-			Env: []kapi.EnvVar{
-				{
-					Name:  "name",
-					Value: "value",
+func TestHookExecutor_makeHookPod(t *testing.T) {
+	deploymentName := "deployment-1"
+	deploymentNamespace := "test"
+	maxDeploymentDurationSeconds := deployapi.MaxDeploymentDurationSeconds
+
+	tests := []struct {
+		name     string
+		hook     *deployapi.LifecycleHook
+		expected *kapi.Pod
+	}{
+		{
+			name: "overrides",
+			hook: &deployapi.LifecycleHook{
+				FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+				ExecNewPod: &deployapi.ExecNewPodHook{
+					ContainerName: "container1",
+					Command:       []string{"overridden"},
+					Env: []kapi.EnvVar{
+						{
+							Name:  "name",
+							Value: "value",
+						},
+						{
+							Name:  "ENV1",
+							Value: "overridden",
+						},
+					},
+					Volumes: []string{"volume-2"},
 				},
-				{
-					Name:  "ENV1",
-					Value: "overridden",
+			},
+			expected: &kapi.Pod{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: namer.GetPodName(deploymentName, "hook"),
+					Labels: map[string]string{
+						deployapi.DeployerPodForDeploymentLabel: deploymentName,
+					},
+					Annotations: map[string]string{
+						deployapi.DeploymentAnnotation: deploymentName,
+					},
+				},
+				Spec: kapi.PodSpec{
+					RestartPolicy: kapi.RestartPolicyNever,
+					Volumes: []kapi.Volume{
+						{
+							Name: "volume-2",
+						},
+					},
+					ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
+					Containers: []kapi.Container{
+						{
+							Name:    "lifecycle",
+							Image:   "registry:8080/repo1:ref1",
+							Command: []string{"overridden"},
+							Env: []kapi.EnvVar{
+								{
+									Name:  "name",
+									Value: "value",
+								},
+								{
+									Name:  "ENV1",
+									Value: "overridden",
+								},
+								{
+									Name:  "OPENSHIFT_DEPLOYMENT_NAME",
+									Value: deploymentName,
+								},
+								{
+									Name:  "OPENSHIFT_DEPLOYMENT_NAMESPACE",
+									Value: deploymentNamespace,
+								},
+							},
+							Resources: kapi.ResourceRequirements{
+								Limits: kapi.ResourceList{
+									kapi.ResourceCPU:    resource.MustParse("10"),
+									kapi.ResourceMemory: resource.MustParse("10M"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no overrides",
+			hook: &deployapi.LifecycleHook{
+				FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
+				ExecNewPod: &deployapi.ExecNewPodHook{
+					ContainerName: "container1",
+				},
+			},
+			expected: &kapi.Pod{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: namer.GetPodName(deploymentName, "hook"),
+					Labels: map[string]string{
+						deployapi.DeployerPodForDeploymentLabel: deploymentName,
+					},
+					Annotations: map[string]string{
+						deployapi.DeploymentAnnotation: deploymentName,
+					},
+				},
+				Spec: kapi.PodSpec{
+					RestartPolicy:         kapi.RestartPolicyNever,
+					ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
+					Containers: []kapi.Container{
+						{
+							Name:  "lifecycle",
+							Image: "registry:8080/repo1:ref1",
+							Env: []kapi.EnvVar{
+								{
+									Name:  "ENV1",
+									Value: "VAL1",
+								},
+								{
+									Name:  "OPENSHIFT_DEPLOYMENT_NAME",
+									Value: deploymentName,
+								},
+								{
+									Name:  "OPENSHIFT_DEPLOYMENT_NAMESPACE",
+									Value: deploymentNamespace,
+								},
+							},
+							Resources: kapi.ResourceRequirements{
+								Limits: kapi.ResourceList{
+									kapi.ResourceCPU:    resource.MustParse("10"),
+									kapi.ResourceMemory: resource.MustParse("10M"),
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 	}
 
-	config := deploytest.OkDeploymentConfig(1)
-
-	cpuLimit := resource.MustParse("10")
-	memoryLimit := resource.MustParse("10M")
-	config.Template.ControllerTemplate.Template.Spec.Containers[0].Resources = kapi.ResourceRequirements{
-		Limits: kapi.ResourceList{
-			kapi.ResourceCPU:    cpuLimit,
-			kapi.ResourceMemory: memoryLimit,
-		},
-	}
-
-	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
-
-	pod, err := makeHookPod(hook, deployment, "hook")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if e, a := namer.GetPodName(deployment.Name, "hook"), pod.Name; e != a {
-		t.Errorf("expected pod name %s, got %s", e, a)
-	}
-
-	if e, a := kapi.RestartPolicyNever, pod.Spec.RestartPolicy; e != a {
-		t.Errorf("expected pod restart policy %s, got %s", e, a)
-	}
-
-	gotContainer := pod.Spec.Containers[0]
-
-	// Verify the correct image was selected
-	if e, a := deployment.Spec.Template.Spec.Containers[0].Image, gotContainer.Image; e != a {
-		t.Fatalf("expected container image %s, got %s", e, a)
-	}
-
-	// Verify command overriding
-	if e, a := "overridden", gotContainer.Command[0]; e != a {
-		t.Fatalf("expected container command %s, got %s", e, a)
-	}
-
-	// Verify environment merging
-	expectedEnv := map[string]string{
-		"name": "value",
-		"ENV1": "overridden",
-		"OPENSHIFT_DEPLOYMENT_NAME":      deployment.Name,
-		"OPENSHIFT_DEPLOYMENT_NAMESPACE": deployment.Namespace,
-	}
-
-	for k, v := range expectedEnv {
-		found := false
-		for _, env := range gotContainer.Env {
-			if env.Name == k && env.Value == v {
-				found = true
-				break
-			}
+	for _, test := range tests {
+		t.Logf("evaluating test: %s", test.name)
+		pod, err := makeHookPod(test.hook, deployment("deployment", "test"), "hook")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
 		}
-		if !found {
-			t.Errorf("expected to find %s=%s in pod environment", k, v)
+		for _, c := range pod.Spec.Containers {
+			sort.Sort(envByNameAsc(c.Env))
 		}
-	}
-
-	for _, env := range gotContainer.Env {
-		val, found := expectedEnv[env.Name]
-		if !found || val != env.Value {
-			t.Errorf("container has unexpected environment entry %s=%s", env.Name, env.Value)
+		for _, c := range test.expected.Spec.Containers {
+			sort.Sort(envByNameAsc(c.Env))
 		}
-	}
-
-	// Verify resource limit inheritance
-	if cpu := gotContainer.Resources.Limits.Cpu(); cpu.Value() != cpuLimit.Value() {
-		t.Errorf("expected cpu %v, got: %v", cpuLimit, cpu)
-	}
-	if memory := gotContainer.Resources.Limits.Memory(); memory.Value() != memoryLimit.Value() {
-		t.Errorf("expected memory %v, got: %v", memoryLimit, memory)
-	}
-
-	// Verify restart policy
-	if e, a := kapi.RestartPolicyNever, pod.Spec.RestartPolicy; e != a {
-		t.Fatalf("expected restart policy %s, got %s", e, a)
-	}
-
-	// Verify correlation stuff
-	if l, e, a := deployapi.DeployerPodForDeploymentLabel,
-		deployment.Name,
-		pod.Labels[deployapi.DeployerPodForDeploymentLabel]; e != a {
-		t.Errorf("expected label %s=%s, got %s", l, e, a)
-	}
-	if l, e, a := deployapi.DeploymentAnnotation,
-		deployment.Name,
-		pod.Annotations[deployapi.DeploymentAnnotation]; e != a {
-		t.Errorf("expected annotation %s=%s, got %s", l, e, a)
+		if !kapi.Semantic.DeepEqual(pod, test.expected) {
+			t.Errorf("unexpected pod diff: %v", kutil.ObjectDiff(pod, test.expected))
+		}
 	}
 }
 
@@ -377,4 +420,85 @@ func TestAcceptNewlyObservedReadyPods_scenarios(t *testing.T) {
 			t.Logf("got expected error: %s", err)
 		}
 	}
+}
+
+func deployment(name, namespace string) *kapi.ReplicationController {
+	config := &deployapi.DeploymentConfig{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		LatestVersion: 1,
+		Template: deployapi.DeploymentTemplate{
+			Strategy: deployapi.DeploymentStrategy{
+				Type: deployapi.DeploymentStrategyTypeRecreate,
+				Resources: kapi.ResourceRequirements{
+					Limits: kapi.ResourceList{
+						kapi.ResourceName(kapi.ResourceCPU):    resource.MustParse("10"),
+						kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
+					},
+				},
+			},
+			ControllerTemplate: kapi.ReplicationControllerSpec{
+				Replicas: 1,
+				Selector: map[string]string{"a": "b"},
+				Template: &kapi.PodTemplateSpec{
+					Spec: kapi.PodSpec{
+						Containers: []kapi.Container{
+							{
+								Name:  "container1",
+								Image: "registry:8080/repo1:ref1",
+								Env: []kapi.EnvVar{
+									{
+										Name:  "ENV1",
+										Value: "VAL1",
+									},
+								},
+								ImagePullPolicy: kapi.PullIfNotPresent,
+								Resources: kapi.ResourceRequirements{
+									Limits: kapi.ResourceList{
+										kapi.ResourceCPU:    resource.MustParse("10"),
+										kapi.ResourceMemory: resource.MustParse("10M"),
+									},
+								},
+							},
+							{
+								Name:            "container2",
+								Image:           "registry:8080/repo1:ref2",
+								ImagePullPolicy: kapi.PullIfNotPresent,
+							},
+						},
+						Volumes: []kapi.Volume{
+							{
+								Name: "volume-1",
+							},
+							{
+								Name: "volume-2",
+							},
+						},
+						RestartPolicy: kapi.RestartPolicyAlways,
+						DNSPolicy:     kapi.DNSClusterFirst,
+					},
+					ObjectMeta: kapi.ObjectMeta{
+						Labels: map[string]string{"a": "b"},
+					},
+				},
+			},
+		},
+	}
+	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
+	deployment.Namespace = namespace
+	return deployment
+}
+
+type envByNameAsc []kapi.EnvVar
+
+func (a envByNameAsc) Len() int {
+	return len(a)
+}
+func (a envByNameAsc) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+func (a envByNameAsc) Less(i, j int) bool {
+	return a[j].Name < a[i].Name
 }


### PR DESCRIPTION
Enhance the deployment API to support volume inheritance in hooks.

Add a new 'volumes' field to the 'execNewPod' hook API which allows
users to reference named volumes in the pod spec. Any matching volumes
will be copied to the hook pod spec.

Fixes #3739
Implements https://trello.com/c/S1J0hGqB