### PR TITLE
fix exec admission controller flake

### DIFF
--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -25,7 +25,9 @@ import (
 
 func init() {
 	admission.RegisterPlugin("SCCExecRestrictions", func(client client.Interface, config io.Reader) (admission.Interface, error) {
-		return NewSCCExecRestrictions(client), nil
+		execAdmitter := NewSCCExecRestrictions(client)
+		execAdmitter.constraintAdmission.Run()
+		return execAdmitter, nil
 	})
 }
 
@@ -65,10 +67,10 @@ func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
 }
 
 // NewSCCExecRestrictions creates a new admission controller that denies an exec operation on a privileged pod
-func NewSCCExecRestrictions(client client.Interface) admission.Interface {
+func NewSCCExecRestrictions(client client.Interface) *sccExecRestrictions {
 	return &sccExecRestrictions{
 		Handler:             admission.NewHandler(admission.Connect),
-		constraintAdmission: NewConstraint(client).(*constraint),
+		constraintAdmission: NewConstraint(client),
 		client:              client,
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4924

The delegated constraint admission controller was starting a reflector cache.  This simply excludes those two actions from the list since we aren't interesting in them.

@pweil- or @liggitt 