### PR TITLE
move bash_completion.d/oc to clients package

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -251,7 +251,9 @@ install -p -m 644 contrib/completions/bash/* %{buildroot}%{_sysconfdir}/bash_com
 %{_bindir}/kube-controller-manager
 %{_bindir}/kube-scheduler
 %{_sharedstatedir}/origin
-%{_sysconfdir}/bash_completion.d/*
+%{_sysconfdir}/bash_completion.d/atomic-enterprise
+%{_sysconfdir}/bash_completion.d/oadm
+%{_sysconfdir}/bash_completion.d/openshift
 %dir %config(noreplace) %{_sysconfdir}/origin
 
 %pre
@@ -375,6 +377,7 @@ fi
 %files clients
 %{_bindir}/oc
 %{_bindir}/kubectl
+%{_sysconfdir}/bash_completion.d/oc
 
 %files clients-redistributable
 %{_datadir}/%{name}/linux/oc


### PR DESCRIPTION
Move bash completion for oc to the clients package so it is truly a stand along package.

https://bugzilla.redhat.com/show_bug.cgi?id=1270731