### PR TITLE
UPSTREAM: 16590: Create all streams before copying in exec/attach

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v1.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/v1.go
@@ -55,12 +55,50 @@ func (e *streamProtocolV1) stream(conn httpstream.Connection) error {
 		}
 	}
 
+	var (
+		err                                                  error
+		errorStream, remoteStdin, remoteStdout, remoteStderr httpstream.Stream
+	)
+
+	// set up all the streams first
 	headers := http.Header{}
 	headers.Set(api.StreamType, api.StreamTypeError)
-	errorStream, err := conn.CreateStream(headers)
+	errorStream, err = conn.CreateStream(headers)
 	if err != nil {
 		return err
 	}
+	defer errorStream.Reset()
+
+	if e.stdin != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdin)
+		remoteStdin, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+		defer remoteStdin.Reset()
+	}
+
+	if e.stdout != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdout)
+		remoteStdout, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+		defer remoteStdout.Reset()
+	}
+
+	if e.stderr != nil && !e.tty {
+		headers.Set(api.StreamType, api.StreamTypeStderr)
+		remoteStderr, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+		defer remoteStderr.Reset()
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	// always read from errorStream
 	go func() {
 		message, err := ioutil.ReadAll(errorStream)
 		if err != nil && err != io.EOF {
@@ -72,15 +110,8 @@ func (e *streamProtocolV1) stream(conn httpstream.Connection) error {
 			return
 		}
 	}()
-	defer errorStream.Reset()
 
 	if e.stdin != nil {
-		headers.Set(api.StreamType, api.StreamTypeStdin)
-		remoteStdin, err := conn.CreateStream(headers)
-		if err != nil {
-			return err
-		}
-		defer remoteStdin.Reset()
 		// TODO this goroutine will never exit cleanly (the io.Copy never unblocks)
 		// because stdin is not closed until the process exits. If we try to call
 		// stdin.Close(), it returns no error but doesn't unblock the copy. It will
@@ -93,23 +124,11 @@ func (e *streamProtocolV1) stream(conn httpstream.Connection) error {
 
 	if e.stdout != nil {
 		waitCount++
-		headers.Set(api.StreamType, api.StreamTypeStdout)
-		remoteStdout, err := conn.CreateStream(headers)
-		if err != nil {
-			return err
-		}
-		defer remoteStdout.Reset()
 		go cp(api.StreamTypeStdout, e.stdout, remoteStdout)
 	}
 
 	if e.stderr != nil && !e.tty {
 		waitCount++
-		headers.Set(api.StreamType, api.StreamTypeStderr)
-		remoteStderr, err := conn.CreateStream(headers)
-		if err != nil {
-			return err
-		}
-		defer remoteStderr.Reset()
 		go cp(api.StreamTypeStderr, e.stderr, remoteStderr)
 	}
 


### PR DESCRIPTION
Create error, stdin, stdout, stderr streams first, and only start
copying once all the streams have been created. This fixes an issue
where the client immediately starts sending data for stdin before all
the other streams have been created. This ends up blocking the spdy
connection frame handler and causes the entire exec/attach session to
time out.

Fixes #5377