### PR TITLE
Add a LatestBuilds diagnostic.

### DIFF
--- a/pkg/cmd/experimental/diagnostics/client.go
+++ b/pkg/cmd/experimental/diagnostics/client.go
@@ -13,7 +13,8 @@ import (
 var (
 	// availableClientDiagnostics contains the names of client diagnostics that can be executed
 	// during a single run of diagnostics. Add more diagnostics to the list as they are defined.
-	availableClientDiagnostics = sets.NewString(clientdiags.ConfigContextsName)
+	availableClientDiagnostics = sets.NewString(clientdiags.ConfigContextsName,
+		clientdiags.LatestBuildsName)
 )
 
 // buildClientDiagnostics builds client Diagnostic objects based on the rawConfig passed in.
@@ -30,13 +31,15 @@ func (o DiagnosticsOptions) buildClientDiagnostics(rawConfig *clientcmdapi.Confi
 
 	diagnostics := []types.Diagnostic{}
 	requestedDiagnostics := intersection(sets.NewString(o.RequestedDiagnostics...), available).List()
+
 	for _, diagnosticName := range requestedDiagnostics {
 		switch diagnosticName {
 		case clientdiags.ConfigContextsName:
 			for contextName := range rawConfig.Contexts {
 				diagnostics = append(diagnostics, clientdiags.ConfigContext{rawConfig, contextName})
 			}
-
+		case clientdiags.LatestBuildsName:
+			diagnostics = append(diagnostics, &clientdiags.LatestBuilds{RawConfig: rawConfig})
 		default:
 			return nil, false, fmt.Errorf("unknown diagnostic: %v", diagnosticName)
 		}

--- a/pkg/diagnostics/client/latest_builds.go
+++ b/pkg/diagnostics/client/latest_builds.go
@@ -1,0 +1,166 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	api "github.com/openshift/origin/pkg/build/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclientcmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	kclientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/diagnostics/types"
+)
+
+// LatestBuilds diagnostics check for issues with recent builds in the client's current context.
+type LatestBuilds struct {
+	RawConfig *kclientcmdapi.Config
+}
+
+const (
+	LatestBuildsName = "LatestBuilds"
+
+	warningTemplate = `
+Found potential problem in build logs: %s
+%s
+`
+
+	registrySelinuxErrorKey = "DCli4010"
+	registrySelinuxRegex    = ".*Failed to push image: Error pushing to registry:.*unexpected 500 response status trying to initiate upload"
+	registrySelinuxWarning  = `Indicates the registry container may be getting denied by SELinux.
+This may be corrected by running 'sudo chcon -R -t svirt_sandbox_file_t [PATH TO]/openshift.local.volumes' on the registry host.`
+)
+
+// LogNeedle represents a suspicious line (needle) in a failed log (haystack) we might be able to
+// inform the user about.
+type LogNeedle struct {
+	ErrorKey  string
+	SearchFor *regexp.Regexp
+	Warning   string
+	Found     bool // tracks if we've already seen this regex match on a previous line
+}
+
+func (d *LatestBuilds) Name() string {
+	return LatestBuildsName
+}
+
+func (d *LatestBuilds) Description() string {
+	return "Check latest builds and their logs for errors in the current context and project."
+}
+
+func (d *LatestBuilds) CanRun() (bool, error) {
+	if d.RawConfig == nil {
+		return false, errors.New("There is no client config file")
+	}
+
+	_, exists := d.RawConfig.Contexts[d.RawConfig.CurrentContext]
+	if !exists {
+		return false, errors.New(fmt.Sprintf(
+			"Client default config context '%s' is not defined.", d.RawConfig.CurrentContext))
+	}
+
+	return true, nil
+}
+
+func (d *LatestBuilds) Check() types.DiagnosticResult {
+	r := types.NewDiagnosticResult(LatestBuildsName)
+
+	// We know this exists, we just checked for it in CanRun:
+	context, _ := d.RawConfig.Contexts[d.RawConfig.CurrentContext]
+
+	project := context.Namespace
+	if project == "" {
+		project = kapi.NamespaceDefault // k8s fills this in anyway if missing from the context
+	}
+
+	osClient, _, err := osclientcmd.NewFactory(kclientcmd.NewDefaultClientConfig(*d.RawConfig, &kclientcmd.ConfigOverrides{Context: *context})).Clients()
+	if err != nil {
+		r.Error("DCli4001", nil, "Unable to connect with default context.")
+		return r
+	}
+
+	buildConfigs, err := osClient.BuildConfigs(project).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		r.Error("DCli4002", nil, fmt.Sprintf("Error listing buildconfigs in project %s: %s",
+			project, err))
+	}
+
+	for _, bc := range buildConfigs.Items {
+		lastBuildId := fmt.Sprintf("%s-%s", bc.ObjectMeta.Name, strconv.Itoa(bc.Status.LastVersion))
+		build, err := osClient.Builds(project).Get(lastBuildId)
+		if err != nil {
+			r.Error("DCli4003", nil, fmt.Sprintf("Unable to lookup latest build: %s", lastBuildId))
+			continue
+		}
+		if build.Status.Phase == buildapi.BuildPhaseError {
+			// TODO: Is there a command we could recommend if an error prevented the build from running at all?
+			r.Error("DCli4004", nil, fmt.Sprintf("An error prevented latest build from running for build config '%s'", bc.ObjectMeta.Name))
+		} else if build.Status.Phase == buildapi.BuildPhaseFailed {
+			r.Error("DCli4005", nil, fmt.Sprintf("Latest build for build config '%s' failed. Run 'oc build-logs %s' for details.", bc.ObjectMeta.Name, lastBuildId))
+			fmt.Println("\n")
+
+			opts := api.BuildLogOptions{Follow: false, NoWait: true}
+			buildLogs := osClient.BuildLogs(project)
+			readCloser, err := buildLogs.Get(lastBuildId, opts).Stream()
+			if err != nil {
+				r.Error("DCli4006", nil, fmt.Sprintf("Error reading build logs for %s: %s", lastBuildId, err))
+				continue
+			}
+			defer readCloser.Close()
+
+			buffer := new(bytes.Buffer)
+			buffer.ReadFrom(readCloser)
+			logStr := buffer.String()
+			scanBuildLog(r, logStr, BuildNeedles())
+		} else {
+			r.Debug("DCli4007", fmt.Sprintf("Latest build for build config '%s' status: %s",
+				bc.ObjectMeta.Name, build.Status.Phase))
+		}
+	}
+
+	return r
+}
+
+// buildNeedles creates the LogNeedle's we'll scan the build log for.
+// (as we can't really use const's for this)
+func BuildNeedles() []*LogNeedle {
+
+	// Scan for an error indicating selinux is preventing the registry container from writing to disk:
+	selinuxRegex, _ := regexp.Compile(registrySelinuxRegex)
+	selinuxNeedle := LogNeedle{
+		ErrorKey:  registrySelinuxErrorKey,
+		SearchFor: selinuxRegex,
+		Warning:   registrySelinuxWarning,
+	}
+
+	needles := []*LogNeedle{&selinuxNeedle}
+	return needles
+}
+
+func scanBuildLog(r types.DiagnosticResult, buildLog string, needles []*LogNeedle) {
+
+	lines := strings.Split(buildLog, "\n")
+
+	for _, line := range lines {
+		for _, needle := range needles {
+			// We only report on needle once to avoid spamming:
+			if needle.Found == true {
+				continue
+			}
+			reg := needle.SearchFor
+			if reg.MatchString(line) {
+				r.Warn(needle.ErrorKey, nil, fmt.Sprintf(warningTemplate, line, needle.Warning))
+				needle.Found = true
+
+			}
+		}
+	}
+}

--- a/pkg/diagnostics/client/latest_builds_test.go
+++ b/pkg/diagnostics/client/latest_builds_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/openshift/origin/pkg/diagnostics/types"
+)
+
+const fakeBuildLog = `
+I1002 14:37:05.078169       1 sti.go:149] Using provided push secret for pushing 172.30.150.249:5000/test/nodejs-ex:latest image
+I1002 14:37:05.078184       1 sti.go:151] Pushing 172.30.150.249:5000/test/nodejs-ex:latest image ...
+F1002 14:37:06.981434       1 builder.go:54] Build error: Failed to push image: Error pushing to registry: Server error: unexpected 500 response status trying to initiate upload of test/nodejs-ex
+I1002 14:37:05.078184       1 sti.go:151] This is some other stuff I made up.
+F1002 14:37:05.078184       1 sti.go:151] WOW this looks really bad.
+F1002 14:37:05.078184       1 sti.go:151] WOW this looks really bad. And it happened again, only warn me once.
+`
+
+// compares the expected error keys against the given errors/warnings.
+func compareKeys(t *testing.T, errors []types.DiagnosticError, expErrKeys []string) {
+	for _, expKey := range expErrKeys {
+		found := false
+		for _, diagErr := range errors {
+			if diagErr.ID == expKey {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Unable to locate expected error key: %s", expKey)
+		}
+	}
+}
+
+func assertResults(t *testing.T, r types.DiagnosticResult, expErrKeys []string, expWarnKeys []string) {
+	if len(r.Errors()) != len(expErrKeys) {
+		t.Errorf("Expected %d errors, got %d.", len(expErrKeys), len(r.Errors()))
+	}
+	if len(r.Warnings()) != len(expWarnKeys) {
+		t.Errorf("Expected %d warnings, got %d.", len(expWarnKeys), len(r.Warnings()))
+	}
+	compareKeys(t, r.Errors(), expErrKeys)
+	compareKeys(t, r.Warnings(), expWarnKeys)
+}
+
+func TestReportsRegistrySelinuxProblem(t *testing.T) {
+	r := types.NewDiagnosticResult(LatestBuildsName)
+	needles := BuildNeedles()
+	scanBuildLog(r, fakeBuildLog, needles)
+	assertResults(t, r, []string{}, []string{registrySelinuxErrorKey})
+}
+
+func TestReportsMultipleProblems(t *testing.T) {
+	r := types.NewDiagnosticResult(LatestBuildsName)
+	needles := BuildNeedles()
+
+	// Add an additional needle to look for, it will match twice but we want to only be warned once:
+	regex, _ := regexp.Compile(".*WOW this looks really bad.*")
+	fakeNeedle := &LogNeedle{
+		ErrorKey:  "FAKE001",
+		SearchFor: regex,
+		Warning:   "Something looks really bad.",
+	}
+	needles = append(needles, fakeNeedle)
+
+	scanBuildLog(r, fakeBuildLog, needles)
+	assertResults(t, r, []string{}, []string{registrySelinuxErrorKey, "FAKE001"})
+}


### PR DESCRIPTION
This diagnostic lists all build configs in the current client context and
project, then checks if the latest build was successful or not. If the build
status reported error or failure we notify the user immediately.

The diagnostic then scans the build logs for any build with failed status, and
applies a series of regexes to each line looking for common problems we could
report on. Today the only problem being detected is the registry being denied
writing to disk due to a common selinux issue.