### PR TITLE
Systemd throws an error on Restart=Always

### DIFF
--- a/contrib/systemd/atomic-openshift-node.service
+++ b/contrib/systemd/atomic-openshift-node.service
@@ -14,7 +14,7 @@ LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=atomic-openshift-node
-Restart=Always
+Restart=always
 OOMScoreAdjust=-999
 
 [Install]

--- a/contrib/systemd/origin-node.service
+++ b/contrib/systemd/origin-node.service
@@ -14,7 +14,7 @@ LimitNOFILE=65536
 LimitCORE=infinity
 WorkingDirectory=/var/lib/origin/
 SyslogIdentifier=origin-node
-Restart=Always
+Restart=always
 OOMScoreAdjust=-999
 
 [Install]


### PR DESCRIPTION
Always should not be capitalized.

CC: @sosiouxme 
@abutcher need to make sure the HA services in ansible, don't have this problem too.