### PR TITLE
Add Restart=always to master service

### DIFF
--- a/rel-eng/atomic-openshift-master.service
+++ b/rel-eng/atomic-openshift-master.service
@@ -15,6 +15,7 @@ LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=atomic-openshift-master
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/rel-eng/origin-master.service
+++ b/rel-eng/origin-master.service
@@ -15,6 +15,7 @@ LimitNOFILE=131072
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=origin-master
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If you've got an etcd cluster and the entire environment is rebooted it may be
quite some time before the etcd cluster comes online and is ready for use. This
allows openshift-master to continue restarting indefinitely so that when etcd
becomes available the master will start properly.

Fixes #4837 

CC: @derekwaynecarr @brenton 