### PR TITLE
UPSTREAM: 14705: Inline fields of SecurityContext into PodSecurityContext

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -12500,6 +12500,10 @@
       "type": "boolean",
       "description": "Use the host's ipc namespace. Optional: Default to false."
      },
+     "securityContext": {
+      "$ref": "v1.PodSecurityContext",
+      "description": "SecurityContext holds pod-level security attributes and common container settings"
+     },
      "imagePullSecrets": {
       "type": "array",
       "items": {
@@ -13046,6 +13050,11 @@
       "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
      }
     }
+   },
+   "v1.PodSecurityContext": {
+    "id": "v1.PodSecurityContext",
+    "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "properties": {}
    },
    "v1.PodStatus": {
     "id": "v1.PodStatus",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/api/swagger-spec/v1.json
@@ -12980,28 +12980,28 @@
    },
    "v1.SecurityContext": {
     "id": "v1.SecurityContext",
-    "description": "SecurityContext holds security configuration that will be applied to a container.",
+    "description": "SecurityContext holds security configuration that will be applied to a container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "Capabilities are the capabilities to add/drop when running containers. Optional: Defaults to the default set of capabilities granted by the container runtime."
      },
      "privileged": {
       "type": "boolean",
-      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Optional: Default to false"
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "SELinuxOptions is the SELinux context to be applied to the container Optional: container runtime will allocate a random SELinux context for each container if unspecified."
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context"
+      "description": "RunAsUser is the UID to run the entrypoint of the container process. Optional: defaults to user specified in image metadata if unspecified."
      },
      "runAsNonRoot": {
       "type": "boolean",
-      "description": "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user."
+      "description": "RunAsNonRoot indicates that the container should be run as a non-root user. Optional: if false, then the kubelet may check the image for a specified user or perform defaulting to specify a user."
      }
     }
    },
@@ -13054,7 +13054,29 @@
    "v1.PodSecurityContext": {
     "id": "v1.PodSecurityContext",
     "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
-    "properties": {}
+    "properties": {
+     "capabilities": {
+      "$ref": "v1.Capabilities",
+      "description": "Capabilities are the capabilities to add/drop when running containers. Optional: Defaults to the default set of capabilities granted by the container runtime."
+     },
+     "privileged": {
+      "type": "boolean",
+      "description": "Run all containers in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Optional: Default to false"
+     },
+     "seLinuxOptions": {
+      "$ref": "v1.SELinuxOptions",
+      "description": "SELinuxOptions is the SELinux context to be applied to all containers Optional: docker daemon will allocate a random SELinux context for each container if unspecified."
+     },
+     "runAsUser": {
+      "type": "integer",
+      "format": "int64",
+      "description": "RunAsUser is the UID to run the entrypoint of all container processes. Optional: defaults to user specified in image metadata if unspecified."
+     },
+     "runAsNonRoot": {
+      "type": "boolean",
+      "description": "RunAsNonRoot indicates that all containers should be run as a non-root user. Optional: if false, then the kubelet may check the image for a specified user or perform defaulting to specify a user."
+     }
+    }
    },
    "v1.PodStatus": {
     "id": "v1.PodStatus",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -1389,6 +1389,35 @@ func deepCopy_api_PodSecurityContext(in PodSecurityContext, out *PodSecurityCont
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
+	if in.Capabilities != nil {
+		out.Capabilities = new(Capabilities)
+		if err := deepCopy_api_Capabilities(*in.Capabilities, out.Capabilities, c); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(SELinuxOptions)
+		if err := deepCopy_api_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -1385,6 +1385,13 @@ func deepCopy_api_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *c
 	return nil
 }
 
+func deepCopy_api_PodSecurityContext(in PodSecurityContext, out *PodSecurityContext, c *conversion.Cloner) error {
+	out.HostNetwork = in.HostNetwork
+	out.HostPID = in.HostPID
+	out.HostIPC = in.HostIPC
+	return nil
+}
+
 func deepCopy_api_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error {
 	if in.Volumes != nil {
 		out.Volumes = make([]Volume, len(in.Volumes))
@@ -1430,9 +1437,14 @@ func deepCopy_api_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error 
 	}
 	out.ServiceAccountName = in.ServiceAccountName
 	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(PodSecurityContext)
+		if err := deepCopy_api_PodSecurityContext(*in.SecurityContext, out.SecurityContext, c); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -2451,6 +2463,7 @@ func init() {
 		deepCopy_api_PodList,
 		deepCopy_api_PodLogOptions,
 		deepCopy_api_PodProxyOptions,
+		deepCopy_api_PodSecurityContext,
 		deepCopy_api_PodSpec,
 		deepCopy_api_PodStatus,
 		deepCopy_api_PodStatusResult,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/serialization_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/serialization_test.go
@@ -103,7 +103,7 @@ func TestSpecificKind(t *testing.T) {
 	api.Scheme.Log(t)
 	defer api.Scheme.Log(nil)
 
-	kind := "PodList"
+	kind := "Pod"
 	doRoundTripTest(kind, t)
 }
 
@@ -164,6 +164,8 @@ func TestEncode_Ptr(t *testing.T) {
 			DNSPolicy:     api.DNSClusterFirst,
 
 			TerminationGracePeriodSeconds: &grace,
+
+			SecurityContext: &api.PodSecurityContext{},
 		},
 	}
 	obj := runtime.Object(pod)
@@ -176,7 +178,8 @@ func TestEncode_Ptr(t *testing.T) {
 		t.Fatalf("Got wrong type")
 	}
 	if !api.Semantic.DeepEqual(obj2, pod) {
-		t.Errorf("Expected:\n %#v,\n Got:\n %#v", pod, obj2)
+		t.Errorf("\nExpected:\n\n %#v,\n\nGot:\n\n %#vDiff: %v\n\n", pod, obj2, util.ObjectDiff(obj2, pod))
+
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/compat/compatibility_tester.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/compat/compatibility_tester.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+
+	"k8s.io/kubernetes/pkg/kubectl"
+)
+
+// Based on: https://github.com/openshift/origin/blob/master/pkg/api/compatibility_test.go
+//
+// TestCompatibility reencodes the input using the codec for the given
+// version and checks for the presence of the expected keys and absent
+// keys in the resulting JSON.
+func TestCompatibility(
+	t *testing.T,
+	version string,
+	input []byte,
+	validator func(obj runtime.Object) fielderrors.ValidationErrorList,
+	expectedKeys map[string]string,
+	absentKeys []string,
+) {
+
+	// Decode
+	codec := runtime.CodecFor(api.Scheme, version)
+	obj, err := codec.Decode(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Validate
+	errs := validator(obj)
+	if len(errs) != 0 {
+		t.Fatalf("Unexpected validation errors: %v", errs)
+	}
+
+	// Encode
+	output, err := codec.Encode(obj)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Validate old and new fields are encoded
+	generic := map[string]interface{}{}
+	if err := json.Unmarshal(output, &generic); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	hasError := false
+	for k, expectedValue := range expectedKeys {
+		keys := strings.Split(k, ".")
+		if actualValue, ok, err := getJSONValue(generic, keys...); err != nil || !ok {
+			t.Errorf("Unexpected error for %s: %v", k, err)
+			hasError = true
+		} else if !reflect.DeepEqual(expectedValue, fmt.Sprintf("%v", actualValue)) {
+			hasError = true
+			t.Errorf("Unexpected value for %v: expected %v, got %v", k, expectedValue, actualValue)
+		}
+	}
+
+	for _, absentKey := range absentKeys {
+		keys := strings.Split(absentKey, ".")
+		actualValue, ok, err := getJSONValue(generic, keys...)
+		if err == nil || ok {
+			t.Errorf("Unexpected value found for for key %s: %v", absentKey, actualValue)
+			hasError = true
+		}
+	}
+
+	if hasError {
+		printer := new(kubectl.JSONPrinter)
+		printer.PrintObj(obj, os.Stdout)
+		t.Logf("2: Encoded value: %#v", string(output))
+	}
+}
+
+func getJSONValue(data map[string]interface{}, keys ...string) (interface{}, bool, error) {
+	// No keys, current value is it
+	if len(keys) == 0 {
+		return data, true, nil
+	}
+
+	// Get the key (and optional index)
+	key := keys[0]
+	index := -1
+	if matches := regexp.MustCompile(`^(.*)\[(\d+)\]$`).FindStringSubmatch(key); len(matches) > 0 {
+		key = matches[1]
+		index, _ = strconv.Atoi(matches[2])
+	}
+
+	// Look up the value
+	value, ok := data[key]
+	if !ok {
+		return nil, false, fmt.Errorf("No key %s found", key)
+	}
+
+	// Get the indexed value if an index is specified
+	if index >= 0 {
+		valueSlice, ok := value.([]interface{})
+		if !ok {
+			return nil, false, fmt.Errorf("Key %s did not hold a slice", key)
+		}
+		if index >= len(valueSlice) {
+			return nil, false, fmt.Errorf("Index %d out of bounds for slice at key: %v", index, key)
+		}
+		value = valueSlice[index]
+	}
+
+	if len(keys) == 1 {
+		return value, true, nil
+	}
+
+	childData, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("Key %s did not hold a map", keys[0])
+	}
+	return getJSONValue(childData, keys[1:]...)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
@@ -91,14 +91,18 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			j.LabelSelector, _ = labels.Parse("a=b")
 			j.FieldSelector, _ = fields.ParseSelector("a=b")
 		},
-		func(j *api.PodSpec, c fuzz.Continue) {
-			c.FuzzNoCustom(j)
+		func(s *api.PodSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(s)
 			// has a default value
 			ttl := int64(30)
 			if c.RandBool() {
 				ttl = int64(c.Uint32())
 			}
-			j.TerminationGracePeriodSeconds = &ttl
+			s.TerminationGracePeriodSeconds = &ttl
+
+			if s.SecurityContext == nil {
+				s.SecurityContext = &api.PodSecurityContext{}
+			}
 		},
 		func(j *api.PodPhase, c fuzz.Continue) {
 			statuses := []api.PodPhase{api.PodPending, api.PodRunning, api.PodFailed, api.PodUnknown}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/pod_specs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/pod_specs.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// DeepEqualSafePodSpec returns a PodSpec which is ready to be used with api.Semantic.DeepEqual
+func DeepEqualSafePodSpec() api.PodSpec {
+	grace := int64(30)
+	return api.PodSpec{
+		RestartPolicy:                 api.RestartPolicyAlways,
+		DNSPolicy:                     api.DNSClusterFirst,
+		TerminationGracePeriodSeconds: &grace,
+		SecurityContext:               &api.PodSecurityContext{},
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -994,13 +994,31 @@ type PodSecurityContext struct {
 	// used must be specified.
 	// Optional: Default to false
 	HostNetwork bool `json:"hostNetwork,omitempty"`
-
 	// Use the host's pid namespace.
 	// Optional: Default to false.
 	HostPID bool `json:"hostPID,omitempty"`
 	// Use the host's ipc namespace.
 	// Optional: Default to false.
 	HostIPC bool `json:"hostIPC,omitempty"`
+	// Capabilities are the capabilities to add/drop when running containers.
+	// Optional: Defaults to the default set of capabilities granted by the container
+	// runtime.
+	Capabilities *Capabilities `json:"capabilities,omitempty"`
+	// Run all containers in privileged mode.
+	// Processes in privileged containers are essentially equivalent to root on the host.
+	// Optional: Default to false
+	Privileged *bool `json:"privileged,omitempty"`
+	// SELinuxOptions is the SELinux context to be applied to all containers
+	// Optional: container runtime will allocate a random SELinux context for each
+	// container if unspecified.
+	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
+	// RunAsUser is the UID to run the entrypoint of all container processes.
+	// Optional: defaults to user specified in image metadata if unspecified.
+	RunAsUser *int64 `json:"runAsUser,omitempty"`
+	// RunAsNonRoot indicates that all containers should be run as a non-root user.
+	// Optional: if false, then the kubelet may check the image for a specified user
+	// or perform defaulting to specify a user.
+	RunAsNonRoot bool `json:"runAsNonRoot,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual
@@ -2190,36 +2208,35 @@ type ComponentStatusList struct {
 // will be populated based on the Container configuration if they are not set.  Defining them on
 // both the Container AND the SecurityContext will result in an error.
 type SecurityContext struct {
-	// Capabilities are the capabilities to add/drop when running the container
+	// Capabilities are the capabilities to add/drop when running containers.
+	// Optional: Defaults to the default set of capabilities granted by the container
+	// runtime.
 	Capabilities *Capabilities `json:"capabilities,omitempty"`
-
-	// Run the container in privileged mode
+	// Run container in privileged mode.
+	// Processes in privileged containers are essentially equivalent to root on the host.
+	// Optional: Default to false
 	Privileged *bool `json:"privileged,omitempty"`
-
-	// SELinuxOptions are the labels to be applied to the container
-	// and volumes
+	// SELinuxOptions is the SELinux context to be applied to the container
+	// Optional: container runtime will allocate a random SELinux context for each
+	// container if unspecified.
 	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
-
 	// RunAsUser is the UID to run the entrypoint of the container process.
+	// Optional: defaults to user specified in image metadata if unspecified.
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
-
-	// RunAsNonRoot indicates that the container should be run as a non-root user.  If the RunAsUser
-	// field is not explicitly set then the kubelet may check the image for a specified user or
-	// perform defaulting to specify a user.
-	RunAsNonRoot bool
+	// RunAsNonRoot indicates that the container should be run as a non-root user.
+	// Optional: if false, then the kubelet may check the image for a specified user
+	// or perform defaulting to specify a user.
+	RunAsNonRoot bool `json:"runAsNonRoot,omitempty"`
 }
 
 // SELinuxOptions are the labels to be applied to the container.
 type SELinuxOptions struct {
 	// SELinux user label
 	User string `json:"user,omitempty"`
-
 	// SELinux role label
 	Role string `json:"role,omitempty"`
-
 	// SELinux type label
 	Type string `json:"type,omitempty"`
-
 	// SELinux level label.
 	Level string `json:"level,omitempty"`
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -980,20 +980,27 @@ type PodSpec struct {
 	// the scheduler simply schedules this pod onto that node, assuming that it fits resource
 	// requirements.
 	NodeName string `json:"nodeName,omitempty"`
-	// Use the host's network namespace. If this option is set, the ports that will be
+	// SecurityContext holds pod-level security attributes and common container settings
+	SecurityContext *PodSecurityContext `json:"securityContext,omitempty"`
+	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+	// If specified, these secrets will be passed to individual puller implementations for them to use.  For example,
+	// in the case of docker, only DockerConfig type secrets are honored.
+	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
+}
+
+// PodSecurityContext holds pod-level security attributes and common container settings.
+type PodSecurityContext struct {
+	// Use the host's network namespace.  If this option is set, the ports that will be
 	// used must be specified.
-	// Optional: Default to false.
+	// Optional: Default to false
 	HostNetwork bool `json:"hostNetwork,omitempty"`
+
 	// Use the host's pid namespace.
 	// Optional: Default to false.
 	HostPID bool `json:"hostPID,omitempty"`
 	// Use the host's ipc namespace.
 	// Optional: Default to false.
 	HostIPC bool `json:"hostIPC,omitempty"`
-	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
-	// If specified, these secrets will be passed to individual puller implementations for them to use.  For example,
-	// in the case of docker, only DockerConfig type secrets are honored.
-	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/backward_compatibility_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/backward_compatibility_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testing/compat"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+)
+
+func TestCompatibility_v1_PodSecurityContext(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        string
+		expectedKeys map[string]string
+		absentKeys   []string
+	}{
+		{
+			name: "hostNetwork = true",
+			input: `
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"hostNetwork": true,
+		"containers":[{
+			"name":"a",
+			"image":"my-container-image"
+		}]
+	}
+}
+`,
+			expectedKeys: map[string]string{
+				"spec.hostNetwork": "true",
+			},
+		},
+		{
+			name: "hostNetwork = false",
+			input: `
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"hostNetwork": false,
+		"containers":[{
+			"name":"a",
+			"image":"my-container-image"
+		}]
+	}
+}
+`,
+			absentKeys: []string{
+				"spec.hostNetwork",
+			},
+		},
+		{
+			name: "hostIPC = true",
+			input: `
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"hostIPC": true,
+		"containers":[{
+			"name":"a",
+			"image":"my-container-image"
+		}]
+	}
+}
+`,
+			expectedKeys: map[string]string{
+				"spec.hostIPC": "true",
+			},
+		},
+		{
+			name: "hostIPC = false",
+			input: `
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"hostIPC": false,
+		"containers":[{
+			"name":"a",
+			"image":"my-container-image"
+		}]
+	}
+}
+`,
+			absentKeys: []string{
+				"spec.hostIPC",
+			},
+		},
+		{
+			name: "hostPID = true",
+			input: `
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"hostPID": true,
+		"containers":[{
+			"name":"a",
+			"image":"my-container-image"
+		}]
+	}
+}
+`,
+			expectedKeys: map[string]string{
+				"spec.hostPID": "true",
+			},
+		},
+		{
+			name: "hostPID = false",
+			input: `
+{
+	"kind":"Pod",
+	"apiVersion":"v1",
+	"metadata":{"name":"my-pod-name", "namespace":"my-pod-namespace"},
+	"spec": {
+		"hostPID": false,
+		"containers":[{
+			"name":"a",
+			"image":"my-container-image"
+		}]
+	}
+}
+`,
+			absentKeys: []string{
+				"spec.hostPID",
+			},
+		},
+	}
+
+	validator := func(obj runtime.Object) fielderrors.ValidationErrorList {
+		return validation.ValidatePodSpec(&(obj.(*api.Pod).Spec))
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing 1.0.0 backward compatibility for %v", tc.name)
+		compat.TestCompatibility(t, "v1", []byte(tc.input), validator, tc.expectedKeys, tc.absentKeys)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -289,6 +289,8 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 			return err
 		}
 
+		// the host namespace fields have to be handled here for backward compatibilty
+		// with v1.0.0
 		out.HostPID = in.SecurityContext.HostPID
 		out.HostNetwork = in.SecurityContext.HostNetwork
 		out.HostIPC = in.SecurityContext.HostIPC
@@ -375,6 +377,9 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 			return err
 		}
 	}
+
+	// the host namespace fields have to be handled specially for backward compatibility
+	// with v1.0.0
 	if out.SecurityContext == nil {
 		out.SecurityContext = new(api.PodSecurityContext)
 	}
@@ -492,6 +497,35 @@ func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurity
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.PodSecurityContext))(in)
 	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(Capabilities)
+		if err := convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(SELinuxOptions)
+		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 
@@ -499,5 +533,34 @@ func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityCont
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*PodSecurityContext))(in)
 	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(api.Capabilities)
+		if err := convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(api.SELinuxOptions)
+		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -283,9 +283,16 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conversi
 	// DeprecatedServiceAccount is an alias for ServiceAccountName.
 	out.DeprecatedServiceAccount = in.ServiceAccountName
 	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(PodSecurityContext)
+		if err := convert_api_PodSecurityContext_To_v1_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+
+		out.HostPID = in.SecurityContext.HostPID
+		out.HostNetwork = in.SecurityContext.HostNetwork
+		out.HostIPC = in.SecurityContext.HostIPC
+	}
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -362,9 +369,18 @@ func convert_v1_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s conversi
 		out.NodeName = in.DeprecatedHost
 	}
 
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(api.PodSecurityContext)
+		if err := convert_v1_PodSecurityContext_To_api_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+	}
+	if out.SecurityContext == nil {
+		out.SecurityContext = new(api.PodSecurityContext)
+	}
+	out.SecurityContext.HostNetwork = in.HostNetwork
+	out.SecurityContext.HostPID = in.HostPID
+	out.SecurityContext.HostIPC = in.HostIPC
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -468,6 +484,20 @@ func convert_v1_MetadataFile_To_api_DownwardAPIVolumeFile(in *MetadataFile, out 
 	out.Path = in.Name
 	if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
 		return err
+	}
+	return nil
+}
+
+func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurityContext, out *PodSecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.PodSecurityContext))(in)
+	}
+	return nil
+}
+
+func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*PodSecurityContext))(in)
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1406,6 +1406,10 @@ func deepCopy_v1_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *co
 	return nil
 }
 
+func deepCopy_v1_PodSecurityContext(in PodSecurityContext, out *PodSecurityContext, c *conversion.Cloner) error {
+	return nil
+}
+
 func deepCopy_v1_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error {
 	if in.Volumes != nil {
 		out.Volumes = make([]Volume, len(in.Volumes))
@@ -1456,6 +1460,14 @@ func deepCopy_v1_PodSpec(in PodSpec, out *PodSpec, c *conversion.Cloner) error {
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(PodSecurityContext)
+		if err := deepCopy_v1_PodSecurityContext(*in.SecurityContext, out.SecurityContext, c); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -2490,6 +2502,7 @@ func init() {
 		deepCopy_v1_PodList,
 		deepCopy_v1_PodLogOptions,
 		deepCopy_v1_PodProxyOptions,
+		deepCopy_v1_PodSecurityContext,
 		deepCopy_v1_PodSpec,
 		deepCopy_v1_PodStatus,
 		deepCopy_v1_PodStatusResult,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -1407,6 +1407,35 @@ func deepCopy_v1_PodProxyOptions(in PodProxyOptions, out *PodProxyOptions, c *co
 }
 
 func deepCopy_v1_PodSecurityContext(in PodSecurityContext, out *PodSecurityContext, c *conversion.Cloner) error {
+	if in.Capabilities != nil {
+		out.Capabilities = new(Capabilities)
+		if err := deepCopy_v1_Capabilities(*in.Capabilities, out.Capabilities, c); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(SELinuxOptions)
+		if err := deepCopy_v1_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
@@ -134,7 +134,9 @@ func addDefaultingFuncs() {
 			if len(obj.NodeName) == 0 && len(obj.DeprecatedHost) > 0 {
 				obj.NodeName = obj.DeprecatedHost
 			}
-
+			if obj.SecurityContext == nil {
+				obj.SecurityContext = &PodSecurityContext{}
+			}
 			if obj.TerminationGracePeriodSeconds == nil {
 				period := int64(DefaultTerminationGracePeriodSeconds)
 				obj.TerminationGracePeriodSeconds = &period

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1241,11 +1241,17 @@ type PodSpec struct {
 	// Use the host's ipc namespace.
 	// Optional: Default to false.
 	HostIPC bool `json:"hostIPC,omitempty"`
+	// SecurityContext holds pod-level security attributes and common container settings
+	SecurityContext *PodSecurityContext `json:"securityContext,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use. For example,
 	// in the case of docker, only DockerConfig type secrets are honored.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+}
+
+// PodSecurityContext holds pod-level security attributes and common container settings.
+type PodSecurityContext struct {
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1252,6 +1252,25 @@ type PodSpec struct {
 
 // PodSecurityContext holds pod-level security attributes and common container settings.
 type PodSecurityContext struct {
+	// Capabilities are the capabilities to add/drop when running containers.
+	// Optional: Defaults to the default set of capabilities granted by the container
+	// runtime.
+	Capabilities *Capabilities `json:"capabilities,omitempty"`
+	// Run all containers in privileged mode.
+	// Processes in privileged containers are essentially equivalent to root on the host.
+	// Optional: Default to false
+	Privileged *bool `json:"privileged,omitempty"`
+	// SELinuxOptions is the SELinux context to be applied to all containers
+	// Optional: docker daemon will allocate a random SELinux context for each
+	// container if unspecified.
+	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
+	// RunAsUser is the UID to run the entrypoint of all container processes.
+	// Optional: defaults to user specified in image metadata if unspecified.
+	RunAsUser *int64 `json:"runAsUser,omitempty"`
+	// RunAsNonRoot indicates that all containers should be run as a non-root user.
+	// Optional: if false, then the kubelet may check the image for a specified user
+	// or perform defaulting to specify a user.
+	RunAsNonRoot bool `json:"runAsNonRoot,omitempty"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual
@@ -2589,31 +2608,26 @@ type DownwardAPIVolumeFile struct {
 }
 
 // SecurityContext holds security configuration that will be applied to a container.
+// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
 type SecurityContext struct {
-	// The linux kernel capabilites that should be added or removed.
-	// Default to Container.Capabilities if left unset.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// Capabilities are the capabilities to add/drop when running containers.
+	// Optional: Defaults to the default set of capabilities granted by the container
+	// runtime.
 	Capabilities *Capabilities `json:"capabilities,omitempty"`
-
-	// Run the container in privileged mode.
-	// Default to Container.Privileged if left unset.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// Run container in privileged mode.
+	// Processes in privileged containers are essentially equivalent to root on the host.
+	// Optional: Default to false
 	Privileged *bool `json:"privileged,omitempty"`
-
-	// SELinuxOptions are the labels to be applied to the container
-	// and volumes.
-	// Options that control the SELinux labels applied.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// SELinuxOptions is the SELinux context to be applied to the container
+	// Optional: container runtime will allocate a random SELinux context for each
+	// container if unspecified.
 	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
-
 	// RunAsUser is the UID to run the entrypoint of the container process.
-	// The user id that runs the first process in the container.
-	// More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context
+	// Optional: defaults to user specified in image metadata if unspecified.
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
-
-	// RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser
-	// field is not explicitly set then the kubelet may check the image for a specified user or
-	// perform defaulting to specify a user.
+	// RunAsNonRoot indicates that the container should be run as a non-root user.
+	// Optional: if false, then the kubelet may check the image for a specified user
+	// or perform defaulting to specify a user.
 	RunAsNonRoot bool `json:"runAsNonRoot,omitempty"`
 }
 
@@ -2622,15 +2636,12 @@ type SELinuxOptions struct {
 	// User is a SELinux user label that applies to the container.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	User string `json:"user,omitempty"`
-
 	// Role is a SELinux role label that applies to the container.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	Role string `json:"role,omitempty"`
-
 	// Type is a SELinux type label that applies to the container.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	Type string `json:"type,omitempty"`
-
 	// Level is SELinux level label that applies to the container.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md
 	Level string `json:"level,omitempty"`

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -941,6 +941,14 @@ func (PodProxyOptions) SwaggerDoc() map[string]string {
 	return map_PodProxyOptions
 }
 
+var map_PodSecurityContext = map[string]string{
+	"": "PodSecurityContext holds pod-level security attributes and common container settings.",
+}
+
+func (PodSecurityContext) SwaggerDoc() map[string]string {
+	return map_PodSecurityContext
+}
+
 var map_PodSpec = map[string]string{
 	"":                              "PodSpec is a description of a pod.",
 	"volumes":                       "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md",
@@ -956,6 +964,7 @@ var map_PodSpec = map[string]string{
 	"hostNetwork":                   "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
 	"hostPID":                       "Use the host's pid namespace. Optional: Default to false.",
 	"hostIPC":                       "Use the host's ipc namespace. Optional: Default to false.",
+	"securityContext":               "SecurityContext holds pod-level security attributes and common container settings",
 	"imagePullSecrets":              "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod",
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types_swagger_doc_generated.go
@@ -942,7 +942,12 @@ func (PodProxyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityContext = map[string]string{
-	"": "PodSecurityContext holds pod-level security attributes and common container settings.",
+	"":               "PodSecurityContext holds pod-level security attributes and common container settings.",
+	"capabilities":   "Capabilities are the capabilities to add/drop when running containers. Optional: Defaults to the default set of capabilities granted by the container runtime.",
+	"privileged":     "Run all containers in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Optional: Default to false",
+	"seLinuxOptions": "SELinuxOptions is the SELinux context to be applied to all containers Optional: docker daemon will allocate a random SELinux context for each container if unspecified.",
+	"runAsUser":      "RunAsUser is the UID to run the entrypoint of all container processes. Optional: defaults to user specified in image metadata if unspecified.",
+	"runAsNonRoot":   "RunAsNonRoot indicates that all containers should be run as a non-root user. Optional: if false, then the kubelet may check the image for a specified user or perform defaulting to specify a user.",
 }
 
 func (PodSecurityContext) SwaggerDoc() map[string]string {
@@ -1200,12 +1205,12 @@ func (SecretVolumeSource) SwaggerDoc() map[string]string {
 }
 
 var map_SecurityContext = map[string]string{
-	"":               "SecurityContext holds security configuration that will be applied to a container.",
-	"capabilities":   "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"privileged":     "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"seLinuxOptions": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"runAsUser":      "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
-	"runAsNonRoot":   "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user.",
+	"":               "SecurityContext holds security configuration that will be applied to a container. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
+	"capabilities":   "Capabilities are the capabilities to add/drop when running containers. Optional: Defaults to the default set of capabilities granted by the container runtime.",
+	"privileged":     "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Optional: Default to false",
+	"seLinuxOptions": "SELinuxOptions is the SELinux context to be applied to the container Optional: container runtime will allocate a random SELinux context for each container if unspecified.",
+	"runAsUser":      "RunAsUser is the UID to run the entrypoint of the container process. Optional: defaults to user specified in image metadata if unspecified.",
+	"runAsNonRoot":   "RunAsNonRoot indicates that the container should be run as a non-root user. Optional: if false, then the kubelet may check the image for a specified user or perform defaulting to specify a user.",
 }
 
 func (SecurityContext) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
@@ -506,9 +506,15 @@ func convert_v1beta3_PodSpec_To_api_PodSpec(in *PodSpec, out *api.PodSpec, s con
 	}
 	out.ServiceAccountName = in.ServiceAccount
 	out.NodeName = in.Host
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+	// Backward compatibility with internal API changes for PodSecurityContext.
+	// No conversion is necessary here because PodSecurityContext is not exposed
+	// though the v1beta3 API.
+	if out.SecurityContext == nil {
+		out.SecurityContext = new(api.PodSecurityContext)
+	}
+	out.SecurityContext.HostNetwork = in.HostNetwork
+	out.SecurityContext.HostPID = in.HostPID
+	out.SecurityContext.HostIPC = in.HostIPC
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -570,9 +576,16 @@ func convert_api_PodSpec_To_v1beta3_PodSpec(in *api.PodSpec, out *PodSpec, s con
 	}
 	out.ServiceAccount = in.ServiceAccountName
 	out.Host = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+
+	// Backward compatibility with internal API changes for PodSecurityContext.
+	// No conversion is necessary here because PodSecurityContext is not exposed
+	// though the v1beta3 API.
+	if in.SecurityContext != nil {
+		out.HostPID = in.SecurityContext.HostPID
+		out.HostNetwork = in.SecurityContext.HostNetwork
+		out.HostIPC = in.SecurityContext.HostIPC
+	}
+
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
@@ -1059,7 +1059,7 @@ func ValidatePodSpec(spec *api.PodSpec) errs.ValidationErrorList {
 	allErrs = append(allErrs, validateRestartPolicy(&spec.RestartPolicy).Prefix("restartPolicy")...)
 	allErrs = append(allErrs, validateDNSPolicy(&spec.DNSPolicy).Prefix("dnsPolicy")...)
 	allErrs = append(allErrs, ValidateLabels(spec.NodeSelector, "nodeSelector")...)
-	allErrs = append(allErrs, validateHostNetwork(spec.HostNetwork, spec.Containers).Prefix("hostNetwork")...)
+	allErrs = append(allErrs, ValidatePodSecurityContext(spec.SecurityContext, spec).Prefix("securityContext")...)
 	allErrs = append(allErrs, validateImagePullSecrets(spec.ImagePullSecrets).Prefix("imagePullSecrets")...)
 	if len(spec.ServiceAccountName) > 0 {
 		if ok, msg := ValidateServiceAccountName(spec.ServiceAccountName, false); !ok {
@@ -1072,6 +1072,17 @@ func ValidatePodSpec(spec *api.PodSpec) errs.ValidationErrorList {
 			allErrs = append(allErrs, errs.NewFieldInvalid("activeDeadlineSeconds", spec.ActiveDeadlineSeconds, "activeDeadlineSeconds must be a positive integer greater than 0"))
 		}
 	}
+	return allErrs
+}
+
+// ValidatePodSecurityContext test that the specified PodSecurityContext has valid data.
+func ValidatePodSecurityContext(securityContext *api.PodSecurityContext, spec *api.PodSpec) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+
+	if securityContext != nil {
+		allErrs = append(allErrs, validateHostNetwork(securityContext.HostNetwork, spec.Containers).Prefix("hostNetwork")...)
+	}
+
 	return allErrs
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
@@ -1247,20 +1247,25 @@ func TestValidatePodSpec(t *testing.T) {
 					{HostPort: 8080, ContainerPort: 8080, Protocol: "TCP"}},
 				},
 			},
-			HostNetwork:   true,
-			HostIPC:       true,
+			SecurityContext: &api.PodSecurityContext{
+				HostNetwork: true,
+			},
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
 		},
 		{ // Populate HostIPC.
-			HostIPC:       true,
+			SecurityContext: &api.PodSecurityContext{
+				HostIPC: true,
+			},
 			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
 			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
 		},
 		{ // Populate HostPID.
-			HostPID:       true,
+			SecurityContext: &api.PodSecurityContext{
+				HostPID: true,
+			},
 			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
 			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
 			RestartPolicy: api.RestartPolicyAlways,
@@ -1312,7 +1317,9 @@ func TestValidatePodSpec(t *testing.T) {
 					{HostPort: 8080, ContainerPort: 2600, Protocol: "TCP"}},
 				},
 			},
-			HostNetwork:   true,
+			SecurityContext: &api.PodSecurityContext{
+				HostNetwork: true,
+			},
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
 		},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/experimental/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/experimental/deep_copy_generated.go
@@ -419,6 +419,42 @@ func deepCopy_api_PersistentVolumeClaimVolumeSource(in api.PersistentVolumeClaim
 	return nil
 }
 
+func deepCopy_api_PodSecurityContext(in api.PodSecurityContext, out *api.PodSecurityContext, c *conversion.Cloner) error {
+	out.HostNetwork = in.HostNetwork
+	out.HostPID = in.HostPID
+	out.HostIPC = in.HostIPC
+	if in.Capabilities != nil {
+		out.Capabilities = new(api.Capabilities)
+		if err := deepCopy_api_Capabilities(*in.Capabilities, out.Capabilities, c); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(api.SELinuxOptions)
+		if err := deepCopy_api_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
+	return nil
+}
+
 func deepCopy_api_PodSpec(in api.PodSpec, out *api.PodSpec, c *conversion.Cloner) error {
 	if in.Volumes != nil {
 		out.Volumes = make([]api.Volume, len(in.Volumes))
@@ -464,9 +500,14 @@ func deepCopy_api_PodSpec(in api.PodSpec, out *api.PodSpec, c *conversion.Cloner
 	}
 	out.ServiceAccountName = in.ServiceAccountName
 	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(api.PodSecurityContext)
+		if err := deepCopy_api_PodSecurityContext(*in.SecurityContext, out.SecurityContext, c); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -1295,6 +1336,7 @@ func init() {
 		deepCopy_api_ObjectFieldSelector,
 		deepCopy_api_ObjectMeta,
 		deepCopy_api_PersistentVolumeClaimVolumeSource,
+		deepCopy_api_PodSecurityContext,
 		deepCopy_api_PodSpec,
 		deepCopy_api_PodTemplateSpec,
 		deepCopy_api_Probe,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/experimental/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/experimental/v1/conversion.go
@@ -99,9 +99,16 @@ func convert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s conve
 	// DeprecatedServiceAccount is an alias for ServiceAccountName.
 	out.DeprecatedServiceAccount = in.ServiceAccountName
 	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(v1.PodSecurityContext)
+		if err := convert_api_PodSecurityContext_To_v1_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+
+		out.HostNetwork = in.SecurityContext.HostNetwork
+		out.HostPID = in.SecurityContext.HostPID
+		out.HostIPC = in.SecurityContext.HostIPC
+	}
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]v1.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -168,9 +175,19 @@ func convert_v1_PodSpec_To_api_PodSpec(in *v1.PodSpec, out *api.PodSpec, s conve
 		out.ServiceAccountName = in.DeprecatedServiceAccount
 	}
 	out.NodeName = in.NodeName
-	out.HostNetwork = in.HostNetwork
-	out.HostPID = in.HostPID
-	out.HostIPC = in.HostIPC
+
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(api.PodSecurityContext)
+		if err := convert_v1_PodSecurityContext_To_api_PodSecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+	}
+	if out.SecurityContext == nil {
+		out.SecurityContext = new(api.PodSecurityContext)
+	}
+	out.SecurityContext.HostNetwork = in.HostNetwork
+	out.SecurityContext.HostPID = in.HostPID
+	out.SecurityContext.HostIPC = in.HostIPC
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]api.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -421,5 +438,77 @@ func convert_v1_MetadataFile_To_api_DownwardAPIVolumeFile(in *v1.MetadataFile, o
 	if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
 		return err
 	}
+	return nil
+}
+
+func convert_api_PodSecurityContext_To_v1_PodSecurityContext(in *api.PodSecurityContext, out *v1.PodSecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*api.PodSecurityContext))(in)
+	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(v1.Capabilities)
+		if err := convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(v1.SELinuxOptions)
+		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
+	return nil
+}
+
+func convert_v1_PodSecurityContext_To_api_PodSecurityContext(in *v1.PodSecurityContext, out *api.PodSecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1.PodSecurityContext))(in)
+	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(api.Capabilities)
+		if err := convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(api.SELinuxOptions)
+		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/experimental/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/experimental/v1/deep_copy_generated.go
@@ -458,6 +458,39 @@ func deepCopy_v1_PersistentVolumeClaimVolumeSource(in v1.PersistentVolumeClaimVo
 	return nil
 }
 
+func deepCopy_v1_PodSecurityContext(in v1.PodSecurityContext, out *v1.PodSecurityContext, c *conversion.Cloner) error {
+	if in.Capabilities != nil {
+		out.Capabilities = new(v1.Capabilities)
+		if err := deepCopy_v1_Capabilities(*in.Capabilities, out.Capabilities, c); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(v1.SELinuxOptions)
+		if err := deepCopy_v1_SELinuxOptions(*in.SELinuxOptions, out.SELinuxOptions, c); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	out.RunAsNonRoot = in.RunAsNonRoot
+	return nil
+}
+
 func deepCopy_v1_PodSpec(in v1.PodSpec, out *v1.PodSpec, c *conversion.Cloner) error {
 	if in.Volumes != nil {
 		out.Volumes = make([]v1.Volume, len(in.Volumes))
@@ -508,6 +541,14 @@ func deepCopy_v1_PodSpec(in v1.PodSpec, out *v1.PodSpec, c *conversion.Cloner) e
 	out.HostNetwork = in.HostNetwork
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(v1.PodSecurityContext)
+		if err := deepCopy_v1_PodSecurityContext(*in.SecurityContext, out.SecurityContext, c); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
 	if in.ImagePullSecrets != nil {
 		out.ImagePullSecrets = make([]v1.LocalObjectReference, len(in.ImagePullSecrets))
 		for i := range in.ImagePullSecrets {
@@ -1351,6 +1392,7 @@ func init() {
 		deepCopy_v1_ObjectFieldSelector,
 		deepCopy_v1_ObjectMeta,
 		deepCopy_v1_PersistentVolumeClaimVolumeSource,
+		deepCopy_v1_PodSecurityContext,
 		deepCopy_v1_PodSpec,
 		deepCopy_v1_PodTemplateSpec,
 		deepCopy_v1_Probe,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/get_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/get_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
@@ -38,7 +39,6 @@ import (
 )
 
 func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList) {
-	grace := int64(30)
 	pods := &api.PodList{
 		ListMeta: api.ListMeta{
 			ResourceVersion: "15",
@@ -46,19 +46,11 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 		Items: []api.Pod{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}
@@ -566,7 +558,6 @@ func TestGetMultipleTypeObjectsWithDirectReference(t *testing.T) {
 	}
 }
 func watchTestData() ([]api.Pod, []watch.Event) {
-	grace := int64(30)
 	pods := []api.Pod{
 		{
 			ObjectMeta: api.ObjectMeta{
@@ -574,11 +565,7 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 				Namespace:       "test",
 				ResourceVersion: "10",
 			},
-			Spec: api.PodSpec{
-				RestartPolicy:                 api.RestartPolicyAlways,
-				DNSPolicy:                     api.DNSClusterFirst,
-				TerminationGracePeriodSeconds: &grace,
-			},
+			Spec: apitesting.DeepEqualSafePodSpec(),
 		},
 	}
 	events := []watch.Event{
@@ -590,11 +577,7 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 					Namespace:       "test",
 					ResourceVersion: "11",
 				},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec: apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 		{
@@ -605,11 +588,7 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 					Namespace:       "test",
 					ResourceVersion: "12",
 				},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec: apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}
@@ -651,7 +630,7 @@ func TestWatchSelector(t *testing.T) {
 	expected := []runtime.Object{&api.PodList{Items: pods}, events[0].Object, events[1].Object}
 	actual := tf.Printer.(*testPrinter).Objects
 	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("unexpected object: %#v %#v", expected[0], actual[0])
+		t.Errorf("unexpected object:\nExpected: %#v\n\nGot: %#v\n\n", expected[0], actual[0])
 	}
 	if len(buf.String()) == 0 {
 		t.Errorf("unexpected empty output")
@@ -689,7 +668,7 @@ func TestWatchResource(t *testing.T) {
 	expected := []runtime.Object{&pods[0], events[0].Object, events[1].Object}
 	actual := tf.Printer.(*testPrinter).Objects
 	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("unexpected object: %#v", actual)
+		t.Errorf("unexpected object:\nExpected: %#v\n\nGot: %#v\n\n", expected, actual)
 	}
 	if len(buf.String()) == 0 {
 		t.Errorf("unexpected empty output")

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 )
@@ -54,11 +55,7 @@ func TestMerge(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec: apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 		/* TODO: uncomment this test once Merge is updated to use
@@ -127,6 +124,7 @@ func TestMerge(t *testing.T) {
 					RestartPolicy:                 api.RestartPolicyAlways,
 					DNSPolicy:                     api.DNSClusterFirst,
 					TerminationGracePeriodSeconds: &grace,
+					SecurityContext:               &api.PodSecurityContext{},
 				},
 			},
 		},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/builder_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/builder_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/watch"
@@ -83,7 +84,6 @@ func fakeClientWith(testName string, t *testing.T, data map[string]string) Clien
 }
 
 func testData() (*api.PodList, *api.ServiceList) {
-	grace := int64(30)
 	pods := &api.PodList{
 		ListMeta: api.ListMeta{
 			ResourceVersion: "15",
@@ -91,19 +91,11 @@ func testData() (*api.PodList, *api.ServiceList) {
 		Items: []api.Pod{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/helper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource/helper_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -128,7 +129,6 @@ func TestHelperCreate(t *testing.T) {
 		return true
 	}
 
-	grace := int64(30)
 	tests := []struct {
 		Resp     *http.Response
 		RespFunc client.HTTPClientFunc
@@ -172,11 +172,7 @@ func TestHelperCreate(t *testing.T) {
 			Object: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
 			ExpectObject: &api.Pod{
 				ObjectMeta: api.ObjectMeta{Name: "foo"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			Resp: &http.Response{StatusCode: http.StatusOK, Body: objBody(&api.Status{Status: api.StatusSuccess})},
 			Req:  expectPost,
@@ -383,7 +379,6 @@ func TestHelperReplace(t *testing.T) {
 		return true
 	}
 
-	grace := int64(30)
 	tests := []struct {
 		Resp      *http.Response
 		RespFunc  client.HTTPClientFunc
@@ -420,11 +415,7 @@ func TestHelperReplace(t *testing.T) {
 			Object: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
 			ExpectObject: &api.Pod{
 				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			Overwrite: true,
 			RespFunc: func(req *http.Request) (*http.Response, error) {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/rolling_updater_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/rolling_updater_test.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -1010,7 +1011,6 @@ func TestUpdateExistingReplicationController(t *testing.T) {
 
 func TestUpdateWithRetries(t *testing.T) {
 	codec := testapi.Default.Codec()
-	grace := int64(30)
 	rc := &api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{Name: "rc",
 			Labels: map[string]string{
@@ -1027,11 +1027,7 @@ func TestUpdateWithRetries(t *testing.T) {
 						"foo": "bar",
 					},
 				},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec: apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/config/common_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/config/common_test.go
@@ -52,6 +52,7 @@ func TestDecodeSinglePod(t *testing.T) {
 				TerminationMessagePath: "/dev/termination-log",
 				SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults(),
 			}},
+			SecurityContext: &api.PodSecurityContext{},
 		},
 	}
 	json, err := testapi.Default.Codec().Encode(pod)
@@ -114,6 +115,7 @@ func TestDecodePodList(t *testing.T) {
 				TerminationMessagePath: "/dev/termination-log",
 				SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults(),
 			}},
+			SecurityContext: &api.PodSecurityContext{},
 		},
 	}
 	podList := &api.PodList{

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/config/file_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/config/file_test.go
@@ -88,7 +88,8 @@ func TestReadPodsFromFile(t *testing.T) {
 					Namespace: "mynamespace",
 				},
 				Spec: api.PodSpec{
-					Containers: []api.Container{{Name: "image", Image: "test/image", SecurityContext: securitycontext.ValidSecurityContextWithContainerDefaults()}},
+					Containers:      []api.Container{{Name: "image", Image: "test/image", SecurityContext: securitycontext.ValidSecurityContextWithContainerDefaults()}},
+					SecurityContext: &api.PodSecurityContext{},
 				},
 			},
 			expected: CreatePodUpdate(kubelet.SET, kubelet.FileSource, &api.Pod{
@@ -109,6 +110,7 @@ func TestReadPodsFromFile(t *testing.T) {
 						TerminationMessagePath: "/dev/termination-log",
 						ImagePullPolicy:        "IfNotPresent",
 						SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults()}},
+					SecurityContext: &api.PodSecurityContext{},
 				},
 			}),
 		},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/config/http_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/config/http_test.go
@@ -142,8 +142,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 					Namespace: "mynamespace",
 				},
 				Spec: api.PodSpec{
-					NodeName:   hostname,
-					Containers: []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
+					NodeName:        hostname,
+					Containers:      []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
+					SecurityContext: &api.PodSecurityContext{},
 				},
 			},
 			expected: CreatePodUpdate(kubelet.SET,
@@ -160,6 +161,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 						NodeName:                      hostname,
 						RestartPolicy:                 api.RestartPolicyAlways,
 						DNSPolicy:                     api.DNSClusterFirst,
+						SecurityContext:               &api.PodSecurityContext{},
 						TerminationGracePeriodSeconds: &grace,
 
 						Containers: []api.Container{{
@@ -185,8 +187,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							UID:  "111",
 						},
 						Spec: api.PodSpec{
-							NodeName:   hostname,
-							Containers: []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
+							NodeName:        hostname,
+							Containers:      []api.Container{{Name: "1", Image: "foo", ImagePullPolicy: api.PullAlways}},
+							SecurityContext: &api.PodSecurityContext{},
 						},
 					},
 					{
@@ -195,8 +198,9 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 							UID:  "222",
 						},
 						Spec: api.PodSpec{
-							NodeName:   hostname,
-							Containers: []api.Container{{Name: "2", Image: "bar", ImagePullPolicy: ""}},
+							NodeName:        hostname,
+							Containers:      []api.Container{{Name: "2", Image: "bar", ImagePullPolicy: ""}},
+							SecurityContext: &api.PodSecurityContext{},
 						},
 					},
 				},
@@ -216,6 +220,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 						RestartPolicy:                 api.RestartPolicyAlways,
 						DNSPolicy:                     api.DNSClusterFirst,
 						TerminationGracePeriodSeconds: &grace,
+						SecurityContext:               &api.PodSecurityContext{},
 
 						Containers: []api.Container{{
 							Name:  "1",
@@ -238,6 +243,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 						RestartPolicy:                 api.RestartPolicyAlways,
 						DNSPolicy:                     api.DNSClusterFirst,
 						TerminationGracePeriodSeconds: &grace,
+						SecurityContext:               &api.PodSecurityContext{},
 
 						Containers: []api.Container{{
 							Name:  "2",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager.go
@@ -908,9 +908,9 @@ func (dm *DockerManager) podInfraContainerChanged(pod *api.Pod, podInfraContaine
 	if dockerPodInfraContainer.HostConfig != nil {
 		networkMode = dockerPodInfraContainer.HostConfig.NetworkMode
 	}
-	if pod.Spec.HostNetwork {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
 		if networkMode != "host" {
-			glog.V(4).Infof("host: %v, %v", pod.Spec.HostNetwork, networkMode)
+			glog.V(4).Infof("host: %v, %v", pod.Spec.SecurityContext.HostNetwork, networkMode)
 			return true, nil
 		}
 	} else {
@@ -1387,7 +1387,7 @@ func (dm *DockerManager) runContainerInPod(pod *api.Pod, container *api.Containe
 	}
 
 	utsMode := ""
-	if pod.Spec.HostNetwork {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
 		utsMode = "host"
 	}
 	id, err := dm.runContainer(pod, container, opts, ref, netMode, ipcMode, utsMode, pidMode)
@@ -1500,7 +1500,7 @@ func (dm *DockerManager) createPodInfraContainer(pod *api.Pod) (kubeletTypes.Doc
 	netNamespace := ""
 	var ports []api.ContainerPort
 
-	if pod.Spec.HostNetwork {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
 		netNamespace = "host"
 	} else {
 		// Docker only exports ports from the pod infra container.  Let's
@@ -1899,7 +1899,7 @@ func (dm *DockerManager) doBackOff(pod *api.Pod, container *api.Container, podSt
 // getPidMode returns the pid mode to use on the docker container based on pod.Spec.HostPID.
 func getPidMode(pod *api.Pod) string {
 	pidMode := ""
-	if pod.Spec.HostPID {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostPID {
 		pidMode = "host"
 	}
 	return pidMode
@@ -1908,7 +1908,7 @@ func getPidMode(pod *api.Pod) string {
 // getIPCMode returns the ipc mode to use on the docker container based on pod.Spec.HostIPC.
 func getIPCMode(pod *api.Pod) string {
 	ipcMode := ""
-	if pod.Spec.HostIPC {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostIPC {
 		ipcMode = "host"
 	}
 	return ipcMode

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/manager_test.go
@@ -828,7 +828,7 @@ func TestIsAExitError(t *testing.T) {
 
 func generatePodInfraContainerHash(pod *api.Pod) uint64 {
 	var ports []api.ContainerPort
-	if !pod.Spec.HostNetwork {
+	if pod.Spec.SecurityContext == nil || !pod.Spec.SecurityContext.HostNetwork {
 		for _, container := range pod.Spec.Containers {
 			ports = append(ports, container.Ports...)
 		}
@@ -2124,7 +2124,9 @@ func TestSyncPodWithHostNetwork(t *testing.T) {
 			Containers: []api.Container{
 				{Name: "bar"},
 			},
-			HostNetwork: true,
+			SecurityContext: &api.PodSecurityContext{
+				HostNetwork: true,
+			},
 		},
 	}
 
@@ -2346,7 +2348,8 @@ func TestGetPidMode(t *testing.T) {
 	}
 
 	// test true
-	pod.Spec.HostPID = true
+	pod.Spec.SecurityContext = &api.PodSecurityContext{}
+	pod.Spec.SecurityContext.HostPID = true
 	pidMode = getPidMode(pod)
 	if pidMode != "host" {
 		t.Errorf("expected host pid mode for pod but got %v", pidMode)
@@ -2363,7 +2366,8 @@ func TestGetIPCMode(t *testing.T) {
 	}
 
 	// test true
-	pod.Spec.HostIPC = true
+	pod.Spec.SecurityContext = &api.PodSecurityContext{}
+	pod.Spec.SecurityContext.HostIPC = true
 	ipcMode = getIPCMode(pod)
 	if ipcMode != "host" {
 		t.Errorf("expected host ipc mode for pod but got %v", ipcMode)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1332,7 +1332,7 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 		return err
 	}
 	if egress != nil || ingress != nil {
-		if pod.Spec.HostNetwork {
+		if podUsesHostNetwork(pod) {
 			kl.recorder.Event(pod, "HostNetworkNotSupported", "Bandwidth shaping is not currently supported on the host network")
 		} else if kl.shaper != nil {
 			status, found := kl.statusManager.GetPodStatus(pod.UID)
@@ -1369,6 +1369,10 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 		}
 	}
 	return nil
+}
+
+func podUsesHostNetwork(pod *api.Pod) bool {
+	return pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork
 }
 
 // getPullSecretsForPod inspects the Pod and retrieves the referenced pull secrets
@@ -2593,7 +2597,7 @@ func (kl *Kubelet) generatePodStatus(pod *api.Pod) (api.PodStatus, error) {
 			glog.V(4).Infof("Cannot get host IP: %v", err)
 		} else {
 			podStatus.HostIP = hostIP.String()
-			if pod.Spec.HostNetwork && podStatus.PodIP == "" {
+			if podUsesHostNetwork(pod) && podStatus.PodIP == "" {
 				podStatus.PodIP = hostIP.String()
 			}
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go
@@ -2921,7 +2921,9 @@ func TestHostNetworkAllowed(t *testing.T) {
 			Containers: []api.Container{
 				{Name: "foo"},
 			},
-			HostNetwork: true,
+			SecurityContext: &api.PodSecurityContext{
+				HostNetwork: true,
+			},
 		},
 	}
 	kubelet.podManager.SetPods([]*api.Pod{pod})
@@ -2953,7 +2955,9 @@ func TestHostNetworkDisallowed(t *testing.T) {
 			Containers: []api.Container{
 				{Name: "foo"},
 			},
-			HostNetwork: true,
+			SecurityContext: &api.PodSecurityContext{
+				HostNetwork: true,
+			},
 		},
 	}
 	err := kubelet.syncPod(pod, nil, container.Pod{}, SyncPodUpdate)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/rkt/rkt.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/rkt/rkt.go
@@ -587,7 +587,7 @@ func (r *runtime) preparePod(pod *api.Pod, pullSecrets []api.Secret) (string, *k
 	}
 
 	var runPrepared string
-	if pod.Spec.HostNetwork {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
 		runPrepared = fmt.Sprintf("%s run-prepared --mds-register=false %s", r.rktBinAbsPath, uuid)
 	} else {
 		runPrepared = fmt.Sprintf("%s run-prepared --mds-register=false --private-net %s", r.rktBinAbsPath, uuid)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/util.go
@@ -40,7 +40,7 @@ func CapacityFromMachineInfo(info *cadvisorApi.MachineInfo) api.ResourceList {
 
 // Check whether we have the capabilities to run the specified pod.
 func canRunPod(pod *api.Pod) error {
-	if pod.Spec.HostNetwork {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
 		allowed, err := allowHostNetwork(pod)
 		if err != nil {
 			return err
@@ -50,7 +50,7 @@ func canRunPod(pod *api.Pod) error {
 		}
 	}
 
-	if pod.Spec.HostPID {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostPID {
 		allowed, err := allowHostPID(pod)
 		if err != nil {
 			return err
@@ -60,7 +60,7 @@ func canRunPod(pod *api.Pod) error {
 		}
 	}
 
-	if pod.Spec.HostIPC {
+	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostIPC {
 		allowed, err := allowHostIPC(pod)
 		if err != nil {
 			return err

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/pod/etcd/etcd_test.go
@@ -64,6 +64,7 @@ func validNewPod() *api.Pod {
 					SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults(),
 				},
 			},
+			SecurityContext: &api.PodSecurityContext{},
 		},
 	}
 }
@@ -617,6 +618,7 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 					SecurityContext: securitycontext.ValidSecurityContextWithContainerDefaults(),
 				},
 			},
+			SecurityContext: &api.PodSecurityContext{},
 		},
 	}), 1)
 
@@ -631,19 +633,18 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 		},
 		Spec: api.PodSpec{
 			NodeName: "machine",
-			Containers: []api.Container{
-				{
-					Name:                   "foobar",
-					Image:                  "foo:v2",
-					ImagePullPolicy:        api.PullIfNotPresent,
-					TerminationMessagePath: api.TerminationMessagePathDefault,
-					SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults(),
-				},
-			},
+			Containers: []api.Container{{
+				Name:                   "foobar",
+				Image:                  "foo:v2",
+				ImagePullPolicy:        api.PullIfNotPresent,
+				TerminationMessagePath: api.TerminationMessagePathDefault,
+				SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults(),
+			}},
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
 
 			TerminationGracePeriodSeconds: &grace,
+			SecurityContext:               &api.PodSecurityContext{},
 		},
 	}
 	_, _, err := storage.Update(ctx, &podIn)
@@ -682,6 +683,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 					SecurityContext: securitycontext.ValidSecurityContextWithContainerDefaults(),
 				},
 			},
+			SecurityContext: &api.PodSecurityContext{},
 		},
 	}
 	fakeClient.Set(key, runtime.EncodeOrDie(testapi.Default.Codec(), &podStart), 0)
@@ -703,6 +705,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 					TerminationMessagePath: api.TerminationMessagePathDefault,
 				},
 			},
+			SecurityContext: &api.PodSecurityContext{},
 		},
 		Status: api.PodStatus{
 			Phase:   api.PodRunning,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontext/provider_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontext/provider_test.go
@@ -28,91 +28,174 @@ import (
 )
 
 func TestModifyContainerConfig(t *testing.T) {
-	var uid int64 = 1
-	testCases := map[string]struct {
-		securityContext *api.SecurityContext
-		expected        *docker.Config
+	var uid int64 = 123
+	var overrideUid int64 = 321
+
+	cases := []struct {
+		name     string
+		podSc    *api.PodSecurityContext
+		sc       *api.SecurityContext
+		expected *docker.Config
 	}{
-		"modify config, value set for user": {
-			securityContext: &api.SecurityContext{
+		{
+			name: "container.SecurityContext.RunAsUser set",
+			sc: &api.SecurityContext{
 				RunAsUser: &uid,
 			},
 			expected: &docker.Config{
 				User: strconv.FormatInt(uid, 10),
 			},
 		},
-		"modify config, nil user value": {
-			securityContext: &api.SecurityContext{},
-			expected:        &docker.Config{},
+		{
+			name:     "no RunAsUser value set",
+			sc:       &api.SecurityContext{},
+			expected: &docker.Config{},
+		},
+		{
+			name: "pod.Spec.SecurityContext.RunAsUser set",
+			podSc: &api.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			expected: &docker.Config{
+				User: strconv.FormatInt(uid, 10),
+			},
+		},
+		{
+			name: "container.SecurityContext.RunAsUser overrides pod.Spec.SecurityContext.RunAsUser",
+			podSc: &api.PodSecurityContext{
+				RunAsUser: &uid,
+			},
+			sc: &api.SecurityContext{
+				RunAsUser: &overrideUid,
+			},
+			expected: &docker.Config{
+				User: strconv.FormatInt(overrideUid, 10),
+			},
 		},
 	}
 
 	provider := NewSimpleSecurityContextProvider()
 	dummyContainer := &api.Container{}
-	for k, v := range testCases {
-		dummyContainer.SecurityContext = v.securityContext
+	for _, tc := range cases {
+		pod := &api.Pod{Spec: api.PodSpec{SecurityContext: tc.podSc}}
+		dummyContainer.SecurityContext = tc.sc
 		dockerCfg := &docker.Config{}
-		provider.ModifyContainerConfig(nil, dummyContainer, dockerCfg)
-		if !reflect.DeepEqual(v.expected, dockerCfg) {
-			t.Errorf("unexpected modification of docker config for %s.  Expected: %#v Got: %#v", k, v.expected, dockerCfg)
+
+		provider.ModifyContainerConfig(pod, dummyContainer, dockerCfg)
+
+		if e, a := tc.expected, dockerCfg; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: unexpected modification of docker config\nExpected:\n\n%#v\n\nGot:\n\n%#v", tc.name, e, a)
 		}
 	}
 }
 
 func TestModifyHostConfig(t *testing.T) {
-	nilPrivSC := fullValidSecurityContext()
-	nilPrivSC.Privileged = nil
-	nilPrivHC := fullValidHostConfig()
-	nilPrivHC.Privileged = false
+	priv := true
+	setPrivSC := &api.SecurityContext{}
+	setPrivSC.Privileged = &priv
+	setPrivHC := &docker.HostConfig{
+		Privileged: true,
+	}
 
-	nilCapsSC := fullValidSecurityContext()
-	nilCapsSC.Capabilities = nil
-	nilCapsHC := fullValidHostConfig()
-	nilCapsHC.CapAdd = *new([]string)
-	nilCapsHC.CapDrop = *new([]string)
+	setCapsHC := &docker.HostConfig{
+		CapAdd:  []string{"addCapA", "addCapB"},
+		CapDrop: []string{"dropCapA", "dropCapB"},
+	}
 
-	nilSELinuxSC := fullValidSecurityContext()
-	nilSELinuxSC.SELinuxOptions = nil
-	nilSELinuxHC := fullValidHostConfig()
-	nilSELinuxHC.SecurityOpt = *new([]string)
+	setSELinuxHC := &docker.HostConfig{}
+	setSELinuxHC.SecurityOpt = []string{
+		fmt.Sprintf("%s:%s", dockerLabelUser, "user"),
+		fmt.Sprintf("%s:%s", dockerLabelRole, "role"),
+		fmt.Sprintf("%s:%s", dockerLabelType, "type"),
+		fmt.Sprintf("%s:%s", dockerLabelLevel, "level"),
+	}
 
-	seLinuxLabelsSC := fullValidSecurityContext()
-	seLinuxLabelsHC := fullValidHostConfig()
+	// seLinuxLabelsSC := fullValidSecurityContext()
+	// seLinuxLabelsHC := fullValidHostConfig()
 
-	testCases := map[string]struct {
-		securityContext *api.SecurityContext
-		expected        *docker.HostConfig
+	cases := []struct {
+		name     string
+		podSc    *api.PodSecurityContext
+		sc       *api.SecurityContext
+		expected *docker.HostConfig
 	}{
-		"full settings": {
-			securityContext: fullValidSecurityContext(),
-			expected:        fullValidHostConfig(),
+		{
+			name:     "fully set container.SecurityContext",
+			sc:       fullValidSecurityContext(),
+			expected: fullValidHostConfig(),
 		},
-		"nil privileged": {
-			securityContext: nilPrivSC,
-			expected:        nilPrivHC,
+		{
+			name:     "container.SecurityContext.Privileged",
+			sc:       setPrivSC,
+			expected: setPrivHC,
 		},
-		"nil capabilities": {
-			securityContext: nilCapsSC,
-			expected:        nilCapsHC,
+		{
+			name: "container.SecurityContext.Capabilities",
+			sc: &api.SecurityContext{
+				Capabilities: inputCapabilities(),
+			},
+			expected: setCapsHC,
 		},
-		"nil selinux options": {
-			securityContext: nilSELinuxSC,
-			expected:        nilSELinuxHC,
+		{
+			name: "container.SecurityContext.SELinuxOptions",
+			sc: &api.SecurityContext{
+				SELinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
 		},
-		"selinux labels": {
-			securityContext: seLinuxLabelsSC,
-			expected:        seLinuxLabelsHC,
+		{
+			name:     "full pod.Spec.SecurityContext",
+			podSc:    fullValidPodSecurityContext(),
+			expected: fullValidHostConfig(),
+		},
+		{
+			name: "pod.Spec.SecurityContext.SELinuxOptions",
+			podSc: &api.PodSecurityContext{
+				SELinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
+		},
+		{
+			name: "pod.Spec.SecurityContext.Privileged",
+			podSc: &api.PodSecurityContext{
+				Privileged: &priv,
+			},
+			expected: setPrivHC,
+		},
+		{
+			name: "pod.Spec.SecurityContext.Capabilities",
+			podSc: &api.PodSecurityContext{
+				Capabilities: inputCapabilities(),
+			},
+			expected: setCapsHC,
+		},
+		{
+			name: "pod.Spec.SecurityContext.SELinuxOptions",
+			podSc: &api.PodSecurityContext{
+				SELinuxOptions: inputSELinuxOptions(),
+			},
+			expected: setSELinuxHC,
+		},
+		{
+			name:     "container.SecurityContext overrides pod.Spec.SecurityContext",
+			podSc:    overridePodSecurityContext(),
+			sc:       fullValidSecurityContext(),
+			expected: fullValidHostConfig(),
 		},
 	}
 
 	provider := NewSimpleSecurityContextProvider()
 	dummyContainer := &api.Container{}
-	for k, v := range testCases {
-		dummyContainer.SecurityContext = v.securityContext
+
+	for _, tc := range cases {
+		pod := &api.Pod{Spec: api.PodSpec{SecurityContext: tc.podSc}}
+		dummyContainer.SecurityContext = tc.sc
 		dockerCfg := &docker.HostConfig{}
-		provider.ModifyHostConfig(nil, dummyContainer, dockerCfg)
-		if !reflect.DeepEqual(v.expected, dockerCfg) {
-			t.Errorf("unexpected modification of host config for %s.  Expected: %#v Got: %#v", k, v.expected, dockerCfg)
+
+		provider.ModifyHostConfig(pod, dummyContainer, dockerCfg)
+
+		if e, a := tc.expected, dockerCfg; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: unexpected modification of host config\nExpected:\n\n%#v\n\nGot:\n\n%#v", tc.name, e, a)
 		}
 	}
 }
@@ -149,20 +232,54 @@ func TestModifySecurityOption(t *testing.T) {
 	}
 }
 
+func overridePodSecurityContext() *api.PodSecurityContext {
+	priv := false
+	return &api.PodSecurityContext{
+		Privileged: &priv,
+		Capabilities: &api.Capabilities{
+			Add:  []api.Capability{"addCapC", "addCapD"},
+			Drop: []api.Capability{"dropCapC", "dropCapD"},
+		},
+		SELinuxOptions: &api.SELinuxOptions{
+			User:  "user2",
+			Role:  "role2",
+			Type:  "type2",
+			Level: "level2",
+		},
+	}
+}
+
+func fullValidPodSecurityContext() *api.PodSecurityContext {
+	priv := true
+	return &api.PodSecurityContext{
+		Privileged:     &priv,
+		Capabilities:   inputCapabilities(),
+		SELinuxOptions: inputSELinuxOptions(),
+	}
+}
+
 func fullValidSecurityContext() *api.SecurityContext {
 	priv := true
 	return &api.SecurityContext{
-		Privileged: &priv,
-		Capabilities: &api.Capabilities{
-			Add:  []api.Capability{"addCapA", "addCapB"},
-			Drop: []api.Capability{"dropCapA", "dropCapB"},
-		},
-		SELinuxOptions: &api.SELinuxOptions{
-			User:  "user",
-			Role:  "role",
-			Type:  "type",
-			Level: "level",
-		},
+		Privileged:     &priv,
+		Capabilities:   inputCapabilities(),
+		SELinuxOptions: inputSELinuxOptions(),
+	}
+}
+
+func inputCapabilities() *api.Capabilities {
+	return &api.Capabilities{
+		Add:  []api.Capability{"addCapA", "addCapB"},
+		Drop: []api.Capability{"dropCapA", "dropCapB"},
+	}
+}
+
+func inputSELinuxOptions() *api.SELinuxOptions {
+	return &api.SELinuxOptions{
+		User:  "user",
+		Role:  "role",
+		Type:  "type",
+		Level: "level",
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
@@ -167,8 +167,8 @@ func (s *simpleProvider) ValidateSecurityContext(pod *api.Pod, container *api.Co
 		}
 	}
 
-	if !s.scc.AllowHostNetwork && pod.Spec.HostNetwork {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostNetwork", pod.Spec.HostNetwork, "Host network is not allowed to be used"))
+	if !s.scc.AllowHostNetwork && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostNetwork", pod.Spec.SecurityContext.HostNetwork, "Host network is not allowed to be used"))
 	}
 
 	if !s.scc.AllowHostPorts {
@@ -177,12 +177,12 @@ func (s *simpleProvider) ValidateSecurityContext(pod *api.Pod, container *api.Co
 		}
 	}
 
-	if !s.scc.AllowHostPID && pod.Spec.HostPID {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostPID", pod.Spec.HostPID, "Host PID is not allowed to be used"))
+	if !s.scc.AllowHostPID && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostPID {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostPID", pod.Spec.SecurityContext.HostPID, "Host PID is not allowed to be used"))
 	}
 
-	if !s.scc.AllowHostIPC && pod.Spec.HostIPC {
-		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostIPC", pod.Spec.HostIPC, "Host IPC is not allowed to be used"))
+	if !s.scc.AllowHostIPC && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostIPC {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("hostIPC", pod.Spec.SecurityContext.HostIPC, "Host IPC is not allowed to be used"))
 	}
 
 	return allErrs

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider_test.go
@@ -101,6 +101,7 @@ func TestValidateFailures(t *testing.T) {
 	defaultPod := func() *api.Pod {
 		return &api.Pod{
 			Spec: api.PodSpec{
+				SecurityContext: &api.PodSecurityContext{},
 				Containers: []api.Container{
 					{
 						SecurityContext: &api.SecurityContext{
@@ -158,13 +159,13 @@ func TestValidateFailures(t *testing.T) {
 	}
 
 	failHostNetworkPod := defaultPod()
-	failHostNetworkPod.Spec.HostNetwork = true
+	failHostNetworkPod.Spec.SecurityContext.HostNetwork = true
 
 	failHostPIDPod := defaultPod()
-	failHostPIDPod.Spec.HostPID = true
+	failHostPIDPod.Spec.SecurityContext.HostPID = true
 
 	failHostIPCPod := defaultPod()
-	failHostIPCPod.Spec.HostIPC = true
+	failHostIPCPod.Spec.SecurityContext.HostIPC = true
 
 	failHostPortPod := defaultPod()
 	failHostPortPod.Spec.Containers[0].Ports = []api.ContainerPort{{HostPort: 1}}
@@ -256,6 +257,7 @@ func TestValidateSuccess(t *testing.T) {
 	defaultPod := func() *api.Pod {
 		return &api.Pod{
 			Spec: api.PodSpec{
+				SecurityContext: &api.PodSecurityContext{},
 				Containers: []api.Container{
 					{
 						SecurityContext: &api.SecurityContext{
@@ -320,17 +322,17 @@ func TestValidateSuccess(t *testing.T) {
 	hostNetworkSCC := defaultSCC()
 	hostNetworkSCC.AllowHostNetwork = true
 	hostNetworkPod := defaultPod()
-	hostNetworkPod.Spec.HostNetwork = true
+	hostNetworkPod.Spec.SecurityContext.HostNetwork = true
 
 	hostPIDSCC := defaultSCC()
 	hostPIDSCC.AllowHostPID = true
 	hostPIDPod := defaultPod()
-	hostPIDPod.Spec.HostPID = true
+	hostPIDPod.Spec.SecurityContext.HostPID = true
 
 	hostIPCSCC := defaultSCC()
 	hostIPCSCC.AllowHostIPC = true
 	hostIPCPod := defaultPod()
-	hostIPCPod.Spec.HostIPC = true
+	hostIPCPod.Spec.SecurityContext.HostIPC = true
 
 	hostPortSCC := defaultSCC()
 	hostPortSCC.AllowHostPorts = true

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/cacher_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/cacher_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
@@ -55,14 +56,9 @@ func newTestCacher(client tools.EtcdClient) *storage.Cacher {
 }
 
 func makeTestPod(name string) *api.Pod {
-	gracePeriod := int64(30)
 	return &api.Pod{
 		ObjectMeta: api.ObjectMeta{Namespace: "ns", Name: name},
-		Spec: api.PodSpec{
-			TerminationGracePeriodSeconds: &gracePeriod,
-			DNSPolicy:                     api.DNSClusterFirst,
-			RestartPolicy:                 api.RestartPolicyAlways,
-		},
+		Spec:       apitesting.DeepEqualSafePodSpec(),
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/etcd_helper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/etcd_helper_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
@@ -123,33 +124,20 @@ func TestList(t *testing.T) {
 			},
 		},
 	}
-	grace := int64(30)
 	expect := api.PodList{
 		ListMeta: api.ListMeta{ResourceVersion: "10"},
 		Items: []api.Pod{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", ResourceVersion: "2"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "baz", ResourceVersion: "3"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}
@@ -210,34 +198,21 @@ func TestListAcrossDirectories(t *testing.T) {
 			},
 		},
 	}
-	grace := int64(30)
 	expect := api.PodList{
 		ListMeta: api.ListMeta{ResourceVersion: "10"},
 		Items: []api.Pod{
 			// We expect list to be sorted by directory (e.g. namespace) first, then by name.
 			{
 				ObjectMeta: api.ObjectMeta{Name: "baz", ResourceVersion: "3"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", ResourceVersion: "2"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}
@@ -286,33 +261,20 @@ func TestListExcludesDirectories(t *testing.T) {
 			},
 		},
 	}
-	grace := int64(30)
 	expect := api.PodList{
 		ListMeta: api.ListMeta{ResourceVersion: "10"},
 		Items: []api.Pod{
 			{
 				ObjectMeta: api.ObjectMeta{Name: "bar", ResourceVersion: "2"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "baz", ResourceVersion: "3"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
-				Spec: api.PodSpec{
-					RestartPolicy:                 api.RestartPolicyAlways,
-					DNSPolicy:                     api.DNSClusterFirst,
-					TerminationGracePeriodSeconds: &grace,
-				},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 		},
 	}
@@ -331,14 +293,9 @@ func TestGet(t *testing.T) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	helper := newEtcdHelper(fakeClient, testapi.Default.Codec(), etcdtest.PathPrefix())
 	key := etcdtest.AddPrefix("/some/key")
-	grace := int64(30)
 	expect := api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo"},
-		Spec: api.PodSpec{
-			RestartPolicy:                 api.RestartPolicyAlways,
-			DNSPolicy:                     api.DNSClusterFirst,
-			TerminationGracePeriodSeconds: &grace,
-		},
+		Spec:       apitesting.DeepEqualSafePodSpec(),
 	}
 	fakeClient.Set(key, runtime.EncodeOrDie(testapi.Default.Codec(), &expect), 0)
 	var got api.Pod

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/exec/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/exec/admission.go
@@ -90,11 +90,11 @@ func (d *denyExec) Admit(a admission.Attributes) (err error) {
 		return admission.NewForbidden(a, err)
 	}
 
-	if d.hostPID && pod.Spec.HostPID {
+	if d.hostPID && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostPID {
 		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a container using host pid"))
 	}
 
-	if d.hostIPC && pod.Spec.HostIPC {
+	if d.hostIPC && pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostIPC {
 		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a container using host ipc"))
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/exec/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/exec/admission_test.go
@@ -34,10 +34,12 @@ func TestAdmission(t *testing.T) {
 	}
 
 	hostPIDPod := validPod("hostPID")
-	hostPIDPod.Spec.HostPID = true
+	hostPIDPod.Spec.SecurityContext = &api.PodSecurityContext{}
+	hostPIDPod.Spec.SecurityContext.HostPID = true
 
 	hostIPCPod := validPod("hostIPC")
-	hostIPCPod.Spec.HostIPC = true
+	hostIPCPod.Spec.SecurityContext = &api.PodSecurityContext{}
+	hostIPCPod.Spec.SecurityContext.HostIPC = true
 
 	testCases := map[string]struct {
 		pod          *api.Pod
@@ -130,10 +132,12 @@ func TestDenyExecOnPrivileged(t *testing.T) {
 	}
 
 	hostPIDPod := validPod("hostPID")
-	hostPIDPod.Spec.HostPID = true
+	hostPIDPod.Spec.SecurityContext = &api.PodSecurityContext{}
+	hostPIDPod.Spec.SecurityContext.HostPID = true
 
 	hostIPCPod := validPod("hostIPC")
-	hostIPCPod.Spec.HostIPC = true
+	hostIPCPod.Spec.SecurityContext = &api.PodSecurityContext{}
+	hostIPCPod.Spec.SecurityContext.HostIPC = true
 
 	testCases := map[string]struct {
 		pod          *api.Pod

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -46,8 +46,7 @@ func NewSecurityContextDeny(client client.Interface) admission.Interface {
 	}
 }
 
-// Admit will deny any SecurityContext that defines options that were not previously available in the api.Container
-// struct (Capabilities and Privileged)
+// Admit will deny any pod that defines SELinuxOptions or RunAsUser.
 func (p *plugin) Admit(a admission.Attributes) (err error) {
 	if a.GetResource() != string(api.ResourcePods) {
 		return nil
@@ -56,6 +55,14 @@ func (p *plugin) Admit(a admission.Attributes) (err error) {
 	pod, ok := a.GetObject().(*api.Pod)
 	if !ok {
 		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+	if pod.Spec.SecurityContext != nil {
+		if pod.Spec.SecurityContext.SELinuxOptions != nil {
+			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.SELinuxOptions is forbidden"))
+		}
+		if pod.Spec.SecurityContext.RunAsUser != nil {
+			return apierrors.NewForbidden(a.GetResource(), pod.Name, fmt.Errorf("pod.Spec.SecurityContext.RunAsUser is forbidden"))
+		}
 	}
 	for _, v := range pod.Spec.Containers {
 		if v.SecurityContext != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny/admission_test.go
@@ -29,37 +29,64 @@ func TestAdmission(t *testing.T) {
 
 	var runAsUser int64 = 1
 	priv := true
-	successCases := map[string]*api.SecurityContext{
-		"no sc":    nil,
-		"empty sc": {},
-		"valid sc": {Privileged: &priv, Capabilities: &api.Capabilities{}},
-	}
 
-	pod := api.Pod{
-		Spec: api.PodSpec{
-			Containers: []api.Container{
-				{},
-			},
+	cases := []struct {
+		name        string
+		sc          *api.SecurityContext
+		podSc       *api.PodSecurityContext
+		expectError bool
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name: "empty container.SecurityContext",
+			sc:   &api.SecurityContext{},
+		},
+		{
+			name:  "empty pod.Spec.SecurityContext",
+			podSc: &api.PodSecurityContext{},
+		},
+		{
+			name: "valid container.SecurityContext",
+			sc:   &api.SecurityContext{Privileged: &priv, Capabilities: &api.Capabilities{}},
+		},
+		{
+			name:  "valid pod.Spec.SecurityContext",
+			podSc: &api.PodSecurityContext{Privileged: &priv, Capabilities: &api.Capabilities{}},
+		},
+		{
+			name:        "container.SecurityContext.RunAsUser",
+			sc:          &api.SecurityContext{RunAsUser: &runAsUser},
+			expectError: true,
+		},
+		{
+			name:        "container.SecurityContext.SELinuxOptions",
+			sc:          &api.SecurityContext{SELinuxOptions: &api.SELinuxOptions{}},
+			expectError: true,
+		},
+		{
+			name:        "pod.Spec.SecurityContext.RunAsUser",
+			podSc:       &api.PodSecurityContext{RunAsUser: &runAsUser},
+			expectError: true,
+		},
+		{
+			name:        "pod.Spec.SecurityContext.SELinuxOptions",
+			podSc:       &api.PodSecurityContext{SELinuxOptions: &api.SELinuxOptions{}},
+			expectError: true,
 		},
 	}
-	for k, v := range successCases {
-		pod.Spec.Containers[0].SecurityContext = v
-		err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", "foo", "name", string(api.ResourcePods), "", "ignored", nil))
-		if err != nil {
-			t.Errorf("Unexpected error returned from admission handler for case %s", k)
-		}
-	}
 
-	errorCases := map[string]*api.SecurityContext{
-		"run as user":     {RunAsUser: &runAsUser},
-		"se linux optons": {SELinuxOptions: &api.SELinuxOptions{}},
-		"mixed settings":  {Privileged: &priv, RunAsUser: &runAsUser, SELinuxOptions: &api.SELinuxOptions{}},
-	}
-	for k, v := range errorCases {
-		pod.Spec.Containers[0].SecurityContext = v
-		err := handler.Admit(admission.NewAttributesRecord(&pod, "Pod", "foo", "name", string(api.ResourcePods), "", "ignored", nil))
-		if err == nil {
-			t.Errorf("Expected error returned from admission handler for case %s", k)
+	for _, tc := range cases {
+		pod := pod()
+		pod.Spec.SecurityContext = tc.podSc
+		pod.Spec.Containers[0].SecurityContext = tc.sc
+
+		err := handler.Admit(admission.NewAttributesRecord(pod, "Pod", "foo", "name", string(api.ResourcePods), "", "ignored", nil))
+		if err != nil && !tc.expectError {
+			t.Errorf("%v: unexpected error: %v", tc.name, err)
+		} else if err == nil && tc.expectError {
+			t.Errorf("%v: expected error", tc.name)
 		}
 	}
 }
@@ -77,5 +104,15 @@ func TestHandles(t *testing.T) {
 		if result != expected {
 			t.Errorf("Unexpected result for operation %s: %v\n", op, result)
 		}
+	}
+}
+
+func pod() *api.Pod {
+	return &api.Pod{
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{},
+			},
+		},
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -133,14 +134,9 @@ func PriorityTwo(pod *api.Pod, podLister algorithm.PodLister, minionLister algor
 }
 
 func TestDefaultErrorFunc(t *testing.T) {
-	grace := int64(30)
 	testPod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "bar"},
-		Spec: api.PodSpec{
-			RestartPolicy:                 api.RestartPolicyAlways,
-			DNSPolicy:                     api.DNSClusterFirst,
-			TerminationGracePeriodSeconds: &grace,
-		},
+		Spec:       apitesting.DeepEqualSafePodSpec(),
 	}
 	handler := util.FakeHandler{
 		StatusCode:   200,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/security_context.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/security_context.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("[Skipped] Security Context", func() {
+	framework := NewFramework("security-context")
+
+	It("should support pod.Spec.SecurityContext.RunAsUser", func() {
+		podName := "security-context-" + string(util.NewUUID())
+		pod := &api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name:   podName,
+				Labels: map[string]string{"name": podName},
+			},
+			Spec: api.PodSpec{
+				SecurityContext: &api.PodSecurityContext{},
+				Containers: []api.Container{
+					{
+						Name:    "test-container",
+						Image:   "gcr.io/google_containers/busybox",
+						Command: []string{"sh", "-c", "id -u"},
+					},
+				},
+				RestartPolicy: api.RestartPolicyNever,
+			},
+		}
+
+		var uid int64 = 1001
+		pod.Spec.SecurityContext.RunAsUser = &uid
+
+		framework.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+			fmt.Sprintf("%v", uid),
+		})
+	})
+
+	It("should support container.SecurityContext.RunAsUser", func() {
+		podName := "security-context-" + string(util.NewUUID())
+		pod := &api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name:   podName,
+				Labels: map[string]string{"name": podName},
+			},
+			Spec: api.PodSpec{
+				SecurityContext: &api.PodSecurityContext{},
+				Containers: []api.Container{
+					{
+						Name:            "test-container",
+						Image:           "gcr.io/google_containers/busybox",
+						Command:         []string{"sh", "-c", "id -u"},
+						SecurityContext: &api.SecurityContext{},
+					},
+				},
+				RestartPolicy: api.RestartPolicyNever,
+			},
+		}
+
+		var uid int64 = 1001
+		var overrideUid int64 = 1002
+		pod.Spec.SecurityContext.RunAsUser = &uid
+		pod.Spec.Containers[0].SecurityContext.RunAsUser = &overrideUid
+
+		framework.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+			fmt.Sprintf("%v", overrideUid),
+		})
+	})
+})

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -13384,6 +13384,10 @@
       "type": "boolean",
       "description": "Use the host's ipc namespace. Optional: Default to false."
      },
+     "securityContext": {
+      "$ref": "v1.PodSecurityContext",
+      "description": "SecurityContext holds pod-level security attributes and common container settings"
+     },
      "imagePullSecrets": {
       "type": "array",
       "items": {
@@ -13960,6 +13964,19 @@
      "level": {
       "type": "string",
       "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+     }
+    }
+   },
+   "v1.PodSecurityContext": {
+    "id": "v1.PodSecurityContext",
+    "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "properties": {
+     "supplementalGroups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "SupplementalGroups can be used to specify a list of groups which the main container process will run as. This will be applied to all containers in the pod."
      }
     }
    },

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -15356,6 +15356,10 @@
       "type": "boolean",
       "description": "Use the host's ipc namespace. Optional: Default to false."
      },
+     "securityContext": {
+      "$ref": "v1.PodSecurityContext",
+      "description": "SecurityContext holds pod-level security attributes and common container settings"
+     },
      "imagePullSecrets": {
       "type": "array",
       "items": {
@@ -16127,6 +16131,19 @@
      "level": {
       "type": "string",
       "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+     }
+    }
+   },
+   "v1.PodSecurityContext": {
+    "id": "v1.PodSecurityContext",
+    "description": "PodSecurityContext holds pod-level security attributes and common container settings.",
+    "properties": {
+     "supplementalGroups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "SupplementalGroups can be used to specify a list of groups which the main container process will run as. This will be applied to all containers in the pod."
      }
     }
    },

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -382,7 +382,7 @@ func TestSpecificKind(t *testing.T) {
 	api.Scheme.Log(t)
 	defer api.Scheme.Log(nil)
 
-	kind := "ImageStreamTag"
+	kind := "DeploymentConfig"
 	item, err := api.Scheme.New("", kind)
 	if err != nil {
 		t.Errorf("Couldn't make a %v? %v", kind, err)

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -371,8 +371,13 @@ func roundTrip(t *testing.T, codec runtime.Codec, originalItem runtime.Object) {
 	}
 }
 
+// skipStandardVersions is a map of Kind to a list of API versions to test with.
 var skipStandardVersions = map[string][]string{
-	"DockerImage": {"pre012", "1.0"},
+	// The API versions here are to test our object that serializes from/into
+	// docker's registry API.
+	"DockerImage":          {"pre012", "1.0"},
+	"DeploymentConfigList": {"", "v1"},
+	"DeploymentConfig":     {"", "v1"},
 }
 
 const fuzzIters = 20
@@ -382,17 +387,25 @@ func TestSpecificKind(t *testing.T) {
 	api.Scheme.Log(t)
 	defer api.Scheme.Log(nil)
 
-	kind := "DeploymentConfig"
+	kind := "BuildConfig"
 	item, err := api.Scheme.New("", kind)
 	if err != nil {
 		t.Errorf("Couldn't make a %v? %v", kind, err)
 		return
 	}
 	seed := int64(2703387474910584091) //rand.Int63()
-	fuzzInternalObject(t, "", item, seed)
-	roundTrip(t, osapi.Codec, item)
-	roundTrip(t, v1beta3.Codec, item)
-	roundTrip(t, v1.Codec, item)
+
+	for i := 0; i < fuzzIters; i++ {
+		t.Logf(`About to test %v with ""`, kind)
+		fuzzInternalObject(t, "", item, seed)
+		roundTrip(t, osapi.Codec, item)
+		t.Logf(`About to test %v with "v1beta3"`, kind)
+		fuzzInternalObject(t, "v1beta3", item, seed)
+		roundTrip(t, v1beta3.Codec, item)
+		t.Logf(`About to test %v with "v1"`, kind)
+		fuzzInternalObject(t, "v1", item, seed)
+		roundTrip(t, v1.Codec, item)
+	}
 }
 
 func TestTypes(t *testing.T) {
@@ -400,7 +413,6 @@ func TestTypes(t *testing.T) {
 		if !strings.Contains(reflectType.PkgPath(), "/origin/") {
 			continue
 		}
-		t.Logf("About to test %v", reflectType)
 		// Try a few times, since runTest uses random values.
 		for i := 0; i < fuzzIters; i++ {
 			item, err := api.Scheme.New("", kind)
@@ -415,17 +427,21 @@ func TestTypes(t *testing.T) {
 
 			if versions, ok := skipStandardVersions[kind]; ok {
 				for _, v := range versions {
-					fuzzInternalObject(t, "", item, seed)
+					t.Logf("About to test %v in %v", reflectType, v)
+					fuzzInternalObject(t, v, item, seed)
 					roundTrip(t, runtime.CodecFor(api.Scheme, v), item)
 				}
 				continue
 			}
-			fuzzInternalObject(t, "", item, seed)
-			roundTrip(t, osapi.Codec, item)
+			// t.Logf(`About to test %v with ""`, kind)
+			// fuzzInternalObject(t, "", item, seed)
+			// roundTrip(t, osapi.Codec, item)
+			t.Logf(`About to test %v with "v1beta3"`, kind)
 			fuzzInternalObject(t, "v1beta3", item, seed)
 			roundTrip(t, v1beta3.Codec, item)
-			fuzzInternalObject(t, "v1", item, seed)
-			roundTrip(t, v1.Codec, item)
+			// t.Logf(`About to test %v with "v1"`, kind)
+			// fuzzInternalObject(t, "v1", item, seed)
+			// roundTrip(t, v1.Codec, item)
 		}
 	}
 }

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -527,7 +527,9 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 						Template: &kapi.PodTemplateSpec{
 							ObjectMeta: kapi.ObjectMeta{Labels: label},
 							Spec: kapi.PodSpec{
-								HostNetwork:        cfg.HostNetwork,
+								SecurityContext: &kapi.PodSecurityContext{
+									HostNetwork: cfg.HostNetwork,
+								},
 								ServiceAccountName: cfg.ServiceAccount,
 								NodeSelector:       nodeSelector,
 								Containers: []kapi.Container{

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -155,7 +155,9 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 	podTemplate := &kapi.PodTemplateSpec{
 		ObjectMeta: kapi.ObjectMeta{Labels: selector},
 		Spec: kapi.PodSpec{
-			HostNetwork:        true,
+			SecurityContext: &kapi.PodSecurityContext{
+				HostNetwork: true,
+			},
 			NodeSelector:       generateNodeSelector(name, selector),
 			Containers:         containers,
 			Volumes:            generateVolumeConfig(),

--- a/pkg/ipfailover/keepalived/generator_test.go
+++ b/pkg/ipfailover/keepalived/generator_test.go
@@ -101,7 +101,7 @@ func TestGenerateDeploymentConfig(t *testing.T) {
 		}
 
 		podSpec := controller.Template.Spec
-		if !podSpec.HostNetwork {
+		if podSpec.SecurityContext == nil || !podSpec.SecurityContext.HostNetwork {
 			t.Errorf("Test case for %s got HostNetwork disabled where HostNetwork was expected to be enabled", tc.Name)
 		}
 

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -91,6 +91,7 @@ func TestAdmit(t *testing.T) {
 		return &kapi.Pod{
 			Spec: kapi.PodSpec{
 				ServiceAccountName: "default",
+				SecurityContext:    &kapi.PodSecurityContext{},
 				Containers: []kapi.Container{
 					{
 						SecurityContext: &kapi.SecurityContext{},
@@ -125,13 +126,13 @@ func TestAdmit(t *testing.T) {
 	}
 
 	requestsHostNetwork := goodPod()
-	requestsHostNetwork.Spec.HostNetwork = true
+	requestsHostNetwork.Spec.SecurityContext.HostNetwork = true
 
 	requestsHostPID := goodPod()
-	requestsHostPID.Spec.HostPID = true
+	requestsHostPID.Spec.SecurityContext.HostPID = true
 
 	requestsHostIPC := goodPod()
-	requestsHostIPC.Spec.HostIPC = true
+	requestsHostIPC.Spec.SecurityContext.HostIPC = true
 
 	requestsHostPorts := goodPod()
 	requestsHostPorts.Spec.Containers[0].Ports = []kapi.ContainerPort{{HostPort: 1}}


### PR DESCRIPTION
Depends on #5144; patch PR for kubernetes/kubernetes#14705

@pweil- @swagiaal @deads2k @liggitt