### PR TITLE
Ensure imageStream.spec.dockerImageRepository never has tags or IDs

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -147,6 +147,23 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 			// successfully, the ImageStreamImage's ObjectMeta must match the Image's.
 			j.ObjectMeta = j.Image.ObjectMeta
 		},
+		func(j *image.ImageStreamSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			// if the generated fuzz value has a tag or image id, strip it
+			if strings.ContainsAny(j.DockerImageRepository, ":@") {
+				j.DockerImageRepository = ""
+			}
+			if j.Tags == nil {
+				j.Tags = make(map[string]image.TagReference)
+			}
+		},
+		func(j *image.ImageStreamStatus, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			// if the generated fuzz value has a tag or image id, strip it
+			if strings.ContainsAny(j.DockerImageRepository, ":@") {
+				j.DockerImageRepository = ""
+			}
+		},
 		func(j *image.ImageStreamTag, c fuzz.Continue) {
 			c.Fuzz(&j.Image)
 			// because we de-embedded Image from ImageStreamTag, in order to round trip

--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/golang/glog"
 
@@ -189,9 +188,12 @@ func (bc *BuildController) resolveOutputDockerImageReference(build *buildapi.Bui
 		var tag string
 		streamName := outputTo.Name
 		if outputTo.Kind == "ImageStreamTag" {
-			bits := strings.Split(outputTo.Name, ":")
-			streamName = bits[0]
-			tag = ":" + bits[1]
+			var ok bool
+			streamName, tag, ok = imageapi.SplitImageStreamTag(streamName)
+			if !ok {
+				return "", fmt.Errorf("the referenced ImageStreamTag is invalid: %s", outputTo.Name)
+			}
+			tag = ":" + tag
 		}
 		stream, err := bc.ImageStreamClient.GetImageStream(namespace, streamName)
 		if err != nil {

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -293,7 +293,7 @@ func (r *ImageRef) ImageStream() (*imageapi.ImageStream, error) {
 		},
 	}
 	if !r.OutputImage {
-		stream.Spec.DockerImageRepository = r.StringNoTag()
+		stream.Spec.DockerImageRepository = r.AsRepository().String()
 		if r.Insecure {
 			stream.ObjectMeta.Annotations = map[string]string{
 				imageapi.InsecureRepositoryAnnotation: "true",

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -188,6 +188,47 @@ func TestParseDockerImageReference(t *testing.T) {
 	}
 }
 
+func TestDockerImageReferenceAsRepository(t *testing.T) {
+	testCases := []struct {
+		Registry, Namespace, Name, Tag, ID string
+		Expected                           string
+	}{
+		{
+			Namespace: "bar",
+			Name:      "foo",
+			Tag:       "tag",
+			Expected:  "bar/foo",
+		},
+		{
+			Namespace: "bar",
+			Name:      "foo",
+			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Expected:  "bar/foo",
+		},
+		{
+			Registry:  "bar",
+			Namespace: "foo",
+			Name:      "baz",
+			Expected:  "bar/foo/baz",
+		},
+	}
+
+	for i, testCase := range testCases {
+		ref := DockerImageReference{
+			Registry:  testCase.Registry,
+			Namespace: testCase.Namespace,
+			Name:      testCase.Name,
+			Tag:       testCase.Tag,
+			ID:        testCase.ID,
+		}
+		actual := ref.AsRepository().String()
+		if e, a := testCase.Expected, actual; e != a {
+			t.Errorf("%d: expected %q, got %q", i, e, a)
+		}
+	}
+
+}
+
 func TestDockerImageReferenceString(t *testing.T) {
 	testCases := []struct {
 		Registry, Namespace, Name, Tag, ID string

--- a/pkg/image/api/v1/conversion.go
+++ b/pkg/image/api/v1/conversion.go
@@ -71,6 +71,15 @@ func convert_v1_ImageStreamSpec_To_api_ImageStreamSpec(in *ImageStreamSpec, out 
 
 func convert_api_ImageStreamSpec_To_v1_ImageStreamSpec(in *newer.ImageStreamSpec, out *ImageStreamSpec, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
+	if len(in.DockerImageRepository) > 0 {
+		// ensure that stored image references have no tag or ID, which was possible from 1.0.0 until 1.0.7
+		if ref, err := newer.ParseDockerImageReference(in.DockerImageRepository); err == nil {
+			if len(ref.Tag) > 0 || len(ref.ID) > 0 {
+				ref.Tag, ref.ID = "", ""
+				out.DockerImageRepository = ref.Exact()
+			}
+		}
+	}
 	out.Tags = make([]NamedTagReference, 0, 0)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
@@ -83,6 +92,15 @@ func convert_v1_ImageStreamStatus_To_api_ImageStreamStatus(in *ImageStreamStatus
 
 func convert_api_ImageStreamStatus_To_v1_ImageStreamStatus(in *newer.ImageStreamStatus, out *ImageStreamStatus, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
+	if len(in.DockerImageRepository) > 0 {
+		// ensure that stored image references have no tag or ID, which was possible from 1.0.0 until 1.0.7
+		if ref, err := newer.ParseDockerImageReference(in.DockerImageRepository); err == nil {
+			if len(ref.Tag) > 0 || len(ref.ID) > 0 {
+				ref.Tag, ref.ID = "", ""
+				out.DockerImageRepository = ref.Exact()
+			}
+		}
+	}
 	out.Tags = make([]NamedTagEventList, 0, 0)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }

--- a/pkg/image/api/v1beta3/conversion.go
+++ b/pkg/image/api/v1beta3/conversion.go
@@ -65,6 +65,15 @@ func convert_v1beta3_Image_To_api_Image(in *Image, out *newer.Image, s conversio
 
 func convert_v1beta3_ImageStreamSpec_To_api_ImageStreamSpec(in *ImageStreamSpec, out *newer.ImageStreamSpec, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
+	if len(in.DockerImageRepository) > 0 {
+		// ensure that stored image references have no tag or ID, which was possible from 1.0.0 until 1.0.7
+		if ref, err := newer.ParseDockerImageReference(in.DockerImageRepository); err == nil {
+			if len(ref.Tag) > 0 || len(ref.ID) > 0 {
+				ref.Tag, ref.ID = "", ""
+				out.DockerImageRepository = ref.Exact()
+			}
+		}
+	}
 	out.Tags = make(map[string]newer.TagReference)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }
@@ -77,6 +86,15 @@ func convert_api_ImageStreamSpec_To_v1beta3_ImageStreamSpec(in *newer.ImageStrea
 
 func convert_v1beta3_ImageStreamStatus_To_api_ImageStreamStatus(in *ImageStreamStatus, out *newer.ImageStreamStatus, s conversion.Scope) error {
 	out.DockerImageRepository = in.DockerImageRepository
+	if len(in.DockerImageRepository) > 0 {
+		// ensure that stored image references have no tag or ID, which was possible from 1.0.0 until 1.0.7
+		if ref, err := newer.ParseDockerImageReference(in.DockerImageRepository); err == nil {
+			if len(ref.Tag) > 0 || len(ref.ID) > 0 {
+				ref.Tag, ref.ID = "", ""
+				out.DockerImageRepository = ref.Exact()
+			}
+		}
+	}
 	out.Tags = make(map[string]newer.TagEventList)
 	return s.Convert(&in.Tags, &out.Tags, 0)
 }

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -69,8 +69,15 @@ func ValidateImageStream(stream *api.ImageStream) fielderrors.ValidationErrorLis
 	}
 
 	if len(stream.Spec.DockerImageRepository) != 0 {
-		if _, err := api.ParseDockerImageReference(stream.Spec.DockerImageRepository); err != nil {
+		if ref, err := api.ParseDockerImageReference(stream.Spec.DockerImageRepository); err != nil {
 			result = append(result, fielderrors.NewFieldInvalid("spec.dockerImageRepository", stream.Spec.DockerImageRepository, err.Error()))
+		} else {
+			if len(ref.Tag) > 0 {
+				result = append(result, fielderrors.NewFieldInvalid("spec.dockerImageRepository", stream.Spec.DockerImageRepository, "the repository name may not contain a tag"))
+			}
+			if len(ref.ID) > 0 {
+				result = append(result, fielderrors.NewFieldInvalid("spec.dockerImageRepository", stream.Spec.DockerImageRepository, "the repository name may not contain an ID"))
+			}
 		}
 	}
 	for tag, tagRef := range stream.Spec.Tags {

--- a/pkg/image/api/validation/validation_test.go
+++ b/pkg/image/api/validation/validation_test.go
@@ -250,6 +250,22 @@ func TestValidateImageStream(t *testing.T) {
 				fielderrors.NewFieldInvalid("spec.dockerImageRepository", "a-|///bbb", "the docker pull spec \"a-|///bbb\" must be two or three segments separated by slashes"),
 			},
 		},
+		"invalid dockerImageRepository with tag": {
+			namespace: "namespace",
+			name:      "foo",
+			dockerImageRepository: "a/b:tag",
+			expected: fielderrors.ValidationErrorList{
+				fielderrors.NewFieldInvalid("spec.dockerImageRepository", "a/b:tag", "the repository name may not contain a tag"),
+			},
+		},
+		"invalid dockerImageRepository with ID": {
+			namespace: "namespace",
+			name:      "foo",
+			dockerImageRepository: "a/b@sha256:something",
+			expected: fielderrors.ValidationErrorList{
+				fielderrors.NewFieldInvalid("spec.dockerImageRepository", "a/b@sha256:something", "the repository name may not contain an ID"),
+			},
+		},
 		"status tag missing dockerImageReference": {
 			namespace: "namespace",
 			name:      "foo",


### PR DESCRIPTION
We should not have allowed it, therefore added backwards compatible conversions
and new validations to reject it.  Also slight tweaks to DockerImageReference
to reduce overlapping code.