### PR TITLE
fix --config flag

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -240,6 +240,7 @@ oc get projects
 oc project project-foo
 [ "$(oc config view | grep current-context | grep project-foo/${API_HOST}:${API_PORT}/test-user)" ]
 [ "$(oc whoami | grep 'test-user')" ]
+[ "$(oc whoami --config="${MASTER_CONFIG_DIR}/admin.kubeconfig" | grep 'system:admin')" ]
 [ -n "$(oc whoami -t)" ]
 [ -n "$(oc whoami -c)" ]
 

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -109,9 +109,7 @@ To search templates, image streams, and Docker images that match the arguments p
 
 // NewCmdNewApplication implements the OpenShift cli new-app command
 func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
-	mapper, typer := f.Object()
-	clientMapper := f.ClientMapperForCommand()
-	config := newcmd.NewAppConfig(typer, mapper, clientMapper)
+	config := newcmd.NewAppConfig()
 
 	cmd := &cobra.Command{
 		Use:        "new-app (IMAGE | IMAGESTREAM | TEMPLATE | PATH | URL ...)",
@@ -120,6 +118,11 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 		Example:    fmt.Sprintf(newAppExample, fullName),
 		SuggestFor: []string{"app", "application"},
 		Run: func(c *cobra.Command, args []string) {
+			mapper, typer := f.Object()
+			config.SetMapper(mapper)
+			config.SetTyper(typer)
+			config.SetClientMapper(f.ClientMapperForCommand())
+
 			err := RunNewApplication(fullName, f, out, c, args, config)
 			if err == errExit {
 				os.Exit(1)

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -48,9 +48,7 @@ You can use '%[1]s status' to check the progress.`
 
 // NewCmdNewBuild implements the OpenShift cli new-build command
 func NewCmdNewBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
-	mapper, typer := f.Object()
-	clientMapper := f.ClientMapperForCommand()
-	config := newcmd.NewAppConfig(typer, mapper, clientMapper)
+	config := newcmd.NewAppConfig()
 
 	cmd := &cobra.Command{
 		Use:        "new-build (IMAGE | IMAGESTREAM | PATH | URL ...)",
@@ -59,6 +57,11 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.
 		Example:    fmt.Sprintf(newBuildExample, fullName),
 		SuggestFor: []string{"build", "builds"},
 		Run: func(c *cobra.Command, args []string) {
+			mapper, typer := f.Object()
+			config.SetMapper(mapper)
+			config.SetTyper(typer)
+			config.SetClientMapper(f.ClientMapperForCommand())
+
 			config.AddEnvironmentToBuild = true
 			err := RunNewBuild(fullName, f, out, in, c, args, config)
 			if err == errExit {

--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -97,8 +97,9 @@ type errlist interface {
 	Errors() []error
 }
 
-// NewAppConfig returns a new AppConfig
-func NewAppConfig(typer runtime.ObjectTyper, mapper meta.RESTMapper, clientMapper resource.ClientMapper) *AppConfig {
+// NewAppConfig returns a new AppConfig, but you must set your typer, mapper, and clientMapper after the command has been run
+// and flags have been parsed.
+func NewAppConfig() *AppConfig {
 	dockerSearcher := app.DockerRegistrySearcher{
 		Client: dockerregistry.NewClient(),
 	}
@@ -108,11 +109,20 @@ func NewAppConfig(typer runtime.ObjectTyper, mapper meta.RESTMapper, clientMappe
 			Tester:    dockerfile.NewTester(),
 		},
 		dockerSearcher: dockerSearcher,
-		typer:          typer,
-		mapper:         mapper,
-		clientMapper:   clientMapper,
 		refBuilder:     &app.ReferenceBuilder{},
 	}
+}
+
+func (c *AppConfig) SetMapper(mapper meta.RESTMapper) {
+	c.mapper = mapper
+}
+
+func (c *AppConfig) SetTyper(typer runtime.ObjectTyper) {
+	c.typer = typer
+}
+
+func (c *AppConfig) SetClientMapper(clientMapper resource.ClientMapper) {
+	c.clientMapper = clientMapper
 }
 
 func (c *AppConfig) dockerRegistrySearcher() app.Searcher {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5218

The access to the factory (specifically `ClientMapperForCommand`), requires a `RESTClient`, which requires `NegotiateVersion`, which was being called before flags were parsed, so a fully default `ClientConfig` was used and subsequently cached.

This moves that access to after the flags are parsed.  I move all the fields for consistency and it will be easier for reviewers to follow the rule: "don't access a factory before flags are parsed" than "don't call a method that transitively fills in a cache".  

This also eliminates an extra negotiate for every command.

@csrwng ptal.