### PR TITLE
Bug 1271965 - Increase height of metrics utilization sparkline

### DIFF
--- a/assets/app/views/directives/_pod-metrics.html
+++ b/assets/app/views/directives/_pod-metrics.html
@@ -38,7 +38,7 @@
            donut-config="donutConfigByMetric[metric.id]"
            sparkline-config="sparklineConfigByMetric[metric.id]"
            chart-data="chartDataByMetric[metric.id]"
-           sparkline-chart-height="75"
+           sparkline-chart-height="100"
            show-sparkline-x-axis="true"
            show-sparkline-y-axis="true">
       </div>


### PR DESCRIPTION
This prevents the millicores label from overlapping the x-axis.

![screen shot 2015-10-22 at 2 24 09 pm](https://cloud.githubusercontent.com/assets/1167259/10674559/9633a79c-78c9-11e5-9b49-62e0a1a99304.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1271965