### PR TITLE
Fix vagrant provisioning network interface cleanup

### DIFF
--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -14,7 +14,7 @@ if [ "${FIXUP_NET_UDEV}" == "true" ]; then
     sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
     nmcli con reload
     nmcli dev disconnect eth1
-    nmcli dev connect eth1
+    nmcli con up "System eth1"
   fi
 fi
 

--- a/contrib/vagrant/provision-minion.sh
+++ b/contrib/vagrant/provision-minion.sh
@@ -13,7 +13,7 @@ if [ "${FIXUP_NET_UDEV}" == "true" ]; then
     sed -i 's/^NM_CONTROLLED=no/#NM_CONTROLLED=no/' ${NETWORK_CONF_PATH}ifcfg-eth1
     nmcli con reload
     nmcli dev disconnect eth1
-    nmcli dev connect eth1
+    nmcli con up "System eth1"
   fi
 fi
 


### PR DESCRIPTION
The merge of #3523 didn't quite fix the libvirt provisioning situation; the "nmcli dev connect eth1" ends up reconnecting the autogenerated DHCP connection rather than the vagrant-provided static connection.

This patch fixes that, but I don't know if it maybe breaks VirtualBox provisioning or something? Or if there's a more future-proof way to do this...
@dcbw @rajatchopra 