### PR TITLE
Bug 1266859: expose: Truncate service names

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/expose.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/expose.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/util"
 )
 
 // ExposeOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -128,7 +129,11 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 	names := generator.ParamNames()
 	params := kubectl.MakeParams(cmd, names)
-	params["default-name"] = info.Name
+	name := info.Name
+	if len(name) > util.DNS952LabelMaxLength {
+		name = name[:util.DNS952LabelMaxLength]
+	}
+	params["default-name"] = name
 
 	// For objects that need a pod selector, derive it from the exposed object in case a user
 	// didn't explicitly specify one via --selector


### PR DESCRIPTION
@smarterclayton we are currently truncating dc names in new-app for getting a valid service name. Is it ok for oc expose to have the same behavior?

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1266859