### PR TITLE
status: Report routes that have no route port specified

### DIFF
--- a/pkg/api/graph/graph.go
+++ b/pkg/api/graph/graph.go
@@ -28,7 +28,7 @@ func (n Node) DOTAttributes() []dot.Attribute {
 // The graph needs something in that location to track the information we have about the node, but the
 // backing object doesn't exist.
 type ExistenceChecker interface {
-	// Found returns true if the node represents an object that we don't have the backing object for
+	// Found returns false if the node represents an object that we don't have the backing object for
 	Found() bool
 }
 

--- a/pkg/api/graph/test/lonely-route.yaml
+++ b/pkg/api/graph/test/lonely-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Route
+metadata:
+  creationTimestamp: 2015-10-13T10:13:11Z
+  labels:
+    route: lonely
+  name: lonely-route
+  resourceVersion: "260"
+  uid: 025407f7-7193-11e5-b84d-080027c5bfa9
+spec:
+  host: www.example.com
+  to:
+    kind: Service
+    name: frontend
+status: {}

--- a/pkg/api/graph/test/missing-route-port.yaml
+++ b/pkg/api/graph/test/missing-route-port.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: 2015-10-13T10:13:11Z
+    labels:
+      test: missing-route-port
+    name: frontend
+    resourceVersion: "259"
+    selfLink: /api/v1/namespaces/test/services/frontend
+    uid: 024d82eb-7193-11e5-b84d-080027c5bfa9
+  spec:
+    clusterIP: 172.30.182.32
+    portalIP: 172.30.182.32
+    ports:
+    - name: web
+      port: 5432
+      protocol: TCP
+      targetPort: 8080
+    - name: web2
+      port: 5433
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: frontend
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Route
+  metadata:
+    creationTimestamp: 2015-10-13T10:13:11Z
+    labels:
+      test: missing-route-port
+    name: route-edge
+    resourceVersion: "260"
+    selfLink: /oapi/v1/namespaces/test/routes/route-edge
+    uid: 025407f7-7193-11e5-b84d-080027c5bfa9
+  spec:
+    host: www.example.com
+    to:
+      kind: Service
+      name: frontend
+  status: {}

--- a/pkg/api/graph/test/runtimeobject_nodebuilder.go
+++ b/pkg/api/graph/test/runtimeobject_nodebuilder.go
@@ -19,6 +19,8 @@ import (
 	deploygraph "github.com/openshift/origin/pkg/deploy/graph/nodes"
 	imageapi "github.com/openshift/origin/pkg/image/api"
 	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	routegraph "github.com/openshift/origin/pkg/route/graph/nodes"
 )
 
 // typeToEnsureMethod stores types to Ensure*Node methods
@@ -53,6 +55,9 @@ func init() {
 		panic(err)
 	}
 	if err := RegisterEnsureNode(&kapi.ReplicationController{}, kubegraph.EnsureReplicationControllerNode); err != nil {
+		panic(err)
+	}
+	if err := RegisterEnsureNode(&routeapi.Route{}, routegraph.EnsureRouteNode); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/api/kubegraph/nodes/nodes.go
+++ b/pkg/api/kubegraph/nodes/nodes.go
@@ -37,7 +37,17 @@ func EnsureServiceNode(g osgraph.MutableUniqueGraph, svc *kapi.Service) *Service
 	return osgraph.EnsureUnique(g,
 		ServiceNodeName(svc),
 		func(node osgraph.Node) graph.Node {
-			return &ServiceNode{node, svc}
+			return &ServiceNode{node, svc, true}
+		},
+	).(*ServiceNode)
+}
+
+// FindOrCreateSyntheticServiceNode returns the existing service node or creates a synthetic node in its place
+func FindOrCreateSyntheticServiceNode(g osgraph.MutableUniqueGraph, svc *kapi.Service) *ServiceNode {
+	return osgraph.EnsureUnique(g,
+		ServiceNodeName(svc),
+		func(node osgraph.Node) graph.Node {
+			return &ServiceNode{node, svc, false}
 		},
 	).(*ServiceNode)
 }

--- a/pkg/api/kubegraph/nodes/types.go
+++ b/pkg/api/kubegraph/nodes/types.go
@@ -27,6 +27,8 @@ func ServiceNodeName(o *kapi.Service) osgraph.UniqueName {
 type ServiceNode struct {
 	osgraph.Node
 	*kapi.Service
+
+	IsFound bool
 }
 
 func (n ServiceNode) Object() interface{} {
@@ -43,6 +45,10 @@ func (n ServiceNode) ResourceString() string {
 
 func (*ServiceNode) Kind() string {
 	return ServiceNodeKind
+}
+
+func (n ServiceNode) Found() bool {
+	return n.IsFound
 }
 
 func PodNodeName(o *kapi.Pod) osgraph.UniqueName {

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -61,7 +61,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/empty-service",
+				"svc/empty-service",
 				"<initializing>:5432",
 				"To see more, use",
 			},
@@ -76,7 +76,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/database-rc",
+				"svc/database-rc",
 				"rc/database-rc-1 runs mysql",
 				"0/1 pods growing to 1",
 				"To see more, use",
@@ -122,7 +122,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/frontend-app",
+				"svc/frontend-app",
 				"pod/frontend-app-1-bjwh8 runs openshift/ruby-hello-world",
 				"To see more, use",
 			},
@@ -151,7 +151,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/sinatra-example-2 - 172.30.17.48:8080",
+				"svc/sinatra-example-2 - 172.30.17.48:8080",
 				"builds git://github.com",
 				"with docker.io/openshift/ruby-20-centos7:latest",
 				"not built yet",
@@ -193,7 +193,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/sinatra-example-1 - 172.30.17.47:8080",
+				"svc/sinatra-example-1 - 172.30.17.47:8080",
 				"builds git://github.com",
 				"with docker.io/openshift/ruby-20-centos7:latest",
 				"#1 build running for about a minute",
@@ -212,7 +212,7 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/sinatra-app-example - 172.30.17.49:8080",
+				"svc/sinatra-app-example - 172.30.17.49:8080",
 				"sinatra-app-example-a deploys",
 				"sinatra-app-example-b deploys",
 				"with docker.io/openshift/ruby-20-centos7:latest",
@@ -232,8 +232,9 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				"In project example on server https://example.com:8443\n",
-				"service/database - 172.30.17.240:5434 -> 3306",
-				"service/frontend - 172.30.17.154:5432 -> 8080",
+				"svc/database - 172.30.17.240:5434 -> 3306",
+				"exposed by route/frontend on pod port 8080",
+				"svc/frontend - 172.30.17.154:5432 -> 8080",
 				"database deploys",
 				"frontend deploys",
 				"with docker.io/openshift/ruby-20-centos7:latest",

--- a/pkg/route/doc.go
+++ b/pkg/route/doc.go
@@ -18,5 +18,4 @@ Kubernetes Service port and let it do the load balancing and routing. Alternatel
 a more meaningful implementation of a router could take the endpoints for the service
 and route/load balance the incoming requests to the corresponding service endpoints.
 */
-
 package route

--- a/pkg/route/graph/analysis/analysis.go
+++ b/pkg/route/graph/analysis/analysis.go
@@ -1,0 +1,65 @@
+package analysis
+
+import (
+	"fmt"
+
+	"github.com/gonum/graph"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+	routeedges "github.com/openshift/origin/pkg/route/graph"
+	routegraph "github.com/openshift/origin/pkg/route/graph/nodes"
+)
+
+const (
+	// MissingRoutePortWarning is returned when a route has no route port specified
+	// and the service it routes to has multiple ports.
+	MissingRoutePortWarning = "MissingRoutePort"
+	// MissingServiceWarning is returned when there is no service for the specific route.
+	MissingServiceWarning = "MissingService"
+)
+
+// FindMissingPortMapping checks all routes and reports those that don't specify a port while
+// the service they are routing to, has multiple ports. Also if a service for a route doesn't
+// exist, will be reported.
+func FindMissingPortMapping(g osgraph.Graph) []osgraph.Marker {
+	markers := []osgraph.Marker{}
+
+route:
+	for _, uncastRouteNode := range g.NodesByKind(routegraph.RouteNodeKind) {
+		for _, uncastServiceNode := range g.SuccessorNodesByEdgeKind(uncastRouteNode, routeedges.ExposedThroughRouteEdgeKind) {
+			routeNode := uncastRouteNode.(*routegraph.RouteNode)
+			svcNode := uncastServiceNode.(*kubegraph.ServiceNode)
+
+			if !svcNode.Found() {
+				markers = append(markers, osgraph.Marker{
+					Node:         routeNode,
+					RelatedNodes: []graph.Node{svcNode},
+
+					Severity: osgraph.WarningSeverity,
+					Key:      MissingServiceWarning,
+					Message: fmt.Sprintf("%s is supposed to route traffic to %s but %s doesn't exist.",
+						routeNode.ResourceString(), svcNode.ResourceString(), svcNode.ResourceString()),
+				})
+
+				continue route
+			}
+
+			if len(svcNode.Spec.Ports) > 1 && (routeNode.Spec.Port == nil || len(routeNode.Spec.Port.TargetPort.String()) == 0) {
+				markers = append(markers, osgraph.Marker{
+					Node:         routeNode,
+					RelatedNodes: []graph.Node{svcNode},
+
+					Severity: osgraph.WarningSeverity,
+					Key:      MissingRoutePortWarning,
+					Message: fmt.Sprintf("%s doesn't have a port specified and is routing traffic to %s which uses multiple ports.",
+						routeNode.ResourceString(), svcNode.ResourceString()),
+				})
+
+				continue route
+			}
+		}
+	}
+
+	return markers
+}

--- a/pkg/route/graph/analysis/analysis_test.go
+++ b/pkg/route/graph/analysis/analysis_test.go
@@ -1,0 +1,40 @@
+package analysis
+
+import (
+	"testing"
+
+	osgraphtest "github.com/openshift/origin/pkg/api/graph/test"
+	routeedges "github.com/openshift/origin/pkg/route/graph"
+)
+
+func TestMissingPortMapping(t *testing.T) {
+	// Multiple service ports - no route port specified
+	g, _, err := osgraphtest.BuildGraph("../../../api/graph/test/missing-route-port.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	routeedges.AddAllRouteEdges(g)
+
+	markers := FindMissingPortMapping(g)
+	if expected, got := 1, len(markers); expected != got {
+		t.Fatalf("expected %d markers, got %d", expected, got)
+	}
+	if expected, got := MissingRoutePortWarning, markers[0].Key; expected != got {
+		t.Fatalf("expected %s marker key, got %s", expected, got)
+	}
+
+	// Dangling route
+	g, _, err = osgraphtest.BuildGraph("../../../api/graph/test/lonely-route.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	routeedges.AddAllRouteEdges(g)
+
+	markers = FindMissingPortMapping(g)
+	if expected, got := 1, len(markers); expected != got {
+		t.Fatalf("expected %d markers, got %d", expected, got)
+	}
+	if expected, got := MissingServiceWarning, markers[0].Key; expected != got {
+		t.Fatalf("expected %s marker key, got %s", expected, got)
+	}
+}

--- a/pkg/route/graph/analysis/doc.go
+++ b/pkg/route/graph/analysis/doc.go
@@ -1,0 +1,3 @@
+// Package analysis provides functions that analyse routes and setup markers
+// that will be reported by oc status
+package analysis

--- a/pkg/route/graph/doc.go
+++ b/pkg/route/graph/doc.go
@@ -1,0 +1,2 @@
+// Package graph contains graph utilities for routes
+package graph

--- a/pkg/route/graph/edges.go
+++ b/pkg/route/graph/edges.go
@@ -1,0 +1,36 @@
+package graph
+
+import (
+	"github.com/gonum/graph"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
+	routegraph "github.com/openshift/origin/pkg/route/graph/nodes"
+)
+
+const (
+	// ExposedThroughRouteEdgeKind is an edge from a route to any object that
+	// is exposed through routes
+	ExposedThroughRouteEdgeKind = "ExposedThroughRoute"
+)
+
+// AddRouteEdges adds an edge that connect a service to a route in the given graph
+func AddRouteEdges(g osgraph.MutableUniqueGraph, node *routegraph.RouteNode) {
+	syntheticService := &kapi.Service{}
+	syntheticService.Namespace = node.Namespace
+	syntheticService.Name = node.Spec.To.Name
+
+	serviceNode := kubegraph.FindOrCreateSyntheticServiceNode(g, syntheticService)
+	g.AddEdge(node, serviceNode, ExposedThroughRouteEdgeKind)
+}
+
+// AddAllRouteEdges adds service edges to all route nodes in the given graph
+func AddAllRouteEdges(g osgraph.MutableUniqueGraph) {
+	for _, node := range g.(graph.Graph).Nodes() {
+		if routeNode, ok := node.(*routegraph.RouteNode); ok {
+			AddRouteEdges(g, routeNode)
+		}
+	}
+}

--- a/pkg/route/graph/nodes/doc.go
+++ b/pkg/route/graph/nodes/doc.go
@@ -1,0 +1,2 @@
+// Package nodes contains graph functions and types for routes
+package nodes

--- a/pkg/route/graph/nodes/nodes.go
+++ b/pkg/route/graph/nodes/nodes.go
@@ -1,0 +1,22 @@
+package nodes
+
+import (
+	"github.com/gonum/graph"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+// EnsureRouteNode adds a graph node for the specific route if it does not exist
+func EnsureRouteNode(g osgraph.MutableUniqueGraph, route *routeapi.Route) *RouteNode {
+	return osgraph.EnsureUnique(
+		g,
+		RouteNodeName(route),
+		func(node osgraph.Node) graph.Node {
+			return &RouteNode{
+				Node:  node,
+				Route: route,
+			}
+		},
+	).(*RouteNode)
+}

--- a/pkg/route/graph/nodes/types.go
+++ b/pkg/route/graph/nodes/types.go
@@ -1,0 +1,37 @@
+package nodes
+
+import (
+	"reflect"
+
+	osgraph "github.com/openshift/origin/pkg/api/graph"
+	routeapi "github.com/openshift/origin/pkg/route/api"
+)
+
+var (
+	RouteNodeKind = reflect.TypeOf(routeapi.Route{}).Name()
+)
+
+func RouteNodeName(o *routeapi.Route) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(RouteNodeKind, o)
+}
+
+type RouteNode struct {
+	osgraph.Node
+	*routeapi.Route
+}
+
+func (n RouteNode) Object() interface{} {
+	return n.Route
+}
+
+func (n RouteNode) String() string {
+	return string(RouteNodeName(n.Route))
+}
+
+func (n RouteNode) ResourceString() string {
+	return "route/" + n.Name
+}
+
+func (*RouteNode) Kind() string {
+	return RouteNodeKind
+}

--- a/test/fixtures/app-scenarios/new-project-deployed-app.yaml
+++ b/test/fixtures/app-scenarios/new-project-deployed-app.yaml
@@ -470,6 +470,24 @@ items:
     type: ClusterIP
   status:
     loadBalancer: {}
+- apiVersion: v1beta3
+  kind: Route
+  metadata:
+    annotations:
+      openshift.io/host.generated: "true"
+    creationTimestamp: 2015-04-07T04:12:17Z
+    labels:
+      template: application-template-stibuild
+    name: frontend
+    namespace: example
+    resourceVersion: "393"
+  spec:
+    host: frontend-example.router.default.svc.cluster.local
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: frontend
 kind: List
 metadata:
   resourceVersion: "592"


### PR DESCRIPTION
This PR adds graph pieces for routes and makes `oc status` report routes with missing route ports when they expose multiport services.

@deads2k @smarterclayton @pweil- PTAL