### PR TITLE
Enable TLS client cert in API proxy

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -302,6 +302,30 @@ func (s *APIServer) Run(_ []string) error {
 		glog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}
 
+	// Setup tunneler if needed
+	var tunneler master.Tunneler
+	var proxyDialerFn apiserver.ProxyDialerFunc
+	if len(s.SSHUser) > 0 {
+		// Get ssh key distribution func, if supported
+		var installSSH master.InstallSSHKey
+		if cloud != nil {
+			if instances, supported := cloud.Instances(); supported {
+				installSSH = instances.AddSSHKeyToAllInstances
+			}
+		}
+
+		// Set up the tunneler
+		tunneler = master.NewSSHTunneler(s.SSHUser, s.SSHKeyfile, installSSH)
+
+		// Use the tunneler's dialer to connect to the kubelet
+		s.KubeletConfig.Dial = tunneler.Dial
+		// Use the tunneler's dialer when proxying to pods, services, and nodes
+		proxyDialerFn = tunneler.Dial
+	}
+
+	// Proxying to pods and services is IP-based... don't expect to be able to verify the hostname
+	proxyTLSClientConfig := &tls.Config{InsecureSkipVerify: true}
+
 	kubeletClient, err := client.NewKubeletClient(&s.KubeletConfig)
 	if err != nil {
 		glog.Fatalf("Failure to start kubelet client: %v", err)
@@ -409,12 +433,7 @@ func (s *APIServer) Run(_ []string) error {
 			}
 		}
 	}
-	var installSSH master.InstallSSHKey
-	if cloud != nil {
-		if instances, supported := cloud.Instances(); supported {
-			installSSH = instances.AddSSHKeyToAllInstances
-		}
-	}
+
 	config := &master.Config{
 		DatabaseStorage:    etcdStorage,
 		ExpDatabaseStorage: expEtcdStorage,
@@ -444,10 +463,10 @@ func (s *APIServer) Run(_ []string) error {
 		ClusterName:            s.ClusterName,
 		ExternalHost:           s.ExternalHost,
 		MinRequestTimeout:      s.MinRequestTimeout,
-		SSHUser:                s.SSHUser,
-		SSHKeyfile:             s.SSHKeyfile,
-		InstallSSHKey:          installSSH,
 		ServiceNodePortRange:   s.ServiceNodePortRange,
+		ProxyDialer:               proxyDialerFn,
+		ProxyTLSClientConfig:      proxyTLSClientConfig,
+		Tunneler:                  tunneler,
 	}
 	m := master.New(config)
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/api_installer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/api_installer.go
@@ -41,7 +41,6 @@ type APIInstaller struct {
 	info              *APIRequestInfoResolver
 	prefix            string // Path prefix where API resources are to be registered.
 	minRequestTimeout time.Duration
-	proxyDialerFn     ProxyDialerFunc
 }
 
 // Struct capturing information about an action ("GET", "POST", "WATCH", PROXY", etc).
@@ -67,7 +66,7 @@ func (a *APIInstaller) Install() (ws *restful.WebService, errors []error) {
 	// Create the WebService.
 	ws = a.newWebService()
 
-	proxyHandler := (&ProxyHandler{a.prefix + "/proxy/", a.group.Storage, a.group.Codec, a.group.Context, a.info, a.proxyDialerFn})
+	proxyHandler := (&ProxyHandler{a.prefix + "/proxy/", a.group.Storage, a.group.Codec, a.group.Context, a.info})
 
 	// Register the paths in a deterministic (sorted) order to get a deterministic swagger spec.
 	paths := make([]string, len(a.group.Storage))

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/apiserver.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/apiserver.go
@@ -99,7 +99,6 @@ type APIGroupVersion struct {
 	Admit   admission.Interface
 	Context api.RequestContextMapper
 
-	ProxyDialerFn     ProxyDialerFunc
 	MinRequestTimeout time.Duration
 }
 
@@ -125,7 +124,6 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container) error {
 		info:              info,
 		prefix:            prefix,
 		minRequestTimeout: g.MinRequestTimeout,
-		proxyDialerFn:     g.ProxyDialerFn,
 	}
 	ws, registrationErrors := installer.Install()
 	container.Add(ws)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/apiserver_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/apiserver_test.go
@@ -325,6 +325,7 @@ type SimpleRESTStorage struct {
 	// The id requested, and location to return for ResourceLocation
 	requestedResourceLocationID string
 	resourceLocation            *url.URL
+	resourceLocationTransport   http.RoundTripper
 	expectedResourceNamespace   string
 
 	// If non-nil, called inside the WorkFunc when answering update, delete, create.
@@ -470,7 +471,7 @@ func (storage *SimpleRESTStorage) ResourceLocation(ctx api.Context, id string) (
 	}
 	// Make a copy so the internal URL never gets mutated
 	locationCopy := *storage.resourceLocation
-	return &locationCopy, nil, nil
+	return &locationCopy, storage.resourceLocationTransport, nil
 }
 
 // Implement Connecter

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy.go
@@ -17,11 +17,8 @@ limitations under the License.
 package apiserver
 
 import (
-	"crypto/tls"
-	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -40,7 +37,6 @@ import (
 	proxyutil "k8s.io/kubernetes/pkg/util/proxy"
 
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/third_party/golang/netutil"
 )
 
 // ProxyHandler provides a http.Handler which will proxy traffic to locations
@@ -51,8 +47,6 @@ type ProxyHandler struct {
 	codec                  runtime.Codec
 	context                api.RequestContextMapper
 	apiRequestInfoResolver *APIRequestInfoResolver
-
-	dial func(network, addr string) (net.Conn, error)
 }
 
 func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -125,11 +119,8 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		httpCode = http.StatusNotFound
 		return
 	}
-	// If we have a custom dialer, and no pre-existing transport, initialize it to use the dialer.
-	if roundTripper == nil && r.dial != nil {
-		glog.V(5).Infof("[%x: %v] making a dial-only transport...", proxyHandlerTraceID, req.URL)
-		roundTripper = &http.Transport{Dial: r.dial}
-	} else if roundTripper != nil {
+
+	if roundTripper != nil {
 		glog.V(5).Infof("[%x: %v] using transport %T...", proxyHandlerTraceID, req.URL, roundTripper)
 	}
 
@@ -217,7 +208,7 @@ func (r *ProxyHandler) tryUpgrade(w http.ResponseWriter, req, newReq *http.Reque
 	if !httpstream.IsUpgradeRequest(req) {
 		return false
 	}
-	backendConn, err := dialURL(location, transport)
+	backendConn, err := proxyutil.DialURL(location, transport)
 	if err != nil {
 		status := errToAPIStatus(err)
 		writeJSON(status.Code, r.codec, status, w, true)
@@ -262,46 +253,6 @@ func (r *ProxyHandler) tryUpgrade(w http.ResponseWriter, req, newReq *http.Reque
 
 	<-done
 	return true
-}
-
-func dialURL(url *url.URL, transport http.RoundTripper) (net.Conn, error) {
-	dialAddr := netutil.CanonicalAddr(url)
-
-	switch url.Scheme {
-	case "http":
-		return net.Dial("tcp", dialAddr)
-	case "https":
-		// Get the tls config from the transport if we recognize it
-		var tlsConfig *tls.Config
-		if transport != nil {
-			httpTransport, ok := transport.(*http.Transport)
-			if ok {
-				tlsConfig = httpTransport.TLSClientConfig
-			}
-		}
-
-		// Dial
-		tlsConn, err := tls.Dial("tcp", dialAddr, tlsConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		// Return if we were configured to skip validation
-		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
-			return tlsConn, nil
-		}
-
-		// Verify
-		host, _, _ := net.SplitHostPort(dialAddr)
-		if err := tlsConn.VerifyHostname(host); err != nil {
-			tlsConn.Close()
-			return nil, err
-		}
-
-		return tlsConn, nil
-	default:
-		return nil, fmt.Errorf("Unknown scheme: %s", url.Scheme)
-	}
 }
 
 // borrowed from net/http/httputil/reverseproxy.go

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy.go
@@ -286,6 +286,11 @@ func dialURL(url *url.URL, transport http.RoundTripper) (net.Conn, error) {
 			return nil, err
 		}
 
+		// Return if we were configured to skip validation
+		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
+			return tlsConn, nil
+		}
+
 		// Verify
 		host, _, _ := net.SplitHostPort(dialAddr)
 		if err := tlsConn.VerifyHostname(host); err != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -170,6 +171,21 @@ func TestProxyUpgrade(t *testing.T) {
 				return ts
 			},
 			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+		},
+		"https (valid hostname + RootCAs + custom dialer)": {
+			ServerFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			ProxyTransport: &http.Transport{Dial: net.Dial, TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/proxy_test.go
@@ -18,6 +18,8 @@ package apiserver
 
 import (
 	"compress/gzip"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -125,43 +127,97 @@ func TestProxy(t *testing.T) {
 }
 
 func TestProxyUpgrade(t *testing.T) {
-	backendServer := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+
+	localhostPool := x509.NewCertPool()
+	if !localhostPool.AppendCertsFromPEM(localhostCert) {
+		t.Errorf("error setting up localhostCert pool")
+	}
+
+	testcases := map[string]struct {
+		ServerFunc     func(http.Handler) *httptest.Server
+		ProxyTransport http.RoundTripper
+	}{
+		"http": {
+			ServerFunc:     httptest.NewServer,
+			ProxyTransport: nil,
+		},
+		"https (invalid hostname + InsecureSkipVerify)": {
+			ServerFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+				if err != nil {
+					t.Errorf("https (invalid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		},
+		"https (valid hostname + RootCAs)": {
+			ServerFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+		},
+	}
+
+	for k, tc := range testcases {
+
+		backendServer := tc.ServerFunc(websocket.Handler(func(ws *websocket.Conn) {
+			defer ws.Close()
+			body := make([]byte, 5)
+			ws.Read(body)
+			ws.Write([]byte("hello " + string(body)))
+		}))
+		defer backendServer.Close()
+
+		serverURL, _ := url.Parse(backendServer.URL)
+		simpleStorage := &SimpleRESTStorage{
+			errors:                    map[string]error{},
+			resourceLocation:          serverURL,
+			resourceLocationTransport: tc.ProxyTransport,
+			expectedResourceNamespace: "myns",
+		}
+
+		namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
+
+		server := httptest.NewServer(namespaceHandler)
+		defer server.Close()
+
+		ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/api/version2/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
+		if err != nil {
+			t.Errorf("%s: websocket dial err: %s", k, err)
+			continue
+		}
 		defer ws.Close()
-		body := make([]byte, 5)
-		ws.Read(body)
-		ws.Write([]byte("hello " + string(body)))
-	}))
-	defer backendServer.Close()
 
-	serverURL, _ := url.Parse(backendServer.URL)
-	simpleStorage := &SimpleRESTStorage{
-		errors:                    map[string]error{},
-		resourceLocation:          serverURL,
-		expectedResourceNamespace: "myns",
-	}
+		if _, err := ws.Write([]byte("world")); err != nil {
+			t.Errorf("%s: write err: %s", k, err)
+			continue
+		}
 
-	namespaceHandler := handleNamespaced(map[string]rest.Storage{"foo": simpleStorage})
-
-	server := httptest.NewServer(namespaceHandler)
-	defer server.Close()
-
-	ws, err := websocket.Dial("ws://"+server.Listener.Addr().String()+"/api/version2/proxy/namespaces/myns/foo/123", "", "http://127.0.0.1/")
-	if err != nil {
-		t.Fatalf("websocket dial err: %s", err)
-	}
-	defer ws.Close()
-
-	if _, err := ws.Write([]byte("world")); err != nil {
-		t.Fatalf("write err: %s", err)
-	}
-
-	response := make([]byte, 20)
-	n, err := ws.Read(response)
-	if err != nil {
-		t.Fatalf("read err: %s", err)
-	}
-	if e, a := "hello world", string(response[0:n]); e != a {
-		t.Fatalf("expected '%#v', got '%#v'", e, a)
+		response := make([]byte, 20)
+		n, err := ws.Read(response)
+		if err != nil {
+			t.Errorf("%s: read err: %s", k, err)
+			continue
+		}
+		if e, a := "hello world", string(response[0:n]); e != a {
+			t.Errorf("%s: expected '%#v', got '%#v'", k, e, a)
+			continue
+		}
 	}
 }
 
@@ -225,3 +281,50 @@ func TestRedirectOnMissingTrailingSlash(t *testing.T) {
 		}
 	}
 }
+
+// exampleCert was generated from crypto/tls/generate_cert.go with the following command:
+//    go run generate_cert.go  --rsa-bits 512 --host example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBcjCCAR6gAwIBAgIQBOUTYowZaENkZi0faI9DgTALBgkqhkiG9w0BAQswEjEQ
+MA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2MDAw
+MFowEjEQMA4GA1UEChMHQWNtZSBDbzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCZ
+xfR3sgeHBraGFfF/24tTn4PRVAHOf2UOOxSQRs+aYjNqimFqf/SRIblQgeXdBJDR
+gVK5F1Js2zwlehw0bHxRAgMBAAGjUDBOMA4GA1UdDwEB/wQEAwIApDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MBYGA1UdEQQPMA2CC2V4YW1w
+bGUuY29tMAsGCSqGSIb3DQEBCwNBAI/mfBB8dm33IpUl+acSyWfL6gX5Wc0FFyVj
+dKeesE1XBuPX1My/rzU6Oy/YwX7LOL4FaeNUS6bbL4axSLPKYSs=
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAJnF9HeyB4cGtoYV8X/bi1Ofg9FUAc5/ZQ47FJBGz5piM2qKYWp/
+9JEhuVCB5d0EkNGBUrkXUmzbPCV6HDRsfFECAwEAAQJBAJLH9yPuButniACTn5L5
+IJQw1mWQt6zBw9eCo41YWkA0866EgjC53aPZaRjXMp0uNJGdIsys2V5rCOOLWN2C
+ODECIQDICHsi8QQQ9wpuJy8X5l8MAfxHL+DIqI84wQTeVM91FQIhAMTME8A18/7h
+1Ad6drdnxAkuC0tX6Sx0LDozrmen+HFNAiAlcEDrt0RVkIcpOrg7tuhPLQf0oudl
+Zvb3Xlj069awSQIgcT15E/43w2+RASifzVNhQ2MCTr1sSA8lL+xzK+REmnUCIBhQ
+j4139pf8Re1J50zBxS/JlQfgDQi9sO9pYeiHIxNs
+-----END RSA PRIVATE KEY-----`)
+
+// localhostCert was generated from crypto/tls/generate_cert.go with the following command:
+//     go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
+bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
+bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
+IUSdtXdcbItRB/yfXGBhiex00IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEA
+AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
+AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
+Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
+0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
+NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d
+AekCIQDhRQG5Li0Wj8TM4obOnnXUXf1jRv0UkzE9AHWLG5q3AwIhAPzSjpYUDjVW
+MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
+EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
+1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
+-----END RSA PRIVATE KEY-----`)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/chaosclient/chaosclient.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/chaosclient/chaosclient.go
@@ -28,6 +28,8 @@ import (
 	"net/http"
 	"reflect"
 	"runtime"
+
+	"k8s.io/kubernetes/pkg/util"
 )
 
 // chaosrt provides the ability to perform simulations of HTTP client failures
@@ -84,6 +86,12 @@ func (rt *chaosrt) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 	return rt.rt.RoundTrip(req)
+}
+
+var _ = util.RoundTripperWrapper(&chaosrt{})
+
+func (rt *chaosrt) WrappedRoundTripper() http.RoundTripper {
+	return rt.rt
 }
 
 // Seed represents a consistent stream of chaos.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/debugging.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/debugging.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -132,4 +133,10 @@ func (rt *DebuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 
 	return response, err
+}
+
+var _ = util.RoundTripperWrapper(&DebuggingRoundTripper{})
+
+func (rt *DebuggingRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return rt.delegatedRoundTripper
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/kubelet.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/kubelet.go
@@ -19,6 +19,8 @@ package unversioned
 import (
 	"errors"
 	"net/http"
+
+	"k8s.io/kubernetes/pkg/util"
 )
 
 // KubeletClient is an interface for all kubelet functionality
@@ -51,10 +53,10 @@ func MakeTransport(config *KubeletConfig) (http.RoundTripper, error) {
 
 	transport := http.DefaultTransport
 	if config.Dial != nil || tlsConfig != nil {
-		transport = &http.Transport{
+		transport = util.SetTransportDefaults(&http.Transport{
 			Dial:            config.Dial,
 			TLSClientConfig: tlsConfig,
-		}
+		})
 	}
 
 	if len(config.BearerToken) > 0 {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/transport.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/transport.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"k8s.io/kubernetes/pkg/util"
 )
 
 type userAgentRoundTripper struct {
@@ -40,6 +42,12 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	req = cloneRequest(req)
 	req.Header.Set("User-Agent", rt.agent)
 	return rt.rt.RoundTrip(req)
+}
+
+var _ = util.RoundTripperWrapper(&userAgentRoundTripper{})
+
+func (rt *userAgentRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return rt.rt
 }
 
 type basicAuthRoundTripper struct {
@@ -63,6 +71,12 @@ func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	return rt.rt.RoundTrip(req)
 }
 
+var _ = util.RoundTripperWrapper(&basicAuthRoundTripper{})
+
+func (rt *basicAuthRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return rt.rt
+}
+
 type bearerAuthRoundTripper struct {
 	bearer string
 	rt     http.RoundTripper
@@ -82,6 +96,12 @@ func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	req = cloneRequest(req)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
 	return rt.rt.RoundTrip(req)
+}
+
+var _ = util.RoundTripperWrapper(&bearerAuthRoundTripper{})
+
+func (rt *bearerAuthRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return rt.rt
 }
 
 // TLSConfigFor returns a tls.Config that will provide the transport level security defined

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master.go
@@ -17,18 +17,14 @@ limitations under the License.
 package master
 
 import (
+	"crypto/tls"
 	"fmt"
-	"io/ioutil"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"k8s.io/kubernetes/pkg/admission"
@@ -173,10 +169,12 @@ type Config struct {
 	// The range of ports to be assigned to services with type=NodePort or greater
 	ServiceNodePortRange util.PortRange
 
-	// Used for secure proxy.  If empty, don't use secure proxy.
-	SSHUser       string
-	SSHKeyfile    string
-	InstallSSHKey InstallSSHKey
+	// Used to customize default proxy dial/tls options
+	ProxyDialer          apiserver.ProxyDialerFunc
+	ProxyTLSClientConfig *tls.Config
+
+	// Used to start and monitor tunneling
+	Tunneler Tunneler
 }
 
 type InstallSSHKey func(user string, data []byte) error
@@ -237,14 +235,11 @@ type Master struct {
 	Handler         http.Handler
 	InsecureHandler http.Handler
 
-	// Used for secure proxy
-	dialer         apiserver.ProxyDialerFunc
-	tunnels        *util.SSHTunnelList
-	tunnelsLock    sync.Mutex
-	installSSHKey  InstallSSHKey
-	lastSync       int64 // Seconds since Epoch
-	lastSyncMetric prometheus.GaugeFunc
-	clock          util.Clock
+	// Used for custom proxy dialing, and proxy TLS options
+	proxyTransport http.RoundTripper
+
+	// Used to start and monitor tunneling
+	tunneler Tunneler
 
 	// storage for third party objects
 	thirdPartyStorage storage.Interface
@@ -381,7 +376,7 @@ func New(c *Config) *Master {
 		// TODO: serviceReadWritePort should be passed in as an argument, it may not always be 443
 		serviceReadWritePort: 443,
 
-		installSSHKey: c.InstallSSHKey,
+		tunneler: c.Tunneler,
 	}
 
 	var handlerContainer *restful.Container
@@ -432,9 +427,16 @@ func NewHandlerContainer(mux *http.ServeMux) *restful.Container {
 
 // init initializes master.
 func (m *Master) init(c *Config) {
+
+	if c.ProxyDialer != nil || c.ProxyTLSClientConfig != nil {
+		m.proxyTransport = util.SetTransportDefaults(&http.Transport{
+			Dial:            c.ProxyDialer,
+			TLSClientConfig: c.ProxyTLSClientConfig,
+		})
+	}
+
 	healthzChecks := []healthz.HealthzChecker{}
-	m.clock = util.RealClock{}
-	podStorage := podetcd.NewStorage(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient)
+	podStorage := podetcd.NewStorage(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient, m.proxyTransport)
 
 	podTemplateStorage := podtemplateetcd.NewREST(c.DatabaseStorage)
 
@@ -455,7 +457,7 @@ func (m *Master) init(c *Config) {
 
 	securityContextConstraintsStorage := sccetcd.NewStorage(c.DatabaseStorage)
 
-	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient)
+	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient, m.proxyTransport)
 	m.nodeRegistry = node.NewRegistry(nodeStorage)
 
 	serviceStorage := serviceetcd.NewREST(c.DatabaseStorage)
@@ -496,7 +498,7 @@ func (m *Master) init(c *Config) {
 		"podTemplates": podTemplateStorage,
 
 		"replicationControllers": controllerStorage,
-		"services":               service.NewStorage(m.serviceRegistry, m.endpointRegistry, serviceClusterIPAllocator, serviceNodePortAllocator),
+		"services":               service.NewStorage(m.serviceRegistry, m.endpointRegistry, serviceClusterIPAllocator, serviceNodePortAllocator, m.proxyTransport),
 		"endpoints":              endpointsStorage,
 		"nodes":                  nodeStorage,
 		"nodes/status":           nodeStatusStorage,
@@ -519,51 +521,13 @@ func (m *Master) init(c *Config) {
 		"componentStatuses": componentstatus.NewStorage(func() map[string]apiserver.Server { return m.getServersToValidate(c) }),
 	}
 
-	// establish the node proxy dialer
-	if len(c.SSHUser) > 0 {
-		// Usernames are capped @ 32
-		if len(c.SSHUser) > 32 {
-			glog.Warning("SSH User is too long, truncating to 32 chars")
-			c.SSHUser = c.SSHUser[0:32]
-		}
-		glog.Infof("Setting up proxy: %s %s", c.SSHUser, c.SSHKeyfile)
-
-		// public keyfile is written last, so check for that.
-		publicKeyFile := c.SSHKeyfile + ".pub"
-		exists, err := util.FileExists(publicKeyFile)
-		if err != nil {
-			glog.Errorf("Error detecting if key exists: %v", err)
-		} else if !exists {
-			glog.Infof("Key doesn't exist, attempting to create")
-			err := m.generateSSHKey(c.SSHUser, c.SSHKeyfile, publicKeyFile)
-			if err != nil {
-				glog.Errorf("Failed to create key pair: %v", err)
-			}
-		}
-		m.tunnels = &util.SSHTunnelList{}
-		m.dialer = m.Dial
-		m.setupSecureProxy(c.SSHUser, c.SSHKeyfile, publicKeyFile)
-		m.lastSync = m.clock.Now().Unix()
-
-		// This is pretty ugly.  A better solution would be to pull this all the way up into the
-		// server.go file.
-		httpKubeletClient, ok := c.KubeletClient.(*client.HTTPKubeletClient)
-		if ok {
-			httpKubeletClient.Config.Dial = m.dialer
-			transport, err := client.MakeTransport(httpKubeletClient.Config)
-			if err != nil {
-				glog.Errorf("Error setting up transport over SSH: %v", err)
-			} else {
-				httpKubeletClient.Client.Transport = transport
-			}
-		} else {
-			glog.Errorf("Failed to cast %v to HTTPKubeletClient, skipping SSH tunnel.", c.KubeletClient)
-		}
+	if m.tunneler != nil {
+		m.tunneler.Run(m.getNodeAddresses)
 		healthzChecks = append(healthzChecks, healthz.NamedCheck("SSH Tunnel Check", m.IsTunnelSyncHealthy))
-		m.lastSyncMetric = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 			Name: "apiserver_proxy_tunnel_sync_latency_secs",
 			Help: "The time since the last successful synchronization of the SSH tunnels for proxy requests.",
-		}, func() float64 { return float64(m.secondsSinceSync()) })
+		}, func() float64 { return float64(m.tunneler.SecondsSinceSync()) })
 	}
 
 	apiVersions := []string{}
@@ -772,7 +736,6 @@ func (m *Master) defaultAPIGroupVersion() *apiserver.APIGroupVersion {
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,
 
-		ProxyDialerFn:     m.dialer,
 		MinRequestTimeout: m.minRequestTimeout,
 	}
 }
@@ -847,7 +810,6 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,
 
-		ProxyDialerFn:     m.dialer,
 		MinRequestTimeout: m.minRequestTimeout,
 	}
 }
@@ -887,7 +849,6 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,
 
-		ProxyDialerFn:     m.dialer,
 		MinRequestTimeout: m.minRequestTimeout,
 	}
 }
@@ -910,41 +871,6 @@ func findExternalAddress(node *api.Node) (string, error) {
 	return "", fmt.Errorf("Couldn't find external address: %v", node)
 }
 
-func (m *Master) Dial(net, addr string) (net.Conn, error) {
-	// Only lock while picking a tunnel.
-	tunnel, err := func() (util.SSHTunnelEntry, error) {
-		m.tunnelsLock.Lock()
-		defer m.tunnelsLock.Unlock()
-		return m.tunnels.PickRandomTunnel()
-	}()
-	if err != nil {
-		return nil, err
-	}
-
-	start := time.Now()
-	id := rand.Int63() // So you can match begins/ends in the log.
-	glog.V(3).Infof("[%x: %v] Dialing...", id, tunnel.Address)
-	defer func() {
-		glog.V(3).Infof("[%x: %v] Dialed in %v.", id, tunnel.Address, time.Now().Sub(start))
-	}()
-	return tunnel.Tunnel.Dial(net, addr)
-}
-
-func (m *Master) needToReplaceTunnels(addrs []string) bool {
-	m.tunnelsLock.Lock()
-	defer m.tunnelsLock.Unlock()
-	if m.tunnels == nil || m.tunnels.Len() != len(addrs) {
-		return true
-	}
-	// TODO (cjcullen): This doesn't need to be n^2
-	for ix := range addrs {
-		if !m.tunnels.Has(addrs[ix]) {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *Master) getNodeAddresses() ([]string, error) {
 	nodes, err := m.nodeRegistry.ListNodes(api.NewDefaultContext(), labels.Everything(), fields.Everything())
 	if err != nil {
@@ -963,126 +889,12 @@ func (m *Master) getNodeAddresses() ([]string, error) {
 }
 
 func (m *Master) IsTunnelSyncHealthy(req *http.Request) error {
-	lag := m.secondsSinceSync()
+	if m.tunneler == nil {
+		return nil
+	}
+	lag := m.tunneler.SecondsSinceSync()
 	if lag > 600 {
 		return fmt.Errorf("Tunnel sync is taking to long: %d", lag)
 	}
 	return nil
-}
-
-func (m *Master) secondsSinceSync() int64 {
-	now := m.clock.Now().Unix()
-	then := atomic.LoadInt64(&m.lastSync)
-	return now - then
-}
-
-func (m *Master) replaceTunnels(user, keyfile string, newAddrs []string) error {
-	glog.Infof("replacing tunnels. New addrs: %v", newAddrs)
-	tunnels := util.MakeSSHTunnels(user, keyfile, newAddrs)
-	if err := tunnels.Open(); err != nil {
-		return err
-	}
-	m.tunnelsLock.Lock()
-	defer m.tunnelsLock.Unlock()
-	if m.tunnels != nil {
-		m.tunnels.Close()
-	}
-	m.tunnels = tunnels
-	atomic.StoreInt64(&m.lastSync, m.clock.Now().Unix())
-	return nil
-}
-
-func (m *Master) loadTunnels(user, keyfile string) error {
-	addrs, err := m.getNodeAddresses()
-	if err != nil {
-		return err
-	}
-	if !m.needToReplaceTunnels(addrs) {
-		return nil
-	}
-	// TODO: This is going to unnecessarily close connections to unchanged nodes.
-	// See comment about using Watch above.
-	glog.Info("found different nodes. Need to replace tunnels")
-	return m.replaceTunnels(user, keyfile, addrs)
-}
-
-func (m *Master) refreshTunnels(user, keyfile string) error {
-	addrs, err := m.getNodeAddresses()
-	if err != nil {
-		return err
-	}
-	return m.replaceTunnels(user, keyfile, addrs)
-}
-
-func (m *Master) setupSecureProxy(user, privateKeyfile, publicKeyfile string) {
-	// Sync loop to ensure that the SSH key has been installed.
-	go util.Until(func() {
-		if m.installSSHKey == nil {
-			glog.Error("Won't attempt to install ssh key: installSSHKey function is nil")
-			return
-		}
-		key, err := util.ParsePublicKeyFromFile(publicKeyfile)
-		if err != nil {
-			glog.Errorf("Failed to load public key: %v", err)
-			return
-		}
-		keyData, err := util.EncodeSSHKey(key)
-		if err != nil {
-			glog.Errorf("Failed to encode public key: %v", err)
-			return
-		}
-		if err := m.installSSHKey(user, keyData); err != nil {
-			glog.Errorf("Failed to install ssh key: %v", err)
-		}
-	}, 5*time.Minute, util.NeverStop)
-	// Sync loop for tunnels
-	// TODO: switch this to watch.
-	go util.Until(func() {
-		if err := m.loadTunnels(user, privateKeyfile); err != nil {
-			glog.Errorf("Failed to load SSH Tunnels: %v", err)
-		}
-		if m.tunnels != nil && m.tunnels.Len() != 0 {
-			// Sleep for 10 seconds if we have some tunnels.
-			// TODO (cjcullen): tunnels can lag behind actually existing nodes.
-			time.Sleep(9 * time.Second)
-		}
-	}, 1*time.Second, util.NeverStop)
-	// Refresh loop for tunnels
-	// TODO: could make this more controller-ish
-	go util.Until(func() {
-		time.Sleep(5 * time.Minute)
-		if err := m.refreshTunnels(user, privateKeyfile); err != nil {
-			glog.Errorf("Failed to refresh SSH Tunnels: %v", err)
-		}
-	}, 0*time.Second, util.NeverStop)
-}
-
-func (m *Master) generateSSHKey(user, privateKeyfile, publicKeyfile string) error {
-	// TODO: user is not used. Consider removing it as an input to the function.
-	private, public, err := util.GenerateKey(2048)
-	if err != nil {
-		return err
-	}
-	// If private keyfile already exists, we must have only made it halfway
-	// through last time, so delete it.
-	exists, err := util.FileExists(privateKeyfile)
-	if err != nil {
-		glog.Errorf("Error detecting if private key exists: %v", err)
-	} else if exists {
-		glog.Infof("Private key exists, but public key does not")
-		if err := os.Remove(privateKeyfile); err != nil {
-			glog.Errorf("Failed to remove stale private key: %v", err)
-		}
-	}
-	if err := ioutil.WriteFile(privateKeyfile, util.EncodePrivateKey(private), 0600); err != nil {
-		return err
-	}
-	publicKeyBytes, err := util.EncodePublicKey(public)
-	if err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(publicKeyfile+".tmp", publicKeyBytes, 0600); err != nil {
-		return err
-	}
-	return os.Rename(publicKeyfile+".tmp", publicKeyfile)
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master_test.go
@@ -18,6 +18,7 @@ package master
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,10 +27,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/emicklei/go-restful"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +71,12 @@ func TestNew(t *testing.T) {
 	os.Setenv("ETCD_PREFIX", "thirdparty")
 
 	_, config, assert := setUp(t)
+
 	config.KubeletClient = client.FakeKubeletClient{}
+
+	config.ProxyDialer = func(network, addr string) (net.Conn, error) { return nil, nil }
+	config.ProxyTLSClientConfig = &tls.Config{}
+
 	master := New(&config)
 
 	// Verify many of the variables match their config counterparts
@@ -97,7 +101,15 @@ func TestNew(t *testing.T) {
 	assert.Equal(master.clusterIP, config.PublicAddress)
 	assert.Equal(master.publicReadWritePort, config.ReadWritePort)
 	assert.Equal(master.serviceReadWriteIP, config.ServiceReadWriteIP)
-	assert.Equal(master.installSSHKey, config.InstallSSHKey)
+	assert.Equal(master.tunneler, config.Tunneler)
+
+	// These functions should point to the same memory location
+	masterDialer, _ := util.Dialer(master.proxyTransport)
+	masterDialerFunc := fmt.Sprintf("%p", masterDialer)
+	configDialerFunc := fmt.Sprintf("%p", config.ProxyDialer)
+	assert.Equal(masterDialerFunc, configDialerFunc)
+
+	assert.Equal(master.proxyTransport.(*http.Transport).TLSClientConfig, config.ProxyTLSClientConfig)
 }
 
 // TestNewEtcdStorage verifies that the usage of NewEtcdStorage reacts properly when
@@ -262,7 +274,6 @@ func TestInstallSwaggerAPI(t *testing.T) {
 // creates the expected APIGroupVersion based off of master.
 func TestDefaultAPIGroupVersion(t *testing.T) {
 	master, _, assert := setUp(t)
-	master.dialer = func(network, addr string) (net.Conn, error) { return nil, nil }
 
 	apiGroup := master.defaultAPIGroupVersion()
 
@@ -270,11 +281,6 @@ func TestDefaultAPIGroupVersion(t *testing.T) {
 	assert.Equal(apiGroup.Admit, master.admissionControl)
 	assert.Equal(apiGroup.Context, master.requestContextMapper)
 	assert.Equal(apiGroup.MinRequestTimeout, master.minRequestTimeout)
-
-	// These functions should be different instances of the same function
-	groupDialerFunc := fmt.Sprintf("%+v", apiGroup.ProxyDialerFn)
-	masterDialerFunc := fmt.Sprintf("%+v", master.dialer)
-	assert.Equal(groupDialerFunc, masterDialerFunc)
 }
 
 // TestExpapi verifies that the unexported exapi creates
@@ -288,42 +294,6 @@ func TestExpapi(t *testing.T) {
 	assert.Equal(expAPIGroup.Codec, explatest.Codec)
 	assert.Equal(expAPIGroup.Linker, explatest.SelfLinker)
 	assert.Equal(expAPIGroup.Version, explatest.Version)
-}
-
-// TestSecondsSinceSync verifies that proper results are returned
-// when checking the time between syncs
-func TestSecondsSinceSync(t *testing.T) {
-	master, _, assert := setUp(t)
-	master.lastSync = time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix()
-
-	// Nano Second. No difference.
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 1, 1, 2, time.UTC)}
-	assert.Equal(int64(0), master.secondsSinceSync())
-
-	// Second
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 1, 2, 1, time.UTC)}
-	assert.Equal(int64(1), master.secondsSinceSync())
-
-	// Minute
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 2, 1, 1, time.UTC)}
-	assert.Equal(int64(60), master.secondsSinceSync())
-
-	// Hour
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 2, 1, 1, 1, time.UTC)}
-	assert.Equal(int64(3600), master.secondsSinceSync())
-
-	// Day
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 2, 1, 1, 1, 1, time.UTC)}
-	assert.Equal(int64(86400), master.secondsSinceSync())
-
-	// Month
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC)}
-	assert.Equal(int64(2678400), master.secondsSinceSync())
-
-	// Future Month. Should be -Month.
-	master.lastSync = time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC).Unix()
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC)}
-	assert.Equal(int64(-2678400), master.secondsSinceSync())
 }
 
 // TestGetNodeAddresses verifies that proper results are returned
@@ -355,73 +325,6 @@ func TestGetNodeAddresses(t *testing.T) {
 	addrs, err = master.getNodeAddresses()
 	assert.NoError(err, "getNodeAddresses failback should not have returned an error.")
 	assert.Equal([]string{"127.0.0.2", "127.0.0.2"}, addrs)
-}
-
-// TestRefreshTunnels verifies that the function errors when no addresses
-// are associated with nodes
-func TestRefreshTunnels(t *testing.T) {
-	master, _, assert := setUp(t)
-
-	// Fail case (no addresses associated with nodes)
-	assert.Error(master.refreshTunnels("test", "/tmp/undefined"))
-
-	// TODO: pass case without needing actual connections?
-}
-
-// TestIsTunnelSyncHealthy verifies that the 600 second lag test
-// is honored.
-func TestIsTunnelSyncHealthy(t *testing.T) {
-	master, _, assert := setUp(t)
-
-	// Pass case: 540 second lag
-	master.lastSync = time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix()
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 9, 1, 1, time.UTC)}
-	err := master.IsTunnelSyncHealthy(nil)
-	assert.NoError(err, "IsTunnelSyncHealthy() should not have returned an error.")
-
-	// Fail case: 720 second lag
-	master.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 12, 1, 1, time.UTC)}
-	err = master.IsTunnelSyncHealthy(nil)
-	assert.Error(err, "IsTunnelSyncHealthy() should have returned an error.")
-}
-
-// generateTempFile creates a temporary file path
-func generateTempFilePath(prefix string) string {
-	tmpPath, _ := filepath.Abs(fmt.Sprintf("%s/%s-%d", os.TempDir(), prefix, time.Now().Unix()))
-	return tmpPath
-}
-
-// TestGenerateSSHKey verifies that SSH key generation does indeed
-// generate keys even with keys already exist.
-func TestGenerateSSHKey(t *testing.T) {
-	master, _, assert := setUp(t)
-
-	privateKey := generateTempFilePath("private")
-	publicKey := generateTempFilePath("public")
-
-	// Make sure we have no test keys laying around
-	os.Remove(privateKey)
-	os.Remove(publicKey)
-
-	// Pass case: Sunny day case
-	err := master.generateSSHKey("unused", privateKey, publicKey)
-	assert.NoError(err, "generateSSHKey should not have retuend an error: %s", err)
-
-	// Pass case: PrivateKey exists test case
-	os.Remove(publicKey)
-	err = master.generateSSHKey("unused", privateKey, publicKey)
-	assert.NoError(err, "generateSSHKey should not have retuend an error: %s", err)
-
-	// Pass case: PublicKey exists test case
-	os.Remove(privateKey)
-	err = master.generateSSHKey("unused", privateKey, publicKey)
-	assert.NoError(err, "generateSSHKey should not have retuend an error: %s", err)
-
-	// Make sure we have no test keys laying around
-	os.Remove(privateKey)
-	os.Remove(publicKey)
-
-	// TODO: testing error cases where the file can not be removed?
 }
 
 var versionsToTest = []string{"v1", "v3"}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/tunneler.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/tunneler.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type AddressFunc func() (addresses []string, err error)
+
+type Tunneler interface {
+	Run(AddressFunc)
+	Stop()
+	Dial(net, addr string) (net.Conn, error)
+	SecondsSinceSync() int64
+}
+
+type SSHTunneler struct {
+	SSHUser       string
+	SSHKeyfile    string
+	InstallSSHKey InstallSSHKey
+
+	tunnels        *util.SSHTunnelList
+	tunnelsLock    sync.Mutex
+	lastSync       int64 // Seconds since Epoch
+	lastSyncMetric prometheus.GaugeFunc
+	clock          util.Clock
+
+	getAddresses AddressFunc
+	stopChan     chan struct{}
+}
+
+func NewSSHTunneler(sshUser string, sshKeyfile string, installSSHKey InstallSSHKey) Tunneler {
+	return &SSHTunneler{
+		SSHUser:       sshUser,
+		SSHKeyfile:    sshKeyfile,
+		InstallSSHKey: installSSHKey,
+
+		clock: util.RealClock{},
+	}
+}
+
+// Run establishes tunnel loops and returns
+func (c *SSHTunneler) Run(getAddresses AddressFunc) {
+	if c.stopChan != nil {
+		return
+	}
+	c.stopChan = make(chan struct{})
+
+	// Save the address getter
+	if getAddresses != nil {
+		c.getAddresses = getAddresses
+	}
+
+	// Usernames are capped @ 32
+	if len(c.SSHUser) > 32 {
+		glog.Warning("SSH User is too long, truncating to 32 chars")
+		c.SSHUser = c.SSHUser[0:32]
+	}
+	glog.Infof("Setting up proxy: %s %s", c.SSHUser, c.SSHKeyfile)
+
+	// public keyfile is written last, so check for that.
+	publicKeyFile := c.SSHKeyfile + ".pub"
+	exists, err := util.FileExists(publicKeyFile)
+	if err != nil {
+		glog.Errorf("Error detecting if key exists: %v", err)
+	} else if !exists {
+		glog.Infof("Key doesn't exist, attempting to create")
+		err := c.generateSSHKey(c.SSHUser, c.SSHKeyfile, publicKeyFile)
+		if err != nil {
+			glog.Errorf("Failed to create key pair: %v", err)
+		}
+	}
+	c.tunnels = &util.SSHTunnelList{}
+	c.setupSecureProxy(c.SSHUser, c.SSHKeyfile, publicKeyFile)
+	c.lastSync = c.clock.Now().Unix()
+}
+
+// Stop gracefully shuts down the tunneler
+func (c *SSHTunneler) Stop() {
+	if c.stopChan != nil {
+		close(c.stopChan)
+		c.stopChan = nil
+	}
+}
+
+func (c *SSHTunneler) Dial(net, addr string) (net.Conn, error) {
+	// Only lock while picking a tunnel.
+	tunnel, err := func() (util.SSHTunnelEntry, error) {
+		c.tunnelsLock.Lock()
+		defer c.tunnelsLock.Unlock()
+		return c.tunnels.PickRandomTunnel()
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Now()
+	id := rand.Int63() // So you can match begins/ends in the log.
+	glog.V(3).Infof("[%x: %v] Dialing...", id, tunnel.Address)
+	defer func() {
+		glog.V(3).Infof("[%x: %v] Dialed in %v.", id, tunnel.Address, time.Now().Sub(start))
+	}()
+	return tunnel.Tunnel.Dial(net, addr)
+}
+
+func (c *SSHTunneler) SecondsSinceSync() int64 {
+	now := c.clock.Now().Unix()
+	then := atomic.LoadInt64(&c.lastSync)
+	return now - then
+}
+
+func (c *SSHTunneler) needToReplaceTunnels(addrs []string) bool {
+	c.tunnelsLock.Lock()
+	defer c.tunnelsLock.Unlock()
+	if c.tunnels == nil || c.tunnels.Len() != len(addrs) {
+		return true
+	}
+	// TODO (cjcullen): This doesn't need to be n^2
+	for ix := range addrs {
+		if !c.tunnels.Has(addrs[ix]) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *SSHTunneler) replaceTunnels(user, keyfile string, newAddrs []string) error {
+	glog.Infof("replacing tunnels. New addrs: %v", newAddrs)
+	tunnels := util.MakeSSHTunnels(user, keyfile, newAddrs)
+	if err := tunnels.Open(); err != nil {
+		return err
+	}
+	c.tunnelsLock.Lock()
+	defer c.tunnelsLock.Unlock()
+	if c.tunnels != nil {
+		c.tunnels.Close()
+	}
+	c.tunnels = tunnels
+	atomic.StoreInt64(&c.lastSync, c.clock.Now().Unix())
+	return nil
+}
+
+func (c *SSHTunneler) loadTunnels(user, keyfile string) error {
+	addrs, err := c.getAddresses()
+	if err != nil {
+		return err
+	}
+	if !c.needToReplaceTunnels(addrs) {
+		return nil
+	}
+	// TODO: This is going to unnecessarily close connections to unchanged nodes.
+	// See comment about using Watch above.
+	glog.Info("found different nodes. Need to replace tunnels")
+	return c.replaceTunnels(user, keyfile, addrs)
+}
+
+func (c *SSHTunneler) refreshTunnels(user, keyfile string) error {
+	addrs, err := c.getAddresses()
+	if err != nil {
+		return err
+	}
+	return c.replaceTunnels(user, keyfile, addrs)
+}
+
+func (c *SSHTunneler) setupSecureProxy(user, privateKeyfile, publicKeyfile string) {
+	// Sync loop to ensure that the SSH key has been installed.
+	go util.Until(func() {
+		if c.InstallSSHKey == nil {
+			glog.Error("Won't attempt to install ssh key: InstallSSHKey function is nil")
+			return
+		}
+		key, err := util.ParsePublicKeyFromFile(publicKeyfile)
+		if err != nil {
+			glog.Errorf("Failed to load public key: %v", err)
+			return
+		}
+		keyData, err := util.EncodeSSHKey(key)
+		if err != nil {
+			glog.Errorf("Failed to encode public key: %v", err)
+			return
+		}
+		if err := c.InstallSSHKey(user, keyData); err != nil {
+			glog.Errorf("Failed to install ssh key: %v", err)
+		}
+	}, 5*time.Minute, c.stopChan)
+	// Sync loop for tunnels
+	// TODO: switch this to watch.
+	go util.Until(func() {
+		if err := c.loadTunnels(user, privateKeyfile); err != nil {
+			glog.Errorf("Failed to load SSH Tunnels: %v", err)
+		}
+		if c.tunnels != nil && c.tunnels.Len() != 0 {
+			// Sleep for 10 seconds if we have some tunnels.
+			// TODO (cjcullen): tunnels can lag behind actually existing nodes.
+			time.Sleep(9 * time.Second)
+		}
+	}, 1*time.Second, c.stopChan)
+	// Refresh loop for tunnels
+	// TODO: could make this more controller-ish
+	go util.Until(func() {
+		time.Sleep(5 * time.Minute)
+		if err := c.refreshTunnels(user, privateKeyfile); err != nil {
+			glog.Errorf("Failed to refresh SSH Tunnels: %v", err)
+		}
+	}, 0*time.Second, c.stopChan)
+}
+
+func (c *SSHTunneler) generateSSHKey(user, privateKeyfile, publicKeyfile string) error {
+	// TODO: user is not used. Consider removing it as an input to the function.
+	private, public, err := util.GenerateKey(2048)
+	if err != nil {
+		return err
+	}
+	// If private keyfile already exists, we must have only made it halfway
+	// through last time, so delete it.
+	exists, err := util.FileExists(privateKeyfile)
+	if err != nil {
+		glog.Errorf("Error detecting if private key exists: %v", err)
+	} else if exists {
+		glog.Infof("Private key exists, but public key does not")
+		if err := os.Remove(privateKeyfile); err != nil {
+			glog.Errorf("Failed to remove stale private key: %v", err)
+		}
+	}
+	if err := ioutil.WriteFile(privateKeyfile, util.EncodePrivateKey(private), 0600); err != nil {
+		return err
+	}
+	publicKeyBytes, err := util.EncodePublicKey(public)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(publicKeyfile+".tmp", publicKeyBytes, 0600); err != nil {
+		return err
+	}
+	return os.Rename(publicKeyfile+".tmp", publicKeyfile)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/tunneler_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/tunneler_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSecondsSinceSync verifies that proper results are returned
+// when checking the time between syncs
+func TestSecondsSinceSync(t *testing.T) {
+	tunneler := &SSHTunneler{}
+	assert := assert.New(t)
+
+	tunneler.lastSync = time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix()
+
+	// Nano Second. No difference.
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 1, 1, 2, time.UTC)}
+	assert.Equal(int64(0), tunneler.SecondsSinceSync())
+
+	// Second
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 1, 2, 1, time.UTC)}
+	assert.Equal(int64(1), tunneler.SecondsSinceSync())
+
+	// Minute
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 2, 1, 1, time.UTC)}
+	assert.Equal(int64(60), tunneler.SecondsSinceSync())
+
+	// Hour
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 2, 1, 1, 1, time.UTC)}
+	assert.Equal(int64(3600), tunneler.SecondsSinceSync())
+
+	// Day
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 2, 1, 1, 1, 1, time.UTC)}
+	assert.Equal(int64(86400), tunneler.SecondsSinceSync())
+
+	// Month
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC)}
+	assert.Equal(int64(2678400), tunneler.SecondsSinceSync())
+
+	// Future Month. Should be -Month.
+	tunneler.lastSync = time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC).Unix()
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC)}
+	assert.Equal(int64(-2678400), tunneler.SecondsSinceSync())
+}
+
+// TestRefreshTunnels verifies that the function errors when no addresses
+// are associated with nodes
+func TestRefreshTunnels(t *testing.T) {
+	tunneler := &SSHTunneler{}
+	tunneler.getAddresses = func() ([]string, error) { return []string{}, nil }
+	assert := assert.New(t)
+
+	// Fail case (no addresses associated with nodes)
+	assert.Error(tunneler.refreshTunnels("test", "/tmp/undefined"))
+
+	// TODO: pass case without needing actual connections?
+}
+
+// TestIsTunnelSyncHealthy verifies that the 600 second lag test
+// is honored.
+func TestIsTunnelSyncHealthy(t *testing.T) {
+	tunneler := &SSHTunneler{}
+	master, _, assert := setUp(t)
+	master.tunneler = tunneler
+
+	// Pass case: 540 second lag
+	tunneler.lastSync = time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix()
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 9, 1, 1, time.UTC)}
+	err := master.IsTunnelSyncHealthy(nil)
+	assert.NoError(err, "IsTunnelSyncHealthy() should not have returned an error.")
+
+	// Fail case: 720 second lag
+	tunneler.clock = &util.FakeClock{Time: time.Date(2015, time.January, 1, 1, 12, 1, 1, time.UTC)}
+	err = master.IsTunnelSyncHealthy(nil)
+	assert.Error(err, "IsTunnelSyncHealthy() should have returned an error.")
+}
+
+// generateTempFile creates a temporary file path
+func generateTempFilePath(prefix string) string {
+	tmpPath, _ := filepath.Abs(fmt.Sprintf("%s/%s-%d", os.TempDir(), prefix, time.Now().Unix()))
+	return tmpPath
+}
+
+// TestGenerateSSHKey verifies that SSH key generation does indeed
+// generate keys even with keys already exist.
+func TestGenerateSSHKey(t *testing.T) {
+	tunneler := &SSHTunneler{}
+	assert := assert.New(t)
+
+	privateKey := generateTempFilePath("private")
+	publicKey := generateTempFilePath("public")
+
+	// Make sure we have no test keys laying around
+	os.Remove(privateKey)
+	os.Remove(publicKey)
+
+	// Pass case: Sunny day case
+	err := tunneler.generateSSHKey("unused", privateKey, publicKey)
+	assert.NoError(err, "generateSSHKey should not have retuend an error: %s", err)
+
+	// Pass case: PrivateKey exists test case
+	os.Remove(publicKey)
+	err = tunneler.generateSSHKey("unused", privateKey, publicKey)
+	assert.NoError(err, "generateSSHKey should not have retuend an error: %s", err)
+
+	// Pass case: PublicKey exists test case
+	os.Remove(privateKey)
+	err = tunneler.generateSSHKey("unused", privateKey, publicKey)
+	assert.NoError(err, "generateSSHKey should not have retuend an error: %s", err)
+
+	// Make sure we have no test keys laying around
+	os.Remove(privateKey)
+	os.Remove(publicKey)
+
+	// TODO: testing error cases where the file can not be removed?
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy.go
@@ -17,10 +17,7 @@ limitations under the License.
 package rest
 
 import (
-	"crypto/tls"
-	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -29,12 +26,12 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/proxy"
 
 	"github.com/golang/glog"
 	"github.com/mxk/go-flowrate/flowrate"
-	"k8s.io/kubernetes/third_party/golang/netutil"
 )
 
 // UpgradeAwareProxyHandler is a handler for proxy requests that may require an upgrade
@@ -128,7 +125,7 @@ func (h *UpgradeAwareProxyHandler) tryUpgrade(w http.ResponseWriter, req *http.R
 		return false
 	}
 
-	backendConn, err := h.dialURL()
+	backendConn, err := proxy.DialURL(h.Location, h.Transport)
 	if err != nil {
 		h.err = err
 		return true
@@ -189,79 +186,6 @@ func (h *UpgradeAwareProxyHandler) tryUpgrade(w http.ResponseWriter, req *http.R
 	return true
 }
 
-func (h *UpgradeAwareProxyHandler) dialURL() (net.Conn, error) {
-	dialAddr := netutil.CanonicalAddr(h.Location)
-
-	var dialer func(network, addr string) (net.Conn, error)
-	if httpTransport, ok := h.Transport.(*http.Transport); ok && httpTransport.Dial != nil {
-		dialer = httpTransport.Dial
-	}
-
-	switch h.Location.Scheme {
-	case "http":
-		if dialer != nil {
-			return dialer("tcp", dialAddr)
-		}
-		return net.Dial("tcp", dialAddr)
-	case "https":
-		// TODO: this TLS logic can probably be cleaned up; it's messy in an attempt
-		// to preserve behavior that we don't know for sure is exercised.
-
-		// Get the tls config from the transport if we recognize it
-		var tlsConfig *tls.Config
-		var tlsConn *tls.Conn
-		var err error
-		if h.Transport != nil {
-			httpTransport, ok := h.Transport.(*http.Transport)
-			if ok {
-				tlsConfig = httpTransport.TLSClientConfig
-			}
-		}
-		if dialer != nil {
-			// We have a dialer; use it to open the connection, then
-			// create a tls client using the connection.
-			netConn, err := dialer("tcp", dialAddr)
-			if err != nil {
-				return nil, err
-			}
-			// tls.Client requires non-nil config
-			if tlsConfig == nil {
-				glog.Warningf("using custom dialer with no TLSClientConfig. Defaulting to InsecureSkipVerify")
-				tlsConfig = &tls.Config{
-					InsecureSkipVerify: true,
-				}
-			}
-			tlsConn = tls.Client(netConn, tlsConfig)
-			if err := tlsConn.Handshake(); err != nil {
-				return nil, err
-			}
-
-		} else {
-			// Dial
-			tlsConn, err = tls.Dial("tcp", dialAddr, tlsConfig)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		// Return if we were configured to skip validation
-		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
-			return tlsConn, nil
-		}
-
-		// Verify
-		host, _, _ := net.SplitHostPort(dialAddr)
-		if err := tlsConn.VerifyHostname(host); err != nil {
-			tlsConn.Close()
-			return nil, err
-		}
-
-		return tlsConn, nil
-	default:
-		return nil, fmt.Errorf("unknown scheme: %s", h.Location.Scheme)
-	}
-}
-
 func (h *UpgradeAwareProxyHandler) defaultProxyTransport(url *url.URL, internalTransport http.RoundTripper) http.RoundTripper {
 	scheme := url.Scheme
 	host := url.Host
@@ -294,7 +218,12 @@ func (p *corsRemovingTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 	removeCORSHeaders(resp)
 	return resp, nil
+}
 
+var _ = util.RoundTripperWrapper(&corsRemovingTransport{})
+
+func (rt *corsRemovingTransport) WrappedRoundTripper() http.RoundTripper {
+	return rt.RoundTripper
 }
 
 // removeCORSHeaders strip CORS headers sent from the backend

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy.go
@@ -240,6 +240,11 @@ func (h *UpgradeAwareProxyHandler) dialURL() (net.Conn, error) {
 			}
 		}
 
+		// Return if we were configured to skip validation
+		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
+			return tlsConn, nil
+		}
+
 		// Verify
 		host, _, _ := net.SplitHostPort(dialAddr)
 		if err := tlsConn.VerifyHostname(host); err != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -304,6 +305,21 @@ func TestProxyUpgrade(t *testing.T) {
 				return ts
 			},
 			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+		},
+		"https (valid hostname + RootCAs + custom dialer)": {
+			ServerFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			ProxyTransport: &http.Transport{Dial: net.Dial, TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
@@ -388,7 +388,7 @@ func TestDefaultProxyTransport(t *testing.T) {
 		h := UpgradeAwareProxyHandler{
 			Location: locURL,
 		}
-		result := h.defaultProxyTransport(URL)
+		result := h.defaultProxyTransport(URL, nil)
 		transport := result.(*corsRemovingTransport).RoundTripper.(*proxy.Transport)
 		if transport.Scheme != test.expectedScheme {
 			t.Errorf("%s: unexpected scheme. Actual: %s, Expected: %s", test.name, transport.Scheme, test.expectedScheme)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/generic/rest/proxy_test.go
@@ -18,6 +18,8 @@ package rest
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -259,38 +261,88 @@ func TestServeHTTP(t *testing.T) {
 }
 
 func TestProxyUpgrade(t *testing.T) {
-	backendServer := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+
+	localhostPool := x509.NewCertPool()
+	if !localhostPool.AppendCertsFromPEM(localhostCert) {
+		t.Errorf("error setting up localhostCert pool")
+	}
+
+	testcases := map[string]struct {
+		ServerFunc     func(http.Handler) *httptest.Server
+		ProxyTransport http.RoundTripper
+	}{
+		"http": {
+			ServerFunc:     httptest.NewServer,
+			ProxyTransport: nil,
+		},
+		"https (invalid hostname + InsecureSkipVerify)": {
+			ServerFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+				if err != nil {
+					t.Errorf("https (invalid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		},
+		"https (valid hostname + RootCAs)": {
+			ServerFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			ProxyTransport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: localhostPool}},
+		},
+	}
+
+	for k, tc := range testcases {
+
+		backendServer := tc.ServerFunc(websocket.Handler(func(ws *websocket.Conn) {
+			defer ws.Close()
+			body := make([]byte, 5)
+			ws.Read(body)
+			ws.Write([]byte("hello " + string(body)))
+		}))
+		defer backendServer.Close()
+
+		serverURL, _ := url.Parse(backendServer.URL)
+		proxyHandler := &UpgradeAwareProxyHandler{
+			Location:  serverURL,
+			Transport: tc.ProxyTransport,
+		}
+		proxy := httptest.NewServer(proxyHandler)
+		defer proxy.Close()
+
+		ws, err := websocket.Dial("ws://"+proxy.Listener.Addr().String()+"/some/path", "", "http://127.0.0.1/")
+		if err != nil {
+			t.Fatalf("%s: websocket dial err: %s", k, err)
+		}
 		defer ws.Close()
-		body := make([]byte, 5)
-		ws.Read(body)
-		ws.Write([]byte("hello " + string(body)))
-	}))
-	defer backendServer.Close()
 
-	serverURL, _ := url.Parse(backendServer.URL)
-	proxyHandler := &UpgradeAwareProxyHandler{
-		Location: serverURL,
-	}
-	proxy := httptest.NewServer(proxyHandler)
-	defer proxy.Close()
+		if _, err := ws.Write([]byte("world")); err != nil {
+			t.Fatalf("%s: write err: %s", k, err)
+		}
 
-	ws, err := websocket.Dial("ws://"+proxy.Listener.Addr().String()+"/some/path", "", "http://127.0.0.1/")
-	if err != nil {
-		t.Fatalf("websocket dial err: %s", err)
-	}
-	defer ws.Close()
-
-	if _, err := ws.Write([]byte("world")); err != nil {
-		t.Fatalf("write err: %s", err)
-	}
-
-	response := make([]byte, 20)
-	n, err := ws.Read(response)
-	if err != nil {
-		t.Fatalf("read err: %s", err)
-	}
-	if e, a := "hello world", string(response[0:n]); e != a {
-		t.Fatalf("expected '%#v', got '%#v'", e, a)
+		response := make([]byte, 20)
+		n, err := ws.Read(response)
+		if err != nil {
+			t.Fatalf("%s: read err: %s", k, err)
+		}
+		if e, a := "hello world", string(response[0:n]); e != a {
+			t.Fatalf("%s: expected '%#v', got '%#v'", k, e, a)
+		}
 	}
 }
 
@@ -349,3 +401,50 @@ func TestDefaultProxyTransport(t *testing.T) {
 		}
 	}
 }
+
+// exampleCert was generated from crypto/tls/generate_cert.go with the following command:
+//    go run generate_cert.go  --rsa-bits 512 --host example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBcjCCAR6gAwIBAgIQBOUTYowZaENkZi0faI9DgTALBgkqhkiG9w0BAQswEjEQ
+MA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2MDAw
+MFowEjEQMA4GA1UEChMHQWNtZSBDbzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCZ
+xfR3sgeHBraGFfF/24tTn4PRVAHOf2UOOxSQRs+aYjNqimFqf/SRIblQgeXdBJDR
+gVK5F1Js2zwlehw0bHxRAgMBAAGjUDBOMA4GA1UdDwEB/wQEAwIApDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MBYGA1UdEQQPMA2CC2V4YW1w
+bGUuY29tMAsGCSqGSIb3DQEBCwNBAI/mfBB8dm33IpUl+acSyWfL6gX5Wc0FFyVj
+dKeesE1XBuPX1My/rzU6Oy/YwX7LOL4FaeNUS6bbL4axSLPKYSs=
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAJnF9HeyB4cGtoYV8X/bi1Ofg9FUAc5/ZQ47FJBGz5piM2qKYWp/
+9JEhuVCB5d0EkNGBUrkXUmzbPCV6HDRsfFECAwEAAQJBAJLH9yPuButniACTn5L5
+IJQw1mWQt6zBw9eCo41YWkA0866EgjC53aPZaRjXMp0uNJGdIsys2V5rCOOLWN2C
+ODECIQDICHsi8QQQ9wpuJy8X5l8MAfxHL+DIqI84wQTeVM91FQIhAMTME8A18/7h
+1Ad6drdnxAkuC0tX6Sx0LDozrmen+HFNAiAlcEDrt0RVkIcpOrg7tuhPLQf0oudl
+Zvb3Xlj069awSQIgcT15E/43w2+RASifzVNhQ2MCTr1sSA8lL+xzK+REmnUCIBhQ
+j4139pf8Re1J50zBxS/JlQfgDQi9sO9pYeiHIxNs
+-----END RSA PRIVATE KEY-----`)
+
+// localhostCert was generated from crypto/tls/generate_cert.go with the following command:
+//     go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
+bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
+bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
+IUSdtXdcbItRB/yfXGBhiex00IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEA
+AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
+AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
+Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
+0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
+NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d
+AekCIQDhRQG5Li0Wj8TM4obOnnXUXf1jRv0UkzE9AHWLG5q3AwIhAPzSjpYUDjVW
+MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
+EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
+1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
+-----END RSA PRIVATE KEY-----`)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/node/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/node/etcd/etcd_test.go
@@ -38,7 +38,7 @@ func (fakeConnectionInfoGetter) GetConnectionInfo(host string) (string, uint, ht
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage, _ := NewREST(etcdStorage, false, fakeConnectionInfoGetter{})
+	storage, _ := NewREST(etcdStorage, false, fakeConnectionInfoGetter{}, nil)
 	return storage, fakeClient
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/node/strategy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/node/strategy.go
@@ -136,7 +136,7 @@ func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 }
 
 // ResourceLocation returns an URL and transport which one can use to send traffic for the specified node.
-func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
+func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
 	schemeReq, name, portReq, valid := util.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid node request %q", id))
@@ -155,7 +155,7 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 
 	if portReq == "" || strconv.Itoa(ports.KubeletPort) == portReq {
 		// Ignore requested scheme, use scheme provided by GetConnectionInfo
-		scheme, port, transport, err := connection.GetConnectionInfo(host)
+		scheme, port, kubeletTransport, err := connection.GetConnectionInfo(host)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -166,8 +166,8 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 					strconv.FormatUint(uint64(port), 10),
 				),
 			},
-			transport,
+			kubeletTransport,
 			nil
 	}
-	return &url.URL{Scheme: schemeReq, Host: net.JoinHostPort(host, portReq)}, nil, nil
+	return &url.URL{Scheme: schemeReq, Host: net.JoinHostPort(host, portReq)}, proxyTransport, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/node/strategy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/node/strategy.go
@@ -137,7 +137,7 @@ func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 
 // ResourceLocation returns an URL and transport which one can use to send traffic for the specified node.
 func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
-	name, portReq, valid := util.SplitPort(id)
+	schemeReq, name, portReq, valid := util.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid node request %q", id))
 	}
@@ -154,6 +154,7 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 	host := hostIP.String()
 
 	if portReq == "" || strconv.Itoa(ports.KubeletPort) == portReq {
+		// Ignore requested scheme, use scheme provided by GetConnectionInfo
 		scheme, port, transport, err := connection.GetConnectionInfo(host)
 		if err != nil {
 			return nil, nil, err
@@ -168,5 +169,5 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 			transport,
 			nil
 	}
-	return &url.URL{Host: net.JoinHostPort(host, portReq)}, nil, nil
+	return &url.URL{Scheme: schemeReq, Host: net.JoinHostPort(host, portReq)}, nil, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
@@ -54,10 +54,11 @@ type PodStorage struct {
 // REST implements a RESTStorage for pods against etcd
 type REST struct {
 	*etcdgeneric.Etcd
+	proxyTransport http.RoundTripper
 }
 
 // NewStorage returns a RESTStorage object that will work against pods.
-func NewStorage(s storage.Interface, useCacher bool, k client.ConnectionInfoGetter) PodStorage {
+func NewStorage(s storage.Interface, useCacher bool, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper) PodStorage {
 	prefix := "/pods"
 
 	storageInterface := s
@@ -104,11 +105,11 @@ func NewStorage(s storage.Interface, useCacher bool, k client.ConnectionInfoGett
 	statusStore.UpdateStrategy = pod.StatusStrategy
 
 	return PodStorage{
-		Pod:         &REST{store},
+		Pod:         &REST{store, proxyTransport},
 		Binding:     &BindingREST{store: store},
 		Status:      &StatusREST{store: &statusStore},
 		Log:         &LogREST{store: store, kubeletConn: k},
-		Proxy:       &ProxyREST{store: store},
+		Proxy:       &ProxyREST{store: store, proxyTransport: proxyTransport},
 		Exec:        &ExecREST{store: store, kubeletConn: k},
 		Attach:      &AttachREST{store: store, kubeletConn: k},
 		PortForward: &PortForwardREST{store: store, kubeletConn: k},
@@ -120,7 +121,7 @@ var _ = rest.Redirector(&REST{})
 
 // ResourceLocation returns a pods location from its HostIP
 func (r *REST) ResourceLocation(ctx api.Context, name string) (*url.URL, http.RoundTripper, error) {
-	return pod.ResourceLocation(r, ctx, name)
+	return pod.ResourceLocation(r, r.proxyTransport, ctx, name)
 }
 
 // BindingREST implements the REST endpoint for binding pods to nodes when etcd is in use.
@@ -249,7 +250,8 @@ func (r *LogREST) NewGetOptions() (runtime.Object, bool, string) {
 
 // ProxyREST implements the proxy subresource for a Pod
 type ProxyREST struct {
-	store *etcdgeneric.Etcd
+	store          *etcdgeneric.Etcd
+	proxyTransport http.RoundTripper
 }
 
 // Implement Connecter
@@ -278,7 +280,7 @@ func (r *ProxyREST) Connect(ctx api.Context, id string, opts runtime.Object) (re
 	if !ok {
 		return nil, fmt.Errorf("Invalid options object: %#v", opts)
 	}
-	location, transport, err := pod.ResourceLocation(r.store, ctx, id)
+	location, transport, err := pod.ResourceLocation(r.store, r.proxyTransport, ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd.go
@@ -278,12 +278,13 @@ func (r *ProxyREST) Connect(ctx api.Context, id string, opts runtime.Object) (re
 	if !ok {
 		return nil, fmt.Errorf("Invalid options object: %#v", opts)
 	}
-	location, _, err := pod.ResourceLocation(r.store, ctx, id)
+	location, transport, err := pod.ResourceLocation(r.store, ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	location.Path = path.Join(location.Path, proxyOpts.Path)
-	return newUpgradeAwareProxyHandler(location, nil, false), nil
+	// Return a proxy handler that uses the desired transport, wrapped with additional proxy handling (to get URL rewriting, X-Forwarded-* headers, etc)
+	return newThrottledUpgradeAwareProxyHandler(location, transport, true, false), nil
 }
 
 // Support both GET and POST methods. We must support GET for browsers that want to use WebSockets.
@@ -313,7 +314,7 @@ func (r *AttachREST) Connect(ctx api.Context, name string, opts runtime.Object) 
 	if err != nil {
 		return nil, err
 	}
-	return genericrest.NewUpgradeAwareProxyHandler(location, transport, true), nil
+	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true), nil
 }
 
 // NewConnectOptions returns the versioned object that represents exec parameters
@@ -350,7 +351,7 @@ func (r *ExecREST) Connect(ctx api.Context, name string, opts runtime.Object) (r
 	if err != nil {
 		return nil, err
 	}
-	return newUpgradeAwareProxyHandler(location, transport, true), nil
+	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true), nil
 }
 
 // NewConnectOptions returns the versioned object that represents exec parameters
@@ -393,11 +394,11 @@ func (r *PortForwardREST) Connect(ctx api.Context, name string, opts runtime.Obj
 	if err != nil {
 		return nil, err
 	}
-	return newUpgradeAwareProxyHandler(location, transport, true), nil
+	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true), nil
 }
 
-func newUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, upgradeRequired bool) *genericrest.UpgradeAwareProxyHandler {
-	handler := genericrest.NewUpgradeAwareProxyHandler(location, transport, upgradeRequired)
+func newThrottledUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired bool) *genericrest.UpgradeAwareProxyHandler {
+	handler := genericrest.NewUpgradeAwareProxyHandler(location, transport, wrapTransport, upgradeRequired)
 	handler.MaxBytesPerSec = capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
 	return handler
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd_test.go
@@ -38,7 +38,7 @@ import (
 
 func newStorage(t *testing.T) (*REST, *BindingREST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage := NewStorage(etcdStorage, false, nil)
+	storage := NewStorage(etcdStorage, false, nil, nil)
 	return storage.Pod, storage.Binding, storage.Status, fakeClient
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/strategy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/strategy.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -44,13 +43,6 @@ type podStrategy struct {
 // Strategy is the default logic that applies when creating and updating Pod
 // objects via the REST API.
 var Strategy = podStrategy{api.Scheme, api.SimpleNameGenerator}
-
-// PodProxyTransport is used by the API proxy to connect to pods
-// Exported to allow overriding TLS options (like adding a client certificate)
-var PodProxyTransport = util.SetTransportDefaults(&http.Transport{
-	// Turn off hostname verification, because connections are to assigned IPs, not deterministic
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-})
 
 // NamespaceScoped is true for pods.
 func (podStrategy) NamespaceScoped() bool {
@@ -193,7 +185,7 @@ func getPod(getter ResourceGetter, ctx api.Context, name string) (*api.Pod, erro
 }
 
 // ResourceLocation returns a URL to which one can send traffic for the specified pod.
-func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
+func ResourceLocation(getter ResourceGetter, rt http.RoundTripper, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
 	// Allow ID as "podname" or "podname:port" or "scheme:podname:port".
 	// If port is not specified, try to use the first defined port on the pod.
 	scheme, name, port, valid := util.SplitSchemeNamePort(id)
@@ -225,7 +217,7 @@ func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.U
 	} else {
 		loc.Host = net.JoinHostPort(pod.Status.PodIP, port)
 	}
-	return loc, PodProxyTransport, nil
+	return loc, rt, nil
 }
 
 // LogLocation returns the log URL for a pod container. If opts.Container is blank

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/strategy.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/strategy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -43,6 +44,13 @@ type podStrategy struct {
 // Strategy is the default logic that applies when creating and updating Pod
 // objects via the REST API.
 var Strategy = podStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// PodProxyTransport is used by the API proxy to connect to pods
+// Exported to allow overriding TLS options (like adding a client certificate)
+var PodProxyTransport = util.SetTransportDefaults(&http.Transport{
+	// Turn off hostname verification, because connections are to assigned IPs, not deterministic
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+})
 
 // NamespaceScoped is true for pods.
 func (podStrategy) NamespaceScoped() bool {
@@ -186,9 +194,9 @@ func getPod(getter ResourceGetter, ctx api.Context, name string) (*api.Pod, erro
 
 // ResourceLocation returns a URL to which one can send traffic for the specified pod.
 func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
-	// Allow ID as "podname" or "podname:port".  If port is not specified,
-	// try to use the first defined port on the pod.
-	name, port, valid := util.SplitPort(id)
+	// Allow ID as "podname" or "podname:port" or "scheme:podname:port".
+	// If port is not specified, try to use the first defined port on the pod.
+	scheme, name, port, valid := util.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid pod request %q", id))
 	}
@@ -209,15 +217,15 @@ func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.U
 		}
 	}
 
-	// We leave off the scheme ('http://') because we have no idea what sort of server
-	// is listening at this endpoint.
-	loc := &url.URL{}
+	loc := &url.URL{
+		Scheme: scheme,
+	}
 	if port == "" {
 		loc.Host = pod.Status.PodIP
 	} else {
 		loc.Host = net.JoinHostPort(pod.Status.PodIP, port)
 	}
-	return loc, nil, nil
+	return loc, PodProxyTransport, nil
 }
 
 // LogLocation returns the log URL for a pod container. If opts.Container is blank

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net"
@@ -47,23 +46,18 @@ type REST struct {
 	endpoints        endpoint.Registry
 	serviceIPs       ipallocator.Interface
 	serviceNodePorts portallocator.Interface
+	proxyTransport   http.RoundTripper
 }
-
-// ServiceProxyTransport is used by the API proxy to connect to services
-// Exported to allow overriding TLS options (like adding a client certificate)
-var ServiceProxyTransport = util.SetTransportDefaults(&http.Transport{
-	// Turn off hostname verification, because connections are to assigned IPs, not deterministic
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-})
 
 // NewStorage returns a new REST.
 func NewStorage(registry Registry, endpoints endpoint.Registry, serviceIPs ipallocator.Interface,
-	serviceNodePorts portallocator.Interface) *REST {
+	serviceNodePorts portallocator.Interface, proxyTransport http.RoundTripper) *REST {
 	return &REST{
 		registry:         registry,
 		endpoints:        endpoints,
 		serviceIPs:       serviceIPs,
 		serviceNodePorts: serviceNodePorts,
+		proxyTransport:   proxyTransport,
 	}
 }
 
@@ -310,7 +304,7 @@ func (rs *REST) ResourceLocation(ctx api.Context, id string) (*url.URL, http.Rou
 				return &url.URL{
 					Scheme: svcScheme,
 					Host:   net.JoinHostPort(ip, strconv.Itoa(port)),
-				}, ServiceProxyTransport, nil
+				}, rs.proxyTransport, nil
 			}
 		}
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest.go
@@ -17,6 +17,7 @@ limitations under the License.
 package service
 
 import (
+	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net"
@@ -47,6 +48,13 @@ type REST struct {
 	serviceIPs       ipallocator.Interface
 	serviceNodePorts portallocator.Interface
 }
+
+// ServiceProxyTransport is used by the API proxy to connect to services
+// Exported to allow overriding TLS options (like adding a client certificate)
+var ServiceProxyTransport = util.SetTransportDefaults(&http.Transport{
+	// Turn off hostname verification, because connections are to assigned IPs, not deterministic
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+})
 
 // NewStorage returns a new REST.
 func NewStorage(registry Registry, endpoints endpoint.Registry, serviceIPs ipallocator.Interface,
@@ -276,8 +284,8 @@ var _ = rest.Redirector(&REST{})
 
 // ResourceLocation returns a URL to which one can send traffic for the specified service.
 func (rs *REST) ResourceLocation(ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
-	// Allow ID as "svcname" or "svcname:port".
-	svcName, portStr, valid := util.SplitPort(id)
+	// Allow ID as "svcname", "svcname:port", or "scheme:svcname:port".
+	svcScheme, svcName, portStr, valid := util.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid service request %q", id))
 	}
@@ -299,11 +307,10 @@ func (rs *REST) ResourceLocation(ctx api.Context, id string) (*url.URL, http.Rou
 				// Pick a random address.
 				ip := ss.Addresses[rand.Intn(len(ss.Addresses))].IP
 				port := ss.Ports[i].Port
-				// We leave off the scheme ('http://') because we have no idea what sort of server
-				// is listening at this endpoint.
 				return &url.URL{
-					Host: net.JoinHostPort(ip, strconv.Itoa(port)),
-				}, nil, nil
+					Scheme: svcScheme,
+					Host:   net.JoinHostPort(ip, strconv.Itoa(port)),
+				}, ServiceProxyTransport, nil
 			}
 		}
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest_test.go
@@ -475,6 +475,18 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", e, a)
 	}
 
+	// Test a scheme + name + port.
+	location, _, err = redirector.ResourceLocation(ctx, "https:foo:p")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if location == nil {
+		t.Errorf("Unexpected nil: %v", location)
+	}
+	if e, a := "https://1.2.3.4:93", location.String(); e != a {
+		t.Errorf("Expected %v, but got %v", e, a)
+	}
+
 	// Test a non-existent name + port.
 	location, _, err = redirector.ResourceLocation(ctx, "foo:q")
 	if err == nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/service/rest_test.go
@@ -46,7 +46,7 @@ func NewTestREST(t *testing.T, endpoints *api.EndpointsList) (*REST, *registryte
 	portRange := util.PortRange{Base: 30000, Size: 1000}
 	portAllocator := portallocator.NewPortAllocator(portRange)
 
-	storage := NewStorage(registry, endpointRegistry, r, portAllocator)
+	storage := NewStorage(registry, endpointRegistry, r, portAllocator, nil)
 
 	return storage, registry
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/http.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/http.go
@@ -17,7 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"crypto/tls"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -61,4 +64,41 @@ func SetTransportDefaults(t *http.Transport) *http.Transport {
 		t.TLSHandshakeTimeout = defaultTransport.TLSHandshakeTimeout
 	}
 	return t
+}
+
+type RoundTripperWrapper interface {
+	http.RoundTripper
+	WrappedRoundTripper() http.RoundTripper
+}
+
+type DialFunc func(net, addr string) (net.Conn, error)
+
+func Dialer(transport http.RoundTripper) (DialFunc, error) {
+	if transport == nil {
+		return nil, nil
+	}
+
+	switch transport := transport.(type) {
+	case *http.Transport:
+		return transport.Dial, nil
+	case RoundTripperWrapper:
+		return Dialer(transport.WrappedRoundTripper())
+	default:
+		return nil, fmt.Errorf("unknown transport type: %v", transport)
+	}
+}
+
+func TLSClientConfig(transport http.RoundTripper) (*tls.Config, error) {
+	if transport == nil {
+		return nil, nil
+	}
+
+	switch transport := transport.(type) {
+	case *http.Transport:
+		return transport.TLSClientConfig, nil
+	case RoundTripperWrapper:
+		return TLSClientConfig(transport.WrappedRoundTripper())
+	default:
+		return nil, fmt.Errorf("unknown transport type: %v", transport)
+	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper.go
@@ -86,6 +86,11 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return nil, err
 	}
 
+	// Return if we were configured to skip validation
+	if s.tlsConfig != nil && s.tlsConfig.InsecureSkipVerify {
+		return conn, nil
+	}
+
 	host, _, err := net.SplitHostPort(dialAddr)
 	if err != nil {
 		return nil, err

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -17,64 +17,97 @@ limitations under the License.
 package spdy
 
 import (
-	"bytes"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"io"
-	"math/big"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"k8s.io/kubernetes/pkg/util/httpstream"
 )
 
 func TestRoundTripAndNewConnection(t *testing.T) {
-	testCases := []struct {
+
+	localhostPool := x509.NewCertPool()
+	if !localhostPool.AppendCertsFromPEM(localhostCert) {
+		t.Errorf("error setting up localhostCert pool")
+	}
+
+	testCases := map[string]struct {
+		serverFunc             func(http.Handler) *httptest.Server
+		clientTLS              *tls.Config
 		serverConnectionHeader string
 		serverUpgradeHeader    string
-		useTLS                 bool
 		shouldError            bool
 	}{
-		{
+		"no headers": {
+			serverFunc:             httptest.NewServer,
 			serverConnectionHeader: "",
 			serverUpgradeHeader:    "",
 			shouldError:            true,
 		},
-		{
+		"no upgrade header": {
+			serverFunc:             httptest.NewServer,
 			serverConnectionHeader: "Upgrade",
 			serverUpgradeHeader:    "",
 			shouldError:            true,
 		},
-		{
+		"no connection header": {
+			serverFunc:             httptest.NewServer,
 			serverConnectionHeader: "",
 			serverUpgradeHeader:    "SPDY/3.1",
 			shouldError:            true,
 		},
-		{
+		"http": {
+			serverFunc:             httptest.NewServer,
 			serverConnectionHeader: "Upgrade",
 			serverUpgradeHeader:    "SPDY/3.1",
 			shouldError:            false,
 		},
-		{
+		"https (invalid hostname + InsecureSkipVerify)": {
+			serverFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+				if err != nil {
+					t.Errorf("https (invalid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			clientTLS:              &tls.Config{InsecureSkipVerify: true},
 			serverConnectionHeader: "Upgrade",
 			serverUpgradeHeader:    "SPDY/3.1",
-			useTLS:                 true,
+			shouldError:            false,
+		},
+		"https (valid hostname + RootCAs)": {
+			serverFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			clientTLS:              &tls.Config{RootCAs: localhostPool},
+			serverConnectionHeader: "Upgrade",
+			serverUpgradeHeader:    "SPDY/3.1",
 			shouldError:            false,
 		},
 	}
 
-	for i, testCase := range testCases {
-		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	for k, testCase := range testCases {
+		server := testCase.serverFunc(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if testCase.shouldError {
 				if e, a := httpstream.HeaderUpgrade, req.Header.Get(httpstream.HeaderConnection); e != a {
-					t.Fatalf("%d: Expected connection=upgrade header, got '%s", i, a)
+					t.Fatalf("%s: Expected connection=upgrade header, got '%s", k, a)
 				}
 
 				w.Header().Set(httpstream.HeaderConnection, testCase.serverConnectionHeader)
@@ -92,102 +125,32 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 				return nil
 			})
 			if spdyConn == nil {
-				t.Fatalf("%d: unexpected nil spdyConn", i)
+				t.Fatalf("%s: unexpected nil spdyConn", k)
 			}
 			defer spdyConn.Close()
 
 			stream := <-streamCh
 			io.Copy(stream, stream)
 		}))
-
-		clientTLS := &tls.Config{}
-
-		if testCase.useTLS {
-			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-			if err != nil {
-				t.Fatalf("%d: error generating keypair: %s", i, err)
-			}
-
-			notBefore := time.Now()
-			notAfter := notBefore.Add(1 * time.Hour)
-
-			template := x509.Certificate{
-				SerialNumber: big.NewInt(1),
-				Subject: pkix.Name{
-					Organization: []string{"Localhost Co"},
-				},
-				NotBefore:             notBefore,
-				NotAfter:              notAfter,
-				KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-				ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-				BasicConstraintsValid: true,
-				IsCA: true,
-			}
-
-			host := "127.0.0.1"
-			if ip := net.ParseIP(host); ip != nil {
-				template.IPAddresses = append(template.IPAddresses, ip)
-			}
-			template.DNSNames = append(template.DNSNames, host)
-
-			derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
-			if err != nil {
-				t.Fatalf("%d: error creating cert: %s", i, err)
-			}
-
-			cert, err := x509.ParseCertificate(derBytes)
-			if err != nil {
-				t.Fatalf("%d: error parsing cert: %s", i, err)
-			}
-
-			roots := x509.NewCertPool()
-			roots.AddCert(cert)
-			server.TLS = &tls.Config{
-				RootCAs: roots,
-			}
-			clientTLS.RootCAs = roots
-
-			certBuf := bytes.Buffer{}
-			err = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
-			if err != nil {
-				t.Fatalf("%d: error encoding cert: %s", i, err)
-			}
-
-			keyBuf := bytes.Buffer{}
-			err = pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-			if err != nil {
-				t.Fatalf("%d: error encoding key: %s", i, err)
-			}
-
-			tlsCert, err := tls.X509KeyPair(certBuf.Bytes(), keyBuf.Bytes())
-			if err != nil {
-				t.Fatalf("%d: error calling tls.X509KeyPair: %s", i, err)
-			}
-			server.TLS.Certificates = []tls.Certificate{tlsCert}
-			clientTLS.Certificates = []tls.Certificate{tlsCert}
-			server.StartTLS()
-		} else {
-			server.Start()
-		}
 		defer server.Close()
 
 		req, err := http.NewRequest("GET", server.URL, nil)
 		if err != nil {
-			t.Fatalf("%d: Error creating request: %s", i, err)
+			t.Fatalf("%s: Error creating request: %s", k, err)
 		}
 
-		spdyTransport := NewRoundTripper(clientTLS)
+		spdyTransport := NewRoundTripper(testCase.clientTLS)
 		client := &http.Client{Transport: spdyTransport}
 
 		resp, err := client.Do(req)
 		if err != nil {
-			t.Fatalf("%d: unexpected error from client.Do: %s", i, err)
+			t.Fatalf("%s: unexpected error from client.Do: %s", k, err)
 		}
 
 		conn, err := spdyTransport.NewConnection(resp)
 		haveErr := err != nil
 		if e, a := testCase.shouldError, haveErr; e != a {
-			t.Fatalf("%d: shouldError=%t, got %t: %v", i, e, a, err)
+			t.Fatalf("%s: shouldError=%t, got %t: %v", k, e, a, err)
 		}
 		if testCase.shouldError {
 			continue
@@ -195,32 +158,79 @@ func TestRoundTripAndNewConnection(t *testing.T) {
 		defer conn.Close()
 
 		if resp.StatusCode != http.StatusSwitchingProtocols {
-			t.Fatalf("%d: expected http 101 switching protocols, got %d", i, resp.StatusCode)
+			t.Fatalf("%s: expected http 101 switching protocols, got %d", k, resp.StatusCode)
 		}
 
 		stream, err := conn.CreateStream(http.Header{})
 		if err != nil {
-			t.Fatalf("%d: error creating client stream: %s", i, err)
+			t.Fatalf("%s: error creating client stream: %s", k, err)
 		}
 
 		n, err := stream.Write([]byte("hello"))
 		if err != nil {
-			t.Fatalf("%d: error writing to stream: %s", i, err)
+			t.Fatalf("%s: error writing to stream: %s", k, err)
 		}
 		if n != 5 {
-			t.Fatalf("%d: Expected to write 5 bytes, but actually wrote %d", i, n)
+			t.Fatalf("%s: Expected to write 5 bytes, but actually wrote %d", k, n)
 		}
 
 		b := make([]byte, 5)
 		n, err = stream.Read(b)
 		if err != nil {
-			t.Fatalf("%d: error reading from stream: %s", i, err)
+			t.Fatalf("%s: error reading from stream: %s", k, err)
 		}
 		if n != 5 {
-			t.Fatalf("%d: Expected to read 5 bytes, but actually read %d", i, n)
+			t.Fatalf("%s: Expected to read 5 bytes, but actually read %d", k, n)
 		}
 		if e, a := "hello", string(b[0:n]); e != a {
-			t.Fatalf("%d: expected '%s', got '%s'", i, e, a)
+			t.Fatalf("%s: expected '%s', got '%s'", k, e, a)
 		}
 	}
 }
+
+// exampleCert was generated from crypto/tls/generate_cert.go with the following command:
+//    go run generate_cert.go  --rsa-bits 512 --host example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBcjCCAR6gAwIBAgIQBOUTYowZaENkZi0faI9DgTALBgkqhkiG9w0BAQswEjEQ
+MA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2MDAw
+MFowEjEQMA4GA1UEChMHQWNtZSBDbzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCZ
+xfR3sgeHBraGFfF/24tTn4PRVAHOf2UOOxSQRs+aYjNqimFqf/SRIblQgeXdBJDR
+gVK5F1Js2zwlehw0bHxRAgMBAAGjUDBOMA4GA1UdDwEB/wQEAwIApDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MBYGA1UdEQQPMA2CC2V4YW1w
+bGUuY29tMAsGCSqGSIb3DQEBCwNBAI/mfBB8dm33IpUl+acSyWfL6gX5Wc0FFyVj
+dKeesE1XBuPX1My/rzU6Oy/YwX7LOL4FaeNUS6bbL4axSLPKYSs=
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAJnF9HeyB4cGtoYV8X/bi1Ofg9FUAc5/ZQ47FJBGz5piM2qKYWp/
+9JEhuVCB5d0EkNGBUrkXUmzbPCV6HDRsfFECAwEAAQJBAJLH9yPuButniACTn5L5
+IJQw1mWQt6zBw9eCo41YWkA0866EgjC53aPZaRjXMp0uNJGdIsys2V5rCOOLWN2C
+ODECIQDICHsi8QQQ9wpuJy8X5l8MAfxHL+DIqI84wQTeVM91FQIhAMTME8A18/7h
+1Ad6drdnxAkuC0tX6Sx0LDozrmen+HFNAiAlcEDrt0RVkIcpOrg7tuhPLQf0oudl
+Zvb3Xlj069awSQIgcT15E/43w2+RASifzVNhQ2MCTr1sSA8lL+xzK+REmnUCIBhQ
+j4139pf8Re1J50zBxS/JlQfgDQi9sO9pYeiHIxNs
+-----END RSA PRIVATE KEY-----`)
+
+// localhostCert was generated from crypto/tls/generate_cert.go with the following command:
+//     go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
+bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
+bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
+IUSdtXdcbItRB/yfXGBhiex00IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEA
+AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
+AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
+Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
+0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
+NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d
+AekCIQDhRQG5Li0Wj8TM4obOnnXUXf1jRv0UkzE9AHWLG5q3AwIhAPzSjpYUDjVW
+MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
+EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
+1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
+-----END RSA PRIVATE KEY-----`)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/port_split.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/port_split.go
@@ -18,23 +18,60 @@ package util
 
 import (
 	"strings"
+
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-// Takes a string of the form "name:port" or "name".
-//  * If id is of the form "name" or "name:", then return (name, "", true)
-//  * If id is of the form "name:port", then return (name, port, true)
-//  * Otherwise, return ("", "", false)
-// Additionally, name must be non-empty or valid will be returned false.
+var validSchemes = sets.NewString("http", "https", "")
+
+// SplitSchemeNamePort takes a string of the following forms:
+//  * "<name>",                 returns "",        "<name>","",      true
+//  * "<name>:<port>",          returns "",        "<name>","<port>",true
+//  * "<scheme>:<name>:<port>", returns "<scheme>","<name>","<port>",true
 //
+// Name must be non-empty or valid will be returned false.
+// Scheme must be "http" or "https" if specified
 // Port is returned as a string, and it is not required to be numeric (could be
 // used for a named port, for example).
-func SplitPort(id string) (name, port string, valid bool) {
+func SplitSchemeNamePort(id string) (scheme, name, port string, valid bool) {
 	parts := strings.Split(id, ":")
-	if len(parts) > 2 {
-		return "", "", false
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		name = parts[0]
+		port = parts[1]
+	case 3:
+		scheme = parts[0]
+		name = parts[1]
+		port = parts[2]
+	default:
+		return "", "", "", false
 	}
-	if len(parts) == 2 {
-		return parts[0], parts[1], len(parts[0]) > 0
+
+	if len(name) > 0 && validSchemes.Has(scheme) {
+		return scheme, name, port, true
+	} else {
+		return "", "", "", false
 	}
-	return id, "", len(id) > 0
+}
+
+// JoinSchemeNamePort returns a string that specifies the scheme, name, and port:
+//  * "<name>"
+//  * "<name>:<port>"
+//  * "<scheme>:<name>:<port>"
+// None of the parameters may contain a ':' character
+// Name is required
+// Scheme must be "", "http", or "https"
+func JoinSchemeNamePort(scheme, name, port string) string {
+	if len(scheme) > 0 {
+		// Must include three segments to specify scheme
+		return scheme + ":" + name + ":" + port
+	}
+	if len(port) > 0 {
+		// Must include two segments to specify port
+		return name + ":" + port
+	}
+	// Return name alone
+	return name
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/dial.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/dial.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/third_party/golang/netutil"
+)
+
+func DialURL(url *url.URL, transport http.RoundTripper) (net.Conn, error) {
+	dialAddr := netutil.CanonicalAddr(url)
+
+	dialer, _ := util.Dialer(transport)
+
+	switch url.Scheme {
+	case "http":
+		if dialer != nil {
+			return dialer("tcp", dialAddr)
+		}
+		return net.Dial("tcp", dialAddr)
+	case "https":
+		// Get the tls config from the transport if we recognize it
+		var tlsConfig *tls.Config
+		var tlsConn *tls.Conn
+		var err error
+		tlsConfig, _ = util.TLSClientConfig(transport)
+
+		if dialer != nil {
+			// We have a dialer; use it to open the connection, then
+			// create a tls client using the connection.
+			netConn, err := dialer("tcp", dialAddr)
+			if err != nil {
+				return nil, err
+			}
+			if tlsConfig == nil {
+				// tls.Client requires non-nil config
+				glog.Warningf("using custom dialer with no TLSClientConfig. Defaulting to InsecureSkipVerify")
+				// tls.Handshake() requires ServerName or InsecureSkipVerify
+				tlsConfig = &tls.Config{
+					InsecureSkipVerify: true,
+				}
+			} else if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
+				// tls.Handshake() requires ServerName or InsecureSkipVerify
+				// infer the ServerName from the hostname we're connecting to.
+				inferredHost := dialAddr
+				if host, _, err := net.SplitHostPort(dialAddr); err == nil {
+					inferredHost = host
+				}
+				// Make a copy to avoid polluting the provided config
+				tlsConfigCopy := *tlsConfig
+				tlsConfigCopy.ServerName = inferredHost
+				tlsConfig = &tlsConfigCopy
+			}
+			tlsConn = tls.Client(netConn, tlsConfig)
+			if err := tlsConn.Handshake(); err != nil {
+				netConn.Close()
+				return nil, err
+			}
+
+		} else {
+			// Dial
+			tlsConn, err = tls.Dial("tcp", dialAddr, tlsConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Return if we were configured to skip validation
+		if tlsConfig != nil && tlsConfig.InsecureSkipVerify {
+			return tlsConn, nil
+		}
+
+		// Verify
+		host, _, _ := net.SplitHostPort(dialAddr)
+		if err := tlsConn.VerifyHostname(host); err != nil {
+			tlsConn.Close()
+			return nil, err
+		}
+
+		return tlsConn, nil
+	default:
+		return nil, fmt.Errorf("Unknown scheme: %s", url.Scheme)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/transport.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/transport.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -116,6 +117,12 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	return t.rewriteResponse(req, resp)
+}
+
+var _ = util.RoundTripperWrapper(&Transport{})
+
+func (rt *Transport) WrappedRoundTripper() http.RoundTripper {
+	return rt.RoundTripper
 }
 
 // rewriteURL rewrites a single URL to go through the proxy, if the URL refers

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -160,6 +160,7 @@ func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 		func() error { return o.createAPIClients(&getSignerCertOptions) },
 		func() error { return o.createEtcdClientCerts(&getSignerCertOptions) },
 		func() error { return o.createKubeletClientCerts(&getSignerCertOptions) },
+		func() error { return o.createProxyClientCerts(&getSignerCertOptions) },
 		func() error { return o.createServiceAccountKeys() },
 	)
 	return utilerrors.NewAggregate(errs)
@@ -196,6 +197,15 @@ func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *SignerC
 
 func (o CreateMasterCertsOptions) createEtcdClientCerts(getSignerCertOptions *SignerCertOptions) error {
 	for _, clientCertInfo := range DefaultEtcdClientCerts(o.CertDir) {
+		if err := o.createClientCert(clientCertInfo, getSignerCertOptions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o CreateMasterCertsOptions) createProxyClientCerts(getSignerCertOptions *SignerCertOptions) error {
+	for _, clientCertInfo := range DefaultProxyClientCerts(o.CertDir) {
 		if err := o.createClientCert(clientCertInfo, getSignerCertOptions); err != nil {
 			return err
 		}

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -72,6 +72,21 @@ func DefaultMasterEtcdClientCertInfo(certDir string) ClientCertInfo {
 	}
 }
 
+func DefaultProxyClientCerts(certDir string) []ClientCertInfo {
+	return []ClientCertInfo{
+		DefaultProxyClientCertInfo(certDir),
+	}
+}
+func DefaultProxyClientCertInfo(certDir string) ClientCertInfo {
+	return ClientCertInfo{
+		CertLocation: configapi.CertInfo{
+			CertFile: path.Join(certDir, MasterFilePrefix+".proxy-client.crt"),
+			KeyFile:  path.Join(certDir, MasterFilePrefix+".proxy-client.key"),
+		},
+		User: bootstrappolicy.MasterProxyUsername,
+	}
+}
+
 func DefaultAPIClientCAFile(certDir string) string {
 	return DefaultRootCAFile(certDir)
 }

--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -195,6 +195,9 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 
 	if config.KubernetesMasterConfig != nil {
 		refs = append(refs, &config.KubernetesMasterConfig.SchedulerConfigFile)
+
+		refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.CertFile)
+		refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.KeyFile)
 	}
 
 	refs = append(refs, &config.ServiceAccountConfig.MasterCA)

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -712,6 +712,10 @@ type KubernetesMasterConfig struct {
 	// PodEvictionTimeout controls grace period for deleting pods on failed nodes.
 	// It takes valid time duration string. If empty, you get the default pod eviction timeout.
 	PodEvictionTimeout string
+
+	// ProxyClientInfo specifies the client cert/key to use when proxying to pods
+	ProxyClientInfo CertInfo
+
 	// APIServerArguments are key value pairs that will be passed directly to the Kube apiserver that match the apiservers's
 	// command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not
 	// start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -689,6 +689,8 @@ type KubernetesMasterConfig struct {
 	// PodEvictionTimeout controls grace period for deleting pods on failed nodes.
 	// It takes valid time duration string. If empty, you get the default pod eviction timeout.
 	PodEvictionTimeout string `json:"podEvictionTimeout"`
+	// ProxyClientInfo specifies the client cert/key to use when proxying to pods
+	ProxyClientInfo CertInfo `json:"proxyClientInfo"`
 	// APIServerArguments are key value pairs that will be passed directly to the Kube apiserver that match the apiservers's
 	// command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not
 	// start. These values may override other settings in KubernetesMasterConfig which may cause invalid configurations.

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -126,6 +126,9 @@ kubernetesMasterConfig:
   masterCount: 0
   masterIP: ""
   podEvictionTimeout: ""
+  proxyClientInfo:
+    certFile: ""
+    keyFile: ""
   schedulerConfigFile: ""
   servicesNodePortRange: ""
   servicesSubnet: ""

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -373,6 +373,11 @@ func ValidateKubernetesMasterConfig(config *api.KubernetesMasterConfig) Validati
 		validationResults.AddErrors(fielderrors.NewFieldInvalid("masterCount", config.MasterCount, "must be a positive integer or -1"))
 	}
 
+	validationResults.AddErrors(ValidateCertInfo(config.ProxyClientInfo, false).Prefix("proxyClientInfo")...)
+	if len(config.ProxyClientInfo.CertFile) == 0 && len(config.ProxyClientInfo.KeyFile) == 0 {
+		validationResults.AddWarnings(fielderrors.NewFieldInvalid("proxyClientInfo", "", "if no client certificate is specified, TLS pods and services cannot validate requests came from the proxy"))
+	}
+
 	if len(config.ServicesSubnet) > 0 {
 		if _, _, err := net.ParseCIDR(strings.TrimSpace(config.ServicesSubnet)); err != nil {
 			validationResults.AddErrors(fielderrors.NewFieldInvalid("servicesSubnet", config.ServicesSubnet, "must be a valid CIDR notation IP range (e.g. 172.30.0.0/16)"))

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -24,6 +24,11 @@ const (
 	RouterUsername   = "system:" + RouterUnqualifiedUsername
 	RegistryUsername = "system:" + RegistryUnqualifiedUsername
 
+	// Not granted any API permissions, just an identity for a client certificate for the API proxy to use
+	// Should not be changed without considering impact to pods that may be verifying this identity by default
+	MasterProxyUnqualifiedUsername = "master-proxy"
+	MasterProxyUsername            = "system:" + MasterProxyUnqualifiedUsername
+
 	// Previous versions used this as the username for the master to connect to the kubelet
 	// This should remain in the default role bindings for the NodeAdmin role
 	LegacyMasterKubeletAdminClientUsername = "system:master"

--- a/pkg/cmd/server/crypto/crypto.go
+++ b/pkg/cmd/server/crypto/crypto.go
@@ -103,8 +103,11 @@ func GetTLSCertificateConfig(certFile, keyFile string) (*TLSCertificateConfig, e
 }
 
 var (
-	// Default templates to last for a year
-	lifetime = time.Hour * 24 * 365
+	// Default ca certs to be long-lived
+	caLifetime = time.Hour * 24 * 365 * 5
+
+	// Default templates to last for two years
+	lifetime = time.Hour * 24 * 365 * 2
 
 	// Default keys are 2048 bits
 	keyBits = 2048
@@ -312,7 +315,7 @@ func newSigningCertificateTemplate(subject pkix.Name) (*x509.Certificate, error)
 		SignatureAlgorithm: x509.SHA256WithRSA,
 
 		NotBefore:    time.Now().Add(-1 * time.Second),
-		NotAfter:     time.Now().Add(lifetime),
+		NotAfter:     time.Now().Add(caLifetime),
 		SerialNumber: big.NewInt(1),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -415,6 +415,7 @@ func (args MasterArgs) BuildSerializeableKubeMasterConfig() (*configapi.Kubernet
 		ServicesSubnet:      args.NetworkArgs.ServiceNetworkCIDR,
 		StaticNodeNames:     staticNodeList.List(),
 		SchedulerConfigFile: args.SchedulerConfigFile,
+		ProxyClientInfo:     admin.DefaultProxyClientCertInfo(args.ConfigDir.Value()).CertLocation,
 	}
 
 	return config, nil


### PR DESCRIPTION
**Adds the ability to proxy to pods and services which are serving TLS through the API proxy:**

* .../proxy/nodes/**https:**nodename:port/path/to/proxy
* .../proxy/namespace/foo/services/**https:**servicename:port-name/path/to/proxy
* .../proxy/namespace/foo/pods/**https:**podname:port/path/to/proxy
* .../namespace/foo/pods/**https:**podname:port/proxy/path/to/proxy

**Adds the ability for TLS backends to validate requests are via the API proxy:**

A configuration option in `master-config.yaml` allows setting a client cert for the proxy to present when proxying using TLS:
```
kubernetesMasterConfig:
  ...
  proxyClientInfo:
    certFile: "path/to/client-cert.crt"
    keyFile: "path/to/client-cert.key"
```

**Default client cert info for API proxy**:
When running `openshift start` or `openshift start --write-config=...`, a client certificate is signed by the generated CA (and available to pods in the service account CA bundle), with the RDN **cn=system:master-proxy**

Fixes #4497
Incidentally fixes #5002

**TODO:**
- [ ] open doc issue
- [ ] open ansible issue