### PR TITLE
Enable HorizontalPodAutoscaler Support for DeploymentConfigs

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -296,7 +296,7 @@ func (s *CMServer) Run(_ []string) error {
 		go job.NewJobController(kubeClient, s.ResyncPeriod).
 			Run(s.ConcurrentJobSyncs, util.NeverStop)
 
-		podautoscaler.NewHorizontalController(kubeClient, kubeClient, kubeClient, metrics.NewHeapsterMetricsClient(kubeClient)).
+		podautoscaler.NewHorizontalController(kubeClient, kubeClient, kubeClient, metrics.NewHeapsterMetricsClient(kubeClient, "kube-system", "heapster")).
 			Run(s.HorizontalPodAutoscalerSyncPeriod)
 
 		deployment.New(kubeClient).

--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -296,7 +296,7 @@ func (s *CMServer) Run(_ []string) error {
 		go job.NewJobController(kubeClient, s.ResyncPeriod).
 			Run(s.ConcurrentJobSyncs, util.NeverStop)
 
-		podautoscaler.NewHorizontalController(kubeClient, metrics.NewHeapsterMetricsClient(kubeClient)).
+		podautoscaler.NewHorizontalController(kubeClient, kubeClient, kubeClient, metrics.NewHeapsterMetricsClient(kubeClient)).
 			Run(s.HorizontalPodAutoscalerSyncPeriod)
 
 		deployment.New(kubeClient).

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/testing/fuzzer.go
@@ -386,6 +386,12 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			fsGroupTypes := []api.FSGroupStrategyType{api.FSGroupStrategyMustRunAs, api.FSGroupStrategyRunAsAny}
 			scc.FSGroup.Type = fsGroupTypes[c.Rand.Intn(len(fsGroupTypes))]
 		},
+		func(s *extensions.HorizontalPodAutoscalerSpec, c fuzz.Continue) {
+			c.FuzzNoCustom(s) // fuzz self without calling this function again
+			minReplicas := c.Rand.Int()
+			s.MinReplicas = &minReplicas
+			s.CPUUtilization = &extensions.CPUTargetUtilization{TargetPercentage: int(c.RandUint64())}
+		},
 	)
 	return f
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/deep_copy_generated.go
@@ -888,6 +888,11 @@ func deepCopy_extensions_APIVersion(in APIVersion, out *APIVersion, c *conversio
 	return nil
 }
 
+func deepCopy_extensions_CPUTargetUtilization(in CPUTargetUtilization, out *CPUTargetUtilization, c *conversion.Cloner) error {
+	out.TargetPercentage = in.TargetPercentage
+	return nil
+}
+
 func deepCopy_extensions_ClusterAutoscaler(in ClusterAutoscaler, out *ClusterAutoscaler, c *conversion.Cloner) error {
 	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1139,40 +1144,49 @@ func deepCopy_extensions_HorizontalPodAutoscalerList(in HorizontalPodAutoscalerL
 }
 
 func deepCopy_extensions_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscalerSpec, out *HorizontalPodAutoscalerSpec, c *conversion.Cloner) error {
-	if in.ScaleRef != nil {
-		out.ScaleRef = new(SubresourceReference)
-		if err := deepCopy_extensions_SubresourceReference(*in.ScaleRef, out.ScaleRef, c); err != nil {
+	if err := deepCopy_extensions_SubresourceReference(in.ScaleRef, &out.ScaleRef, c); err != nil {
+		return err
+	}
+	if in.MinReplicas != nil {
+		out.MinReplicas = new(int)
+		*out.MinReplicas = *in.MinReplicas
+	} else {
+		out.MinReplicas = nil
+	}
+	out.MaxReplicas = in.MaxReplicas
+	if in.CPUUtilization != nil {
+		out.CPUUtilization = new(CPUTargetUtilization)
+		if err := deepCopy_extensions_CPUTargetUtilization(*in.CPUUtilization, out.CPUUtilization, c); err != nil {
 			return err
 		}
 	} else {
-		out.ScaleRef = nil
-	}
-	out.MinReplicas = in.MinReplicas
-	out.MaxReplicas = in.MaxReplicas
-	if err := deepCopy_extensions_ResourceConsumption(in.Target, &out.Target, c); err != nil {
-		return err
+		out.CPUUtilization = nil
 	}
 	return nil
 }
 
 func deepCopy_extensions_HorizontalPodAutoscalerStatus(in HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, c *conversion.Cloner) error {
+	if in.ObservedGeneration != nil {
+		out.ObservedGeneration = new(int64)
+		*out.ObservedGeneration = *in.ObservedGeneration
+	} else {
+		out.ObservedGeneration = nil
+	}
+	if in.LastScaleTime != nil {
+		out.LastScaleTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.LastScaleTime, out.LastScaleTime, c); err != nil {
+			return err
+		}
+	} else {
+		out.LastScaleTime = nil
+	}
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentConsumption != nil {
-		out.CurrentConsumption = new(ResourceConsumption)
-		if err := deepCopy_extensions_ResourceConsumption(*in.CurrentConsumption, out.CurrentConsumption, c); err != nil {
-			return err
-		}
+	if in.CurrentCPUUtilizationPercentage != nil {
+		out.CurrentCPUUtilizationPercentage = new(int)
+		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
 	} else {
-		out.CurrentConsumption = nil
-	}
-	if in.LastScaleTimestamp != nil {
-		out.LastScaleTimestamp = new(unversioned.Time)
-		if err := deepCopy_unversioned_Time(*in.LastScaleTimestamp, out.LastScaleTimestamp, c); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTimestamp = nil
+		out.CurrentCPUUtilizationPercentage = nil
 	}
 	return nil
 }
@@ -1429,14 +1443,6 @@ func deepCopy_extensions_ReplicationControllerDummy(in ReplicationControllerDumm
 	return nil
 }
 
-func deepCopy_extensions_ResourceConsumption(in ResourceConsumption, out *ResourceConsumption, c *conversion.Cloner) error {
-	out.Resource = in.Resource
-	if err := deepCopy_resource_Quantity(in.Quantity, &out.Quantity, c); err != nil {
-		return err
-	}
-	return nil
-}
-
 func deepCopy_extensions_RollingUpdateDeployment(in RollingUpdateDeployment, out *RollingUpdateDeployment, c *conversion.Cloner) error {
 	if err := deepCopy_util_IntOrString(in.MaxUnavailable, &out.MaxUnavailable, c); err != nil {
 		return err
@@ -1626,6 +1632,7 @@ func init() {
 		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
 		deepCopy_extensions_APIVersion,
+		deepCopy_extensions_CPUTargetUtilization,
 		deepCopy_extensions_ClusterAutoscaler,
 		deepCopy_extensions_ClusterAutoscalerList,
 		deepCopy_extensions_ClusterAutoscalerSpec,
@@ -1660,7 +1667,6 @@ func init() {
 		deepCopy_extensions_PodSelector,
 		deepCopy_extensions_PodSelectorRequirement,
 		deepCopy_extensions_ReplicationControllerDummy,
-		deepCopy_extensions_ResourceConsumption,
 		deepCopy_extensions_RollingUpdateDeployment,
 		deepCopy_extensions_Scale,
 		deepCopy_extensions_ScaleSpec,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -1879,6 +1879,18 @@ func convert_extensions_APIVersion_To_v1beta1_APIVersion(in *extensions.APIVersi
 	return autoconvert_extensions_APIVersion_To_v1beta1_APIVersion(in, out, s)
 }
 
+func autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in *extensions.CPUTargetUtilization, out *CPUTargetUtilization, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*extensions.CPUTargetUtilization))(in)
+	}
+	out.TargetPercentage = in.TargetPercentage
+	return nil
+}
+
+func convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in *extensions.CPUTargetUtilization, out *CPUTargetUtilization, s conversion.Scope) error {
+	return autoconvert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in, out, s)
+}
+
 func autoconvert_extensions_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *extensions.ClusterAutoscaler, out *ClusterAutoscaler, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.ClusterAutoscaler))(in)
@@ -2241,18 +2253,23 @@ func autoconvert_extensions_HorizontalPodAutoscalerSpec_To_v1beta1_HorizontalPod
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HorizontalPodAutoscalerSpec))(in)
 	}
-	if in.ScaleRef != nil {
-		out.ScaleRef = new(SubresourceReference)
-		if err := convert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(in.ScaleRef, out.ScaleRef, s); err != nil {
+	if err := convert_extensions_SubresourceReference_To_v1beta1_SubresourceReference(&in.ScaleRef, &out.ScaleRef, s); err != nil {
+		return err
+	}
+	if in.MinReplicas != nil {
+		out.MinReplicas = new(int)
+		*out.MinReplicas = *in.MinReplicas
+	} else {
+		out.MinReplicas = nil
+	}
+	out.MaxReplicas = in.MaxReplicas
+	if in.CPUUtilization != nil {
+		out.CPUUtilization = new(CPUTargetUtilization)
+		if err := convert_extensions_CPUTargetUtilization_To_v1beta1_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
 			return err
 		}
 	} else {
-		out.ScaleRef = nil
-	}
-	out.MinReplicas = in.MinReplicas
-	out.MaxReplicas = in.MaxReplicas
-	if err := convert_extensions_ResourceConsumption_To_v1beta1_ResourceConsumption(&in.Target, &out.Target, s); err != nil {
-		return err
+		out.CPUUtilization = nil
 	}
 	return nil
 }
@@ -2265,22 +2282,26 @@ func autoconvert_extensions_HorizontalPodAutoscalerStatus_To_v1beta1_HorizontalP
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.HorizontalPodAutoscalerStatus))(in)
 	}
+	if in.ObservedGeneration != nil {
+		out.ObservedGeneration = new(int64)
+		*out.ObservedGeneration = *in.ObservedGeneration
+	} else {
+		out.ObservedGeneration = nil
+	}
+	if in.LastScaleTime != nil {
+		if err := s.Convert(&in.LastScaleTime, &out.LastScaleTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.LastScaleTime = nil
+	}
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentConsumption != nil {
-		out.CurrentConsumption = new(ResourceConsumption)
-		if err := convert_extensions_ResourceConsumption_To_v1beta1_ResourceConsumption(in.CurrentConsumption, out.CurrentConsumption, s); err != nil {
-			return err
-		}
+	if in.CurrentCPUUtilizationPercentage != nil {
+		out.CurrentCPUUtilizationPercentage = new(int)
+		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
 	} else {
-		out.CurrentConsumption = nil
-	}
-	if in.LastScaleTimestamp != nil {
-		if err := s.Convert(&in.LastScaleTimestamp, &out.LastScaleTimestamp, 0); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTimestamp = nil
+		out.CurrentCPUUtilizationPercentage = nil
 	}
 	return nil
 }
@@ -2651,21 +2672,6 @@ func convert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControl
 	return autoconvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy(in, out, s)
 }
 
-func autoconvert_extensions_ResourceConsumption_To_v1beta1_ResourceConsumption(in *extensions.ResourceConsumption, out *ResourceConsumption, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*extensions.ResourceConsumption))(in)
-	}
-	out.Resource = v1.ResourceName(in.Resource)
-	if err := s.Convert(&in.Quantity, &out.Quantity, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_extensions_ResourceConsumption_To_v1beta1_ResourceConsumption(in *extensions.ResourceConsumption, out *ResourceConsumption, s conversion.Scope) error {
-	return autoconvert_extensions_ResourceConsumption_To_v1beta1_ResourceConsumption(in, out, s)
-}
-
 func autoconvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment(in *extensions.RollingUpdateDeployment, out *RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*extensions.RollingUpdateDeployment))(in)
@@ -2864,6 +2870,18 @@ func autoconvert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out
 
 func convert_v1beta1_APIVersion_To_extensions_APIVersion(in *APIVersion, out *extensions.APIVersion, s conversion.Scope) error {
 	return autoconvert_v1beta1_APIVersion_To_extensions_APIVersion(in, out, s)
+}
+
+func autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in *CPUTargetUtilization, out *extensions.CPUTargetUtilization, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*CPUTargetUtilization))(in)
+	}
+	out.TargetPercentage = in.TargetPercentage
+	return nil
+}
+
+func convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in *CPUTargetUtilization, out *extensions.CPUTargetUtilization, s conversion.Scope) error {
+	return autoconvert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in, out, s)
 }
 
 func autoconvert_v1beta1_ClusterAutoscaler_To_extensions_ClusterAutoscaler(in *ClusterAutoscaler, out *extensions.ClusterAutoscaler, s conversion.Scope) error {
@@ -3208,18 +3226,23 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerSpec_To_extensions_HorizontalPod
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HorizontalPodAutoscalerSpec))(in)
 	}
-	if in.ScaleRef != nil {
-		out.ScaleRef = new(extensions.SubresourceReference)
-		if err := convert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(in.ScaleRef, out.ScaleRef, s); err != nil {
+	if err := convert_v1beta1_SubresourceReference_To_extensions_SubresourceReference(&in.ScaleRef, &out.ScaleRef, s); err != nil {
+		return err
+	}
+	if in.MinReplicas != nil {
+		out.MinReplicas = new(int)
+		*out.MinReplicas = *in.MinReplicas
+	} else {
+		out.MinReplicas = nil
+	}
+	out.MaxReplicas = in.MaxReplicas
+	if in.CPUUtilization != nil {
+		out.CPUUtilization = new(extensions.CPUTargetUtilization)
+		if err := convert_v1beta1_CPUTargetUtilization_To_extensions_CPUTargetUtilization(in.CPUUtilization, out.CPUUtilization, s); err != nil {
 			return err
 		}
 	} else {
-		out.ScaleRef = nil
-	}
-	out.MinReplicas = in.MinReplicas
-	out.MaxReplicas = in.MaxReplicas
-	if err := convert_v1beta1_ResourceConsumption_To_extensions_ResourceConsumption(&in.Target, &out.Target, s); err != nil {
-		return err
+		out.CPUUtilization = nil
 	}
 	return nil
 }
@@ -3232,22 +3255,26 @@ func autoconvert_v1beta1_HorizontalPodAutoscalerStatus_To_extensions_HorizontalP
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*HorizontalPodAutoscalerStatus))(in)
 	}
+	if in.ObservedGeneration != nil {
+		out.ObservedGeneration = new(int64)
+		*out.ObservedGeneration = *in.ObservedGeneration
+	} else {
+		out.ObservedGeneration = nil
+	}
+	if in.LastScaleTime != nil {
+		if err := s.Convert(&in.LastScaleTime, &out.LastScaleTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.LastScaleTime = nil
+	}
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentConsumption != nil {
-		out.CurrentConsumption = new(extensions.ResourceConsumption)
-		if err := convert_v1beta1_ResourceConsumption_To_extensions_ResourceConsumption(in.CurrentConsumption, out.CurrentConsumption, s); err != nil {
-			return err
-		}
+	if in.CurrentCPUUtilizationPercentage != nil {
+		out.CurrentCPUUtilizationPercentage = new(int)
+		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
 	} else {
-		out.CurrentConsumption = nil
-	}
-	if in.LastScaleTimestamp != nil {
-		if err := s.Convert(&in.LastScaleTimestamp, &out.LastScaleTimestamp, 0); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTimestamp = nil
+		out.CurrentCPUUtilizationPercentage = nil
 	}
 	return nil
 }
@@ -3618,21 +3645,6 @@ func convert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControl
 	return autoconvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy(in, out, s)
 }
 
-func autoconvert_v1beta1_ResourceConsumption_To_extensions_ResourceConsumption(in *ResourceConsumption, out *extensions.ResourceConsumption, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*ResourceConsumption))(in)
-	}
-	out.Resource = api.ResourceName(in.Resource)
-	if err := s.Convert(&in.Quantity, &out.Quantity, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1beta1_ResourceConsumption_To_extensions_ResourceConsumption(in *ResourceConsumption, out *extensions.ResourceConsumption, s conversion.Scope) error {
-	return autoconvert_v1beta1_ResourceConsumption_To_extensions_ResourceConsumption(in, out, s)
-}
-
 func autoconvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment(in *RollingUpdateDeployment, out *extensions.RollingUpdateDeployment, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*RollingUpdateDeployment))(in)
@@ -3893,7 +3905,6 @@ func init() {
 		autoconvert_extensions_PodSelectorRequirement_To_v1beta1_PodSelectorRequirement,
 		autoconvert_extensions_PodSelector_To_v1beta1_PodSelector,
 		autoconvert_extensions_ReplicationControllerDummy_To_v1beta1_ReplicationControllerDummy,
-		autoconvert_extensions_ResourceConsumption_To_v1beta1_ResourceConsumption,
 		autoconvert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
 		autoconvert_extensions_ScaleSpec_To_v1beta1_ScaleSpec,
 		autoconvert_extensions_ScaleStatus_To_v1beta1_ScaleStatus,
@@ -3977,7 +3988,6 @@ func init() {
 		autoconvert_v1beta1_PodSelectorRequirement_To_extensions_PodSelectorRequirement,
 		autoconvert_v1beta1_PodSelector_To_extensions_PodSelector,
 		autoconvert_v1beta1_ReplicationControllerDummy_To_extensions_ReplicationControllerDummy,
-		autoconvert_v1beta1_ResourceConsumption_To_extensions_ResourceConsumption,
 		autoconvert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
 		autoconvert_v1beta1_ScaleSpec_To_extensions_ScaleSpec,
 		autoconvert_v1beta1_ScaleStatus_To_extensions_ScaleStatus,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -922,6 +922,11 @@ func deepCopy_v1beta1_APIVersion(in APIVersion, out *APIVersion, c *conversion.C
 	return nil
 }
 
+func deepCopy_v1beta1_CPUTargetUtilization(in CPUTargetUtilization, out *CPUTargetUtilization, c *conversion.Cloner) error {
+	out.TargetPercentage = in.TargetPercentage
+	return nil
+}
+
 func deepCopy_v1beta1_ClusterAutoscaler(in ClusterAutoscaler, out *ClusterAutoscaler, c *conversion.Cloner) error {
 	if err := deepCopy_unversioned_TypeMeta(in.TypeMeta, &out.TypeMeta, c); err != nil {
 		return err
@@ -1183,40 +1188,49 @@ func deepCopy_v1beta1_HorizontalPodAutoscalerList(in HorizontalPodAutoscalerList
 }
 
 func deepCopy_v1beta1_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscalerSpec, out *HorizontalPodAutoscalerSpec, c *conversion.Cloner) error {
-	if in.ScaleRef != nil {
-		out.ScaleRef = new(SubresourceReference)
-		if err := deepCopy_v1beta1_SubresourceReference(*in.ScaleRef, out.ScaleRef, c); err != nil {
+	if err := deepCopy_v1beta1_SubresourceReference(in.ScaleRef, &out.ScaleRef, c); err != nil {
+		return err
+	}
+	if in.MinReplicas != nil {
+		out.MinReplicas = new(int)
+		*out.MinReplicas = *in.MinReplicas
+	} else {
+		out.MinReplicas = nil
+	}
+	out.MaxReplicas = in.MaxReplicas
+	if in.CPUUtilization != nil {
+		out.CPUUtilization = new(CPUTargetUtilization)
+		if err := deepCopy_v1beta1_CPUTargetUtilization(*in.CPUUtilization, out.CPUUtilization, c); err != nil {
 			return err
 		}
 	} else {
-		out.ScaleRef = nil
-	}
-	out.MinReplicas = in.MinReplicas
-	out.MaxReplicas = in.MaxReplicas
-	if err := deepCopy_v1beta1_ResourceConsumption(in.Target, &out.Target, c); err != nil {
-		return err
+		out.CPUUtilization = nil
 	}
 	return nil
 }
 
 func deepCopy_v1beta1_HorizontalPodAutoscalerStatus(in HorizontalPodAutoscalerStatus, out *HorizontalPodAutoscalerStatus, c *conversion.Cloner) error {
+	if in.ObservedGeneration != nil {
+		out.ObservedGeneration = new(int64)
+		*out.ObservedGeneration = *in.ObservedGeneration
+	} else {
+		out.ObservedGeneration = nil
+	}
+	if in.LastScaleTime != nil {
+		out.LastScaleTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.LastScaleTime, out.LastScaleTime, c); err != nil {
+			return err
+		}
+	} else {
+		out.LastScaleTime = nil
+	}
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentConsumption != nil {
-		out.CurrentConsumption = new(ResourceConsumption)
-		if err := deepCopy_v1beta1_ResourceConsumption(*in.CurrentConsumption, out.CurrentConsumption, c); err != nil {
-			return err
-		}
+	if in.CurrentCPUUtilizationPercentage != nil {
+		out.CurrentCPUUtilizationPercentage = new(int)
+		*out.CurrentCPUUtilizationPercentage = *in.CurrentCPUUtilizationPercentage
 	} else {
-		out.CurrentConsumption = nil
-	}
-	if in.LastScaleTimestamp != nil {
-		out.LastScaleTimestamp = new(unversioned.Time)
-		if err := deepCopy_unversioned_Time(*in.LastScaleTimestamp, out.LastScaleTimestamp, c); err != nil {
-			return err
-		}
-	} else {
-		out.LastScaleTimestamp = nil
+		out.CurrentCPUUtilizationPercentage = nil
 	}
 	return nil
 }
@@ -1473,14 +1487,6 @@ func deepCopy_v1beta1_ReplicationControllerDummy(in ReplicationControllerDummy, 
 	return nil
 }
 
-func deepCopy_v1beta1_ResourceConsumption(in ResourceConsumption, out *ResourceConsumption, c *conversion.Cloner) error {
-	out.Resource = in.Resource
-	if err := deepCopy_resource_Quantity(in.Quantity, &out.Quantity, c); err != nil {
-		return err
-	}
-	return nil
-}
-
 func deepCopy_v1beta1_RollingUpdateDeployment(in RollingUpdateDeployment, out *RollingUpdateDeployment, c *conversion.Cloner) error {
 	if in.MaxUnavailable != nil {
 		out.MaxUnavailable = new(util.IntOrString)
@@ -1682,6 +1688,7 @@ func init() {
 		deepCopy_v1_VolumeMount,
 		deepCopy_v1_VolumeSource,
 		deepCopy_v1beta1_APIVersion,
+		deepCopy_v1beta1_CPUTargetUtilization,
 		deepCopy_v1beta1_ClusterAutoscaler,
 		deepCopy_v1beta1_ClusterAutoscalerList,
 		deepCopy_v1beta1_ClusterAutoscalerSpec,
@@ -1716,7 +1723,6 @@ func init() {
 		deepCopy_v1beta1_PodSelector,
 		deepCopy_v1beta1_PodSelectorRequirement,
 		deepCopy_v1beta1_ReplicationControllerDummy,
-		deepCopy_v1beta1_ResourceConsumption,
 		deepCopy_v1beta1_RollingUpdateDeployment,
 		deepCopy_v1beta1_Scale,
 		deepCopy_v1beta1_ScaleSpec,

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/defaults.go
@@ -109,5 +109,14 @@ func addDefaultingFuncs() {
 				obj.Spec.Parallelism = obj.Spec.Completions
 			}
 		},
+		func(obj *HorizontalPodAutoscaler) {
+			if obj.Spec.MinReplicas == nil {
+				minReplicas := 1
+				obj.Spec.MinReplicas = &minReplicas
+			}
+			if obj.Spec.CPUUtilization == nil {
+				obj.Spec.CPUUtilization = &CPUTargetUtilization{TargetPercentage: 80}
+			}
+		},
 	)
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types.go
@@ -17,37 +17,36 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util"
 )
 
-// ScaleSpec describes the attributes a Scale subresource
+// describes the attributes of a scale subresource
 type ScaleSpec struct {
-	// Replicas is the number of desired replicas. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+	// desired number of instances for the scaled object.
 	Replicas int `json:"replicas,omitempty"`
 }
 
-// ScaleStatus represents the current status of a Scale subresource.
+// represents the current status of a scale subresource.
 type ScaleStatus struct {
-	// Replicas is the number of actual replicas. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller
+	// actual number of observed instances of the scaled object.
 	Replicas int `json:"replicas"`
 
-	// Selector is a label query over pods that should match the replicas count. If it is empty, it is defaulted to labels on Pod template; More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors
+	// label query over pods that should match the replicas count. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
 }
 
-// Scale subresource, applicable to ReplicationControllers and (in future) Deployment.
+// represents a scaling request for a resource.
 type Scale struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.
+	// defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.
 	Spec ScaleSpec `json:"spec,omitempty"`
 
-	// Status represents the current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.
+	// current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.
 	Status ScaleStatus `json:"status,omitempty"`
 }
 
@@ -70,66 +69,66 @@ type SubresourceReference struct {
 	Subresource string `json:"subresource,omitempty"`
 }
 
-// ResourceConsumption is an object for specifying average resource consumption of a particular resource.
-type ResourceConsumption struct {
-	// Resource specifies either the name of the target resource when present in the spec, or the name of the observed resource when present in the status.
-	Resource v1.ResourceName `json:"resource,omitempty"`
-	// Quantity specifies either the target average consumption of the resource when present in the spec, or the observed average consumption when present in the status.
-	Quantity resource.Quantity `json:"quantity,omitempty"`
+type CPUTargetUtilization struct {
+	// fraction of the requested CPU that should be utilized/used,
+	// e.g. 70 means that 70% of the requested CPU should be in use.
+	TargetPercentage int `json:"targetPercentage"`
 }
 
-// HorizontalPodAutoscalerSpec is the specification of a horizontal pod autoscaler.
+// specification of a horizontal pod autoscaler.
 type HorizontalPodAutoscalerSpec struct {
-	// ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current resource consumption from its status,
-	// and will set the desired number of pods by modyfying its spec.
-	ScaleRef *SubresourceReference `json:"scaleRef"`
-	// MinReplicas is the lower limit for the number of pods that can be set by the autoscaler.
-	MinReplicas int `json:"minReplicas"`
-	// MaxReplicas is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinReplicas.
+	// reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status,
+	// and will set the desired number of pods by modifying its spec.
+	ScaleRef SubresourceReference `json:"scaleRef"`
+	// lower limit for the number of pods that can be set by the autoscaler, default 1.
+	MinReplicas *int `json:"minReplicas,omitempty"`
+	// upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 	MaxReplicas int `json:"maxReplicas"`
-	// Target is the target average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods.
-	// Currently two types of resources are supported: "cpu" and "memory".
-	Target ResourceConsumption `json:"target"`
+	// target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
+	// if not specified it defaults to the target CPU utilization at 80% of the requested resources.
+	CPUUtilization *CPUTargetUtilization `json:"cpuUtilization,omitempty"`
 }
 
-// HorizontalPodAutoscalerStatus contains the current status of a horizontal pod autoscaler
+// current status of a horizontal pod autoscaler
 type HorizontalPodAutoscalerStatus struct {
-	// CurrentReplicas is the number of replicas of pods managed by this autoscaler.
+	// most recent generation observed by this autoscaler.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
+
+	// last time the HorizontalPodAutoscaler scaled the number of pods;
+	// used by the autoscaler to control how often the number of pods is changed.
+	LastScaleTime *unversioned.Time `json:"lastScaleTime,omitempty"`
+
+	// current number of replicas of pods managed by this autoscaler.
 	CurrentReplicas int `json:"currentReplicas"`
 
-	// DesiredReplicas is the desired number of replicas of pods managed by this autoscaler.
+	// desired number of replicas of pods managed by this autoscaler.
 	DesiredReplicas int `json:"desiredReplicas"`
 
-	// CurrentConsumption is the current average consumption of the given resource that the autoscaler will
-	// try to maintain by adjusting the desired number of pods.
-	// Two types of resources are supported: "cpu" and "memory".
-	CurrentConsumption *ResourceConsumption `json:"currentConsumption"`
-
-	// LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods.
-	// This is used by the autoscaler to controll how often the number of pods is changed.
-	LastScaleTimestamp *unversioned.Time `json:"lastScaleTimestamp,omitempty"`
+	// current average CPU utilization over all pods, represented as a percentage of requested CPU,
+	// e.g. 70 means that an average pod is using now 70% of its requested CPU.
+	CurrentCPUUtilizationPercentage *int `json:"currentCPUUtilizationPercentage,omitempty"`
 }
 
-// HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.
+// configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscaler struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec defines the behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.
+	// behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 
-	// Status represents the current information about the autoscaler.
+	// current information about the autoscaler.
 	Status HorizontalPodAutoscalerStatus `json:"status,omitempty"`
 }
 
-// HorizontalPodAutoscalerList is a list of HorizontalPodAutoscalers.
+// list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
-	// Items is the list of HorizontalPodAutoscalers.
+	// list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscaler `json:"items"`
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -37,6 +37,14 @@ func (APIVersion) SwaggerDoc() map[string]string {
 	return map_APIVersion
 }
 
+var map_CPUTargetUtilization = map[string]string{
+	"targetPercentage": "fraction of the requested CPU that should be utilized/used, e.g. 70 means that 70% of the requested CPU should be in use.",
+}
+
+func (CPUTargetUtilization) SwaggerDoc() map[string]string {
+	return map_CPUTargetUtilization
+}
+
 var map_ClusterAutoscaler = map[string]string{
 	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata For now (experimental api) it is required that the name is set to \"ClusterAutoscaler\" and namespace is \"default\".",
 	"spec":     "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
@@ -182,10 +190,10 @@ func (HTTPIngressRuleValue) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscaler = map[string]string{
-	"":         "HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.",
+	"":         "configuration of a horizontal pod autoscaler.",
 	"metadata": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-	"status":   "Status represents the current information about the autoscaler.",
+	"spec":     "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+	"status":   "current information about the autoscaler.",
 }
 
 func (HorizontalPodAutoscaler) SwaggerDoc() map[string]string {
@@ -193,9 +201,9 @@ func (HorizontalPodAutoscaler) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscalerList = map[string]string{
-	"":         "HorizontalPodAutoscalerList is a list of HorizontalPodAutoscalers.",
+	"":         "list of horizontal pod autoscaler objects.",
 	"metadata": "Standard list metadata.",
-	"items":    "Items is the list of HorizontalPodAutoscalers.",
+	"items":    "list of horizontal pod autoscaler objects.",
 }
 
 func (HorizontalPodAutoscalerList) SwaggerDoc() map[string]string {
@@ -203,11 +211,11 @@ func (HorizontalPodAutoscalerList) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscalerSpec = map[string]string{
-	"":            "HorizontalPodAutoscalerSpec is the specification of a horizontal pod autoscaler.",
-	"scaleRef":    "ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modyfying its spec.",
-	"minReplicas": "MinReplicas is the lower limit for the number of pods that can be set by the autoscaler.",
-	"maxReplicas": "MaxReplicas is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinReplicas.",
-	"target":      "Target is the target average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods. Currently two types of resources are supported: \"cpu\" and \"memory\".",
+	"":               "specification of a horizontal pod autoscaler.",
+	"scaleRef":       "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec.",
+	"minReplicas":    "lower limit for the number of pods that can be set by the autoscaler, default 1.",
+	"maxReplicas":    "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+	"cpuUtilization": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources.",
 }
 
 func (HorizontalPodAutoscalerSpec) SwaggerDoc() map[string]string {
@@ -215,11 +223,12 @@ func (HorizontalPodAutoscalerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscalerStatus = map[string]string{
-	"":                   "HorizontalPodAutoscalerStatus contains the current status of a horizontal pod autoscaler",
-	"currentReplicas":    "CurrentReplicas is the number of replicas of pods managed by this autoscaler.",
-	"desiredReplicas":    "DesiredReplicas is the desired number of replicas of pods managed by this autoscaler.",
-	"currentConsumption": "CurrentConsumption is the current average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods. Two types of resources are supported: \"cpu\" and \"memory\".",
-	"lastScaleTimestamp": "LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods. This is used by the autoscaler to controll how often the number of pods is changed.",
+	"":                                "current status of a horizontal pod autoscaler",
+	"observedGeneration":              "most recent generation observed by this autoscaler.",
+	"lastScaleTime":                   "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+	"currentReplicas":                 "current number of replicas of pods managed by this autoscaler.",
+	"desiredReplicas":                 "desired number of replicas of pods managed by this autoscaler.",
+	"currentCPUUtilizationPercentage": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
 }
 
 func (HorizontalPodAutoscalerStatus) SwaggerDoc() map[string]string {
@@ -392,16 +401,6 @@ func (ReplicationControllerDummy) SwaggerDoc() map[string]string {
 	return map_ReplicationControllerDummy
 }
 
-var map_ResourceConsumption = map[string]string{
-	"":         "ResourceConsumption is an object for specifying average resource consumption of a particular resource.",
-	"resource": "Resource specifies either the name of the target resource when present in the spec, or the name of the observed resource when present in the status.",
-	"quantity": "Quantity specifies either the target average consumption of the resource when present in the spec, or the observed average consumption when present in the status.",
-}
-
-func (ResourceConsumption) SwaggerDoc() map[string]string {
-	return map_ResourceConsumption
-}
-
 var map_RollingUpdateDeployment = map[string]string{
 	"":                "Spec to control the desired behavior of rolling update.",
 	"maxUnavailable":  "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
@@ -414,10 +413,10 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 }
 
 var map_Scale = map[string]string{
-	"":         "Scale subresource, applicable to ReplicationControllers and (in future) Deployment.",
+	"":         "represents a scaling request for a resource.",
 	"metadata": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
-	"spec":     "Spec defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-	"status":   "Status represents the current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
+	"spec":     "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+	"status":   "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
 }
 
 func (Scale) SwaggerDoc() map[string]string {
@@ -425,8 +424,8 @@ func (Scale) SwaggerDoc() map[string]string {
 }
 
 var map_ScaleSpec = map[string]string{
-	"":         "ScaleSpec describes the attributes a Scale subresource",
-	"replicas": "Replicas is the number of desired replicas. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller\"",
+	"":         "describes the attributes of a scale subresource",
+	"replicas": "desired number of instances for the scaled object.",
 }
 
 func (ScaleSpec) SwaggerDoc() map[string]string {
@@ -434,9 +433,9 @@ func (ScaleSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ScaleStatus = map[string]string{
-	"":         "ScaleStatus represents the current status of a Scale subresource.",
-	"replicas": "Replicas is the number of actual replicas. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
-	"selector": "Selector is a label query over pods that should match the replicas count. If it is empty, it is defaulted to labels on Pod template; More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors",
+	"":         "represents the current status of a scale subresource.",
+	"replicas": "actual number of observed instances of the scaled object.",
+	"selector": "label query over pods that should match the replicas count. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors",
 }
 
 func (ScaleStatus) SwaggerDoc() map[string]string {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/validation/validation_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/util"
 	errors "k8s.io/kubernetes/pkg/util/fielderrors"
@@ -36,12 +35,25 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: extensions.HorizontalPodAutoscalerSpec{
-				ScaleRef: &extensions.SubresourceReference{
+				ScaleRef: extensions.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinReplicas: 1,
+				MinReplicas:    newInt(1),
+				MaxReplicas:    5,
+				CPUUtilization: &extensions.CPUTargetUtilization{TargetPercentage: 70},
+			},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "myautoscaler",
+				Namespace: api.NamespaceDefault,
+			},
+			Spec: extensions.HorizontalPodAutoscalerSpec{
+				ScaleRef: extensions.SubresourceReference{
+					Subresource: "scale",
+				},
+				MinReplicas: newInt(1),
 				MaxReplicas: 5,
-				Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
 	}
@@ -52,18 +64,17 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 	}
 
 	errorCases := map[string]extensions.HorizontalPodAutoscaler{
-		"must be non-negative": {
+		"must be bigger or equal to 1": {
 			ObjectMeta: api.ObjectMeta{
 				Name:      "myautoscaler",
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: extensions.HorizontalPodAutoscalerSpec{
-				ScaleRef: &extensions.SubresourceReference{
+				ScaleRef: extensions.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinReplicas: -1,
+				MinReplicas: newInt(-1),
 				MaxReplicas: 5,
-				Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
 		"must be bigger or equal to minReplicas": {
@@ -72,51 +83,25 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: extensions.HorizontalPodAutoscalerSpec{
-				ScaleRef: &extensions.SubresourceReference{
+				ScaleRef: extensions.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinReplicas: 7,
+				MinReplicas: newInt(7),
 				MaxReplicas: 5,
-				Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
-		"invalid value": {
+		"must be non-negative": {
 			ObjectMeta: api.ObjectMeta{
 				Name:      "myautoscaler",
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: extensions.HorizontalPodAutoscalerSpec{
-				ScaleRef: &extensions.SubresourceReference{
+				ScaleRef: extensions.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinReplicas: 1,
-				MaxReplicas: 5,
-				Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("-0.8")},
-			},
-		},
-		"resource not supported": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "myautoscaler",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.HorizontalPodAutoscalerSpec{
-				ScaleRef: &extensions.SubresourceReference{
-					Subresource: "scale",
-				},
-				MinReplicas: 1,
-				MaxReplicas: 5,
-				Target:      extensions.ResourceConsumption{Resource: api.ResourceName("NotSupportedResource"), Quantity: resource.MustParse("0.8")},
-			},
-		},
-		"required value": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "myautoscaler",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.HorizontalPodAutoscalerSpec{
-				MinReplicas: 1,
-				MaxReplicas: 5,
-				Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+				MinReplicas:    newInt(1),
+				MaxReplicas:    5,
+				CPUUtilization: &extensions.CPUTargetUtilization{TargetPercentage: -70},
 			},
 		},
 	}
@@ -1054,4 +1039,10 @@ func TestValidateClusterAutoscaler(t *testing.T) {
 			t.Errorf("unexpected error: %v, expected: %s", errs[0], k)
 		}
 	}
+}
+
+func newInt(val int) *int {
+	p := new(int)
+	*p = val
+	return p
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/apiserver.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/apiserver.go
@@ -79,6 +79,12 @@ type Mux interface {
 type APIGroupVersion struct {
 	Storage map[string]rest.Storage
 
+	// NonDefaultGroupVersions is a map of resource[/subresource] to group/version to use for serialization
+	// of the rest.Storage kind.  Missing entries simply preserve existing behavior (uses .Version).
+	// This allows a single rest.Storage to be registed in multiple APIGroupVersions with different
+	// serializations in each one.
+	NonDefaultGroupVersions map[string]string
+
 	Root string
 	// TODO: caesarxuchao: Version actually contains "group/version", refactor it to avoid confusion.
 	Version string

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers_test.go
@@ -228,12 +228,15 @@ func TestGetAPIRequestInfo(t *testing.T) {
 
 		// special verbs
 		{"GET", "/api/v1/proxy/namespaces/other/pods/foo", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
+		{"GET", "/api/v1/proxy/namespaces/other/pods/foo/subpath/not/a/subresource", "proxy", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo", "subpath", "not", "a", "subresource"}},
 		{"GET", "/api/v1/redirect/namespaces/other/pods/foo", "redirect", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
+		{"GET", "/api/v1/redirect/namespaces/other/pods/foo/subpath/not/a/subresource", "redirect", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo", "subpath", "not", "a", "subresource"}},
 		{"GET", "/api/v1/watch/pods", "watch", "api", "", "v1", api.NamespaceAll, "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/watch/namespaces/other/pods", "watch", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 
 		// subresource identification
 		{"GET", "/api/v1/namespaces/other/pods/foo/status", "get", "api", "", "v1", "other", "pods", "status", "foo", []string{"pods", "foo", "status"}},
+		{"GET", "/api/v1/namespaces/other/pods/foo/proxy/subpath", "get", "api", "", "v1", "other", "pods", "proxy", "foo", []string{"pods", "foo", "proxy", "subpath"}},
 		{"PUT", "/api/v1/namespaces/other/finalize", "update", "api", "", "v1", "other", "finalize", "", "", []string{"finalize"}},
 
 		// verb identification

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal_test.go
@@ -206,7 +206,7 @@ func (tc *testCase) verifyResults(t *testing.T) {
 
 func (tc *testCase) runTest(t *testing.T) {
 	testClient := tc.prepareTestClient(t)
-	hpaController := NewHorizontalController(testClient, metrics.NewHeapsterMetricsClient(testClient))
+	hpaController := NewHorizontalController(testClient, testClient.Extensions(), testClient.Extensions(), metrics.NewHeapsterMetricsClient(testClient))
 	err := hpaController.reconcileAutoscalers()
 	assert.Equal(t, nil, err)
 	if tc.verifyEvents {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal_test.go
@@ -206,7 +206,8 @@ func (tc *testCase) verifyResults(t *testing.T) {
 
 func (tc *testCase) runTest(t *testing.T) {
 	testClient := tc.prepareTestClient(t)
-	hpaController := NewHorizontalController(testClient, testClient.Extensions(), testClient.Extensions(), metrics.NewHeapsterMetricsClient(testClient))
+	metricsClient := metrics.NewHeapsterMetricsClient(testClient, "kube-system", "heapster")
+	hpaController := NewHorizontalController(testClient, testClient.Extensions(), testClient.Extensions(), metricsClient)
 	err := hpaController.reconcileAutoscalers()
 	assert.Equal(t, nil, err)
 	if tc.verifyEvents {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/metrics/metrics_client_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/metrics/metrics_client_test.go
@@ -148,7 +148,7 @@ func (tc *testCase) verifyResults(t *testing.T, val *ResourceConsumption, err er
 
 func (tc *testCase) runTest(t *testing.T) {
 	testClient := tc.prepareTestClient(t)
-	metricsClient := NewHeapsterMetricsClient(testClient)
+	metricsClient := NewHeapsterMetricsClient(testClient, "kube-system", "heapster")
 	val, _, err := metricsClient.GetResourceConsumptionAndRequest(tc.targetResource, tc.namespace, tc.selector)
 	tc.verifyResults(t, val, err)
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/describe.go
@@ -1251,17 +1251,14 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string) (str
 			hpa.Spec.ScaleRef.Namespace,
 			hpa.Spec.ScaleRef.Name,
 			hpa.Spec.ScaleRef.Subresource)
-		fmt.Fprintf(out, "Target resource consumption:\t%s %s\n",
-			hpa.Spec.Target.Quantity.String(),
-			hpa.Spec.Target.Resource)
-		fmt.Fprintf(out, "Current resource consumption:\t")
-
-		if hpa.Status.CurrentConsumption != nil {
-			fmt.Fprintf(out, "%s %s\n",
-				hpa.Status.CurrentConsumption.Quantity.String(),
-				hpa.Status.CurrentConsumption.Resource)
-		} else {
-			fmt.Fprintf(out, "<not available>\n")
+		if hpa.Spec.CPUUtilization != nil {
+			fmt.Fprintf(out, "Target CPU utilization:\t%d%%\n", hpa.Spec.CPUUtilization.TargetPercentage)
+			fmt.Fprintf(out, "Current CPU utilization:\t")
+			if hpa.Status.CurrentCPUUtilizationPercentage != nil {
+				fmt.Fprintf(out, "%d%%\n", *hpa.Status.CurrentCPUUtilizationPercentage)
+			} else {
+				fmt.Fprintf(out, "<not available>\n")
+			}
 		}
 		fmt.Fprintf(out, "Min pods:\t%d\n", hpa.Spec.MinReplicas)
 		fmt.Fprintf(out, "Max pods:\t%d\n", hpa.Spec.MaxReplicas)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
@@ -1391,11 +1391,13 @@ func printHorizontalPodAutoscaler(hpa *extensions.HorizontalPodAutoscaler, w io.
 		hpa.Spec.ScaleRef.Namespace,
 		hpa.Spec.ScaleRef.Name,
 		hpa.Spec.ScaleRef.Subresource)
-	target := fmt.Sprintf("%s %v", hpa.Spec.Target.Quantity.String(), hpa.Spec.Target.Resource)
-
+	target := "<unknown>"
+	if hpa.Spec.CPUUtilization != nil {
+		target = fmt.Sprintf("%d%%", hpa.Spec.CPUUtilization.TargetPercentage)
+	}
 	current := "<waiting>"
-	if hpa.Status.CurrentConsumption != nil {
-		current = fmt.Sprintf("%s %v", hpa.Status.CurrentConsumption.Quantity.String(), hpa.Status.CurrentConsumption.Resource)
+	if hpa.Status.CurrentCPUUtilizationPercentage != nil {
+		current = fmt.Sprintf("%d%%", *hpa.Status.CurrentCPUUtilizationPercentage)
 	}
 	minPods := hpa.Spec.MinReplicas
 	maxPods := hpa.Spec.MaxReplicas

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	// Ensure that extensions/v1beta1 package is initialized.
 	_ "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -44,12 +43,11 @@ func validNewHorizontalPodAutoscaler(name string) *extensions.HorizontalPodAutos
 			Namespace: api.NamespaceDefault,
 		},
 		Spec: extensions.HorizontalPodAutoscalerSpec{
-			ScaleRef: &extensions.SubresourceReference{
+			ScaleRef: extensions.SubresourceReference{
 				Subresource: "scale",
 			},
-			MinReplicas: 1,
-			MaxReplicas: 5,
-			Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+			MaxReplicas:    5,
+			CPUUtilization: &extensions.CPUTargetUtilization{TargetPercentage: 70},
 		},
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/horizontal_pod_autoscaling.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/horizontal_pod_autoscaling.go
@@ -17,10 +17,7 @@ limitations under the License.
 package e2e
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/apis/extensions"
-
+	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo"
 )
 
@@ -34,7 +31,7 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 	f := NewFramework("horizontal-pod-autoscaling")
 
 	// CPU tests
-	It("[Skipped][Autoscaling Suite] should scale from 1 pod to 3 pods and from 3 to 5 (scale resource: CPU)", func() {
+	It("[Skipped] should scale from 1 pod to 3 pods and from 3 to 5 (scale resource: CPU)", func() {
 		rc = NewDynamicResourceConsumer("rc", 1, 250, 0, 400, 100, f)
 		defer rc.CleanUp()
 		createCPUHorizontalPodAutoscaler(rc, "0.1")
@@ -43,7 +40,7 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 		rc.WaitForReplicas(5)
 	})
 
-	It("[Skipped][Autoscaling Suite] should scale from 5 pods to 3 pods and from 3 to 1 (scale resource: CPU)", func() {
+	It("[Skipped] should scale from 5 pods to 3 pods and from 3 to 1 (scale resource: CPU)", func() {
 		rc = NewDynamicResourceConsumer("rc", 5, 700, 0, 200, 100, f)
 		defer rc.CleanUp()
 		createCPUHorizontalPodAutoscaler(rc, "0.3")
@@ -53,7 +50,7 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 	})
 
 	// Memory tests
-	It("[Skipped][Autoscaling Suite] should scale from 1 pod to 3 pods and from 3 to 5 (scale resource: Memory)", func() {
+	It("[Skipped] should scale from 1 pod to 3 pods and from 3 to 5 (scale resource: Memory)", func() {
 		rc = NewDynamicResourceConsumer("rc", 1, 0, 2200, 100, 2500, f)
 		defer rc.CleanUp()
 		createMemoryHorizontalPodAutoscaler(rc, "1000")
@@ -62,7 +59,7 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 		rc.WaitForReplicas(5)
 	})
 
-	It("[Skipped][Autoscaling Suite] should scale from 5 pods to 3 pods and from 3 to 1 (scale resource: Memory)", func() {
+	It("[Skipped] should scale from 5 pods to 3 pods and from 3 to 1 (scale resource: Memory)", func() {
 		rc = NewDynamicResourceConsumer("rc", 5, 0, 2200, 100, 2500, f)
 		defer rc.CleanUp()
 		createMemoryHorizontalPodAutoscaler(rc, "1000")
@@ -152,46 +149,12 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 })
 
 func createCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu string) {
-	hpa := &extensions.HorizontalPodAutoscaler{
-		ObjectMeta: api.ObjectMeta{
-			Name:      rc.name,
-			Namespace: rc.framework.Namespace.Name,
-		},
-		Spec: extensions.HorizontalPodAutoscalerSpec{
-			ScaleRef: &extensions.SubresourceReference{
-				Kind:        kind,
-				Name:        rc.name,
-				Namespace:   rc.framework.Namespace.Name,
-				Subresource: subresource,
-			},
-			MinReplicas: 1,
-			MaxReplicas: 5,
-			Target:      extensions.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse(cpu)},
-		},
-	}
-	_, errHPA := rc.framework.Client.Extensions().HorizontalPodAutoscalers(rc.framework.Namespace.Name).Create(hpa)
-	expectNoError(errHPA)
+	glog.Fatal("createCPUHorizontalPodAutoscaler not implemented!")
+	// TODO: reimplemente e2e tests for the new API.
 }
 
 // argument memory is in megabytes
 func createMemoryHorizontalPodAutoscaler(rc *ResourceConsumer, memory string) {
-	hpa := &extensions.HorizontalPodAutoscaler{
-		ObjectMeta: api.ObjectMeta{
-			Name:      rc.name,
-			Namespace: rc.framework.Namespace.Name,
-		},
-		Spec: extensions.HorizontalPodAutoscalerSpec{
-			ScaleRef: &extensions.SubresourceReference{
-				Kind:        kind,
-				Name:        rc.name,
-				Namespace:   rc.framework.Namespace.Name,
-				Subresource: subresource,
-			},
-			MinReplicas: 1,
-			MaxReplicas: 5,
-			Target:      extensions.ResourceConsumption{Resource: api.ResourceMemory, Quantity: resource.MustParse(memory + "M")},
-		},
-	}
-	_, errHPA := rc.framework.Client.Extensions().HorizontalPodAutoscalers(rc.framework.Namespace.Name).Create(hpa)
-	expectNoError(errHPA)
+	glog.Fatal("createMemoryHorizontalPodAutoscaler not implemented!")
+	// TODO: reimplemente e2e tests for the new API.
 }

--- a/api/definitions/v1beta1.scale/description.adoc
+++ b/api/definitions/v1beta1.scale/description.adoc
@@ -1,0 +1,7 @@
+Scale is a subresource representing the current "scale" of certain objects, such as
+ReplicationControllers and DeploymentConfigs.  It may be checked to determine the current
+replica count of these objects, or updated to set the replica count of these objects.
+
+In the case of ReplicationControllers, this directly reflects the scale the ReplicationController.
+For DeploymentConfigs, it reflects the scale of the deployment(s), or, if none are present, the
+scale of the DeploymentConfig's template.

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -4492,6 +4492,165 @@
     ]
    },
    {
+    "path": "/oapi/v1/namespaces/{namespace}/deploymentconfigs/{name}/scale",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1beta1.Scale",
+      "method": "GET",
+      "summary": "read scale of the specified Scale",
+      "nickname": "readNamespacedScaleScale",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Scale",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.Scale"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta1.Scale",
+      "method": "PUT",
+      "summary": "replace scale of the specified Scale",
+      "nickname": "replaceNamespacedScaleScale",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Scale",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Scale",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.Scale"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1beta1.Scale",
+      "method": "PATCH",
+      "summary": "partially update scale of the specified Scale",
+      "nickname": "patchNamespacedScaleScale",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Scale",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.Scale"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/namespaces/{namespace}/generatedeploymentconfigs/{name}",
     "description": "OpenShift REST API, version v1",
     "operations": [
@@ -16862,6 +17021,61 @@
      "apiVersion": {
       "type": "string",
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     }
+    }
+   },
+   "v1beta1.Scale": {
+    "id": "v1beta1.Scale",
+    "description": "represents a scaling request for a resource.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata."
+     },
+     "spec": {
+      "$ref": "v1beta1.ScaleSpec",
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1beta1.ScaleStatus",
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only."
+     }
+    }
+   },
+   "v1beta1.ScaleSpec": {
+    "id": "v1beta1.ScaleSpec",
+    "description": "describes the attributes of a scale subresource",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of instances for the scaled object."
+     }
+    }
+   },
+   "v1beta1.ScaleStatus": {
+    "id": "v1beta1.ScaleStatus",
+    "description": "represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "actual number of observed instances of the scaled object."
+     },
+     "selector": {
+      "type": "any",
+      "description": "label query over pods that should match the replicas count. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors"
      }
     }
    },

--- a/hack/api-description-whitelist.txt
+++ b/hack/api-description-whitelist.txt
@@ -233,3 +233,5 @@ unversioned.statuscause
 unversioned.statusdetails
 unversioned.patch
 unversioned.listmeta
+v1beta1.scalestatus
+v1beta1.scalespec

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -11,6 +11,7 @@ import (
 	sdnvalidation "github.com/openshift/origin/pkg/sdn/api/validation"
 	templatevalidation "github.com/openshift/origin/pkg/template/api/validation"
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
+	extvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	buildapi "github.com/openshift/origin/pkg/build/api"
@@ -22,6 +23,7 @@ import (
 	sdnapi "github.com/openshift/origin/pkg/sdn/api"
 	templateapi "github.com/openshift/origin/pkg/template/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func init() {
@@ -48,6 +50,7 @@ func init() {
 	Validator.Register(&deployapi.DeploymentConfig{}, deployvalidation.ValidateDeploymentConfig, deployvalidation.ValidateDeploymentConfigUpdate)
 	Validator.Register(&deployapi.DeploymentConfigRollback{}, deployvalidation.ValidateDeploymentConfigRollback, nil)
 	Validator.Register(&deployapi.DeploymentLogOptions{}, deployvalidation.ValidateDeploymentLogOptions, nil)
+	Validator.Register(&extensions.Scale{}, extvalidation.ValidateScale, extvalidation.ValidateScaleUpdate)
 
 	Validator.Register(&imageapi.Image{}, imagevalidation.ValidateImage, imagevalidation.ValidateImageUpdate)
 	Validator.Register(&imageapi.ImageStream{}, imagevalidation.ValidateImageStream, imagevalidation.ValidateImageStreamUpdate)

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -76,7 +76,7 @@ var (
 	GroupsToResources = map[string][]string{
 		BuildGroupName:       {"builds", "buildconfigs", "buildlogs", "buildconfigs/instantiate", "buildconfigs/instantiatebinary", "builds/log", "builds/clone", "buildconfigs/webhooks"},
 		ImageGroupName:       {"imagestreams", "imagestreammappings", "imagestreamtags", "imagestreamimages"},
-		DeploymentGroupName:  {"deployments", "deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/log"},
+		DeploymentGroupName:  {"deployments", "deploymentconfigs", "generatedeploymentconfigs", "deploymentconfigrollbacks", "deploymentconfigs/log", "deploymentconfigs/scale"},
 		SDNGroupName:         {"clusternetworks", "hostsubnets", "netnamespaces"},
 		TemplateGroupName:    {"templates", "templateconfigs", "processedtemplates"},
 		UserGroupName:        {"identities", "users", "useridentitymappings", "groups"},

--- a/pkg/client/scale.go
+++ b/pkg/client/scale.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/openshift/origin/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type delegatingScaleInterface struct {
+	dcs    DeploymentConfigInterface
+	scales kclient.ScaleInterface
+}
+
+type delegatingScaleNamespacer struct {
+	dcNS    DeploymentConfigsNamespacer
+	scaleNS kclient.ScaleNamespacer
+}
+
+func (c *delegatingScaleNamespacer) Scales(namespace string) kclient.ScaleInterface {
+	return &delegatingScaleInterface{
+		dcs:    c.dcNS.DeploymentConfigs(namespace),
+		scales: c.scaleNS.Scales(namespace),
+	}
+}
+
+func NewDelegatingScaleNamespacer(dcNamespacer DeploymentConfigsNamespacer, sNamespacer kclient.ScaleNamespacer) kclient.ScaleNamespacer {
+	return &delegatingScaleNamespacer{
+		dcNS:    dcNamespacer,
+		scaleNS: sNamespacer,
+	}
+}
+
+// Get takes the reference to scale subresource and returns the subresource or error, if one occurs.
+func (c *delegatingScaleInterface) Get(kind string, name string) (result *extensions.Scale, err error) {
+	switch {
+	case kind == "DeploymentConfig":
+		return c.dcs.GetScale(name)
+	case latest.OriginKind(kind, ""):
+		return nil, errors.NewBadRequest(fmt.Sprintf("Kind %s has no Scale subresource", kind))
+	default:
+		return c.scales.Get(kind, name)
+	}
+}
+
+// Update takes a scale subresource object, updates the stored version to match it, and
+// returns the subresource or error, if one occurs.
+func (c *delegatingScaleInterface) Update(kind string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	switch {
+	case kind == "DeploymentConfig":
+		return c.dcs.UpdateScale(scale)
+	case latest.OriginKind(kind, ""):
+		return nil, errors.NewBadRequest(fmt.Sprintf("Kind %s has no Scale subresource", kind))
+	default:
+		return c.scales.Update(kind, scale)
+	}
+}

--- a/pkg/client/testclient/fake_deploymentconfigs.go
+++ b/pkg/client/testclient/fake_deploymentconfigs.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -78,4 +79,22 @@ func (c *FakeDeploymentConfigs) Rollback(inObj *deployapi.DeploymentConfigRollba
 	}
 
 	return obj.(*deployapi.DeploymentConfig), err
+}
+
+func (c *FakeDeploymentConfigs) GetScale(name string) (*extensions.Scale, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewGetAction("deploymentconfigs/scale", c.Namespace, name), &extensions.Scale{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.Scale), err
+}
+
+func (c *FakeDeploymentConfigs) UpdateScale(inObj *extensions.Scale) (*extensions.Scale, error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewUpdateAction("deploymentconfigs/scale", c.Namespace, inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*extensions.Scale), err
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -39,6 +39,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					Verbs:     sets.NewString(authorizationapi.VerbAll),
 					Resources: sets.NewString(authorizationapi.ResourceAll),
+					APIGroups: []string{authorizationapi.APIGroupAll},
 				},
 				{
 					Verbs:           sets.NewString(authorizationapi.VerbAll),
@@ -396,7 +397,44 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			ObjectMeta: kapi.ObjectMeta{
 				Name: HPAControllerRoleName,
 			},
-			Rules: []authorizationapi.PolicyRule{},
+			Rules: []authorizationapi.PolicyRule{
+				// HPA Controller
+				{
+					APIGroups: []string{authorizationapi.APIGroupExtensions},
+					Verbs:     sets.NewString("get", "list"),
+					Resources: sets.NewString("horizontalpodautoscalers"),
+				},
+				{
+					APIGroups: []string{authorizationapi.APIGroupExtensions},
+					Verbs:     sets.NewString("update"),
+					Resources: sets.NewString("horizontalpodautoscalers/status"),
+				},
+				{
+					APIGroups: []string{authorizationapi.APIGroupExtensions},
+					Verbs:     sets.NewString("get", "update"),
+					Resources: sets.NewString("replicationcontrollers/scale"),
+				},
+				{
+					Verbs:     sets.NewString("get", "update"),
+					Resources: sets.NewString("deploymentconfigs/scale"),
+				},
+				{
+					Verbs:     sets.NewString("create", "update", "patch"),
+					Resources: sets.NewString("events"),
+				},
+				// Heapster MetricsClient
+				{
+					Verbs:     sets.NewString("list"),
+					Resources: sets.NewString("pods"),
+				},
+				{
+					// TODO: fix MetricsClient to no longer require root proxy access
+					// TODO: restrict this to the appropriate namespace
+					Verbs:         sets.NewString("proxy"),
+					Resources:     sets.NewString("services"),
+					ResourceNames: sets.NewString("heapster"),
+				},
+			},
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -332,8 +332,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 	buildConfigStorage := buildconfigetcd.NewStorage(c.EtcdHelper)
 	buildConfigRegistry := buildconfigregistry.NewRegistry(buildConfigStorage)
 
-	deployConfigStorage := deployconfigetcd.NewStorage(c.EtcdHelper)
-	deployConfigRegistry := deployconfigregistry.NewRegistry(deployConfigStorage)
+	deployConfigStorage := deployconfigetcd.NewStorage(c.EtcdHelper, c.DeploymentConfigScaleClient())
+	deployConfigRegistry := deployconfigregistry.NewRegistry(deployConfigStorage.DeploymentConfig)
 
 	routeAllocator := c.RouteAllocator()
 
@@ -437,7 +437,8 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		"imageStreamMappings": imageStreamMappingStorage,
 		"imageStreamTags":     imageStreamTagStorage,
 
-		"deploymentConfigs":         deployConfigStorage,
+		"deploymentConfigs":         deployConfigStorage.DeploymentConfig,
+		"deploymentConfigs/scale":   deployConfigStorage.Scale,
 		"generateDeploymentConfigs": deployconfiggenerator.NewREST(deployConfigGenerator, c.EtcdHelper.Codec()),
 		"deploymentConfigRollbacks": deployrollback.NewREST(deployRollbackClient, c.EtcdHelper.Codec()),
 		"deploymentConfigs/log":     deploylogregistry.NewREST(configClient, kclient, c.DeploymentLogClient(), kubeletClient),
@@ -576,6 +577,7 @@ func (c *MasterConfig) api_v1beta3(all map[string]rest.Storage) *apiserver.APIGr
 	version.Storage = storage
 	version.Version = OpenShiftAPIV1Beta3
 	version.Codec = v1beta3.Codec
+	version.NonDefaultGroupVersions["deploymentconfigs/scale"] = "extensions/v1beta1"
 	return version
 }
 
@@ -592,6 +594,7 @@ func (c *MasterConfig) api_v1(all map[string]rest.Storage) *apiserver.APIGroupVe
 	version.Storage = storage
 	version.Version = OpenShiftAPIV1
 	version.Codec = v1.Codec
+	version.NonDefaultGroupVersions["deploymentconfigs/scale"] = "extensions/v1beta1"
 	return version
 }
 

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -556,8 +556,9 @@ func (c *MasterConfig) defaultAPIGroupVersion() *apiserver.APIGroupVersion {
 		Convertor: kapi.Scheme,
 		Linker:    latest.SelfLinker,
 
-		Admit:   c.AdmissionControl,
-		Context: c.getRequestContextMapper(),
+		Admit:                   c.AdmissionControl,
+		Context:                 c.getRequestContextMapper(),
+		NonDefaultGroupVersions: map[string]string{},
 	}
 }
 

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -440,6 +440,11 @@ func (c *MasterConfig) ImageImportControllerClient() *osclient.Client {
 	return c.PrivilegedLoopbackOpenShiftClient
 }
 
+// DeploymentConfigScaleClient returns the client used by the Scale subresource registry
+func (c *MasterConfig) DeploymentConfigScaleClient() *kclient.Client {
+	return c.PrivilegedLoopbackKubernetesClient
+}
+
 // DeploymentControllerClients returns the deployment controller client objects
 func (c *MasterConfig) DeploymentControllerClients() (*osclient.Client, *kclient.Client) {
 	osClient, kClient, err := c.GetServiceAccountClients(c.DeploymentControllerServiceAccount)

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -534,7 +534,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		if err != nil {
 			glog.Fatalf("Could not get client for job controller: %v", err)
 		}
-		_, hpaKClient, err := oc.GetServiceAccountClients(oc.HPAControllerServiceAccount)
+		hpaOClient, hpaKClient, err := oc.GetServiceAccountClients(oc.HPAControllerServiceAccount)
 		if err != nil {
 			glog.Fatalf("Could not get client for HPA controller: %v", err)
 		}
@@ -547,7 +547,7 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunScheduler()
 		kc.RunReplicationController(rcClient)
 		kc.RunJobController(jobClient)
-		kc.RunHPAController(hpaKClient)
+		kc.RunHPAController(hpaOClient, hpaKClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace)
 		kc.RunEndpointController()
 		kc.RunNamespaceController()
 		kc.RunPersistentVolumeClaimBinder()

--- a/pkg/deploy/registry/deployconfig/etcd/etcd.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd.go
@@ -1,7 +1,13 @@
 package etcd
 
 import (
+	"fmt"
+
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
@@ -11,16 +17,40 @@ import (
 
 	"github.com/openshift/origin/pkg/deploy/api"
 	"github.com/openshift/origin/pkg/deploy/registry/deployconfig"
+	"github.com/openshift/origin/pkg/deploy/util"
+	extvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
 )
 
 const DeploymentConfigPath string = "/deploymentconfigs"
 
+// DeploymentConfigStorage contains the REST storage information for both DeploymentConfigs
+// and their Scale subresources.
+type DeploymentConfigStorage struct {
+	DeploymentConfig *REST
+	Scale            *ScaleREST
+}
+
+// NewStorage returns a DeploymentConfigStorage containing the REST storage for
+// DeploymentConfig objects and their Scale subresources.
+func NewStorage(s storage.Interface, rcNamespacer kclient.ReplicationControllersNamespacer) DeploymentConfigStorage {
+	deploymentConfigREST := newREST(s)
+	deploymentConfigRegistry := deployconfig.NewRegistry(deploymentConfigREST)
+	return DeploymentConfigStorage{
+		DeploymentConfig: deploymentConfigREST,
+		Scale: &ScaleREST{
+			registry:     deploymentConfigRegistry,
+			rcNamespacer: rcNamespacer,
+		},
+	}
+}
+
+// REST contains the REST storage for DeploymentConfig objects.
 type REST struct {
 	*etcdgeneric.Etcd
 }
 
-// NewStorage returns a RESTStorage object that will work against DeploymentConfig objects.
-func NewStorage(s storage.Interface) *REST {
+// newREST returns a RESTStorage object that will work against DeploymentConfig objects.
+func newREST(s storage.Interface) *REST {
 	store := &etcdgeneric.Etcd{
 		NewFunc:      func() runtime.Object { return &api.DeploymentConfig{} },
 		NewListFunc:  func() runtime.Object { return &api.DeploymentConfigList{} },
@@ -45,4 +75,186 @@ func NewStorage(s storage.Interface) *REST {
 	}
 
 	return &REST{store}
+}
+
+// ScaleREST contains the REST storage for the Scale subresource of DeploymentConfigs.
+type ScaleREST struct {
+	registry     deployconfig.Registry
+	rcNamespacer kclient.ReplicationControllersNamespacer
+}
+
+// ScaleREST implements Patcher
+var _ = rest.Patcher(&ScaleREST{})
+
+// New creates a new Scale object
+func (r *ScaleREST) New() runtime.Object {
+	return &extensions.Scale{}
+}
+
+// Get retrieves (computes) the Scale subresource for the given DeploymentConfig name.
+func (r *ScaleREST) Get(ctx kapi.Context, name string) (runtime.Object, error) {
+	deploymentConfig, err := r.registry.GetDeploymentConfig(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(directxman12): this is going to be a bit out of sync, since we are calculating it
+	// here and not as part of the deploymentconfig loop -- is there a better way of doing it?
+	totalReplicas, err := r.replicasForDeploymentConfig(deploymentConfig.Namespace, deploymentConfig.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	scaleRet := &extensions.Scale{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:              name,
+			Namespace:         deploymentConfig.Namespace,
+			CreationTimestamp: deploymentConfig.CreationTimestamp,
+		},
+		Spec: extensions.ScaleSpec{
+			Replicas: deploymentConfig.Template.ControllerTemplate.Replicas,
+		},
+		Status: extensions.ScaleStatus{
+			Replicas: totalReplicas,
+			Selector: deploymentConfig.Template.ControllerTemplate.Selector,
+		},
+	}
+
+	// current replicas reflects either the scale of the current deployment,
+	// or the scale of the RC template if no current deployment exists
+	controller, err := r.rcNamespacer.ReplicationControllers(deploymentConfig.Namespace).Get(util.LatestDeploymentNameForConfig(deploymentConfig))
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+
+		return scaleRet, nil
+
+	}
+
+	scaleRet.Spec.Replicas = controller.Spec.Replicas
+	return scaleRet, nil
+
+}
+
+// Update scales the DeploymentConfig for the given Scale subresource, returning the updated Scale.
+func (r *ScaleREST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, bool, error) {
+	if obj == nil {
+		return nil, false, errors.NewBadRequest(fmt.Sprintf("nil update passed to Scale"))
+	}
+	scale, ok := obj.(*extensions.Scale)
+	if !ok {
+		return nil, false, errors.NewBadRequest(fmt.Sprintf("wrong object passed to Scale update: %v", obj))
+	}
+
+	// fake an existing object to validate
+	existing := &extensions.Scale{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:              scale.Name,
+			CreationTimestamp: scale.CreationTimestamp,
+		},
+	}
+
+	if existing.Namespace, ok = kapi.NamespaceFrom(ctx); !ok {
+		existing.Namespace = scale.Namespace
+	}
+
+	if errs := extvalidation.ValidateScaleUpdate(scale, existing); len(errs) > 0 {
+		return nil, false, errors.NewInvalid("scale", scale.Name, errs)
+	}
+
+	deploymentConfig, err := r.registry.GetDeploymentConfig(ctx, scale.Name)
+	if err != nil {
+		return nil, false, errors.NewNotFound("scale", scale.Name)
+	}
+
+	// This code tries to mitigate any race conditions caused by the DC controller
+	// not actually basing RC replicas on the template after the first deploy.
+	//
+	// If the DC controller isn't doing anything, and isn't about to start anything,
+	// then we'll have updated the DC or deployment RC correctly (the easy case)
+	//
+	// If we are dealing with a deployment, the following happens on updates to resources:
+	// 1. The DC controller catches an update to a DC, and creates a new RC, naming it based on the value of dc.LatestVersion
+	// 2. The Deployment Controller then picks up a change to the RC, launches a deployer pod, and updates the status annotation of the RC to pending
+	// 3a. The Deployer Pod Controller picks up the change to the pod, and updates the status annotation of the RC to running
+	// 3b. The deployer pod itself runs the deployment strategy
+	// 4. the deployer pod finishes or errors out, and the Deployer Pod Controller picks this up and updates the status annotation of the RC to either complete or failed
+	//
+	// We try to refuse to scale while a deployment is in progress, based on the annotation of the latest RC.
+	// Unfortunately, we can have a case where we pick up a DC, calculate the name of the latest DC using its
+	// LatestVersion field, and then someone updates that before twe run the scale.  In this case, it is possible
+	// that we may try to scale the wrong RC.  However, since /scale is used mainly by the HPA,
+	// we should see the updated values and annotations the next HPA cycle, and cease the incorrect behavior.
+
+	scaleRet := &extensions.Scale{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:              deploymentConfig.Name,
+			Namespace:         deploymentConfig.Namespace,
+			CreationTimestamp: deploymentConfig.CreationTimestamp,
+		},
+		Spec: extensions.ScaleSpec{
+			Replicas: scale.Spec.Replicas,
+		},
+		Status: extensions.ScaleStatus{
+			Replicas: 0,
+			Selector: deploymentConfig.Template.ControllerTemplate.Selector,
+		},
+	}
+
+	// this tries to update the current deployment RC first, since updating
+	// Replicas on a DeploymentConfig doesn't do anything after the first deployment
+	// has been made
+	controller, err := r.rcNamespacer.ReplicationControllers(deploymentConfig.Namespace).Get(util.LatestDeploymentNameForConfig(deploymentConfig))
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, false, err
+		}
+
+		deploymentConfig.Template.ControllerTemplate.Replicas = scale.Spec.Replicas
+		if err = r.registry.UpdateDeploymentConfig(ctx, deploymentConfig); err != nil {
+			return nil, false, err
+		}
+
+		return scaleRet, false, nil
+	}
+
+	if deploymentStatus := util.DeploymentStatusFor(controller); deploymentStatus != api.DeploymentStatusComplete {
+		return nil, false, err
+	}
+
+	// TODO(directxman12): this is going to be a bit out of sync, since we are calculating it
+	// here and not as part of the deploymentconfig loop -- is there a better way of doing it?
+	totalReplicas, err := r.replicasForDeploymentConfig(deploymentConfig.Namespace, deploymentConfig.Name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	oldReplicas := controller.Spec.Replicas
+	controller.Spec.Replicas = scale.Spec.Replicas
+	if _, err = r.rcNamespacer.ReplicationControllers(deploymentConfig.Namespace).Update(controller); err != nil {
+		return nil, false, err
+	}
+	scaleRet.Status.Replicas = totalReplicas + (scale.Spec.Replicas - oldReplicas)
+
+	return scaleRet, false, nil
+}
+
+func (r *ScaleREST) deploymentsForConfig(namespace, configName string) (*kapi.ReplicationControllerList, error) {
+	selector := util.ConfigSelector(configName)
+	return r.rcNamespacer.ReplicationControllers(namespace).List(selector, fields.Everything())
+}
+
+func (r *ScaleREST) replicasForDeploymentConfig(namespace, configName string) (int, error) {
+	rcList, err := r.deploymentsForConfig(namespace, configName)
+	if err != nil {
+		return 0, err
+	}
+
+	replicas := 0
+	for _, rc := range rcList.Items {
+		replicas += rc.Spec.Replicas
+	}
+
+	return replicas, nil
 }

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -363,8 +363,8 @@ func NewTestDeployOpenshift(t *testing.T) *testDeployOpenshift {
 	imageStreamTagStorage := imagestreamtag.NewREST(imageRegistry, imageStreamRegistry)
 	//imageStreamTagRegistry := imagestreamtag.NewRegistry(imageStreamTagStorage)
 
-	deployConfigStorage := deployconfigetcd.NewStorage(etcdHelper)
-	deployConfigRegistry := deployconfigregistry.NewRegistry(deployConfigStorage)
+	deployConfigStorage := deployconfigetcd.NewStorage(etcdHelper, kubeClient)
+	deployConfigRegistry := deployconfigregistry.NewRegistry(deployConfigStorage.DeploymentConfig)
 
 	deployConfigGenerator := &deployconfiggenerator.DeploymentConfigGenerator{
 		Client: deployconfiggenerator.Client{
@@ -380,7 +380,7 @@ func NewTestDeployOpenshift(t *testing.T) *testDeployOpenshift {
 		"imageStreamImages":         imageStreamImageStorage,
 		"imageStreamMappings":       imageStreamMappingStorage,
 		"imageStreamTags":           imageStreamTagStorage,
-		"deploymentConfigs":         deployConfigStorage,
+		"deploymentConfigs":         deployConfigStorage.DeploymentConfig,
 		"generateDeploymentConfigs": deployconfiggenerator.NewREST(deployConfigGenerator, latest.Codec),
 	}
 	for k, v := range storage {


### PR DESCRIPTION
This PR adds support for HPAs scaling DeploymentConfigs.   A new "HybridClient" struct is introduced to support Namespacers that need to point at resources or subresources that could be in either the Origin API or the Kube API (like `Scale`).

This commit also imports the Scale kind into the Origin v1 API (but it's still "backed" in the unversioned API by the underlying Kube resource).

Finally, this commit contains a patch to Kube that converts the HPA controller from using a single `Client` type to using separate `Namespacers` for its various needs.


--- 
TODOs
 - [x] cherry-pick kubernetes/kubernetes#16570 and update policy.
 - [x] cherry pick kubernetes/kubernetes#15706 from upstream into this PR (underneath your changes
 - [x] open issue for " fix the metrics client to take pod names, rather than requiring cluster-wide pod-listing privileges" https://github.com/openshift/origin/pull/5310/files#r43427148 (DONE: kubernetes/kubernetes#16675)
 - [x] rename UPSTREAM commits to match `UPSTREAM: PR` or `UPSTREAM: <carry>` format
 - [x] remove WIP from commit name
 - [ ] open issue for " fix the client to no longer need root proxy access" https://github.com/openshift/origin/pull/5310/files#r43427078
 - [ ] add end-to-end or extended test in origin to prove that this works without default (and comparatively restrictive) policy.
 - [x] add a comment to `Update` to document the order in which the deploymentconfig controller does the updates to resources as it creates new RCs and changes its RC's replicas.  That information is required to reason about race potential.
 - [x] resolve issue with cross-namespace HPA requests (prevent it and add a test ensuring it is prevented) https://github.com/openshift/origin/pull/5579