### PR TITLE
Fixes infinite loop on login and forces auth when password were provided

### DIFF
--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -222,8 +222,9 @@ func (o *LoginOptions) gatherAuthInfo() error {
 		}
 	}
 
-	// if a username was provided try to make use of it
-	if o.usernameProvided() {
+	// if a username was provided try to make use of it, but if a password were provided we force a token
+	// request which will return a proper response code for that given password
+	if o.usernameProvided() && !o.passwordProvided() {
 		// search all valid contexts with matching server stanzas to see if we have a matching user stanza
 		kubeconfig := *o.StartingKubeConfig
 		matchingClusters := getMatchingClusters(*clientConfig, kubeconfig)
@@ -425,6 +426,10 @@ func (o LoginOptions) whoAmI() (*api.User, error) {
 
 func (o *LoginOptions) usernameProvided() bool {
 	return len(o.Username) > 0
+}
+
+func (o *LoginOptions) passwordProvided() bool {
+	return len(o.Password) > 0
 }
 
 func (o *LoginOptions) serverProvided() bool {

--- a/pkg/cmd/util/tokencmd/basicauth.go
+++ b/pkg/cmd/util/tokencmd/basicauth.go
@@ -42,8 +42,8 @@ func (c *BasicChallengeHandler) HandleChallenge(headers http.Header) (http.Heade
 		glog.V(2).Info("already prompted for challenge, won't prompt again")
 		return nil, false, nil
 	}
-	if c.Reader == nil && c.handled {
-		glog.V(2).Info("already handled basic challenge, no reader to alter inputs")
+	if c.handled {
+		glog.V(2).Info("already handled basic challenge")
 		return nil, false, nil
 	}
 

--- a/pkg/cmd/util/tokencmd/basicauth_test.go
+++ b/pkg/cmd/util/tokencmd/basicauth_test.go
@@ -124,6 +124,33 @@ Username: Password: `,
 				},
 			},
 		},
+
+		"non-interactive challenge with reader defaults": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   bytes.NewBufferString(""),
+				Username: "myuser",
+				Password: "mypassword",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   http.Header{AUTHORIZATION: []string{getBasicHeader("myuser", "mypassword")}},
+					ExpectedHandled:   true,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+			},
+		},
 	}
 
 	for k, tc := range testCases {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1273623 and one more issue.

Note: in order to reproduce the bug we need a provider that can actually return 401 errors, like the htpasswd provider for example.