### PR TITLE
allocate fsgroup id to namespace

### DIFF
--- a/pkg/security/controller/controller.go
+++ b/pkg/security/controller/controller.go
@@ -65,6 +65,7 @@ func (c *Allocation) Next(ns *kapi.Namespace) error {
 	}
 	tx.Add(func() error { return c.uid.Release(block) })
 	ns.Annotations[security.UIDRangeAnnotation] = block.String()
+	ns.Annotations[security.SupplementalGroupsAnnotation] = block.String()
 	if _, ok := ns.Annotations[security.MCSAnnotation]; !ok {
 		if label := c.mcs(block); label != nil {
 			ns.Annotations[security.MCSAnnotation] = label.String()
@@ -102,6 +103,7 @@ func (c *Allocation) Next(ns *kapi.Namespace) error {
 			newNs.Annotations = make(map[string]string)
 		}
 		newNs.Annotations[security.UIDRangeAnnotation] = ns.Annotations[security.UIDRangeAnnotation]
+		newNs.Annotations[security.SupplementalGroupsAnnotation] = ns.Annotations[security.SupplementalGroupsAnnotation]
 		newNs.Annotations[security.MCSAnnotation] = ns.Annotations[security.MCSAnnotation]
 		ns = newNs
 	}
@@ -114,6 +116,9 @@ func changedAndSetAnnotations(old, ns *kapi.Namespace) bool {
 		return true
 	}
 	if value, ok := ns.Annotations[security.MCSAnnotation]; ok && value != old.Annotations[security.MCSAnnotation] {
+		return true
+	}
+	if value, ok := ns.Annotations[security.SupplementalGroupsAnnotation]; ok && value != old.Annotations[security.SupplementalGroupsAnnotation] {
 		return true
 	}
 	return false

--- a/pkg/security/controller/controller_test.go
+++ b/pkg/security/controller/controller_test.go
@@ -40,10 +40,13 @@ func TestController(t *testing.T) {
 
 	got := action.(testclient.CreateAction).GetObject().(*kapi.Namespace)
 	if got.Annotations[security.UIDRangeAnnotation] != "10/2" {
-		t.Errorf("unexpected annotation: %#v", got)
+		t.Errorf("unexpected uid annotation: %#v", got)
+	}
+	if got.Annotations[security.SupplementalGroupsAnnotation] != "10/2" {
+		t.Errorf("unexpected supplemental group annotation: %#v", got)
 	}
 	if got.Annotations[security.MCSAnnotation] != "s0:c1,c0" {
-		t.Errorf("unexpected annotation: %#v", got)
+		t.Errorf("unexpected mcs annotation: %#v", got)
 	}
 	if !uida.Has(uid.Block{Start: 10, End: 11}) {
 		t.Errorf("did not allocate uid: %#v", uida)

--- a/pkg/security/util.go
+++ b/pkg/security/util.go
@@ -1,7 +1,11 @@
 package security
 
 const (
-	UIDRangeAnnotation     = "openshift.io/sa.scc.uid-range"
-	MCSAnnotation          = "openshift.io/sa.scc.mcs"
-	ValidatedSCCAnnotation = "openshift.io/scc"
+	UIDRangeAnnotation = "openshift.io/sa.scc.uid-range"
+	// SupplementalGroupsAnnotation contains a comma delimited list of allocated supplemental groups
+	// for the namespace.  Groups are in the form of individual group ids or a range of group ids.
+	// Range format is supported in the form of a Block which supports {start}/{length} or {start}-{end}
+	SupplementalGroupsAnnotation = "openshift.io/sa.scc.supplemental-groups"
+	MCSAnnotation                = "openshift.io/sa.scc.mcs"
+	ValidatedSCCAnnotation       = "openshift.io/scc"
 )


### PR DESCRIPTION
In preparation for the PodSecurityContext changes for volume support this suggests allocating a namespace wide fsgroup id which is defaulted to the first uid in the allocated uid range.  

This will be used by admission strategies to set the PodSecurityContext defaults on incoming pods and then by volume plugins to enable shared volumes between pods.

@smarterclayton 

cc @pmorie @swagiaal @liggitt 