### PR TITLE
Make logs work for builds

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -459,7 +459,7 @@ End the current server session
 
 
 == oc logs
-Print the logs for a container in a pod.
+Print the logs for a resource.
 
 ====
 
@@ -470,6 +470,9 @@ Print the logs for a container in a pod.
 
   # Starts streaming of ruby-container logs from pod 123456-7890.
   $ openshift cli logs -f 123456-7890 -c ruby-container
+
+  # Starts streaming the logs of the most recent build of the openldap BuildConfig.
+  $ openshift cli logs -f bc/openldap
 ----
 ====
 

--- a/pkg/cmd/cli/cmd/logs.go
+++ b/pkg/cmd/cli/cmd/logs.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/labels"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	logsLong = `
+Print the logs for a container in a pod
+
+If the pod has only one container, the container name is optional.`
+
+	logsExample = `  # Returns snapshot of ruby-container logs from pod 123456-7890.
+  $ %[1]s logs 123456-7890 -c ruby-container
+
+  # Starts streaming of ruby-container logs from pod 123456-7890.
+  $ %[1]s logs -f 123456-7890 -c ruby-container
+
+  # Starts streaming the logs of the most recent build of the openldap BuildConfig.
+  $ %[1]s logs -f bc/openldap`
+)
+
+type OpenShiftLogsOptions struct {
+	KubeClient   *kclient.Client
+	OriginClient *client.Client
+
+	Namespace      string
+	ResourceString string
+	ContainerName  string
+	Follow         bool
+	Interactive    bool
+	Previous       bool
+	Out            io.Writer
+}
+
+// NewCmdLogs creates a new pod log command
+func NewCmdLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	o := &OpenShiftLogsOptions{
+		Out:         out,
+		Interactive: true,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "logs [-f] RESOURCE",
+		Short:   "Print the logs for a resource.",
+		Long:    logsLong,
+		Example: fmt.Sprintf(logsExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, out, cmd, args))
+			if err := o.Validate(); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
+			}
+			cmdutil.CheckErr(o.RunLog())
+
+		},
+		Aliases: []string{"log"},
+	}
+	cmd.Flags().BoolVarP(&o.Follow, "follow", "f", o.Follow, "Specify if the logs should be streamed.")
+	cmd.Flags().BoolVar(&o.Interactive, "interactive", o.Interactive, "If true, prompt the user for input when required. Default true.")
+	cmd.Flags().BoolVarP(&o.Previous, "previous", "p", o.Previous, "If true, print the logs for the previous instance of the container in a pod if it exists.")
+	cmd.Flags().StringVarP(&o.ContainerName, "container", "c", o.ContainerName, "Container name")
+	return cmd
+}
+
+func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	switch len(args) {
+	case 0:
+		return cmdutil.UsageError(cmd, "RESOURCE is required for log")
+
+	case 1:
+		o.ResourceString = args[0]
+	case 2:
+		o.ResourceString = args[0]
+		o.ContainerName = args[1]
+
+	default:
+		return cmdutil.UsageError(cmd, "log RESOURCE")
+	}
+
+	var err error
+	o.Namespace, _, err = f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	o.OriginClient, o.KubeClient, err = f.Clients()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *OpenShiftLogsOptions) Validate() error {
+	if len(o.ResourceString) == 0 {
+		return errors.New("RESOURCE must be specified")
+	}
+
+	return nil
+}
+
+func (o *OpenShiftLogsOptions) RunLog() error {
+	kLogsOptions := &kcmd.LogsOptions{
+		Client: o.KubeClient,
+
+		PodNamespace:  o.Namespace,
+		ContainerName: o.ContainerName,
+		Follow:        o.Follow,
+		Interactive:   o.Interactive,
+		Previous:      o.Previous,
+		Out:           o.Out,
+	}
+
+	resourceType := "pod"
+	resourceName := o.ResourceString
+	tokens := strings.SplitN(o.ResourceString, "/", 2)
+	if len(tokens) == 2 {
+		resourceType = tokens[0]
+		resourceName = tokens[1]
+	}
+	resourceType = strings.ToLower(resourceType)
+
+	// if we're requesting a pod, delegate directly to kubectl logs
+	if (tokens[0] == "pods") || (tokens[0] == "pod") || len(o.ContainerName) > 0 {
+		kLogsOptions.PodName = resourceName
+		return kLogsOptions.RunLog()
+	}
+
+	switch resourceType {
+	case "bc", "buildconfig", "buildconfigs":
+		buildsForBCSelector := labels.SelectorFromSet(map[string]string{buildapi.BuildConfigLabel: resourceName})
+		builds, err := o.OriginClient.Builds(o.Namespace).List(buildsForBCSelector, fields.Everything())
+		if err != nil {
+			return err
+		}
+		if len(builds.Items) == 0 {
+			return fmt.Errorf("no builds found for %v", o.ResourceString)
+		}
+
+		sort.Sort(sort.Reverse(buildapi.BuildSliceByCreationTimestamp(builds.Items)))
+
+		return o.runLogsForBuild(&builds.Items[0])
+
+	case "build", "builds":
+		build, err := o.OriginClient.Builds(o.Namespace).Get(resourceName)
+		if err != nil {
+			return err
+		}
+		return o.runLogsForBuild(build)
+
+	default:
+		return fmt.Errorf("unknown resource type %v", resourceType)
+	}
+}
+
+// TODO I would recommend finding the Pod in this method and delegating the log call to the upstream LogsOptions
+// to take advantage of all of their extra options.
+func (o *OpenShiftLogsOptions) runLogsForBuild(build *buildapi.Build) error {
+	opts := buildapi.BuildLogOptions{
+		Follow: o.Follow,
+		NoWait: false,
+	}
+
+	readCloser, err := o.OriginClient.BuildLogs(build.Namespace).Get(build.Name, opts).Stream()
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	_, err = io.Copy(o.Out, readCloser)
+	return err
+}

--- a/pkg/cmd/cli/cmd/logs_test.go
+++ b/pkg/cmd/cli/cmd/logs_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
+)
+
+// TestFlagParity makes sure that our copied flags don't slip during rebases
+func TestFlagParity(t *testing.T) {
+	kubeCmd := kcmd.NewCmdLog(nil, ioutil.Discard)
+	originCmd := NewCmdLogs("", nil, ioutil.Discard)
+
+	kubeCmd.LocalFlags().VisitAll(func(kubeFlag *pflag.Flag) {
+		originFlag := originCmd.LocalFlags().Lookup(kubeFlag.Name)
+		if originFlag == nil {
+			t.Errorf("missing %v flag", kubeFlag.Name)
+			return
+		}
+
+		if !reflect.DeepEqual(originFlag, kubeFlag) {
+			t.Errorf("flag %v %v does not match %v", kubeFlag.Name, kubeFlag, originFlag)
+		}
+	})
+}

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -132,27 +132,6 @@ func NewCmdDelete(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 }
 
 const (
-	logsLong = `
-Print the logs for a container in a pod
-
-If the pod has only one container, the container name is optional.`
-
-	logsExample = `  # Returns snapshot of ruby-container logs from pod 123456-7890.
-  $ %[1]s logs 123456-7890 -c ruby-container
-
-  # Starts streaming of ruby-container logs from pod 123456-7890.
-  $ %[1]s logs -f 123456-7890 -c ruby-container`
-)
-
-// NewCmdLogs is a wrapper for the Kubernetes cli logs command
-func NewCmdLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	cmd := kcmd.NewCmdLog(f.Factory, out)
-	cmd.Long = logsLong
-	cmd.Example = fmt.Sprintf(logsExample, fullName)
-	return cmd
-}
-
-const (
 	createLong = `Create a resource by filename or stdin
 
 JSON and YAML formats are accepted.`

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -140,6 +140,16 @@ os::build:wait_for_start "test"
 os::build:wait_for_end "test"
 wait_for_app "test"
 
+# logs can't be tested without a node, so has to be in e2e
+BUILD_NAME=`oc get builds -o name -n test | head -n 1`
+oc logs ${BUILD_NAME} --loglevel=6
+oc logs ${BUILD_NAME} --loglevel=6
+oc logs bc/ruby-sample-build --loglevel=6
+oc logs buildconfigs/ruby-sample-build --loglevel=6
+oc logs buildconfig/ruby-sample-build --loglevel=6
+echo "build-logs: ok"
+
+
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} with non-existing commit..."
 set +e
 oc start-build test --commit=fffffff --wait && echo "The build was supposed to fail, but it succeeded." && exit 1


### PR DESCRIPTION
This adds support to `oc logs` to handle buildconfigs and builds.  For a buildconfig, it locates the most recent build for the buildconfig and displays its logs.  I could see an argument for including `--nowait` on `oc logs`, but for now I've hardcoded the default.

Fixes https://github.com/openshift/origin/issues/2659

@bparees @csrwng @smarterclayton @kargakis Complaints in principle?