### PR TITLE
Apply OOMScoreAdjust and Restart policy to openshift node unit file

### DIFF
--- a/rel-eng/atomic-openshift-node.service
+++ b/rel-eng/atomic-openshift-node.service
@@ -14,6 +14,8 @@ LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=atomic-openshift-node
+Restart=Always
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target

--- a/rel-eng/origin-node.service
+++ b/rel-eng/origin-node.service
@@ -14,6 +14,8 @@ LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=origin-node
+Restart=Always
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The OpenShift node should start with a OOMScoreAdjust value that skews the Kernel OOM killer from killing the node daemon in low memory situations.

Upstream Kubernetes has code that does this automatically for the kubelet and kube-proxy by pid look-up, but we need to do something manually via systemd instead.

Finally, we should be setting a Restart policy to keep in synch with upstream's use of monit/etc.

@sdodson - i think you are the most appropriate reviewer here.

/cc @smarterclayton @danmcp  - we need to talk longer term on some process specific things that are going on in the Kubelet and how we want to handle it.  