### PR TITLE
Add configuration options for logging and metrics endpoints

### DIFF
--- a/assets/app/config.js
+++ b/assets/app/config.js
@@ -99,5 +99,7 @@ window.OPENSHIFT_CONFIG = {
   	oauth_redirect_base: "https://localhost:9000",
   	oauth_client_id: "openshift-web-console",
   	logout_uri: ""
-  }
+  },
+  loggingURL: "",
+  metricsURL: ""
 };

--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -138,6 +138,7 @@
         <script src="scripts/services/userstore.js"></script>
         <script src="scripts/services/auth.js"></script>
         <script src="scripts/services/data.js"></script>
+        <script src="scripts/services/discovery.js"></script>
         <script src="scripts/services/project.js"></script>
         <script src="scripts/services/applicationGenerator.js"></script>
         <script src="scripts/services/alertMessage.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -206,6 +206,8 @@ angular
   })
   .constant("API_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).api))
   .constant("AUTH_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).auth))
+  .constant("LOGGING_URL", (window.OPENSHIFT_CONFIG || {}).loggingURL)
+  .constant("METRICS_URL", (window.OPENSHIFT_CONFIG || {}).metricsURL)
   .config(function($httpProvider, AuthServiceProvider, RedirectLoginServiceProvider, AUTH_CFG, API_CFG) {
     $httpProvider.interceptors.push('AuthInterceptor');
 

--- a/assets/app/scripts/services/discovery.js
+++ b/assets/app/scripts/services/discovery.js
@@ -1,0 +1,13 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('APIDiscovery', ['LOGGING_URL', 'METRICS_URL', '$q', function(LOGGING_URL, METRICS_URL, $q) {
+    return {
+      getLoggingURL: function() {
+        return $q.when(LOGGING_URL);
+      },
+      getMetricsURL: function() {
+        return $q.when(METRICS_URL);
+      }
+    };
+  }]);

--- a/pkg/assets/handlers.go
+++ b/pkg/assets/handlers.go
@@ -171,7 +171,9 @@ window.OPENSHIFT_CONFIG = {
   	oauth_redirect_base: "{{ .OAuthRedirectBase | js}}",
   	oauth_client_id: "{{ .OAuthClientID | js}}",
   	logout_uri: "{{ .LogoutURI | js}}"
-  }
+  },
+  loggingURL: "{{ .LoggingURL | js}}",
+  metricsURL: "{{ .MetricsURL | js}}"
 };
 `))
 
@@ -199,6 +201,10 @@ type WebConsoleConfig struct {
 	OAuthClientID string
 	// LogoutURI is an optional (absolute) URI to redirect to after completing a logout. If not specified, the built-in logout page is shown.
 	LogoutURI string
+	// LoggingURL is the endpoint for logging (optional)
+	LoggingURL string
+	// MetricsURL is the endpoint for metrics (optional)
+	MetricsURL string
 }
 
 func GeneratedConfigHandler(config WebConsoleConfig) (http.Handler, error) {

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -378,6 +378,12 @@ type AssetConfig struct {
 	// MasterPublicURL is how the web console can access the OpenShift api server
 	MasterPublicURL string
 
+	// LoggingPublicURL is the public endpoint for logging (optional)
+	LoggingPublicURL string
+
+	// MetricsPublicURL is the public endpoint for metrics (optional)
+	MetricsPublicURL string
+
 	// ExtensionScripts are file paths on the asset server files to load as scripts when the Web
 	// Console loads
 	ExtensionScripts []string

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -358,6 +358,12 @@ type AssetConfig struct {
 	// MasterPublicURL is how the web console can access the OpenShift v1 server
 	MasterPublicURL string `json:"masterPublicURL"`
 
+	// LoggingPublicURL is the public endpoint for logging (optional)
+	LoggingPublicURL string `json:"loggingPublicURL"`
+
+	// MetricsPublicURL is the public endpoint for metrics (optional)
+	MetricsPublicURL string `json:"metricsPublicURL"`
+
 	// ExtensionScripts are file paths on the asset server files to load as scripts when the Web
 	// Console loads
 	ExtensionScripts []string `json:"extensionScripts"`

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -64,8 +64,10 @@ assetConfig:
   - html5Mode: false
     name: ""
     sourceDirectory: ""
+  loggingPublicURL: ""
   logoutURL: ""
   masterPublicURL: ""
+  metricsPublicURL: ""
   publicURL: ""
   servingInfo:
     bindAddress: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -287,6 +287,18 @@ func ValidateAssetConfig(config *api.AssetConfig) fielderrors.ValidationErrorLis
 		allErrs = append(allErrs, urlErrs...)
 	}
 
+	if len(config.LoggingPublicURL) > 0 {
+		if _, loggingURLErrs := ValidateSecureURL(config.LoggingPublicURL, "loggingPublicURL"); len(loggingURLErrs) > 0 {
+			allErrs = append(allErrs, loggingURLErrs...)
+		}
+	}
+
+	if len(config.MetricsPublicURL) > 0 {
+		if _, metricsURLErrs := ValidateSecureURL(config.MetricsPublicURL, "metricsPublicURL"); len(metricsURLErrs) > 0 {
+			allErrs = append(allErrs, metricsURLErrs...)
+		}
+	}
+
 	for i, scriptFile := range config.ExtensionScripts {
 		allErrs = append(allErrs, ValidateFile(scriptFile, fmt.Sprintf("extensionScripts[%d]", i))...)
 	}

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -198,6 +198,8 @@ func (c *AssetConfig) addHandlers(mux *http.ServeMux) error {
 		OAuthRedirectBase:   c.Options.PublicURL,
 		OAuthClientID:       OpenShiftWebConsoleClientID,
 		LogoutURI:           c.Options.LogoutURL,
+		LoggingURL:          c.Options.LoggingPublicURL,
+		MetricsURL:          c.Options.MetricsPublicURL,
 	}
 	configPath := path.Join(publicURL.Path, "config.js")
 	configHandler, err := assets.GeneratedConfigHandler(config)


### PR DESCRIPTION
Adds optional `assetConfig` options for public logging and metrics URLs.

```
assetConfig:
  ...
  loggingPublicURL: https://example.com/logging
  metricsPublicURL: https://example.com/metrics
```

TODO:

- [ ] Open docs and install issues for new config options

/cc @jwforres @benjaminapetersen @sosiouxme 