### PR TITLE
allow role resolution errors in RARs

### DIFF
--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -59,15 +59,21 @@ func (a *openshiftAuthorizer) Authorize(ctx kapi.Context, passedAttributes Autho
 	return false, denyReason, nil
 }
 
+// GetAllowedSubjects returns the subjects it knows can perform the action.
+// If we got an error, then the list of subjects may not be complete, but it does not contain any incorrect names.
+// This is done because policy rules are purely additive and policy determinations
+// can be made on the basis of those rules that are found.
 func (a *openshiftAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes AuthorizationAttributes) (sets.String, sets.String, error) {
+	errs := []error{}
+
 	masterContext := kapi.WithNamespace(ctx, kapi.NamespaceNone)
 	globalUsers, globalGroups, err := a.getAllowedSubjectsFromNamespaceBindings(masterContext, attributes)
 	if err != nil {
-		return nil, nil, err
+		errs = append(errs, err)
 	}
 	localUsers, localGroups, err := a.getAllowedSubjectsFromNamespaceBindings(ctx, attributes)
 	if err != nil {
-		return nil, nil, err
+		errs = append(errs, err)
 	}
 
 	users := sets.String{}
@@ -78,11 +84,13 @@ func (a *openshiftAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes Au
 	groups.Insert(globalGroups.List()...)
 	groups.Insert(localGroups.List()...)
 
-	return users, groups, nil
+	return users, groups, kerrors.NewAggregate(errs)
 }
 
 func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.Context, passedAttributes AuthorizationAttributes) (sets.String, sets.String, error) {
 	attributes := coerceToDefaultAuthorizationAttributes(passedAttributes)
+
+	errs := []error{}
 
 	roleBindings, err := a.ruleResolver.GetRoleBindings(ctx)
 	if err != nil {
@@ -94,13 +102,18 @@ func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.C
 	for _, roleBinding := range roleBindings {
 		role, err := a.ruleResolver.GetRole(roleBinding)
 		if err != nil {
-			return nil, nil, err
+			// If we got an error, then the list of subjects may not be complete, but it does not contain any incorrect names.
+			// This is done because policy rules are purely additive and policy determinations
+			// can be made on the basis of those rules that are found.
+			errs = append(errs, err)
+			continue
 		}
 
 		for _, rule := range role.Rules() {
 			matches, err := attributes.RuleMatches(rule)
 			if err != nil {
-				return nil, nil, err
+				errs = append(errs, err)
+				continue
 			}
 
 			if matches {
@@ -110,7 +123,7 @@ func (a *openshiftAuthorizer) getAllowedSubjectsFromNamespaceBindings(ctx kapi.C
 		}
 	}
 
-	return users, groups, nil
+	return users, groups, kerrors.NewAggregate(errs)
 }
 
 // authorizeWithNamespaceRules returns isAllowed, reason, and error.  If an error is returned, isAllowed and reason are still valid.  This seems strange

--- a/pkg/authorization/registry/localresourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest_test.go
@@ -122,25 +122,6 @@ func TestNoErrors(t *testing.T) {
 	test.runTest(t)
 }
 
-func TestErrors(t *testing.T) {
-	test := &resourceAccessTest{
-		authorizer: &testAuthorizer{
-			users:  sets.String{},
-			groups: sets.String{},
-			err:    "some-random-failure",
-		},
-		reviewRequest: &authorizationapi.LocalResourceAccessReview{
-			Action: authorizationapi.AuthorizationAttributes{
-				Namespace: "unittest",
-				Verb:      "get",
-				Resource:  "pods",
-			},
-		},
-	}
-
-	test.runTest(t)
-}
-
 func (r *resourceAccessTest) runTest(t *testing.T) {
 	storage := NewREST(resourceaccessreview.NewRegistry(resourceaccessreview.NewREST(r.authorizer)))
 

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -52,10 +52,7 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 
 	requestContext := kapi.WithNamespace(ctx, resourceAccessReview.Action.Namespace)
 	attributes := authorizer.ToDefaultAuthorizationAttributes(resourceAccessReview.Action)
-	users, groups, err := r.authorizer.GetAllowedSubjects(requestContext, attributes)
-	if err != nil {
-		return nil, err
-	}
+	users, groups, _ := r.authorizer.GetAllowedSubjects(requestContext, attributes)
 
 	response := &authorizationapi.ResourceAccessReviewResponse{
 		Namespace: resourceAccessReview.Action.Namespace,

--- a/pkg/authorization/registry/resourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest_test.go
@@ -106,24 +106,6 @@ func TestNoErrors(t *testing.T) {
 	test.runTest(t)
 }
 
-func TestErrors(t *testing.T) {
-	test := &resourceAccessTest{
-		authorizer: &testAuthorizer{
-			users:  sets.String{},
-			groups: sets.String{},
-			err:    "some-random-failure",
-		},
-		reviewRequest: &authorizationapi.ResourceAccessReview{
-			Action: authorizationapi.AuthorizationAttributes{
-				Verb:     "get",
-				Resource: "pods",
-			},
-		},
-	}
-
-	test.runTest(t)
-}
-
 func (r *resourceAccessTest) runTest(t *testing.T) {
 	storage := REST{r.authorizer}
 

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -299,6 +299,24 @@ func TestAuthorizationResourceAccessReview(t *testing.T) {
 		test.response.Groups.Insert("system:cluster-readers")
 		test.run(t)
 	}
+
+	{
+		if err := clusterAdminClient.ClusterRoles().Delete(bootstrappolicy.AdminRoleName); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		test := localResourceAccessReviewTest{
+			clientInterface: clusterAdminClient.LocalResourceAccessReviews("mallet-project"),
+			review:          localRequestWhoCanViewDeployments,
+			response: authorizationapi.ResourceAccessReviewResponse{
+				Users:     sets.NewString("edgar"),
+				Groups:    globalClusterAdminGroups,
+				Namespace: "mallet-project",
+			},
+		}
+		test.response.Users.Insert(globalClusterAdminUsers.List()...)
+		test.response.Groups.Insert("system:cluster-readers")
+		test.run(t)
+	}
 }
 
 type subjectAccessReviewTest struct {


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1192310.

This allows role and rolebinding resolution problems during an RAR without failures.  This is ok because we never return too broad a list.