### PR TITLE
Preserve deployment status sequence

### DIFF
--- a/pkg/deploy/controller/deployerpod/controller.go
+++ b/pkg/deploy/controller/deployerpod/controller.go
@@ -80,13 +80,16 @@ func (c *DeployerPodController) Handle(pod *kapi.Pod) error {
 
 	switch pod.Status.Phase {
 	case kapi.PodRunning:
-		nextStatus = deployapi.DeploymentStatusRunning
+		if !deployutil.IsTerminatedDeployment(deployment) {
+			nextStatus = deployapi.DeploymentStatusRunning
+		}
 	case kapi.PodSucceeded:
 		// Detect failure based on the container state
 		nextStatus = deployapi.DeploymentStatusComplete
 		for _, info := range pod.Status.ContainerStatuses {
 			if info.State.Terminated != nil && info.State.Terminated.ExitCode != 0 {
 				nextStatus = deployapi.DeploymentStatusFailed
+				break
 			}
 		}
 		if nextStatus == deployapi.DeploymentStatusComplete {

--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -227,6 +227,13 @@ func IsDeploymentCancelled(deployment *api.ReplicationController) bool {
 	return strings.EqualFold(value, deployapi.DeploymentCancelledAnnotationValue)
 }
 
+// IsTerminatedDeployment returns true if the passed deployment has terminated (either
+// complete or failed).
+func IsTerminatedDeployment(deployment *api.ReplicationController) bool {
+	current := DeploymentStatusFor(deployment)
+	return current == deployapi.DeploymentStatusComplete || current == deployapi.DeploymentStatusFailed
+}
+
 // annotationFor returns the annotation with key for obj.
 func annotationFor(obj runtime.Object, key string) string {
 	meta, err := api.ObjectMetaFor(obj)


### PR DESCRIPTION
@ironcladlou have you seen this before? http://pastebin.com/fLhd1aiK

Full log: http://pastebin.com/xa3Qigvk

Happens on latest master. A deployment runs to complete, the deployer pod status isn't updated on time (or something else maybe related to the rc manager upstream), so the deployment status comes back from the dead as running, in the meantime the deployer pod since complete, gets deleted and now we end up with a failed deployment which is actually successful.

I am not sure this fix is what we need since this seems a bigger problem, but it does the trick.