### PR TITLE
hack/install-assets: fix nonstandard bash

### DIFF
--- a/hack/install-assets.sh
+++ b/hack/install-assets.sh
@@ -18,7 +18,8 @@ function cmd() {
   echo "[install-assets] ${cmd}"
   rc="0"
   while [[ "$tries" -gt 0 ]]; do
-    $cmd &>> ${log_file} || rc=$?
+    $cmd &> ${log_file}
+    rc=$?
     [[ "$rc" == "0" ]] && return 0
     ((tries--))
   done


### PR DESCRIPTION
Should fix https://github.com/openshift/origin/issues/5561

Apparently &>> is non-standard. I thought it would be a good idea to capture *all* the failure logs, but probably the last one suffices.