### PR TITLE
WIP: Delete Builds associated with a BC after it is deleted

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14970,13 +14970,18 @@
    "v1.BuildConfigStatus": {
     "id": "v1.BuildConfigStatus",
     "required": [
-     "lastVersion"
+     "lastVersion",
+     "canDelete"
     ],
     "properties": {
      "lastVersion": {
       "type": "integer",
       "format": "int32",
       "description": "used to inform about number of last triggered build"
+     },
+     "canDelete": {
+      "type": "boolean",
+      "description": "used to indicate the build config can be deleted by the system"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -772,6 +772,7 @@ func deepCopy_api_BuildConfigSpec(in buildapi.BuildConfigSpec, out *buildapi.Bui
 
 func deepCopy_api_BuildConfigStatus(in buildapi.BuildConfigStatus, out *buildapi.BuildConfigStatus, c *conversion.Cloner) error {
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1207,6 +1207,7 @@ func autoconvert_api_BuildConfigStatus_To_v1_BuildConfigStatus(in *buildapi.Buil
 		defaulting.(func(*buildapi.BuildConfigStatus))(in)
 	}
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 
@@ -1936,6 +1937,7 @@ func autoconvert_v1_BuildConfigStatus_To_api_BuildConfigStatus(in *apiv1.BuildCo
 		defaulting.(func(*apiv1.BuildConfigStatus))(in)
 	}
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -796,6 +796,7 @@ func deepCopy_v1_BuildConfigSpec(in apiv1.BuildConfigSpec, out *apiv1.BuildConfi
 
 func deepCopy_v1_BuildConfigStatus(in apiv1.BuildConfigStatus, out *apiv1.BuildConfigStatus, c *conversion.Cloner) error {
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1216,6 +1216,7 @@ func autoconvert_api_BuildConfigStatus_To_v1beta3_BuildConfigStatus(in *buildapi
 		defaulting.(func(*buildapi.BuildConfigStatus))(in)
 	}
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 
@@ -1945,6 +1946,7 @@ func autoconvert_v1beta3_BuildConfigStatus_To_api_BuildConfigStatus(in *apiv1bet
 		defaulting.(func(*apiv1beta3.BuildConfigStatus))(in)
 	}
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -804,6 +804,7 @@ func deepCopy_v1beta3_BuildConfigSpec(in apiv1beta3.BuildConfigSpec, out *apiv1b
 
 func deepCopy_v1beta3_BuildConfigStatus(in apiv1beta3.BuildConfigStatus, out *apiv1beta3.BuildConfigStatus, c *conversion.Cloner) error {
 	out.LastVersion = in.LastVersion
+	out.CanDelete = in.CanDelete
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -438,6 +438,10 @@ type BuildConfigSpec struct {
 type BuildConfigStatus struct {
 	// LastVersion is used to inform about number of last triggered build.
 	LastVersion int
+
+	// CanDelete indicates that the BuildConfig has no outstanding instantiated
+	// Builds and can be removed.
+	CanDelete bool
 }
 
 // WebHookTrigger is a trigger that gets invoked using a webhook type of post

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -377,6 +377,10 @@ type BuildConfigSpec struct {
 type BuildConfigStatus struct {
 	// LastVersion is used to inform about number of last triggered build.
 	LastVersion int `json:"lastVersion" description:"used to inform about number of last triggered build"`
+
+	// CanDelete indicates that the BuildConfig has no outstanding instantiated
+	// Builds and can be removed.
+	CanDelete bool `json:"canDelete" description:"used to indicate the build config can be deleted by the system"`
 }
 
 // WebHookTrigger is a trigger that gets invoked using a webhook type of post

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -365,6 +365,10 @@ type BuildConfigSpec struct {
 type BuildConfigStatus struct {
 	// LastVersion is used to inform about number of last triggered build.
 	LastVersion int `json:"lastVersion"`
+
+	// CanDelete indicates that the BuildConfig has no outstanding instantiated
+	// Builds and can be removed.
+	CanDelete bool `json:"canDelete" description:"used to indicate the build config can be deleted by the system"`
 }
 
 // WebHookTrigger is a trigger that gets invoked using a webhook type of post

--- a/pkg/build/client/clients.go
+++ b/pkg/build/client/clients.go
@@ -3,6 +3,8 @@ package client
 import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	osclient "github.com/openshift/origin/pkg/client"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 // BuildConfigGetter provides methods for getting BuildConfigs
@@ -13,6 +15,11 @@ type BuildConfigGetter interface {
 // BuildConfigUpdater provides methods for updating BuildConfigs
 type BuildConfigUpdater interface {
 	Update(buildConfig *buildapi.BuildConfig) error
+}
+
+// BuildConfigDeleter provides methods for deleting BuildConfigs
+type BuildConfigDeleter interface {
+	Delete(namespace, name string) error
 }
 
 // OSClientBuildConfigClient delegates get and update operations to the OpenShift client interface
@@ -36,9 +43,24 @@ func (c OSClientBuildConfigClient) Update(buildConfig *buildapi.BuildConfig) err
 	return err
 }
 
+// Delete deletes a BuildConfig using the OpenShift client.
+func (c OSClientBuildConfigClient) Delete(namespace, name string) error {
+	return c.Client.BuildConfigs(namespace).Delete(name)
+}
+
 // BuildUpdater provides methods for updating existing Builds.
 type BuildUpdater interface {
 	Update(namespace string, build *buildapi.Build) error
+}
+
+// BuildDeleter provides methods for deleting Builds.
+type BuildDeleter interface {
+	Delete(namespace, name string) error
+}
+
+// BuildLister provides methods for listing Builds.
+type BuildLister interface {
+	List(namespace string, label labels.Selector, field fields.Selector) (*buildapi.BuildList, error)
 }
 
 // OSClientBuildClient deletes build create and update operations to the OpenShift client interface
@@ -55,6 +77,16 @@ func NewOSClientBuildClient(client osclient.Interface) *OSClientBuildClient {
 func (c OSClientBuildClient) Update(namespace string, build *buildapi.Build) error {
 	_, e := c.Client.Builds(namespace).Update(build)
 	return e
+}
+
+// Delete deletes builds using the OpenShift client.
+func (c OSClientBuildClient) Delete(namespace, name string) error {
+	return c.Client.Builds(namespace).Delete(name)
+}
+
+// List lists builds using the OpenShift client.
+func (c OSClientBuildClient) List(namespace string, label labels.Selector, field fields.Selector) (*buildapi.BuildList, error) {
+	return c.Client.Builds(namespace).List(label, field)
 }
 
 // BuildCloner provides methods for cloning builds

--- a/pkg/build/controller/config_controller.go
+++ b/pkg/build/controller/config_controller.go
@@ -5,19 +5,64 @@ import (
 
 	"github.com/golang/glog"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kerrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/util"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	kutil "k8s.io/kubernetes/pkg/util"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildclient "github.com/openshift/origin/pkg/build/client"
+	"github.com/openshift/origin/pkg/build/util"
 )
 
 type BuildConfigController struct {
 	BuildConfigInstantiator buildclient.BuildConfigInstantiator
+	BuildConfigUpdater      buildclient.BuildConfigUpdater
+	BuildConfigDeleter      buildclient.BuildConfigDeleter
+	BuildDeleter            buildclient.BuildDeleter
+	BuildLister             buildclient.BuildLister
 }
 
 func (c *BuildConfigController) HandleBuildConfig(bc *buildapi.BuildConfig) error {
 	glog.V(4).Infof("Handling BuildConfig %s/%s", bc.Namespace, bc.Name)
+
+	if !bc.DeletionTimestamp.IsZero() {
+		if bc.Status.CanDelete {
+			return nil
+		}
+
+		builds, err := c.BuildLister.List(bc.Namespace, util.ConfigSelector(bc.Name), nil)
+		if err != nil {
+			return err
+		}
+
+		buildsWithDeprecatedLabel, err := c.BuildLister.List(bc.Namespace, util.ConfigSelectorDeprecated(bc.Name), nil)
+		if err != nil {
+			return err
+		}
+
+		var errlist []error
+		buildList := append(builds.Items, buildsWithDeprecatedLabel.Items...)
+		for _, build := range buildList {
+			if err = c.BuildDeleter.Delete(build.Namespace, build.Name); err != nil {
+				glog.Errorf("Cannot delete Build %s/%s: %v", build.Namespace, build.Name, err)
+				errlist = append(errlist, err)
+			}
+		}
+		err = kerrors.NewAggregate(errlist)
+		if err != nil {
+			return kapierrors.NewInternalError(err)
+		}
+
+		bc.Status.CanDelete = true
+		err = c.BuildConfigUpdater.Update(bc)
+		if err != nil {
+			if kapierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		return c.BuildConfigDeleter.Delete(bc.Namespace, bc.Name)
+	}
 
 	hasChangeTrigger := false
 	for _, trigger := range bc.Spec.Triggers {
@@ -47,12 +92,12 @@ func (c *BuildConfigController) HandleBuildConfig(bc *buildapi.BuildConfig) erro
 	}
 	if _, err := c.BuildConfigInstantiator.Instantiate(bc.Namespace, request); err != nil {
 		var instantiateErr error
-		if kerrors.IsConflict(err) {
+		if kapierrors.IsConflict(err) {
 			instantiateErr = fmt.Errorf("unable to instantiate Build for BuildConfig %s/%s due to a conflicting update: %v", bc.Namespace, bc.Name, err)
-			util.HandleError(instantiateErr)
+			kutil.HandleError(instantiateErr)
 		} else {
 			instantiateErr = fmt.Errorf("error instantiating Build from BuildConfig %s/%s: %v", bc.Namespace, bc.Name, err)
-			util.HandleError(instantiateErr)
+			kutil.HandleError(instantiateErr)
 		}
 		return instantiateErr
 	}

--- a/pkg/build/controller/config_controller_test.go
+++ b/pkg/build/controller/config_controller_test.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
@@ -12,6 +17,8 @@ func TestHandleBuildConfig(t *testing.T) {
 		name              string
 		bc                *buildapi.BuildConfig
 		expectBuild       bool
+		withBuilds        bool
+		failFirstDelete   bool
 		instantiatorError bool
 		expectErr         bool
 	}{
@@ -36,14 +43,41 @@ func TestHandleBuildConfig(t *testing.T) {
 			instantiatorError: true,
 			expectErr:         true,
 		},
+		{
+			name:              "build config with non-zero deletion timestamp",
+			bc:                buildConfigWithNonZeroDeletionTimestamp(),
+			instantiatorError: true,
+		},
+		{
+			name:              "build config with non-zero deletion timestamp with builds",
+			bc:                buildConfigWithNonZeroDeletionTimestamp(),
+			instantiatorError: true,
+			withBuilds:        true,
+		},
+		{
+			name:              "build config with non-zero deletion timestamp with builds and first deletion failure",
+			bc:                buildConfigWithNonZeroDeletionTimestamp(),
+			instantiatorError: true,
+			withBuilds:        true,
+			failFirstDelete:   true,
+			expectErr:         true,
+		},
 	}
 
 	for _, tc := range tests {
-		instantiator := &testInstantiator{
+		client := &testBuildConfigClient{
 			err: tc.instantiatorError,
 		}
+		buildClient := &testBuildClient{
+			withBuilds:      tc.withBuilds,
+			failFirstDelete: tc.failFirstDelete,
+		}
 		controller := &BuildConfigController{
-			BuildConfigInstantiator: instantiator,
+			BuildConfigInstantiator: client,
+			BuildConfigUpdater:      client,
+			BuildConfigDeleter:      client,
+			BuildDeleter:            buildClient,
+			BuildLister:             buildClient,
 		}
 		err := controller.HandleBuildConfig(tc.bc)
 		if err != nil {
@@ -56,27 +90,81 @@ func TestHandleBuildConfig(t *testing.T) {
 			t.Errorf("%s: expected error, but got none", tc.name)
 			continue
 		}
-		if tc.expectBuild && len(instantiator.requestName) == 0 {
+		if tc.expectBuild && len(client.requestName) == 0 {
 			t.Errorf("%s: expected a build to be started.", tc.name)
 		}
-		if !tc.expectBuild && len(instantiator.requestName) > 0 {
+		if !tc.expectBuild && len(client.requestName) > 0 {
 			t.Errorf("%s: did not expect a build to be started.", tc.name)
+		}
+		if tc.withBuilds && buildClient.deleteCount == 0 {
+			t.Errorf("%s: buildConfig had builds, but delete was not called", tc.name)
+		}
+		if !tc.withBuilds && buildClient.deleteCount > 0 {
+			t.Errorf("%s: delete was called even though there are no builds", tc.name)
+		}
+		if tc.failFirstDelete {
+			if buildClient.deleteCount != 1 {
+				t.Errorf("%s: delete was called even though there are no builds", tc.name)
+				continue
+			}
+			err := controller.HandleBuildConfig(tc.bc)
+			if err != nil {
+				t.Errorf("%s: unexpected error on second try", tc.name)
+			}
 		}
 	}
 
 }
 
-type testInstantiator struct {
+type testBuildConfigClient struct {
 	requestName string
 	err         bool
 }
 
-func (i *testInstantiator) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
-	i.requestName = request.Name
-	if i.err {
+func (c *testBuildConfigClient) Instantiate(namespace string, request *buildapi.BuildRequest) (*buildapi.Build, error) {
+	c.requestName = request.Name
+	if c.err {
 		return nil, fmt.Errorf("error")
 	}
 	return &buildapi.Build{}, nil
+}
+
+func (c *testBuildConfigClient) Update(buildConfig *buildapi.BuildConfig) error {
+	return nil
+}
+
+func (c *testBuildConfigClient) Delete(namespace, name string) error {
+	return nil
+}
+
+type testBuildClient struct {
+	withBuilds      bool
+	failFirstDelete bool
+	deleteCount     int
+}
+
+func (c *testBuildClient) Delete(namespace, name string) error {
+	c.deleteCount++
+	if c.failFirstDelete && c.deleteCount == 1 {
+		return fmt.Errorf("planned error")
+	}
+	return nil
+}
+
+func (c *testBuildClient) List(namespace string, label labels.Selector, field fields.Selector) (*buildapi.BuildList, error) {
+	items := []buildapi.Build{}
+	if c.withBuilds {
+		items = append(items, buildapi.Build{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:      "build",
+				Namespace: "ns",
+			},
+		})
+	}
+	builds := &buildapi.BuildList{
+		Items: items,
+	}
+	return builds, nil
 }
 
 func baseBuildConfig() *buildapi.BuildConfig {
@@ -100,5 +188,12 @@ func buildConfigWithConfigChangeTrigger() *buildapi.BuildConfig {
 func buildConfigWithNonZeroLastVersion() *buildapi.BuildConfig {
 	bc := buildConfigWithConfigChangeTrigger()
 	bc.Status.LastVersion = 1
+	return bc
+}
+
+func buildConfigWithNonZeroDeletionTimestamp() *buildapi.BuildConfig {
+	bc := baseBuildConfig()
+	now := unversioned.Now()
+	bc.DeletionTimestamp = &now
 	return bc
 }

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -281,6 +281,10 @@ func (factory *ImageChangeControllerFactory) Create() controller.RunnableControl
 type BuildConfigControllerFactory struct {
 	Client                  osclient.Interface
 	BuildConfigInstantiator buildclient.BuildConfigInstantiator
+	BuildConfigUpdater      buildclient.BuildConfigUpdater
+	BuildConfigDeleter      buildclient.BuildConfigDeleter
+	BuildDeleter            buildclient.BuildDeleter
+	BuildLister             buildclient.BuildLister
 	// Stop may be set to allow controllers created by this factory to be terminated.
 	Stop <-chan struct{}
 }
@@ -292,6 +296,10 @@ func (factory *BuildConfigControllerFactory) Create() controller.RunnableControl
 
 	bcController := &buildcontroller.BuildConfigController{
 		BuildConfigInstantiator: factory.BuildConfigInstantiator,
+		BuildConfigUpdater:      factory.BuildConfigUpdater,
+		BuildConfigDeleter:      factory.BuildConfigDeleter,
+		BuildDeleter:            factory.BuildDeleter,
+		BuildLister:             factory.BuildLister,
 	}
 
 	return &controller.RetryController{

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -197,6 +197,10 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 		return nil, err
 	}
 
+	if bc.DeletionTimestamp != nil {
+		return nil, errors.NewConflict("BuildConfig", bc.Name, fmt.Errorf("Cannot generate Build from BuildConfig %s/%s because it is being deleted", bc.Namespace, bc.Name))
+	}
+
 	if err := g.checkLastVersion(bc, request.LastVersion); err != nil {
 		return nil, err
 	}

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
@@ -78,4 +79,16 @@ func IsBuildComplete(build *buildapi.Build) bool {
 // for the config that has the provided name
 func BuildNameForConfigVersion(name string, version int) string {
 	return fmt.Sprintf("%s-%d", name, version)
+}
+
+// ConfigSelector returns a label Selector which can be used to find all
+// builds for a BuildConfig.
+func ConfigSelector(name string) labels.Selector {
+	return labels.Set{buildapi.BuildConfigLabel: name}.AsSelector()
+}
+
+// ConfigSelectorDeprecated returns a label Selector which can be used to find
+// all builds for a BuildConfig that use the deprecated labels.
+func ConfigSelectorDeprecated(name string) labels.Selector {
+	return labels.Set{buildapi.BuildConfigLabelDeprecated: name}.AsSelector()
 }

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -250,8 +250,16 @@ func (c *MasterConfig) RunBuildImageChangeTriggerController() {
 // RunBuildConfigChangeController starts the build config change trigger controller process.
 func (c *MasterConfig) RunBuildConfigChangeController() {
 	bcClient, _ := c.BuildConfigChangeControllerClients()
-	bcInstantiator := buildclient.NewOSClientBuildConfigInstantiatorClient(bcClient)
-	factory := buildcontrollerfactory.BuildConfigControllerFactory{Client: bcClient, BuildConfigInstantiator: bcInstantiator}
+	buildConfigClient := buildclient.NewOSClientBuildConfigClient(bcClient)
+	buildClient := buildclient.NewOSClientBuildClient(bcClient)
+	factory := buildcontrollerfactory.BuildConfigControllerFactory{
+		Client:                  bcClient,
+		BuildConfigInstantiator: buildclient.NewOSClientBuildConfigInstantiatorClient(bcClient),
+		BuildConfigUpdater:      buildConfigClient,
+		BuildConfigDeleter:      buildConfigClient,
+		BuildDeleter:            buildClient,
+		BuildLister:             buildClient,
+	}
 	factory.Create().Run()
 }
 

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -1,0 +1,68 @@
+package builds
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: deleting buildconfig", func() {
+	defer g.GinkgoRecover()
+	var (
+		buildFixture = exutil.FixturePath("..", "extended", "fixtures", "test-build.json")
+		oc           = exutil.NewCLI("cli-start-build", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.Run("create").Args("-f", buildFixture).Execute()
+	})
+
+	g.Describe("oc delete buildconfig", func() {
+		g.It("should start a build and wait for the build to complete", func() {
+			var (
+				err    error
+				builds [4]string
+			)
+
+			g.By("starting multiple builds")
+			for i := range builds {
+				builds[i], err = oc.Run("start-build").Args("sample-build").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			g.By("waiting for half of them")
+			for i := range builds[:len(builds)/2] {
+				// Note that it's not important to check for success here. We
+				// only care about builds being deleted after BC is deleted and
+				// we don't really care about their status prior to that.
+				exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), builds[i], exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
+			}
+
+			g.By("deleting the buildconfig")
+			err = oc.Run("delete").Args("bc/sample-build").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for builds to clear")
+			err = wait.Poll(3*time.Second, 3*time.Minute, func() (bool, error) {
+				out, err := oc.Run("get").Args("-o", "name", "builds").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if len(out) == 0 {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err == wait.ErrWaitTimeout {
+				g.Fail("timed out waiting for builds to clear")
+			}
+		})
+
+	})
+})


### PR DESCRIPTION
I'm still missing tests, but would like feedback as soon as possible. I've used a different approach than we do with Deployments and DeploymentConfigs, since that one is susceptible to the config being deleted with Deployments remaining.

I've also managed to do without introducing a phase field into the BC. Instead, it is sufficient to enable graceful deletion in the BC registry strategy. This will mark the BC with a deletion timestamp which I'm using to disable any further Builds to be instantiated. If any Build fails to get deleted, the BC controller will return error, so the whole thing gets retried later.

@bparees wanna review?