### PR TITLE
Allow importing tags from ImageStreams pointing to external registries

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -16842,6 +16842,10 @@
      "from": {
       "$ref": "v1.ObjectReference",
       "description": "a reference to an image stream tag or image stream this tag should track"
+     },
+     "reference": {
+      "type": "boolean",
+      "description": "if true consider this tag a reference only and do not attempt to import metadata about the image"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1973,6 +1973,7 @@ func deepCopy_api_TagReference(in imageapi.TagReference, out *imageapi.TagRefere
 	} else {
 		out.From = nil
 	}
+	out.Reference = in.Reference
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1872,6 +1872,7 @@ func deepCopy_v1_NamedTagReference(in imageapiv1.NamedTagReference, out *imageap
 	} else {
 		out.From = nil
 	}
+	out.Reference = in.Reference
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1862,6 +1862,7 @@ func deepCopy_v1beta3_NamedTagReference(in imageapiv1beta3.NamedTagReference, ou
 	} else {
 		out.From = nil
 	}
+	out.Reference = in.Reference
 	return nil
 }
 

--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -79,6 +79,8 @@ type TagReference struct {
 	Annotations map[string]string
 	// Optional; if specified, a reference to another image that this tag should point to. Valid values are ImageStreamTag, ImageStreamImage, and DockerImage.
 	From *kapi.ObjectReference
+	// Reference states if the tag will be imported. Default value is false, which means the tag will be imported.
+	Reference bool
 }
 
 // ImageStreamStatus contains information about the state of this image stream.

--- a/pkg/image/api/v1/conversion.go
+++ b/pkg/image/api/v1/conversion.go
@@ -149,6 +149,7 @@ func init() {
 			for _, curr := range *in {
 				r := newer.TagReference{
 					Annotations: curr.Annotations,
+					Reference:   curr.Reference,
 				}
 				if err := s.Convert(&curr.From, &r.From, 0); err != nil {
 					return err
@@ -169,6 +170,7 @@ func init() {
 				oldTagReference := NamedTagReference{
 					Name:        tag,
 					Annotations: newTagReference.Annotations,
+					Reference:   newTagReference.Reference,
 				}
 				if err := s.Convert(&newTagReference.From, &oldTagReference.From, 0); err != nil {
 					return err

--- a/pkg/image/api/v1/types.go
+++ b/pkg/image/api/v1/types.go
@@ -68,6 +68,8 @@ type NamedTagReference struct {
 	Annotations map[string]string `json:"annotations,omitempty" description:"annotations associated with images using this tag"`
 	// From is a reference to an image stream tag or image stream this tag should track
 	From *kapi.ObjectReference `json:"from,omitempty" description:"a reference to an image stream tag or image stream this tag should track"`
+	// Reference states if the tag will be imported. Default value is false, which means the tag will be imported.
+	Reference bool `json:"reference,omitempty" description:"if true consider this tag a reference only and do not attempt to import metadata about the image"`
 }
 
 // ImageStreamStatus contains information about the state of this image stream.

--- a/pkg/image/api/v1beta3/conversion.go
+++ b/pkg/image/api/v1beta3/conversion.go
@@ -234,6 +234,7 @@ func init() {
 			for _, curr := range *in {
 				r := newer.TagReference{
 					Annotations: curr.Annotations,
+					Reference:   curr.Reference,
 				}
 				if err := s.Convert(&curr.From, &r.From, 0); err != nil {
 					return err
@@ -254,6 +255,7 @@ func init() {
 				oldTagReference := NamedTagReference{
 					Name:        tag,
 					Annotations: newTagReference.Annotations,
+					Reference:   newTagReference.Reference,
 				}
 				if err := s.Convert(&newTagReference.From, &oldTagReference.From, 0); err != nil {
 					return err

--- a/pkg/image/api/v1beta3/types.go
+++ b/pkg/image/api/v1beta3/types.go
@@ -63,6 +63,8 @@ type NamedTagReference struct {
 	Name        string                `json:"name"`
 	Annotations map[string]string     `json:"annotations,omitempty"`
 	From        *kapi.ObjectReference `json:"from,omitempty"`
+	// Reference states if the tag will be imported. Default value is false, which means the tag will be imported.
+	Reference bool `json:"reference,omitempty" description:"if true consider this tag a reference only and do not attempt to import metadata about the image"`
 }
 
 // ImageStreamStatus contains information about the state of this image stream.

--- a/pkg/image/controller/controller.go
+++ b/pkg/image/controller/controller.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
+
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/util"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry"
@@ -23,13 +27,7 @@ type ImportController struct {
 
 // needsImport returns true if the provided image stream should have its tags imported.
 func needsImport(stream *api.ImageStream) bool {
-	if len(stream.Spec.DockerImageRepository) == 0 {
-		return false
-	}
-	if stream.Annotations != nil && len(stream.Annotations[api.DockerImageRepositoryCheckAnnotation]) != 0 {
-		return false
-	}
-	return true
+	return stream.Annotations == nil || len(stream.Annotations[api.DockerImageRepositoryCheckAnnotation]) == 0
 }
 
 // retryCount is the number of times to retry on a conflict when updating an image stream
@@ -40,126 +38,207 @@ const retryCount = 2
 // the image stream is not modified (so it will be tried again later). If a permanent
 // failure occurs the image is marked with an annotation. The tags of the original spec image
 // are left as is (those are updated through status).
+// There are 3 use cases here:
+// 1. spec.DockerImageRepository defined without any tags results in all tags being imported
+//    from upstream image repository
+// 2. spec.DockerImageRepository + tags defined - import all tags from upstream image repository,
+//    and all the specified which (if name matches) will overwrite the default ones.
+//    Additionally:
+//    for kind == DockerImage import or reference underlying image, iow. exact tag (not provided means latest),
+//    for kind != DockerImage reference tag from the same or other ImageStream
+// 3. spec.DockerImageRepository not defined - import tags per its definition.
+// Current behavior of the controller is to process import as far as possible, but
+// we still want to keep backwards compatibility and retries, for that we'll return
+// error in the following cases:
+// 1. connection failure to upstream image repository
+// 2. reading tags when error is different from RepositoryNotFound or RegistryNotFound
+// 3. image retrieving when error is different from RepositoryNotFound, RegistryNotFound or ImageNotFound
+// 4. ImageStreamMapping save error
+// 5. error when marking ImageStream as imported
+
 func (c *ImportController) Next(stream *api.ImageStream) error {
 	if !needsImport(stream) {
 		return nil
 	}
-	name := stream.Spec.DockerImageRepository
 
-	ref, err := api.ParseDockerImageReference(name)
-	if err != nil {
-		err = fmt.Errorf("invalid docker image repository, cannot import data: %v", err)
-		util.HandleError(err)
-		return c.done(stream, err.Error(), retryCount)
-	}
-
-	insecure := stream.Annotations != nil && stream.Annotations[api.InsecureRepositoryAnnotation] == "true"
-
+	insecure := stream.Annotations[api.InsecureRepositoryAnnotation] == "true"
 	client := c.client
 	if client == nil {
 		client = dockerregistry.NewClient()
 	}
-	conn, err := client.Connect(ref.Registry, insecure)
+
+	toImport, err := getTags(stream, client, insecure)
+	// return here, only if there is an error and nothing to import
+	if err != nil && len(toImport) == 0 {
+		return err
+	}
+
+	errs := c.importTags(stream, toImport, client, insecure)
+	// one of retry-able error happened, we need to inform the RetryController
+	// the import should be retried by returning error
+	if len(errs) > 0 {
+		return kerrors.NewAggregate(errs)
+	}
 	if err != nil {
 		return err
 	}
-	tags, err := conn.ImageTags(ref.Namespace, ref.Name)
+
+	return c.done(stream, "", retryCount)
+}
+
+// getTags returns tags from default upstream image repository and explicitly defined.
+// Returns a map of tags to be imported and an error if one occurs.
+// Tags explicitly defined will overwrite those from default upstream image repository.
+func getTags(stream *api.ImageStream, client dockerregistry.Client, insecure bool) (map[string]api.DockerImageReference, error) {
+	imports := make(map[string]api.DockerImageReference)
+	references := sets.NewString()
+
+	// read explicitly defined tags
+	for tagName, specTag := range stream.Spec.Tags {
+		if specTag.From == nil {
+			continue
+		}
+		if specTag.From.Kind != "DockerImage" || specTag.Reference {
+			references.Insert(tagName)
+			continue
+		}
+		ref, err := api.ParseDockerImageReference(specTag.From.Name)
+		if err != nil {
+			glog.V(2).Infof("error parsing DockerImage %s: %v", specTag.From.Name, err)
+			continue
+		}
+		imports[tagName] = ref.DockerClientDefaults()
+	}
+
+	if len(stream.Spec.DockerImageRepository) == 0 {
+		return imports, nil
+	}
+
+	// read tags from default upstream image repository
+	streamRef, err := api.ParseDockerImageReference(stream.Spec.DockerImageRepository)
+	if err != nil {
+		util.HandleError(fmt.Errorf("invalid docker image repository, cannot import data: %v", err))
+		return imports, nil
+	}
+	conn, err := client.Connect(streamRef.Registry, insecure)
+	if err != nil {
+		// retry-able error no. 1
+		return imports, err
+	}
+	tags, err := conn.ImageTags(streamRef.Namespace, streamRef.Name)
 	switch {
 	case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err):
-		return c.done(stream, err.Error(), retryCount)
+		return imports, nil
 	case err != nil:
-		return err
+		// retry-able error no. 2
+		return imports, err
 	}
-
-	imageToTag := make(map[string][]string)
 	for tag, image := range tags {
-		if specTag, ok := stream.Spec.Tags[tag]; ok && specTag.From != nil {
-			// spec tag is set to track another tag - do not import
+		if _, ok := imports[tag]; ok || references.Has(tag) {
 			continue
 		}
-
-		imageToTag[image] = append(imageToTag[image], tag)
-	}
-
-	// no tags to import
-	if len(imageToTag) == 0 {
-		return c.done(stream, "", retryCount)
-	}
-
-	for id, tags := range imageToTag {
-		dockerImage, err := conn.ImageByID(ref.Namespace, ref.Name, id)
-		switch {
-		case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err):
-			return c.done(stream, err.Error(), retryCount)
-		case dockerregistry.IsImageNotFound(err):
-			continue
-		case err != nil:
-			return err
-		}
-		var image api.DockerImage
-		if err := kapi.Scheme.Convert(&dockerImage.Image, &image); err != nil {
-			err = fmt.Errorf("could not convert image: %#v", err)
-			util.HandleError(err)
-			return c.done(stream, err.Error(), retryCount)
-		}
-
 		idTagPresent := false
-		if len(tags) > 1 && hasTag(tags, id) {
-			// only set to true if we have at least 1 tag that isn't the image id
-			idTagPresent = true
-		}
-		for _, tag := range tags {
-			if idTagPresent && id == tag {
-				continue
-			}
-
-			pullRef := api.DockerImageReference{
-				Registry:  ref.Registry,
-				Namespace: ref.Namespace,
-				Name:      ref.Name,
-				Tag:       tag,
-			}
-			// prefer to pull by ID always
-			if dockerImage.PullByID {
-				// if the registry indicates the image is pullable by ID, clear the tag
-				pullRef.Tag = ""
-				pullRef.ID = dockerImage.ID
-			} else if idTagPresent {
-				// if there is a tag for the image by its id (tag=tag), we can pull by id
-				pullRef.Tag = id
-			}
-
-			mapping := &api.ImageStreamMapping{
-				ObjectMeta: kapi.ObjectMeta{
-					Name:      stream.Name,
-					Namespace: stream.Namespace,
-				},
-				Tag: tag,
-				Image: api.Image{
-					ObjectMeta: kapi.ObjectMeta{
-						Name: dockerImage.ID,
-					},
-					DockerImageReference: pullRef.String(),
-					DockerImageMetadata:  image,
-				},
-			}
-			if err := c.mappings.ImageStreamMappings(stream.Namespace).Create(mapping); err != nil {
-				if errors.IsNotFound(err) {
-					return c.done(stream, err.Error(), retryCount)
-				}
-				return err
+		// this for loop is for backwards compatibility with v1 repo, where
+		// there was no image id returned with tags, like v2 does right now.
+		for t2, i2 := range tags {
+			if i2 == image && t2 == image {
+				idTagPresent = true
+				break
 			}
 		}
+		ref := streamRef
+		if idTagPresent {
+			ref.Tag = image
+		} else {
+			ref.Tag = tag
+		}
+		ref.ID = image
+		imports[tag] = ref
 	}
 
-	// we've completed our updates
-	return c.done(stream, "", retryCount)
+	return imports, nil
+}
+
+// importTags imports tags specified in a map from given ImageStream. Returns an error if one occurs.
+func (c *ImportController) importTags(stream *api.ImageStream, imports map[string]api.DockerImageReference, client dockerregistry.Client, insecure bool) []error {
+	retrieved := make(map[string]*dockerregistry.Image)
+	var errlist []error
+	for tag, ref := range imports {
+		image, err := c.importTag(stream, tag, ref, retrieved[ref.ID], client, insecure)
+		if err != nil {
+			util.HandleError(err)
+			errlist = append(errlist, err)
+			continue
+		}
+		// save image object for next tag imports, this is to avoid re-downloading the default image registry
+		if len(ref.ID) > 0 {
+			retrieved[ref.ID] = image
+		}
+	}
+	return errlist
+}
+
+// importTag import single tag from given ImageStream. Returns an error if one occurs.
+func (c *ImportController) importTag(stream *api.ImageStream, tag string, ref api.DockerImageReference, dockerImage *dockerregistry.Image, client dockerregistry.Client, insecure bool) (*dockerregistry.Image, error) {
+	if dockerImage == nil {
+		// TODO insecure applies to the stream's spec.dockerImageRepository, not necessarily to an external one!
+		conn, err := client.Connect(ref.Registry, insecure)
+		if err != nil {
+			return nil, err
+		}
+		if len(ref.ID) > 0 {
+			dockerImage, err = conn.ImageByID(ref.Namespace, ref.Name, ref.ID)
+		} else {
+			dockerImage, err = conn.ImageByTag(ref.Namespace, ref.Name, ref.Tag)
+		}
+		switch {
+		case dockerregistry.IsRepositoryNotFound(err), dockerregistry.IsRegistryNotFound(err), dockerregistry.IsImageNotFound(err):
+			return nil, nil
+		case err != nil:
+			// retry-able error no. 3
+			return nil, err
+		}
+	}
+	var image api.DockerImage
+	if err := kapi.Scheme.Convert(&dockerImage.Image, &image); err != nil {
+		return nil, fmt.Errorf("could not convert image: %#v", err)
+	}
+
+	// prefer to pull by ID always
+	if dockerImage.PullByID {
+		// if the registry indicates the image is pullable by ID, clear the tag
+		ref.Tag = ""
+		ref.ID = dockerImage.ID
+	}
+
+	mapping := &api.ImageStreamMapping{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      stream.Name,
+			Namespace: stream.Namespace,
+		},
+		Tag: tag,
+		Image: api.Image{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: dockerImage.ID,
+			},
+			DockerImageReference: ref.String(),
+			DockerImageMetadata:  image,
+		},
+	}
+	if err := c.mappings.ImageStreamMappings(stream.Namespace).Create(mapping); err != nil {
+		// retry-able no. 4
+		return nil, err
+	}
+	return dockerImage, nil
 }
 
 // done marks the stream as being processed due to an error or failure condition
 func (c *ImportController) done(stream *api.ImageStream, reason string, retry int) error {
 	if len(reason) == 0 {
 		reason = unversioned.Now().UTC().Format(time.RFC3339)
+	} else if len(reason) > 300 {
+		// cut down the reason up to 300 characters max.
+		reason = reason[:300]
 	}
 	if stream.Annotations == nil {
 		stream.Annotations = make(map[string]string)
@@ -174,13 +253,4 @@ func (c *ImportController) done(stream *api.ImageStream, reason string, retry in
 		return err
 	}
 	return nil
-}
-
-func hasTag(tags []string, tag string) bool {
-	for _, s := range tags {
-		if s == tag {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -153,12 +153,14 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) fielderrors.Validati
 		}
 
 		if tagRef.From.Kind == "DockerImage" && len(tagRef.From.Name) > 0 {
-			event, err := tagReferenceToTagEvent(stream, tagRef, "")
-			if err != nil {
-				errs = append(errs, fielderrors.NewFieldInvalid(fmt.Sprintf("spec.tags[%s].from", tag), tagRef.From, err.Error()))
-				continue
+			if tagRef.Reference {
+				event, err := tagReferenceToTagEvent(stream, tagRef, "")
+				if err != nil {
+					errs = append(errs, fielderrors.NewFieldInvalid(fmt.Sprintf("spec.tags[%s].from", tag), tagRef.From, err.Error()))
+					continue
+				}
+				api.AddTagEventToImageStream(stream, tag, *event)
 			}
-			api.AddTagEventToImageStream(stream, tag, *event)
 			continue
 		}
 

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -347,6 +347,7 @@ func TestTagsChanged(t *testing.T) {
 						Kind: "DockerImage",
 						Name: "registry:5000/ns/stream:t1",
 					},
+					Reference: true,
 				},
 			},
 			existingTagHistory: map[string]api.TagEventList{
@@ -399,12 +400,14 @@ func TestTagsChanged(t *testing.T) {
 						Kind: "DockerImage",
 						Name: "registry:5000/ns/stream:t1",
 					},
+					Reference: true,
 				},
 				"t2": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
+					Reference: true,
 				},
 			},
 			existingTagHistory: make(map[string]api.TagEventList),
@@ -503,18 +506,21 @@ func TestTagsChanged(t *testing.T) {
 						Kind: "DockerImage",
 						Name: "registry:5000/ns/stream:v1image1",
 					},
+					Reference: true,
 				},
 				"t2": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "registry:5000/ns/stream:v1image1",
 					},
+					Reference: true,
 				},
 				"t3": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
 						Name: "@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
+					Reference: true,
 				},
 			},
 			existingTagHistory: map[string]api.TagEventList{


### PR DESCRIPTION
This is the initial version of improved importer, to address [card 514](https://trello.com/c/Y2MnDbaI/514-ability-to-define-imagestreamtag-pointing-to-a-different-image-registry-each).

@ncdc I know it's bit messy still, I'm working on getting it DRY-ed and most importantly fully tested, still I'd appreciate first raw pass, if this makes sense. The general flow is following:

1. if no tags are defined import all from default spec
2. if tags are defined import only the ones defined, both from default spec and from external repos

@pweil- fyi