### PR TITLE
disable apply

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/apply.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/apply.go
@@ -166,14 +166,17 @@ func GetModifiedConfiguration(info *resource.Info, annotate bool) ([]byte, error
 // UpdateApplyAnnotation gets the modified configuration of the object,
 // without embedding it again, and then sets it on the object as the annotation.
 func UpdateApplyAnnotation(info *resource.Info) error {
-	modified, err := GetModifiedConfiguration(info, false)
-	if err != nil {
-		return err
-	}
-
-	if err := SetOriginalConfiguration(info, modified); err != nil {
-		return err
-	}
-
+	// TODO, we'll probably never accept this implementation, but rather than update callers, this keeps
+	// the upstream carry/diff smaller
 	return nil
+	// modified, err := GetModifiedConfiguration(info, false)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// if err := SetOriginalConfiguration(info, modified); err != nil {
+	// 	return err
+	// }
+
+	// return nil
 }

--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -1306,33 +1306,6 @@ _oc_replace()
     must_have_one_noun=()
 }
 
-_oc_apply()
-{
-    last_command="oc_apply"
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--filename=")
-    flags_with_completion+=("--filename")
-    flags_completion+=("__handle_filename_extension_flag json|stdin|yaml|yml")
-    two_word_flags+=("-f")
-    flags_with_completion+=("-f")
-    flags_completion+=("__handle_filename_extension_flag json|stdin|yaml|yml")
-    flags+=("--output=")
-    two_word_flags+=("-o")
-    flags+=("--schema-cache-dir=")
-    flags+=("--validate")
-
-    must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
-    must_have_one_noun=()
-}
-
 _oc_patch()
 {
     last_command="oc_patch"
@@ -2060,7 +2033,6 @@ _oc()
     commands+=("proxy")
     commands+=("create")
     commands+=("replace")
-    commands+=("apply")
     commands+=("patch")
     commands+=("process")
     commands+=("export")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -3045,33 +3045,6 @@ _openshift_cli_replace()
     must_have_one_noun=()
 }
 
-_openshift_cli_apply()
-{
-    last_command="openshift_cli_apply"
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--filename=")
-    flags_with_completion+=("--filename")
-    flags_completion+=("__handle_filename_extension_flag json|stdin|yaml|yml")
-    two_word_flags+=("-f")
-    flags_with_completion+=("-f")
-    flags_completion+=("__handle_filename_extension_flag json|stdin|yaml|yml")
-    flags+=("--output=")
-    two_word_flags+=("-o")
-    flags+=("--schema-cache-dir=")
-    flags+=("--validate")
-
-    must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
-    must_have_one_noun=()
-}
-
 _openshift_cli_patch()
 {
     last_command="openshift_cli_patch"
@@ -3799,7 +3772,6 @@ _openshift_cli()
     commands+=("proxy")
     commands+=("create")
     commands+=("replace")
-    commands+=("apply")
     commands+=("patch")
     commands+=("process")
     commands+=("export")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -32,22 +32,6 @@ Update the annotations on a resource
 ====
 
 
-== oc apply
-Apply a configuration to a resource by filename or stdin
-
-====
-
-[options="nowrap"]
-----
-# Apply the configuration in pod.json to a pod.
-$ openshift cli apply -f ./pod.json
-
-# Apply the JSON passed into stdin to a pod.
-$ cat pod.json | openshift cli apply -f -
-----
-====
-
-
 == oc attach
 Attach to a running container.
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -122,7 +122,8 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 			Commands: []*cobra.Command{
 				cmd.NewCmdCreate(fullName, f, out),
 				cmd.NewCmdReplace(fullName, f, out),
-				cmd.NewCmdApply(fullName, f, out),
+				// TODO decide what to do about apply.  Its doing unusual things
+				// cmd.NewCmdApply(fullName, f, out),
 				cmd.NewCmdPatch(fullName, f, out),
 				cmd.NewCmdProcess(fullName, f, out),
 				cmd.NewCmdExport(fullName, f, in, out),

--- a/pkg/cmd/cli/kubectl_compat_test.go
+++ b/pkg/cmd/cli/kubectl_compat_test.go
@@ -16,7 +16,9 @@ import (
 // MissingCommands is the list of commands we're already missing.
 // NEVER ADD TO THIS LIST
 // TODO kill this list
-var MissingCommands = sets.NewString("namespace", "rolling-update", "cluster-info", "api-versions")
+var MissingCommands = sets.NewString("namespace", "rolling-update", "cluster-info", "api-versions",
+	"apply", // we don't want to support this implementation
+)
 
 // WhitelistedCommands is the list of commands we're never going to have in oc
 // defend each one with a comment

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -93,7 +93,7 @@ oadm policy reconcile-cluster-roles --additive-only --confirm
 [ "$(oc get clusterroles/basic-user -o json | grep custom-annotation)" ]
 [ "$(oc get clusterroles/basic-user -o json | grep groups)" ]
 oadm policy reconcile-cluster-roles --confirm
-[ ! "$(oc get clusterroles/basic-user -o yaml | grep -v "kubectl.kubernetes.io/last-applied-configuration" | grep groups)" ]
+[ ! "$(oc get clusterroles/basic-user -o yaml | grep groups)" ]
 
 # Ensure a removed binding gets re-added
 oc delete clusterrolebinding/cluster-status-binding
@@ -113,10 +113,10 @@ oadm policy reconcile-cluster-role-bindings --confirm
 [ "$(oc get clusterrolebindings/basic-users -o json | grep custom-annotation)" ]
 [ "$(oc get clusterrolebindings/basic-users -o json | grep custom-user)" ]
 # Ensure a customized binding's roleref is corrected
-[ ! "$(oc get clusterrolebindings/basic-users -o json | grep -v "kubectl.kubernetes.io/last-applied-configuration" | grep cluster-status)" ]
+[ ! "$(oc get clusterrolebindings/basic-users -o json | grep cluster-status)" ]
 # Ensure --additive-only=false removes customized users from the binding
 oadm policy reconcile-cluster-role-bindings --additive-only=false --confirm
-[ ! "$(oc get clusterrolebindings/basic-users -o json | grep -v "kubectl.kubernetes.io/last-applied-configuration" | grep custom-user)" ]
+[ ! "$(oc get clusterrolebindings/basic-users -o json | grep custom-user)" ]
 
 echo "admin-policy: ok"
 


### PR DESCRIPTION
 1. removes `oc apply` (updates unit test too)
 1. removes the annotation with minimal patch
 1. updates completions.
 1. updates `test-cmd.sh` to make sure slips are caught.

@liggitt 