### PR TITLE
Do not treat directories named Dockerfile as file

### DIFF
--- a/pkg/generate/dockerfile/finder.go
+++ b/pkg/generate/dockerfile/finder.go
@@ -42,26 +42,32 @@ func NewFinder() Finder {
 	return &finder{fsWalk: filepath.Walk}
 }
 
-// Find returns a list of of found Dockerfile(s) in the given directory
+// Find returns the relative paths of Dockerfiles in the given directory dir.
 func (f *finder) Find(dir string) ([]string, error) {
 	dockerfiles := []string{}
 	err := f.fsWalk(dir, func(path string, info os.FileInfo, err error) error {
-		if info == nil {
-			return nil
+		if err != nil {
+			return err
 		}
-		// Skip hidden directories
+		// Skip hidden directories.
 		if info.IsDir() && strings.HasPrefix(info.Name(), ".") {
 			return filepath.SkipDir
 		}
-
-		// Add files named Dockerfile
-		if info.Name() == "Dockerfile" && err == nil {
+		// Add relative path to Dockerfile.
+		if isDockerfile(info) {
 			relpath, err := filepath.Rel(dir, path)
-			if err == nil {
-				dockerfiles = append(dockerfiles, relpath)
+			if err != nil {
+				return err
 			}
+			dockerfiles = append(dockerfiles, relpath)
 		}
-		return err
+		return nil
 	})
 	return dockerfiles, err
+}
+
+// isDockerfile returns true if info looks like a Dockerfile. It must be named
+// "Dockerfile" and be either a regular file or a symlink.
+func isDockerfile(info os.FileInfo) bool {
+	return info.Name() == "Dockerfile" && (info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0)
 }

--- a/pkg/generate/dockerfile/finder_test.go
+++ b/pkg/generate/dockerfile/finder_test.go
@@ -57,6 +57,11 @@ func TestFind(t *testing.T) {
 			isDir: false,
 		},
 		{
+			name:  "Dockerfile",
+			path:  "test2/Dockerfile",
+			isDir: true,
+		},
+		{
 			name:  ".hidden",
 			path:  ".hidden",
 			isDir: true,


### PR DESCRIPTION
Given a directory tree with a directory named "Dockerfile", Find would
mistakenly append it to the list of dockerfiles.