### PR TITLE
Bug 1268000 - replace Image.DockerImageReference with value from status.

### DIFF
--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -236,13 +236,18 @@ func newISTag(tag string, imageStream *api.ImageStream, image *api.Image) (*api.
 		if err != nil {
 			return nil, err
 		}
-
 		ist.Image = *imageWithMetadata
 	} else {
 		ist.Image = api.Image{}
-		ist.Image.DockerImageReference = event.DockerImageReference
 		ist.Image.Name = event.Image
 	}
+
+	// Replace the DockerImageReference with the value from event, which contains
+	// real value from status. This should fix the problem for v1 registries,
+	// where mutliple tags point to a single id and only the first image's metadata
+	// is saved. This in turn will always return the pull spec from the first
+	// imported image, which might be different than the requested tag.
+	ist.Image.DockerImageReference = event.DockerImageReference
 
 	return ist, nil
 }

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -200,7 +200,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "test:newest" || fromTag.Image.UID == "" || fromTag.Image.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newest" || fromTag.Image.UID == "" || fromTag.Image.DockerImageReference != "different" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 
@@ -235,7 +235,7 @@ func TestImageStreamMappingCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if fromTag.Name != "test:newest" || fromTag.Image.UID == "" || fromTag.Image.DockerImageReference != "some/other/name" {
+	if fromTag.Name != "test:newest" || fromTag.Image.UID == "" || fromTag.Image.DockerImageReference != "different" {
 		t.Errorf("unexpected object: %#v", fromTag)
 	}
 	fromTag, err = clusterAdminClient.ImageStreamTags(testutil.Namespace()).Get(stream.Name, "anothertag")


### PR DESCRIPTION
Fixes #5481 and https://bugzilla.redhat.com/show_bug.cgi?id=1268000.

@miminar @ncdc ptal