### PR TITLE
oc: Use default resources where it makes sense

### DIFF
--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -9,6 +9,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -68,11 +69,20 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 		return err
 	}
 	buildClient := client.Builds(namespace)
-	build, err := buildClient.Get(buildName)
+
+	mapper, typer := f.Object()
+	obj, err := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
+		NamespaceParam(namespace).
+		ResourceNames("builds", buildName).
+		SingleResourceType().
+		Do().Object()
 	if err != nil {
 		return err
 	}
-
+	build, ok := obj.(*buildapi.Build)
+	if !ok {
+		return fmt.Errorf("%q is not a valid build", buildName)
+	}
 	if !isBuildCancellable(build) {
 		return nil
 	}

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -120,7 +120,7 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 
 func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Writer) error {
 	if len(args) > 1 {
-		return errors.New("only one deploymentConfig name is supported as argument.")
+		return errors.New("only one deployment config name is supported as argument.")
 	}
 	var err error
 
@@ -139,11 +139,7 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 	o.out = out
 
 	if len(args) > 0 {
-		name := args[0]
-		if strings.Index(name, "/") == -1 {
-			name = fmt.Sprintf("dc/%s", name)
-		}
-		o.deploymentConfigName = name
+		o.deploymentConfigName = args[0]
 	}
 
 	return nil
@@ -151,7 +147,7 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 
 func (o DeployOptions) Validate() error {
 	if len(o.deploymentConfigName) == 0 {
-		return errors.New("a deploymentConfig name is required.")
+		return errors.New("a deployment config name is required.")
 	}
 	numOptions := 0
 	if o.deployLatest {
@@ -175,7 +171,7 @@ func (o DeployOptions) Validate() error {
 func (o DeployOptions) RunDeploy() error {
 	r := o.builder.
 		NamespaceParam(o.namespace).
-		ResourceTypeOrNameArgs(false, o.deploymentConfigName).
+		ResourceNames("deploymentconfigs", o.deploymentConfigName).
 		SingleResourceType().
 		Do()
 	resultObj, err := r.Object()
@@ -184,7 +180,7 @@ func (o DeployOptions) RunDeploy() error {
 	}
 	config, ok := resultObj.(*deployapi.DeploymentConfig)
 	if !ok {
-		return fmt.Errorf("%s is not a valid deploymentconfig", o.deploymentConfigName)
+		return fmt.Errorf("%s is not a valid deployment config", o.deploymentConfigName)
 	}
 
 	switch {

--- a/pkg/cmd/cli/secrets/add_secret_to_obj.go
+++ b/pkg/cmd/cli/secrets/add_secret_to_obj.go
@@ -162,7 +162,7 @@ func (o AddSecretOptions) Validate() error {
 func (o AddSecretOptions) AddSecrets() error {
 	r := resource.NewBuilder(o.Mapper, o.Typer, o.ClientMapper).
 		NamespaceParam(o.Namespace).
-		ResourceTypeOrNameArgs(false, o.TargetName).
+		ResourceNames("serviceaccounts", o.TargetName).
 		SingleResourceType().
 		Do()
 	if r.Err() != nil {
@@ -223,7 +223,7 @@ func (o AddSecretOptions) addSecretsToServiceAccount(serviceaccount *kapi.Servic
 func (o AddSecretOptions) getSecrets() ([]*kapi.Secret, error) {
 	r := resource.NewBuilder(o.Mapper, o.Typer, o.ClientMapper).
 		NamespaceParam(o.Namespace).
-		ResourceTypeOrNameArgs(false, o.SecretNames...).
+		ResourceNames("secrets", o.SecretNames...).
 		SingleResourceType().
 		Do()
 	if r.Err() != nil {

--- a/pkg/cmd/util/cmd_test.go
+++ b/pkg/cmd/util/cmd_test.go
@@ -1,0 +1,181 @@
+package util_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/kubectl"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	"github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+func TestResolveResource(t *testing.T) {
+	mapper := clientcmd.ShortcutExpander{RESTMapper: kubectl.ShortcutExpander{RESTMapper: latest.RESTMapper}}
+
+	tests := []struct {
+		name             string
+		defaultResource  string
+		resourceString   string
+		expectedResource string
+		expectedName     string
+		expectedErr      bool
+	}{
+		{
+			name:             "invalid case #1",
+			defaultResource:  "",
+			resourceString:   "a/b/c",
+			expectedResource: "",
+			expectedName:     "",
+			expectedErr:      true,
+		},
+		{
+			name:             "invalid case #2",
+			defaultResource:  "",
+			resourceString:   "foo/bar",
+			expectedResource: "",
+			expectedName:     "",
+			expectedErr:      true,
+		},
+		{
+			name:             "empty resource string case #1",
+			defaultResource:  "",
+			resourceString:   "",
+			expectedResource: "",
+			expectedName:     "",
+			expectedErr:      false,
+		},
+		{
+			name:             "empty resource string case #2",
+			defaultResource:  "",
+			resourceString:   "bar",
+			expectedResource: "",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "empty resource string case #3",
+			defaultResource:  "foo",
+			resourceString:   "bar",
+			expectedResource: "foo",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(KUBE) short name",
+			defaultResource:  "foo",
+			resourceString:   "rc/bar",
+			expectedResource: "replicationcontrollers",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(KUBE) long name, case insensitive #1",
+			defaultResource:  "foo",
+			resourceString:   "replicationcontroller/bar",
+			expectedResource: "replicationcontrollers",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(KUBE) long name, case insensitive #2",
+			defaultResource:  "foo",
+			resourceString:   "replicationcontrollers/bar",
+			expectedResource: "replicationcontrollers",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(KUBE) long name, case insensitive #3",
+			defaultResource:  "foo",
+			resourceString:   "ReplicationControllers/bar",
+			expectedResource: "replicationcontrollers",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(KUBE) long name, case insensitive #4",
+			defaultResource:  "foo",
+			resourceString:   "ReplicationControllers/bar",
+			expectedResource: "replicationcontrollers",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(KUBE) long name, case insensitive #5",
+			defaultResource:  "foo",
+			resourceString:   "ReplicationControllers/Bar",
+			expectedResource: "replicationcontrollers",
+			expectedName:     "Bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(ORIGIN) short name",
+			defaultResource:  "foo",
+			resourceString:   "bc/bar",
+			expectedResource: "buildconfigs",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(ORIGIN) long name, case insensitive #1",
+			defaultResource:  "foo",
+			resourceString:   "buildconfig/bar",
+			expectedResource: "buildconfigs",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(ORIGIN) long name, case insensitive #2",
+			defaultResource:  "foo",
+			resourceString:   "buildconfigs/bar",
+			expectedResource: "buildconfigs",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(ORIGIN) long name, case insensitive #3",
+			defaultResource:  "foo",
+			resourceString:   "BuildConfigs/bar",
+			expectedResource: "buildconfigs",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(ORIGIN) long name, case insensitive #4",
+			defaultResource:  "foo",
+			resourceString:   "BuildConfigs/bar",
+			expectedResource: "buildconfigs",
+			expectedName:     "bar",
+			expectedErr:      false,
+		},
+		{
+			name:             "(ORIGIN) long name, case insensitive #5",
+			defaultResource:  "foo",
+			resourceString:   "BuildConfigs/Bar",
+			expectedResource: "buildconfigs",
+			expectedName:     "Bar",
+			expectedErr:      false,
+		},
+	}
+
+	for _, test := range tests {
+		gotResource, gotName, gotErr := util.ResolveResource(test.defaultResource, test.resourceString, mapper)
+		if gotErr != nil && !test.expectedErr {
+			t.Errorf("%s: expected no error, got %v", test.name, gotErr)
+			continue
+		}
+		if gotErr == nil && test.expectedErr {
+			t.Errorf("%s: expected error but got none", test.name)
+			continue
+		}
+		if gotResource != test.expectedResource {
+			t.Errorf("%s: expected resource type %s, got %s", test.name, test.expectedResource, gotResource)
+			continue
+		}
+		if gotName != test.expectedName {
+			t.Errorf("%s: expected resource name %s, got %s", test.name, test.expectedName, gotName)
+			continue
+		}
+	}
+}

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -210,6 +210,16 @@ func JoinImageStreamTag(name, tag string) string {
 	return fmt.Sprintf("%s:%s", name, tag)
 }
 
+// NormalizeImageStreamTag normalizes an image stream tag by defaulting to 'latest'
+// if no tag has been specified.
+func NormalizeImageStreamTag(name string) string {
+	if !strings.Contains(name, ":") {
+		// Default to latest
+		return JoinImageStreamTag(name, DefaultImageTag)
+	}
+	return name
+}
+
 // ImageWithMetadata returns a copy of image with the DockerImageMetadata filled in
 // from the raw DockerImageManifest data stored in the image.
 func ImageWithMetadata(image Image) (*Image, error) {

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -173,6 +173,9 @@ echo "registry: ok"
 
 # Test building a dependency tree
 oc process -f examples/sample-app/application-template-stibuild.json -l build=sti | oc create -f -
+# Test both the type/name resource syntax and the fact that istag/origin-ruby-sample:latest is still
+# not created but due to a buildConfig pointing to it, we get back its graph of deps.
+[ "$(oadm build-chain istag/origin-ruby-sample | grep 'imagestreamtag/origin-ruby-sample:latest')" ]
 [ "$(oadm build-chain ruby-20-centos7 -o dot | grep 'graph')" ]
 oc delete all -l build=sti
 echo "ex build-chain: ok"

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -31,6 +31,7 @@ oc describe deploymentConfigs test-deployment-config
 [ "$(oc env dc/test-deployment-config TEST=bar OTHER=baz BAR-)" ]
 
 oc deploy test-deployment-config
+oc deploy dc/test-deployment-config
 oc delete deploymentConfigs test-deployment-config
 echo "deploymentConfigs: ok"
 

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -24,11 +24,11 @@ oc secrets new from-file .dockercfg=${HOME}/dockerconfig
 
 # attach secrets to service account
 # single secret with prefix
-oc secrets add serviceaccounts/deployer secrets/dockercfg
+oc secrets add deployer dockercfg
 # don't add the same secret twice
-oc secrets add serviceaccounts/deployer secrets/dockercfg secrets/from-file
+oc secrets add serviceaccounts/deployer dockercfg secrets/from-file
 # make sure we can add as as pull secret
-oc secrets add serviceaccounts/deployer secrets/dockercfg secrets/from-file --for=pull
+oc secrets add deployer dockercfg from-file --for=pull
 # make sure we can add as as pull secret and mount secret at once
 oc secrets add serviceaccounts/deployer secrets/dockercfg secrets/from-file --for=pull,mount
 


### PR DESCRIPTION
Commands I have defaulted using the builder/RESTMapper in this PR:
* oc deploy 
(Was using both syntaxes before, now achieves it via the resource builder.)

* oadm build-chain 
(Was using both syntaxes before, now achieves it via the RESTMapper.)

* oc start-build 
(Was using only NAME syntax, now uses bc/NAME too.)

* oadm secrets add 
(Was using only TYPE/NAME syntax, now uses NAME too.)

* oc cancel-build 
(Was using only NAME syntax, now uses build/NAME too.)

@smarterclayton @fabianofranz 

Fixes https://github.com/openshift/origin/issues/4781
Fixes https://github.com/openshift/origin/issues/1995