### PR TITLE
Auto-create router users as needed

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -191,7 +191,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 
 		ServiceAccount: "router",
 		StatsUsername:  "admin",
-		StatsPort:      1936,
+		StatsPort:      defaultStatsPort,
 		HostNetwork:    true,
 	}
 


### PR DESCRIPTION
Changed the code to:
 - Defaults to the service account 'router' when service account is not specified
 - Automatically creates the service account when it does not exist
 - If the router will bind to the host-network, then it tests to see if the service account has the AllowHostPorts security constraint. If it does not, it prints a warning to the user

Fixes issue https://github.com/openshift/origin/issues/4133