### PR TITLE
logs: Support all flags for builds and deployments

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -1428,6 +1428,32 @@ func convert_api_PodLogOptions_To_v1beta3_PodLogOptions(in *api.PodLogOptions, o
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	return nil
 }
 
@@ -3648,6 +3674,32 @@ func convert_v1beta3_PodLogOptions_To_api_PodLogOptions(in *PodLogOptions, out *
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
@@ -1388,6 +1388,33 @@ func deepCopy_v1beta3_PodLogOptions(in PodLogOptions, out *PodLogOptions, c *con
 	out.Container = in.Container
 	out.Follow = in.Follow
 	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		out.SinceTime = new(unversioned.Time)
+		if err := deepCopy_util_Time(*in.SinceTime, out.SinceTime, c); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	return nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -1588,15 +1588,32 @@ type ListOptions struct {
 // PodLogOptions is the query options for a Pod's logs REST call
 type PodLogOptions struct {
 	TypeMeta `json:",inline"`
-
 	// Container for which to return logs
 	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
-
 	// If true, follow the logs for the pod
 	Follow bool `json:"follow,omitempty" description:"follow the log stream of the pod; defaults to false"`
-
 	//  If true, return previous terminated container logs
 	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false"`
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64 `json:"sinceSeconds,omitempty"`
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty"`
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output. Defaults to false.
+	Timestamps bool `json:"timestamps,omitempty"`
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64 `json:"tailLines,omitempty"`
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64 `json:"limitBytes,omitempty"`
 }
 
 // PodExecOptions is the query options to a Pod's remote exec call

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -1655,9 +1655,65 @@
         "allowMultiple": false
        },
        {
+        "type": "string",
+        "paramType": "query",
+        "name": "container",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "boolean",
         "paramType": "query",
         "name": "follow",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "previous",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*int64",
+        "paramType": "query",
+        "name": "sinceSeconds",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "sinceTime",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "timestamps",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*int64",
+        "paramType": "query",
+        "name": "tailLines",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*int64",
+        "paramType": "query",
+        "name": "limitBytes",
         "description": "",
         "required": false,
         "allowMultiple": false
@@ -4323,9 +4379,65 @@
         "allowMultiple": false
        },
        {
+        "type": "string",
+        "paramType": "query",
+        "name": "container",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "boolean",
         "paramType": "query",
         "name": "follow",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "previous",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*int64",
+        "paramType": "query",
+        "name": "sinceSeconds",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "sinceTime",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "timestamps",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*int64",
+        "paramType": "query",
+        "name": "tailLines",
+        "description": "",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "*int64",
+        "paramType": "query",
+        "name": "limitBytes",
         "description": "",
         "required": false,
         "allowMultiple": false

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -814,7 +814,37 @@ func deepCopy_api_BuildLogOptions(in buildapi.BuildLogOptions, out *buildapi.Bui
 	} else {
 		out.TypeMeta = newVal.(unversioned.TypeMeta)
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if newVal, err := c.DeepCopy(in.SinceTime); err != nil {
+			return err
+		} else {
+			out.SinceTime = newVal.(*unversioned.Time)
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -1402,7 +1432,37 @@ func deepCopy_api_DeploymentLogOptions(in deployapi.DeploymentLogOptions, out *d
 	} else {
 		out.TypeMeta = newVal.(unversioned.TypeMeta)
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if newVal, err := c.DeepCopy(in.SinceTime); err != nil {
+			return err
+		} else {
+			out.SinceTime = newVal.(*unversioned.Time)
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1262,7 +1262,35 @@ func autoconvert_api_BuildLogOptions_To_v1_BuildLogOptions(in *buildapi.BuildLog
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -1947,7 +1975,35 @@ func autoconvert_v1_BuildLogOptions_To_api_BuildLogOptions(in *apiv1.BuildLogOpt
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -2539,7 +2595,35 @@ func autoconvert_api_DeploymentLogOptions_To_v1_DeploymentLogOptions(in *deploya
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)
@@ -2652,7 +2736,35 @@ func autoconvert_v1_DeploymentLogOptions_To_api_DeploymentLogOptions(in *deploya
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -838,7 +838,37 @@ func deepCopy_v1_BuildLogOptions(in apiv1.BuildLogOptions, out *apiv1.BuildLogOp
 	} else {
 		out.TypeMeta = newVal.(unversioned.TypeMeta)
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if newVal, err := c.DeepCopy(in.SinceTime); err != nil {
+			return err
+		} else {
+			out.SinceTime = newVal.(*unversioned.Time)
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -1461,7 +1491,37 @@ func deepCopy_v1_DeploymentLogOptions(in deployapiv1.DeploymentLogOptions, out *
 	} else {
 		out.TypeMeta = newVal.(unversioned.TypeMeta)
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if newVal, err := c.DeepCopy(in.SinceTime); err != nil {
+			return err
+		} else {
+			out.SinceTime = newVal.(*unversioned.Time)
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1271,7 +1271,35 @@ func autoconvert_api_BuildLogOptions_To_v1beta3_BuildLogOptions(in *buildapi.Bui
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -1956,7 +1984,35 @@ func autoconvert_v1beta3_BuildLogOptions_To_api_BuildLogOptions(in *apiv1beta3.B
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -2548,7 +2604,35 @@ func autoconvert_api_DeploymentLogOptions_To_v1beta3_DeploymentLogOptions(in *de
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)
@@ -2661,7 +2745,35 @@ func autoconvert_v1beta3_DeploymentLogOptions_To_api_DeploymentLogOptions(in *de
 	if err := s.Convert(&in.TypeMeta, &out.TypeMeta, 0); err != nil {
 		return err
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if err := s.Convert(&in.SinceTime, &out.SinceTime, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -846,7 +846,37 @@ func deepCopy_v1beta3_BuildLogOptions(in apiv1beta3.BuildLogOptions, out *apiv1b
 	} else {
 		out.TypeMeta = newVal.(unversioned.TypeMeta)
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if newVal, err := c.DeepCopy(in.SinceTime); err != nil {
+			return err
+		} else {
+			out.SinceTime = newVal.(*unversioned.Time)
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	return nil
 }
@@ -1469,7 +1499,37 @@ func deepCopy_v1beta3_DeploymentLogOptions(in deployapiv1beta3.DeploymentLogOpti
 	} else {
 		out.TypeMeta = newVal.(unversioned.TypeMeta)
 	}
+	out.Container = in.Container
 	out.Follow = in.Follow
+	out.Previous = in.Previous
+	if in.SinceSeconds != nil {
+		out.SinceSeconds = new(int64)
+		*out.SinceSeconds = *in.SinceSeconds
+	} else {
+		out.SinceSeconds = nil
+	}
+	if in.SinceTime != nil {
+		if newVal, err := c.DeepCopy(in.SinceTime); err != nil {
+			return err
+		} else {
+			out.SinceTime = newVal.(*unversioned.Time)
+		}
+	} else {
+		out.SinceTime = nil
+	}
+	out.Timestamps = in.Timestamps
+	if in.TailLines != nil {
+		out.TailLines = new(int64)
+		*out.TailLines = *in.TailLines
+	} else {
+		out.TailLines = nil
+	}
+	if in.LimitBytes != nil {
+		out.LimitBytes = new(int64)
+		*out.LimitBytes = *in.LimitBytes
+	} else {
+		out.LimitBytes = nil
+	}
 	out.NoWait = in.NoWait
 	if in.Version != nil {
 		out.Version = new(int)

--- a/pkg/api/validation/register.go
+++ b/pkg/api/validation/register.go
@@ -43,6 +43,7 @@ func init() {
 	Validator.Register(&buildapi.Build{}, buildvalidation.ValidateBuild, buildvalidation.ValidateBuildUpdate)
 	Validator.Register(&buildapi.BuildConfig{}, buildvalidation.ValidateBuildConfig, buildvalidation.ValidateBuildConfigUpdate)
 	Validator.Register(&buildapi.BuildRequest{}, buildvalidation.ValidateBuildRequest, nil)
+	Validator.Register(&buildapi.BuildLogOptions{}, buildvalidation.ValidateBuildLogOptions, nil)
 
 	Validator.Register(&deployapi.DeploymentConfig{}, deployvalidation.ValidateDeploymentConfig, deployvalidation.ValidateDeploymentConfigUpdate)
 	Validator.Register(&deployapi.DeploymentConfigRollback{}, deployvalidation.ValidateDeploymentConfigRollback, nil)

--- a/pkg/build/api/helpers.go
+++ b/pkg/build/api/helpers.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+// BuildToPodLogOptions builds a PodLogOptions object out of a BuildLogOptions.
+// Currently BuildLogOptions.Container and BuildLogOptions.Previous aren't used
+// so they won't be copied to PodLogOptions.
+func BuildToPodLogOptions(opts *BuildLogOptions) *kapi.PodLogOptions {
+	return &kapi.PodLogOptions{
+		Follow:       opts.Follow,
+		SinceSeconds: opts.SinceSeconds,
+		SinceTime:    opts.SinceTime,
+		Timestamps:   opts.Timestamps,
+		TailLines:    opts.TailLines,
+		LimitBytes:   opts.LimitBytes,
+	}
+}

--- a/pkg/build/api/log_options_test.go
+++ b/pkg/build/api/log_options_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func TestLogOptionsDrift(t *testing.T) {
+	popts := reflect.TypeOf(kapi.PodLogOptions{})
+	bopts := reflect.TypeOf(BuildLogOptions{})
+
+	for i := 0; i < popts.NumField(); i++ {
+		// Verify name
+		name := popts.Field(i).Name
+		boptsField, found := bopts.FieldByName(name)
+		if !found {
+			t.Errorf("buildLogOptions drifting from podLogOptions! Field %q wasn't found!", name)
+		}
+		// Verify type
+		if should, is := popts.Field(i).Type, boptsField.Type; is != should {
+			t.Errorf("buildLogOptions drifting from podLogOptions! Field %q should be a %s but is %s!", name, should.String(), is.String())
+		}
+	}
+}

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -604,9 +604,33 @@ type BinaryBuildRequestOptions struct {
 type BuildLogOptions struct {
 	unversioned.TypeMeta
 
+	// Container for which to return logs
+	Container string
 	// Follow if true indicates that the build log should be streamed until
 	// the build terminates.
 	Follow bool
+	// If true, return previous terminated container logs
+	Previous bool
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output.
+	Timestamps bool
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64
 
 	// NoWait if true causes the call to return immediately even if the build
 	// is not available yet. Otherwise the server will wait until the build has started.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -533,9 +533,33 @@ type BinaryBuildRequestOptions struct {
 type BuildLogOptions struct {
 	unversioned.TypeMeta
 
+	// The container for which to stream logs. Defaults to only container if there is one container in the pod.
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
 	// Follow if true indicates that the build log should be streamed until
 	// the build terminates.
 	Follow bool `json:"follow,omitempty" description:"if true indicates that the log should be streamed; defaults to false"`
+	// Return previous terminated container logs. Defaults to false.
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false."`
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64 `json:"sinceSeconds,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output. Defaults to false.
+	Timestamps bool `json:"timestamps,omitempty" description:"add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output"`
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64 `json:"tailLines,omitempty" description:"the number of lines from the end of the logs to show"`
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64 `json:"limitBytes,omitempty" description:"the number of bytes to read from the server before terminating the log output"`
 
 	// NoWait if true causes the call to return immediately even if the build
 	// is not available yet. Otherwise the server will wait until the build has started.

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -512,9 +512,33 @@ type BinaryBuildRequestOptions struct {
 type BuildLogOptions struct {
 	unversioned.TypeMeta
 
+	// The container for which to stream logs. Defaults to only container if there is one container in the pod.
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
 	// Follow if true indicates that the build log should be streamed until
 	// the build terminates.
 	Follow bool `json:"follow,omitempty" description:"if true indicates that the log should be streamed; defaults to false"`
+	// Return previous terminated container logs. Defaults to false.
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false."`
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64 `json:"sinceSeconds,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output. Defaults to false.
+	Timestamps bool `json:"timestamps,omitempty" description:"add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output"`
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64 `json:"tailLines,omitempty" description:"the number of lines from the end of the logs to show"`
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64 `json:"limitBytes,omitempty" description:"the number of bytes to read from the server before terminating the log output"`
 
 	// NoWait if true causes the call to return immediately even if the build
 	// is not available yet. Otherwise the server will wait until the build has started.

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -461,3 +461,15 @@ func isValidURL(uri string) bool {
 	_, err := url.Parse(uri)
 	return err == nil
 }
+
+func ValidateBuildLogOptions(opts *buildapi.BuildLogOptions) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	// TODO: Replace by validating PodLogOptions via BuildLogOptions once it's bundled in
+	popts := buildapi.BuildToPodLogOptions(opts)
+	if errs := validation.ValidatePodLogOptions(popts); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	return allErrs
+}

--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -101,9 +101,7 @@ func (r *REST) Get(ctx kapi.Context, name string, opts runtime.Object) (runtime.
 	}
 	// The container should be the default build container, so setting it to blank
 	buildPodName := buildutil.GetBuildPodName(build)
-	logOpts := &kapi.PodLogOptions{
-		Follow: buildLogOpts.Follow,
-	}
+	logOpts := api.BuildToPodLogOptions(buildLogOpts)
 	location, transport, err := pod.LogLocation(r.PodGetter, r.ConnectionInfo, ctx, buildPodName, logOpts)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/client/buildlogs.go
+++ b/pkg/client/buildlogs.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	api "github.com/openshift/origin/pkg/build/api"
@@ -31,13 +32,6 @@ func newBuildLogs(c *Client, namespace string) *buildLogs {
 }
 
 // Get builds and returns a buildLog request
-func (c *buildLogs) Get(name string, opt api.BuildLogOptions) *kclient.Request {
-	req := c.r.Get().Namespace(c.ns).Resource("builds").Name(name).SubResource("log")
-	if opt.NoWait {
-		req.Param("nowait", "true")
-	}
-	if opt.Follow {
-		req.Param("follow", "true")
-	}
-	return req
+func (c *buildLogs) Get(name string, opts api.BuildLogOptions) *kclient.Request {
+	return c.r.Get().Namespace(c.ns).Resource("builds").Name(name).SubResource("log").VersionedParams(&opts, kapi.Scheme)
 }

--- a/pkg/client/deploymentlogs.go
+++ b/pkg/client/deploymentlogs.go
@@ -1,8 +1,7 @@
 package client
 
 import (
-	"fmt"
-
+	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	"github.com/openshift/origin/pkg/deploy/api"
@@ -34,15 +33,5 @@ func newDeploymentLogs(c *Client, namespace string) *deploymentLogs {
 
 // Get gets the deploymentlogs and return a deploymentLog request
 func (c *deploymentLogs) Get(name string, opts api.DeploymentLogOptions) *kclient.Request {
-	req := c.r.Get().Namespace(c.ns).Resource("deploymentConfigs").Name(name).SubResource("log")
-	if opts.NoWait {
-		req.Param("nowait", "true")
-	}
-	if opts.Follow {
-		req.Param("follow", "true")
-	}
-	if opts.Version != nil {
-		req.Param("version", fmt.Sprintf("%d", *opts.Version))
-	}
-	return req
+	return c.r.Get().Namespace(c.ns).Resource("deploymentConfigs").Name(name).SubResource("log").VersionedParams(&opts, kapi.Scheme)
 }

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -81,7 +81,6 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 	if cmdutil.GetFlagBool(cmd, "dump-logs") {
 		opts := buildapi.BuildLogOptions{
 			NoWait: true,
-			Follow: false,
 		}
 		response, err := client.BuildLogs(namespace).Get(buildName, opts).Do().Raw()
 		if err != nil {

--- a/pkg/cmd/cli/cmd/logs.go
+++ b/pkg/cmd/cli/cmd/logs.go
@@ -97,17 +97,23 @@ func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, out io.Writer, cmd
 
 	// TODO: podLogOptions should be included in our own logOptions objects.
 	switch resource {
-	case "build":
+	case "build", "buildconfig":
 		o.Options = &buildapi.BuildLogOptions{
-			Follow: podLogOptions.Follow,
-		}
-	case "buildconfig":
-		o.Options = &buildapi.BuildLogOptions{
-			Follow: podLogOptions.Follow,
+			Follow:       podLogOptions.Follow,
+			SinceSeconds: podLogOptions.SinceSeconds,
+			SinceTime:    podLogOptions.SinceTime,
+			Timestamps:   podLogOptions.Timestamps,
+			TailLines:    podLogOptions.TailLines,
+			LimitBytes:   podLogOptions.LimitBytes,
 		}
 	case "deploymentconfig":
 		o.Options = &deployapi.DeploymentLogOptions{
-			Follow: podLogOptions.Follow,
+			Follow:       podLogOptions.Follow,
+			SinceSeconds: podLogOptions.SinceSeconds,
+			SinceTime:    podLogOptions.SinceTime,
+			Timestamps:   podLogOptions.Timestamps,
+			TailLines:    podLogOptions.TailLines,
+			LimitBytes:   podLogOptions.LimitBytes,
 		}
 	default:
 		o.Options = nil

--- a/pkg/deploy/api/helpers.go
+++ b/pkg/deploy/api/helpers.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+// DeploymentToPodLogOptions builds a PodLogOptions object out of a DeploymentLogOptions.
+// Currently DeploymentLogOptions.Container and DeploymentLogOptions.Previous aren't used
+// so they won't be copied to PodLogOptions.
+func DeploymentToPodLogOptions(opts *DeploymentLogOptions) *kapi.PodLogOptions {
+	return &kapi.PodLogOptions{
+		Follow:       opts.Follow,
+		SinceSeconds: opts.SinceSeconds,
+		SinceTime:    opts.SinceTime,
+		Timestamps:   opts.Timestamps,
+		TailLines:    opts.TailLines,
+		LimitBytes:   opts.LimitBytes,
+	}
+}

--- a/pkg/deploy/api/log_options_test.go
+++ b/pkg/deploy/api/log_options_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func TestLogOptionsDrift(t *testing.T) {
+	popts := reflect.TypeOf(kapi.PodLogOptions{})
+	dopts := reflect.TypeOf(DeploymentLogOptions{})
+
+	for i := 0; i < popts.NumField(); i++ {
+		// Verify name
+		name := popts.Field(i).Name
+		doptsField, found := dopts.FieldByName(name)
+		if !found {
+			t.Errorf("deploymentLogOptions drifting from podLogOptions! Field %q wasn't found!", name)
+		}
+		// Verify type
+		if should, is := popts.Field(i).Type, doptsField.Type; is != should {
+			t.Errorf("deploymentLogOptions drifting from podLogOptions! Field %q should be a %s but is %s!", name, should.String(), is.String())
+		}
+	}
+}

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -367,9 +367,33 @@ type DeploymentLog struct {
 type DeploymentLogOptions struct {
 	unversioned.TypeMeta
 
+	// Container for which to return logs
+	Container string
 	// Follow if true indicates that the deployment log should be streamed until
 	// the deployment terminates.
 	Follow bool
+	// If true, return previous terminated container logs
+	Previous bool
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output.
+	Timestamps bool
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64
 
 	// NoWait if true causes the call to return immediately even if the deployment
 	// is not available yet. Otherwise the server will wait until the deployment has started.

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -358,9 +358,33 @@ type DeploymentLog struct {
 type DeploymentLogOptions struct {
 	unversioned.TypeMeta `json:",inline"`
 
-	// Follow if true indicates that the deployment log should be streamed until
-	// the deployment terminates.
+	// The container for which to stream logs. Defaults to only container if there is one container in the pod.
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
+	// Follow if true indicates that the build log should be streamed until
+	// the build terminates.
 	Follow bool `json:"follow,omitempty" description:"if true indicates that the log should be streamed; defaults to false"`
+	// Return previous terminated container logs. Defaults to false.
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false."`
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64 `json:"sinceSeconds,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output. Defaults to false.
+	Timestamps bool `json:"timestamps,omitempty" description:"add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output"`
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64 `json:"tailLines,omitempty" description:"the number of lines from the end of the logs to show"`
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64 `json:"limitBytes,omitempty" description:"the number of bytes to read from the server before terminating the log output"`
 
 	// NoWait if true causes the call to return immediately even if the deployment
 	// is not available yet. Otherwise the server will wait until the deployment has started.

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -370,9 +370,33 @@ type DeploymentLog struct {
 type DeploymentLogOptions struct {
 	unversioned.TypeMeta `json:",inline"`
 
-	// Follow if true indicates that the deployment log should be streamed until
-	// the deployment terminates.
+	// The container for which to stream logs. Defaults to only container if there is one container in the pod.
+	Container string `json:"container,omitempty" description:"the container for which to stream logs; defaults to only container if there is one container in the pod"`
+	// Follow if true indicates that the build log should be streamed until
+	// the build terminates.
 	Follow bool `json:"follow,omitempty" description:"if true indicates that the log should be streamed; defaults to false"`
+	// Return previous terminated container logs. Defaults to false.
+	Previous bool `json:"previous,omitempty" description:"return previous terminated container logs; defaults to false."`
+	// A relative time in seconds before the current time from which to show logs. If this value
+	// precedes the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceSeconds *int64 `json:"sinceSeconds,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// An RFC3339 timestamp from which to show logs. If this value
+	// preceeds the time a pod was started, only logs since the pod start will be returned.
+	// If this value is in the future, no logs will be returned.
+	// Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime *unversioned.Time `json:"sinceTime,omitempty" description:"relative time in seconds before the current time from which to show logs"`
+	// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+	// of log output. Defaults to false.
+	Timestamps bool `json:"timestamps,omitempty" description:"add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output"`
+	// If set, the number of lines from the end of the logs to show. If not specified,
+	// logs are shown from the creation of the container or sinceSeconds or sinceTime
+	TailLines *int64 `json:"tailLines,omitempty" description:"the number of lines from the end of the logs to show"`
+	// If set, the number of bytes to read from the server before terminating the
+	// log output. This may not display a complete final line of logging, and may return
+	// slightly more or slightly less than the specified limit.
+	LimitBytes *int64 `json:"limitBytes,omitempty" description:"the number of bytes to read from the server before terminating the log output"`
 
 	// NoWait if true causes the call to return immediately even if the deployment
 	// is not available yet. Otherwise the server will wait until the deployment has started.

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -338,11 +338,13 @@ func IsValidPercent(percent string) bool {
 const isNegativeErrorMsg string = `must be non-negative`
 
 func ValidateDeploymentLogOptions(opts *deployapi.DeploymentLogOptions) fielderrors.ValidationErrorList {
-	errs := fielderrors.ValidationErrorList{}
+	allErrs := fielderrors.ValidationErrorList{}
 
-	if opts.Version != nil && *opts.Version <= 0 {
-		errs = append(errs, fielderrors.NewFieldInvalid("version", *opts.Version, "deployment version must be greater than 0"))
+	// TODO: Replace by validating PodLogOptions via DeploymentLogOptions once it's bundled in
+	popts := deployapi.DeploymentToPodLogOptions(opts)
+	if errs := validation.ValidatePodLogOptions(popts); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
 	}
 
-	return errs
+	return allErrs
 }

--- a/pkg/deploy/registry/deploylog/rest.go
+++ b/pkg/deploy/registry/deploylog/rest.go
@@ -137,9 +137,7 @@ func (r *REST) Get(ctx kapi.Context, name string, opts runtime.Object) (runtime.
 
 	// Setup url of the deployer pod
 	deployPodName := deployutil.DeployerPodNameForDeployment(target.Name)
-	logOpts := &kapi.PodLogOptions{
-		Follow: deployLogOpts.Follow,
-	}
+	logOpts := deployapi.DeploymentToPodLogOptions(deployLogOpts)
 	location, transport, err := pod.LogLocation(r.PodGetter, r.ConnectionInfo, ctx, deployPodName, logOpts)
 	if err != nil {
 		return nil, errors.NewBadRequest(err.Error())


### PR DESCRIPTION
@deads2k podLogOptions doesn't deserialize correctly in the server and I am not sure what else am I missing... 

I had to update v1beta3 conversions manually (both in Origin and Kube) and updating swagger doesn't work too.

Fixes https://github.com/openshift/origin/issues/5070, https://bugzilla.redhat.com/show_bug.cgi?id=1273948, and https://bugzilla.redhat.com/show_bug.cgi?id=1273817.