### PR TITLE
Use the privileged SCC for all kube e2e tests

### DIFF
--- a/test/extended/images/s2i_ruby.go
+++ b/test/extended/images/s2i_ruby.go
@@ -14,7 +14,7 @@ var _ = g.Describe("images: s2i: ruby", func() {
 	defer g.GinkgoRecover()
 	var (
 		railsTemplate = "https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json"
-		oc            = exutil.NewCLI("s2i-php", exutil.KubeConfigPath())
+		oc            = exutil.NewCLI("s2i-ruby", exutil.KubeConfigPath())
 		modifyCommand = []string{"sed", "-ie", `s%render :file => 'public/index.html'%%`, "app/controllers/welcome_controller.rb"}
 		removeCommand = []string{"rm", "-f", "public/index.html"}
 		dcName        = "rails-postgresql-example-1"

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -57,26 +57,37 @@ func VarSubOnFile(srcFile, destFile, varToSub, val string) error {
 	return err
 }
 
-// WaitForABuild waits for a Build object to match either isOK or isFailed conditions
+// WaitForABuild waits for a Build object to match either isOK or isFailed conditions.
 func WaitForABuild(c client.BuildInterface, name string, isOK, isFailed func(*buildapi.Build) bool) error {
-	for {
+	// wait 2 minutes for build to exist
+	err := wait.Poll(1*time.Second, 2*time.Minute, func() (bool, error) {
+		if _, err := c.Get(name); err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	// wait longer for the build to run to completion
+	return wait.Poll(5*time.Second, 20*time.Minute, func() (bool, error) {
 		list, err := c.List(labels.Everything(), fields.Set{"name": name}.AsSelector())
 		if err != nil {
-			return err
+			return false, err
 		}
 		for i := range list.Items {
 			if name == list.Items[i].Name && isOK(&list.Items[i]) {
-				return nil
+				return true, nil
 			}
 			if name != list.Items[i].Name || isFailed(&list.Items[i]) {
-				return fmt.Errorf("The build %q status is %q", name, &list.Items[i].Status.Phase)
+				return false, fmt.Errorf("The build %q status is %q", name, &list.Items[i].Status.Phase)
 			}
 		}
 
 		rv := list.ResourceVersion
 		w, err := c.Watch(labels.Everything(), fields.Set{"name": name}.AsSelector(), rv)
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer w.Stop()
 
@@ -84,18 +95,18 @@ func WaitForABuild(c client.BuildInterface, name string, isOK, isFailed func(*bu
 			val, ok := <-w.ResultChan()
 			if !ok {
 				// reget and re-watch
-				break
+				return false, nil
 			}
 			if e, ok := val.Object.(*buildapi.Build); ok {
 				if name == e.Name && isOK(e) {
-					return nil
+					return true, nil
 				}
 				if name != e.Name || isFailed(e) {
-					return fmt.Errorf("The build %q status is %q", name, e.Status.Phase)
+					return false, fmt.Errorf("The build %q status is %q", name, e.Status.Phase)
 				}
 			}
 		}
-	}
+	})
 }
 
 // CheckBuildSuccessFunc returns true if the build succeeded

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/golang/glog"
@@ -13,8 +14,13 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 	flag "github.com/spf13/pflag"
-	// "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+
+	apierrs "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/test/e2e"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 )
 
 // init initialize the extended testing suite.
@@ -40,6 +46,9 @@ func InitTest() {
 
 	//flag.StringVar(&TestContext.KubeConfig, clientcmd.RecommendedConfigPathFlag, KubeConfigPath(), "Path to kubeconfig containing embedded authinfo.")
 	flag.StringVar(&TestContext.OutputDir, "extended-tests-output-dir", extendedOutputDir, "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
+
+	// Ensure that Kube tests run privileged (like they do upstream)
+	ginkgo.JustBeforeEach(ensureKubeE2EPrivilegedSA)
 
 	// Override the default Kubernetes E2E configuration
 	e2e.SetTestContext(TestContext)
@@ -68,4 +77,43 @@ func ExecuteTest(t *testing.T, reportDir string) {
 	r = append(r, NewSimpleReporter())
 
 	ginkgo.RunSpecsWithCustomReporters(t, "OpenShift extended tests suite", r)
+}
+
+// ensureKubeE2EPrivilegedSA ensures that all namespaces prefixed with 'e2e-' have their
+// service accounts in the privileged SCC
+func ensureKubeE2EPrivilegedSA() {
+	desc := ginkgo.CurrentGinkgoTestDescription()
+	if strings.Contains(desc.FileName, "/kubernetes/test/e2e/") {
+		e2e.Logf("About to run a Kube e2e test, ensuring namespace is privileged")
+		c, _, err := configapi.GetKubeClient(KubeConfigPath())
+		if err != nil {
+			FatalErr(err)
+		}
+		priv, err := c.SecurityContextConstraints().Get("privileged")
+		if err != nil {
+			if apierrs.IsNotFound(err) {
+				return
+			}
+			FatalErr(err)
+		}
+		namespaces, err := c.Namespaces().List(labels.Everything(), fields.Everything())
+		if err != nil {
+			FatalErr(err)
+		}
+		groups := []string{}
+		for _, name := range priv.Groups {
+			if !strings.Contains(name, "e2e-") {
+				groups = append(groups, name)
+			}
+		}
+		for _, ns := range namespaces.Items {
+			if strings.HasPrefix(ns.Name, "e2e-") {
+				groups = append(groups, fmt.Sprintf("system:serviceaccounts:%s", ns.Name))
+			}
+		}
+		priv.Groups = groups
+		if _, err := c.SecurityContextConstraints().Update(priv); err != nil {
+			FatalErr(err)
+		}
+	}
 }


### PR DESCRIPTION
Also prevent infinite waits on builds that never start due to missed or
invalid triggers.

[test][extended:core]