### PR TITLE
Refactored Openshift Origin builder, decoupled from S2I builder, added mocks and testing

### DIFF
--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -10,6 +10,7 @@ import (
 	stiapi "github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/api/describe"
 	"github.com/openshift/source-to-image/pkg/api/validation"
+	"github.com/openshift/source-to-image/pkg/build"
 	sti "github.com/openshift/source-to-image/pkg/build/strategies"
 	kapi "k8s.io/kubernetes/pkg/api"
 
@@ -17,24 +18,67 @@ import (
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"
 )
 
+// internal interface to decouple S2I-specific code from Origin builder code
+type stiBuilderFactory interface {
+	// Create S2I Builder based on S2I configuration
+	GetStrategy(config *stiapi.Config) (build.Builder, error)
+}
+
+// interval interface to decouple S2I-specific code from Origin builder code
+type stiConfigValidator interface {
+	// Perform validation of S2I configuration, returns slice of validation errors
+	ValidateConfig(config *stiapi.Config) []validation.ValidationError
+}
+
+// default implementation of stiBuilderFactory
+type runtimeBuilderFactory struct{}
+
+// default implementation of stiConfigValidator
+type runtimeConfigValidator struct{}
+
+// default implementation of stiBuildFactory.GetStrategy method. Just delegates to S2I-specific code
+func (_ runtimeBuilderFactory) GetStrategy(config *stiapi.Config) (build.Builder, error) {
+	return sti.GetStrategy(config)
+}
+
+// default implementation of stiConfigValidator.ValidateConfig method. Just delegates to S2I-specific code
+func (_ runtimeConfigValidator) ValidateConfig(config *stiapi.Config) []validation.ValidationError {
+	return validation.ValidateConfig(config)
+}
+
 // STIBuilder performs an STI build given the build object
 type STIBuilder struct {
-	dockerClient DockerClient
-	dockerSocket string
-	build        *api.Build
+	dockerClient    DockerClient
+	dockerSocket    string
+	build           *api.Build
+	builderFactory  stiBuilderFactory
+	configValidator stiConfigValidator
 }
 
 // NewSTIBuilder creates a new STIBuilder instance
 func NewSTIBuilder(client DockerClient, dockerSocket string, build *api.Build) *STIBuilder {
+	// delegate to internal implementation passing default implementation of stiBuilderFactory and stiConfigValidator
+	return newSTIBuilder(client, dockerSocket, build,
+		new(runtimeBuilderFactory), new(runtimeConfigValidator))
+
+}
+
+// internal factory function to create STIBuilder based on arameters. Used for testing.
+func newSTIBuilder(client DockerClient, dockerSocket string, build *api.Build,
+	builderFactory stiBuilderFactory, configValidator stiConfigValidator) *STIBuilder {
+	// just create instance
 	return &STIBuilder{
-		dockerClient: client,
-		dockerSocket: dockerSocket,
-		build:        build,
+		dockerClient:    client,
+		dockerSocket:    dockerSocket,
+		build:           build,
+		builderFactory:  builderFactory,
+		configValidator: configValidator,
 	}
 }
 
-// Build executes the STI build
+// executes STI build based on configured builder, S2I builder factory and S2I config validator
 func (s *STIBuilder) Build() error {
+
 	var push bool
 
 	// if there is no output target, set one up so the docker build logic
@@ -79,7 +123,7 @@ func (s *STIBuilder) Build() error {
 		}
 	}
 
-	if errs := validation.ValidateConfig(config); len(errs) != 0 {
+	if errs := s.configValidator.ValidateConfig(config); len(errs) != 0 {
 		var buffer bytes.Buffer
 		for _, ve := range errs {
 			buffer.WriteString(ve.Error())
@@ -94,7 +138,7 @@ func (s *STIBuilder) Build() error {
 	config.IncrementalAuthentication, _ = dockercfg.NewHelper().GetDockerAuth(tag, dockercfg.PushAuthType)
 
 	glog.V(2).Infof("Creating a new S2I builder with build config: %#v\n", describe.DescribeConfig(config))
-	builder, err := sti.GetStrategy(config)
+	builder, err := s.builderFactory.GetStrategy(config)
 	if err != nil {
 		return err
 	}
@@ -119,10 +163,24 @@ func (s *STIBuilder) Build() error {
 		)
 		if authPresent {
 			glog.Infof("Using provided push secret for pushing %s image", tag)
+		} else {
+			glog.Infof("No push secret provided")
 		}
 		glog.Infof("Pushing %s image ...", tag)
 		if err := pushImage(s.dockerClient, tag, pushAuthConfig); err != nil {
-			return fmt.Errorf("Failed to push image: %v", err)
+			// write extended error message to assist in problem resolution
+			msg := fmt.Sprintf("Failed to push image. Response from registry is: %v", err)
+			if authPresent {
+				glog.Infof("Registry server Address: %s", pushAuthConfig.ServerAddress)
+				glog.Infof("Registry server User Name: %s", pushAuthConfig.Username)
+				glog.Infof("Registry server Email: %s", pushAuthConfig.Email)
+				passwordPresent := "<<empty>>"
+				if len(pushAuthConfig.Password) > 0 {
+					passwordPresent = "<<non-empty>>"
+				}
+				glog.Infof("Registry server address: %s", passwordPresent)
+			}
+			return errors.New(msg)
 		}
 		glog.Infof("Successfully pushed %s", tag)
 		glog.Flush()

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -1,0 +1,168 @@
+package builder
+
+import (
+	"errors"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/openshift/origin/pkg/build/api"
+	stiapi "github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/api/validation"
+	"github.com/openshift/source-to-image/pkg/build"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"strings"
+	"testing"
+)
+
+// mock docker client
+type testDockerClient struct {
+	// flag if BuildImage was called
+	buildImageCalled bool
+	// flag if PushImage was called
+	pushImageCalled bool
+	// flag if RemoveImage was called
+	removeImageCalled bool
+	// emulated error to return from PushImage call
+	errPushImage error
+}
+
+// Registers a call and returns an error (if any)
+func (client testDockerClient) BuildImage(opts docker.BuildImageOptions) error {
+	return nil
+}
+
+// Registers PushImage call and returns an error (if any)
+func (client testDockerClient) PushImage(opts docker.PushImageOptions, auth docker.AuthConfiguration) error {
+	client.pushImageCalled = true
+	return client.errPushImage
+}
+
+// Registers RemoveImage call and returns an error (if any)
+func (client testDockerClient) RemoveImage(name string) error {
+	return nil
+}
+
+// Mock S2I Builder factory implementation
+type testStiBuilderFactory struct {
+	// error to return from GetStrategy function
+	getStrategyErr error
+	// error to return from Build function
+	buildError error
+}
+
+// Mock S2I Config Validator implementation
+type testStiConfigValidator struct {
+	// errors to return
+	errors []validation.ValidationError
+}
+
+// Mock S2I builder factory implementation. Just returns mock S2I builder instances ot error (if set)
+func (factory testStiBuilderFactory) GetStrategy(config *stiapi.Config) (build.Builder, error) {
+	// if there is error set, return this error
+	if factory.getStrategyErr != nil {
+		return nil, factory.getStrategyErr
+	}
+	return testBuilder{buildError: factory.buildError}, nil
+}
+
+// mock STI builder
+type testBuilder struct {
+	// error to return from build process
+	buildError error
+}
+
+// provide mock implementation for STI builder, returns nil result and error if any
+func (builder testBuilder) Build(config *stiapi.Config) (*stiapi.Result, error) {
+	return nil, builder.buildError
+}
+
+// creates mock implemenation of STI builder, instrumenting different parts of a process to return errors
+func makeStiBuilder(
+	errPushImage error,
+	getStrategyErr error,
+	buildError error,
+	validationErrors []validation.ValidationError) STIBuilder {
+	return *newSTIBuilder(
+		testDockerClient{
+			errPushImage: errPushImage,
+		},
+		"/docker.socket",
+		makeBuild(),
+		testStiBuilderFactory{getStrategyErr: getStrategyErr, buildError: buildError},
+		testStiConfigValidator{errors: validationErrors},
+	)
+}
+
+// Mock implementation for config validator. returns error if set or nil
+func (validator testStiConfigValidator) ValidateConfig(config *stiapi.Config) []validation.ValidationError {
+	return validator.errors
+}
+
+// create simple mock build config
+func makeBuild() *api.Build {
+	return &api.Build{
+		Spec: api.BuildSpec{
+			Source: api.BuildSource{
+				Type: api.BuildSourceGit,
+				Git: &api.GitBuildSource{
+					URI: "http://localhost/123",
+				}},
+			Strategy: api.BuildStrategy{
+				Type: api.SourceBuildStrategyType,
+				SourceStrategy: &api.SourceBuildStrategy{
+					From: kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "test/builder:latest",
+					},
+					Incremental: true,
+				}},
+			Output: api.BuildOutput{
+				To: &kapi.ObjectReference{
+					Kind: "DockerImage",
+					Name: "test/test-result:latest",
+				},
+			},
+		},
+	}
+}
+
+// Test docker registry image build error
+func TestDockerBuildError(t *testing.T) {
+	expErr := errors.New("Artificial exception: Error building")
+	stiBuilder := makeStiBuilder(expErr, nil, nil, make([]validation.ValidationError, 0))
+	err := stiBuilder.Build()
+	if err == nil {
+		t.Error("Artificial error expected from build process")
+
+	} else {
+		if !strings.Contains(err.Error(), expErr.Error()) {
+			t.Errorf("Artificial error expected from build process: \n Returned error: %s\n Expected error: %s", err.Error(), expErr.Error())
+		}
+	}
+}
+
+// Test docker registry image push error
+func TestPushError(t *testing.T) {
+	expErr := errors.New("Artificial exception: Error pushing image")
+	stiBuilder := makeStiBuilder(nil, nil, expErr, make([]validation.ValidationError, 0))
+	err := stiBuilder.Build()
+	if err == nil {
+		t.Error("Artificial error expected from build process")
+	} else {
+		if !strings.Contains(err.Error(), expErr.Error()) {
+			t.Errorf("Artificial error expected from build process: \n Returned error: %s\n Expected error: %s", err.Error(), expErr.Error())
+		}
+	}
+}
+
+// Test error creating sti builder
+func TestGetStrategyError(t *testing.T) {
+	expErr := errors.New("Artificial exception: config error")
+	stiBuilder := makeStiBuilder(nil, expErr, nil, make([]validation.ValidationError, 0))
+	err := stiBuilder.Build()
+	if err == nil {
+		t.Error("Artificial error expected from build process")
+	} else {
+		if !strings.Contains(err.Error(), expErr.Error()) {
+			t.Errorf("Artificial error expected from build process: \n Returned error: %s\n Expected error: %s", err.Error(), expErr.Error())
+		}
+	}
+}


### PR DESCRIPTION
I added more detailed logging messages (and hopefully they are less confusing now). Also I refactored code slightly to allow for testing Origin's builder mechanism itself without tightly coupling with S2I. Tests are as simple as they can be (and definitely not exhaustive), but now we can test agains interfaces and mock implementations instead of creating the entire build infrastructure etc. Just normal unit-testing.
It should resolve issue #4763.