### PR TITLE
unified printing strategy

### DIFF
--- a/contrib/completions/bash/oadm
+++ b/contrib/completions/bash/oadm
@@ -188,6 +188,12 @@ _oadm_new-project()
     flags+=("--description=")
     flags+=("--display-name=")
     flags+=("--node-selector=")
+<<<<<<< HEAD
+=======
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--alsologtostderr")
+>>>>>>> unified printing strategy
     flags+=("--api-version=")
     flags+=("--certificate-authority=")
     flags_with_completion+=("--certificate-authority")
@@ -1038,6 +1044,12 @@ _oadm_groups_new()
     flags_with_completion=()
     flags_completion=()
 
+<<<<<<< HEAD
+=======
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--alsologtostderr")
+>>>>>>> unified printing strategy
     flags+=("--api-version=")
     flags+=("--certificate-authority=")
     flags_with_completion+=("--certificate-authority")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -743,6 +743,12 @@ _openshift_admin_new-project()
     flags+=("--description=")
     flags+=("--display-name=")
     flags+=("--node-selector=")
+<<<<<<< HEAD
+=======
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--alsologtostderr")
+>>>>>>> unified printing strategy
     flags+=("--api-version=")
     flags+=("--certificate-authority=")
     flags_with_completion+=("--certificate-authority")
@@ -1593,6 +1599,12 @@ _openshift_admin_groups_new()
     flags_with_completion=()
     flags_completion=()
 
+<<<<<<< HEAD
+=======
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--alsologtostderr")
+>>>>>>> unified printing strategy
     flags+=("--api-version=")
     flags+=("--certificate-authority=")
     flags_with_completion+=("--certificate-authority")

--- a/pkg/cmd/admin/groups/sync/cli/prune.go
+++ b/pkg/cmd/admin/groups/sync/cli/prune.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/api/validation"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 )
 
 const (
@@ -70,6 +71,9 @@ type PruneOptions struct {
 
 	// Out is the writer to write output to
 	Out io.Writer
+
+	// MutationOutputOptions allows us to correctly output the mutations we make to objects in etcd
+	MutationOutputOptions mutation.MutationOutputOptions
 }
 
 func NewPruneOptions() *PruneOptions {
@@ -96,6 +100,8 @@ func NewCmdPrune(name, fullName string, f *clientcmd.Factory, out io.Writer) *co
 			if err := options.Complete(whitelistFile, blacklistFile, configFile, args, f); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(c, err.Error()))
 			}
+
+			options.MutationOutputOptions = mutation.NewMutationOutputOptions(f.Factory, c, options.Out)
 
 			if err := options.Validate(); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(c, err.Error()))
@@ -188,6 +194,7 @@ func (o *PruneOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
 
 		Out: o.Out,
 		Err: os.Stderr,
+		MutationOutputOptions: o.MutationOutputOptions,
 	}
 
 	listerMapper, err := getOpenShiftGroupListerMapper(clientConfig.Host(), o)

--- a/pkg/cmd/admin/groups/sync/grouppruner_test.go
+++ b/pkg/cmd/admin/groups/sync/grouppruner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client/testclient"
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/interfaces"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 )
 
 func TestGoodPrune(t *testing.T) {
@@ -121,6 +122,7 @@ func newTestPruner() (*LDAPGroupPruner, *testclient.Fake) {
 		Host:            newTestHost(),
 		Out:             ioutil.Discard,
 		Err:             ioutil.Discard,
+		MutationOutputOptions: mutation.NewFakeOptions(),
 	}, tc
 
 }

--- a/pkg/cmd/admin/groups/sync/groupsyncer_test.go
+++ b/pkg/cmd/admin/groups/sync/groupsyncer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/client/testclient"
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/interfaces"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 	userapi "github.com/openshift/origin/pkg/user/api"
 )
 
@@ -190,7 +191,7 @@ var Group3Members []*ldap.Entry = []*ldap.Entry{Member3, Member4}
 // TestGoodSync ensures that data is exchanged and rearranged correctly during the sync process.
 func TestGoodSync(t *testing.T) {
 	testGroupSyncer, tc := newTestSyncer()
-	_, errs := testGroupSyncer.Sync()
+	errs := testGroupSyncer.Sync()
 	for _, err := range errs {
 		t.Errorf("unexpected sync error: %v", err)
 	}
@@ -202,16 +203,12 @@ func TestListFails(t *testing.T) {
 	testGroupSyncer, _ := newTestSyncer()
 	testGroupSyncer.GroupLister.(*TestGroupLister).err = errors.New("error during listing")
 
-	groups, errs := testGroupSyncer.Sync()
+	errs := testGroupSyncer.Sync()
 	if len(errs) != 1 {
 		t.Errorf("unexpected sync error: %v", errs)
 
 	} else if errs[0] != testGroupSyncer.GroupLister.(*TestGroupLister).err {
 		t.Errorf("unexpected sync error: %v", errs)
-	}
-
-	if groups != nil {
-		t.Errorf("unexpected groups %v", groups)
 	}
 }
 
@@ -219,7 +216,7 @@ func TestMissingLDAPGroupUIDMapping(t *testing.T) {
 	testGroupSyncer, tc := newTestSyncer()
 	testGroupSyncer.GroupLister.(*TestGroupLister).GroupUIDs = append(testGroupSyncer.GroupLister.(*TestGroupLister).GroupUIDs, "ldapgroupwithnouid")
 
-	_, errs := testGroupSyncer.Sync()
+	errs := testGroupSyncer.Sync()
 	if len(errs) != 1 {
 		t.Errorf("unexpected sync error: %v", errs)
 
@@ -333,6 +330,7 @@ func newTestSyncer() (*LDAPGroupSyncer, *testclient.Fake) {
 		Host:                 newTestHost(),
 		Out:                  ioutil.Discard,
 		Err:                  ioutil.Discard,
+		MutationOutputOptions: mutation.NewFakeOptions(),
 	}, tc
 
 }

--- a/pkg/cmd/cli/secrets/basicauth.go
+++ b/pkg/cmd/cli/secrets/basicauth.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/term"
 
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 )
 
 const (
@@ -53,6 +54,9 @@ type CreateBasicAuthSecretOptions struct {
 	Out    io.Writer
 
 	SecretsInterface client.SecretsInterface
+
+	// MutationOutputOptions allows us to correctly output the mutations we make to objects in etcd
+	MutationOutputOptions mutation.MutationOutputOptions
 }
 
 // NewCmdCreateBasicAuthSecret implements the OpenShift cli secrets new-basicauth subcommand
@@ -71,6 +75,8 @@ func NewCmdCreateBasicAuthSecret(name, fullName string, f *kcmdutil.Factory, rea
 			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
 			}
+
+			o.MutationOutputOptions = mutation.NewMutationOutputOptions(f, c, o.Out)
 
 			if err := o.Validate(); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
@@ -116,7 +122,9 @@ func (o *CreateBasicAuthSecretOptions) CreateBasicAuthSecret() error {
 		return err
 	}
 
-	fmt.Fprintf(o.GetOut(), "secret/%s\n", secret.Name)
+	if err := o.MutationOutputOptions.PrintSuccess(secret, "created"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cmd/cli/secrets/dockercfg.go
+++ b/pkg/cmd/cli/secrets/dockercfg.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 	"github.com/spf13/cobra"
 )
 
@@ -56,6 +57,9 @@ type CreateDockerConfigOptions struct {
 	SecretsInterface client.SecretsInterface
 
 	Out io.Writer
+
+	// MutationOutputOptions allows us to correctly output the mutations we make to objects in etcd
+	MutationOutputOptions mutation.MutationOutputOptions
 }
 
 // NewCmdCreateDockerConfigSecret creates a command object for making a dockercfg secret
@@ -71,6 +75,8 @@ func NewCmdCreateDockerConfigSecret(name, fullName string, f *kcmdutil.Factory, 
 			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
 			}
+
+			o.MutationOutputOptions = mutation.NewMutationOutputOptions(f, c, o.Out)
 
 			if err := o.Validate(); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
@@ -110,8 +116,9 @@ func (o CreateDockerConfigOptions) CreateDockerSecret() error {
 		return err
 	}
 
-	fmt.Fprintf(o.GetOut(), "secret/%s\n", secret.Name)
-
+	if err := o.MutationOutputOptions.PrintSuccess(secret, "created"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cmd/cli/secrets/sshauth.go
+++ b/pkg/cmd/cli/secrets/sshauth.go
@@ -10,6 +10,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +49,9 @@ type CreateSSHAuthSecretOptions struct {
 	Out io.Writer
 
 	SecretsInterface client.SecretsInterface
+
+	// MutationOutputOptions allows us to correctly output the mutations we make to objects in etcd
+	MutationOutputOptions mutation.MutationOutputOptions
 }
 
 // NewCmdCreateSSHAuthSecret implements the OpenShift cli secrets new-sshauth subcommand
@@ -65,6 +69,8 @@ func NewCmdCreateSSHAuthSecret(name, fullName string, f *kcmdutil.Factory, out i
 			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
 			}
+
+			o.MutationOutputOptions = mutation.NewMutationOutputOptions(f, c, o.Out)
 
 			if err := o.Validate(); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
@@ -109,7 +115,9 @@ func (o *CreateSSHAuthSecretOptions) CreateSSHAuthSecret() error {
 		return err
 	}
 
-	fmt.Fprintf(o.GetOut(), "secret/%s\n", secret.Name)
+	if err := o.MutationOutputOptions.PrintSuccess(secret, "created"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cmd/util/mutation/mutate.go
+++ b/pkg/cmd/util/mutation/mutate.go
@@ -1,0 +1,70 @@
+package mutation
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/kubernetes/pkg/api/meta"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func NewMutationOutputOptions(factory *kcmdutil.Factory, cmd *cobra.Command, out io.Writer) MutationOutputOptions {
+	mapper, typer := factory.Object()
+	if out == nil {
+		out = ioutil.Discard
+	}
+
+	return &mutationOutputOptions{
+		mapper:         mapper,
+		resourceMapper: resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: factory.ClientMapperForCommand()},
+		shortOutput:    kcmdutil.GetFlagString(cmd, "output") == "name",
+		out:            out,
+	}
+}
+
+// MutationOutputOptions holds all of the information necessary to correctly output the reslult of mutating
+// an object in etcd.
+type MutationOutputOptions interface {
+	PrintSuccess(object runtime.Object, operation string) error
+	PrintSuccessForDescription(resource, name, operation string)
+}
+
+type mutationOutputOptions struct {
+	mapper         meta.RESTMapper
+	resourceMapper resource.Mapper
+	shortOutput    bool
+	out            io.Writer
+}
+
+// PrintSuccess wraps around kcmdutil.PrintSuccess
+func (o *mutationOutputOptions) PrintSuccess(object runtime.Object, operation string) error {
+	info, err := o.resourceMapper.InfoForObject(object)
+	if err != nil {
+		return err
+	}
+	kcmdutil.PrintSuccess(o.mapper, o.shortOutput, o.out, info.Mapping.Resource, info.Name, operation)
+	return nil
+}
+
+// PrintSuccessForDescription allows for success printing when no object is present
+func (o *mutationOutputOptions) PrintSuccessForDescription(resource, name, operation string) {
+	kcmdutil.PrintSuccess(o.mapper, o.shortOutput, o.out, resource, name, operation)
+}
+
+// NewFakeOptions returns a fake set of options for use in testing
+func NewFakeOptions() MutationOutputOptions {
+	return &fakeOutputOptions{}
+}
+
+// fakeOutputOptions can be used for testing
+type fakeOutputOptions struct{}
+
+func (o *fakeOutputOptions) PrintSuccess(object runtime.Object, operation string) error {
+	return nil
+}
+
+func (o *fakeOutputOptions) PrintSuccessForDescription(resource, name, operation string) {}

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -8,6 +8,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
 	groupscmd "github.com/openshift/origin/pkg/cmd/admin/groups"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	userapi "github.com/openshift/origin/pkg/user/api"
 	uservalidation "github.com/openshift/origin/pkg/user/api/validation"
@@ -182,7 +183,12 @@ func TestGroupCommands(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	newGroup := &groupscmd.NewGroupOptions{clusterAdminClient.Groups(), "group1", []string{"first", "second", "third", "first"}}
+	newGroup := &groupscmd.NewGroupOptions{
+		GroupClient: clusterAdminClient.Groups(),
+		Group:       "group1",
+		Users:       []string{"first", "second", "third", "first"},
+		MutationOutputOptions: mutation.NewFakeOptions(),
+	}
 	if err := newGroup.AddGroup(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 	"github.com/openshift/origin/pkg/user/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -61,10 +62,11 @@ func TestLogin(t *testing.T) {
 	}
 
 	newProjectOptions := &newproject.NewProjectOptions{
-		Client:      clusterAdminClient,
-		ProjectName: project,
-		AdminRole:   bootstrappolicy.AdminRoleName,
-		AdminUser:   username,
+		Client:                clusterAdminClient,
+		ProjectName:           project,
+		AdminRole:             bootstrappolicy.AdminRoleName,
+		AdminUser:             username,
+		MutationOutputOptions: mutation.NewFakeOptions(),
 	}
 	if err := newProjectOptions.Run(false); err != nil {
 		t.Fatalf("unexpected error, a project is required to continue: %v", err)

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/util/mutation"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -424,6 +425,8 @@ func CreateNewProject(clusterAdminClient *client.Client, clientConfig kclient.Co
 		ProjectName: projectName,
 		AdminRole:   bootstrappolicy.AdminRoleName,
 		AdminUser:   adminUser,
+
+		MutationOutputOptions: mutation.NewFakeOptions(),
 	}
 
 	if err := newProjectOptions.Run(false); err != nil {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5332
Fixes https://github.com/openshift/origin/issues/5256

Updates the following commands to use `cmdutil.PrintSuccess`:
* `openshift admin new-project`
* `openshift admin groups new`
* `openshift cli new-project` (TODO)
* `openshift cli start-build`
* `openshift cli secrets new`
* `openshift cli secrets new-dockercfg`
* `openshift cli secrets new-basicauth`
* `openshift cli secrets new-sshauth`
* `openshift ex sync-groups`

@deads2k 