### PR TITLE
change test-cmd to be silent

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -2,6 +2,9 @@
 
 # This command checks that the built commands can function together for
 # simple scenarios.  It does not require Docker so it can run in travis.
+# Options for this command include VERBOSE and PROFILE. If VERBOSE is true
+# no output from the tests will be silenced. If PROFILE is set, pprof is 
+# used to profile the test and the output is shown at the conclusion of testing.
 
 set -o errexit
 set -o nounset
@@ -28,10 +31,12 @@ function cleanup()
         echo
     else
         if path=$(go tool -n pprof 2>&1); then
-          echo
-          echo "pprof: top output"
-          echo
-          go tool pprof -text ./_output/local/bin/$(os::util::host_platform)/openshift cpu.pprof
+          if [ -n "${PROFILE-}" ]; then
+            echo
+            echo "pprof: top output"
+            echo
+            go tool pprof -text ./_output/local/bin/$(os::util::host_platform)/openshift cpu.pprof
+          fi
         fi
 
         echo
@@ -44,6 +49,36 @@ function cleanup()
 
 trap "exit" INT TERM
 trap "cleanup" EXIT
+
+function exectest() {
+  testname=$1
+  testcmd=$2
+  echo "Running $testname..."
+
+  result=1
+  if [ -n "${VERBOSE-}" ]; then
+    if ${testcmd} 2>&1; then
+      result=$?
+    fi
+  else
+    out=$(${testcmd} 2>&1)
+    result=$?
+  fi
+
+  tput cuu 1 # Move up one line
+  tput el   # Clear "running" line
+
+  if [[ ${result} -eq 0 ]]; then
+    tput setaf 2 # green
+    echo "ok      $testname"
+    tput sgr0   # reset
+  else
+    tput setaf 1 # red
+    echo "failed  $testname"
+    tput sgr0   # reset
+    echo "${out}"
+  fi
+}
 
 set -e
 
@@ -72,18 +107,19 @@ PUBLIC_MASTER_HOST="${PUBLIC_MASTER_HOST:-${API_HOST}}"
 # Prevent user environment from colliding with the test setup
 unset KUBECONFIG
 
-
-# handle profiling defaults
-profile="${OPENSHIFT_PROFILE-}"
-unset OPENSHIFT_PROFILE
-if [[ -n "${profile}" ]]; then
-    if [[ "${TEST_PROFILE-}" == "cli" ]]; then
-        export CLI_PROFILE="${profile}"
-    else
-        export WEB_PROFILE="${profile}"
-    fi
-else
-  export WEB_PROFILE=cpu
+if [ -n "${PROFILE-}" ]; then 
+  # handle profiling defaults
+  profile="${OPENSHIFT_PROFILE-}"
+  unset OPENSHIFT_PROFILE
+  if [[ -n "${profile}" ]]; then
+      if [[ "${TEST_PROFILE-}" == "cli" ]]; then
+          export CLI_PROFILE="${profile}"
+      else
+          export WEB_PROFILE="${profile}"
+      fi
+  else
+    export WEB_PROFILE=cpu
+  fi
 fi
 
 # Check openshift version
@@ -130,22 +166,29 @@ openshift start \
   --etcd-dir="${ETCD_DATA_DIR}" \
   --images="${USE_IMAGES}"
 
-# validate config that was generated
-[ "$(openshift ex validate master-config ${MASTER_CONFIG_DIR}/master-config.yaml 2>&1 | grep SUCCESS)" ]
-[ "$(openshift ex validate node-config ${NODE_CONFIG_DIR}/node-config.yaml 2>&1 | grep SUCCESS)" ]
-# breaking the config fails the validation check
-cp ${MASTER_CONFIG_DIR}/master-config.yaml ${BASETMPDIR}/master-config-broken.yaml
-sed -i '5,10d' ${BASETMPDIR}/master-config-broken.yaml
-[ "$(openshift ex validate master-config ${BASETMPDIR}/master-config-broken.yaml 2>&1 | grep error)" ]
-
-cp ${NODE_CONFIG_DIR}/node-config.yaml ${BASETMPDIR}/node-config-broken.yaml
-sed -i '5,10d' ${BASETMPDIR}/node-config-broken.yaml
-[ "$(openshift ex validate node-config ${BASETMPDIR}/node-config-broken.yaml 2>&1 | grep ERROR)" ]
-echo "validation: ok"
-
 # Don't try this at home.  We don't have flags for setting etcd ports in the config, but we want deconflicted ones.  Use sed to replace defaults in a completely unsafe way
 os::util::sed "s/:4001$/:${ETCD_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
 os::util::sed "s/:7001$/:${ETCD_PEER_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
+
+echo && echo "Running tests..."
+
+function test_validate_config() {
+  set -o errexit
+  # validate config that was generated
+  [ "$(openshift ex validate master-config ${MASTER_CONFIG_DIR}/master-config.yaml 2>&1 | grep SUCCESS)" ]
+  [ "$(openshift ex validate node-config ${NODE_CONFIG_DIR}/node-config.yaml 2>&1 | grep SUCCESS)" ]
+  # breaking the config fails the validation check
+  cp ${MASTER_CONFIG_DIR}/master-config.yaml ${BASETMPDIR}/master-config-broken.yaml
+  sed -i '5,10d' ${BASETMPDIR}/master-config-broken.yaml
+  [ "$(openshift ex validate master-config ${BASETMPDIR}/master-config-broken.yaml 2>&1 | grep error)" ]
+
+  cp ${NODE_CONFIG_DIR}/node-config.yaml ${BASETMPDIR}/node-config-broken.yaml
+  sed -i '5,10d' ${BASETMPDIR}/node-config-broken.yaml
+  [ "$(openshift ex validate node-config ${BASETMPDIR}/node-config-broken.yaml 2>&1 | grep ERROR)" ]
+  echo "validation: ok"
+}
+
+(exectest "validate" test_validate_config)
 
 # Start openshift
 OPENSHIFT_ON_PANIC=crash openshift start master \
@@ -160,8 +203,13 @@ if [[ "${API_SCHEME}" == "https" ]]; then
     export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
 fi
 
-wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
-wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz/ready" "apiserver(ready): " 0.25 80
+function test_apiserver_endpoints() {
+  set -o errexit
+  wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
+  wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz/ready" "apiserver(ready): " 0.25 80
+}
+
+(exectest "apiserver" test_apiserver_endpoints)
 
 # profile the cli commands
 export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
@@ -170,25 +218,29 @@ export OPENSHIFT_PROFILE="${CLI_PROFILE-}"
 # Begin tests
 #
 
-# create master config as atomic-enterprise just to test it works
-atomic-enterprise start \
-  --write-config="${BASETMPDIR}/atomic.local.config" \
-  --create-certs=true \
-  --master="${API_SCHEME}://${API_HOST}:${API_PORT}" \
-  --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" \
-  --hostname="${KUBELET_HOST}" \
-  --volume-dir="${VOLUME_DIR}" \
-  --etcd-dir="${ETCD_DATA_DIR}" \
-  --images="${USE_IMAGES}"
+function test_atomic_enterprise() {
+  # create master config as atomic-enterprise just to test it works
+  atomic-enterprise start \
+    --write-config="${BASETMPDIR}/atomic.local.config" \
+    --create-certs=true \
+    --master="${API_SCHEME}://${API_HOST}:${API_PORT}" \
+    --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" \
+    --hostname="${KUBELET_HOST}" \
+    --volume-dir="${VOLUME_DIR}" \
+    --etcd-dir="${ETCD_DATA_DIR}" \
+    --images="${USE_IMAGES}"
 
-# ensure that DisabledFeatures aren't written to config files
-! grep -i '\<disabledFeatures\>' \
-	"${MASTER_CONFIG_DIR}/master-config.yaml" \
-	"${BASETMPDIR}/atomic.local.config/master/master-config.yaml" \
-	"${NODE_CONFIG_DIR}/node-config.yaml"
+  # ensure that DisabledFeatures aren't written to config files
+  ! grep -i '\<disabledFeatures\>' \
+  	"${MASTER_CONFIG_DIR}/master-config.yaml" \
+  	"${BASETMPDIR}/atomic.local.config/master/master-config.yaml" \
+  	"${NODE_CONFIG_DIR}/node-config.yaml"
 
-# test client not configured
-[ "$(oc get services 2>&1 | grep 'Error in configuration')" ]
+  # test client not configured
+  [ "$(oc get services 2>&1 | grep 'Error in configuration')" ]
+}
+
+(exectest "atomic" test_atomic_enterprise)
 
 # Set KUBERNETES_MASTER for oc from now on
 export KUBERNETES_MASTER="${API_SCHEME}://${API_HOST}:${API_PORT}"
@@ -199,85 +251,97 @@ if [[ "${API_SCHEME}" == "https" ]]; then
     [ "$(oc get services 2>&1 | grep 'certificate signed by unknown authority')" ]
 fi
 
+function test_login_logout() {
+  # login and logout tests
+  # --token and --username are mutually exclusive
+  [ "$(oc login ${KUBERNETES_MASTER} -u test-user --token=tmp --insecure-skip-tls-verify 2>&1 | grep 'mutually exclusive')" ]
+  # must only accept one arg (server)
+  [ "$(oc login https://server1 https://server2.com 2>&1 | grep 'Only the server URL may be specified')" ]
+  # logs in with a valid certificate authority
+  oc login ${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything --api-version=v1beta3
+  grep -q "v1beta3" ${HOME}/.kube/config
+  oc logout
+  # logs in skipping certificate check
+  oc login ${KUBERNETES_MASTER} --insecure-skip-tls-verify -u test-user -p anything
+  # logs in by an existing and valid token
+  temp_token=$(oc config view -o template --template='{{range .users}}{{ index .user.token }}{{end}}')
+  [ "$(oc login --token=${temp_token} 2>&1 | grep 'using the token provided')" ]
+  oc logout
+  # properly parse server port
+  [ "$(oc login https://server1:844333 2>&1 | grep 'Not a valid port')" ]
+  # properly handle trailing slash
+  oc login --server=${KUBERNETES_MASTER}/ --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
+  # create a new project
+  oc new-project project-foo --display-name="my project" --description="boring project description"
+  [ "$(oc project | grep 'Using project "project-foo"')" ]
+  # denies access after logging out
+  oc logout
+  [ -z "$(oc get pods | grep 'system:anonymous')" ]
 
-# login and logout tests
-# --token and --username are mutually exclusive
-[ "$(oc login ${KUBERNETES_MASTER} -u test-user --token=tmp --insecure-skip-tls-verify 2>&1 | grep 'mutually exclusive')" ]
-# must only accept one arg (server)
-[ "$(oc login https://server1 https://server2.com 2>&1 | grep 'Only the server URL may be specified')" ]
-# logs in with a valid certificate authority
-oc login ${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything --api-version=v1beta3
-grep -q "v1beta3" ${HOME}/.kube/config
-oc logout
-# logs in skipping certificate check
-oc login ${KUBERNETES_MASTER} --insecure-skip-tls-verify -u test-user -p anything
-# logs in by an existing and valid token
-temp_token=$(oc config view -o template --template='{{range .users}}{{ index .user.token }}{{end}}')
-[ "$(oc login --token=${temp_token} 2>&1 | grep 'using the token provided')" ]
-oc logout
-# properly parse server port
-[ "$(oc login https://server1:844333 2>&1 | grep 'Not a valid port')" ]
-# properly handle trailing slash
-oc login --server=${KUBERNETES_MASTER}/ --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
-# create a new project
-oc new-project project-foo --display-name="my project" --description="boring project description"
-[ "$(oc project | grep 'Using project "project-foo"')" ]
-# denies access after logging out
-oc logout
-[ -z "$(oc get pods | grep 'system:anonymous')" ]
+  # log in as an image-pruner and test that oadm prune images works against the atomic binary
+  oadm policy add-cluster-role-to-user system:image-pruner pruner --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+  oc login --server=${KUBERNETES_MASTER}/ --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u pruner -p anything
+  # this shouldn't fail but instead output "Dry run enabled - no modifications will be made. Add --confirm to remove images"
+  oadm prune images
+}
 
-# log in as an image-pruner and test that oadm prune images works against the atomic binary
-oadm policy add-cluster-role-to-user system:image-pruner pruner --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
-oc login --server=${KUBERNETES_MASTER}/ --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u pruner -p anything
-# this shouldn't fail but instead output "Dry run enabled - no modifications will be made. Add --confirm to remove images"
-oadm prune images
+(exectest "login" test_login_logout)
 
 # log in and set project to use from now on
-oc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything
-oc get projects
-oc project project-foo
-[ "$(oc whoami | grep 'test-user')" ]
-[ -n "$(oc whoami -t)" ]
-[ -n "$(oc whoami -c)" ]
+oc login --server=${KUBERNETES_MASTER} --certificate-authority="${MASTER_CONFIG_DIR}/ca.crt" -u test-user -p anything 2>&1 > /dev/null
 
-# test config files from the --config flag
-oc get services --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+function test_whoami() {
+  [ "$(oc whoami | grep 'test-user')" ]
+  [ -n "$(oc whoami -t)" ]
+  [ -n "$(oc whoami -c)" ]
+}
 
-# test config files from env vars
-KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" oc get services
+(exectest "whoami" test_whoami)
 
-# test config files in the home directory
-mkdir -p ${HOME}/.kube
-cp ${MASTER_CONFIG_DIR}/admin.kubeconfig ${HOME}/.kube/config
-oc get services
-mv ${HOME}/.kube/config ${HOME}/.kube/non-default-config
-echo "config files: ok"
+function test_config() {
+  # test config files from the --config flag
+  oc get services --config="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+
+  # test config files from env vars
+  KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig" oc get services
+
+  # test config files in the home directory
+  mkdir -p ${HOME}/.kube
+  cp ${MASTER_CONFIG_DIR}/admin.kubeconfig ${HOME}/.kube/config
+  oc get services
+  mv ${HOME}/.kube/config ${HOME}/.kube/non-default-config
+  echo "config files: ok"
+}
+
+(exectest "config" test_config)
 
 # from this point every command will use config from the KUBECONFIG env var
 export KUBECONFIG="${HOME}/.kube/non-default-config"
 export CLUSTER_ADMIN_CONTEXT=$(oc config view --flatten -o template --template='{{index . "current-context"}}')
+
+function isolate_test() {
+  name=$1
+  testcmd=$2
+  oc project ${CLUSTER_ADMIN_CONTEXT}
+  oc new-project "cmd-${name}"
+  ${testcmd}
+  oc delete project "cmd-${name}"
+}
 
 
 # NOTE: Do not add tests here, add them to test/cmd/*.
 # Tests should assume they run in an empty project, and should be reentrant if possible
 # to make it easy to run individual tests
 for test in "${tests[@]}"; do
-  echo
-  echo "++ ${test}"
   name=$(basename ${test} .sh)
-
   # switch back to a standard identity. This prevents individual tests from changing contexts and messing up other tests
-  oc project ${CLUSTER_ADMIN_CONTEXT}
-  oc new-project "cmd-${name}"
-  ${test}
-  oc delete project "cmd-${name}"
+  (exectest ${name} "isolate_test ${name} ${test}")
 done
 
 
 # Done
-echo
-echo
-wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/metrics" "metrics: " 0.25 80
-echo
-echo
-echo "test-cmd: ok"
+function test_metrics() {
+  wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/metrics" "metrics: " 0.25 80
+}
+
+(exectest "metrics" test_metrics)


### PR DESCRIPTION
cc @liggitt 
This follows the template in `hack/test-integration` for buckets in `hack/test-cmd` to reduce output spam.