### PR TITLE
new-app: Better output in case of invalid Dockerfile

### DIFF
--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -90,14 +90,14 @@ func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, in io.Rea
 		config.Dockerfile = string(data)
 	}
 
-	if err := setupAppConfig(f, c, args, config); err != nil {
+	if err := setupAppConfig(f, out, c, args, config); err != nil {
 		return err
 	}
 
 	if err := setAppConfigLabels(c, config); err != nil {
 		return err
 	}
-	result, err := config.RunBuilds(out, c.Out())
+	result, err := config.RunBuilds()
 	if err != nil {
 		if errs, ok := err.(errors.Aggregate); ok {
 			if len(errs.Errors()) == 1 {

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -787,7 +787,8 @@ func TestRunAll(t *testing.T) {
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
-		res, err := test.config.RunAll(os.Stdout, os.Stderr)
+		test.config.Out, test.config.ErrOut = os.Stdout, os.Stderr
+		res, err := test.config.RunAll()
 		if err != test.expectedErr {
 			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
 			continue
@@ -1000,7 +1001,8 @@ func TestRunBuild(t *testing.T) {
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
-		res, err := test.config.RunBuilds(os.Stdout, os.Stderr)
+		test.config.Out, test.config.ErrOut = os.Stdout, os.Stderr
+		res, err := test.config.RunBuilds()
 		if (test.expectedErr == nil && err != nil) || (test.expectedErr != nil && !test.expectedErr(err)) {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 			continue
@@ -1078,7 +1080,8 @@ func TestNewBuildEnvVars(t *testing.T) {
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
-		res, err := test.config.RunBuilds(os.Stdout, os.Stderr)
+		test.config.Out, test.config.ErrOut = os.Stdout, os.Stderr
+		res, err := test.config.RunBuilds()
 		if err != test.expectedErr {
 			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
 			continue
@@ -1133,7 +1136,8 @@ func TestNewAppBuildConfigEnvVars(t *testing.T) {
 
 	for _, test := range tests {
 		test.config.refBuilder = &app.ReferenceBuilder{}
-		res, err := test.config.RunAll(os.Stdout, os.Stderr)
+		test.config.Out, test.config.ErrOut = os.Stdout, os.Stderr
+		res, err := test.config.RunAll()
 		if err != test.expectedErr {
 			t.Errorf("%s: Error mismatch! Expected %v, got %v", test.name, test.expectedErr, err)
 			continue


### PR DESCRIPTION
Remove logging level for informing that a provided Dockerfile is invalid
and recommend running 'oc status' only when new-app has created something

Closes https://github.com/openshift/origin/issues/4812

@smarterclayton @rhcarvalho 

Removed the glog call in favor of fmt since it's less verbose
```
[vagrant@openshiftdev sample-app]$ oc new-app --code=../.. --strategy=docker
I0926 18:34:30.499079    2374 newapp.go:318] The Dockerfile for the repository "/data/src/github.com/openshift/origin" could not be parsed - no image stream can be created for the FROM
[vagrant@openshiftdev sample-app]$ oc new-app --code=../.. --strategy=docker
The Dockerfile for the repository "/data/src/github.com/openshift/origin" could not be parsed - no image stream can be created for the FROM
```