### PR TITLE
[Bugzilla 1261860] fix adding labels to build-pod

### DIFF
--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -210,5 +210,16 @@ func getContainerVerbosity(containerEnv []kapi.EnvVar) (verbosity string) {
 
 // getPodLabels creates labels for the Build Pod
 func getPodLabels(build *buildapi.Build) map[string]string {
-	return map[string]string{buildapi.BuildLabel: build.Name}
+	labels := make(map[string]string)
+	labels[buildapi.BuildLabel] = build.Name
+	append(build.ObjectMeta.Labels, labels)
+
+	return labels
+}
+
+// append adds elements from one map to another
+func append(source *map[string]string, dest *map[string]string) {
+	for key, value := range source {
+		dest[key] = value
+	}
 }


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1261860

I've fixed adding labels to build-pod. @rhcarvalho  PTAL.

One doubt that I have is we should add all labels? Because after this fix I see the following
```
[vagrant@openshiftdev sample-app]$ oc new-app application-template-stibuild.json -l bug=1261860 
...
[vagrant@openshiftdev sample-app]$ oc describe pod ruby-sample-build-1-build | grep Labels
Labels:				bug=1261860,buildconfig=ruby-sample-build,name=ruby-sample-build,openshift.io/build.name=ruby-sample-build-1,template=application-template-stibuild
```
As we can see there is one mine label, one standard and 3 additional. I'm not sure about these extra labels. Do we need them?
