### PR TITLE
Support --binary on new-build

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -469,6 +469,7 @@ _oc_new-build()
     flags_completion=()
 
     flags+=("--allow-missing-images")
+    flags+=("--binary")
     flags+=("--code=")
     flags+=("--docker-image=")
     flags+=("--dockerfile=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -2277,6 +2277,7 @@ _openshift_cli_new-build()
     flags_completion=()
 
     flags+=("--allow-missing-images")
+    flags+=("--binary")
     flags+=("--code=")
     flags+=("--docker-image=")
     flags+=("--dockerfile=")

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -49,6 +49,7 @@ You can use '%[1]s status' to check the progress.`
 // NewCmdNewBuild implements the OpenShift cli new-build command
 func NewCmdNewBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
 	config := newcmd.NewAppConfig()
+	config.ExpectToBuild = true
 
 	cmd := &cobra.Command{
 		Use:        "new-build (IMAGE | IMAGESTREAM | PATH | URL ...)",
@@ -78,6 +79,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.
 	cmd.Flags().VarP(&config.Environment, "env", "e", "Specify key value pairs of environment variables to set into resulting image.")
 	cmd.Flags().StringVar(&config.Strategy, "strategy", "", "Specify the build strategy to use if you don't want to detect (docker|source).")
 	cmd.Flags().StringVarP(&config.Dockerfile, "dockerfile", "D", "", "Specify the contents of a Dockerfile to build directly, implies --strategy=docker. Pass '-' to read from STDIN.")
+	cmd.Flags().BoolVar(&config.BinaryBuild, "binary", false, "Instead of expecting a source URL, set the build to expect binary contents. Will disable triggers.")
 	cmd.Flags().BoolVar(&config.OutputDocker, "to-docker", false, "Have the build output push to a Docker repository.")
 	cmd.Flags().StringP("labels", "l", "", "Label to set in all generated resources.")
 	cmd.Flags().BoolVar(&config.AllowMissingImages, "allow-missing-images", false, "If true, indicates that referenced Docker images that cannot be found locally or in a registry should still be used.")

--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -335,7 +335,7 @@ func (o TagOptions) RunTag() error {
 			}
 
 			target.Spec.Tags[destTag] = targetRef
-			msg = fmt.Sprintf("Tag %s set up to track tag %s/%s.", o.ref, o.destNamespace[i], destNameAndTag)
+			msg = fmt.Sprintf("Tag %s set up to track tag %s/%s.", o.ref.Exact(), o.destNamespace[i], destNameAndTag)
 		} else {
 			// The user wants to delete a spec tag.
 			if _, ok := target.Spec.Tags[destTag]; !ok {

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -67,6 +67,11 @@ func (r ComponentReferences) filter(filterFunc func(ref ComponentReference) bool
 	return refs
 }
 
+// HasSource returns true if there is more than one component that has a repo associated
+func (r ComponentReferences) HasSource() bool {
+	return len(r.filter(func(ref ComponentReference) bool { return ref.Input().Uses != nil })) > 0
+}
+
 // NeedsSource returns all the components that need source code in order to build
 func (r ComponentReferences) NeedsSource() (refs ComponentReferences) {
 	return r.filter(func(ref ComponentReference) bool {

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -82,6 +82,12 @@ oc delete template ruby-helloworld-sample
 oc new-app https://github.com/openshift/ruby-hello-world -l app=ruby
 oc delete all -l app=ruby
 
+# check new-build
+[ "$(oc new-build mysql -o yaml 2>&1 | grep -F 'you must specify at least one source repository URL')" ]
+[ "$(oc new-build mysql --binary -o yaml | grep -F 'type: Binary')" ]
+[ "$(oc new-build mysql https://github.com/openshift/ruby-hello-world --strategy=docker -o yaml | grep -F 'type: Docker')" ]
+[ "$(oc new-build mysql https://github.com/openshift/ruby-hello-world --binary 2>&1 | grep -F 'specifying binary builds and source repositories at the same time is not allowed')" ]
+
 # do not allow use of non-existent image (should fail)
 [ "$(oc new-app  openshift/bogusImage https://github.com/openshift/ruby-hello-world.git -o yaml 2>&1 | grep "no image or template matched")" ]
 # allow use of non-existent image (should succeed)


### PR DESCRIPTION
Allows callers to bypass passing a source URL, add more error checking on input.