### PR TITLE
Always chcon node volume dir

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -20,15 +20,6 @@ BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-e2e-containerized}"
 setup_env_vars
 reset_tmp_dir
 
-# when selinux is enforcing, the volume dir selinux label needs to be
-# svirt_sandbox_file_t
-#
-# TODO: fix the selinux policy to either allow openshift_var_lib_dir_t
-# or to default the volume dir to svirt_sandbox_file_t.
-if selinuxenabled; then
-	sudo chcon -t svirt_sandbox_file_t ${VOLUME_DIR}
-fi
-
 function cleanup()
 {
 	out=$?

--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -110,12 +110,13 @@ func (c *NodeConfig) initializeVolumeDir(ce commandExecutor, path string) (strin
 		if err := os.MkdirAll(rootDirectory, 0750); err != nil {
 			return "", fmt.Errorf("Couldn't create kubelet volume root directory '%s': %s", rootDirectory, err)
 		}
-		if chconPath, err := ce.LookPath("chcon"); err != nil {
-			glog.V(2).Infof("Couldn't locate 'chcon' to set the kubelet volume root directory SELinux context: %s", err)
-		} else {
-			if err := ce.Run(chconPath, "-t", "svirt_sandbox_file_t", rootDirectory); err != nil {
-				glog.Warningf("Error running 'chcon' to set the kubelet volume root directory SELinux context: %s", err)
-			}
+	}
+	// always try to chcon, in case the volume dir existed prior to the node starting
+	if chconPath, err := ce.LookPath("chcon"); err != nil {
+		glog.V(2).Infof("Couldn't locate 'chcon' to set the kubelet volume root directory SELinux context: %s", err)
+	} else {
+		if err := ce.Run(chconPath, "-t", "svirt_sandbox_file_t", rootDirectory); err != nil {
+			glog.Warningf("Error running 'chcon' to set the kubelet volume root directory SELinux context: %s", err)
 		}
 	}
 	return rootDirectory, nil


### PR DESCRIPTION
Always try to chcon the volume dir to svirt_sandbox_file_t, regardless
of whether or not the dir previously existed. This is required to avoid
SELinux denials that occur when the volume dir is created prior to
starting the node and it doesn't have the correct SELinux label.

@smarterclayton @pmorie @rhatdan @bparees @deads2k @danmcp @liggitt 