### PR TITLE
[DONOTMERGE] (Pending 5169) OpenShift Volume Security Integration

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/libcontainer/configs/config.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/configs/config.go
@@ -81,7 +81,7 @@ type Config struct {
 
 	// AdditionalGroups specifies the gids that should be added to supplementary groups
 	// in addition to those that the user belongs to.
-	AdditionalGroups []int `json:"additional_groups"`
+	AdditionalGroups []string `json:"additional_groups"`
 
 	// UidMappings is an array of User ID mappings for User Namespaces
 	UidMappings []IDMap `json:"uid_mappings"`

--- a/Godeps/_workspace/src/github.com/docker/libcontainer/init_linux.go
+++ b/Godeps/_workspace/src/github.com/docker/libcontainer/init_linux.go
@@ -176,7 +176,12 @@ func setupUser(config *initConfig) error {
 	if err != nil {
 		return err
 	}
-	suppGroups := append(execUser.Sgids, config.Config.AdditionalGroups...)
+	addGroups, err := user.GetAdditionalGroupsPath(config.Config.AdditionalGroups, groupPath)
+	if err != nil {
+		return err
+	}
+
+	suppGroups := append(execUser.Sgids, addGroups...)
 	if err := syscall.Setgroups(suppGroups); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/google/cadvisor/container/docker/handler.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/container/docker/handler.go
@@ -156,7 +156,7 @@ func (self *dockerContainerHandler) ContainerReference() (info.ContainerReferenc
 func (self *dockerContainerHandler) readLibcontainerConfig() (*libcontainerConfigs.Config, error) {
 	config, err := containerLibcontainer.ReadConfig(*dockerRootDir, *dockerRunDir, self.id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read libcontainer config: %v", err)
+		return nil, fmt.Errorf("failed to read libcontainer config from (%v/%v): %v", *dockerRunDir, self.id, err)
 	}
 
 	// Replace cgroup parent and name with our own since we may be running in a different context.

--- a/Godeps/_workspace/src/github.com/google/cadvisor/container/libcontainer/compatibility.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/container/libcontainer/compatibility.go
@@ -16,6 +16,7 @@ package libcontainer
 
 import (
 	"encoding/json"
+	"github.com/golang/glog"
 	"io/ioutil"
 	"path"
 
@@ -159,6 +160,7 @@ func ReadConfig(dockerRoot, dockerRun, containerID string) (*configs.Config, err
 		var state libcontainer.State
 		err = json.Unmarshal(out, &state)
 		if err != nil {
+			glog.Errorf("Unmarshal failure for: \n\n%v\n", string(out))
 			return nil, err
 		}
 		return &state.Config, nil
@@ -168,6 +170,7 @@ func ReadConfig(dockerRoot, dockerRun, containerID string) (*configs.Config, err
 	oldConfigPath := oldConfigPath(dockerRoot, containerID)
 	out, err := ioutil.ReadFile(oldConfigPath)
 	if err != nil {
+		glog.Errorf("Unmarshal failure for: \n\n%v\n", string(out))
 		return nil, err
 	}
 

--- a/Godeps/_workspace/src/github.com/google/cadvisor/manager/manager.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/manager/manager.go
@@ -981,7 +981,7 @@ func (self *manager) watchForNewContainers(quit chan error) error {
 					err = self.destroyContainer(event.Name)
 				}
 				if err != nil {
-					glog.Warningf("Failed to process watch event: %v", err)
+					glog.Warningf("Failed to process watch event (type: %v): (%v): %v", event.EventType, event, err)
 				}
 			case <-quit:
 				// Stop processing events if asked to quit.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -12708,7 +12708,7 @@
      },
      "securityContext": {
       "$ref": "v1.PodSecurityContext",
-      "description": "SecurityContext holds pod-level security attributes and common container settings"
+      "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
      },
      "imagePullSecrets": {
       "type": "array",
@@ -13194,28 +13194,28 @@
    },
    "v1.SecurityContext": {
     "id": "v1.SecurityContext",
-    "description": "SecurityContext holds security configuration that will be applied to a container.",
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
      },
      "privileged": {
       "type": "boolean",
-      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false."
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      },
      "runAsNonRoot": {
       "type": "boolean",
-      "description": "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user."
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      }
     }
    },
@@ -13249,19 +13249,19 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "User is a SELinux user label that applies to the container."
      },
      "role": {
       "type": "string",
-      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Role is a SELinux role label that applies to the container."
      },
      "type": {
       "type": "string",
-      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Type is a SELinux type label that applies to the container."
      },
      "level": {
       "type": "string",
-      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Level is SELinux level label that applies to the container."
      }
     }
    },
@@ -13275,6 +13275,19 @@
        "$ref": "integer"
       },
       "description": "SupplementalGroups can be used to specify a list of additional groups which the main container process will run as. This will be applied to all containers in the pod in addition to the primary group of the container."
+     },
+     "seLinuxOptions": {
+      "$ref": "v1.SELinuxOptions",
+      "description": "SELinuxOptions is the SELinux context to be applied to all containers If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+     },
+     "runAsUser": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+     },
+     "runAsNonRoot": {
+      "type": "boolean",
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      }
     }
    },

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -13267,18 +13267,11 @@
    },
    "v1.PodSecurityContext": {
     "id": "v1.PodSecurityContext",
-    "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
     "properties": {
-     "supplementalGroups": {
-      "type": "array",
-      "items": {
-       "$ref": "integer"
-      },
-      "description": "SupplementalGroups can be used to specify a list of additional groups which the main container process will run as. This will be applied to all containers in the pod in addition to the primary group of the container."
-     },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions is the SELinux context to be applied to all containers If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+      "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
      },
      "runAsUser": {
       "type": "integer",
@@ -13288,6 +13281,18 @@
      "runAsNonRoot": {
       "type": "boolean",
       "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+     },
+     "supplementalGroups": {
+      "type": "array",
+      "items": {
+       "$ref": "integer"
+      },
+      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container."
+     },
+     "fsGroup": {
+      "type": "integer",
+      "format": "int64",
+      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw "
      }
     }
    },

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -13268,6 +13268,18 @@
    "v1.PodSecurityContext": {
     "id": "v1.PodSecurityContext",
     "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "properties": {
+     "supplementalGroups": {
+      "type": "array",
+      "items": {
+       "$ref": "integer"
+      },
+      "description": "SupplementalGroups can be used to specify a list of additional groups which the main container process will run as. This will be applied to all containers in the pod in addition to the primary group of the container."
+     }
+    }
+   },
+   "integer": {
+    "id": "integer",
     "properties": {}
    },
    "v1.PodStatus": {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kubelet/app/server.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kubelet/app/server.go
@@ -52,6 +52,8 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/chmod"
+	"k8s.io/kubernetes/pkg/util/chown"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
@@ -320,6 +322,9 @@ func (s *KubeletServer) UnsecuredKubeletConfig() (*KubeletConfig, error) {
 		writer = &io.NsenterWriter{}
 	}
 
+	chmodRunner := chmod.New()
+	chownRunner := chown.New()
+
 	tlsOptions, err := s.InitializeTLS()
 	if err != nil {
 		return nil, err
@@ -393,6 +398,8 @@ func (s *KubeletServer) UnsecuredKubeletConfig() (*KubeletConfig, error) {
 		MaxPods:                   s.MaxPods,
 		MinimumGCAge:              s.MinimumGCAge,
 		Mounter:                   mounter,
+		ChownRunner:               chownRunner,
+		ChmodRunner:               chmodRunner,
 		NetworkPluginName:         s.NetworkPluginName,
 		NetworkPlugins:            ProbeNetworkPlugins(s.NetworkPluginDir),
 		NodeStatusUpdateFrequency: s.NodeStatusUpdateFrequency,
@@ -661,6 +668,8 @@ func SimpleKubelet(client *client.Client,
 		MaxPods:                   maxPods,
 		MinimumGCAge:              minimumGCAge,
 		Mounter:                   mount.New(),
+		ChownRunner:               chown.New(),
+		ChmodRunner:               chmod.New(),
 		NodeStatusUpdateFrequency: nodeStatusUpdateFrequency,
 		OOMAdjuster:               oom.NewFakeOOMAdjuster(),
 		OSInterface:               osInterface,
@@ -846,6 +855,8 @@ type KubeletConfig struct {
 	MaxPods                        int
 	MinimumGCAge                   time.Duration
 	Mounter                        mount.Interface
+	ChownRunner                    chown.Interface
+	ChmodRunner                    chmod.Interface
 	NetworkPluginName              string
 	NetworkPlugins                 []network.NetworkPlugin
 	NodeName                       string
@@ -942,6 +953,8 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		kc.RktStage1Image,
 		kc.Mounter,
 		kc.Writer,
+		kc.ChownRunner,
+		kc.ChmodRunner,
 		kc.DockerDaemonContainer,
 		kc.SystemContainer,
 		kc.ConfigureCBR0,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -1493,6 +1493,26 @@ func deepCopy_api_PodSecurityContext(in PodSecurityContext, out *PodSecurityCont
 	} else {
 		out.SupplementalGroups = nil
 	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(SELinuxOptions)
+		if err := deepCopy_api_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -2037,7 +2057,12 @@ func deepCopy_api_SecurityContext(in SecurityContext, out *SecurityContext, c *c
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -1485,14 +1485,6 @@ func deepCopy_api_PodSecurityContext(in PodSecurityContext, out *PodSecurityCont
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
-	if in.SupplementalGroups != nil {
-		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
-		for i := range in.SupplementalGroups {
-			out.SupplementalGroups[i] = in.SupplementalGroups[i]
-		}
-	} else {
-		out.SupplementalGroups = nil
-	}
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(SELinuxOptions)
 		if err := deepCopy_api_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
@@ -1512,6 +1504,20 @@ func deepCopy_api_PodSecurityContext(in PodSecurityContext, out *PodSecurityCont
 		*out.RunAsNonRoot = *in.RunAsNonRoot
 	} else {
 		out.RunAsNonRoot = nil
+	}
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -1485,6 +1485,14 @@ func deepCopy_api_PodSecurityContext(in PodSecurityContext, out *PodSecurityCont
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
@@ -381,7 +381,7 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			scc.RunAsUser.Type = userTypes[c.Rand.Intn(len(userTypes))]
 			seLinuxTypes := []api.SELinuxContextStrategyType{api.SELinuxStrategyRunAsAny, api.SELinuxStrategyMustRunAs}
 			scc.SELinuxContext.Type = seLinuxTypes[c.Rand.Intn(len(seLinuxTypes))]
-			supGroupTypes := []api.SupplementalGroupsStrategyType{api.SupplementalGroupsStrategyMustRunAs, api.SupplementalGroupsStrategyMustRunAs}
+			supGroupTypes := []api.SupplementalGroupsStrategyType{api.SupplementalGroupsStrategyMustRunAs, api.SupplementalGroupsStrategyRunAsAny}
 			scc.SupplementalGroups.Type = supGroupTypes[c.Rand.Intn(len(supGroupTypes))]
 			fsGroupTypes := []api.FSGroupStrategyType{api.FSGroupStrategyMustRunAs, api.FSGroupStrategyRunAsAny}
 			scc.FSGroup.Type = fsGroupTypes[c.Rand.Intn(len(fsGroupTypes))]

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -789,7 +789,8 @@ type Container struct {
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty"`
 	// Required: Policy for pulling images for this container
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy"`
-	// Optional: SecurityContext defines the security options the pod should be run with
+	// Optional: SecurityContext defines the security options the container should be run with.
+	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 
 	// Variables for interactive containers, these have very specialized use-cases (e.g. debugging)
@@ -986,7 +987,8 @@ type PodSpec struct {
 	// the scheduler simply schedules this pod onto that node, assuming that it fits resource
 	// requirements.
 	NodeName string `json:"nodeName,omitempty"`
-	// SecurityContext holds pod-level security attributes and common container settings
+	// SecurityContext holds pod-level security attributes and common container settings.
+	// Optional: Defaults to empty.  See type description for default values of each field.
 	SecurityContext *PodSecurityContext `json:"securityContext,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use.  For example,
@@ -995,12 +997,13 @@ type PodSpec struct {
 }
 
 // PodSecurityContext holds pod-level security attributes and common container settings.
+// Some fields are also present in SecurityContext.  Field values of SecurityContext take
+// precedence over field values of PodSecurityContext.
 type PodSecurityContext struct {
 	// Use the host's network namespace.  If this option is set, the ports that will be
 	// used must be specified.
 	// Optional: Default to false
 	HostNetwork bool `json:"hostNetwork,omitempty"`
-
 	// Use the host's pid namespace.
 	// Optional: Default to false.
 	HostPID bool `json:"hostPID,omitempty"`
@@ -1013,6 +1016,25 @@ type PodSecurityContext struct {
 	// as. This will be applied to all containers in the pod in
 	// addition to the primary group of the container.
 	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
+	// The SELinux context to be applied to all containers.
+	// If unspecified, the container runtime will allocate a random SELinux context for each
+	// container.  May also be set in SecurityContext.  If set in
+	// both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+	// takes precedence for that container.
+	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
+	// The UID to run the entrypoint of the container process.
+	// Defaults to user specified in image metadata if unspecified.
+	// May also be set in SecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence
+	// for that container.
+	RunAsUser *int64 `json:"runAsUser,omitempty"`
+	// Indicates that the container must run as a non-root user.
+	// If true, the Kubelet will validate the image at runtime to ensure that it
+	// does not run as UID 0 (root) and fail to start the container if it does.
+	// If unset or false, no such validation will be performed.
+	// May also be set in SecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
+	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual
@@ -2036,41 +2058,44 @@ type ComponentStatusList struct {
 	Items []ComponentStatus `json:"items"`
 }
 
-// SecurityContext holds security configuration that will be applied to a container.  SecurityContext
-// contains duplication of some existing fields from the Container resource.  These duplicate fields
-// will be populated based on the Container configuration if they are not set.  Defining them on
-// both the Container AND the SecurityContext will result in an error.
+// SecurityContext holds security configuration that will be applied to a container.
+// Some fields are present in both SecurityContext and PodSecurityContext.  When both
+// are set, the values in SecurityContext take precedence.
 type SecurityContext struct {
-	// Capabilities are the capabilities to add/drop when running the container
+	// The capabilities to add/drop when running containers.
+	// Defaults to the default set of capabilities granted by the container runtime.
 	Capabilities *Capabilities `json:"capabilities,omitempty"`
-
-	// Run the container in privileged mode
+	// Run container in privileged mode.
+	// Processes in privileged containers are essentially equivalent to root on the host.
+	// Defaults to false.
 	Privileged *bool `json:"privileged,omitempty"`
-
-	// SELinuxOptions are the labels to be applied to the container
-	// and volumes
+	// The SELinux context to be applied to the container.
+	// If unspecified, the container runtime will allocate a random SELinux context for each
+	// container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
 	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
-
-	// RunAsUser is the UID to run the entrypoint of the container process.
+	// The UID to run the entrypoint of the container process.
+	// Defaults to user specified in image metadata if unspecified.
+	// May also be set in PodSecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
-
-	// RunAsNonRoot indicates that the container should be run as a non-root user.  If the RunAsUser
-	// field is not explicitly set then the kubelet may check the image for a specified user or
-	// perform defaulting to specify a user.
-	RunAsNonRoot bool
+	// Indicates that the container must run as a non-root user.
+	// If true, the Kubelet will validate the image at runtime to ensure that it
+	// does not run as UID 0 (root) and fail to start the container if it does.
+	// If unset or false, no such validation will be performed.
+	// May also be set in PodSecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
+	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
 }
 
 // SELinuxOptions are the labels to be applied to the container.
 type SELinuxOptions struct {
 	// SELinux user label
 	User string `json:"user,omitempty"`
-
 	// SELinux role label
 	Role string `json:"role,omitempty"`
-
 	// SELinux type label
 	Type string `json:"type,omitempty"`
-
 	// SELinux level label.
 	Level string `json:"level,omitempty"`
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -1007,6 +1007,12 @@ type PodSecurityContext struct {
 	// Use the host's ipc namespace.
 	// Optional: Default to false.
 	HostIPC bool `json:"hostIPC,omitempty"`
+
+	// SupplementalGroups can be used to specify a list of
+	// additional groups which the main container process will run
+	// as. This will be applied to all containers in the pod in
+	// addition to the primary group of the container.
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -997,8 +997,8 @@ type PodSpec struct {
 }
 
 // PodSecurityContext holds pod-level security attributes and common container settings.
-// Some fields are also present in SecurityContext.  Field values of SecurityContext take
-// precedence over field values of PodSecurityContext.
+// Some fields are also present in container.securityContext.  Field values of
+// container.securityContext take precedence over field values of PodSecurityContext.
 type PodSecurityContext struct {
 	// Use the host's network namespace.  If this option is set, the ports that will be
 	// used must be specified.
@@ -1010,12 +1010,6 @@ type PodSecurityContext struct {
 	// Use the host's ipc namespace.
 	// Optional: Default to false.
 	HostIPC bool `json:"hostIPC,omitempty"`
-
-	// SupplementalGroups can be used to specify a list of
-	// additional groups which the main container process will run
-	// as. This will be applied to all containers in the pod in
-	// addition to the primary group of the container.
-	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
 	// The SELinux context to be applied to all containers.
 	// If unspecified, the container runtime will allocate a random SELinux context for each
 	// container.  May also be set in SecurityContext.  If set in
@@ -1035,6 +1029,20 @@ type PodSecurityContext struct {
 	// May also be set in SecurityContext.  If set in both SecurityContext and
 	// PodSecurityContext, the value specified in SecurityContext takes precedence.
 	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
+	// A list of groups applied to the first process run in each container, in addition
+	// to the container's primary GID.  If unspecified, no groups will be added to
+	// any container.
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
+	// A special supplemental group that applies to all containers in a pod.
+	// Some volume types allow the Kubelet to change the ownership of that volume
+	// to be owned by the pod:
+	//
+	// 1. The owning GID will be the FSGroup
+	// 2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+	// 3. The permission bits are OR'd with rw-rw----
+	//
+	// If unset, the Kubelet will not modify the ownership and permissions of any volume.
+	FSGroup *int64 `json:"fsGroup,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2251,7 +2251,7 @@ const (
 	// container must run as a particular gid.
 	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
 	// container may make requests for any gid.
-	SupplementalGroupsrStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
+	SupplementalGroupsStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // SecurityContextConstraintsList is a list of SecurityContextConstraints objects

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -454,6 +454,12 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	} else {
 		out.RunAsNonRoot = nil
 	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
+	}
 	return nil
 }
 
@@ -482,6 +488,12 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityCont
 		*out.RunAsNonRoot = *in.RunAsNonRoot
 	} else {
 		out.RunAsNonRoot = nil
+	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -292,6 +292,8 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 			return err
 		}
 
+		// the host namespace fields have to be handled here for backward compatibilty
+		// with v1.0.0
 		out.HostPID = in.SecurityContext.HostPID
 		out.HostNetwork = in.SecurityContext.HostNetwork
 		out.HostIPC = in.SecurityContext.HostIPC
@@ -378,6 +380,9 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 			return err
 		}
 	}
+
+	// the host namespace fields have to be handled specially for backward compatibility
+	// with v1.0.0
 	if out.SecurityContext == nil {
 		out.SecurityContext = new(api.PodSecurityContext)
 	}
@@ -429,6 +434,26 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	}
 
 	out.SupplementalGroups = in.SupplementalGroups
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(SELinuxOptions)
+		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -438,6 +463,26 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityCont
 	}
 
 	out.SupplementalGroups = in.SupplementalGroups
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(api.SELinuxOptions)
+		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -427,6 +427,8 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSecurityContext))(in)
 	}
+
+	out.SupplementalGroups = in.SupplementalGroups
 	return nil
 }
 
@@ -434,6 +436,8 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityCont
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodSecurityContext))(in)
 	}
+
+	out.SupplementalGroups = in.SupplementalGroups
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2691,7 +2691,12 @@ func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -5691,7 +5696,12 @@ func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *SecurityContext, 
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1532,6 +1532,26 @@ func deepCopy_v1_PodSecurityContext(in PodSecurityContext, out *PodSecurityConte
 	} else {
 		out.SupplementalGroups = nil
 	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(SELinuxOptions)
+		if err := deepCopy_v1_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -2087,7 +2107,12 @@ func deepCopy_v1_SecurityContext(in SecurityContext, out *SecurityContext, c *co
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1524,6 +1524,14 @@ func deepCopy_v1_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *co
 }
 
 func deepCopy_v1_PodSecurityContext(in PodSecurityContext, out *PodSecurityContext, c *conversion.Cloner) error {
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1524,14 +1524,6 @@ func deepCopy_v1_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *co
 }
 
 func deepCopy_v1_PodSecurityContext(in PodSecurityContext, out *PodSecurityContext, c *conversion.Cloner) error {
-	if in.SupplementalGroups != nil {
-		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
-		for i := range in.SupplementalGroups {
-			out.SupplementalGroups[i] = in.SupplementalGroups[i]
-		}
-	} else {
-		out.SupplementalGroups = nil
-	}
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(SELinuxOptions)
 		if err := deepCopy_v1_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
@@ -1551,6 +1543,20 @@ func deepCopy_v1_PodSecurityContext(in PodSecurityContext, out *PodSecurityConte
 		*out.RunAsNonRoot = *in.RunAsNonRoot
 	} else {
 		out.RunAsNonRoot = nil
+	}
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
@@ -254,6 +254,9 @@ func addDefaultingFuncs() {
 				}
 			}
 		},
+		func(obj *SecurityContextConstraints) {
+			defaultSecurityContextConstraints(obj)
+		},
 	)
 }
 
@@ -264,6 +267,26 @@ func defaultHostNetworkPorts(containers *[]Container) {
 			if (*containers)[i].Ports[j].HostPort == 0 {
 				(*containers)[i].Ports[j].HostPort = (*containers)[i].Ports[j].ContainerPort
 			}
+		}
+	}
+}
+
+// Default SCCs for new fields.  Defaults are based on the RunAsUser type if not explicitly set.
+// If the SCC allows RunAsAny UID then the FSGroup/SupGroups will default to RunAsAny.  Otherwise
+// default to MustRunAs with namespace allocation.
+func defaultSecurityContextConstraints(scc *SecurityContextConstraints) {
+	if len(scc.FSGroup.Type) == 0 {
+		if scc.RunAsUser.Type == RunAsUserStrategyRunAsAny {
+			scc.FSGroup.Type = FSGroupStrategyRunAsAny
+		} else {
+			scc.FSGroup.Type = FSGroupStrategyMustRunAs
+		}
+	}
+	if len(scc.SupplementalGroups.Type) == 0 {
+		if scc.RunAsUser.Type == RunAsUserStrategyRunAsAny {
+			scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
+		} else {
+			scc.SupplementalGroups.Type = SupplementalGroupsStrategyMustRunAs
 		}
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
@@ -545,3 +545,83 @@ func TestSetDefaultLimitRangeItem(t *testing.T) {
 		t.Errorf("Expected request memory: %s, got: %s", "100Mi", requestMinValue.String())
 	}
 }
+
+func TestDefaultSecurityContextConstraints(t *testing.T) {
+	tests := map[string]struct {
+		scc              *versioned.SecurityContextConstraints
+		expectedFSGroup  versioned.FSGroupStrategyType
+		expectedSupGroup versioned.SupplementalGroupsStrategyType
+	}{
+		"shouldn't default": {
+			scc: &versioned.SecurityContextConstraints{
+				FSGroup: versioned.FSGroupStrategyOptions{
+					Type: versioned.FSGroupStrategyMustRunAs,
+				},
+				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
+					Type: versioned.SupplementalGroupsStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+		"default fsgroup runAsAny": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyRunAsAny,
+				},
+				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
+					Type: versioned.SupplementalGroupsStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyRunAsAny,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+		"default sup group runAsAny": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyRunAsAny,
+				},
+				FSGroup: versioned.FSGroupStrategyOptions{
+					Type: versioned.FSGroupStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
+		},
+		"default fsgroup mustRunAs": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyMustRunAsRange,
+				},
+				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
+					Type: versioned.SupplementalGroupsStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+		"default sup group mustRunAs": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyMustRunAsRange,
+				},
+				FSGroup: versioned.FSGroupStrategyOptions{
+					Type: versioned.FSGroupStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+	}
+	for k, v := range tests {
+		output := roundTrip(t, runtime.Object(v.scc))
+		scc := output.(*versioned.SecurityContextConstraints)
+
+		if scc.FSGroup.Type != v.expectedFSGroup {
+			t.Errorf("%s has invalid fsgroup.  Expected: %v got: %v", k, v.expectedFSGroup, scc.FSGroup.Type)
+		}
+		if scc.SupplementalGroups.Type != v.expectedSupGroup {
+			t.Errorf("%s has invalid supplemental group.  Expected: %v got: %v", k, v.expectedSupGroup, scc.SupplementalGroups.Type)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1244,7 +1244,8 @@ type PodSpec struct {
 	// Use the host's ipc namespace.
 	// Optional: Default to false.
 	HostIPC bool `json:"hostIPC,omitempty"`
-	// SecurityContext holds pod-level security attributes and common container settings
+	// SecurityContext holds pod-level security attributes and common container settings.
+	// Optional: Defaults to empty.  See type description for default values of each field.
 	SecurityContext *PodSecurityContext `json:"securityContext,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use. For example,
@@ -1260,6 +1261,25 @@ type PodSecurityContext struct {
 	// as. This will be applied to all containers in the pod in
 	// addition to the primary group of the container.
 	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
+	// SELinuxOptions is the SELinux context to be applied to all containers
+	// If unspecified, the container runtime will allocate a random SELinux context for each
+	// container.  May also be set in SecurityContext.  If set in
+	// both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+	// takes precedence for that container.
+	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
+	// The UID to run the entrypoint of the container process.
+	// Defaults to user specified in image metadata if unspecified.
+	// May also be set in SecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence
+	// for that container.
+	RunAsUser *int64 `json:"runAsUser,omitempty"`
+	// Indicates that the container must run as a non-root user.
+	// If true, the Kubelet will validate the image at runtime to ensure that it
+	// does not run as UID 0 (root) and fail to start the container if it does.
+	// If unset or false, no such validation will be performed.
+	// May also be set in SecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
+	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual
@@ -2490,50 +2510,44 @@ type DownwardAPIVolumeFile struct {
 }
 
 // SecurityContext holds security configuration that will be applied to a container.
+// Some fields are present in both SecurityContext and PodSecurityContext.  When both
+// are set, the values in SecurityContext take precedence.
 type SecurityContext struct {
-	// The linux kernel capabilites that should be added or removed.
-	// Default to Container.Capabilities if left unset.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// The capabilities to add/drop when running containers.
+	// Defaults to the default set of capabilities granted by the container runtime.
 	Capabilities *Capabilities `json:"capabilities,omitempty"`
-
-	// Run the container in privileged mode.
-	// Default to Container.Privileged if left unset.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// Run container in privileged mode.
+	// Processes in privileged containers are essentially equivalent to root on the host.
+	// Defaults to false.
 	Privileged *bool `json:"privileged,omitempty"`
-
-	// SELinuxOptions are the labels to be applied to the container
-	// and volumes.
-	// Options that control the SELinux labels applied.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// The SELinux context to be applied to the container.
+	// If unspecified, the container runtime will allocate a random SELinux context for each
+	// container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
 	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
-
-	// RunAsUser is the UID to run the entrypoint of the container process.
-	// The user id that runs the first process in the container.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// The UID to run the entrypoint of the container process.
+	// Defaults to user specified in image metadata if unspecified.
+	// May also be set in PodSecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
-
-	// RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser
-	// field is not explicitly set then the kubelet may check the image for a specified user or
-	// perform defaulting to specify a user.
-	RunAsNonRoot bool `json:"runAsNonRoot,omitempty"`
+	// Indicates that the container must run as a non-root user.
+	// If true, the Kubelet will validate the image at runtime to ensure that it
+	// does not run as UID 0 (root) and fail to start the container if it does.
+	// If unset or false, no such validation will be performed.
+	// May also be set in PodSecurityContext.  If set in both SecurityContext and
+	// PodSecurityContext, the value specified in SecurityContext takes precedence.
+	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
 }
 
 // SELinuxOptions are the labels to be applied to the container
 type SELinuxOptions struct {
 	// User is a SELinux user label that applies to the container.
-	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	User string `json:"user,omitempty"`
-
 	// Role is a SELinux role label that applies to the container.
-	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	Role string `json:"role,omitempty"`
-
 	// Type is a SELinux type label that applies to the container.
-	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	Type string `json:"type,omitempty"`
-
 	// Level is SELinux level label that applies to the container.
-	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	Level string `json:"level,omitempty"`
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1255,6 +1255,11 @@ type PodSpec struct {
 
 // PodSecurityContext holds pod-level security attributes and common container settings.
 type PodSecurityContext struct {
+	// SupplementalGroups can be used to specify a list of
+	// additional groups which the main container process will run
+	// as. This will be applied to all containers in the pod in
+	// addition to the primary group of the container.
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -2697,7 +2697,7 @@ const (
 	// container must run as a particular gid.
 	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
 	// container may make requests for any gid.
-	SupplementalGroupsrStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
+	SupplementalGroupsStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // SecurityContextConstraintsList is a list of SecurityContextConstraints objects

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1255,13 +1255,10 @@ type PodSpec struct {
 }
 
 // PodSecurityContext holds pod-level security attributes and common container settings.
+// Some fields are also present in container.securityContext.  Field values of
+// container.securityContext take precedence over field values of PodSecurityContext.
 type PodSecurityContext struct {
-	// SupplementalGroups can be used to specify a list of
-	// additional groups which the main container process will run
-	// as. This will be applied to all containers in the pod in
-	// addition to the primary group of the container.
-	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
-	// SELinuxOptions is the SELinux context to be applied to all containers
+	// The SELinux context to be applied to all containers.
 	// If unspecified, the container runtime will allocate a random SELinux context for each
 	// container.  May also be set in SecurityContext.  If set in
 	// both SecurityContext and PodSecurityContext, the value specified in SecurityContext
@@ -1280,6 +1277,20 @@ type PodSecurityContext struct {
 	// May also be set in SecurityContext.  If set in both SecurityContext and
 	// PodSecurityContext, the value specified in SecurityContext takes precedence.
 	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
+	// A list of groups applied to the first process run in each container, in addition
+	// to the container's primary GID.  If unspecified, no groups will be added to
+	// any container.
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
+	// A special supplemental group that applies to all containers in a pod.
+	// Some volume types allow the Kubelet to change the ownership of that volume
+	// to be owned by the pod:
+	//
+	// 1. The owning GID will be the FSGroup
+	// 2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+	// 3. The permission bits are OR'd with rw-rw----
+	//
+	// If unset, the Kubelet will not modify the ownership and permissions of any volume.
+	FSGroup *int64 `json:"fsGroup,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -974,11 +974,12 @@ func (PodProxyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityContext = map[string]string{
-	"":                   "PodSecurityContext holds pod-level security attributes and common container settings.",
-	"supplementalGroups": "SupplementalGroups can be used to specify a list of additional groups which the main container process will run as. This will be applied to all containers in the pod in addition to the primary group of the container.",
-	"seLinuxOptions":     "SELinuxOptions is the SELinux context to be applied to all containers If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+	"":                   "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+	"seLinuxOptions":     "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
 	"runAsUser":          "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
 	"runAsNonRoot":       "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+	"supplementalGroups": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+	"fsGroup":            "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw ",
 }
 
 func (PodSecurityContext) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -974,7 +974,8 @@ func (PodProxyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityContext = map[string]string{
-	"": "PodSecurityContext holds pod-level security attributes and common container settings.",
+	"":                   "PodSecurityContext holds pod-level security attributes and common container settings.",
+	"supplementalGroups": "SupplementalGroups can be used to specify a list of additional groups which the main container process will run as. This will be applied to all containers in the pod in addition to the primary group of the container.",
 }
 
 func (PodSecurityContext) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -976,6 +976,9 @@ func (PodProxyOptions) SwaggerDoc() map[string]string {
 var map_PodSecurityContext = map[string]string{
 	"":                   "PodSecurityContext holds pod-level security attributes and common container settings.",
 	"supplementalGroups": "SupplementalGroups can be used to specify a list of additional groups which the main container process will run as. This will be applied to all containers in the pod in addition to the primary group of the container.",
+	"seLinuxOptions":     "SELinuxOptions is the SELinux context to be applied to all containers If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+	"runAsUser":          "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+	"runAsNonRoot":       "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
 }
 
 func (PodSecurityContext) SwaggerDoc() map[string]string {
@@ -997,7 +1000,7 @@ var map_PodSpec = map[string]string{
 	"hostNetwork":                   "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
 	"hostPID":                       "Use the host's pid namespace. Optional: Default to false.",
 	"hostIPC":                       "Use the host's ipc namespace. Optional: Default to false.",
-	"securityContext":               "SecurityContext holds pod-level security attributes and common container settings",
+	"securityContext":               "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
 	"imagePullSecrets":              "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod",
 }
 
@@ -1192,10 +1195,10 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 
 var map_SELinuxOptions = map[string]string{
 	"":      "SELinuxOptions are the labels to be applied to the container",
-	"user":  "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md",
-	"role":  "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md",
-	"type":  "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md",
-	"level": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md",
+	"user":  "User is a SELinux user label that applies to the container.",
+	"role":  "Role is a SELinux role label that applies to the container.",
+	"type":  "Type is a SELinux type label that applies to the container.",
+	"level": "Level is SELinux level label that applies to the container.",
 }
 
 func (SELinuxOptions) SwaggerDoc() map[string]string {
@@ -1233,12 +1236,12 @@ func (SecretVolumeSource) SwaggerDoc() map[string]string {
 }
 
 var map_SecurityContext = map[string]string{
-	"":               "SecurityContext holds security configuration that will be applied to a container.",
-	"capabilities":   "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"privileged":     "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"seLinuxOptions": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"runAsUser":      "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"runAsNonRoot":   "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user.",
+	"":               "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+	"capabilities":   "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+	"privileged":     "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+	"seLinuxOptions": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+	"runAsUser":      "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+	"runAsNonRoot":   "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
 }
 
 func (SecurityContext) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -1965,7 +1965,12 @@ func convert_api_SecurityContext_To_v1beta3_SecurityContext(in *api.SecurityCont
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -4185,7 +4190,12 @@ func convert_v1beta3_SecurityContext_To_api_SecurityContext(in *SecurityContext,
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults_test.go
@@ -469,3 +469,83 @@ func areSecurityContextAndContainerEqual(c *versioned.Container) (bool, []string
 	}
 	return equal, issues
 }
+
+func TestDefaultSecurityContextConstraints(t *testing.T) {
+	tests := map[string]struct {
+		scc              *versioned.SecurityContextConstraints
+		expectedFSGroup  versioned.FSGroupStrategyType
+		expectedSupGroup versioned.SupplementalGroupsStrategyType
+	}{
+		"shouldn't default": {
+			scc: &versioned.SecurityContextConstraints{
+				FSGroup: versioned.FSGroupStrategyOptions{
+					Type: versioned.FSGroupStrategyMustRunAs,
+				},
+				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
+					Type: versioned.SupplementalGroupsStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+		"default fsgroup runAsAny": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyRunAsAny,
+				},
+				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
+					Type: versioned.SupplementalGroupsStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyRunAsAny,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+		"default sup group runAsAny": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyRunAsAny,
+				},
+				FSGroup: versioned.FSGroupStrategyOptions{
+					Type: versioned.FSGroupStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
+		},
+		"default fsgroup mustRunAs": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyMustRunAsRange,
+				},
+				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
+					Type: versioned.SupplementalGroupsStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+		"default sup group mustRunAs": {
+			scc: &versioned.SecurityContextConstraints{
+				RunAsUser: versioned.RunAsUserStrategyOptions{
+					Type: versioned.RunAsUserStrategyMustRunAsRange,
+				},
+				FSGroup: versioned.FSGroupStrategyOptions{
+					Type: versioned.FSGroupStrategyMustRunAs,
+				},
+			},
+			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+		},
+	}
+	for k, v := range tests {
+		output := roundTrip(t, runtime.Object(v.scc))
+		scc := output.(*versioned.SecurityContextConstraints)
+
+		if scc.FSGroup.Type != v.expectedFSGroup {
+			t.Errorf("%s has invalid fsgroup.  Expected: %v got: %v", k, v.expectedFSGroup, scc.FSGroup.Type)
+		}
+		if scc.SupplementalGroups.Type != v.expectedSupGroup {
+			t.Errorf("%s has invalid supplemental group.  Expected: %v got: %v", k, v.expectedSupGroup, scc.SupplementalGroups.Type)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -2224,7 +2224,7 @@ const (
 	// container must run as a particular gid.
 	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
 	// container may make requests for any gid.
-	SupplementalGroupsrStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
+	SupplementalGroupsStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // SecurityContextConstraintsList is a list of SecurityContextConstraints objects

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -2075,7 +2075,7 @@ type SecurityContext struct {
 	// RunAsNonRoot indicates that the container should be run as a non-root user.  If the RunAsUser
 	// field is not explicitly set then the kubelet may check the image for a specified user or
 	// perform defaulting to specify a user.
-	RunAsNonRoot bool `json:"runAsNonRoot,omitempty" description:"indicates the container be must run as a non-root user either by specifying the runAsUser or in the image specification"`
+	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty" description:"indicates the container be must run as a non-root user either by specifying the runAsUser or in the image specification"`
 }
 
 // SELinuxOptions are the labels to be applied to the container.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
@@ -2060,7 +2060,45 @@ func ValidateSecurityContextConstraints(scc *api.SecurityContextConstraints) err
 		//good types
 	default:
 		msg := fmt.Sprintf("invalid strategy type.  Valid values are %s, %s", api.SELinuxStrategyMustRunAs, api.SELinuxStrategyRunAsAny)
-		allErrs = append(allErrs, errs.NewFieldInvalid("seLinuxContext.type", scc.RunAsUser.Type, msg))
+		allErrs = append(allErrs, errs.NewFieldInvalid("seLinuxContext.type", scc.SELinuxContext.Type, msg))
+	}
+
+	// ensure the fsgroup strat has a valid type
+	if scc.FSGroup.Type != api.FSGroupStrategyMustRunAs && scc.FSGroup.Type != api.FSGroupStrategyRunAsAny {
+		allErrs = append(allErrs, errs.NewFieldValueNotSupported("fsGroup.type", scc.FSGroup.Type,
+			[]string{string(api.FSGroupStrategyMustRunAs), string(api.FSGroupStrategyRunAsAny)}))
+	}
+	allErrs = append(allErrs, validateIDRanges(scc.FSGroup.Ranges).Prefix("fsGroup")...)
+
+	if scc.SupplementalGroups.Type != api.SupplementalGroupsStrategyMustRunAs &&
+		scc.SupplementalGroups.Type != api.SupplementalGroupsStrategyRunAsAny {
+		allErrs = append(allErrs, errs.NewFieldValueNotSupported("supplementalGroups.type", scc.SupplementalGroups.Type,
+			[]string{string(api.SupplementalGroupsStrategyMustRunAs), string(api.SupplementalGroupsStrategyRunAsAny)}))
+	}
+	allErrs = append(allErrs, validateIDRanges(scc.SupplementalGroups.Ranges).Prefix("supplementalGroups")...)
+
+	return allErrs
+}
+
+// validateIDRanges ensures the range is valid.
+func validateIDRanges(rng []api.IDRange) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	for i, r := range rng {
+		// if 0 <= Min <= Max then we do not need to validate max.  It is always greater than or
+		// equal to 0 and Min.
+		minField := fmt.Sprintf("ranges[%d].min", i)
+		maxField := fmt.Sprintf("ranges[%d].max", i)
+
+		if r.Min < 0 {
+			allErrs = append(allErrs, errs.NewFieldInvalid(minField, r.Min, "min cannot be negative"))
+		}
+		if r.Max < 0 {
+			allErrs = append(allErrs, errs.NewFieldInvalid(maxField, r.Max, "max cannot be negative"))
+		}
+		if r.Min > r.Max {
+			allErrs = append(allErrs, errs.NewFieldInvalid(minField, r, "min cannot be greater than max"))
+		}
 	}
 
 	return allErrs

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
@@ -4067,81 +4067,140 @@ func TestValidPodLogOptions(t *testing.T) {
 
 func TestValidateSecurityContextConstraints(t *testing.T) {
 	var invalidUID int64 = -1
+
+	validSCC := func() *api.SecurityContextConstraints {
+		return &api.SecurityContextConstraints{
+			ObjectMeta: api.ObjectMeta{Name: "foo"},
+			SELinuxContext: api.SELinuxContextStrategyOptions{
+				Type: api.SELinuxStrategyRunAsAny,
+			},
+			RunAsUser: api.RunAsUserStrategyOptions{
+				Type: api.RunAsUserStrategyRunAsAny,
+			},
+			FSGroup: api.FSGroupStrategyOptions{
+				Type: api.FSGroupStrategyRunAsAny,
+			},
+			SupplementalGroups: api.SupplementalGroupsStrategyOptions{
+				Type: api.SupplementalGroupsStrategyRunAsAny,
+			},
+		}
+	}
+
+	noUserOptions := validSCC()
+	noUserOptions.RunAsUser.Type = ""
+
+	noSELinuxOptions := validSCC()
+	noSELinuxOptions.SELinuxContext.Type = ""
+
+	invalidUserStratType := validSCC()
+	invalidUserStratType.RunAsUser.Type = "invalid"
+
+	invalidSELinuxStratType := validSCC()
+	invalidSELinuxStratType.SELinuxContext.Type = "invalid"
+
+	invalidUIDSCC := validSCC()
+	invalidUIDSCC.RunAsUser.Type = api.RunAsUserStrategyMustRunAs
+	invalidUIDSCC.RunAsUser.UID = &invalidUID
+
+	missingObjectMetaName := validSCC()
+	missingObjectMetaName.ObjectMeta.Name = ""
+
+	noFSGroupOptions := validSCC()
+	noFSGroupOptions.FSGroup.Type = ""
+
+	invalidFSGroupStratType := validSCC()
+	invalidFSGroupStratType.FSGroup.Type = "invalid"
+
+	noSupplementalGroupsOptions := validSCC()
+	noSupplementalGroupsOptions.SupplementalGroups.Type = ""
+
+	invalidSupGroupStratType := validSCC()
+	invalidSupGroupStratType.SupplementalGroups.Type = "invalid"
+
+	invalidRangeMinGreaterThanMax := validSCC()
+	invalidRangeMinGreaterThanMax.FSGroup.Ranges = []api.IDRange{
+		{Min: 2, Max: 1},
+	}
+
+	invalidRangeNegativeMin := validSCC()
+	invalidRangeNegativeMin.FSGroup.Ranges = []api.IDRange{
+		{Min: -1, Max: 10},
+	}
+
+	invalidRangeNegativeMax := validSCC()
+	invalidRangeNegativeMax.FSGroup.Ranges = []api.IDRange{
+		{Min: 1, Max: -10},
+	}
+
 	errorCases := map[string]struct {
 		scc         *api.SecurityContextConstraints
 		errorType   fielderrors.ValidationErrorType
 		errorDetail string
 	}{
 		"no user options": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyMustRunAs,
-				},
-			},
+			scc:         noUserOptions,
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, RunAsAny",
 		},
 		"no selinux options": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyMustRunAs,
-				},
-			},
+			scc:         noSELinuxOptions,
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "invalid strategy type.  Valid values are MustRunAs, RunAsAny",
 		},
+		"no fsgroup options": {
+			scc:         noFSGroupOptions,
+			errorType:   errors.ValidationErrorTypeNotSupported,
+			errorDetail: "supported values: MustRunAs, RunAsAny",
+		},
+		"no sup group options": {
+			scc:         noSupplementalGroupsOptions,
+			errorType:   errors.ValidationErrorTypeNotSupported,
+			errorDetail: "supported values: MustRunAs, RunAsAny",
+		},
 		"invalid user strategy type": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: "invalid",
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyMustRunAs,
-				},
-			},
+			scc:         invalidUserStratType,
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, RunAsAny",
 		},
 		"invalid selinux strategy type": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyMustRunAs,
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: "invalid",
-				},
-			},
+			scc:         invalidSELinuxStratType,
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "invalid strategy type.  Valid values are MustRunAs, RunAsAny",
 		},
+		"invalid sup group strategy type": {
+			scc:         invalidSupGroupStratType,
+			errorType:   errors.ValidationErrorTypeNotSupported,
+			errorDetail: "supported values: MustRunAs, RunAsAny",
+		},
+		"invalid fs group strategy type": {
+			scc:         invalidFSGroupStratType,
+			errorType:   errors.ValidationErrorTypeNotSupported,
+			errorDetail: "supported values: MustRunAs, RunAsAny",
+		},
 		"invalid uid": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyMustRunAs,
-					UID:  &invalidUID,
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyMustRunAs,
-				},
-			},
+			scc:         invalidUIDSCC,
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "uid cannot be negative",
 		},
 		"missing object meta name": {
-			scc: &api.SecurityContextConstraints{
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyMustRunAs,
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyMustRunAs,
-				},
-			},
-			errorType: errors.ValidationErrorTypeRequired,
+			scc:         missingObjectMetaName,
+			errorType:   errors.ValidationErrorTypeRequired,
+			errorDetail: "name or generateName is required",
+		},
+		"invalid range min greater than max": {
+			scc:         invalidRangeMinGreaterThanMax,
+			errorType:   errors.ValidationErrorTypeInvalid,
+			errorDetail: "min cannot be greater than max",
+		},
+		"invalid range negative min": {
+			scc:         invalidRangeNegativeMin,
+			errorType:   errors.ValidationErrorTypeInvalid,
+			errorDetail: "min cannot be negative",
+		},
+		"invalid range negative max": {
+			scc:         invalidRangeNegativeMax,
+			errorType:   errors.ValidationErrorTypeInvalid,
+			errorDetail: "max cannot be negative",
 		},
 	}
 
@@ -4152,42 +4211,28 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 	}
 
 	var validUID int64 = 1
+
+	mustRunAs := validSCC()
+	mustRunAs.FSGroup.Type = api.FSGroupStrategyMustRunAs
+	mustRunAs.SupplementalGroups.Type = api.SupplementalGroupsStrategyMustRunAs
+	mustRunAs.RunAsUser.Type = api.RunAsUserStrategyMustRunAs
+	mustRunAs.RunAsUser.UID = &validUID
+	mustRunAs.SELinuxContext.Type = api.SELinuxStrategyMustRunAs
+
+	runAsNonRoot := validSCC()
+	runAsNonRoot.RunAsUser.Type = api.RunAsUserStrategyMustRunAsNonRoot
+
 	successCases := map[string]struct {
 		scc *api.SecurityContextConstraints
 	}{
 		"must run as": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyMustRunAs,
-					UID:  &validUID,
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyMustRunAs,
-				},
-			},
+			scc: mustRunAs,
 		},
 		"run as any": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyRunAsAny,
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyRunAsAny,
-				},
-			},
+			scc: validSCC(),
 		},
 		"run as non-root (user only)": {
-			scc: &api.SecurityContextConstraints{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				RunAsUser: api.RunAsUserStrategyOptions{
-					Type: api.RunAsUserStrategyMustRunAsNonRoot,
-				},
-				SELinuxContext: api.SELinuxContextStrategyOptions{
-					Type: api.SELinuxStrategyRunAsAny,
-				},
-			},
+			scc: runAsNonRoot,
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
@@ -471,6 +471,26 @@ func deepCopy_api_PodSecurityContext(in api.PodSecurityContext, out *api.PodSecu
 	} else {
 		out.SupplementalGroups = nil
 	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(api.SELinuxOptions)
+		if err := deepCopy_api_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -655,7 +675,12 @@ func deepCopy_api_SecurityContext(in api.SecurityContext, out *api.SecurityConte
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
@@ -463,14 +463,6 @@ func deepCopy_api_PodSecurityContext(in api.PodSecurityContext, out *api.PodSecu
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
-	if in.SupplementalGroups != nil {
-		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
-		for i := range in.SupplementalGroups {
-			out.SupplementalGroups[i] = in.SupplementalGroups[i]
-		}
-	} else {
-		out.SupplementalGroups = nil
-	}
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(api.SELinuxOptions)
 		if err := deepCopy_api_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
@@ -490,6 +482,20 @@ func deepCopy_api_PodSecurityContext(in api.PodSecurityContext, out *api.PodSecu
 		*out.RunAsNonRoot = *in.RunAsNonRoot
 	} else {
 		out.RunAsNonRoot = nil
+	}
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
@@ -463,6 +463,14 @@ func deepCopy_api_PodSecurityContext(in api.PodSecurityContext, out *api.PodSecu
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
@@ -334,6 +334,8 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSecurityContext))(in)
 	}
+
+	out.SupplementalGroups = in.SupplementalGroups
 	return nil
 }
 
@@ -341,6 +343,8 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityC
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.PodSecurityContext))(in)
 	}
+
+	out.SupplementalGroups = in.SupplementalGroups
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
@@ -356,6 +356,12 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	} else {
 		out.RunAsNonRoot = nil
 	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
+	}
 	return nil
 }
 
@@ -384,6 +390,12 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityC
 		*out.RunAsNonRoot = *in.RunAsNonRoot
 	} else {
 		out.RunAsNonRoot = nil
+	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
@@ -336,6 +336,26 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	}
 
 	out.SupplementalGroups = in.SupplementalGroups
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(v1.SELinuxOptions)
+		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -345,6 +365,26 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityC
 	}
 
 	out.SupplementalGroups = in.SupplementalGroups
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(api.SELinuxOptions)
+		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -888,7 +888,12 @@ func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *api.SecurityConte
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -1942,7 +1947,12 @@ func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *v1.SecurityContex
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -520,14 +520,6 @@ func deepCopy_v1_PersistentVolumeClaimVolumeSource(in v1.PersistentVolumeClaimVo
 }
 
 func deepCopy_v1_PodSecurityContext(in v1.PodSecurityContext, out *v1.PodSecurityContext, c *conversion.Cloner) error {
-	if in.SupplementalGroups != nil {
-		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
-		for i := range in.SupplementalGroups {
-			out.SupplementalGroups[i] = in.SupplementalGroups[i]
-		}
-	} else {
-		out.SupplementalGroups = nil
-	}
 	if in.SELinuxOptions != nil {
 		out.SELinuxOptions = new(v1.SELinuxOptions)
 		if err := deepCopy_v1_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
@@ -547,6 +539,20 @@ func deepCopy_v1_PodSecurityContext(in v1.PodSecurityContext, out *v1.PodSecurit
 		*out.RunAsNonRoot = *in.RunAsNonRoot
 	} else {
 		out.RunAsNonRoot = nil
+	}
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
+	if in.FSGroup != nil {
+		out.FSGroup = new(int64)
+		*out.FSGroup = *in.FSGroup
+	} else {
+		out.FSGroup = nil
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -520,6 +520,14 @@ func deepCopy_v1_PersistentVolumeClaimVolumeSource(in v1.PersistentVolumeClaimVo
 }
 
 func deepCopy_v1_PodSecurityContext(in v1.PodSecurityContext, out *v1.PodSecurityContext, c *conversion.Cloner) error {
+	if in.SupplementalGroups != nil {
+		out.SupplementalGroups = make([]int64, len(in.SupplementalGroups))
+		for i := range in.SupplementalGroups {
+			out.SupplementalGroups[i] = in.SupplementalGroups[i]
+		}
+	} else {
+		out.SupplementalGroups = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -528,6 +528,26 @@ func deepCopy_v1_PodSecurityContext(in v1.PodSecurityContext, out *v1.PodSecurit
 	} else {
 		out.SupplementalGroups = nil
 	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(v1.SELinuxOptions)
+		if err := deepCopy_v1_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 
@@ -717,7 +737,12 @@ func deepCopy_v1_SecurityContext(in v1.SecurityContext, out *v1.SecurityContext,
 	} else {
 		out.RunAsUser = nil
 	}
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
@@ -407,7 +407,7 @@ var thirdPartyResourceColumns = []string{"NAME", "DESCRIPTION", "VERSION(S)"}
 var horizontalPodAutoscalerColumns = []string{"NAME", "REFERENCE", "TARGET", "CURRENT", "MINPODS", "MAXPODS", "AGE"}
 var withNamespacePrefixColumns = []string{"NAMESPACE"} // TODO(erictune): print cluster name too.
 var deploymentColumns = []string{"NAME", "UPDATEDREPLICAS", "AGE"}
-var securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "HOSTDIR", "SELINUX", "RUNASUSER"}
+var securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "HOSTDIR", "SELINUX", "RUNASUSER", "FSGROUP", "SUPGROUP"}
 
 // addDefaultHandlers adds print handlers for default Kubernetes types.
 func (h *HumanReadablePrinter) addDefaultHandlers() {
@@ -1428,9 +1428,9 @@ func printHorizontalPodAutoscalerList(list *extensions.HorizontalPodAutoscalerLi
 }
 
 func printSecurityContextConstraints(item *api.SecurityContextConstraints, w io.Writer, withNamespace, wide, showAll bool, columnLabels []string) error {
-	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%t\t%s\t%s\n", item.Name, item.AllowPrivilegedContainer,
+	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%t\t%s\t%s\t%s\t%s\n", item.Name, item.AllowPrivilegedContainer,
 		item.AllowedCapabilities, item.AllowHostDirVolumePlugin, item.SELinuxContext.Type,
-		item.RunAsUser.Type)
+		item.RunAsUser.Type, item.FSGroup.Type, item.SupplementalGroups.Type)
 	return err
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/container/runtime.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/container/runtime.go
@@ -234,6 +234,8 @@ type Mount struct {
 	HostPath string
 	// Whether the mount is read-only.
 	ReadOnly bool
+	// Whether the mount needs SELinux relabeling
+	SELinuxRelabel bool
 }
 
 type PortMapping struct {
@@ -269,7 +271,16 @@ type RunContainerOptions struct {
 	CgroupParent string
 }
 
-type VolumeMap map[string]volume.Volume
+// VolumeInfo contains information about the volume.
+type VolumeInfo struct {
+	// Builder is the volume's builder
+	Builder volume.Builder
+	// SELinuxLabeled indicates whether this volume has had the
+	// pod's SELinux label applied to it or not
+	SELinuxLabeled bool
+}
+
+type VolumeMap map[string]VolumeInfo
 
 type Pods []*Pod
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
@@ -1916,7 +1916,7 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, pod
 			continue
 		}
 
-		if container.SecurityContext != nil && container.SecurityContext.RunAsNonRoot {
+		if container.SecurityContext != nil && container.SecurityContext.RunAsNonRoot != nil && *container.SecurityContext.RunAsNonRoot {
 			err := dm.verifyNonRoot(container)
 			dm.updateReasonCache(pod, container, "VerifyNonRootError", err)
 			if err != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
@@ -626,12 +626,28 @@ func makeEnvList(envs []kubecontainer.EnvVar) (result []string) {
 // can be understood by docker.
 // Each element in the string is in the form of:
 // '<HostPath>:<ContainerPath>', or
-// '<HostPath>:<ContainerPath>:ro', if the path is read only.
-func makeMountBindings(mounts []kubecontainer.Mount) (result []string) {
+// '<HostPath>:<ContainerPath>:ro', if the path is read only, or
+// '<HostPath>:<ContainerPath>:Z', if the volume requires SELinux
+// relabeling and the pod provides an SELinux label
+func makeMountBindings(mounts []kubecontainer.Mount, podHasSELinuxLabel bool) (result []string) {
 	for _, m := range mounts {
 		bind := fmt.Sprintf("%s:%s", m.HostPath, m.ContainerPath)
 		if m.ReadOnly {
 			bind += ":ro"
+		}
+		// Only request relabeling if the pod provides an
+		// SELinux context. If the pod does not provide an
+		// SELinux context relabeling will label the volume
+		// with the container's randomly allocated MCS label.
+		// This would restrict access to the volume to the
+		// container which mounts it first.
+		if m.SELinuxRelabel && podHasSELinuxLabel {
+			if m.ReadOnly {
+				bind += ",Z"
+			} else {
+				bind += ":Z"
+			}
+
 		}
 		result = append(result, bind)
 	}
@@ -782,7 +798,8 @@ func (dm *DockerManager) runContainer(
 		dm.recorder.Eventf(ref, "Created", "Created with docker id %v", util.ShortenString(dockerContainer.ID, 12))
 	}
 
-	binds := makeMountBindings(opts.Mounts)
+	podHasSELinuxLabel := pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SELinuxOptions != nil
+	binds := makeMountBindings(opts.Mounts, podHasSELinuxLabel)
 
 	// The reason we create and mount the log file in here (not in kubelet) is because
 	// the file's location depends on the ID of the container, and we need to create and

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -64,6 +64,8 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/bandwidth"
+	"k8s.io/kubernetes/pkg/util/chmod"
+	"k8s.io/kubernetes/pkg/util/chown"
 	utilErrors "k8s.io/kubernetes/pkg/util/errors"
 	kubeio "k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -174,6 +176,8 @@ func NewMainKubelet(
 	rktStage1Image string,
 	mounter mount.Interface,
 	writer kubeio.Writer,
+	chownRunner chown.Interface,
+	chmodRunner chmod.Interface,
 	dockerDaemonContainer string,
 	systemContainer string,
 	configureCBR0 bool,
@@ -286,6 +290,8 @@ func NewMainKubelet(
 		cgroupRoot:                     cgroupRoot,
 		mounter:                        mounter,
 		writer:                         writer,
+		chmodRunner:                    chmodRunner,
+		chownRunner:                    chownRunner,
 		configureCBR0:                  configureCBR0,
 		podCIDR:                        podCIDR,
 		reconcileCIDR:                  reconcileCIDR,
@@ -574,6 +580,10 @@ type Kubelet struct {
 
 	// Mounter to use for volumes.
 	mounter mount.Interface
+	// chown.Interface implementation to use
+	chownRunner chown.Interface
+	// chmod.Interface implementation to use
+	chmodRunner chmod.Interface
 
 	// Writer interface to use for volumes.
 	writer kubeio.Writer

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go
@@ -501,6 +501,26 @@ func (f *stubVolume) GetPath() string {
 	return f.path
 }
 
+func (f *stubVolume) IsReadOnly() bool {
+	return false
+}
+
+func (f *stubVolume) SetUp() error {
+	return nil
+}
+
+func (f *stubVolume) SetUpAt(dir string) error {
+	return nil
+}
+
+func (f *stubVolume) SupportsSELinux() bool {
+	return false
+}
+
+func (f *stubVolume) SupportsOwnershipManagement() bool {
+	return false
+}
+
 func TestMakeVolumeMounts(t *testing.T) {
 	container := api.Container{
 		VolumeMounts: []api.VolumeMount{
@@ -528,9 +548,9 @@ func TestMakeVolumeMounts(t *testing.T) {
 	}
 
 	podVolumes := kubecontainer.VolumeMap{
-		"disk":  &stubVolume{"/mnt/disk"},
-		"disk4": &stubVolume{"/mnt/host"},
-		"disk5": &stubVolume{"/var/lib/kubelet/podID/volumes/empty/disk5"},
+		"disk":  kubecontainer.VolumeInfo{Builder: &stubVolume{"/mnt/disk"}},
+		"disk4": kubecontainer.VolumeInfo{Builder: &stubVolume{"/mnt/host"}},
+		"disk5": kubecontainer.VolumeInfo{Builder: &stubVolume{"/var/lib/kubelet/podID/volumes/empty/disk5"}},
 	}
 
 	mounts := makeMounts(&container, podVolumes)
@@ -541,23 +561,27 @@ func TestMakeVolumeMounts(t *testing.T) {
 			"/mnt/path",
 			"/mnt/disk",
 			false,
+			false,
 		},
 		{
 			"disk",
 			"/mnt/path3",
 			"/mnt/disk",
 			true,
+			false,
 		},
 		{
 			"disk4",
 			"/mnt/path4",
 			"/mnt/host",
 			false,
+			false,
 		},
 		{
 			"disk5",
 			"/mnt/path5",
 			"/var/lib/kubelet/podID/volumes/empty/disk5",
+			false,
 			false,
 		},
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/rkt/rkt.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/rkt/rkt.go
@@ -471,7 +471,7 @@ func (r *Runtime) makePodManifest(pod *api.Pod, pullSecrets []api.Secret) (*appc
 		manifest.Volumes = append(manifest.Volumes, appctypes.Volume{
 			Name:   *volName,
 			Kind:   "host",
-			Source: volume.GetPath(),
+			Source: volume.Builder.GetPath(),
 		})
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/volumes.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/volumes.go
@@ -146,7 +146,7 @@ func (kl *Kubelet) mountExternalVolumes(pod *api.Pod) (kubecontainer.VolumeMap, 
 				return nil, err
 			}
 		}
-		podVolumes[volSpec.Name] = builder
+		podVolumes[volSpec.Name] = kubecontainer.VolumeInfo{Builder: builder}
 	}
 	return podVolumes, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/volumes_linux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/volumes_linux.go
@@ -1,0 +1,63 @@
+// +build linux
+
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+// Bitmask to OR with current ownership of volumes that allow ownership management by the Kubelet
+const managedOwnershipBitmask = os.FileMode(0660)
+
+// manageVolumeOwnership modifies the given volume to be owned by fsGroup.
+func (kl *Kubelet) manageVolumeOwnership(pod *api.Pod, volSpec *volume.Spec, builder volume.Builder, fsGroup int64) error {
+	return filepath.Walk(builder.GetPath(), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil
+		}
+
+		if stat == nil {
+			glog.Errorf("Got nil stat_t for path %v while managing ownership of volume %v for pod %s/%s", path, volSpec.Name, pod.Namespace, pod.Name)
+			return nil
+		}
+
+		err = kl.chownRunner.Chown(path, int(stat.Uid), int(fsGroup))
+		if err != nil {
+			glog.Errorf("Chown failed on %v: %v", path, err)
+		}
+
+		err = kl.chmodRunner.Chmod(path, info.Mode()|managedOwnershipBitmask|os.ModeSetgid)
+		if err != nil {
+			glog.Errorf("Chmod failed on %v: %v", path, err)
+		}
+
+		return nil
+	})
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/volumes_unsupported.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/volumes_unsupported.go
@@ -1,0 +1,28 @@
+// +build !linux
+
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+func (_ *Kubelet) manageVolumeOwnership(pod *api.Pod, volSpec *volume.Spec, builder volume.Builder, fsGroup int64) error {
+	return nil
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/securitycontextconstraints/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/securitycontextconstraints/etcd/etcd_test.go
@@ -41,6 +41,12 @@ func validNewSecurityContextConstraints(name string) *api.SecurityContextConstra
 		RunAsUser: api.RunAsUserStrategyOptions{
 			Type: api.RunAsUserStrategyRunAsAny,
 		},
+		FSGroup: api.FSGroupStrategyOptions{
+			Type: api.FSGroupStrategyRunAsAny,
+		},
+		SupplementalGroups: api.SupplementalGroupsStrategyOptions{
+			Type: api.SupplementalGroupsStrategyRunAsAny,
+		},
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontext/provider_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontext/provider_test.go
@@ -28,94 +28,148 @@ import (
 )
 
 func TestModifyContainerConfig(t *testing.T) {
-	var uid int64 = 1
-	testCases := map[string]struct {
-		securityContext *api.SecurityContext
-		expected        *docker.Config
+	var uid int64 = 123
+	var overrideUid int64 = 321
+
+	cases := []struct {
+		name     string
+		podSc    *api.PodSecurityContext
+		sc       *api.SecurityContext
+		expected *docker.Config
 	}{
-		"modify config, value set for user": {
-			securityContext: &api.SecurityContext{
+		{
+			name: "container.SecurityContext.RunAsUser set",
+			sc: &api.SecurityContext{
 				RunAsUser: &uid,
 			},
 			expected: &docker.Config{
 				User: strconv.FormatInt(uid, 10),
 			},
 		},
-		"modify config, nil user value": {
-			securityContext: &api.SecurityContext{},
-			expected:        &docker.Config{},
+		{
+			name:     "no RunAsUser value set",
+			sc:       &api.SecurityContext{},
+			expected: &docker.Config{},
+		},
+		{
+			name: "pod.Spec.SecurityContext.RunAsUser set",
+			podSc: &api.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			expected: &docker.Config{
+				User: strconv.FormatInt(uid, 10),
+			},
+		},
+		{
+			name: "container.SecurityContext.RunAsUser overrides pod.Spec.SecurityContext.RunAsUser",
+			podSc: &api.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			sc: &api.SecurityContext{
+				RunAsUser: &overrideUid,
+			},
+			expected: &docker.Config{
+				User: strconv.FormatInt(overrideUid, 10),
+			},
 		},
 	}
 
 	provider := NewSimpleSecurityContextProvider()
 	dummyContainer := &api.Container{}
-	for k, v := range testCases {
-		dummyContainer.SecurityContext = v.securityContext
+	for _, tc := range cases {
+		pod := &api.Pod{Spec: api.PodSpec{SecurityContext: tc.podSc}}
+		dummyContainer.SecurityContext = tc.sc
 		dockerCfg := &docker.Config{}
-		provider.ModifyContainerConfig(nil, dummyContainer, dockerCfg)
-		if !reflect.DeepEqual(v.expected, dockerCfg) {
-			t.Errorf("unexpected modification of docker config for %s.  Expected: %#v Got: %#v", k, v.expected, dockerCfg)
+
+		provider.ModifyContainerConfig(pod, dummyContainer, dockerCfg)
+
+		if e, a := tc.expected, dockerCfg; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: unexpected modification of docker config\nExpected:\n\n%#v\n\nGot:\n\n%#v", tc.name, e, a)
 		}
 	}
 }
 
 func TestModifyHostConfig(t *testing.T) {
-	nilPrivSC := fullValidSecurityContext()
-	nilPrivSC.Privileged = nil
-	nilPrivHC := fullValidHostConfig()
-	nilPrivHC.Privileged = false
+	priv := true
+	setPrivSC := &api.SecurityContext{}
+	setPrivSC.Privileged = &priv
+	setPrivHC := &docker.HostConfig{
+		Privileged: true,
+	}
 
-	nilCapsSC := fullValidSecurityContext()
-	nilCapsSC.Capabilities = nil
-	nilCapsHC := fullValidHostConfig()
-	nilCapsHC.CapAdd = *new([]string)
-	nilCapsHC.CapDrop = *new([]string)
+	setCapsHC := &docker.HostConfig{
+		CapAdd:  []string{"addCapA", "addCapB"},
+		CapDrop: []string{"dropCapA", "dropCapB"},
+	}
 
-	nilSELinuxSC := fullValidSecurityContext()
-	nilSELinuxSC.SELinuxOptions = nil
-	nilSELinuxHC := fullValidHostConfig()
-	nilSELinuxHC.SecurityOpt = *new([]string)
+	setSELinuxHC := &docker.HostConfig{}
+	setSELinuxHC.SecurityOpt = []string{
+		fmt.Sprintf("%s:%s", dockerLabelUser, "user"),
+		fmt.Sprintf("%s:%s", dockerLabelRole, "role"),
+		fmt.Sprintf("%s:%s", dockerLabelType, "type"),
+		fmt.Sprintf("%s:%s", dockerLabelLevel, "level"),
+	}
 
-	seLinuxLabelsSC := fullValidSecurityContext()
-	seLinuxLabelsHC := fullValidHostConfig()
+	// seLinuxLabelsSC := fullValidSecurityContext()
+	// seLinuxLabelsHC := fullValidHostConfig()
 
-	testCases := map[string]struct {
-		securityContext *api.SecurityContext
-		expected        *docker.HostConfig
+	cases := []struct {
+		name     string
+		podSc    *api.PodSecurityContext
+		sc       *api.SecurityContext
+		expected *docker.HostConfig
 	}{
-		"full settings": {
-			securityContext: fullValidSecurityContext(),
-			expected:        fullValidHostConfig(),
+		{
+			name:     "fully set container.SecurityContext",
+			sc:       fullValidSecurityContext(),
+			expected: fullValidHostConfig(),
 		},
-		"nil privileged": {
-			securityContext: nilPrivSC,
-			expected:        nilPrivHC,
+		{
+			name:     "container.SecurityContext.Privileged",
+			sc:       setPrivSC,
+			expected: setPrivHC,
 		},
-		"nil capabilities": {
-			securityContext: nilCapsSC,
-			expected:        nilCapsHC,
+		{
+			name: "container.SecurityContext.Capabilities",
+			sc: &api.SecurityContext{
+				Capabilities: inputCapabilities(),
+			},
+			expected: setCapsHC,
 		},
-		"nil selinux options": {
-			securityContext: nilSELinuxSC,
-			expected:        nilSELinuxHC,
+		{
+			name: "container.SecurityContext.SELinuxOptions",
+			sc: &api.SecurityContext{
+				SELinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
 		},
-		"selinux labels": {
-			securityContext: seLinuxLabelsSC,
-			expected:        seLinuxLabelsHC,
+		{
+			name: "pod.Spec.SecurityContext.SELinuxOptions",
+			podSc: &api.PodSecurityContext{
+				SELinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
+		},
+		{
+			name:     "container.SecurityContext overrides pod.Spec.SecurityContext",
+			podSc:    overridePodSecurityContext(),
+			sc:       fullValidSecurityContext(),
+			expected: fullValidHostConfig(),
 		},
 	}
 
 	provider := NewSimpleSecurityContextProvider()
 	dummyContainer := &api.Container{}
-	dummyPod := &api.Pod{
-		Spec: apitesting.DeepEqualSafePodSpec(),
-	}
-	for k, v := range testCases {
-		dummyContainer.SecurityContext = v.securityContext
+
+	for _, tc := range cases {
+		pod := &api.Pod{Spec: api.PodSpec{SecurityContext: tc.podSc}}
+		dummyContainer.SecurityContext = tc.sc
 		dockerCfg := &docker.HostConfig{}
-		provider.ModifyHostConfig(dummyPod, dummyContainer, dockerCfg)
-		if !reflect.DeepEqual(v.expected, dockerCfg) {
-			t.Errorf("unexpected modification of host config for %s.  Expected: %#v Got: %#v", k, v.expected, dockerCfg)
+
+		provider.ModifyHostConfig(pod, dummyContainer, dockerCfg)
+
+		if e, a := tc.expected, dockerCfg; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: unexpected modification of host config\nExpected:\n\n%#v\n\nGot:\n\n%#v", tc.name, e, a)
 		}
 	}
 }
@@ -189,20 +243,45 @@ func TestModifySecurityOption(t *testing.T) {
 	}
 }
 
+func overridePodSecurityContext() *api.PodSecurityContext {
+	return &api.PodSecurityContext{
+		SELinuxOptions: &api.SELinuxOptions{
+			User:  "user2",
+			Role:  "role2",
+			Type:  "type2",
+			Level: "level2",
+		},
+	}
+}
+
+func fullValidPodSecurityContext() *api.PodSecurityContext {
+	return &api.PodSecurityContext{
+		SELinuxOptions: inputSELinuxOptions(),
+	}
+}
+
 func fullValidSecurityContext() *api.SecurityContext {
 	priv := true
 	return &api.SecurityContext{
-		Privileged: &priv,
-		Capabilities: &api.Capabilities{
-			Add:  []api.Capability{"addCapA", "addCapB"},
-			Drop: []api.Capability{"dropCapA", "dropCapB"},
-		},
-		SELinuxOptions: &api.SELinuxOptions{
-			User:  "user",
-			Role:  "role",
-			Type:  "type",
-			Level: "level",
-		},
+		Privileged:     &priv,
+		Capabilities:   inputCapabilities(),
+		SELinuxOptions: inputSELinuxOptions(),
+	}
+}
+
+func inputCapabilities() *api.Capabilities {
+	return &api.Capabilities{
+		Add:  []api.Capability{"addCapA", "addCapB"},
+		Drop: []api.Capability{"dropCapA", "dropCapB"},
+	}
+}
+
+func inputSELinuxOptions() *api.SELinuxOptions {
+	return &api.SELinuxOptions{
+		User:  "user",
+		Role:  "role",
+		Type:  "type",
+		Level: "level",
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontext/provider_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontext/provider_test.go
@@ -179,18 +179,34 @@ func TestModifyHostConfigPodSecurityContext(t *testing.T) {
 	supplementalGroupsSC.SupplementalGroups = []int64{2222}
 	supplementalGroupHC := fullValidHostConfig()
 	supplementalGroupHC.GroupAdd = []string{"2222"}
+	fsGroupHC := fullValidHostConfig()
+	fsGroupHC.GroupAdd = []string{"1234"}
+	bothHC := fullValidHostConfig()
+	bothHC.GroupAdd = []string{"2222", "1234"}
+	fsGroup := int64(1234)
 
 	testCases := map[string]struct {
 		securityContext *api.PodSecurityContext
 		expected        *docker.HostConfig
 	}{
-		"nil Security Context": {
+		"nil": {
 			securityContext: nil,
 			expected:        fullValidHostConfig(),
 		},
-		"Security Context with SupplementalGroup": {
+		"SupplementalGroup": {
 			securityContext: supplementalGroupsSC,
 			expected:        supplementalGroupHC,
+		},
+		"FSGroup": {
+			securityContext: &api.PodSecurityContext{FSGroup: &fsGroup},
+			expected:        fsGroupHC,
+		},
+		"FSGroup + SupplementalGroups": {
+			securityContext: &api.PodSecurityContext{
+				SupplementalGroups: []int64{2222},
+				FSGroup:            &fsGroup,
+			},
+			expected: bothHC,
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/mustrunas.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/mustrunas.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"fmt"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+)
+
+// mustRunAs implements the GroupSecurityContextConstraintsStrategy interface
+type mustRunAs struct {
+	ranges []api.IDRange
+	field  string
+}
+
+var _ GroupSecurityContextConstraintsStrategy = &mustRunAs{}
+
+// NewMustRunAs provides a new MustRunAs strategy based on ranges.
+func NewMustRunAs(ranges []api.IDRange, field string) (GroupSecurityContextConstraintsStrategy, error) {
+	if len(ranges) == 0 {
+		return nil, fmt.Errorf("ranges must be supplied for MustRunAs")
+	}
+	return &mustRunAs{
+		ranges: ranges,
+		field:  field,
+	}, nil
+}
+
+// Generate creates the group based on policy rules.  By default this returns the first group of the
+// first range (min val).
+func (s *mustRunAs) Generate(pod *api.Pod) ([]int64, error) {
+	return []int64{s.ranges[0].Min}, nil
+}
+
+// Generate a single value to be applied.  This is used for FSGroup.  This strategy will return
+// the first group of the first range (min val).
+func (s *mustRunAs) GenerateSingle(pod *api.Pod) (*int64, error) {
+	single := new(int64)
+	*single = s.ranges[0].Min
+	return single, nil
+}
+
+// Validate ensures that the specified values fall within the range of the strategy.
+// Groups are passed in here to allow this strategy to support multiple group fields (fsgroup and
+// supplemental groups).
+func (s *mustRunAs) Validate(pod *api.Pod, groups []int64) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if pod.Spec.SecurityContext == nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("securityContext", pod.Spec.SecurityContext, "unable to validate nil security context"))
+		return allErrs
+	}
+
+	if len(groups) == 0 && len(s.ranges) > 0 {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid(s.field, groups, "unable to validate empty groups against required ranges"))
+	}
+
+	for _, group := range groups {
+		if !s.isGroupValid(group) {
+			detail := fmt.Sprintf("%d is not an allowed group", group)
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid(s.field, groups, detail))
+		}
+	}
+
+	return allErrs
+}
+
+func (s *mustRunAs) isGroupValid(group int64) bool {
+	for _, rng := range s.ranges {
+		if fallsInRange(group, rng) {
+			return true
+		}
+	}
+	return false
+}
+
+func fallsInRange(group int64, rng api.IDRange) bool {
+	return group >= rng.Min && group <= rng.Max
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/mustrunas_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/mustrunas_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"testing"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestMustRunAsOptions(t *testing.T){
+	tests := map[string]struct{
+		ranges []api.IDRange
+		pass bool
+	}{
+		"empty": {
+			ranges: []api.IDRange{},
+		},
+		"ranges": {
+			ranges: []api.IDRange{
+				{Min: 1, Max: 1},
+			},
+			pass: true,
+		},
+	}
+
+	for k, v := range tests {
+		_, err := NewMustRunAs(v.ranges, "")
+		if v.pass && err != nil {
+			t.Errorf("error creating strategy for %s: %v", k, err)
+		}
+		if !v.pass && err == nil {
+			t.Errorf("expected error for %s but got none", k)
+		}
+	}
+}
+
+func TestGenerate(t *testing.T){
+	tests := map[string]struct{
+		ranges []api.IDRange
+		expected []int64
+	}{
+		"multi value": {
+			ranges: []api.IDRange{
+				{Min: 1, Max: 2,},
+			},
+			expected: []int64{1},
+		},
+		"single value": {
+			ranges: []api.IDRange{
+				{Min: 1, Max: 1,},
+			},
+			expected: []int64{1},
+		},
+		"multi range": {
+			ranges: []api.IDRange{
+				{Min: 1, Max: 1,},
+				{Min: 2, Max: 500,},
+			},
+			expected: []int64{1},
+		},
+	}
+
+	for k, v := range tests {
+		s, err := NewMustRunAs(v.ranges, "")
+		if err != nil {
+			t.Errorf("error creating strategy for %s: %v", k, err)
+		}
+		actual, err := s.Generate(nil)
+		if err != nil {
+			t.Errorf("unexpected error for %s: %v", k, err)
+		}
+		if len(actual) != len(v.expected) {
+			t.Errorf("unexpected generated values.  Expected %v, got %v", v.expected, actual)
+			continue
+		}
+		if len(actual) > 0 && len(v.expected) > 0 {
+			if actual[0] != v.expected[0] {
+				t.Errorf("unexpected generated values.  Expected %v, got %v", v.expected, actual)
+			}
+		}
+
+		single, err := s.GenerateSingle(nil)
+		if err != nil {
+			t.Errorf("unexpected error for %s: %v", k, err)
+		}
+		if single == nil {
+			t.Errorf("unexpected nil generated value for %s: %v", k, single)
+		}
+		if *single != v.expected[0] {
+			t.Errorf("unexpected generated single value.  Expected %v, got %v", v.expected, actual)
+		}
+	}
+}
+
+func TestValidate(t *testing.T){
+	validPod := func() *api.Pod {
+		return &api.Pod{
+			Spec: api.PodSpec{
+				SecurityContext: &api.PodSecurityContext{
+
+				},
+			},
+		}
+	}
+
+	tests := map[string]struct{
+		ranges []api.IDRange
+		pod *api.Pod
+		groups []int64
+		pass bool
+	}{
+		"nil security context": {
+			pod: &api.Pod{},
+			ranges: []api.IDRange{
+				{Min: 1, Max: 3},
+			},
+		},
+		"empty groups": {
+			pod: validPod(),
+			ranges: []api.IDRange{
+				{Min: 1, Max: 3},
+			},
+		},
+		"not in range": {
+			pod: validPod(),
+			groups: []int64{5},
+			ranges: []api.IDRange{
+				{Min: 1, Max: 3},
+				{Min: 4, Max: 4},
+			},
+		},
+		"in range 1": {
+			pod: validPod(),
+			groups: []int64{2},
+			ranges: []api.IDRange{
+				{Min: 1, Max: 3},
+			},
+			pass: true,
+		},
+		"in range boundry min": {
+			pod: validPod(),
+			groups: []int64{1},
+			ranges: []api.IDRange{
+				{Min: 1, Max: 3},
+			},
+			pass: true,
+		},
+		"in range boundry max": {
+			pod: validPod(),
+			groups: []int64{3},
+			ranges: []api.IDRange{
+				{Min: 1, Max: 3},
+			},
+			pass: true,
+		},
+		"singular range": {
+			pod: validPod(),
+			groups: []int64{4},
+			ranges: []api.IDRange{
+				{Min: 4, Max: 4},
+			},
+			pass: true,
+		},
+	}
+
+	for k, v := range tests {
+		s, err := NewMustRunAs(v.ranges, "")
+		if err != nil {
+			t.Errorf("error creating strategy for %s: %v", k, err)
+		}
+		errs := s.Validate(v.pod, v.groups)
+		if v.pass && len(errs) > 0 {
+			t.Errorf("unexpected errors for %s: %v", k, errs)
+		}
+		if !v.pass && len(errs) == 0 {
+			t.Errorf("expected no errors for %s but got: %v", k, errs)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/runasany.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/runasany.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+)
+
+// mustRunAs implements the GroupSecurityContextConstraintsStrategy interface
+type runAsAny struct {
+}
+
+var _ GroupSecurityContextConstraintsStrategy = &runAsAny{}
+
+// NewRunAsAny provides a new RunAsAny strategy.
+func NewRunAsAny() (GroupSecurityContextConstraintsStrategy, error){
+	return &runAsAny{}, nil
+}
+
+
+// Generate creates the group based on policy rules.  This strategy returns an empty slice.
+func (s *runAsAny) Generate(pod *api.Pod) ([]int64, error){
+	return []int64{}, nil
+}
+
+// Generate a single value to be applied.  This is used for FSGroup.  This strategy returns nil.
+func (s *runAsAny) GenerateSingle(pod *api.Pod) (*int64, error) {
+	return nil, nil
+}
+
+// Validate ensures that the specified values fall within the range of the strategy.
+func (s *runAsAny) Validate(pod *api.Pod, groups []int64) fielderrors.ValidationErrorList {
+	return fielderrors.ValidationErrorList{}
+
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/runasany_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/runasany_test.go
@@ -14,58 +14,47 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package selinux
+package group
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"testing"
 )
 
-func TestRunAsAnyOptions(t *testing.T) {
-	_, err := NewRunAsAny(nil)
-	if err != nil {
-		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
-	}
-	_, err = NewRunAsAny(&api.SELinuxContextStrategyOptions{})
-	if err != nil {
-		t.Errorf("unexpected error initializing NewRunAsAny %v", err)
-	}
-}
-
 func TestRunAsAnyGenerate(t *testing.T) {
-	s, err := NewRunAsAny(&api.SELinuxContextStrategyOptions{})
+	s, err := NewRunAsAny()
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
-	uid, err := s.Generate(nil, nil)
-	if uid != nil {
-		t.Errorf("expected nil uid but got %d", *uid)
+	groups, err := s.Generate(nil)
+	if len(groups) > 0 {
+		t.Errorf("expected empty but got %v", groups)
 	}
 	if err != nil {
-		t.Errorf("unexpected error generating uid %v", err)
+		t.Errorf("unexpected error generating groups: %v", err)
 	}
 }
 
-func TestRunAsAnyValidate(t *testing.T) {
-	s, err := NewRunAsAny(&api.SELinuxContextStrategyOptions{
-		SELinuxOptions: &api.SELinuxOptions{
-			Level: "foo",
-		},
-	},
-	)
+func TestRunAsAnyGenerateSingle(t *testing.T) {
+	s, err := NewRunAsAny()
+	if err != nil {
+		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
+	}
+	group, err := s.GenerateSingle(nil)
+	if group != nil {
+		t.Errorf("expected empty but got %v", group)
+	}
+	if err != nil {
+		t.Errorf("unexpected error generating groups: %v", err)
+	}
+}
+
+func TestRunAsAnyValidte(t *testing.T){
+	s, err := NewRunAsAny()
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
 	errs := s.Validate(nil, nil)
 	if len(errs) != 0 {
-		t.Errorf("unexpected errors validating with ")
-	}
-	s, err = NewRunAsAny(&api.SELinuxContextStrategyOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
-	}
-	errs = s.Validate(nil, nil)
-	if len(errs) != 0 {
-		t.Errorf("unexpected errors validating %v", errs)
+		t.Errorf("unexpected errors: %v", errs)
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/group/types.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+)
+
+// GroupSecurityContextConstraintsStrategy defines the interface for all group constraint strategies.
+type GroupSecurityContextConstraintsStrategy interface {
+	// Generate creates the group based on policy rules.  The underlying implementation can
+	// decide whether it will return a full range of values or a subset of values from the
+	// configured ranges.
+	Generate(pod *api.Pod) ([]int64, error)
+	// Generate a single value to be applied.  The underlying implementation decides which
+	// value to return if configured with multiple ranges.  This is used for FSGroup.
+	GenerateSingle(pod *api.Pod) (*int64, error)
+	// Validate ensures that the specified values fall within the range of the strategy.
+	Validate(pod *api.Pod, groups []int64) fielderrors.ValidationErrorList
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
@@ -120,7 +120,8 @@ func (s *simpleProvider) CreateSecurityContext(pod *api.Pod, container *api.Cont
 	// run as root which will signal to the kubelet to do a final check either on the runAsUser
 	// or, if runAsUser is not set, the image
 	if s.scc.RunAsUser.Type == api.RunAsUserStrategyMustRunAsNonRoot {
-		sc.RunAsNonRoot = true
+		b := true
+		sc.RunAsNonRoot = &b
 	}
 
 	// No need to touch capabilities, they will validate or not.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
@@ -20,16 +20,26 @@ import (
 	"fmt"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/securitycontextconstraints/group"
 	"k8s.io/kubernetes/pkg/securitycontextconstraints/selinux"
 	"k8s.io/kubernetes/pkg/securitycontextconstraints/user"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 )
 
+// used to pass in the field being validated for reusable group strategies so they
+// can create informative error messages.
+const (
+	fsGroupField = "fsGroup"
+	supplementalGroupsField = "supplementalGroups"
+)
+
 // simpleProvider is the default implementation of SecurityContextConstraintsProvider
 type simpleProvider struct {
-	scc               *api.SecurityContextConstraints
-	runAsUserStrategy user.RunAsUserSecurityContextConstraintsStrategy
-	seLinuxStrategy   selinux.SELinuxSecurityContextConstraintsStrategy
+	scc                       *api.SecurityContextConstraints
+	runAsUserStrategy         user.RunAsUserSecurityContextConstraintsStrategy
+	seLinuxStrategy           selinux.SELinuxSecurityContextConstraintsStrategy
+	fsGroupStrategy           group.GroupSecurityContextConstraintsStrategy
+	supplementalGroupStrategy group.GroupSecurityContextConstraintsStrategy
 }
 
 // ensure we implement the interface correctly.
@@ -41,43 +51,76 @@ func NewSimpleProvider(scc *api.SecurityContextConstraints) (SecurityContextCons
 		return nil, fmt.Errorf("NewSimpleProvider requires a SecurityContextConstraints")
 	}
 
-	var userStrat user.RunAsUserSecurityContextConstraintsStrategy = nil
-	var err error = nil
-	switch scc.RunAsUser.Type {
-	case api.RunAsUserStrategyMustRunAs:
-		userStrat, err = user.NewMustRunAs(&scc.RunAsUser)
-	case api.RunAsUserStrategyMustRunAsRange:
-		userStrat, err = user.NewMustRunAsRange(&scc.RunAsUser)
-	case api.RunAsUserStrategyMustRunAsNonRoot:
-		userStrat, err = user.NewRunAsNonRoot(&scc.RunAsUser)
-	case api.RunAsUserStrategyRunAsAny:
-		userStrat, err = user.NewRunAsAny(&scc.RunAsUser)
-	default:
-		err = fmt.Errorf("Unrecognized RunAsUser strategy type %s", scc.RunAsUser.Type)
-	}
+	userStrat, err := createUserStrategy(&scc.RunAsUser)
 	if err != nil {
 		return nil, err
 	}
 
-	var seLinuxStrat selinux.SELinuxSecurityContextConstraintsStrategy = nil
-	err = nil
-	switch scc.SELinuxContext.Type {
-	case api.SELinuxStrategyMustRunAs:
-		seLinuxStrat, err = selinux.NewMustRunAs(&scc.SELinuxContext)
-	case api.SELinuxStrategyRunAsAny:
-		seLinuxStrat, err = selinux.NewRunAsAny(&scc.SELinuxContext)
-	default:
-		err = fmt.Errorf("Unrecognized SELinuxContext strategy type %s", scc.SELinuxContext.Type)
+	seLinuxStrat, err := createSELinuxStrategy(&scc.SELinuxContext)
+	if err != nil {
+		return nil, err
 	}
+
+	fsGroupStrat, err := createFSGroupStrategy(&scc.FSGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	supGroupStrat, err := createSupplementalGroupStrategy(&scc.SupplementalGroups)
 	if err != nil {
 		return nil, err
 	}
 
 	return &simpleProvider{
-		scc:               scc,
-		runAsUserStrategy: userStrat,
-		seLinuxStrategy:   seLinuxStrat,
+		scc:                       scc,
+		runAsUserStrategy:         userStrat,
+		seLinuxStrategy:           seLinuxStrat,
+		fsGroupStrategy:           fsGroupStrat,
+		supplementalGroupStrategy: supGroupStrat,
 	}, nil
+}
+
+// Create a PodSecurityContext based on the given constraints.  If a setting is already set
+// on the PodSecurityContext it will not be changed.  Validate should be used after the context
+// is created to ensure it complies with the required restrictions.
+//
+// NOTE: this method works on a copy of the PodSecurityContext.  It is up to the caller to
+// apply the PSC if validation passes.
+func (s *simpleProvider) CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurityContext, error) {
+	var sc *api.PodSecurityContext = nil
+	if pod.Spec.SecurityContext != nil {
+		// work with a copy
+		copy := *pod.Spec.SecurityContext
+		sc = &copy
+	} else {
+		sc = &api.PodSecurityContext{}
+	}
+
+	if len(sc.SupplementalGroups) == 0 {
+		supGroups, err := s.supplementalGroupStrategy.Generate(pod)
+		if err != nil {
+			return nil, err
+		}
+		sc.SupplementalGroups = supGroups
+	}
+
+	if sc.FSGroup == nil {
+		fsGroup, err := s.fsGroupStrategy.GenerateSingle(pod)
+		if err != nil {
+			return nil, err
+		}
+		sc.FSGroup = fsGroup
+	}
+
+	if sc.SELinuxOptions == nil {
+		seLinux, err := s.seLinuxStrategy.Generate(pod, nil)
+		if err != nil {
+			return nil, err
+		}
+		sc.SELinuxOptions = seLinux
+	}
+
+	return sc, nil
 }
 
 // Create a SecurityContext based on the given constraints.  If a setting is already set on the
@@ -86,7 +129,7 @@ func NewSimpleProvider(scc *api.SecurityContextConstraints) (SecurityContextCons
 //
 // NOTE: this method works on a copy of the SC of the container.  It is up to the caller to apply
 // the SC if validation passes.
-func (s *simpleProvider) CreateSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, error) {
+func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, error) {
 	var sc *api.SecurityContext = nil
 	if container.SecurityContext != nil {
 		// work with a copy of the original
@@ -128,8 +171,48 @@ func (s *simpleProvider) CreateSecurityContext(pod *api.Pod, container *api.Cont
 	return sc, nil
 }
 
+// Ensure a pod's SecurityContext is in compliance with the given constraints.
+func (s *simpleProvider) ValidatePodSecurityContext(pod *api.Pod) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	if pod.Spec.SecurityContext == nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("securityContext", pod.Spec.SecurityContext, "No security context is set"))
+		return allErrs
+	}
+
+	fsGroups := []int64{}
+	if pod.Spec.SecurityContext.FSGroup != nil {
+		fsGroups = append(fsGroups, *pod.Spec.SecurityContext.FSGroup)
+	}
+	allErrs = append(allErrs, s.fsGroupStrategy.Validate(pod, fsGroups)...)
+	allErrs = append(allErrs, s.supplementalGroupStrategy.Validate(pod, pod.Spec.SecurityContext.SupplementalGroups)...)
+
+	// make a dummy container context to reuse the selinux strategies
+	container := &api.Container{
+		Name: pod.Name,
+		SecurityContext: &api.SecurityContext{
+			SELinuxOptions: pod.Spec.SecurityContext.SELinuxOptions,
+		},
+	}
+	allErrs = append(allErrs, s.seLinuxStrategy.Validate(pod, container)...)
+
+	if !s.scc.AllowHostNetwork && pod.Spec.SecurityContext.HostNetwork {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostNetwork", pod.Spec.SecurityContext.HostNetwork, "Host network is not allowed to be used"))
+	}
+
+	if !s.scc.AllowHostPID && pod.Spec.SecurityContext.HostPID {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostPID", pod.Spec.SecurityContext.HostPID, "Host PID is not allowed to be used"))
+	}
+
+	if !s.scc.AllowHostIPC && pod.Spec.SecurityContext.HostIPC {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostIPC", pod.Spec.SecurityContext.HostIPC, "Host IPC is not allowed to be used"))
+	}
+
+	return allErrs
+}
+
 // Ensure a container's SecurityContext is in compliance with the given constraints
-func (s *simpleProvider) ValidateSecurityContext(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList {
+func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList {
 	allErrs := fielderrors.ValidationErrorList{}
 
 	if container.SecurityContext == nil {
@@ -168,22 +251,10 @@ func (s *simpleProvider) ValidateSecurityContext(pod *api.Pod, container *api.Co
 		}
 	}
 
-	if !s.scc.AllowHostNetwork && pod.Spec.SecurityContext.HostNetwork {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostNetwork", pod.Spec.SecurityContext.HostNetwork, "Host network is not allowed to be used"))
-	}
-
 	if !s.scc.AllowHostPorts {
 		for idx, c := range pod.Spec.Containers {
 			allErrs = append(allErrs, s.hasHostPort(&c).Prefix(fmt.Sprintf("containers.%d", idx))...)
 		}
-	}
-
-	if !s.scc.AllowHostPID && pod.Spec.SecurityContext.HostPID {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostPID", pod.Spec.SecurityContext.HostPID, "Host PID is not allowed to be used"))
-	}
-
-	if !s.scc.AllowHostIPC && pod.Spec.SecurityContext.HostIPC {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostIPC", pod.Spec.SecurityContext.HostIPC, "Host IPC is not allowed to be used"))
 	}
 
 	return allErrs
@@ -203,4 +274,56 @@ func (s *simpleProvider) hasHostPort(container *api.Container) fielderrors.Valid
 // Get the name of the SCC that this provider was initialized with.
 func (s *simpleProvider) GetSCCName() string {
 	return s.scc.Name
+}
+
+// createUserStrategy creates a new user strategy.
+func createUserStrategy(opts *api.RunAsUserStrategyOptions) (user.RunAsUserSecurityContextConstraintsStrategy, error) {
+	switch opts.Type {
+	case api.RunAsUserStrategyMustRunAs:
+		return user.NewMustRunAs(opts)
+	case api.RunAsUserStrategyMustRunAsRange:
+		return user.NewMustRunAsRange(opts)
+	case api.RunAsUserStrategyMustRunAsNonRoot:
+		return user.NewRunAsNonRoot(opts)
+	case api.RunAsUserStrategyRunAsAny:
+		return user.NewRunAsAny(opts)
+	default:
+		return nil, fmt.Errorf("Unrecognized RunAsUser strategy type %s", opts.Type)
+	}
+}
+
+// createSELinuxStrategy creates a new selinux strategy.
+func createSELinuxStrategy(opts *api.SELinuxContextStrategyOptions) (selinux.SELinuxSecurityContextConstraintsStrategy, error) {
+	switch opts.Type {
+	case api.SELinuxStrategyMustRunAs:
+		return selinux.NewMustRunAs(opts)
+	case api.SELinuxStrategyRunAsAny:
+		return selinux.NewRunAsAny(opts)
+	default:
+		return nil, fmt.Errorf("Unrecognized SELinuxContext strategy type %s", opts.Type)
+	}
+}
+
+// createFSGroupStrategy creates a new fsgroup strategy
+func createFSGroupStrategy(opts *api.FSGroupStrategyOptions) (group.GroupSecurityContextConstraintsStrategy, error) {
+	switch opts.Type {
+	case api.FSGroupStrategyRunAsAny:
+		return group.NewRunAsAny()
+	case api.FSGroupStrategyMustRunAs:
+		return group.NewMustRunAs(opts.Ranges, fsGroupField)
+	default:
+		return nil, fmt.Errorf("Unrecognized FSGroup strategy type %s", opts.Type)
+	}
+}
+
+// createSupplementalGroupStrategy creates a new supplemental group strategy
+func createSupplementalGroupStrategy(opts *api.SupplementalGroupsStrategyOptions) (group.GroupSecurityContextConstraintsStrategy, error) {
+	switch opts.Type {
+	case api.SupplementalGroupsStrategyRunAsAny:
+		return group.NewRunAsAny()
+	case api.SupplementalGroupsStrategyMustRunAs:
+		return group.NewMustRunAs(opts.Ranges, supplementalGroupsField)
+	default:
+		return nil, fmt.Errorf("Unrecognized SupplementalGroups strategy type %s", opts.Type)
+	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider_test.go
@@ -25,7 +25,72 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 )
 
-func TestCreateSecurityContextNonmutating(t *testing.T) {
+func TestCreatePodSecurityContextNonmutating(t *testing.T) {
+	// Create a pod with a security context that needs filling in
+	createPod := func() *api.Pod {
+		return &api.Pod{
+			Spec: api.PodSpec{
+				SecurityContext: &api.PodSecurityContext{},
+			},
+		}
+	}
+
+	// Create an SCC with strategies that will populate a blank psc
+	createSCC := func() *api.SecurityContextConstraints {
+		return &api.SecurityContextConstraints{
+			ObjectMeta: api.ObjectMeta{
+				Name: "scc-sa",
+			},
+			RunAsUser: api.RunAsUserStrategyOptions{
+				Type: api.RunAsUserStrategyRunAsAny,
+			},
+			SELinuxContext: api.SELinuxContextStrategyOptions{
+				Type:           api.SELinuxStrategyRunAsAny,
+			},
+			// these are pod mutating strategies that are tested above
+			FSGroup: api.FSGroupStrategyOptions{
+				Type: api.FSGroupStrategyMustRunAs,
+				Ranges: []api.IDRange{
+					{Min: 1, Max: 1},
+				},
+			},
+			SupplementalGroups: api.SupplementalGroupsStrategyOptions{
+				Type: api.SupplementalGroupsStrategyMustRunAs,
+				Ranges: []api.IDRange{
+					{Min: 1, Max: 1},
+				},
+			},
+		}
+	}
+
+	pod := createPod()
+	scc := createSCC()
+
+	provider, err := NewSimpleProvider(scc)
+	if err != nil {
+		t.Fatal("unable to create provider %v", err)
+	}
+	sc, err := provider.CreatePodSecurityContext(pod)
+	if err != nil {
+		t.Fatal("unable to create psc %v", err)
+	}
+
+	// The generated security context should have filled in missing options, so they should differ
+	if reflect.DeepEqual(sc, &pod.Spec.SecurityContext) {
+		t.Error("expected created security context to be different than container's, but they were identical")
+	}
+
+	// Creating the provider or the security context should not have mutated the scc or pod
+	if !reflect.DeepEqual(createPod(), pod) {
+		diff := util.ObjectDiff(createPod(), pod)
+		t.Errorf("pod was mutated by CreatePodSecurityContext. diff:\n%s", diff)
+	}
+	if !reflect.DeepEqual(createSCC(), scc) {
+		t.Error("scc was mutated by CreatePodSecurityContext")
+	}
+}
+
+func TestCreateContainerSecurityContextNonmutating(t *testing.T) {
 	// Create a pod with a security context that needs filling in
 	createPod := func() *api.Pod {
 		return &api.Pod{
@@ -52,6 +117,13 @@ func TestCreateSecurityContextNonmutating(t *testing.T) {
 				Type:           api.SELinuxStrategyMustRunAs,
 				SELinuxOptions: &api.SELinuxOptions{User: "you"},
 			},
+			// these are pod mutating strategies that are tested above
+			FSGroup: api.FSGroupStrategyOptions{
+				Type: api.FSGroupStrategyRunAsAny,
+			},
+			SupplementalGroups: api.SupplementalGroupsStrategyOptions{
+				Type: api.SupplementalGroupsStrategyRunAsAny,
+			},
 		}
 	}
 
@@ -62,7 +134,7 @@ func TestCreateSecurityContextNonmutating(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to create provider %v", err)
 	}
-	sc, err := provider.CreateSecurityContext(pod, &pod.Spec.Containers[0])
+	sc, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.Containers[0])
 	if err != nil {
 		t.Fatal("unable to create provider %v", err)
 	}
@@ -75,46 +147,124 @@ func TestCreateSecurityContextNonmutating(t *testing.T) {
 	// Creating the provider or the security context should not have mutated the scc or pod
 	if !reflect.DeepEqual(createPod(), pod) {
 		diff := util.ObjectDiff(createPod(), pod)
-		t.Errorf("pod was mutated by CreateSecurityContext. diff:\n%s", diff)
+		t.Errorf("pod was mutated by CreateContainerSecurityContext. diff:\n%s", diff)
 	}
 	if !reflect.DeepEqual(createSCC(), scc) {
-		t.Error("different")
+		t.Error("scc was mutated by CreateContainerSecurityContext")
 	}
 }
 
-func TestValidateFailures(t *testing.T) {
-	defaultSCC := func() *api.SecurityContextConstraints {
-		return &api.SecurityContextConstraints{
-			ObjectMeta: api.ObjectMeta{
-				Name: "scc-sa",
-			},
-			RunAsUser: api.RunAsUserStrategyOptions{
-				Type: api.RunAsUserStrategyRunAsAny,
-			},
-			SELinuxContext: api.SELinuxContextStrategyOptions{
-				Type: api.SELinuxStrategyRunAsAny,
-			},
-		}
+func TestValidatePodSecurityContextFailures(t *testing.T) {
+	failHostNetworkPod := defaultPod()
+	failHostNetworkPod.Spec.SecurityContext.HostNetwork = true
+
+	failHostPIDPod := defaultPod()
+	failHostPIDPod.Spec.SecurityContext.HostPID = true
+
+	failHostIPCPod := defaultPod()
+	failHostIPCPod.Spec.SecurityContext.HostIPC = true
+
+	failSupplementalGroupPod := defaultPod()
+	failSupplementalGroupPod.Spec.SecurityContext.SupplementalGroups = []int64{999}
+	failSupplementalGroupSCC := defaultSCC()
+	failSupplementalGroupSCC.SupplementalGroups = api.SupplementalGroupsStrategyOptions {
+		Type: api.SupplementalGroupsStrategyMustRunAs,
+		Ranges: []api.IDRange{
+			{Min: 1, Max: 1},
+		},
 	}
 
-	var notPriv bool = false
-	defaultPod := func() *api.Pod {
-		return &api.Pod{
-			Spec: api.PodSpec{
-				SecurityContext: &api.PodSecurityContext{},
-				Containers: []api.Container{
-					{
-						SecurityContext: &api.SecurityContext{
-							// expected to be set by defaulting mechanisms
-							Privileged: &notPriv,
-							// fill in the rest for test cases
-						},
-					},
-				},
-			},
-		}
+	failFSGroupPod := defaultPod()
+	fsGroup := int64(999)
+	failFSGroupPod.Spec.SecurityContext.FSGroup = &fsGroup
+	failFSGroupSCC := defaultSCC()
+	failFSGroupSCC.FSGroup = api.FSGroupStrategyOptions {
+		Type: api.FSGroupStrategyMustRunAs,
+		Ranges: []api.IDRange{
+			{Min: 1, Max: 1},
+		},
 	}
 
+	failNilSELinuxPod := defaultPod()
+	failSELinuxSCC := defaultSCC()
+	failSELinuxSCC.SELinuxContext.Type = api.SELinuxStrategyMustRunAs
+	failSELinuxSCC.SELinuxContext.SELinuxOptions = &api.SELinuxOptions{
+		Level: "foo",
+	}
+
+	failInvalidSELinuxPod := defaultPod()
+	failInvalidSELinuxPod.Spec.SecurityContext.SELinuxOptions = &api.SELinuxOptions{
+		Level: "bar",
+	}
+
+	errorCases := map[string]struct {
+		pod           *api.Pod
+		scc           *api.SecurityContextConstraints
+		expectedError string
+	}{
+		"failHostNetworkSCC": {
+			pod:           failHostNetworkPod,
+			scc:           defaultSCC(),
+			expectedError: "Host network is not allowed to be used",
+		},
+		"failHostPIDSCC": {
+			pod:           failHostPIDPod,
+			scc:           defaultSCC(),
+			expectedError: "Host PID is not allowed to be used",
+		},
+		"failHostIPCSCC": {
+			pod:           failHostIPCPod,
+			scc:           defaultSCC(),
+			expectedError: "Host IPC is not allowed to be used",
+		},
+		"failSupplementalGroupOutOfRange": {
+			pod: failSupplementalGroupPod,
+			scc: failSupplementalGroupSCC,
+			expectedError: "999 is not an allowed group",
+		},
+		"failSupplementalGroupEmpty": {
+			pod: defaultPod(),
+			scc: failSupplementalGroupSCC,
+			expectedError: "unable to validate empty groups against required ranges",
+		},
+		"failFSGroupOutOfRange": {
+			pod: failFSGroupPod,
+			scc: failFSGroupSCC,
+			expectedError: "999 is not an allowed group",
+		},
+		"failFSGroupEmpty": {
+			pod: defaultPod(),
+			scc: failFSGroupSCC,
+			expectedError: "unable to validate empty groups against required ranges",
+		},
+		"failNilSELinux": {
+			pod: failNilSELinuxPod,
+			scc: failSELinuxSCC,
+			expectedError: "unable to validate nil seLinuxOptions",
+		},
+		"failInvalidSELinux": {
+			pod: failInvalidSELinuxPod,
+			scc: failSELinuxSCC,
+			expectedError: "does not match required level.  Found bar, wanted foo",
+		},
+	}
+	for k, v := range errorCases {
+		provider, err := NewSimpleProvider(v.scc)
+		if err != nil {
+			t.Fatal("unable to create provider %v", err)
+		}
+		errs := provider.ValidatePodSecurityContext(v.pod)
+		if len(errs) == 0 {
+			t.Errorf("%s expected validation failure but did not receive errors", k)
+			continue
+		}
+		if !strings.Contains(errs[0].Error(), v.expectedError) {
+			t.Errorf("%s received unexpected error %v", k, errs)
+		}
+	}
+}
+
+func TestValidateContainerSecurityContextFailures(t *testing.T) {
 	// fail user strat
 	failUserSCC := defaultSCC()
 	var uid int64 = 999
@@ -158,15 +308,6 @@ func TestValidateFailures(t *testing.T) {
 		},
 	}
 
-	failHostNetworkPod := defaultPod()
-	failHostNetworkPod.Spec.SecurityContext.HostNetwork = true
-
-	failHostPIDPod := defaultPod()
-	failHostPIDPod.Spec.SecurityContext.HostPID = true
-
-	failHostIPCPod := defaultPod()
-	failHostIPCPod.Spec.SecurityContext.HostIPC = true
-
 	failHostPortPod := defaultPod()
 	failHostPortPod.Spec.Containers[0].Ports = []api.ContainerPort{{HostPort: 1}}
 
@@ -200,25 +341,10 @@ func TestValidateFailures(t *testing.T) {
 			scc:           defaultSCC(),
 			expectedError: "Host Volumes are not allowed to be used",
 		},
-		"failHostNetworkSCC": {
-			pod:           failHostNetworkPod,
-			scc:           defaultSCC(),
-			expectedError: "Host network is not allowed to be used",
-		},
 		"failHostPortSCC": {
 			pod:           failHostPortPod,
 			scc:           defaultSCC(),
 			expectedError: "Host ports are not allowed to be used",
-		},
-		"failHostPIDSCC": {
-			pod:           failHostPIDPod,
-			scc:           defaultSCC(),
-			expectedError: "Host PID is not allowed to be used",
-		},
-		"failHostIPCSCC": {
-			pod:           failHostIPCPod,
-			scc:           defaultSCC(),
-			expectedError: "Host IPC is not allowed to be used",
 		},
 	}
 
@@ -227,7 +353,7 @@ func TestValidateFailures(t *testing.T) {
 		if err != nil {
 			t.Fatal("unable to create provider %v", err)
 		}
-		errs := provider.ValidateSecurityContext(v.pod, &v.pod.Spec.Containers[0])
+		errs := provider.ValidateContainerSecurityContext(v.pod, &v.pod.Spec.Containers[0])
 		if len(errs) == 0 {
 			t.Errorf("%s expected validation failure but did not receive errors", k)
 			continue
@@ -238,21 +364,103 @@ func TestValidateFailures(t *testing.T) {
 	}
 }
 
-func TestValidateSuccess(t *testing.T) {
-	defaultSCC := func() *api.SecurityContextConstraints {
-		return &api.SecurityContextConstraints{
-			ObjectMeta: api.ObjectMeta{
-				Name: "scc-sa",
-			},
-			RunAsUser: api.RunAsUserStrategyOptions{
-				Type: api.RunAsUserStrategyRunAsAny,
-			},
-			SELinuxContext: api.SELinuxContextStrategyOptions{
-				Type: api.SELinuxStrategyRunAsAny,
-			},
-		}
+func TestValidatePodSecurityContextSuccess(t *testing.T) {
+	hostNetworkSCC := defaultSCC()
+	hostNetworkSCC.AllowHostNetwork = true
+	hostNetworkPod := defaultPod()
+	hostNetworkPod.Spec.SecurityContext.HostNetwork = true
+
+	hostPIDSCC := defaultSCC()
+	hostPIDSCC.AllowHostPID = true
+	hostPIDPod := defaultPod()
+	hostPIDPod.Spec.SecurityContext.HostPID = true
+
+	hostIPCSCC := defaultSCC()
+	hostIPCSCC.AllowHostIPC = true
+	hostIPCPod := defaultPod()
+	hostIPCPod.Spec.SecurityContext.HostIPC = true
+
+	supGroupSCC := defaultSCC()
+	supGroupSCC.SupplementalGroups = api.SupplementalGroupsStrategyOptions{
+		Type: api.SupplementalGroupsStrategyMustRunAs,
+		Ranges: []api.IDRange{
+			{Min: 1, Max: 5},
+		},
+	}
+	supGroupPod := defaultPod()
+	supGroupPod.Spec.SecurityContext.SupplementalGroups = []int64{3}
+
+	fsGroupSCC := defaultSCC()
+	fsGroupSCC.FSGroup = api.FSGroupStrategyOptions{
+		Type: api.FSGroupStrategyMustRunAs,
+		Ranges: []api.IDRange{
+			{Min: 1, Max: 5},
+		},
+	}
+	fsGroupPod := defaultPod()
+	fsGroup := int64(3)
+	fsGroupPod.Spec.SecurityContext.FSGroup = &fsGroup
+
+	seLinuxPod := defaultPod()
+	seLinuxPod.Spec.SecurityContext.SELinuxOptions = &api.SELinuxOptions{
+		User: "user",
+		Role: "role",
+		Type: "type",
+		Level: "level",
+	}
+	seLinuxSCC := defaultSCC()
+	seLinuxSCC.SELinuxContext.Type = api.SELinuxStrategyMustRunAs
+	seLinuxSCC.SELinuxContext.SELinuxOptions = &api.SELinuxOptions{
+		User: "user",
+		Role: "role",
+		Type: "type",
+		Level: "level",
 	}
 
+	errorCases := map[string]struct {
+		pod *api.Pod
+		scc *api.SecurityContextConstraints
+	}{
+		"pass hostNetwork validating SCC": {
+			pod: hostNetworkPod,
+			scc: hostNetworkSCC,
+		},
+		"pass hostPID validating SCC": {
+			pod: hostPIDPod,
+			scc: hostPIDSCC,
+		},
+		"pass hostIPC validating SCC": {
+			pod: hostIPCPod,
+			scc: hostIPCSCC,
+		},
+		"pass supplemental group validating SCC": {
+			pod: supGroupPod,
+			scc: supGroupSCC,
+		},
+		"pass fs group validating SCC": {
+			pod: fsGroupPod,
+			scc: fsGroupSCC,
+		},
+		"pass selinux validating SCC": {
+			pod: seLinuxPod,
+			scc: seLinuxSCC,
+		},
+	}
+
+	for k, v := range errorCases {
+		provider, err := NewSimpleProvider(v.scc)
+		if err != nil {
+			t.Fatal("unable to create provider %v", err)
+		}
+		errs := provider.ValidatePodSecurityContext(v.pod)
+		if len(errs) != 0 {
+			t.Errorf("%s expected validation pass but received errors %v", k, errs)
+			continue
+		}
+	}
+}
+
+func TestValidateContainerSecurityContextSuccess(t *testing.T) {
 	var notPriv bool = false
 	defaultPod := func() *api.Pod {
 		return &api.Pod{
@@ -270,7 +478,7 @@ func TestValidateSuccess(t *testing.T) {
 			},
 		}
 	}
-
+	
 	// fail user strat
 	userSCC := defaultSCC()
 	var uid int64 = 999
@@ -319,21 +527,6 @@ func TestValidateSuccess(t *testing.T) {
 		},
 	}
 
-	hostNetworkSCC := defaultSCC()
-	hostNetworkSCC.AllowHostNetwork = true
-	hostNetworkPod := defaultPod()
-	hostNetworkPod.Spec.SecurityContext.HostNetwork = true
-
-	hostPIDSCC := defaultSCC()
-	hostPIDSCC.AllowHostPID = true
-	hostPIDPod := defaultPod()
-	hostPIDPod.Spec.SecurityContext.HostPID = true
-
-	hostIPCSCC := defaultSCC()
-	hostIPCSCC.AllowHostIPC = true
-	hostIPCPod := defaultPod()
-	hostIPCPod.Spec.SecurityContext.HostIPC = true
-
 	hostPortSCC := defaultSCC()
 	hostPortSCC.AllowHostPorts = true
 	hostPortPod := defaultPod()
@@ -363,21 +556,9 @@ func TestValidateSuccess(t *testing.T) {
 			pod: hostDirPod,
 			scc: hostDirSCC,
 		},
-		"pass hostNetwork validating SCC": {
-			pod: hostNetworkPod,
-			scc: hostNetworkSCC,
-		},
 		"pass hostPort validating SCC": {
 			pod: hostPortPod,
 			scc: hostPortSCC,
-		},
-		"pass hostPID validating SCC": {
-			pod: hostPIDPod,
-			scc: hostPIDSCC,
-		},
-		"pass hostIPC validating SCC": {
-			pod: hostIPCPod,
-			scc: hostIPCSCC,
 		},
 	}
 
@@ -386,10 +567,50 @@ func TestValidateSuccess(t *testing.T) {
 		if err != nil {
 			t.Fatal("unable to create provider %v", err)
 		}
-		errs := provider.ValidateSecurityContext(v.pod, &v.pod.Spec.Containers[0])
+		errs := provider.ValidateContainerSecurityContext(v.pod, &v.pod.Spec.Containers[0])
 		if len(errs) != 0 {
 			t.Errorf("%s expected validation pass but received errors %v", k, errs)
 			continue
 		}
+	}
+}
+
+func defaultSCC() *api.SecurityContextConstraints {
+	return &api.SecurityContextConstraints{
+		ObjectMeta: api.ObjectMeta{
+			Name: "scc-sa",
+		},
+		RunAsUser: api.RunAsUserStrategyOptions{
+			Type: api.RunAsUserStrategyRunAsAny,
+		},
+		SELinuxContext: api.SELinuxContextStrategyOptions{
+			Type: api.SELinuxStrategyRunAsAny,
+		},
+		FSGroup: api.FSGroupStrategyOptions{
+			Type: api.FSGroupStrategyRunAsAny,
+		},
+		SupplementalGroups: api.SupplementalGroupsStrategyOptions{
+			Type: api.SupplementalGroupsStrategyRunAsAny,
+		},
+	}
+}
+
+func defaultPod() *api.Pod {
+	var notPriv bool = false
+	return &api.Pod{
+		Spec: api.PodSpec{
+			SecurityContext: &api.PodSecurityContext{
+				// fill in for test cases
+			},
+			Containers: []api.Container{
+				{
+					SecurityContext: &api.SecurityContext{
+						// expected to be set by defaulting mechanisms
+						Privileged: &notPriv,
+						// fill in the rest for test cases
+					},
+				},
+			},
+		},
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/selinux/mustrunas.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/selinux/mustrunas.go
@@ -51,30 +51,30 @@ func (s *mustRunAs) Validate(pod *api.Pod, container *api.Container) fielderrors
 	allErrs := fielderrors.ValidationErrorList{}
 
 	if container.SecurityContext == nil {
-		detail := fmt.Sprintf("unable to validate nil security context for container %s", container.Name)
+		detail := fmt.Sprintf("unable to validate nil security context for %s", container.Name)
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("securityContext", container.SecurityContext, detail))
 		return allErrs
 	}
 	if container.SecurityContext.SELinuxOptions == nil {
-		detail := fmt.Sprintf("unable to validate nil seLinuxOptions for container %s", container.Name)
+		detail := fmt.Sprintf("unable to validate nil seLinuxOptions for %s", container.Name)
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("seLinuxOptions", container.SecurityContext.SELinuxOptions, detail))
 		return allErrs
 	}
 	seLinux := container.SecurityContext.SELinuxOptions
 	if seLinux.Level != s.opts.SELinuxOptions.Level {
-		detail := fmt.Sprintf("seLinuxOptions.level on container %s does not match required level.  Found %s, wanted %s", container.Name, seLinux.Level, s.opts.SELinuxOptions.Level)
+		detail := fmt.Sprintf("seLinuxOptions.level on %s does not match required level.  Found %s, wanted %s", container.Name, seLinux.Level, s.opts.SELinuxOptions.Level)
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("seLinuxOptions.level", seLinux.Level, detail))
 	}
 	if seLinux.Role != s.opts.SELinuxOptions.Role {
-		detail := fmt.Sprintf("seLinuxOptions.role on container %s does not match required role.  Found %s, wanted %s", container.Name, seLinux.Role, s.opts.SELinuxOptions.Role)
+		detail := fmt.Sprintf("seLinuxOptions.role on %s does not match required role.  Found %s, wanted %s", container.Name, seLinux.Role, s.opts.SELinuxOptions.Role)
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("seLinuxOptions.role", seLinux.Role, detail))
 	}
 	if seLinux.Type != s.opts.SELinuxOptions.Type {
-		detail := fmt.Sprintf("seLinuxOptions.type on container %s does not match required type.  Found %s, wanted %s", container.Name, seLinux.Type, s.opts.SELinuxOptions.Type)
+		detail := fmt.Sprintf("seLinuxOptions.type on %s does not match required type.  Found %s, wanted %s", container.Name, seLinux.Type, s.opts.SELinuxOptions.Type)
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("seLinuxOptions.type", seLinux.Type, detail))
 	}
 	if seLinux.User != s.opts.SELinuxOptions.User {
-		detail := fmt.Sprintf("seLinuxOptions.user on container %s does not match required user.  Found %s, wanted %s", container.Name, seLinux.User, s.opts.SELinuxOptions.User)
+		detail := fmt.Sprintf("seLinuxOptions.user on %s does not match required user.  Found %s, wanted %s", container.Name, seLinux.User, s.opts.SELinuxOptions.User)
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("seLinuxOptions.user", seLinux.User, detail))
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/types.go
@@ -24,10 +24,14 @@ import (
 // SecurityContextConstraintsProvider provides the implementation to generate a new security
 // context based on constraints or validate an existing security context against constraints.
 type SecurityContextConstraintsProvider interface {
-	// Create a SecurityContext based on the given constraints
-	CreateSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, error)
+	// Create a PodSecurityContext based on the given constraints.
+	CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurityContext, error)
+	// Create a container SecurityContext based on the given constraints
+	CreateContainerSecurityContext(pod *api.Pod, container *api.Container) (*api.SecurityContext, error)
+	// Ensure a pod's SecurityContext is in compliance with the given constraints.
+	ValidatePodSecurityContext(pod *api.Pod) fielderrors.ValidationErrorList
 	// Ensure a container's SecurityContext is in compliance with the given constraints
-	ValidateSecurityContext(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
+	ValidateContainerSecurityContext(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
 	// Get the name of the SCC that this provider was initialized with.
 	GetSCCName() string
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chmod/chmod.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chmod/chmod.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chmod
+
+import (
+	"os"
+)
+
+// Interface is something that knows how to run the chmod system call.
+// It is non-recursive.
+type Interface interface {
+	// Chmod changes the mode of the given file, implementing the same
+	// semantics as os.Chmod.
+	Chmod(path string, filemode os.FileMode) error
+}
+
+func New() Interface {
+	return &chmodRunner{}
+}
+
+type chmodRunner struct{}
+
+func (_ *chmodRunner) Chmod(path string, mode os.FileMode) error {
+	return os.Chmod(path, mode)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chmod/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chmod/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package chown provides an interface and implementations
+// for things that run run the chmod system call.
+package chmod

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chown/chown.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chown/chown.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chown
+
+import (
+	"os"
+)
+
+// Interface is something that knows how to run the chown system call.
+// It is non-recursive.
+type Interface interface {
+	// Chown changes the owning UID and GID of a file, implementing
+	// the exact same semantics as os.Chown.
+	Chown(path string, uid, gid int) error
+}
+
+func New() Interface {
+	return &chownRunner{}
+}
+
+type chownRunner struct{}
+
+func (_ *chownRunner) Chown(path string, uid, gid int) error {
+	return os.Chown(path, uid, gid)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chown/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/chown/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package chown provides utilities to chown a path
+package chown

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/doc.go
@@ -1,7 +1,5 @@
-// +build !linux
-
 /*
-Copyright 2014 The Kubernetes Authors All rights reserved.
+Copyright 2015 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,11 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package empty_dir
-
-type realChconRunner struct{}
-
-func (_ *realChconRunner) SetContext(dir, context string) error {
-	// NOP
-	return nil
-}
+// Package selinux contains selinux utility functions.
+package selinux

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/selinux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/selinux.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package empty_dir
+package selinux
 
 // chconRunner knows how to chcon a directory.
-type chconRunner interface {
+type ChconRunner interface {
 	SetContext(dir, context string) error
 }
 
 // newChconRunner returns a new chconRunner.
-func newChconRunner() chconRunner {
+func NewChconRunner() ChconRunner {
 	return &realChconRunner{}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/selinux_linux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/selinux_linux.go
@@ -1,7 +1,7 @@
 // +build linux
 
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2014 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,20 +16,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubelet
+package selinux
 
 import (
 	"github.com/docker/libcontainer/selinux"
 )
 
-// getRootDirContext gets the SELinux context of the kubelet rootDir
-// or returns an error.
-func (kl *Kubelet) getRootDirContext() (string, error) {
+type realChconRunner struct{}
+
+func (_ *realChconRunner) SetContext(dir, context string) error {
 	// If SELinux is not enabled, return an empty string
 	if !selinux.SelinuxEnabled() {
-		return "", nil
+		return nil
 	}
 
-	// Get the SELinux context of the rootDir.
-	return selinux.Getfilecon(kl.getRootDir())
+	return selinux.Setfilecon(dir, context)
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/selinux_unsupported.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/selinux/selinux_unsupported.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build !linux
 
 /*
 Copyright 2014 The Kubernetes Authors All rights reserved.
@@ -16,19 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package empty_dir
-
-import (
-	"github.com/docker/libcontainer/selinux"
-)
+package selinux
 
 type realChconRunner struct{}
 
 func (_ *realChconRunner) SetContext(dir, context string) error {
-	// If SELinux is not enabled, return an empty string
-	if !selinux.SelinuxEnabled() {
-		return nil
-	}
-
-	return selinux.Setfilecon(dir, context)
+	// NOP
+	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
@@ -177,6 +177,10 @@ type awsElasticBlockStoreBuilder struct {
 
 var _ volume.Builder = &awsElasticBlockStoreBuilder{}
 
+func (_ *awsElasticBlockStoreBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 // SetUp attaches the disk and bind mounts to the volume path.
 func (b *awsElasticBlockStoreBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
@@ -250,6 +250,10 @@ func (b *awsElasticBlockStoreBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *awsElasticBlockStoreBuilder) SupportsSELinux() bool {
+	return true
+}
+
 func makeGlobalPDPath(host volume.VolumeHost, volumeID string) string {
 	// Clean up the URI to be more fs-friendly
 	name := volumeID

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cephfs/cephfs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cephfs/cephfs.go
@@ -151,6 +151,10 @@ type cephfsBuilder struct {
 
 var _ volume.Builder = &cephfsBuilder{}
 
+func (_ *cephfsBuilder) SupportsOwnershipManagement() bool {
+	return false
+}
+
 // SetUp attaches the disk and bind mounts to the volume path.
 func (cephfsVolume *cephfsBuilder) SetUp() error {
 	return cephfsVolume.SetUpAt(cephfsVolume.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cephfs/cephfs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cephfs/cephfs.go
@@ -187,6 +187,10 @@ func (cephfsVolume *cephfsBuilder) IsReadOnly() bool {
 	return cephfsVolume.readonly
 }
 
+func (cephfsVolume *cephfsBuilder) SupportsSELinux() bool {
+	return false
+}
+
 type cephfsCleaner struct {
 	*cephfs
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
@@ -225,6 +225,10 @@ func (b *cinderVolumeBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *cinderVolumeBuilder) SupportsSELinux() bool {
+	return true
+}
+
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
 	return path.Join(host.GetPluginDir(cinderVolumePluginName), "mounts", devName)
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
@@ -153,6 +153,10 @@ func detachDiskLogError(cd *cinderVolume) {
 	}
 }
 
+func (_ *cinderVolumeBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 func (b *cinderVolumeBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/downwardapi/downwardapi.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/downwardapi/downwardapi.go
@@ -107,6 +107,10 @@ type downwardAPIVolumeBuilder struct {
 // downwardAPIVolumeBuilder implements volume.Builder interface
 var _ volume.Builder = &downwardAPIVolumeBuilder{}
 
+func (_ *downwardAPIVolumeBuilder) SupportsOwnershipManagement() bool {
+	return false
+}
+
 // SetUp puts in place the volume plugin.
 // This function is not idempotent by design. We want the data to be refreshed periodically.
 // The internal sync interval of kubelet will drive the refresh of data.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/downwardapi/downwardapi.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/downwardapi/downwardapi.go
@@ -157,6 +157,10 @@ func (d *downwardAPIVolume) IsReadOnly() bool {
 	return true
 }
 
+func (d *downwardAPIVolume) SupportsSELinux() bool {
+	return true
+}
+
 // collectData collects requested downwardAPI in data map.
 // Map's key is the requested name of file to dump
 // Map's value is the (sorted) content of the field to be dumped in the file.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/empty_dir/empty_dir.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/empty_dir/empty_dir.go
@@ -137,6 +137,10 @@ type emptyDir struct {
 	chconRunner   chconRunner
 }
 
+func (_ *emptyDir) SupportsOwnershipManagement() bool {
+	return true
+}
+
 // SetUp creates new directory.
 func (ed *emptyDir) SetUp() error {
 	return ed.SetUpAt(ed.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/empty_dir/empty_dir.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/empty_dir/empty_dir.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/util/selinux"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
@@ -70,10 +71,10 @@ func (plugin *emptyDirPlugin) CanSupport(spec *volume.Spec) bool {
 }
 
 func (plugin *emptyDirPlugin) NewBuilder(spec *volume.Spec, pod *api.Pod, opts volume.VolumeOptions) (volume.Builder, error) {
-	return plugin.newBuilderInternal(spec, pod, plugin.host.GetMounter(), &realMountDetector{plugin.host.GetMounter()}, opts, newChconRunner())
+	return plugin.newBuilderInternal(spec, pod, plugin.host.GetMounter(), &realMountDetector{plugin.host.GetMounter()}, opts, selinux.NewChconRunner())
 }
 
-func (plugin *emptyDirPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod, mounter mount.Interface, mountDetector mountDetector, opts volume.VolumeOptions, chconRunner chconRunner) (volume.Builder, error) {
+func (plugin *emptyDirPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod, mounter mount.Interface, mountDetector mountDetector, opts volume.VolumeOptions, chconrunner selinux.ChconRunner) (volume.Builder, error) {
 	medium := api.StorageMediumDefault
 	if spec.Volume.EmptyDir != nil { // Support a non-specified source as EmptyDir.
 		medium = spec.Volume.EmptyDir.Medium
@@ -86,7 +87,7 @@ func (plugin *emptyDirPlugin) newBuilderInternal(spec *volume.Spec, pod *api.Pod
 		mountDetector: mountDetector,
 		plugin:        plugin,
 		rootContext:   opts.RootContext,
-		chconRunner:   chconRunner,
+		chconRunner:   chconrunner,
 	}, nil
 }
 
@@ -134,7 +135,7 @@ type emptyDir struct {
 	mountDetector mountDetector
 	plugin        *emptyDirPlugin
 	rootContext   string
-	chconRunner   chconRunner
+	chconRunner   selinux.ChconRunner
 }
 
 func (_ *emptyDir) SupportsOwnershipManagement() bool {
@@ -191,6 +192,10 @@ func (ed *emptyDir) SetUpAt(dir string) error {
 
 func (ed *emptyDir) IsReadOnly() bool {
 	return false
+}
+
+func (ed *emptyDir) SupportsSELinux() bool {
+	return true
 }
 
 // setupTmpfs creates a tmpfs mount at the specified directory with the

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/fc/fc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/fc/fc.go
@@ -191,6 +191,10 @@ func (b *fcDiskBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *fcDiskBuilder) SupportsSELinux() bool {
+	return true
+}
+
 // Unmounts the bind mount, and detaches the disk only if the disk
 // resource was the last reference to that disk on the kubelet.
 func (c *fcDiskCleaner) TearDown() error {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/fc/fc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/fc/fc.go
@@ -164,6 +164,10 @@ type fcDiskBuilder struct {
 
 var _ volume.Builder = &fcDiskBuilder{}
 
+func (_ *fcDiskBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 func (b *fcDiskBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/flocker/plugin.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/flocker/plugin.go
@@ -205,6 +205,10 @@ func (b flockerBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b flockerBuilder) SupportsSELinux() bool {
+	return false
+}
+
 // updateDatasetPrimary will update the primary in Flocker and wait for it to
 // be ready. If it never gets to ready state it will timeout and error.
 func (b flockerBuilder) updateDatasetPrimary(datasetID, primaryUUID string) error {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/flocker/plugin.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/flocker/plugin.go
@@ -113,6 +113,10 @@ type flockerBuilder struct {
 	readOnly bool
 }
 
+func (_ *flockerBuilder) SupportsOwnershipManagement() bool {
+	return false
+}
+
 func (b flockerBuilder) GetPath() string {
 	return b.flocker.path
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
@@ -238,6 +238,10 @@ func (b *gcePersistentDiskBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *gcePersistentDiskBuilder) SupportsSELinux() bool {
+	return true
+}
+
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
 	return path.Join(host.GetPluginDir(gcePersistentDiskPluginName), "mounts", devName)
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
@@ -165,6 +165,10 @@ type gcePersistentDiskBuilder struct {
 
 var _ volume.Builder = &gcePersistentDiskBuilder{}
 
+func (_ *gcePersistentDiskBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 // SetUp attaches the disk and bind mounts to the volume path.
 func (b *gcePersistentDiskBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/git_repo/git_repo.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/git_repo/git_repo.go
@@ -109,6 +109,10 @@ type gitRepoVolumeBuilder struct {
 
 var _ volume.Builder = &gitRepoVolumeBuilder{}
 
+func (_ *gitRepoVolumeBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 // SetUp creates new directory and clones a git repo.
 func (b *gitRepoVolumeBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/git_repo/git_repo.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/git_repo/git_repo.go
@@ -122,6 +122,10 @@ func (b *gitRepoVolumeBuilder) IsReadOnly() bool {
 	return false
 }
 
+func (b *gitRepoVolumeBuilder) SupportsSELinux() bool {
+	return true
+}
+
 // This is the spec for the volume that this plugin wraps.
 var wrappedVolumeSpec = &volume.Spec{
 	Volume: &api.Volume{VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
@@ -135,6 +135,10 @@ type glusterfsBuilder struct {
 
 var _ volume.Builder = &glusterfsBuilder{}
 
+func (_ *glusterfsBuilder) SupportsOwnershipManagement() bool {
+	return false
+}
+
 // SetUp attaches the disk and bind mounts to the volume path.
 func (b *glusterfsBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
@@ -170,6 +170,10 @@ func (b *glusterfsBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *glusterfsBuilder) SupportsSELinux() bool {
+	return false
+}
+
 func (glusterfsVolume *glusterfs) GetPath() string {
 	name := glusterfsPluginName
 	return glusterfsVolume.plugin.host.GetPodVolumeDir(glusterfsVolume.pod.UID, util.EscapeQualifiedNameForDisk(name), glusterfsVolume.volName)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/host_path/host_path.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/host_path/host_path.go
@@ -185,6 +185,10 @@ func (b *hostPathBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *hostPathBuilder) SupportsSELinux() bool {
+	return false
+}
+
 func (b *hostPathBuilder) GetPath() string {
 	return b.path
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/host_path/host_path.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/host_path/host_path.go
@@ -167,6 +167,10 @@ type hostPathBuilder struct {
 
 var _ volume.Builder = &hostPathBuilder{}
 
+func (_ *hostPathBuilder) SupportsOwnershipManagement() bool {
+	return false
+}
+
 // SetUp does nothing.
 func (b *hostPathBuilder) SetUp() error {
 	return nil

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/iscsi/iscsi.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/iscsi/iscsi.go
@@ -156,6 +156,10 @@ type iscsiDiskBuilder struct {
 
 var _ volume.Builder = &iscsiDiskBuilder{}
 
+func (_ *iscsiDiskBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 func (b *iscsiDiskBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/iscsi/iscsi.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/iscsi/iscsi.go
@@ -183,6 +183,10 @@ func (b *iscsiDiskBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *iscsiDiskBuilder) SupportsSELinux() bool {
+	return true
+}
+
 // Unmounts the bind mount, and detaches the disk only if the disk
 // resource was the last reference to that disk on the kubelet.
 func (c *iscsiDiskCleaner) TearDown() error {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/nfs/nfs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/nfs/nfs.go
@@ -147,6 +147,10 @@ type nfsBuilder struct {
 
 var _ volume.Builder = &nfsBuilder{}
 
+func (_ *nfsBuilder) SupportsOwnershipManagement() bool {
+	return false
+}
+
 // SetUp attaches the disk and bind mounts to the volume path.
 func (b *nfsBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/nfs/nfs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/nfs/nfs.go
@@ -204,6 +204,10 @@ func (b *nfsBuilder) IsReadOnly() bool {
 	return b.readOnly
 }
 
+func (b *nfsBuilder) SupportsSELinux() bool {
+	return false
+}
+
 //
 //func (c *nfsCleaner) GetPath() string {
 //	name := nfsPluginName

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/rbd/rbd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/rbd/rbd.go
@@ -219,6 +219,10 @@ func (b *rbd) IsReadOnly() bool {
 	return b.ReadOnly
 }
 
+func (b *rbd) SupportsSELinux() bool {
+	return true
+}
+
 // Unmounts the bind mount, and detaches the disk only if the disk
 // resource was the last reference to that disk on the kubelet.
 func (c *rbdCleaner) TearDown() error {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/rbd/rbd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/rbd/rbd.go
@@ -192,6 +192,10 @@ type rbdBuilder struct {
 
 var _ volume.Builder = &rbdBuilder{}
 
+func (_ *rbdBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 func (b *rbdBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/secret/secret.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/secret/secret.go
@@ -97,6 +97,10 @@ type secretVolumeBuilder struct {
 
 var _ volume.Builder = &secretVolumeBuilder{}
 
+func (_ *secretVolumeBuilder) SupportsOwnershipManagement() bool {
+	return true
+}
+
 func (b *secretVolumeBuilder) SetUp() error {
 	return b.SetUpAt(b.GetPath())
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/secret/secret.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/secret/secret.go
@@ -176,6 +176,10 @@ func (sv *secretVolume) IsReadOnly() bool {
 	return false
 }
 
+func (sv *secretVolume) SupportsSELinux() bool {
+	return true
+}
+
 func totalSecretBytes(secret *api.Secret) int {
 	totalSize := 0
 	for _, bytes := range secret.Data {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/testing.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/testing.go
@@ -156,6 +156,10 @@ type FakeVolume struct {
 	Plugin  *FakeVolumePlugin
 }
 
+func (_ *FakeVolume) SupportsOwnershipManagement() bool {
+	return false
+}
+
 func (fv *FakeVolume) SetUp() error {
 	return fv.SetUpAt(fv.GetPath())
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/testing.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/testing.go
@@ -172,6 +172,10 @@ func (fv *FakeVolume) IsReadOnly() bool {
 	return false
 }
 
+func (fv *FakeVolume) SupportsSELinux() bool {
+	return false
+}
+
 func (fv *FakeVolume) GetPath() string {
 	return path.Join(fv.Plugin.Host.GetPodVolumeDir(fv.PodUID, util.EscapeQualifiedNameForDisk(fv.Plugin.PluginName), fv.VolName))
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/volume.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/volume.go
@@ -45,6 +45,14 @@ type Builder interface {
 	// IsReadOnly is a flag that gives the builder's ReadOnly attribute.
 	// All persistent volumes have a private readOnly flag in their builders.
 	IsReadOnly() bool
+	// SupportsOwnershipManagement returns whether this builder wants
+	// ownership management for the volume.  If this method returns true,
+	// the Kubelet will:
+	//
+	// 1. Make the volume owned by group FSGroup
+	// 2. Set the setgid bit is set (new files created in the volume will be owned by FSGroup)
+	// 3. Logical OR the permission bits with rw-rw----
+	SupportsOwnershipManagement() bool
 }
 
 // Cleaner interface provides methods to cleanup/unmount the volumes.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/volume.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/volume.go
@@ -53,6 +53,10 @@ type Builder interface {
 	// 2. Set the setgid bit is set (new files created in the volume will be owned by FSGroup)
 	// 3. Logical OR the permission bits with rw-rw----
 	SupportsOwnershipManagement() bool
+	// SupportsSELinux reports whether the given builder supports
+	// SELinux and would like the kubelet to relabel the volume to
+	// match the pod to which it will be attached.
+	SupportsSELinux() bool
 }
 
 // Cleaner interface provides methods to cleanup/unmount the volumes.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -69,6 +69,10 @@ func (p *plugin) Admit(a admission.Attributes) (err error) {
 		}
 	}
 
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.FSGroup != nil {
+		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.FSGroup is forbidden"))
+	}
+
 	for _, v := range pod.Spec.Containers {
 		if v.SecurityContext != nil {
 			if v.SecurityContext.SELinuxOptions != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -57,6 +57,11 @@ func (p *plugin) Admit(a admission.Attributes) (err error) {
 	if !ok {
 		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
+
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SupplementalGroups != nil {
+		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SupplementalGroups is forbidden"))
+	}
+
 	for _, v := range pod.Spec.Containers {
 		if v.SecurityContext != nil {
 			if v.SecurityContext.SELinuxOptions != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -46,8 +46,7 @@ func NewSecurityContextDeny(client client.Interface) admission.Interface {
 	}
 }
 
-// Admit will deny any SecurityContext that defines options that were not previously available in the api.Container
-// struct (Capabilities and Privileged)
+// Admit will deny any pod that defines SELinuxOptions or RunAsUser.
 func (p *plugin) Admit(a admission.Attributes) (err error) {
 	if a.GetResource() != string(api.ResourcePods) {
 		return nil
@@ -60,6 +59,14 @@ func (p *plugin) Admit(a admission.Attributes) (err error) {
 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SupplementalGroups != nil {
 		return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("SecurityContext.SupplementalGroups is forbidden"))
+	}
+	if pod.Spec.SecurityContext != nil {
+		if pod.Spec.SecurityContext.SELinuxOptions != nil {
+			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.SELinuxOptions is forbidden"))
+		}
+		if pod.Spec.SecurityContext.RunAsUser != nil {
+			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.RunAsUser is forbidden"))
+		}
 	}
 
 	for _, v := range pod.Spec.Containers {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
@@ -101,6 +101,8 @@ func TestPodSecurityContextAdmission(t *testing.T) {
 		},
 	}
 
+	fsGroup := int64(1001)
+
 	tests := []struct {
 		securityContext api.PodSecurityContext
 		errorExpected   bool
@@ -112,6 +114,12 @@ func TestPodSecurityContextAdmission(t *testing.T) {
 		{
 			securityContext: api.PodSecurityContext{
 				SupplementalGroups: []int64{1234},
+			},
+			errorExpected: true,
+		},
+		{
+			securityContext: api.PodSecurityContext{
+				FSGroup: &fsGroup,
 			},
 			errorExpected: true,
 		},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/security_context.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/security_context.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* This test check that SecurityContext parameters specified at the
+ * pod or the container level work as intended. These tests cannot be
+ * run when the 'SecurityContextDeny' addmissioin controller is not used
+ * so they are skipped by default.
+ */
+
+package e2e
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func getSecurityContextTestPod() *api.Pod {
+	podName := "security-context-" + string(util.NewUUID())
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:   podName,
+			Labels: map[string]string{"name": podName},
+		},
+		Spec: api.PodSpec{
+			SecurityContext: &api.PodSecurityContext{},
+			Containers: []api.Container{
+				{
+					Name:  "test-container",
+					Image: "gcr.io/google_containers/busybox",
+				},
+			},
+			RestartPolicy: api.RestartPolicyNever,
+		},
+	}
+
+	return pod
+}
+
+var _ = Describe("[Skipped] Security Context", func() {
+	framework := NewFramework("security-context")
+
+	It("should support pod.Spec.SecurityContext.SupplementalGroups", func() {
+		pod := getSecurityContextTestPod()
+		pod.Spec.Containers[0].Command = []string{"id", "-G"}
+		pod.Spec.SecurityContext.SupplementalGroups = []int64{1234, 5678}
+		groups := []string{"1234", "5678"}
+		framework.TestContainerOutput("pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
+	})
+
+})

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,8 +32,26 @@ At that time, the openshift docker registry image must be upgraded in order to c
 
 1. The `volume.metadata` field is deprecated as of Origin 1.0.6 in favor of `volume.downwardAPI`.
 
-1. New fields (`allowHostPID` and `allowHostIPC`) have been added to the default SCCs in Origin 1.0.7.  
-You may set these fields manually or [reset your default SCCs](https://docs.openshift.org/latest/admin_guide/manage_scc.html#updating-the-default-security-context-constraints).
+1. New fields (`fsGroup`, `supplementalGroups`, `allowHostPID` and `allowHostIPC`) have been added 
+to the default SCCs in Origin 1.0.7.  These allow you to control groups for persistent volumes,
+supplemental groups for the container, and usage of the host PID/IPC namespaces.  The fields will 
+default as follows for existing SCCs:
+
+  1.  allowHostPID - defaults to false.  You may wish to change this to true on any privileged SCCs or 
+  [reset your default SCCs](https://docs.openshift.org/latest/admin_guide/manage_scc.html#updating-the-default-security-context-constraints) 
+  which will set this field to true for the privileged SCC and false for the restricted SCC.
+  1.  allowHostIPC - defaults to false.  You may wish to change this to true on any privileged SCCs or 
+  [reset your default SCCs](https://docs.openshift.org/latest/admin_guide/manage_scc.html#updating-the-default-security-context-constraints) 
+  which will set this field to true for the privileged SCC and false for the restricted SCC.
+  1.  fsGroup - if the strategy type is unset this field will default based on the runAsUser strategy.
+  If runAsUser is set to RunAsAny this field will also be set to RunAsAny.  If the strategy type is
+  any other value this field will default to MustRunAs and look to the namespace for [annotation 
+  configuration](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#understanding-pre-allocated-values-and-security-context-constraints).
+  1.  supplementalGroups - if the strategy type is unset this field will default based on the runAsUser strategy.
+  If runAsUser is set to RunAsAny this field will also be set to RunAsAny.  If the strategy type is
+  any other value this field will default to MustRunAs and look to the namespace for [annotation 
+  configuration](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#understanding-pre-allocated-values-and-security-context-constraints).    
+   
 
 1. The `v1beta3` API version is being removed in Origin 1.1 (OSE 3.1).
 Existing `v1beta3` resources stored in etcd will still be readable and

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -13592,7 +13592,7 @@
      },
      "securityContext": {
       "$ref": "v1.PodSecurityContext",
-      "description": "SecurityContext holds pod-level security attributes and common container settings"
+      "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
      },
      "imagePullSecrets": {
       "type": "array",
@@ -14110,28 +14110,28 @@
    },
    "v1.SecurityContext": {
     "id": "v1.SecurityContext",
-    "description": "SecurityContext holds security configuration that will be applied to a container.",
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
      },
      "privileged": {
       "type": "boolean",
-      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false."
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      },
      "runAsNonRoot": {
       "type": "boolean",
-      "description": "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user."
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      }
     }
    },
@@ -14165,25 +14165,55 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "User is a SELinux user label that applies to the container."
      },
      "role": {
       "type": "string",
-      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Role is a SELinux role label that applies to the container."
      },
      "type": {
       "type": "string",
-      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Type is a SELinux type label that applies to the container."
      },
      "level": {
       "type": "string",
-      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Level is SELinux level label that applies to the container."
      }
     }
    },
    "v1.PodSecurityContext": {
     "id": "v1.PodSecurityContext",
-    "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+    "properties": {
+     "seLinuxOptions": {
+      "$ref": "v1.SELinuxOptions",
+      "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+     },
+     "runAsUser": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+     },
+     "runAsNonRoot": {
+      "type": "boolean",
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+     },
+     "supplementalGroups": {
+      "type": "array",
+      "items": {
+       "$ref": "integer"
+      },
+      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container."
+     },
+     "fsGroup": {
+      "type": "integer",
+      "format": "int64",
+      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw "
+     }
+    }
+   },
+   "integer": {
+    "id": "integer",
     "properties": {}
    },
    "v1.PodStatus": {

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -15455,7 +15455,7 @@
      },
      "securityContext": {
       "$ref": "v1.PodSecurityContext",
-      "description": "SecurityContext holds pod-level security attributes and common container settings"
+      "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
      },
      "imagePullSecrets": {
       "type": "array",
@@ -16212,28 +16212,28 @@
    },
    "v1.SecurityContext": {
     "id": "v1.SecurityContext",
-    "description": "SecurityContext holds security configuration that will be applied to a container.",
+    "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
      },
      "privileged": {
       "type": "boolean",
-      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false."
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      },
      "runAsNonRoot": {
       "type": "boolean",
-      "description": "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user."
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
      }
     }
    },
@@ -16267,25 +16267,55 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "User is a SELinux user label that applies to the container."
      },
      "role": {
       "type": "string",
-      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Role is a SELinux role label that applies to the container."
      },
      "type": {
       "type": "string",
-      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Type is a SELinux type label that applies to the container."
      },
      "level": {
       "type": "string",
-      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "description": "Level is SELinux level label that applies to the container."
      }
     }
    },
    "v1.PodSecurityContext": {
     "id": "v1.PodSecurityContext",
-    "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+    "properties": {
+     "seLinuxOptions": {
+      "$ref": "v1.SELinuxOptions",
+      "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+     },
+     "runAsUser": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+     },
+     "runAsNonRoot": {
+      "type": "boolean",
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+     },
+     "supplementalGroups": {
+      "type": "array",
+      "items": {
+       "$ref": "integer"
+      },
+      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container."
+     },
+     "fsGroup": {
+      "type": "integer",
+      "format": "int64",
+      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw "
+     }
+    }
+   },
+   "integer": {
+    "id": "integer",
     "properties": {}
    },
    "v1.DeploymentConfigStatus": {
@@ -17499,10 +17529,6 @@
    "runtime.RawExtension": {
     "id": "runtime.RawExtension",
     "description": "this may be any JSON object with a 'kind' and 'apiVersion' field; and is preserved unmodified by processing",
-    "properties": {}
-   },
-   "integer": {
-    "id": "integer",
     "properties": {}
    },
    "v1.Parameter": {

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -375,7 +375,9 @@ func roundTrip(t *testing.T, codec runtime.Codec, originalItem runtime.Object) {
 var skipStandardVersions = map[string][]string{
 	// The API versions here are to test our object that serializes from/into
 	// docker's registry API.
-	"DockerImage": {"pre012", "1.0"},
+	"DockerImage":          {"pre012", "1.0"},
+	"DeploymentConfigList": {"", "v1"},
+	"DeploymentConfig":     {"", "v1"},
 }
 
 const fuzzIters = 20
@@ -385,7 +387,7 @@ func TestSpecificKind(t *testing.T) {
 	api.Scheme.Log(t)
 	defer api.Scheme.Log(nil)
 
-	kind := "ImageStreamTag"
+	kind := "BuildConfig"
 	item, err := api.Scheme.New("", kind)
 	if err != nil {
 		t.Errorf("Couldn't make a %v? %v", kind, err)

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -31,6 +31,12 @@ func GetBootstrapSecurityContextConstraints(buildControllerUsername string) []ka
 			RunAsUser: kapi.RunAsUserStrategyOptions{
 				Type: kapi.RunAsUserStrategyRunAsAny,
 			},
+			FSGroup: kapi.FSGroupStrategyOptions{
+				Type: kapi.FSGroupStrategyRunAsAny,
+			},
+			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
+				Type: kapi.SupplementalGroupsStrategyRunAsAny,
+			},
 			Users:  []string{buildControllerUsername},
 			Groups: []string{ClusterAdminGroup, NodesGroup},
 		},
@@ -49,6 +55,22 @@ func GetBootstrapSecurityContextConstraints(buildControllerUsername string) []ka
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
 				Type: kapi.RunAsUserStrategyMustRunAsRange,
+			},
+			FSGroup: kapi.FSGroupStrategyOptions{
+				// This strategy requires that annotations on the namespace which will be populated
+				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
+				// on the namespace and if it is unable to find that annotation it will attempt
+				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
+				// of the SCC will fail.
+				Type: kapi.FSGroupStrategyMustRunAs,
+			},
+			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
+				// This strategy requires that annotations on the namespace which will be populated
+				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
+				// on the namespace and if it is unable to find that annotation it will attempt
+				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
+				// of the SCC will fail.
+				Type: kapi.SupplementalGroupsStrategyMustRunAs,
 			},
 			Groups: []string{AuthenticatedGroup},
 		},

--- a/pkg/security/util.go
+++ b/pkg/security/util.go
@@ -3,8 +3,7 @@ package security
 const (
 	UIDRangeAnnotation = "openshift.io/sa.scc.uid-range"
 	// SupplementalGroupsAnnotation contains a comma delimited list of allocated supplemental groups
-	// for the namespace.  Groups are in the form of individual group ids or a range of group ids.
-	// Range format is supported in the form of a Block which supports {start}/{length} or {start}-{end}
+	// for the namespace.  Groups are in the form of a Block which supports {start}/{length} or {start}-{end}
 	SupplementalGroupsAnnotation = "openshift.io/sa.scc.supplemental-groups"
 	MCSAnnotation                = "openshift.io/sa.scc.mcs"
 	ValidatedSCCAnnotation       = "openshift.io/scc"

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/images"
 	_ "github.com/openshift/origin/test/extended/router"
+	_ "github.com/openshift/origin/test/extended/security"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )

--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -1,0 +1,182 @@
+package security
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e"
+
+	testutil "github.com/openshift/origin/test/util"
+)
+
+var _ = g.Describe("security: supplemental groups", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		f = e2e.NewFramework("security-supgroups")
+	)
+
+	g.Describe("Ensure supplemental groups propagate to docker", func() {
+		g.It("should propagate requested groups to the docker host config", func() {
+			// Before running any of this test we need to first check that
+			// the docker version being used supports the supplemental groups feature
+			g.By("ensuring the feature is supported")
+			dockerCli, err := testutil.NewDockerClient()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			env, err := dockerCli.Version()
+			o.Expect(err).NotTo(o.HaveOccurred(), "error getting docker environment")
+			version := env.Get("Version")
+			supports, err, requiredVersion := supportsSupplementalGroups(version)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			if !supports {
+				msg := fmt.Sprintf("skipping supplemental groups test, docker version %s does not meet required version %s", version, requiredVersion)
+				g.Skip(msg)
+			}
+
+			// on to the real test
+			fsGroup := int64(1111)
+			supGroup := int64(2222)
+
+			// create a pod that is requesting supplemental groups.  We request specific sup groups
+			// so that we can check for the exact values later and not rely on SCC allocation.
+			g.By("creating a pod that requests supplemental groups")
+			submittedPod := supGroupPod(fsGroup, supGroup)
+			_, err = f.Client.Pods(f.Namespace.Name).Create(submittedPod)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer f.Client.Pods(f.Namespace.Name).Delete(submittedPod.Name, nil)
+
+			// we should have been admitted with the groups that we requested but if for any
+			// reason they are different we will fail.
+			g.By("retrieving the pod and ensuring groups are set")
+			retrievedPod, err := f.Client.Pods(f.Namespace.Name).Get(submittedPod.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(*retrievedPod.Spec.SecurityContext.FSGroup).To(o.Equal(*submittedPod.Spec.SecurityContext.FSGroup))
+			o.Expect(retrievedPod.Spec.SecurityContext.SupplementalGroups).To(o.Equal(submittedPod.Spec.SecurityContext.SupplementalGroups))
+
+			// wait for the pod to run so we can inspect it.
+			g.By("waiting for the pod to become running")
+			err = f.WaitForPodRunning(submittedPod.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// find the docker id of our running container.
+			g.By("finding the docker container id on the pod")
+			retrievedPod, err = f.Client.Pods(f.Namespace.Name).Get(submittedPod.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			containerID, err := getContainerID(retrievedPod)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// now check the host config of the container which should have been updated by the
+			// kubelet.  If that is good then ensure we have the groups we expected.
+			g.By("inspecting the container")
+			dockerContainer, err := dockerCli.InspectContainer(containerID)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("ensuring the host config has GroupAdd")
+			groupAdd := dockerContainer.HostConfig.GroupAdd
+			o.Expect(groupAdd).ToNot(o.BeEmpty(), fmt.Sprintf("groupAdd on host config was %v", groupAdd))
+
+			g.By("ensuring the groups are set")
+			o.Expect(configHasGroup(fsGroup, dockerContainer.HostConfig)).To(o.Equal(true), fmt.Sprintf("fsGroup should exist on host config: %v", groupAdd))
+			o.Expect(configHasGroup(supGroup, dockerContainer.HostConfig)).To(o.Equal(true), fmt.Sprintf("supGroup should exist on host config: %v", groupAdd))
+		})
+
+	})
+})
+
+// supportsSupplementalGroups does a check on the docker version to ensure it is at least
+// 1.8.2.  This could still fail if the version does not have the /etc/groups patch
+// but it will fail when launching the pod so this is as safe as we can get.
+func supportsSupplementalGroups(dockerVersion string) (bool, error, string) {
+	parts := strings.Split(dockerVersion, ".")
+
+	var (
+		requiredMajor   = 1
+		requiredMinor   = 8
+		requiredPatch   = 2
+		requiredVersion = fmt.Sprintf("%d.%d.%d", requiredMajor, requiredMinor, requiredPatch)
+
+		major       = 0
+		minor       = 0
+		patch       = 0
+		err   error = nil
+	)
+	if len(parts) > 0 {
+		major, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return false, err, requiredVersion
+		}
+	}
+
+	if len(parts) > 1 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return false, err, requiredVersion
+		}
+	}
+
+	if len(parts) > 2 {
+		patch, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return false, err, requiredVersion
+		}
+	}
+
+	// requires at least 1.8.2
+	if major > requiredMajor || (major == requiredMajor && minor > requiredMinor) ||
+		(major == requiredMajor && minor == requiredMinor && patch >= requiredPatch) {
+		return true, nil, requiredVersion
+	}
+
+	return false, nil, requiredVersion
+}
+
+// configHasGroup is a helper to ensure that a group is in the host config's addGroups field.
+func configHasGroup(group int64, config *docker.HostConfig) bool {
+	strGroup := strconv.FormatInt(group, 10)
+	for _, g := range config.GroupAdd {
+		if g == strGroup {
+			return true
+		}
+	}
+	return false
+}
+
+// getContainerID is a helper to parse the docker container id from a status.
+func getContainerID(p *kapi.Pod) (string, error) {
+	for _, status := range p.Status.ContainerStatuses {
+		if len(status.ContainerID) > 0 {
+			containerID := strings.Replace(status.ContainerID, "docker://", "", -1)
+			return containerID, nil
+		}
+	}
+	return "", fmt.Errorf("unable to find container id on pod")
+}
+
+// supGroupPod generates the pod requesting supplemental groups.
+func supGroupPod(fsGroup int64, supGroup int64) *kapi.Pod {
+	return &kapi.Pod{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "supplemental-groups",
+		},
+		Spec: kapi.PodSpec{
+			SecurityContext: &kapi.PodSecurityContext{
+				FSGroup:            &fsGroup,
+				SupplementalGroups: []int64{supGroup},
+			},
+			Containers: []kapi.Container{
+				{
+					Name:  "supplemental-groups",
+					Image: "openshift/origin-pod",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This is based on @pmorie 's WIP branch https://github.com/openshift/origin/pull/5169.  The last two commits are what I'm working on.

Contains:

1.  SecurityContextConstraints api support
   1.  Includes a defaulter for SCCs without FSGroup/SupplementalGroups strategies so no upgrade is necessary
   1.  Defaulting is based on the value of the RunAsUser strategy
1.  Strategies for groups (fsgroup and sup groups use the same underlying strategy code but have their own definitions/types)
   1.  Both strategies allow namespace configuration by using MustRunAs with no ranges set
   1.  Both strategies will provide a default value of the first value in the first range configured
   1.  When using namespace configuration for the FSGroup strategy it will create a single range with a min/max of the first value in the supplemental group annotation. 
   1.  When using namespace configuration for the SupGroup strategy it will parse the entire annotation into ranges.
1.  provider implementation
   1.  new interface methods introduced to generate and validate a PSC 
   1.  support for fsgroup/sup group strategies
   1.  reuse of the selinux strategy validation on the PSC by mocking up a container to validate (generation never uses the container so no mock is necessary)
1.  admission control for PSC
   1.  generates and validates the PSC
   1.  uses the SecurityContext provider to determine the effective SC for the container prior to container generation/validation (provides us initial value defaulting and allows container overrides)
   1.  retrieval of the supplemental group annotation has fallback code to use the uid annotation if necessary for a better upgrade experience

@pmorie @swagiaal @liggitt @smarterclayton 

---
Remaining Work:
 - [ ] blacklisting `v1beta3` `PodSpecs` has rippled into a lot of objects now not getting fuzzed.  At the very least, we need an issue find a way to test `v1beta3 -> internal -> v1beta3` with fidelity.  See the ripples here: https://github.com/openshift/origin/pull/5079/files#diff-394377845c8dfd9eec363c059cdde354R379
 - [ ] UPSTREAM commit names need fixing.
 - [ ] issue to allow admission based on a union of available SCCs.  With multiple ranges and options, its really annoying to have an SCC that combines all of them.
 - [ ] issue to convert code to a `DeepCopy` of the pod.  This would help readability and its only going to happen on pod creation.  I'm not convinced that an in-memory copy of data we already have, just for creates of pods, will show up on profiling, but it be a big improvement for inspectability of this code.
 - [ ] issue for `reconcile-sccs` to help admins update correctly.