### PR TITLE
Remove code duplication

### DIFF
--- a/pkg/image/graph/nodes/nodes.go
+++ b/pkg/image/graph/nodes/nodes.go
@@ -48,15 +48,7 @@ func EnsureDockerRepositoryNode(g osgraph.MutableUniqueGraph, name, tag string) 
 		if len(tag) != 0 {
 			ref.Tag = tag
 		}
-		if len(ref.Tag) == 0 {
-			ref.Tag = imageapi.DefaultImageTag
-		}
-		if len(ref.Registry) == 0 {
-			ref.Registry = "docker.io"
-		}
-		if len(ref.Namespace) == 0 {
-			ref.Namespace = imageapi.DockerDefaultNamespace
-		}
+		ref = ref.DockerClientDefaults()
 	} else {
 		ref = imageapi.DockerImageReference{Name: name}
 	}


### PR DESCRIPTION
Came across this while working on the `image/api` package.

When name could not be parsed as a DockerImageReference, we were
creating a new DockerImageReference but (accidentaly?) not setting the
tag nor the default values.
Likely, if name is not parseable, we should not use it to construct a
(invalid?) DockerImageReference.