### PR TITLE
UPSTREAM: 16286: Avoid CPU hotloop on client-closed websocket

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/wsstream/conn.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/wsstream/conn.go
@@ -97,9 +97,7 @@ func ignoreReceives(ws *websocket.Conn, timeout time.Duration) {
 	for {
 		resetTimeout(ws, timeout)
 		if err := websocket.Message.Receive(ws, &data); err != nil {
-			if err == io.EOF {
-				return
-			}
+			return
 		}
 	}
 }


### PR DESCRIPTION
Fixes #5355