### PR TITLE
Make deployment trigger logging quieter

### DIFF
--- a/pkg/deploy/controller/configchange/controller.go
+++ b/pkg/deploy/controller/configchange/controller.go
@@ -45,7 +45,7 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 	}
 
 	if !hasChangeTrigger {
-		glog.V(4).Infof("Ignoring DeploymentConfig %s; no change triggers detected", deployutil.LabelForDeploymentConfig(config))
+		glog.V(5).Infof("Ignoring DeploymentConfig %s; no change triggers detected", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -69,7 +69,7 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 		// comparison. It's the responsibility of the deployment config controller
 		// to make the deployment for the config, so return early.
 		if kerrors.IsNotFound(err) {
-			glog.V(2).Infof("Ignoring change for DeploymentConfig %s; no existing Deployment found", deployutil.LabelForDeploymentConfig(config))
+			glog.V(5).Infof("Ignoring change for DeploymentConfig %s; no existing Deployment found", deployutil.LabelForDeploymentConfig(config))
 			return nil
 		}
 		return fmt.Errorf("couldn't retrieve Deployment for DeploymentConfig %s: %v", deployutil.LabelForDeploymentConfig(config), err)
@@ -82,7 +82,7 @@ func (c *DeploymentConfigChangeController) Handle(config *deployapi.DeploymentCo
 
 	// Detect template diffs, and return early if there aren't any changes.
 	if kapi.Semantic.DeepEqual(config.Template.ControllerTemplate.Template, deployedConfig.Template.ControllerTemplate.Template) {
-		glog.V(2).Infof("Ignoring DeploymentConfig change for %s (latestVersion=%d); same as Deployment %s", deployutil.LabelForDeploymentConfig(config), config.LatestVersion, deployutil.LabelForDeployment(deployment))
+		glog.V(5).Infof("Ignoring DeploymentConfig change for %s (latestVersion=%d); same as Deployment %s", deployutil.LabelForDeploymentConfig(config), config.LatestVersion, deployutil.LabelForDeployment(deployment))
 		return nil
 	}
 

--- a/pkg/deploy/controller/imagechange/controller.go
+++ b/pkg/deploy/controller/imagechange/controller.go
@@ -53,7 +53,7 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 			// Find the latest tag event for the trigger tag
 			latestEvent := imageapi.LatestTaggedImage(imageRepo, params.Tag)
 			if latestEvent == nil {
-				glog.V(2).Infof("Couldn't find latest tag event for tag %s in ImageStream %s", params.Tag, labelForRepo(imageRepo))
+				glog.V(5).Infof("Couldn't find latest tag event for tag %s in ImageStream %s", params.Tag, labelForRepo(imageRepo))
 				continue
 			}
 
@@ -75,15 +75,13 @@ func (c *ImageChangeController) Handle(imageRepo *imageapi.ImageStream) error {
 			glog.V(2).Infof("Couldn't regenerate DeploymentConfig %s: %s", deployutil.LabelForDeploymentConfig(config), err)
 			continue
 		}
-
-		glog.V(4).Infof("Regenerated DeploymentConfig %s in response to image change trigger", deployutil.LabelForDeploymentConfig(config))
 	}
 
 	if anyFailed {
 		return fatalError(fmt.Sprintf("couldn't update some DeploymentConfig for trigger on ImageStream %s", labelForRepo(imageRepo)))
 	}
 
-	glog.V(4).Infof("Updated all DeploymentConfigs for trigger on ImageStream %s", labelForRepo(imageRepo))
+	glog.V(5).Infof("Updated all DeploymentConfigs for trigger on ImageStream %s", labelForRepo(imageRepo))
 	return nil
 }
 
@@ -124,7 +122,7 @@ func (c *ImageChangeController) regenerate(config *deployapi.DeploymentConfig) e
 
 	// No update occurred
 	if config.LatestVersion == newConfig.LatestVersion {
-		glog.V(4).Infof("No version difference for generated DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
+		glog.V(5).Infof("No version difference for generated DeploymentConfig %s", deployutil.LabelForDeploymentConfig(config))
 		return nil
 	}
 
@@ -134,7 +132,7 @@ func (c *ImageChangeController) regenerate(config *deployapi.DeploymentConfig) e
 		return err
 	}
 
-	glog.Infof("Regenerated DeploymentConfig %s for image updates", deployutil.LabelForDeploymentConfig(config))
+	glog.V(4).Infof("Regenerated DeploymentConfig %s for image updates", deployutil.LabelForDeploymentConfig(config))
 	return nil
 }
 


### PR DESCRIPTION
Decrease the severity of many common deployment trigger controller
logs which are almost never useful except when debugging in a scenario
where the user has access to the API server and can just increase the
log level and retry for additional details.

Many of these logs are being emitted at V(2) which is extremely spammy
in the master logs for default installations.