### PR TITLE
Support retries on conflicting image stream mapping create attempts

### DIFF
--- a/pkg/image/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/registry/imagestreammapping/rest_test.go
@@ -1,6 +1,7 @@
 package imagestreammapping
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -9,11 +10,15 @@ import (
 	"github.com/coreos/go-etcd/etcd"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	kstorage "k8s.io/kubernetes/pkg/storage"
 	etcdstorage "k8s.io/kubernetes/pkg/storage/etcd"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
+	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/openshift/origin/pkg/api/latest"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
@@ -441,4 +446,193 @@ func TestTrackingTags(t *testing.T) {
 	if e, a := "9999", nonTracking.Image; e != a {
 		t.Errorf("image: expected %s, got %s", e, a)
 	}
+}
+
+// TestCreateRetryUnrecoverable ensures that an attempt to create a mapping
+// using failing registry update calls will return an error.
+func TestCreateRetryUnrecoverable(t *testing.T) {
+	rest := &REST{
+		imageRegistry: &fakeImageRegistry{
+			createImage: func(ctx kapi.Context, image *api.Image) error {
+				return nil
+			},
+		},
+		imageStreamRegistry: &fakeImageStreamRegistry{
+			getImageStream: func(ctx kapi.Context, id string) (*api.ImageStream, error) {
+				return validImageStream(), nil
+			},
+			listImageStreams: func(ctx kapi.Context, selector labels.Selector) (*api.ImageStreamList, error) {
+				s := validImageStream()
+				return &api.ImageStreamList{Items: []api.ImageStream{*s}}, nil
+			},
+			updateImageStreamStatus: func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+				return nil, errors.NewServiceUnavailable("unrecoverable error")
+			},
+		},
+	}
+	obj, err := rest.Create(kapi.NewDefaultContext(), validNewMappingWithName())
+	if err == nil {
+		t.Errorf("expected an error")
+	}
+	if obj != nil {
+		t.Fatalf("expected a nil result")
+	}
+}
+
+// TestCreateRetryConflictNoTagDiff ensures that attempts to create a mapping
+// that result in resource conflicts that do NOT include tag diffs causes the
+// create to be retried successfully.
+func TestCreateRetryConflictNoTagDiff(t *testing.T) {
+	firstUpdate := true
+	rest := &REST{
+		imageRegistry: &fakeImageRegistry{
+			createImage: func(ctx kapi.Context, image *api.Image) error {
+				return nil
+			},
+		},
+		imageStreamRegistry: &fakeImageStreamRegistry{
+			getImageStream: func(ctx kapi.Context, id string) (*api.ImageStream, error) {
+				stream := validImageStream()
+				stream.Status = api.ImageStreamStatus{
+					Tags: map[string]api.TagEventList{
+						"latest": {Items: []api.TagEvent{{DockerImageReference: "localhost:5000/someproject/somerepo:original"}}},
+					},
+				}
+				return stream, nil
+			},
+			updateImageStreamStatus: func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+				// For the first update call, return a conflict to cause a retry of an
+				// image stream whose tags haven't changed.
+				if firstUpdate {
+					firstUpdate = false
+					return nil, errors.NewConflict("ImageStream", repo.Name, fmt.Errorf("resource modified"))
+				}
+				return repo, nil
+			},
+		},
+	}
+	obj, err := rest.Create(kapi.NewDefaultContext(), validNewMappingWithName())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if obj == nil {
+		t.Fatalf("expected a result")
+	}
+}
+
+// TestCreateRetryConflictTagDiff ensures that attempts to create a mapping
+// that result in resource conflicts that DO contain tag diffs causes the
+// conflict error to be returned.
+func TestCreateRetryConflictTagDiff(t *testing.T) {
+	firstGet := true
+	firstUpdate := true
+	rest := &REST{
+		imageRegistry: &fakeImageRegistry{
+			createImage: func(ctx kapi.Context, image *api.Image) error {
+				return nil
+			},
+		},
+		imageStreamRegistry: &fakeImageStreamRegistry{
+			getImageStream: func(ctx kapi.Context, id string) (*api.ImageStream, error) {
+				// For the first get, return a stream with a latest tag pointing to "original"
+				if firstGet {
+					firstGet = false
+					stream := validImageStream()
+					stream.Status = api.ImageStreamStatus{
+						Tags: map[string]api.TagEventList{
+							"latest": {Items: []api.TagEvent{{DockerImageReference: "localhost:5000/someproject/somerepo:original"}}},
+						},
+					}
+					return stream, nil
+				}
+				// For subsequent gets, return a stream with the latest tag changed to "newer"
+				stream := validImageStream()
+				stream.Status = api.ImageStreamStatus{
+					Tags: map[string]api.TagEventList{
+						"latest": {Items: []api.TagEvent{{DockerImageReference: "localhost:5000/someproject/somerepo:newer"}}},
+					},
+				}
+				return stream, nil
+			},
+			updateImageStreamStatus: func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+				// For the first update, return a conflict so that the stream
+				// get/compare is retried.
+				if firstUpdate {
+					firstUpdate = false
+					return nil, errors.NewConflict("ImageStream", repo.Name, fmt.Errorf("resource modified"))
+				}
+				return repo, nil
+			},
+		},
+	}
+	obj, err := rest.Create(kapi.NewDefaultContext(), validNewMappingWithName())
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !errors.IsConflict(err) {
+		t.Errorf("expected a conflict error, got %v", err)
+	}
+	if obj != nil {
+		t.Fatalf("expected a nil result")
+	}
+}
+
+type fakeImageRegistry struct {
+	listImages  func(ctx kapi.Context, selector labels.Selector) (*api.ImageList, error)
+	getImage    func(ctx kapi.Context, id string) (*api.Image, error)
+	createImage func(ctx kapi.Context, image *api.Image) error
+	deleteImage func(ctx kapi.Context, id string) error
+	watchImages func(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+func (f *fakeImageRegistry) ListImages(ctx kapi.Context, selector labels.Selector) (*api.ImageList, error) {
+	return f.listImages(ctx, selector)
+}
+func (f *fakeImageRegistry) GetImage(ctx kapi.Context, id string) (*api.Image, error) {
+	return f.getImage(ctx, id)
+}
+func (f *fakeImageRegistry) CreateImage(ctx kapi.Context, image *api.Image) error {
+	return f.createImage(ctx, image)
+}
+func (f *fakeImageRegistry) DeleteImage(ctx kapi.Context, id string) error {
+	return f.deleteImage(ctx, id)
+}
+func (f *fakeImageRegistry) WatchImages(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return f.watchImages(ctx, label, field, resourceVersion)
+}
+
+type fakeImageStreamRegistry struct {
+	listImageStreams        func(ctx kapi.Context, selector labels.Selector) (*api.ImageStreamList, error)
+	getImageStream          func(ctx kapi.Context, id string) (*api.ImageStream, error)
+	createImageStream       func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	updateImageStream       func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	updateImageStreamSpec   func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	updateImageStreamStatus func(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error)
+	deleteImageStream       func(ctx kapi.Context, id string) (*unversioned.Status, error)
+	watchImageStreams       func(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+func (f *fakeImageStreamRegistry) ListImageStreams(ctx kapi.Context, selector labels.Selector) (*api.ImageStreamList, error) {
+	return f.listImageStreams(ctx, selector)
+}
+func (f *fakeImageStreamRegistry) GetImageStream(ctx kapi.Context, id string) (*api.ImageStream, error) {
+	return f.getImageStream(ctx, id)
+}
+func (f *fakeImageStreamRegistry) CreateImageStream(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+	return f.createImageStream(ctx, repo)
+}
+func (f *fakeImageStreamRegistry) UpdateImageStream(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+	return f.updateImageStream(ctx, repo)
+}
+func (f *fakeImageStreamRegistry) UpdateImageStreamSpec(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+	return f.updateImageStreamSpec(ctx, repo)
+}
+func (f *fakeImageStreamRegistry) UpdateImageStreamStatus(ctx kapi.Context, repo *api.ImageStream) (*api.ImageStream, error) {
+	return f.updateImageStreamStatus(ctx, repo)
+}
+func (f *fakeImageStreamRegistry) DeleteImageStream(ctx kapi.Context, id string) (*unversioned.Status, error) {
+	return f.deleteImageStream(ctx, id)
+}
+func (f *fakeImageStreamRegistry) WatchImageStreams(ctx kapi.Context, label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return f.watchImageStreams(ctx, label, field, resourceVersion)
 }


### PR DESCRIPTION
Add retry support to mapping creation to allow repeated update attempts
when the conflicting resource doesn't contain any tag diffs.

Fixes #5421