### PR TITLE
Miscellaneous rsync fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -689,48 +689,48 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
-			"Comment": "v1.0.3-10-g84e4633",
-			"Rev": "84e4633329181926ec8d746e189769522b1ff6a7"
+			"Comment": "v1.0.3-16-g9728b53",
+			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/api/validation/validation_test.go
@@ -1,0 +1,48 @@
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestValidation(t *testing.T) {
+	testCases := []struct {
+		value    *api.Config
+		expected []ValidationError
+	}{
+		{
+			&api.Config{
+				Source:       "http://github.com/openshift/source",
+				BuilderImage: "openshift/builder",
+				DockerConfig: &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+			},
+			[]ValidationError{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: "foobar",
+			},
+			[]ValidationError{{ValidationErrorInvalidValue, "dockerNetworkMode"}},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: api.NewDockerNetworkModeContainer("8d873e496bc3e80a1cb22e67f7de7be5b0633e27916b1144978d1419c0abfcdb"),
+			},
+			[]ValidationError{},
+		},
+	}
+	for _, test := range testCases {
+		result := ValidateConfig(test.value)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("got %+v, expected %+v", result, test.expected)
+		}
+	}
+}

--- a/pkg/cmd/cli/cmd/rsync/copymulti.go
+++ b/pkg/cmd/cli/cmd/rsync/copymulti.go
@@ -11,7 +11,7 @@ import (
 )
 
 // copyStrategies is an ordered list of copyStrategy objects that behaves as a single
-// strategy.
+// strategy. If a strategy fails with a setup error, it continues on to the next strategy.
 type copyStrategies []copyStrategy
 
 // ensure copyStrategies implements the copyStrategy interface

--- a/pkg/cmd/cli/cmd/rsync/rsync.go
+++ b/pkg/cmd/cli/cmd/rsync/rsync.go
@@ -36,7 +36,7 @@ for the copy.`
   $ %[1]s POD:/remote/dir/ ./local/dir`
 
 	noRsyncUnixWarning    = "rsync command not found in path. Please use your package manager to install it."
-	noRsyncWindowsWarning = "rsync command not found in path. Download cwRsync for windows and add it to your path."
+	noRsyncWindowsWarning = "rsync command not found in path. Download cwRsync for Windows and add it to your PATH."
 )
 
 // copyStrategy

--- a/pkg/cmd/cli/cmd/rsync/util.go
+++ b/pkg/cmd/cli/cmd/rsync/util.go
@@ -11,6 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	testRsyncCommand = []string{"rsync", "--version"}
+	testTarCommand   = []string{"tar", "--version"}
+)
+
 // executeWithLogging will execute a command and log its output
 func executeWithLogging(e executor, cmd []string) error {
 	w := &bytes.Buffer{}
@@ -61,4 +66,12 @@ func isExitError(err error) bool {
 	}
 	_, exitErr := err.(*exec.ExitError)
 	return exitErr
+}
+
+func checkRsync(e executor) error {
+	return executeWithLogging(e, testRsyncCommand)
+}
+
+func checkTar(e executor) error {
+	return executeWithLogging(e, testTarCommand)
 }


### PR DESCRIPTION
Miscellaneous fixes for rsync in windows and tar strategy:
- Added verbose logging of tar extract when extracting to local machine
- Fixed truncation of directory name when archiving a directory relative to current directory (tar)
- Rsync in windows not falling back to tar when rsync not present in container
- Added check for presence of tar in remote container if tarring failed
- Added descriptions for each strategy