### PR TITLE
SNI support

### DIFF
--- a/pkg/cmd/admin/validate/master.go
+++ b/pkg/cmd/admin/validate/master.go
@@ -94,12 +94,13 @@ func (o *ValidateMasterConfigOptions) Run() (bool, error) {
 }
 
 const (
-	minColumnWidth          = 4
-	tabWidth                = 4
-	padding                 = 2
-	padchar                 = byte(' ')
-	flags                   = 0
-	validationErrorHeadings = "ERROR\tFIELD\tVALUE\tDETAILS\n"
+	minColumnWidth            = 4
+	tabWidth                  = 4
+	padding                   = 2
+	padchar                   = byte(' ')
+	flags                     = 0
+	validationErrorHeadings   = "ERROR\tFIELD\tVALUE\tDETAILS\n"
+	validationWarningHeadings = "WARNING\tFIELD\tVALUE\tDETAILS\n"
 )
 
 // prettyPrintValidationResults prints the contents of the ValidationResults into the buffer of a tabwriter.Writer.
@@ -107,14 +108,14 @@ const (
 func prettyPrintValidationResults(results validation.ValidationResults, writer *tabwriter.Writer) error {
 	if len(results.Errors) > 0 {
 		fmt.Fprintf(writer, "VALIDATION ERRORS:\t\t\t\n")
-		err := prettyPrintValidationErrorList(results.Errors, writer)
+		err := prettyPrintValidationErrorList(validationErrorHeadings, results.Errors, writer)
 		if err != nil {
 			return err
 		}
 	}
 	if len(results.Warnings) > 0 {
 		fmt.Fprintf(writer, "VALIDATION WARNINGS:\t\t\t\n")
-		err := prettyPrintValidationErrorList(results.Errors, writer)
+		err := prettyPrintValidationErrorList(validationWarningHeadings, results.Warnings, writer)
 		if err != nil {
 			return err
 		}
@@ -124,9 +125,9 @@ func prettyPrintValidationResults(results validation.ValidationResults, writer *
 
 // prettyPrintValidationErrorList prints the contents of the ValidationErrorList into the buffer of a tabwriter.Writer.
 // The writer must be Flush()ed after calling this to write the buffered data.
-func prettyPrintValidationErrorList(validationErrors fielderrors.ValidationErrorList, writer *tabwriter.Writer) error {
+func prettyPrintValidationErrorList(headings string, validationErrors fielderrors.ValidationErrorList, writer *tabwriter.Writer) error {
 	if len(validationErrors) > 0 {
-		fmt.Fprintf(writer, validationErrorHeadings)
+		fmt.Fprintf(writer, headings)
 		for _, err := range validationErrors {
 			switch validationError := err.(type) {
 			case (*fielderrors.ValidationError):

--- a/pkg/cmd/admin/validate/node.go
+++ b/pkg/cmd/admin/validate/node.go
@@ -84,10 +84,10 @@ func (o *ValidateNodeConfigOptions) Run() (ok bool, err error) {
 
 	results := validation.ValidateNodeConfig(nodeConfig)
 	writer := tabwriter.NewWriter(o.Out, minColumnWidth, tabWidth, padding, padchar, flags)
-	err = prettyPrintValidationErrorList(results, writer)
+	err = prettyPrintValidationResults(results, writer)
 	if err != nil {
-		return len(results) == 0, fmt.Errorf("could not print results: %v", err)
+		return len(results.Errors) == 0, fmt.Errorf("could not print results: %v", err)
 	}
 	writer.Flush()
-	return len(results) == 0, nil
+	return len(results.Errors) == 0, nil
 }

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -339,6 +339,17 @@ type ServingInfo struct {
 	ServerCert CertInfo
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA string
+	// NamedCertificates is a list of certificates to use to secure requests to specific hostnames
+	NamedCertificates []NamedCertificate
+}
+
+// NamedCertificate specifies a certificate/key, and the names it should be served for
+type NamedCertificate struct {
+	// Names is a list of DNS names this certificate should be used to secure
+	// A name can be a normal DNS name, or can contain leading wildcard segments.
+	Names []string
+	// CertInfo is the TLS cert info for serving secure traffic
+	CertInfo
 }
 
 type HTTPServingInfo struct {

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -141,17 +141,17 @@ func init() {
 			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
 		},
 		func(in *ServingInfo, out *newer.ServingInfo, s conversion.Scope) error {
-			out.BindAddress = in.BindAddress
-			out.BindNetwork = in.BindNetwork
-			out.ClientCA = in.ClientCA
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
 			out.ServerCert.CertFile = in.CertFile
 			out.ServerCert.KeyFile = in.KeyFile
 			return nil
 		},
 		func(in *newer.ServingInfo, out *ServingInfo, s conversion.Scope) error {
-			out.BindAddress = in.BindAddress
-			out.BindNetwork = in.BindNetwork
-			out.ClientCA = in.ClientCA
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
 			out.CertFile = in.ServerCert.CertFile
 			out.KeyFile = in.ServerCert.KeyFile
 			return nil

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -319,6 +319,17 @@ type ServingInfo struct {
 	CertInfo `json:",inline"`
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA string `json:"clientCA"`
+	// NamedCertificates is a list of certificates to use to secure requests to specific hostnames
+	NamedCertificates []NamedCertificate `json:"namedCertificates"`
+}
+
+// NamedCertificate specifies a certificate/key, and the names it should be served for
+type NamedCertificate struct {
+	// Names is a list of DNS names this certificate should be used to secure
+	// A name can be a normal DNS name, or can contain leading wildcard segments.
+	Names []string `json:"names"`
+	// CertInfo is the TLS cert info for serving secure traffic
+	CertInfo `json:",inline"`
 }
 
 type HTTPServingInfo struct {

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -46,6 +46,7 @@ servingInfo:
   certFile: ""
   clientCA: ""
   keyFile: ""
+  namedCertificates: null
 volumeDirectory: ""
 `
 
@@ -76,6 +77,7 @@ assetConfig:
     clientCA: ""
     keyFile: ""
     maxRequestsInFlight: 0
+    namedCertificates: null
     requestTimeoutSeconds: 0
 controllerLeaseTTL: 0
 controllers: ""
@@ -98,12 +100,14 @@ etcdConfig:
     certFile: ""
     clientCA: ""
     keyFile: ""
+    namedCertificates: null
   servingInfo:
     bindAddress: ""
     bindNetwork: ""
     certFile: ""
     clientCA: ""
     keyFile: ""
+    namedCertificates: null
   storageDirectory: ""
 etcdStorageConfig:
   kubernetesStoragePrefix: ""
@@ -276,6 +280,10 @@ servingInfo:
   clientCA: ""
   keyFile: ""
   maxRequestsInFlight: 0
+  namedCertificates:
+  - certFile: ""
+    keyFile: ""
+    names: null
   requestTimeoutSeconds: 0
 `
 )
@@ -295,6 +303,11 @@ func TestNodeConfig(t *testing.T) {
 
 func TestMasterConfig(t *testing.T) {
 	config := &internal.MasterConfig{
+		ServingInfo: internal.HTTPServingInfo{
+			ServingInfo: internal.ServingInfo{
+				NamedCertificates: []internal.NamedCertificate{{}},
+			},
+		},
 		KubernetesMasterConfig: &internal.KubernetesMasterConfig{},
 		EtcdConfig:             &internal.EtcdConfig{},
 		OAuthConfig: &internal.OAuthConfig{

--- a/pkg/cmd/server/api/validation/allinone.go
+++ b/pkg/cmd/server/api/validation/allinone.go
@@ -9,7 +9,7 @@ func ValidateAllInOneConfig(master *api.MasterConfig, node *api.NodeConfig) Vali
 
 	validationResults.Append(ValidateMasterConfig(master).Prefix("masterConfig"))
 
-	validationResults.AddErrors(ValidateNodeConfig(node).Prefix("nodeConfig")...)
+	validationResults.Append(ValidateNodeConfig(node).Prefix("nodeConfig"))
 
 	// Validation between the configs
 

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -57,8 +58,6 @@ func (r ValidationResults) Prefix(prefix string) ValidationResults {
 func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 	validationResults := ValidationResults{}
 
-	validationResults.AddErrors(ValidateHTTPServingInfo(config.ServingInfo).Prefix("servingInfo")...)
-
 	if _, urlErrs := ValidateURL(config.MasterPublicURL, "masterPublicURL"); len(urlErrs) > 0 {
 		validationResults.AddErrors(urlErrs...)
 	}
@@ -73,12 +72,15 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 	validationResults.AddErrors(ValidateDisabledFeatures(config.DisabledFeatures, "disabledFeatures")...)
 
 	if config.AssetConfig != nil {
-		validationResults.AddErrors(ValidateAssetConfig(config.AssetConfig).Prefix("assetConfig")...)
+		validationResults.Append(ValidateAssetConfig(config.AssetConfig).Prefix("assetConfig"))
 		colocated := config.AssetConfig.ServingInfo.BindAddress == config.ServingInfo.BindAddress
 		if colocated {
 			publicURL, _ := url.Parse(config.AssetConfig.PublicURL)
 			if publicURL.Path == "/" {
 				validationResults.AddErrors(fielderrors.NewFieldInvalid("assetConfig.publicURL", config.AssetConfig.PublicURL, "path can not be / when colocated with master API"))
+			}
+			if !reflect.DeepEqual(config.AssetConfig.ServingInfo, config.ServingInfo) {
+				validationResults.AddWarnings(fielderrors.NewFieldInvalid("assetConfig.servingInfo", "<not displayed>", "assetConfig.servingInfo is ignored when colocated with master API"))
 			}
 		}
 
@@ -106,9 +108,9 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 
 	if config.EtcdConfig != nil {
 		etcdConfigErrs := ValidateEtcdConfig(config.EtcdConfig).Prefix("etcdConfig")
-		validationResults.AddErrors(etcdConfigErrs...)
+		validationResults.Append(etcdConfigErrs)
 
-		if len(etcdConfigErrs) == 0 {
+		if len(etcdConfigErrs.Errors) == 0 {
 			// Validate the etcdClientInfo with the internal etcdConfig
 			validationResults.AddErrors(ValidateEtcdConnectionInfo(config.EtcdClientInfo, config.EtcdConfig).Prefix("etcdClientInfo")...)
 		} else {
@@ -157,7 +159,7 @@ func ValidateMasterConfig(config *api.MasterConfig) ValidationResults {
 
 	validationResults.Append(ValidateServiceAccountConfig(config.ServiceAccountConfig, builtInKubernetes).Prefix("serviceAccountConfig"))
 
-	validationResults.AddErrors(ValidateHTTPServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	validationResults.Append(ValidateHTTPServingInfo(config.ServingInfo).Prefix("servingInfo"))
 
 	validationResults.Append(ValidateProjectConfig(config.ProjectConfig).Prefix("projectConfig"))
 
@@ -261,65 +263,65 @@ func ValidateServiceAccountConfig(config api.ServiceAccountConfig, builtInKubern
 	return validationResults
 }
 
-func ValidateAssetConfig(config *api.AssetConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
+func ValidateAssetConfig(config *api.AssetConfig) ValidationResults {
+	validationResults := ValidationResults{}
 
-	allErrs = append(allErrs, ValidateHTTPServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	validationResults.Append(ValidateHTTPServingInfo(config.ServingInfo).Prefix("servingInfo"))
 
 	if len(config.LogoutURL) > 0 {
 		_, urlErrs := ValidateURL(config.LogoutURL, "logoutURL")
 		if len(urlErrs) > 0 {
-			allErrs = append(allErrs, urlErrs...)
+			validationResults.AddErrors(urlErrs...)
 		}
 	}
 
 	urlObj, urlErrs := ValidateURL(config.PublicURL, "publicURL")
 	if len(urlErrs) > 0 {
-		allErrs = append(allErrs, urlErrs...)
+		validationResults.AddErrors(urlErrs...)
 	}
 	if urlObj != nil {
 		if !strings.HasSuffix(urlObj.Path, "/") {
-			allErrs = append(allErrs, fielderrors.NewFieldInvalid("publicURL", config.PublicURL, "must have a trailing slash in path"))
+			validationResults.AddErrors(fielderrors.NewFieldInvalid("publicURL", config.PublicURL, "must have a trailing slash in path"))
 		}
 	}
 
 	if _, urlErrs := ValidateURL(config.MasterPublicURL, "masterPublicURL"); len(urlErrs) > 0 {
-		allErrs = append(allErrs, urlErrs...)
+		validationResults.AddErrors(urlErrs...)
 	}
 
 	if len(config.LoggingPublicURL) > 0 {
 		if _, loggingURLErrs := ValidateSecureURL(config.LoggingPublicURL, "loggingPublicURL"); len(loggingURLErrs) > 0 {
-			allErrs = append(allErrs, loggingURLErrs...)
+			validationResults.AddErrors(loggingURLErrs...)
 		}
 	}
 
 	if len(config.MetricsPublicURL) > 0 {
 		if _, metricsURLErrs := ValidateSecureURL(config.MetricsPublicURL, "metricsPublicURL"); len(metricsURLErrs) > 0 {
-			allErrs = append(allErrs, metricsURLErrs...)
+			validationResults.AddErrors(metricsURLErrs...)
 		}
 	}
 
 	for i, scriptFile := range config.ExtensionScripts {
-		allErrs = append(allErrs, ValidateFile(scriptFile, fmt.Sprintf("extensionScripts[%d]", i))...)
+		validationResults.AddErrors(ValidateFile(scriptFile, fmt.Sprintf("extensionScripts[%d]", i))...)
 	}
 
 	for i, stylesheetFile := range config.ExtensionStylesheets {
-		allErrs = append(allErrs, ValidateFile(stylesheetFile, fmt.Sprintf("extensionStylesheets[%d]", i))...)
+		validationResults.AddErrors(ValidateFile(stylesheetFile, fmt.Sprintf("extensionStylesheets[%d]", i))...)
 	}
 
 	nameTaken := map[string]bool{}
 	for i, extConfig := range config.Extensions {
 		extConfigErrors := ValidateAssetExtensionsConfig(extConfig).Prefix(fmt.Sprintf("extensions[%d]", i))
-		allErrs = append(allErrs, extConfigErrors...)
+		validationResults.AddErrors(extConfigErrors...)
 		if nameTaken[extConfig.Name] {
 			dupError := fielderrors.NewFieldInvalid(fmt.Sprintf("extensions[%d].name", i), extConfig.Name, "duplicate extension name")
-			allErrs = append(allErrs, dupError)
+			validationResults.AddErrors(dupError)
 		} else {
 			nameTaken[extConfig.Name] = true
 		}
 	}
 
-	return allErrs
+	return validationResults
 }
 
 var extNameExp = regexp.MustCompile(`^[A-Za-z0-9_]+$`)

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -11,45 +11,45 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-func ValidateNodeConfig(config *api.NodeConfig) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
+func ValidateNodeConfig(config *api.NodeConfig) ValidationResults {
+	validationResults := ValidationResults{}
 
 	if len(config.NodeName) == 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldRequired("nodeName"))
+		validationResults.AddErrors(fielderrors.NewFieldRequired("nodeName"))
 	}
 	if len(config.NodeIP) > 0 {
-		allErrs = append(allErrs, ValidateSpecifiedIP(config.NodeIP, "nodeIP")...)
+		validationResults.AddErrors(ValidateSpecifiedIP(config.NodeIP, "nodeIP")...)
 	}
 
-	allErrs = append(allErrs, ValidateServingInfo(config.ServingInfo).Prefix("servingInfo")...)
+	validationResults.Append(ValidateServingInfo(config.ServingInfo).Prefix("servingInfo"))
 	if config.ServingInfo.BindNetwork == "tcp6" {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("servingInfo.bindNetwork", config.ServingInfo.BindNetwork, "tcp6 is not a valid bindNetwork for nodes, must be tcp or tcp4"))
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("servingInfo.bindNetwork", config.ServingInfo.BindNetwork, "tcp6 is not a valid bindNetwork for nodes, must be tcp or tcp4"))
 	}
-	allErrs = append(allErrs, ValidateKubeConfig(config.MasterKubeConfig, "masterKubeConfig")...)
+	validationResults.AddErrors(ValidateKubeConfig(config.MasterKubeConfig, "masterKubeConfig")...)
 
 	if len(config.DNSIP) > 0 {
-		allErrs = append(allErrs, ValidateSpecifiedIP(config.DNSIP, "dnsIP")...)
+		validationResults.AddErrors(ValidateSpecifiedIP(config.DNSIP, "dnsIP")...)
 	}
 
-	allErrs = append(allErrs, ValidateImageConfig(config.ImageConfig).Prefix("imageConfig")...)
+	validationResults.AddErrors(ValidateImageConfig(config.ImageConfig).Prefix("imageConfig")...)
 
 	if config.PodManifestConfig != nil {
-		allErrs = append(allErrs, ValidatePodManifestConfig(config.PodManifestConfig).Prefix("podManifestConfig")...)
+		validationResults.AddErrors(ValidatePodManifestConfig(config.PodManifestConfig).Prefix("podManifestConfig")...)
 	}
 
-	allErrs = append(allErrs, ValidateNetworkConfig(config.NetworkConfig).Prefix("networkConfig")...)
+	validationResults.AddErrors(ValidateNetworkConfig(config.NetworkConfig).Prefix("networkConfig")...)
 
-	allErrs = append(allErrs, ValidateDockerConfig(config.DockerConfig).Prefix("dockerConfig")...)
+	validationResults.AddErrors(ValidateDockerConfig(config.DockerConfig).Prefix("dockerConfig")...)
 
-	allErrs = append(allErrs, ValidateNodeAuthConfig(config.AuthConfig).Prefix("authConfig")...)
+	validationResults.AddErrors(ValidateNodeAuthConfig(config.AuthConfig).Prefix("authConfig")...)
 
-	allErrs = append(allErrs, ValidateKubeletExtendedArguments(config.KubeletArguments).Prefix("kubeletArguments")...)
+	validationResults.AddErrors(ValidateKubeletExtendedArguments(config.KubeletArguments).Prefix("kubeletArguments")...)
 
 	if _, err := time.ParseDuration(config.IPTablesSyncPeriod); err != nil {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("iptablesSyncPeriod", config.IPTablesSyncPeriod, fmt.Sprintf("unable to parse iptablesSyncPeriod: %v. Examples with correct format: '5s', '1m', '2h22m'", err)))
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("iptablesSyncPeriod", config.IPTablesSyncPeriod, fmt.Sprintf("unable to parse iptablesSyncPeriod: %v. Examples with correct format: '5s', '1m', '2h22m'", err)))
 	}
 
-	return allErrs
+	return validationResults
 }
 
 func ValidateNodeAuthConfig(config api.NodeAuthConfig) fielderrors.ValidationErrorList {

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/url"
@@ -10,9 +12,12 @@ import (
 	"github.com/spf13/pflag"
 
 	kvalidation "k8s.io/kubernetes/pkg/api/validation"
+	kutil "k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/cmd/server/api"
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 )
 
@@ -48,46 +53,124 @@ func ValidateCertInfo(certInfo api.CertInfo, required bool) fielderrors.Validati
 		allErrs = append(allErrs, ValidateFile(certInfo.KeyFile, "keyFile")...)
 	}
 
+	// validate certfile/keyfile load/parse?
+
 	return allErrs
 }
 
-func ValidateServingInfo(info api.ServingInfo) fielderrors.ValidationErrorList {
-	allErrs := fielderrors.ValidationErrorList{}
+func ValidateServingInfo(info api.ServingInfo) ValidationResults {
+	validationResults := ValidationResults{}
 
-	allErrs = append(allErrs, ValidateHostPort(info.BindAddress, "bindAddress")...)
-	allErrs = append(allErrs, ValidateCertInfo(info.ServerCert, false)...)
+	validationResults.AddErrors(ValidateHostPort(info.BindAddress, "bindAddress")...)
+	validationResults.AddErrors(ValidateCertInfo(info.ServerCert, false)...)
+
+	if len(info.NamedCertificates) > 0 && len(info.ServerCert.CertFile) == 0 {
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("namedCertificates", "", "a default certificate and key is required in certFile/keyFile in order to use namedCertificates"))
+	}
+
+	validationResults.Append(ValidateNamedCertificates("namedCertificates", info.NamedCertificates))
 
 	switch info.BindNetwork {
 	case "tcp", "tcp4", "tcp6":
 	default:
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("bindNetwork", info.BindNetwork, "must be 'tcp', 'tcp4', or 'tcp6'"))
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("bindNetwork", info.BindNetwork, "must be 'tcp', 'tcp4', or 'tcp6'"))
 	}
 
 	if len(info.ServerCert.CertFile) > 0 {
 		if len(info.ClientCA) > 0 {
-			allErrs = append(allErrs, ValidateFile(info.ClientCA, "clientCA")...)
+			validationResults.AddErrors(ValidateFile(info.ClientCA, "clientCA")...)
 		}
 	} else {
 		if len(info.ClientCA) > 0 {
-			allErrs = append(allErrs, fielderrors.NewFieldInvalid("clientCA", info.ClientCA, "cannot specify a clientCA without a certFile"))
+			validationResults.AddErrors(fielderrors.NewFieldInvalid("clientCA", info.ClientCA, "cannot specify a clientCA without a certFile"))
 		}
 	}
 
-	return allErrs
+	return validationResults
 }
 
-func ValidateHTTPServingInfo(info api.HTTPServingInfo) fielderrors.ValidationErrorList {
-	allErrs := ValidateServingInfo(info.ServingInfo)
+func ValidateNamedCertificates(fieldName string, namedCertificates []api.NamedCertificate) ValidationResults {
+	validationResults := ValidationResults{}
+
+	takenNames := sets.NewString()
+	for i, namedCertificate := range namedCertificates {
+		fieldName := fmt.Sprintf("%s[%d]", fieldName, i)
+
+		certDNSNames := []string{}
+		if len(namedCertificate.CertFile) == 0 {
+			validationResults.AddErrors(fielderrors.NewFieldRequired(fieldName + ".certInfo"))
+		} else if certInfoErrors := ValidateCertInfo(namedCertificate.CertInfo, false); len(certInfoErrors) > 0 {
+			validationResults.AddErrors(certInfoErrors.Prefix(fieldName)...)
+		} else if cert, err := tls.LoadX509KeyPair(namedCertificate.CertFile, namedCertificate.KeyFile); err != nil {
+			validationResults.AddErrors(fielderrors.NewFieldInvalid(fieldName+".certInfo", namedCertificate.CertInfo, fmt.Sprintf("error loading certificate/key: %v", err)))
+		} else {
+			leaf, _ := x509.ParseCertificate(cert.Certificate[0])
+			certDNSNames = append(certDNSNames, leaf.Subject.CommonName)
+			certDNSNames = append(certDNSNames, leaf.DNSNames...)
+		}
+
+		if len(namedCertificate.Names) == 0 {
+			validationResults.AddErrors(fielderrors.NewFieldRequired(fieldName + ".names"))
+		}
+		for j, name := range namedCertificate.Names {
+			nameFieldName := fieldName + fmt.Sprintf(".names[%d]", j)
+			if len(name) == 0 {
+				validationResults.AddErrors(fielderrors.NewFieldRequired(nameFieldName))
+				continue
+			}
+
+			if takenNames.Has(name) {
+				validationResults.AddErrors(fielderrors.NewFieldInvalid(nameFieldName, name, "this name is already used in another named certificate"))
+				continue
+			}
+
+			// validate names as domain names or *.*.foo.com domain names
+			validDNSName := true
+			for _, s := range strings.Split(name, ".") {
+				if s != "*" && !kutil.IsDNS1123Label(s) {
+					validDNSName = false
+				}
+			}
+			if !validDNSName {
+				validationResults.AddErrors(fielderrors.NewFieldInvalid(nameFieldName, name, "must be a valid DNS name"))
+				continue
+			}
+
+			takenNames.Insert(name)
+
+			// validate certificate has common name or subject alt names that match
+			if len(certDNSNames) > 0 {
+				foundMatch := false
+				for _, dnsName := range certDNSNames {
+					if cmdutil.HostnameMatches(dnsName, name) {
+						foundMatch = true
+						break
+					}
+				}
+				if !foundMatch {
+					validationResults.AddWarnings(fielderrors.NewFieldInvalid(nameFieldName, name, "the specified certificate does not have a CommonName or DNS subjectAltName that matches this name"))
+				}
+			}
+		}
+	}
+
+	return validationResults
+}
+
+func ValidateHTTPServingInfo(info api.HTTPServingInfo) ValidationResults {
+	validationResults := ValidationResults{}
+
+	validationResults.Append(ValidateServingInfo(info.ServingInfo))
 
 	if info.MaxRequestsInFlight < 0 {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("maxRequestsInFlight", info.MaxRequestsInFlight, "must be zero (no limit) or greater"))
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("maxRequestsInFlight", info.MaxRequestsInFlight, "must be zero (no limit) or greater"))
 	}
 
 	if info.RequestTimeoutSeconds < -1 {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("requestTimeoutSeconds", info.RequestTimeoutSeconds, "must be -1 (no timeout), 0 (default timeout), or greater"))
+		validationResults.AddErrors(fielderrors.NewFieldInvalid("requestTimeoutSeconds", info.RequestTimeoutSeconds, "must be -1 (no timeout), 0 (default timeout), or greater"))
 	}
 
-	return allErrs
+	return validationResults
 }
 
 func ValidateDisabledFeatures(disabledFeatures []string, field string) fielderrors.ValidationErrorList {

--- a/pkg/cmd/server/api/validation/validation_test.go
+++ b/pkg/cmd/server/api/validation/validation_test.go
@@ -1,0 +1,208 @@
+package validation
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+func TestValidateServingInfo(t *testing.T) {
+	certFile, err := ioutil.TempFile("", "cert.crt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(certFile.Name())
+	certFileName := certFile.Name()
+	ioutil.WriteFile(certFile.Name(), localhostCert, os.FileMode(0755))
+
+	keyFile, err := ioutil.TempFile("", "cert.key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(keyFile.Name())
+	keyFileName := keyFile.Name()
+	ioutil.WriteFile(keyFile.Name(), localhostKey, os.FileMode(0755))
+
+	testcases := map[string]struct {
+		ServingInfo      api.ServingInfo
+		ExpectedErrors   []string
+		ExpectedWarnings []string
+	}{
+		"basic": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+			},
+		},
+		"missing key": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert: api.CertInfo{
+					CertFile: certFileName,
+				},
+			},
+			ExpectedErrors: []string{"keyFile: required"},
+		},
+
+		"namedCertificates valid": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{"example.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+		},
+
+		"namedCertificates without default cert": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				//ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{"example.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+			ExpectedErrors: []string{"namedCertificates: invalid"},
+		},
+
+		"namedCertificates with missing names": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{ /*"example.com"*/ }, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+			ExpectedErrors: []string{"namedCertificates[0].names: required"},
+		},
+		"namedCertificates with missing key": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{"example.com"}, CertInfo: api.CertInfo{CertFile: certFileName /*, KeyFile: keyFileName*/}},
+				},
+			},
+			ExpectedErrors: []string{"namedCertificates[0].keyFile: required"},
+		},
+		"namedCertificates with duplicate names": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{"example.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+					{Names: []string{"example.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+			ExpectedErrors: []string{"namedCertificates[1].names[0]: invalid"},
+		},
+		"namedCertificates with empty name": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{""}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+			ExpectedErrors: []string{"namedCertificates[0].names[0]: required"},
+		},
+
+		"namedCertificates with unmatched DNS name": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{"badexample.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+			ExpectedWarnings: []string{"namedCertificates[0].names[0]: invalid"},
+		},
+		"namedCertificates with non-DNS names": {
+			ServingInfo: api.ServingInfo{
+				BindAddress: "0.0.0.0:1234",
+				BindNetwork: "tcp",
+				ServerCert:  api.CertInfo{CertFile: certFileName, KeyFile: keyFileName},
+				NamedCertificates: []api.NamedCertificate{
+					{Names: []string{"foo bar.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
+				},
+			},
+			ExpectedErrors: []string{
+				"namedCertificates[0].names[0]: invalid value 'foo bar.com', Details: must be a valid DNS name",
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		result := ValidateServingInfo(tc.ServingInfo)
+
+		if len(tc.ExpectedErrors) != len(result.Errors) {
+			t.Errorf("%s: Expected %d errors, got %d", k, len(tc.ExpectedErrors), len(result.Errors))
+			for _, e := range tc.ExpectedErrors {
+				t.Logf("\tExpected error: %s", e)
+			}
+			for _, r := range result.Errors {
+				t.Logf("\tActual error: %s", r.Error())
+			}
+			continue
+		}
+		for i, r := range result.Errors {
+			if !strings.Contains(r.Error(), tc.ExpectedErrors[i]) {
+				t.Errorf("%s: Expected error containing %s, got %s", k, tc.ExpectedErrors[i], r.Error())
+			}
+		}
+
+		if len(tc.ExpectedWarnings) != len(result.Warnings) {
+			t.Errorf("%s: Expected %d warning, got %d", k, len(tc.ExpectedWarnings), len(result.Warnings))
+			for _, e := range tc.ExpectedErrors {
+				t.Logf("\tExpected warning: %s", e)
+			}
+			for _, r := range result.Warnings {
+				t.Logf("\tActual warning: %s", r.Error())
+			}
+			continue
+		}
+		for i, r := range result.Warnings {
+			if !strings.Contains(r.Error(), tc.ExpectedWarnings[i]) {
+				t.Errorf("%s: Expected warning containing %s, got %s", k, tc.ExpectedWarnings[i], r.Error())
+			}
+		}
+	}
+}
+
+// localhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at the last second of 2049 (the end
+// of ASN.1 time).
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
+bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
+bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
+IUSdtXdcbItRB/yfXGBhiex00IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEA
+AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
+AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
+Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
+0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
+NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d
+AekCIQDhRQG5Li0Wj8TM4obOnnXUXf1jRv0UkzE9AHWLG5q3AwIhAPzSjpYUDjVW
+MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
+EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
+1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
+-----END RSA PRIVATE KEY-----`)

--- a/pkg/cmd/server/origin/asset.go
+++ b/pkg/cmd/server/origin/asset.go
@@ -81,9 +81,15 @@ func (c *AssetConfig) Run() {
 
 	go util.Forever(func() {
 		if isTLS {
+			extraCerts, err := configapi.GetNamedCertificateMap(c.Options.ServingInfo.NamedCertificates)
+			if err != nil {
+				glog.Fatal(err)
+			}
 			server.TLSConfig = &tls.Config{
 				// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
 				MinVersion: tls.VersionTLS10,
+				// Set SNI certificate func
+				GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
 			}
 			glog.Infof("Web console listening at https://%s", c.Options.ServingInfo.BindAddress)
 			glog.Fatal(cmdutil.ListenAndServeTLS(server, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.ServerCert.CertFile, c.Options.ServingInfo.ServerCert.KeyFile))

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -163,9 +163,14 @@ func (o NodeOptions) RunNode() error {
 		return err
 	}
 
-	errs := validation.ValidateNodeConfig(nodeConfig)
-	if len(errs) != 0 {
-		return kerrors.NewInvalid("NodeConfig", o.ConfigFile, errs)
+	validationResults := validation.ValidateNodeConfig(nodeConfig)
+	if len(validationResults.Warnings) != 0 {
+		for _, warning := range validationResults.Warnings {
+			glog.Warningf("%v", warning)
+		}
+	}
+	if len(validationResults.Errors) != 0 {
+		return kerrors.NewInvalid("NodeConfig", o.ConfigFile, validationResults.Errors)
 	}
 
 	_, kubeClientConfig, err := configapi.GetKubeClient(nodeConfig.MasterKubeConfig)

--- a/pkg/cmd/util/net_test.go
+++ b/pkg/cmd/util/net_test.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHostnameMatchSpecCandidates(t *testing.T) {
+	testcases := []struct {
+		Hostname      string
+		ExpectedSpecs []string
+	}{
+		{
+			Hostname:      "",
+			ExpectedSpecs: nil,
+		},
+		{
+			Hostname:      "a",
+			ExpectedSpecs: []string{"a", "*"},
+		},
+		{
+			Hostname:      "foo.bar",
+			ExpectedSpecs: []string{"foo.bar", "*.bar", "*.*"},
+		},
+	}
+
+	for _, tc := range testcases {
+		specs := HostnameMatchSpecCandidates(tc.Hostname)
+		if !reflect.DeepEqual(specs, tc.ExpectedSpecs) {
+			t.Errorf("%s: Expected %#v, got %#v", tc.Hostname, tc.ExpectedSpecs, specs)
+		}
+	}
+}
+
+func TestHostnameMatches(t *testing.T) {
+	testcases := []struct {
+		Hostname      string
+		Spec          string
+		ExpectedMatch bool
+	}{
+		// Empty hostname matches nothing
+		{Hostname: "", Spec: "", ExpectedMatch: false},
+
+		// Empty spec matches nothing
+		{Hostname: "a", Spec: "", ExpectedMatch: false},
+
+		// Exact match
+		{Hostname: "a", Spec: "a", ExpectedMatch: true},
+		// Single segment wildcard match
+		{Hostname: "a", Spec: "*", ExpectedMatch: true},
+
+		// Mismatched segment count should not match
+		{Hostname: "a", Spec: "*.a", ExpectedMatch: false},
+		{Hostname: "a", Spec: "*.*", ExpectedMatch: false},
+
+		// Exact match, multi-segment
+		{Hostname: "a.b", Spec: "a.b", ExpectedMatch: true},
+		// Wildcard subdomain match
+		{Hostname: "a.b", Spec: "*.b", ExpectedMatch: true},
+		// Multi-level wildcard match
+		{Hostname: "a.b", Spec: "*.*", ExpectedMatch: true},
+
+		// Only subdomain wildcards are allowed
+		{Hostname: "a.b", Spec: "a.*", ExpectedMatch: false},
+		// Mismatched segment count should not match
+		{Hostname: "a.b", Spec: "*.a.b", ExpectedMatch: false},
+	}
+
+	for i, tc := range testcases {
+		matches := HostnameMatches(tc.Hostname, tc.Spec)
+		if matches != tc.ExpectedMatch {
+			t.Errorf("%d: Expected match=%v, got %v (hostname=%s, specs=%v)", i, tc.ExpectedMatch, matches, tc.Hostname, tc.Spec)
+		}
+	}
+}

--- a/pkg/diagnostics/host/check_node_config.go
+++ b/pkg/diagnostics/host/check_node_config.go
@@ -41,8 +41,12 @@ func (d NodeConfigCheck) Check() types.DiagnosticResult {
 
 	r.Info("DH1003", fmt.Sprintf("Found a node config file: %[1]s", d.NodeConfigFile))
 
-	for _, err := range configvalidation.ValidateNodeConfig(nodeConfig) {
+	results := configvalidation.ValidateNodeConfig(nodeConfig)
+	for _, err := range results.Errors {
 		r.Error("DH1004", err, fmt.Sprintf("Validation of node config file '%s' failed:\n(%T) %[2]v", d.NodeConfigFile, err))
+	}
+	for _, err := range results.Warnings {
+		r.Warn("DH1005", err, fmt.Sprintf("Validation of node config file '%s' warning:\n(%T) %[2]v", d.NodeConfigFile, err))
 	}
 	return r
 }

--- a/test/integration/sni_test.go
+++ b/test/integration/sni_test.go
@@ -1,0 +1,306 @@
+// +build integration,etcd
+
+package integration
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+const (
+	// oadm ca create-signer-cert --cert=sni-ca.crt --key=sni-ca.key --name=sni-signer --serial=sni-serial.txt
+	sniCACert = "sni-ca.crt"
+
+	// oadm ca create-server-cert --cert=sni.crt --key=sni.key --hostnames=127.0.0.1,customhost.com,*.wildcardhost.com --signer-cert=sni-ca.crt --signer-key=sni-ca.key --signer-serial=sni-serial.txt
+	sniServerCert = "sni-server.crt"
+	sniServerKey  = "sni-server.key"
+)
+
+func TestSNI(t *testing.T) {
+	// Create tempfiles with certs and keys we're going to use
+	certNames := map[string]string{}
+	for certName, certContents := range sniCerts {
+		f, err := ioutil.TempFile("", certName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer os.Remove(f.Name())
+		if err := ioutil.WriteFile(f.Name(), certContents, os.FileMode(0600)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		certNames[certName] = f.Name()
+	}
+
+	// Build master config
+	masterOptions, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Set custom cert
+	masterOptions.ServingInfo.NamedCertificates = []configapi.NamedCertificate{
+		{
+			Names: []string{"customhost.com"},
+			CertInfo: configapi.CertInfo{
+				CertFile: certNames[sniServerCert],
+				KeyFile:  certNames[sniServerKey],
+			},
+		},
+		{
+			Names: []string{"*.wildcardhost.com"},
+			CertInfo: configapi.CertInfo{
+				CertFile: certNames[sniServerCert],
+				KeyFile:  certNames[sniServerKey],
+			},
+		},
+	}
+
+	// Start server
+	_, err = testserver.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Build transports
+	sniRoots, err := util.CertPoolFromFile(certNames[sniCACert])
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sniConfig := &tls.Config{RootCAs: sniRoots}
+
+	generatedRoots, err := util.CertPoolFromFile(masterOptions.ServiceAccountConfig.MasterCA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	generatedConfig := &tls.Config{RootCAs: generatedRoots}
+
+	insecureConfig := &tls.Config{InsecureSkipVerify: true}
+
+	tests := map[string]struct {
+		Hostname   string
+		TLSConfig  *tls.Config
+		ExpectedOK bool
+	}{
+		"sni client -> generated ip": {
+			Hostname:  "127.0.0.1",
+			TLSConfig: sniConfig,
+		},
+		"sni client -> generated hostname": {
+			Hostname:  "openshift",
+			TLSConfig: sniConfig,
+		},
+		"sni client -> sni host": {
+			Hostname:   "customhost.com",
+			TLSConfig:  sniConfig,
+			ExpectedOK: true,
+		},
+		"sni client -> sni wildcard host": {
+			Hostname:   "www.wildcardhost.com",
+			TLSConfig:  sniConfig,
+			ExpectedOK: true,
+		},
+		"sni client -> invalid ip": {
+			Hostname:  "10.10.10.10",
+			TLSConfig: sniConfig,
+		},
+		"sni client -> invalid host": {
+			Hostname:  "invalidhost.com",
+			TLSConfig: sniConfig,
+		},
+
+		"generated client -> generated ip": {
+			Hostname:   "127.0.0.1",
+			TLSConfig:  generatedConfig,
+			ExpectedOK: true,
+		},
+		"generated client -> generated hostname": {
+			Hostname:   "openshift",
+			TLSConfig:  generatedConfig,
+			ExpectedOK: true,
+		},
+		"generated client -> sni host": {
+			Hostname:  "customhost.com",
+			TLSConfig: generatedConfig,
+		},
+		"generated client -> sni wildcard host": {
+			Hostname:  "www.wildcardhost.com",
+			TLSConfig: generatedConfig,
+		},
+		"generated client -> invalid ip": {
+			Hostname:  "10.10.10.10",
+			TLSConfig: generatedConfig,
+		},
+		"generated client -> invalid host": {
+			Hostname:  "invalidhost.com",
+			TLSConfig: generatedConfig,
+		},
+
+		"insecure client -> generated ip": {
+			Hostname:   "127.0.0.1",
+			TLSConfig:  insecureConfig,
+			ExpectedOK: true,
+		},
+		"insecure client -> generated hostname": {
+			Hostname:   "openshift",
+			TLSConfig:  insecureConfig,
+			ExpectedOK: true,
+		},
+		"insecure client -> sni host": {
+			Hostname:   "customhost.com",
+			TLSConfig:  insecureConfig,
+			ExpectedOK: true,
+		},
+		"insecure client -> sni wildcard host": {
+			Hostname:   "www.wildcardhost.com",
+			TLSConfig:  insecureConfig,
+			ExpectedOK: true,
+		},
+		"insecure client -> invalid ip": {
+			Hostname:   "10.10.10.10",
+			TLSConfig:  insecureConfig,
+			ExpectedOK: true,
+		},
+		"insecure client -> invalid host": {
+			Hostname:   "invalidhost.com",
+			TLSConfig:  insecureConfig,
+			ExpectedOK: true,
+		},
+	}
+
+	masterPublicURL, err := url.Parse(masterOptions.MasterPublicURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for k, tc := range tests {
+		u := *masterPublicURL
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		u.Path = "/healthz"
+
+		if _, port, err := net.SplitHostPort(u.Host); err == nil {
+			u.Host = net.JoinHostPort(tc.Hostname, port)
+		} else {
+			u.Host = tc.Hostname
+		}
+
+		req, err := http.NewRequest("GET", u.String(), nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+
+		transport := &http.Transport{
+			// Custom Dial func to always dial the real master, no matter what host is asked for
+			Dial: func(network, addr string) (net.Conn, error) {
+				// t.Logf("%s: Dialing for %s", k, addr)
+				return net.Dial(network, masterPublicURL.Host)
+			},
+			TLSClientConfig: tc.TLSConfig,
+		}
+		resp, err := transport.RoundTrip(req)
+		if tc.ExpectedOK && err != nil {
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+		if !tc.ExpectedOK && err == nil {
+			t.Errorf("%s: expected error, got none", k)
+			continue
+		}
+		if err == nil {
+			data, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", k, err)
+				continue
+			}
+			if string(data) != "ok" {
+				t.Errorf("%s: expected %q, got %q", k, "ok", string(data))
+				continue
+			}
+		}
+	}
+}
+
+var (
+	sniCerts = map[string][]byte{
+		sniCACert: []byte(`-----BEGIN CERTIFICATE-----
+MIICxjCCAbCgAwIBAgIBATALBgkqhkiG9w0BAQswFTETMBEGA1UEAxMKc25pLXNp
+Z25lcjAgFw0xNTEwMTMwNTEyMzFaGA8yMDY1MDkzMDA1MTIzMlowFTETMBEGA1UE
+AxMKc25pLXNpZ25lcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANOb
+OG1vBlq8UdJZJbumpiSEZbC7Jkyh4IceLmRvojGlMPgyoT67PedZAOD4EAbMVh+h
+tAYZgcTC8ASCA1UelXFPng5OwurQv1uBdJTLiTBzPusDenWaCZc/zf2EJEM03WZ9
+k4VgYecYkOmSZqvDj5Dl4lvEsVUL9RBaNMzgbzXsZE1+brlUKR+UmF2yX56vBj2R
+WiQHOIQgjYLaAciHJsZVkqznoN155vPggX791l62fC5Ungil6TQTPdcizBR+deLN
+S+HFxH0+YjEPiTb8PdoSUH+W3Y6d2zSzebm1GZUOKtgOQTXhmIuB3GGwOSDLC9Rq
+6a1z3HTZNBMQ7Y8NOJsCAwEAAaMjMCEwDgYDVR0PAQH/BAQDAgCkMA8GA1UdEwEB
+/wQFMAMBAf8wCwYJKoZIhvcNAQELA4IBAQCQ2laesgvXmT6EKXvnASbKPt35Lr26
+Jp0mayAGhJgf17WzQnmN0IFyZyu0H81TdIydximxKX6KWMrTk4z/7CbUa07AwVCy
+zBecwL0ajIgGakKqiiH3EJKrlg4jNKNOKboMuouNoROrwc5UkWfjSATFkjTTShDO
+Qd8JrAEBtEBaXr0Xueb5rdlrR/j7UMEpjUT7bGUxnhgF/h1TJ6cIiRpVKpA8NxyL
+ZBkouK3hPEeu92K7U/NBBE//YRQz6EghixQSv/ZEGmlsU8z6g8ay+d9iZa5DhYsh
+/IYxG0ykvGUH9d1AWplmHAqPwrcWSym49cZEmiHx/tO/wRp6+51lyfcn
+-----END CERTIFICATE-----
+`),
+
+		sniServerCert: []byte(`-----BEGIN CERTIFICATE-----
+MIIDIDCCAgqgAwIBAgIBAzALBgkqhkiG9w0BAQswFTETMBEGA1UEAxMKc25pLXNp
+Z25lcjAgFw0xNTEwMTMwNTMzMTVaGA8yMDY1MDkzMDA1MzMxNlowHTEbMBkGA1UE
+AxMSKi53aWxkY2FyZGhvc3QuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEA2hh1F9DXwkCDLi20i4ehoL40DhHFPsVfHa4/nIvmcOgJE6qZCh2oH+H8
+vDLQg4wNNpa47le5AuYqupXcXeTtrGq/AwXSnrC3LVJYqleAnVgLoL5+Y2NEj8Hx
+fzdWGhkCMDtA1QdZeq8HpCv3ZziRUxiZ/ddI4rZjFsCDoZUAhGGDzHCqkKbsuBI8
+bNkz9V0FfXn8OprfRCUPtMJrHusNsWCHrQ4ceRYOzsa9y4IVQnmvcpMlh7qu7kiO
+AbbFm41J8W/BEMxIBwJOITB2qAgkOKxF48IpsDeCWbOJ2qedisR5PNl/te4Qv/Kt
+D6FTqpIHv/cSkn9fz2ji6Jy574oR7wIDAQABo3UwczAOBgNVHQ8BAf8EBAMCAKAw
+EwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADA+BgNVHREENzA1ghIq
+LndpbGRjYXJkaG9zdC5jb22CDmN1c3RvbWhvc3QuY29tggkxMjcuMC4wLjGHBH8A
+AAEwCwYJKoZIhvcNAQELA4IBAQB5Q7Pbx9jBP566XgjQGnpoNK5jJf3CqkjBKSdG
+OdoumjDEx2Ast3h1edXBVnU0DPxbfxMo3lBIAiJ+sNWGErYlIDVdpglFVyYIn+V6
+71gUDaA+1rXBS3f0QEQ9pOh3b4qSWbmYr9mbYRQus1cFYq+KTsLmzuNGvRwSvvE7
+5nSTgUozXTF4fSyWGGTcy13ZFg6mLlMoivjVswUJsi2nLf/yejnwdJGs4ZR06qCx
+dYB2LaUCbI6AQlaQMVrxsVXTfUkstKF5cuPKq/MenBcH88j3uqj8BF6YjR1wRfHc
+p0NuWIRsuXBHEr6o3iQ3KlmQLWfLeS0K+FkN60mwDTteIzuR
+-----END CERTIFICATE-----
+`),
+
+		sniServerKey: []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA2hh1F9DXwkCDLi20i4ehoL40DhHFPsVfHa4/nIvmcOgJE6qZ
+Ch2oH+H8vDLQg4wNNpa47le5AuYqupXcXeTtrGq/AwXSnrC3LVJYqleAnVgLoL5+
+Y2NEj8HxfzdWGhkCMDtA1QdZeq8HpCv3ZziRUxiZ/ddI4rZjFsCDoZUAhGGDzHCq
+kKbsuBI8bNkz9V0FfXn8OprfRCUPtMJrHusNsWCHrQ4ceRYOzsa9y4IVQnmvcpMl
+h7qu7kiOAbbFm41J8W/BEMxIBwJOITB2qAgkOKxF48IpsDeCWbOJ2qedisR5PNl/
+te4Qv/KtD6FTqpIHv/cSkn9fz2ji6Jy574oR7wIDAQABAoIBAQDTq2UJpkGhYGdw
+zB8sRIjTr4ZqGUkscPatoc5PK2COOEWG9s3tiXcA6p4WMeM5qRWx43q8qBsB+02B
+Ja1o26To7/lO/7m5Fp3RuNghCyfije9LJVcZMuD5/StbYuOIFLmRAhEcMDPh5Dow
+VhOZ9MbmtTvPp8AveQCWtmWKz0hfMVLGUP91yqbXD/7h7/VpN+kKEOwoOUFqBshZ
+ziJs261VnI1UYeDg6jokZTDD9t1vS0EbPoe8NozPt8zF4bihXpLX7MCjJO32ISQl
+4cjH+94Wl1/X2MerG0RA8BTMlMSACiQdyeE7C4d/4tfRFp2EHqSBgwsTMLAJKy1P
+1NjejLmxAoGBAOxx1i22W/J1tqNvO7we3G8nuojRG5f69u1YKrW/yhk89a3hmyQ6
+MB15xz55CyTEl+FqPQReMJlmBsbKqHl8viOWhRc12t4i/JsYgroCcbIHME86FXuH
+boNJo0DB0Q1xoCQEuNiygyv3qLq5tKPBk0lAn2Sxhyt398MDukOcZ8ujAoGBAOwi
+HuM/d6A78F6l1NHJdOoTFvLXCbM3mWSdfoU/UxQmEk9Wr3kfudOu2ZAsWfiznjw4
+jgN/JS/WTY+NvVEXMIASz3QoNmLFSN0c5DCBSBVW/1B9rFP9GLCDrZMspluYg/gR
+8MLxC6AAVBcbNZj7Z16mmAyUs3LCJmP9P/7GcgVFAoGANesrvVbllt/zG0gFZjvf
+ZtW3evW8hibr4moFq1amHqVBHTriZxuB12bq4bs2qFbQj83rRjC4gnK6vuB+FN42
+eeUcSpO0ao2t7yxiu0pNZRywjpCfT4Et2XCUcvL/2kH8E9qj0H683OzoJFSu9dzx
+2nWLI6o8OdRswqL5+esT3GMCgYEApYnmDXnY60QZ5sBqygdpJw/q7qNB8Znwt1CR
++efC3kUyYNxsd4V+SKAzdZciG/AP5jfflyPzde3Oweyj481V+vM07EGknumfgyNV
+9YssdYlfw5XW0aqFPHmTnbGXjm8FVUt+dat2ctzIFsrEcFMOzJQN1AQLKVBiiYZo
+7rtAA+ECgYEAoR685udqJrCnvhL911cT+7/DrUyNLFmYvoIMlfG9DRXmKTIlyFH9
+A+TGxO02VaWYxm/zFTNIkXsEpNrxW4CVZtWM6biktT20S0p11IA1x8SCGqOimlF8
+Yg4OZRDUUYRAl0MUaslTyIxBfEVal4XgvBwhjXk0BMP6OJNDHWT3mUY=
+-----END RSA PRIVATE KEY-----
+`),
+	}
+)


### PR DESCRIPTION
Enable SNI certificate selection for the master, asset server, and node
Allow setting a certificate to use for a particular hostname or wildcard.
A default cert (servingInfo.{certFile,keyFile}) is required in order to specify per host certs.
```
servingInfo:
  certFile: master.server.crt
  keyFile: master.server.key
  namedCertificates:
  - certFile: custom.crt
    keyFile: custom.key
    names:
    - "customhost.com"
    - "api.customhost.com"
    - "console.customhost.com"
  - certFile: wildcard.crt
    keyFile: wildcard.key
    names:
    - "*.wildcardhost.com"
  ...
```

TODO:
- [x] finalize config struct and names
- [ ] ansible issue
- [ ] doc issue

Follow-ups:
- [x] improve config file file reference extraction (maybe using reflection?) https://github.com/openshift/origin/issues/5125