### PR TITLE
new-app: Actually use the Docker parser

### DIFF
--- a/pkg/generate/dockerfile/parser_test.go
+++ b/pkg/generate/dockerfile/parser_test.go
@@ -41,11 +41,25 @@ func TestParse(t *testing.T) {
 }
 
 func TestParseInvalidFile(t *testing.T) {
-	p := NewParser()
-	_, err := p.Parse(invalidDockerfile())
+	tests := []struct {
+		name string
+		df   io.Reader
+	}{
+		{
+			name: "invalidated by us",
+			df:   invalidDockerfile(),
+		},
+		{
+			name: "invalidated by the Docker parser",
+			df:   invalidDockerfile2(),
+		},
+	}
 
-	if err == nil {
-		t.Errorf("Expected error to be reported. No error was returned.")
+	p := NewParser()
+	for _, test := range tests {
+		if _, err := p.Parse(test.df); err == nil {
+			t.Errorf("%s: Expected error to be reported. No error was returned.", test.name)
+		}
 	}
 }
 
@@ -93,5 +107,11 @@ this is some more useful stuff`
 func invalidDockerfile() io.Reader {
 	content := `FROM test
 TESTERROR`
+	return bytes.NewBufferString(content)
+}
+
+func invalidDockerfile2() io.Reader {
+	content := `FROM test
+ENV keyMissingValue`
 	return bytes.NewBufferString(content)
 }


### PR DESCRIPTION
The byte slice passed to the Docker parser for validation is empty. Reported by @rhcarvalho (https://github.com/openshift/origin/pull/4813#issuecomment-143534132). This fixes the issue and now both the Docker parser and our custom parsing get the same content.

@smarterclayton @mfojtik 