### PR TITLE
Bug 1273704 - Fix problems with overview donut chart on IE

### DIFF
--- a/assets/app/scripts/directives/podStatusChart.js
+++ b/assets/app/scripts/directives/podStatusChart.js
@@ -64,7 +64,7 @@ angular.module('openshiftConsole')
         };
 
         var updateCenterText = function() {
-          var donutChartTitle = element[0].querySelector('text.c3-chart-arcs-title'),
+          var donutChartTitle = d3.select(element[0]).select('text.c3-chart-arcs-title'),
             total = hashSizeFilter($scope.pods),
             smallText;
           if (!donutChartTitle) {
@@ -77,11 +77,11 @@ angular.module('openshiftConsole')
           } else {
             smallText = "scaling to " + $scope.desired + "...";
           }
-          // Use the same classes as patternfly so they're consistent with the
-          // donut charts for limits on the pod metrics tab.
-          donutChartTitle.innerHTML =
-            '<tspan dy="0" x="0" class="pod-count donut-title-big-pf">' + total + '</tspan>' +
-            '<tspan dy="20" x="0" class="donut-title-small-pf">' + smallText + '</tspan>';
+
+          // Replace donut title content.
+          donutChartTitle.html('');
+          donutChartTitle.insert('tspan').text(total).classed('pod-count donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
+          donutChartTitle.insert('tspan').text(smallText).classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
         };
 
         var updateChart = function() {

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -215,6 +215,7 @@
       color: #d1d1d1;
       &:hover, &:active {
         color: #72767b;
+        text-decoration: none;
       }
     }
   }

--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -96,14 +96,18 @@
           <!-- spacer -->
           <div flex></div>
           <div column>
-            <a href="" ng-click="scaleUp()" title="Scale up">
-              <i class="fa fa-chevron-up"></i>
-              <span class="sr-only">Scale up</span>
-            </a>
-            <a href="" ng-click="scaleDown()" title="Scale down">
-              <i class="fa fa-chevron-down"></i>
-              <span class="sr-only">Scale down</span>
-            </a>
+            <div>
+              <a href="" ng-click="scaleUp()" title="Scale up">
+                <i class="fa fa-chevron-up"></i>
+                <span class="sr-only">Scale up</span>
+              </a>
+            </div>
+            <div>
+              <a href="" ng-click="scaleDown()" title="Scale down">
+                <i class="fa fa-chevron-down"></i>
+                <span class="sr-only">Scale down</span>
+              </a>
+            </div>
           </div>
           <!-- spacer -->
           <div flex></div>


### PR DESCRIPTION
* Use d3 methods rather than innerHTML on SVG elements to set donut chart title.
* Put overview scaling controls inside block elements so they don't display side-by-side.

<img width="662" alt="ie10_-_win7__running__and_podstatuschart_js____go_src_github_com_openshift_origin_assets_app_scripts_directives__-_vim" src="https://cloud.githubusercontent.com/assets/1167259/10654618/bf01f6f4-783a-11e5-84d5-e7dd1aa042dd.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1273704