### PR TITLE
Update pod status chart styles

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -20,6 +20,7 @@
   "unused": true,
   "globals": {
     "angular": false,
+    "c3": false,
     "d3": false,
     "hawtioPluginLoader": false,
     "HawtioCore": false,

--- a/assets/app/scripts/directives/podStatusChart.js
+++ b/assets/app/scripts/directives/podStatusChart.js
@@ -14,56 +14,15 @@ angular.module('openshiftConsole')
       },
       templateUrl: 'views/_pod-status-chart.html',
       link: function($scope, element) {
+        var chart, config;
+
         // The phases to show (in order).
         var phases = ["Running", "Warning", "Failed", "Pending", "Succeeded", "Unknown"];
 
         lastId++;
         $scope.chartId = 'pods-donut-chart-' + lastId;
 
-        // c3.js config for the pods donut chart
-        $scope.chartConfig = {
-          type: "donut",
-          donut: {
-            width: 8,
-            label: {
-              show: false
-            }
-          },
-          size: {
-            height: 130,
-            width: 130
-          },
-          legend: {
-            show: false
-          },
-          tooltip: {
-            format: {
-              value: function(value) {
-                return value;
-              }
-            },
-            position: function() {
-              // Position in the top-left to avoid problems with tooltip text wrapping.
-              return { top: 0, left: 0 };
-            }
-          },
-          data: {
-            type: "donut",
-            groups: [ phases ],
-            // Keep groups in our order.
-            order: null,
-            colors: {
-             Running: "#6eb664",
-             Warning: "#f9d67a",
-             Failed: "#d9534f",
-             Pending: "#e8e8e8",
-             Succeeded: "#0088ce",
-             Unknown: "#f9d67a"
-            }
-          }
-        };
-
-        var updateCenterText = function() {
+        function updateCenterText() {
           var donutChartTitle = d3.select(element[0]).select('text.c3-chart-arcs-title'),
             total = hashSizeFilter($scope.pods),
             smallText;
@@ -82,42 +41,86 @@ angular.module('openshiftConsole')
           donutChartTitle.html('');
           donutChartTitle.insert('tspan').text(total).classed('pod-count donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
           donutChartTitle.insert('tspan').text(smallText).classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
+        }
+
+
+        // c3.js config for the pods donut chart
+        config = {
+          type: "donut",
+          bindto: '#' + $scope.chartId,
+          donut: {
+            width: 10,
+            label: {
+              show: false
+            }
+          },
+          size: {
+            height: 150,
+            width: 150
+          },
+          legend: {
+            show: false
+          },
+          onrendered: updateCenterText,
+          tooltip: {
+            format: {
+              value: function(value) {
+                return value;
+              }
+            },
+            position: function() {
+              // Position in the top-left to avoid problems with tooltip text wrapping.
+              return { top: 0, left: 0 };
+            }
+          },
+          data: {
+            type: "donut",
+            groups: [ phases ],
+            // Start with an empty chart and call chart.load() when we have data.
+            columns: ['Running', 0],
+            // Keep groups in our order.
+            order: null,
+            colors: {
+             Running: "#00b9e4",
+             Warning: "#f9d67a",
+             Failed: "#d9534f",
+             Pending: "#e8e8e8",
+             Succeeded: "#3f9c35",
+             Unknown: "#f9d67a"
+            }
+          }
         };
 
-        var updateChart = function() {
-          // Make sure we're inside a digest loop.
-          $scope.$evalAsync(function() {
-            var countByPhase = {};
-            var config = $scope.chartConfig;
-            var incrementCount = function(phase) {
-              countByPhase[phase] = (countByPhase[phase] || 0) + 1;
-            };
+        function updateChart() {
+          var columns = [];
+          var countByPhase = {};
+          var incrementCount = function(phase) {
+            countByPhase[phase] = (countByPhase[phase] || 0) + 1;
+          };
 
-            angular.forEach($scope.pods, function(pod) {
-              // Count 'Warning' as its own phase, even if not strictly accurate,
-              // so it appears in the donut chart. Warnings are too important not
-              // to call out.
-              if (isTroubledPodFilter(pod)) {
-                incrementCount('Warning');
-              } else {
-                incrementCount(pod.status.phase);
-              }
-            });
-
-            config.data.columns = [];
-            angular.forEach(phases, function(phase) {
-              var count = countByPhase[phase];
-              if (count) {
-                config.data.columns.push([phase, count]);
-              }
-            });
-
-            config.oninit = updateCenterText;
+          angular.forEach($scope.pods, function(pod) {
+            // Count 'Warning' as its own phase, even if not strictly accurate,
+            // so it appears in the donut chart. Warnings are too important not
+            // to call out.
+            if (isTroubledPodFilter(pod)) {
+              incrementCount('Warning');
+            } else {
+              incrementCount(pod.status.phase);
+            }
           });
-        };
 
-        $scope.$watch('pods', updateChart, true);
-        $scope.$watch('desired', updateCenterText);
+          angular.forEach(phases, function(phase) {
+            columns.push([phase, countByPhase[phase] || 0]);
+          });
+
+          chart.load({ columns: columns });
+        }
+
+        $timeout(function() {
+          chart = c3.generate(config);
+          $scope.$watch('pods', updateChart, true);
+          $scope.$watch('desired', updateCenterText);
+        }, 0, false);
       }
     };
   });

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -208,21 +208,19 @@
 }
 
 .pod-block {
-  .scaling-controls {
-    font-size: 24px;
-    margin: 0 10px 10px 0;
-    a {
-      color: #d1d1d1;
-      &:hover, &:active {
-        color: #72767b;
-        text-decoration: none;
+  .overview-pods {
+    margin-right: 10px;
+    min-width: 190px;
+    .scaling-controls {
+      font-size: 24px;
+      a {
+        color: #d1d1d1;
+        &:hover, &:active {
+          color: #72767b;
+          text-decoration: none;
+        }
       }
     }
-  }
-  // Create a spacer the same width as the scaling controls to line up donuts
-  // that don't have the controls with those that do.
-  .scaling-spacer {
-    width: 34px;
   }
 }
 

--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -67,25 +67,14 @@
   </div>
 
   <div row mobile="column" axis="center center" class="pod-block">
-    <!-- Pod template -->
-    <div column grow="2" class="pod-template-column">
-      <div class="component-label">Pod Template</div>
-      <pod-template
-        pod-template="rc.spec.template"
-        images-by-docker-reference="imagesByDockerReference"
-        builds="builds">
-      </pod-template>
-    </div>
-
     <!-- Pods donut chart and scaling controls -->
-    <div column>
-      <div axis="center center" row>
+    <div column class="overview-pods" axis="center center">
+      <div row>
         <!-- spacer -->
         <div flex class="visible-xs-block"></div>
 
         <div column>
           <pod-status-chart
-              chart-id="rc-{{rc.metadata.name}}-donut-chart"
               pods="pods"
               desired="desiredReplicas || rc.spec.replicas || 1"
               ng-click="viewPodsForDeployment(rc)">
@@ -116,6 +105,19 @@
         <!-- spacer -->
         <div flex class="visible-xs-block"></div>
       </div>
+    </div>
+
+    <!-- Pod template -->
+    <div column grow="2" class="pod-template-column">
+      <!-- spacer -->
+      <div flex></div>
+      <pod-template
+        pod-template="rc.spec.template"
+        images-by-docker-reference="imagesByDockerReference"
+        builds="builds">
+      </pod-template>
+      <!-- spacer -->
+      <div flex></div>
     </div>
   </div>
 </div>

--- a/assets/app/views/_overview-monopod.html
+++ b/assets/app/views/_overview-monopod.html
@@ -20,23 +20,23 @@
   </div>
 
   <div row mobile="column" axis="center center" class="pod-block">
-    <div column grow="2">
-      <div class="component-label">Containers</div>
-      <pod-template pod-template="pod"></pod-template>
-    </div>
     <div row>
       <!-- spacer -->
       <div flex class="visible-xs-block"></div>
-      <div column>
+      <div column class="overview-pods">
         <div column>
           <pod-status-chart pods="[pod]"></pod-status-chart>
         </div>
-        <!-- Add a spacer equal to the width of the scaling controls on
-             replication controllers so that everything aligns. -->
       </div>
-      <div class="scaling-spacer hidden-xs"></div>
       <!-- spacer -->
       <div flex class="visible-xs-block"></div>
+    </div>
+    <div column grow="2">
+      <!-- spacer -->
+      <div flex></div>
+      <pod-template pod-template="pod"></pod-template>
+      <!-- spacer -->
+      <div flex></div>
     </div>
   </div>
 </div>

--- a/assets/app/views/_pod-status-chart.html
+++ b/assets/app/views/_pod-status-chart.html
@@ -1,4 +1,4 @@
-<div pf-c3-chart id="{{chartId}}" config="chartConfig"></div>
+<div ng-attr-id="{{chartId}}"></div>
 <!-- Include text values for screen readers -->
 <div class="sr-only">
   Pod status:


### PR DESCRIPTION
Update pod status chart styles

- Move pods donut chart to left of pod template.
- Increase the size of the donut chart.
- Remove pod template component label.
- Set min-width on the pod flex column to avoid overlapping controls on Safari.
- Avoid flicker and animate the chart when data is updated by calling chart.load().

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/10677743/34f10548-78dc-11e5-8224-6a909a16f81a.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1273724