### PR TITLE
api group support for authorizer

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14704,6 +14704,7 @@
     "id": "v1.PolicyRule",
     "required": [
      "verbs",
+     "apiGroups",
      "resources"
     ],
     "properties": {
@@ -14717,6 +14718,13 @@
      "attributeRestrictions": {
       "type": "string",
       "description": "vary depending on what the authorizer supports.  If the authorizer does not recognize how to handle the specified value, it should report an error."
+     },
+     "apiGroups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "list of API groups this rule applies to.  * represents all API groups."
      },
      "resources": {
       "type": "array",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -429,6 +429,14 @@ func deepCopy_api_PolicyRule(in api.PolicyRule, out *api.PolicyRule, c *conversi
 	} else {
 		out.AttributeRestrictions = newVal.(runtime.EmbeddedObject)
 	}
+	if in.APIGroups != nil {
+		out.APIGroups = make([]string, len(in.APIGroups))
+		for i := range in.APIGroups {
+			out.APIGroups[i] = in.APIGroups[i]
+		}
+	} else {
+		out.APIGroups = nil
+	}
 	if in.Resources != nil {
 		out.Resources = make(sets.String)
 		for key, val := range in.Resources {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -461,6 +461,14 @@ func deepCopy_v1_PolicyRule(in v1.PolicyRule, out *v1.PolicyRule, c *conversion.
 	} else {
 		out.AttributeRestrictions = newVal.(runtime.RawExtension)
 	}
+	if in.APIGroups != nil {
+		out.APIGroups = make([]string, len(in.APIGroups))
+		for i := range in.APIGroups {
+			out.APIGroups[i] = in.APIGroups[i]
+		}
+	} else {
+		out.APIGroups = nil
+	}
 	if in.Resources != nil {
 		out.Resources = make([]string, len(in.Resources))
 		for i := range in.Resources {

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -461,6 +461,14 @@ func deepCopy_v1beta3_PolicyRule(in v1beta3.PolicyRule, out *v1beta3.PolicyRule,
 	} else {
 		out.AttributeRestrictions = newVal.(runtime.RawExtension)
 	}
+	if in.APIGroups != nil {
+		out.APIGroups = make([]string, len(in.APIGroups))
+		for i := range in.APIGroups {
+			out.APIGroups[i] = in.APIGroups[i]
+		}
+	} else {
+		out.APIGroups = nil
+	}
 	if in.ResourceKinds != nil {
 		out.ResourceKinds = make([]string, len(in.ResourceKinds))
 		for i := range in.ResourceKinds {

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -17,6 +17,7 @@ import (
 const (
 	// PolicyName is the name of Policy
 	PolicyName     = "default"
+	APIGroupAll    = "*"
 	ResourceAll    = "*"
 	VerbAll        = "*"
 	NonResourceAll = "*"
@@ -119,6 +120,10 @@ type PolicyRule struct {
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
 	AttributeRestrictions kruntime.EmbeddedObject
+	// APIGroups is the name of the APIGroup that contains the resources.  If this field is empty, then both kubernetes and origin API groups are assumed.
+	// That means that if an action is requested against one of the enumerated resources in either the kubernetes or the origin API group, the request
+	// will be allowed
+	APIGroups []string
 	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
 	Resources sets.String
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.

--- a/pkg/authorization/api/v1/conversion.go
+++ b/pkg/authorization/api/v1/conversion.go
@@ -134,6 +134,8 @@ func convert_v1_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.PolicyRu
 		return err
 	}
 
+	out.APIGroups = in.APIGroups
+
 	out.Resources = sets.String{}
 	out.Resources.Insert(in.Resources...)
 
@@ -151,6 +153,8 @@ func convert_api_PolicyRule_To_v1_PolicyRule(in *newer.PolicyRule, out *PolicyRu
 	if err := s.Convert(&in.AttributeRestrictions, &out.AttributeRestrictions, 0); err != nil {
 		return err
 	}
+
+	out.APIGroups = in.APIGroups
 
 	out.Resources = []string{}
 	out.Resources = append(out.Resources, in.Resources.List()...)

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -21,6 +21,10 @@ type PolicyRule struct {
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
 	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions,omitempty" description:"vary depending on what the authorizer supports.  If the authorizer does not recognize how to handle the specified value, it should report an error."`
+	// APIGroups is the name of the APIGroup that contains the resources.  If this field is empty, then both kubernetes and origin API groups are assumed.
+	// That means that if an action is requested against one of the enumerated resources in either the kubernetes or the origin API group, the request
+	// will be allowed
+	APIGroups []string `json:"apiGroups" description:"list of API groups this rule applies to.  * represents all API groups."`
 	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
 	Resources []string `json:"resources" description:"list of resources this rule applies to.  * represents all resources."`
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.

--- a/pkg/authorization/api/v1beta3/conversion.go
+++ b/pkg/authorization/api/v1beta3/conversion.go
@@ -134,6 +134,8 @@ func convert_v1beta3_PolicyRule_To_api_PolicyRule(in *PolicyRule, out *newer.Pol
 		return err
 	}
 
+	out.APIGroups = in.APIGroups
+
 	out.Resources = sets.String{}
 	out.Resources.Insert(in.Resources...)
 	out.Resources.Insert(in.ResourceKinds...)
@@ -152,6 +154,8 @@ func convert_api_PolicyRule_To_v1beta3_PolicyRule(in *newer.PolicyRule, out *Pol
 	if err := s.Convert(&in.AttributeRestrictions, &out.AttributeRestrictions, 0); err != nil {
 		return err
 	}
+
+	out.APIGroups = in.APIGroups
 
 	out.Resources = []string{}
 	out.Resources = append(out.Resources, in.Resources.List()...)

--- a/pkg/authorization/api/v1beta3/types.go
+++ b/pkg/authorization/api/v1beta3/types.go
@@ -21,6 +21,10 @@ type PolicyRule struct {
 	// AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports.
 	// If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.
 	AttributeRestrictions kruntime.RawExtension `json:"attributeRestrictions,omitempty"`
+	// APIGroups is the name of the APIGroup that contains the resources.  If this field is empty, then both kubernetes and origin API groups are assumed.
+	// That means that if an action is requested against one of the enumerated resources in either the kubernetes or the origin API group, the request
+	// will be allowed
+	APIGroups []string `json:"apiGroups" description:"list of API groups this rule applies to.  * represents all API groups."`
 	// ResourceKinds is a list of resources this rule applies to.  ResourceAll represents all resources.
 	// DEPRECATED
 	ResourceKinds []string `json:"resourceKinds,omitempty"`

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -157,6 +157,7 @@ func coerceToDefaultAuthorizationAttributes(passedAttributes AuthorizationAttrib
 	attributes, ok := passedAttributes.(*DefaultAuthorizationAttributes)
 	if !ok {
 		attributes = &DefaultAuthorizationAttributes{
+			APIGroup:          passedAttributes.GetAPIGroup(),
 			Verb:              passedAttributes.GetVerb(),
 			RequestAttributes: passedAttributes.GetRequestAttributes(),
 			Resource:          passedAttributes.GetResource(),

--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -34,6 +34,119 @@ type authorizeTest struct {
 	expectedError   string
 }
 
+func TestAPIGroupDeny(t *testing.T) {
+	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Anna"}),
+		attributes: &DefaultAuthorizationAttributes{
+			Verb:     "list",
+			APIGroup: "group",
+			Resource: "pods",
+		},
+		expectedAllowed: false,
+		expectedReason:  `User "Anna" cannot list group/pods in project "adze"`,
+	}
+	test.clusterPolicies = newDefaultClusterPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.clusterBindings = newDefaultClusterPolicyBindings()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.test(t)
+}
+
+func TestAPIGroupDefaultAllow(t *testing.T) {
+	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Anna"}),
+		attributes: &DefaultAuthorizationAttributes{
+			Verb:     "list",
+			Resource: "pods",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in adze",
+	}
+	test.clusterPolicies = newDefaultClusterPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.clusterBindings = newDefaultClusterPolicyBindings()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.test(t)
+}
+
+func TestAPIGroupAllAllow(t *testing.T) {
+	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Anna"}),
+		attributes: &DefaultAuthorizationAttributes{
+			Verb:     "list",
+			APIGroup: "group",
+			Resource: "pods",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in adze",
+	}
+	test.clusterPolicies = newDefaultClusterPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.clusterBindings = newDefaultClusterPolicyBindings()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.policies[0].Roles["by-group"] = &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "by-group",
+			Namespace: "adze",
+		},
+		Rules: []authorizationapi.PolicyRule{
+			{
+				Verbs: sets.NewString("list"), APIGroups: []string{"group"}, Resources: sets.NewString("pods"),
+			},
+		},
+	}
+	test.bindings[0].RoleBindings["by-group"] = &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "by-group",
+		},
+		RoleRef: kapi.ObjectReference{
+			Namespace: "adze",
+			Name:      "by-group",
+		},
+		Subjects: []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "Anna"}},
+	}
+	test.test(t)
+}
+
+func TestAPIAllAllow(t *testing.T) {
+	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "adze"), &user.DefaultInfo{Name: "Anna"}),
+		attributes: &DefaultAuthorizationAttributes{
+			Verb:     "list",
+			APIGroup: "group",
+			Resource: "pods",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by rule in adze",
+	}
+	test.clusterPolicies = newDefaultClusterPolicies()
+	test.policies = append(test.policies, newAdzePolicies()...)
+	test.clusterBindings = newDefaultClusterPolicyBindings()
+	test.bindings = append(test.bindings, newAdzeBindings()...)
+	test.policies[0].Roles["by-group"] = &authorizationapi.Role{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      "by-group",
+			Namespace: "adze",
+		},
+		Rules: []authorizationapi.PolicyRule{
+			{
+				Verbs: sets.NewString("list"), APIGroups: []string{authorizationapi.APIGroupAll}, Resources: sets.NewString("pods"),
+			},
+		},
+	}
+	test.bindings[0].RoleBindings["by-group"] = &authorizationapi.RoleBinding{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "by-group",
+		},
+		RoleRef: kapi.ObjectReference{
+			Namespace: "adze",
+			Name:      "by-group",
+		},
+		Subjects: []kapi.ObjectReference{{Kind: authorizationapi.UserKind, Name: "Anna"}},
+	}
+	test.test(t)
+}
+
 func TestResourceNameDeny(t *testing.T) {
 	test := &authorizeTest{
 		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceNone), &user.DefaultInfo{Name: "just-a-user"}),

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -20,6 +20,7 @@ type AuthorizationAttributeBuilder interface {
 type AuthorizationAttributes interface {
 	GetVerb() string
 	GetAPIVersion() string
+	GetAPIGroup() string
 	// GetResource returns the resource type.  If IsNonResourceURL() is true, then GetResource() is "".
 	GetResource() string
 	GetResourceName() string

--- a/pkg/authorization/authorizer/messages.go
+++ b/pkg/authorization/authorizer/messages.go
@@ -27,17 +27,19 @@ func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *Forbid
 		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot "{{.Attributes.GetVerb}}" "{{.Attributes.GetResource}}" with name "{{.Attributes.GetResourceName}}" in project "{{.Namespace}}"`),
 	}
 
+	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}{{.Attributes.GetAPIGroup}}/{{end}}"
+
 	// general messages
-	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create {{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create {{.Attributes.GetResource}} at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get {{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get {{.Attributes.GetResource}} at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list {{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list all {{.Attributes.GetResource}} in the cluster`))
-	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update {{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update {{.Attributes.GetResource}} at the cluster scope`))
-	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete {{.Attributes.GetResource}} in project "{{.Namespace}}"`))
-	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete {{.Attributes.GetResource}} at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("get", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot get `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("list", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot list all `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in the cluster`))
+	messageResolver.addNamespacedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("update", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot update `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
+	messageResolver.addNamespacedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))
+	messageResolver.addRootScopedForbiddenMessageMaker("delete", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot delete `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} at the cluster scope`))
 
 	// project request rejection
 	projectRequestDeny := projectRequestForbiddenTemplate


### PR DESCRIPTION
Adds backwards compatible support for `APIGroups` to our authorizer.  This is not plumbed all the way through, due to limitations in the kube `APIRequestInfoResolver`.  That means that for now, all resource appear to be in the default group.

@liggitt 