### PR TITLE
Add a monitoring uri to the stats port. 

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -25,6 +25,13 @@ defaults
 {{ if and (and (ne .StatsUser "") (ne .StatsPassword "")) (gt .StatsPort 0) }}
 listen stats :{{.StatsPort}}
     mode http
+
+    # Health check monitoring uri.
+    monitor-uri /health
+
+    # Add your custom health check monitoring failure condition here.
+    # monitor fail if <condition>
+
     stats enable
     stats hide-version
     stats realm Haproxy\ Statistics

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -27,7 +27,7 @@ listen stats :{{.StatsPort}}
     mode http
 
     # Health check monitoring uri.
-    monitor-uri /health
+    monitor-uri /healthz
 
     # Add your custom health check monitoring failure condition here.
     # monitor fail if <condition>


### PR DESCRIPTION
@pweil-  PTAL  Thx

This allows us to not affect hosted backends but rather use the listener on the stats port to
service health check requests. Of course the side effect here is that if you turn off stats, then the monitoring uri will not be available.

I debated putting this into the frontends 80 and 443 but felt it would be too onerous to introduce a config option or even allow a custom uri to be specified and there's of course the issue of clashing within the URI space of the backends (```/health``` won't be available to the backend) But figured its easier to do it on a haproxy specific port we listen on for the web stats service,

Usage examples: 
```  
$ echo $(curl -w "%{http_code}" -s -o /dev/null  http://127.0.0.1:1936/healthz)      
200  
$  # old stats uri works as normal - auth required. 
$ echo $(curl -w "%{http_code}" -s -o /dev/null  http://127.0.0.1:1936/)  
401  
$ echo $(curl -w "%{http_code}" --user admin:FNdzbCXEwh  -s -o /dev/null  http://127.0.0.1:1936/)
200  
```

The return code of 200 satisfies providers like GCE that don't just check connectivity but also the response code.

*Update*: Usage examples.