### PR TITLE
SCC sorting by priority

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -2080,6 +2080,13 @@ func deepCopy_api_SecurityContextConstraints(in SecurityContextConstraints, out 
 	if err := deepCopy_api_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
 		return err
 	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
+	}
+	out.Priority = in.Priority
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {
 		out.AllowedCapabilities = make([]Capability, len(in.AllowedCapabilities))

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2136,6 +2136,11 @@ type SecurityContextConstraints struct {
 	unversioned.TypeMeta
 	ObjectMeta
 
+	// Priority influences the sort order of SCCs when evaluating which SCCs to try first for
+	// a given pod request based on access in the Users and Groups fields.  The higher the int, the
+	// higher priority.  If scores for multiple SCCs are equal they will be sorted by name.
+	Priority *int
+
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
 	AllowPrivilegedContainer bool
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2728,6 +2728,12 @@ func convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in 
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
+	}
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {
 		out.AllowedCapabilities = make([]Capability, len(in.AllowedCapabilities))
@@ -5729,6 +5735,12 @@ func convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in 
 	}
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
+	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
 	}
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -2130,6 +2130,12 @@ func deepCopy_v1_SecurityContextConstraints(in SecurityContextConstraints, out *
 	if err := deepCopy_v1_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
 		return err
 	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
+	}
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {
 		out.AllowedCapabilities = make([]Capability, len(in.AllowedCapabilities))

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -2590,6 +2590,11 @@ type SecurityContextConstraints struct {
 	unversioned.TypeMeta `json:",inline"`
 	ObjectMeta           `json:"metadata,omitempty"`
 
+	// Priority influences the sort order of SCCs when evaluating which SCCs to try first for
+	// a given pod request based on access in the Users and Groups fields.  The higher the int, the
+	// higher priority.  If scores for multiple SCCs are equal they will be sorted by name.
+	Priority *int `json:"priority" description:"determines which SCC is used when multiple SCCs allow a particular pod; higher priority SCCs are preferred"`
+
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
 	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer" description:"allow containers to run as privileged"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -2112,6 +2112,12 @@ func convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraint
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
+	}
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {
 		out.AllowedCapabilities = make([]Capability, len(in.AllowedCapabilities))
@@ -4439,6 +4445,12 @@ func convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraint
 	}
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
+	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
 	}
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
@@ -2111,6 +2111,12 @@ func deepCopy_v1beta3_SecurityContextConstraints(in SecurityContextConstraints, 
 	if err := deepCopy_v1beta3_ObjectMeta(in.ObjectMeta, &out.ObjectMeta, c); err != nil {
 		return err
 	}
+	if in.Priority != nil {
+		out.Priority = new(int)
+		*out.Priority = *in.Priority
+	} else {
+		out.Priority = nil
+	}
 	out.AllowPrivilegedContainer = in.AllowPrivilegedContainer
 	if in.AllowedCapabilities != nil {
 		out.AllowedCapabilities = make([]Capability, len(in.AllowedCapabilities))

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -2085,6 +2085,11 @@ type SecurityContextConstraints struct {
 	TypeMeta   `json:",inline"`
 	ObjectMeta `json:"metadata,omitempty"`
 
+	// Priority influences the sort order of SCCs when evaluating which SCCs to try first for
+	// a given pod request based on access in the Users and Groups fields.  The higher the int, the
+	// higher priority.  If scores for multiple SCCs are equal they will be sorted by name.
+	Priority *int `json:"priority" description:"determines which SCC is used when multiple SCCs allow a particular pod; higher priority SCCs are preferred"`
+
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
 	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer" description:"allow containers to run as privileged"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation.go
@@ -2038,6 +2038,12 @@ func ValidateSecurityContextConstraints(scc *api.SecurityContextConstraints) err
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMeta(&scc.ObjectMeta, false, ValidateSecurityContextConstraintsName).Prefix("metadata")...)
 
+	if scc.Priority != nil {
+		if *scc.Priority < 0 {
+			allErrs = append(allErrs, errs.NewFieldInvalid("priority", *scc.Priority, "priority cannot be negative"))
+		}
+	}
+
 	// ensure the user strat has a valid type
 	switch scc.RunAsUser.Type {
 	case api.RunAsUserStrategyMustRunAs, api.RunAsUserStrategyMustRunAsNonRoot, api.RunAsUserStrategyRunAsAny, api.RunAsUserStrategyMustRunAsRange:

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
@@ -4067,6 +4067,8 @@ func TestValidPodLogOptions(t *testing.T) {
 
 func TestValidateSecurityContextConstraints(t *testing.T) {
 	var invalidUID int64 = -1
+	var invalidPriority = -1
+	var validPriority = 1
 
 	validSCC := func() *api.SecurityContextConstraints {
 		return &api.SecurityContextConstraints{
@@ -4083,6 +4085,7 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 			SupplementalGroups: api.SupplementalGroupsStrategyOptions{
 				Type: api.SupplementalGroupsStrategyRunAsAny,
 			},
+			Priority: &validPriority,
 		}
 	}
 
@@ -4131,6 +4134,9 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 	invalidRangeNegativeMax.FSGroup.Ranges = []api.IDRange{
 		{Min: 1, Max: -10},
 	}
+
+	negativePriority := validSCC()
+	negativePriority.Priority = &invalidPriority
 
 	errorCases := map[string]struct {
 		scc         *api.SecurityContextConstraints
@@ -4201,6 +4207,11 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 			scc:         invalidRangeNegativeMax,
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "max cannot be negative",
+		},
+		"negative priority": {
+			scc:         negativePriority,
+			errorType:   errors.ValidationErrorTypeInvalid,
+			errorDetail: "priority cannot be negative",
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/resource_printer.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/jsonpath"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"strconv"
 )
 
 const (
@@ -407,7 +408,7 @@ var thirdPartyResourceColumns = []string{"NAME", "DESCRIPTION", "VERSION(S)"}
 var horizontalPodAutoscalerColumns = []string{"NAME", "REFERENCE", "TARGET", "CURRENT", "MINPODS", "MAXPODS", "AGE"}
 var withNamespacePrefixColumns = []string{"NAMESPACE"} // TODO(erictune): print cluster name too.
 var deploymentColumns = []string{"NAME", "UPDATEDREPLICAS", "AGE"}
-var securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "HOSTDIR", "SELINUX", "RUNASUSER", "FSGROUP", "SUPGROUP"}
+var securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "HOSTDIR", "SELINUX", "RUNASUSER", "FSGROUP", "SUPGROUP", "PRIORITY"}
 
 // addDefaultHandlers adds print handlers for default Kubernetes types.
 func (h *HumanReadablePrinter) addDefaultHandlers() {
@@ -1430,9 +1431,14 @@ func printHorizontalPodAutoscalerList(list *extensions.HorizontalPodAutoscalerLi
 }
 
 func printSecurityContextConstraints(item *api.SecurityContextConstraints, w io.Writer, withNamespace, wide, showAll bool, columnLabels []string) error {
-	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%t\t%s\t%s\t%s\t%s\n", item.Name, item.AllowPrivilegedContainer,
+	priority := "<none>"
+	if item.Priority != nil {
+		priority = strconv.Itoa(*item.Priority)
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%t\t%s\t%s\t%s\t%s\t%s\n", item.Name, item.AllowPrivilegedContainer,
 		item.AllowedCapabilities, item.AllowHostDirVolumePlugin, item.SELinuxContext.Type,
-		item.RunAsUser.Type, item.FSGroup.Type, item.SupplementalGroups.Type)
+		item.RunAsUser.Type, item.FSGroup.Type, item.SupplementalGroups.Type, priority)
 	return err
 }
 

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -14741,6 +14741,7 @@
    "v1.SecurityContextConstraints": {
     "id": "v1.SecurityContextConstraints",
     "required": [
+     "priority",
      "allowPrivilegedContainer",
      "allowedCapabilities",
      "allowHostDirVolumePlugin",
@@ -14760,6 +14761,11 @@
      },
      "metadata": {
       "$ref": "v1.ObjectMeta"
+     },
+     "priority": {
+      "type": "integer",
+      "format": "int32",
+      "description": "determines which SCC is used when multiple SCCs allow a particular pod; higher priority SCCs are preferred"
      },
      "allowPrivilegedContainer": {
       "type": "boolean",

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -39,6 +39,14 @@ const (
 // for system bootstrapping.  This method takes additional users and groups that should be added
 // to the strategies.  Use GetBoostrapSCCAccess to produce the default set of mappings.
 func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string][]string, sccNameToAdditionalUsers map[string][]string) []kapi.SecurityContextConstraints {
+	// define priorities here and reference them below so it is easy to see, at a glance
+	// what we're setting
+	var (
+		// this is set to 10 to allow wiggle room for admins to set other priorities without
+		// having to adjust anyUID.
+		securityContextConstraintsAnyUIDPriority = 10
+	)
+
 	constraints := []kapi.SecurityContextConstraints{
 		// SecurityContextConstraintPrivileged allows all access for every field
 		{
@@ -246,6 +254,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
 				Type: kapi.SupplementalGroupsStrategyRunAsAny,
 			},
+			// prefer the anyuid SCC over ones that force a uid
+			Priority: &securityContextConstraintsAnyUIDPriority,
 		},
 	}
 

--- a/pkg/security/admission/admission.go
+++ b/pkg/security/admission/admission.go
@@ -127,7 +127,7 @@ func (c *constraint) Admit(a kadmission.Attributes) error {
 
 	// remove duplicate constraints and sort
 	matchedConstraints = deduplicateSecurityContextConstraints(matchedConstraints)
-	sort.Sort(ByRestrictions(matchedConstraints))
+	sort.Sort(ByPriority(matchedConstraints))
 	providers, errs := c.createProvidersFromConstraints(a.GetNamespace(), matchedConstraints)
 	logProviders(pod, providers, errs)
 

--- a/pkg/security/admission/bypriority.go
+++ b/pkg/security/admission/bypriority.go
@@ -1,0 +1,54 @@
+package admission
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+// ByRestrictions is a helper to sort SCCs based on priority.  If priorities are equal
+// a string compare of the name is used.
+type ByPriority []*kapi.SecurityContextConstraints
+
+func (s ByPriority) Len() int {
+	return len(s)
+}
+func (s ByPriority) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s ByPriority) Less(i, j int) bool {
+	iSCC := s[i]
+	jSCC := s[j]
+
+	iSCCPriority := getPriority(iSCC)
+	jSCCPriority := getPriority(jSCC)
+
+	// a higher priority is considered "less" so that it moves to the front of the line
+	if iSCCPriority > jSCCPriority {
+		return true
+	}
+
+	if iSCCPriority < jSCCPriority {
+		return false
+	}
+
+	// priorities are equal, let's try point values
+	iRestrictionScore := pointValue(iSCC)
+	jRestrictionScore := pointValue(jSCC)
+
+	// a lower restriction score is considered "less" so that it moves to the front of the line
+	// (the greater the score, the more lax the SCC is)
+	if iRestrictionScore < jRestrictionScore {
+		return true
+	}
+
+	if iRestrictionScore > jRestrictionScore {
+		return false
+	}
+
+	// they are still equal, sort by name
+	return iSCC.Name < jSCC.Name
+}
+
+func getPriority(scc *kapi.SecurityContextConstraints) int {
+	if scc.Priority == nil {
+		return 0
+	}
+	return *scc.Priority
+}

--- a/pkg/security/admission/bypriority_test.go
+++ b/pkg/security/admission/bypriority_test.go
@@ -1,0 +1,86 @@
+package admission
+
+import (
+	"sort"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func TestByPriority(t *testing.T) {
+	sccs := []*kapi.SecurityContextConstraints{testSCC("one", 1), testSCC("two", 2), testSCC("three", 3), testSCC("negative", -1), testSCC("super", 100)}
+	expected := []string{"super", "three", "two", "one", "negative"}
+
+	sort.Sort(ByPriority(sccs))
+
+	for i, scc := range sccs {
+		if scc.Name != expected[i] {
+			t.Errorf("sort by priority found %s at element %d but expected %s", scc.Name, i, expected[i])
+		}
+	}
+}
+
+func TestByPrioritiesScore(t *testing.T) {
+	privilegedSCC := testSCC("privileged", 1)
+	privilegedSCC.AllowPrivilegedContainer = true
+
+	nonPriviledSCC := testSCC("nonprivileged", 1)
+
+	hostDirSCC := testSCC("hostdir", 1)
+	hostDirSCC.AllowHostDirVolumePlugin = true
+
+	sccs := []*kapi.SecurityContextConstraints{nonPriviledSCC, privilegedSCC, hostDirSCC}
+	// with equal priorities expect that the SCCs will be sorted with hold behavior based on their score,
+	// most restrictive first
+	expected := []string{"nonprivileged", "hostdir", "privileged"}
+
+	sort.Sort(ByPriority(sccs))
+
+	for i, scc := range sccs {
+		if scc.Name != expected[i] {
+			t.Errorf("sort by score found %s at element %d but expected %s", scc.Name, i, expected[i])
+		}
+	}
+}
+
+func TestByPrioritiesName(t *testing.T) {
+	sccs := []*kapi.SecurityContextConstraints{testSCC("e", 1), testSCC("d", 1), testSCC("a", 1), testSCC("c", 1), testSCC("b", 1)}
+	// expect that with equal priorities AND an equal point value that SCCs are sorted by name
+	expected := []string{"a", "b", "c", "d", "e"}
+
+	sort.Sort(ByPriority(sccs))
+
+	for i, scc := range sccs {
+		if scc.Name != expected[i] {
+			t.Errorf("sort by priority found %s at element %d but expected %s", scc.Name, i, expected[i])
+		}
+	}
+}
+
+func TestByPrioritiesMixedSCCs(t *testing.T) {
+	privilegedSCC := testSCC("privileged", 1)
+	privilegedSCC.AllowPrivilegedContainer = true
+
+	nonPriviledSCC := testSCC("nonprivileged", 1)
+
+	sccs := []*kapi.SecurityContextConstraints{testSCC("priorityB", 5), testSCC("priorityA", 5), testSCC("super", 100), privilegedSCC, nonPriviledSCC}
+	// highest priority first, equal priority and equal score sorted by name, equal priority and non-equal score sorted most restrictive to least.
+	expected := []string{"super", "priorityA", "priorityB", "nonprivileged", "privileged"}
+
+	sort.Sort(ByPriority(sccs))
+
+	for i, scc := range sccs {
+		if scc.Name != expected[i] {
+			t.Errorf("sort by priority found %s at element %d but expected %s", scc.Name, i, expected[i])
+		}
+	}
+}
+
+func testSCC(name string, priority int) *kapi.SecurityContextConstraints {
+	return &kapi.SecurityContextConstraints{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: name,
+		},
+		Priority: &priority,
+	}
+}

--- a/pkg/security/admission/byrestrictions.go
+++ b/pkg/security/admission/byrestrictions.go
@@ -12,12 +12,12 @@ func (s ByRestrictions) Len() int {
 }
 func (s ByRestrictions) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ByRestrictions) Less(i, j int) bool {
-	return s.pointValue(s[i]) < s.pointValue(s[j])
+	return pointValue(s[i]) < pointValue(s[j])
 }
 
 // pointValue places a value on the SCC based on the settings of the SCC that can be used
 // to determine how restrictive it is.  The lower the number, the more restrictive it is.
-func (s ByRestrictions) pointValue(constraint *kapi.SecurityContextConstraints) int {
+func pointValue(constraint *kapi.SecurityContextConstraints) int {
 	points := 0
 
 	// make sure these are always valued higher than the combination of the highest strategies


### PR DESCRIPTION
Sorts SCCs by a priority field and then by name.  Adds a priority to the privileged SCC so that if you have administrative access you will use that SCC by default (though this is largely unnecessary since the first commit allows authenticated users to run as any uid).

Builds on https://github.com/openshift/origin/pull/5498 which is hanging out in the merge queue right now so only the last three commits need reviewed.

Fixes https://github.com/openshift/origin/issues/5317

@liggitt @smarterclayton 