### PR TITLE
append missing flags to cobra flags

### DIFF
--- a/pkg/cmd/server/start/kubernetes/apiserver.go
+++ b/pkg/cmd/server/start/kubernetes/apiserver.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -40,8 +41,8 @@ func NewAPIServerCommand(name, fullName string, out io.Writer) *cobra.Command {
 	cmd.SetOutput(out)
 
 	flags := cmd.Flags()
-	//TODO: uncomment after picking up a newer cobra
-	//pflag.AddFlagSetToPFlagSet(flag, flags)
+	flags.SetNormalizeFunc(util.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(flag.CommandLine)
 	s.AddFlags(flags)
 
 	return cmd

--- a/pkg/cmd/server/start/kubernetes/controllers.go
+++ b/pkg/cmd/server/start/kubernetes/controllers.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -40,8 +41,8 @@ func NewControllersCommand(name, fullName string, out io.Writer) *cobra.Command 
 	cmd.SetOutput(out)
 
 	flags := cmd.Flags()
-	//TODO: uncomment after picking up a newer cobra
-	//pflag.AddFlagSetToPFlagSet(flag, flags)
+	flags.SetNormalizeFunc(util.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(flag.CommandLine)
 	s.AddFlags(flags)
 
 	return cmd

--- a/pkg/cmd/server/start/kubernetes/kubelet.go
+++ b/pkg/cmd/server/start/kubernetes/kubelet.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -39,8 +40,8 @@ func NewKubeletCommand(name, fullName string, out io.Writer) *cobra.Command {
 	cmd.SetOutput(out)
 
 	flags := cmd.Flags()
-	//TODO: uncomment after picking up a newer cobra
-	//pflag.AddFlagSetToPFlagSet(flag, flags)
+	flags.SetNormalizeFunc(util.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(flag.CommandLine)
 	s.AddFlags(flags)
 
 	return cmd

--- a/pkg/cmd/server/start/kubernetes/proxy.go
+++ b/pkg/cmd/server/start/kubernetes/proxy.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -40,8 +41,8 @@ func NewProxyCommand(name, fullName string, out io.Writer) *cobra.Command {
 	cmd.SetOutput(out)
 
 	flags := cmd.Flags()
-	//TODO: uncomment after picking up a newer cobra
-	//pflag.AddFlagSetToPFlagSet(flag, flags)
+	flags.SetNormalizeFunc(util.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(flag.CommandLine)
 	s.AddFlags(flags)
 
 	return cmd

--- a/pkg/cmd/server/start/kubernetes/scheduler.go
+++ b/pkg/cmd/server/start/kubernetes/scheduler.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -40,8 +41,8 @@ func NewSchedulerCommand(name, fullName string, out io.Writer) *cobra.Command {
 	cmd.SetOutput(out)
 
 	flags := cmd.Flags()
-	//TODO: uncomment after picking up a newer cobra
-	//pflag.AddFlagSetToPFlagSet(flag, flags)
+	flags.SetNormalizeFunc(util.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(flag.CommandLine)
 	s.AddFlags(flags)
 
 	return cmd


### PR DESCRIPTION
When building kubernetes from origin source codes, kube-apiserver and other binaries are missing glog flags, i.e. --logtostderr, --v0, etc. Without them, kubernetes in Fedora will not start with the current configuration files.

This patch just uncomments out and updates pflag.AddFlagSetToPFlagSet call to add missing flags.