### PR TITLE
Bug 1270728 - username in the secret don't override the username in the source URL

### DIFF
--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -45,8 +45,12 @@ func run(builderFactory factoryFunc) {
 				glog.Fatalf("Cannot parse build URL: %s", build.Spec.Source.Git.URI)
 			}
 			scmAuths := auths(sourceURL)
-			if err := setupSourceSecret(build.Spec.Source.SourceSecret.Name, scmAuths); err != nil {
+			sourceURL, err = setupSourceSecret(build.Spec.Source.SourceSecret.Name, scmAuths)
+			if err != nil {
 				glog.Fatalf("Cannot setup secret file for accessing private repository: %v", err)
+			}
+			if sourceURL != nil {
+				build.Spec.Source.Git.URI = sourceURL.String()
 			}
 		}
 	}
@@ -86,12 +90,12 @@ func fixSecretPermissions() error {
 	return nil
 }
 
-func setupSourceSecret(sourceSecretName string, scmAuths []scmauth.SCMAuth) error {
+func setupSourceSecret(sourceSecretName string, scmAuths []scmauth.SCMAuth) (*url.URL, error) {
 	fixSecretPermissions()
 	sourceSecretDir := os.Getenv("SOURCE_SECRET_PATH")
 	files, err := ioutil.ReadDir(sourceSecretDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Filter the list of SCMAuths based on the secret files that are present
@@ -107,19 +111,29 @@ func setupSourceSecret(sourceSecretName string, scmAuths []scmauth.SCMAuth) erro
 	}
 
 	if len(scmAuthsPresent) == 0 {
-		return fmt.Errorf("no auth handler was found for the provided secret %q",
+		return nil, fmt.Errorf("no auth handler was found for the provided secret %q",
 			sourceSecretName)
 	}
 
+	var urlOverride *url.URL = nil
 	for name, auth := range scmAuthsPresent {
 		glog.V(3).Infof("Setting up SCMAuth %q", name)
-		if err := auth.Setup(sourceSecretDir); err != nil {
+		u, err := auth.Setup(sourceSecretDir)
+		if err != nil {
 			// If an error occurs during setup, fail the build
-			return fmt.Errorf("cannot set up source authentication method %q: %v", name, err)
+			return nil, fmt.Errorf("cannot set up source authentication method %q: %v", name, err)
+		}
+
+		if u != nil {
+			if urlOverride == nil {
+				urlOverride = u
+			} else if urlOverride.String() != u.String() {
+				return nil, fmt.Errorf("secret handler %s set a conflicting override URL %q (conflicts with earlier override URL %q)", auth.Name(), u.String(), urlOverride.String())
+			}
 		}
 	}
 
-	return nil
+	return urlOverride, nil
 }
 
 func auths(sourceURL *url.URL) []scmauth.SCMAuth {

--- a/pkg/build/builder/cmd/scmauth/cacert.go
+++ b/pkg/build/builder/cmd/scmauth/cacert.go
@@ -22,17 +22,17 @@ type CACert struct {
 }
 
 // Setup creates a .gitconfig fragment that points to the given ca.crt
-func (s CACert) Setup(baseDir string) error {
+func (s CACert) Setup(baseDir string) (*url.URL, error) {
 	if strings.ToLower(s.SourceURL.Scheme) != "https" {
-		return nil
+		return nil, nil
 	}
 	gitconfig, err := ioutil.TempFile("", "ca.crt.")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer gitconfig.Close()
 	gitconfig.WriteString(fmt.Sprintf(CACertConfig, filepath.Join(baseDir, CACertName)))
-	return ensureGitConfigIncludes(gitconfig.Name())
+	return nil, ensureGitConfigIncludes(gitconfig.Name())
 }
 
 // Name returns the name of this auth method.

--- a/pkg/build/builder/cmd/scmauth/gitconfig.go
+++ b/pkg/build/builder/cmd/scmauth/gitconfig.go
@@ -1,6 +1,7 @@
 package scmauth
 
 import (
+	"net/url"
 	"path/filepath"
 )
 
@@ -10,8 +11,8 @@ const GitConfigName = ".gitconfig"
 type GitConfig struct{}
 
 // Setup adds the secret .gitconfig as an include to the .gitconfig file to be used in the build
-func (_ GitConfig) Setup(baseDir string) error {
-	return ensureGitConfigIncludes(filepath.Join(baseDir, GitConfigName))
+func (_ GitConfig) Setup(baseDir string) (*url.URL, error) {
+	return nil, ensureGitConfigIncludes(filepath.Join(baseDir, GitConfigName))
 }
 
 // Name returns the name of this auth method.

--- a/pkg/build/builder/cmd/scmauth/password.go
+++ b/pkg/build/builder/cmd/scmauth/password.go
@@ -29,40 +29,25 @@ type UsernamePassword struct {
 }
 
 // Setup creates a gitconfig fragment that includes a substitution URL with the username/password
-// included in the URL
-func (u UsernamePassword) Setup(baseDir string) error {
+// included in the URL. Returns source URL stripped of username/password credentials.
+func (u UsernamePassword) Setup(baseDir string) (*url.URL, error) {
 
 	// Only apply to https and http URLs
 	if scheme := strings.ToLower(u.SourceURL.Scheme); scheme != "http" && scheme != "https" {
-		return nil
-	}
-
-	// Determine username
-	// 1. Look for a username secret
-	username, err := readSecret(baseDir, UsernameSecret)
-	if err != nil {
-		return err
-	}
-	// 2. If not provided, look at the username in the URL
-	if username == "" && u.SourceURL.User != nil {
-		username = u.SourceURL.User.Username()
-	}
-	// 3. If still not found, use a default username
-	if username == "" {
-		username = DefaultUsername
+		return nil, nil
 	}
 
 	// Determine password
 	// 1. Look for a token secret
 	password, err := readSecret(baseDir, TokenSecret)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// 2. Look for a password secret
 	if password == "" {
 		password, err = readSecret(baseDir, PasswordSecret)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 	// 3. Look for a password in the URL
@@ -70,14 +55,34 @@ func (u UsernamePassword) Setup(baseDir string) error {
 		password, _ = u.SourceURL.User.Password()
 	}
 
+	// Determine username
+	// 1. Look for a username secret
+	username, err := readSecret(baseDir, UsernameSecret)
+	if err != nil {
+		return nil, err
+	}
+	// 2. If not provided, look at the username in the URL
+	if username == "" && u.SourceURL.User != nil {
+		username = u.SourceURL.User.Username()
+	}
+
+	// 3. If username and password not found return error. If password is
+	// present use a default username
+	if username == "" {
+		if password == "" {
+			return nil, fmt.Errorf("username and password credentials not found in provided secret or source URL")
+		}
+		username = DefaultUsername
+	}
+
 	gitcredentials, err := ioutil.TempFile("", "gitcredentials.")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer gitcredentials.Close()
 	gitconfig, err := ioutil.TempFile("", "gitcredentialscfg.")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer gitconfig.Close()
 
@@ -86,7 +91,10 @@ func (u UsernamePassword) Setup(baseDir string) error {
 	fmt.Fprintf(gitconfig, UserPassGitConfig, gitcredentials.Name())
 	fmt.Fprintf(gitcredentials, "%s", usernamePasswordURL.String())
 
-	return ensureGitConfigIncludes(gitconfig.Name())
+	sourceURL := u.SourceURL
+	sourceURL.User = nil
+
+	return &sourceURL, ensureGitConfigIncludes(gitconfig.Name())
 }
 
 // Name returns the name of this auth method.

--- a/pkg/build/builder/cmd/scmauth/scmauth.go
+++ b/pkg/build/builder/cmd/scmauth/scmauth.go
@@ -1,5 +1,7 @@
 package scmauth
 
+import "net/url"
+
 // SCMAuth is an interface implemented by different authentication providers
 // which are responsible for setting up the credentials to be used when accessing
 // private repository.
@@ -10,6 +12,7 @@ type SCMAuth interface {
 	// Handles returns true if this authentication method handles a file with the given name
 	Handles(name string) bool
 
-	// Setup lays down the required files for this authentication method to work
-	Setup(baseDir string) error
+	// Setup lays down the required files for this authentication method to work.
+	// Returns the the source URL stripped of credentials.
+	Setup(baseDir string) (*url.URL, error)
 }

--- a/pkg/build/builder/cmd/scmauth/sshkey.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey.go
@@ -2,6 +2,7 @@ package scmauth
 
 import (
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 )
@@ -13,25 +14,25 @@ type SSHPrivateKey struct{}
 
 // Setup creates a wrapper script for SSH command to be able to use the provided
 // SSH key while accessing private repository.
-func (_ SSHPrivateKey) Setup(baseDir string) error {
+func (_ SSHPrivateKey) Setup(baseDir string) (*url.URL, error) {
 	script, err := ioutil.TempFile("", "gitssh")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer script.Close()
 	if err := script.Chmod(0711); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := script.WriteString("#!/bin/sh\nssh -i " +
 		filepath.Join(baseDir, SSHPrivateKeyMethodName) +
 		" -o StrictHostKeyChecking=false \"$@\"\n"); err != nil {
-		return err
+		return nil, err
 	}
 	// set environment variable to tell git to use the SSH wrapper
 	if err := os.Setenv("GIT_SSH", script.Name()); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return nil, nil
 }
 
 // Name returns the name of this auth method.


### PR DESCRIPTION
Returning the url in the `password.go` and `cacert.go`
@csrwng PTAL

