### PR TITLE
extend role covers with groups

### DIFF
--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -39,7 +39,7 @@ func ExpandResources(rawResources sets.String) sets.String {
 }
 
 func (r PolicyRule) String() string {
-	return fmt.Sprintf("PolicyRule{Verbs:%v, Resources:%v, ResourceNames:%v, Restrictions:%v}", r.Verbs.List(), r.Resources.List(), r.ResourceNames.List(), r.AttributeRestrictions)
+	return fmt.Sprintf("PolicyRule{Verbs:%v, APIGroups:%v, Resources:%v, ResourceNames:%v, Restrictions:%v}", r.Verbs.List(), r.APIGroups, r.Resources.List(), r.ResourceNames.List(), r.AttributeRestrictions)
 }
 
 func getRoleBindingValues(roleBindingMap map[string]*RoleBinding) []*RoleBinding {

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -270,6 +270,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
+					APIGroups: []string{authorizationapi.APIGroupAll},
 					Verbs:     sets.NewString(authorizationapi.VerbAll),
 					Resources: sets.NewString(authorizationapi.ResourceAll),
 				},


### PR DESCRIPTION
This extends covers to properly handle the `APIGroups`.  Without this fix, access to `"", "jobs"` will cover  `"extensions", "jobs"` for the purposes of granting permissions.