### PR TITLE
Expose RAR evaluation errors

### DIFF
--- a/pkg/authorization/api/deep_copy_generated.go
+++ b/pkg/authorization/api/deep_copy_generated.go
@@ -505,6 +505,7 @@ func DeepCopy_api_ResourceAccessReviewResponse(in ResourceAccessReviewResponse, 
 	} else {
 		out.Groups = nil
 	}
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -174,6 +174,11 @@ type ResourceAccessReviewResponse struct {
 	Users sets.String
 	// Groups is the list of groups who can perform the action
 	Groups sets.String
+
+	// EvaluationError is an indication that some error occurred during resolution, but partial results can still be returned.
+	// It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is
+	// most common when a bound role is missing, but enough roles are still present and bound to reason about the request.
+	EvaluationError string
 }
 
 // ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the

--- a/pkg/authorization/api/v1/deep_copy_generated.go
+++ b/pkg/authorization/api/v1/deep_copy_generated.go
@@ -497,6 +497,7 @@ func DeepCopy_v1_ResourceAccessReviewResponse(in ResourceAccessReviewResponse, o
 	} else {
 		out.GroupsSlice = nil
 	}
+	out.EvaluationError = in.EvaluationError
 	return nil
 }
 

--- a/pkg/authorization/api/v1/swagger_doc.go
+++ b/pkg/authorization/api/v1/swagger_doc.go
@@ -239,10 +239,11 @@ func (ResourceAccessReview) SwaggerDoc() map[string]string {
 }
 
 var map_ResourceAccessReviewResponse = map[string]string{
-	"":          "ResourceAccessReviewResponse describes who can perform the action",
-	"namespace": "Namespace is the namespace used for the access review",
-	"users":     "UsersSlice is the list of users who can perform the action",
-	"groups":    "GroupsSlice is the list of groups who can perform the action",
+	"":               "ResourceAccessReviewResponse describes who can perform the action",
+	"namespace":      "Namespace is the namespace used for the access review",
+	"users":          "UsersSlice is the list of users who can perform the action",
+	"groups":         "GroupsSlice is the list of groups who can perform the action",
+	"evalutionError": "EvaluationError is an indication that some error occurred during resolution, but partial results can still be returned. It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is most common when a bound role is missing, but enough roles are still present and bound to reason about the request.",
 }
 
 func (ResourceAccessReviewResponse) SwaggerDoc() map[string]string {

--- a/pkg/authorization/api/v1/types.go
+++ b/pkg/authorization/api/v1/types.go
@@ -155,6 +155,11 @@ type ResourceAccessReviewResponse struct {
 	UsersSlice []string `json:"users"`
 	// GroupsSlice is the list of groups who can perform the action
 	GroupsSlice []string `json:"groups"`
+
+	// EvaluationError is an indication that some error occurred during resolution, but partial results can still be returned.
+	// It is entirely possible to get an error and be able to continue determine authorization status in spite of it.  This is
+	// most common when a bound role is missing, but enough roles are still present and bound to reason about the request.
+	EvaluationError string `json:"evalutionError"`
 }
 
 // ResourceAccessReview is a means to request a list of which users and groups are authorized to perform the

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -51,12 +51,15 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 
 	requestContext := kapi.WithNamespace(ctx, resourceAccessReview.Action.Namespace)
 	attributes := authorizer.ToDefaultAuthorizationAttributes(resourceAccessReview.Action)
-	users, groups, _ := r.authorizer.GetAllowedSubjects(requestContext, attributes)
+	users, groups, err := r.authorizer.GetAllowedSubjects(requestContext, attributes)
 
 	response := &authorizationapi.ResourceAccessReviewResponse{
 		Namespace: resourceAccessReview.Action.Namespace,
 		Users:     users,
 		Groups:    groups,
+	}
+	if err != nil {
+		response.EvaluationError = err.Error()
 	}
 
 	return response, nil

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -138,5 +138,9 @@ func (o *whoCanOptions) run() error {
 		fmt.Printf("Groups: %s\n\n", strings.Join(resourceAccessReviewResponse.Groups.List(), "\n        "))
 	}
 
+	if len(resourceAccessReviewResponse.EvaluationError) != 0 {
+		fmt.Printf("Error during evaluation, results may not be complete: %s\n", resourceAccessReviewResponse.EvaluationError)
+	}
+
 	return nil
 }

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -304,7 +304,10 @@ func (test resourceAccessReviewTest) run(t *testing.T) {
 			}
 		}
 
-		if actualResponse.Namespace != test.response.Namespace || !reflect.DeepEqual(actualResponse.Users.List(), test.response.Users.List()) || !reflect.DeepEqual(actualResponse.Groups.List(), test.response.Groups.List()) {
+		if actualResponse.Namespace != test.response.Namespace ||
+			!reflect.DeepEqual(actualResponse.Users.List(), test.response.Users.List()) ||
+			!reflect.DeepEqual(actualResponse.Groups.List(), test.response.Groups.List()) ||
+			actualResponse.EvaluationError != test.response.EvaluationError {
 			failMessage = fmt.Sprintf("%s: %#v: expected %#v, got %#v", test.description, test.review, test.response, actualResponse)
 			return false, nil
 		}
@@ -354,7 +357,10 @@ func (test localResourceAccessReviewTest) run(t *testing.T) {
 			}
 		}
 
-		if actualResponse.Namespace != test.response.Namespace || !reflect.DeepEqual(actualResponse.Users.List(), test.response.Users.List()) || !reflect.DeepEqual(actualResponse.Groups.List(), test.response.Groups.List()) {
+		if actualResponse.Namespace != test.response.Namespace ||
+			!reflect.DeepEqual(actualResponse.Users.List(), test.response.Users.List()) ||
+			!reflect.DeepEqual(actualResponse.Groups.List(), test.response.Groups.List()) ||
+			actualResponse.EvaluationError != test.response.EvaluationError {
 			failMessage = fmt.Sprintf("%s: %#v: expected %#v, got %#v", test.description, test.review, test.response, actualResponse)
 			return false, nil
 		}
@@ -495,9 +501,10 @@ func TestAuthorizationResourceAccessReview(t *testing.T) {
 			clientInterface: clusterAdminClient.LocalResourceAccessReviews("mallet-project"),
 			review:          localRequestWhoCanViewDeploymentConfigs,
 			response: authorizationapi.ResourceAccessReviewResponse{
-				Users:     sets.NewString("edgar"),
-				Groups:    sets.NewString(),
-				Namespace: "mallet-project",
+				Users:           sets.NewString("edgar"),
+				Groups:          sets.NewString(),
+				Namespace:       "mallet-project",
+				EvaluationError: `role "admin" not found`,
 			},
 		}
 		test.response.Users.Insert(globalClusterReaderUsers.List()...)


### PR DESCRIPTION
If an RAR has errors during evaluation, this allows clients to be aware of it.

A RoleBinding indicates intent.  Often, a user will check his effective policy during modification cycles by running a RAR.  A RoleBinding that fails a referential integrity check (for whatever reason), indicates a failure in that intent.  That failure may or may not affect the results of the RAR (there's no way to know, since the information is missing).  Exposing that failure of intent to a user is valuable information.

@smarterclayton @liggitt continuing the discussion from https://github.com/openshift/origin/pull/4809