### PR TITLE
Bug 1276657 - Reuse --insecure-registry flag value when creating ImageStream from passed docker image.

### DIFF
--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -213,6 +213,7 @@ func (r DockerRegistrySearcher) Search(terms ...string) (ComponentMatches, error
 			Score:       0,
 			Image:       dockerImage,
 			ImageTag:    ref.Tag,
+			Insecure:    r.AllowInsecure,
 			Meta:        map[string]string{"registry": ref.Registry},
 		})
 	}


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1276657

@csrwng ptal