### PR TITLE
Remove "Pod" prefix from header on browse pod page

### DIFF
--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -8,7 +8,7 @@
         <div class="col-md-12">
           <div class="tile">
             <h1>
-              Pod {{pod.metadata.name}}
+              {{pod.metadata.name}}
               <span ng-if="pod | isTroubledPod">
                 <pod-warnings pod="pod" style="vertical-align: middle;"></pod-warnings>
               </span>


### PR DESCRIPTION
None of the other browse pages prefix the type. You can also see the type in the breadcrumb.

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/10640990/352485aa-77e5-11e5-85e3-1a9411ffbbff.png)