### PR TITLE
Bug 1275003: expose: Set route port based on service target port

### DIFF
--- a/pkg/route/generator/generate.go
+++ b/pkg/route/generator/generate.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -68,10 +67,8 @@ func (RouteGenerator) Generate(genericParams map[string]interface{}) (runtime.Ob
 	if !found || len(portString) == 0 {
 		portString = strings.Split(params["ports"], ",")[0]
 	}
-
-	port, err := strconv.ParseInt(portString, 10, 0)
-	if err != nil {
-		return nil, err
+	if len(portString) == 0 {
+		return nil, fmt.Errorf("exposed service does not have any target ports specified")
 	}
 
 	return &api.Route{
@@ -85,10 +82,7 @@ func (RouteGenerator) Generate(genericParams map[string]interface{}) (runtime.Ob
 				Name: params["default-name"],
 			},
 			Port: &api.RoutePort{
-				TargetPort: util.IntOrString{
-					Kind:   util.IntstrInt,
-					IntVal: int(port),
-				},
+				TargetPort: util.NewIntOrStringFromString(portString),
 			},
 		},
 	}, nil

--- a/pkg/route/generator/generate_test.go
+++ b/pkg/route/generator/generate_test.go
@@ -39,8 +39,8 @@ func TestGenerateRoute(t *testing.T) {
 					},
 					Port: &routeapi.RoutePort{
 						TargetPort: util.IntOrString{
-							Kind:   util.IntstrInt,
-							IntVal: 80,
+							Kind:   util.IntstrString,
+							StrVal: "80",
 						},
 					},
 				},
@@ -68,8 +68,8 @@ func TestGenerateRoute(t *testing.T) {
 					},
 					Port: &routeapi.RoutePort{
 						TargetPort: util.IntOrString{
-							Kind:   util.IntstrInt,
-							IntVal: 80,
+							Kind:   util.IntstrString,
+							StrVal: "80",
 						},
 					},
 				},

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -78,7 +78,7 @@ oc delete svc external
 # Expose multiport service and verify we set a port in the route
 oc create -f test/fixtures/multiport-service.yaml
 oc expose svc/frontend --name route-with-set-port
-os::util::get_object_assert 'route route-with-set-port' "{{.spec.port.targetPort}}" '5432'
+os::util::get_object_assert 'route route-with-set-port' "{{.spec.port.targetPort}}" '8080'
 echo "expose: ok"
 
 oc delete all --all


### PR DESCRIPTION
Route should be using the port used from the endpoints of the service
and not the port the service is exposing.

@pweil- @smarterclayton @thoraxe 