### PR TITLE
assets: Fix null dereference in updateTopology()

### DIFF
--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -491,7 +491,7 @@ angular.module('openshiftConsole')
       angular.forEach($scope.deployments, function(deployment, deploymentName) {
 	var deploymentConfig, annotations = deployment.metadata.annotations || {};
 	var deploymentConfigName = annotations["openshift.io/deployment-config.name"] || deploymentName;
-	if (deploymentConfigName) {
+	if (deploymentConfigName && $scope.deploymentConfigs) {
           deploymentConfig = $scope.deploymentConfigs[deploymentConfigName];
           if (deploymentConfig) {
             topologyRelations.push({ source: makeId(deploymentConfig), target: makeId(deployment) });


### PR DESCRIPTION
This function might be loaded before $scope.deploymentConfigs has
been initialized.

Fixes #5020