### PR TITLE
pin openshift group name mappings when referencing from openshift groups

### DIFF
--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -4757,6 +4757,7 @@ _openshift_ex_sync-groups()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--blacklist=")
     flags+=("--confirm")
     flags+=("--no-headers")
     flags+=("--output=")

--- a/pkg/auth/ldaputil/syncutil.go
+++ b/pkg/auth/ldaputil/syncutil.go
@@ -2,6 +2,11 @@ package ldaputil
 
 // These constants contain values for annotations and labels affixed to Groups by the LDAP sync job
 const (
+	// LDAPHostLabel is the Label value that stores the host of the LDAP server
+	// TODO: we don't store port here because labels don't allow for colons. We might want to add this back
+	// with a different separator
+	LDAPHostLabel string = "openshift.io/ldap.host"
+
 	// LDAPURLAnnotation is the Annotation value that stores the host:port of the LDAP server
 	LDAPURLAnnotation string = "openshift.io/ldap.url"
 	// LDAPUIDAnnotation is the Annotation value that stores the corresponding LDAP group UID for the Group

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -38,16 +38,19 @@ stored on an LDAP server. The path to a sync configuration file is required in o
 requested from the external record store and migrated to OpenShift records. Default behavior is to sync all 
 groups from the LDAP server returned by the LDAP query templates.
 `
-	syncGroupsExamples = `  // Sync all groups from an LDAP server
+	syncGroupsExamples = `  # Sync all groups from an LDAP server
   $ %[1]s --sync-config=/path/to/ldap-sync-config.yaml
 
-  // Sync specific groups specified in a whitelist file with an LDAP server 
+  # Sync all groups except the ones from the blacklist file from an LDAP server
+  $ %[1]s --blacklist=/path/to/blacklist.txt --sync-config=/path/to/ldap-sync-config.yaml
+
+  # Sync specific groups specified in a whitelist file with an LDAP server 
   $ %[1]s --whitelist=/path/to/whitelist.txt --sync-config=/path/to/sync-config.yaml
 
-  // Sync all OpenShift Groups that have been synced previously with an LDAP server
+  # Sync all OpenShift Groups that have been synced previously with an LDAP server
   $ %[1]s --existing --sync-config=/path/to/ldap-sync-config.yaml
 
-  // Sync specific OpenShift Groups if they have been synced previously with an LDAP server
+  # Sync specific OpenShift Groups if they have been synced previously with an LDAP server
   $ %[1]s groups/group1 groups/group2 groups/group3 --sync-config=/path/to/sync-config.yaml
 `
 )
@@ -76,8 +79,11 @@ type SyncGroupsOptions struct {
 	// Config is the LDAP sync config read from file
 	Config api.LDAPSyncConfig
 
-	// WhitelistContents are the contents of the whitelist: names of OpenShift group or LDAP group UIDs
-	WhitelistContents []string
+	// Whitelist are the names of OpenShift group or LDAP group UIDs to use for syncing
+	Whitelist []string
+
+	// Blacklist are the names of OpenShift group or LDAP group UIDs to exclude
+	Blacklist []string
 
 	// Confirm determines whether not to write to openshift
 	Confirm bool
@@ -94,8 +100,8 @@ type SyncGroupsOptions struct {
 
 func NewSyncGroupsOptions() *SyncGroupsOptions {
 	return &SyncGroupsOptions{
-		Stderr:            os.Stderr,
-		WhitelistContents: []string{},
+		Stderr:    os.Stderr,
+		Whitelist: []string{},
 	}
 }
 
@@ -105,6 +111,7 @@ func NewCmdSyncGroups(name, fullName string, f *clientcmd.Factory, out io.Writer
 
 	typeArg := string(GroupSyncSourceLDAP)
 	whitelistFile := ""
+	blacklistFile := ""
 	configFile := ""
 
 	cmd := &cobra.Command{
@@ -113,7 +120,7 @@ func NewCmdSyncGroups(name, fullName string, f *clientcmd.Factory, out io.Writer
 		Long:    syncGroupsLong,
 		Example: fmt.Sprintf(syncGroupsExamples, fullName),
 		Run: func(c *cobra.Command, args []string) {
-			if err := options.Complete(typeArg, whitelistFile, configFile, args, f); err != nil {
+			if err := options.Complete(typeArg, whitelistFile, blacklistFile, configFile, args, f); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(c, err.Error()))
 			}
 
@@ -134,7 +141,10 @@ func NewCmdSyncGroups(name, fullName string, f *clientcmd.Factory, out io.Writer
 		},
 	}
 
-	cmd.Flags().StringVar(&whitelistFile, "whitelist", whitelistFile, "path to the group whitelist")
+	cmd.Flags().StringVar(&whitelistFile, "whitelist", whitelistFile, "path to the group whitelist file")
+	cmd.Flags().StringVar(&blacklistFile, "blacklist", whitelistFile, "path to the group blacklist file")
+	// TODO enable this we're able to support string slice elements that have commas
+	// cmd.Flags().StringSliceVar(&options.Blacklist, "blacklist-group", options.Blacklist, "group to blacklist")
 	cmd.Flags().StringVar(&configFile, "sync-config", configFile, "path to the sync config")
 	cmd.Flags().StringVar(&typeArg, "type", typeArg, "type of group used to locate LDAP group UIDs: "+strings.Join(AllowedSourceTypes, ","))
 	cmd.Flags().BoolVar(&options.Confirm, "confirm", false, "if true, modify OpenShift groups; if false, display groups")
@@ -152,7 +162,7 @@ type SyncBuilder interface {
 	GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error)
 }
 
-func (o *SyncGroupsOptions) Complete(typeArg, whitelistFile, configFile string, args []string, f *clientcmd.Factory) error {
+func (o *SyncGroupsOptions) Complete(typeArg, whitelistFile, blacklistFile, configFile string, args []string, f *clientcmd.Factory) error {
 	switch typeArg {
 	case string(GroupSyncSourceLDAP):
 		o.Source = GroupSyncSourceLDAP
@@ -165,7 +175,7 @@ func (o *SyncGroupsOptions) Complete(typeArg, whitelistFile, configFile string, 
 
 	// if args are given, they are OpenShift Group names forming a whitelist
 	if len(args) > 0 {
-		o.WhitelistContents = append(o.WhitelistContents, args[0:]...)
+		o.Whitelist = append(o.Whitelist, args...)
 	}
 
 	// unpack whitelist file from source
@@ -174,7 +184,16 @@ func (o *SyncGroupsOptions) Complete(typeArg, whitelistFile, configFile string, 
 		if err != nil {
 			return err
 		}
-		o.WhitelistContents = append(o.WhitelistContents, whitelistData...)
+		o.Whitelist = append(o.Whitelist, whitelistData...)
+	}
+
+	// unpack blacklist file from source
+	if len(blacklistFile) != 0 {
+		blacklistData, err := readLines(blacklistFile)
+		if err != nil {
+			return err
+		}
+		o.Blacklist = append(o.Blacklist, blacklistData...)
 	}
 
 	yamlConfig, err := ioutil.ReadFile(configFile)
@@ -302,19 +321,32 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 
 func (o *SyncGroupsOptions) GetGroupLister(syncBuilder SyncBuilder, clientConfig *ldaputil.LDAPClientConfig) (interfaces.LDAPGroupLister, error) {
 	// if we have a whitelist, it trumps alls
-	if len(o.WhitelistContents) != 0 {
+	if len(o.Whitelist) != 0 {
 		if o.Source == GroupSyncSourceOpenShift {
-			return syncgroups.NewOpenShiftWhitelistGroupLister(o.WhitelistContents, o.GroupInterface), nil
+			return syncgroups.NewOpenShiftGroupLister(o.Whitelist, o.Blacklist, clientConfig.Host, o.GroupInterface), nil
 		}
-		return syncgroups.NewLDAPWhitelistGroupLister(o.WhitelistContents), nil
+
+		ldapWhitelist := syncgroups.NewLDAPWhitelistGroupLister(o.Whitelist)
+		if len(o.Blacklist) == 0 {
+			return ldapWhitelist, nil
+		}
+		return syncgroups.NewLDAPBlacklistGroupLister(o.Blacklist, ldapWhitelist), nil
 	}
 
 	// openshift as a listing source works the same for all schemas
 	if o.Source == GroupSyncSourceOpenShift {
-		return syncgroups.NewAllOpenShiftGroupLister(clientConfig.Host, o.GroupInterface), nil
+		return syncgroups.NewAllOpenShiftGroupLister(clientConfig.Host, o.GroupInterface, o.Blacklist), nil
 	}
 
-	return syncBuilder.GetGroupLister()
+	syncLister, err := syncBuilder.GetGroupLister()
+	if err != nil {
+		return nil, err
+	}
+	if len(o.Blacklist) == 0 {
+		return syncLister, nil
+	}
+
+	return syncgroups.NewLDAPBlacklistGroupLister(o.Blacklist, syncLister), nil
 }
 
 func (o *SyncGroupsOptions) GetGroupNameMapper(syncBuilder SyncBuilder) (interfaces.LDAPGroupNameMapper, error) {

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -344,7 +344,7 @@ func (o *SyncGroupsOptions) GetOpenShiftGroupListerMapper(syncBuilder SyncBuilde
 		return syncgroups.NewOpenShiftGroupLister(o.Whitelist, o.Blacklist, clientConfig.Host, o.GroupInterface), nil
 	}
 
-	return syncgroups.NewAllOpenShiftGroupLister(clientConfig.Host, o.GroupInterface, o.Blacklist), nil
+	return syncgroups.NewAllOpenShiftGroupLister(o.Blacklist, clientConfig.Host, o.GroupInterface), nil
 }
 
 func (o *SyncGroupsOptions) GetLDAPGroupLister(syncBuilder SyncBuilder) (interfaces.LDAPGroupLister, error) {

--- a/pkg/cmd/experimental/syncgroups/grouplister.go
+++ b/pkg/cmd/experimental/syncgroups/grouplister.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	osclient "github.com/openshift/origin/pkg/client"
@@ -12,115 +13,163 @@ import (
 	ouserapi "github.com/openshift/origin/pkg/user/api"
 )
 
-// NewAllOpenShiftGroupLister returns a new AllLocalGroupLister
-func NewAllOpenShiftGroupLister(ldapURL string, groupClient osclient.GroupInterface) interfaces.LDAPGroupLister {
-	return &AllLocalGroupLister{
-		client:  groupClient,
-		ldapURL: ldapURL,
+// NewAllOpenShiftGroupLister returns a new allOpenShiftGroupLister
+func NewAllOpenShiftGroupLister(ldapURL string, groupClient osclient.GroupInterface, blacklist []string) interfaces.LDAPGroupLister {
+	return &allOpenShiftGroupLister{
+		blacklist: sets.NewString(blacklist...),
+		client:    groupClient,
+		ldapURL:   ldapURL,
 	}
 }
 
-// AllLocalGroupLister lists unique identifiers for LDAP lookup of all local OpenShift Groups that
+// allOpenShiftGroupLister lists unique identifiers for LDAP lookup of all local OpenShift Groups that
 // have been marked with an LDAP URL annotation as a result of a previous sync.
-type AllLocalGroupLister struct {
+type allOpenShiftGroupLister struct {
+	blacklist sets.String
+
 	client osclient.GroupInterface
 	// ldapURL is the host:port of the LDAP server, used to identify if an OpenShift Group has
 	// been synced with a specific server in order to isolate sync jobs between different servers
 	ldapURL string
 }
 
-func (l *AllLocalGroupLister) ListGroups() ([]string, error) {
+func (l *allOpenShiftGroupLister) ListGroups() ([]string, error) {
 	allGroups, err := l.client.List(labels.Everything(), fields.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	var potentialGroups []ouserapi.Group
+	var ldapldapGroupUIDs []string
 	for _, group := range allGroups.Items {
-		val, exists := group.Annotations[ldaputil.LDAPURLAnnotation]
-		if exists && (val == l.ldapURL) {
-			potentialGroups = append(potentialGroups, group)
+		if l.blacklist.Has(group.Name) {
+			continue
 		}
-	}
 
-	var ldapGroupUIDs []string
-	for _, group := range potentialGroups {
-		if err := validateGroupAnnotations(group); err != nil {
+		matches, err := validateGroupAnnotations(l.ldapURL, group)
+		if err != nil {
 			return nil, err
 		}
-		ldapGroupUIDs = append(ldapGroupUIDs, group.Annotations[ldaputil.LDAPUIDAnnotation])
+		if !matches {
+			continue
+		}
+
+		ldapldapGroupUIDs = append(ldapldapGroupUIDs, group.Annotations[ldaputil.LDAPUIDAnnotation])
 	}
-	return ldapGroupUIDs, nil
+
+	return ldapldapGroupUIDs, nil
 }
 
-// validateGroupAnnotations determines if the appropriate and annotations exist on a group
-func validateGroupAnnotations(group ouserapi.Group) error {
-	_, exists := group.Annotations[ldaputil.LDAPUIDAnnotation]
-	if !exists {
-		return fmt.Errorf("an OpenShift Group marked as having been synced did not have a %s annotation: %v",
-			ldaputil.LDAPUIDAnnotation, group)
+// validateGroupAnnotations determines if the group matches and errors if the annotations are missing
+func validateGroupAnnotations(ldapURL string, group ouserapi.Group) (bool, error) {
+	if actualURL, exists := group.Annotations[ldaputil.LDAPURLAnnotation]; !exists {
+		return false, fmt.Errorf("an OpenShift Group marked as having been synced did not have a %s annotation: %v", ldaputil.LDAPURLAnnotation, group)
+	} else if actualURL != ldapURL {
+		return false, nil
 	}
-	return nil
+
+	if _, exists := group.Annotations[ldaputil.LDAPUIDAnnotation]; !exists {
+		return false, fmt.Errorf("an OpenShift Group marked as having been synced did not have a %s annotation: %v", ldaputil.LDAPUIDAnnotation, group)
+	}
+	return true, nil
 }
 
-// NewOpenShiftWhitelistGroupLister returns a new LocalGroupLister that divulges the LDAP group unique identifier for
+// NewOpenShiftGroupLister returns a new openshiftGroupLister that divulges the LDAP group unique identifier for
 // each entry in the given whitelist of OpenShift Group names
-func NewOpenShiftWhitelistGroupLister(whitelist []string, client osclient.GroupInterface) interfaces.LDAPGroupLister {
-	return &LocalGroupLister{
+func NewOpenShiftGroupLister(whitelist []string, blacklist []string, ldapURL string, client osclient.GroupInterface) interfaces.LDAPGroupLister {
+	return &openshiftGroupLister{
 		whitelist: whitelist,
+		blacklist: sets.NewString(blacklist...),
 		client:    client,
+		ldapURL:   ldapURL,
 	}
 }
 
-// LocalGroupLister lists unique identifiers for LDAP lookup of all local OpenShift groups that have
+// openshiftGroupLister lists unique identifiers for LDAP lookup of all local OpenShift groups that have
 // been given to it upon creation.
-type LocalGroupLister struct {
+type openshiftGroupLister struct {
 	whitelist []string
-	client    osclient.GroupInterface
+	blacklist sets.String
+
+	client  osclient.GroupInterface
+	ldapURL string
 }
 
-func (l *LocalGroupLister) ListGroups() ([]string, error) {
-	groups, err := getOpenShiftGroups(l.whitelist, l.client)
-	if err != nil {
-		return nil, err
-	}
-
-	var ldapGroupUIDs []string
-	for _, group := range groups {
-		if err := validateGroupAnnotations(group); err != nil {
-			return nil, err
-		}
-		ldapGroupUIDs = append(ldapGroupUIDs, group.Annotations[ldaputil.LDAPUIDAnnotation])
-	}
-	return ldapGroupUIDs, err
-}
-
-// getOpenShiftGroups uses a client to retrieve all groups from the names given
-func getOpenShiftGroups(names []string, client osclient.GroupInterface) ([]ouserapi.Group, error) {
+func (l *openshiftGroupLister) ListGroups() ([]string, error) {
 	var groups []ouserapi.Group
-	for _, name := range names {
-		group, err := client.Get(name)
+	for _, name := range l.whitelist {
+		if l.blacklist.Has(name) {
+			continue
+		}
+
+		group, err := l.client.Get(name)
 		if err != nil {
 			return nil, err
 		}
 		groups = append(groups, *group)
 	}
-	return groups, nil
+
+	var ldapldapGroupUIDs []string
+	for _, group := range groups {
+		matches, err := validateGroupAnnotations(l.ldapURL, group)
+		if err != nil {
+			return nil, err
+		}
+		if !matches {
+			return nil, fmt.Errorf("%s was not synchronized from: %s", group.Name, l.ldapURL)
+		}
+
+		ldapldapGroupUIDs = append(ldapldapGroupUIDs, group.Annotations[ldaputil.LDAPUIDAnnotation])
+	}
+	return ldapldapGroupUIDs, nil
 }
 
-// NewLDAPWhitelistGroupLister returns a new WhitelistLDAPGroupLister that divulges the given whitelist
+// NewLDAPWhitelistGroupLister returns a new whitelistLDAPGroupLister that divulges the given whitelist
 // of LDAP group unique identifiers
 func NewLDAPWhitelistGroupLister(whitelist []string) interfaces.LDAPGroupLister {
-	return &WhitelistLDAPGroupLister{
-		GroupUIDs: whitelist,
+	return &whitelistLDAPGroupLister{
+		ldapGroupUIDs: whitelist,
 	}
 }
 
 // LDAPGroupLister lists LDAP groups unique group identifiers given to it upon creation.
-type WhitelistLDAPGroupLister struct {
-	GroupUIDs []string
+type whitelistLDAPGroupLister struct {
+	ldapGroupUIDs []string
 }
 
-func (l *WhitelistLDAPGroupLister) ListGroups() ([]string, error) {
-	return l.GroupUIDs, nil
+func (l *whitelistLDAPGroupLister) ListGroups() ([]string, error) {
+	return l.ldapGroupUIDs, nil
+}
+
+// NewLDAPBlacklistGroupLister filters out the blacklisted names from the base lister
+func NewLDAPBlacklistGroupLister(blacklist []string, baseLister interfaces.LDAPGroupLister) interfaces.LDAPGroupLister {
+	return &blacklistLDAPGroupLister{
+		blacklist:  sets.NewString(blacklist...),
+		baseLister: baseLister,
+	}
+}
+
+// LDAPGroupLister lists LDAP groups unique group identifiers given to it upon creation.
+type blacklistLDAPGroupLister struct {
+	blacklist sets.String
+
+	baseLister interfaces.LDAPGroupLister
+}
+
+func (l *blacklistLDAPGroupLister) ListGroups() ([]string, error) {
+	allNames, err := l.baseLister.ListGroups()
+	if err != nil {
+		return nil, err
+	}
+
+	// iterate through instead of  "Difference" to preserve ordering
+	ret := []string{}
+	for _, name := range allNames {
+		if l.blacklist.Has(name) {
+			continue
+		}
+
+		ret = append(ret, name)
+	}
+
+	return ret, nil
 }

--- a/pkg/cmd/experimental/syncgroups/grouplister_test.go
+++ b/pkg/cmd/experimental/syncgroups/grouplister_test.go
@@ -1,6 +1,7 @@
 package syncgroups
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -13,6 +14,244 @@ import (
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
+func TestListAllOpenShiftGroups(t *testing.T) {
+	testCases := map[string]struct {
+		startingGroups []runtime.Object
+		blacklist      []string
+		expectedName   string
+		expectedErr    string
+	}{
+		"good": {
+			startingGroups: []runtime.Object{
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			expectedName: "alpha-uid",
+		},
+		"no url annotation": {
+			startingGroups: []runtime.Object{
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{ldaputil.LDAPUIDAnnotation: "alpha-uid"},
+					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.url annotation`,
+		},
+		"no uid annotation": {
+			startingGroups: []runtime.Object{
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port"},
+					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.uid annotation`,
+		},
+		"no match: different port": {
+			startingGroups: []runtime.Object{
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port2",
+						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "beta",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "beta-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			expectedName: "beta-uid",
+		},
+		"blacklist": {
+			startingGroups: []runtime.Object{
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+				&userapi.Group{ObjectMeta: kapi.ObjectMeta{Name: "beta",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "beta-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			blacklist:    []string{"alpha"},
+			expectedName: "beta-uid",
+		},
+	}
+
+	for name, testCase := range testCases {
+		fakeClient := testclient.NewSimpleFake(testCase.startingGroups...)
+		lister := NewAllOpenShiftGroupLister(testCase.blacklist, "test-host:port", fakeClient.Groups())
+
+		groupNames, err := lister.ListGroups()
+		if err != nil {
+			if len(testCase.expectedErr) == 0 {
+				t.Errorf("%s: unexpected error: %v", name, err)
+			}
+			if expected, actual := testCase.expectedErr, err.Error(); expected != actual {
+				t.Errorf("%s: expected error %v, got %v", name, expected, actual)
+			}
+		} else {
+			if len(testCase.expectedErr) != 0 {
+				t.Errorf("%s: expected error %v, got nil", name, testCase.expectedErr)
+			}
+			if expected, actual := []string{testCase.expectedName}, groupNames; !reflect.DeepEqual(expected, actual) {
+				t.Errorf("%s: expected UIDs %v, got %v", name, expected, actual)
+			}
+		}
+	}
+}
+
+func TestListAllOpenShiftGroupsListErr(t *testing.T) {
+	listFailClient := testclient.NewSimpleFake()
+	listFailClient.PrependReactor("list", "groups", func(action ktestclient.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("fail")
+	})
+
+	lister := NewAllOpenShiftGroupLister([]string{}, "test-host:port", listFailClient.Groups())
+	groupUIDs, err := lister.ListGroups()
+	if err == nil {
+		t.Error("expected an error listing groups, got none")
+		if len(groupUIDs) != 0 {
+			t.Errorf("did not expect any groups to be listed, got: %v", groupUIDs)
+		}
+	} else {
+		if expected, actual := "fail", err.Error(); expected != actual {
+			t.Errorf("did not get correct error listing groups: expected %q, got %q", expected, actual)
+		}
+	}
+}
+
+func TestListWhitelistOpenShiftGroups(t *testing.T) {
+	testCases := map[string]struct {
+		startingGroups []*userapi.Group
+		whitelist      []string
+		blacklist      []string
+		expectedName   string
+		expectedErr    string
+	}{
+		"good": {
+			startingGroups: []*userapi.Group{
+				{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			whitelist:    []string{"alpha"},
+			expectedName: "alpha-uid",
+		},
+		"no url annotation": {
+			startingGroups: []*userapi.Group{
+				{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{ldaputil.LDAPUIDAnnotation: "alpha-uid"},
+					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			whitelist:   []string{"alpha"},
+			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.url annotation`,
+		},
+		"no uid annotation": {
+			startingGroups: []*userapi.Group{
+				{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port"},
+					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			whitelist:   []string{"alpha"},
+			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.uid annotation`,
+		},
+		"no match: different port": {
+			startingGroups: []*userapi.Group{
+				{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port2",
+						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			whitelist:   []string{"alpha"},
+			expectedErr: `group "alpha" was not synchronized from: test-host:port`,
+		},
+		"blacklist": {
+			startingGroups: []*userapi.Group{
+				{ObjectMeta: kapi.ObjectMeta{Name: "alpha",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+				{ObjectMeta: kapi.ObjectMeta{Name: "beta",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "test-host:port",
+						ldaputil.LDAPUIDAnnotation: "beta-uid",
+					},
+					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+			},
+			whitelist:    []string{"alpha", "beta"},
+			blacklist:    []string{"alpha"},
+			expectedName: "beta-uid",
+		},
+	}
+
+	for name, testCase := range testCases {
+		fakeClient := testclient.NewSimpleFake()
+		fakeClient.PrependReactor("get", "groups", func(action ktestclient.Action) (bool, runtime.Object, error) {
+			groups := map[string]*userapi.Group{}
+			for _, group := range testCase.startingGroups {
+				groups[group.Name] = group
+			}
+			if group, exists := groups[action.(ktestclient.GetAction).GetName()]; exists {
+				return true, group, nil
+			}
+			return false, nil, nil
+		})
+		lister := NewOpenShiftGroupLister(testCase.whitelist, testCase.blacklist, "test-host:port", fakeClient.Groups())
+
+		groupNames, err := lister.ListGroups()
+		if err != nil {
+			if len(testCase.expectedErr) == 0 {
+				t.Errorf("%s: unexpected error: %v", name, err)
+			}
+			if expected, actual := testCase.expectedErr, err.Error(); expected != actual {
+				t.Errorf("%s: expected error %v, got %v", name, expected, actual)
+			}
+		} else {
+			if len(testCase.expectedErr) != 0 {
+				t.Errorf("%s: expected error %v, got nil", name, testCase.expectedErr)
+			}
+			if expected, actual := []string{testCase.expectedName}, groupNames; !reflect.DeepEqual(expected, actual) {
+				t.Errorf("%s: expected UIDs %v, got %v", name, expected, actual)
+			}
+		}
+	}
+}
+
+func TestListOpenShiftGroupsListErr(t *testing.T) {
+	listFailClient := testclient.NewSimpleFake()
+	listFailClient.PrependReactor("get", "groups", func(action ktestclient.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("fail")
+	})
+
+	lister := NewOpenShiftGroupLister([]string{"alpha", "beta"}, []string{"beta"}, "", listFailClient.Groups())
+	groupUIDs, err := lister.ListGroups()
+	if err == nil {
+		t.Error("expected an error listing groups, got none")
+		if len(groupUIDs) != 0 {
+			t.Errorf("did not expect any groups to be listed, got: %v", groupUIDs)
+		}
+	} else {
+		if expected, actual := "fail", err.Error(); expected != actual {
+			t.Errorf("did not get correct error listing groups: expected %q, got %q", expected, actual)
+		}
+	}
+}
+
 func TestLDAPBlacklistFilter(t *testing.T) {
 	whitelister := NewLDAPWhitelistGroupLister([]string{"rebecca", "valerie"})
 	blacklister := NewLDAPBlacklistGroupLister([]string{"rebecca"}, whitelister)
@@ -22,85 +261,6 @@ func TestLDAPBlacklistFilter(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if e, a := []string{"valerie"}, result; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-}
-
-func TestAllOpenShiftFilter(t *testing.T) {
-	tc := testclient.NewSimpleFake()
-	tc.PrependReactor("list", "groups", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		groupList := &userapi.GroupList{}
-
-		groupA := userapi.Group{
-			ObjectMeta: kapi.ObjectMeta{
-				Name: "groupA",
-				Annotations: map[string]string{
-					ldaputil.LDAPURLAnnotation: "host:port",
-					ldaputil.LDAPUIDAnnotation: "ldapGroupA",
-				},
-			},
-		}
-		groupB := userapi.Group{
-			ObjectMeta: kapi.ObjectMeta{
-				Name: "groupB",
-				Annotations: map[string]string{
-					ldaputil.LDAPURLAnnotation: "host:port",
-					ldaputil.LDAPUIDAnnotation: "ldapGroupB",
-				},
-			},
-		}
-		groupList.Items = append(groupList.Items, groupA, groupB)
-
-		return true, groupList, nil
-	})
-
-	lister := NewAllOpenShiftGroupLister("host:port", tc.Groups(), []string{"groupA"})
-
-	ldapGroups, err := lister.ListGroups()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if e, a := []string{"ldapGroupB"}, ldapGroups; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-}
-
-func TestOpenShiftWhitelistFilter(t *testing.T) {
-	tc := testclient.NewSimpleFake()
-	tc.PrependReactor("get", "groups", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
-		switch action.(ktestclient.GetAction).GetName() {
-		case "groupA":
-			return true, &userapi.Group{
-				ObjectMeta: kapi.ObjectMeta{
-					Name: "groupA",
-					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "host:port",
-						ldaputil.LDAPUIDAnnotation: "ldapGroupA",
-					},
-				},
-			}, nil
-		case "groupB":
-			return true, &userapi.Group{
-				ObjectMeta: kapi.ObjectMeta{
-					Name: "groupB",
-					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "host:port",
-						ldaputil.LDAPUIDAnnotation: "ldapGroupB",
-					},
-				},
-			}, nil
-		}
-
-		return false, nil, nil
-	})
-
-	lister := NewOpenShiftGroupLister([]string{"groupA", "groupB"}, []string{"groupA"}, "host:port", tc.Groups())
-
-	ldapGroups, err := lister.ListGroups()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if e, a := []string{"ldapGroupB"}, ldapGroups; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }

--- a/pkg/cmd/experimental/syncgroups/grouplister_test.go
+++ b/pkg/cmd/experimental/syncgroups/grouplister_test.go
@@ -1,0 +1,106 @@
+package syncgroups
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/client/testclient"
+	userapi "github.com/openshift/origin/pkg/user/api"
+)
+
+func TestLDAPBlacklistFilter(t *testing.T) {
+	whitelister := NewLDAPWhitelistGroupLister([]string{"rebecca", "valerie"})
+	blacklister := NewLDAPBlacklistGroupLister([]string{"rebecca"}, whitelister)
+
+	result, err := blacklister.ListGroups()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if e, a := []string{"valerie"}, result; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestAllOpenShiftFilter(t *testing.T) {
+	tc := testclient.NewSimpleFake()
+	tc.PrependReactor("list", "groups", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		groupList := &userapi.GroupList{}
+
+		groupA := userapi.Group{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "groupA",
+				Annotations: map[string]string{
+					ldaputil.LDAPURLAnnotation: "host:port",
+					ldaputil.LDAPUIDAnnotation: "ldapGroupA",
+				},
+			},
+		}
+		groupB := userapi.Group{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "groupB",
+				Annotations: map[string]string{
+					ldaputil.LDAPURLAnnotation: "host:port",
+					ldaputil.LDAPUIDAnnotation: "ldapGroupB",
+				},
+			},
+		}
+		groupList.Items = append(groupList.Items, groupA, groupB)
+
+		return true, groupList, nil
+	})
+
+	lister := NewAllOpenShiftGroupLister("host:port", tc.Groups(), []string{"groupA"})
+
+	ldapGroups, err := lister.ListGroups()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if e, a := []string{"ldapGroupB"}, ldapGroups; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestOpenShiftWhitelistFilter(t *testing.T) {
+	tc := testclient.NewSimpleFake()
+	tc.PrependReactor("get", "groups", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		switch action.(ktestclient.GetAction).GetName() {
+		case "groupA":
+			return true, &userapi.Group{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "groupA",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "host:port",
+						ldaputil.LDAPUIDAnnotation: "ldapGroupA",
+					},
+				},
+			}, nil
+		case "groupB":
+			return true, &userapi.Group{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "groupB",
+					Annotations: map[string]string{
+						ldaputil.LDAPURLAnnotation: "host:port",
+						ldaputil.LDAPUIDAnnotation: "ldapGroupB",
+					},
+				},
+			}, nil
+		}
+
+		return false, nil, nil
+	})
+
+	lister := NewOpenShiftGroupLister([]string{"groupA", "groupB"}, []string{"groupA"}, "host:port", tc.Groups())
+
+	ldapGroups, err := lister.ListGroups()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if e, a := []string{"ldapGroupB"}, ldapGroups; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}

--- a/pkg/cmd/experimental/syncgroups/interfaces/interfaces.go
+++ b/pkg/cmd/experimental/syncgroups/interfaces/interfaces.go
@@ -30,3 +30,8 @@ type LDAPUserNameMapper interface {
 type LDAPGroupGetter interface {
 	GroupEntryFor(ldapGroupUID string) (group *ldap.Entry, err error)
 }
+
+type LDAPGroupListerNameMapper interface {
+	LDAPGroupLister
+	LDAPGroupNameMapper
+}

--- a/test/extended/authentication.sh
+++ b/test/extended/authentication.sh
@@ -220,6 +220,14 @@ for (( i=0; i<${#schema[@]}; i++ )); do
 	openshift ex sync-groups --sync-config=sync-config-partially-user-defined.yaml --confirm || true
 	compare_and_cleanup valid_all_ldap_sync_partially_user_defined.txt
 
+	echo -e "\tTEST: Sync based on OpenShift groups respecting OpenShift mappings"
+	openshift ex sync-groups --sync-config=sync-config-user-defined.yaml --confirm || true
+	oc get group -o name --no-headers | xargs -n 1 oc patch -p 'users: []'
+	openshift ex sync-groups --type=openshift --sync-config=sync-config.yaml --confirm
+	compare_and_cleanup valid_all_ldap_sync_user_defined.txt
+
+
+
 	echo -e "\tTEST: Sync all LDAP groups from LDAP server using DN as attribute whenever possible"
     openshift ex sync-groups --sync-config=sync-config-dn-everywhere.yaml --confirm || true
 	compare_and_cleanup valid_all_ldap_sync_dn_everywhere.txt

--- a/test/extended/authentication/ldap/ad/blacklist_ldap.txt
+++ b/test/extended/authentication/ldap/ad/blacklist_ldap.txt
@@ -1,0 +1,2 @@
+group1
+group3

--- a/test/extended/authentication/ldap/ad/blacklist_openshift.txt
+++ b/test/extended/authentication/ldap/ad/blacklist_openshift.txt
@@ -1,0 +1,2 @@
+group1
+group3

--- a/test/extended/authentication/ldap/ad/valid_all_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_blacklist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/ad/valid_all_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_blacklist_sync.txt
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: group2
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group2
+users:
+- person1smith@example.com
+- 'person2mith@example.com '
+- person3smith@example.com

--- a/test/extended/authentication/ldap/ad/valid_all_ldap_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_ldap_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: group3
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group3
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/ad/valid_all_ldap_sync_dn_everywhere.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_ldap_sync_dn_everywhere.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - cn=Person1,ou=people,ou=ad,dc=example,dc=com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - cn=Person1,ou=people,ou=ad,dc=example,dc=com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: group3
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group3
 users:
 - cn=Person1,ou=people,ou=ad,dc=example,dc=com

--- a/test/extended/authentication/ldap/ad/valid_all_ldap_sync_partially_user_defined.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_ldap_sync_partially_user_defined.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: firstgroup
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: group3
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: thirdgroup
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/ad/valid_all_ldap_sync_user_defined.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_ldap_sync_user_defined.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: firstgroup
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: secondgroup
 users:
 - person1smith@example.com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: group3
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: thirdgroup
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/ad/valid_all_openshift_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_openshift_blacklist_sync.txt
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: group1
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group1
+users: []
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: group2
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group2
+users:
+- person1smith@example.com
+- 'person2mith@example.com '
+- person3smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: group3
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group3
+users: []

--- a/test/extended/authentication/ldap/ad/valid_all_openshift_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_openshift_blacklist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users: []
 apiVersion: v1
@@ -14,6 +16,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com
@@ -26,5 +30,7 @@ metadata:
     openshift.io/ldap.uid: group3
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group3
 users: []

--- a/test/extended/authentication/ldap/ad/valid_whitelist_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_whitelist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/ad/valid_whitelist_union_sync.txt
+++ b/test/extended/authentication/ldap/ad/valid_whitelist_union_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: group1
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: group2
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/blacklist_ldap.txt
+++ b/test/extended/authentication/ldap/augmented-ad/blacklist_ldap.txt
@@ -1,0 +1,2 @@
+cn=group1,ou=groups,ou=adextended,dc=example,dc=com
+cn=group3,ou=groups,ou=adextended,dc=example,dc=com

--- a/test/extended/authentication/ldap/augmented-ad/blacklist_openshift.txt
+++ b/test/extended/authentication/ldap/augmented-ad/blacklist_openshift.txt
@@ -1,0 +1,2 @@
+extended-group1
+extended-group3

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_blacklist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_blacklist_sync.txt
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: extended-group2
+users:
+- person1smith@example.com
+- 'person2mith@example.com '
+- person3smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group1
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group2
 users:
 - person1smith@example.com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group3
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_dn_everywhere.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_dn_everywhere.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
 users:
 - cn=Person1,ou=people,ou=adextended,dc=example,dc=com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
 users:
 - cn=Person1,ou=people,ou=adextended,dc=example,dc=com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
 users:
 - cn=Person1,ou=people,ou=adextended,dc=example,dc=com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_partially_user_defined.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_partially_user_defined.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group2
 users:
 - person1smith@example.com
@@ -17,6 +19,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: firstgroup
 users:
 - person1smith@example.com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: thirdgroup
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_user_defined.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_user_defined.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: firstgroup
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: secondgroup
 users:
 - person1smith@example.com
@@ -31,6 +35,8 @@ metadata:
     openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: thirdgroup
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_openshift_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_openshift_blacklist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group1
 users: []
 apiVersion: v1
@@ -14,6 +16,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group2
 users:
 - person1smith@example.com
@@ -26,5 +30,7 @@ metadata:
     openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group3
 users: []

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_openshift_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_openshift_blacklist_sync.txt
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: extended-group1
+users: []
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: extended-group2
+users:
+- person1smith@example.com
+- 'person2mith@example.com '
+- person3smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: extended-group3
+users: []

--- a/test/extended/authentication/ldap/augmented-ad/valid_whitelist_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_whitelist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group1
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_whitelist_union_sync.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_whitelist_union_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group1
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=adextended,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: extended-group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/blacklist_ldap.txt
+++ b/test/extended/authentication/ldap/rfc2307/blacklist_ldap.txt
@@ -1,0 +1,2 @@
+cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
+cn=group3,ou=groups,ou=rfc2307,dc=example,dc=com

--- a/test/extended/authentication/ldap/rfc2307/blacklist_openshift.txt
+++ b/test/extended/authentication/ldap/rfc2307/blacklist_openshift.txt
@@ -1,0 +1,2 @@
+group1
+group3

--- a/test/extended/authentication/ldap/rfc2307/valid_all_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_blacklist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_blacklist_sync.txt
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group2
+users:
+- person1smith@example.com
+- 'person2mith@example.com '
+- person3smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_dn_everywhere.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_dn_everywhere.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
 users:
 - cn=Person1,ou=people,ou=rfc2307,dc=example,dc=com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
 users:
 - cn=Person1,ou=people,ou=rfc2307,dc=example,dc=com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_partially_user_defined.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_partially_user_defined.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: firstgroup
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_user_defined.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_user_defined.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: firstgroup
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: secondgroup
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_openshift_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_openshift_blacklist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users: []
 apiVersion: v1
@@ -14,6 +16,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_openshift_blacklist_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_openshift_blacklist_sync.txt
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group1
+users: []
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  name: group2
+users:
+- person1smith@example.com
+- 'person2mith@example.com '
+- person3smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_whitelist_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_whitelist_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_whitelist_union_sync.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_whitelist_union_sync.txt
@@ -5,6 +5,8 @@ metadata:
     openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group1
 users:
 - person1smith@example.com
@@ -19,6 +21,8 @@ metadata:
     openshift.io/ldap.uid: cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com
     openshift.io/ldap.url: LDAP_SERVICE_IP:389
   creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
   name: group2
 users:
 - person1smith@example.com

--- a/test/extended/authentication/ldap_group_sync.go
+++ b/test/extended/authentication/ldap_group_sync.go
@@ -49,8 +49,8 @@ var _ = g.Describe("authentication: OpenLDAP build and deployment", func() {
 				{
 					name: "schema 1 whitelist LDAP",
 					options: syncgroupscli.SyncGroupsOptions{
-						Source:            syncgroupscli.GroupSyncSourceLDAP,
-						WhitelistContents: []string{GroupName1, GroupName2},
+						Source:    syncgroupscli.GroupSyncSourceLDAP,
+						Whitelist: []string{GroupName1, GroupName2},
 					},
 					expected:   []string{GroupName1, GroupName2},
 					seedGroups: []userapi.Group{},
@@ -77,8 +77,8 @@ var _ = g.Describe("authentication: OpenLDAP build and deployment", func() {
 				{
 					name: "schema 1 whitelist openshift no previous sync",
 					options: syncgroupscli.SyncGroupsOptions{
-						Source:            syncgroupscli.GroupSyncSourceOpenShift,
-						WhitelistContents: []string{GroupName1, GroupName2},
+						Source:    syncgroupscli.GroupSyncSourceOpenShift,
+						Whitelist: []string{GroupName1, GroupName2},
 					},
 					expected:   []string{}, // cant sync OpenShift groups that haven't been linked to an LDAP entry
 					seedGroups: []userapi.Group{},
@@ -87,8 +87,8 @@ var _ = g.Describe("authentication: OpenLDAP build and deployment", func() {
 				{
 					name: "schema 1 whitelist openshift with previous sync",
 					options: syncgroupscli.SyncGroupsOptions{
-						Source:            syncgroupscli.GroupSyncSourceOpenShift,
-						WhitelistContents: []string{GroupName1, GroupName2},
+						Source:    syncgroupscli.GroupSyncSourceOpenShift,
+						Whitelist: []string{GroupName1, GroupName2},
 					},
 					expected:   []string{GroupName1, GroupName2},
 					seedGroups: []userapi.Group{},


### PR DESCRIPTION
This allows us to properly update the openshift groups without creating new groups or updating the incorrect mappings.

@stevekuznetsov  includes https://github.com/openshift/origin/pull/5104