### PR TITLE
source-to-image bump to get cleaner build logs

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -690,47 +690,47 @@
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
 			"Comment": "v1.0.3-16-g9728b53",
-			"Rev": "9728b53c11218598acb2cc1b9c8cc762c36f44bc"
+			"Rev": "65d46436ab599633b76e570311a05f46a818389b"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
+++ b/Godeps/_workspace/src/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
@@ -2,7 +2,9 @@ package sti
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -444,9 +446,16 @@ func (b *STI) Execute(command string, config *api.Config) error {
 				}
 				break
 			}
-			if glog.V(2) || config.Quiet != true || command == api.Usage {
-				glog.Info(text)
+			// Nothing is printed when the quiet option is set
+			if config.Quiet {
+				continue
 			}
+			// The log level > 3 forces to use glog instead of printing to stdout
+			if glog.V(3) {
+				glog.Info(text)
+				continue
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", strings.TrimSpace(text))
 		}
 	}(outReader)
 


### PR DESCRIPTION
With this path we're getting rid of glog prefix in build logs.