### PR TITLE
add commands for managing SCCs

### DIFF
--- a/contrib/completions/bash/oadm
+++ b/contrib/completions/bash/oadm
@@ -417,6 +417,70 @@ _oadm_policy_reconcile-cluster-role-bindings()
     must_have_one_noun=()
 }
 
+_oadm_policy_add-scc-to-user()
+{
+    last_command="oadm_policy_add-scc-to-user"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--serviceaccount=")
+    two_word_flags+=("-z")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_oadm_policy_add-scc-to-group()
+{
+    last_command="oadm_policy_add-scc-to-group"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_oadm_policy_remove-scc-from-user()
+{
+    last_command="oadm_policy_remove-scc-from-user"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--serviceaccount=")
+    two_word_flags+=("-z")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_oadm_policy_remove-scc-from-group()
+{
+    last_command="oadm_policy_remove-scc-from-group"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oadm_policy()
 {
     last_command="oadm_policy"
@@ -434,6 +498,10 @@ _oadm_policy()
     commands+=("remove-cluster-role-from-group")
     commands+=("reconcile-cluster-roles")
     commands+=("reconcile-cluster-role-bindings")
+    commands+=("add-scc-to-user")
+    commands+=("add-scc-to-group")
+    commands+=("remove-scc-from-user")
+    commands+=("remove-scc-from-group")
 
     flags=()
     two_word_flags=()

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -1006,6 +1006,70 @@ _openshift_admin_policy_reconcile-cluster-role-bindings()
     must_have_one_noun=()
 }
 
+_openshift_admin_policy_add-scc-to-user()
+{
+    last_command="openshift_admin_policy_add-scc-to-user"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--serviceaccount=")
+    two_word_flags+=("-z")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_admin_policy_add-scc-to-group()
+{
+    last_command="openshift_admin_policy_add-scc-to-group"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_admin_policy_remove-scc-from-user()
+{
+    last_command="openshift_admin_policy_remove-scc-from-user"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--serviceaccount=")
+    two_word_flags+=("-z")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
+_openshift_admin_policy_remove-scc-from-group()
+{
+    last_command="openshift_admin_policy_remove-scc-from-group"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_admin_policy()
 {
     last_command="openshift_admin_policy"
@@ -1023,6 +1087,10 @@ _openshift_admin_policy()
     commands+=("remove-cluster-role-from-group")
     commands+=("reconcile-cluster-roles")
     commands+=("reconcile-cluster-role-bindings")
+    commands+=("add-scc-to-user")
+    commands+=("add-scc-to-group")
+    commands+=("remove-scc-from-user")
+    commands+=("remove-scc-from-group")
 
     flags=()
     two_word_flags=()

--- a/pkg/cmd/admin/policy/modify_scc.go
+++ b/pkg/cmd/admin/policy/modify_scc.go
@@ -1,0 +1,234 @@
+package policy
+
+import (
+	"errors"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
+)
+
+const (
+	AddSCCToGroupRecommendedName      = "add-scc-to-group"
+	AddSCCToUserRecommendedName       = "add-scc-to-user"
+	RemoveSCCFromGroupRecommendedName = "remove-scc-from-group"
+	RemoveSCCFromUserRecommendedName  = "remove-scc-from-user"
+)
+
+type SCCModificationOptions struct {
+	SCCName      string
+	SCCInterface kclient.SecurityContextConstraintsInterface
+
+	DefaultSubjectNamespace string
+	Subjects                []kapi.ObjectReference
+}
+
+func NewCmdAddSCCToGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &SCCModificationOptions{}
+
+	cmd := &cobra.Command{
+		Use:   name + " SCC GROUP [GROUP ...]",
+		Short: "Add groups to a security context constraint",
+		Long:  `Add groups to a security context constraint`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.CompleteGroups(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			if err := options.AddSCC(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	return cmd
+}
+
+func NewCmdAddSCCToUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &SCCModificationOptions{}
+	saNames := util.StringList{}
+
+	cmd := &cobra.Command{
+		Use:   name + " SCC USER [USER ...]",
+		Short: "Add users to a security context constraint",
+		Long:  `Add users to a security context constraint`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.CompleteUsers(f, args, saNames); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			if err := options.AddSCC(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	cmd.Flags().VarP(&saNames, "serviceaccount", "z", "service account in the current namespace to use as a user")
+
+	return cmd
+}
+
+func NewCmdRemoveSCCFromGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &SCCModificationOptions{}
+
+	cmd := &cobra.Command{
+		Use:   name + " SCC GROUP [GROUP ...]",
+		Short: "Remove group from scc",
+		Long:  `Remove group from scc`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.CompleteGroups(f, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			if err := options.RemoveSCC(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	return cmd
+}
+
+func NewCmdRemoveSCCFromUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := &SCCModificationOptions{}
+	saNames := util.StringList{}
+
+	cmd := &cobra.Command{
+		Use:   name + " SCC USER [USER ...]",
+		Short: "Remove user from scc",
+		Long:  `Remove user from scc`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.CompleteUsers(f, args, saNames); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+
+			if err := options.RemoveSCC(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	cmd.Flags().VarP(&saNames, "serviceaccount", "z", "service account in the current namespace to use as a user")
+
+	return cmd
+}
+
+func (o *SCCModificationOptions) CompleteUsers(f *clientcmd.Factory, args []string, saNames util.StringList) error {
+	if (len(args) < 2) && (len(saNames) == 0) {
+		return errors.New("you must specify at least two arguments (<scc> <user> [user]...) or a service account (<scc> -z <service account name>) ")
+	}
+
+	o.SCCName = args[0]
+	o.Subjects = authorizationapi.BuildSubjects(args[1:], []string{}, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+
+	var err error
+	_, o.SCCInterface, err = f.Clients()
+	if err != nil {
+		return err
+	}
+
+	o.DefaultSubjectNamespace, _, err = f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	for _, sa := range saNames {
+		o.Subjects = append(o.Subjects, kapi.ObjectReference{Namespace: o.DefaultSubjectNamespace, Name: sa, Kind: "ServiceAccount"})
+	}
+
+	return nil
+}
+
+func (o *SCCModificationOptions) CompleteGroups(f *clientcmd.Factory, args []string) error {
+	if len(args) < 2 {
+		return errors.New("you must specify at least two arguments: <scc> <group> [group]...")
+	}
+
+	o.SCCName = args[0]
+	o.Subjects = authorizationapi.BuildSubjects([]string{}, args[1:], uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+
+	var err error
+	_, o.SCCInterface, err = f.Clients()
+	if err != nil {
+		return err
+	}
+
+	o.DefaultSubjectNamespace, _, err = f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *SCCModificationOptions) AddSCC() error {
+	scc, err := o.SCCInterface.SecurityContextConstraints().Get(o.SCCName)
+	if err != nil {
+		return err
+	}
+
+	users, groups := authorizationapi.StringSubjectsFor(o.DefaultSubjectNamespace, o.Subjects)
+	usersToAdd, _ := diff(users, scc.Users)
+	groupsToAdd, _ := diff(groups, scc.Groups)
+
+	scc.Users = append(scc.Users, usersToAdd...)
+	scc.Groups = append(scc.Groups, groupsToAdd...)
+
+	_, err = o.SCCInterface.SecurityContextConstraints().Update(scc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *SCCModificationOptions) RemoveSCC() error {
+	scc, err := o.SCCInterface.SecurityContextConstraints().Get(o.SCCName)
+	if err != nil {
+		return err
+	}
+
+	users, groups := authorizationapi.StringSubjectsFor(o.DefaultSubjectNamespace, o.Subjects)
+	_, remainingUsers := diff(users, scc.Users)
+	_, remainingGroups := diff(groups, scc.Groups)
+
+	scc.Users = remainingUsers
+	scc.Groups = remainingGroups
+
+	_, err = o.SCCInterface.SecurityContextConstraints().Update(scc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func diff(lhsSlice, rhsSlice []string) (lhsOnly []string, rhsOnly []string) {
+	return singleDiff(lhsSlice, rhsSlice), singleDiff(rhsSlice, lhsSlice)
+}
+
+func singleDiff(lhsSlice, rhsSlice []string) (lhsOnly []string) {
+	for _, lhs := range lhsSlice {
+		found := false
+		for _, rhs := range rhsSlice {
+			if lhs == rhs {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			lhsOnly = append(lhsOnly, lhs)
+		}
+	}
+
+	return lhsOnly
+}

--- a/pkg/cmd/admin/policy/modify_scc_test.go
+++ b/pkg/cmd/admin/policy/modify_scc_test.go
@@ -1,0 +1,152 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+)
+
+func TestModifySCC(t *testing.T) {
+	tests := map[string]struct {
+		startingSCC *kapi.SecurityContextConstraints
+		subjects    []kapi.ObjectReference
+		expectedSCC *kapi.SecurityContextConstraints
+		remove      bool
+	}{
+		"add-user-to-empty": {
+			startingSCC: &kapi.SecurityContextConstraints{},
+			subjects:    []kapi.ObjectReference{{Name: "one", Kind: authorizationapi.UserKind}, {Name: "two", Kind: authorizationapi.UserKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"one", "two"}},
+			remove:      false,
+		},
+		"add-user-to-existing": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"one"}},
+			subjects:    []kapi.ObjectReference{{Name: "two", Kind: authorizationapi.UserKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"one", "two"}},
+			remove:      false,
+		},
+		"add-user-to-existing-with-overlap": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"one"}},
+			subjects:    []kapi.ObjectReference{{Name: "one", Kind: authorizationapi.UserKind}, {Name: "two", Kind: authorizationapi.UserKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"one", "two"}},
+			remove:      false,
+		},
+
+		"add-sa-to-empty": {
+			startingSCC: &kapi.SecurityContextConstraints{},
+			subjects:    []kapi.ObjectReference{{Namespace: "a", Name: "one", Kind: authorizationapi.ServiceAccountKind}, {Namespace: "b", Name: "two", Kind: authorizationapi.ServiceAccountKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
+			remove:      false,
+		},
+		"add-sa-to-existing": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"one"}},
+			subjects:    []kapi.ObjectReference{{Namespace: "b", Name: "two", Kind: authorizationapi.ServiceAccountKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"one", "system:serviceaccount:b:two"}},
+			remove:      false,
+		},
+		"add-sa-to-existing-with-overlap": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one"}},
+			subjects:    []kapi.ObjectReference{{Namespace: "a", Name: "one", Kind: authorizationapi.ServiceAccountKind}, {Namespace: "b", Name: "two", Kind: authorizationapi.ServiceAccountKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
+			remove:      false,
+		},
+
+		"add-group-to-empty": {
+			startingSCC: &kapi.SecurityContextConstraints{},
+			subjects:    []kapi.ObjectReference{{Name: "one", Kind: authorizationapi.GroupKind}, {Name: "two", Kind: authorizationapi.GroupKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			remove:      false,
+		},
+		"add-group-to-existing": {
+			startingSCC: &kapi.SecurityContextConstraints{Groups: []string{"one"}},
+			subjects:    []kapi.ObjectReference{{Name: "two", Kind: authorizationapi.GroupKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			remove:      false,
+		},
+		"add-group-to-existing-with-overlap": {
+			startingSCC: &kapi.SecurityContextConstraints{Groups: []string{"one"}},
+			subjects:    []kapi.ObjectReference{{Name: "one", Kind: authorizationapi.GroupKind}, {Name: "two", Kind: authorizationapi.GroupKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			remove:      false,
+		},
+
+		"remove-user": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"one", "two"}},
+			subjects:    []kapi.ObjectReference{{Name: "one", Kind: authorizationapi.UserKind}, {Name: "two", Kind: authorizationapi.UserKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{},
+			remove:      true,
+		},
+		"remove-user-from-existing-with-overlap": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"one", "two"}},
+			subjects:    []kapi.ObjectReference{{Name: "two", Kind: authorizationapi.UserKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"one"}},
+			remove:      true,
+		},
+
+		"remove-sa": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
+			subjects:    []kapi.ObjectReference{{Namespace: "a", Name: "one", Kind: authorizationapi.ServiceAccountKind}, {Namespace: "b", Name: "two", Kind: authorizationapi.ServiceAccountKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{},
+			remove:      true,
+		},
+		"remove-sa-from-existing-with-overlap": {
+			startingSCC: &kapi.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
+			subjects:    []kapi.ObjectReference{{Namespace: "b", Name: "two", Kind: authorizationapi.ServiceAccountKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one"}},
+			remove:      true,
+		},
+
+		"remove-group": {
+			startingSCC: &kapi.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			subjects:    []kapi.ObjectReference{{Name: "one", Kind: authorizationapi.GroupKind}, {Name: "two", Kind: authorizationapi.GroupKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{},
+			remove:      true,
+		},
+		"remove-group-from-existing-with-overlap": {
+			startingSCC: &kapi.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			subjects:    []kapi.ObjectReference{{Name: "two", Kind: authorizationapi.GroupKind}},
+			expectedSCC: &kapi.SecurityContextConstraints{Groups: []string{"one"}},
+			remove:      true,
+		},
+	}
+
+	for tcName, tc := range tests {
+		fakeClient := ktestclient.NewSimpleFake()
+		fakeClient.PrependReactor("get", "securitycontextconstraints", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			return true, tc.startingSCC, nil
+		})
+		var actualSCC *kapi.SecurityContextConstraints
+		fakeClient.PrependReactor("update", "securitycontextconstraints", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			actualSCC = action.(ktestclient.UpdateAction).GetObject().(*kapi.SecurityContextConstraints)
+			return true, actualSCC, nil
+		})
+
+		o := &SCCModificationOptions{
+			SCCName:                 "foo",
+			SCCInterface:            fakeClient,
+			DefaultSubjectNamespace: "",
+			Subjects:                tc.subjects,
+		}
+
+		var err error
+		if tc.remove {
+			err = o.RemoveSCC()
+		} else {
+			err = o.AddSCC()
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected err %v", tcName, err)
+		}
+		if e, a := tc.expectedSCC.Users, actualSCC.Users; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expected %v, actual %v", tcName, e, a)
+		}
+		if e, a := tc.expectedSCC.Groups, actualSCC.Groups; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expected %v, actual %v", tcName, e, a)
+		}
+	}
+}

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -26,8 +26,8 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,
-		Short: "Manage authorization policy",
-		Long:  `Manage authorization policy`,
+		Short: "Manage policy",
+		Long:  `Manage policy`,
 		Run:   cmdutil.DefaultSubCommandRun(out),
 	}
 
@@ -46,6 +46,11 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	cmds.AddCommand(NewCmdRemoveClusterRoleFromGroup(RemoveClusterRoleFromGroupRecommendedName, fullName+" "+RemoveClusterRoleFromGroupRecommendedName, f, out))
 	cmds.AddCommand(NewCmdReconcileClusterRoles(ReconcileClusterRolesRecommendedName, fullName+" "+ReconcileClusterRolesRecommendedName, f, out))
 	cmds.AddCommand(NewCmdReconcileClusterRoleBindings(ReconcileClusterRoleBindingsRecommendedName, fullName+" "+ReconcileClusterRoleBindingsRecommendedName, f, out))
+
+	cmds.AddCommand(NewCmdAddSCCToUser(AddSCCToUserRecommendedName, fullName+" "+AddSCCToUserRecommendedName, f, out))
+	cmds.AddCommand(NewCmdAddSCCToGroup(AddSCCToGroupRecommendedName, fullName+" "+AddSCCToGroupRecommendedName, f, out))
+	cmds.AddCommand(NewCmdRemoveSCCFromUser(RemoveSCCFromUserRecommendedName, fullName+" "+RemoveSCCFromUserRecommendedName, f, out))
+	cmds.AddCommand(NewCmdRemoveSCCFromGroup(RemoveSCCFromGroupRecommendedName, fullName+" "+RemoveSCCFromGroupRecommendedName, f, out))
 
 	return cmds
 }

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -77,6 +77,19 @@ oadm policy remove-cluster-role-from-group cluster-admin system:unauthenticated
 oadm policy add-cluster-role-to-user cluster-admin system:no-user
 oadm policy remove-cluster-role-from-user cluster-admin system:no-user
 
+oadm policy add-scc-to-user privileged fake-user
+oc get scc/privileged -o yaml | grep fake-user
+oadm policy add-scc-to-user privileged -z fake-sa
+oc get scc/privileged -o yaml | grep "system:serviceaccount:cmd-admin:fake-sa"
+oadm policy add-scc-to-group privileged fake-group
+oc get scc/privileged -o yaml | grep fake-group
+oadm policy remove-scc-from-user privileged fake-user
+[ ! "$(oc get scc/privileged -o yaml | grep fake-user)" ]
+oadm policy remove-scc-from-user privileged -z fake-sa
+[ ! "$(oc get scc/privileged -o yaml | grep 'system:serviceaccount:cmd-admin:fake-sa')" ]
+oadm policy remove-scc-from-group privileged fake-group
+[ ! "$(oadm policy add-scc-to-group privileged fake-group)" ]
+
 oc delete clusterrole/cluster-status
 [ ! "$(oc get clusterrole/cluster-status)" ]
 oadm policy reconcile-cluster-roles


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5190

adds
```
oadm policy add-scc-to-user privileged fake-user
oadm policy add-scc-to-user privileged -z fake-sa
oadm policy add-scc-to-group privileged fake-group
oadm policy remove-scc-from-user privileged fake-user
oadm policy remove-scc-from-user privileged -z fake-sa
oadm policy remove-scc-from-group privileged fake-group
```

@smarterclayton Is this what you wanted?
@pweil- ptal
@simon3z These will help you