### PR TITLE
Add support to expose/redirect/disable insecure schemes (http) for edge secured routes.

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -17967,7 +17967,7 @@
       "type": "string",
       "description": "provides the contents of the ca certificate of the final destination.  When using re-encrypt termination this file should be provided in order to have routers use it for health checks on the secure connection"
      },
-     "insecure": {
+     "insecureEdgeTerminationPolicy": {
       "type": "string",
       "description": "indicates desired behavior for insecure connections to an edge-terminated route.  If not set, insecure connections will not be allowed"
      }

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -17966,6 +17966,10 @@
      "destinationCACertificate": {
       "type": "string",
       "description": "provides the contents of the ca certificate of the final destination.  When using re-encrypt termination this file should be provided in order to have routers use it for health checks on the secure connection"
+     },
+     "insecure": {
+      "type": "string",
+      "description": "indicates desired behavior for insecure connections to an edge-terminated route.  If not set, insecure connections will not be allowed"
      }
     }
    },

--- a/images/router/haproxy-base/Dockerfile
+++ b/images/router/haproxy-base/Dockerfile
@@ -14,7 +14,7 @@ FROM openshift/origin-base
 RUN yum -y install haproxy && \
     mkdir -p /var/lib/containers/router/{certs,cacerts} && \
     mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
-    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt}.map,haproxy.config} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_edge_http_expose,os_edge_http_redirect}.map,haproxy.config} && \
     chmod -R 777 /var && \
     yum clean all
 

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -61,6 +61,14 @@ frontend public
   tcp-request inspect-delay 5s
   tcp-request content accept if HTTP
 
+  # check if we need to redirect/force using https.
+  acl secure_redirect base,map_beg(/var/lib/haproxy/conf/os_edge_http_redirect.map) -m found
+  redirect scheme https if secure_redirect
+
+  # Check if it is an edge route exposed insecurely.
+  acl edge_http_expose base,map_beg(/var/lib/haproxy/conf/os_edge_http_expose.map) -m found
+  use_backend be_edge_http_%[base,map_beg(/var/lib/haproxy/conf/os_edge_http_expose.map)] if edge_http_expose
+
   # map to http backend
   # Search from most specific to general path (host case).
   # Note: If no match, haproxy uses the default_backend, no other
@@ -262,6 +270,36 @@ backend be_secure_{{$cfgIdx}}
 {{     end }}
 {{   end }}
 {{ end }}{{/* end edge http host map template */}}
+
+{{/*
+    os_edge_http_expose.map: contains a mapping of www.example.com -> <service name>.
+    Map is used to also expose edge terminated routes via an insecure scheme
+    (http) if acls match for routes with insecure option set to expose.
+*/}}
+{{ define "/var/lib/haproxy/conf/os_edge_http_expose.map" }}
+{{   range $id, $serviceUnit := .State }}
+{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.Insecure "expose"))}}
+{{$cfg.Host}}{{$cfg.Path}} {{$idx}}
+{{       end }}
+{{     end }}
+{{   end }}
+{{ end }}{{/* end edge insecure expose http host map template */}}
+
+{{/*
+    os_edge_http_redirect.map: contains a mapping of www.example.com -> <service name>.
+    Map is used to redirect insecure traffic to use a secure scheme (https)
+    if acls match for routes that have the insecure option set to redirect.
+*/}}
+{{ define "/var/lib/haproxy/conf/os_edge_http_redirect.map" }}
+{{   range $id, $serviceUnit := .State }}
+{{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
+{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.Insecure "redirect"))}}
+{{$cfg.Host}}{{$cfg.Path}} {{$idx}}
+{{       end }}
+{{     end }}
+{{   end }}
+{{ end }}{{/* end edge insecure redirect http host map template */}}
 
 
 {{/*

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -279,7 +279,7 @@ backend be_secure_{{$cfgIdx}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_expose.map" }}
 {{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "allow"))}}
+{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "Allow"))}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
@@ -294,7 +294,7 @@ backend be_secure_{{$cfgIdx}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_redirect.map" }}
 {{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "redirect"))}}
+{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "Redirect"))}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -279,7 +279,7 @@ backend be_secure_{{$cfgIdx}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_expose.map" }}
 {{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.Insecure "expose"))}}
+{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "allow"))}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}
@@ -294,7 +294,7 @@ backend be_secure_{{$cfgIdx}}
 {{ define "/var/lib/haproxy/conf/os_edge_http_redirect.map" }}
 {{   range $id, $serviceUnit := .State }}
 {{     range $idx, $cfg := $serviceUnit.ServiceAliasConfigs }}
-{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.Insecure "redirect"))}}
+{{       if and (ne $cfg.Host "") (and (eq $cfg.TLSTermination "edge") (eq $cfg.InsecureEdgeTerminationPolicy "redirect"))}}
 {{$cfg.Host}}{{$cfg.Path}} {{$idx}}
 {{       end }}
 {{     end }}

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -2346,7 +2346,7 @@ func deepCopy_api_TLSConfig(in routeapi.TLSConfig, out *routeapi.TLSConfig, c *c
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = in.Insecure
+	out.InsecureEdgeTerminationPolicy = in.InsecureEdgeTerminationPolicy
 	return nil
 }
 

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -2346,6 +2346,7 @@ func deepCopy_api_TLSConfig(in routeapi.TLSConfig, out *routeapi.TLSConfig, c *c
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = in.Insecure
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -3786,6 +3786,7 @@ func autoconvert_api_TLSConfig_To_v1_TLSConfig(in *routeapi.TLSConfig, out *rout
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = routeapiv1.TLSInsecureType(in.Insecure)
 	return nil
 }
 
@@ -3909,6 +3910,7 @@ func autoconvert_v1_TLSConfig_To_api_TLSConfig(in *routeapiv1.TLSConfig, out *ro
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = routeapi.TLSInsecureType(in.Insecure)
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -3786,7 +3786,7 @@ func autoconvert_api_TLSConfig_To_v1_TLSConfig(in *routeapi.TLSConfig, out *rout
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = routeapiv1.TLSInsecureType(in.Insecure)
+	out.InsecureEdgeTerminationPolicy = routeapiv1.InsecureEdgeTerminationPolicyType(in.InsecureEdgeTerminationPolicy)
 	return nil
 }
 
@@ -3910,7 +3910,7 @@ func autoconvert_v1_TLSConfig_To_api_TLSConfig(in *routeapiv1.TLSConfig, out *ro
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = routeapi.TLSInsecureType(in.Insecure)
+	out.InsecureEdgeTerminationPolicy = routeapi.InsecureEdgeTerminationPolicyType(in.InsecureEdgeTerminationPolicy)
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -2256,7 +2256,7 @@ func deepCopy_v1_TLSConfig(in routeapiv1.TLSConfig, out *routeapiv1.TLSConfig, c
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = in.Insecure
+	out.InsecureEdgeTerminationPolicy = in.InsecureEdgeTerminationPolicy
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -2256,6 +2256,7 @@ func deepCopy_v1_TLSConfig(in routeapiv1.TLSConfig, out *routeapiv1.TLSConfig, c
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = in.Insecure
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -3761,7 +3761,7 @@ func autoconvert_api_TLSConfig_To_v1beta3_TLSConfig(in *routeapi.TLSConfig, out 
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = routeapiv1beta3.TLSInsecureType(in.Insecure)
+	out.InsecureEdgeTerminationPolicy = routeapiv1beta3.InsecureEdgeTerminationPolicyType(in.InsecureEdgeTerminationPolicy)
 	return nil
 }
 
@@ -3885,7 +3885,7 @@ func autoconvert_v1beta3_TLSConfig_To_api_TLSConfig(in *routeapiv1beta3.TLSConfi
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = routeapi.TLSInsecureType(in.Insecure)
+	out.InsecureEdgeTerminationPolicy = routeapi.InsecureEdgeTerminationPolicyType(in.InsecureEdgeTerminationPolicy)
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -3761,6 +3761,7 @@ func autoconvert_api_TLSConfig_To_v1beta3_TLSConfig(in *routeapi.TLSConfig, out 
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = routeapiv1beta3.TLSInsecureType(in.Insecure)
 	return nil
 }
 
@@ -3884,6 +3885,7 @@ func autoconvert_v1beta3_TLSConfig_To_api_TLSConfig(in *routeapiv1beta3.TLSConfi
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = routeapi.TLSInsecureType(in.Insecure)
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -2246,7 +2246,7 @@ func deepCopy_v1beta3_TLSConfig(in routeapiv1beta3.TLSConfig, out *routeapiv1bet
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
-	out.Insecure = in.Insecure
+	out.InsecureEdgeTerminationPolicy = in.InsecureEdgeTerminationPolicy
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -2246,6 +2246,7 @@ func deepCopy_v1beta3_TLSConfig(in routeapiv1beta3.TLSConfig, out *routeapiv1bet
 	out.Key = in.Key
 	out.CACertificate = in.CACertificate
 	out.DestinationCACertificate = in.DestinationCACertificate
+	out.Insecure = in.Insecure
 	return nil
 }
 

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -569,13 +569,13 @@ func (d *RouteDescriber) Describe(namespace, name string) (string, error) {
 		formatString(out, "Service", route.Spec.To.Name)
 
 		tlsTerm := ""
-		tlsInsecure := ""
+		insecurePolicy := ""
 		if route.Spec.TLS != nil {
 			tlsTerm = string(route.Spec.TLS.Termination)
-			tlsInsecure = string(route.Spec.TLS.Insecure)
+			insecurePolicy = string(route.Spec.TLS.InsecureEdgeTerminationPolicy)
 		}
 		formatString(out, "TLS Termination", tlsTerm)
-		formatString(out, "Insecure", tlsInsecure)
+		formatString(out, "Insecure Policy", insecurePolicy)
 		return nil
 	})
 }

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -569,10 +569,13 @@ func (d *RouteDescriber) Describe(namespace, name string) (string, error) {
 		formatString(out, "Service", route.Spec.To.Name)
 
 		tlsTerm := ""
+		tlsInsecure := ""
 		if route.Spec.TLS != nil {
 			tlsTerm = string(route.Spec.TLS.Termination)
+			tlsInsecure = string(route.Spec.TLS.Insecure)
 		}
 		formatString(out, "TLS Termination", tlsTerm)
+		formatString(out, "Insecure", tlsInsecure)
 		return nil
 	})
 }

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -34,7 +34,7 @@ var (
 	imageStreamImageColumns = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
 	imageStreamColumns      = []string{"NAME", "DOCKER REPO", "TAGS", "UPDATED"}
 	projectColumns          = []string{"NAME", "DISPLAY NAME", "STATUS"}
-	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "LABELS", "TLS TERMINATION"}
+	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "LABELS", "INSECURE", "TLS TERMINATION"}
 	deploymentColumns       = []string{"NAME", "STATUS", "CAUSE"}
 	deploymentConfigColumns = []string{"NAME", "TRIGGERS", "LATEST"}
 	templateColumns         = []string{"NAME", "DESCRIPTION", "PARAMETERS", "OBJECTS"}
@@ -417,15 +417,17 @@ func printProjectList(projects *projectapi.ProjectList, w io.Writer, withNamespa
 
 func printRoute(route *routeapi.Route, w io.Writer, withNamespace, wide, showAll bool, columnLabels []string) error {
 	tlsTerm := ""
+	tlsInsecure := ""
 	if route.Spec.TLS != nil {
 		tlsTerm = string(route.Spec.TLS.Termination)
+		tlsInsecure = string(route.Spec.TLS.Insecure)
 	}
 	if withNamespace {
 		if _, err := fmt.Fprintf(w, "%s\t", route.Namespace); err != nil {
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", route.Name, route.Spec.Host, route.Spec.Path, route.Spec.To.Name, labels.Set(route.Labels), tlsTerm)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", route.Name, route.Spec.Host, route.Spec.Path, route.Spec.To.Name, labels.Set(route.Labels), tlsInsecure, tlsTerm)
 	return err
 }
 

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -34,7 +34,7 @@ var (
 	imageStreamImageColumns = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
 	imageStreamColumns      = []string{"NAME", "DOCKER REPO", "TAGS", "UPDATED"}
 	projectColumns          = []string{"NAME", "DISPLAY NAME", "STATUS"}
-	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "LABELS", "INSECURE", "TLS TERMINATION"}
+	routeColumns            = []string{"NAME", "HOST/PORT", "PATH", "SERVICE", "LABELS", "INSECURE POLICY", "TLS TERMINATION"}
 	deploymentColumns       = []string{"NAME", "STATUS", "CAUSE"}
 	deploymentConfigColumns = []string{"NAME", "TRIGGERS", "LATEST"}
 	templateColumns         = []string{"NAME", "DESCRIPTION", "PARAMETERS", "OBJECTS"}
@@ -417,17 +417,18 @@ func printProjectList(projects *projectapi.ProjectList, w io.Writer, withNamespa
 
 func printRoute(route *routeapi.Route, w io.Writer, withNamespace, wide, showAll bool, columnLabels []string) error {
 	tlsTerm := ""
-	tlsInsecure := ""
+	insecurePolicy := ""
 	if route.Spec.TLS != nil {
 		tlsTerm = string(route.Spec.TLS.Termination)
-		tlsInsecure = string(route.Spec.TLS.Insecure)
+		insecurePolicy = string(route.Spec.TLS.InsecureEdgeTerminationPolicy)
 	}
 	if withNamespace {
 		if _, err := fmt.Fprintf(w, "%s\t", route.Namespace); err != nil {
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", route.Name, route.Spec.Host, route.Spec.Path, route.Spec.To.Name, labels.Set(route.Labels), tlsInsecure, tlsTerm)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		route.Name, route.Spec.Host, route.Spec.Path, route.Spec.To.Name, labels.Set(route.Labels), insecurePolicy, tlsTerm)
 	return err
 }
 

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -89,10 +89,18 @@ type TLSConfig struct {
 	// DestinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
 	// termination this file should be provided in order to have routers use it for health checks on the secure connection
 	DestinationCACertificate string `json:"destinationCACertificate,omitempty"`
+
+	// Insecure indicates the desired behavior for insecure connections
+	// to an edge-terminated route: expose, redirect or disable.
+	Insecure TLSInsecureType `json:"insecure,omitempty"`
 }
 
 // TLSTerminationType dictates where the secure communication will stop
 type TLSTerminationType string
+
+// TLSInsecureType dictates the behavior of insecure connections to an
+// edge-terminated route.
+type TLSInsecureType string
 
 const (
 	// TLSTerminationEdge terminate encryption at the edge router.
@@ -101,4 +109,11 @@ const (
 	TLSTerminationPassthrough TLSTerminationType = "passthrough"
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
+
+	// TLSInsecureDisable disables insecure connections for an edge-terminated route.
+	TLSInsecureDisable TLSInsecureType = "disable"
+	// TLSInsecureExpose allows insecure connections for an edge-terminated route.
+	TLSInsecureExpose TLSInsecureType = "expose"
+	// TLSInsecureRedirect redirects insecure connections for an edge-terminated route.
+	TLSInsecureRedirect TLSInsecureType = "redirect"
 )

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -112,11 +112,11 @@ const (
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
 
 	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
-	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "none"
+	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "None"
 	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
-	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "allow"
+	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "Allow"
 	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
 	// As an example, for routers that support HTTP and HTTPS, the
 	// insecure HTTP connections will be redirected to use HTTPS.
-	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "redirect"
+	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "Redirect"
 )

--- a/pkg/route/api/types.go
+++ b/pkg/route/api/types.go
@@ -90,17 +90,18 @@ type TLSConfig struct {
 	// termination this file should be provided in order to have routers use it for health checks on the secure connection
 	DestinationCACertificate string `json:"destinationCACertificate,omitempty"`
 
-	// Insecure indicates the desired behavior for insecure connections
-	// to an edge-terminated route: expose, redirect or disable.
-	Insecure TLSInsecureType `json:"insecure,omitempty"`
+	// InsecureEdgeTerminationPolicy indicates the desired behavior for
+	// insecure connections to an edge-terminated route:
+	//   disable, allow or redirect
+	InsecureEdgeTerminationPolicy InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty"`
 }
 
 // TLSTerminationType dictates where the secure communication will stop
 type TLSTerminationType string
 
-// TLSInsecureType dictates the behavior of insecure connections to an
-// edge-terminated route.
-type TLSInsecureType string
+// InsecureEdgeTerminationPolicyType dictates the behavior of insecure
+// connections to an edge-terminated route.
+type InsecureEdgeTerminationPolicyType string
 
 const (
 	// TLSTerminationEdge terminate encryption at the edge router.
@@ -110,10 +111,12 @@ const (
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
 
-	// TLSInsecureDisable disables insecure connections for an edge-terminated route.
-	TLSInsecureDisable TLSInsecureType = "disable"
-	// TLSInsecureExpose allows insecure connections for an edge-terminated route.
-	TLSInsecureExpose TLSInsecureType = "expose"
-	// TLSInsecureRedirect redirects insecure connections for an edge-terminated route.
-	TLSInsecureRedirect TLSInsecureType = "redirect"
+	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "none"
+	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "allow"
+	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
+	// As an example, for routers that support HTTP and HTTPS, the
+	// insecure HTTP connections will be redirected to use HTTPS.
+	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "redirect"
 )

--- a/pkg/route/api/v1/types.go
+++ b/pkg/route/api/v1/types.go
@@ -95,17 +95,18 @@ type TLSConfig struct {
 	// termination this file should be provided in order to have routers use it for health checks on the secure connection
 	DestinationCACertificate string `json:"destinationCACertificate,omitempty" description:"provides the contents of the ca certificate of the final destination.  When using re-encrypt termination this file should be provided in order to have routers use it for health checks on the secure connection"`
 
-	// Insecure indicates the desired behavior for insecure connections
-	// to an edge-terminated route: expose, redirect or disable.
-	Insecure TLSInsecureType `json:"insecure,omitempty" description:"indicates desired behavior for insecure connections to an edge-terminated route.  If not set, insecure connections will not be allowed"`
+	// InsecureEdgeTerminationPolicy indicates the desired behavior for
+	// insecure connections to an edge-terminated route:
+	//   disable, allow or redirect
+	InsecureEdgeTerminationPolicy InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty" description:"indicates desired behavior for insecure connections to an edge-terminated route.  If not set, insecure connections will not be allowed"`
 }
 
 // TLSTerminationType dictates where the secure communication will stop
 type TLSTerminationType string
 
-// TLSInsecureType dictates the behavior of insecure connections to an
-// edge-terminated route.
-type TLSInsecureType string
+// InsecureEdgeTerminationPolicyType dictates the behavior of insecure
+// connections to an edge-terminated route.
+type InsecureEdgeTerminationPolicyType string
 
 const (
 	// TLSTerminationEdge terminate encryption at the edge router.
@@ -115,10 +116,12 @@ const (
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
 
-	// TLSInsecureDisable disables insecure connections for an edge-terminated route.
-	TLSInsecureDisable TLSInsecureType = "disable"
-	// TLSInsecureExpose allows insecure connections for an edge-terminated route.
-	TLSInsecureExpose TLSInsecureType = "expose"
-	// TLSInsecureRedirect redirects insecure connections for an edge-terminated route.
-	TLSInsecureRedirect TLSInsecureType = "redirect"
+	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "none"
+	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "allow"
+	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
+	// As an example, for routers that support HTTP and HTTPS, the
+	// insecure HTTP connections will be redirected to use HTTPS.
+	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "redirect"
 )

--- a/pkg/route/api/v1/types.go
+++ b/pkg/route/api/v1/types.go
@@ -115,13 +115,4 @@ const (
 	TLSTerminationPassthrough TLSTerminationType = "passthrough"
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
-
-	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
-	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "none"
-	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
-	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "allow"
-	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
-	// As an example, for routers that support HTTP and HTTPS, the
-	// insecure HTTP connections will be redirected to use HTTPS.
-	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "redirect"
 )

--- a/pkg/route/api/v1/types.go
+++ b/pkg/route/api/v1/types.go
@@ -94,10 +94,18 @@ type TLSConfig struct {
 	// DestinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
 	// termination this file should be provided in order to have routers use it for health checks on the secure connection
 	DestinationCACertificate string `json:"destinationCACertificate,omitempty" description:"provides the contents of the ca certificate of the final destination.  When using re-encrypt termination this file should be provided in order to have routers use it for health checks on the secure connection"`
+
+	// Insecure indicates the desired behavior for insecure connections
+	// to an edge-terminated route: expose, redirect or disable.
+	Insecure TLSInsecureType `json:"insecure,omitempty" description:"indicates desired behavior for insecure connections to an edge-terminated route.  If not set, insecure connections will not be allowed"`
 }
 
 // TLSTerminationType dictates where the secure communication will stop
 type TLSTerminationType string
+
+// TLSInsecureType dictates the behavior of insecure connections to an
+// edge-terminated route.
+type TLSInsecureType string
 
 const (
 	// TLSTerminationEdge terminate encryption at the edge router.
@@ -106,4 +114,11 @@ const (
 	TLSTerminationPassthrough TLSTerminationType = "passthrough"
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
+
+	// TLSInsecureDisable disables insecure connections for an edge-terminated route.
+	TLSInsecureDisable TLSInsecureType = "disable"
+	// TLSInsecureExpose allows insecure connections for an edge-terminated route.
+	TLSInsecureExpose TLSInsecureType = "expose"
+	// TLSInsecureRedirect redirects insecure connections for an edge-terminated route.
+	TLSInsecureRedirect TLSInsecureType = "redirect"
 )

--- a/pkg/route/api/v1beta3/types.go
+++ b/pkg/route/api/v1beta3/types.go
@@ -90,10 +90,18 @@ type TLSConfig struct {
 	// DestinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
 	// termination this file should be provided in order to have routers use it for health checks on the secure connection
 	DestinationCACertificate string `json:"destinationCACertificate,omitempty"`
+
+	// Insecure indicates the desired behavior for insecure connections
+	// to an edge-terminated route: expose, redirect or disable.
+	Insecure TLSInsecureType `json:"insecure,omitempty"`
 }
 
 // TLSTerminationType dictates where the secure communication will stop
 type TLSTerminationType string
+
+// TLSInsecureType dictates the behavior of insecure connections to an
+// edge-terminated route.
+type TLSInsecureType string
 
 const (
 	// TLSTerminationEdge terminate encryption at the edge router.
@@ -102,4 +110,11 @@ const (
 	TLSTerminationPassthrough TLSTerminationType = "passthrough"
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
+
+	// TLSInsecureDisable disables insecure connections for an edge-terminated route.
+	TLSInsecureDisable TLSInsecureType = "disable"
+	// TLSInsecureExpose allows insecure connections for an edge-terminated route.
+	TLSInsecureExpose TLSInsecureType = "expose"
+	// TLSInsecureRedirect redirects insecure connections for an edge-terminated route.
+	TLSInsecureRedirect TLSInsecureType = "redirect"
 )

--- a/pkg/route/api/v1beta3/types.go
+++ b/pkg/route/api/v1beta3/types.go
@@ -111,13 +111,4 @@ const (
 	TLSTerminationPassthrough TLSTerminationType = "passthrough"
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
-
-	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
-	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "none"
-	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
-	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "allow"
-	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
-	// As an example, for routers that support HTTP and HTTPS, the
-	// insecure HTTP connections will be redirected to use HTTPS.
-	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "redirect"
 )

--- a/pkg/route/api/v1beta3/types.go
+++ b/pkg/route/api/v1beta3/types.go
@@ -91,17 +91,18 @@ type TLSConfig struct {
 	// termination this file should be provided in order to have routers use it for health checks on the secure connection
 	DestinationCACertificate string `json:"destinationCACertificate,omitempty"`
 
-	// Insecure indicates the desired behavior for insecure connections
-	// to an edge-terminated route: expose, redirect or disable.
-	Insecure TLSInsecureType `json:"insecure,omitempty"`
+	// InsecureEdgeTerminationPolicy indicates the desired behavior for
+	// insecure connections to an edge-terminated route:
+	//   disable, allow or redirect
+	InsecureEdgeTerminationPolicy InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty"`
 }
 
 // TLSTerminationType dictates where the secure communication will stop
 type TLSTerminationType string
 
-// TLSInsecureType dictates the behavior of insecure connections to an
-// edge-terminated route.
-type TLSInsecureType string
+// InsecureEdgeTerminationPolicyType dictates the behavior of insecure
+// connections to an edge-terminated route.
+type InsecureEdgeTerminationPolicyType string
 
 const (
 	// TLSTerminationEdge terminate encryption at the edge router.
@@ -111,10 +112,12 @@ const (
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
 
-	// TLSInsecureDisable disables insecure connections for an edge-terminated route.
-	TLSInsecureDisable TLSInsecureType = "disable"
-	// TLSInsecureExpose allows insecure connections for an edge-terminated route.
-	TLSInsecureExpose TLSInsecureType = "expose"
-	// TLSInsecureRedirect redirects insecure connections for an edge-terminated route.
-	TLSInsecureRedirect TLSInsecureType = "redirect"
+	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "none"
+	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "allow"
+	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
+	// As an example, for routers that support HTTP and HTTPS, the
+	// insecure HTTP connections will be redirected to use HTTPS.
+	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "redirect"
 )

--- a/pkg/route/api/validation/validation.go
+++ b/pkg/route/api/validation/validation.go
@@ -156,7 +156,7 @@ func validateInsecureEdgeTerminationPolicy(tls *routeapi.TLSConfig) *fielderrors
 	}
 
 	// It is an edge-terminated route, check insecure option value is
-	// one of none(or disable), allow or redirect.
+	// one of None(for disable), Allow or Redirect.
 	allowedValues := map[routeapi.InsecureEdgeTerminationPolicyType]bool{
 		routeapi.InsecureEdgeTerminationPolicyNone:     true,
 		routeapi.InsecureEdgeTerminationPolicyAllow:    true,

--- a/pkg/route/api/validation/validation_test.go
+++ b/pkg/route/api/validation/validation_test.go
@@ -369,7 +369,7 @@ func TestValidateTLS(t *testing.T) {
 	}
 }
 
-func TestValidateTLSInsecure(t *testing.T) {
+func TestValidateTLSInsecureEdgeTerminationPolicy(t *testing.T) {
 	tests := []struct {
 		name  string
 		route *api.Route
@@ -397,10 +397,10 @@ func TestValidateTLSInsecure(t *testing.T) {
 		},
 	}
 
-	insecureTypes := []api.TLSInsecureType{
-		api.TLSInsecureDisable,
-		api.TLSInsecureExpose,
-		api.TLSInsecureRedirect,
+	insecureTypes := []api.InsecureEdgeTerminationPolicyType{
+		api.InsecureEdgeTerminationPolicyNone,
+		api.InsecureEdgeTerminationPolicyAllow,
+		api.InsecureEdgeTerminationPolicyRedirect,
 		"support HTTPsec",
 		"or maybe HSTS",
 	}
@@ -411,14 +411,14 @@ func TestValidateTLSInsecure(t *testing.T) {
 				tc.name, len(errs), errs)
 		}
 
-		tc.route.Spec.TLS.Insecure = ""
+		tc.route.Spec.TLS.InsecureEdgeTerminationPolicy = ""
 		if errs := validateTLS(tc.route); len(errs) != 0 {
 			t.Errorf("Test case %s got %d errors where none were expected. %v",
 				tc.name, len(errs), errs)
 		}
 
 		for _, val := range insecureTypes {
-			tc.route.Spec.TLS.Insecure = val
+			tc.route.Spec.TLS.InsecureEdgeTerminationPolicy = val
 			if errs := validateTLS(tc.route); len(errs) != 1 {
 				t.Errorf("Test case %s with insecure=%q got %d errors where one was expected. %v",
 					tc.name, val, len(errs), errs)
@@ -427,10 +427,10 @@ func TestValidateTLSInsecure(t *testing.T) {
 	}
 }
 
-func TestValidateTLSEdgeInsecure(t *testing.T) {
+func TestValidateInsecureEdgeTerminationPolicy(t *testing.T) {
 	tests := []struct {
 		name           string
-		insecure       api.TLSInsecureType
+		insecure       api.InsecureEdgeTerminationPolicyType
 		expectedErrors int
 	}{
 		{
@@ -444,22 +444,22 @@ func TestValidateTLSEdgeInsecure(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
-			name:           "disabled insecure option",
-			insecure:       api.TLSInsecureDisable,
+			name:           "insecure option none",
+			insecure:       api.InsecureEdgeTerminationPolicyNone,
 			expectedErrors: 0,
 		},
 		{
-			name:           "exposed insecure option",
-			insecure:       api.TLSInsecureExpose,
+			name:           "insecure option allow",
+			insecure:       api.InsecureEdgeTerminationPolicyAllow,
 			expectedErrors: 0,
 		},
 		{
-			name:           "redirected insecure option",
-			insecure:       api.TLSInsecureRedirect,
+			name:           "insecure option redirect",
+			insecure:       api.InsecureEdgeTerminationPolicyRedirect,
 			expectedErrors: 0,
 		},
 		{
-			name:           "other insecure option",
+			name:           "insecure option other",
 			insecure:       "something else",
 			expectedErrors: 1,
 		},
@@ -469,8 +469,8 @@ func TestValidateTLSEdgeInsecure(t *testing.T) {
 		route := &api.Route{
 			Spec: api.RouteSpec{
 				TLS: &api.TLSConfig{
-					Termination: api.TLSTerminationEdge,
-					Insecure:    tc.insecure,
+					Termination:                   api.TLSTerminationEdge,
+					InsecureEdgeTerminationPolicy: tc.insecure,
 				},
 			},
 		}
@@ -482,11 +482,11 @@ func TestValidateTLSEdgeInsecure(t *testing.T) {
 	}
 }
 
-func TestValidateTLSNoTerminationInsecure(t *testing.T) {
-	insecureTypes := []api.TLSInsecureType{
-		api.TLSInsecureDisable,
-		api.TLSInsecureExpose,
-		api.TLSInsecureRedirect,
+func TestValidateNoTLSInsecureEdgeTerminationPolicy(t *testing.T) {
+	insecureTypes := []api.InsecureEdgeTerminationPolicyType{
+		api.InsecureEdgeTerminationPolicyNone,
+		api.InsecureEdgeTerminationPolicyAllow,
+		api.InsecureEdgeTerminationPolicyRedirect,
 		"support HTTPsec",
 		"or maybe HSTS",
 	}
@@ -495,8 +495,8 @@ func TestValidateTLSNoTerminationInsecure(t *testing.T) {
 		route := &api.Route{
 			Spec: api.RouteSpec{
 				TLS: &api.TLSConfig{
-					Termination: "",
-					Insecure:    val,
+					Termination:                   "",
+					InsecureEdgeTerminationPolicy: val,
 				},
 			},
 		}

--- a/plugins/router/f5/plugin.go
+++ b/plugins/router/f5/plugin.go
@@ -359,6 +359,18 @@ func (p *F5Plugin) addRoute(routename, poolname, hostname, pathname string,
 				routename, err)
 			return err
 		}
+
+		// TODO(ramr):  need to handle redirect case for F5.
+		if tls.Termination == routeapi.TLSTerminationEdge &&
+			tls.Insecure == routeapi.TLSInsecureExpose {
+			glog.V(4).Infof("Exposing insecure route %s for pool %s, hostname %s, pathname %s...",
+				routename, poolname, hostname, prettyPathname)
+			err := p.F5Client.AddInsecureRoute(routename, poolname, hostname, pathname)
+			if err != nil {
+				glog.V(4).Infof("Error exposing insecure route for pool %s: %v", poolname, err)
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/plugins/router/f5/plugin.go
+++ b/plugins/router/f5/plugin.go
@@ -362,12 +362,12 @@ func (p *F5Plugin) addRoute(routename, poolname, hostname, pathname string,
 
 		// TODO(ramr):  need to handle redirect case for F5.
 		if tls.Termination == routeapi.TLSTerminationEdge &&
-			tls.Insecure == routeapi.TLSInsecureExpose {
-			glog.V(4).Infof("Exposing insecure route %s for pool %s, hostname %s, pathname %s...",
+			tls.InsecureEdgeTerminationPolicy == routeapi.InsecureEdgeTerminationPolicyAllow {
+			glog.V(4).Infof("Allowing insecure route %s for pool %s, hostname %s, pathname %s...",
 				routename, poolname, hostname, prettyPathname)
 			err := p.F5Client.AddInsecureRoute(routename, poolname, hostname, pathname)
 			if err != nil {
-				glog.V(4).Infof("Error exposing insecure route for pool %s: %v", poolname, err)
+				glog.V(4).Infof("Error allowing insecure route for pool %s: %v", poolname, err)
 				return err
 			}
 		}

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -368,6 +368,10 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string)
 	if tls != nil && len(tls.Termination) > 0 {
 		config.TLSTermination = tls.Termination
 
+		if tls.Termination == routeapi.TLSTerminationEdge {
+			config.Insecure = tls.Insecure
+		}
+
 		if tls.Termination != routeapi.TLSTerminationPassthrough {
 			if config.Certificates == nil {
 				config.Certificates = make(map[string]Certificate)

--- a/plugins/router/template/router.go
+++ b/plugins/router/template/router.go
@@ -369,7 +369,7 @@ func (r *templateRouter) AddRoute(id string, route *routeapi.Route, host string)
 		config.TLSTermination = tls.Termination
 
 		if tls.Termination == routeapi.TLSTerminationEdge {
-			config.Insecure = tls.Insecure
+			config.InsecureEdgeTerminationPolicy = tls.InsecureEdgeTerminationPolicy
 		}
 
 		if tls.Termination != routeapi.TLSTerminationPassthrough {

--- a/plugins/router/template/types.go
+++ b/plugins/router/template/types.go
@@ -33,9 +33,10 @@ type ServiceAliasConfig struct {
 	Status ServiceAliasConfigStatus
 	// Indicates the port the user wishes to expose. If empty, a port will be selected for the service.
 	PreferPort string
-	// Insecure indicates desired behavior for insecure connections to
-	// an edge-terminated route: expose, redirect or disable.
-	Insecure routeapi.TLSInsecureType
+	// InsecureEdgeTerminationPolicy indicates desired behavior for
+	// insecure connections to an edge-terminated route:
+	//   none (or disable), allow or redirect
+	InsecureEdgeTerminationPolicy routeapi.InsecureEdgeTerminationPolicyType
 }
 
 type ServiceAliasConfigStatus string

--- a/plugins/router/template/types.go
+++ b/plugins/router/template/types.go
@@ -33,6 +33,9 @@ type ServiceAliasConfig struct {
 	Status ServiceAliasConfigStatus
 	// Indicates the port the user wishes to expose. If empty, a port will be selected for the service.
 	PreferPort string
+	// Insecure indicates desired behavior for insecure connections to
+	// an edge-terminated route: expose, redirect or disable.
+	Insecure routeapi.TLSInsecureType
 }
 
 type ServiceAliasConfigStatus string


### PR DESCRIPTION
This allows secure and non-secure routes for the same host. Fix for #4848 

@smarterclayton / @pweil-   PTAL  Thx

New routes can contain an insecure field w/ supported values `Redirect | Allow | None` - default is None (or empty string for older routes). 
Example route to redirect http to https:
```
{  
  "kind": "Route",  
  "apiVersion": "v1beta3",  
  "metadata": {  
    "name": "header-test-edge-redirect-route"  
  },  
  "spec": {  
    "host": "edge.header.test",  
    "tls": {  
      "termination": "edge",  
      "insecureEdgeTerminationPolicy": "Redirect"  
    },  
    "to": {  
      "name": "header-test"  
    }  
  }  
}  
``` 

```
[vagrant@openshiftdev origin]$ oc create -f test-route-redirect.json  
route "header-test-edge-redirect-route" created  
[vagrant@openshiftdev origin]$ curl -vvv -k --resolve edge.header.test:80:127.0.0.1 http://edge.header.test  
... <snipped> ...   
< HTTP/1.1 302 Found  
< Cache-Control: no-cache  
< Content-length: 0  
< Location: https://edge.header.test/  
< Connection: close  
<   
* Closing connection 0  
```
 
*Updated:  Updated examples to use the new constants / field names.