### PR TITLE
Print etcd version when calling openshift version

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 
+	etcdversion "github.com/coreos/etcd/version"
 	"github.com/spf13/cobra"
 	kubeversion "k8s.io/kubernetes/pkg/version"
 )
@@ -58,6 +59,7 @@ func NewVersionCommand(basename string) *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			fmt.Printf("%s %v\n", basename, Get())
 			fmt.Printf("kubernetes %v\n", kubeversion.Get())
+			fmt.Printf("etcd %v\n", etcdversion.Version)
 		},
 	}
 }


### PR DESCRIPTION
```
[root@openshiftdev origin]# openshift version
openshift v1.0.6-413-g767e9ff-dirty
kubernetes v1.1.0-alpha.1-653-g86b4e77
etcd 2.1.2
```

Fixes: https://github.com/openshift/origin/issues/5003