### PR TITLE
Updates to address several issues

### DIFF
--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -103,13 +103,14 @@
     background-color: lighten(@log-bg-color, 13%);
     color: @link-hover-color-bright;
   }
-  span {
+  div {
     width: 60px;
     padding-right: 10px;
   }
 }
 .log-line-text {
   padding: 0 10px;
+  white-space: pre-wrap;
 }
 .log-chromeless {
   margin-top: -1px;

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -43,7 +43,7 @@
                 </div>
                 <div ng-if="logError" class="text-muted">
                   Log error
-                  <a ng-click="runLogs()">reconnect?</a>
+                  <a href="" ng-click="runLogs()">reconnect?</a>
                 </div>
               </tab>
             </tabset>

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -67,7 +67,7 @@
                 </div>
                 <div ng-if="logError" class="text-muted">
                   Log error
-                  <a ng-click="restartLogs()">reconnect?</a>
+                  <a href="" ng-click="restartLogs()">reconnect?</a>
                 </div>
               </tab>
 

--- a/assets/app/views/directives/logs/_log-formatted.html
+++ b/assets/app/views/directives/logs/_log-formatted.html
@@ -14,9 +14,9 @@
         Go to end of log
       </a>
     </div>
-    <div layout flex column class="log-view-output">
+    <div flex column class="log-view-output">
       <div
-        layout row
+        row
         class="log-line"
         ng-repeat="logLine in logs  | filter:logSearch"
         ng-class-odd="'odd'"
@@ -27,22 +27,20 @@
         <!-- not supporting click to line # yet
         <a class="log-line-number"
           ng-click="scrollTo('line_'+($index+1), $event)">
-          <span layout flex main-axis="end">
+          <div flex main-axis="end">
           {{:: $index+1 }}
-          </span>
+          </div>
         </a>
         -->
-        <span class="log-line-number">
-          <span layout flex main-axis="end">
+        <div class="log-line-number">
+          <div row flex main-axis="end">
           {{:: $index+1 }}
-          </span>
-        </span>
+          </div>
+        </div>
 
-        <span flex class="log-line-text">
-        {{::logLine.text}}
-        </span>
+        <div flex class="log-line-text">{{::logLine.text}}</div>
       </div>
-      <div layout row main-axis="center">
+      <div row main-axis="center">
         <ellipsis-loader ng-show="loading"></ellipsis-loader>
       </div>
     </div>

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -1,13 +1,19 @@
-<div layout column flex ng-if="links">
-  <div layout row class="log-timestamp" ng-if="start">
-    <span>Current log from {{start}}&nbsp;</span>
-    <span ng-if="end">to {{end}}</span>
+<div column flex ng-if="links">
+  <div row mobile="column" class="log-timestamp" ng-if="start">
+    <span row>
+      <span>Current log from &nbsp;</span>
+      <span flex class="text-right">{{start}}</span>
+    </span>
+    <span row ng-if="end">
+      <span>&nbsp;to&nbsp;</span>
+      <span flex class="text-right">{{end}}</span>
+    </span>
   </div>
-  <div layout sm="column" md="row">
-    <div flex row main-axis="end">
+  <div sm="column" md="row">
+    <div flex row tablet="column" main-axis="end">
       <div ng-transclude flex></div>
-      <div layout row cross-axis="end" class="log-link-external">
-        <a href="" 
+      <div row main-axis="end" cross-axis="end" class="log-link-external">
+        <a href=""
           ng-show="download"
           ng-click="makeDownload(logs)">
           Raw <i class="fa fa-external-link"></i>


### PR DESCRIPTION
 - switch spans to divs so IE10 renders log-lines correctly
   Fixes https://github.com/openshift/origin/issues/5370

 - prevent text on log-view from overlapping at <400
   Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1276004

 - add white-space: pre-wrap so log output is is formatted correctly when needed
   Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1275911

misc
 - adds href to ng-click for correct cursor  Fixes https://github.com/openshift/origin/issues/5469
 - remove depricated layout attribute no longer needed