### PR TITLE
Add labels/annotations to DeploymentStrategy

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -15836,6 +15836,14 @@
      "resources": {
       "$ref": "v1.ResourceRequirements",
       "description": "resource requirements to execute the deployment"
+     },
+     "labels": {
+      "type": "any",
+      "description": "labels for deployer and hook pods"
+     },
+     "annotations": {
+      "type": "any",
+      "description": "annotations for deployer and hook pods"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1510,6 +1510,22 @@ func deepCopy_api_DeploymentStrategy(in deployapi.DeploymentStrategy, out *deplo
 	} else {
 		out.Resources = newVal.(pkgapi.ResourceRequirements)
 	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1569,6 +1569,22 @@ func deepCopy_v1_DeploymentStrategy(in deployapiv1.DeploymentStrategy, out *depl
 	} else {
 		out.Resources = newVal.(pkgapiv1.ResourceRequirements)
 	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1577,6 +1577,22 @@ func deepCopy_v1beta3_DeploymentStrategy(in deployapiv1beta3.DeploymentStrategy,
 	} else {
 		out.Resources = newVal.(pkgapiv1beta3.ResourceRequirements)
 	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
 	return nil
 }
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -36,6 +36,10 @@ type DeploymentStrategy struct {
 	RollingParams *RollingDeploymentStrategyParams
 	// Resources contains resource requirements to execute the deployment
 	Resources kapi.ResourceRequirements
+	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Labels map[string]string
+	// Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Annotations map[string]string
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.

--- a/pkg/deploy/api/v1/conversion.go
+++ b/pkg/deploy/api/v1/conversion.go
@@ -82,6 +82,12 @@ func convert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in *DeploymentStrat
 	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
 		return err
 	}
+	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -99,6 +105,12 @@ func convert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *newer.Deploymen
 		return err
 	}
 	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -36,6 +36,10 @@ type DeploymentStrategy struct {
 	RollingParams *RollingDeploymentStrategyParams `json:"rollingParams,omitempty" description:"input to the Rolling deployment strategy"`
 	// Resources contains resource requirements to execute the deployment
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"resource requirements to execute the deployment"`
+	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Labels map[string]string `json:"labels,omitempty" description:"labels for deployer and hook pods"`
+	// Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Annotations map[string]string `json:"annotations,omitempty" description:"annotations for deployer and hook pods"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.

--- a/pkg/deploy/api/v1beta3/conversion.go
+++ b/pkg/deploy/api/v1beta3/conversion.go
@@ -81,6 +81,12 @@ func convert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy(in *Deployment
 	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
 		return err
 	}
+	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -98,6 +104,12 @@ func convert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy(in *newer.Depl
 		return err
 	}
 	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -36,6 +36,10 @@ type DeploymentStrategy struct {
 	RollingParams *RollingDeploymentStrategyParams `json:"rollingParams,omitempty" description:"input to the Rolling deployment strategy"`
 	// Compute resource requirements to execute the deployment
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"resource requirements to execute the deployment"`
+	// Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Labels map[string]string `json:"labels,omitempty" description:"labels for deployer and hook pods"`
+	// Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.
+	Annotations map[string]string `json:"annotations,omitempty" description:"annotations for deployer and hook pods"`
 }
 
 // DeploymentStrategyType refers to a specific DeploymentStrategy implementation.

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -91,6 +91,13 @@ func validateDeploymentStrategy(strategy *deployapi.DeploymentStrategy) fielderr
 		}
 	}
 
+	if strategy.Labels != nil {
+		errs = append(errs, validation.ValidateLabels(strategy.Labels, "labels")...)
+	}
+	if strategy.Annotations != nil {
+		errs = append(errs, validation.ValidateAnnotations(strategy.Annotations, "annotations")...)
+	}
+
 	// TODO: validate resource requirements (prereq: https://github.com/kubernetes/kubernetes/pull/7059)
 
 	return errs

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -12,6 +12,7 @@ import (
 
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	"github.com/openshift/origin/pkg/util"
 )
 
 // DeploymentController starts a deployment by creating a deployer pod which
@@ -248,6 +249,10 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 			ServiceAccountName: c.serviceAccount,
 		},
 	}
+
+	// MergeInfo will not overwrite values unless the flag OverwriteExistingDstKey is set.
+	util.MergeInto(pod.Labels, deploymentConfig.Template.Strategy.Labels, 0)
+	util.MergeInto(pod.Annotations, deploymentConfig.Template.Strategy.Annotations, 0)
 
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -51,7 +51,7 @@ func NewRecreateDeploymentStrategy(client kclient.Interface, codec runtime.Codec
 		},
 		scaler:       scaler,
 		codec:        codec,
-		hookExecutor: stratsupport.NewHookExecutor(client, os.Stdout),
+		hookExecutor: stratsupport.NewHookExecutor(client, os.Stdout, codec),
 		retryTimeout: 120 * time.Second,
 		retryPeriod:  1 * time.Second,
 	}

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -87,7 +87,7 @@ func NewRollingDeploymentStrategy(namespace string, client kclient.Interface, co
 			updater := kubectl.NewRollingUpdater(namespace, client)
 			return updater.Update(config)
 		},
-		hookExecutor: stratsupport.NewHookExecutor(client, os.Stdout),
+		hookExecutor: stratsupport.NewHookExecutor(client, os.Stdout, codec),
 		getUpdateAcceptor: func(timeout time.Duration) strat.UpdateAcceptor {
 			return stratsupport.NewAcceptNewlyObservedReadyPods(client, timeout, AcceptorInterval)
 		},


### PR DESCRIPTION
This PR allows for the deployer to work in a scenario where an application is using per-tier network segmentation.

For instance, the rails-postgresql-example app sets the label "name": rails-postgresql-example. OpenContrail creates a network segment for this project/tier. The postgresql database sits in the network "default" (by the fact that no label is specified).

The deploymentConfig uses the following labels:
```
+        "labels": {
+          "name": "rails-postgresql-example",
+          "uses": "default"
+        },
```

This allows the deployer to be in the same application as the application front-end and deployer-hook to access the postgresql db.
