### PR TITLE
Referenced tags should get updated on a direct tag

### DIFF
--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -197,6 +197,10 @@ func (s Strategy) tagsChanged(old, stream *api.ImageStream) fielderrors.Validati
 		api.AddTagEventToImageStream(stream, tag, *event)
 	}
 
+	if old != nil {
+		api.UpdateChangedTrackingTags(stream, old)
+	}
+
 	// use a consistent timestamp on creation
 	if old == nil && !stream.CreationTimestamp.IsZero() {
 		for tag, list := range stream.Status.Tags {
@@ -315,7 +319,7 @@ func (v *TagVerifier) Verify(old, stream *api.ImageStream, user user.Info) field
 			Groups: sets.NewString(user.GetGroups()...),
 		}
 		ctx := kapi.WithNamespace(kapi.NewContext(), tagRef.From.Namespace)
-		glog.V(1).Infof("Performing SubjectAccessReview for user=%s, groups=%v to %s/%s", user.GetName(), user.GetGroups(), tagRef.From.Namespace, streamName)
+		glog.V(4).Infof("Performing SubjectAccessReview for user=%s, groups=%v to %s/%s", user.GetName(), user.GetGroups(), tagRef.From.Namespace, streamName)
 		resp, err := v.subjectAccessReviewClient.CreateSubjectAccessReview(ctx, &subjectAccessReview)
 		if err != nil || resp == nil || (resp != nil && !resp.Allowed) {
 			errors = append(errors, fielderrors.NewFieldForbidden(fmt.Sprintf("spec.tags[%s].from", tag), fmt.Sprintf("%s/%s", tagRef.From.Namespace, streamName)))


### PR DESCRIPTION
Explicitly tagging tag1 with an ImageStreamImage should update any tag
that references tag1 in the same imagestream. We needed to walk the
Status tags after we updated the Spec tags.

@ncdc this resolves the issue raised in #5176