### PR TITLE
Handle passwords with colon in basic auth

### DIFF
--- a/pkg/auth/authenticator/request/basicauthrequest/basicauth.go
+++ b/pkg/auth/authenticator/request/basicauthrequest/basicauth.go
@@ -53,8 +53,8 @@ func getBasicAuthInfo(r *http.Request) (string, string, bool, error) {
 		return "", "", false, errors.New("No valid base64 data in basic auth scheme found")
 	}
 
-	cred := strings.Split(string(str), ":")
-	if len(cred) != 2 {
+	cred := strings.SplitN(string(str), ":", 2)
+	if len(cred) < 2 {
 		return "", "", false, errors.New("Invalid Authorization header")
 	}
 


### PR DESCRIPTION
While parsing the basic-auth header (Basic username:password) it checked that it had exactly two parts separated with a colon (":"). This doesn't work if the password itself contains one or more ":" characters.

Fixes bug 1276599