### PR TITLE
Bump proxy resync from 30s to 10m

### DIFF
--- a/pkg/cmd/server/kubernetes/node.go
+++ b/pkg/cmd/server/kubernetes/node.go
@@ -217,7 +217,7 @@ func (c *NodeConfig) RunProxy(endpointsFilterer FilteringEndpointsConfigHandler)
 
 		pconfig.NewSourceAPI(
 			c.Client,
-			30*time.Second,
+			10*time.Minute,
 			serviceConfig.Channel("api"),
 			endpointsConfig.Channel("api"))
 


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/15682 for the
corresponding upstream change