### PR TITLE
Introduce group controls to SCC

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -1806,6 +1806,42 @@ func deepCopy_api_SELinuxOptions(in SELinuxOptions, out *SELinuxOptions, c *conv
 	return nil
 }
 
+func deepCopy_api_SupplementalGroupsStrategyOptions(in SupplementalGroupsStrategyOptions, out *SupplementalGroupsStrategyOptions, c *conversion.Cloner) error {
+	out.Type = in.Type
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := deepCopy_api_IDRange(in.Ranges[i], &out.Ranges[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func deepCopy_api_FSGroupStrategyOptions(in FSGroupStrategyOptions, out *FSGroupStrategyOptions, c *conversion.Cloner) error {
+	out.Type = in.Type
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := deepCopy_api_IDRange(in.Ranges[i], &out.Ranges[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func deepCopy_api_IDRange(in IDRange, out *IDRange, c *conversion.Cloner) error {
+	out.Max = in.Max
+	out.Min = in.Min
+	return nil
+}
+
 func deepCopy_api_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
 	if err := deepCopy_api_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1910,6 +1946,12 @@ func deepCopy_api_SecurityContextConstraints(in SecurityContextConstraints, out 
 		return err
 	}
 	if err := deepCopy_api_RunAsUserStrategyOptions(in.RunAsUser, &out.RunAsUser, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_FSGroupStrategyOptions(in.FSGroup, &out.FSGroup, c); err != nil {
+		return err
+	}
+	if err := deepCopy_api_SupplementalGroupsStrategyOptions(in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -2353,12 +2395,14 @@ func init() {
 		deepCopy_api_EventList,
 		deepCopy_api_EventSource,
 		deepCopy_api_ExecAction,
+		deepCopy_api_FSGroupStrategyOptions,
 		deepCopy_api_GCEPersistentDiskVolumeSource,
 		deepCopy_api_GitRepoVolumeSource,
 		deepCopy_api_GlusterfsVolumeSource,
 		deepCopy_api_HTTPGetAction,
 		deepCopy_api_Handler,
 		deepCopy_api_HostPathVolumeSource,
+		deepCopy_api_IDRange,
 		deepCopy_api_ISCSIVolumeSource,
 		deepCopy_api_Lifecycle,
 		deepCopy_api_LimitRange,
@@ -2441,6 +2485,7 @@ func init() {
 		deepCopy_api_Status,
 		deepCopy_api_StatusCause,
 		deepCopy_api_StatusDetails,
+		deepCopy_api_SupplementalGroupsStrategyOptions,
 		deepCopy_api_TCPSocketAction,
 		deepCopy_api_TypeMeta,
 		deepCopy_api_Volume,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
@@ -362,6 +362,10 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			scc.RunAsUser.Type = userTypes[c.Rand.Intn(len(userTypes))]
 			seLinuxTypes := []api.SELinuxContextStrategyType{api.SELinuxStrategyRunAsAny, api.SELinuxStrategyMustRunAs}
 			scc.SELinuxContext.Type = seLinuxTypes[c.Rand.Intn(len(seLinuxTypes))]
+			supGroupTypes := []api.SupplementalGroupsStrategyType{api.SupplementalGroupsStrategyMustRunAs, api.SupplementalGroupsStrategyMustRunAs}
+			scc.SupplementalGroups.Type = supGroupTypes[c.Rand.Intn(len(supGroupTypes))]
+			fsGroupTypes := []api.FSGroupStrategyType{api.FSGroupStrategyMustRunAs, api.FSGroupStrategyRunAsAny}
+			scc.FSGroup.Type = fsGroupTypes[c.Rand.Intn(len(fsGroupTypes))]
 		},
 	)
 	return f

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2284,6 +2284,10 @@ type SecurityContextConstraints struct {
 	SELinuxContext SELinuxContextStrategyOptions
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
 	RunAsUser RunAsUserStrategyOptions
+	// SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+	SupplementalGroups SupplementalGroupsStrategyOptions
+	// FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+	FSGroup FSGroupStrategyOptions
 
 	// The users who have permissions to use this security context constraints
 	Users []string
@@ -2312,6 +2316,33 @@ type RunAsUserStrategyOptions struct {
 	UIDRangeMax *int64
 }
 
+// FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+type FSGroupStrategyOptions struct {
+	// Type is the strategy that will dictate what FSGroup is used in the SecurityContext.
+	Type FSGroupStrategyType
+	// Ranges are the allowed ranges of fs groups.  If you would like to force a single
+	// fs group then supply a single range with the same start and end.
+	Ranges []IDRange
+}
+
+// SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+type SupplementalGroupsStrategyOptions struct {
+	// Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+	Type SupplementalGroupsStrategyType
+	// Ranges are the allowed ranges of supplemental groups.  If you would like to force a single
+	// supplemental group then supply a single range with the same start and end.
+	Ranges []IDRange
+}
+
+// IDRange provides a min/max of an allowed range of IDs.
+// TODO: this could be reused for UIDs.
+type IDRange struct {
+	// Min is the start of the range, inclusive.
+	Min int64
+	// Max is the end of the range, inclusive.
+	Max int64
+}
+
 // SELinuxContextStrategyType denotes strategy types for generating SELinux options for a
 // SecurityContext
 type SELinuxContextStrategyType string
@@ -2319,6 +2350,14 @@ type SELinuxContextStrategyType string
 // RunAsUserStrategyType denotes strategy types for generating RunAsUser values for a
 // SecurityContext
 type RunAsUserStrategyType string
+
+// SupplementalGroupsStrategyType denotes strategy types for determining valid supplemental
+// groups for a SecurityContext.
+type SupplementalGroupsStrategyType string
+
+// FSGroupStrategyType denotes strategy types for generating FSGroup values for a
+// SecurityContext
+type FSGroupStrategyType string
 
 const (
 	// container must have SELinux labels of X applied.
@@ -2334,6 +2373,16 @@ const (
 	RunAsUserStrategyMustRunAsNonRoot RunAsUserStrategyType = "MustRunAsNonRoot"
 	// container may make requests for any uid.
 	RunAsUserStrategyRunAsAny RunAsUserStrategyType = "RunAsAny"
+
+	// container must have FSGroup of X applied.
+	FSGroupStrategyMustRunAs FSGroupStrategyType = "MustRunAs"
+	// container may make requests for any FSGroup labels.
+	FSGroupStrategyRunAsAny FSGroupStrategyType = "RunAsAny"
+
+	// container must run as a particular gid.
+	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
+	// container may make requests for any gid.
+	SupplementalGroupsrStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // SecurityContextConstraintsList is a list of SecurityContextConstraints objects

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -1940,6 +1940,48 @@ func convert_api_ResourceRequirements_To_v1_ResourceRequirements(in *api.Resourc
 	return nil
 }
 
+func convert_api_FSGroupStrategyOptions_To_v1_FSGroupStrategyOptions(in *api.FSGroupStrategyOptions, out *FSGroupStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.FSGroupStrategyOptions))(in)
+	}
+	out.Type = FSGroupStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_api_IDRange_To_v1_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_api_SupplementalGroupsStrategyOptions_To_v1_SupplementalGroupsStrategyOptions(in *api.SupplementalGroupsStrategyOptions, out *SupplementalGroupsStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.SupplementalGroupsStrategyOptions))(in)
+	}
+	out.Type = SupplementalGroupsStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_api_IDRange_To_v1_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_api_IDRange_To_v1_IDRange(in *api.IDRange, out *IDRange, s conversion.Scope) error {
+	out.Min = in.Min
+	out.Max = in.Max
+	return nil
+}
+
 func convert_api_RunAsUserStrategyOptions_To_v1_RunAsUserStrategyOptions(in *api.RunAsUserStrategyOptions, out *RunAsUserStrategyOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RunAsUserStrategyOptions))(in)
@@ -2112,6 +2154,12 @@ func convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in 
 		return err
 	}
 	if err := convert_api_RunAsUserStrategyOptions_To_v1_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, s); err != nil {
+		return err
+	}
+	if err := convert_api_FSGroupStrategyOptions_To_v1_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, s); err != nil {
+		return err
+	}
+	if err := convert_api_SupplementalGroupsStrategyOptions_To_v1_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -4341,6 +4389,48 @@ func convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *ResourceReq
 	return nil
 }
 
+func convert_v1_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions(in *FSGroupStrategyOptions, out *api.FSGroupStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*FSGroupStrategyOptions))(in)
+	}
+	out.Type = api.FSGroupStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]api.IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_v1_IDRange_To_api_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_v1_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(in *SupplementalGroupsStrategyOptions, out *api.SupplementalGroupsStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*SupplementalGroupsStrategyOptions))(in)
+	}
+	out.Type = api.SupplementalGroupsStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]api.IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_v1_IDRange_To_api_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_v1_IDRange_To_api_IDRange(in *IDRange, out *api.IDRange, s conversion.Scope) error {
+	out.Min = in.Min
+	out.Max = in.Max
+	return nil
+}
+
 func convert_v1_RunAsUserStrategyOptions_To_api_RunAsUserStrategyOptions(in *RunAsUserStrategyOptions, out *api.RunAsUserStrategyOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RunAsUserStrategyOptions))(in)
@@ -4513,6 +4603,12 @@ func convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in 
 		return err
 	}
 	if err := convert_v1_RunAsUserStrategyOptions_To_api_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, s); err != nil {
+		return err
+	}
+	if err := convert_v1_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, s); err != nil {
+		return err
+	}
+	if err := convert_v1_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -4856,12 +4952,14 @@ func init() {
 		convert_api_EventSource_To_v1_EventSource,
 		convert_api_Event_To_v1_Event,
 		convert_api_ExecAction_To_v1_ExecAction,
+		convert_api_FSGroupStrategyOptions_To_v1_FSGroupStrategyOptions,
 		convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource,
 		convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource,
 		convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource,
 		convert_api_HTTPGetAction_To_v1_HTTPGetAction,
 		convert_api_Handler_To_v1_Handler,
 		convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource,
+		convert_api_IDRange_To_v1_IDRange,
 		convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource,
 		convert_api_Lifecycle_To_v1_Lifecycle,
 		convert_api_LimitRangeItem_To_v1_LimitRangeItem,
@@ -4942,6 +5040,7 @@ func init() {
 		convert_api_StatusCause_To_v1_StatusCause,
 		convert_api_StatusDetails_To_v1_StatusDetails,
 		convert_api_Status_To_v1_Status,
+		convert_api_SupplementalGroupsStrategyOptions_To_v1_SupplementalGroupsStrategyOptions,
 		convert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		convert_api_TypeMeta_To_v1_TypeMeta,
 		convert_api_VolumeMount_To_v1_VolumeMount,
@@ -4976,12 +5075,14 @@ func init() {
 		convert_v1_EventSource_To_api_EventSource,
 		convert_v1_Event_To_api_Event,
 		convert_v1_ExecAction_To_api_ExecAction,
+		convert_v1_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions,
 		convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
 		convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
 		convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
 		convert_v1_HTTPGetAction_To_api_HTTPGetAction,
 		convert_v1_Handler_To_api_Handler,
 		convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource,
+		convert_v1_IDRange_To_api_IDRange,
 		convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
 		convert_v1_Lifecycle_To_api_Lifecycle,
 		convert_v1_LimitRangeItem_To_api_LimitRangeItem,
@@ -5062,6 +5163,7 @@ func init() {
 		convert_v1_StatusCause_To_api_StatusCause,
 		convert_v1_StatusDetails_To_api_StatusDetails,
 		convert_v1_Status_To_api_Status,
+		convert_v1_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions,
 		convert_v1_TCPSocketAction_To_api_TCPSocketAction,
 		convert_v1_TypeMeta_To_api_TypeMeta,
 		convert_v1_VolumeMount_To_api_VolumeMount,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1835,6 +1835,42 @@ func deepCopy_v1_SELinuxOptions(in SELinuxOptions, out *SELinuxOptions, c *conve
 	return nil
 }
 
+func deepCopy_v1_SupplementalGroupsStrategyOptions(in SupplementalGroupsStrategyOptions, out *SupplementalGroupsStrategyOptions, c *conversion.Cloner) error {
+	out.Type = in.Type
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := deepCopy_v1_IDRange(in.Ranges[i], &out.Ranges[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_FSGroupStrategyOptions(in FSGroupStrategyOptions, out *FSGroupStrategyOptions, c *conversion.Cloner) error {
+	out.Type = in.Type
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := deepCopy_v1_IDRange(in.Ranges[i], &out.Ranges[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func deepCopy_v1_IDRange(in IDRange, out *IDRange, c *conversion.Cloner) error {
+	out.Max = in.Max
+	out.Min = in.Min
+	return nil
+}
+
 func deepCopy_v1_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
 	if err := deepCopy_v1_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1939,6 +1975,12 @@ func deepCopy_v1_SecurityContextConstraints(in SecurityContextConstraints, out *
 		return err
 	}
 	if err := deepCopy_v1_RunAsUserStrategyOptions(in.RunAsUser, &out.RunAsUser, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_FSGroupStrategyOptions(in.FSGroup, &out.FSGroup, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1_SupplementalGroupsStrategyOptions(in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -2390,12 +2432,14 @@ func init() {
 		deepCopy_v1_EventList,
 		deepCopy_v1_EventSource,
 		deepCopy_v1_ExecAction,
+		deepCopy_v1_FSGroupStrategyOptions,
 		deepCopy_v1_GCEPersistentDiskVolumeSource,
 		deepCopy_v1_GitRepoVolumeSource,
 		deepCopy_v1_GlusterfsVolumeSource,
 		deepCopy_v1_HTTPGetAction,
 		deepCopy_v1_Handler,
 		deepCopy_v1_HostPathVolumeSource,
+		deepCopy_v1_IDRange,
 		deepCopy_v1_ISCSIVolumeSource,
 		deepCopy_v1_Lifecycle,
 		deepCopy_v1_LimitRange,
@@ -2480,6 +2524,7 @@ func init() {
 		deepCopy_v1_Status,
 		deepCopy_v1_StatusCause,
 		deepCopy_v1_StatusDetails,
+		deepCopy_v1_SupplementalGroupsStrategyOptions,
 		deepCopy_v1_TCPSocketAction,
 		deepCopy_v1_TypeMeta,
 		deepCopy_v1_Volume,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -2703,6 +2703,10 @@ type SecurityContextConstraints struct {
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
 	RunAsUser RunAsUserStrategyOptions `json:"runAsUser,omitempty" description:"strategy used to generate RunAsUser"`
+	// SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+	SupplementalGroups SupplementalGroupsStrategyOptions `json:"supplementalGroups,omitempty" description:"strategy used to generate supplemental groups"`
+	// FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+	FSGroup FSGroupStrategyOptions `json:"fsGroup,omitempty" description:"strategy used to generate fsGroup"`
 
 	// The users who have permissions to use this security context constraints
 	Users []string `json:"users,omitempty" description:"users allowed to use this SecurityContextConstraints"`
@@ -2731,6 +2735,33 @@ type RunAsUserStrategyOptions struct {
 	UIDRangeMax *int64 `json:"uidRangeMax,omitempty" description:"max value for range based allocators"`
 }
 
+// FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+type FSGroupStrategyOptions struct {
+	// Type is the strategy that will dictate what FSGroup is used in the SecurityContext.
+	Type FSGroupStrategyType `json:"type,omitempty" description:"strategy used to generate fsGroup"`
+	// Ranges are the allowed ranges of fs groups.  If you would like to force a single
+	// fs group then supply a single range with the same start and end.
+	Ranges []IDRange `json:"ranges,omitempty" description:"ranges of allowable IDs for fsGroup"`
+}
+
+// SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+type SupplementalGroupsStrategyOptions struct {
+	// Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+	Type SupplementalGroupsStrategyType `json:"type,omitempty" description:"strategy used to generate supplemental groups"`
+	// Ranges are the allowed ranges of supplemental groups.  If you would like to force a single
+	// supplemental group then supply a single range with the same start and end.
+	Ranges []IDRange `json:"ranges,omitempty" description:"ranges of allowable IDs for supplemental groups"`
+}
+
+// IDRange provides a min/max of an allowed range of IDs.
+// TODO: this could be reused for UIDs.
+type IDRange struct {
+	// Min is the start of the range, inclusive.
+	Min int64 `json:"min,omitempty" description:"min value for the range"`
+	// Max is the end of the range, inclusive.
+	Max int64 `json:"max,omitempty" description:"min value for the range"`
+}
+
 // SELinuxContextStrategyType denotes strategy types for generating SELinux options for a
 // SecurityContext
 type SELinuxContextStrategyType string
@@ -2738,6 +2769,14 @@ type SELinuxContextStrategyType string
 // RunAsUserStrategyType denotes strategy types for generating RunAsUser values for a
 // SecurityContext
 type RunAsUserStrategyType string
+
+// SupplementalGroupsStrategyType denotes strategy types for determining valid supplemental
+// groups for a SecurityContext.
+type SupplementalGroupsStrategyType string
+
+// FSGroupStrategyType denotes strategy types for generating FSGroup values for a
+// SecurityContext
+type FSGroupStrategyType string
 
 const (
 	// container must have SELinux labels of X applied.
@@ -2753,6 +2792,16 @@ const (
 	RunAsUserStrategyMustRunAsNonRoot RunAsUserStrategyType = "MustRunAsNonRoot"
 	// container may make requests for any uid.
 	RunAsUserStrategyRunAsAny RunAsUserStrategyType = "RunAsAny"
+
+	// container must have FSGroup of X applied.
+	FSGroupStrategyMustRunAs FSGroupStrategyType = "MustRunAs"
+	// container may make requests for any FSGroup labels.
+	FSGroupStrategyRunAsAny FSGroupStrategyType = "RunAsAny"
+
+	// container must run as a particular gid.
+	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
+	// container may make requests for any gid.
+	SupplementalGroupsrStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // SecurityContextConstraintsList is a list of SecurityContextConstraints objects

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -1780,6 +1780,48 @@ func convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(in *api.Re
 	return nil
 }
 
+func convert_api_FSGroupStrategyOptions_To_v1beta3_FSGroupStrategyOptions(in *api.FSGroupStrategyOptions, out *FSGroupStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.FSGroupStrategyOptions))(in)
+	}
+	out.Type = FSGroupStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_api_IDRange_To_v1beta3_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_api_SupplementalGroupsStrategyOptions_To_v1beta3_SupplementalGroupsStrategyOptions(in *api.SupplementalGroupsStrategyOptions, out *SupplementalGroupsStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.SupplementalGroupsStrategyOptions))(in)
+	}
+	out.Type = SupplementalGroupsStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_api_IDRange_To_v1beta3_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_api_IDRange_To_v1beta3_IDRange(in *api.IDRange, out *IDRange, s conversion.Scope) error {
+	out.Min = in.Min
+	out.Max = in.Max
+	return nil
+}
+
 func convert_api_RunAsUserStrategyOptions_To_v1beta3_RunAsUserStrategyOptions(in *api.RunAsUserStrategyOptions, out *RunAsUserStrategyOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.RunAsUserStrategyOptions))(in)
@@ -1952,6 +1994,12 @@ func convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraint
 		return err
 	}
 	if err := convert_api_RunAsUserStrategyOptions_To_v1beta3_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, s); err != nil {
+		return err
+	}
+	if err := convert_api_FSGroupStrategyOptions_To_v1beta3_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, s); err != nil {
+		return err
+	}
+	if err := convert_api_SupplementalGroupsStrategyOptions_To_v1beta3_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -3950,6 +3998,48 @@ func convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(in *Resour
 	return nil
 }
 
+func convert_v1beta3_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions(in *FSGroupStrategyOptions, out *api.FSGroupStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*FSGroupStrategyOptions))(in)
+	}
+	out.Type = api.FSGroupStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]api.IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_v1beta3_IDRange_To_api_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(in *SupplementalGroupsStrategyOptions, out *api.SupplementalGroupsStrategyOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*SupplementalGroupsStrategyOptions))(in)
+	}
+	out.Type = api.SupplementalGroupsStrategyType(in.Type)
+	if in.Ranges != nil {
+		out.Ranges = make([]api.IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := convert_v1beta3_IDRange_To_api_IDRange(&in.Ranges[i], &out.Ranges[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_IDRange_To_api_IDRange(in *IDRange, out *api.IDRange, s conversion.Scope) error {
+	out.Min = in.Min
+	out.Max = in.Max
+	return nil
+}
+
 func convert_v1beta3_RunAsUserStrategyOptions_To_api_RunAsUserStrategyOptions(in *RunAsUserStrategyOptions, out *api.RunAsUserStrategyOptions, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RunAsUserStrategyOptions))(in)
@@ -4122,6 +4212,12 @@ func convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraint
 		return err
 	}
 	if err := convert_v1beta3_RunAsUserStrategyOptions_To_api_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -4395,12 +4491,14 @@ func init() {
 		convert_api_EventSource_To_v1beta3_EventSource,
 		convert_api_Event_To_v1beta3_Event,
 		convert_api_ExecAction_To_v1beta3_ExecAction,
+		convert_api_FSGroupStrategyOptions_To_v1beta3_FSGroupStrategyOptions,
 		convert_api_GCEPersistentDiskVolumeSource_To_v1beta3_GCEPersistentDiskVolumeSource,
 		convert_api_GitRepoVolumeSource_To_v1beta3_GitRepoVolumeSource,
 		convert_api_GlusterfsVolumeSource_To_v1beta3_GlusterfsVolumeSource,
 		convert_api_HTTPGetAction_To_v1beta3_HTTPGetAction,
 		convert_api_Handler_To_v1beta3_Handler,
 		convert_api_HostPathVolumeSource_To_v1beta3_HostPathVolumeSource,
+		convert_api_IDRange_To_v1beta3_IDRange,
 		convert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource,
 		convert_api_Lifecycle_To_v1beta3_Lifecycle,
 		convert_api_LimitRangeItem_To_v1beta3_LimitRangeItem,
@@ -4477,6 +4575,7 @@ func init() {
 		convert_api_ServiceStatus_To_v1beta3_ServiceStatus,
 		convert_api_Service_To_v1beta3_Service,
 		convert_api_Status_To_v1beta3_Status,
+		convert_api_SupplementalGroupsStrategyOptions_To_v1beta3_SupplementalGroupsStrategyOptions,
 		convert_api_TCPSocketAction_To_v1beta3_TCPSocketAction,
 		convert_api_TypeMeta_To_v1beta3_TypeMeta,
 		convert_api_VolumeMount_To_v1beta3_VolumeMount,
@@ -4508,12 +4607,14 @@ func init() {
 		convert_v1beta3_EventSource_To_api_EventSource,
 		convert_v1beta3_Event_To_api_Event,
 		convert_v1beta3_ExecAction_To_api_ExecAction,
+		convert_v1beta3_FSGroupStrategyOptions_To_api_FSGroupStrategyOptions,
 		convert_v1beta3_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
 		convert_v1beta3_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
 		convert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
 		convert_v1beta3_HTTPGetAction_To_api_HTTPGetAction,
 		convert_v1beta3_Handler_To_api_Handler,
 		convert_v1beta3_HostPathVolumeSource_To_api_HostPathVolumeSource,
+		convert_v1beta3_IDRange_To_api_IDRange,
 		convert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
 		convert_v1beta3_Lifecycle_To_api_Lifecycle,
 		convert_v1beta3_LimitRangeItem_To_api_LimitRangeItem,
@@ -4590,6 +4691,7 @@ func init() {
 		convert_v1beta3_ServiceStatus_To_api_ServiceStatus,
 		convert_v1beta3_Service_To_api_Service,
 		convert_v1beta3_Status_To_api_Status,
+		convert_v1beta3_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions,
 		convert_v1beta3_TCPSocketAction_To_api_TCPSocketAction,
 		convert_v1beta3_TypeMeta_To_api_TypeMeta,
 		convert_v1beta3_VolumeMount_To_api_VolumeMount,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
@@ -1823,6 +1823,42 @@ func deepCopy_v1beta3_SELinuxOptions(in SELinuxOptions, out *SELinuxOptions, c *
 	return nil
 }
 
+func deepCopy_v1beta3_SupplementalGroupsStrategyOptions(in SupplementalGroupsStrategyOptions, out *SupplementalGroupsStrategyOptions, c *conversion.Cloner) error {
+	out.Type = in.Type
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := deepCopy_v1beta3_IDRange(in.Ranges[i], &out.Ranges[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_FSGroupStrategyOptions(in FSGroupStrategyOptions, out *FSGroupStrategyOptions, c *conversion.Cloner) error {
+	out.Type = in.Type
+	if in.Ranges != nil {
+		out.Ranges = make([]IDRange, len(in.Ranges))
+		for i := range in.Ranges {
+			if err := deepCopy_v1beta3_IDRange(in.Ranges[i], &out.Ranges[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ranges = nil
+	}
+	return nil
+}
+
+func deepCopy_v1beta3_IDRange(in IDRange, out *IDRange, c *conversion.Cloner) error {
+	out.Max = in.Max
+	out.Min = in.Min
+	return nil
+}
+
 func deepCopy_v1beta3_Secret(in Secret, out *Secret, c *conversion.Cloner) error {
 	if err := deepCopy_v1beta3_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1927,6 +1963,12 @@ func deepCopy_v1beta3_SecurityContextConstraints(in SecurityContextConstraints, 
 		return err
 	}
 	if err := deepCopy_v1beta3_RunAsUserStrategyOptions(in.RunAsUser, &out.RunAsUser, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_FSGroupStrategyOptions(in.FSGroup, &out.FSGroup, c); err != nil {
+		return err
+	}
+	if err := deepCopy_v1beta3_SupplementalGroupsStrategyOptions(in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 		return err
 	}
 	if in.Users != nil {
@@ -2375,12 +2417,14 @@ func init() {
 		deepCopy_v1beta3_EventList,
 		deepCopy_v1beta3_EventSource,
 		deepCopy_v1beta3_ExecAction,
+		deepCopy_v1beta3_FSGroupStrategyOptions,
 		deepCopy_v1beta3_GCEPersistentDiskVolumeSource,
 		deepCopy_v1beta3_GitRepoVolumeSource,
 		deepCopy_v1beta3_GlusterfsVolumeSource,
 		deepCopy_v1beta3_HTTPGetAction,
 		deepCopy_v1beta3_Handler,
 		deepCopy_v1beta3_HostPathVolumeSource,
+		deepCopy_v1beta3_IDRange,
 		deepCopy_v1beta3_ISCSIVolumeSource,
 		deepCopy_v1beta3_Lifecycle,
 		deepCopy_v1beta3_LimitRange,
@@ -2464,6 +2508,7 @@ func init() {
 		deepCopy_v1beta3_Status,
 		deepCopy_v1beta3_StatusCause,
 		deepCopy_v1beta3_StatusDetails,
+		deepCopy_v1beta3_SupplementalGroupsStrategyOptions,
 		deepCopy_v1beta3_TCPSocketAction,
 		deepCopy_v1beta3_TypeMeta,
 		deepCopy_v1beta3_Volume,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -2099,6 +2099,10 @@ type SecurityContextConstraints struct {
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
 	RunAsUser RunAsUserStrategyOptions `json:"runAsUser,omitempty" description:"strategy used to generate RunAsUser"`
+	// SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+	SupplementalGroups SupplementalGroupsStrategyOptions `json:"supplementalGroups,omitempty" description:"strategy used to generate supplemental groups"`
+	// FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+	FSGroup FSGroupStrategyOptions `json:"fsGroup,omitempty" description:"strategy used to generate fsGroup"`
 
 	// The users who have permissions to use this security context constraints
 	Users []string `json:"users,omitempty" description:"users allowed to use this SecurityContextConstraints"`
@@ -2127,6 +2131,33 @@ type RunAsUserStrategyOptions struct {
 	UIDRangeMax *int64 `json:"uidRangeMax,omitempty" description:"max value for range based allocators"`
 }
 
+// FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+type FSGroupStrategyOptions struct {
+	// Type is the strategy that will dictate what FSGroup is used in the SecurityContext.
+	Type FSGroupStrategyType `json:"type,omitempty" description:"strategy used to generate fsGroup"`
+	// Ranges are the allowed ranges of fs groups.  If you would like to force a single
+	// fs group then supply a single range with the same start and end.
+	Ranges []IDRange `json:"ranges,omitempty" description:"ranges of allowable IDs for fsGroup"`
+}
+
+// SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+type SupplementalGroupsStrategyOptions struct {
+	// Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+	Type SupplementalGroupsStrategyType `json:"type,omitempty" description:"strategy used to generate supplemental groups"`
+	// Ranges are the allowed ranges of supplemental groups.  If you would like to force a single
+	// supplemental group then supply a single range with the same start and end.
+	Ranges []IDRange `json:"ranges,omitempty" description:"ranges of allowable IDs for supplemental groups"`
+}
+
+// IDRange provides a min/max of an allowed range of IDs.
+// TODO: this could be reused for UIDs.
+type IDRange struct {
+	// Min is the start of the range, inclusive.
+	Min int64 `json:"min,omitempty" description:"min value for the range"`
+	// Max is the end of the range, inclusive.
+	Max int64 `json:"max,omitempty" description:"min value for the range"`
+}
+
 // SELinuxContextStrategyType denotes strategy types for generating SELinux options for a
 // SecurityContext
 type SELinuxContextStrategyType string
@@ -2134,6 +2165,14 @@ type SELinuxContextStrategyType string
 // RunAsUserStrategyType denotes strategy types for generating RunAsUser values for a
 // SecurityContext
 type RunAsUserStrategyType string
+
+// SupplementalGroupsStrategyType denotes strategy types for determining valid supplemental
+// groups for a SecurityContext.
+type SupplementalGroupsStrategyType string
+
+// FSGroupStrategyType denotes strategy types for generating FSGroup values for a
+// SecurityContext
+type FSGroupStrategyType string
 
 const (
 	// container must have SELinux labels of X applied.
@@ -2149,6 +2188,16 @@ const (
 	RunAsUserStrategyMustRunAsNonRoot RunAsUserStrategyType = "MustRunAsNonRoot"
 	// container may make requests for any uid.
 	RunAsUserStrategyRunAsAny RunAsUserStrategyType = "RunAsAny"
+
+	// container must have FSGroup of X applied.
+	FSGroupStrategyMustRunAs FSGroupStrategyType = "MustRunAs"
+	// container may make requests for any FSGroup labels.
+	FSGroupStrategyRunAsAny FSGroupStrategyType = "RunAsAny"
+
+	// container must run as a particular gid.
+	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
+	// container may make requests for any gid.
+	SupplementalGroupsrStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // SecurityContextConstraintsList is a list of SecurityContextConstraints objects

--- a/api/definitions/v1.fsgroupstrategyoptions/description.adoc
+++ b/api/definitions/v1.fsgroupstrategyoptions/description.adoc
@@ -1,0 +1,1 @@
+FSGroupStrategyOptions is the strategy that will dictate what fs group is used by the SecurityContext.

--- a/api/definitions/v1.idrange/description.adoc
+++ b/api/definitions/v1.idrange/description.adoc
@@ -1,0 +1,1 @@
+IDRange provides a min/max of an allowed range of IDs.

--- a/api/definitions/v1.supplementalgroupsstrategyoptions/description.adoc
+++ b/api/definitions/v1.supplementalgroupsstrategyoptions/description.adoc
@@ -1,0 +1,1 @@
+SupplementalGroupsStrategyOptions is the strategy that will dictate what supplemental groups are used by the SecurityContext.

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -14509,6 +14509,14 @@
       "$ref": "v1.RunAsUserStrategyOptions",
       "description": "strategy used to generate RunAsUser"
      },
+     "supplementalGroups": {
+      "$ref": "v1.SupplementalGroupsStrategyOptions",
+      "description": "strategy used to generate supplemental groups"
+     },
+     "fsGroup": {
+      "$ref": "v1.FSGroupStrategyOptions",
+      "description": "strategy used to generate fsGroup"
+     },
      "users": {
       "type": "array",
       "items": {
@@ -14559,6 +14567,53 @@
       "type": "integer",
       "format": "int64",
       "description": "max value for range based allocators"
+     }
+    }
+   },
+   "v1.SupplementalGroupsStrategyOptions": {
+    "id": "v1.SupplementalGroupsStrategyOptions",
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "strategy used to generate supplemental groups"
+     },
+     "ranges": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.IDRange"
+      },
+      "description": "ranges of allowable IDs for supplemental groups"
+     }
+    }
+   },
+   "v1.IDRange": {
+    "id": "v1.IDRange",
+    "properties": {
+     "min": {
+      "type": "integer",
+      "format": "int64",
+      "description": "min value for the range"
+     },
+     "max": {
+      "type": "integer",
+      "format": "int64",
+      "description": "min value for the range"
+     }
+    }
+   },
+   "v1.FSGroupStrategyOptions": {
+    "id": "v1.FSGroupStrategyOptions",
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "strategy used to generate fsGroup"
+     },
+     "ranges": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.IDRange"
+      },
+      "description": "ranges of allowable IDs for fsGroup"
      }
     }
    },


### PR DESCRIPTION
Introduce new strategy knobs for supplemental groups and fsgroup to the SCC.  Both strategies are range based setup (which, in hindsight could've been done for the user strats - I think I will update the PSP proposal with this if folks like it).

In preparation for https://github.com/kubernetes/kubernetes/pull/14991 and <PR pending for FSGroups by @pmorie>

@swagiaal @pmorie @smarterclayton @liggitt  