### PR TITLE
Bug 1274590 - Use remove() rather than html('') to empty SVG element

### DIFF
--- a/assets/app/scripts/directives/podStatusChart.js
+++ b/assets/app/scripts/directives/podStatusChart.js
@@ -38,7 +38,7 @@ angular.module('openshiftConsole')
           }
 
           // Replace donut title content.
-          donutChartTitle.html('');
+          donutChartTitle.selectAll('*').remove();
           donutChartTitle.insert('tspan').text(total).classed('pod-count donut-title-big-pf', true).attr('dy', 0).attr('x', 0);
           donutChartTitle.insert('tspan').text(smallText).classed('donut-title-small-pf', true).attr('dy', 20).attr('x', 0);
         }


### PR DESCRIPTION
Fixes a problem with overlapping text in the pods donut chart on IE.

https://bugzilla.redhat.com/show_bug.cgi?id=1274590
