### PR TITLE
resync openshift-sdn

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -671,12 +671,12 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "5a41fee40db41b65578c07eff9fef35d183dce1c"
+			"Rev": "62ec906f6563828364474ef117371ea2ad804dc8"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "5a41fee40db41b65578c07eff9fef35d183dce1c"
+			"Rev": "62ec906f6563828364474ef117371ea2ad804dc8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -76,6 +76,7 @@ Setup() {
     get_ipaddr_pid_veth
     add_ovs_port
     add_ovs_flows
+    add_subnet_route
 }
 
 Teardown() {

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -87,6 +87,9 @@ function setup_required() {
     if ! docker_network_config check; then
         return 0
     fi
+    if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q 'table=0.*arp'; then
+        return 0
+    fi
     return 1
 }
 

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -87,6 +87,9 @@ function setup_required() {
     if ! docker_network_config check; then
         return 0
     fi
+    if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q NXM_NX_TUN_IPV4; then
+        return 0
+    fi
     return 1
 }
 


### PR DESCRIPTION
Picks up https://github.com/openshift/openshift-sdn/pull/181 (simplifies the process of switching between single-tenant and multi-tenant plugins) and https://github.com/openshift/openshift-sdn/pull/183 (makes single-tenant plugin work again)

Closes #5152
