### PR TITLE
Only run pod nodeenv admission on create

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -212,3 +212,29 @@ func TestObjectMetaUpdate(t *testing.T) {
 		}
 	}
 }
+
+func TestPodSpecNodeSelectorUpdateDisallowed(t *testing.T) {
+	oldPod := &kapi.Pod{
+		ObjectMeta: kapi.ObjectMeta{
+			ResourceVersion: "1",
+		},
+		Spec: kapi.PodSpec{
+			NodeSelector: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	if errs := validation.ValidatePodUpdate(oldPod, oldPod); len(errs) != 0 {
+		t.Fatal("expected no errors")
+	}
+
+	newPod := *oldPod
+	// use a new map so it doesn't change oldPod's map too
+	newPod.Spec.NodeSelector = map[string]string{"foo": "other"}
+
+	errs := validation.ValidatePodUpdate(&newPod, oldPod)
+	if len(errs) == 0 {
+		t.Fatal("expected at least 1 error")
+	}
+}

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -122,3 +122,22 @@ func TestPodAdmission(t *testing.T) {
 		}
 	}
 }
+
+func TestHandles(t *testing.T) {
+	for op, shouldHandle := range map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  false,
+		admission.Connect: false,
+		admission.Delete:  false,
+	} {
+		n, err := NewPodNodeEnvironment(nil)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		if e, a := shouldHandle, n.Handles(op); e != a {
+			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
+		}
+	}
+}


### PR DESCRIPTION
Only run pod nodeenv admission on create. Don't run it on update. Fixes
the following scenario:

1. label a node with region=infra
2. set project's default node selector to region=infra
3. create a pod with node selector region=infra
4. change project's default node selector to region=primary
5. try to delete pod

Without this fix, the nodeenv admission plugin will reject a pod update
with this error:

    Failed to updated pod status: error updating status for pod
    "docker-registry-1-jo0js_default": pods "docker-registry-1-jo0js" is
    forbidden: pod node label selector conflicts with its project node
    label selector.

The end result is the pod remains in the Terminating phase, instead of
being deleted.

Fixes bug 1274239