### PR TITLE
Make kube-proxy iptables sync period configurable

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -73,6 +73,9 @@ type NodeConfig struct {
 	// command line arguments.  These are not migrated or validated, so if you use them they may become invalid.
 	// These values override other settings in NodeConfig which may cause invalid configurations.
 	KubeletArguments ExtendedArguments
+
+	// IPTablesSyncPeriod is how often iptable rules are refreshed
+	IPTablesSyncPeriod string
 }
 
 // NodeNetworkConfig provides network options for the node

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -62,6 +62,9 @@ func init() {
 			if obj.NetworkConfig.MTU == 0 {
 				obj.NetworkConfig.MTU = 1450
 			}
+			if len(obj.IPTablesSyncPeriod) == 0 {
+				obj.IPTablesSyncPeriod = "5s"
+			}
 		},
 		func(obj *EtcdStorageConfig) {
 			if len(obj.KubernetesStorageVersion) == 0 {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -58,6 +58,9 @@ type NodeConfig struct {
 	// command line arguments.  These are not migrated or validated, so if you use them they may become invalid.
 	// These values override other settings in NodeConfig which may cause invalid configurations.
 	KubeletArguments ExtendedArguments `json:"kubeletArguments,omitempty"`
+
+	// IPTablesSyncPeriod is how often iptable rules are refreshed
+	IPTablesSyncPeriod string `json:"iptablesSyncPeriod"`
 }
 
 // NodeNetworkConfig provides network options for the node

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -24,6 +24,7 @@ dockerConfig:
 imageConfig:
   format: ""
   latest: false
+iptablesSyncPeriod: ""
 kind: NodeConfig
 masterKubeConfig: ""
 networkConfig:

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	kapp "k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
@@ -41,6 +42,10 @@ func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList 
 	allErrs = append(allErrs, ValidateDockerConfig(config.DockerConfig).Prefix("dockerConfig")...)
 
 	allErrs = append(allErrs, ValidateKubeletExtendedArguments(config.KubeletArguments).Prefix("kubeletArguments")...)
+
+	if _, err := time.ParseDuration(config.IPTablesSyncPeriod); err != nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("iptablesSyncPeriod", config.IPTablesSyncPeriod, fmt.Sprintf("unable to parse iptablesSyncPeriod: %v. Examples with correct format: '5s', '1m', '2h22m'", err)))
+	}
 
 	return allErrs
 }

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -149,7 +149,6 @@ func (c *NodeConfig) RunProxy() {
 	endpointsConfig := pconfig.NewEndpointsConfig()
 	loadBalancer := proxy.NewLoadBalancerRR()
 	endpointsConfig.RegisterHandler(loadBalancer)
-	syncPeriod := 5 * time.Second
 
 	host, _, err := net.SplitHostPort(c.BindAddress)
 	if err != nil {
@@ -163,6 +162,11 @@ func (c *NodeConfig) RunProxy() {
 	protocol := iptables.ProtocolIpv4
 	if ip.To4() == nil {
 		protocol = iptables.ProtocolIpv6
+	}
+
+	syncPeriod, err := time.ParseDuration(c.IPTablesSyncPeriod)
+	if err != nil {
+		glog.Fatalf("Cannot parse the provided ip-tables sync period (%s) : %v", c.IPTablesSyncPeriod, err)
 	}
 
 	go util.Forever(func() {

--- a/pkg/cmd/server/kubernetes/node_config.go
+++ b/pkg/cmd/server/kubernetes/node_config.go
@@ -35,11 +35,12 @@ type NodeConfig struct {
 	Client *client.Client
 	// DockerClient is a client to connect to Docker
 	DockerClient dockertools.DockerInterface
-
 	// KubeletServer contains the KubeletServer configuration
 	KubeletServer *kapp.KubeletServer
 	// KubeletConfig is the configuration for the kubelet, fully initialized
 	KubeletConfig *kapp.KubeletConfig
+	// IPTablesSyncPeriod is how often iptable rules are refreshed
+	IPTablesSyncPeriod string
 }
 
 func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error) {
@@ -184,6 +185,8 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig) (*NodeConfig, error
 
 		KubeletServer: server,
 		KubeletConfig: cfg,
+
+		IPTablesSyncPeriod: options.IPTablesSyncPeriod,
 	}
 
 	return config, nil

--- a/pkg/cmd/server/start/node_args.go
+++ b/pkg/cmd/server/start/node_args.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/pkg/master/ports"
@@ -17,10 +18,9 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/admin"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/spf13/cobra"
 )
 
-// NodeArgs is a struct that the command stores flag values into.  It holds a partially complete set of parameters for starting the master
+// NodeArgs is a struct that the command stores flag values into.  It holds a partially complete set of parameters for starting a node.
 // This object should hold the common set values, but not attempt to handle all cases.  The expected path is to use this object to create
 // a fully specified config later on.  If you need something not set here, then create a fully specified config file and pass that as argument
 // to starting the master.


### PR DESCRIPTION
Add an iptablesSyncPeriod field in the node config, used for setting up the interval between iptables syncs (defaults to 5s)

Closes https://github.com/openshift/origin/issues/4797

@deads2k @liggitt  PTAL