### PR TITLE
Bug 1268484 - Use build.metadata.uid to track dismissed builds in UI

### DIFF
--- a/assets/app/scripts/directives/resources.js
+++ b/assets/app/scripts/directives/resources.js
@@ -90,7 +90,7 @@ angular.module('openshiftConsole')
   })  
   .directive('triggers', function() {
     var hideBuildKey = function(build) {
-      return 'hide/build/' + build.metadata.namespace + '/' + build.metadata.name;
+      return 'hide/build/' + build.metadata.uid;
     };
     return {
       restrict: 'E',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1268484