### PR TITLE
Add users/<name>/projects endpoint

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14194,6 +14194,81 @@
     ]
    },
    {
+    "path": "/oapi/v1/users/{name}/projects",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.ProjectList",
+      "method": "GET",
+      "summary": "read projects of the specified ProjectList",
+      "nickname": "readNamespacedProjectListProjects",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ProjectList",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ProjectList"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1",
     "description": "OpenShift REST API, version v1",
     "operations": [

--- a/pkg/authorization/api/types.go
+++ b/pkg/authorization/api/types.go
@@ -87,7 +87,7 @@ var (
 		// TODO remove once we have eliminated the namespace scoped resource.
 		PermissionGrantingGroupName: {"roles", "rolebindings", "resourceaccessreviews" /* cluster scoped*/, "subjectaccessreviews" /* cluster scoped*/, "localresourceaccessreviews", "localsubjectaccessreviews"},
 		OpenshiftExposedGroupName:   {BuildGroupName, ImageGroupName, DeploymentGroupName, TemplateGroupName, "routes"},
-		OpenshiftAllGroupName: {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, SDNGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects",
+		OpenshiftAllGroupName: {OpenshiftExposedGroupName, UserGroupName, OAuthGroupName, PolicyOwnerGroupName, SDNGroupName, PermissionGrantingGroupName, OpenshiftStatusGroupName, "projects", "users/projects",
 			"clusterroles", "clusterrolebindings", "clusterpolicies", "clusterpolicybindings", "images" /* cluster scoped*/, "projectrequests"},
 		OpenshiftStatusGroupName: {"imagestreams/status", "routes/status"},
 

--- a/pkg/client/projects.go
+++ b/pkg/client/projects.go
@@ -17,6 +17,7 @@ type ProjectInterface interface {
 	Delete(name string) error
 	Get(name string) (*projectapi.Project, error)
 	List(label labels.Selector, field fields.Selector) (*projectapi.ProjectList, error)
+	ListForUser(username string, label labels.Selector, field fields.Selector) (*projectapi.ProjectList, error)
 }
 
 type projects struct {
@@ -42,6 +43,20 @@ func (c *projects) List(label labels.Selector, field fields.Selector) (result *p
 	result = &projectapi.ProjectList{}
 	err = c.r.Get().
 		Resource("projects").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+	return
+}
+
+// ListForUser returns all projects for the provided user
+func (c *projects) ListForUser(username string, label labels.Selector, field fields.Selector) (result *projectapi.ProjectList, err error) {
+	result = &projectapi.ProjectList{}
+	err = c.r.Get().
+		Resource("users").
+		Name(username).
+		SubResource("projects").
 		LabelsSelectorParam(label).
 		FieldsSelectorParam(field).
 		Do().

--- a/pkg/client/testclient/fake_projects.go
+++ b/pkg/client/testclient/fake_projects.go
@@ -32,6 +32,15 @@ func (c *FakeProjects) List(label labels.Selector, field fields.Selector) (*proj
 	return obj.(*projectapi.ProjectList), err
 }
 
+func (c *FakeProjects) ListForUser(username string, label labels.Selector, field fields.Selector) (result *projectapi.ProjectList, err error) {
+	obj, err := c.Fake.Invokes(ktestclient.NewRootListAction("user-projects", label, field), &projectapi.ProjectList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*projectapi.ProjectList), err
+}
+
 func (c *FakeProjects) Create(inObj *projectapi.Project) (*projectapi.Project, error) {
 	obj, err := c.Fake.Invokes(ktestclient.NewRootCreateAction("projects", inObj), inObj)
 	if obj == nil {

--- a/pkg/project/registry/project/proxy/proxy_test.go
+++ b/pkg/project/registry/project/proxy/proxy_test.go
@@ -72,7 +72,7 @@ func TestCreateProjectBadObject(t *testing.T) {
 
 func TestCreateInvalidProject(t *testing.T) {
 	mockClient := &testclient.Fake{}
-	storage := NewREST(mockClient.Namespaces(), &mockLister{})
+	storage, _ := NewREST(mockClient.Namespaces(), &mockLister{}, nil)
 	_, err := storage.Create(nil, &api.Project{
 		ObjectMeta: kapi.ObjectMeta{
 			Annotations: map[string]string{"openshift.io/display-name": "h\t\ni"},
@@ -85,7 +85,7 @@ func TestCreateInvalidProject(t *testing.T) {
 
 func TestCreateProjectOK(t *testing.T) {
 	mockClient := &testclient.Fake{}
-	storage := NewREST(mockClient.Namespaces(), &mockLister{})
+	storage, _ := NewREST(mockClient.Namespaces(), &mockLister{}, nil)
 	_, err := storage.Create(kapi.NewContext(), &api.Project{
 		ObjectMeta: kapi.ObjectMeta{Name: "foo"},
 	})
@@ -102,7 +102,7 @@ func TestCreateProjectOK(t *testing.T) {
 
 func TestGetProjectOK(t *testing.T) {
 	mockClient := testclient.NewSimpleFake(&kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
-	storage := NewREST(mockClient.Namespaces(), &mockLister{})
+	storage, _ := NewREST(mockClient.Namespaces(), &mockLister{}, nil)
 	project, err := storage.Get(kapi.NewContext(), "foo")
 	if project == nil {
 		t.Error("Unexpected nil project")

--- a/pkg/user/cache/groups.go
+++ b/pkg/user/cache/groups.go
@@ -33,6 +33,22 @@ func ByUserIndexKeys(obj interface{}) ([]string, error) {
 	return group.Users, nil
 }
 
+type GroupNameRetriever struct {
+	*GroupCache
+}
+
+func (r GroupNameRetriever) GroupsFor(username string) ([]string, error) {
+	groups, err := r.GroupCache.GroupsFor(username)
+	if err != nil {
+		return nil, err
+	}
+	names := []string{}
+	for _, g := range groups {
+		names = append(names, g.Name)
+	}
+	return names, nil
+}
+
 func NewGroupCache(groupRegistry groupregistry.Registry) *GroupCache {
 	allNamespaceContext := kapi.WithNamespace(kapi.NewContext(), kapi.NamespaceAll)
 

--- a/pkg/user/retriever/retriever.go
+++ b/pkg/user/retriever/retriever.go
@@ -1,0 +1,58 @@
+package user
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+	authuser "k8s.io/kubernetes/pkg/auth/user"
+
+	"github.com/openshift/origin/pkg/user/registry/user"
+)
+
+// GroupRetriever abstracts returning a list of groups the specified user is in.
+type GroupRetriever interface {
+	GroupsFor(name string) ([]string, error)
+}
+
+// RegistryRetriever retrieves user.Info objects from a user name.
+type RegistryRetriever struct {
+	users  user.Registry
+	groups GroupRetriever
+
+	allowUserErrors  bool
+	allowGroupErrors bool
+}
+
+// NewRegistryRetriever allows user.Info objects to be retrieved with group info.
+// TODO: insert virtual groups for system users
+func NewRegistryRetriever(users user.Registry, groups GroupRetriever, allowUserErrors bool, allowGroupErrors bool) *RegistryRetriever {
+	return &RegistryRetriever{
+		users:  users,
+		groups: groups,
+
+		allowUserErrors:  allowUserErrors,
+		allowGroupErrors: allowGroupErrors,
+	}
+}
+
+// User returns information about the provided user or an error. If user or group errors
+// are ignored, the remaining info is left empty.
+func (r *RegistryRetriever) User(name string) (authuser.Info, error) {
+	info := &authuser.DefaultInfo{Name: name}
+
+	user, err := r.users.GetUser(kapi.NewContext(), name)
+	if err != nil && !r.allowUserErrors {
+		return nil, err
+	}
+	if user != nil {
+		info.Name = user.Name
+		info.UID = string(user.UID)
+	}
+
+	// use name on the info in case it is different
+	groups, err := r.groups.GroupsFor(info.Name)
+	if err != nil && !r.allowGroupErrors {
+		return nil, err
+	}
+	info.Groups = groups
+
+	return info, nil
+}


### PR DESCRIPTION
Does not do magic group inference on virtual users, although a user can always view their own projects (we treat /users/self/projects exactly like /projects).

Only invocable by cluster-admins and cluster-readers.