### PR TITLE
Fix govet error

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -212,7 +212,7 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 					continue
 				}
 				hasMissingRepo = true
-				fmt.Fprintf(c.Out(), "WARNING: No Docker registry has been configured with the server. Automatic builds and deployments may not function.\n", t.Name)
+				fmt.Fprint(c.Out(), "WARNING: No Docker registry has been configured with the server. Automatic builds and deployments may not function.\n")
 			}
 		}
 	}


### PR DESCRIPTION
https://travis-ci.org/openshift/origin/jobs/85660875#L521
```
hack/verify-govet.sh
pkg/cmd/cli/cmd/newapp.go:215: no formatting directive in Fprintf call
make[1]: *** [verify] Error 1
```