### PR TITLE
UPSTREAM: Fix typo in e2e pods test

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/pods.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/pods.go
@@ -611,7 +611,7 @@ var _ = Describe("Pods", func() {
 		podClient := framework.Client.Pods(framework.Namespace.Name)
 
 		By("creating the pod")
-		name := "pod-exec-websocket-" string(util.NewUUID())
+		name := "pod-exec-websocket-" + string(util.NewUUID())
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name: name,


### PR DESCRIPTION
This was introduced in https://github.com/openshift/origin/pull/4931
The original upstream PR is https://github.com/kubernetes/kubernetes/pull/13885 and doesn't contain the typo.

@smarterclayton