### PR TITLE
Revert 'Retry ISM save upon conflicting IS error' 

### DIFF
--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/net/context"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 func init() {
@@ -204,9 +203,7 @@ func (r *repository) Put(ctx context.Context, manifest *manifest.SignedManifest)
 		}
 
 		// try to create the ISM again
-		if err := unversioned.RetryOnConflict(unversioned.DefaultRetry, func() error {
-			return r.registryClient.ImageStreamMappings(r.namespace).Create(&ism)
-		}); err != nil {
+		if err := r.registryClient.ImageStreamMappings(r.namespace).Create(&ism); err != nil {
 			log.Errorf("Error creating image stream mapping: %s", err)
 			return err
 		}


### PR DESCRIPTION
Since #5455 landed already, we don't need to retry the ISM creation at the internal repository level.

@smarterclayton ptal