### PR TITLE
Remove templates.js from bindata and fix HTML minification

### DIFF
--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -384,10 +384,10 @@ module.exports = function (grunt) {
       dist: {
         cwd: '<%= yeoman.app %>',
         src: 'views/**/*.html',
-        dest: '<%= yeoman.dist %>/scripts/templates.js',
+        dest: '.tmp/scripts/templates.js',
         options: {
           module: 'openshiftConsole',
-          htmlmin: '<%= htmlmin.dist %>',
+          htmlmin: '<%= htmlmin.dist.options %>',
           usemin: 'scripts/scripts.js'
         }
       }

--- a/assets/npm-shrinkwrap.json
+++ b/assets/npm-shrinkwrap.json
@@ -1,0 +1,14 @@
+{
+  "name": "assets",
+  "version": "0.0.0",
+  "dependencies": {
+    "grunt-angular-templates": {
+      "version": "0.5.7",
+      "dependencies": {
+        "html-minifier": {
+          "version": "0.7.2"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Set `dest` to `.tmp/scripts/templates.js` so `templates.js` isn't included in bindata.
* Fix grunt-angular-templates `htmlmin` setting.
* Force grunt-angular-templates to use html-minifier 0.7.2 with npm shrinkwrap. This html-minifier version doesn't have the bug with `preserveLineBreaks: true`.

Related to #4582