### PR TITLE
Include status reason in oc get build output

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14603,6 +14603,10 @@
       "type": "boolean",
       "description": "describes if a canceling event was triggered for the build"
      },
+     "reason": {
+      "type": "string",
+      "description": "brief CamelCase string describing a failure, meant for machine parsing and tidy display in the CLI"
+     },
      "message": {
       "type": "string",
       "description": "human-readable message indicating details about why the build has this status"

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -926,6 +926,7 @@ func deepCopy_api_BuildSpec(in buildapi.BuildSpec, out *buildapi.BuildSpec, c *c
 func deepCopy_api_BuildStatus(in buildapi.BuildStatus, out *buildapi.BuildStatus, c *conversion.Cloner) error {
 	out.Phase = in.Phase
 	out.Cancelled = in.Cancelled
+	out.Reason = in.Reason
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if newVal, err := c.DeepCopy(in.StartTimestamp); err != nil {

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1384,6 +1384,7 @@ func autoconvert_api_BuildStatus_To_v1_BuildStatus(in *buildapi.BuildStatus, out
 	}
 	out.Phase = apiv1.BuildPhase(in.Phase)
 	out.Cancelled = in.Cancelled
+	out.Reason = apiv1.StatusReason(in.Reason)
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if err := s.Convert(&in.StartTimestamp, &out.StartTimestamp, 0); err != nil {
@@ -2016,6 +2017,7 @@ func autoconvert_v1_BuildStatus_To_api_BuildStatus(in *apiv1.BuildStatus, out *b
 	}
 	out.Phase = buildapi.BuildPhase(in.Phase)
 	out.Cancelled = in.Cancelled
+	out.Reason = buildapi.StatusReason(in.Reason)
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if err := s.Convert(&in.StartTimestamp, &out.StartTimestamp, 0); err != nil {

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -950,6 +950,7 @@ func deepCopy_v1_BuildSpec(in apiv1.BuildSpec, out *apiv1.BuildSpec, c *conversi
 func deepCopy_v1_BuildStatus(in apiv1.BuildStatus, out *apiv1.BuildStatus, c *conversion.Cloner) error {
 	out.Phase = in.Phase
 	out.Cancelled = in.Cancelled
+	out.Reason = in.Reason
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if newVal, err := c.DeepCopy(in.StartTimestamp); err != nil {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1393,6 +1393,7 @@ func autoconvert_api_BuildStatus_To_v1beta3_BuildStatus(in *buildapi.BuildStatus
 	}
 	out.Phase = apiv1beta3.BuildPhase(in.Phase)
 	out.Cancelled = in.Cancelled
+	out.Reason = apiv1beta3.StatusReason(in.Reason)
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if err := s.Convert(&in.StartTimestamp, &out.StartTimestamp, 0); err != nil {
@@ -2025,6 +2026,7 @@ func autoconvert_v1beta3_BuildStatus_To_api_BuildStatus(in *apiv1beta3.BuildStat
 	}
 	out.Phase = buildapi.BuildPhase(in.Phase)
 	out.Cancelled = in.Cancelled
+	out.Reason = buildapi.StatusReason(in.Reason)
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if err := s.Convert(&in.StartTimestamp, &out.StartTimestamp, 0); err != nil {

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -958,6 +958,7 @@ func deepCopy_v1beta3_BuildSpec(in apiv1beta3.BuildSpec, out *apiv1beta3.BuildSp
 func deepCopy_v1beta3_BuildStatus(in apiv1beta3.BuildStatus, out *apiv1beta3.BuildStatus, c *conversion.Cloner) error {
 	out.Phase = in.Phase
 	out.Cancelled = in.Cancelled
+	out.Reason = in.Reason
 	out.Message = in.Message
 	if in.StartTimestamp != nil {
 		if newVal, err := c.DeepCopy(in.StartTimestamp); err != nil {

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -71,7 +71,10 @@ type BuildStatus struct {
 	// Cancelled describes if a cancelling event was triggered for the build.
 	Cancelled bool
 
-	// Message is a human-readable message indicating details about why the build has this status
+	// Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
+	Reason StatusReason
+
+	// Message is a human-readable message indicating details about why the build has this status.
 	Message string
 
 	// StartTimestamp is a timestamp representing the server time when this Build started
@@ -124,6 +127,41 @@ const (
 
 	// BuildPhaseCancelled indicates that a running/pending build was stopped from executing.
 	BuildPhaseCancelled BuildPhase = "Cancelled"
+)
+
+// StatusReason is a brief CamelCase string that describes a temporary or
+// permanent build error condition, meant for machine parsing and tidy display
+// in the CLI.
+type StatusReason string
+
+// These are the valid reasons of build statuses.
+const (
+	// StatusReasonError is a generic reason for a build error condition.
+	StatusReasonError StatusReason = "Error"
+
+	// StatusReasonCannotCreateBuildPodSpec is an error condition when the build
+	// strategy cannot create a build pod spec.
+	StatusReasonCannotCreateBuildPodSpec = "CannotCreateBuildPodSpec"
+
+	// StatusReasonCannotCreateBuildPod is an error condition when a build pod
+	// cannot be created.
+	StatusReasonCannotCreateBuildPod = "CannotCreateBuildPod"
+
+	// StatusReasonInvalidOutputReference is an error condition when the build
+	// output is an invalid reference.
+	StatusReasonInvalidOutputReference = "InvalidOutputReference"
+
+	// StatusReasonCancelBuildFailed is an error condition when cancelling a build
+	// fails.
+	StatusReasonCancelBuildFailed = "CancelBuildFailed"
+
+	// StatusReasonBuildPodDeleted is an error condition when the build pod is
+	// deleted before build completion.
+	StatusReasonBuildPodDeleted = "BuildPodDeleted"
+
+	// StatusReasonExceededRetryTimeout is an error condition when the build has
+	// not completed and retrying the build times out.
+	StatusReasonExceededRetryTimeout = "ExceededRetryTimeout"
 )
 
 // BuildSourceType is the type of SCM used.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -57,7 +57,10 @@ type BuildStatus struct {
 	// Cancelled describes if a cancelling event was triggered for the build.
 	Cancelled bool `json:"cancelled,omitempty" description:"describes if a canceling event was triggered for the build"`
 
-	// Message is a human-readable message indicating details about why the build has this status
+	// Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
+	Reason StatusReason `json:"reason,omitempty" description:"brief CamelCase string describing a failure, meant for machine parsing and tidy display in the CLI"`
+
+	// Message is a human-readable message indicating details about why the build has this status.
 	Message string `json:"message,omitempty" description:"human-readable message indicating details about why the build has this status"`
 
 	// StartTimestamp is a timestamp representing the server time when this Build started
@@ -111,6 +114,11 @@ const (
 	// BuildPhaseCancelled indicates that a running/pending build was stopped from executing.
 	BuildPhaseCancelled BuildPhase = "Cancelled"
 )
+
+// StatusReason is a brief CamelCase string that describes a temporary or
+// permanent build error condition, meant for machine parsing and tidy display
+// in the CLI.
+type StatusReason string
 
 // BuildSourceType is the type of SCM used.
 type BuildSourceType string

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -57,7 +57,10 @@ type BuildStatus struct {
 	// Cancelled describes if a cancelling event was triggered for the build.
 	Cancelled bool `json:"cancelled,omitempty"`
 
-	// A human readable message indicating details about why the build has this status
+	// Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
+	Reason StatusReason `json:"reason,omitempty" description:"brief CamelCase string describing a failure, meant for machine parsing and tidy display in the CLI"`
+
+	// Message is a human-readable message indicating details about why the build has this status.
 	Message string `json:"message,omitempty"`
 
 	// StartTimestamp is a timestamp representing the server time when this Build started
@@ -111,6 +114,11 @@ const (
 	// BuildPhaseCancelled indicates that a running/pending build was stopped from executing.
 	BuildPhaseCancelled BuildPhase = "Cancelled"
 )
+
+// StatusReason is a brief CamelCase string that describes a temporary or
+// permanent build error condition, meant for machine parsing and tidy display
+// in the CLI.
+type StatusReason string
 
 // BuildSourceType is the type of SCM used.
 type BuildSourceType string

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -39,6 +39,7 @@ func limitedLogAndRetry(buildupdater buildclient.BuildUpdater, maxTimeout time.D
 			return true
 		}
 		build.Status.Phase = buildapi.BuildPhaseFailed
+		build.Status.Reason = buildapi.StatusReasonExceededRetryTimeout
 		build.Status.Message = err.Error()
 		now := unversioned.Now()
 		build.Status.CompletionTimestamp = &now
@@ -98,6 +99,10 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 			if err != nil {
 				// Update the build status message only if it changed.
 				if msg := err.Error(); build.Status.Message != msg {
+					// Set default Reason.
+					if len(build.Status.Reason) == 0 {
+						build.Status.Reason = buildapi.StatusReasonError
+					}
 					build.Status.Message = msg
 					if err := buildController.BuildUpdater.Update(build.Namespace, build); err != nil {
 						glog.V(2).Infof("Failed to update status message of Build %s/%s: %v", build.Namespace, build.Name, err)

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -208,7 +208,11 @@ func printBuild(build *buildapi.Build, w io.Writer, withNamespace, wide, showAll
 		created = fmt.Sprintf("%s ago", formatRelativeTime(build.Status.StartTimestamp.Time))
 	}
 	from := describeSourceShort(build.Spec)
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", build.Name, describeStrategy(build.Spec.Strategy.Type), from, build.Status.Phase, created)
+	status := string(build.Status.Phase)
+	if len(build.Status.Reason) > 0 {
+		status = fmt.Sprintf("%s (%s)", status, build.Status.Reason)
+	}
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", build.Name, describeStrategy(build.Spec.Strategy.Type), from, status, created)
 	return err
 }
 


### PR DESCRIPTION
Useful to find at a glance potential errors with existing builds.

Follow up on #4872