### PR TITLE
Completed field label conversion funcs for Namespace

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/conversion_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/conversion_test.go
@@ -160,16 +160,6 @@ func TestSelectableFieldLabelConversions(t *testing.T) {
 		{testapi.Extensions.Version(), "ThirdPartyResourceData", true, thirdpartyresourcedata.SelectableFields(&extensions.ThirdPartyResourceData{}), nil},
 	}
 
-	// re-test all v1 kinds with v1beta3 conversion functions
-	kindFieldsLen := len(kindFields)
-	for i := 0; i < kindFieldsLen; i++ {
-		if kindFields[i].apiVersion == testapi.Default.Version() {
-			kfs := kindFields[i]
-			kfs.apiVersion = "v1beta3"
-			kindFields = append(kindFields, kfs)
-		}
-	}
-
 	badFieldLabels := []string{
 		".name",
 		"bad",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -84,6 +84,7 @@ func addConversionFuncs() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
+				"metadata.namespace",
 				"status.replicas":
 				return label, value, nil
 			default:
@@ -118,7 +119,52 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name", "metadata.name", "status.phase":
+			case "name":
+				return "metadata.name", value, nil
+			case "metadata.name", "status.phase":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "PersistentVolume",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return "metadata.name", value, nil
+			case "metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "PersistentVolumeClaim",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return "metadata.name", value, nil
+			case "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ResourceQuota",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -144,7 +190,7 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ServiceAccount",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name":
+			case "metadata.name", "metadata.namespace":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion.go
@@ -118,7 +118,7 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "status.phase":
+			case "name", "metadata.name", "status.phase":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
@@ -126,7 +126,7 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "status.phase":
+			case "name", "metadata.name", "status.phase":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
@@ -61,7 +61,8 @@ func addConversionFuncs() {
 				"metadata.labels",
 				"metadata.annotations",
 				"status.podIP",
-				"status.phase":
+				"status.phase",
+				"spec.nodeName":
 				return label, value, nil
 			case "spec.host":
 				return "spec.nodeName", value, nil
@@ -92,6 +93,7 @@ func addConversionFuncs() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
+				"metadata.namespace",
 				"status.replicas":
 				return label, value, nil
 			default:
@@ -126,7 +128,52 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name", "metadata.name", "status.phase":
+			case "name":
+				return "metadata.name", value, nil
+			case "metadata.name", "status.phase":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "PersistentVolume",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return "metadata.name", value, nil
+			case "metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "PersistentVolumeClaim",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "name":
+				return "metadata.name", value, nil
+			case "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "ResourceQuota",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -152,7 +199,7 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "ServiceAccount",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name":
+			case "metadata.name", "metadata.namespace":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion.go
@@ -61,8 +61,7 @@ func addConversionFuncs() {
 				"metadata.labels",
 				"metadata.annotations",
 				"status.podIP",
-				"status.phase",
-				"spec.nodeName":
+				"status.phase":
 				return label, value, nil
 			case "spec.host":
 				return "spec.nodeName", value, nil
@@ -93,7 +92,6 @@ func addConversionFuncs() {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name",
-				"metadata.namespace",
 				"status.replicas":
 				return label, value, nil
 			default:
@@ -128,52 +126,7 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "Namespace",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "name":
-				return "metadata.name", value, nil
-			case "metadata.name", "status.phase":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		})
-	if err != nil {
-		// If one of the conversion functions is malformed, detect it immediately.
-		panic(err)
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "PersistentVolume",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "name":
-				return "metadata.name", value, nil
-			case "metadata.name":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		})
-	if err != nil {
-		// If one of the conversion functions is malformed, detect it immediately.
-		panic(err)
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "PersistentVolumeClaim",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "name":
-				return "metadata.name", value, nil
-			case "metadata.name", "metadata.namespace":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		})
-	if err != nil {
-		// If one of the conversion functions is malformed, detect it immediately.
-		panic(err)
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "ResourceQuota",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "metadata.name", "metadata.namespace":
+			case "status.phase":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)
@@ -199,7 +152,7 @@ func addConversionFuncs() {
 	err = api.Scheme.AddFieldLabelConversionFunc("v1beta3", "ServiceAccount",
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace":
+			case "metadata.name":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apis/extensions/v1beta1/conversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"reflect"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -41,6 +42,62 @@ func addConversionFuncs() {
 		convert_api_VolumeSource_To_v1beta1_VolumeSource,
 		convert_v1beta1_VolumeSource_To_api_VolumeSource,
 	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta1", "DaemonSet",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta1", "Deployment",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta1", "Ingress",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+
+	err = api.Scheme.AddFieldLabelConversionFunc("v1beta1", "Job",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", "status.successful":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)


### PR DESCRIPTION
- New selectable fields of Namespace added upstream:
  - "metadata.name"
  - "name"

which were not covered by field label conversion functions.

Resolves #5462