### PR TITLE
PROPOSAL: allow custom router directives via annotations

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -186,6 +186,9 @@ backend be_edge_http_{{$cfgIdx}}
   option forwardfor
   balance leastconn
   timeout check 5000ms
+  {{ range $addlCfg := $cfg.AdditionalConfig }}
+  {{$addlCfg}}
+  {{ end }}
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
   http-request set-header X-Forwarded-Port %[dst_port]
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
@@ -206,6 +209,9 @@ backend be_tcp_{{$cfgIdx}}
   balance source
   hash-type consistent
   timeout check 5000ms
+  {{ range $addlCfg := $cfg.AdditionalConfig }}
+  {{$addlCfg}}
+  {{ end }}
                 {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} check inter 5000ms
                 {{ end }}
@@ -217,6 +223,9 @@ backend be_secure_{{$cfgIdx}}
   option redispatch
   balance leastconn
   timeout check 5000ms
+  {{ range $addlCfg := $cfg.AdditionalConfig }}
+  {{$addlCfg}}
+  {{ end }}
   cookie OPENSHIFT_REENCRYPT_{{$cfgIdx}}_SERVERID insert indirect nocache httponly secure
                 {{ range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} ssl check inter 5000ms verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem cookie {{$endpoint.ID}}

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -158,6 +158,9 @@ type RouterConfig struct {
 	// This is used by some routers to create access access control
 	// boundaries for users and applications.
 	ExternalHostPartitionPath string
+
+	// Enable an annotation strategy for customizing routes.  Valid values are haproxy or empty
+	Annotations string
 }
 
 var errExit = fmt.Errorf("exit")
@@ -222,6 +225,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 	cmd.Flags().StringVar(&cfg.ExternalHostPrivateKey, "external-host-private-key", cfg.ExternalHostPrivateKey, "If the underlying router implementation requires an SSH private key, this is the path to the private key file.")
 	cmd.Flags().BoolVar(&cfg.ExternalHostInsecure, "external-host-insecure", cfg.ExternalHostInsecure, "If the underlying router implementation connects with an external host over a secure connection, this causes the router to skip strict certificate verification with the external host.")
 	cmd.Flags().StringVar(&cfg.ExternalHostPartitionPath, "external-host-partition-path", cfg.ExternalHostPartitionPath, "If the underlying router implementation uses partitions for control boundaries, this is the path to use for that partition.")
+	cmd.Flags().StringVar(&cfg.Annotations, "annotations", cfg.Annotations, "Enable an annotation strategy for customizing routes.  Valid values are haproxy or empty.  It is up to the underlying implementation to allow the annotations.")
 
 	cmd.MarkFlagFilename("credentials", "kubeconfig")
 
@@ -495,6 +499,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 			"STATS_PORT":                          strconv.Itoa(cfg.StatsPort),
 			"STATS_USERNAME":                      cfg.StatsUsername,
 			"STATS_PASSWORD":                      cfg.StatsPassword,
+			"ANNOTATIONS":                         cfg.Annotations,
 		}
 
 		updatePercent := int(-25)

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -48,6 +48,7 @@ type TemplateRouter struct {
 	ReloadScript       string
 	DefaultCertificate string
 	RouterService      *ktypes.NamespacedName
+	Annotations        string
 }
 
 func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
@@ -55,6 +56,7 @@ func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.DefaultCertificate, "default-certificate", util.Env("DEFAULT_CERTIFICATE", ""), "A path to default certificate to use for routes that don't expose a TLS server cert; in PEM format")
 	flag.StringVar(&o.TemplateFile, "template", util.Env("TEMPLATE_FILE", ""), "The path to the template file to use")
 	flag.StringVar(&o.ReloadScript, "reload", util.Env("RELOAD_SCRIPT", ""), "The path to the reload script to use")
+	flag.StringVar(&o.Annotations, "annotations", util.Env("ANNOTATIONS", ""), "Enable an annotation strategy for customizing routes.  Valid values are haproxy or empty")
 }
 
 type RouterStats struct {
@@ -132,6 +134,10 @@ func (o *TemplateRouterOptions) Validate() error {
 	if len(o.ReloadScript) == 0 {
 		return errors.New("reload script must be specified")
 	}
+
+	if len(o.Annotations) > 0 && o.Annotations != templateplugin.AnnotationStrategyHAProxy {
+		return errors.New("invalid annotations value")
+	}
 	return nil
 }
 
@@ -147,6 +153,7 @@ func (o *TemplateRouterOptions) Run() error {
 		StatsPassword:      o.StatsPassword,
 		PeerService:        o.RouterService,
 		IncludeUDP:         o.RouterSelection.IncludeUDP,
+		Annotations:        o.Annotations,
 	}
 
 	templatePlugin, err := templateplugin.NewTemplatePlugin(pluginCfg)

--- a/plugins/router/template/annotations.go
+++ b/plugins/router/template/annotations.go
@@ -1,0 +1,69 @@
+package templaterouter
+
+import (
+	"fmt"
+	"time"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+
+	"github.com/golang/glog"
+)
+
+type AnnotationsFunc func(route *routeapi.Route) []string
+type AnnotationValidator func(s string) bool
+
+const (
+	HAProxyBase          = "openshift.io/route.haproxy."
+	HAProxyTimeoutServer = HAProxyBase + "timeout-server"
+)
+
+func AnnotationFuncFor(t string) AnnotationsFunc {
+	switch t {
+	case AnnotationStrategyHAProxy:
+		return HAProxy
+	default:
+		return NoOp
+	}
+}
+
+func HAProxy(route *routeapi.Route) []string {
+	cfg := []string{}
+	for allowed, validator := range AllowedAnnotations(AnnotationStrategyHAProxy) {
+		if val, ok := route.Annotations[allowed]; ok {
+			if validator(val) {
+				cfg = append(cfg, fmt.Sprintf("%s %s", HAProxyAnnotationToConfig(allowed), val))
+			} else {
+				glog.V(4).Infof("skipping annotation %s due to invalid value %s", allowed, val)
+			}
+		}
+	}
+	return cfg
+}
+
+func NoOp(route *routeapi.Route) []string {
+	return []string{}
+}
+
+func AllowedAnnotations(t string) map[string]AnnotationValidator {
+	switch t {
+	case AnnotationStrategyHAProxy:
+		return map[string]AnnotationValidator{
+			HAProxyTimeoutServer: isValidTimeout,
+		}
+	default:
+		return map[string]AnnotationValidator{}
+	}
+}
+
+func HAProxyAnnotationToConfig(s string) string {
+	switch s {
+	case HAProxyTimeoutServer:
+		return "timeout server"
+	}
+	return ""
+}
+
+func isValidTimeout(s string) bool {
+	_, err := time.ParseDuration(s)
+	return err == nil
+}

--- a/plugins/router/template/plugin.go
+++ b/plugins/router/template/plugin.go
@@ -39,6 +39,7 @@ type TemplatePluginConfig struct {
 	StatsPassword      string
 	IncludeUDP         bool
 	PeerService        *ktypes.NamespacedName
+	Annotations        string
 }
 
 // routerInterface controls the interaction of the plugin with the underlying router implementation
@@ -104,7 +105,9 @@ func NewTemplatePlugin(cfg TemplatePluginConfig) (*TemplatePlugin, error) {
 		statsPassword:      cfg.StatsPassword,
 		statsPort:          cfg.StatsPort,
 		peerEndpointsKey:   peerKey,
+		annotationsFunc:    AnnotationFuncFor(cfg.Annotations),
 	}
+
 	router, err := newTemplateRouter(templateRouterCfg)
 	return newDefaultTemplatePlugin(router, cfg.IncludeUDP), err
 }

--- a/plugins/router/template/types.go
+++ b/plugins/router/template/types.go
@@ -33,6 +33,8 @@ type ServiceAliasConfig struct {
 	Status ServiceAliasConfigStatus
 	// Indicates the port the user wishes to expose. If empty, a port will be selected for the service.
 	PreferPort string
+	// AdditionalConfig provide additional configuration parameter per route.
+	AdditionalConfig []string
 }
 
 type ServiceAliasConfigStatus string
@@ -102,3 +104,7 @@ type certificateWriter interface {
 func (s ServiceUnit) TemplateSafeName() string {
 	return strings.Replace(s.Name, "/", "-", -1)
 }
+
+const (
+	AnnotationStrategyHAProxy = "haproxy"
+)


### PR DESCRIPTION
Proposal - allow custom router directives via annotations.  Prompted by https://github.com/openshift/origin/issues/4981

Mechanics:

1.  Define acceptable annotations is a backend router implementation strategy.  Why?  We don't want to accept any old config with an annotation prefix (ie `openshift.io/route.haproxy.*`) because it is not safe and also means one bad value can crash the router
1.  Define annotation -> config/validation routines
1.  Allow the router to accept an implementation strategy: in this PR a no-op and haproxy strategy are implemented
1.  Allow a user to create a route with a custom annotation which is reflected in the backend.

Pros:

1.  Most secure - only acceptable annotations are allowed
1.  Validation is thorough

Cons:

1.  Extensible only in code - blech
1.  Individual validations at runtime could present a perf issue

Example route with custom haproxy directives

```
 {
      "kind": "Route",
      "apiVersion": "v1",
      "metadata": {
        "name": "route1",
        "annotations": {
	  "openshift.io/route.haproxy.timeout-server": "500s"
        }
      },
      "spec": {
        "host": "www.example.com",
        "to": {
          "kind": "Service",
          "name": "hello-pod"
        }
      }
}
```

Strategy parsed route
(route 2 had bad values, hence the empty AdditionalConfig.  Error displayed below)
```
"ServiceAliasConfigs": {
      "default_route1": {
        "Host": "www.example.com",
        "Path": "",
        "TLSTermination": "",
        "Certificates": null,
        "Status": "saved",
        "PreferPort": "",
        "AdditionalConfig": [
          "timeout server 500s"
        ]
      },
      "default_route2": {
        "Host": "www.example2.com",
        "Path": "",
        "TLSTermination": "",
        "Certificates": null,
        "Status": "",
        "PreferPort": "",
        "AdditionalConfig": []
      }
    }
  },
```

Route with bad value
```
I1020 17:11:40.387085       1 annotations.go:36] skipping annotation openshift.io/route.haproxy.timeout-server due to invalid value foo
```

Reflected haproxy backend

```
backend be_http_default_route1
                
  mode http
  option redispatch
  option forwardfor
  balance leastconn
  timeout check 5000ms
  
  timeout server 500s
```

@ramr @smarterclayton 