### PR TITLE
add SA and role for job and hpa controllers

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -15,6 +15,8 @@ const (
 	InfraBuildControllerServiceAccountName       = "build-controller"
 	InfraReplicationControllerServiceAccountName = "replication-controller"
 	InfraDeploymentControllerServiceAccountName  = "deployment-controller"
+	InfraJobControllerServiceAccountName         = "job-controller"
+	InfraHPAControllerServiceAccountName         = "hpa-controller"
 
 	MasterUnqualifiedUsername   = "openshift-master"
 	RouterUnqualifiedUsername   = "openshift-router"
@@ -65,6 +67,8 @@ const (
 	BuildControllerRoleName       = "system:build-controller"
 	ReplicationControllerRoleName = "system:replication-controller"
 	DeploymentControllerRoleName  = "system:deployment-controller"
+	JobControllerRoleName         = "system:job-controller"
+	HPAControllerRoleName         = "system:hpa-controller"
 
 	ImagePullerRoleName       = "system:image-puller"
 	ImageBuilderRoleName      = "system:image-builder"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -359,6 +359,18 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 		},
 		{
 			ObjectMeta: kapi.ObjectMeta{
+				Name: JobControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: HPAControllerRoleName,
+			},
+			Rules: []authorizationapi.PolicyRule{},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
 				Name: OAuthTokenDeleterRoleName,
 			},
 			Rules: []authorizationapi.PolicyRule{

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	endpointcontroller "k8s.io/kubernetes/pkg/controller/endpoint"
+	jobcontroller "k8s.io/kubernetes/pkg/controller/job"
 	namespacecontroller "k8s.io/kubernetes/pkg/controller/namespace"
 	nodecontroller "k8s.io/kubernetes/pkg/controller/node"
 	volumeclaimbinder "k8s.io/kubernetes/pkg/controller/persistentvolume"
@@ -103,6 +104,17 @@ func (c *MasterConfig) RunPersistentVolumeClaimRecycler(recyclerImageName string
 func (c *MasterConfig) RunReplicationController(client *client.Client) {
 	controllerManager := replicationcontroller.NewReplicationManager(client, c.ControllerManager.ResyncPeriod, replicationcontroller.BurstReplicas)
 	go controllerManager.Run(c.ControllerManager.ConcurrentRCSyncs, util.NeverStop)
+}
+
+// RunJobController starts the Kubernetes job controller sync loop
+func (c *MasterConfig) RunJobController(client *client.Client) {
+	controller := jobcontroller.NewJobController(client, c.ControllerManager.ResyncPeriod)
+	go controller.Run(c.ControllerManager.ConcurrentJobSyncs, util.NeverStop)
+}
+
+// RunHPAController starts the Kubernetes hpa controller sync loop
+func (c *MasterConfig) RunHPAController(client *client.Client) {
+	// TDO fix stub
 }
 
 // RunEndpointController starts the Kubernetes replication controller sync loop

--- a/pkg/cmd/server/origin/ensure.go
+++ b/pkg/cmd/server/origin/ensure.go
@@ -50,7 +50,10 @@ func (c *MasterConfig) ensureOpenShiftInfraNamespace() {
 	}
 
 	// Ensure service accounts exist
-	serviceAccounts := []string{c.BuildControllerServiceAccount, c.DeploymentControllerServiceAccount, c.ReplicationControllerServiceAccount}
+	serviceAccounts := []string{
+		c.BuildControllerServiceAccount, c.DeploymentControllerServiceAccount, c.ReplicationControllerServiceAccount,
+		c.JobControllerServiceAccount, c.HPAControllerServiceAccount,
+	}
 	for _, serviceAccountName := range serviceAccounts {
 		_, err := c.KubeClient().ServiceAccounts(ns).Create(&kapi.ServiceAccount{ObjectMeta: kapi.ObjectMeta{Name: serviceAccountName}})
 		if err != nil && !kapierror.IsAlreadyExists(err) {
@@ -63,6 +66,8 @@ func (c *MasterConfig) ensureOpenShiftInfraNamespace() {
 		bootstrappolicy.BuildControllerRoleName:       {{Namespace: ns, Name: c.BuildControllerServiceAccount, Kind: "ServiceAccount"}},
 		bootstrappolicy.DeploymentControllerRoleName:  {{Namespace: ns, Name: c.DeploymentControllerServiceAccount, Kind: "ServiceAccount"}},
 		bootstrappolicy.ReplicationControllerRoleName: {{Namespace: ns, Name: c.ReplicationControllerServiceAccount, Kind: "ServiceAccount"}},
+		bootstrappolicy.JobControllerRoleName:         {{Namespace: ns, Name: c.JobControllerServiceAccount, Kind: "ServiceAccount"}},
+		bootstrappolicy.HPAControllerRoleName:         {{Namespace: ns, Name: c.HPAControllerServiceAccount, Kind: "ServiceAccount"}},
 	}
 	roleAccessor := policy.NewClusterRoleBindingAccessor(c.ServiceAccountRoleBindingClient())
 	for clusterRole, subjects := range clusterRolesToSubjects {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -125,6 +125,10 @@ type MasterConfig struct {
 	DeploymentControllerServiceAccount string
 	// ReplicationControllerServiceAccount is the name of the service account in the infra namespace to use to run the replication controller
 	ReplicationControllerServiceAccount string
+	// JobControllerServiceAccount is the name of the service account in the infra namespace to use to run the job controller
+	JobControllerServiceAccount string
+	// HPAControllerServiceAccount is the name of the service account in the infra namespace to use to run the hpa controller
+	HPAControllerServiceAccount string
 }
 
 // BuildMasterConfig builds and returns the OpenShift master configuration based on the
@@ -216,6 +220,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		BuildControllerServiceAccount:       bootstrappolicy.InfraBuildControllerServiceAccountName,
 		DeploymentControllerServiceAccount:  bootstrappolicy.InfraDeploymentControllerServiceAccountName,
 		ReplicationControllerServiceAccount: bootstrappolicy.InfraReplicationControllerServiceAccountName,
+		JobControllerServiceAccount:         bootstrappolicy.InfraJobControllerServiceAccountName,
+		HPAControllerServiceAccount:         bootstrappolicy.InfraHPAControllerServiceAccountName,
 	}
 
 	return config, nil

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -530,6 +530,14 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		if err != nil {
 			glog.Fatalf("Could not get client for replication controller: %v", err)
 		}
+		_, jobClient, err := oc.GetServiceAccountClients(oc.JobControllerServiceAccount)
+		if err != nil {
+			glog.Fatalf("Could not get client for job controller: %v", err)
+		}
+		_, hpaKClient, err := oc.GetServiceAccountClients(oc.HPAControllerServiceAccount)
+		if err != nil {
+			glog.Fatalf("Could not get client for HPA controller: %v", err)
+		}
 
 		// called by admission control
 		kc.RunResourceQuotaManager()
@@ -538,6 +546,8 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunNodeController()
 		kc.RunScheduler()
 		kc.RunReplicationController(rcClient)
+		kc.RunJobController(jobClient)
+		kc.RunHPAController(hpaKClient)
 		kc.RunEndpointController()
 		kc.RunNamespaceController()
 		kc.RunPersistentVolumeClaimBinder()


### PR DESCRIPTION
@ncdc @soltysh @DirectXMan12

When you create your controllers, you should use a specific identity with enumerated permissions.  Here's a commit that stubs in the identity and the role for you.  You'll have to fill in the specific permissions.