### PR TITLE
Add git ls-remote to validate the remote GIT repository

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +24,17 @@ const (
 	// not proceed further and stop
 	urlCheckTimeout = 16 * time.Second
 )
+
+type gitAuthError string
+type gitNotFoundError string
+
+func (e gitAuthError) Error() string {
+	return fmt.Sprintf("failed to fetch requested repository %q with provided credentials", string(e))
+}
+
+func (e gitNotFoundError) Error() string {
+	return fmt.Sprintf("requested repository %q not found", string(e))
+}
 
 // fetchSource retrieves the inputs defined by the build source into the
 // provided directory, or returns an error if retrieval is not possible.
@@ -56,38 +65,52 @@ func fetchSource(dir string, build *api.Build, urlTimeout time.Duration, in io.R
 	return nil
 }
 
+// checkRemoteGit validates the specified Git URL. It returns GitNotFoundError
+// when the remote repository not found and GitAuthenticationError when the
+// remote repository failed to authenticate.
+// Since this is calling the 'git' binary, the proxy settings should be
+// available for this command.
+func checkRemoteGit(url string, timeout time.Duration) error {
+	glog.V(4).Infof("git ls-remote --heads %q", url)
+	cmd := exec.Command("git", "ls-remote", "--heads", url)
+	cmd.Env = []string{"GIT_ASKPASS=/bin/true"}
+
+	var (
+		out []byte
+		err error
+	)
+
+	finish := make(chan struct{}, 1)
+	go func() {
+		out, err = cmd.CombinedOutput()
+		close(finish)
+	}()
+	select {
+	case <-finish:
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout while waiting for remote repository %q", url)
+	}
+
+	glog.V(4).Infof(string(out))
+
+	switch {
+	case strings.Contains(string(out), "Authentication failed"):
+		return gitAuthError(url)
+	case strings.Contains(string(out), "not found"):
+		return gitNotFoundError(url)
+	}
+
+	return err
+}
+
 // checkSourceURI performs a check on the URI associated with the build
 // to make sure that it is valid.  It also optionally tests the connection
 // to the source uri.
-func checkSourceURI(git git.Git, rawurl string, testConnection bool, timeout time.Duration) error {
+func checkSourceURI(git git.Git, rawurl string, timeout time.Duration) error {
 	if !git.ValidCloneSpec(rawurl) {
 		return fmt.Errorf("Invalid git source url: %s", rawurl)
 	}
-	if strings.HasPrefix(rawurl, "git@") || strings.HasPrefix(rawurl, "git://") {
-		return nil
-	}
-	srcURL, err := url.Parse(rawurl)
-	if err != nil {
-		return err
-	}
-	if !testConnection {
-		return nil
-	}
-	host := srcURL.Host
-	if strings.Index(host, ":") == -1 {
-		switch srcURL.Scheme {
-		case "http":
-			host += ":80"
-		case "https":
-			host += ":443"
-		}
-	}
-	dialer := net.Dialer{Timeout: timeout}
-	conn, err := dialer.Dial("tcp", host)
-	if err != nil {
-		return err
-	}
-	return conn.Close()
+	return checkRemoteGit(rawurl, timeout)
 }
 
 // extractInputBinary processes the provided input stream as directed by BinaryBuildSource
@@ -137,8 +160,7 @@ func extractGitSource(git git.Git, gitSource *api.GitBuildSource, revision *api.
 	defer resetHTTPProxy(originalProxies)
 
 	// Check source URI, trying to connect to the server only if not using a proxy.
-	usingProxy := len(originalProxies) > 0
-	if err := checkSourceURI(git, gitSource.URI, !usingProxy, timeout); err != nil {
+	if err := checkSourceURI(git, gitSource.URI, timeout); err != nil {
 		return true, err
 	}
 

--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -1,0 +1,40 @@
+package builder
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckRemoteGit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	var err error
+	err = checkRemoteGit(server.URL, 10*time.Second)
+	switch v := err.(type) {
+	case gitAuthError:
+	default:
+		t.Errorf("expected gitAuthError, got %q", v)
+	}
+
+	t0 := time.Now()
+	err = checkRemoteGit("https://254.254.254.254/foo/bar", 4*time.Second)
+	t1 := time.Now()
+	if err == nil || (err != nil && !strings.Contains(fmt.Sprintf("%s", err), "timeout")) {
+		t.Errorf("expected timeout error, got %q", err)
+	}
+	if t1.Sub(t0) > 5*time.Second {
+		t.Errorf("expected timeout in 4 seconds, it took %v", t1.Sub(t0))
+	}
+
+	err = checkRemoteGit("https://github.com/openshift/origin", 10*time.Second)
+	if err != nil {
+		t.Errorf("unexpected error %q", err)
+	}
+}

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -1,0 +1,43 @@
+package builds
+
+import (
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: parallel: s2i build with proxy", func() {
+	defer g.GinkgoRecover()
+	var (
+		buildFixture = exutil.FixturePath("..", "extended", "fixtures", "test-build-proxy.json")
+		oc           = exutil.NewCLI("build-proxy", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.Run("create").Args("-f", buildFixture).Execute()
+	})
+
+	g.Describe("start build with broken proxy", func() {
+		g.It("should start a build and wait for the build to to fail", func() {
+			g.By("starting the build with --wait and --follow flags")
+			out, err := oc.Run("start-build").Args("sample-build", "--follow", "--wait").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			g.By("verifying the build sample-app-1 output")
+			// The git ls-remote check should exit the build when the remote
+			// repository is not accessible. It should never get to the clone.
+			o.Expect(out).NotTo(o.ContainSubstring("clone"))
+			o.Expect(out).To(o.ContainSubstring(`unable to access 'https://github.com/openshift/ruby-hello-world.git/': Failed connect to 127.0.0.1:3128`))
+			g.By("verifying the build sample-build-1 status")
+			build, err := oc.REST().Builds(oc.Namespace()).Get("sample-build-1")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseFailed))
+		})
+
+	})
+
+})

--- a/test/extended/fixtures/test-build-proxy.json
+++ b/test/extended/fixtures/test-build-proxy.json
@@ -1,0 +1,60 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "origin-ruby-sample",
+        "creationTimestamp": null
+      },
+      "spec": {},
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "sample-build",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "imageChange",
+            "imageChange": {}
+          }
+        ],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "https://github.com/openshift/ruby-hello-world.git",
+            "httpProxy": "127.0.0.1:3128",
+            "httpsProxy": "127.0.0.1:3128"
+          }
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "env": [
+              { "name": "HTTPS_PROXY", "value": "127.0.0.1:3128" },
+              { "name": "HTTP_PROXY", "value": "127.0.0.1:3128" }
+            ],
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/ruby-20-centos7"
+            }
+          }
+        },
+        "resources": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/4564
Fixes: https://github.com/openshift/origin/issues/5944

@bparees @soltysh this will use `git ls-remote` command to check the source repository URL. It should pickup all credentials we have for the GIT in case the repo is private. It also perform check if the repository is reachable. Proxy vars should be picked up as well (I didn't tested this).