### PR TITLE
Allow processing template from different namespace

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -663,6 +663,9 @@ Process a template into list of resources
   # Convert stored template into resource list
   $ openshift cli process foo
 
+  # Convert template stored in different namespace into a resource list
+  $ openshift cli process openshift//foo
+
   # Convert template.json into resource list
   $ cat template.json | openshift cli process -f -
 

--- a/pkg/cmd/cli/cmd/helper.go
+++ b/pkg/cmd/cli/cmd/helper.go
@@ -80,3 +80,22 @@ func selectString(s, spec string) bool {
 	}
 	return match
 }
+
+// parseNamespaceResourceName parses the value and returns namespace, resource and the
+// value (resource name) itself. The valid syntax is:
+// oc process mytemplate - implicit namespace (current), implicit resource (template)
+// oc process template/mytemplate - implicit namespace (current), explicit resource
+// oc process ns/template/mytemplate - explicit namespace, explicit resource
+// oc process ns//mytemplate - explicit namespace, implicit resource (template)
+func parseNamespaceResourceName(v, defaultNamespace string) (ns, resource, name string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(v), "/")
+	switch len(parts) {
+	case 3:
+		return parts[0], parts[1], parts[2], true
+	case 2:
+		return defaultNamespace, parts[0], parts[1], true
+	case 1:
+		return defaultNamespace, "", parts[0], true
+	}
+	return "", "", "", false
+}

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -11,7 +11,7 @@ os::log::install_errexit
 # This test validates template commands
 
 oc get templates
-oc create -f examples/sample-app/application-template-dockerbuild.json
+oc create -f examples/sample-app/application-template-dockerbuild.json 
 oc get templates
 oc get templates ruby-helloworld-sample
 oc get template ruby-helloworld-sample -o json | oc process -f -
@@ -27,3 +27,14 @@ oc process -f test/templates/fixtures/guestbook.json -l app=guestbook | oc creat
 oc status
 [ "$(oc status | grep frontend-service)" ]
 echo "template+config: ok"
+
+oc create -f examples/sample-app/application-template-dockerbuild.json -n openshift
+oc policy add-role-to-user admin test-user
+oc login -u test-user -p password
+oc new-project test-template-project
+oc create -f examples/sample-app/application-template-dockerbuild.json
+oc process template/ruby-helloworld-sample >/dev/null
+oc process templates/ruby-helloworld-sample > /dev/null
+oc process openshift//ruby-helloworld-sample > /dev/null
+oc process openshift/template/ruby-helloworld-sample >/dev/null
+echo "processing templates in different namespace: ok"


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/3307

So:

```bash
oc project foo`

# will read the template from openshift namespace and also process (create) 
# it in openshift namespace (which will fail)
oc process -n openshift template

# will read the template from openshift namespace BUT process it in "foo" 
# namespace (which will succeed)
oc process openshift//template     
```