### PR TITLE
Removed unneeded squash and chown from nfs doc

### DIFF
--- a/examples/wordpress/nfs/README.md
+++ b/examples/wordpress/nfs/README.md
@@ -14,17 +14,13 @@ Create two NFS exports, each of which will become a Persistent Volume in the clu
 mkdir -p /home/data/pv0001
 mkdir -p /home/data/pv0002
 
-# data written to NFS by a pod gets squashed by NFS and is owned by 'nfsnobody'
-# we'll make our export directories owned by the same user
-chown -R nfsnobody:nfsnobody /home/data
-
 # security needs to be permissive currently, but the export will soon be restricted 
 # to the same UID/GID that wrote the data
 chmod -R 777 /home/data/
 
 # Add to /etc/exports
-/home/data/pv0001 *(rw,sync,no_root_squash)
-/home/data/pv0002 *(rw,sync,no_root_squash)
+/home/data/pv0001 *(rw,sync)
+/home/data/pv0002 *(rw,sync)
 
 # Enable the new exports without bouncing the NFS service
 exportfs -a


### PR DESCRIPTION
I tested through examples/wordpress/nfs without `no_root_squash` and with the exports owned by root (subsequent writes by pods are owned by the expected uid).

Chown and squash are both not needed.

@eparis @smarterclayton 