### PR TITLE
added readiness check to LDAP server pod

### DIFF
--- a/test/extended/fixtures/ldap/ldapserver-deploymentconfig.json
+++ b/test/extended/fixtures/ldap/ldapserver-deploymentconfig.json
@@ -58,7 +58,14 @@
             "securityContext": {
               "capabilities": {},
               "privileged": false
-            }
+            },
+            "readinessProbe": {
+              "exec": {
+                "command": ["ldapsearch", "-x", "-b", "dc=example,dc=com"]
+              },
+              "initialDelaySeconds": 5,
+              "timeoutSeconds": 1
+            }            
           }
         ],
         "restartPolicy": "Always",

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -88,9 +88,6 @@ server_ready_template=$(IFS=$""; echo "${server_ready_template[*]}") # re-format
 # wait for LDAP server to be ready
 wait_for_command 'oc get pods -l deploymentconfig=openldap-server --template="${server_ready_template}" | grep "ReadyTrue "' $((60*TIME_SEC))
 
-# TODO(skuznets): readiness check is premature
-sleep 10
-
 oc login -u system:admin -n openldap
 
 


### PR DESCRIPTION
Implemented an `exec` readiness probe, with the following check:
```sh
$ bash -c "ldapsearch -x -b dc=example,dc=com | grep organization"
```

This should catch the `organization` in the `dc=example,dc=com` as well as all of the `organizationalUnit` entries we have. This currently never returns a `true` ... cc @liggitt  @deads2k thoughts appreciated