### PR TITLE
Add back a fix for libvirt that was accidentally removed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -216,6 +216,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       override.vm.box     = vagrant_openshift_config['libvirt']['box_name']
       override.vm.box_url = vagrant_openshift_config['libvirt']['box_url']
       override.ssh.insert_key = vagrant_openshift_config['insert_key']
+      if dev_cluster
+        # Work around https://github.com/pradels/vagrant-libvirt/issues/419
+        override.vm.synced_folder ".", "/vagrant", type: 'nfs'
+      end
       libvirt.driver      = 'kvm'
       libvirt.memory      = vagrant_openshift_config['memory'].to_i
       libvirt.cpus        = vagrant_openshift_config['cpus'].to_i


### PR DESCRIPTION
https://github.com/openshift/origin/pull/5175 removed the line

    override.vm.synced_folder ".", "/vagrant", type: 'nfs'

from the libvirt section of Vagrantfile, presumably because it looked unnecessary, but it's actually needed due to a vagrant-libvirt bug (https://github.com/pradels/vagrant-libvirt/issues/419). (Without it, some machines will default to rsync instead, which will get stuck in an infinite loop because of a circular symlink in one of the packages under Godeps/.)

@danmcp 