### PR TITLE
WIP: Optimize deploymentConfig status updates

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -16987,6 +16987,10 @@
        "$ref": "v1.DeploymentCause"
       },
       "description": "extended data associated with all the causes for creating a new deployment"
+     },
+     "lastMessageUpdatedTime": {
+      "type": "string",
+      "description": "the last time message was updated"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1420,6 +1420,11 @@ func deepCopy_api_DeploymentDetails(in deployapi.DeploymentDetails, out *deploya
 	} else {
 		out.Causes = nil
 	}
+	if newVal, err := c.DeepCopy(in.LastMessageUpdatedTime); err != nil {
+		return err
+	} else {
+		out.LastMessageUpdatedTime = newVal.(unversioned.Time)
+	}
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1479,6 +1479,11 @@ func deepCopy_v1_DeploymentDetails(in deployapiv1.DeploymentDetails, out *deploy
 	} else {
 		out.Causes = nil
 	}
+	if newVal, err := c.DeepCopy(in.LastMessageUpdatedTime); err != nil {
+		return err
+	} else {
+		out.LastMessageUpdatedTime = newVal.(unversioned.Time)
+	}
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1487,6 +1487,11 @@ func deepCopy_v1beta3_DeploymentDetails(in deployapiv1beta3.DeploymentDetails, o
 	} else {
 		out.Causes = nil
 	}
+	if newVal, err := c.DeepCopy(in.LastMessageUpdatedTime); err != nil {
+		return err
+	} else {
+		out.LastMessageUpdatedTime = newVal.(unversioned.Time)
+	}
 	return nil
 }
 

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -310,6 +310,8 @@ type DeploymentDetails struct {
 	Message string
 	// Causes are extended data associated with all the causes for creating a new deployment
 	Causes []*DeploymentCause
+	// LastMessageUpdatedTime is the last time the message was updated.
+	LastMessageUpdatedTime unversioned.Time
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -301,6 +301,8 @@ type DeploymentDetails struct {
 	Message string `json:"message,omitempty" description:"a user specified change message"`
 	// Causes are extended data associated with all the causes for creating a new deployment
 	Causes []*DeploymentCause `json:"causes,omitempty" description:"extended data associated with all the causes for creating a new deployment"`
+	// LastMessageUpdatedTime is the last time message was updated.
+	LastMessageUpdatedTime unversioned.Time `json:"lastMessageUpdatedTime,omitempty" description:"the last time message was updated"`
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -315,6 +315,8 @@ type DeploymentDetails struct {
 	Message string `json:"message,omitempty" description:"a user specified change message"`
 	// Extended data associated with all the causes for creating a new deployment
 	Causes []*DeploymentCause `json:"causes,omitempty" description:"extended data associated with all the causes for creating a new deployment"`
+	// LastMessageUpdatedTime is the last time message was updated.
+	LastMessageUpdatedTime unversioned.Time `json:"lastMessageUpdatedTime,omitempty" description:"the last time message was updated"`
 }
 
 // DeploymentCause captures information about a particular cause of a deployment.

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -13,7 +13,6 @@ import (
 	kutil "k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/watch"
 
-	buildapi "github.com/openshift/origin/pkg/build/api"
 	osclient "github.com/openshift/origin/pkg/client"
 	controller "github.com/openshift/origin/pkg/controller"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
@@ -52,9 +51,6 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 	queue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
 	cache.NewReflector(deploymentConfigLW, &deployapi.DeploymentConfig{}, queue, 2*time.Minute).Run()
 
-	buildConfigStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	cache.NewReflector(buildConfigLW, &buildapi.BuildConfig{}, buildConfigStore, 2*time.Minute).Run()
-
 	configController := &DeploymentConfigController{
 		deploymentClient: &deploymentClientImpl{
 			createDeploymentFunc: func(namespace string, deployment *kapi.ReplicationController) (*kapi.ReplicationController, error) {
@@ -76,7 +72,6 @@ func (factory *DeploymentConfigControllerFactory) Create() controller.RunnableCo
 		makeDeployment: func(config *deployapi.DeploymentConfig) (*kapi.ReplicationController, error) {
 			return deployutil.MakeDeployment(config, factory.Codec)
 		},
-		buildConfigs:        buildConfigStore,
 		messageUpdatePeriod: DefaultMessageUpdatePeriod,
 		now:                 defaultNow,
 	}


### PR DESCRIPTION
## :construction: WIP :construction: 

Optimize deploymentConfig status updates. Goals:

1. Limit updates to occur at most once per configurable period
2. Optimize expensive API calls (e.g. full buildConfig list per trigger)
3. Optimize status string building to reduce memory consumption (if necessary given 1 and 2)

The current code will recompute every time the deploymentConfig changes. Memory consumption is analyzed in #5504.

Fixes #5504