### PR TITLE
[#5182] Improve generation of name based on a git repo url to make it valid

### DIFF
--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -1265,6 +1265,11 @@ func TestEnsureValidUniqueName(t *testing.T) {
 			expected: []string{"one", "one-1", "two"},
 		},
 		{
+			name:     "non-standard characters",
+			input:    []string{"Emby.One", "test-_test", "_-_", "@-MyRepo"},
+			expected: []string{"embyone", "test-test", "", "myrepo"},
+		},
+		{
 			name:        "short name",
 			input:       []string{"t"},
 			expectError: true,


### PR DESCRIPTION
@bparees @mfojtik PTAL. I'm going to write unit tests after yours approval if this fix is correct (I've tested it and it works, but may be we should fix it somewhere else?)

Additional idea:  may be we should replace invalid characters by hyphen instead of space (and `amby.build` becomes to `amby-build` instead of `ambybuild`) WDYT?

Fixes #5182