### PR TITLE
Unique output image stream names in new-app

### DIFF
--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -964,7 +964,7 @@ func TestRunAll(t *testing.T) {
 	}
 }
 
-func TestRunBuild(t *testing.T) {
+func TestRunBuilds(t *testing.T) {
 	dockerSearcher := app.DockerRegistrySearcher{
 		Client: dockerregistry.NewClient(),
 	}
@@ -1044,7 +1044,43 @@ func TestRunBuild(t *testing.T) {
 			},
 			expected: map[string][]string{
 				"buildConfig": {"origin-base"},
-				"imageStream": {"origin-base"},
+				"imageStream": {"origin-base", "origin-base-app"},
+			},
+		},
+		{
+			name: "successful build from dockerfile with custom name",
+			config: &AppConfig{
+				Dockerfile: "FROM openshift/origin-base\nUSER foo",
+
+				dockerSearcher: dockerSearcher,
+				imageStreamSearcher: app.ImageStreamSearcher{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				imageStreamByAnnotationSearcher: &app.ImageStreamByAnnotationSearcher{
+					Client:            &client.Fake{},
+					ImageStreamImages: &client.Fake{},
+					Namespaces:        []string{"default"},
+				},
+				templateSearcher: app.TemplateSearcher{
+					Client: &client.Fake{},
+					TemplateConfigsNamespacer: &client.Fake{},
+					Namespaces:                []string{"openshift", "default"},
+				},
+
+				detector: app.SourceRepositoryEnumerator{
+					Detectors: source.DefaultDetectors,
+					Tester:    dockerfile.NewTester(),
+				},
+				typer:           kapi.Scheme,
+				osclient:        &client.Fake{},
+				originNamespace: "default",
+				Name:            "foobar",
+			},
+			expected: map[string][]string{
+				"buildConfig": {"foobar"},
+				"imageStream": {"origin-base", "foobar"},
 			},
 		},
 		{

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/docker/distribution/registry/api/v2"
 	"github.com/golang/glog"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -16,9 +17,10 @@ import (
 	deploy "github.com/openshift/origin/pkg/deploy/api"
 	image "github.com/openshift/origin/pkg/image/api"
 	route "github.com/openshift/origin/pkg/route/api"
+	"github.com/openshift/origin/pkg/util/namer"
 )
 
-// Pipeline holds components
+// Pipeline holds components.
 type Pipeline struct {
 	From string
 
@@ -29,8 +31,8 @@ type Pipeline struct {
 	Labels     map[string]string
 }
 
-// NewImagePipeline creates a new pipeline with components that are not
-// expected to be built
+// NewImagePipeline creates a new pipeline with components that are not expected
+// to be built.
 func NewImagePipeline(from string, image *ImageRef) (*Pipeline, error) {
 	return &Pipeline{
 		From:  from,
@@ -38,20 +40,24 @@ func NewImagePipeline(from string, image *ImageRef) (*Pipeline, error) {
 	}, nil
 }
 
-// NewBuildPipeline creates a new pipeline with components that are
-// expected to be built
+// NewBuildPipeline creates a new pipeline with components that are expected to
+// be built.
 func NewBuildPipeline(from string, input *ImageRef, outputDocker bool, strategy *BuildStrategyRef, env Environment, source *SourceRef) (*Pipeline, error) {
 	name, ok := NameSuggestions{source, input}.SuggestName()
 	if !ok {
-		name = fmt.Sprintf("app%d", rand.Intn(10000))
+		name = fmt.Sprintf("app-%04d", rand.Intn(10000))
 	}
+	if name == input.Name {
+		// Make output image name consistently different than input image name.
+		name += "-app"
+	}
+	name = namer.LimitLength(name, v2.RepositoryNameTotalLengthMax-kutil.DNS1123LabelMaxLength-1)
 
 	output := &ImageRef{
 		DockerImageReference: image.DockerImageReference{
 			Name: name,
 			Tag:  image.DefaultImageTag,
 		},
-
 		OutputImage:   true,
 		AsImageStream: !outputDocker,
 	}
@@ -77,7 +83,7 @@ func NewBuildPipeline(from string, input *ImageRef, outputDocker bool, strategy 
 	}, nil
 }
 
-// NeedsDeployment sets the pipeline for deployment
+// NeedsDeployment sets the pipeline for deployment.
 func (p *Pipeline) NeedsDeployment(env Environment, labels map[string]string, name string) error {
 	if p.Deployment != nil {
 		return nil
@@ -93,7 +99,7 @@ func (p *Pipeline) NeedsDeployment(env Environment, labels map[string]string, na
 	return nil
 }
 
-// Objects converts all the components in the pipeline into runtime objects
+// Objects converts all the components in the pipeline into runtime objects.
 func (p *Pipeline) Objects(accept, objectAccept Acceptor) (Objects, error) {
 	objects := Objects{}
 	if p.InputImage != nil && p.InputImage.AsImageStream && accept.Accept(p.InputImage) {
@@ -135,10 +141,10 @@ func (p *Pipeline) Objects(accept, objectAccept Acceptor) (Objects, error) {
 	return objects, nil
 }
 
-// PipelineGroup is a group of Pipelines
+// PipelineGroup is a group of Pipelines.
 type PipelineGroup []*Pipeline
 
-// Reduce squashes all common components from the pipelines
+// Reduce squashes all common components from the pipelines.
 func (g PipelineGroup) Reduce() error {
 	var deployment *DeploymentConfigRef
 	for _, p := range g {
@@ -164,8 +170,6 @@ func (g PipelineGroup) String() string {
 	return strings.Join(s, "+")
 }
 
-const maxServiceNameLength = 24
-
 var invalidServiceChars = regexp.MustCompile("[^-a-z0-9]")
 
 func makeValidServiceName(name string) (string, string) {
@@ -178,8 +182,8 @@ func makeValidServiceName(name string) (string, string) {
 	switch {
 	case len(name) == 0:
 		return "", "service-"
-	case len(name) > maxServiceNameLength:
-		name = name[:maxServiceNameLength]
+	case len(name) > kutil.DNS952LabelMaxLength:
+		name = name[:kutil.DNS952LabelMaxLength]
 	}
 	return name, ""
 }
@@ -194,7 +198,8 @@ func (s sortablePorts) Swap(i, j int) {
 	s[j] = p
 }
 
-// portName returns a unique key for the given port and protocol which can be used as a service port name
+// portName returns a unique key for the given port and protocol which can be
+// used as a service port name.
 func portName(port int, protocol kapi.Protocol) string {
 	if protocol == "" {
 		protocol = kapi.ProtocolTCP
@@ -202,7 +207,7 @@ func portName(port int, protocol kapi.Protocol) string {
 	return strings.ToLower(fmt.Sprintf("%d-%s", port, protocol))
 }
 
-// AddServices sets up services for the provided objects
+// AddServices sets up services for the provided objects.
 func AddServices(objects Objects, firstPortOnly bool) Objects {
 	svcs := []runtime.Object{}
 	for _, o := range objects {
@@ -252,7 +257,7 @@ func AddServices(objects Objects, firstPortOnly bool) Objects {
 	return append(objects, svcs...)
 }
 
-// AddRoutes sets up routes for the provided objects
+// AddRoutes sets up routes for the provided objects.
 func AddRoutes(objects Objects) Objects {
 	routes := []runtime.Object{}
 	for _, o := range objects {
@@ -279,7 +284,7 @@ type acceptNew struct{}
 // AcceptNew only accepts runtime.Objects with an empty resource version.
 var AcceptNew Acceptor = acceptNew{}
 
-// Accept accepts any kind of object
+// Accept accepts any kind of object.
 func (acceptNew) Accept(from interface{}) bool {
 	_, meta, err := objectMetaData(from)
 	if err != nil {
@@ -296,7 +301,7 @@ type acceptUnique struct {
 	objects map[string]struct{}
 }
 
-// Accept accepts any kind of object it hasn't accepted before
+// Accept accepts any kind of object it hasn't accepted before.
 func (a *acceptUnique) Accept(from interface{}) bool {
 	obj, meta, err := objectMetaData(from)
 	if err != nil {
@@ -315,8 +320,8 @@ func (a *acceptUnique) Accept(from interface{}) bool {
 	return true
 }
 
-// NewAcceptUnique creates an acceptor that only accepts unique objects
-// by kind and name
+// NewAcceptUnique creates an acceptor that only accepts unique objects by kind
+// and name.
 func NewAcceptUnique(typer runtime.ObjectTyper) Acceptor {
 	return &acceptUnique{
 		typer:   typer,
@@ -340,7 +345,7 @@ type acceptBuildConfigs struct {
 	typer runtime.ObjectTyper
 }
 
-// Accept accepts BuildConfigs and ImageStreams
+// Accept accepts BuildConfigs and ImageStreams.
 func (a *acceptBuildConfigs) Accept(from interface{}) bool {
 	obj, _, err := objectMetaData(from)
 	if err != nil {
@@ -366,7 +371,7 @@ func NewAcceptBuildConfigs(typer runtime.ObjectTyper) Acceptor {
 type Acceptors []Acceptor
 
 // Accept iterates through all acceptors and determines whether the object
-// should be accepted
+// should be accepted.
 func (aa Acceptors) Accept(from interface{}) bool {
 	for _, a := range aa {
 		if !a.Accept(from) {
@@ -378,18 +383,18 @@ func (aa Acceptors) Accept(from interface{}) bool {
 
 type acceptAll struct{}
 
-// AcceptAll accepts all objects
+// AcceptAll accepts all objects.
 var AcceptAll Acceptor = acceptAll{}
 
-// Accept accepts everything
+// Accept accepts everything.
 func (acceptAll) Accept(_ interface{}) bool {
 	return true
 }
 
-// Objects is a set of runtime objects
+// Objects is a set of runtime objects.
 type Objects []runtime.Object
 
-// Acceptor is an interface for accepting objects
+// Acceptor is an interface for accepting objects.
 type Acceptor interface {
 	Accept(from interface{}) bool
 }
@@ -398,12 +403,12 @@ type acceptFirst struct {
 	handled map[interface{}]struct{}
 }
 
-// NewAcceptFirst returns a new Acceptor
+// NewAcceptFirst returns a new Acceptor.
 func NewAcceptFirst() Acceptor {
 	return &acceptFirst{make(map[interface{}]struct{})}
 }
 
-// Accept accepts any object it hasn't accepted before
+// Accept accepts any object it hasn't accepted before.
 func (s *acceptFirst) Accept(from interface{}) bool {
 	if _, ok := s.handled[from]; ok {
 		return false

--- a/pkg/util/namer/namer.go
+++ b/pkg/util/namer/namer.go
@@ -37,6 +37,30 @@ func GetPodName(base, suffix string) string {
 	return GetName(base, suffix, util.DNS1123SubdomainMaxLength)
 }
 
+// LimitLength returns a string of at most maxLength characters based on name.
+// It returns name unchanged if it is short enough, otherwise it returns a
+// prefix of name plus a suffix computed from a hash of name.
+func LimitLength(name string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	if len(name) <= maxLength {
+		return name
+	}
+	suffix := hash(name)
+	prefix := name[:min(max(0, maxLength-len(suffix)), len(name))]
+	shortName := fmt.Sprintf("%s%s", prefix, suffix)[:maxLength]
+	return shortName
+}
+
+// max returns the greater of its 2 inputs
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
 // min returns the lesser of its 2 inputs
 func min(a, b int) int {
 	if b < a {

--- a/pkg/util/namer/namer_test.go
+++ b/pkg/util/namer/namer_test.go
@@ -77,6 +77,36 @@ func TestGetNameIsDifferent(t *testing.T) {
 	}
 }
 
+func TestLimitLength(t *testing.T) {
+	tests := []struct {
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"helloworld", 0, ""},
+		{"helloworld", 3, "3b9"},         // only part of the hash
+		{"helloworld", 8, "3b9f5c61"},    // the whole hash
+		{"helloworld", 9, "h3b9f5c61"},   // first char + hash
+		{"helloworld", 10, "helloworld"}, // s fits in maxLen
+	}
+	for _, test := range tests {
+		got := LimitLength(test.s, test.maxLen)
+		if got != test.want {
+			t.Errorf("LimitLength(%q, %d) = %q; want %q", test.s, test.maxLen, got, test.want)
+		}
+	}
+}
+
+func TestLimitLengthReturnShortNames(t *testing.T) {
+	s := randSeq(32)
+	for i := 0; i < len(s)+2; i++ {
+		got := LimitLength(s, i)
+		if len(got) > i {
+			t.Errorf("len(LimitLength(%[1]q, %[2]d)) = len(%[3]q) = %[4]d; want %[2]d", s, i, got, len(got))
+		}
+	}
+}
+
 // From k8s.io/kubernetes/pkg/api/generator.go
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789-")
 


### PR DESCRIPTION
This fixes a bug when the suggested name for the output image stream matches that of the input image stream. We end up removing the duplicate image stream (by name) and the build config is set to output to the same image stream as the input. E.g.:

Before (current master):
```
$ oc new-build -n demo -D $'FROM centos:7\nRUN yum install -y httpd'
imagestreams/centos
buildconfigs/centos
A build configuration was created - you can run `oc start-build centos` to start it.
```

Build fails, logs:
```
...
Successfully built bb96d195f1fc
I1007 14:37:58.863109       1 docker.go:102] Pushing library/centos:latest image ...
F1007 14:38:00.172054       1 builder.go:54] Build error: Failed to push image: API error (500): You cannot push a "root" repository. Please rename your repository to <user>/<repo> (ex: <user>/centos)
```

But we want to have two image streams, one for input and one for output.

After (this PR):
```
$ oc new-build -n demo -D $'FROM centos:7\nRUN yum install -y httpd'
imagestreams/centos
imagestreams/centos-app
buildconfigs/centos
A build configuration was created - you can run `oc start-build centos` to start it.
```

Two image streams created, build succeeds.

```
...
Successfully built a0d5dae76672
I1007 14:40:35.651262       1 docker.go:100] Using provided push secret for pushing 172.30.24.103:5000/demo/centos-app:latest image
I1007 14:40:35.653053       1 docker.go:102] Pushing 172.30.24.103:5000/demo/centos-app:latest image ...
I1007 14:41:07.455730       1 docker.go:106] Successfully pushed 172.30.24.103:5000/demo/centos-app:latest
```