### PR TITLE
UPSTREAM: 15194: hairpin: unless the pod is on the host's network

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/network/hairpin/hairpin.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/network/hairpin/hairpin.go
@@ -64,7 +64,7 @@ func findPairInterfaceOfContainerInterface(e exec.Interface, containerPid int, c
 	// Get container's interface index
 	output, err := e.Command(nsenterPath, "-t", fmt.Sprintf("%d", containerPid), "-n", "-F", "--", ethtoolPath, "--statistics", containerInterfaceName).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("Unable to query interface %s of container %d: %v", containerInterfaceName, containerPid, err)
+		return "", fmt.Errorf("Unable to query interface %s of container %d: %v: %s", containerInterfaceName, containerPid, err, string(output))
 	}
 	// look for peer_ifindex
 	match := ethtoolOutputRegex.FindSubmatch(output)


### PR DESCRIPTION
We spuriously log errors like:

    Oct 15 16:28:58 ose3-master.example.com atomic-openshift-node[2287]: W1015 16:28:58.191381    2287 manager.go:1748] Hairpin setup failed for pod "docker-registry-1-6jk36_default": open /sys/devices/virtual/net/veth85084d2/brport/hairpin_mode: no such file or directory

This pulls in the upstream fix for that.

(cherry-pick.sh wouldn't actually let me cherry-pick this as "15194" because it is already merged upstream, so I had to cherry-pick it by commit ID, but then I rewrote the commit message to use the PR number instead, to match all the other UPSTREAM commits.)

Also FWIW note that this isn't exactly the same as the upstream commit in https://github.com/kubernetes/kubernetes/pull/15194 because that depended on changes from another unrelated commit that we don't yet have (https://github.com/kubernetes/kubernetes/pull/13939).

(cc: @sdodson)