### PR TITLE
Add oc rsync command

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -680,48 +680,48 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
-			"Comment": "v1.0.2-12-g847bf02",
-			"Rev": "847bf029b540c689f1644419efd2e70b64b90547"
+			"Comment": "v1.0.2-22-g1fd4429",
+			"Rev": "1fd4429c584d688d83c1247c03fa2eeb0b083ccb"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
@@ -52,12 +52,13 @@ func New(config *api.Config) (*OnBuild, error) {
 	// Use STI Prepare() and download the 'run' script optionally.
 	s, err := sti.New(config)
 	s.SetScripts([]string{}, []string{api.Assemble, api.Run})
-
-	b.source = onBuildSourceHandler{
-		scm.DownloaderForSource(config.Source),
-		s,
-		&ignore.DockerIgnorer{},
+	downloader, sourceUrl, err := scm.DownloaderForSource(config.Source)
+	if err != nil {
+		return nil, err
 	}
+	config.Source = sourceUrl
+
+	b.source = onBuildSourceHandler{downloader, s, &ignore.DockerIgnorer{}}
 	b.garbage = &build.DefaultCleaner{b.fs, b.docker}
 	return b, nil
 }

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
@@ -99,7 +99,11 @@ func New(req *api.Config) (*STI, error) {
 
 	// The sources are downloaded using the GIT downloader.
 	// TODO: Add more SCM in future.
-	b.source = scm.DownloaderForSource(req.Source)
+	b.source, req.Source, err = scm.DownloaderForSource(req.Source)
+	if err != nil {
+		return nil, err
+	}
+
 	b.garbage = &build.DefaultCleaner{b.fs, b.docker}
 	b.layered, err = layered.New(req, b)
 
@@ -215,6 +219,20 @@ func (b *STI) SetScripts(required, optional []string) {
 	b.optionalScripts = optional
 }
 
+func mergeLabels(newLabels, existingLabels map[string]string) map[string]string {
+	if existingLabels == nil {
+		return newLabels
+	}
+	result := map[string]string{}
+	for k, v := range existingLabels {
+		result[k] = v
+	}
+	for k, v := range newLabels {
+		result[k] = v
+	}
+	return result
+}
+
 // PostExecute allows to execute post-build actions after the Docker build
 // finishes.
 func (b *STI) PostExecute(containerID, location string) error {
@@ -245,12 +263,17 @@ func (b *STI) PostExecute(containerID, location string) error {
 		// were extracted and append scripts dir and name
 		runCmd = filepath.Join(location, "scripts", api.Run)
 	}
+	existingLabels, err := b.docker.GetLabels(b.config.BuilderImage)
+	if err != nil {
+		glog.Errorf("Unable to read existing labels from current builder image %s", b.config.BuilderImage)
+	}
+
 	opts := dockerpkg.CommitContainerOptions{
 		Command:     append([]string{}, runCmd),
 		Env:         buildEnv,
 		ContainerID: containerID,
 		Repository:  b.config.Tag,
-		Labels:      util.GenerateOutputImageLabels(b.sourceInfo, b.config),
+		Labels:      mergeLabels(util.GenerateOutputImageLabels(b.sourceInfo, b.config), existingLabels),
 	}
 
 	imageID, err := b.docker.CommitContainer(opts)

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/docker/docker.go
@@ -61,6 +61,7 @@ type Docker interface {
 	CheckAndPullImage(name string) (*docker.Image, error)
 	BuildImage(opts BuildImageOptions) error
 	GetImageUser(name string) (string, error)
+	GetLabels(name string) (map[string]string, error)
 }
 
 // Client contains all methods called on the go Docker
@@ -246,6 +247,17 @@ func (d *stiDocker) RemoveContainer(id string) error {
 		Force:         true,
 	}
 	return d.client.RemoveContainer(opts)
+}
+
+// GetLabels retrieves the labels of the given image.
+func (d *stiDocker) GetLabels(name string) (map[string]string, error) {
+	name = getImageName(name)
+	image, err := d.client.InspectImage(name)
+	if err != nil {
+		return nil, errors.NewInspectImageError(name, err)
+	}
+	return image.Config.Labels, nil
+
 }
 
 // getImageName checks the image name and adds DefaultTag if none is specified

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/file/download.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/file/download.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -18,9 +17,6 @@ type File struct {
 
 func (f *File) Download(config *api.Config) (*api.SourceInfo, error) {
 	targetSourceDir := filepath.Join(config.WorkingDir, api.Source)
-	if !strings.HasPrefix(config.Source, "file://") {
-		return nil, fmt.Errorf("File downloader can be used only for file:// protocol")
-	}
 	sourceDir := strings.TrimPrefix(config.Source, "file://")
 	config.WorkingSourceDir = targetSourceDir
 

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/git/git.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/git/git.go
@@ -131,7 +131,7 @@ func (h *stiGit) GetInfo(repo string) *api.SourceInfo {
 	return &api.SourceInfo{
 		Location: git("config", "--get", "remote.origin.url"),
 		Ref:      git("rev-parse", "--abbrev-ref", "HEAD"),
-		CommitID: git("rev-parse", "--short", "--verify", "HEAD"),
+		CommitID: git("rev-parse", "--verify", "HEAD"),
 		Author:   git("--no-pager", "show", "-s", "--format=%an <%ae>", "HEAD"),
 		Date:     git("--no-pager", "show", "-s", "--format=%ad", "HEAD"),
 		Message:  git("--no-pager", "show", "-s", "--format=%<(80,trunc)%s", "HEAD"),

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm.go
@@ -1,10 +1,12 @@
 package scm
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/scm/file"
 	"github.com/openshift/source-to-image/pkg/scm/git"
@@ -13,22 +15,52 @@ import (
 
 // DownloaderForSource determines what SCM plugin should be used for downloading
 // the sources from the repository.
-func DownloaderForSource(s string) build.Downloader {
-	// If the source starts with file:// and there is no GIT binary, use 'file'
-	// SCM plugin
-	if (strings.HasPrefix(s, "file://") || strings.HasPrefix(s, "/")) && !hasGitBinary() {
-		return &file.File{util.NewFileSystem()}
+func DownloaderForSource(s string) (build.Downloader, string, error) {
+	// If the source is using file:// protocol but it is not a GIT repository,
+	// trim the prefix and treat it as a file copy.
+	if strings.HasPrefix(s, "file://") && !isLocalGitRepository(s) {
+		s = strings.TrimPrefix(s, "file://")
 	}
 
-	g := git.New()
-	if g.ValidCloneSpec(s) {
-		return &git.Clone{g, util.NewFileSystem()}
+	// If the source is file:// protocol and it is GIT repository, but we don't
+	// have GIT binary to fetch it, treat it as file copy.
+	if strings.HasPrefix(s, "file://") && !hasGitBinary() {
+		s = strings.TrimPrefix(s, "file://")
 	}
 
-	glog.Errorf("No downloader defined for %q source URL", s)
-	return nil
+	// If the source is valid GIT protocol (file://, git://, git@, etc..) use GIT
+	// binary to download the sources
+	if g := git.New(); g.ValidCloneSpec(s) {
+		return &git.Clone{g, util.NewFileSystem()}, s, nil
+	}
+
+	// Convert relative path to absolute path.
+	if !strings.HasPrefix(s, "/") {
+		if absolutePath, err := filepath.Abs(s); err == nil {
+			s = absolutePath
+		}
+	}
+
+	if isLocalGitRepository(s) {
+		return DownloaderForSource("file://" + s)
+	}
+
+	// If we have local directory and that directory exists, use file copy
+	if _, err := os.Stat(s); err == nil {
+		return &file.File{util.NewFileSystem()}, s, nil
+	}
+
+	return nil, s, fmt.Errorf("No downloader defined for location: %q", s)
 }
 
+// isLocalGitRepository checks if the specified directory has .git subdirectory (it
+// is a GIT repository)
+func isLocalGitRepository(dir string) bool {
+	_, err := os.Stat(fmt.Sprintf("%s/.git", strings.TrimPrefix(dir, "file://")))
+	return !(err != nil && os.IsNotExist(err))
+}
+
+// hasGitBinary checks if the 'git' binary is available on the system
 func hasGitBinary() bool {
 	_, err := exec.LookPath("git")
 	return err == nil

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/scm/scm_test.go
@@ -1,0 +1,89 @@
+package scm
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func createLocalGitDirectory(t *testing.T) string {
+	dir, err := ioutil.TempDir(os.TempDir(), "s2i-test")
+	if err != nil {
+		t.Error(err)
+	}
+	os.Mkdir(filepath.Join(dir, ".git"), 0600)
+	return dir
+}
+
+func TestIsLocalGitRepository(t *testing.T) {
+	d := createLocalGitDirectory(t)
+	defer os.RemoveAll(d)
+	if isLocalGitRepository(d) == false {
+		t.Errorf("The %q directory is git repository", d)
+	}
+	os.RemoveAll(filepath.Join(d, ".git"))
+	if isLocalGitRepository(d) == true {
+		t.Errorf("The %q directory is not git repository", d)
+	}
+}
+
+func TestDownloaderForSource(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	localDir, _ := ioutil.TempDir(os.TempDir(), "s2i-test")
+	defer os.RemoveAll(localDir)
+
+	tc := map[string]string{
+		// Valid GIT clone specs
+		"git://github.com/bar":       "git.Clone",
+		"https://github.com/bar":     "git.Clone",
+		"git@github.com:foo/bar.git": "git.Clone",
+		// Non-existing local path (it is not git repository, so it is file
+		// download)
+		"file://foo/bar": "error",
+		"/foo/bar":       "error",
+		// Local directory with valid GIT repository
+		gitLocalDir:             "git.Clone",
+		"file://" + gitLocalDir: "git.Clone",
+		// Local directory that exists but it is not GIT repository
+		localDir:             "file.File",
+		"file://" + localDir: "file.File",
+		".":                  "file.File",
+		"foo://github.com/bar": "error",
+		"./foo":                "error",
+	}
+
+	for s, expected := range tc {
+		r, _, err := DownloaderForSource(s)
+		if err != nil {
+			if expected != "error" {
+				t.Errorf("Unexpected error %q for %q, expected %q", err, s, expected)
+			}
+			continue
+		}
+
+		expected = "*" + expected
+		if reflect.TypeOf(r).String() != expected {
+			t.Errorf("Expected %q for %q, got %q", expected, s, reflect.TypeOf(r).String())
+		}
+	}
+}
+
+func TestDownloaderForSourceOnRelativeGit(t *testing.T) {
+	gitLocalDir := createLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	os.Chdir(gitLocalDir)
+	r, s, err := DownloaderForSource(".")
+	if err != nil {
+		t.Errorf("Unexpected error %q for %q, expected %q", err, ".", "git.Clone")
+	}
+	if !strings.HasPrefix(s, "file://") {
+		t.Errorf("Expected source to have 'file://' prefix, it is %q", s)
+	}
+	if reflect.TypeOf(r).String() != "*git.Clone" {
+		t.Errorf("Expected %q for %q, got %q", "*git.Clone", ".", reflect.TypeOf(r).String())
+	}
+}

--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -1127,6 +1127,27 @@ _oc_rsh()
     must_have_one_noun=()
 }
 
+_oc_rsync()
+{
+    last_command="oc_rsync"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--container=")
+    two_word_flags+=("-c")
+    flags+=("--delete")
+    flags+=("--quiet")
+    flags+=("-q")
+    flags+=("--use-tar")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oc_exec()
 {
     last_command="oc_exec"
@@ -1939,6 +1960,7 @@ _oc()
     commands+=("delete")
     commands+=("logs")
     commands+=("rsh")
+    commands+=("rsync")
     commands+=("exec")
     commands+=("port-forward")
     commands+=("proxy")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -2655,6 +2655,27 @@ _openshift_cli_rsh()
     must_have_one_noun=()
 }
 
+_openshift_cli_rsync()
+{
+    last_command="openshift_cli_rsync"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--container=")
+    two_word_flags+=("-c")
+    flags+=("--delete")
+    flags+=("--quiet")
+    flags+=("-q")
+    flags+=("--use-tar")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_cli_exec()
 {
     last_command="openshift_cli_exec"
@@ -3467,6 +3488,7 @@ _openshift_cli()
     commands+=("delete")
     commands+=("logs")
     commands+=("rsh")
+    commands+=("rsync")
     commands+=("exec")
     commands+=("port-forward")
     commands+=("proxy")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -718,6 +718,20 @@ Start a shell session in a pod
 ====
 
 
+== oc rsync
+Copy local files to a pod
+
+====
+
+[options="nowrap"]
+----
+
+  # Synchronize a local directory with a pod directory
+  $ openshift cli rsync ./local/dir/ POD:/remote/dir
+----
+====
+
+
 == oc run
 Run a particular image on the cluster.
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -109,7 +109,8 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
 				cmd.NewCmdLogs(fullName, f, out),
-				cmd.NewCmdRsh(fullName, f, in, out, errout),
+				cmd.NewCmdRsh(cmd.RshRecommendedName, fullName, f, in, out, errout),
+				cmd.NewCmdRsync(cmd.RsyncRecommendedName, fullName, f, out, errout),
 				cmd.NewCmdExec(fullName, f, in, out, errout),
 				cmd.NewCmdPortForward(fullName, f),
 				cmd.NewCmdProxy(fullName, f, out),

--- a/pkg/cmd/cli/cmd/rsync.go
+++ b/pkg/cmd/cli/cmd/rsync.go
@@ -1,0 +1,413 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/openshift/source-to-image/pkg/tar"
+	"github.com/spf13/cobra"
+	kvalidation "k8s.io/kubernetes/pkg/api/validation"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	// RsyncRecommendedName is the recommended name for the rsync command
+	RsyncRecommendedName = "rsync"
+
+	rsyncLong = `
+Copy local files to a container
+
+This command will attempt to copy local files to a remote container. It will default to the
+first container if none is specified, and will attempt to use 'rsync' if available locally and in the
+container. If 'rsync' is not present, it will attempt to use 'tar' to send files to the container.`
+
+	rsyncExample = `
+  # Synchronize a local directory with a pod directory
+  $ %[1]s ./local/dir/ POD:/remote/dir`
+
+	defaultRsyncExecutable = "rsync"
+	defaultTarExecutable   = "tar"
+)
+
+var (
+	testRsyncCommand = []string{"rsync", "--version"}
+	testTarCommand   = []string{"tar", "--version"}
+)
+
+// RsyncOptions holds the options to execute the sync command
+type RsyncOptions struct {
+	Namespace      string
+	PodName        string
+	ContainerName  string
+	Source         string
+	Destination    string
+	DestinationDir string
+	RshCommand     string
+	UseTar         bool
+	Quiet          bool
+	Delete         bool
+
+	Out    io.Writer
+	ErrOut io.Writer
+
+	LocalExecutor  executor
+	RemoteExecutor executor
+	Tar            tar.Tar
+	PodClient      kclient.PodInterface
+}
+
+// executor executes commands
+type executor interface {
+	Execute(command []string, in io.Reader, out, err io.Writer) error
+}
+
+// NewCmdRsync creates a new sync command
+func NewCmdRsync(name, parent string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+	tarHelper := tar.New()
+	tarHelper.SetExclusionPattern(nil)
+	o := RsyncOptions{
+		Out:           out,
+		ErrOut:        errOut,
+		LocalExecutor: &defaultLocalExecutor{},
+		Tar:           tarHelper,
+	}
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s SOURCE_DIR POD:DESTINATION_DIR", name),
+		Short:   "Copy local files to a pod",
+		Long:    rsyncLong,
+		Example: fmt.Sprintf(rsyncExample, parent+" "+name),
+		Run: func(c *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, c, args))
+			kcmdutil.CheckErr(o.Validate())
+			kcmdutil.CheckErr(o.RunRsync())
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.ContainerName, "container", "c", "", "Container within the pod")
+	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", false, "Quiet copy")
+	cmd.Flags().BoolVar(&o.Delete, "delete", false, "Delete files not present in source")
+	cmd.Flags().BoolVar(&o.UseTar, "use-tar", false, "Use tar instead of rsync")
+	return cmd
+}
+
+func parseDestination(destination string) (string, string, error) {
+	parts := strings.SplitN(destination, ":", 2)
+	if len(parts) < 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return "", "", fmt.Errorf("invalid destination %s: must be of the form PODNAME:DESTINATION_DIR", destination)
+	}
+	valid, msg := kvalidation.ValidatePodName(parts[0], false)
+	if !valid {
+		return "", "", fmt.Errorf("invalid pod name %s: %s", parts[0], msg)
+	}
+	return parts[0], parts[1], nil
+}
+
+// Complete verifies command line arguments and loads data from the command environment
+func (o *RsyncOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+	switch n := len(args); {
+	case n == 0:
+		cmd.Help()
+		fallthrough
+	case n < 2:
+		return kcmdutil.UsageError(cmd, "SOURCE_DIR and POD:DESTINATION_DIR are required arguments")
+	case n > 2:
+		return kcmdutil.UsageError(cmd, "only SOURCE_DIR and POD:DESTINATION_DIR should be specified as arguments")
+	}
+
+	// Set main command arguments
+	o.Source = args[0]
+	o.Destination = args[1]
+
+	// Determine pod name
+	var err error
+	o.PodName, o.DestinationDir, err = parseDestination(o.Destination)
+	if err != nil {
+		return kcmdutil.UsageError(cmd, err.Error())
+	}
+
+	// Use tar if running on windows
+	// TODO: Figure out how to use rsync in windows so that I/O can be
+	// redirected from the openshift native command to the cygwin rsync command
+	if runtime.GOOS == "windows" {
+		o.UseTar = true
+	}
+
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	o.Namespace = namespace
+
+	// Determine the Rsh command to use for rsync
+	if !o.UseTar {
+		rsh := siblingCommand(cmd, "rsh")
+		rshCmd := []string{rsh, "-n", o.Namespace}
+		if len(o.ContainerName) > 0 {
+			rshCmd = append(rshCmd, "-c", o.ContainerName)
+		}
+		o.RshCommand = strings.Join(rshCmd, " ")
+		glog.V(4).Infof("Rsh command: %s", o.RshCommand)
+	}
+
+	config, err := f.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := f.Client()
+	if err != nil {
+		return err
+	}
+
+	o.RemoteExecutor = &defaultRemoteExecutor{
+		Namespace:     o.Namespace,
+		PodName:       o.PodName,
+		ContainerName: o.ContainerName,
+		Config:        config,
+		Client:        client,
+	}
+
+	o.PodClient = client.Pods(namespace)
+
+	return nil
+}
+
+// sibling command returns a sibling command to the current command
+func siblingCommand(cmd *cobra.Command, name string) string {
+	c := cmd.Parent()
+	command := []string{}
+	for c != nil {
+		glog.V(5).Infof("Found parent command: %s", c.Name())
+		command = append([]string{c.Name()}, command...)
+		c = c.Parent()
+	}
+	// Replace the root command with what was actually used
+	// in the command line
+	glog.V(4).Infof("Setting root command to: %s", os.Args[0])
+	command[0] = os.Args[0]
+
+	// Append the sibling command
+	command = append(command, name)
+	glog.V(4).Infof("The sibling command is: %s", strings.Join(command, " "))
+
+	return strings.Join(command, " ")
+}
+
+// Validate checks that SyncOptions has all necessary fields
+func (o *RsyncOptions) Validate() error {
+	if len(o.PodName) == 0 {
+		return fmt.Errorf("pod name must be provided")
+	}
+	if len(o.Source) == 0 {
+		return fmt.Errorf("local source must be provided")
+	}
+	if len(o.Destination) == 0 {
+		return fmt.Errorf("remote destination must be provided")
+	}
+	if o.UseTar && len(o.DestinationDir) == 0 {
+		return fmt.Errorf("destination directory must be provided if using tar")
+	}
+	if !o.UseTar && len(o.RshCommand) == 0 {
+		return fmt.Errorf("rsh command must be provided when not using tar")
+	}
+	if o.Out == nil || o.ErrOut == nil {
+		return fmt.Errorf("output and error streams must be specified")
+	}
+	if o.LocalExecutor == nil || o.RemoteExecutor == nil {
+		return fmt.Errorf("local and remote executors must be provided")
+	}
+	if o.PodClient == nil {
+		return fmt.Errorf("pod client must be provided")
+	}
+	return nil
+}
+
+func (o *RsyncOptions) copyWithRsync(out, errOut io.Writer) error {
+	glog.V(3).Infof("Copying files with rsync")
+	flags := "-a"
+	if !o.Quiet {
+		flags += "v"
+	}
+	cmd := []string{defaultRsyncExecutable, flags}
+	if o.Delete {
+		cmd = append(cmd, "--delete")
+	}
+	cmd = append(cmd, "-e", o.RshCommand, o.Source, o.Destination)
+	glog.V(4).Infof("Local command: %s", strings.Join(cmd, " "))
+	return o.LocalExecutor.Execute(cmd, nil, out, errOut)
+}
+
+func (o *RsyncOptions) copyWithTar(out, errOut io.Writer) error {
+	glog.V(3).Infof("Copying files with tar")
+	if o.Delete {
+		// Implement the rsync --delete flag as a separate call to first delete directory contents
+		deleteCmd := []string{"sh", "-c", fmt.Sprintf("rm -rf %s", filepath.Join(o.DestinationDir, "*"))}
+		err := executeWithLogging(o.RemoteExecutor, deleteCmd)
+		if err != nil {
+			return fmt.Errorf("unable to delete files in destination: %v", err)
+		}
+	}
+	tmp, err := ioutil.TempFile("", "rsync")
+	if err != nil {
+		return fmt.Errorf("cannot create local temporary file for tar: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	err = tarLocal(o.Tar, o.Source, tmp)
+	if err != nil {
+		return fmt.Errorf("error creating tar of source directory: %v", err)
+	}
+	err = tmp.Close()
+	if err != nil {
+		return fmt.Errorf("error closing temporary tar file %s: %v", tmp.Name(), err)
+	}
+	tmp, err = os.Open(tmp.Name())
+	if err != nil {
+		return fmt.Errorf("cannot open temporary tar file %s: %v", tmp.Name(), err)
+	}
+	flags := "x"
+	if !o.Quiet {
+		flags += "v"
+	}
+	remoteCmd := []string{defaultTarExecutable, flags, "-C", o.DestinationDir}
+	errBuf := &bytes.Buffer{}
+	return o.RemoteExecutor.Execute(remoteCmd, tmp, out, errBuf)
+}
+
+func tarLocal(tar tar.Tar, sourceDir string, w io.Writer) error {
+	glog.V(4).Infof("Tarring %s locally", sourceDir)
+	// includeParent mimics rsync's behavior. When the source path ends in a path
+	// separator, then only the contents of the directory are copied. Otherwise,
+	// the directory itself is copied.
+	includeParent := true
+	if strings.HasSuffix(sourceDir, string(filepath.Separator)) {
+		includeParent = false
+		sourceDir = sourceDir[:len(sourceDir)-1]
+	}
+	return tar.CreateTarStream(sourceDir, includeParent, w)
+}
+
+// RunRsync copies files from source to destination
+func (o *RsyncOptions) RunRsync() error {
+	// If not going straight to tar and rsync exists locally, attempt to copy with rsync
+	if !o.UseTar && o.checkLocalRsync() {
+		errBuf := &bytes.Buffer{}
+		err := o.copyWithRsync(o.Out, errBuf)
+		// If no error occurred, we're done
+		if err == nil {
+			return nil
+		}
+		// If an error occurred, check whether rsync exists on the container.
+		// If it doesn't, fallback to tar
+		if o.checkRemoteRsync() {
+			// If remote rsync does exist, simply report the error
+			io.Copy(o.ErrOut, errBuf)
+			return err
+		}
+	}
+	return o.copyWithTar(o.Out, o.ErrOut)
+}
+
+func executeWithLogging(e executor, cmd []string) error {
+	w := &bytes.Buffer{}
+	err := e.Execute(cmd, nil, w, w)
+	glog.V(4).Infof("%s", w.String())
+	glog.V(4).Infof("error: %v", err)
+	return err
+}
+
+func (o *RsyncOptions) checkLocalRsync() bool {
+	_, err := exec.LookPath("rsync")
+	if err != nil {
+		glog.Warningf("rsync not found in local computer")
+		return false
+	}
+	return true
+}
+
+func (o *RsyncOptions) checkRemoteRsync() bool {
+	err := executeWithLogging(o.RemoteExecutor, testRsyncCommand)
+	if err != nil {
+		glog.Warningf("rsync not found in container %s of pod %s", o.containerName(), o.PodName)
+		return false
+	}
+	return true
+}
+
+func (o *RsyncOptions) containerName() string {
+	if len(o.ContainerName) > 0 {
+		return o.ContainerName
+	}
+	pod, err := o.PodClient.Get(o.PodName)
+	if err != nil {
+		glog.V(1).Infof("Error getting pod %s: %v", o.PodName, err)
+		return "[unknown]"
+	}
+	return pod.Spec.Containers[0].Name
+}
+
+// defaultLocalExecutor will execute commands on the local machine
+type defaultLocalExecutor struct{}
+
+// Execute will run a command locally
+func (*defaultLocalExecutor) Execute(command []string, in io.Reader, out, errOut io.Writer) error {
+	glog.V(3).Infof("Local executor running command: %s", strings.Join(command, " "))
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+	cmd.Stdin = in
+	err := cmd.Run()
+	if err != nil {
+		glog.V(4).Infof("Error from local command execution: %v", err)
+	}
+	return err
+}
+
+// defaultRemoteExecutor will execute commands on a given pod/container by using the kube Exec command
+type defaultRemoteExecutor struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+	Client        *kclient.Client
+	Config        *kclient.Config
+}
+
+// Execute will run a command in a pod
+func (e *defaultRemoteExecutor) Execute(command []string, in io.Reader, out, errOut io.Writer) error {
+	glog.V(3).Infof("Remote executor running command: %s", strings.Join(command, " "))
+	execOptions := &kubecmd.ExecOptions{
+		In:            in,
+		Out:           out,
+		Err:           errOut,
+		Stdin:         in != nil,
+		Executor:      &kubecmd.DefaultRemoteExecutor{},
+		Client:        e.Client,
+		Config:        e.Config,
+		PodName:       e.PodName,
+		ContainerName: e.ContainerName,
+		Namespace:     e.Namespace,
+		Command:       command,
+	}
+	err := execOptions.Validate()
+	if err != nil {
+		glog.V(4).Infof("Error from remote command validation: %v", err)
+		return err
+	}
+	err = execOptions.Run()
+	if err != nil {
+		glog.V(4).Infof("Error from remote execution: %v", err)
+	}
+	return err
+}

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -159,7 +159,10 @@ echo "[INFO] Validating port-forward"
 oc port-forward -p ${frontend_pod} 10080:8080  &> "${LOG_DIR}/port-forward.log" &
 wait_for_url_timed "http://localhost:10080" "[INFO] Frontend says: " $((10*TIME_SEC))
 
-
+# Rsync
+echo "[INFO] Validating rsync"
+oc rsync examples/sample-app ${frontend_pod}:/tmp
+[ "$(oc rsh ${frontend_pod} ls /tmp/sample-app | grep "application-template-stibuild")" ]
 
 #echo "[INFO] Applying Docker application config"
 #oc create -n docker -f "${DOCKER_CONFIG_FILE}"

--- a/test/extended/cli/rsync.go
+++ b/test/extended/cli/rsync.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("cli: parallel: rsync", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc           = exutil.NewCLI("cli-rsync", exutil.KubeConfigPath())
+		templatePath = exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json")
+		sourcePath1  = exutil.FixturePath("..", "..", "examples", "image-streams")
+		sourcePath2  = exutil.FixturePath("..", "..", "examples", "sample-app")
+	)
+
+	g.Describe("oc rsync", func() {
+		g.It("should copy files with rsync and tar to running container", func() {
+			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+			g.By(fmt.Sprintf("calling oc new-app -f %q", templatePath))
+			err := oc.Run("new-app").Args("-f", templatePath).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting the jenkins service get endpoints")
+			err = oc.KubeFramework().WaitForAnEndpoint("jenkins")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Getting the jenkins pod name")
+			selector, _ := labels.Parse("name=jenkins")
+			pods, err := oc.KubeREST().Pods(oc.Namespace()).List(selector, fields.Everything())
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(len(pods.Items)).ToNot(o.BeZero())
+			podName := pods.Items[0].Name
+
+			g.By(fmt.Sprintf("calling oc rsync %s %s:/tmp", sourcePath1, podName))
+			err = oc.Run("rsync").Args(sourcePath1, fmt.Sprintf("%s:/tmp", podName)).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Verifying that files are copied to the container")
+			result, err := oc.Run("rsh").Args(podName, "ls", "/tmp/image-streams").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(result).To(o.ContainSubstring("image-streams-centos7.json"))
+
+			g.By(fmt.Sprintf("calling oc rsync --use-tar --delete %s/ %s:/tmp/image-streams", sourcePath2, podName))
+			err = oc.Run("rsync").Args("--use-tar", "--delete", sourcePath2+"/", fmt.Sprintf("%s:/tmp/image-streams", podName)).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Verifying that the expected files are in the container")
+			result, err = oc.Run("rsh").Args(podName, "ls", "/tmp/image-streams").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(result).To(o.ContainSubstring("application-template-stibuild.json"))
+			o.Expect(result).NotTo(o.ContainSubstring("image-streams-centos7.json"))
+
+			g.By("Getting an error if copying to a destination directory where there is no write permission")
+			result, err = oc.Run("rsync").Args(sourcePath1, fmt.Sprintf("%s:/", podName)).Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(result).To(o.ContainSubstring("Permission denied"))
+		})
+	})
+})

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -7,6 +7,7 @@ import (
 
 	_ "github.com/openshift/origin/test/extended/authentication"
 	_ "github.com/openshift/origin/test/extended/builds"
+	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/images"
 	_ "github.com/openshift/origin/test/extended/router"
 


### PR DESCRIPTION
Refactors existing rsh command to match upstream structure. Adds rsync command that will use 'rsync' if available and on Linux, otherwise will fall back to 'tar'.

In windows, it will use 'tar' and not try rsync.