### PR TITLE
Fixes in image import controller

### DIFF
--- a/pkg/cmd/cli/describe/helpers.go
+++ b/pkg/cmd/cli/describe/helpers.go
@@ -154,7 +154,7 @@ func webhookURL(c *buildapi.BuildConfig, cli client.BuildConfigsNamespacer) map[
 }
 
 func formatImageStreamTags(out *tabwriter.Writer, stream *imageapi.ImageStream) {
-	if len(stream.Status.Tags) == 0 {
+	if len(stream.Status.Tags) == 0 && len(stream.Spec.Tags) == 0 {
 		fmt.Fprintf(out, "Tags:\t<none>\n")
 		return
 	}


### PR DESCRIPTION
I've reworked the the error reporting from `getTags` and `imprortTags` to include information whether an error is or not a retry-able. The former should just return the error and retry controller will re-kick the import. The latter should place the error in an import annotation. 

Additionally I've reworked slightly how we print tags in our describer, to show all the tags from spec and status and inform about status of each of those. This is needed for external tags to be printed.

This fixes problem described in https://bugzilla.redhat.com/show_bug.cgi?id=1275537

@smarterclayton @miminar ptal