### PR TITLE
assets: Use $evalAsync when updating topology widget

### DIFF
--- a/assets/app/scripts/controllers/overview.js
+++ b/assets/app/scripts/controllers/overview.js
@@ -502,9 +502,10 @@ angular.module('openshiftConsole')
         }
       });
 
-      $scope.topologyItems = topologyItems;
-      $scope.topologyRelations = topologyRelations;
-      $scope.$digest();
+      $scope.$evalAsync(function() {
+        $scope.topologyItems = topologyItems;
+        $scope.topologyRelations = topologyRelations;
+      });
     }
 
     function updateTopologyLater() {


### PR DESCRIPTION
This prevents strange backtraces

Fixes #5279