### PR TITLE
Fix the reference of openshift command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,10 @@ endif
 #
 # Example:
 #   make run
+OS_OUTPUT_BINPATH=$(shell bash -c 'source hack/common.sh; echo $${OS_OUTPUT_BINPATH}')
+PLATFORM=$(shell bash -c 'source hack/common.sh; os::build::host_platform')
 run: build
-	$(OUT_DIR)/local/go/bin/openshift start
+	$(OS_OUTPUT_BINPATH)/$(PLATFORM)/openshift start
 .PHONY: run
 
 # Remove all build artifacts.


### PR DESCRIPTION
The changes of the reference of the openshift command that has been made these days affects the reference in Makefile as well. I'm proposing this change to fix that issue.