### PR TITLE
contrib/systemd: Fix capitalization of Restart=always

### DIFF
--- a/contrib/systemd/atomic-openshift-node.service
+++ b/contrib/systemd/atomic-openshift-node.service
@@ -14,7 +14,7 @@ LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=atomic-openshift-node
-Restart=Always
+Restart=always
 OOMScoreAdjust=-999
 
 [Install]

--- a/contrib/systemd/origin-node.service
+++ b/contrib/systemd/origin-node.service
@@ -14,7 +14,7 @@ LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=origin-node
-Restart=Always
+Restart=always
 OOMScoreAdjust=-999
 
 [Install]


### PR DESCRIPTION
systemd-219 at least wants these lowercased, which matches
`man systemd.service`.