### PR TITLE
Build and Pod logs in web console

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -135,7 +135,7 @@
 
     <!-- This needs to be loaded before scripts.js -->
     <script src="scripts/templates.js"></script>
-    
+
         <!-- build:js({.tmp,app}) scripts/scripts.js -->
         <script src="scripts/app.js"></script>
         <script src="scripts/services/logger.js"></script>
@@ -172,7 +172,7 @@
         <script src="scripts/controllers/image.js"></script>
         <script src="scripts/controllers/deployments.js"></script>
         <script src="scripts/controllers/deploymentConfig.js"></script>
-        <script src="scripts/controllers/deployment.js"></script>        
+        <script src="scripts/controllers/deployment.js"></script>
         <script src="scripts/controllers/services.js"></script>
         <script src="scripts/controllers/service.js"></script>
         <script src="scripts/controllers/routes.js"></script>
@@ -186,7 +186,6 @@
         <script src="scripts/controllers/util/oauth.js"></script>
         <script src="scripts/controllers/util/error.js"></script>
         <script src="scripts/controllers/util/logout.js"></script>
-        <script src="scripts/controllers/catalog/images.js"></script>
         <script src="scripts/controllers/create.js"></script>
         <script src="scripts/controllers/createProject.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
@@ -210,11 +209,15 @@
         <script src="scripts/directives/catalog.js"></script>
         <script src="scripts/directives/oscObjectDescriber.js"></script>
         <script src="scripts/directives/metrics.js"></script>
-        <script src="scripts/directives/podStatusChart.js"></script>
+		<script src="scripts/directives/logViewer.js"></script>
+        <script src="scripts/directives/statusIcon.js"></script>
+		<script src="scripts/directives/podStatusChart.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>
         <script src="scripts/extensions/javaLink.js"></script>
+        <script src="scripts/directives/affix.js"></script>
+        <script src="scripts/services/logLinks.js"></script>
         <!-- endbuild -->
 
     <!-- Load any extensions last. -->

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -73,6 +73,7 @@ angular
     tab.icon = "sitemap";
     tabs.push(tab);
 
+
     tab = builder.create()
      .id(builder.join(pluginName, "settings"))
      .title(function () { return "Settings"; })
@@ -117,7 +118,12 @@ angular
         templateUrl: 'views/browse/build-config.html'
       })
       .when('/project/:project/browse/builds/:buildconfig/:build', {
-        templateUrl: 'views/browse/build.html'
+        templateUrl: function(params) {
+          return params.view ?
+                  'views/logs/'+params.view+'_log.html' :
+                  'views/browse/build.html';
+        },
+        controller: 'BuildController'
       })
       // For when a build is missing a buildconfig label
       // Needs to still be prefixed with browse/builds so the secondary nav active state is correct
@@ -150,7 +156,11 @@ angular
         templateUrl: 'views/pods.html'
       })
       .when('/project/:project/browse/pods/:pod', {
-        templateUrl: 'views/browse/pod.html',
+        templateUrl: function(params) {
+          return params.view ?
+                  'views/logs/'+params.view+'_log.html' :
+                  'views/browse/pod.html';
+        },
         controller: 'PodController'
       })
       .when('/project/:project/browse/services', {

--- a/assets/app/scripts/directives/affix.js
+++ b/assets/app/scripts/directives/affix.js
@@ -1,0 +1,38 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .directive('affix', function() {
+    return {
+      restrict: 'AE',
+      scope: {
+        offsetTop: '=',
+        offsetBottom: '='
+      },
+      controller: [
+        function() {
+        //'$window',
+        //function($window) {
+          this.init = function(/* affixedEl */) {
+            // FOR DEBUGGING
+            // angular
+            // .element($window)
+            // .bind("scroll", function() {
+            //   var pos = affixedEl.affix('checkPosition')[0];
+            //     console.log('affix position', pos.offsetWidth, pos.offsetHeight, pos.offsetTop, pos.offsetBottom);
+            //     //scope.$apply();
+            // });
+          };
+        }
+      ],
+      link: function($scope, $elem, $attrs, ctrl) {
+        ctrl.init(
+            $elem.affix({
+              offset: {
+                top: $attrs.offsetTop,
+                bottom: $attrs.offsetBottom
+              }
+            }));
+      }
+    };
+  });
+

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -1,0 +1,46 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .directive('logViewer', [
+    'DataService',
+    'logLinks',
+    function(DataService, logLinks) {
+      return {
+        restrict: 'AE',
+        transclude: true,
+        templateUrl: 'views/directives/logs/_log-viewer.html',
+        scope: {
+          logs: '=',
+          loading: '=',
+          links: '=',
+          download: '=',
+          start: '=',
+          end: '='
+        },
+        controller: [
+          '$scope',
+          function($scope) {
+            angular.extend($scope, {
+              ready: true,
+              canDownload: logLinks.canDownload(),
+              makeDownload: _.flow(function(arr) {
+                                    return _.reduce(
+                                              arr,
+                                              function(memo, next, i) {
+                                                return i <= arr.length ?
+                                                        memo + next.text :
+                                                        memo;
+                                              }, '');
+                                  }, logLinks.makeDownload),
+              scrollTo: logLinks.scrollTo,
+              scrollTop: logLinks.scrollTop,
+              scrollBottom: logLinks.scrollBottom,
+              goFull: logLinks.fullPageLink,
+              goChromeless: logLinks.chromelessLink,
+              goText: logLinks.textOnlyLink
+            });
+          }
+        ]
+      };
+    }
+  ]);

--- a/assets/app/scripts/directives/statusIcon.js
+++ b/assets/app/scripts/directives/statusIcon.js
@@ -1,0 +1,14 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .directive('statusIcon', [
+    function() {
+      return {
+        restrict: 'E',
+        templateUrl: 'views/directives/_status-icon.html',
+        scope: {
+          status: '='
+        }
+      };
+    }
+  ]);

--- a/assets/app/scripts/services/data.js
+++ b/assets/app/scripts/services/data.js
@@ -1,5 +1,5 @@
 'use strict';
-/* jshint eqeqeq: false, unused: false */
+/* jshint eqeqeq: false, unused: false, expr: true */
 
 angular.module('openshiftConsole')
 .factory('DataService', function($http, $ws, $rootScope, $q, API_CFG, Notification, Logger, $timeout) {
@@ -376,6 +376,124 @@ angular.module('openshiftConsole')
     return deferred.promise;
   };
 
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa
+function utf8_to_b64( str ) {
+    return window.btoa(window.unescape(encodeURIComponent( str )));
+}
+function b64_to_utf8( str ) {
+    return decodeURIComponent(window.escape(window.atob( str )));
+}
+
+// TODO (bpeterse): Create a new Streamer service & get this out of DataService.
+DataService.prototype.createStream = function(kind, name, context, isRaw) {
+  var getNamespace = this._getNamespace.bind(this);
+  var urlForResource = this._urlForResource.bind(this);
+  kind = this.kindToResource(kind) ?
+              this.kindToResource(kind) :
+              normalizeResource(kind);
+
+  var protocols = isRaw ? 'binary.k8s.io' : 'base64.binary.k8s.io';
+  var identifier = 'stream_';
+  var openQueue = {};
+  var messageQueue = {};
+  var closeQueue = {};
+  var errorQueue = {};
+
+  var stream;
+  var makeStream = function() {
+     return getNamespace(kind, context, {})
+                .then(function(params) {
+                  return  $ws({
+                            url: urlForResource(kind, name, null, context, true, _.extend(params, {follow: true})),
+                            auth: {},
+                            onopen: function(evt) {
+                              _.each(openQueue, function(fn) {
+                                fn(evt);
+                              });
+                            },
+                            onmessage: function(evt) {
+                              if(!_.isString(evt.data)) {
+                                Logger.log('log stream response is not a string', evt.data);
+                                return;
+                              }
+                              _.each(messageQueue, function(fn) {
+                                if(isRaw) {
+                                  fn(evt.data);
+                                } else {
+                                  fn(b64_to_utf8(evt.data), evt.data);
+                                }
+                              });
+                            },
+                            onclose: function(evt) {
+                              _.each(closeQueue, function(fn) {
+                                fn(evt);
+                              });
+                            },
+                            onerror: function(evt) {
+                              _.each(errorQueue, function(fn) {
+                                fn(evt);
+                              });
+                            },
+                            protocols: protocols
+                          }).then(function(ws) {
+                            Logger.log("Streaming pod log", ws);
+                            return ws;
+                          });
+                });
+  };
+  return {
+    onOpen: function(fn) {
+      if(!_.isFunction(fn)) {
+        return;
+      }
+      var id = _.uniqueId(identifier);
+      openQueue[id] = fn;
+      return id;
+    },
+    onMessage: function(fn) {
+      if(!_.isFunction(fn)) {
+        return;
+      }
+      var id = _.uniqueId(identifier);
+      messageQueue[id] = fn;
+      return id;
+    },
+    onClose: function(fn) {
+      if(!_.isFunction(fn)) {
+        return;
+      }
+      var id = _.uniqueId(identifier);
+      closeQueue[id] = fn;
+      return id;
+    },
+    onError: function(fn) {
+      if(!_.isFunction(fn)) {
+        return;
+      }
+      var id = _.uniqueId(identifier);
+      errorQueue[id] = fn;
+      return id;
+    },
+    // can remove any callback from open, message, close or error
+    remove: function(id) {
+      if (openQueue[id]) { delete openQueue[id]; }
+      if (messageQueue[id]) { delete messageQueue[id]; }
+      if (closeQueue[id]) { delete closeQueue[id]; }
+      if (errorQueue[id]) { delete errorQueue[id]; }
+    },
+    start: function() {
+      stream = makeStream();
+      return stream;
+    },
+    stop: function() {
+      stream.then(function(ws) {
+        ws.close();
+      });
+    }
+  };
+};
+
+
 // resource:  API resource (e.g. "pods")
 // context:   API context (e.g. {project: "..."})
 // callback:  optional function to be called with the initial list of the requested resource,
@@ -436,14 +554,14 @@ angular.module('openshiftConsole')
       if (callback) {
         var existingData = this._data(resource, context);
         if (existingData) {
-          $timeout(function() {          
+          $timeout(function() {
             callback(existingData);
           }, 0);
         }
       }
       if (!this._listInFlight(resource, context)) {
         this._startListOp(resource, context);
-      }      
+      }
     }
 
     // returned handle needs resource, context, and callback in order to unwatch
@@ -454,6 +572,8 @@ angular.module('openshiftConsole')
       opts: opts
     };
   };
+
+
 
 // resource:  API resource (e.g. "pods")
 // name:      API name, the unique name for the object
@@ -506,7 +626,7 @@ angular.module('openshiftConsole')
     var handle = this.watch(resource, context, wrapperCallback, opts);
     handle.objectCallback = callback;
     handle.objectName = name;
-    
+
     return handle;
   };
 
@@ -517,7 +637,7 @@ angular.module('openshiftConsole')
     var callback = handle.callback;
     var objectCallback = handle.objectCallback;
     var opts = handle.opts;
-    
+
     if (objectCallback && objectName) {
       var objCallbacks = this._watchObjectCallbacks(resource, objectName, context);
       objCallbacks.remove(objectCallback);
@@ -567,7 +687,7 @@ angular.module('openshiftConsole')
       this._watchObjectCallbacksMap[key] = $.Callbacks();
     }
     return this._watchObjectCallbacksMap[key];
-  };  
+  };
 
   DataService.prototype._listCallbacks = function(resource, context) {
     var key = this._uniqueKeyForResourceContext(resource, context);
@@ -720,10 +840,10 @@ angular.module('openshiftConsole')
       return resource + "/" + context.project.metadata.name;
     }
     else if (context.namespace) {
-      return resource + "/" + context.namespace; 
+      return resource + "/" + context.namespace;
     }
     else if (context.projectName) {
-      return resource + "/" + context.projectName;      
+      return resource + "/" + context.projectName;
     }
     else {
       return resource;
@@ -815,6 +935,7 @@ angular.module('openshiftConsole')
     if ($ws.available()) {
       var self = this;
       var params = {};
+      params.watch = true;
       if (resourceVersion) {
         params.resourceVersion = resourceVersion;
       }
@@ -975,10 +1096,8 @@ angular.module('openshiftConsole')
   };
 
   var URL_ROOT_TEMPLATE         = "{protocol}://{+serverUrl}{+apiPrefix}/{apiVersion}/";
-  var URL_WATCH_LIST            = URL_ROOT_TEMPLATE + "watch/{resource}{?q*}";
   var URL_GET_LIST              = URL_ROOT_TEMPLATE + "{resource}{?q*}";
   var URL_OBJECT                = URL_ROOT_TEMPLATE + "{resource}/{name}{/subresource*}{?q*}";
-  var URL_NAMESPACED_WATCH_LIST = URL_ROOT_TEMPLATE + "watch/namespaces/{namespace}/{resource}{?q*}";
   var URL_NAMESPACED_GET_LIST   = URL_ROOT_TEMPLATE + "namespaces/{namespace}/{resource}{?q*}";
   var URL_NAMESPACED_OBJECT     = URL_ROOT_TEMPLATE + "namespaces/{namespace}/{resource}/{name}{/subresource*}{?q*}";
 
@@ -1039,10 +1158,7 @@ angular.module('openshiftConsole')
       namespace: namespace,
       q: params
     };
-    if (isWebsocket) {
-      template = namespaceInPath ? URL_NAMESPACED_WATCH_LIST : URL_WATCH_LIST;
-    }
-    else if (name) {
+    if (name) {
       template = namespaceInPath ? URL_NAMESPACED_OBJECT : URL_OBJECT;
     }
     else {

--- a/assets/app/scripts/services/logLinks.js
+++ b/assets/app/scripts/services/logLinks.js
@@ -1,0 +1,90 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('logLinks', [
+    '$anchorScroll',
+    '$document',
+    '$location',
+    '$window',
+    function($anchorScroll, $document, $location, $window) {
+      // TODO (bpeterse): a lot of these functions are generic and could be moved/renamed to
+      // a navigation oriented service.
+      var doc = $document[0];
+
+      var createObjectURL = function() {
+        return (window.URL || window.webkitURL || {}).createObjectURL || _.noop;
+      };
+
+      var revokeObjectURL = function() {
+        return (window.URL || window.webkitURL || {}).revokeObjectURL || _.noop;
+      };
+
+      var canDownload = function() {
+        return !!createObjectURL();
+      };
+
+      var makeDownload = function(obj, filename) {
+        obj = _.isString(obj) ? obj : JSON.stringify(obj);
+        var a = doc.createElement('a');
+        a.href = createObjectURL()(new Blob([obj], {type: 'text/plain'}));
+        a.download = (filename || 'download') + '.txt';
+        doc.body.appendChild(a);
+        a.click();
+        revokeObjectURL()(a.href);
+        doc.body.removeChild(a);
+      };
+
+      var scrollTop = function() {
+        $window.scrollTo(null, 0);
+      };
+
+      var scrollBottom = function() {
+        $window.scrollTo(null, $document.innerHeight());
+      };
+
+      var scrollTo = function(anchor, event) {
+        // sad face. stop reloading the page!!!!
+        event.preventDefault();
+        event.stopPropagation();
+        $location.hash(anchor);
+        $anchorScroll(anchor);
+      };
+
+      var fullPageLink = function() {
+         $location.search('view', 'chromeless');
+      };
+      // @params an object or array of objects
+      var newTab = function(params) {
+        params = _.isArray(params) ?
+                  params :
+                  [params];
+        var uri = new URI();
+        _.each(params, function(param) {
+          uri.addSearch(param);
+        });
+        $window.open(uri.toString(), '_blank');
+      };
+
+      // new tab: path/to/current?view=chromeless
+      var chromelessLink = function() {
+        newTab({view: 'chromeless'});
+      };
+
+      // new tab: path/to/current?view=textonly
+      var textOnlyLink = function() {
+        newTab({view: 'textonly'});
+      };
+
+      return {
+        canDownload: canDownload,
+        makeDownload: makeDownload,
+        scrollTop: scrollTop,
+        scrollBottom: scrollBottom,
+        scrollTo: scrollTo,
+        fullPageLink: fullPageLink,
+        newTab: newTab,
+        chromelessLink: chromelessLink,
+        textOnlyLink: textOnlyLink
+      };
+    }
+  ]);

--- a/assets/app/scripts/services/ws.js
+++ b/assets/app/scripts/services/ws.js
@@ -36,10 +36,11 @@ angular.module('openshiftConsole')
       authLogger.log("$ws (pre-intercept)", config.url.toString());
       var serverRequest = function(config) {
         authLogger.log("$ws (post-intercept)", config.url.toString());
-        var ws = new WebSocket(config.url);
+        var ws = new WebSocket(config.url, config.protocols);
         if (config.onclose)   { ws.onclose   = config.onclose;   }
         if (config.onmessage) { ws.onmessage = config.onmessage; }
         if (config.onopen)    { ws.onopen    = config.onopen;    }
+        if (config.onerror)   { ws.onerror    = config.onerror;  }
         return ws;
       };
 

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -59,7 +59,7 @@ html, body {
         border-top: 1px solid @navbar-pf-navbar-header-border-color;
       }
     }
-    .navbar-brand { 
+    .navbar-brand {
       border: 0;
       margin-left: 20px;
       margin-top: 4px;
@@ -512,7 +512,9 @@ label.checkbox {
   margin-left: 3px;
 }
 
+
 // Misc
+// TODO: pull out into _partials where it makes sense
 // --------------------------------------------------
 .action-inline {
   margin-left: @action-link-inline-margin;
@@ -533,7 +535,7 @@ label.required:before {
   padding: 0 4px;
 }
 .btn-lg, .btn-group-lg > .btn {
-  line-height: 1.334; // needed to make same height as inputs 
+  line-height: 1.334; // needed to make same height as inputs
 }
 
 code {
@@ -545,7 +547,7 @@ pre {
     background-color: #fff;
     border: none;
     border-left: 2px solid rgb(204, 204, 204);
-  }  
+  }
 }
 
 // Fix to override the Firefox 40+ behavior to add text-decoration
@@ -617,6 +619,11 @@ select:invalid {
   width: 12px;
 }
 
+.spinner.spinner-inverse {
+  border-color: rgba(0,153,211, .25);
+  border-top-color: rgba(0,153,211, .75);
+}
+
 .attention-message {
   background-color: lighten(@brand-primary, 20%);
   border: 1px solid darken(@brand-primary, 10%);
@@ -683,7 +690,6 @@ a.action-button {
     text-align: center;
   }
 }
-
 pre.clipped {
   display: inline-block;
 }
@@ -733,3 +739,9 @@ pre.clipped {
 labels + dl {
   margin-top: 10px;
 }
+
+[flex].page-header {
+  // reduced for consistency if used with flex
+  margin-top: 21px;
+}
+

--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -1,0 +1,109 @@
+.log-title {
+  margin-top: 0;
+}
+.log-timestamp {
+  margin-bottom: 10px;
+}
+.log-view {
+  background-color: @log-bg-color;
+  min-height: 60px;
+  padding: 0;
+  position: relative;
+  pre, pre code {
+    background-color: transparent;
+    border: 0;
+    color: #98C1C8;
+    margin-bottom: 0;
+    overflow: visible;
+    padding: 0 10px;
+  }
+  .log-scroll {
+    text-align:right;
+    a {
+      padding-right:10px;
+    }
+    a:hover {
+      color: @link-hover-color-bright;
+    }
+  }
+  .log-scroll-top.affix {
+    position: fixed;
+    right: 30px;
+    top: 0;
+  }
+  .log-scroll-top.affix-top {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+  .log-scroll-top.affix-bottom {
+
+  }
+  .log-scroll-bottom {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+  .log-view-output {
+    font-size: 12px;
+    padding: 20px 0 20px;
+    &:before {
+      content: '';
+      display: block;
+      height: 100%;
+      width: 1px;
+      background-color: lighten(@log-bg-color, 5%);
+      top: 0;
+      left: 60px;
+      position: absolute;
+    }
+  }
+}
+
+.log-link-external {
+  a {
+    margin-left: 20px;
+  }
+  i {
+    font-size: @font-size-xsmall;
+    margin-left: 5px;
+  }
+}
+.log-line {
+    color: #98C1C8;
+}
+.log-line.even {}
+.log-line.odd {}
+.log-line:hover {
+  background-color: lighten(@log-bg-color, 3%);
+  color: 000;
+}
+.log-line-number {
+  &:hover, &:focus {
+    background-color: lighten(@log-bg-color, 8%);
+    color: @link-hover-color-bright;
+  }
+  span {
+    width: 60px;
+    padding-right: 10px;
+  }
+}
+.log-line-text {
+  padding: 0 10px;
+}
+.log-chromeless {
+  margin-top: -1px;
+  .log-view {
+    .log-scroll-top.affix {
+      right: 10px;
+    }
+  }
+}
+
+.table-log-pods {
+  > tbody + tbody {
+    border-top-width: 1px;
+  }
+  background-color: #fff;
+  border: 1px solid #D1D1D1;
+}

--- a/assets/app/styles/_sidebar.less
+++ b/assets/app/styles/_sidebar.less
@@ -236,6 +236,17 @@
   }
 }
 
+@media (min-width: @screen-sm-min) and (max-width: @screen-lg-max) {
+  //Ensure icon and text stack
+  ul.nav-sidenav > li {
+    > a {
+      span {
+        padding: 0 10px;
+      }
+    }
+  }
+}
+
 @media (min-width: @screen-lg-min) { 
   .console-os {
     .wrap {

--- a/assets/app/styles/_variables.less
+++ b/assets/app/styles/_variables.less
@@ -28,6 +28,8 @@
 @console-dark-blue: #006e9c;
 @console-text-color-default: @gray-dark;
 @font-size-base: 13px;
+@link-hover-color-bright: lighten(@link-color, 13%);
+@log-bg-color: #031920;
 @navbar-os-bg-color: #34383c;
 @navbar-os-label-filter-bg: @navbar-os-project-menu-bg;
 @navbar-os-project-bg: #eee;
@@ -62,6 +64,7 @@
 @sidebar-right-width-lg: 33%;
 @sidebar-right-width-md: 30%;
 @sidebar-right-width-sm: 27%;
+@screen-lg-max: (@screen-xlg-min - 1);
 @screen-xlg-min: 1600px;
 @status-bg-color: #E6ECF1;
 @status-border-color: #BFCEDB;
@@ -79,4 +82,6 @@
 @font-size-h5: @font-size-base; // ~13px
 @font-size-large: ceil(@font-size-base * 1.1); // ~15px
 @font-size-small: ceil(@font-size-base * .83); // ~11px
+@font-size-xsmall: ceil(@font-size-base * .75); // ~10px
+@font-size-xxsmall: ceil(@font-size-base * .68); // ~9px
 @line-height-base: 1.66666667; // 20/12

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -63,7 +63,7 @@
 @import "@{pf-path}/type.less";
 
 
-/* OpenShift V3 
+/* OpenShift V3
 ------------------------------------------------- */
 @import "_variables.less";
 @import "_mixins.less";
@@ -80,3 +80,4 @@
 @import "_tables.less";
 @import "_tile.less";
 @import "_topology.less";
+@import "_log.less";

--- a/assets/app/views/_triggers.html
+++ b/assets/app/views/_triggers.html
@@ -32,7 +32,11 @@
         <span ng-switch-when="Cancelled">was cancelled.</span>
         <span ng-switch-default>is {{build.status.phase | lowercase}}.
           <span ng-if="trigger.imageChangeParams.automatic">
-            A new deployment will be created automatically once the build completes.
+            A new deployment will be created automatically once the build completes.&nbsp;&nbsp;
+            <a
+              href="/project/{{build.metadata.namespace}}/browse/builds/{{build.metadata.labels.buildconfig}}/{{build.metadata.name}}?tab=logs">
+              View Log
+            </a>
           </span>
         </span>
       </span>
@@ -40,3 +44,6 @@
     </div>
   </div>
 </div>
+
+
+

--- a/assets/app/views/browse/_build-details.html
+++ b/assets/app/views/browse/_build-details.html
@@ -1,0 +1,76 @@
+<dl class="dl-horizontal left">
+  <dt>Status:</dt>
+  <dd>
+    <span ng-switch="build.status.phase" class="hide-ng-leave">
+      <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
+      <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
+      <span ng-switch-when="Error" class="fa fa-times text-danger" aria-hidden="true"></span>
+      <span ng-switch-when="Cancelled" class="fa fa-ban text-warning" aria-hidden="true"></span>
+      <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
+      <span ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
+    </span>
+    {{build.status.phase}}
+
+  <button class="btn btn-default build-status-button btn-primary" ng-click="cancelBuild(build, buildConfigName)" ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)">Cancel</button>
+  <button class="btn btn-default build-status-button" ng-click="cloneBuild(build.metadata.name)" ng-hide="build.metadata.deletionTimestamp || (build | isIncompleteBuild)" ng-disabled="(buildConfigBuildsInProgress[buildConfigName] | hashSize) !== 0">Rebuild</button>
+  </dd>
+  <dt>Created:</dt>
+  <dd><relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp></dd>
+  <dt>Labels:</dt>
+  <dd>
+    <span ng-if="!build.metadata.labels">none</span>
+    <span ng-repeat="(labelKey, labelValue) in build.metadata.labels">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
+  </dd>
+  <dt>Started:</dt>
+  <dd>
+    <relative-timestamp timestamp="build.status.startTimestamp"></relative-timestamp>
+    <span>- {{(build.status.startTimestamp || build.metadata.creationTimestamp) | date : 'short'}}</span>
+  </dd>
+  <dt>Duration:</dt>
+  <dd>
+    <span ng-switch="build.status.phase" class="hide-ng-leave">
+      <span ng-switch-when="Complete">{{(build.status.startTimestamp || build.metadata.creationTimestamp) | duration : build.status.completionTimestamp}}</span>
+      <span ng-switch-when="Failed">{{build.status.startTimestamp | duration : build.status.completionTimestamp}}</span>
+      <span ng-switch-when="Running">running for <duration-until-now timestamp="build.status.startTimestamp"></duration-until-now></span>
+      <span ng-switch-when="New">waiting for <duration-until-now timestamp="build.metadata.creationTimestamp"></duration-until-now></span>
+      <span ng-switch-when="Pending">waiting for <duration-until-now timestamp="build.metadata.creationTimestamp"></duration-until-now></span>
+      <span ng-switch-default>
+        <span ng-if="build.status.startTimestamp">{{build.status.startTimestamp | duration : build.status.completionTimestamp}}</span>
+        <span ng-if="!build.status.startTimestamp">waited for {{build.metadata.creationTimestamp | duration : build.status.completionTimestamp}}</span>
+      </span>
+    </span>
+  </dd>
+  <dt ng-if="buildConfigName">Build configuration:</dt>
+  <dd ng-if="buildConfigName"><a href="project/{{build.metadata.namespace}}/browse/builds/{{buildConfigName}}">{{buildConfigName}}</a></dd>
+  <dt>Build strategy:</dt>
+  <dd>{{build.spec.strategy.type}}</dd>
+  <dt>Builder image:</dt>
+  <dd>
+    <div class="build-detail" ng-switch="build.spec.strategy.type">
+      <div ng-switch-when="Source" ng-if="build.spec.strategy.sourceStrategy.from">
+        <span class="build-detail-label">Builder image:</span>{{build.spec.strategy.sourceStrategy.from | imageObjectRef : build.metadata.namespace}}
+      </div>
+      <div ng-switch-when="Docker">
+        <div ng-if="build.spec.strategy.dockerStrategy.from">
+          <span class="build-detail-label">Builder image:</span>{{build.spec.strategy.dockerStrategy.from | imageObjectRef : build.metadata.namespace}}
+        </div>
+      </div>
+      <div ng-switch-when="Custom" ng-if="build.spec.strategy.customStrategy.from">
+        <span class="build-detail-label">Builder image:</span>{{build.spec.strategy.customStrategy.from | imageObjectRef : build.metadata.namespace}}
+      </div>
+    </div>
+  </dd>
+  <dt>Source type:</dt>
+  <dd>{{build.spec.source.type}}</dd>
+  <dt ng-if="build.spec.source.type === 'Git'">Source repo:</dt>
+  <dd ng-if="build.spec.source.type === 'Git'"><span ng-bind-html='build.spec.source.git.uri | githubLink : build.spec.source.git.ref : build.spec.source.contextDir | linky'></span></dd>
+  <dt ng-if="build.spec.source.git.ref">Source ref:</dt>
+  <dd ng-if="build.spec.source.git.ref">{{build.spec.source.git.ref}}</dd>
+  <dt ng-if="build.spec.source.contextDir">Source context dir:</dt>
+  <dd ng-if="build.spec.source.contextDir">{{build.spec.source.contextDir}}</dd>
+  <dt ng-if="build.spec.output.to">Output image:</dt>
+  <dd ng-if="build.spec.output.to">{{build.spec.output.to | imageObjectRef : build.metadata.namespace}}</dd>
+  <dt ng-if="build.spec.output.pushSecret.name">Push secret:</dt>
+  <dd ng-if="build.spec.output.pushSecret.name">{{build.spec.output.pushSecret.name}}</dd>
+</dl>
+<annotations annotations="build.metadata.annotations"></annotations>

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -1,0 +1,64 @@
+<dl class="dl-horizontal left">
+  <dt>Node:</dt>
+  <dd>{{pod.spec.nodeName || 'unknown'}} <span ng-if="pod.status.hostIP && pod.spec.nodeName != pod.status.hostIP">({{pod.status.hostIP}})</span></dd>
+  <dt>Status:</dt>
+  <dd>
+    <span ng-switch="pod.status.phase">
+      <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
+      <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
+      <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
+      <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
+      <span ng-switch-when="Running" class="fa fa-refresh fa-spin" aria-hidden="true"></span>
+    </span>
+    {{pod.status.phase}}
+  </dd>
+  <dt>IP:</dt>
+  <dd>{{pod.status.podIP || 'unknown'}}</dd>
+  <dt>Restart policy:</dt>
+  <dd>{{pod.spec.restartPolicy || 'Always'}}</dd>
+</dl>
+<div ng-if="pod.spec.volumes.length">
+  <span class="pod-detail-label">Volumes:</span>
+  <ul>
+    <li ng-repeat="volume in pod.spec.volumes">
+      <div>{{volume.name}}</div>
+      <div ng-if="volume.source.hostPath">
+        <div>Type: host path</div>
+        <div>Path: {{volume.source.hostPath.path}}</div>
+      </div>
+      <div ng-if="volume.source.emptyDir">Type: empty directory</div>
+      <!-- TODO fill out GCE persistent disk details -->
+      <div ng-if="volume.source.gcePersistentDisk">Type: GCE persistent disk</div>
+      <div ng-if="volume.source.gitRepo">
+        <div>Type: Git repository</div>
+        <div>Repository: {{volume.source.gitRepo.repository}}</div>
+        <div ng-if="volume.source.gitRepo.revision">Revision: {{volume.source.gitRepo.revision}}</div>
+      </div>
+    </li>
+  </ul>
+</div>
+<div>Pod template:</div>
+<pod-template
+  pod-template="pod"
+  images-by-docker-reference="imagesByDockerReference"
+  builds="builds">
+</pod-template>
+<div>Container Statuses:</div>
+<div ng-if="!pod.status.containerStatuses"><em>none</em></div>
+<dl ng-repeat="containerStatus in pod.status.containerStatuses | orderBy:'name'" class="dl-horizontal left indent">
+  <dt>Name:</dt>
+  <dd>{{containerStatus.name}}</dd>
+  <dt>State:</dt>
+  <dd>
+    <kubernetes-object-describe-container-state container-state="containerStatus.state"></kubernetes-object-describe-container-state>
+  </dd>
+  <dt ng-if="!(containerStatus.lastState | isEmptyObj)">Last State</dt>
+  <dd ng-if="!(containerStatus.lastState | isEmptyObj)">
+    <kubernetes-object-describe-container-state container-state="containerStatus.lastState"></kubernetes-object-describe-container-state>
+  </dd>
+  <dt>Ready:</dt>
+  <dd>{{containerStatus.ready}}</dd>
+  <dt>Restart Count:</dt>
+  <dd>{{containerStatus.restartCount}}</dd>
+</dl>
+<annotations annotations="pod.metadata.annotations"></annotations>

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -10,82 +10,36 @@
             <h1>{{build.metadata.name}}</h1>
             <labels ng-if="buildConfigName" labels="build.metadata.labels" clickable="true" kind="builds" title-kind="builds for build config {{buildConfigName}}" project-name="{{build.metadata.namespace}}" limit="3" navigate-url="project/{{build.metadata.namespace}}/browse/builds/{{buildConfigName}}"></labels>
             <labels ng-if="!buildConfigName" labels="build.metadata.labels" limit="3"></labels>
-            <dl class="dl-horizontal left">
-              <dt>Status:</dt>
-              <dd>
-                <span ng-switch="build.status.phase" class="hide-ng-leave">
-                  <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
-                  <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
-                  <span ng-switch-when="Error" class="fa fa-times text-danger" aria-hidden="true"></span>
-                  <span ng-switch-when="Cancelled" class="fa fa-ban text-warning" aria-hidden="true"></span>
-                  <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
-                  <span ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
-                </span>
-                {{build.status.phase}}
 
-              <button class="btn btn-default build-status-button btn-primary" ng-click="cancelBuild(build, buildConfigName)" ng-if="!build.metadata.deletionTimestamp && (build | isIncompleteBuild)">Cancel</button>
-              <button class="btn btn-default build-status-button" ng-click="cloneBuild(build.metadata.name)" ng-hide="build.metadata.deletionTimestamp || (build | isIncompleteBuild)" ng-disabled="(buildConfigBuildsInProgress[buildConfigName] | hashSize) !== 0">Rebuild</button>
-              </dd>
-              <dt>Created:</dt>
-              <dd><relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp></dd>
-              <dt>Labels:</dt>
-              <dd>
-                <span ng-if="!build.metadata.labels">none</span>
-                <span ng-repeat="(labelKey, labelValue) in build.metadata.labels">{{labelKey}}={{labelValue}}<span ng-show="!$last">, </span></span>
-              </dd>
-              <dt>Started:</dt>
-              <dd>
-                <relative-timestamp timestamp="build.status.startTimestamp"></relative-timestamp>
-                <span>- {{(build.status.startTimestamp || build.metadata.creationTimestamp) | date : 'short'}}</span>
-              </dd>
-              <dt>Duration:</dt>
-              <dd>
-                <span ng-switch="build.status.phase" class="hide-ng-leave">
-                  <span ng-switch-when="Complete">{{(build.status.startTimestamp || build.metadata.creationTimestamp) | duration : build.status.completionTimestamp}}</span>
-                  <span ng-switch-when="Failed">{{build.status.startTimestamp | duration : build.status.completionTimestamp}}</span>
-                  <span ng-switch-when="Running">running for <duration-until-now timestamp="build.status.startTimestamp"></duration-until-now></span>
-                  <span ng-switch-when="New">waiting for <duration-until-now timestamp="build.metadata.creationTimestamp"></duration-until-now></span>
-                  <span ng-switch-when="Pending">waiting for <duration-until-now timestamp="build.metadata.creationTimestamp"></duration-until-now></span>
-                  <span ng-switch-default>
-                    <span ng-if="build.status.startTimestamp">{{build.status.startTimestamp | duration : build.status.completionTimestamp}}</span>
-                    <span ng-if="!build.status.startTimestamp">waited for {{build.metadata.creationTimestamp | duration : build.status.completionTimestamp}}</span>
-                  </span>
-                </span>
-              </dd>
-              <dt ng-if="buildConfigName">Build configuration:</dt>
-              <dd ng-if="buildConfigName"><a href="project/{{build.metadata.namespace}}/browse/builds/{{buildConfigName}}">{{buildConfigName}}</a></dd>
-              <dt>Build strategy:</dt>
-              <dd>{{build.spec.strategy.type}}</dd>
-              <dt>Builder image:</dt>
-              <dd>
-                <div class="build-detail" ng-switch="build.spec.strategy.type">
-                  <div ng-switch-when="Source" ng-if="build.spec.strategy.sourceStrategy.from">
-                    <span class="build-detail-label">Builder image:</span>{{build.spec.strategy.sourceStrategy.from | imageObjectRef : build.metadata.namespace}}
+            <tabset>
+              <tab active="selectedTab.details">
+                <tab-heading>Details</tab-heading>
+                <ng-include src=" 'views/browse/_build-details.html' "></ng-include>
+              </tab>
+
+              <tab active="selectedTab.logs">
+                <tab-heading>Logs</tab-heading>
+                <log-viewer
+                  logs="logs"
+                  loading="logsLoading"
+                  start="build.status.startTimestamp | date : 'short'"
+                  end="build.status.completionTimestamp | date : 'short'"
+                  links="true"
+                  download="canShowDownload">
+                  <div row>
+                    <span>Status:&nbsp;&nbsp;</span>
+                    <status-icon status="build.status.phase"></status-icon>
+                    <span flex>&nbsp;&nbsp;{{build.status.phase}}</span>
                   </div>
-                  <div ng-switch-when="Docker">
-                    <div ng-if="build.spec.strategy.dockerStrategy.from">
-                      <span class="build-detail-label">Builder image:</span>{{build.spec.strategy.dockerStrategy.from | imageObjectRef : build.metadata.namespace}}
-                    </div>
-                  </div>
-                  <div ng-switch-when="Custom" ng-if="build.spec.strategy.customStrategy.from">
-                    <span class="build-detail-label">Builder image:</span>{{build.spec.strategy.customStrategy.from | imageObjectRef : build.metadata.namespace}}
-                  </div>
+                </log-viewer>
+                <div ng-show="!logsLoading" class="text-muted">
+                  connection closed.
+                  <a ng-click="initLogs()" ng-show="canInitAgain">reconnect</a>
                 </div>
-              </dd>
-              <dt>Source type:</dt>
-              <dd>{{build.spec.source.type}}</dd>
-              <dt ng-if="build.spec.source.type === 'Git'">Source repo:</dt>
-              <dd ng-if="build.spec.source.type === 'Git'"><span ng-bind-html='build.spec.source.git.uri | githubLink : build.spec.source.git.ref : build.spec.source.contextDir | linky'></span></dd>
-              <dt ng-if="build.spec.source.git.ref">Source ref:</dt>
-              <dd ng-if="build.spec.source.git.ref">{{build.spec.source.git.ref}}</dd>
-              <dt ng-if="build.spec.source.contextDir">Source context dir:</dt>
-              <dd ng-if="build.spec.source.contextDir">{{build.spec.source.contextDir}}</dd>            
-              <dt ng-if="build.spec.output.to">Output image:</dt>
-              <dd ng-if="build.spec.output.to">{{build.spec.output.to | imageObjectRef : build.metadata.namespace}}</dd>
-              <dt ng-if="build.spec.output.pushSecret.name">Push secret:</dt>
-              <dd ng-if="build.spec.output.pushSecret.name">{{build.spec.output.pushSecret.name}}</dd>
-            </dl>
-            <annotations annotations="build.metadata.annotations"></annotations>            
+              </tab>
+            </tabset>
+
+
           </div>
         </div>
       </div><!-- /.row -->

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -16,70 +16,8 @@
             <labels labels="pod.metadata.labels" clickable="true" kind="pods" project-name="{{pod.metadata.namespace}}" limit="3"></labels>
             <tabset>
               <tab heading="Details" active="selectedTab.details">
-                <dl class="dl-horizontal left">
-                  <dt>Node:</dt>
-                  <dd>{{pod.spec.nodeName || 'unknown'}} <span ng-if="pod.status.hostIP && pod.spec.nodeName != pod.status.hostIP">({{pod.status.hostIP}})</span></dd>
-                  <dt>Status:</dt>
-                  <dd>
-                    <span ng-switch="pod.status.phase">
-                      <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
-                      <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
-                      <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
-                      <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
-                      <span ng-switch-when="Running" class="fa fa-refresh fa-spin" aria-hidden="true"></span>
-                    </span>
-                    {{pod.status.phase}}
-                  </dd>
-                  <dt>IP:</dt>
-                  <dd>{{pod.status.podIP || 'unknown'}}</dd>
-                  <dt>Restart policy:</dt>
-                  <dd>{{pod.spec.restartPolicy || 'Always'}}</dd>
-                </dl>
-                <div ng-if="pod.spec.volumes.length">
-                  <span class="pod-detail-label">Volumes:</span>
-                  <ul>
-                    <li ng-repeat="volume in pod.spec.volumes">
-                      <div>{{volume.name}}</div>
-                      <div ng-if="volume.source.hostPath">
-                        <div>Type: host path</div>
-                        <div>Path: {{volume.source.hostPath.path}}</div>
-                      </div>
-                      <div ng-if="volume.source.emptyDir">Type: empty directory</div>
-                      <!-- TODO fill out GCE persistent disk details -->
-                      <div ng-if="volume.source.gcePersistentDisk">Type: GCE persistent disk</div>
-                      <div ng-if="volume.source.gitRepo">
-                        <div>Type: Git repository</div>
-                        <div>Repository: {{volume.source.gitRepo.repository}}</div>
-                        <div ng-if="volume.source.gitRepo.revision">Revision: {{volume.source.gitRepo.revision}}</div>
-                      </div>
-                    </li>
-                  </ul>
-                </div>
-                <div>Pod template:</div>
-                <pod-template
-                  pod-template="pod"
-                  images-by-docker-reference="imagesByDockerReference"
-                  builds="builds">
-                </pod-template>
-                <div>Container Statuses:</div>
-                <div ng-if="!pod.status.containerStatuses"><em>none</em></div>
-                <dl ng-repeat="containerStatus in pod.status.containerStatuses | orderBy:'name'" class="dl-horizontal left indent">
-                  <dt>Name:</dt>
-                  <dd>{{containerStatus.name}}</dd>
-                  <dt>State:</dt>
-                  <dd>
-                    <kubernetes-object-describe-container-state container-state="containerStatus.state"></kubernetes-object-describe-container-state>
-                  </dd>
-                  <dt ng-if="!(containerStatus.lastState | isEmptyObj)">Last State</dt>
-                  <dd ng-if="!(containerStatus.lastState | isEmptyObj)">
-                    <kubernetes-object-describe-container-state container-state="containerStatus.lastState"></kubernetes-object-describe-container-state>
-                  </dd>
-                  <dt>Ready:</dt>
-                  <dd>{{containerStatus.ready}}</dd>
-                  <dt>Restart Count:</dt>
-                  <dd>{{containerStatus.restartCount}}</dd>
-                </dl>
-                <annotations annotations="pod.metadata.annotations"></annotations>
+                <tab-heading>Details</tab-heading>
+                <ng-include src=" 'views/browse/_pod-details.html' "></ng-include>
               </tab>
 
               <tab ng-if="metricsAvailable" heading="Metrics" active="selectedTab.metrics">
@@ -92,11 +30,26 @@
                 </pod-metrics>
               </tab>
 
-              <!--
-              <tab heading="Logs" active="selectedTab.logs">
-              Logs content
+
+              <tab active="selectedTab.logs">
+                <tab-heading>Logs</tab-heading>
+                <log-viewer
+                  logs="logs"
+                  loading="logsLoading"
+                  start="pod.status.startTime | date : 'short'"
+                  links="true"
+                  download="canShowDownload">
+                  <div row>
+                    <span>Status:&nbsp;&nbsp;</span>
+                    <status-icon status="pod.status.phase"></status-icon>
+                    <span flex>&nbsp;&nbsp;{{pod.status.phase}}</span>
+                  </div>
+                </log-viewer>
+                <div ng-show="!logsLoading" class="text-muted">
+                  connection closed
+                  <a ng-click="initLogs()" ng-show="canInitAgain">reconnect</a>
+                </div>
               </tab>
-              -->
             </tabset>
           </div>
         </div>

--- a/assets/app/views/directives/_status-icon.html
+++ b/assets/app/views/directives/_status-icon.html
@@ -1,0 +1,11 @@
+<span ng-switch="status" class="hide-ng-leave">
+  <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
+  <span ng-switch-when="Error" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="Cancelled" class="fa fa-ban text-warning" aria-hidden="true"></span>
+  <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
+  <span ng-switch-when="Failed" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
+  <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
+  <span ng-switch-when="Running" class="fa fa-refresh fa-spin" aria-hidden="true"></span>
+  <span ng-switch-default class="fa fa-refresh fa-spin" aria-hidden="true"></span>
+</span>

--- a/assets/app/views/directives/logs/_log-formatted.html
+++ b/assets/app/views/directives/logs/_log-formatted.html
@@ -1,0 +1,56 @@
+<div>
+  <a
+    name="logTop"
+    id="logTop"></a>
+
+  <div class="log-view">
+    <div
+      ng-show="logs.length > 25"
+      class="log-scroll log-scroll-top"
+      affix
+      offset-top="285"
+      offset-bottom="90">
+      <a ng-click="scrollBottom()">
+        Go to end of log
+      </a>
+    </div>
+    <div layout flex column class="log-view-output">
+      <div
+        layout row
+        class="log-line"
+        ng-repeat="logLine in logs  | filter:logSearch"
+        ng-class-odd="'odd'"
+        ng-class-even="'even'">
+        <a
+          name="line_{{::$index+1}}"
+          id="line_{{::$index+1}}"></a>
+        <!-- not supporting click to line # yet
+        <a class="log-line-number"
+          ng-click="scrollTo('line_'+($index+1), $event)">
+          <span layout flex main-axis="end">
+          {{:: $index+1 }}
+          </span>
+        </a>
+        -->
+        <span class="log-line-number">
+          <span layout flex main-axis="end">
+          {{:: $index+1 }}
+          </span>
+        </span>
+
+        <span flex class="log-line-text">
+        {{::logLine.text}}
+        </span>
+      </div>
+      <div class="spinner spinner-inverse" ng-show="loading"></div>
+    </div>
+    <div
+      ng-show="logs.length > 25"
+      class="log-scroll log-scroll-bottom">
+      <a ng-click="scrollTop()">Go to start of log</a>
+    </div>
+  </div>
+  <a
+    id="logBottom"
+    name="logBottom"></a>
+</div>

--- a/assets/app/views/directives/logs/_log-raw.html
+++ b/assets/app/views/directives/logs/_log-raw.html
@@ -1,0 +1,5 @@
+<pre>
+<code>
+{{::log}}
+</code>
+</pre>

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -1,0 +1,30 @@
+<div layout column flex ng-if="links">
+  <div layout row class="log-timestamp" ng-if="start">
+    <span>Current log from {{start}}&nbsp;</span>
+    <span ng-if="end">to {{end}}</span>
+  </div>
+  <div layout sm="column" md="row">
+    <div flex row main-axis="end">
+      <div ng-transclude flex></div>
+      <div layout row cross-axis="end" class="log-link-external">
+        <a
+          ng-show="download"
+          ng-click="makeDownload(logs)">
+          Raw <i class="fa fa-external-link"></i>
+        </a>
+        <a ng-click="goChromeless()">
+          Open full view of log<i class="fa fa-external-link"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!--
+<ng-include
+  src="'views/directives/logs/_log-raw.html'"></ng-include>
+-->
+<ng-include
+  src="'views/directives/logs/_log-formatted.html'"></ng-include>
+
+

--- a/assets/app/views/logs/chromeless_log.html
+++ b/assets/app/views/logs/chromeless_log.html
@@ -1,0 +1,8 @@
+<div class="content">
+  <div class="log-chromeless">
+    <alerts alerts="alerts"></alerts>
+    <log-viewer
+      logs="logs"
+      loading="logsLoading"></log-viewer>
+  </div>
+</div>

--- a/assets/app/views/logs/textonly_log.html
+++ b/assets/app/views/logs/textonly_log.html
@@ -1,0 +1,6 @@
+<!--
+  TODO: this probably needs a different root (index.html) file w/o all the chrome.
+-->
+<log-viewer
+  logs="logs"
+  loading="logsLoading"></log-viewer>

--- a/assets/test/spec/services/dataServiceSpec.js
+++ b/assets/test/spec/services/dataServiceSpec.js
@@ -53,9 +53,20 @@ describe("DataService", function(){
       // Subresources aren't lowercased
       [{resource:'buildconfigs/webhooks/Aa1/github',     name:"mycfg",      namespace:"foo"}, "http://localhost:8443/oapi/v1/namespaces/foo/buildconfigs/mycfg/webhooks/Aa1/github"],
 
-      // Watch
-      [{resource:'pods', namespace:"foo", isWebsocket:true                     }, "ws://localhost:8443/api/v1/watch/namespaces/foo/pods"],
-      [{resource:'pods', namespace:"foo", isWebsocket:true, resourceVersion:"5"}, "ws://localhost:8443/api/v1/watch/namespaces/foo/pods?resourceVersion=5"],
+
+
+      // Plain websocket
+      [{resource:'pods', namespace:"foo", isWebsocket:true      }, "ws://localhost:8443/api/v1/namespaces/foo/pods"],
+
+      // Watch resource
+      [{resource:'pods', namespace:"foo", isWebsocket:true, watch: true                       }, "ws://localhost:8443/api/v1/namespaces/foo/pods?watch=true"],
+      [{resource:'pods', namespace:"foo", isWebsocket:true, watch: true, resourceVersion:"5"  }, "ws://localhost:8443/api/v1/namespaces/foo/pods?watch=true&resourceVersion=5"],
+
+      // Follow log
+      [{resource:'pods/log', namespace:"foo", isWebsocket:true, follow: true                       }, "ws://localhost:8443/api/v1/namespaces/foo/pods?follow=true"],
+      [{resource:'builds/log', namespace:"foo", isWebsocket:true, follow: true                     }, "ws://localhost:8443/oapi/v1/namespaces/foo/builds?follow=true"],
+
+
 
       // Namespaced subresource with params
       [{resource:'pods/proxy', name:"mypod", namespace:"myns", myparam1:"myvalue"}, "http://localhost:8443/api/v1/namespaces/myns/pods/mypod/proxy?myparam1=myvalue"],


### PR DESCRIPTION
- currently supports streaming build & pod logs
- structure pod container logs into table view
- add download link, make builds a table to match pods, add created to table
- update tabs on build and pod page template
- update data service log stream
- add new log viewer directive
- add reconnect functionality to log views

@jwforres @spadgett @sg00dwin ping for review!