### PR TITLE
[WIP] Add link to apiman console

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -205,6 +205,7 @@
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>
         <script src="scripts/extensions/javaLink.js"></script>
+        <script src="scripts/extensions/apimanLink.js"></script>
         <!-- endbuild -->
 
     <!-- Load any extensions last. -->

--- a/assets/app/scripts/extensions/apimanLink.js
+++ b/assets/app/scripts/extensions/apimanLink.js
@@ -1,0 +1,80 @@
+'use strict';
+
+angular.module('openshiftConsoleExtensions', ['openshiftConsole'])
+  .factory('ApimanLink', function() {
+    return {
+      hasApimanConsole: false,
+      href: '/'
+    };
+  })
+  .run(['HawtioNav', 'ApimanLink', 'AuthService', 'DataService', '$rootScope', '$routeParams', '$timeout', function(nav, ApimanLink, AuthService, DataService, $rootScope, $routeParams, $timeout) {
+    var $scope = $rootScope.$new();
+    $scope.$routeParams = $routeParams;
+    $scope.projectPromise = $.Deferred();
+    
+    var handle = null;
+
+    function clearApimanLink() {
+      ApimanLink.hasApimanConsole = false;
+      ApimanLink.href = '/';
+    }
+
+    function discoverApiman(projectName) {
+      var last = $scope.projectName;
+      $scope.projectName = projectName;
+      if ($scope.projectName === last) {
+        return;
+      }
+      if (handle) {
+        DataService.unwatch(handle);
+        handle = null;
+      }
+      if ($scope.projectName) {
+        handle = DataService.watch('routes', $scope, function(data) {
+          var routes = data._data;
+          if (!routes || !('apiman' in routes)) {
+            clearApimanLink();
+            return;
+          }
+          var apimanRoute = routes.apiman;
+          var args = {
+            backTo: window.location.href,
+            token: AuthService.UserStore().getToken() || ''
+          };
+          ApimanLink.href = new URI()
+          .host(apimanRoute.spec.host)
+          .scheme('http')
+          .path('/apimanui/index.html')
+          .hash(URI.encode(angular.toJson(args)))
+          .toString();
+          ApimanLink.hasApimanConsole = true;
+        });
+        $scope.projectPromise.resolve({
+          metadata: {
+            name: $scope.projectName
+          }
+        });
+      } else {
+        clearApimanLink();
+      }
+    }
+
+    $scope.$watch('$routeParams.project', discoverApiman);
+
+    nav.add({
+      id: 'apiman-link',
+      icon: 'wrench',
+      title: function() { return 'Manage APIs'; },
+      // avoid having query params added to our link
+      oldHref: function() { return ''; },
+      href: function() { return ApimanLink.href; },
+      isValid: function() { return ApimanLink.hasApimanConsole; },
+      template: function() { return '<sidebar-nav-item></sidebar-nav-item>'; }
+    });
+
+    // trigger discovery since $routeChangeSuccess doesn't happen if you
+    // click refresh
+    $timeout(function() {
+      $rootScope.$broadcast('discoverApiman');
+    }, 50);
+  }]);


### PR DESCRIPTION
This PR adds a link to the [APIman console](http://www.apiman.io/latest/) when it's deployed in a project.

It's a WIP though for a few reasons:

1)  **Link location** - Currently the code adds it to the main navigation when the apiman service is present *however* maybe there's a better place for it.  For example, it'd be nice to update the link that's present in the overview that shows up due to the route.
2)  **Link title** - `API Management` or `Manage APIs` is too wordy, `APIman` isn't appropriate either really.  I'm going to ask the apiman folks to chime on this a bit too actually, but any thoughts appreciated.
3)  **icon** - went with a generic wrench for now.  We annotate the template and service I think in fabric8 with an icon path, so could use that, or I could use a data url and encode the apiman icon, think that might look out of place though.

When you click the link and it takes you over to the apiman console there will be a link back to the openshift console, think slightly similar to the java console.  Here's a screenshot of it's current state:

![apiman](https://cloud.githubusercontent.com/assets/351660/10202062/1da01ef8-677d-11e5-8a08-df46c6bf2231.png)


@jwforres FYI

