### PR TITLE
skip project validation when creating a new-project

### DIFF
--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -114,6 +114,7 @@ func (o *NewProjectOptions) Run() error {
 	if o.ProjectOptions != nil {
 		o.ProjectOptions.ProjectName = project.Name
 		o.ProjectOptions.ProjectOnly = true
+		o.ProjectOptions.SkipAccessValidation = true
 
 		if err := o.ProjectOptions.RunProject(); err != nil {
 			return err


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4870

Review with ignore whitespace.  This just provides an option to skip the project get.  We set it during the  `oc new-project` flow.

