### PR TITLE
Bug 1275564 - Removed the requirement for spec.dockerImageRepository from import-image command

### DIFF
--- a/pkg/cmd/cli/cmd/importimage.go
+++ b/pkg/cmd/cli/cmd/importimage.go
@@ -83,22 +83,12 @@ func RunImportImage(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 			Spec:       imageapi.ImageStreamSpec{DockerImageRepository: from},
 		}
 	} else {
-		if len(stream.Spec.DockerImageRepository) == 0 {
-			if len(from) == 0 {
-				return fmt.Errorf("only image streams with spec.dockerImageRepository set may have images imported")
-			}
-			if !confirm {
-				return fmt.Errorf("the image stream already has an import repository set, pass --confirm to update")
-			}
-			stream.Spec.DockerImageRepository = from
-		} else {
-			if len(from) != 0 {
-				if from != stream.Spec.DockerImageRepository {
-					if !confirm {
-						return fmt.Errorf("the image stream has a different import spec %q, pass --confirm to update", stream.Spec.DockerImageRepository)
-					}
-					stream.Spec.DockerImageRepository = from
+		if len(from) != 0 {
+			if from != stream.Spec.DockerImageRepository {
+				if !confirm {
+					return fmt.Errorf("the image stream has a different import spec %q, pass --confirm to update", stream.Spec.DockerImageRepository)
 				}
+				stream.Spec.DockerImageRepository = from
 			}
 		}
 	}


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1275564.

@miminar ptal