### PR TITLE
Allow POST access to node stats for cluster-reader and system:node-reader

### DIFF
--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -90,13 +90,13 @@ var (
 		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status"},
 
 		QuotaGroupName:         {"limitranges", "resourcequotas", "resourcequotausages"},
-		KubeInternalsGroupName: {"minions", "nodes", NodeMetricsResource, NodeStatsResource, NodeLogResource, "bindings", "events", "namespaces"},
+		KubeInternalsGroupName: {"minions", "nodes", "bindings", "events", "namespaces"},
 		KubeExposedGroupName:   {"pods", "replicationcontrollers", "serviceaccounts", "services", "endpoints", "persistentvolumeclaims", "pods/log"},
 		KubeAllGroupName:       {KubeInternalsGroupName, KubeExposedGroupName, QuotaGroupName},
 		KubeStatusGroupName:    {"pods/status", "resourcequotas/status", "namespaces/status"},
 
 		OpenshiftEscalatingViewableGroupName: {"oauthauthorizetokens", "oauthaccesstokens"},
-		KubeEscalatingViewableGroupName:      {"secrets", NodeLogResource}, // consider NodeLogResource a potentially escalating resource since it proxies to /var/log on the nodes
+		KubeEscalatingViewableGroupName:      {"secrets"},
 		EscalatingResourcesGroupName:         {OpenshiftEscalatingViewableGroupName, KubeEscalatingViewableGroupName},
 
 		NonEscalatingResourcesGroupName: {OpenshiftNonEscalatingViewableGroupName, KubeNonEscalatingViewableGroupName},

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -59,6 +59,17 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     sets.NewString("create"),
 					Resources: sets.NewString("resourceaccessreviews", "subjectaccessreviews"),
 				},
+				// Allow read access to node metrics
+				{
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString(authorizationapi.NodeMetricsResource),
+				},
+				// Allow read access to stats
+				// Node stats requests are submitted as POSTs.  These creates are non-mutating
+				{
+					Verbs:     sets.NewString("get", "create"),
+					Resources: sets.NewString(authorizationapi.NodeStatsResource),
+				},
 				{
 					Verbs:           sets.NewString("get"),
 					NonResourceURLs: sets.NewString(authorizationapi.NonResourceAll),
@@ -407,12 +418,18 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     sets.NewString("get", "list", "watch"),
 					Resources: sets.NewString("nodes"),
 				},
-				// Allow read access to metrics and stats
-				// TODO: expose other things like /healthz on the node once we figure out non-resource URL policy across systems
+				// Allow read access to node metrics
 				{
 					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString(authorizationapi.NodeMetricsResource, authorizationapi.NodeStatsResource),
+					Resources: sets.NewString(authorizationapi.NodeMetricsResource),
 				},
+				// Allow read access to stats
+				// Node stats requests are submitted as POSTs.  These creates are non-mutating
+				{
+					Verbs:     sets.NewString("get", "create"),
+					Resources: sets.NewString(authorizationapi.NodeStatsResource),
+				},
+				// TODO: expose other things like /healthz on the node once we figure out non-resource URL policy across systems
 			},
 		},
 		{

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -178,15 +178,18 @@ func TestNodeAuth(t *testing.T) {
 			// Responses to invalid paths are the same for all users
 			{"GET", "/", http.StatusNotFound},
 			{"GET", "/stats", http.StatusMovedPermanently}, // ServeMux redirects to the directory
+			{"GET", "/logs", http.StatusMovedPermanently},  // ServeMux redirects to the directory
 			{"GET", "/invalid", http.StatusNotFound},
 
 			// viewer requests
 			{"GET", "/metrics", viewResult},
 			{"GET", "/stats/", viewResult},
+			{"POST", "/stats/", viewResult}, // stats requests can be POSTs which contain query options
 
 			// successful admin requests
 			{"GET", "/healthz", adminResultOK},
 			{"GET", "/pods", adminResultOK},
+			{"GET", "/logs/", adminResultOK},
 
 			// not found admin requests
 			{"GET", "/containerLogs/mynamespace/mypod/mycontainer", adminResultMissing},


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5041