### PR TITLE
oc tag should take an explicit reference to ImageStreamImage

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -565,6 +565,7 @@ _oc_tag()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--alias")
     flags+=("--delete")
     flags+=("-d")
     flags+=("--source=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -2304,6 +2304,7 @@ _openshift_cli_tag()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--alias")
     flags+=("--delete")
     flags+=("-d")
     flags+=("--source=")

--- a/pkg/image/api/validation/validation.go
+++ b/pkg/image/api/validation/validation.go
@@ -92,7 +92,7 @@ func ValidateImageStream(stream *api.ImageStream) fielderrors.ValidationErrorLis
 	for tag, history := range stream.Status.Tags {
 		for i, tagEvent := range history.Items {
 			if len(tagEvent.DockerImageReference) == 0 {
-				result = append(result, fielderrors.NewFieldRequired(fmt.Sprintf("status.tags[%s].Items[%d].dockerImageReference", tag, i)))
+				result = append(result, fielderrors.NewFieldRequired(fmt.Sprintf("status.tags[%s].items[%d].dockerImageReference", tag, i)))
 			}
 		}
 	}

--- a/pkg/image/api/validation/validation_test.go
+++ b/pkg/image/api/validation/validation_test.go
@@ -279,8 +279,8 @@ func TestValidateImageStream(t *testing.T) {
 				},
 			},
 			expected: fielderrors.ValidationErrorList{
-				fielderrors.NewFieldRequired("status.tags[tag].Items[0].dockerImageReference"),
-				fielderrors.NewFieldRequired("status.tags[tag].Items[2].dockerImageReference"),
+				fielderrors.NewFieldRequired("status.tags[tag].items[0].dockerImageReference"),
+				fielderrors.NewFieldRequired("status.tags[tag].items[2].dockerImageReference"),
 			},
 		},
 		"valid": {

--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -176,7 +176,11 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) fielderrors.Validati
 		if streamRefNamespace != stream.Namespace || tagRefStreamName != stream.Name {
 			obj, err := s.ImageStreamGetter.Get(kapi.WithNamespace(kapi.NewContext(), streamRefNamespace), tagRefStreamName)
 			if err != nil {
-				errs = append(errs, fielderrors.NewFieldInvalid(fmt.Sprintf("spec.tags[%s].from.name", tag), tagRef.From.Name, fmt.Sprintf("error retrieving ImageStream %s/%s: %v", streamRefNamespace, tagRefStreamName, err)))
+				if kerrors.IsNotFound(err) {
+					errs = append(errs, fielderrors.NewFieldNotFound(fmt.Sprintf("spec.tags[%s].from.name", tag), tagRef.From.Name))
+				} else {
+					errs = append(errs, fielderrors.NewFieldInvalid(fmt.Sprintf("spec.tags[%s].from.name", tag), tagRef.From.Name, fmt.Sprintf("unable to retrieve image stream: %v", err)))
+				}
 				continue
 			}
 

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -50,7 +50,6 @@ tryuntil oc get imagestreamtags wildfly:latest
 oc delete imageStreams ruby
 oc delete imageStreams nodejs
 oc delete imageStreams wildfly
-#oc delete imageStreams mysql
 oc delete imageStreams postgresql
 oc delete imageStreams mongodb
 [ -z "$(oc get imageStreams ruby --template="{{.status.dockerImageRepository}}")" ]
@@ -78,41 +77,45 @@ oc describe is/mysql
 echo "import-image: ok"
 
 # oc tag
-oc tag mysql:latest tagtest:tag1
+oc tag mysql:latest tagtest:tag1 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 
-oc tag mysql@${name} tagtest:tag2
+oc tag mysql@${name} tagtest:tag2 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 1).from.kind}}')" == "ImageStreamImage" ]
 
-oc tag mysql:notfound tagtest:tag3
+oc tag mysql:notfound tagtest:tag3 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 2).from.kind}}')" == "ImageStreamTag" ]
 
-oc tag --source=imagestreamtag mysql:latest tagtest:tag4
+oc tag --source=imagestreamtag mysql:latest tagtest:tag4 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 3).from.kind}}')" == "ImageStreamTag" ]
 
-oc tag --source=istag mysql:latest tagtest:tag5
+oc tag --source=istag mysql:latest tagtest:tag5 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 4).from.kind}}')" == "ImageStreamTag" ]
 
-oc tag --source=imagestreamimage mysql@${name} tagtest:tag6
+oc tag --source=imagestreamimage mysql@${name} tagtest:tag6 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 5).from.kind}}')" == "ImageStreamImage" ]
 
-oc tag --source=isimage mysql@${name} tagtest:tag7
+oc tag --source=isimage mysql@${name} tagtest:tag7 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 6).from.kind}}')" == "ImageStreamImage" ]
 
-oc tag --source=docker mysql:latest tagtest:tag8
+oc tag --source=docker mysql:latest tagtest:tag8 --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 7).from.kind}}')" == "DockerImage" ]
 
-oc tag mysql:latest tagtest:zzz tagtest2:zzz
+oc tag mysql:latest tagtest:zzz tagtest2:zzz --alias
 [ "$(oc get is/tagtest --template='{{(index .spec.tags 8).from.kind}}')" == "ImageStreamTag" ]
 [ "$(oc get is/tagtest2 --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 
-# TODO: bug
-# oc tag registry-1.docker.io/openshift/origin:v1.0.4 newrepo:latest
+oc tag registry-1.docker.io/openshift/origin:v1.0.4 newrepo:latest
+[ "$(oc get is/newrepo --template='{{(index .spec.tags 0).from.kind}}')" == "DockerImage" ]
+oc tag mysql:5.5 newrepo:latest
+[ "$(oc get is/newrepo --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamImage" ]
+oc tag mysql:5.5 newrepo:latest --alias
+[ "$(oc get is/newrepo --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 
 # test creating streams that don't exist
 [ -z "$(oc get imageStreams tagtest3 --template="{{.status.dockerImageRepository}}")" ]
 [ -z "$(oc get imageStreams tagtest4 --template="{{.status.dockerImageRepository}}")" ]
-oc tag mysql:latest tagtest3:latest tagtest4:latest
+oc tag mysql:latest tagtest3:latest tagtest4:latest --alias
 [ "$(oc get is/tagtest3 --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 [ "$(oc get is/tagtest4 --template='{{(index .spec.tags 0).from.kind}}')" == "ImageStreamTag" ]
 oc delete is/tagtest is/tagtest2 is/tagtest3 is/tagtest4


### PR DESCRIPTION
When a user invokes "oc tag ab:5 ab:latest", the default behavior should
be to lookup the image stream image that ab:5 points to, and set it
explicitly to ab:latest.

Also support "oc tag ab:5 ab:latest --alias" which creates a tag reference.

Reported by a user

@ncdc - when I do this, I'm noticing that we aren't propagating the latest
tag to its referenced tags (explicitly tagging image1 to ab:5 when ab:latest 
is an alias to to ab:5 won't result in ab:latest pointing to image1). Did we
change this recently?  Or it never worked?

* [x] tests for --alias and direct reference
* [x] fix referencing