### PR TITLE
updated template use

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -382,7 +382,7 @@ Available formats include:
 An example of using `-o template` to retrieve the *name* of the first build:
 
 ```bash
-$ oc get builds -o template -t "{{with index .items 0}}{{.metadata.name}}{{end}}"
+$ oc get builds -o template --template="{{with index .items 0}}{{.metadata.name}}{{end}}"
 ```
 
 #### Selectors

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -32,7 +32,7 @@ To create this service account:
 
     # You may either create a new SCC or use an existing SCC.  The following command will
     # display existing SCCs and if they support host network and host ports.
-    $ oc get scc -t "{{range .items}}{{.metadata.name}}: n={{.allowHostNetwork}},p={{.allowHostPorts}}; {{end}}"
+    $ oc get scc --template="{{range .items}}{{.metadata.name}}: n={{.allowHostNetwork}},p={{.allowHostPorts}}; {{end}}"
     privileged: n=true,p=true; restricted: n=false,p=false;
 
     $ oc edit scc <name>

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -357,7 +357,7 @@ the ip address shown below with the correct one for your environment.
 
             # You may either create a new SCC or use an existing SCC.  The following command will
             # display existing SCCs and if they support host network and host ports.
-            $ oc get scc -t "{{range .items}}{{.metadata.name}}: n={{.allowHostNetwork}},p={{.allowHostPorts}}; {{end}}"
+            $ oc get scc --template="{{range .items}}{{.metadata.name}}: n={{.allowHostNetwork}},p={{.allowHostPorts}}; {{end}}"
             privileged: n=true,p=true; restricted: n=false,p=false;
 
             # Edit your security context constraint to add the new service account in the users section

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -255,7 +255,7 @@ echo "config files: ok"
 
 # from this point every command will use config from the KUBECONFIG env var
 export KUBECONFIG="${HOME}/.kube/non-default-config"
-export CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template -t '{{index . "current-context"}}')
+export CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template --template='{{index . "current-context"}}')
 
 
 # NOTE: Do not add tests here, add them to test/cmd/*.

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -102,7 +102,7 @@ IMAGE_WORKING_DIR=/var/lib/openshift
 docker cp origin:${IMAGE_WORKING_DIR}/openshift.local.config ${BASETMPDIR}
 
 export ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
-export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template -t '{{index . "current-context"}}')
+export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template --template='{{index . "current-context"}}')
 sudo chmod -R a+rwX "${ADMIN_KUBECONFIG}"
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
 echo "[INFO] To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -107,7 +107,7 @@ function configure_os_server {
 
 	# Make oc use ${MASTER_CONFIG_DIR}/admin.kubeconfig, and ignore anything in the running user's $HOME dir
 	export ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
-	export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template -t '{{index . "current-context"}}')
+	export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template --template='{{index . "current-context"}}')
 	sudo chmod -R a+rwX "${ADMIN_KUBECONFIG}"
 	echo "[INFO] To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
 }
@@ -512,7 +512,7 @@ function install_registry {
 }
 
 function wait_for_registry {
-	wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=${ADMIN_KUBECONFIG} || echo "0")" != "0" ]]' $((5*TIME_MIN))
+	wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1 --template="{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=${ADMIN_KUBECONFIG} || echo "0")" != "0" ]]' $((5*TIME_MIN))
 }
 
 
@@ -521,7 +521,7 @@ function wait_for_registry {
 function os::build:wait_for_start() {
 	echo "[INFO] Waiting for $1 namespace build to start"
 	wait_for_command "oc get -n $1 builds | grep -i running" $((10*TIME_MIN)) "oc get -n $1 builds | grep -i -e failed -e error"
-	BUILD_ID=`oc get -n $1 builds  --output-version=v1 -t "{{with index .items 0}}{{.metadata.name}}{{end}}"`
+	BUILD_ID=`oc get -n $1 builds  --output-version=v1 --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
 	echo "[INFO] Build ${BUILD_ID} started"
 }
 
@@ -530,7 +530,7 @@ function os::build:wait_for_start() {
 function os::build:wait_for_end() {
 	echo "[INFO] Waiting for $1 namespace build to complete"
 	wait_for_command "oc get -n $1 builds | grep -i complete" $((10*TIME_MIN)) "oc get -n $1 builds | grep -i -e failed -e error"
-	BUILD_ID=`oc get -n $1 builds --output-version=v1beta3 -t "{{with index .items 0}}{{.metadata.name}}{{end}}"`
+	BUILD_ID=`oc get -n $1 builds --output-version=v1beta3 --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
 	echo "[INFO] Build ${BUILD_ID} finished"
 	# TODO: fix
 	set +e

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -85,9 +85,9 @@ oc delete all -l name=mytemplate
 oc new-app https://github.com/openshift/ruby-hello-world
 [ "$(oc get dc/ruby-hello-world)" ]
 
-oc get dc/ruby-hello-world -t '{{ .spec.replicas }}' | grep -q 1
+oc get dc/ruby-hello-world --template='{{ .spec.replicas }}' | grep -q 1
 oc patch dc/ruby-hello-world -p '{"spec": {"replicas": 2}}'
-oc get dc/ruby-hello-world -t '{{ .spec.replicas }}' | grep -q 2
+oc get dc/ruby-hello-world --template='{{ .spec.replicas }}' | grep -q 2
 
 oc delete all -l app=ruby-hello-world
 [ ! "$(oc get dc/ruby-hello-world)" ]

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -17,7 +17,7 @@ oc export all --all-namespaces
 # make sure the deprecated flag doesn't fail
 oc export all --all
 
-[ "$(oc export svc -t '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | wc -l)" -ne 0 ]
+[ "$(oc export svc --template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | wc -l)" -ne 0 ]
 [ "$(oc export svc --as-template=template | grep 'kind: Template')" ]
 [ ! "$(oc export svc | grep 'clusterIP')" ]
 [ ! "$(oc export svc --exact | grep 'clusterIP: ""')" ]

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -28,43 +28,43 @@ echo "images: ok"
 oc get imageStreams
 oc create -f test/integration/fixtures/test-image-stream.json
 # verify that creating a registry fills out .status.dockerImageRepository
-if [ -z "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]; then
+if [ -z "$(oc get imageStreams test --template="{{.status.dockerImageRepository}}")" ]; then
   # create the registry
   oadm registry --credentials="${KUBECONFIG}" --images="${USE_IMAGES}" -n default
   # make sure stream.status.dockerImageRepository IS set
-  [ -n "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]
+  [ -n "$(oc get imageStreams test --template="{{.status.dockerImageRepository}}")" ]
 fi
 oc delete imageStreams test
-[ -z "$(oc get imageStreams test -t "{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams test --template="{{.status.dockerImageRepository}}")" ]
 
 oc create -f examples/image-streams/image-streams-centos7.json
-[ -n "$(oc get imageStreams ruby -t "{{.status.dockerImageRepository}}")" ]
-[ -n "$(oc get imageStreams nodejs -t "{{.status.dockerImageRepository}}")" ]
-[ -n "$(oc get imageStreams wildfly -t "{{.status.dockerImageRepository}}")" ]
-[ -n "$(oc get imageStreams mysql -t "{{.status.dockerImageRepository}}")" ]
-[ -n "$(oc get imageStreams postgresql -t "{{.status.dockerImageRepository}}")" ]
-[ -n "$(oc get imageStreams mongodb -t "{{.status.dockerImageRepository}}")" ]
+[ -n "$(oc get imageStreams ruby --template="{{.status.dockerImageRepository}}")" ]
+[ -n "$(oc get imageStreams nodejs --template="{{.status.dockerImageRepository}}")" ]
+[ -n "$(oc get imageStreams wildfly --template="{{.status.dockerImageRepository}}")" ]
+[ -n "$(oc get imageStreams mysql --template="{{.status.dockerImageRepository}}")" ]
+[ -n "$(oc get imageStreams postgresql --template="{{.status.dockerImageRepository}}")" ]
+[ -n "$(oc get imageStreams mongodb --template="{{.status.dockerImageRepository}}")" ]
 # verify the image repository had its tags populated
 tryuntil oc get imagestreamtags wildfly:latest
-[ -n "$(oc get imageStreams wildfly -t "{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}")" ]
+[ -n "$(oc get imageStreams wildfly --template="{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}")" ]
 oc delete imageStreams ruby
 oc delete imageStreams nodejs
 oc delete imageStreams wildfly
 #oc delete imageStreams mysql
 oc delete imageStreams postgresql
 oc delete imageStreams mongodb
-[ -z "$(oc get imageStreams ruby -t "{{.status.dockerImageRepository}}")" ]
-[ -z "$(oc get imageStreams nodejs -t "{{.status.dockerImageRepository}}")" ]
-[ -z "$(oc get imageStreams postgresql -t "{{.status.dockerImageRepository}}")" ]
-[ -z "$(oc get imageStreams mongodb -t "{{.status.dockerImageRepository}}")" ]
-[ -z "$(oc get imageStreams wildfly -t "{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams ruby --template="{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams nodejs --template="{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams postgresql --template="{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams mongodb --template="{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams wildfly --template="{{.status.dockerImageRepository}}")" ]
 tryuntil oc get imagestreamTags mysql:latest
-[ -n "$(oc get imagestreams mysql -t "{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}")" ]
+[ -n "$(oc get imagestreams mysql --template="{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}")" ]
 oc describe istag/mysql:latest
 [ "$(oc describe istag/mysql:latest | grep "Environment:")" ]
 [ "$(oc describe istag/mysql:latest | grep "Image Created:")" ]
 [ "$(oc describe istag/mysql:latest | grep "Image Name:")" ]
-name=$(oc get istag/mysql:latest -t '{{ .image.metadata.name }}')
+name=$(oc get istag/mysql:latest --template='{{ .image.metadata.name }}')
 imagename="isimage/mysql@${name:0:7}"
 oc describe "${imagename}"
 [ "$(oc describe ${imagename} | grep "Environment:")" ]
@@ -79,42 +79,42 @@ echo "import-image: ok"
 
 # oc tag
 oc tag mysql:latest tagtest:tag1
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 
 oc tag mysql@${name} tagtest:tag2
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 1).from.kind}}')" == "ImageStreamImage" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 1).from.kind}}')" == "ImageStreamImage" ]
 
 oc tag mysql:notfound tagtest:tag3
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 2).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 2).from.kind}}')" == "ImageStreamTag" ]
 
 oc tag --source=imagestreamtag mysql:latest tagtest:tag4
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 3).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 3).from.kind}}')" == "ImageStreamTag" ]
 
 oc tag --source=istag mysql:latest tagtest:tag5
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 4).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 4).from.kind}}')" == "ImageStreamTag" ]
 
 oc tag --source=imagestreamimage mysql@${name} tagtest:tag6
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 5).from.kind}}')" == "ImageStreamImage" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 5).from.kind}}')" == "ImageStreamImage" ]
 
 oc tag --source=isimage mysql@${name} tagtest:tag7
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 6).from.kind}}')" == "ImageStreamImage" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 6).from.kind}}')" == "ImageStreamImage" ]
 
 oc tag --source=docker mysql:latest tagtest:tag8
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 7).from.kind}}')" == "DockerImage" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 7).from.kind}}')" == "DockerImage" ]
 
 oc tag mysql:latest tagtest:zzz tagtest2:zzz
-[ "$(oc get is/tagtest -t '{{(index .spec.tags 8).from.kind}}')" == "ImageStreamTag" ]
-[ "$(oc get is/tagtest2 -t '{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest --template='{{(index .spec.tags 8).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest2 --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 
 # TODO: bug
 # oc tag registry-1.docker.io/openshift/origin:v1.0.4 newrepo:latest
 
 # test creating streams that don't exist
-[ -z "$(oc get imageStreams tagtest3 -t "{{.status.dockerImageRepository}}")" ]
-[ -z "$(oc get imageStreams tagtest4 -t "{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams tagtest3 --template="{{.status.dockerImageRepository}}")" ]
+[ -z "$(oc get imageStreams tagtest4 --template="{{.status.dockerImageRepository}}")" ]
 oc tag mysql:latest tagtest3:latest tagtest4:latest
-[ "$(oc get is/tagtest3 -t '{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
-[ "$(oc get is/tagtest4 -t '{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest3 --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
+[ "$(oc get is/tagtest4 --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 
 oc delete is/tagtest is/tagtest2 is/tagtest3 is/tagtest4
 echo "tag: ok"

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -15,7 +15,7 @@ oc secrets new-dockercfg dockercfg --docker-username=sample-user --docker-passwo
 oc describe secrets/dockercfg | grep "dockercfg:" | awk '{print $2}' > ${HOME}/dockerconfig
 oc secrets new from-file .dockercfg=${HOME}/dockerconfig
 # check to make sure the type was correctly auto-detected
-[ "$(oc get secret/from-file -t "{{ .type }}" | grep 'kubernetes.io/dockercfg')" ]
+[ "$(oc get secret/from-file --template="{{ .type }}" | grep 'kubernetes.io/dockercfg')" ]
 # make sure the -o works correctly
 [ "$(oc secrets new-dockercfg dockercfg --docker-username=sample-user --docker-password=sample-password --docker-email=fake@example.org -o yaml | grep "kubernetes.io/dockercfg")" ]
 [ "$(oc secrets new from-file .dockercfg=${HOME}/dockerconfig -o yaml | grep "kubernetes.io/dockercfg")" ]

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -184,7 +184,7 @@ wait_for_command '[[ "$(oc get endpoints router --output-version=v1beta3 --templ
 
 # Check for privileged exec limitations.
 echo "[INFO] Validating privileged pod exec"
-router_pod=$(oc get pod -n default -l deploymentconfig=router -t '{{(index .items 0).metadata.name}}')
+router_pod=$(oc get pod -n default -l deploymentconfig=router --template='{{(index .items 0).metadata.name}}')
 oc policy add-role-to-user admin e2e-default-admin
 # login as a user that can't run privileged pods
 oc login -u e2e-default-admin -p pass

--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -145,7 +145,7 @@ oc = oc.Run("get").Args("foo").Template("{{ .spec }}")
 ```
 is an equivalent to
 ```console
-$ oc get foo -o template -t '{{ .spec }}'
+$ oc get foo -o template --template='{{ .spec }}'
 ```
 
 To execute the command you will need to call either `Execute()`, which will execute the command and return any error that occurs, or `Output()`  which returns any error that occurs as well as the output.

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -227,7 +227,7 @@ func (c *CLI) Run(verb string) *CLI {
 }
 
 // Template sets a Go template for the OpenShift CLI command.
-// This is equivalent of running "oc get foo -o template -t '{{ .spec }}'"
+// This is equivalent of running "oc get foo -o template --template='{{ .spec }}'"
 func (c *CLI) Template(t string) *CLI {
 	if c.verb != "get" {
 		FatalErr("Cannot use Template() for non-get verbs.")

--- a/test/old-start-configs/v1.0.0/test-end-to-end.sh
+++ b/test/old-start-configs/v1.0.0/test-end-to-end.sh
@@ -225,7 +225,7 @@ function wait_for_app() {
 function wait_for_build() {
 	echo "[INFO] Waiting for $1 namespace build to complete"
 	wait_for_command "oc get -n $1 builds | grep -i complete" $((10*TIME_MIN)) "oc get -n $1 builds | grep -i -e failed -e error"
-	BUILD_ID=`oc get -n $1 builds --output-version=v1beta3 -t "{{with index .items 0}}{{.metadata.name}}{{end}}"`
+	BUILD_ID=`oc get -n $1 builds --output-version=v1beta3 --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
 	echo "[INFO] Build ${BUILD_ID} finished"
   # TODO: fix
   set +e
@@ -259,7 +259,7 @@ export HOME="${FAKE_HOME_DIR}"
 mkdir -p ${FAKE_HOME_DIR}
 
 export KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
-CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template -t '{{index . "current-context"}}')
+CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template --template='{{index . "current-context"}}')
 
 if [[ "${API_SCHEME}" == "https" ]]; then
 	export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
@@ -311,7 +311,7 @@ echo "[INFO] Pulled ruby-20-centos7"
 
 echo "[INFO] Waiting for Docker registry pod to start"
 # TODO: simplify when #4702 is fixed upstream
-wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1beta3 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" || echo "0")" != "0" ]]' $((5*TIME_MIN))
+wait_for_command '[[ "$(oc get endpoints docker-registry --output-version=v1beta3 --template="{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" || echo "0")" != "0" ]]' $((5*TIME_MIN))
 
 # services can end up on any IP.	Make sure we get the IP we need for the docker registry
 DOCKER_REGISTRY=$(oc get --output-version=v1beta3 --template="{{ .spec.portalIP }}:{{ with index .spec.ports 0 }}{{ .port }}{{ end }}" service docker-registry)
@@ -330,7 +330,7 @@ echo "[INFO] Logging in as a regular user (e2e-user:pass) with project 'test'...
 oc login -u e2e-user -p pass
 [ "$(oc whoami | grep 'e2e-user')" ]
 oc project cache
-token=$(oc config view --flatten -o template -t '{{with index .users 0}}{{.user.token}}{{end}}')
+token=$(oc config view --flatten -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
 [[ -n ${token} ]]
 
 echo "[INFO] Docker login as e2e-user to ${DOCKER_REGISTRY}"
@@ -388,14 +388,14 @@ oc project ${CLUSTER_ADMIN_CONTEXT}
 
 # ensure the router is started
 # TODO: simplify when #4702 is fixed upstream
-wait_for_command '[[ "$(oc get endpoints router --output-version=v1beta3 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" || echo "0")" != "0" ]]' $((5*TIME_MIN))
+wait_for_command '[[ "$(oc get endpoints router --output-version=v1beta3 --template="{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" || echo "0")" != "0" ]]' $((5*TIME_MIN))
 
 echo "[INFO] Validating routed app response..."
 validate_response "-s -k --resolve www.example.com:443:${CONTAINER_ACCESSIBLE_API_HOST} https://www.example.com" "Hello from OpenShift" 0.2 50
 
 # Remote command execution
 echo "[INFO] Validating exec"
-registry_pod=$(oc get pod -l deploymentconfig=docker-registry -t '{{(index .items 0).metadata.name}}')
+registry_pod=$(oc get pod -l deploymentconfig=docker-registry --template='{{(index .items 0).metadata.name}}')
 # when running as a restricted pod the registry will run with a pre-allocated
 # user in the neighborhood of 1000000+.  Look for a substring of the pre-allocated uid range
 oc exec -p ${registry_pod} id | grep 10


### PR DESCRIPTION
@mfojtik @deads2k PTAL

Currently this is spitting out quite a lot of:
```
[INFO] Waiting for command to finish: '[[ "$(oc get endpoints docker-registry --output-version=v1 -t "{{ if .subsets }}{{ len .subsets }}{{ else }}0{{ end }}" --config=${ADMIN_KUBECONFIG} || echo "0")" != "0" ]]'...
Flag shorthand -t has been deprecated, please use --template instead
Error from server: endpoints "docker-registry" not found
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
Flag shorthand -t has been deprecated, please use --template instead
```