### PR TITLE
Add build timeout, by setting ActiveDeadlineSeconds on a build pod

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -13819,6 +13819,11 @@
      "resources": {
       "$ref": "v1.ResourceRequirements",
       "description": "the desired compute resources the build should have"
+     },
+     "completionDeadlineSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "optional duration in seconds the build may be active on a node before the system will actively try to mark it failed and kill associated containers; value must be a positive integer"
      }
     }
    },
@@ -14481,6 +14486,11 @@
      "resources": {
       "$ref": "v1.ResourceRequirements",
       "description": "the desired compute resources the build should have"
+     },
+     "completionDeadlineSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "optional duration in seconds the build may be active on a node before the system will actively try to mark it failed and kill associated containers; value must be a positive integer"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -918,6 +918,12 @@ func deepCopy_api_BuildSpec(in buildapi.BuildSpec, out *buildapi.BuildSpec, c *c
 	} else {
 		out.Resources = newVal.(pkgapi.ResourceRequirements)
 	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
+	}
 	return nil
 }
 

--- a/pkg/api/latest/tags_test.go
+++ b/pkg/api/latest/tags_test.go
@@ -49,6 +49,7 @@ func checkDescriptions(objType reflect.Type, seen *map[reflect.Type]bool, t *tes
 
 		descriptionTag := structField.Tag.Get("description")
 		if len(descriptionTag) == 0 {
+			t.Errorf("%v", structField.Tag)
 			t.Errorf("%v.%v does not have a description", objType, structField.Name)
 		}
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -771,6 +771,12 @@ func convert_api_BuildSpec_To_v1_BuildSpec(in *buildapi.BuildSpec, out *apiv1.Bu
 	if err := convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
+	}
 	return nil
 }
 
@@ -1158,6 +1164,12 @@ func convert_v1_BuildSpec_To_api_BuildSpec(in *apiv1.BuildSpec, out *buildapi.Bu
 	}
 	if err := convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
+	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
 	}
 	return nil
 }

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -942,6 +942,12 @@ func deepCopy_v1_BuildSpec(in apiv1.BuildSpec, out *apiv1.BuildSpec, c *conversi
 	} else {
 		out.Resources = newVal.(pkgapiv1.ResourceRequirements)
 	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -809,6 +809,12 @@ func convert_api_BuildSpec_To_v1beta3_BuildSpec(in *buildapi.BuildSpec, out *api
 	if err := convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
 	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
+	}
 	return nil
 }
 
@@ -1196,6 +1202,12 @@ func convert_v1beta3_BuildSpec_To_api_BuildSpec(in *apiv1beta3.BuildSpec, out *b
 	}
 	if err := convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
 		return err
+	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
 	}
 	return nil
 }

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -950,6 +950,12 @@ func deepCopy_v1beta3_BuildSpec(in apiv1beta3.BuildSpec, out *apiv1beta3.BuildSp
 	} else {
 		out.Resources = newVal.(pkgapiv1beta3.ResourceRequirements)
 	}
+	if in.CompletionDeadlineSeconds != nil {
+		out.CompletionDeadlineSeconds = new(int64)
+		*out.CompletionDeadlineSeconds = *in.CompletionDeadlineSeconds
+	} else {
+		out.CompletionDeadlineSeconds = nil
+	}
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -58,6 +58,11 @@ type BuildSpec struct {
 
 	// Compute resource requirements to execute the build
 	Resources kapi.ResourceRequirements
+
+	// Optional duration in seconds, counted from the time when a build pod gets
+	// scheduled in the system, that the build may be active on a node before the
+	// system actively tries to terminate the build; value must be positive integer
+	CompletionDeadlineSeconds *int64
 }
 
 // BuildStatus contains the status of a build

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -42,6 +42,11 @@ type BuildSpec struct {
 
 	// Compute resource requirements to execute the build
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"the desired compute resources the build should have"`
+
+	// Optional duration in seconds, counted from the time when a build pod gets
+	// scheduled in the system, that the build may be active on a node before the
+	// system actively tries to terminate the build; value must be positive integer
+	CompletionDeadlineSeconds *int64 `json:"completionDeadlineSeconds,omitempty" description:"optional duration in seconds the build may be active on a node before the system will actively try to mark it failed and kill associated containers; value must be a positive integer"`
 }
 
 // BuildStatus contains the status of a build

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -42,6 +42,11 @@ type BuildSpec struct {
 
 	// Compute resource requirements to execute the build
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"the desired compute resources the build should have"`
+
+	// Optional duration in seconds, counted from the time when a build pod gets
+	// scheduled in the system, that the build may be active on a node before the
+	// system actively tries to terminate the build; value must be positive integer
+	CompletionDeadlineSeconds *int64 `json:"completionDeadlineSeconds,omitempty" description:"optional duration in seconds the build may be active on a node before the system will actively try to mark it failed and kill associated containers; value must be a positive integer"`
 }
 
 // BuildStatus contains the status of a build

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -125,6 +125,11 @@ func validateBuildSpec(spec *buildapi.BuildSpec) fielderrors.ValidationErrorList
 	if spec.Revision != nil {
 		allErrs = append(allErrs, validateRevision(spec.Revision).Prefix("revision")...)
 	}
+	if spec.CompletionDeadlineSeconds != nil {
+		if *spec.CompletionDeadlineSeconds <= 0 {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("completionDeadlineSeconds", spec.CompletionDeadlineSeconds, "completionDeadlineSeconds must be a positive integer greater than 0"))
+		}
+	}
 
 	allErrs = append(allErrs, validateOutput(&spec.Output).Prefix("output")...)
 	allErrs = append(allErrs, validateStrategy(&spec.Strategy).Prefix("strategy")...)

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -567,6 +567,7 @@ func TestValidateSource(t *testing.T) {
 }
 
 func TestValidateBuildSpec(t *testing.T) {
+	zero := int64(0)
 	longString := strings.Repeat("1234567890", 100*61)
 	shortString := "FROM foo"
 	errorCases := []struct {
@@ -873,6 +874,7 @@ func TestValidateBuildSpec(t *testing.T) {
 				},
 			},
 		},
+		// 13
 		{
 			string(fielderrors.ValidationErrorTypeInvalid) + "source.dockerfile",
 			&buildapi.BuildSpec{
@@ -886,6 +888,7 @@ func TestValidateBuildSpec(t *testing.T) {
 				},
 			},
 		},
+		// 14
 		{
 			string(fielderrors.ValidationErrorTypeInvalid) + "source.dockerfile",
 			&buildapi.BuildSpec{
@@ -900,6 +903,31 @@ func TestValidateBuildSpec(t *testing.T) {
 					Type:           buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
+			},
+		},
+		// 15
+		// invalid because CompletionDeadlineSeconds <= 0
+		{
+			string(fielderrors.ValidationErrorTypeInvalid) + "completionDeadlineSeconds",
+			&buildapi.BuildSpec{
+				Source: buildapi.BuildSource{
+					Type: buildapi.BuildSourceGit,
+					Git: &buildapi.GitBuildSource{
+						URI: "http://github.com/my/repository",
+					},
+					ContextDir: "context",
+				},
+				Strategy: buildapi.BuildStrategy{
+					Type:           buildapi.DockerBuildStrategyType,
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+				CompletionDeadlineSeconds: &zero,
 			},
 		},
 	}

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -70,6 +70,9 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 			RestartPolicy: kapi.RestartPolicyNever,
 		},
 	}
+	if build.Spec.CompletionDeadlineSeconds != nil {
+		pod.Spec.ActiveDeadlineSeconds = build.Spec.CompletionDeadlineSeconds
+	}
 
 	if err := setupBuildEnv(build, pod); err != nil {
 		return nil, err

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -67,6 +67,9 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 	pod.Spec.Containers[0].Resources = build.Spec.Resources
+	if build.Spec.CompletionDeadlineSeconds != nil {
+		pod.Spec.ActiveDeadlineSeconds = build.Spec.CompletionDeadlineSeconds
+	}
 
 	setupDockerSocket(pod)
 	setupDockerSecrets(pod, build.Spec.Output.PushSecret, strategy.PullSecret)

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -49,6 +49,9 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if len(container.VolumeMounts) != 4 {
 		t.Fatalf("Expected 4 volumes in container, got %d", len(container.VolumeMounts))
 	}
+	if *actual.Spec.ActiveDeadlineSeconds != 60 {
+		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
+	}
 	for i, expected := range []string{dockerSocketPath, DockerPushSecretMountPath, DockerPullSecretMountPath, sourceSecretMountPath} {
 		if container.VolumeMounts[i].MountPath != expected {
 			t.Fatalf("Expected %s in VolumeMount[%d], got %s", expected, i, container.VolumeMounts[i].MountPath)
@@ -89,6 +92,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 }
 
 func mockDockerBuild() *buildapi.Build {
+	timeout := int64(60)
 	return &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "dockerBuild",
@@ -131,6 +135,7 @@ func mockDockerBuild() *buildapi.Build {
 					kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
 				},
 			},
+			CompletionDeadlineSeconds: &timeout,
 		},
 		Status: buildapi.BuildStatus{
 			Phase: buildapi.BuildPhaseNew,

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -89,6 +89,9 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 	pod.Spec.Containers[0].Resources = build.Spec.Resources
+	if build.Spec.CompletionDeadlineSeconds != nil {
+		pod.Spec.ActiveDeadlineSeconds = build.Spec.CompletionDeadlineSeconds
+	}
 
 	setupDockerSocket(pod)
 	setupDockerSecrets(pod, build.Spec.Output.PushSecret, strategy.PullSecret)

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -96,6 +96,9 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	if len(actual.Spec.Volumes) != 4 {
 		t.Fatalf("Expected 4 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
+	if *actual.Spec.ActiveDeadlineSeconds != 60 {
+		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
+	}
 	if !kapi.Semantic.DeepEqual(container.Resources, expected.Spec.Resources) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, expected.Spec.Resources)
 	}
@@ -137,6 +140,7 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 }
 
 func mockSTIBuild() *buildapi.Build {
+	timeout := int64(60)
 	return &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "stiBuild",
@@ -184,6 +188,7 @@ func mockSTIBuild() *buildapi.Build {
 					kapi.ResourceName(kapi.ResourceMemory): resource.MustParse("10G"),
 				},
 			},
+			CompletionDeadlineSeconds: &timeout,
 		},
 		Status: buildapi.BuildStatus{
 			Phase: buildapi.BuildPhaseNew,

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -314,12 +314,13 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 	bcCopy := obj.(*buildapi.BuildConfig)
 	build := &buildapi.Build{
 		Spec: buildapi.BuildSpec{
-			ServiceAccount: serviceAccount,
-			Source:         bcCopy.Spec.Source,
-			Strategy:       bcCopy.Spec.Strategy,
-			Output:         bcCopy.Spec.Output,
-			Revision:       revision,
-			Resources:      bcCopy.Spec.Resources,
+			ServiceAccount:            serviceAccount,
+			Source:                    bcCopy.Spec.Source,
+			Strategy:                  bcCopy.Spec.Strategy,
+			Output:                    bcCopy.Spec.Output,
+			Revision:                  revision,
+			Resources:                 bcCopy.Spec.Resources,
+			CompletionDeadlineSeconds: bcCopy.Spec.CompletionDeadlineSeconds,
 		},
 		ObjectMeta: kapi.ObjectMeta{
 			Labels: bcCopy.Labels,

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/docker/docker/pkg/units"
 
@@ -248,6 +249,10 @@ func describeBuildSpec(p buildapi.BuildSpec, out *tabwriter.Writer) {
 		if len(p.Revision.Git.Message) > 0 {
 			formatString(out, "Revision Message", p.Revision.Git.Message)
 		}
+	}
+
+	if p.CompletionDeadlineSeconds != nil {
+		formatString(out, "Fail Build After", time.Duration(*p.CompletionDeadlineSeconds)*time.Second)
 	}
 }
 

--- a/test/extended/builds/completiondeadlineseconds.go
+++ b/test/extended/builds/completiondeadlineseconds.go
@@ -1,0 +1,84 @@
+package builds
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: build with CompletionDeadlineSeconds", func() {
+	defer g.GinkgoRecover()
+	var (
+		sourceFixture = exutil.FixturePath("..", "extended", "fixtures", "test-cds-sourcebuild.json")
+		dockerFixture = exutil.FixturePath("..", "extended", "fixtures", "test-cds-dockerbuild.json")
+		oc            = exutil.NewCLI("cli-start-build", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.Describe("oc start-build source-build --wait", func() {
+		g.It("Source: should start a build and wait for the build failed and build pod being killed by kubelet", func() {
+
+			g.By("calling oc create source-build")
+			err := oc.Run("create").Args("-f", sourceFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting the build with --wait flag")
+			_, err = oc.Run("start-build").Args("source-build", "--wait").Output()
+			o.Expect(err).To(o.HaveOccurred())
+
+			g.By("verifying the build status")
+			builds, err := oc.REST().Builds(oc.Namespace()).List(labels.Everything(), fields.Everything())
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(builds.Items).To(o.HaveLen(1))
+
+			build := builds.Items[0]
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseFailed))
+
+			g.By("verifying the build pod status")
+			pod, err := oc.KubeREST().Pods(oc.Namespace()).Get(buildutil.GetBuildPodName(&build))
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(pod.Status.Phase).Should(o.BeEquivalentTo(kapi.PodFailed))
+			o.Expect(pod.Status.Reason).Should(o.ContainSubstring("DeadlineExceeded"))
+		})
+	})
+
+	g.Describe("oc start-build docker-build --wait", func() {
+		g.It("Docker: should start a build and wait for the build failed and build pod being killed by kubelet", func() {
+
+			g.By("calling oc create docker-build")
+			err := oc.Run("create").Args("-f", dockerFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting the build with --wait flag")
+			_, err = oc.Run("start-build").Args("docker-build", "--wait").Output()
+			o.Expect(err).To(o.HaveOccurred())
+
+			g.By("verifying the build status")
+			builds, err := oc.REST().Builds(oc.Namespace()).List(labels.Everything(), fields.Everything())
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(builds.Items).To(o.HaveLen(1))
+
+			build := builds.Items[0]
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseFailed))
+
+			g.By("verifying the build pod status")
+			pod, err := oc.KubeREST().Pods(oc.Namespace()).Get(buildutil.GetBuildPodName(&build))
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(pod.Status.Phase).Should(o.BeEquivalentTo(kapi.PodFailed))
+			o.Expect(pod.Status.Reason).Should(o.ContainSubstring("DeadlineExceeded"))
+		})
+	})
+
+})

--- a/test/extended/fixtures/test-cds-dockerbuild.json
+++ b/test/extended/fixtures/test-cds-dockerbuild.json
@@ -1,0 +1,27 @@
+{
+  "kind":"BuildConfig",
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"docker-build"
+  },
+  "spec":{
+    "completionDeadlineSeconds": 5,
+    "triggers":[],
+    "source":{
+      "type":"Git",
+      "git":{
+        "uri":"https://github.com/openshift/origin"
+      },
+      "contextDir":"test/extended/fixtures/test-build-app"
+    },
+    "strategy":{
+      "type":"Docker",
+      "dockerStrategy":{
+        "from":{
+          "kind":"DockerImage",
+          "name":"openshift/ruby-20-centos7"
+        }
+      }
+    }
+  }
+}

--- a/test/extended/fixtures/test-cds-sourcebuild.json
+++ b/test/extended/fixtures/test-cds-sourcebuild.json
@@ -1,0 +1,44 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "origin-ruby-sample"
+      },
+      "spec": {},
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "source-build"
+      },
+      "spec": {
+        "completionDeadlineSeconds": 5,
+        "triggers": [],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          }
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/ruby-20-centos7"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
@bparees this is partially dealing with the problems mentioned in #341 by adding possibility to timeout build. But there are two questions:

1. The name of the variable, I've chosen exactly the same name you apply to a pod, which is `ActiveDeadlineSeconds`, is it ok?
2. Do we want to default that to some reasonable value, eg. 30mins, for now it's not. If yes - will we allow disabling it, by setting it to zero or negative value?

One last thing, you specify this timeout in seconds, exactly as you do with ADS.