### PR TITLE
ImageStream status.dockerImageRepository should point to local registry

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -427,7 +427,9 @@ func printHumanReadableQueryResult(r *newcmd.QueryResult, out io.Writer, fullNam
 
 			fmt.Fprintln(out, imageStream.Name)
 			fmt.Fprintf(out, "  Project: %v\n", imageStream.Namespace)
-			fmt.Fprintf(out, "  Tracks:  %v\n", imageStream.Status.DockerImageRepository)
+			if len(imageStream.Spec.DockerImageRepository) > 0 {
+				fmt.Fprintf(out, "  Tracks:  %v\n", imageStream.Spec.DockerImageRepository)
+			}
 			fmt.Fprintf(out, "  Tags:    %v\n", tags)
 			if len(description) > 0 {
 				fmt.Fprintf(out, "  %v\n", description)

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -348,7 +348,11 @@ func printImageStream(stream *imageapi.ImageStream, w io.Writer, withNamespace, 
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", stream.Name, stream.Status.DockerImageRepository, tags, latestTime)
+	repo := stream.Spec.DockerImageRepository
+	if len(repo) == 0 {
+		repo = stream.Status.DockerImageRepository
+	}
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", stream.Name, repo, tags, latestTime)
 	return err
 }
 

--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -89,13 +89,9 @@ func (Strategy) AllowUnconditionalUpdate() bool {
 // if a default registry exists, the value returned is of the form
 // <default registry>/<namespace>/<stream name>.
 func (s Strategy) dockerImageRepository(stream *api.ImageStream) string {
-	if len(stream.Spec.DockerImageRepository) != 0 {
-		return stream.Spec.DockerImageRepository
-	}
-
 	registry, ok := s.defaultRegistry.DefaultRegistry()
 	if !ok {
-		return ""
+		return stream.Spec.DockerImageRepository
 	}
 
 	if len(stream.Namespace) == 0 {

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -73,6 +73,19 @@ func TestDockerImageRepository(t *testing.T) {
 			},
 			expected: "a/b",
 		},
+		"DockerImageRepository set on stream with default registry": {
+			stream: &api.ImageStream{
+				ObjectMeta: kapi.ObjectMeta{
+					Namespace: "foo",
+					Name:      "somerepo",
+				},
+				Spec: api.ImageStreamSpec{
+					DockerImageRepository: "a/b",
+				},
+			},
+			defaultRegistry: "registry:5000",
+			expected:        "registry:5000/foo/somerepo",
+		},
 		"default namespace": {
 			stream: &api.ImageStream{
 				ObjectMeta: kapi.ObjectMeta{

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -18,7 +18,7 @@ oc create -f examples/image-streams/image-streams-centos7.json
 [ "$(oc new-app mongo -o yaml | grep library/mongo)" ]
 # the local image repository takes precedence over the Docker Hub "mysql" image
 tryuntil oc get imagestreamtags mysql:latest
-[ "$(oc new-app mysql -o yaml | grep mysql-55-centos7)" ]
+[ "$(oc new-app mysql -o yaml | grep mysql)" ]
 
 # check label creation
 oc new-app php mysql -l no-source=php-mysql

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -12,10 +12,14 @@ import (
 var _ = g.Describe("builds: parallel: Dockerfile input", func() {
 	defer g.GinkgoRecover()
 	var (
-		imageStreamFixture = exutil.FixturePath("..", "integration", "fixtures", "test-image-stream.json")
-		oc                 = exutil.NewCLI("build-dockerfile-env", exutil.KubeConfigPath())
-		testDockerfile     = `
+		oc             = exutil.NewCLI("build-dockerfile-env", exutil.KubeConfigPath())
+		testDockerfile = `
 FROM openshift/origin-base
+USER 1001
+`
+		testDockerfile2 = `
+FROM centos:7
+RUN yum install -y httpd
 USER 1001
 `
 	)
@@ -24,18 +28,13 @@ USER 1001
 		g.By("waiting for builder service account")
 		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
 		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
 	})
 
-	g.Describe("being created from new-app", func() {
+	g.Describe("being created from new-build", func() {
 		g.It("should create a image via new-build", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
-
-			g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
-			err := oc.Run("create").Args("-f", imageStreamFixture).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By(fmt.Sprintf("calling oc new-app with Dockerfile"))
-			err = oc.Run("new-build").Args("-D", "-").InputString(testDockerfile).Execute()
+			g.By(fmt.Sprintf("calling oc new-build with Dockerfile"))
+			err := oc.Run("new-build").Args("-D", "-").InputString(testDockerfile).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting a test build")
@@ -44,16 +43,45 @@ USER 1001
 			o.Expect(bc.Spec.Source.Git).To(o.BeNil())
 			o.Expect(bc.Spec.Source.Dockerfile).NotTo(o.BeNil())
 			o.Expect(*bc.Spec.Source.Dockerfile).To(o.Equal(testDockerfile))
-			buildName := "origin-base-1"
 
+			buildName := "origin-base-1"
 			g.By("expecting the Dockerfile build is in Complete phase")
 			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFunc, exutil.CheckBuildFailedFunc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("getting the Docker image reference from ImageStream")
-			image, err := oc.REST().ImageStreamTags(oc.Namespace()).Get("test", "latest")
+			g.By("getting the build Docker image reference from ImageStream")
+			image, err := oc.REST().ImageStreamTags(oc.Namespace()).Get("origin-base", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
+		})
+
+		g.It("should create a image via new-build and infer the origin tag", func() {
+			g.By(fmt.Sprintf("calling oc new-build with Dockerfile that uses the same tag as the output"))
+			err := oc.Run("new-build").Args("-D", "-").InputString(testDockerfile2).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting a test build")
+			bc, err := oc.REST().BuildConfigs(oc.Namespace()).Get("centos")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(bc.Spec.Source.Git).To(o.BeNil())
+			o.Expect(bc.Spec.Source.Dockerfile).NotTo(o.BeNil())
+			o.Expect(*bc.Spec.Source.Dockerfile).To(o.Equal(testDockerfile2))
+			o.Expect(bc.Spec.Output.To).ToNot(o.BeNil())
+			o.Expect(bc.Spec.Output.To.Name).To(o.Equal("centos:latest"))
+
+			buildName := "centos-1"
+			g.By("expecting the Dockerfile build is in Complete phase")
+			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFunc, exutil.CheckBuildFailedFunc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("getting the built Docker image reference from ImageStream")
+			image, err := oc.REST().ImageStreamTags(oc.Namespace()).Get("centos", "latest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
+
+			g.By("checking for the imported tag")
+			_, err = oc.REST().ImageStreamTags(oc.Namespace()).Get("centos", "7")
+			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
Callers cannot assume status.dockerImageRepository is the spec value.

Fixes #4102

This is an API change, but is required to properly support push to image stream.

@ncdc