### PR TITLE
status: Warn about transient deployment trigger errors

### DIFF
--- a/pkg/api/graph/test/missing-istag.yaml
+++ b/pkg/api/graph/test/missing-istag.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ruby-goodbye-world:latest
+    resources: {}
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: ruby-20-centos7:latest
+      type: Docker
+    triggers:
+    - github:
+        secret: LyddbeCAaw1a0x08xz9n
+      type: GitHub
+    - generic:
+        secret: ZnYJJeEvo1ri0Gk0f6YY
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    labels:
+      app: ruby
+    name: ruby-hello-world
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: ruby-hello-world
+    strategy:
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          deploymentconfig: ruby-hello-world
+      spec:
+        containers:
+        - image: library/ruby-hello-world:latest
+          imagePullPolicy: Always
+          name: ruby-hello-world
+          ports:
+          - containerPort: 8080
+            name: ruby-hello-world-tcp-8080
+            protocol: TCP
+          resources: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ruby-hello-world
+        from:
+          kind: ImageStreamTag
+          name: ruby-hello-world:latest
+      type: ImageChange
+kind: List
+metadata: {}

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployedges "github.com/openshift/origin/pkg/deploy/graph"
+	deployanalysis "github.com/openshift/origin/pkg/deploy/graph/analysis"
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -212,13 +213,19 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 		if errorMarkers := allMarkers.BySeverity(osgraph.ErrorSeverity); len(errorMarkers) > 0 {
 			fmt.Fprintln(out, "Errors:")
 			for _, marker := range errorMarkers {
-				fmt.Fprintln(out, indent+marker.Message)
+				fmt.Fprintln(out, indent+"* "+marker.Message)
 			}
 		}
 		if warningMarkers := allMarkers.BySeverity(osgraph.WarningSeverity); len(warningMarkers) > 0 {
 			fmt.Fprintln(out, "Warnings:")
 			for _, marker := range warningMarkers {
-				fmt.Fprintln(out, indent+marker.Message)
+				fmt.Fprintln(out, indent+"* "+marker.Message)
+			}
+		}
+		if infoMarkers := allMarkers.BySeverity(osgraph.InfoSeverity); len(infoMarkers) > 0 {
+			fmt.Fprintln(out, "Info:")
+			for _, marker := range infoMarkers {
+				fmt.Fprintln(out, indent+"* "+marker.Message)
 			}
 		}
 
@@ -256,6 +263,7 @@ func getMarkerScanners() []osgraph.MarkerScanner {
 		kubeanalysis.FindMissingSecrets,
 		buildanalysis.FindUnpushableBuildConfigs,
 		buildanalysis.FindCircularBuilds,
+		deployanalysis.FindDeploymentConfigTriggerErrors,
 		routeanalysis.FindMissingPortMapping,
 	}
 }

--- a/pkg/deploy/graph/analysis/dc.go
+++ b/pkg/deploy/graph/analysis/dc.go
@@ -1,0 +1,97 @@
+package analysis
+
+import (
+	"fmt"
+
+	"github.com/gonum/graph"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	buildedges "github.com/openshift/origin/pkg/build/graph"
+	buildgraph "github.com/openshift/origin/pkg/build/graph/nodes"
+	deployedges "github.com/openshift/origin/pkg/deploy/graph"
+	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
+	imageedges "github.com/openshift/origin/pkg/image/graph"
+	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
+)
+
+const (
+	ImageStreamTagNotAvailableInfo = "ImageStreamTagNotAvailable"
+	MissingImageStreamWarning      = "MissingImageStream"
+	MissingImageStreamTagWarning   = "MissingImageStreamTag"
+)
+
+// FindDeploymentConfigTriggerErrors checks for possible failures in deployment config
+// image change triggers.
+//
+// Precedence of failures:
+// 1. The image stream of the tag of interest does not exist.
+// 2. The image stream tag does not exist but a build config points to it.
+// 3. The image stream tag does not exist.
+func FindDeploymentConfigTriggerErrors(g osgraph.Graph) []osgraph.Marker {
+	markers := []osgraph.Marker{}
+
+dc:
+	for _, uncastDcNode := range g.NodesByKind(deploygraph.DeploymentConfigNodeKind) {
+		for _, uncastIstNode := range g.PredecessorNodesByEdgeKind(uncastDcNode, deployedges.TriggersDeploymentEdgeKind) {
+			if istNode := uncastIstNode.(*imagegraph.ImageStreamTagNode); !istNode.Found() {
+				dcNode := uncastDcNode.(*deploygraph.DeploymentConfigNode)
+
+				// 1. Image stream for tag of interest does not exist
+				if isNode, exists := doesImageStreamExist(g, uncastIstNode); !exists {
+					markers = append(markers, osgraph.Marker{
+						Node:         uncastDcNode,
+						RelatedNodes: []graph.Node{uncastIstNode, isNode},
+
+						Severity: osgraph.WarningSeverity,
+						Key:      MissingImageStreamWarning,
+						Message: fmt.Sprintf("The image trigger for %s will have no effect because %s does not exist.",
+							dcNode.ResourceString(), isNode.(*imagegraph.ImageStreamNode).ResourceString()),
+					})
+					continue dc
+				}
+
+				// 2. Build config points to image stream tag of interest
+				if bcNode, points := buildPointsToTag(g, uncastIstNode); points {
+					markers = append(markers, osgraph.Marker{
+						Node:         uncastDcNode,
+						RelatedNodes: []graph.Node{uncastIstNode, bcNode},
+
+						Severity: osgraph.InfoSeverity,
+						Key:      ImageStreamTagNotAvailableInfo,
+						Message: fmt.Sprintf("The image trigger for %s will have no effect because %s does not exist but %s points to %s.",
+							dcNode.ResourceString(), istNode.ResourceString(), bcNode.(*buildgraph.BuildConfigNode).ResourceString(), istNode.ResourceString()),
+					})
+					continue dc
+				}
+
+				// 3. Image stream tag of interest does not exist
+				markers = append(markers, osgraph.Marker{
+					Node:         uncastDcNode,
+					RelatedNodes: []graph.Node{uncastIstNode},
+
+					Severity: osgraph.WarningSeverity,
+					Key:      MissingImageStreamTagWarning,
+					Message: fmt.Sprintf("The image trigger for %s will have no effect because %s does not exist.",
+						dcNode.ResourceString(), istNode.ResourceString()),
+				})
+				continue dc
+			}
+		}
+	}
+
+	return markers
+}
+
+func doesImageStreamExist(g osgraph.Graph, istag graph.Node) (graph.Node, bool) {
+	for _, imagestream := range g.SuccessorNodesByEdgeKind(istag, imageedges.ReferencedImageStreamGraphEdgeKind) {
+		return imagestream, imagestream.(*imagegraph.ImageStreamNode).Found()
+	}
+	return nil, false
+}
+
+func buildPointsToTag(g osgraph.Graph, istag graph.Node) (graph.Node, bool) {
+	for _, bcNode := range g.PredecessorNodesByEdgeKind(istag, buildedges.BuildOutputEdgeKind) {
+		return bcNode, true
+	}
+	return nil, false
+}

--- a/pkg/deploy/graph/analysis/dc_test.go
+++ b/pkg/deploy/graph/analysis/dc_test.go
@@ -1,0 +1,67 @@
+package analysis
+
+import (
+	"testing"
+
+	osgraphtest "github.com/openshift/origin/pkg/api/graph/test"
+	buildedges "github.com/openshift/origin/pkg/build/graph"
+	deployedges "github.com/openshift/origin/pkg/deploy/graph"
+	imageedges "github.com/openshift/origin/pkg/image/graph"
+)
+
+func TestMissingImageStreamTag(t *testing.T) {
+	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/missing-istag.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	buildedges.AddAllInputOutputEdges(g)
+	deployedges.AddAllTriggerEdges(g)
+	imageedges.AddAllImageStreamRefEdges(g)
+
+	markers := FindDeploymentConfigTriggerErrors(g)
+	if e, a := 1, len(markers); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	if got, expected := markers[0].Key, MissingImageStreamTagWarning; got != expected {
+		t.Fatalf("expected marker key %q, got %q", expected, got)
+	}
+}
+
+func TestMissingImageStream(t *testing.T) {
+	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/unpushable-build-2.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	buildedges.AddAllInputOutputEdges(g)
+	deployedges.AddAllTriggerEdges(g)
+	imageedges.AddAllImageStreamRefEdges(g)
+
+	markers := FindDeploymentConfigTriggerErrors(g)
+	if e, a := 1, len(markers); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	if got, expected := markers[0].Key, MissingImageStreamWarning; got != expected {
+		t.Fatalf("expected marker key %q, got %q", expected, got)
+	}
+}
+
+func TestSyntheticImageStreamTag(t *testing.T) {
+	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/unpushable-build.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	buildedges.AddAllInputOutputEdges(g)
+	deployedges.AddAllTriggerEdges(g)
+	imageedges.AddAllImageStreamRefEdges(g)
+
+	markers := FindDeploymentConfigTriggerErrors(g)
+	if e, a := 1, len(markers); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	if got, expected := markers[0].Key, ImageStreamTagNotAvailableInfo; got != expected {
+		t.Fatalf("expected marker key %q, got %q", expected, got)
+	}
+}

--- a/pkg/deploy/graph/analysis/doc.go
+++ b/pkg/deploy/graph/analysis/doc.go
@@ -1,0 +1,3 @@
+// Package analysis provides functions that analyse deployment configurations and setup markers
+// that will be reported by oc status
+package analysis


### PR DESCRIPTION
@deads2k 

>  I do think we should handle multiple bad triggers as markers for warnings and the separately mark a deployment that can't succeed on the same line. Something like " #1 deployment waiting on image or update (image stream doesn't exist)"

Separate marker for each warning means we traverse the graph and not follow the message set up by the dc controller. Or is it enough to break down the message into markers?
