### PR TITLE
Remove duplicate bootstrap.js from dependencies

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -128,8 +128,7 @@
     <script src="bower_components/kubernetes-topology-graph/dist/topology-graph.js"></script>
     <script src="bower_components/kubernetes-object-describer/dist/object-describer.js"></script>
     <script src="bower_components/openshift-object-describer/dist/object-describer.js"></script>
-    <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
-    <script src="bower_components/bootstrap-hover-dropdown/bootstrap-hover-dropdown.js"></script>
+    <script src="bower_components/bootstrap-hover-dropdown/bootstrap-hover-dropdown.min.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -44,6 +44,12 @@
         "dist/angular-patternfly.js"
       ]
     },
+    "bootstrap-hover-dropdown": {
+      "main": [
+        "bootstrap-hover-dropdown.min.js"
+      ],
+      "dependencies": {}
+    },
     "patternfly": {
       "main": [
         "components/bootstrap-combobox/js/bootstrap-combobox.js",


### PR DESCRIPTION
Use bootstrap.js from patternfly and don't include the one from bootstap-hover-dropdown.