### PR TITLE
Kubelet authentication/authorization

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -587,6 +587,10 @@
 			"Rev": "aa5e036e6c44aec69a32eb41097001978b29ad31"
 		},
 		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "7f9ef20a0256f494e24126014135cf893ab71e9e"
+		},
+		{
 			"ImportPath": "github.com/imdario/mergo",
 			"Comment": "0.1.3-8-g6633656",
 			"Rev": "6633656539c1639d9d78127b7d47c622b5d7b6dc"

--- a/Godeps/_workspace/src/github.com/hashicorp/golang-lru/.gitignore
+++ b/Godeps/_workspace/src/github.com/hashicorp/golang-lru/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/Godeps/_workspace/src/github.com/hashicorp/golang-lru/LICENSE
+++ b/Godeps/_workspace/src/github.com/hashicorp/golang-lru/LICENSE
@@ -1,0 +1,362 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/Godeps/_workspace/src/github.com/hashicorp/golang-lru/README.md
+++ b/Godeps/_workspace/src/github.com/hashicorp/golang-lru/README.md
@@ -1,0 +1,25 @@
+golang-lru
+==========
+
+This provides the `lru` package which implements a fixed-size
+thread safe LRU cache. It is based on the cache in Groupcache.
+
+Documentation
+=============
+
+Full docs are available on [Godoc](http://godoc.org/github.com/hashicorp/golang-lru)
+
+Example
+=======
+
+Using the LRU is very simple:
+
+```go
+l, _ := New(128)
+for i := 0; i < 256; i++ {
+    l.Add(i, nil)
+}
+if l.Len() != 128 {
+    panic(fmt.Sprintf("bad len: %v", l.Len()))
+}
+```

--- a/Godeps/_workspace/src/github.com/hashicorp/golang-lru/lru.go
+++ b/Godeps/_workspace/src/github.com/hashicorp/golang-lru/lru.go
@@ -1,0 +1,198 @@
+// This package provides a simple LRU cache. It is based on the
+// LRU implementation in groupcache:
+// https://github.com/golang/groupcache/tree/master/lru
+package lru
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+)
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	lock      sync.RWMutex
+	onEvicted func(key interface{}, value interface{})
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+
+// New creates an LRU of the given size
+func New(size int) (*Cache, error) {
+	return NewWithEvict(size, nil)
+}
+
+func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &Cache{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element, size),
+		onEvicted: onEvicted,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache
+func (c *Cache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.onEvicted != nil {
+		for k, v := range c.items {
+			c.onEvicted(k, v.Value.(*entry).value)
+		}
+	}
+
+	c.evictList = list.New()
+	c.items = make(map[interface{}]*list.Element, c.size)
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occured.
+func (c *Cache) Add(key, value interface{}) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*entry).value = value
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict := c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key interface{}) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Check if a key is in the cache, without updating the recent-ness or deleting it for being stale.
+func (c *Cache) Contains(key interface{}) (ok bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	_, ok = c.items[key]
+	return ok
+}
+
+// Returns the key value (or undefined if not found) without updating the "recently used"-ness of the key.
+// (If you find yourself using this a lot, you might be using the wrong sort of data structure, but there are some use cases where it's handy.)
+func (c *Cache) Peek(key interface{}) (value interface{}, ok bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if ent, ok := c.items[key]; ok {
+		return ent.Value.(*entry).value, true
+	}
+	return nil, ok
+}
+
+// ContainsOrAdd checks if a key is in the cache (without updating the recent-ness or deleting it for being stale),
+// if not, adds the value. Returns whether found and whether an eviction occurred.
+func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evict bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	_, ok = c.items[key]
+	if ok {
+		return true, false
+	}
+
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict = c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return false, evict
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.removeOldest()
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *Cache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	keys := make([]interface{}, len(c.items))
+	ent := c.evictList.Back()
+	i := 0
+	for ent != nil {
+		keys[i] = ent.Value.(*entry).key
+		ent = ent.Prev()
+		i++
+	}
+
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.evictList.Len()
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *Cache) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *Cache) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	if c.onEvicted != nil {
+		c.onEvicted(kv.key, kv.value)
+	}
+}

--- a/Godeps/_workspace/src/github.com/hashicorp/golang-lru/lru_test.go
+++ b/Godeps/_workspace/src/github.com/hashicorp/golang-lru/lru_test.go
@@ -1,0 +1,157 @@
+package lru
+
+import "testing"
+
+func TestLRU(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
+		evictCounter += 1
+	}
+	l, err := NewWithEvict(128, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+
+	if evictCounter != 128 {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		_, ok := l.Get(i)
+		if !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		_, ok := l.Get(i)
+		if ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// test that Add returns true/false if an eviction occured
+func TestLRUAdd(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k interface{}, v interface{}) {
+		evictCounter += 1
+	}
+
+	l, err := NewWithEvict(1, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true || evictCounter != 0 {
+		t.Errorf("should not have an eviction")
+	}
+	if l.Add(2, 2) == false || evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+}
+
+// test that Contains doesn't update recent-ness
+func TestLRUContains(t *testing.T) {
+	l, err := New(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// test that Contains doesn't update recent-ness
+func TestLRUContainsOrAdd(t *testing.T) {
+	l, err := New(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	contains, evict := l.ContainsOrAdd(1, 1)
+	if !contains {
+		t.Errorf("1 should be contained")
+	}
+	if evict {
+		t.Errorf("nothing should be evicted here")
+	}
+
+	l.Add(3, 3)
+	contains, evict = l.ContainsOrAdd(1, 1)
+	if contains {
+		t.Errorf("1 should not have been contained")
+	}
+	if !evict {
+		t.Errorf("an eviction should have occurred")
+	}
+	if !l.Contains(1) {
+		t.Errorf("now 1 should be contained")
+	}
+}
+
+// test that Peek doesn't update recent-ness
+func TestLRUPeek(t *testing.T) {
+	l, err := New(2)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers.go
@@ -375,9 +375,9 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 		}
 	}
 
-	attribs.ReadOnly = IsReadOnlyReq(*req)
-
 	apiRequestInfo, _ := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
+
+	attribs.Verb = apiRequestInfo.Verb
 
 	// If a path follows the conventions of the REST object store, then
 	// we can extract the resource.  Otherwise, not.
@@ -455,7 +455,8 @@ type APIRequestInfoResolver struct {
 // /api/{version}/*
 func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIRequestInfo, error) {
 	requestInfo := APIRequestInfo{
-		Raw: splitPath(req.URL.Path),
+		Raw:  splitPath(req.URL.Path),
+		Verb: strings.ToLower(req.Method),
 	}
 
 	currentParts := requestInfo.Raw
@@ -499,8 +500,9 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 			requestInfo.Verb = "patch"
 		case "DELETE":
 			requestInfo.Verb = "delete"
+		default:
+			requestInfo.Verb = ""
 		}
-
 	}
 
 	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authorizer/abac/abac_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authorizer/abac/abac_test.go
@@ -75,49 +75,49 @@ func TestNotAuthorized(t *testing.T) {
 
 	testCases := []struct {
 		User        user.DefaultInfo
-		RO          bool
+		Verb        string
 		Resource    string
 		NS          string
 		ExpectAllow bool
 	}{
 		// Scheduler can read pods
-		{User: uScheduler, RO: true, Resource: "pods", NS: "ns1", ExpectAllow: true},
-		{User: uScheduler, RO: true, Resource: "pods", NS: "", ExpectAllow: true},
+		{User: uScheduler, Verb: "list", Resource: "pods", NS: "ns1", ExpectAllow: true},
+		{User: uScheduler, Verb: "list", Resource: "pods", NS: "", ExpectAllow: true},
 		// Scheduler cannot write pods
-		{User: uScheduler, RO: false, Resource: "pods", NS: "ns1", ExpectAllow: false},
-		{User: uScheduler, RO: false, Resource: "pods", NS: "", ExpectAllow: false},
+		{User: uScheduler, Verb: "create", Resource: "pods", NS: "ns1", ExpectAllow: false},
+		{User: uScheduler, Verb: "create", Resource: "pods", NS: "", ExpectAllow: false},
 		// Scheduler can write bindings
-		{User: uScheduler, RO: true, Resource: "bindings", NS: "ns1", ExpectAllow: true},
-		{User: uScheduler, RO: true, Resource: "bindings", NS: "", ExpectAllow: true},
+		{User: uScheduler, Verb: "get", Resource: "bindings", NS: "ns1", ExpectAllow: true},
+		{User: uScheduler, Verb: "get", Resource: "bindings", NS: "", ExpectAllow: true},
 
 		// Alice can read and write anything in the right namespace.
-		{User: uAlice, RO: true, Resource: "pods", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: true, Resource: "widgets", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: true, Resource: "", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: false, Resource: "pods", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: false, Resource: "widgets", NS: "projectCaribou", ExpectAllow: true},
-		{User: uAlice, RO: false, Resource: "", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, Verb: "get", Resource: "pods", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, Verb: "get", Resource: "widgets", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, Verb: "get", Resource: "", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, Verb: "update", Resource: "pods", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, Verb: "update", Resource: "widgets", NS: "projectCaribou", ExpectAllow: true},
+		{User: uAlice, Verb: "update", Resource: "", NS: "projectCaribou", ExpectAllow: true},
 		// .. but not the wrong namespace.
-		{User: uAlice, RO: true, Resource: "pods", NS: "ns1", ExpectAllow: false},
-		{User: uAlice, RO: true, Resource: "widgets", NS: "ns1", ExpectAllow: false},
-		{User: uAlice, RO: true, Resource: "", NS: "ns1", ExpectAllow: false},
+		{User: uAlice, Verb: "get", Resource: "pods", NS: "ns1", ExpectAllow: false},
+		{User: uAlice, Verb: "get", Resource: "widgets", NS: "ns1", ExpectAllow: false},
+		{User: uAlice, Verb: "get", Resource: "", NS: "ns1", ExpectAllow: false},
 
 		// Chuck can read events, since anyone can.
-		{User: uChuck, RO: true, Resource: "events", NS: "ns1", ExpectAllow: true},
-		{User: uChuck, RO: true, Resource: "events", NS: "", ExpectAllow: true},
+		{User: uChuck, Verb: "get", Resource: "events", NS: "ns1", ExpectAllow: true},
+		{User: uChuck, Verb: "get", Resource: "events", NS: "", ExpectAllow: true},
 		// Chuck can't do other things.
-		{User: uChuck, RO: false, Resource: "events", NS: "ns1", ExpectAllow: false},
-		{User: uChuck, RO: true, Resource: "pods", NS: "ns1", ExpectAllow: false},
-		{User: uChuck, RO: true, Resource: "floop", NS: "ns1", ExpectAllow: false},
+		{User: uChuck, Verb: "update", Resource: "events", NS: "ns1", ExpectAllow: false},
+		{User: uChuck, Verb: "get", Resource: "pods", NS: "ns1", ExpectAllow: false},
+		{User: uChuck, Verb: "get", Resource: "floop", NS: "ns1", ExpectAllow: false},
 		// Chunk can't access things with no kind or namespace
 		// TODO: find a way to give someone access to miscellaneous endpoints, such as
 		// /healthz, /version, etc.
-		{User: uChuck, RO: true, Resource: "", NS: "", ExpectAllow: false},
+		{User: uChuck, Verb: "get", Resource: "", NS: "", ExpectAllow: false},
 	}
 	for i, tc := range testCases {
 		attr := authorizer.AttributesRecord{
 			User:      &tc.User,
-			ReadOnly:  tc.RO,
+			Verb:      tc.Verb,
 			Resource:  tc.Resource,
 			Namespace: tc.NS,
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authorizer/interfaces.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authorizer/interfaces.go
@@ -17,6 +17,8 @@ limitations under the License.
 package authorizer
 
 import (
+	"net/http"
+
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
@@ -58,6 +60,11 @@ type AuthorizerFunc func(a Attributes) error
 
 func (f AuthorizerFunc) Authorize(a Attributes) error {
 	return f(a)
+}
+
+// RequestAttributesGetter provides a function that extracts Attributes from an http.Request
+type RequestAttributesGetter interface {
+	GetRequestAttributes(user.Info, *http.Request) Attributes
 }
 
 // AttributesRecord implements Attributes interface.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authorizer/interfaces.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authorizer/interfaces.go
@@ -32,6 +32,10 @@ type Attributes interface {
 	// authentication occurred.
 	GetGroups() []string
 
+	// GetVerb returns the kube verb associated with API requests (this includes get, list, watch, create, update, patch, delete, and proxy),
+	// or the lowercased HTTP verb associated with non-API requests (this includes get, put, post, patch, and delete)
+	GetVerb() string
+
 	// When IsReadOnly() == true, the request has no side effects, other than
 	// caching, logging, and other incidentals.
 	IsReadOnly() bool
@@ -59,7 +63,7 @@ func (f AuthorizerFunc) Authorize(a Attributes) error {
 // AttributesRecord implements Attributes interface.
 type AttributesRecord struct {
 	User      user.Info
-	ReadOnly  bool
+	Verb      string
 	Namespace string
 	Resource  string
 }
@@ -72,8 +76,12 @@ func (a AttributesRecord) GetGroups() []string {
 	return a.User.GetGroups()
 }
 
+func (a AttributesRecord) GetVerb() string {
+	return a.Verb
+}
+
 func (a AttributesRecord) IsReadOnly() bool {
-	return a.ReadOnly
+	return a.Verb == "get" || a.Verb == "list" || a.Verb == "watch"
 }
 
 func (a AttributesRecord) GetNamespace() string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
@@ -100,6 +100,9 @@ type KubeletConfig struct {
 	// TLSClientConfig contains settings to enable transport layer security
 	TLSClientConfig
 
+	// Server requires Bearer authentication
+	BearerToken string
+
 	// HTTPTimeout is used by the client to timeout http requests to Kubelet.
 	HTTPTimeout time.Duration
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/kubelet.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/kubelet.go
@@ -48,14 +48,20 @@ func MakeTransport(config *KubeletConfig) (http.RoundTripper, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	transport := http.DefaultTransport
 	if config.Dial != nil || tlsConfig != nil {
-		return &http.Transport{
+		transport = &http.Transport{
 			Dial:            config.Dial,
 			TLSClientConfig: tlsConfig,
-		}, nil
-	} else {
-		return http.DefaultTransport, nil
+		}
 	}
+
+	if len(config.BearerToken) > 0 {
+		transport = NewBearerAuthRoundTripper(config.BearerToken, transport)
+	}
+
+	return transport, nil
 }
 
 // TODO: this structure is questionable, it should be using client.Config and overriding defaults.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/auth.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/auth.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/authorizer"
+)
+
+// KubeletAuth implements AuthInterface
+type KubeletAuth struct {
+	// authenticator identifies the user for requests to the Kubelet API
+	authenticator.Request
+	// authorizerAttributeGetter builds authorization.Attributes for a request to the Kubelet API
+	authorizer.RequestAttributesGetter
+	// authorizer determines whether a given authorization.Attributes is allowed
+	authorizer.Authorizer
+}
+
+// NewKubeletAuth returns a kubelet.AuthInterface composed of the given authenticator, attribute getter, and authorizer
+func NewKubeletAuth(authenticator authenticator.Request, authorizerAttributeGetter authorizer.RequestAttributesGetter, authorizer authorizer.Authorizer) AuthInterface {
+	return &KubeletAuth{authenticator, authorizerAttributeGetter, authorizer}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -2740,8 +2740,8 @@ func (kl *Kubelet) GetCachedMachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return kl.machineInfo, nil
 }
 
-func (kl *Kubelet) ListenAndServe(address net.IP, port uint, tlsOptions *TLSOptions, enableDebuggingHandlers bool) {
-	ListenAndServeKubeletServer(kl, address, port, tlsOptions, enableDebuggingHandlers)
+func (kl *Kubelet) ListenAndServe(address net.IP, port uint, tlsOptions *TLSOptions, auth AuthInterface, enableDebuggingHandlers bool) {
+	ListenAndServeKubeletServer(kl, address, port, tlsOptions, auth, enableDebuggingHandlers)
 }
 
 func (kl *Kubelet) ListenAndServeReadOnly(address net.IP, port uint) {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/server.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/server.go
@@ -37,6 +37,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/httplog"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -49,8 +51,9 @@ import (
 
 // Server is a http.Handler which exposes kubelet functionality over HTTP.
 type Server struct {
+	auth        AuthInterface
 	host        HostInterface
-	restfulCont *restful.Container
+	restfulCont containerInterface
 }
 
 type TLSOptions struct {
@@ -59,10 +62,38 @@ type TLSOptions struct {
 	KeyFile  string
 }
 
+// containerInterface defines the restful.Container functions used on the root container
+type containerInterface interface {
+	Add(service *restful.WebService) *restful.Container
+	Handle(path string, handler http.Handler)
+	Filter(filter restful.FilterFunction)
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+	RegisteredWebServices() []*restful.WebService
+
+	// RegisteredHandlePaths returns the paths of handlers registered directly with the container (non-web-services)
+	// Used to test filters are being applied on non-web-service handlers
+	RegisteredHandlePaths() []string
+}
+
+// filteringContainer delegates all Handle(...) calls to Container.HandleWithFilter(...),
+// so we can ensure restful.FilterFunctions are used for all handlers
+type filteringContainer struct {
+	*restful.Container
+	registeredHandlePaths []string
+}
+
+func (a *filteringContainer) Handle(path string, handler http.Handler) {
+	a.HandleWithFilter(path, handler)
+	a.registeredHandlePaths = append(a.registeredHandlePaths, path)
+}
+func (a *filteringContainer) RegisteredHandlePaths() []string {
+	return a.registeredHandlePaths
+}
+
 // ListenAndServeKubeletServer initializes a server to respond to HTTP network requests on the Kubelet.
-func ListenAndServeKubeletServer(host HostInterface, address net.IP, port uint, tlsOptions *TLSOptions, enableDebuggingHandlers bool) {
+func ListenAndServeKubeletServer(host HostInterface, address net.IP, port uint, tlsOptions *TLSOptions, auth AuthInterface, enableDebuggingHandlers bool) {
 	glog.Infof("Starting to listen on %s:%d", address, port)
-	handler := NewServer(host, enableDebuggingHandlers)
+	handler := NewServer(host, auth, enableDebuggingHandlers)
 	s := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
 		Handler:        &handler,
@@ -81,8 +112,7 @@ func ListenAndServeKubeletServer(host HostInterface, address net.IP, port uint, 
 // ListenAndServeKubeletReadOnlyServer initializes a server to respond to HTTP network requests on the Kubelet.
 func ListenAndServeKubeletReadOnlyServer(host HostInterface, address net.IP, port uint) {
 	glog.V(1).Infof("Starting to listen read-only on %s:%d", address, port)
-	s := NewServer(host, false)
-	s.restfulCont.Handle("/metrics", prometheus.Handler())
+	s := NewServer(host, nil, false)
 
 	server := &http.Server{
 		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
@@ -92,6 +122,13 @@ func ListenAndServeKubeletReadOnlyServer(host HostInterface, address net.IP, por
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Fatal(server.ListenAndServe())
+}
+
+// AuthInterface contains all methods required by the auth filters
+type AuthInterface interface {
+	authenticator.Request
+	authorizer.RequestAttributesGetter
+	authorizer.Authorizer
 }
 
 // HostInterface contains all the kubelet methods required by the server.
@@ -117,16 +154,51 @@ type HostInterface interface {
 }
 
 // NewServer initializes and configures a kubelet.Server object to handle HTTP requests.
-func NewServer(host HostInterface, enableDebuggingHandlers bool) Server {
+func NewServer(host HostInterface, auth AuthInterface, enableDebuggingHandlers bool) Server {
 	server := Server{
 		host:        host,
-		restfulCont: restful.NewContainer(),
+		auth:        auth,
+		restfulCont: &filteringContainer{Container: restful.NewContainer()},
+	}
+	if auth != nil {
+		server.InstallAuthFilter()
 	}
 	server.InstallDefaultHandlers()
 	if enableDebuggingHandlers {
 		server.InstallDebuggingHandlers()
 	}
 	return server
+}
+
+// InstallAuthFilter installs authentication filters with the restful Container.
+func (s *Server) InstallAuthFilter() {
+	s.restfulCont.Filter(func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		// Authenticate
+		u, ok, err := s.auth.AuthenticateRequest(req.Request)
+		if err != nil {
+			glog.Errorf("Unable to authenticate the request due to an error: %v", err)
+			resp.WriteErrorString(http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+		if !ok {
+			resp.WriteErrorString(http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+
+		// Get authorization attributes
+		attrs := s.auth.GetRequestAttributes(u, req.Request)
+
+		// Authorize
+		if err := s.auth.Authorize(attrs); err != nil {
+			msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, namespace=%s, resource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetNamespace(), attrs.GetResource())
+			glog.V(2).Info(msg)
+			resp.WriteErrorString(http.StatusForbidden, msg)
+			return
+		}
+
+		// Continue
+		chain.ProcessFilter(req, resp)
+	})
 }
 
 // InstallDefaultHandlers registers the default set of supported HTTP request
@@ -148,6 +220,7 @@ func (s *Server) InstallDefaultHandlers() {
 	s.restfulCont.Add(ws)
 
 	s.restfulCont.Handle("/stats/", &httpHandler{f: s.handleStats})
+	s.restfulCont.Handle("/metrics", prometheus.Handler())
 
 	ws = new(restful.WebService)
 	ws.
@@ -237,8 +310,6 @@ func (s *Server) InstallDebuggingHandlers() {
 		To(s.getContainerLogs).
 		Operation("getContainerLogs"))
 	s.restfulCont.Add(ws)
-
-	s.restfulCont.Handle("/metrics", prometheus.Handler())
 
 	handlePprofEndpoint := func(req *restful.Request, resp *restful.Response) {
 		name := strings.TrimPrefix(req.Request.URL.Path, pprofBasePath)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/server_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/server_test.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -34,11 +35,14 @@ import (
 
 	cadvisorApi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/authorizer"
+	"k8s.io/kubernetes/pkg/auth/user"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type fakeKubelet struct {
@@ -129,15 +133,38 @@ func (fk *fakeKubelet) StreamingConnectionIdleTimeout() time.Duration {
 	return fk.streamingConnectionIdleTimeoutFunc()
 }
 
+type fakeAuth struct {
+	authenticateFunc func(*http.Request) (user.Info, bool, error)
+	attributesFunc   func(user.Info, *http.Request) authorizer.Attributes
+	authorizeFunc    func(authorizer.Attributes) (err error)
+}
+
+func (f *fakeAuth) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	return f.authenticateFunc(req)
+}
+func (f *fakeAuth) GetRequestAttributes(u user.Info, req *http.Request) authorizer.Attributes {
+	return f.attributesFunc(u, req)
+}
+func (f *fakeAuth) Authorize(a authorizer.Attributes) (err error) {
+	return f.authorizeFunc(a)
+}
+
 type serverTestFramework struct {
 	serverUnderTest *Server
 	fakeKubelet     *fakeKubelet
+	fakeAuth        *fakeAuth
 	testHTTPServer  *httptest.Server
 }
 
 func newServerTest() *serverTestFramework {
 	fw := &serverTestFramework{}
 	fw.fakeKubelet = &fakeKubelet{
+		containerVersionFunc: func() (kubecontainer.Version, error) {
+			return dockertools.NewVersion("1.15")
+		},
+		hostnameFunc: func() string {
+			return "127.0.0.1"
+		},
 		podByNameFunc: func(namespace, name string) (*api.Pod, bool) {
 			return &api.Pod{
 				ObjectMeta: api.ObjectMeta{
@@ -147,7 +174,18 @@ func newServerTest() *serverTestFramework {
 			}, true
 		},
 	}
-	server := NewServer(fw.fakeKubelet, true)
+	fw.fakeAuth = &fakeAuth{
+		authenticateFunc: func(req *http.Request) (user.Info, bool, error) {
+			return &user.DefaultInfo{Name: "test"}, true, nil
+		},
+		attributesFunc: func(u user.Info, req *http.Request) authorizer.Attributes {
+			return &authorizer.AttributesRecord{User: u}
+		},
+		authorizeFunc: func(a authorizer.Attributes) (err error) {
+			return nil
+		},
+	}
+	server := NewServer(fw.fakeKubelet, fw.fakeAuth, true)
 	fw.serverUnderTest = &server
 	fw.testHTTPServer = httptest.NewServer(fw.serverUnderTest)
 	return fw
@@ -497,6 +535,178 @@ func assertHealthFails(t *testing.T, httpURL string, expectedErrorCode int) {
 	defer resp.Body.Close()
 	if resp.StatusCode != expectedErrorCode {
 		t.Errorf("expected status code %d, got %d", expectedErrorCode, resp.StatusCode)
+	}
+}
+
+type authTestCase struct {
+	Method string
+	Path   string
+}
+
+func TestAuthFilters(t *testing.T) {
+	fw := newServerTest()
+
+	testcases := []authTestCase{}
+
+	// This is a sanity check that the Handle->HandleWithFilter() delegation is working
+	// Ideally, these would move to registered web services and this list would get shorter
+	expectedPaths := []string{"/healthz", "/stats/", "/metrics"}
+	paths := sets.NewString(fw.serverUnderTest.restfulCont.RegisteredHandlePaths()...)
+	for _, expectedPath := range expectedPaths {
+		if !paths.Has(expectedPath) {
+			t.Errorf("Expected registered handle path %s was missing", expectedPath)
+		}
+	}
+
+	// Test all the non-web-service handlers
+	for _, path := range fw.serverUnderTest.restfulCont.RegisteredHandlePaths() {
+		testcases = append(testcases, authTestCase{"GET", path})
+		testcases = append(testcases, authTestCase{"POST", path})
+		// Test subpaths for directory handlers
+		if strings.HasSuffix(path, "/") {
+			testcases = append(testcases, authTestCase{"GET", path + "foo"})
+			testcases = append(testcases, authTestCase{"POST", path + "foo"})
+		}
+	}
+
+	// Test all the generated web-service paths
+	for _, ws := range fw.serverUnderTest.restfulCont.RegisteredWebServices() {
+		for _, r := range ws.Routes() {
+			testcases = append(testcases, authTestCase{r.Method, r.Path})
+		}
+	}
+
+	for _, tc := range testcases {
+		var (
+			expectedUser       = &user.DefaultInfo{Name: "test"}
+			expectedAttributes = &authorizer.AttributesRecord{User: expectedUser}
+
+			calledAuthenticate = false
+			calledAuthorize    = false
+			calledAttributes   = false
+		)
+
+		fw.fakeAuth.authenticateFunc = func(req *http.Request) (user.Info, bool, error) {
+			calledAuthenticate = true
+			return expectedUser, true, nil
+		}
+		fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+			calledAttributes = true
+			if u != expectedUser {
+				t.Fatalf("%s: expected user %v, got %v", tc.Path, expectedUser, u)
+			}
+			return expectedAttributes
+		}
+		fw.fakeAuth.authorizeFunc = func(a authorizer.Attributes) (err error) {
+			calledAuthorize = true
+			if a != expectedAttributes {
+				t.Fatalf("%s: expected attributes %v, got %v", tc.Path, expectedAttributes, a)
+			}
+			return errors.New("Forbidden")
+		}
+
+		req, err := http.NewRequest(tc.Method, fw.testHTTPServer.URL+tc.Path, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.Path, err)
+			continue
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.Path, err)
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("%s: unexpected status code %d", tc.Path, resp.StatusCode)
+			continue
+		}
+
+		if !calledAuthenticate {
+			t.Errorf("%s: Authenticate was not called", tc.Path)
+			continue
+		}
+		if !calledAttributes {
+			t.Errorf("%s: Attributes were not called", tc.Path)
+			continue
+		}
+		if !calledAuthorize {
+			t.Errorf("%s: Authorize was not called", tc.Path)
+			continue
+		}
+	}
+}
+
+func TestAuthenticationFailure(t *testing.T) {
+	var (
+		expectedUser       = &user.DefaultInfo{Name: "test"}
+		expectedAttributes = &authorizer.AttributesRecord{User: expectedUser}
+
+		calledAuthenticate = false
+		calledAuthorize    = false
+		calledAttributes   = false
+	)
+
+	fw := newServerTest()
+	fw.fakeAuth.authenticateFunc = func(req *http.Request) (user.Info, bool, error) {
+		calledAuthenticate = true
+		return nil, false, nil
+	}
+	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+		calledAttributes = true
+		return expectedAttributes
+	}
+	fw.fakeAuth.authorizeFunc = func(a authorizer.Attributes) (err error) {
+		calledAuthorize = true
+		return errors.New("not allowed")
+	}
+
+	assertHealthFails(t, fw.testHTTPServer.URL+"/healthz", http.StatusUnauthorized)
+
+	if !calledAuthenticate {
+		t.Fatalf("Authenticate was not called")
+	}
+	if calledAttributes {
+		t.Fatalf("Attributes was called unexpectedly")
+	}
+	if calledAuthorize {
+		t.Fatalf("Authorize was called unexpectedly")
+	}
+}
+
+func TestAuthorizationSuccess(t *testing.T) {
+	var (
+		expectedUser       = &user.DefaultInfo{Name: "test"}
+		expectedAttributes = &authorizer.AttributesRecord{User: expectedUser}
+
+		calledAuthenticate = false
+		calledAuthorize    = false
+		calledAttributes   = false
+	)
+
+	fw := newServerTest()
+	fw.fakeAuth.authenticateFunc = func(req *http.Request) (user.Info, bool, error) {
+		calledAuthenticate = true
+		return expectedUser, true, nil
+	}
+	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+		calledAttributes = true
+		return expectedAttributes
+	}
+	fw.fakeAuth.authorizeFunc = func(a authorizer.Attributes) (err error) {
+		calledAuthorize = true
+		return nil
+	}
+
+	assertHealthIsOk(t, fw.testHTTPServer.URL+"/healthz")
+
+	if !calledAuthenticate {
+		t.Fatalf("Authenticate was not called")
+	}
+	if !calledAttributes {
+		t.Fatalf("Attributes were not called")
+	}
+	if !calledAuthorize {
+		t.Fatalf("Authorize was not called")
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets/set.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets/set.go
@@ -121,6 +121,29 @@ func (s1 String) Union(s2 String) String {
 	return result
 }
 
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {1, 2}
+// s2 = {2, 3}
+// s1.Intersection(s2) = {2}
+func (s1 String) Intersection(s2 String) String {
+	var walk, other String
+	result := NewString()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
 // IsSuperset returns true iff s1 is a superset of s2.
 func (s1 String) IsSuperset(s2 String) bool {
 	for item := range s2 {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets/set_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets/set_test.go
@@ -183,3 +183,88 @@ func TestStringSetEquals(t *testing.T) {
 		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
 	}
 }
+
+func TestStringUnion(t *testing.T) {
+	tests := []struct {
+		s1       String
+		s2       String
+		expected String
+	}{
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("3", "4", "5", "6"),
+			NewString("1", "2", "3", "4", "5", "6"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString(),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString(),
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString(),
+			NewString(),
+			NewString(),
+		},
+	}
+
+	for _, test := range tests {
+		union := test.s1.Union(test.s2)
+		if union.Len() != test.expected.Len() {
+			t.Errorf("Expected union.Len()=%d but got %d", test.expected.Len(), union.Len())
+		}
+
+		if !union.Equal(test.expected) {
+			t.Errorf("Expected union.Equal(expected) but not true.  union:%v expected:%v", union.List(), test.expected.List())
+		}
+	}
+}
+
+func TestStringIntersection(t *testing.T) {
+	tests := []struct {
+		s1       String
+		s2       String
+		expected String
+	}{
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("3", "4", "5", "6"),
+			NewString("3", "4"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString(),
+			NewString(),
+		},
+		{
+			NewString(),
+			NewString("1", "2", "3", "4"),
+			NewString(),
+		},
+		{
+			NewString(),
+			NewString(),
+			NewString(),
+		},
+	}
+
+	for _, test := range tests {
+		intersection := test.s1.Intersection(test.s2)
+		if intersection.Len() != test.expected.Len() {
+			t.Errorf("Expected intersection.Len()=%d but got %d", test.expected.Len(), intersection.Len())
+		}
+
+		if !intersection.Equal(test.expected) {
+			t.Errorf("Expected intersection.Equal(expected) but not true.  intersection:%v expected:%v", intersection.List(), test.expected.List())
+		}
+	}
+}

--- a/pkg/auth/authenticator/anonymous/anonymous.go
+++ b/pkg/auth/authenticator/anonymous/anonymous.go
@@ -1,0 +1,16 @@
+package anonymous
+
+import (
+	"net/http"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+)
+
+func NewAuthenticator() authenticator.Request {
+	return authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
+		return &user.DefaultInfo{Name: bootstrappolicy.UnauthenticatedUsername, Groups: []string{bootstrappolicy.UnauthenticatedGroup}}, true, nil
+	})
+}

--- a/pkg/auth/authenticator/anonymous/anonymous_test.go
+++ b/pkg/auth/authenticator/anonymous/anonymous_test.go
@@ -1,0 +1,27 @@
+package anonymous
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func TestAnonymous(t *testing.T) {
+	var a authenticator.Request = NewAuthenticator()
+	u, ok, err := a.AuthenticateRequest(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if !ok {
+		t.Fatalf("Unexpectedly unauthenticated")
+	}
+	if u.GetName() != bootstrappolicy.UnauthenticatedUsername {
+		t.Fatalf("Expected username %s, got %s", bootstrappolicy.UnauthenticatedUsername, u.GetName())
+	}
+	if !sets.NewString(u.GetGroups()...).Equal(sets.NewString(bootstrappolicy.UnauthenticatedGroup)) {
+		t.Fatalf("Expected group %s, got %v", bootstrappolicy.UnauthenticatedGroup, u.GetGroups())
+	}
+}

--- a/pkg/auth/authenticator/request/bearertoken/bearertoken.go
+++ b/pkg/auth/authenticator/request/bearertoken/bearertoken.go
@@ -30,6 +30,12 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 	}
 
 	token := parts[1]
+
+	// Empty bearer tokens aren't valid
+	if len(token) == 0 {
+		return nil, false, nil
+	}
+
 	user, ok, err := a.auth.AuthenticateToken(token)
 	if ok && a.removeHeader {
 		req.Header.Del("Authorization")

--- a/pkg/auth/authenticator/request/bearertoken/bearertoken_test.go
+++ b/pkg/auth/authenticator/request/bearertoken/bearertoken_test.go
@@ -1,0 +1,119 @@
+package bearertoken
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+func TestBearerToken(t *testing.T) {
+	tests := map[string]struct {
+		AuthorizationHeaders []string
+		TokenAuth            authenticator.Token
+		RemoveHeader         bool
+
+		ExpectedUserName             string
+		ExpectedOK                   bool
+		ExpectedErr                  bool
+		ExpectedAuthorizationHeaders []string
+	}{
+		"no header": {
+			AuthorizationHeaders:         nil,
+			RemoveHeader:                 true,
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: nil,
+		},
+		"empty header": {
+			AuthorizationHeaders:         []string{""},
+			RemoveHeader:                 true,
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: []string{""},
+		},
+		"non-bearer header": {
+			AuthorizationHeaders:         []string{"Basic 123"},
+			RemoveHeader:                 true,
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: []string{"Basic 123"},
+		},
+		"empty bearer token": {
+			AuthorizationHeaders:         []string{"Bearer "},
+			RemoveHeader:                 true,
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: []string{"Bearer "},
+		},
+		"valid bearer token removing header": {
+			AuthorizationHeaders:         []string{"Bearer 123"},
+			TokenAuth:                    authenticator.TokenFunc(func(t string) (user.Info, bool, error) { return &user.DefaultInfo{Name: "myuser"}, true, nil }),
+			RemoveHeader:                 true,
+			ExpectedUserName:             "myuser",
+			ExpectedOK:                   true,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: nil,
+		},
+		"valid bearer token leaving header": {
+			AuthorizationHeaders:         []string{"Bearer 123"},
+			TokenAuth:                    authenticator.TokenFunc(func(t string) (user.Info, bool, error) { return &user.DefaultInfo{Name: "myuser"}, true, nil }),
+			RemoveHeader:                 false,
+			ExpectedUserName:             "myuser",
+			ExpectedOK:                   true,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: []string{"Bearer 123"},
+		},
+		"invalid bearer token": {
+			AuthorizationHeaders:         []string{"Bearer 123"},
+			TokenAuth:                    authenticator.TokenFunc(func(t string) (user.Info, bool, error) { return nil, false, nil }),
+			RemoveHeader:                 true,
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  false,
+			ExpectedAuthorizationHeaders: []string{"Bearer 123"},
+		},
+		"error bearer token": {
+			AuthorizationHeaders:         []string{"Bearer 123"},
+			TokenAuth:                    authenticator.TokenFunc(func(t string) (user.Info, bool, error) { return nil, false, errors.New("error") }),
+			RemoveHeader:                 true,
+			ExpectedUserName:             "",
+			ExpectedOK:                   false,
+			ExpectedErr:                  true,
+			ExpectedAuthorizationHeaders: []string{"Bearer 123"},
+		},
+	}
+
+	for k, tc := range tests {
+		req, _ := http.NewRequest("GET", "/", nil)
+		for _, h := range tc.AuthorizationHeaders {
+			req.Header.Add("Authorization", h)
+		}
+
+		bearerAuth := New(tc.TokenAuth, tc.RemoveHeader)
+		u, ok, err := bearerAuth.AuthenticateRequest(req)
+		if tc.ExpectedErr != (err != nil) {
+			t.Errorf("%s: Expected err=%v, got %v", k, tc.ExpectedErr, err)
+			continue
+		}
+		if ok != tc.ExpectedOK {
+			t.Errorf("%s: Expected ok=%v, got %v", k, tc.ExpectedOK, ok)
+			continue
+		}
+		if ok && u.GetName() != tc.ExpectedUserName {
+			t.Errorf("%s: Expected username=%v, got %v", k, tc.ExpectedUserName, u.GetName())
+			continue
+		}
+		if !reflect.DeepEqual(req.Header["Authorization"], tc.ExpectedAuthorizationHeaders) {
+			t.Errorf("%s: Expected headers=%#v, got %#v", k, tc.ExpectedAuthorizationHeaders, req.Header["Authorization"])
+			continue
+		}
+	}
+}

--- a/pkg/auth/authenticator/request/unionrequest/union.go
+++ b/pkg/auth/authenticator/request/unionrequest/union.go
@@ -38,5 +38,9 @@ func (authHandler *Authenticator) AuthenticateRequest(req *http.Request) (user.I
 		}
 	}
 
+	if len(errors) == 1 {
+		// Avoid wrapping an error if possible
+		return nil, false, errors[0]
+	}
 	return nil, false, kerrors.NewAggregate(errors)
 }

--- a/pkg/auth/authenticator/request/unionrequest/unionauth_test.go
+++ b/pkg/auth/authenticator/request/unionrequest/unionauth_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/auth/user"
+
+	"github.com/openshift/origin/pkg/auth/authenticator"
 )
 
 type mockAuthRequestHandler struct {
@@ -79,6 +81,27 @@ func TestAuthenticateRequestAdditiveErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "second") {
 		t.Errorf("Expected error containing %v, got %v", "second", err)
+	}
+	if isAuthenticated {
+		t.Errorf("Unexpectedly authenticated: %v", isAuthenticated)
+	}
+}
+
+func TestAuthenticateRequestFailEarly(t *testing.T) {
+	handler1 := &mockAuthRequestHandler{err: errors.New("first")}
+	handler2 := &mockAuthRequestHandler{err: errors.New("second")}
+	authRequestHandler := Authenticator{Handlers: []authenticator.Request{handler1, handler2}, FailOnError: true}
+	req, _ := http.NewRequest("GET", "http://example.org", nil)
+
+	_, isAuthenticated, err := authRequestHandler.AuthenticateRequest(req)
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+	if !strings.Contains(err.Error(), "first") {
+		t.Errorf("Expected error containing %v, got %v", "first", err)
+	}
+	if strings.Contains(err.Error(), "second") {
+		t.Errorf("Did not expect second error, got %v", err)
 	}
 	if isAuthenticated {
 		t.Errorf("Unexpectedly authenticated: %v", isAuthenticated)

--- a/pkg/auth/authenticator/token/cache/cache.go
+++ b/pkg/auth/authenticator/token/cache/cache.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/golang-lru"
+
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/openshift/origin/pkg/auth/authenticator"
+)
+
+type CacheAuthenticator struct {
+	authenticator authenticator.Token
+
+	cache *lru.Cache
+
+	ttl time.Duration
+	now func() time.Time
+}
+
+type cacheRecord struct {
+	created time.Time
+	user    user.Info
+	ok      bool
+	err     error
+}
+
+// NewAuthenticator returns an authenticator that caches the results of the given authenticator
+func NewAuthenticator(a authenticator.Token, ttl time.Duration, maxCount int) (authenticator.Token, error) {
+	cache, err := lru.New(maxCount)
+	if err != nil {
+		return nil, err
+	}
+	return &CacheAuthenticator{
+		authenticator: a,
+		cache:         cache,
+		ttl:           ttl,
+		now:           time.Now,
+	}, nil
+}
+
+func (c *CacheAuthenticator) AuthenticateToken(token string) (user.Info, bool, error) {
+	if value, hit := c.cache.Get(token); hit {
+		switch record := value.(type) {
+		case *cacheRecord:
+			if record.created.Add(c.ttl).After(c.now()) {
+				glog.V(5).Infof("cache record found: %#v", record)
+				return record.user, record.ok, record.err
+			} else {
+				glog.V(5).Infof("cache record expired: %#v", record)
+				c.cache.Remove(token)
+			}
+		default:
+			util.HandleError(fmt.Errorf("invalid cache record type: %#v", record))
+		}
+	}
+
+	u, ok, err := c.authenticator.AuthenticateToken(token)
+
+	// Don't cache results if there was an error unrelated to authentication
+	// TODO: figure out a better way to determine this
+	if err == nil || kerrs.IsUnauthorized(err) {
+		c.cache.Add(token, &cacheRecord{created: c.now(), user: u, ok: ok, err: err})
+	}
+
+	return u, ok, err
+}

--- a/pkg/auth/authenticator/token/cache/cache_test.go
+++ b/pkg/auth/authenticator/token/cache/cache_test.go
@@ -1,0 +1,161 @@
+package cache
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+type testRequest struct {
+	Token            string
+	Offset           time.Duration
+	ExpectedUserName string
+	ExpectedOK       bool
+	ExpectedErr      bool
+}
+
+func TestCache(t *testing.T) {
+	tokenAuthInvocations := []string{}
+	tokenAuth := authenticator.TokenFunc(func(token string) (user.Info, bool, error) {
+		tokenAuthInvocations = append(tokenAuthInvocations, token)
+		switch {
+		case strings.HasPrefix(token, "user"):
+			return &user.DefaultInfo{Name: token}, true, nil
+		case strings.HasPrefix(token, "unauthorized"):
+			return nil, false, kerrs.NewUnauthorized(token)
+		case strings.HasPrefix(token, "error"):
+			return nil, false, errors.New(token)
+		default:
+			return nil, false, nil
+		}
+	})
+
+	tests := map[string]struct {
+		TTL       time.Duration
+		CacheSize int
+
+		Requests            []testRequest
+		ExpectedInvocations []string
+		ExpectedCacheSize   int
+	}{
+		"miss": {
+			TTL:       time.Minute,
+			CacheSize: 1,
+			Requests: []testRequest{
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true},
+			},
+			ExpectedInvocations: []string{"user1"},
+			ExpectedCacheSize:   1,
+		},
+		"cache hit user": {
+			TTL:       time.Minute,
+			CacheSize: 1,
+			Requests: []testRequest{
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true},
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true},
+			},
+			ExpectedInvocations: []string{"user1"},
+			ExpectedCacheSize:   1,
+		},
+		"cache hit invalid": {
+			TTL:       time.Minute,
+			CacheSize: 1,
+			Requests: []testRequest{
+				{Token: "invalid1", ExpectedOK: false},
+				{Token: "invalid1", ExpectedOK: false},
+			},
+			ExpectedInvocations: []string{"invalid1"},
+			ExpectedCacheSize:   1,
+		},
+		"cache hit unauthorized error": {
+			TTL:       time.Minute,
+			CacheSize: 1,
+			Requests: []testRequest{
+				{Token: "unauthorized1", ExpectedErr: true},
+				{Token: "unauthorized1", ExpectedErr: true},
+			},
+			ExpectedInvocations: []string{"unauthorized1"},
+			ExpectedCacheSize:   1,
+		},
+		"uncacheable error": {
+			TTL:       time.Minute,
+			CacheSize: 1,
+			Requests: []testRequest{
+				{Token: "error1", ExpectedErr: true},
+				{Token: "error1", ExpectedErr: true},
+			},
+			ExpectedInvocations: []string{"error1", "error1"},
+			ExpectedCacheSize:   0,
+		},
+		"expire": {
+			TTL:       time.Minute,
+			CacheSize: 1,
+			Requests: []testRequest{
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true},
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true, Offset: 2 * time.Minute},
+			},
+			ExpectedInvocations: []string{"user1", "user1"},
+			ExpectedCacheSize:   1,
+		},
+		"evacuation": {
+			TTL:       time.Minute,
+			CacheSize: 2,
+			Requests: []testRequest{
+				// Request user1
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true},
+				// Requests for user2 and user3 evacuate user1
+				{Token: "user2", ExpectedUserName: "user2", ExpectedOK: true, Offset: 10 * time.Second},
+				{Token: "user3", ExpectedUserName: "user3", ExpectedOK: true, Offset: 20 * time.Second},
+				{Token: "user2", ExpectedUserName: "user2", ExpectedOK: true, Offset: 30 * time.Second},
+				{Token: "user3", ExpectedUserName: "user3", ExpectedOK: true, Offset: 40 * time.Second},
+				{Token: "user2", ExpectedUserName: "user2", ExpectedOK: true, Offset: 50 * time.Second},
+				{Token: "user3", ExpectedUserName: "user3", ExpectedOK: true, Offset: 60 * time.Second},
+				// Request for user1 refetches
+				{Token: "user1", ExpectedUserName: "user1", ExpectedOK: true},
+			},
+			ExpectedInvocations: []string{"user1", "user2", "user3", "user1"},
+			ExpectedCacheSize:   2,
+		},
+	}
+
+	for k, tc := range tests {
+		tokenAuthInvocations = []string{}
+		start := time.Now()
+
+		auth, err := NewAuthenticator(tokenAuth, tc.TTL, tc.CacheSize)
+		if err != nil {
+			t.Errorf("%s: Unexpected error: %v", k, err)
+		}
+		cacheAuth := auth.(*CacheAuthenticator)
+		for i, r := range tc.Requests {
+			cacheAuth.now = func() time.Time { return start.Add(r.Offset) }
+			u, ok, err := cacheAuth.AuthenticateToken(r.Token)
+
+			if r.ExpectedErr != (err != nil) {
+				t.Errorf("%s: %d: Expected err=%v, got %v", k, i, r.ExpectedErr, err)
+				continue
+			}
+			if ok != r.ExpectedOK {
+				t.Errorf("%s: %d: Expected ok=%v, got %v", k, i, r.ExpectedOK, ok)
+				continue
+			}
+			if ok && u.GetName() != r.ExpectedUserName {
+				t.Errorf("%s: %d: Expected username=%v, got %v", k, i, r.ExpectedUserName, u.GetName())
+				continue
+			}
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedInvocations, tokenAuthInvocations) {
+			t.Errorf("%s: Expected invocations=%v, got %v", k, tc.ExpectedInvocations, tokenAuthInvocations)
+		}
+		if cacheAuth.cache.Len() != tc.ExpectedCacheSize {
+			t.Errorf("%s: Expected cache size %d, got %d", k, tc.ExpectedCacheSize, cacheAuth.cache.Len())
+		}
+	}
+}

--- a/pkg/auth/authenticator/token/remotemaster/remotemaster.go
+++ b/pkg/auth/authenticator/token/remotemaster/remotemaster.go
@@ -1,0 +1,48 @@
+package remotemaster
+
+import (
+	"k8s.io/kubernetes/pkg/auth/user"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+type Authenticator struct {
+	anonymousConfig kclient.Config
+}
+
+// NewAuthenticator authenticates by fetching users/~ using the provided token as a bearer token
+func NewAuthenticator(anonymousConfig kclient.Config) (*Authenticator, error) {
+	// Ensure credentials are removed from the anonymous config
+	anonymousConfig = clientcmd.AnonymousClientConfig(anonymousConfig)
+
+	return &Authenticator{
+		anonymousConfig: anonymousConfig,
+	}, nil
+}
+
+func (a *Authenticator) AuthenticateToken(value string) (user.Info, bool, error) {
+	if len(value) == 0 {
+		return nil, false, nil
+	}
+
+	tokenConfig := a.anonymousConfig
+	tokenConfig.BearerToken = value
+
+	c, err := client.New(&tokenConfig)
+	if err != nil {
+		return nil, false, err
+	}
+
+	u, err := c.Users().Get("~")
+	if err != nil {
+		return nil, false, err
+	}
+
+	return &user.DefaultInfo{
+		Name:   u.Name,
+		UID:    string(u.UID),
+		Groups: u.Groups,
+	}, true, nil
+}

--- a/pkg/authorization/api/synthetic.go
+++ b/pkg/authorization/api/synthetic.go
@@ -5,4 +5,8 @@ const (
 	DockerBuildResource = "builds/docker"
 	SourceBuildResource = "builds/source"
 	CustomBuildResource = "builds/custom"
+
+	NodeMetricsResource = "nodes/metrics"
+	NodeStatsResource   = "nodes/stats"
+	NodeLogResource     = "nodes/log"
 )

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -90,13 +90,13 @@ var (
 		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status"},
 
 		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
-		KubeInternalsGroupName: {"minions", "nodes", "bindings", "events", "namespaces"},
+		KubeInternalsGroupName: {"minions", "nodes", NodeMetricsResource, NodeStatsResource, NodeLogResource, "bindings", "events", "namespaces"},
 		KubeExposedGroupName:   {"pods", "replicationcontrollers", "serviceaccounts", "services", "endpoints", "persistentvolumeclaims", "pods/log"},
 		KubeAllGroupName:       {KubeInternalsGroupName, KubeExposedGroupName, QuotaGroupName},
 		KubeStatusGroupName:    {"pods/status", "resourcequotas/status", "namespaces/status"},
 
 		OpenshiftEscalatingViewableGroupName: {"oauthauthorizetokens", "oauthaccesstokens"},
-		KubeEscalatingViewableGroupName:      {"secrets"},
+		KubeEscalatingViewableGroupName:      {"secrets", NodeLogResource}, // consider NodeLogResource a potentially escalating resource since it proxies to /var/log on the nodes
 		EscalatingResourcesGroupName:         {OpenshiftEscalatingViewableGroupName, KubeEscalatingViewableGroupName},
 
 		NonEscalatingResourcesGroupName: {OpenshiftNonEscalatingViewableGroupName, KubeNonEscalatingViewableGroupName},

--- a/pkg/authorization/authorizer/adapter/attributes.go
+++ b/pkg/authorization/authorizer/adapter/attributes.go
@@ -1,0 +1,88 @@
+package adapter
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	kauthorizer "k8s.io/kubernetes/pkg/auth/authorizer"
+	"k8s.io/kubernetes/pkg/auth/user"
+
+	oauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+// ensure we satisfy both interfaces
+var _ = oauthorizer.AuthorizationAttributes(AdapterAttributes{})
+var _ = kauthorizer.Attributes(AdapterAttributes{})
+
+// AdapterAttributes satisfies both origin authorizer.AuthorizationAttributes and k8s authorizer.Attributes interfaces
+type AdapterAttributes struct {
+	namespace string
+	userName  string
+	groups    []string
+	oauthorizer.AuthorizationAttributes
+}
+
+// OriginAuthorizerAttributes adapts Kubernetes authorization attributes to Origin authorization attributes
+// Note that some info (like resourceName, apiVersion, apiGroup) is not available from the Kubernetes attributes
+func OriginAuthorizerAttributes(kattrs kauthorizer.Attributes) (kapi.Context, oauthorizer.AuthorizationAttributes) {
+	// Build a context to hold the namespace and user info
+	ctx := kapi.NewContext()
+	ctx = kapi.WithNamespace(ctx, kattrs.GetNamespace())
+	ctx = kapi.WithUser(ctx, &user.DefaultInfo{
+		Name:   kattrs.GetUserName(),
+		Groups: kattrs.GetGroups(),
+	})
+
+	// If the passed attributes already satisfy our interface, use it directly
+	if oattrs, ok := kattrs.(oauthorizer.AuthorizationAttributes); ok {
+		return ctx, oattrs
+	}
+
+	// Otherwise build what we can
+	oattrs := &oauthorizer.DefaultAuthorizationAttributes{
+		Verb:     kattrs.GetVerb(),
+		Resource: kattrs.GetResource(),
+
+		// TODO: add to kube authorizer attributes
+		// APIVersion        string
+		// APIGroup          string
+		// ResourceName      string
+		// RequestAttributes interface{}
+		// NonResourceURL    bool
+		// URL               string
+	}
+	return ctx, oattrs
+}
+
+// KubernetesAuthorizerAttributes adapts Origin authorization attributes to Kubernetes authorization attributes
+// The returned attributes can be passed to OriginAuthorizerAttributes to access extra information from the Origin attributes interface
+func KubernetesAuthorizerAttributes(namespace string, userName string, groups []string, oattrs oauthorizer.AuthorizationAttributes) kauthorizer.Attributes {
+	return AdapterAttributes{
+		namespace:               namespace,
+		userName:                userName,
+		groups:                  groups,
+		AuthorizationAttributes: oattrs,
+	}
+}
+
+// GetNamespace satisfies the kubernetes authorizer.Attributes interface
+// origin gets this value from the request context
+func (a AdapterAttributes) GetNamespace() string {
+	return a.namespace
+}
+
+// GetUserName satisfies the kubernetes authorizer.Attributes interface
+// origin gets this value from the request context
+func (a AdapterAttributes) GetUserName() string {
+	return a.userName
+}
+
+// GetGroups satisfies the kubernetes authorizer.Attributes interface
+// origin gets this value from the request context
+func (a AdapterAttributes) GetGroups() []string {
+	return a.groups
+}
+
+// IsReadOnly satisfies the kubernetes authorizer.Attributes interface based on the verb
+func (a AdapterAttributes) IsReadOnly() bool {
+	v := a.GetVerb()
+	return v == "get" || v == "list" || v == "watch"
+}

--- a/pkg/authorization/authorizer/adapter/attributes_test.go
+++ b/pkg/authorization/authorizer/adapter/attributes_test.go
@@ -1,0 +1,143 @@
+package adapter
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kauthorizer "k8s.io/kubernetes/pkg/auth/authorizer"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	oauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+// ensure we satisfy both interfaces
+var _ = oauthorizer.AuthorizationAttributes(AdapterAttributes{})
+var _ = kauthorizer.Attributes(AdapterAttributes{})
+
+func TestRoundTrip(t *testing.T) {
+	// Start with origin attributes
+	oattrs := oauthorizer.DefaultAuthorizationAttributes{
+		Verb:              "get",
+		APIVersion:        "av",
+		APIGroup:          "ag",
+		Resource:          "r",
+		ResourceName:      "rn",
+		RequestAttributes: "ra",
+		NonResourceURL:    true,
+		URL:               "/123",
+	}
+
+	// Convert to kube attributes
+	kattrs := KubernetesAuthorizerAttributes("ns", "myuser", []string{"mygroup"}, oattrs)
+	if kattrs.GetUserName() != "myuser" {
+		t.Errorf("Expected %v, got %v", "myuser", kattrs.GetUserName())
+	}
+	if !reflect.DeepEqual(kattrs.GetGroups(), []string{"mygroup"}) {
+		t.Errorf("Expected %v, got %v", []string{"mygroup"}, kattrs.GetGroups())
+	}
+	if kattrs.GetVerb() != "get" {
+		t.Errorf("Expected %v, got %v", "get", kattrs.GetVerb())
+	}
+	if kattrs.IsReadOnly() != true {
+		t.Errorf("Expected %v, got %v", true, kattrs.IsReadOnly())
+	}
+	if kattrs.GetNamespace() != "ns" {
+		t.Errorf("Expected %v, got %v", "ns", kattrs.GetNamespace())
+	}
+	if kattrs.GetResource() != "r" {
+		t.Errorf("Expected %v, got %v", "", kattrs.GetResource())
+	}
+
+	// Convert back to context+origin attributes
+	ctx, oattrs2 := OriginAuthorizerAttributes(kattrs)
+
+	// Ensure namespace/user info is preserved
+	if user, ok := kapi.UserFrom(ctx); !ok {
+		t.Errorf("No user in context")
+	} else if user.GetName() != "myuser" {
+		t.Errorf("Expected %v, got %v", "myuser", user.GetName())
+	} else if !reflect.DeepEqual(user.GetGroups(), []string{"mygroup"}) {
+		t.Errorf("Expected %v, got %v", []string{"mygroup"}, user.GetGroups())
+	}
+
+	// Ensure common attribute info is preserved
+	if oattrs.GetVerb() != oattrs2.GetVerb() {
+		t.Errorf("Expected %v, got %v", oattrs.GetVerb(), oattrs2.GetVerb())
+	}
+	if oattrs.GetResource() != oattrs2.GetResource() {
+		t.Errorf("Expected %v, got %v", oattrs.GetResource(), oattrs2.GetResource())
+	}
+
+	// Ensure origin-specific info is preserved
+	if oattrs.GetAPIVersion() != oattrs2.GetAPIVersion() {
+		t.Errorf("Expected %v, got %v", oattrs.GetAPIVersion(), oattrs2.GetAPIVersion())
+	}
+	if oattrs.GetAPIGroup() != oattrs2.GetAPIGroup() {
+		t.Errorf("Expected %v, got %v", oattrs.GetAPIGroup(), oattrs2.GetAPIGroup())
+	}
+	if oattrs.GetResourceName() != oattrs2.GetResourceName() {
+		t.Errorf("Expected %v, got %v", oattrs.GetResourceName(), oattrs2.GetResourceName())
+	}
+	if oattrs.GetRequestAttributes() != oattrs2.GetRequestAttributes() {
+		t.Errorf("Expected %v, got %v", oattrs.GetRequestAttributes(), oattrs2.GetRequestAttributes())
+	}
+	if oattrs.IsNonResourceURL() != oattrs2.IsNonResourceURL() {
+		t.Errorf("Expected %v, got %v", oattrs.IsNonResourceURL(), oattrs2.IsNonResourceURL())
+	}
+	if oattrs.GetURL() != oattrs2.GetURL() {
+		t.Errorf("Expected %v, got %v", oattrs.GetURL(), oattrs2.GetURL())
+	}
+}
+
+func TestAttributeIntersection(t *testing.T) {
+	// These are the things we expect to be shared
+	// Everything in this list should be used by OriginAuthorizerAttributes
+	expectedIntersection := sets.NewString("GetVerb", "GetResource")
+
+	// These are the things we expect to only be in the Kubernetes interface
+	// Everything in this list should be used by OriginAuthorizerAttributes or derivative (like IsReadOnly)
+	expectedKubernetesOnly := sets.NewString(
+		// used to build context in OriginAuthorizerAttributes
+		"GetGroups", "GetUserName", "GetNamespace",
+		// Based on verb, derivative
+		"IsReadOnly",
+	)
+
+	kattributesType := reflect.TypeOf((*kauthorizer.Attributes)(nil)).Elem()
+	oattributesType := reflect.TypeOf((*oauthorizer.AuthorizationAttributes)(nil)).Elem()
+
+	kattributesMethods := sets.NewString()
+	for i := 0; i < kattributesType.NumMethod(); i++ {
+		kattributesMethods.Insert(kattributesType.Method(i).Name)
+	}
+
+	oattributesMethods := sets.NewString()
+	for i := 0; i < oattributesType.NumMethod(); i++ {
+		oattributesMethods.Insert(oattributesType.Method(i).Name)
+	}
+
+	// Make sure all shared functions are used
+	intersection := oattributesMethods.Intersection(kattributesMethods)
+	if !intersection.HasAll(expectedIntersection.List()...) {
+		t.Errorf(
+			"Kubernetes authorizer.Attributes interface changed. Missing expected methods: %v",
+			expectedIntersection.Difference(intersection).List(),
+		)
+	}
+	if !expectedIntersection.HasAll(intersection.List()...) {
+		t.Errorf(
+			"Kubernetes authorizer.Attributes interface changed. Update OriginAuthorizerAttributes to use data from additional shared methods: %v",
+			intersection.Difference(expectedIntersection).List(),
+		)
+	}
+
+	// Make sure all unshared functions are expected
+	kattributesOnlyMethods := kattributesMethods.Difference(oattributesMethods)
+	if !expectedKubernetesOnly.IsSuperset(kattributesOnlyMethods) {
+		t.Errorf(
+			"Kubernetes authorizer.Attributes interface changed. Check if new functions should be used in OriginAuthorizerAttributes: %v",
+			kattributesOnlyMethods.Difference(expectedKubernetesOnly).List(),
+		)
+	}
+}

--- a/pkg/authorization/authorizer/adapter/authorizer.go
+++ b/pkg/authorization/authorizer/adapter/authorizer.go
@@ -1,0 +1,37 @@
+package adapter
+
+import (
+	"errors"
+
+	"github.com/golang/glog"
+
+	kauthorizer "k8s.io/kubernetes/pkg/auth/authorizer"
+
+	oauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+type AdapterAuthorizer struct {
+	originAuthorizer oauthorizer.Authorizer
+}
+
+// NewAuthorizer adapts an Origin Authorizer interface to a Kubernetes Authorizer interface
+func NewAuthorizer(originAuthorizer oauthorizer.Authorizer) (kauthorizer.Authorizer, error) {
+	return &AdapterAuthorizer{originAuthorizer}, nil
+}
+
+func (z *AdapterAuthorizer) Authorize(kattrs kauthorizer.Attributes) error {
+	allowed, reason, err := z.originAuthorizer.Authorize(OriginAuthorizerAttributes(kattrs))
+
+	if err != nil {
+		glog.V(5).Infof("evaluation error: %v", err)
+		return err
+	}
+
+	glog.V(5).Infof("allowed=%v, reason=%s", allowed, reason)
+	if allowed {
+		return nil
+	}
+
+	// Turn the reason into an error so we can reject with the most information possible
+	return errors.New(reason)
+}

--- a/pkg/authorization/authorizer/adapter/authorizer_test.go
+++ b/pkg/authorization/authorizer/adapter/authorizer_test.go
@@ -1,0 +1,7 @@
+package adapter
+
+import "testing"
+
+func TestAuthorizer(t *testing.T) {
+	_, _ = NewAuthorizer(nil)
+}

--- a/pkg/authorization/authorizer/cache/authorizer.go
+++ b/pkg/authorization/authorizer/cache/authorizer.go
@@ -1,0 +1,151 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/golang-lru"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+type CacheAuthorizer struct {
+	authorizer authorizer.Authorizer
+
+	authorizeCache       *lru.Cache
+	allowedSubjectsCache *lru.Cache
+
+	ttl time.Duration
+	now func() time.Time
+}
+
+type authorizeCacheRecord struct {
+	created time.Time
+	allowed bool
+	reason  string
+	err     error
+}
+
+type allowedSubjectsCacheRecord struct {
+	created time.Time
+	users   sets.String
+	groups  sets.String
+}
+
+// NewAuthorizer returns an authorizer that caches the results of the given authorizer
+func NewAuthorizer(a authorizer.Authorizer, ttl time.Duration, cacheSize int) (authorizer.Authorizer, error) {
+	authorizeCache, err := lru.New(cacheSize)
+	if err != nil {
+		return nil, err
+	}
+	allowedSubjectsCache, err := lru.New(cacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &CacheAuthorizer{
+		authorizer:           a,
+		authorizeCache:       authorizeCache,
+		allowedSubjectsCache: allowedSubjectsCache,
+		ttl:                  ttl,
+		now:                  time.Now,
+	}, nil
+}
+
+func (c *CacheAuthorizer) Authorize(ctx kapi.Context, a authorizer.AuthorizationAttributes) (allowed bool, reason string, err error) {
+	key, err := cacheKey(ctx, a)
+	if err != nil {
+		glog.V(5).Infof("could not build cache key for %#v: %v", a, err)
+		return c.authorizer.Authorize(ctx, a)
+	}
+
+	if value, hit := c.authorizeCache.Get(key); hit {
+		switch record := value.(type) {
+		case *authorizeCacheRecord:
+			if record.created.Add(c.ttl).After(c.now()) {
+				return record.allowed, record.reason, record.err
+			} else {
+				glog.V(5).Infof("cache record expired for %s", key)
+				c.authorizeCache.Remove(key)
+			}
+		default:
+			util.HandleError(fmt.Errorf("invalid cache record type for key %s: %#v", key, record))
+		}
+	}
+
+	allowed, reason, err = c.authorizer.Authorize(ctx, a)
+
+	// Don't cache results if there was an error unrelated to authorization
+	// TODO: figure out a better way to determine this
+	if err == nil || kerrs.IsForbidden(err) {
+		c.authorizeCache.Add(key, &authorizeCacheRecord{created: c.now(), allowed: allowed, reason: reason, err: err})
+	}
+
+	return allowed, reason, err
+}
+
+func (c *CacheAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes authorizer.AuthorizationAttributes) (sets.String, sets.String, error) {
+	key, err := cacheKey(ctx, attributes)
+	if err != nil {
+		glog.V(5).Infof("could not build cache key for %#v: %v", attributes, err)
+		return c.authorizer.GetAllowedSubjects(ctx, attributes)
+	}
+
+	if value, hit := c.allowedSubjectsCache.Get(key); hit {
+		switch record := value.(type) {
+		case *allowedSubjectsCacheRecord:
+			if record.created.Add(c.ttl).After(c.now()) {
+				return record.users, record.groups, nil
+			} else {
+				glog.V(5).Infof("cache record expired for %s", key)
+				c.allowedSubjectsCache.Remove(key)
+			}
+		default:
+			util.HandleError(fmt.Errorf("invalid cache record type for key %s: %#v", key, record))
+		}
+	}
+
+	users, groups, err := c.authorizer.GetAllowedSubjects(ctx, attributes)
+
+	// Don't cache results if there was an error
+	if err == nil {
+		c.allowedSubjectsCache.Add(key, &allowedSubjectsCacheRecord{created: c.now(), users: users, groups: groups})
+	}
+
+	return users, groups, err
+}
+
+func cacheKey(ctx kapi.Context, a authorizer.AuthorizationAttributes) (string, error) {
+	if a.GetRequestAttributes() != nil {
+		// TODO: see if we can serialize this?
+		return "", errors.New("cannot cache request attributes")
+	}
+
+	keyData := map[string]interface{}{
+		"verb":           a.GetVerb(),
+		"apiVersion":     a.GetAPIVersion(),
+		"apiGroup":       a.GetAPIGroup(),
+		"resource":       a.GetResource(),
+		"resourceName":   a.GetResourceName(),
+		"nonResourceURL": a.IsNonResourceURL(),
+		"url":            a.GetURL(),
+	}
+
+	if namespace, ok := kapi.NamespaceFrom(ctx); ok {
+		keyData["namespace"] = namespace
+	}
+	if user, ok := kapi.UserFrom(ctx); ok {
+		keyData["user"] = user.GetName()
+		keyData["groups"] = user.GetGroups()
+	}
+
+	key, err := json.Marshal(keyData)
+	return string(key), err
+}

--- a/pkg/authorization/authorizer/cache/authorizer_test.go
+++ b/pkg/authorization/authorizer/cache/authorizer_test.go
@@ -1,0 +1,93 @@
+package cache
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+)
+
+func TestAuthorizer(t *testing.T) {
+	_, _ = NewAuthorizer(nil, time.Minute, 1000)
+}
+
+func TestCacheKey(t *testing.T) {
+	tests := map[string]struct {
+		Context kapi.Context
+		Attrs   authorizer.AuthorizationAttributes
+
+		ExpectedKey string
+		ExpectedErr bool
+	}{
+		"uncacheable request attributes": {
+			Context:     kapi.NewContext(),
+			Attrs:       &authorizer.DefaultAuthorizationAttributes{RequestAttributes: true},
+			ExpectedErr: true,
+		},
+		"empty": {
+			Context:     kapi.NewContext(),
+			Attrs:       &authorizer.DefaultAuthorizationAttributes{},
+			ExpectedKey: `{"apiGroup":"","apiVersion":"","nonResourceURL":false,"resource":"","resourceName":"","url":"","verb":""}`,
+		},
+		"full": {
+			Context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "myns"), &user.DefaultInfo{Name: "me", Groups: []string{"group1", "group2"}}),
+			Attrs: &authorizer.DefaultAuthorizationAttributes{
+				Verb:              "v",
+				APIVersion:        "av",
+				APIGroup:          "ag",
+				Resource:          "r",
+				ResourceName:      "rn",
+				RequestAttributes: nil,
+				NonResourceURL:    true,
+				URL:               "/abc",
+			},
+			ExpectedKey: `{"apiGroup":"ag","apiVersion":"av","groups":["group1","group2"],"namespace":"myns","nonResourceURL":true,"resource":"r","resourceName":"rn","url":"/abc","user":"me","verb":"v"}`,
+		},
+	}
+
+	for k, tc := range tests {
+		key, err := cacheKey(tc.Context, tc.Attrs)
+		if tc.ExpectedErr != (err != nil) {
+			t.Errorf("%s: expected err=%v, got %v", k, tc.ExpectedErr, err)
+		}
+		if tc.ExpectedKey != key {
+			t.Errorf("%s: expected key=%v, got %v", k, tc.ExpectedKey, key)
+		}
+	}
+}
+
+func TestCacheKeyFields(t *testing.T) {
+	keyJSON, err := cacheKey(kapi.NewContext(), &authorizer.DefaultAuthorizationAttributes{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	keyMap := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(keyJSON), &keyMap); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	keys := sets.NewString()
+	for k := range keyMap {
+		keys.Insert(strings.ToLower(k))
+	}
+
+	// These are results we don't expect to be in the cache key
+	expectedMissingKeys := sets.NewString("requestattributes")
+
+	attrType := reflect.TypeOf((*authorizer.AuthorizationAttributes)(nil)).Elem()
+	for i := 0; i < attrType.NumMethod(); i++ {
+		name := attrType.Method(i).Name
+		name = strings.TrimPrefix(name, "Get")
+		name = strings.TrimPrefix(name, "Is")
+		name = strings.ToLower(name)
+		if !keys.Has(name) && !expectedMissingKeys.Has(name) {
+			t.Errorf("computed cache is missing an entry for %s", attrType.Method(i).Name)
+		}
+	}
+}

--- a/pkg/authorization/authorizer/remote/authorizer.go
+++ b/pkg/authorization/authorizer/remote/authorizer.go
@@ -1,0 +1,117 @@
+package remote
+
+import (
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authzapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/authorization/authorizer"
+	oclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+)
+
+// RemoteAuthorizer provides authorization using subject access review and resource access review requests
+type RemoteAuthorizer struct {
+	client RemoteAuthorizerClient
+}
+
+type RemoteAuthorizerClient interface {
+	oclient.SubjectAccessReviews
+	oclient.ResourceAccessReviews
+
+	oclient.LocalSubjectAccessReviewsNamespacer
+	oclient.LocalResourceAccessReviewsNamespacer
+}
+
+func NewAuthorizer(client RemoteAuthorizerClient) (authorizer.Authorizer, error) {
+	return &RemoteAuthorizer{client}, nil
+}
+
+func (r *RemoteAuthorizer) Authorize(ctx kapi.Context, a authorizer.AuthorizationAttributes) (bool, string, error) {
+	var (
+		result *authzapi.SubjectAccessReviewResponse
+		err    error
+	)
+
+	// Extract namespace from context
+	namespace, _ := kapi.NamespaceFrom(ctx)
+
+	// Extract user from context
+	user := ""
+	groups := sets.NewString()
+	if userInfo, ok := kapi.UserFrom(ctx); ok {
+		user = userInfo.GetName()
+		groups.Insert(userInfo.GetGroups()...)
+	}
+
+	// Make sure we don't run a subject access review on our own permissions
+	if len(user) == 0 && len(groups) == 0 {
+		user = bootstrappolicy.UnauthenticatedUsername
+		groups = sets.NewString(bootstrappolicy.UnauthenticatedGroup)
+	}
+
+	if len(namespace) > 0 {
+		result, err = r.client.LocalSubjectAccessReviews(namespace).Create(&authzapi.LocalSubjectAccessReview{
+			User:   user,
+			Groups: groups,
+			Action: getAction(namespace, a),
+		})
+	} else {
+		result, err = r.client.SubjectAccessReviews().Create(&authzapi.SubjectAccessReview{
+			User:   user,
+			Groups: groups,
+			Action: getAction(namespace, a),
+		})
+	}
+
+	if err != nil {
+		glog.Errorf("error running subject access review: %v", err)
+		return false, "", kerrs.NewInternalError(err)
+	}
+	glog.V(2).Infof("allowed=%v, reason=%s", result.Allowed, result.Reason)
+	return result.Allowed, result.Reason, nil
+}
+
+func (r *RemoteAuthorizer) GetAllowedSubjects(ctx kapi.Context, attributes authorizer.AuthorizationAttributes) (sets.String, sets.String, error) {
+	var (
+		result *authzapi.ResourceAccessReviewResponse
+		err    error
+	)
+
+	// Extract namespace from context
+	namespace, _ := kapi.NamespaceFrom(ctx)
+
+	if len(namespace) > 0 {
+		result, err = r.client.LocalResourceAccessReviews(namespace).Create(&authzapi.LocalResourceAccessReview{Action: getAction(namespace, attributes)})
+	} else {
+		result, err = r.client.ResourceAccessReviews().Create(&authzapi.ResourceAccessReview{Action: getAction(namespace, attributes)})
+	}
+
+	if err != nil {
+		glog.Errorf("error running resource access review: %v", err)
+		return nil, nil, kerrs.NewInternalError(err)
+	}
+	return result.Users, result.Groups, nil
+}
+
+func getAction(namespace string, attributes authorizer.AuthorizationAttributes) authzapi.AuthorizationAttributes {
+	return authzapi.AuthorizationAttributes{
+		Namespace:    namespace,
+		Verb:         attributes.GetVerb(),
+		Resource:     attributes.GetResource(),
+		ResourceName: attributes.GetResourceName(),
+
+		// TODO: missing from authorizer.AuthorizationAttributes:
+		// Content
+
+		// TODO: missing from authzapi.AuthorizationAttributes
+		// APIVersion
+		// APIGroup
+		// RequestAttributes (unserializable?)
+		// IsNonResourceURL
+		// URL (doesn't make sense for remote authz?)
+	}
+}

--- a/pkg/authorization/authorizer/remote/authorizer_test.go
+++ b/pkg/authorization/authorizer/remote/authorizer_test.go
@@ -1,0 +1,7 @@
+package remote
+
+import "testing"
+
+func TestAuthorizer(t *testing.T) {
+	_, _ = NewAuthorizer(nil)
+}

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -47,7 +47,8 @@ func DefaultMasterKubeletClientCertInfo(certDir string) ClientCertInfo {
 			CertFile: path.Join(certDir, MasterFilePrefix+".kubelet-client.crt"),
 			KeyFile:  path.Join(certDir, MasterFilePrefix+".kubelet-client.key"),
 		},
-		User: "system:master",
+		User:   bootstrappolicy.MasterKubeletAdminClientUsername,
+		Groups: sets.NewString(bootstrappolicy.NodeAdminsGroup),
 	}
 }
 

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -66,6 +66,9 @@ type NodeConfig struct {
 	// create pods based from a manifest file(s) placed locally on the node
 	PodManifestConfig *PodManifestConfig
 
+	// AuthConfig holds authn/authz configuration options
+	AuthConfig NodeAuthConfig
+
 	// DockerConfig holds Docker related configuration options.
 	DockerConfig DockerConfig
 
@@ -84,6 +87,23 @@ type NodeNetworkConfig struct {
 	NetworkPluginName string
 	// Maximum transmission unit for the network packets
 	MTU uint
+}
+
+// NodeAuthConfig holds authn/authz configuration options
+type NodeAuthConfig struct {
+	// AuthenticationCacheTTL indicates how long an authentication result should be cached.
+	// It takes a valid time duration string (e.g. "5m"). If empty, you get the default timeout. If zero (e.g. "0m"), caching is disabled
+	AuthenticationCacheTTL string
+
+	// AuthenticationCacheSize indicates how many authentication results should be cached. If 0, the default cache size is used.
+	AuthenticationCacheSize int
+
+	// AuthorizationCacheTTL indicates how long an authorization result should be cached.
+	// It takes a valid time duration string (e.g. "5m"). If empty, you get the default timeout. If zero (e.g. "0m"), caching is disabled
+	AuthorizationCacheTTL string
+
+	// AuthorizationCacheSize indicates how many authorization results should be cached. If 0, the default cache size is used.
+	AuthorizationCacheSize int
 }
 
 // DockerConfig holds Docker related configuration options.

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -65,6 +65,20 @@ func init() {
 			if len(obj.IPTablesSyncPeriod) == 0 {
 				obj.IPTablesSyncPeriod = "5s"
 			}
+
+			// Auth cache defaults
+			if len(obj.AuthConfig.AuthenticationCacheTTL) == 0 {
+				obj.AuthConfig.AuthenticationCacheTTL = "5m"
+			}
+			if obj.AuthConfig.AuthenticationCacheSize == 0 {
+				obj.AuthConfig.AuthenticationCacheSize = 1000
+			}
+			if len(obj.AuthConfig.AuthorizationCacheTTL) == 0 {
+				obj.AuthConfig.AuthorizationCacheTTL = "5m"
+			}
+			if obj.AuthConfig.AuthorizationCacheSize == 0 {
+				obj.AuthConfig.AuthorizationCacheSize = 1000
+			}
 		},
 		func(obj *EtcdStorageConfig) {
 			if len(obj.KubernetesStorageVersion) == 0 {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -51,6 +51,9 @@ type NodeConfig struct {
 	// create pods based from a manifest file(s) placed locally on the node
 	PodManifestConfig *PodManifestConfig `json:"podManifestConfig"`
 
+	// AuthConfig holds authn/authz configuration options
+	AuthConfig NodeAuthConfig `json:"authConfig"`
+
 	// DockerConfig holds Docker related configuration options.
 	DockerConfig DockerConfig `json:"dockerConfig"`
 
@@ -61,6 +64,23 @@ type NodeConfig struct {
 
 	// IPTablesSyncPeriod is how often iptable rules are refreshed
 	IPTablesSyncPeriod string `json:"iptablesSyncPeriod"`
+}
+
+// NodeAuthConfig holds authn/authz configuration options
+type NodeAuthConfig struct {
+	// AuthenticationCacheTTL indicates how long an authentication result should be cached.
+	// It takes a valid time duration string (e.g. "5m"). If empty, you get the default timeout. If zero (e.g. "0m"), caching is disabled
+	AuthenticationCacheTTL string `json:"authenticationCacheTTL"`
+
+	// AuthenticationCacheSize indicates how many authentication results should be cached. If 0, the default cache size is used.
+	AuthenticationCacheSize int `json:"authenticationCacheSize"`
+
+	// AuthorizationCacheTTL indicates how long an authorization result should be cached.
+	// It takes a valid time duration string (e.g. "5m"). If empty, you get the default timeout. If zero (e.g. "0m"), caching is disabled
+	AuthorizationCacheTTL string `json:"authorizationCacheTTL"`
+
+	// AuthorizationCacheSize indicates how many authorization results should be cached. If 0, the default cache size is used.
+	AuthorizationCacheSize int `json:"authorizationCacheSize"`
 }
 
 // NodeNetworkConfig provides network options for the node

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -17,6 +17,11 @@ const (
 	// - install: https://github.com/openshift/openshift-ansible/
 	expectedSerializedNodeConfig = `allowDisabledDocker: false
 apiVersion: v1
+authConfig:
+  authenticationCacheSize: 0
+  authenticationCacheTTL: ""
+  authorizationCacheSize: 0
+  authorizationCacheTTL: ""
 dnsDomain: ""
 dnsIP: ""
 dockerConfig:

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -41,10 +41,42 @@ func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList 
 
 	allErrs = append(allErrs, ValidateDockerConfig(config.DockerConfig).Prefix("dockerConfig")...)
 
+	allErrs = append(allErrs, ValidateNodeAuthConfig(config.AuthConfig).Prefix("authConfig")...)
+
 	allErrs = append(allErrs, ValidateKubeletExtendedArguments(config.KubeletArguments).Prefix("kubeletArguments")...)
 
 	if _, err := time.ParseDuration(config.IPTablesSyncPeriod); err != nil {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("iptablesSyncPeriod", config.IPTablesSyncPeriod, fmt.Sprintf("unable to parse iptablesSyncPeriod: %v. Examples with correct format: '5s', '1m', '2h22m'", err)))
+	}
+
+	return allErrs
+}
+
+func ValidateNodeAuthConfig(config api.NodeAuthConfig) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if len(config.AuthenticationCacheTTL) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("authenticationCacheTTL"))
+	} else if ttl, err := time.ParseDuration(config.AuthenticationCacheTTL); err != nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("authenticationCacheTTL", config.AuthenticationCacheTTL, fmt.Sprintf("%v", err)))
+	} else if ttl < 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("authenticationCacheTTL", config.AuthenticationCacheTTL, fmt.Sprintf("cannot be less than zero")))
+	}
+
+	if config.AuthenticationCacheSize <= 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("authenticationCacheSize", config.AuthenticationCacheSize, fmt.Sprintf("must be greater than zero")))
+	}
+
+	if len(config.AuthorizationCacheTTL) == 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldRequired("authorizationCacheTTL"))
+	} else if ttl, err := time.ParseDuration(config.AuthorizationCacheTTL); err != nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("authorizationCacheTTL", config.AuthorizationCacheTTL, fmt.Sprintf("%v", err)))
+	} else if ttl < 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("authorizationCacheTTL", config.AuthorizationCacheTTL, fmt.Sprintf("cannot be less than zero")))
+	}
+
+	if config.AuthorizationCacheSize <= 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("authorizationCacheSize", config.AuthorizationCacheSize, fmt.Sprintf("must be greater than zero")))
 	}
 
 	return allErrs

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -23,6 +23,11 @@ const (
 	MasterUsername   = "system:" + MasterUnqualifiedUsername
 	RouterUsername   = "system:" + RouterUnqualifiedUsername
 	RegistryUsername = "system:" + RegistryUnqualifiedUsername
+
+	// Previous versions used this as the username for the master to connect to the kubelet
+	// This should remain in the default role bindings for the NodeAdmin role
+	LegacyMasterKubeletAdminClientUsername = "system:master"
+	MasterKubeletAdminClientUsername       = "system:openshift-node-admin"
 )
 
 // groups
@@ -35,6 +40,8 @@ const (
 	ClusterReaderGroup   = "system:cluster-readers"
 	MastersGroup         = "system:masters"
 	NodesGroup           = "system:nodes"
+	NodeAdminsGroup      = "system:node-admins"
+	NodeReadersGroup     = "system:node-readers"
 	RouterGroup          = "system:routers"
 	RegistryGroup        = "system:registries"
 )
@@ -68,6 +75,11 @@ const (
 	OAuthTokenDeleterRoleName = "system:oauth-token-deleter"
 	WebHooksRoleName          = "system:webhook"
 
+	// NodeAdmin has full access to the API provided by the kubelet
+	NodeAdminRoleName = "system:node-admin"
+	// NodeReader has read access to the metrics and stats provided by the kubelet
+	NodeReaderRoleName = "system:node-reader"
+
 	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
 )
 
@@ -87,6 +99,8 @@ const (
 	MasterRoleBindingName            = MasterRoleName + "s"
 	NodeRoleBindingName              = NodeRoleName + "s"
 	NodeProxierRoleBindingName       = NodeProxierRoleName + "s"
+	NodeAdminRoleBindingName         = NodeAdminRoleName + "s"
+	NodeReaderRoleBindingName        = NodeReaderRoleName + "s"
 	SDNReaderRoleBindingName         = SDNReaderRoleName + "s"
 	SDNManagerRoleBindingName        = SDNManagerRoleName + "s"
 	WebHooksRoleBindingName          = WebHooksRoleName + "s"

--- a/pkg/cmd/server/kubernetes/node_auth.go
+++ b/pkg/cmd/server/kubernetes/node_auth.go
@@ -1,0 +1,174 @@
+package kubernetes
+
+import (
+	"crypto/x509"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	kauthorizer "k8s.io/kubernetes/pkg/auth/authorizer"
+	"k8s.io/kubernetes/pkg/auth/user"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+
+	oauthenticator "github.com/openshift/origin/pkg/auth/authenticator"
+	"github.com/openshift/origin/pkg/auth/authenticator/anonymous"
+	"github.com/openshift/origin/pkg/auth/authenticator/request/bearertoken"
+	"github.com/openshift/origin/pkg/auth/authenticator/request/unionrequest"
+	"github.com/openshift/origin/pkg/auth/authenticator/request/x509request"
+	authncache "github.com/openshift/origin/pkg/auth/authenticator/token/cache"
+	authnremote "github.com/openshift/origin/pkg/auth/authenticator/token/remotemaster"
+	"github.com/openshift/origin/pkg/auth/group"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	oauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+	authzadapter "github.com/openshift/origin/pkg/authorization/authorizer/adapter"
+	authzcache "github.com/openshift/origin/pkg/authorization/authorizer/cache"
+	authzremote "github.com/openshift/origin/pkg/authorization/authorizer/remote"
+	oclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+)
+
+func newAuthenticator(clientCAs *x509.CertPool, anonymousConfig client.Config, cacheTTL time.Duration, cacheSize int) (authenticator.Request, error) {
+	authenticators := []oauthenticator.Request{}
+
+	// API token auth
+	var (
+		tokenAuthenticator oauthenticator.Token
+		err                error
+	)
+	// Authenticate against the remote master
+	tokenAuthenticator, err = authnremote.NewAuthenticator(anonymousConfig)
+	if err != nil {
+		return nil, err
+	}
+	// Cache results
+	if cacheTTL > 0 && cacheSize > 0 {
+		tokenAuthenticator, err = authncache.NewAuthenticator(tokenAuthenticator, cacheTTL, cacheSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+	authenticators = append(authenticators, bearertoken.New(tokenAuthenticator, true))
+
+	// Client-cert auth
+	if clientCAs != nil {
+		opts := x509request.DefaultVerifyOptions()
+		opts.Roots = clientCAs
+		certauth := x509request.New(opts, x509request.SubjectToUserConversion)
+		authenticators = append(authenticators, certauth)
+	}
+
+	ret := &unionrequest.Authenticator{
+		// Anonymous requests will pass the token and cert checks without errors
+		// Bad tokens or bad certs will produce errors, in which case we should not continue to authenticate them as "system:anonymous"
+		FailOnError: true,
+		Handlers: []oauthenticator.Request{
+			// Add the "system:authenticated" group to users that pass token/cert authentication
+			group.NewGroupAdder(unionrequest.NewUnionAuthentication(authenticators...), []string{bootstrappolicy.AuthenticatedGroup}),
+			// Fall back to the "system:anonymous" user
+			anonymous.NewAuthenticator(),
+		},
+	}
+
+	return ret, nil
+}
+
+func newAuthorizerAttributesGetter(nodeName string) (kauthorizer.RequestAttributesGetter, error) {
+	return NodeAuthorizerAttributesGetter{nodeName}, nil
+}
+
+type NodeAuthorizerAttributesGetter struct {
+	nodeName string
+}
+
+func isSubpath(r *http.Request, path string) bool {
+	path = strings.TrimSuffix(path, "/")
+	return r.URL.Path == path || strings.HasPrefix(r.URL.Path, path+"/")
+}
+
+// GetRequestAttributes populates authorizer attributes for the requests to the kubelet API.
+// Default attributes are {apiVersion=v1,verb=proxy,resource=nodes,resourceName=<node name>}
+// More specific verb/resource is set for the following request patterns:
+//    /stats/*   => verb=<api verb from request>, resource=nodes/stats
+//    /metrics/* => verb=<api verb from request>, resource=nodes/metrics
+//    /logs/*    => verb=<api verb from request>, resource=nodes/log
+func (n NodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *http.Request) kauthorizer.Attributes {
+
+	// Default verb/resource is proxy nodes, which allows full access to the kubelet API
+	attrs := oauthorizer.DefaultAuthorizationAttributes{
+		APIVersion:   "v1",
+		APIGroup:     "",
+		Verb:         "proxy",
+		Resource:     "nodes",
+		ResourceName: n.nodeName,
+		URL:          r.URL.Path,
+	}
+
+	namespace := ""
+	userName := u.GetName()
+	groups := u.GetGroups()
+
+	apiVerb := ""
+	switch r.Method {
+	case "POST":
+		apiVerb = "create"
+	case "GET":
+		apiVerb = "get"
+	case "PUT":
+		apiVerb = "update"
+	case "PATCH":
+		apiVerb = "patch"
+	case "DELETE":
+		apiVerb = "delete"
+	}
+
+	// Override verb/resource for specific paths
+	// Updates to these rules require updating NodeAdminRole and NodeReaderRole in bootstrap policy
+	switch {
+	case isSubpath(r, "/stats"):
+		attrs.Verb = apiVerb
+		attrs.Resource = authorizationapi.NodeStatsResource
+	case isSubpath(r, "/metrics"):
+		attrs.Verb = apiVerb
+		attrs.Resource = authorizationapi.NodeMetricsResource
+	case isSubpath(r, "/logs"):
+		attrs.Verb = apiVerb
+		attrs.Resource = authorizationapi.NodeLogResource
+	}
+	// TODO: handle other things like /healthz/*? not sure if "non-resource" urls on the kubelet make sense to authorize against master non-resource URL policy
+
+	glog.V(2).Infof("Node request attributes: namespace=%s, user=%s, groups=%v, attrs=%#v", namespace, userName, groups, attrs)
+
+	return authzadapter.KubernetesAuthorizerAttributes(namespace, userName, groups, attrs)
+}
+
+func newAuthorizer(c *oclient.Client, cacheTTL time.Duration, cacheSize int) (kauthorizer.Authorizer, error) {
+	var (
+		authz oauthorizer.Authorizer
+		err   error
+	)
+
+	// Authorize against the remote master
+	authz, err = authzremote.NewAuthorizer(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache results
+	if cacheTTL > 0 && cacheSize > 0 {
+		authz, err = authzcache.NewAuthorizer(authz, cacheTTL, cacheSize)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Adapt to the Kubernetes authorizer interface
+	kauthz, err := authzadapter.NewAuthorizer(authz)
+	if err != nil {
+		return nil, err
+	}
+
+	return kauthz, nil
+}

--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -18,6 +18,7 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
@@ -142,7 +143,7 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 		return nil, errors.NewAggregate(err)
 	}
 
-	cfg, err := server.KubeletConfig()
+	cfg, err := server.UnsecuredKubeletConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +153,36 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 	cfg.StreamingConnectionIdleTimeout = 5 * time.Minute // TODO: should be set
 	cfg.KubeClient = kubeClient
 	cfg.DockerExecHandler = dockerExecHandler
+
+	// Setup auth
+	osClient, osClientConfig, err := configapi.GetOpenShiftClient(options.MasterKubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	authnTTL, err := time.ParseDuration(options.AuthConfig.AuthenticationCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+	authn, err := newAuthenticator(clientCAs, clientcmd.AnonymousClientConfig(*osClientConfig), authnTTL, options.AuthConfig.AuthenticationCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	authzAttr, err := newAuthorizerAttributesGetter(options.NodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	authzTTL, err := time.ParseDuration(options.AuthConfig.AuthorizationCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+	authz, err := newAuthorizer(osClient, authzTTL, options.AuthConfig.AuthorizationCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.Auth = kubelet.NewKubeletAuth(authn, authzAttr, authz)
 
 	// Make sure the node doesn't think it is in standalone mode
 	// This is required for the node to enforce nodeSelectors on pods, to set hostIP on pod status updates, etc
@@ -163,8 +194,9 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 			Config: &tls.Config{
 				// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
 				MinVersion: tls.VersionTLS10,
-				// RequireAndVerifyClientCert lets us limit requests to ones with a valid client certificate
-				ClientAuth: tls.RequireAndVerifyClientCert,
+				// RequestClientCert lets us request certs, but allow requests without client certs
+				// Verification is done by the authn layer
+				ClientAuth: tls.RequestClientCert,
 				ClientCAs:  clientCAs,
 			},
 			CertFile: options.ServingInfo.ServerCert.CertFile,

--- a/pkg/cmd/util/clientcmd/clientcmd.go
+++ b/pkg/cmd/util/clientcmd/clientcmd.go
@@ -44,6 +44,18 @@ func NewConfig() *Config {
 	}
 }
 
+// AnonymousClientConfig returns a copy of the given config with all user credentials (cert/key, bearer token, and username/password) removed
+func AnonymousClientConfig(config kclient.Config) kclient.Config {
+	config.BearerToken = ""
+	config.CertData = nil
+	config.CertFile = ""
+	config.KeyData = nil
+	config.KeyFile = ""
+	config.Username = ""
+	config.Password = ""
+	return config
+}
+
 // BindClientConfigSecurityFlags adds flags for the supplied client config
 func BindClientConfigSecurityFlags(config *kclient.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&config.Insecure, "insecure-skip-tls-verify", config.Insecure, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -1,0 +1,228 @@
+// +build integration,!no-etcd
+
+package integration
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	"github.com/openshift/origin/pkg/cmd/admin/policy"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+type testRequest struct {
+	Method string
+	Path   string
+	Result int
+}
+
+func TestNodeAuth(t *testing.T) {
+	// Server config
+	masterConfig, nodeConfig, adminKubeConfigFile, err := testserver.StartTestAllInOne()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Cluster admin clients and client configs
+	adminClient, err := testutil.GetClusterAdminKubeClient(adminKubeConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	originAdminClient, err := testutil.GetClusterAdminClient(adminKubeConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	adminConfig, err := testutil.GetClusterAdminClientConfig(adminKubeConfigFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Client configs for lesser users
+	masterKubeletClientConfig := configapi.GetKubeletClientConfig(*masterConfig)
+
+	anonymousConfig := clientcmd.AnonymousClientConfig(*adminConfig)
+
+	badTokenConfig := clientcmd.AnonymousClientConfig(*adminConfig)
+	badTokenConfig.BearerToken = "bad-token"
+
+	bobClient, _, bobConfig, err := testutil.GetClientForUser(*adminConfig, "bob")
+	_, _, aliceConfig, err := testutil.GetClientForUser(*adminConfig, "alice")
+	sa1Client, _, sa1Config, err := testutil.GetClientForServiceAccount(adminClient, *adminConfig, "default", "sa1")
+	_, _, sa2Config, err := testutil.GetClientForServiceAccount(adminClient, *adminConfig, "default", "sa2")
+
+	// Grant Bob system:node-reader, which should let them read metrics and stats
+	addBob := &policy.RoleModificationOptions{
+		RoleName:            bootstrappolicy.NodeReaderRoleName,
+		RoleBindingAccessor: policy.NewClusterRoleBindingAccessor(originAdminClient),
+		Subjects:            []kapi.ObjectReference{{Kind: "User", Name: "bob"}},
+	}
+	if err := addBob.AddRole(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Grant sa1 system:cluster-reader, which should let them read metrics and stats
+	addSA1 := &policy.RoleModificationOptions{
+		RoleName:            bootstrappolicy.ClusterReaderRoleName,
+		RoleBindingAccessor: policy.NewClusterRoleBindingAccessor(originAdminClient),
+		Subjects:            []kapi.ObjectReference{{Kind: "ServiceAccount", Namespace: "default", Name: "sa1"}},
+	}
+	if err := addSA1.AddRole(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Wait for policy cache
+	if err := testutil.WaitForClusterPolicyUpdate(bobClient, "get", "nodes/metrics", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := testutil.WaitForClusterPolicyUpdate(sa1Client, "get", "nodes/metrics", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, nodePort, err := net.SplitHostPort(nodeConfig.ServingInfo.BindAddress)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	nodePortInt, err := strconv.ParseInt(nodePort, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	nodeTLS := configapi.UseTLS(nodeConfig.ServingInfo)
+
+	kubeletClientConfig := func(config *kclient.Config) *kclient.KubeletConfig {
+		return &kclient.KubeletConfig{
+			Port:            uint(nodePortInt),
+			EnableHttps:     nodeTLS,
+			TLSClientConfig: config.TLSClientConfig,
+			BearerToken:     config.BearerToken,
+		}
+	}
+
+	testCases := map[string]struct {
+		KubeletClientConfig *kclient.KubeletConfig
+		Forbidden           bool
+		NodeViewer          bool
+		NodeAdmin           bool
+	}{
+		"bad token": {
+			KubeletClientConfig: kubeletClientConfig(&badTokenConfig),
+		},
+		"anonymous": {
+			KubeletClientConfig: kubeletClientConfig(&anonymousConfig),
+			Forbidden:           true,
+		},
+		"cluster admin": {
+			KubeletClientConfig: kubeletClientConfig(adminConfig),
+			NodeAdmin:           true,
+		},
+		"master kubelet client": {
+			KubeletClientConfig: masterKubeletClientConfig,
+			NodeAdmin:           true,
+		},
+		"bob": {
+			KubeletClientConfig: kubeletClientConfig(bobConfig),
+			NodeViewer:          true,
+		},
+		"alice": {
+			KubeletClientConfig: kubeletClientConfig(aliceConfig),
+			Forbidden:           true,
+		},
+		"sa1": {
+			KubeletClientConfig: kubeletClientConfig(sa1Config),
+			NodeViewer:          true,
+		},
+		"sa2": {
+			KubeletClientConfig: kubeletClientConfig(sa2Config),
+			Forbidden:           true,
+		},
+	}
+
+	for k, tc := range testCases {
+
+		var (
+			// expected result for requests a viewer should be able to make
+			viewResult int
+			// expected result for requests an admin should be able to make (that can actually complete with a 200 in our tests)
+			adminResultOK int
+			// expected result for requests an admin should be able to make (that return a 404 in this test if the authn/authz layer is completed)
+			adminResultMissing int
+		)
+		switch {
+		case tc.NodeAdmin:
+			viewResult = http.StatusOK
+			adminResultOK = http.StatusOK
+			adminResultMissing = http.StatusNotFound
+		case tc.NodeViewer:
+			viewResult = http.StatusOK
+			adminResultOK = http.StatusForbidden
+			adminResultMissing = http.StatusForbidden
+		case tc.Forbidden:
+			viewResult = http.StatusForbidden
+			adminResultOK = http.StatusForbidden
+			adminResultMissing = http.StatusForbidden
+		default:
+			viewResult = http.StatusUnauthorized
+			adminResultOK = http.StatusUnauthorized
+			adminResultMissing = http.StatusUnauthorized
+		}
+
+		requests := []testRequest{
+			// Responses to invalid paths are the same for all users
+			{"GET", "/", http.StatusNotFound},
+			{"GET", "/stats", http.StatusMovedPermanently}, // ServeMux redirects to the directory
+			{"GET", "/invalid", http.StatusNotFound},
+
+			// viewer requests
+			{"GET", "/metrics", viewResult},
+			{"GET", "/stats/", viewResult},
+
+			// successful admin requests
+			{"GET", "/healthz", adminResultOK},
+			{"GET", "/pods", adminResultOK},
+
+			// not found admin requests
+			{"GET", "/containerLogs/mynamespace/mypod/mycontainer", adminResultMissing},
+			{"POST", "/exec/mynamespace/mypod/mycontainer", adminResultMissing},
+			{"POST", "/run/mynamespace/mypod/mycontainer", adminResultMissing},
+			{"POST", "/attach/mynamespace/mypod/mycontainer", adminResultMissing},
+			{"POST", "/portForward/mynamespace/mypod/mycontainer", adminResultMissing},
+
+			// GET is supported in origin on /exec and /attach for backwards compatibility
+			// make sure node admin permissions are required
+			{"GET", "/exec/mynamespace/mypod/mycontainer", adminResultMissing},
+			{"GET", "/attach/mynamespace/mypod/mycontainer", adminResultMissing},
+		}
+
+		rt, err := kclient.MakeTransport(tc.KubeletClientConfig)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+
+		for _, r := range requests {
+			req, err := http.NewRequest(r.Method, "https://"+nodeConfig.NodeName+":10250"+r.Path, nil)
+			if err != nil {
+				t.Errorf("%s: %s: unexpected error: %v", k, r.Path, err)
+				continue
+			}
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Errorf("%s: %s: unexpected error: %v", k, r.Path, err)
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode != r.Result {
+				t.Errorf("%s: %s: expected %d, got %d", k, r.Path, r.Result, resp.StatusCode)
+				continue
+			}
+		}
+	}
+}

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -4,13 +4,21 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
+	"github.com/openshift/origin/pkg/serviceaccounts"
 )
 
 // GetBaseDir returns the base directory used for test.
@@ -56,14 +64,8 @@ func GetClientForUser(clientConfig kclient.Config, username string) (*client.Cli
 		return nil, nil, nil, err
 	}
 
-	userClientConfig := clientConfig
+	userClientConfig := clientcmd.AnonymousClientConfig(clientConfig)
 	userClientConfig.BearerToken = token
-	userClientConfig.Username = ""
-	userClientConfig.Password = ""
-	userClientConfig.TLSClientConfig.CertFile = ""
-	userClientConfig.TLSClientConfig.KeyFile = ""
-	userClientConfig.TLSClientConfig.CertData = nil
-	userClientConfig.TLSClientConfig.KeyData = nil
 
 	kubeClient, err := kclient.New(&userClientConfig)
 	if err != nil {
@@ -76,4 +78,53 @@ func GetClientForUser(clientConfig kclient.Config, username string) (*client.Cli
 	}
 
 	return osClient, kubeClient, &userClientConfig, nil
+}
+
+func GetClientForServiceAccount(adminClient *kclient.Client, clientConfig kclient.Config, namespace, name string) (*client.Client, *kclient.Client, *kclient.Config, error) {
+	_, err := adminClient.Namespaces().Create(&kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: namespace}})
+	if err != nil && !kerrs.IsAlreadyExists(err) {
+		return nil, nil, nil, err
+	}
+
+	sa, err := adminClient.ServiceAccounts(namespace).Create(&kapi.ServiceAccount{ObjectMeta: kapi.ObjectMeta{Name: name}})
+	if kerrs.IsAlreadyExists(err) {
+		sa, err = adminClient.ServiceAccounts(namespace).Get(name)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	token := ""
+	err = wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
+		selector := fields.OneTermEqualSelector(kclient.SecretType, string(kapi.SecretTypeServiceAccountToken))
+		secrets, err := adminClient.Secrets(namespace).List(labels.Everything(), selector)
+		if err != nil {
+			return false, err
+		}
+		for _, secret := range secrets.Items {
+			if serviceaccounts.IsValidServiceAccountToken(sa, &secret) {
+				token = string(secret.Data[kapi.ServiceAccountTokenKey])
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	saClientConfig := clientcmd.AnonymousClientConfig(clientConfig)
+	saClientConfig.BearerToken = token
+
+	kubeClient, err := kclient.New(&saClientConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	osClient, err := client.New(&saClientConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return osClient, kubeClient, &saClientConfig, nil
 }

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -279,7 +279,7 @@ func StartConfiguredNode(nodeConfig *configapi.NodeConfig) error {
 	if err != nil {
 		return err
 	}
-	nodeTLS := false // TODO: set to configapi.UseTLS(nodeConfig.ServingInfo) once client cert auth isn't required to connect
+	nodeTLS := configapi.UseTLS(nodeConfig.ServingInfo)
 
 	if err := start.StartNode(*nodeConfig); err != nil {
 		return err


### PR DESCRIPTION
Fixes #3020

- [x] Add authentication/authorization interfaces to kubelet, always include /metrics with /stats
- [x] Add verb to authorizer attributes
- [x] token authenticator cache
- [x] authorization cache
- [x] API token authenticator
- [x] Change connection-based kubelet auth to cert authn + SubjectAccessReview/ResourceAccessReview-based authz
- [x] Define roles for full access to the node API (system:node-admin) and read access to the metrics/stats API (system:node-reader, also part of system:cluster-reader)
- [x] integration tests
- [x] unit tests
- [x] godoc
- [ ] doc issue for new roles, node auth config, reconcile-cluster-role-bindings
- [ ] ansible issue for node auth config
- [x] ansible issue for reconcile-cluster-role-bindings (https://github.com/openshift/openshift-ansible/issues/662)