### PR TITLE
Add tabs to pod details page

### DIFF
--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -158,7 +158,8 @@ angular
         templateUrl: 'views/pods.html'
       })
       .when('/project/:project/browse/pods/:pod', {
-        templateUrl: 'views/browse/pod.html'
+        templateUrl: 'views/browse/pod.html',
+        controller: 'PodController'
       })
       .when('/project/:project/browse/services', {
         templateUrl: 'views/services.html'

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -26,6 +26,12 @@ angular.module('openshiftConsole')
       }
     ];
 
+    // Check for a ?tab=<name> query param to allow linking directly to a tab.
+    if ($routeParams.tab) {
+      $scope.selectedTab = {};
+      $scope.selectedTab[$routeParams.tab] = true;
+    }
+
     var watches = [];
 
     project.get($routeParams.project).then(function(resp) {

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -203,6 +203,25 @@ html, body {
   }
 }
 
+.nav-tabs {
+  font-size: @font-size-base;
+  a {
+    // ui.bootstrap.tabs doesn't set the href attr, so the cursor style is
+    // required or it's a vertical bar
+    cursor: pointer;
+  }
+  li.active {
+    a, a:hover {
+      // Remove when we update patternfly
+      background-color: #fff;
+    }
+  }
+}
+
+.nav-tabs, .tab-content {
+  margin-top: @grid-gutter-width / 2;
+}
+
 .empty-project {
   margin: 10px auto;
   max-width: 500px;

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -1,4 +1,4 @@
-<div ng-controller="PodController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>
@@ -6,76 +6,91 @@
       <div class="row">
         <div class="col-md-12">
           <div class="tile">
-            <dl class="dl-horizontal left">
-              <dt>Name:</dt>
-              <dd>{{pod.metadata.name}}</dd>
-              <dt>Node:</dt>
-              <dd>{{pod.spec.nodeName || 'unknown'}} <span ng-if="pod.status.hostIP && pod.spec.nodeName != pod.status.hostIP">({{pod.status.hostIP}})</span></dd>
-              <dt>Labels:</dt>
-              <dd>
-                <span ng-if="!pod.metadata.labels">none</span>
-                <span ng-repeat="(labelKey, labelValue) in pod.metadata.labels">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
-              </dd>
-              <dt>Status:</dt>
-              <dd>
-                <span ng-switch="pod.status.phase">
-                  <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
-                  <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
-                  <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
-                  <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
-                  <span ng-switch-when="Running" class="fa fa-refresh fa-spin" aria-hidden="true"></span>
-                </span>
-                {{pod.status.phase}}
-              </dd>
-              <dt>IP:</dt>
-              <dd>{{pod.status.podIP || 'unknown'}}</dd>
-              <dt>Restart policy:</dt>
-              <dd>{{pod.spec.restartPolicy || 'Always'}}</dd>
-            </dl>
-            <div ng-if="pod.spec.volumes.length">
-              <span class="pod-detail-label">Volumes:</span>
-              <ul>
-                <li ng-repeat="volume in pod.spec.volumes">
-                  <div>{{volume.name}}</div>
-                  <div ng-if="volume.source.hostPath">
-                    <div>Type: host path</div>
-                    <div>Path: {{volume.source.hostPath.path}}</div>
-                  </div>
-                  <div ng-if="volume.source.emptyDir">Type: empty directory</div>
-                  <!-- TODO fill out GCE persistent disk details -->
-                  <div ng-if="volume.source.gcePersistentDisk">Type: GCE persistent disk</div>
-                  <div ng-if="volume.source.gitRepo">
-                    <div>Type: Git repository</div>
-                    <div>Repository: {{volume.source.gitRepo.repository}}</div>
-                    <div ng-if="volume.source.gitRepo.revision">Revision: {{volume.source.gitRepo.revision}}</div>
-                  </div>
-                </li>
-              </ul>
-            </div>
-            <div>Pod template:</div>
-            <pod-template
-              pod-template="pod"
-              images-by-docker-reference="imagesByDockerReference"
-              builds="builds">
-            </pod-template>
-            <div>Container Statuses:</div>
-            <div ng-if="!pod.status.containerStatuses"><em>none</em></div>
-            <dl ng-repeat="containerStatus in pod.status.containerStatuses | orderBy:'name'" class="dl-horizontal left indent">
-              <dt>Name:</dt>
-              <dd>{{containerStatus.name}}</dd>
-              <dt>State:</dt>
-              <dd>
-                <kubernetes-object-describe-container-state container-state="containerStatus.state"></kubernetes-object-describe-container-state>
-              </dd>
-              <dt ng-if="!(containerStatus.lastState | isEmptyObj)">Last State</dt>
-              <dd ng-if="!(containerStatus.lastState | isEmptyObj)">
-                <kubernetes-object-describe-container-state container-state="containerStatus.lastState"></kubernetes-object-describe-container-state>
-              </dd>
-              <dt>Ready:</dt>
-              <dd>{{containerStatus.ready}}</dd>
-              <dt>Restart Count:</dt>
-              <dd>{{containerStatus.restartCount}}</dd>
-            </dl>
+            <h1>Pod {{pod.metadata.name}}</h1>
+            <tabset>
+              <tab heading="Details" active="selectedTab.details">
+                <dl class="dl-horizontal left">
+                  <dt>Node:</dt>
+                  <dd>{{pod.spec.nodeName || 'unknown'}} <span ng-if="pod.status.hostIP && pod.spec.nodeName != pod.status.hostIP">({{pod.status.hostIP}})</span></dd>
+                  <dt>Labels:</dt>
+                  <dd>
+                    <span ng-if="!pod.metadata.labels">none</span>
+                    <span ng-repeat="(labelKey, labelValue) in pod.metadata.labels">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
+                  </dd>
+                  <dt>Status:</dt>
+                  <dd>
+                    <span ng-switch="pod.status.phase">
+                      <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
+                      <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
+                      <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
+                      <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
+                      <span ng-switch-when="Running" class="fa fa-refresh fa-spin" aria-hidden="true"></span>
+                    </span>
+                    {{pod.status.phase}}
+                  </dd>
+                  <dt>IP:</dt>
+                  <dd>{{pod.status.podIP || 'unknown'}}</dd>
+                  <dt>Restart policy:</dt>
+                  <dd>{{pod.spec.restartPolicy || 'Always'}}</dd>
+                </dl>
+                <div ng-if="pod.spec.volumes.length">
+                  <span class="pod-detail-label">Volumes:</span>
+                  <ul>
+                    <li ng-repeat="volume in pod.spec.volumes">
+                      <div>{{volume.name}}</div>
+                      <div ng-if="volume.source.hostPath">
+                        <div>Type: host path</div>
+                        <div>Path: {{volume.source.hostPath.path}}</div>
+                      </div>
+                      <div ng-if="volume.source.emptyDir">Type: empty directory</div>
+                      <!-- TODO fill out GCE persistent disk details -->
+                      <div ng-if="volume.source.gcePersistentDisk">Type: GCE persistent disk</div>
+                      <div ng-if="volume.source.gitRepo">
+                        <div>Type: Git repository</div>
+                        <div>Repository: {{volume.source.gitRepo.repository}}</div>
+                        <div ng-if="volume.source.gitRepo.revision">Revision: {{volume.source.gitRepo.revision}}</div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div>Pod template:</div>
+                <pod-template
+                  pod-template="pod"
+                  images-by-docker-reference="imagesByDockerReference"
+                  builds="builds">
+                </pod-template>
+                <div>Container Statuses:</div>
+                <div ng-if="!pod.status.containerStatuses"><em>none</em></div>
+                <dl ng-repeat="containerStatus in pod.status.containerStatuses | orderBy:'name'" class="dl-horizontal left indent">
+                  <dt>Name:</dt>
+                  <dd>{{containerStatus.name}}</dd>
+                  <dt>State:</dt>
+                  <dd>
+                    <kubernetes-object-describe-container-state container-state="containerStatus.state"></kubernetes-object-describe-container-state>
+                  </dd>
+                  <dt ng-if="!(containerStatus.lastState | isEmptyObj)">Last State</dt>
+                  <dd ng-if="!(containerStatus.lastState | isEmptyObj)">
+                    <kubernetes-object-describe-container-state container-state="containerStatus.lastState"></kubernetes-object-describe-container-state>
+                  </dd>
+                  <dt>Ready:</dt>
+                  <dd>{{containerStatus.ready}}</dd>
+                  <dt>Restart Count:</dt>
+                  <dd>{{containerStatus.restartCount}}</dd>
+                </dl>
+              </tab>
+
+              <!--
+              <tab heading="Metrics" active="selectedTab.metrics">
+              Metrics content
+              </tab>
+              -->
+
+              <!--
+              <tab heading="Logs" active="selectedTab.logs">
+              Logs content
+              </tab>
+              -->
+            </tabset>
           </div>
         </div>
       </div><!-- /row -->


### PR DESCRIPTION
This allows us to add tabs like "Metrics" and "Logs." Those tabs are not part of this pull request, but here is what it would look like:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/10252408/43545248-6905-11e5-81d4-2847215d9c8a.png)

/cc @jwforres @benjaminapetersen @stefwalter 