### PR TITLE
Fix patternfly CSS ordering

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -200,10 +200,6 @@
 }
 
 .pod-block {
-  .c3-tooltip td {
-    background-color: #ffffff;
-    color: #333333;
-  }
   .scaling-controls {
     font-size: 24px;
     margin: 0 10px 10px 0;

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -29,6 +29,7 @@
 @import "@{pf-path}/buttons.less";
 @import "@{pf-path}/close.less";
 @import "@{pf-path}/cards.less";
+@import (less) "@{pf-components-path}/components/c3/c3.css";
 @import "@{pf-path}/charts.less";
 @import "@{pf-path}/close.less";
 @import "@{pf-path}/datatables.less";
@@ -49,7 +50,6 @@
 @import "@{pf-path}/pager.less";
 @import "@{pf-path}/pagination.less";
 @import "@{pf-path}/panels.less";
-@import "@{pf-path}/patternfly-additions.less";
 @import "@{pf-path}/popovers.less";
 @import "@{pf-path}/progress-bars.less";
 @import "@{pf-path}/search.less";


### PR DESCRIPTION
Make sure charts.less is imported after c3.css so that the patternfly
chart styles are used. Remove patternfly-additions.less, which include
the same files we include ourselves in main.less.