### PR TITLE
Inline deployer hook logs

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -262,6 +262,12 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 					Verbs:     sets.NewString("get", "list", "watch", "create"),
 					Resources: sets.NewString("pods"),
 				},
+				{
+					// RecreateDeploymentStrategy.hookExecutor
+					// RollingDeploymentStrategy.hookExecutor
+					Verbs:     sets.NewString("get"),
+					Resources: sets.NewString("pods/log"),
+				},
 			},
 		},
 		{

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -2,6 +2,7 @@ package recreate
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/golang/glog"
@@ -48,18 +49,9 @@ func NewRecreateDeploymentStrategy(client kclient.Interface, codec runtime.Codec
 		getReplicationController: func(namespace, name string) (*kapi.ReplicationController, error) {
 			return client.ReplicationControllers(namespace).Get(name)
 		},
-		scaler: scaler,
-		codec:  codec,
-		hookExecutor: &stratsupport.HookExecutor{
-			PodClient: &stratsupport.HookExecutorPodClientImpl{
-				CreatePodFunc: func(namespace string, pod *kapi.Pod) (*kapi.Pod, error) {
-					return client.Pods(namespace).Create(pod)
-				},
-				PodWatchFunc: func(namespace, name, resourceVersion string, stopChannel chan struct{}) func() *kapi.Pod {
-					return stratsupport.NewPodWatch(client, namespace, name, resourceVersion, stopChannel)
-				},
-			},
-		},
+		scaler:       scaler,
+		codec:        codec,
+		hookExecutor: stratsupport.NewHookExecutor(client, os.Stdout),
 		retryTimeout: 120 * time.Second,
 		retryPeriod:  1 * time.Second,
 	}

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -142,6 +142,7 @@ oc create -f test/fixtures/failing-dc.yaml
 tryuntil oc get rc/failing-dc-1
 oc logs -f dc/failing-dc
 wait_for_command "oc get rc/failing-dc-1 --template={{.metadata.annotations}} | grep openshift.io/deployment.phase:Failed" $((20*TIME_SEC))
+oc logs dc/failing-dc | grep 'test pre hook executed'
 oc deploy failing-dc --latest
 oc logs --version=1 dc/failing-dc
 
@@ -158,13 +159,12 @@ os::build:wait_for_end "test"
 wait_for_app "test"
 
 # logs can't be tested without a node, so has to be in e2e
-POD_NAME=`oc get pods -o name -n test | head -n 1`
+POD_NAME=$(oc get pods -n test --template='{{(index .items 0).metadata.name}}')
+oc logs pod/${POD_NAME} --loglevel=6
 oc logs ${POD_NAME} --loglevel=6
-POD_NAME_NO_KIND=`oc get pods -o name -n test | head -n 1 | cut -d '/' -f 2`
-oc logs ${POD_NAME_NO_KIND} --loglevel=6
-BUILD_NAME=`oc get builds -o name -n test | head -n 1`
-oc logs ${BUILD_NAME} --loglevel=6
-oc logs ${BUILD_NAME} --loglevel=6
+BUILD_NAME=$(oc get builds -n test --template='{{(index .items 0).metadata.name}}')
+oc logs build/${BUILD_NAME} --loglevel=6
+oc logs build/${BUILD_NAME} --loglevel=6
 oc logs bc/ruby-sample-build --loglevel=6
 oc logs buildconfigs/ruby-sample-build --loglevel=6
 oc logs buildconfig/ruby-sample-build --loglevel=6

--- a/test/fixtures/failing-dc.yaml
+++ b/test/fixtures/failing-dc.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     name: failing-dc
   strategy:
+    type: Rolling
     resources: {}
     rollingParams:
       intervalSeconds: 1
@@ -15,7 +16,13 @@ spec:
       maxUnavailable: 25%
       timeoutSeconds: 5
       updatePeriodSeconds: 1
-    type: Rolling
+      pre:
+        failurePolicy: Abort
+        execNewPod:
+          containerName: myapp
+          command:
+          - /bin/echo
+          - test pre hook executed
   template:
     metadata:
       creationTimestamp: null
@@ -23,19 +30,25 @@ spec:
         name: failing-dc
     spec:
       containers:
-      - image: origin-ruby-sample
+      - image: "docker.io/centos:centos7"
         imagePullPolicy: IfNotPresent
-        name: ruby-helloworld
+        name: myapp
+        command:
+        - /bin/false
         ports:
         - containerPort: 8080
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           capabilities: {}
           privileged: false
         terminationMessagePath: /dev/termination-log
       dnsPolicy: ClusterFirst
-      restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 30
   triggers:


### PR DESCRIPTION
Implements inline deployer hook pod logs for #5199.

Logs will be streamed from the hook pod to the deployer pod's stdout.