### PR TITLE
fixed file permissions for admin.kubeconfig and execution of oadm

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -55,8 +55,12 @@ $ mkdir $HOME/go
 +
 ----
 export GOPATH=$HOME/go
-export PATH=$PATH:$GOPATH/bin
+export PATH=$GOPATH/src/github.com/openshift/origin/_output/local/bin/linux/amd64:$GOPATH/bin:$PATH
 ----
+
++
+NOTE: Replace "linux/amd64" with the appropriate value for your platform/architecture.
+
 4. Open up a new terminal or source the changes in your current terminal.  Then clone this repo:
 
         $ mkdir -p $GOPATH/src/github.com/openshift
@@ -86,13 +90,10 @@ export PATH=$PATH:$GOPATH/bin
         $ cd _output/local/bin/linux/amd64
         $ sudo ./openshift start
 
-+
-NOTE: Replace "linux/amd64" with the appropriate value for your platform/architecture.
-
 10.  Launch another terminal, change into the same directory you started OpenShift, and deploy the private docker registry within OpenShift with the following commands (note, the --credentials option allows secure communication between the internal OpenShift Docker registry and the OpenShift server, and the --config option provides your identity (in this case, cluster-admin) to the OpenShift server):
 
         $ sudo chmod +r openshift.local.config/master/openshift-registry.kubeconfig
-        $ sudo chmod +r openshift.local.config/master/admin.kubeconfig
+        $ sudo chmod a+rw openshift.local.config/master/admin.kubeconfig
         $ oadm registry --create --credentials=openshift.local.config/master/openshift-registry.kubeconfig --config=openshift.local.config/master/admin.kubeconfig
 
 11.  If it is not there already, add the current directory to the $PATH, so you can leverage the OpenShift commands elsewhere.
@@ -135,13 +136,11 @@ To facilitate rapid development we've put together a Vagrantfile you can use to 
 
 6.  Run a build in SSH:
 
-        $ cd /data/src/github.com/openshift/origin
         $ make clean build
 
-7.  Now change into the directory with the OpenShift binaries, and start the OpenShift server:
+7.  Now start the OpenShift server:
 
-        $ cd _output/local/bin/linux/amd64
-        $ sudo ./openshift start --public-master=localhost --volume-dir=</absolute/path> &> openshift.log &
+        $ sudo openshift start --public-master=localhost --volume-dir=</absolute/path> &> openshift.log &
 
 +
 NOTE: By default your origin directory will be mounted as a vagrant synced folder into `/data/src/github.com/openshift/origin`, but it is advised to use a different directory for volume storage than the one for the origin directory vagrant synced folder. Hence in the above example of the `openshift start` command invocation the `--volume-dir=</absolute/path>` option is supplied.
@@ -151,8 +150,8 @@ NOTE: By default your origin directory will be mounted as a vagrant synced folde
 9.  Deploy the private docker registry within OpenShift with the following commands (note, the --credentials option allows secure communication between the internal OpenShift Docker registry and the OpenShift server, and the --config option provides your identity (in this case, cluster-admin) to the OpenShift server):
 
         $ sudo chmod +r openshift.local.config/master/openshift-registry.kubeconfig
-        $ sudo chmod +r openshift.local.config/master/admin.kubeconfig
-        $ ./oadm registry --create --credentials=openshift.local.config/master/openshift-registry.kubeconfig --config=openshift.local.config/master/admin.kubeconfig
+        $ sudo chmod a+rw openshift.local.config/master/admin.kubeconfig
+        $ oadm registry --create --credentials=openshift.local.config/master/openshift-registry.kubeconfig --config=openshift.local.config/master/admin.kubeconfig
 
 10.  You are now ready to edit the source, rebuild and restart OpenShift to test your changes.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -196,8 +196,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       config.vm.synced_folder ".", "/vagrant", disabled: true
       unless vagrant_openshift_config['no_synced_folders']
-        config.vm.synced_folder sync_from, sync_to, 
-          rsync__args: %w(--verbose --archive --delete), 
+        config.vm.synced_folder sync_from, sync_to,
+          rsync__args: %w(--verbose --archive --delete),
           type: vagrant_openshift_config['sync_folders_type'],
           nfs_udp: false # has issues when using NFS from within a docker container
       end
@@ -227,6 +227,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       v.memory            = vagrant_openshift_config['memory'].to_i
       v.cpus              = vagrant_openshift_config['cpus'].to_i
       v.customize ["modifyvm", :id, "--cpus", vagrant_openshift_config['cpus'].to_s]
+      full_provision(override.vm)
       # to make the ha-proxy reachable from the host, you need to add a port forwarding rule from 1080 to 80, which
       # requires root privilege. Use iptables on linux based or ipfw on BSD based OS:
       # sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 1080

--- a/contrib/vagrant/provision-full.sh
+++ b/contrib/vagrant/provision-full.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 USERNAME="${1:-vagrant}"
 
-yum update -y
-yum install -y docker-io git vim golang e2fsprogs tmux httpie ctags hg bind-utils which
+#yum update for fedora provider in vagrant breaks vboxfs 
+#yum update -y
+yum install -y docker-io git vim golang e2fsprogs tmux httpie ctags hg bind-utils which ethtool
 
 if [[ ! -d /data/src/github.com/openshift/origin ]]; then
   mkdir -p /data/src/github.com/openshift/origin
@@ -26,7 +27,7 @@ function set_env {
     touch $USER_DIR/.bash_profile
     echo "export GOPATH=/data" >> $USER_DIR/.bash_profile
     echo "export PATH=\$GOPATH/src/github.com/openshift/origin/_output/local/bin/linux/amd64:\$GOPATH/bin:\$PATH" >> $USER_DIR/.bash_profile
-    echo "cd \$GOPATH/src/github.com/openshift/origin" >> $USER_DIR/.bash_profile
+    #echo "cd \$GOPATH/src/github.com/openshift/origin" >> $USER_DIR/.bash_profile
 
     echo "bind '\"\e[A\":history-search-backward'" >> $USER_DIR/.bashrc
     echo "bind '\"\e[B\":history-search-forward'" >> $USER_DIR/.bashrc


### PR DESCRIPTION
i've noticed admin.kubeconfig needs rw permissions for an unprivileged user to be able to create a new registry or a new project, and also added execution for for oadm, export PATH is the step below that and it doesn't resolve so people might find it confusing.