### PR TITLE
Enable cpu cfs quota by default

### DIFF
--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -125,6 +125,7 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 	server.HTTPCheckFrequency = 0 // no remote HTTP pod creation access
 	server.FileCheckFrequency = time.Duration(fileCheckInterval) * time.Second
 	server.PodInfraContainerImage = imageTemplate.ExpandOrDie("pod")
+	server.CPUCFSQuota = true // enable cpu cfs quota enforcement by default
 
 	// prevents kube from generating certs
 	server.TLSCertFile = options.ServingInfo.ServerCert.CertFile


### PR DESCRIPTION
@liggitt 

this enables cpu cfs quota enforcement by default.

only meaningful if running docker >= 1.7, otherwise ignored.