### PR TITLE
Remove duplicated helper

### DIFF
--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -205,13 +205,13 @@ func (r *ImageRef) ObjectReference() kapi.ObjectReference {
 	case r.Stream != nil:
 		return kapi.ObjectReference{
 			Kind:      "ImageStreamTag",
-			Name:      imageapi.NameAndTag(r.Stream.Name, r.Tag),
+			Name:      imageapi.JoinImageStreamTag(r.Stream.Name, r.Tag),
 			Namespace: r.Stream.Namespace,
 		}
 	case r.AsImageStream:
 		return kapi.ObjectReference{
 			Kind: "ImageStreamTag",
-			Name: imageapi.NameAndTag(r.Name, r.Tag),
+			Name: imageapi.JoinImageStreamTag(r.Name, r.Tag),
 		}
 	default:
 		return kapi.ObjectReference{
@@ -258,7 +258,7 @@ func (r *ImageRef) BuildOutput() (*buildapi.BuildOutput, error) {
 	return &buildapi.BuildOutput{
 		To: &kapi.ObjectReference{
 			Kind: kind,
-			Name: imageapi.NameAndTag(imageRepo.Name, r.Tag),
+			Name: imageapi.JoinImageStreamTag(imageRepo.Name, r.Tag),
 		},
 	}, nil
 }

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -376,15 +376,6 @@ func UpdateTrackingTags(stream *ImageStream, updatedTag string, updatedImage Tag
 	}
 }
 
-// NameAndTag returns an image name with a tag. If the tag is blank then
-// DefaultImageTag is used.
-func NameAndTag(name, tag string) string {
-	if len(tag) == 0 {
-		tag = DefaultImageTag
-	}
-	return fmt.Sprintf("%s:%s", name, tag)
-}
-
 // ResolveImageID returns a sets.String of all the image IDs in stream that start with imageID.
 func ResolveImageID(stream *ImageStream, imageID string) sets.String {
 	set := sets.NewString()

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -897,11 +897,11 @@ func TestUpdateTrackingTags(t *testing.T) {
 	}
 }
 
-func TestNameAndTag(t *testing.T) {
-	if e, a := "foo:bar", NameAndTag("foo", "bar"); e != a {
+func TestJoinImageStreamTag(t *testing.T) {
+	if e, a := "foo:bar", JoinImageStreamTag("foo", "bar"); e != a {
 		t.Errorf("Unexpected value: %s", a)
 	}
-	if e, a := "foo:"+DefaultImageTag, NameAndTag("foo", ""); e != a {
+	if e, a := "foo:"+DefaultImageTag, JoinImageStreamTag("foo", ""); e != a {
 		t.Errorf("Unexpected value: %s", a)
 	}
 }


### PR DESCRIPTION
`NameAndTag` and `JoinImageStreamTag` had the very same implementation.

@csrwng @mfojtik PTAL

[test]