### PR TITLE
Make govet succeed

### DIFF
--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -22,6 +22,7 @@ test_dirs=$(find_files | cut -d '/' -f 1-2 | sort -u)
 for test_dir in $test_dirs
 do
   go tool vet -shadow=false \
+              -composites=false \
               $test_dir
   if [ "$?" -ne 0 ]
   then 

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -52,7 +52,7 @@ func NewCmdRequestProject(name, fullName, ocLoginName, ocProjectName string, f *
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s NAME [--display-name=DISPLAYNAME] [--description=DESCRIPTION]", name),
 		Short:   "Request a new project",
-		Long:    fmt.Sprintf(requestProjectLong, ocLoginName, ocProjectName),
+		Long:    requestProjectLong,
 		Example: fmt.Sprintf(requestProjectExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.complete(cmd, f); err != nil {


### PR DESCRIPTION
This PR will exclude checking of 'composites' from govet. What is it?

```go
f := Foo{"joe"} # vs. f := Foo{Name: "joe"}
```

I don't think we have a lot of places where we do this, however you will see a tons of errors regarding to this. 
So where does the errors comes from?

```go
type Foo []int
f := Foo{1,2}
```

This code is invalid according to govet... Because you did not set the "keys". But there are none ;-)

@stevekuznetsov I think it is safe to relax this check and it will leave us with no errors. So we can turn the checks ON in travis.