### PR TITLE
add reconcile-sccs command, create missing SCCs on server start

### DIFF
--- a/contrib/completions/bash/oadm
+++ b/contrib/completions/bash/oadm
@@ -481,6 +481,33 @@ _oadm_policy_remove-scc-from-group()
     must_have_one_noun=()
 }
 
+_oadm_policy_reconcile-sccs()
+{
+    last_command="oadm_policy_reconcile-sccs"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--additive-only")
+    flags+=("--confirm")
+    flags+=("--infrastructure-namespace=")
+    flags+=("--no-headers")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--output-version=")
+    flags+=("--show-all")
+    flags+=("-a")
+    flags+=("--sort-by=")
+    flags+=("--template=")
+    two_word_flags+=("-t")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _oadm_policy()
 {
     last_command="oadm_policy"
@@ -502,6 +529,7 @@ _oadm_policy()
     commands+=("add-scc-to-group")
     commands+=("remove-scc-from-user")
     commands+=("remove-scc-from-group")
+    commands+=("reconcile-sccs")
 
     flags=()
     two_word_flags=()

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -1071,6 +1071,33 @@ _openshift_admin_policy_remove-scc-from-group()
     must_have_one_noun=()
 }
 
+_openshift_admin_policy_reconcile-sccs()
+{
+    last_command="openshift_admin_policy_reconcile-sccs"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--additive-only")
+    flags+=("--confirm")
+    flags+=("--infrastructure-namespace=")
+    flags+=("--no-headers")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--output-version=")
+    flags+=("--show-all")
+    flags+=("-a")
+    flags+=("--sort-by=")
+    flags+=("--template=")
+    two_word_flags+=("-t")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_admin_policy()
 {
     last_command="openshift_admin_policy"
@@ -1092,6 +1119,7 @@ _openshift_admin_policy()
     commands+=("add-scc-to-group")
     commands+=("remove-scc-from-user")
     commands+=("remove-scc-from-group")
+    commands+=("reconcile-sccs")
 
     flags=()
     two_word_flags=()

--- a/docs/generated/oadm_by_example_content.adoc
+++ b/docs/generated/oadm_by_example_content.adoc
@@ -277,6 +277,26 @@ Replace cluster roles to match the recommended bootstrap policy
 ====
 
 
+== oadm policy reconcile-sccs
+Replace cluster SCCs to match the recommended bootstrap policy
+
+====
+
+[options="nowrap"]
+----
+  # Display the cluster SCCs that would be modified
+  $ openshift admin policy reconcile-sccs
+
+  # Update cluster SCCs that don't match the current defaults preserving additional grants
+  # for users and group and keeping any priorities that are already set
+  $ openshift admin policy reconcile-sccs --confirm
+
+  # Replace existing users, groups, and priorities that do not match defaults
+  $ openshift admin policy reconcile-sccs --additive-only=false --confirm
+----
+====
+
+
 == oadm registry
 Install the integrated Docker registry
 

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -51,6 +51,7 @@ func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	cmds.AddCommand(NewCmdAddSCCToGroup(AddSCCToGroupRecommendedName, fullName+" "+AddSCCToGroupRecommendedName, f, out))
 	cmds.AddCommand(NewCmdRemoveSCCFromUser(RemoveSCCFromUserRecommendedName, fullName+" "+RemoveSCCFromUserRecommendedName, f, out))
 	cmds.AddCommand(NewCmdRemoveSCCFromGroup(RemoveSCCFromGroupRecommendedName, fullName+" "+RemoveSCCFromGroupRecommendedName, f, out))
+	cmds.AddCommand(NewCmdReconcileSCC(ReconcileSCCRecommendedName, fullName+" "+ReconcileSCCRecommendedName, f, out))
 
 	return cmds
 }

--- a/pkg/cmd/admin/policy/reconcile_sccs.go
+++ b/pkg/cmd/admin/policy/reconcile_sccs.go
@@ -1,0 +1,255 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"sort"
+)
+
+// ReconcileSCCRecommendedName is the recommended command name
+const ReconcileSCCRecommendedName = "reconcile-sccs"
+
+type ReconcileSCCOptions struct {
+	// confirmed indicates that the data should be persisted
+	Confirmed bool
+	// union controls if we make additive changes to the users/groups fields or overwrite them
+	// as well as preserving existing priorities (unset priorities will always be reconciled)
+	Union bool
+	// is the name of the openshift infrastructure namespace.  It is provided here so that
+	// the command doesn't need to try and parse the policy config.
+	InfraNamespace string
+
+	Out    io.Writer
+	Output string
+
+	SCCClient kclient.SecurityContextConstraintInterface
+	NSClient  kclient.NamespaceInterface
+}
+
+const (
+	reconcileSCCLong = `
+Replace cluster SCCs to match the recommended bootstrap policy
+
+This command will inspect the cluster SCCs against the recommended bootstrap SCCs.
+Any cluster SCC that does not match will be replaced by the recommended SCC.
+This command will not remove any additional cluster SCCs.  By default, this command
+will not remove additional users and groups that have been granted access to the SCC and
+will preserve existing priorities (but will always reconcile unset priorities and the policy
+definition).
+
+You can see which cluster SCCs have recommended changes by choosing an output type.`
+
+	reconcileSCCExample = `  # Display the cluster SCCs that would be modified
+  $ %[1]s
+
+  # Update cluster SCCs that don't match the current defaults preserving additional grants
+  # for users and group and keeping any priorities that are already set
+  $ %[1]s --confirm
+
+  # Replace existing users, groups, and priorities that do not match defaults
+  $ %[1]s --additive-only=false --confirm`
+)
+
+// NewDefaultReconcileSCCOptions provides a ReconcileSCCOptions with default settings.
+func NewDefaultReconcileSCCOptions() *ReconcileSCCOptions {
+	return &ReconcileSCCOptions{
+		Union:          true,
+		InfraNamespace: bootstrappolicy.DefaultOpenShiftInfraNamespace,
+	}
+}
+
+// NewCmdReconcileSCC implements the OpenShift cli reconcile-sccs command.
+func NewCmdReconcileSCC(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	o := NewDefaultReconcileSCCOptions()
+	o.Out = out
+
+	cmd := &cobra.Command{
+		Use:     name,
+		Short:   "Replace cluster SCCs to match the recommended bootstrap policy",
+		Long:    reconcileSCCLong,
+		Example: fmt.Sprintf(reconcileSCCExample, fullName),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := o.Complete(cmd, f, args); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+			if err := o.Validate(); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+			if err := o.RunReconcileSCCs(cmd, f); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&o.Confirmed, "confirm", o.Confirmed, "Specify that cluster SCCs should be modified. Defaults to false, displaying what would be replaced but not actually replacing anything.")
+	cmd.Flags().BoolVar(&o.Union, "additive-only", o.Union, "Preserves extra users and groups in the SCC as well as existing priorities.")
+	cmd.Flags().StringVar(&o.InfraNamespace, "infrastructure-namespace", o.InfraNamespace, "Name of the infrastructure namespace.")
+	kcmdutil.AddPrinterFlags(cmd)
+	cmd.Flags().Lookup("output").DefValue = "yaml"
+	cmd.Flags().Lookup("output").Value.Set("yaml")
+	return cmd
+}
+
+func (o *ReconcileSCCOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+	if len(args) != 0 {
+		return kcmdutil.UsageError(cmd, "no arguments are allowed")
+	}
+
+	_, kClient, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	o.SCCClient = kClient.SecurityContextConstraints()
+	o.NSClient = kClient.Namespaces()
+	o.Output = kcmdutil.GetFlagString(cmd, "output")
+
+	return nil
+}
+
+func (o *ReconcileSCCOptions) Validate() error {
+	if o.SCCClient == nil {
+		return errors.New("a SCC client is required")
+	}
+	if o.Output != "yaml" && o.Output != "json" && o.Output != "" {
+		return fmt.Errorf("unknown output specified: %s", o.Output)
+	}
+	if _, err := o.NSClient.Get(o.InfraNamespace); err != nil {
+		return fmt.Errorf("%s is not a valid namespace", o.InfraNamespace)
+	}
+	return nil
+}
+
+// RunReconcileSCCs contains the functionality for the reconcile-sccs command for making or
+// previewing changes.
+func (o *ReconcileSCCOptions) RunReconcileSCCs(cmd *cobra.Command, f *clientcmd.Factory) error {
+	// get sccs that need updated
+	changedSCCs, err := o.ChangedSCCs()
+	if err != nil {
+		return err
+	}
+
+	if len(changedSCCs) == 0 {
+		return nil
+	}
+
+	if !o.Confirmed {
+		list := &kapi.List{}
+		for _, item := range changedSCCs {
+			list.Items = append(list.Items, item)
+		}
+		if err := f.Factory.PrintObject(cmd, list, o.Out); err != nil {
+			return err
+		}
+	}
+
+	if o.Confirmed {
+		return o.ReplaceChangedSCCs(changedSCCs)
+	}
+	return nil
+}
+
+// ChangedSCCs returns the SCCs that must be created and/or updated to match the
+// recommended bootstrap SCCs.
+func (o *ReconcileSCCOptions) ChangedSCCs() ([]*kapi.SecurityContextConstraints, error) {
+	changedSCCs := []*kapi.SecurityContextConstraints{}
+
+	groups, users := bootstrappolicy.GetBoostrapSCCAccess(o.InfraNamespace)
+	bootstrapSCCs := bootstrappolicy.GetBootstrapSecurityContextConstraints(groups, users)
+
+	for i := range bootstrapSCCs {
+		expectedSCC := &bootstrapSCCs[i]
+		actualSCC, err := o.SCCClient.Get(expectedSCC.Name)
+		// if not found it needs to be created
+		if kapierrors.IsNotFound(err) {
+			changedSCCs = append(changedSCCs, expectedSCC)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// if found then we need to diff to see if it needs updated
+		if updatedSCC, needsUpdating := o.computeUpdatedSCC(*expectedSCC, *actualSCC); needsUpdating {
+			changedSCCs = append(changedSCCs, updatedSCC)
+		}
+	}
+	return changedSCCs, nil
+}
+
+// ReplaceChangedSCCs persists the changed SCCs.
+func (o *ReconcileSCCOptions) ReplaceChangedSCCs(changedSCCs []*kapi.SecurityContextConstraints) error {
+	for i := range changedSCCs {
+		_, err := o.SCCClient.Get(changedSCCs[i].Name)
+		if err != nil && !kapierrors.IsNotFound(err) {
+			return err
+		}
+
+		if kapierrors.IsNotFound(err) {
+			createdSCC, err := o.SCCClient.Create(changedSCCs[i])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(o.Out, "securitycontextconstraints/%s\n", createdSCC.Name)
+			continue
+		}
+
+		updatedSCC, err := o.SCCClient.Update(changedSCCs[i])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(o.Out, "securitycontextconstraints/%s\n", updatedSCC.Name)
+	}
+	return nil
+}
+
+// computeUpdatedSCC determines if the expected SCC looks like the actual SCC
+// it does this by making the expected SCC mirror the actual SCC for items that
+// we are not reconciling and performing a diff (ignoring changes to metadata).
+// If a diff is produced then the expected SCC is submitted as needing an update.
+func (o *ReconcileSCCOptions) computeUpdatedSCC(expected kapi.SecurityContextConstraints, actual kapi.SecurityContextConstraints) (*kapi.SecurityContextConstraints, bool) {
+	needsUpdate := false
+
+	// if unioning old and new groups/users then make the expected contain all
+	// also preserve and set priorities
+	if o.Union {
+		groupSet := sets.NewString(actual.Groups...)
+		groupSet.Insert(expected.Groups...)
+		expected.Groups = groupSet.List()
+
+		userSet := sets.NewString(actual.Users...)
+		userSet.Insert(expected.Users...)
+		expected.Users = userSet.List()
+
+		if actual.Priority != nil {
+			expected.Priority = actual.Priority
+		}
+	}
+
+	// sort users and groups to remove any variants in order when diffing
+	sort.StringSlice(actual.Groups).Sort()
+	sort.StringSlice(actual.Users).Sort()
+	sort.StringSlice(expected.Groups).Sort()
+	sort.StringSlice(expected.Users).Sort()
+
+	// make a copy of the expected scc here so we can ignore metadata diffs.
+	updated := expected
+	expected.ObjectMeta = actual.ObjectMeta
+
+	if !kapi.Semantic.DeepEqual(expected, actual) {
+		needsUpdate = true
+	}
+
+	return &updated, needsUpdate
+}

--- a/pkg/cmd/admin/policy/reconcile_sccs_test.go
+++ b/pkg/cmd/admin/policy/reconcile_sccs_test.go
@@ -1,0 +1,370 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+func TestComputeDefinitions(t *testing.T) {
+	diffPriv := goodSCC()
+	diffPriv.AllowPrivilegedContainer = true
+
+	diffCaps := goodSCC()
+	diffCaps.AllowedCapabilities = []kapi.Capability{"foo"}
+
+	diffHostDir := goodSCC()
+	diffHostDir.AllowHostDirVolumePlugin = true
+
+	diffHostNetwork := goodSCC()
+	diffHostNetwork.AllowHostNetwork = true
+
+	diffHostPorts := goodSCC()
+	diffHostPorts.AllowHostPorts = true
+
+	diffHostPID := goodSCC()
+	diffHostPID.AllowHostPID = true
+
+	diffHostIPC := goodSCC()
+	diffHostIPC.AllowHostIPC = true
+
+	diffSELinux := goodSCC()
+	diffSELinux.SELinuxContext.Type = kapi.SELinuxStrategyMustRunAs
+
+	diffRunAsUser := goodSCC()
+	diffRunAsUser.RunAsUser.Type = kapi.RunAsUserStrategyMustRunAs
+
+	diffSupGroups := goodSCC()
+	diffSupGroups.SupplementalGroups.Type = kapi.SupplementalGroupsStrategyMustRunAs
+
+	diffFSGroup := goodSCC()
+	diffFSGroup.FSGroup.Type = kapi.FSGroupStrategyMustRunAs
+
+	tests := map[string]struct {
+		expected    kapi.SecurityContextConstraints
+		actual      kapi.SecurityContextConstraints
+		needsUpdate bool
+	}{
+		"different priv": {
+			expected:    goodSCC(),
+			actual:      diffPriv,
+			needsUpdate: true,
+		},
+		"different caps": {
+			expected:    goodSCC(),
+			actual:      diffCaps,
+			needsUpdate: true,
+		},
+		"different host dir": {
+			expected:    goodSCC(),
+			actual:      diffHostDir,
+			needsUpdate: true,
+		},
+		"different host network": {
+			expected:    goodSCC(),
+			actual:      diffHostNetwork,
+			needsUpdate: true,
+		},
+		"different host ports": {
+			expected:    goodSCC(),
+			actual:      diffHostPorts,
+			needsUpdate: true,
+		},
+		"different host pid": {
+			expected:    goodSCC(),
+			actual:      diffHostPID,
+			needsUpdate: true,
+		},
+		"different host IPC": {
+			expected:    goodSCC(),
+			actual:      diffHostIPC,
+			needsUpdate: true,
+		},
+		"different host SELinux": {
+			expected:    goodSCC(),
+			actual:      diffSELinux,
+			needsUpdate: true,
+		},
+		"different host RunAsUser": {
+			expected:    goodSCC(),
+			actual:      diffRunAsUser,
+			needsUpdate: true,
+		},
+		"different host Sup Groups": {
+			expected:    goodSCC(),
+			actual:      diffSupGroups,
+			needsUpdate: true,
+		},
+		"different host FS Group": {
+			expected:    goodSCC(),
+			actual:      diffFSGroup,
+			needsUpdate: true,
+		},
+		"no diff": {
+			expected:    goodSCC(),
+			actual:      goodSCC(),
+			needsUpdate: false,
+		},
+	}
+
+	for k, v := range tests {
+		cmd := NewDefaultReconcileSCCOptions()
+
+		computedSCC, needsUpdate := cmd.computeUpdatedSCC(v.expected, v.actual)
+		// ensure we got an update
+		if needsUpdate != v.needsUpdate {
+			t.Errorf("%s expected to need an update but did not trigger one", k)
+		}
+
+		if !reflect.DeepEqual(&v.expected, computedSCC) {
+			t.Errorf("unexpected diffs were produced from %s", k)
+			t.Logf("wanted: %v", &v.expected)
+			t.Logf("got:    %v", computedSCC)
+		}
+
+		// ensure that if the case needed an update that no diff results from passing through again
+		if v.needsUpdate {
+			if _, doubleUpdate := cmd.computeUpdatedSCC(v.expected, *computedSCC); doubleUpdate {
+				t.Errorf("%s resulted in an SCC that needed update even after computing", k)
+			}
+		}
+	}
+}
+
+func TestComputeUnioningUsersAndGroups(t *testing.T) {
+	missingGroup := goodSCC()
+	missingGroup.Groups = []string{"foo"}
+
+	missingUser := goodSCC()
+	missingUser.Users = []string{"foo"}
+
+	tests := map[string]struct {
+		expected       kapi.SecurityContextConstraints
+		actual         kapi.SecurityContextConstraints
+		expectedGroups []string
+		expectedUsers  []string
+		needsUpdate    bool
+		union          bool
+	}{
+		"missing group grants": {
+			expected:       goodSCC(),
+			actual:         missingGroup,
+			expectedGroups: append(missingGroup.Groups, goodSCC().Groups...),
+			expectedUsers:  goodSCC().Users,
+			needsUpdate:    true,
+			union:          true,
+		},
+		"missing user grants": {
+			expected:       goodSCC(),
+			actual:         missingUser,
+			expectedGroups: goodSCC().Groups,
+			expectedUsers:  append(missingUser.Users, goodSCC().Users...),
+			needsUpdate:    true,
+			union:          true,
+		},
+		"no diff union": {
+			expected:       goodSCC(),
+			actual:         goodSCC(),
+			expectedGroups: goodSCC().Groups,
+			expectedUsers:  goodSCC().Users,
+			needsUpdate:    false,
+			union:          true,
+		},
+		"non-unioning user": {
+			// non-union tc will use the values in expected to compare, no need to set here
+			expected:    goodSCC(),
+			actual:      missingUser,
+			needsUpdate: true,
+			union:       false,
+		},
+		"non-unioning group": {
+			// non-union tc will use the values in expected to compare, no need to set here
+			expected:    goodSCC(),
+			actual:      missingGroup,
+			needsUpdate: true,
+			union:       false,
+		},
+		"no diff non-union": {
+			// non-union tc will use the values in expected to compare, no need to set here
+			expected:    goodSCC(),
+			actual:      goodSCC(),
+			needsUpdate: false,
+			union:       false,
+		},
+	}
+
+	for k, v := range tests {
+		cmd := NewDefaultReconcileSCCOptions()
+		cmd.Union = v.union
+
+		computedSCC, needsUpdate := cmd.computeUpdatedSCC(v.expected, v.actual)
+		// ensure we got an update
+		if needsUpdate != v.needsUpdate {
+			t.Errorf("%s expected to need an update but did not trigger one", k)
+		}
+
+		toCompareGroups := v.expectedGroups
+		toCompareUsers := v.expectedUsers
+		// if not unioning then we should be reset to the expected groups/users
+		if !v.union {
+			toCompareGroups = v.expected.Groups
+			toCompareUsers = v.expected.Users
+		}
+		// ensure that we ended up with the union we expected
+		if !reflect.DeepEqual(computedSCC.Groups, toCompareGroups) {
+			t.Errorf("%s had unexpected groups wanted: %v, got: %v", k, toCompareGroups, computedSCC.Groups)
+		}
+		if !reflect.DeepEqual(computedSCC.Users, toCompareUsers) {
+			t.Errorf("%s had unexpected users wanted: %v, got: %v", k, toCompareUsers, computedSCC.Users)
+		}
+
+		// ensure the computed scc doesn't trigger additional updates
+		if v.needsUpdate {
+			if _, doubleUpdate := cmd.computeUpdatedSCC(v.expected, *computedSCC); doubleUpdate {
+				t.Errorf("%s resulted in an SCC that needed update even after computing", k)
+			}
+		}
+	}
+}
+
+func TestComputeUnioningPriorities(t *testing.T) {
+	priorityOne := 1
+	priorityTwo := 2
+
+	tests := map[string]struct {
+		expected         kapi.SecurityContextConstraints
+		actual           kapi.SecurityContextConstraints
+		expectedPriority *int
+		needsUpdate      bool
+		union            bool
+	}{
+		"not overwriting priorities, nil actual and non-nil expected": {
+			expected:         goodSCCWithPriority(priorityOne),
+			actual:           goodSCC(),
+			expectedPriority: &priorityOne,
+			needsUpdate:      true,
+			union:            true,
+		},
+		"not overwriting priorities, non-nil actual and non-nil expected": {
+			expected:         goodSCCWithPriority(priorityOne),
+			actual:           goodSCCWithPriority(priorityTwo),
+			expectedPriority: &priorityTwo,
+			needsUpdate:      false,
+			union:            true,
+		},
+		"not overwriting priorities, non-nil actual and nil expected": {
+			expected:         goodSCC(),
+			actual:           goodSCCWithPriority(priorityTwo),
+			expectedPriority: &priorityTwo,
+			needsUpdate:      false,
+			union:            true,
+		},
+		"not overwriting priorities, both nil": {
+			expected:         goodSCC(),
+			actual:           goodSCC(),
+			expectedPriority: nil,
+			needsUpdate:      false,
+			union:            true,
+		},
+		"not overwriting priorities, no diff": {
+			expected:         goodSCCWithPriority(priorityOne),
+			actual:           goodSCCWithPriority(priorityOne),
+			expectedPriority: &priorityOne,
+			needsUpdate:      false,
+			union:            true,
+		},
+		"overwriting priorities, nil actual and non-nil expected": {
+			expected:         goodSCCWithPriority(priorityOne),
+			actual:           goodSCC(),
+			expectedPriority: &priorityOne,
+			needsUpdate:      true,
+			union:            false,
+		},
+		"overwriting priorities, non-nil actual and non-nil expected": {
+			expected:         goodSCCWithPriority(priorityOne),
+			actual:           goodSCCWithPriority(priorityTwo),
+			expectedPriority: &priorityOne,
+			needsUpdate:      true,
+			union:            false,
+		},
+		"overwriting priorities, nil actual and nil expected": {
+			expected:         goodSCC(),
+			actual:           goodSCC(),
+			expectedPriority: nil,
+			needsUpdate:      false,
+			union:            false,
+		},
+		"overwriting priorities, non-nil actual and nil expected": {
+			expected:         goodSCC(),
+			actual:           goodSCCWithPriority(priorityTwo),
+			expectedPriority: nil,
+			needsUpdate:      true,
+			union:            false,
+		},
+		"overwriting priorities, no diff": {
+			expected:         goodSCCWithPriority(priorityTwo),
+			actual:           goodSCCWithPriority(priorityTwo),
+			expectedPriority: &priorityTwo,
+			needsUpdate:      false,
+			union:            false,
+		},
+	}
+
+	for k, v := range tests {
+		cmd := NewDefaultReconcileSCCOptions()
+		cmd.Union = v.union
+
+		computedSCC, needsUpdate := cmd.computeUpdatedSCC(v.expected, v.actual)
+		// ensure we got an update
+		if needsUpdate != v.needsUpdate {
+			t.Errorf("%s expected to need an update but did not trigger one", k)
+		}
+
+		// ensure priorities are set correctly
+		if v.expectedPriority != nil && computedSCC.Priority == nil {
+			t.Errorf("%s expected a non nil computed priority", k)
+		}
+		if v.expectedPriority == nil && computedSCC.Priority != nil {
+			t.Errorf("%s expected a nil priority but got %d", k, *computedSCC.Priority)
+		}
+		if v.expectedPriority != nil && computedSCC.Priority != nil && *v.expectedPriority != *computedSCC.Priority {
+			t.Errorf("%s expected priority %d but got %d", k, *v.expectedPriority, *computedSCC.Priority)
+		}
+
+		// ensure the computed scc doesn't trigger additional updates
+		if v.needsUpdate {
+			if _, doubleUpdate := cmd.computeUpdatedSCC(v.expected, *computedSCC); doubleUpdate {
+				t.Errorf("%s resulted in an SCC that needed update even after computing", k)
+			}
+		}
+	}
+}
+
+func goodSCCWithPriority(priority int) kapi.SecurityContextConstraints {
+	scc := goodSCC()
+	scc.Priority = &priority
+	return scc
+}
+
+func goodSCC() kapi.SecurityContextConstraints {
+	return kapi.SecurityContextConstraints{
+		ObjectMeta: kapi.ObjectMeta{
+			Name: "scc-admin",
+		},
+		RunAsUser: kapi.RunAsUserStrategyOptions{
+			Type: kapi.RunAsUserStrategyRunAsAny,
+		},
+		SELinuxContext: kapi.SELinuxContextStrategyOptions{
+			Type: kapi.SELinuxStrategyRunAsAny,
+		},
+		FSGroup: kapi.FSGroupStrategyOptions{
+			Type: kapi.FSGroupStrategyRunAsAny,
+		},
+		SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
+			Type: kapi.SupplementalGroupsStrategyRunAsAny,
+		},
+		Users:  []string{"user"},
+		Groups: []string{"group"},
+	}
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -219,6 +219,8 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		PrivilegedLoopbackOpenShiftClient:  privilegedLoopbackOpenShiftClient,
 		PrivilegedLoopbackKubernetesClient: privilegedLoopbackKubeClient,
 
+		// NOTE: if these become configurable we will need to update the reconcile-scc and
+		// scc bootstrap access code to use MasterConfig to pass the values.
 		BuildControllerServiceAccount:            bootstrappolicy.InfraBuildControllerServiceAccountName,
 		DeploymentControllerServiceAccount:       bootstrappolicy.InfraDeploymentControllerServiceAccountName,
 		ReplicationControllerServiceAccount:      bootstrappolicy.InfraReplicationControllerServiceAccountName,

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -189,3 +189,22 @@ oc create -f test/fixtures/app-scenarios
 oc status
 oc status -o dot
 echo "complex-scenarios: ok"
+
+# Test reconciling SCCs
+oc delete scc/restricted
+[ ! "$(oc get scc/restricted)" ]
+oadm policy reconcile-sccs
+[ ! "$(oc get scc/restricted)" ]
+oadm policy reconcile-sccs --confirm
+oc get scc/restricted
+
+oadm policy add-scc-to-user restricted my-restricted-user
+[ "$(oc get scc/restricted -o yaml | grep my-restricted-user)" ]
+oadm policy reconcile-sccs --confirm
+[ "$(oc get scc/restricted -o yaml | grep my-restricted-user)" ]
+
+oadm policy remove-scc-from-group restricted system:authenticated
+[ ! "$(oc get scc/restricted -o yaml | grep system:authenticated)" ]
+oadm policy reconcile-sccs --confirm
+[ "$(oc get scc/restricted -o yaml | grep system:authenticated)" ]
+echo "reconcile-scc: ok"


### PR DESCRIPTION
Add a command to reconcile cluster bootstrap SCCs with existing SCCs.  I think this should be considered for a low risk addition.  Still testing it out but first pass seems to work.

@liggitt @deads2k @smarterclayton 