### PR TITLE
Add local IP addresses to node certificate

### DIFF
--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -204,6 +204,11 @@ func (o NodeOptions) CreateNodeConfig() error {
 		return err
 	}
 
+	hostnames, err := o.NodeArgs.GetServerCertHostnames()
+	if err != nil {
+		return err
+	}
+
 	nodeConfigDir := o.NodeArgs.ConfigDir.Value()
 	createNodeConfigOptions := admin.CreateNodeConfigOptions{
 		SignerCertOptions: getSignerOptions,
@@ -211,7 +216,7 @@ func (o NodeOptions) CreateNodeConfig() error {
 		NodeConfigDir: nodeConfigDir,
 
 		NodeName:            o.NodeArgs.NodeName,
-		Hostnames:           []string{o.NodeArgs.NodeName},
+		Hostnames:           hostnames.List(),
 		VolumeDir:           o.NodeArgs.VolumeDir,
 		ImageTemplate:       o.NodeArgs.ImageFormatArgs.ImageTemplate,
 		AllowDisabledDocker: o.NodeArgs.AllowDisabledDocker,


### PR DESCRIPTION
When running the following commands, add local IP addresses (or the listen IP if specified explicitly) to the generated node serving certificate:
```
openshift start
openshift start --write-config=...
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1273818
Fixes #5294