### PR TITLE
Improve UI performance when displaying large logs

### DIFF
--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -119,9 +119,11 @@ angular
       })
       .when('/project/:project/browse/builds/:buildconfig/:build', {
         templateUrl: function(params) {
-          return params.view ?
-                  'views/logs/'+params.view+'_log.html' :
-                  'views/browse/build.html';
+          if (params.view === 'chromeless') {
+            return 'views/logs/chromeless-build-log.html';
+          }
+
+          return 'views/browse/build.html';
         },
         controller: 'BuildController'
       })
@@ -157,9 +159,11 @@ angular
       })
       .when('/project/:project/browse/pods/:pod', {
         templateUrl: function(params) {
-          return params.view ?
-                  'views/logs/'+params.view+'_log.html' :
-                  'views/browse/pod.html';
+          if (params.view === 'chromeless') {
+            return 'views/logs/chromeless-pod-log.html';
+          }
+
+          return 'views/browse/pod.html';
         },
         controller: 'PodController'
       })

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -10,35 +10,174 @@ angular.module('openshiftConsole')
         transclude: true,
         templateUrl: 'views/directives/logs/_log-viewer.html',
         scope: {
-          logs: '=',
-          loading: '=',
-          links: '=',
+          kind: '@',
           name: '=',
-          download: '=',
-          start: '=',
-          end: '='
+          context: '=',
+          options: '=?',
+          status: '=?',
+          start: '=?',
+          end: '=?',
+          chromeless: '=?'
         },
         controller: [
           '$scope',
           function($scope) {
+            $scope.loading = true;
+
+            // Default to false. Let the user click the follow link to start auto-scrolling.
+            $scope.autoScroll = false;
+
+            // Set to true when we auto-scroll to follow log content.
+            var autoScrolling = false;
+            var onScroll = function() {
+              // Determine if the user scrolled or we auto-scrolled.
+              if (autoScrolling) {
+                // Reset the value.
+                autoScrolling = false;
+              } else {
+                // If the user scrolled the window manually, stop auto-scrolling.
+                $scope.$evalAsync(function() {
+                  $scope.autoScroll = false;
+                });
+              }
+            };
+            $(window).scroll(onScroll);
+
+            var scrollBottom = function() {
+              // Tell the scroll listener this is an auto-scroll. The listener
+              // will reset it to false.
+              autoScrolling = true;
+              logLinks.scrollBottom();
+            };
+
+            var toggleAutoScroll = function() {
+              $scope.autoScroll = !$scope.autoScroll;
+              if ($scope.autoScroll) {
+                // Scroll immediately. Don't wait the next message.
+                scrollBottom();
+              }
+            };
+
+            var scrollTop = function() {
+              // Stop auto-scrolling when the user clicks the scroll top link.
+              $scope.autoScroll = false;
+              logLinks.scrollTop();
+            };
+
+            // maintaining one streamer reference & ensuring its closed before we open a new,
+            // since the user can (potentially) swap between multiple containers
+            var streamer;
+            var stopStreaming = function(keepContent) {
+              if (streamer) {
+                streamer.stop();
+                streamer = null;
+              }
+              if (!keepContent) {
+                $('#logContent').empty();
+              }
+            };
+
+            var streamLogs = function() {
+              // Stop any active streamer.
+              stopStreaming();
+
+              if (!$scope.name) {
+                return;
+              }
+
+              $scope.$evalAsync(function() {
+                angular.extend($scope, {
+                  loading: true,
+                  error: false,
+                  autoScroll: false,
+                  limitReached: false
+                });
+              });
+
+              var options = angular.extend({
+                follow: true,
+                tailLines: 1000,
+                limitBytes: 10 * 1024 * 1024 // Limit log size to 10 MiB
+              }, $scope.options);
+              streamer =
+                DataService.createStream($scope.kind, $scope.name, $scope.context, options);
+
+              var lastLineNumber = 0;
+              streamer.onMessage(function(msg, raw, cumulativeBytes) {
+                if (options.limitBytes && cumulativeBytes >= options.limitBytes) {
+                  $scope.$evalAsync(function() {
+                    $scope.limitReached = true;
+                    $scope.loading = false;
+                  });
+                  stopStreaming(true);
+                }
+
+                lastLineNumber++;
+
+                // Manipulate the DOM directly for better performance displaying large log files.
+                var logLine = $('<div row class="log-line"/>');
+                $('<div class="log-line-number"><div row flex main-axis="end">' + lastLineNumber + '</div></div>').appendTo(logLine);
+                $('<div flex class="log-line-text"/>').text(msg).appendTo(logLine);
+                logLine.appendTo('#logContent');
+
+                // Follow the bottom of the log if auto-scroll is on.
+                if ($scope.autoScroll) {
+                  scrollBottom();
+                }
+
+                // Show the start and end links if the log is more than 25 lines.
+                if (!$scope.showScrollLinks && lastLineNumber > 25) {
+                  $scope.$evalAsync(function() {
+                    $scope.showScrollLinks = true;
+                  });
+                }
+
+                // Warn the user if we might be showing a partial log.
+                if (!$scope.largeLog && lastLineNumber >= options.tailLines) {
+                  $scope.$evalAsync(function() {
+                    $scope.largeLog = true;
+                  });
+                }
+              });
+
+              streamer.onClose(function() {
+                streamer = null;
+                $scope.$evalAsync(function() {
+                  angular.extend($scope, {
+                    loading: false,
+                    autoScroll: false
+                  });
+                });
+              });
+
+              streamer.onError(function() {
+                streamer = null;
+                $scope.$evalAsync(function() {
+                  angular.extend($scope, {
+                    loading: false,
+                    error: true,
+                    autoScroll: false
+                  });
+                });
+              });
+
+              streamer.start();
+            };
+
+            $scope.$watchGroup(['name', 'options.container'], streamLogs);
+
+            $scope.$on('$destroy', function() {
+              stopStreaming();
+              $(window).off('scroll', onScroll);
+            });
+
             angular.extend($scope, {
               ready: true,
-              canDownload: logLinks.canDownload(),
-              makeDownload: _.flow(function(arr) {
-                                    return _.reduce(
-                                              arr,
-                                              function(memo, next, i) {
-                                                return i <= arr.length ?
-                                                        memo + next.text :
-                                                        memo;
-                                              }, '');
-                                  }, logLinks.makeDownload),
-              scrollTo: logLinks.scrollTo,
-              scrollTop: logLinks.scrollTop,
               scrollBottom: logLinks.scrollBottom,
-              goFull: logLinks.fullPageLink,
+              scrollTop: scrollTop,
+              toggleAutoScroll: toggleAutoScroll,
               goChromeless: logLinks.chromelessLink,
-              goText: logLinks.textOnlyLink
+              restartLogs: streamLogs
             });
           }
         ]

--- a/assets/app/scripts/services/logLinks.js
+++ b/assets/app/scripts/services/logLinks.js
@@ -10,33 +10,6 @@ angular.module('openshiftConsole')
     function($anchorScroll, $document, $location, $timeout, $window) {
       // TODO (bpeterse): a lot of these functions are generic and could be moved/renamed to
       // a navigation oriented service.
-      var doc = $document[0];
-
-      var createObjectURL = function() {
-        return (window.URL || window.webkitURL || {}).createObjectURL || _.noop;
-      };
-
-      var revokeObjectURL = function() {
-        return (window.URL || window.webkitURL || {}).revokeObjectURL || _.noop;
-      };
-
-      var canDownload = function() {
-        return !!createObjectURL();
-      };
-
-      var makeDownload = function(obj, filename) {
-        obj = _.isString(obj) ? obj : JSON.stringify(obj);
-        var a = doc.createElement('a');
-        a.href = createObjectURL()(new Blob([obj], {type: 'text/plain'}));
-        a.download = (filename || 'download') + '.txt';
-        doc.body.appendChild(a);
-        a.click();
-        // limit the resource lifespan & destroy
-        $timeout(function() {
-          revokeObjectURL()(a.href);
-          doc.body.removeChild(a);
-        }, 5000);
-      };
 
       var scrollTop = function() {
         $window.scrollTo(null, 0);
@@ -54,9 +27,6 @@ angular.module('openshiftConsole')
         $anchorScroll(anchor);
       };
 
-      var fullPageLink = function() {
-         $location.search('view', 'chromeless');
-      };
       // @params an object or array of objects
       var newTab = function(params) {
         params = _.isArray(params) ?
@@ -70,22 +40,26 @@ angular.module('openshiftConsole')
       };
 
       // new tab: path/to/current?view=chromeless
-      var chromelessLink = function() {
-        newTab({view: 'chromeless'});
+      var chromelessLink = function(options) {
+        var params = {
+          view: 'chromeless'
+        };
+        if (options && options.container) {
+          params.container = options.container;
+        }
+        newTab(params);
       };
 
+      // Not currently used.
       // new tab: path/to/current?view=textonly
       var textOnlyLink = function() {
         newTab({view: 'textonly'});
       };
 
       return {
-        canDownload: canDownload,
-        makeDownload: makeDownload,
         scrollTop: scrollTop,
         scrollBottom: scrollBottom,
         scrollTo: scrollTo,
-        fullPageLink: fullPageLink,
         newTab: newTab,
         chromelessLink: chromelessLink,
         textOnlyLink: textOnlyLink

--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -1,7 +1,7 @@
 .log-title {
   margin-top: 0;
 }
-.log-timestamp {
+.log-timestamp, .log-size-warning {
   margin-bottom: 10px;
 }
 .log-view {
@@ -114,6 +114,9 @@
 }
 .log-chromeless {
   margin-top: -1px;
+  .log-size-warning {
+    margin: 10px;
+  }
   .log-view {
     .log-scroll-top.affix {
       right: 0;

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -21,37 +21,22 @@
                 <ng-include src=" 'views/browse/_build-details.html' "></ng-include>
               </tab>
 
-              <tab active="selectedTab.logs" select="initLogs()">
+              <tab active="selectedTab.logs">
                 <tab-heading>Logs</tab-heading>
                 <log-viewer
-                  logs="logs"
-                  loading="logsLoading"
-                  start="build.status.startTimestamp | date : 'short'"
-                  end="build.status.completionTimestamp | date : 'short'"
-                  links="true"
+                  ng-if="selectedTab.logs"
+                  kind="builds/log"
                   name="build.metadata.name"
-                  download="canShowDownload">
-                  <div row>
-                    <span>Status:&nbsp;&nbsp;</span>
-                    <status-icon status="build.status.phase"></status-icon>
-                    <span flex>&nbsp;&nbsp;{{build.status.phase}}</span>
-                  </div>
+                  context="logContext"
+                  status="build.status.phase"
+                  start="build.status.startTimestamp | date : 'short'"
+                  end="build.status.completionTimestamp | date : 'short'">
                 </log-viewer>
-                <!-- TODO: this should probably get moved up into the directive -->
-                <div ng-if="!logsLoading" class="text-muted">
-                  Log complete
-                </div>
-                <div ng-if="logError" class="text-muted">
-                  Log error
-                  <a href="" ng-click="runLogs()">reconnect?</a>
-                </div>
               </tab>
             </tabset>
-
-
           </div>
         </div>
       </div><!-- /.row -->
-    </div><!-- /build .well -->
+    </div><!-- /build -->
   </project-page>
 </div>

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -31,44 +31,32 @@
                 </pod-metrics>
               </tab>
 
-              <tab active="selectedTab.logs" select="initLogs()">
+              <tab active="selectedTab.logs">
                 <tab-heading>Logs</tab-heading>
 
-                <label for="selectContainer">Container:</label>
+                <label for="selectLogContainer">Container:</label>
 
-                <div class="select-container">
-                  <span ng-show="pod.spec.containers.length === 1">
-                    {{pod.spec.containers[0].name}}
-                  </span>
-                  <select id="selectContainer"
-                          ng-show="pod.spec.containers.length > 1"
-                          ng-init="selectedContainer = pod.spec.containers[0]"
-                          ng-model="selectedContainer"
-                          ng-options="container.name for container in pod.spec.containers track by container.name"
-                          ng-change="selectContainer(selectedContainer)">
-                  </select>
-                </div>
+                <span ng-if="pod.spec.containers.length === 1">
+                  {{pod.spec.containers[0].name}}
+                </span>
+
+                <select
+                    id="selectLogContainer"
+                    ng-if="pod.spec.containers.length > 1"
+                    ng-model="logOptions.container"
+                    ng-options="container.name as container.name for container in pod.spec.containers"
+                    ng-init="logOptions.container = pod.spec.containers[0].name">
+                </select>
 
                 <log-viewer
-                  logs="logs"
-                  loading="logsLoading"
-                  start="pod.status.startTime | date : 'short'"
-                  links="true"
-                  name="pod.metadata.name"
-                  download="canShowDownload">
-                  <div row>
-                    <span>Status:&nbsp;&nbsp;</span>
-                    <status-icon status="pod.status.phase"></status-icon>
-                    <span flex>&nbsp;&nbsp;{{pod.status.phase}}</span>
-                  </div>
+                    ng-if="selectedTab.logs"
+                    kind="pods/log"
+                    name="pod.metadata.name"
+                    context="logContext"
+                    options="logOptions"
+                    status="pod.status.phase"
+                    start="pod.status.startTime | date : 'short'">
                 </log-viewer>
-                <div ng-if="!logsLoading" class="text-muted">
-                  Log complete
-                </div>
-                <div ng-if="logError" class="text-muted">
-                  Log error
-                  <a href="" ng-click="restartLogs()">reconnect?</a>
-                </div>
               </tab>
 
               <tab active="selectedTab.terminal"

--- a/assets/app/views/directives/logs/_log-formatted.html
+++ b/assets/app/views/directives/logs/_log-formatted.html
@@ -5,47 +5,27 @@
 
   <div flex class="log-view">
     <div
-      ng-show="logs.length > 25"
+      ng-show="showScrollLinks"
       class="log-scroll log-scroll-top"
       affix
       offset-top="445"
       offset-bottom="90">
-      <a href="" ng-click="scrollBottom()">
+      <a ng-if="loading" href="" ng-click="toggleAutoScroll()">
+        <span ng-if="!autoScroll">Follow log</span>
+        <span ng-if="autoScroll">Stop following</span>
+      </a>
+      <a ng-if="!loading" href="" ng-click="scrollBottom()">
         Go to end of log
       </a>
     </div>
     <div flex column class="log-view-output">
-      <div
-        row
-        class="log-line"
-        ng-repeat="logLine in logs  | filter:logSearch"
-        ng-class-odd="'odd'"
-        ng-class-even="'even'">
-        <a
-          name="line_{{::$index+1}}"
-          id="line_{{::$index+1}}"></a>
-        <!-- not supporting click to line # yet
-        <a class="log-line-number"
-          ng-click="scrollTo('line_'+($index+1), $event)">
-          <div flex main-axis="end">
-          {{:: $index+1 }}
-          </div>
-        </a>
-        -->
-        <div class="log-line-number">
-          <div row flex main-axis="end">
-          {{:: $index+1 }}
-          </div>
-        </div>
-
-        <div flex class="log-line-text">{{::logLine.text}}</div>
-      </div>
+      <div id="logContent"></div>
       <div row main-axis="center">
         <ellipsis-loader ng-show="loading"></ellipsis-loader>
       </div>
     </div>
     <div
-      ng-show="logs.length > 25"
+      ng-show="showScrollLinks"
       class="log-scroll log-scroll-bottom">
       <a href="" ng-click="scrollTop()">Go to start of log</a>
     </div>

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -1,24 +1,24 @@
-<div column flex ng-if="links">
-  <div row mobile="column" class="log-timestamp" ng-if="start">
-    <span row>
-      <span>Current log from &nbsp;</span>
-      <span flex class="text-right">{{start}}</span>
-    </span>
-    <span row ng-if="end">
-      <span>&nbsp;to&nbsp;</span>
-      <span flex class="text-right">{{end}}</span>
-    </span>
+<div column flex>
+  <div row class="log-timestamp" ng-if="!chromeless && start">
+    <span>Current log from {{start}}&nbsp;</span>
+    <span ng-if="end">to {{end}}</span>
   </div>
-  <div sm="column" md="row">
-    <div flex row tablet="column" main-axis="end">
-      <div ng-transclude flex></div>
+  <div ng-if="largeLog" class="log-size-warning">
+    <span class="pficon pficon-info"></span>
+    Only the previous {{options.tailLines || 1000}} log lines and new log
+    messages will be displayed because of the large log size.
+  </div>
+  <div ng-if="!chromeless" row flex sm="column">
+    <div flex row tablet="column">
+      <div row ng-if="status">
+        <span>Status:&nbsp;&nbsp;</span>
+        <status-icon status="status"></status-icon>
+        <span flex>&nbsp;&nbsp;{{status}}</span>
+      </div>
+      <!-- Spacer -->
+      <div flex></div>
       <div row main-axis="end" cross-axis="end" class="log-link-external">
-        <a href=""
-          ng-show="download"
-          ng-click="makeDownload(logs)">
-          Raw <i class="fa fa-external-link"></i>
-        </a>
-        <a href=""  ng-click="goChromeless()">
+        <a href=""  ng-click="goChromeless(options)">
           Open full view of log<i class="fa fa-external-link"></i>
         </a>
       </div>
@@ -33,4 +33,15 @@
 <ng-include
   src="'views/directives/logs/_log-formatted.html'"></ng-include>
 
-
+<!-- Show a different messsage if the log might have stopped because we reached the byte limit -->
+<div ng-if="limitReached" class="text-muted">
+  The maximum web console log size has been reached. Use the command-line interface or
+  <a href="" ng-click="restartLogs()">reload</a> the log to see new messages.
+</div>
+<div ng-if="!loading && !limitReached && !error" class="text-muted">
+  End of log
+</div>
+<div ng-if="error" class="text-muted">
+  An error occurred.
+  <a href="" ng-click="restartLogs()">Reload</a>
+</div>

--- a/assets/app/views/logs/chromeless-build-log.html
+++ b/assets/app/views/logs/chromeless-build-log.html
@@ -1,0 +1,15 @@
+<div column flex class="content">
+  <div flex class="log-chromeless">
+    <alerts alerts="alerts"></alerts>
+    <log-viewer
+      kind="builds/log"
+      name="build.metadata.name"
+      context="logContext"
+      status="build.status.phase"
+      start="build.status.startTimestamp | date : 'short'"
+      end="build.status.completionTimestamp | date : 'short'"
+      chromeless="true"
+      flex>
+    </log-viewer>
+  </div>
+</div>

--- a/assets/app/views/logs/chromeless-pod-log.html
+++ b/assets/app/views/logs/chromeless-pod-log.html
@@ -1,0 +1,15 @@
+<div column flex class="content">
+  <div flex class="log-chromeless">
+    <alerts alerts="alerts"></alerts>
+    <log-viewer
+        kind="pods/log"
+        name="pod.metadata.name"
+        context="logContext"
+        options="logOptions"
+        status="pod.status.phase"
+        start="pod.status.startTime | date : 'short'"
+        chromeless="true"
+        flex>
+    </log-viewer>
+  </div>
+</div>

--- a/assets/app/views/logs/chromeless_log.html
+++ b/assets/app/views/logs/chromeless_log.html
@@ -1,9 +1,0 @@
-<div column flex class="content">
-  <div flex class="log-chromeless">
-    <alerts alerts="alerts"></alerts>
-    <log-viewer
-      logs="logs"
-      loading="logsLoading"
-      flex></log-viewer>
-  </div>
-</div>


### PR DESCRIPTION
Changes:

* Directly manipulate the DOM rather than using `ng-repeat` for better performance streaming large log files.
* Only show last 1000 lines and then follow large logs.
* Limit the number of bytes we'll stream.
* Add "Start following" link to auto-scroll streaming logs.
* Remove download log link which doesn't work in most browsers.
* Fix problem with container dropdown not working for pod logs.
* Fix error showing chromeless view of pod log when pod has multiple containers.
* Move duplicate code from build and pod controllers/view into log-viewer directive.
* Stop streaming log when user navigates away from Logs tab.

Fixes #5474
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1276212
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1276003 (removes the link)

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/10853374/1d6b03ca-7f0c-11e5-990a-a967ff21eb85.png)


Tested in Chrome, Firefox, IE, and Safari.