### PR TITLE
Bug 1274680 - Update angular-patternfly to version 2.3.3

### DIFF
--- a/assets/bower.json
+++ b/assets/bower.json
@@ -12,7 +12,7 @@
     "angular-touch": "1.3.8",
     "angular-route": "1.3.8",
     "angular-bootstrap": "0.11.2",
-    "angular-patternfly": "2.3.1",
+    "angular-patternfly": "2.3.3",
     "uri.js": "1.14.1",
     "moment": "2.10.6",
     "patternfly": "2.3.0",


### PR DESCRIPTION
Fixes the problem with the metrics utilization chart in IE.

![ie10_-_win7__running_](https://cloud.githubusercontent.com/assets/1167259/10741083/3c97dace-7bfc-11e5-9651-5134554d68f0.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1274680