### PR TITLE
Add iptables to origin image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -7,5 +7,5 @@
 FROM centos:centos7
 
 # components from EPEL must be installed in a separate yum install step
-RUN yum install -y git tar wget socat hostname sysvinit-tools util-linux epel-release ethtool && \
+RUN yum install -y git tar wget socat hostname sysvinit-tools util-linux epel-release ethtool iptables && \
     yum clean all


### PR DESCRIPTION
This package is included in the centos base image but not rhel7 base image.
Anyone who were to change to a rhel7 base image would have problems with the
kube-proxy establishing service NAT rules.

I could see this being moved to the base image but the comment in that Dockerfile indicates it's only to be include packages required of all images, things like ethtool are there, however I don't think iptables is required for all images. Let me know if you're prefer it there as it is now this introduces an additional layer.

@mfojtik @smarterclayton 