### PR TITLE
Fix exposing deployment configs

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -166,6 +166,13 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 	w.Printer = func(mapping *meta.RESTMapping, noHeaders, withNamespace, wide bool, showAll bool, columnLabels []string) (kubectl.ResourcePrinter, error) {
 		return describe.NewHumanReadablePrinter(noHeaders, withNamespace, wide, showAll, columnLabels), nil
 	}
+	kCanBeExposed := w.Factory.CanBeExposed
+	w.CanBeExposed = func(kind string) error {
+		if kind == "DeploymentConfig" {
+			return nil
+		}
+		return kCanBeExposed(kind)
+	}
 
 	return w
 }

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -65,6 +65,10 @@ oc rollback rc/database-1 -o=yaml
 echo "rollback: ok"
 
 oc get dc/database
+oc expose dc/database --name=fromdc
+# should be a service
+oc get svc/fromdc
+oc delete svc/fromdc
 oc stop dc/database
 [ ! "$(oc get dc/database)" ]
 [ ! "$(oc get rc/database-1)" ]


### PR DESCRIPTION
CanBeExposed was introduced during the rebase, this PR adds our overriden
version of it in our factory, plus adds a test to make sure this won't
slip again.

@smarterclayton 