### PR TITLE
Adjust line-height of route link to avoid clipping

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -47,6 +47,10 @@
     border: 1px solid #ddd;
     position: relative;
     .osc-object-highlight();
+    h2 {
+      // Avoid clipping descenders in routes on overview.
+      line-height: 1.3;
+    }
     .component-label {
       color: @gray-light;
       font-size: @component-label;


### PR DESCRIPTION
<img width="453" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/10635656/6028df34-77c8-11e5-8e1e-d24d037decbb.png">

Fixes #5270