### PR TITLE
Make route port configurable in oc expose

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -374,17 +374,20 @@ Expose a replicated application as a service or route
 
 [options="nowrap"]
 ----
-  # Create a route based on service nginx. The new route will re-use nginx's labels
-  $ oc expose service nginx
+  # Create a route based on service nginx. The new route will re-use nginx's labels.
+  $ oc expose svc/nginx
 
-  # Create a route and specify your own label and route name
-  $ oc expose service nginx -l name=myroute --name=fromdowntown
+  # Create a route based on service nginx and specify the port on the container that the route should direct traffic to.
+  $ oc expose svc/nginx --target-port=80
 
-  # Create a route and specify a hostname
-  $ oc expose service nginx --hostname=www.example.com
+  # Create a route and specify your own label and route name.
+  $ oc expose svc/nginx -l name=myroute --name=fromdowntown
 
-  # Expose a deployment configuration as a service and use the specified port
-  $ oc expose dc ruby-hello-world --port=8080
+  # Create a route and specify a hostname.
+  $ oc expose svc/nginx --hostname=www.example.com
+
+  # Expose a deployment configuration as a service and use the specified port.
+  $ oc expose dc/ruby-hello-world --port=8080
 ----
 ====
 

--- a/pkg/cmd/cli/cmd/expose_test.go
+++ b/pkg/cmd/cli/cmd/expose_test.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktc "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func exposeData() []*kapi.Service {
+	// Doesn't support TCP.
+	udp := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "foo", Namespace: "test", ResourceVersion: "12",
+		},
+		Spec: kapi.ServiceSpec{
+			Selector: map[string]string{"service": "test"},
+			Ports: []kapi.ServicePort{
+				{
+					Protocol:   kapi.ProtocolUDP,
+					Port:       80,
+					TargetPort: util.NewIntOrStringFromInt(80),
+				},
+			},
+		},
+	}
+	// Supports TCP, has numeric target port.
+	numeric := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "foo", Namespace: "test", ResourceVersion: "12",
+		},
+		Spec: kapi.ServiceSpec{
+			Selector: map[string]string{"service": "test"},
+			Ports: []kapi.ServicePort{
+				{
+					Protocol:   kapi.ProtocolTCP,
+					Port:       80,
+					TargetPort: util.NewIntOrStringFromInt(80),
+				},
+			},
+		},
+	}
+	// Supports TCP, has named port.
+	named := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "foo", Namespace: "test", ResourceVersion: "12",
+		},
+		Spec: kapi.ServiceSpec{
+			Selector: map[string]string{"service": "test"},
+			Ports: []kapi.ServicePort{
+				{
+					Protocol:   kapi.ProtocolTCP,
+					Port:       80,
+					Name:       "http",
+					TargetPort: util.NewIntOrStringFromString("http"),
+				},
+			},
+		},
+	}
+	// Supports TCP, has multiple ports.
+	multipleTCPPorts := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "foo", Namespace: "test", ResourceVersion: "12",
+		},
+		Spec: kapi.ServiceSpec{
+			Selector: map[string]string{"service": "test"},
+			Ports: []kapi.ServicePort{
+				{
+					Protocol:   kapi.ProtocolTCP,
+					Port:       80,
+					Name:       "http",
+					TargetPort: util.NewIntOrStringFromString("http"),
+				},
+				{
+					Protocol:   kapi.ProtocolTCP,
+					Port:       443,
+					Name:       "https",
+					TargetPort: util.NewIntOrStringFromString("443"),
+				},
+			},
+		},
+	}
+	// Doesn't support TCP, has multiple ports.
+	multipleUDPPorts := &kapi.Service{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "foo", Namespace: "test", ResourceVersion: "12",
+		},
+		Spec: kapi.ServiceSpec{
+			Selector: map[string]string{"service": "test"},
+			Ports: []kapi.ServicePort{
+				{
+					Protocol:   kapi.ProtocolUDP,
+					Port:       7,
+					Name:       "echo",
+					TargetPort: util.NewIntOrStringFromString("echo"),
+				},
+				{
+					Protocol:   kapi.ProtocolUDP,
+					Port:       23,
+					Name:       "telnet",
+					TargetPort: util.NewIntOrStringFromInt(23),
+				},
+			},
+		},
+	}
+
+	return []*kapi.Service{udp, numeric, named, multipleTCPPorts, multipleUDPPorts}
+}
+
+func TestValidateService(t *testing.T) {
+	services := exposeData()
+	tests := []struct {
+		name         string
+		service      *kapi.Service
+		portFlagUsed string
+		expectedPort string
+		expectedErr  error
+	}{
+		{
+			name:         "udp service",
+			service:      services[0],
+			expectedPort: "",
+			expectedErr:  noTCPErr,
+		},
+		{
+			name:         "another udp service",
+			service:      services[4],
+			portFlagUsed: "echo",
+			expectedPort: "",
+			expectedErr:  noTCPErr,
+		},
+		{
+			name:         "round robin tcp service",
+			service:      services[1],
+			expectedPort: "",
+		},
+		{
+			name:         "tcp multiport service",
+			service:      services[3],
+			expectedPort: "http",
+		},
+		{
+			name:         "numeric --target-port",
+			service:      services[3],
+			portFlagUsed: "443",
+			expectedPort: "443",
+		},
+		{
+			name:         "non-numeric --target-port",
+			service:      services[2],
+			portFlagUsed: "http",
+			expectedPort: "http",
+		},
+		{
+			name:         "invalid numeric --target-port",
+			service:      services[3],
+			portFlagUsed: "8080",
+			expectedPort: "",
+			expectedErr:  invalidPortErr,
+		},
+		{
+			name:         "invalid non-numeric --target-port",
+			service:      services[1],
+			portFlagUsed: "udp",
+			expectedPort: "",
+			expectedErr:  invalidPortErr,
+		},
+	}
+
+	for _, test := range tests {
+		fake := &ktc.Fake{}
+		fake.AddReactor("get", "services", func(action ktc.Action) (handled bool, ret runtime.Object, err error) {
+			return true, test.service, nil
+		})
+
+		gotPort, gotErr := validateService(fake, "test", "someservice", test.portFlagUsed)
+		if gotErr != test.expectedErr {
+			t.Errorf("%s: error mismatch: got %v, expected %v", test.name, gotErr, test.expectedErr)
+		}
+		if gotPort != test.expectedPort {
+			t.Errorf("%s: port mismatch: got %s, expected %s", test.name, gotPort, test.expectedPort)
+		}
+	}
+}

--- a/pkg/route/generator/generate_test.go
+++ b/pkg/route/generator/generate_test.go
@@ -72,6 +72,35 @@ func TestGenerateRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			params: map[string]interface{}{
+				"labels":       "foo=bar",
+				"name":         "test",
+				"default-name": "someservice",
+				"target-port":  "8080",
+				"hostname":     "www.example.com",
+			},
+			expected: routeapi.Route{
+				ObjectMeta: api.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: routeapi.RouteSpec{
+					Host: "www.example.com",
+					To: api.ObjectReference{
+						Name: "someservice",
+					},
+					Port: &routeapi.RoutePort{
+						TargetPort: util.IntOrString{
+							Kind:   util.IntstrInt,
+							IntVal: 8080,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		obj, err := generator.Generate(test.params)

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -79,11 +79,17 @@ os::cmd::expect_success 'oc delete route external'
 os::cmd::expect_success 'oc delete svc external'
 # Expose multiport service and verify we set a port in the route
 os::cmd::expect_success 'oc create -f test/fixtures/multiport-service.yaml'
-os::cmd::expect_success 'oc expose svc/frontend --name route-with-set-port'
+os::cmd::expect_success 'oc expose svc/multiport-service --name route-with-set-port'
 os::cmd::expect_success_and_text "oc get route route-with-set-port --template='{{.spec.port.targetPort}}' --output-version=v1" "web"
+os::cmd::expect_success 'oc delete all --all'
+# Verify that we can set a route port
+os::cmd::expect_success 'oc create -f test/fixtures/multiport-service.yaml'
+os::cmd::expect_success 'oc expose svc/multiport-service --target-port 8888 --name test-route'
+os::cmd::expect_success_and_text "oc get route test-route --template='{{.spec.port.targetPort}}'" "8888"
+os::cmd::expect_failure 'oc expose svc/multiport-service --target-port web3 --name failed'
+os::cmd::expect_success 'oc delete all --all'
 echo "expose: ok"
 
-os::cmd::expect_success 'oc delete all --all'
 
 # switch to test user to be sure that default project admin policy works properly
 os::cmd::expect_success 'oc policy add-role-to-user admin test-user'

--- a/test/fixtures/named-port-service.yaml
+++ b/test/fixtures/named-port-service.yaml
@@ -4,28 +4,22 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
-    labels:
-      test: missing-route-port
-    name: multiport-service
+    name: named-port-service
   spec:
     ports:
     - name: web
-      port: 5432
+      port: 80
       protocol: TCP
-      targetPort: 8080
-    - name: web2
-      port: 5433
-      protocol: TCP
-      targetPort: 8888
+      targetPort: http
     selector:
-      name: multiport-service
+      name: named-port-service
     sessionAffinity: None
     type: ClusterIP
 - apiVersion: v1
   kind: Pod
   metadata:
     labels:
-      name: multiport-service
+      name: named-port-service
     name: test-pod
   spec:
     containers:
@@ -33,11 +27,8 @@ items:
       imagePullPolicy: IfNotPresent
       name: test-pod
       ports:
-      - containerPort: 8080
+      - containerPort: 7070
         name: http
-        protocol: TCP
-      - containerPort: 8888
-        name: http2
         protocol: TCP
       resources: {}
       securityContext:


### PR DESCRIPTION
This PR makes the route port configurable in oc expose by
allowing the use of --target-port against routes. Allowed values
include both numeric (must match a valid service target port) and
non-numeric values (must match a valid service port name).

Fixes https://github.com/openshift/origin/issues/6094