### PR TITLE
On Windows, use CRLF line endings in oc edit

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -738,6 +738,7 @@ _oc_edit()
     flags+=("--output=")
     two_word_flags+=("-o")
     flags+=("--output-version=")
+    flags+=("--windows-line-endings")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -2477,6 +2477,7 @@ _openshift_cli_edit()
     flags+=("--output=")
     two_word_flags+=("-o")
     flags+=("--output-version=")
+    flags+=("--windows-line-endings")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -12,7 +12,9 @@ os::log::install_errexit
 
 oc create -f examples/hello-openshift/hello-pod.json
 
-[ "$(OC_EDITOR='cat' oc edit pod/hello-openshift 2>&1 | grep 'Edit cancelled')" ]
-[ "$(OC_EDITOR='cat' oc edit pod/hello-openshift | grep 'name: hello-openshift')" ]
+[ "$(OC_EDITOR=cat oc edit pod/hello-openshift 2>&1 | grep 'Edit cancelled')" ]
+[ "$(OC_EDITOR=cat oc edit pod/hello-openshift | grep 'name: hello-openshift')" ]
+[ "$(OC_EDITOR=cat oc edit --windows-line-endings pod/hello-openshift | file - | grep CRLF)" ]
+[ ! "$(OC_EDITOR=cat oc edit --windows-line-endings=false pod/hello-openshift | file - | grep CRFL)" ]
 echo "edit: ok"
 


### PR DESCRIPTION
Adds `--windows-line-endings` to oc edit and defaults to whatever is correct for the current OS.

@fabianofranz