### PR TITLE
Slim down the extended tests

### DIFF
--- a/test/extended/authentication.sh
+++ b/test/extended/authentication.sh
@@ -14,8 +14,6 @@ source "${OS_ROOT}/hack/common.sh"
 os::log::install_errexit
 cd "${OS_ROOT}"
 
-ensure_iptables_or_die
-
 os::build::setup_env
 
 export TMPDIR="${TMPDIR:-"/tmp"}"
@@ -39,6 +37,7 @@ trap "cleanup" EXIT
 
 echo "[INFO] Starting server"
 
+ensure_iptables_or_die
 setup_env_vars
 reset_tmp_dir
 configure_os_server

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -15,8 +15,6 @@ source "${OS_ROOT}/hack/common.sh"
 os::log::install_errexit
 cd "${OS_ROOT}"
 
-ensure_iptables_or_die
-
 os::build::setup_env
 
 export TMPDIR="${TMPDIR:-"/tmp"}"

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -14,13 +14,12 @@ source "${OS_ROOT}/hack/common.sh"
 os::log::install_errexit
 cd "${OS_ROOT}"
 
-ensure_ginkgo_or_die
-ensure_iptables_or_die
+# ensure_ginkgo_or_die
 
 os::build::setup_env
-if [[ -z ${TEST_ONLY+x} ]]; then
-  go test -c ./test/extended -o ${OS_OUTPUT_BINPATH}/extended.test
-fi
+#if [[ -z ${TEST_ONLY+x} ]]; then
+#  go test -c ./test/extended -o ${OS_OUTPUT_BINPATH}/extended.test
+#fi
 
 export TMPDIR="${TMPDIR:-"/tmp"}"
 export BASETMPDIR="${TMPDIR}/openshift-extended-tests/core"
@@ -81,6 +80,8 @@ DEFAULT_SKIP=$(join '|' "${SKIP_TESTS[@]}")
 SKIP="${SKIP:-$DEFAULT_SKIP}"
 
 if [[ -z ${TEST_ONLY+x} ]]; then
+  ensure_iptables_or_die
+
   function cleanup()
   {
     out=$?
@@ -119,4 +120,4 @@ fi
 echo "[INFO] Running extended tests"
 
 # Run the tests
-TMPDIR=${BASETMPDIR} ginkgo "-skip=${SKIP}" "$@" ${OS_OUTPUT_BINPATH}/extended.test
+TMPDIR=${BASETMPDIR} go test -timeout 6h ./test/extended/ --test.v "--ginkgo.skip=${SKIP}" "$@"

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -3,8 +3,6 @@ package extended
 import (
 	"testing"
 
-	flag "github.com/spf13/pflag"
-
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/images"
@@ -13,17 +11,11 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var (
-	reportDir = flag.String("report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
-)
-
 // init initialize the extended testing suite.
-// You can set these environment variables to configure extended tests:
-// KUBECONFIG - Path to kubeconfig containing embedded authinfo
 func init() {
 	exutil.InitTest()
 }
 
 func TestExtended(t *testing.T) {
-	exutil.ExecuteTest(t, *reportDir)
+	exutil.ExecuteTest(t, "Extended Core")
 }

--- a/test/old-start-configs/run.sh
+++ b/test/old-start-configs/run.sh
@@ -7,9 +7,6 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/../../..
 source "${OS_ROOT}/hack/util.sh"
 cd "${OS_ROOT}"
 
-ensure_iptables_or_die
-
-
 function cleanup()
 {
 	out=$?


### PR DESCRIPTION
Remove iptables requirement from most tests
Switch to executing using go test instead of the ginkgo wrapper and requiring precompilation
Support legacy -focus but otherwise use --ginkgo.*

@deads2k @bparees

[test][extended:core(builds)]