### PR TITLE
Configurable identity mapper strategies

### DIFF
--- a/pkg/auth/userregistry/identitymapper/lookup.go
+++ b/pkg/auth/userregistry/identitymapper/lookup.go
@@ -9,14 +9,12 @@ import (
 	"github.com/openshift/origin/pkg/user/registry/useridentitymapping"
 )
 
+var _ = authapi.UserIdentityMapper(&lookupIdentityMapper{})
+
+// lookupIdentityMapper does not provision a new identity or user, it only allows identities already associated with users
 type lookupIdentityMapper struct {
 	mappings useridentitymapping.Registry
 	users    user.Registry
-}
-
-// NewLookupIdentityMapper returns a mapper that will look up existing mappings for identities
-func NewLookupIdentityMapper(mappings useridentitymapping.Registry, users user.Registry) authapi.UserIdentityMapper {
-	return &lookupIdentityMapper{mappings, users}
 }
 
 // UserFor returns info about the user for whom identity info has been provided

--- a/pkg/auth/userregistry/identitymapper/lookup_test.go
+++ b/pkg/auth/userregistry/identitymapper/lookup_test.go
@@ -1,0 +1,157 @@
+package identitymapper
+
+import (
+	"reflect"
+	"testing"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
+	"github.com/openshift/origin/pkg/user/registry/test"
+	mappingregistry "github.com/openshift/origin/pkg/user/registry/useridentitymapping"
+)
+
+func TestLookup(t *testing.T) {
+	testcases := map[string]struct {
+		ProviderName     string
+		ProviderUserName string
+
+		ExistingIdentity *userapi.Identity
+		ExistingUser     *userapi.User
+
+		ExpectedActions  []test.Action
+		ExpectedError    bool
+		ExpectedUserName string
+	}{
+		"no identity": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: nil,
+			ExistingUser:     nil,
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+			},
+			ExpectedError: true,
+		},
+
+		"existing identity, no user reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "", ""),
+			ExistingUser:     nil,
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, missing user reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+			ExistingUser:     nil,
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, invalid user UID reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUIDInvalid", "bob"),
+			ExistingUser:     makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, user reference without identity backreference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+			ExistingUser:     makeUser("bobUserUID", "bob" /*, "idp:bob"*/),
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, user reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+			ExistingUser:     makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+				{"GetUser", "bob"}, // extra request is for group lookup
+			},
+			ExpectedUserName: "bob",
+		},
+	}
+
+	for k, tc := range testcases {
+		actions := []test.Action{}
+		identityRegistry := &test.IdentityRegistry{
+			Get:     map[string]*api.Identity{},
+			Actions: &actions,
+		}
+		userRegistry := &test.UserRegistry{
+			Get:     map[string]*api.User{},
+			Actions: &actions,
+		}
+		if tc.ExistingIdentity != nil {
+			identityRegistry.Get[tc.ExistingIdentity.Name] = tc.ExistingIdentity
+		}
+		if tc.ExistingUser != nil {
+			userRegistry.Get[tc.ExistingUser.Name] = tc.ExistingUser
+		}
+
+		mappingStorage := mappingregistry.NewREST(userRegistry, identityRegistry)
+		mappingRegistry := mappingregistry.NewRegistry(mappingStorage)
+
+		lookupMapper := &lookupIdentityMapper{
+			mappings: mappingRegistry,
+			users:    userRegistry,
+		}
+
+		identity := authapi.NewDefaultUserIdentityInfo(tc.ProviderName, tc.ProviderUserName)
+		user, err := lookupMapper.UserFor(identity)
+		if tc.ExpectedError != (err != nil) {
+			t.Errorf("%s: Expected error=%v, got %v", k, tc.ExpectedError, err)
+			continue
+		}
+		if !tc.ExpectedError && user.GetName() != tc.ExpectedUserName {
+			t.Errorf("%s: Expected username %v, got %v", k, tc.ExpectedUserName, user.GetName())
+			continue
+		}
+
+		for i, action := range actions {
+			if len(tc.ExpectedActions) <= i {
+				t.Fatalf("%s: expected %d actions, got extras: %#v", k, len(tc.ExpectedActions), actions[i:])
+				continue
+			}
+			expectedAction := tc.ExpectedActions[i]
+			if !reflect.DeepEqual(expectedAction, action) {
+				t.Fatalf("%s: expected\n\t%s %#v\nGot\n\t%s %#v", k, expectedAction.Name, expectedAction.Object, action.Name, action.Object)
+				continue
+			}
+		}
+		if len(actions) < len(tc.ExpectedActions) {
+			t.Errorf("Missing %d additional actions:\n\t%#v", len(tc.ExpectedActions)-len(actions), tc.ExpectedActions[len(actions):])
+		}
+	}
+}

--- a/pkg/auth/userregistry/identitymapper/mapper.go
+++ b/pkg/auth/userregistry/identitymapper/mapper.go
@@ -1,0 +1,59 @@
+package identitymapper
+
+import (
+	"fmt"
+
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	"github.com/openshift/origin/pkg/user"
+	identityregistry "github.com/openshift/origin/pkg/user/registry/identity"
+	userregistry "github.com/openshift/origin/pkg/user/registry/user"
+	mappingregistry "github.com/openshift/origin/pkg/user/registry/useridentitymapping"
+)
+
+type MappingMethodType string
+
+const (
+	// MappingMethodLookup does not provision a new identity or user, it only allows identities already associated with users
+	MappingMethodLookup MappingMethodType = "lookup"
+
+	// MappingMethodClaim associates a new identity with a user with the identity's preferred username
+	// if no other identities are already associated with the user
+	MappingMethodClaim MappingMethodType = "claim"
+
+	// MappingMethodAdd associates a new identity with a user with the identity's preferred username,
+	// creating the user if needed, and adding to any existing identities associated with the user
+	MappingMethodAdd MappingMethodType = "add"
+
+	// MappingMethodGenerate finds an available username for a new identity, based on its preferred username
+	// If a user with the preferred username already exists, a unique username is generated
+	MappingMethodGenerate MappingMethodType = "generate"
+)
+
+// NewIdentityUserMapper returns a UserIdentityMapper that does the following:
+// 1. Returns an existing user if the identity exists and is associated with an existing user
+// 2. Returns an error if the identity exists and is not associated with a user (or is associated with a missing user)
+// 3. Handles new identities according to the requested method
+func NewIdentityUserMapper(identities identityregistry.Registry, users userregistry.Registry, method MappingMethodType) (authapi.UserIdentityMapper, error) {
+	// initUser initializes fields in a User API object from its associated Identity
+	// called when adding the first Identity to a User (during create or update of a User)
+	initUser := user.NewDefaultUserInitStrategy()
+
+	switch method {
+	case MappingMethodLookup:
+		mappingStorage := mappingregistry.NewREST(users, identities)
+		mappingRegistry := mappingregistry.NewRegistry(mappingStorage)
+		return &lookupIdentityMapper{mappingRegistry, users}, nil
+
+	case MappingMethodClaim:
+		return &provisioningIdentityMapper{identities, users, NewStrategyClaim(users, initUser)}, nil
+
+	case MappingMethodAdd:
+		return &provisioningIdentityMapper{identities, users, NewStrategyAdd(users, initUser)}, nil
+
+	case MappingMethodGenerate:
+		return &provisioningIdentityMapper{identities, users, NewStrategyGenerate(users, initUser)}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported mapping method %q", method)
+	}
+}

--- a/pkg/auth/userregistry/identitymapper/provision_test.go
+++ b/pkg/auth/userregistry/identitymapper/provision_test.go
@@ -1,16 +1,38 @@
 package identitymapper
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/types"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
 
 	authapi "github.com/openshift/origin/pkg/auth/api"
 	"github.com/openshift/origin/pkg/user/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
 	"github.com/openshift/origin/pkg/user/registry/test"
 )
+
+type testNewIdentityGetter struct {
+	called    int
+	responses []interface{}
+}
+
+func (t *testNewIdentityGetter) UserForNewIdentity(ctx kapi.Context, preferredUserName string, identity *userapi.Identity) (*userapi.User, error) {
+	t.called++
+	if len(t.responses) < t.called {
+		return nil, fmt.Errorf("Called at least %d times, only %d responses registered", t.called, len(t.responses))
+	}
+	switch response := t.responses[t.called-1].(type) {
+	case error:
+		return nil, response
+	case *userapi.User:
+		return response, nil
+	default:
+		return nil, fmt.Errorf("Invalid response type registered: %#v", response)
+	}
+}
 
 func TestGetPreferredUsername(t *testing.T) {
 	identity := &api.Identity{}
@@ -26,142 +48,246 @@ func TestGetPreferredUsername(t *testing.T) {
 	}
 }
 
-func TestProvisionNewIdentity(t *testing.T) {
-	expectedProviderName := "myprovidername"
-	expectedProviderUserName := "myusername"
-	expectedUserName := "myusername"
-	expectedUserUID := "myuseruid"
-	expectedIdentityName := "myprovidername:myusername"
+func TestProvision(t *testing.T) {
+	testcases := map[string]struct {
+		ProviderName     string
+		ProviderUserName string
 
-	// Expect identity to fully specify a user name and uid
-	expectedCreateIdentity := &api.Identity{
-		ObjectMeta:       kapi.ObjectMeta{Name: expectedIdentityName},
-		ProviderName:     expectedProviderName,
-		ProviderUserName: expectedProviderUserName,
-		User: kapi.ObjectReference{
-			Name: expectedUserName,
-			UID:  types.UID(expectedUserUID),
+		ExistingIdentity           *userapi.Identity
+		ExistingUser               *userapi.User
+		NewIdentityGetterResponses []interface{}
+
+		ExpectedActions  []test.Action
+		ExpectedError    bool
+		ExpectedUserName string
+	}{
+		"no identity, create user succeeds": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: nil,
+			ExistingUser:     nil,
+			NewIdentityGetterResponses: []interface{}{
+				makeUser("bobUserUID", "bob", "idp:bob"),
+			},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter creates user
+				{"CreateIdentity", makeIdentity("", "idp", "bob", "bobUserUID", "bob")},
+			},
+			ExpectedUserName: "bob",
 		},
-		Extra: map[string]string{},
-	}
-	// Expect user to be populated with the right name, display name, and identity
-	expectedCreateUser := &api.User{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: expectedUserName,
+		"no identity, alreadyexists error retries": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: nil,
+			ExistingUser:     nil,
+			NewIdentityGetterResponses: []interface{}{
+				kerrs.NewAlreadyExists("User", "bob"),
+				makeUser("bobUserUID", "bob", "idp:bob"),
+			},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter creates user
+				{"CreateIdentity", makeIdentity("", "idp", "bob", "bobUserUID", "bob")},
+			},
+			ExpectedUserName: "bob",
 		},
-		Identities: []string{expectedIdentityName},
-	}
-	// Return a user containing a uid
-	expectedCreateUserResult := &api.User{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: expectedUserName,
-			UID:  types.UID(expectedUserUID),
+		"no identity, conflict error retries": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: nil,
+			ExistingUser:     nil,
+			NewIdentityGetterResponses: []interface{}{
+				kerrs.NewConflict("User", "bob", fmt.Errorf("conflict")),
+				makeUser("bobUserUID", "bob", "idp:bob"),
+			},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter creates user
+				{"CreateIdentity", makeIdentity("", "idp", "bob", "bobUserUID", "bob")},
+			},
+			ExpectedUserName: "bob",
 		},
-		Identities: []string{expectedIdentityName},
+		"no identity, only retries 3 times": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: nil,
+			ExistingUser:     nil,
+			NewIdentityGetterResponses: []interface{}{
+				kerrs.NewConflict("User", "bob", fmt.Errorf("conflict")),
+				kerrs.NewConflict("User", "bob", fmt.Errorf("conflict")),
+				kerrs.NewConflict("User", "bob", fmt.Errorf("conflict")),
+				kerrs.NewConflict("User", "bob", fmt.Errorf("conflict")),
+			},
+
+			ExpectedActions: []test.Action{
+				// original attempt
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+				// retry #1
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+				// retry #2
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+				// retry #3
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+			},
+			ExpectedError: true,
+		},
+		"no identity, unknown error does not retry": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity: nil,
+			ExistingUser:     nil,
+			NewIdentityGetterResponses: []interface{}{
+				fmt.Errorf("other error"),
+			},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				// ... new identity user getter returns error
+			},
+			ExpectedError: true,
+		},
+
+		"existing identity, no user reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity:           makeIdentity("bobIdentityUID", "idp", "bob", "", ""),
+			ExistingUser:               nil,
+			NewIdentityGetterResponses: []interface{}{},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, missing user reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity:           makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+			ExistingUser:               nil,
+			NewIdentityGetterResponses: []interface{}{},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, invalid user UID reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity:           makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUIDInvalid", "bob"),
+			ExistingUser:               makeUser("bobUserUID", "bob", "idp:bob"),
+			NewIdentityGetterResponses: []interface{}{},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, user reference without identity backreference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity:           makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+			ExistingUser:               makeUser("bobUserUID", "bob" /*, "idp:bob"*/),
+			NewIdentityGetterResponses: []interface{}{},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedError: true,
+		},
+		"existing identity, user reference": {
+			ProviderName:     "idp",
+			ProviderUserName: "bob",
+
+			ExistingIdentity:           makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+			ExistingUser:               makeUser("bobUserUID", "bob", "idp:bob"),
+			NewIdentityGetterResponses: []interface{}{},
+
+			ExpectedActions: []test.Action{
+				{"GetIdentity", "idp:bob"},
+				{"GetUser", "bob"},
+			},
+			ExpectedUserName: "bob",
+		},
 	}
 
-	expectedActions := []test.Action{
-		{"GetIdentity", expectedIdentityName},
-		{"GetUser", expectedProviderUserName},
-		{"CreateUser", expectedCreateUser},
-		{"CreateIdentity", expectedCreateIdentity},
-	}
-
-	actions := []test.Action{}
-	identityRegistry := &test.IdentityRegistry{
-		Create:  expectedCreateIdentity,
-		Actions: &actions,
-	}
-	userRegistry := &test.UserRegistry{
-		Create:  expectedCreateUserResult,
-		Actions: &actions,
-	}
-
-	identityMapper := NewAlwaysCreateUserIdentityToUserMapper(identityRegistry, userRegistry)
-	identity := authapi.NewDefaultUserIdentityInfo(expectedProviderName, expectedProviderUserName)
-
-	identityMapper.UserFor(identity)
-
-	for i, action := range actions {
-		if len(expectedActions) <= i {
-			t.Fatalf("Expected %d actions, got extras: %#v", len(expectedActions), actions[i:])
+	for k, tc := range testcases {
+		actions := []test.Action{}
+		identityRegistry := &test.IdentityRegistry{
+			Get:     map[string]*api.Identity{},
+			Actions: &actions,
 		}
-		expectedAction := expectedActions[i]
-		if !reflect.DeepEqual(expectedAction, action) {
-			t.Fatalf("Expected\n\t%s %#v\nGot\n\t%s %#v", expectedAction.Name, expectedAction.Object, action.Name, action.Object)
+		userRegistry := &test.UserRegistry{
+			Get:     map[string]*api.User{},
+			Actions: &actions,
 		}
-	}
-}
-
-func TestProvisionConflictingIdentity(t *testing.T) {
-	expectedProviderName := "myprovidername"
-	expectedProviderUserName := "myusername"
-	expectedIdentityName := "myprovidername:myusername"
-	expectedUserName := "myusername3"
-	expectedUserUID := "myuseruid"
-
-	// Expect identity to fully specify a user name and uid
-	expectedCreateIdentity := &api.Identity{
-		ObjectMeta:       kapi.ObjectMeta{Name: expectedIdentityName},
-		ProviderName:     expectedProviderName,
-		ProviderUserName: expectedProviderUserName,
-		User: kapi.ObjectReference{
-			Name: expectedUserName,
-			UID:  types.UID(expectedUserUID),
-		},
-		Extra: map[string]string{},
-	}
-	// Expect user to be populated with the right name, display name, and identity
-	expectedCreateUser := &api.User{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: expectedUserName,
-		},
-		Identities: []string{expectedIdentityName},
-	}
-	// Return a user containing a uid
-	expectedCreateUserResult := &api.User{
-		ObjectMeta: kapi.ObjectMeta{
-			Name: expectedUserName,
-			UID:  types.UID(expectedUserUID),
-		},
-		Identities: []string{expectedIdentityName},
-	}
-
-	expectedActions := []test.Action{
-		{"GetIdentity", expectedIdentityName},
-		{"GetUser", expectedProviderUserName},
-		{"GetUser", expectedProviderUserName + "2"},
-		{"GetUser", expectedProviderUserName + "3"},
-		{"CreateUser", expectedCreateUser},
-		{"CreateIdentity", expectedCreateIdentity},
-	}
-
-	actions := []test.Action{}
-	identityRegistry := &test.IdentityRegistry{
-		Create:  expectedCreateIdentity,
-		Actions: &actions,
-	}
-	userRegistry := &test.UserRegistry{
-		Get: map[string]*api.User{
-			expectedProviderUserName:       {},
-			expectedProviderUserName + "2": {},
-		},
-		Create:  expectedCreateUserResult,
-		Actions: &actions,
-	}
-
-	identityMapper := NewAlwaysCreateUserIdentityToUserMapper(identityRegistry, userRegistry)
-	identity := authapi.NewDefaultUserIdentityInfo(expectedProviderName, expectedProviderUserName)
-
-	identityMapper.UserFor(identity)
-
-	for i, action := range actions {
-		if len(expectedActions) <= i {
-			t.Fatalf("Expected %d actions, got extras: %#v", len(expectedActions), actions[i:])
+		if tc.ExistingIdentity != nil {
+			identityRegistry.Get[tc.ExistingIdentity.Name] = tc.ExistingIdentity
 		}
-		expectedAction := expectedActions[i]
-		if !reflect.DeepEqual(expectedAction, action) {
-			t.Fatalf("Expected\n\t%s %#v\nGot\n\t%s %#v", expectedAction.Name, expectedAction.Object, action.Name, action.Object)
+		if tc.ExistingUser != nil {
+			userRegistry.Get[tc.ExistingUser.Name] = tc.ExistingUser
+		}
+
+		newIdentityUserGetter := &testNewIdentityGetter{responses: tc.NewIdentityGetterResponses}
+
+		provisionMapper := &provisioningIdentityMapper{
+			identity:             identityRegistry,
+			user:                 userRegistry,
+			provisioningStrategy: newIdentityUserGetter,
+		}
+
+		identity := authapi.NewDefaultUserIdentityInfo(tc.ProviderName, tc.ProviderUserName)
+		user, err := provisionMapper.UserFor(identity)
+		if tc.ExpectedError != (err != nil) {
+			t.Errorf("%s: Expected error=%v, got %v", k, tc.ExpectedError, err)
+			continue
+		}
+		if !tc.ExpectedError && user.GetName() != tc.ExpectedUserName {
+			t.Errorf("%s: Expected username %v, got %v", k, tc.ExpectedUserName, user.GetName())
+			continue
+		}
+
+		if newIdentityUserGetter.called != len(tc.NewIdentityGetterResponses) {
+			t.Errorf("%s: Expected %d calls to UserForNewIdentity, got %d", k, len(tc.NewIdentityGetterResponses), newIdentityUserGetter.called)
+		}
+
+		for i, action := range actions {
+			if len(tc.ExpectedActions) <= i {
+				t.Fatalf("%s: expected %d actions, got extras: %#v", k, len(tc.ExpectedActions), actions[i:])
+				continue
+			}
+			expectedAction := tc.ExpectedActions[i]
+			if !reflect.DeepEqual(expectedAction, action) {
+				t.Fatalf("%s: expected\n\t%s %#v\nGot\n\t%s %#v", k, expectedAction.Name, expectedAction.Object, action.Name, action.Object)
+				continue
+			}
+		}
+		if len(actions) < len(tc.ExpectedActions) {
+			t.Errorf("Missing %d additional actions:\n\t%#v", len(tc.ExpectedActions)-len(actions), tc.ExpectedActions[len(actions):])
 		}
 	}
 }

--- a/pkg/auth/userregistry/identitymapper/strategy_add.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_add.go
@@ -1,0 +1,57 @@
+package identitymapper
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/user"
+	userapi "github.com/openshift/origin/pkg/user/api"
+	userregistry "github.com/openshift/origin/pkg/user/registry/user"
+)
+
+var _ = UserForNewIdentityGetter(&StrategyAdd{})
+
+// StrategyAdd associates a new identity with a user with the identity's preferred username,
+// adding to any existing identities associated with the user
+type StrategyAdd struct {
+	user        userregistry.Registry
+	initializer user.Initializer
+}
+
+func NewStrategyAdd(user userregistry.Registry, initializer user.Initializer) UserForNewIdentityGetter {
+	return &StrategyAdd{user, initializer}
+}
+
+func (s *StrategyAdd) UserForNewIdentity(ctx kapi.Context, preferredUserName string, identity *userapi.Identity) (*userapi.User, error) {
+
+	persistedUser, err := s.user.GetUser(ctx, preferredUserName)
+
+	switch {
+	case kerrs.IsNotFound(err):
+		// Create a new user
+		desiredUser := &userapi.User{}
+		desiredUser.Name = preferredUserName
+		desiredUser.Identities = []string{identity.Name}
+		s.initializer.InitializeUser(identity, desiredUser)
+		return s.user.CreateUser(ctx, desiredUser)
+
+	case err == nil:
+		// If the existing user already references our identity, we're done
+		if sets.NewString(persistedUser.Identities...).Has(identity.Name) {
+			return persistedUser, nil
+		}
+
+		// Otherwise add our identity and update
+		persistedUser.Identities = append(persistedUser.Identities, identity.Name)
+		// If our newly added identity is the only one, initialize the user
+		if len(persistedUser.Identities) == 1 {
+			s.initializer.InitializeUser(identity, persistedUser)
+		}
+		return s.user.UpdateUser(ctx, persistedUser)
+
+	default:
+		// Fail on errors other than "not found"
+		return nil, err
+	}
+}

--- a/pkg/auth/userregistry/identitymapper/strategy_add_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_add_test.go
@@ -1,0 +1,61 @@
+package identitymapper
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/user/api"
+	"github.com/openshift/origin/pkg/user/registry/test"
+)
+
+func TestStrategyAdd(t *testing.T) {
+	testcases := map[string]strategyTestCase{
+		"no user": {
+			MakeStrategy:      NewStrategyAdd,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			CreateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"CreateUser", makeUser("", "bob", "idp:bob")},
+			},
+			ExpectedUserName:   "bob",
+			ExpectedInitialize: true,
+		},
+		"existing user, no identities": {
+			MakeStrategy:      NewStrategyAdd,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob")},
+			UpdateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"UpdateUser", makeUser("bobUserUID", "bob", "idp:bob")},
+			},
+			ExpectedUserName:   "bob",
+			ExpectedInitialize: true,
+		},
+		"existing user, conflicting identity": {
+			MakeStrategy:      NewStrategyAdd,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob", "otheridp:user")},
+			UpdateResponse: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"UpdateUser", makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob")},
+			},
+			ExpectedUserName:   "bob",
+			ExpectedInitialize: false,
+		},
+	}
+
+	for testCaseName, testCase := range testcases {
+		testCase.run(testCaseName, t)
+	}
+}

--- a/pkg/auth/userregistry/identitymapper/strategy_claim.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_claim.go
@@ -1,0 +1,79 @@
+package identitymapper
+
+import (
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/user"
+	userapi "github.com/openshift/origin/pkg/user/api"
+	userregistry "github.com/openshift/origin/pkg/user/registry/user"
+)
+
+var _ = UserForNewIdentityGetter(&StrategyClaim{})
+
+// StrategyClaim associates a new identity with a user with the identity's preferred username
+// if no other identities are already associated with the user
+type StrategyClaim struct {
+	user        userregistry.Registry
+	initializer user.Initializer
+}
+
+type claimError struct {
+	User     *userapi.User
+	Identity *userapi.Identity
+}
+
+func IsClaimError(err error) bool {
+	_, ok := err.(claimError)
+	return ok
+}
+func NewClaimError(user *userapi.User, identity *userapi.Identity) error {
+	return claimError{user, identity}
+}
+
+func (c claimError) Error() string {
+	return fmt.Sprintf("user %q cannot be claimed by identity %q because it is already mapped to %v", c.User.Name, c.Identity.Name, c.User.Identities)
+}
+
+func NewStrategyClaim(user userregistry.Registry, initializer user.Initializer) UserForNewIdentityGetter {
+	return &StrategyClaim{user, initializer}
+}
+
+func (s *StrategyClaim) UserForNewIdentity(ctx kapi.Context, preferredUserName string, identity *userapi.Identity) (*userapi.User, error) {
+
+	persistedUser, err := s.user.GetUser(ctx, preferredUserName)
+
+	switch {
+	case kerrs.IsNotFound(err):
+		// Create a new user, propagating any "already exists" errors
+		desiredUser := &userapi.User{}
+		desiredUser.Name = preferredUserName
+		desiredUser.Identities = []string{identity.Name}
+		s.initializer.InitializeUser(identity, desiredUser)
+		return s.user.CreateUser(ctx, desiredUser)
+
+	case err == nil:
+		// If the existing user already references our identity, we're done
+		if sets.NewString(persistedUser.Identities...).Has(identity.Name) {
+			return persistedUser, nil
+		}
+
+		// If this user has no other identities, claim, initialize, and update
+		if len(persistedUser.Identities) == 0 {
+			persistedUser.Identities = []string{identity.Name}
+			s.initializer.InitializeUser(identity, persistedUser)
+			return s.user.UpdateUser(ctx, persistedUser)
+		}
+
+		// Otherwise another identity has already claimed this user, return an error
+		return nil, NewClaimError(persistedUser, identity)
+
+	default:
+		// Fail on errors other than "not found"
+		return nil, err
+	}
+
+}

--- a/pkg/auth/userregistry/identitymapper/strategy_claim_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_claim_test.go
@@ -1,0 +1,61 @@
+package identitymapper
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/user/api"
+	"github.com/openshift/origin/pkg/user/registry/test"
+)
+
+func TestStrategyClaim(t *testing.T) {
+	testcases := map[string]strategyTestCase{
+		"no user": {
+			MakeStrategy:      NewStrategyClaim,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			CreateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"CreateUser", makeUser("", "bob", "idp:bob")},
+			},
+			ExpectedUserName:   "bob",
+			ExpectedInitialize: true,
+		},
+		"existing user, no identities": {
+			MakeStrategy:      NewStrategyClaim,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob")},
+			UpdateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"UpdateUser", makeUser("bobUserUID", "bob", "idp:bob")},
+			},
+			ExpectedUserName:   "bob",
+			ExpectedInitialize: true,
+		},
+		"existing user, conflicting identity": {
+			MakeStrategy:      NewStrategyClaim,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob", "otheridp:user")},
+			UpdateResponse: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+			},
+			ExpectedError:      true,
+			ExpectedUserName:   "",
+			ExpectedInitialize: false,
+		},
+	}
+
+	for testCaseName, testCase := range testcases {
+		testCase.run(testCaseName, t)
+	}
+}

--- a/pkg/auth/userregistry/identitymapper/strategy_generate.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_generate.go
@@ -1,0 +1,85 @@
+package identitymapper
+
+import (
+	"errors"
+	"fmt"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/user"
+	userapi "github.com/openshift/origin/pkg/user/api"
+	userregistry "github.com/openshift/origin/pkg/user/registry/user"
+)
+
+// UserNameGenerator returns a username
+type UserNameGenerator func(base string, sequence int) string
+
+var (
+	// MaxGenerateAttempts limits how many times we try to find an available username for a new identity
+	MaxGenerateAttempts = 100
+
+	// DefaultGenerator attempts to use the base name first, then "base2", "base3", ...
+	DefaultGenerator = UserNameGenerator(func(base string, sequence int) string {
+		if sequence == 0 {
+			return base
+		}
+		return fmt.Sprintf("%s%d", base, sequence+1)
+	})
+)
+
+var _ = UserForNewIdentityGetter(&StrategyGenerate{})
+
+// StrategyGenerate finds an available username for a new identity, based on its preferred username
+// If a user with the preferred username already exists, a unique username is generated
+type StrategyGenerate struct {
+	user        userregistry.Registry
+	generator   UserNameGenerator
+	initializer user.Initializer
+}
+
+func NewStrategyGenerate(user userregistry.Registry, initializer user.Initializer) UserForNewIdentityGetter {
+	return &StrategyGenerate{user, DefaultGenerator, initializer}
+}
+
+func (s *StrategyGenerate) UserForNewIdentity(ctx kapi.Context, preferredUserName string, identity *userapi.Identity) (*userapi.User, error) {
+
+	// Iterate through the max allowed generated usernames
+	// If an existing user references this identity, associate the identity with that user and return
+	// Otherwise, create a user with the first generated user name that does not already exist and return.
+	// Names are created in a deterministic order, so the first one that isn't present gets created.
+	// In the case of a race, one will get to persist the user object and the other will fail.
+UserSearch:
+	for sequence := 0; sequence < MaxGenerateAttempts; sequence++ {
+		// Get the username we want
+		potentialUserName := s.generator(preferredUserName, sequence)
+
+		// See if it already exists
+		persistedUser, err := s.user.GetUser(ctx, potentialUserName)
+
+		switch {
+		case kerrs.IsNotFound(err):
+			// Create a new user
+			desiredUser := &userapi.User{}
+			desiredUser.Name = potentialUserName
+			desiredUser.Identities = []string{identity.Name}
+			s.initializer.InitializeUser(identity, desiredUser)
+			return s.user.CreateUser(ctx, desiredUser)
+
+		case err == nil:
+			// If the existing user already references our identity, we're done
+			if sets.NewString(persistedUser.Identities...).Has(identity.Name) {
+				return persistedUser, nil
+			}
+			// Otherwise, continue our search for a user
+			continue UserSearch
+
+		default:
+			// Fail on errors other than "not found"
+			return nil, err
+		}
+	}
+
+	return nil, errors.New("Could not create user, max attempts exceeded")
+}

--- a/pkg/auth/userregistry/identitymapper/strategy_generate_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_generate_test.go
@@ -1,0 +1,83 @@
+package identitymapper
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/user/api"
+	"github.com/openshift/origin/pkg/user/registry/test"
+)
+
+func TestStrategyGenerate(t *testing.T) {
+	testcases := map[string]strategyTestCase{
+		"no user": {
+			MakeStrategy:      NewStrategyGenerate,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			CreateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"CreateUser", makeUser("", "bob", "idp:bob")},
+			},
+			ExpectedUserName:   "bob",
+			ExpectedInitialize: true,
+		},
+		"existing user, no identities": {
+			MakeStrategy:      NewStrategyGenerate,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob")},
+			CreateResponse: makeUser("bob2UserUID", "bob2", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"GetUser", "bob2"},
+				{"CreateUser", makeUser("", "bob2", "idp:bob")},
+			},
+			ExpectedUserName:   "bob2",
+			ExpectedInitialize: true,
+		},
+		"existing user, conflicting identity": {
+			MakeStrategy:      NewStrategyGenerate,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers:  []*api.User{makeUser("bobUserUID", "bob", "otheridp:user")},
+			CreateResponse: makeUser("bob2UserUID", "bob2", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"GetUser", "bob2"},
+				{"CreateUser", makeUser("", "bob2", "idp:bob")},
+			},
+			ExpectedUserName:   "bob2",
+			ExpectedInitialize: true,
+		},
+		"existing users": {
+			MakeStrategy:      NewStrategyGenerate,
+			PreferredUsername: "bob",
+			Identity:          makeIdentity("", "idp", "bob", "", ""),
+
+			ExistingUsers: []*api.User{
+				makeUser("bobUserUID", "bob", "otheridp:user"),
+				makeUser("bob2UserUID", "bob2", "otheridp:user2"),
+			},
+			CreateResponse: makeUser("bob3UserUID", "bob3", "idp:bob"),
+
+			ExpectedActions: []test.Action{
+				{"GetUser", "bob"},
+				{"GetUser", "bob2"},
+				{"GetUser", "bob3"},
+				{"CreateUser", makeUser("", "bob3", "idp:bob")},
+			},
+			ExpectedUserName:   "bob3",
+			ExpectedInitialize: true,
+		},
+	}
+
+	for testCaseName, testCase := range testcases {
+		testCase.run(testCaseName, t)
+	}
+}

--- a/pkg/auth/userregistry/identitymapper/strategy_test.go
+++ b/pkg/auth/userregistry/identitymapper/strategy_test.go
@@ -1,0 +1,110 @@
+package identitymapper
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/types"
+
+	"github.com/openshift/origin/pkg/user"
+	"github.com/openshift/origin/pkg/user/api"
+	"github.com/openshift/origin/pkg/user/registry/test"
+	userregistry "github.com/openshift/origin/pkg/user/registry/user"
+)
+
+type testInitializer struct {
+	called bool
+}
+
+func (t *testInitializer) InitializeUser(identity *api.Identity, user *api.User) error {
+	t.called = true
+	return nil
+}
+
+type strategyTestCase struct {
+	MakeStrategy func(user userregistry.Registry, initializer user.Initializer) UserForNewIdentityGetter
+
+	// Inputs
+	PreferredUsername string
+	Identity          *api.Identity
+
+	// User registry setup
+	ExistingUsers  []*api.User
+	CreateResponse *api.User
+	UpdateResponse *api.User
+
+	// Expectations
+	ExpectedActions    []test.Action
+	ExpectedError      bool
+	ExpectedUserName   string
+	ExpectedInitialize bool
+}
+
+func makeUser(uid string, name string, identities ...string) *api.User {
+	return &api.User{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+			UID:  types.UID(uid),
+		},
+		Identities: identities,
+	}
+}
+func makeIdentity(uid string, providerName string, providerUserName string, userUID string, userName string) *api.Identity {
+	return &api.Identity{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: providerName + ":" + providerUserName,
+			UID:  types.UID(uid),
+		},
+		ProviderName:     providerName,
+		ProviderUserName: providerUserName,
+		User: kapi.ObjectReference{
+			UID:  types.UID(userUID),
+			Name: userName,
+		},
+		Extra: map[string]string{},
+	}
+}
+
+func (tc strategyTestCase) run(k string, t *testing.T) {
+	actions := []test.Action{}
+	userRegistry := &test.UserRegistry{
+		Get:     map[string]*api.User{},
+		Actions: &actions,
+	}
+	for _, u := range tc.ExistingUsers {
+		userRegistry.Get[u.Name] = u
+	}
+
+	testInit := &testInitializer{}
+	strategy := tc.MakeStrategy(userRegistry, testInit)
+
+	user, err := strategy.UserForNewIdentity(kapi.NewContext(), tc.PreferredUsername, tc.Identity)
+	if tc.ExpectedError != (err != nil) {
+		t.Errorf("%s: Expected error=%v, got %v", k, tc.ExpectedError, err)
+		return
+	}
+	if !tc.ExpectedError && user.Name != tc.ExpectedUserName {
+		t.Errorf("%s: Expected username %v, got %v", k, tc.ExpectedUserName, user.Name)
+		return
+	}
+
+	if tc.ExpectedInitialize != testInit.called {
+		t.Errorf("%s: Expected initialize=%v, got initialize=%v", k, tc.ExpectedInitialize, testInit.called)
+	}
+
+	for i, action := range actions {
+		if len(tc.ExpectedActions) <= i {
+			t.Errorf("%s: expected %d actions, got extras: %#v", k, len(tc.ExpectedActions), actions[i:])
+			return
+		}
+		expectedAction := tc.ExpectedActions[i]
+		if !reflect.DeepEqual(expectedAction, action) {
+			t.Errorf("%s: expected\n\t%s %#v\nGot\n\t%s %#v", k, expectedAction.Name, expectedAction.Object, action.Name, action.Object)
+			continue
+		}
+	}
+	if len(actions) < len(tc.ExpectedActions) {
+		t.Errorf("Missing %d additional actions:\n\t%#v", len(tc.ExpectedActions)-len(actions), tc.ExpectedActions[len(actions):])
+	}
+}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -514,6 +514,8 @@ type IdentityProvider struct {
 	UseAsChallenger bool
 	// UseAsLogin indicates whether to use this identity provider for unauthenticated browsers to login against
 	UseAsLogin bool
+	// MappingMethod determines how identities from this provider are mapped to users
+	MappingMethod string
 	// Provider contains the information about how to set up a specific identity provider
 	Provider runtime.EmbeddedObject
 }

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -128,6 +128,14 @@ func init() {
 				obj.MCSLabelsPerProject = 5
 			}
 		},
+		func(obj *IdentityProvider) {
+			if len(obj.MappingMethod) == 0 {
+				// By default, only let one identity provider authenticate a particular user
+				// If multiple identity providers collide, the second one in will fail to auth
+				// The admin can set this to "add" if they want to allow new identities to join existing users
+				obj.MappingMethod = "claim"
+			}
+		},
 	)
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -493,6 +493,8 @@ type IdentityProvider struct {
 	UseAsChallenger bool `json:"challenge"`
 	// UseAsLogin indicates whether to use this identity provider for unauthenticated browsers to login against
 	UseAsLogin bool `json:"login"`
+	// MappingMethod determines how identities from this provider are mapped to users
+	MappingMethod string `json:"mappingMethod"`
 	// Provider contains the information about how to set up a specific identity provider
 	Provider runtime.RawExtension `json:"provider"`
 }

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -153,6 +153,7 @@ oauthConfig:
   identityProviders:
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
@@ -163,18 +164,21 @@ oauthConfig:
       url: ""
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
       kind: AllowAllPasswordIdentityProvider
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
       kind: DenyAllPasswordIdentityProvider
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
@@ -182,6 +186,7 @@ oauthConfig:
       kind: HTPasswdPasswordIdentityProvider
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
@@ -198,6 +203,7 @@ oauthConfig:
       url: ""
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
@@ -208,6 +214,7 @@ oauthConfig:
       loginURL: ""
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
@@ -216,6 +223,7 @@ oauthConfig:
       kind: GitHubIdentityProvider
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1
@@ -225,6 +233,7 @@ oauthConfig:
       kind: GoogleIdentityProvider
   - challenge: false
     login: false
+    mappingMethod: ""
     name: ""
     provider:
       apiVersion: v1

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -327,7 +327,10 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 	redirectors := map[string]handlers.AuthenticationRedirector{}
 
 	for _, identityProvider := range c.Options.IdentityProviders {
-		identityMapper := identitymapper.NewAlwaysCreateUserIdentityToUserMapper(c.IdentityRegistry, c.UserRegistry)
+		identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod))
+		if err != nil {
+			return nil, err
+		}
 
 		// TODO: refactor handler building per type
 		if configapi.IsPasswordAuthenticator(identityProvider) {
@@ -467,7 +470,10 @@ func (c *AuthConfig) getOAuthProvider(identityProvider configapi.IdentityProvide
 }
 
 func (c *AuthConfig) getPasswordAuthenticator(identityProvider configapi.IdentityProvider) (authenticator.Password, error) {
-	identityMapper := identitymapper.NewAlwaysCreateUserIdentityToUserMapper(c.IdentityRegistry, c.UserRegistry)
+	identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod))
+	if err != nil {
+		return nil, err
+	}
 
 	switch provider := identityProvider.Provider.Object.(type) {
 	case (*configapi.AllowAllPasswordIdentityProvider):
@@ -534,7 +540,10 @@ func (c *AuthConfig) getAuthenticationRequestHandler() (authenticator.Request, e
 	}
 
 	for _, identityProvider := range c.Options.IdentityProviders {
-		identityMapper := identitymapper.NewAlwaysCreateUserIdentityToUserMapper(c.IdentityRegistry, c.UserRegistry)
+		identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod))
+		if err != nil {
+			return nil, err
+		}
 
 		if configapi.IsPasswordAuthenticator(identityProvider) {
 			passwordAuthenticator, err := c.getPasswordAuthenticator(identityProvider)

--- a/pkg/user/initializer.go
+++ b/pkg/user/initializer.go
@@ -1,6 +1,9 @@
 package user
 
-import "github.com/openshift/origin/pkg/user/api"
+import (
+	authapi "github.com/openshift/origin/pkg/auth/api"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
 
 type DefaultUserInitStrategy struct {
 }
@@ -10,11 +13,9 @@ func NewDefaultUserInitStrategy() Initializer {
 }
 
 // InitializeUser implements Initializer
-func (*DefaultUserInitStrategy) InitializeUser(identity *api.Identity, user *api.User) error {
-	if identity.Extra != nil {
-		if name, ok := identity.Extra["name"]; ok && len(name) > 0 {
-			user.FullName = name
-		}
+func (*DefaultUserInitStrategy) InitializeUser(identity *userapi.Identity, user *userapi.User) error {
+	if len(user.FullName) == 0 {
+		user.FullName = identity.Extra[authapi.IdentityDisplayNameKey]
 	}
 	return nil
 }

--- a/pkg/user/initializer_test.go
+++ b/pkg/user/initializer_test.go
@@ -1,0 +1,52 @@
+package user
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/pkg/user/api"
+)
+
+func TestInitializerUser(t *testing.T) {
+	testcases := map[string]struct {
+		Identity     *api.Identity
+		User         *api.User
+		ExpectedUser *api.User
+	}{
+		"empty": {
+			Identity:     &api.Identity{},
+			User:         &api.User{},
+			ExpectedUser: &api.User{},
+		},
+		"empty extra": {
+			Identity:     &api.Identity{Extra: map[string]string{}},
+			User:         &api.User{},
+			ExpectedUser: &api.User{},
+		},
+		"sets full name": {
+			Identity: &api.Identity{
+				Extra: map[string]string{"name": "Bob"},
+			},
+			User:         &api.User{},
+			ExpectedUser: &api.User{FullName: "Bob"},
+		},
+		"respects existing full name": {
+			Identity: &api.Identity{
+				Extra: map[string]string{"name": "Bob"},
+			},
+			User:         &api.User{FullName: "Harold"},
+			ExpectedUser: &api.User{FullName: "Harold"},
+		},
+	}
+
+	for k, tc := range testcases {
+		err := NewDefaultUserInitStrategy().InitializeUser(tc.Identity, tc.User)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		if !reflect.DeepEqual(tc.User, tc.ExpectedUser) {
+			t.Errorf("%s: expected \n\t%#v\ngot\n\t%#v", k, tc.ExpectedUser, tc.User)
+		}
+	}
+}

--- a/pkg/user/interfaces.go
+++ b/pkg/user/interfaces.go
@@ -4,6 +4,8 @@ import (
 	"github.com/openshift/origin/pkg/user/api"
 )
 
+// Initializer is responsible for initializing fields in a User API object from its associated Identity
 type Initializer interface {
+	// InitializeUser is responsible for initializing fields in a User API object from its associated Identity
 	InitializeUser(identity *api.Identity, user *api.User) error
 }

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -71,7 +71,10 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 	identityStorage := identityetcd.NewREST(etcdHelper)
 	identityRegistry := identityregistry.NewRegistry(identityStorage)
 
-	identityMapper := identitymapper.NewAlwaysCreateUserIdentityToUserMapper(identityRegistry, userRegistry)
+	identityMapper, err := identitymapper.NewIdentityUserMapper(identityRegistry, userRegistry, identitymapper.MappingMethodGenerate)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// this auth request handler is the one that is supposed to recognize information from a front proxy
 	authRequestHandler := headerrequest.NewAuthenticator("front-proxy-test", headerrequest.NewDefaultConfig(), identityMapper)

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -69,7 +69,10 @@ func TestCLIGetToken(t *testing.T) {
 	identityStorage := identityetcd.NewREST(etcdHelper)
 	identityRegistry := identityregistry.NewRegistry(identityStorage)
 
-	identityMapper := identitymapper.NewAlwaysCreateUserIdentityToUserMapper(identityRegistry, userRegistry)
+	identityMapper, err := identitymapper.NewIdentityUserMapper(identityRegistry, userRegistry, identitymapper.MappingMethodGenerate)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	authRequestHandler := basicauthrequest.NewBasicAuthAuthentication(allowanypassword.New("get-token-test", identityMapper), true)
 	authHandler := oauthhandlers.NewUnionAuthenticationHandler(

--- a/test/integration/oauth_basicauth_test.go
+++ b/test/integration/oauth_basicauth_test.go
@@ -237,6 +237,7 @@ func TestOAuthBasicAuthPassword(t *testing.T) {
 		Name:            "basicauth",
 		UseAsChallenger: true,
 		UseAsLogin:      true,
+		MappingMethod:   "claim",
 		Provider: runtime.EmbeddedObject{
 			Object: &configapi.BasicAuthPasswordIdentityProvider{
 				RemoteConnectionInfo: configapi.RemoteConnectionInfo{

--- a/test/integration/oauth_htpasswd_test.go
+++ b/test/integration/oauth_htpasswd_test.go
@@ -17,7 +17,7 @@ import (
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
-func TestHTPasswd(t *testing.T) {
+func TestOAuthHTPasswd(t *testing.T) {
 	htpasswdFile, err := ioutil.TempFile("", "test.htpasswd")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -33,6 +33,7 @@ func TestHTPasswd(t *testing.T) {
 		Name:            "htpasswd",
 		UseAsChallenger: true,
 		UseAsLogin:      true,
+		MappingMethod:   "claim",
 		Provider: runtime.EmbeddedObject{
 			Object: &configapi.HTPasswdPasswordIdentityProvider{
 				File: htpasswdFile.Name(),

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -86,6 +86,7 @@ func TestOAuthLDAP(t *testing.T) {
 		Name:            providerName,
 		UseAsChallenger: true,
 		UseAsLogin:      true,
+		MappingMethod:   "claim",
 		Provider: runtime.EmbeddedObject{
 			Object: &configapi.LDAPPasswordIdentityProvider{
 				URL:          fmt.Sprintf("ldap://%s/%s?%s?%s?%s", ldapAddress, searchDN, searchAttr, searchScope, searchFilter),

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -167,6 +167,7 @@ func TestOAuthRequestHeader(t *testing.T) {
 		Name:            "requestheader",
 		UseAsChallenger: true,
 		UseAsLogin:      true,
+		MappingMethod:   "claim",
 		Provider: runtime.EmbeddedObject{
 			Object: &configapi.RequestHeaderIdentityProvider{
 				ChallengeURL: proxyServer.URL + "/oauth/authorize?${query}",


### PR DESCRIPTION
https://trello.com/c/cSa9BKUL/512-3-configurable-identity-user-provisioning-strategies

On login, we currently auto-provision a unique username for new identities. Additional strategies should exist.

This PR adds a `mappingMethod` option to all identity providers:

```
oauthConfig:
  identityProviders:
  - challenge: false
    login: false
    mappingMethod: "..."
    ...
```

`mappingMethod` can be set to the following values:

* **lookup**
  * Administrator wants to manually configure identity/user mappings. Login process should only look up existing mappings, not create them
* **generate** (prior default behavior)
  * Provision with generation of unique usernames (e.g. "bob", "bob2")
  * This strategy should not be used in combination with LDAP group sync
* **claim** (new default)
  * Provision with deterministic username, fail if username is already mapped to another identity
* **add**
  * Provision with deterministic username, add to existing user if username is already mapped to another identity
  * Needed when multiple identity providers are configured which identity the same set of users and map to the same usernames

TODO:
- [x] Decide on default strategy... probably "claim"
- [x] Decide on name for "claim" and "generate" strategies
- [x] Decide on name for identityProvider field name (currently "mappingMethod")
- [x] split out tests (https://github.com/openshift/origin/pull/5060#discussion_r42002054)
- [ ] Open ansible issue
- [ ] Open doc issue

Followups:
- [ ] Surface a nicer error to the user when the identity provision fails lookup and claim strategies (currently get a 500 Internal Error, internally there's a UserIdentityMapping NotFound error or a ClaimError)
- [ ] Surface a nicer error to the admin when there's a claim strategy failure (they may want to switch to add or replace)

Fixes #5009