### PR TITLE
Fixes several issues with tabbed output

### DIFF
--- a/pkg/cmd/cli/describe/helpers.go
+++ b/pkg/cmd/cli/describe/helpers.go
@@ -22,8 +22,7 @@ const emptyString = "<none>"
 
 func tabbedString(f func(*tabwriter.Writer) error) (string, error) {
 	out := new(tabwriter.Writer)
-	b := make([]byte, 1024)
-	buf := bytes.NewBuffer(b)
+	buf := &bytes.Buffer{}
 	out.Init(buf, 0, 8, 1, '\t', 0)
 
 	err := f(out)

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -14,6 +14,7 @@ oc get deploymentConfigs
 oc get dc
 oc create -f test/integration/fixtures/test-deployment-config.json
 oc describe deploymentConfigs test-deployment-config
+[ "$(oc describe dc test-deployment-config | grep 'deploymentconfig=test-deployment-config')" ]
 [ "$(oc env dc/test-deployment-config --list | grep TEST=value)" ]
 [ ! "$(oc env dc/test-deployment-config TEST- --list | grep TEST=value)" ]
 [ "$(oc env dc/test-deployment-config TEST=foo --list | grep TEST=foo)" ]


### PR DESCRIPTION
This resulted in printing `null` characters (seen as `^@`) which hurts `grep` (e.g. problems like "Binary file (standard input) matches") and adds unexpected spaces on Windows.