### PR TITLE
allow cluster-admin and cluster-reader to use different groups

### DIFF
--- a/pkg/authorization/authorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/authorizer_test.go
@@ -43,7 +43,7 @@ func TestAPIGroupDeny(t *testing.T) {
 			Resource: "pods",
 		},
 		expectedAllowed: false,
-		expectedReason:  `User "Anna" cannot list group/pods in project "adze"`,
+		expectedReason:  `User "Anna" cannot list group.pods in project "adze"`,
 	}
 	test.clusterPolicies = newDefaultClusterPolicies()
 	test.policies = append(test.policies, newAdzePolicies()...)

--- a/pkg/authorization/authorizer/bootstrap_policy_test.go
+++ b/pkg/authorization/authorizer/bootstrap_policy_test.go
@@ -15,6 +15,40 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
+func TestClusterAdminUseGroup(t *testing.T) {
+	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "root", Groups: []string{bootstrappolicy.ClusterAdminGroup}}),
+		attributes: &DefaultAuthorizationAttributes{
+			APIGroup: "extensions",
+			Verb:     "create",
+			Resource: "jobs",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by cluster rule",
+	}
+	test.clusterPolicies = newDefaultClusterPolicies()
+	test.clusterBindings = newDefaultClusterPolicyBindings()
+
+	test.test(t)
+}
+
+func TestClusterReaderUseGroup(t *testing.T) {
+	test := &authorizeTest{
+		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "root", Groups: []string{bootstrappolicy.ClusterReaderGroup}}),
+		attributes: &DefaultAuthorizationAttributes{
+			APIGroup: "extensions",
+			Verb:     "list",
+			Resource: "jobs",
+		},
+		expectedAllowed: true,
+		expectedReason:  "allowed by cluster rule",
+	}
+	test.clusterPolicies = newDefaultClusterPolicies()
+	test.clusterBindings = newDefaultClusterPolicyBindings()
+
+	test.test(t)
+}
+
 func TestInvalidRole(t *testing.T) {
 	test := &authorizeTest{
 		context: kapi.WithUser(kapi.WithNamespace(kapi.NewContext(), "mallet"), &user.DefaultInfo{Name: "Brad"}),

--- a/pkg/authorization/authorizer/messages.go
+++ b/pkg/authorization/authorizer/messages.go
@@ -27,7 +27,7 @@ func NewForbiddenMessageResolver(projectRequestForbiddenTemplate string) *Forbid
 		defaultForbiddenMessageMaker:                      newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot "{{.Attributes.GetVerb}}" "{{.Attributes.GetResource}}" with name "{{.Attributes.GetResourceName}}" in project "{{.Namespace}}"`),
 	}
 
-	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}{{.Attributes.GetAPIGroup}}/{{end}}"
+	apiGroupIfNotEmpty := "{{if len .Attributes.GetAPIGroup }}{{.Attributes.GetAPIGroup}}.{{end}}"
 
 	// general messages
 	messageResolver.addNamespacedForbiddenMessageMaker("create", authorizationapi.ResourceAll, newTemplateForbiddenMessageMaker(`User "{{.User.GetName}}" cannot create `+apiGroupIfNotEmpty+`{{.Attributes.GetResource}} in project "{{.Namespace}}"`))

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -50,6 +50,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					Verbs:     sets.NewString(authorizationapi.VerbAll),
 					Resources: sets.NewString(authorizationapi.ResourceAll),
+					APIGroups: []string{authorizationapi.APIGroupAll},
 				},
 				{
 					Verbs:           sets.NewString(authorizationapi.VerbAll),
@@ -65,6 +66,11 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{
 					Verbs:     sets.NewString("get", "list", "watch"),
 					Resources: sets.NewString(authorizationapi.NonEscalatingResourcesGroupName),
+				},
+				{
+					Verbs:     sets.NewString("get", "list", "watch"),
+					Resources: sets.NewString("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale"),
+					APIGroups: []string{authorizationapi.APIGroupExtensions},
 				},
 				{ // permissions to check access.  These creates are non-mutating
 					Verbs:     sets.NewString("create"),


### PR DESCRIPTION
Without this, cluster-admins can't use things in the `extensions` group.  

@liggitt @smarterclayton We need this for 3.1
@sdminonne I think this is your problem.