### PR TITLE
added an LDAP test client framework

### DIFF
--- a/pkg/auth/ldaputil/client.go
+++ b/pkg/auth/ldaputil/client.go
@@ -7,11 +7,12 @@ import (
 
 	"k8s.io/kubernetes/pkg/util"
 
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"gopkg.in/ldap.v2"
 )
 
-// NewLDAPClientConfig returns a new LDAPClientConfig
-func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (*LDAPClientConfig, error) {
+// NewLDAPClientConfig returns a new LDAP client config
+func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (ldapclient.Config, error) {
 	url, err := ParseURL(URL)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing URL: %v", err)
@@ -26,64 +27,63 @@ func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (*
 		tlsConfig.RootCAs = roots
 	}
 
-	return &LDAPClientConfig{
-		Scheme:       url.Scheme,
-		Host:         url.Host,
-		BindDN:       bindDN,
-		BindPassword: bindPassword,
-		Insecure:     insecure,
-		TLSConfig:    tlsConfig,
+	return &ldapClientConfig{
+		scheme:       url.Scheme,
+		host:         url.Host,
+		bindDN:       bindDN,
+		bindPassword: bindPassword,
+		insecure:     insecure,
+		tlsConfig:    tlsConfig,
 	}, nil
 }
 
-// LDAPClientConfig holds information for connecting to an LDAP server
-type LDAPClientConfig struct {
-	// Scheme is the LDAP connection scheme, either ldap or ldaps
-	Scheme Scheme
-	// Host is the host:port of the LDAP server
-	Host string
-	// BindDN is an optional DN to bind with during the search phase.
-	BindDN string
-	// BindPassword is an optional password to bind with during the search phase.
-	BindPassword string
-	// Insecure specifies if TLS is required for the connection. If true, either an ldap://... URL or
+// ldapClientConfig holds information for connecting to an LDAP server
+type ldapClientConfig struct {
+	// scheme is the LDAP connection scheme, either ldap or ldaps
+	scheme Scheme
+	// host is the host:port of the LDAP server
+	host string
+	// bindDN is an optional DN to bind with during the search phase.
+	bindDN string
+	// bindPassword is an optional password to bind with during the search phase.
+	bindPassword string
+	// insecure specifies if TLS is required for the connection. If true, either an ldap://... URL or
 	// StartTLS must be supported by the server
-	Insecure bool
-	// TLSConfig holds the TLS options. Only used when Insecure=false
-	TLSConfig *tls.Config
+	insecure bool
+	// tlsConfig holds the TLS options. Only used when insecure=false
+	tlsConfig *tls.Config
 }
 
-func (l LDAPClientConfig) String() string {
-	return fmt.Sprintf("{Scheme: %v Host: %v BindDN: %v len(BindPassword: %v Insecure: %v}", l.Scheme, l.Host, l.BindDN, len(l.BindPassword), l.Insecure)
-}
+// ldapClientConfig is an ldapclient.Config
+var _ ldapclient.Config = &ldapClientConfig{}
 
 // Connect returns an established LDAP connection, or an error if the connection could not
 // be made (or successfully upgraded to TLS). If no error is returned, the caller is responsible for
 // closing the connection
-func (l *LDAPClientConfig) Connect() (*ldap.Conn, error) {
-	tlsConfig := l.TLSConfig
+func (l *ldapClientConfig) Connect() (ldap.Client, error) {
+	tlsConfig := l.tlsConfig
 
 	// Ensure tlsConfig specifies the server we're connecting to
 	if tlsConfig != nil && !tlsConfig.InsecureSkipVerify && len(tlsConfig.ServerName) == 0 {
 		// Add to a copy of the tlsConfig to avoid mutating the original
 		c := *tlsConfig
-		if host, _, err := net.SplitHostPort(l.Host); err == nil {
+		if host, _, err := net.SplitHostPort(l.host); err == nil {
 			c.ServerName = host
 		} else {
-			c.ServerName = l.Host
+			c.ServerName = l.host
 		}
 		tlsConfig = &c
 	}
 
-	switch l.Scheme {
+	switch l.scheme {
 	case SchemeLDAP:
-		con, err := ldap.Dial("tcp", l.Host)
+		con, err := ldap.Dial("tcp", l.host)
 		if err != nil {
 			return nil, err
 		}
 
 		// If an insecure connection is desired, we're done
-		if l.Insecure {
+		if l.insecure {
 			return con, nil
 		}
 
@@ -98,23 +98,22 @@ func (l *LDAPClientConfig) Connect() (*ldap.Conn, error) {
 		return con, nil
 
 	case SchemeLDAPS:
-		return ldap.DialTLS("tcp", l.Host, tlsConfig)
+		return ldap.DialTLS("tcp", l.host, tlsConfig)
 
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q", l.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q", l.scheme)
 	}
 }
 
-// Bind binds to a given LDAP connection if a bind DN and password were given.
-// Bind returns whether a bind occurred and whether an error occurred
-func (l *LDAPClientConfig) Bind(connection *ldap.Conn) (bound bool, err error) {
-	if len(l.BindDN) > 0 {
-		if err := connection.Bind(l.BindDN, l.BindPassword); err != nil {
-			return false, err
-		} else {
-			return true, nil
-		}
-	}
+func (l *ldapClientConfig) GetBindCredentials() (string, string) {
+	return l.bindDN, l.bindPassword
+}
 
-	return false, nil
+func (l *ldapClientConfig) Host() string {
+	return l.host
+}
+
+// String implements Stringer for debugging purposes
+func (l *ldapClientConfig) String() string {
+	return fmt.Sprintf("{Scheme: %v Host: %v BindDN: %v len(BbindPassword): %v Insecure: %v}", l.scheme, l.host, l.bindDN, len(l.bindPassword), l.insecure)
 }

--- a/pkg/auth/ldaputil/errors.go
+++ b/pkg/auth/ldaputil/errors.go
@@ -1,0 +1,75 @@
+package ldaputil
+
+import "fmt"
+
+func NewNoSuchObjectError(baseDN string) error {
+	return &errNoSuchObject{baseDN: baseDN}
+}
+
+// errNoSuchObject is an error that occurs when a base DN for a search refers to an object that does not exist
+type errNoSuchObject struct {
+	baseDN string
+}
+
+// Error returns the error string for the invalid base DN query error
+func (e *errNoSuchObject) Error() string {
+	return fmt.Sprintf("search for entry with base dn=%q refers to a non-existent entry", e.baseDN)
+}
+
+func IsNoSuchObjectError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errNoSuchObject)
+	return ok
+}
+
+func NewEntryNotFoundError(baseDN, filter string) error {
+	return &errEntryNotFound{baseDN: baseDN, filter: filter}
+}
+
+// errEntryNotFound is an error that occurs when trying to find a specific entry fails.
+type errEntryNotFound struct {
+	baseDN string
+	filter string
+}
+
+// Error returns the error string for the entry not found error
+func (e *errEntryNotFound) Error() string {
+	return fmt.Sprintf("search for entry with base dn=%q and filter %q did not return any results", e.baseDN, e.filter)
+}
+
+func IsEntryNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errEntryNotFound)
+	return ok
+}
+
+func NewQueryOutOfBoundsError(queryDN, baseDN string) error {
+	return &errQueryOutOfBounds{baseDN: baseDN, queryDN: queryDN}
+}
+
+// errQueryOutOfBounds is an error that occurs when trying to search by DN for an entry that exists
+// outside of the tree specified with the BaseDN for search.
+type errQueryOutOfBounds struct {
+	baseDN  string
+	queryDN string
+}
+
+// Error returns the error string for the out-of-bounds query
+func (q *errQueryOutOfBounds) Error() string {
+	return fmt.Sprintf("search for entry with dn=%q would search outside of the base dn specified (dn=%q)", q.queryDN, q.baseDN)
+}
+
+func IsQueryOutOfBoundsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errQueryOutOfBounds)
+	return ok
+}

--- a/pkg/auth/ldaputil/errors.go
+++ b/pkg/auth/ldaputil/errors.go
@@ -1,6 +1,10 @@
 package ldaputil
 
-import "fmt"
+import (
+	"fmt"
+
+	"gopkg.in/ldap.v2"
+)
 
 func NewNoSuchObjectError(baseDN string) error {
 	return &errNoSuchObject{baseDN: baseDN}
@@ -16,13 +20,15 @@ func (e *errNoSuchObject) Error() string {
 	return fmt.Sprintf("search for entry with base dn=%q refers to a non-existent entry", e.baseDN)
 }
 
+// IsNoSuchObjectError determines if the error is a NoSuchObjectError or if it is the upstream version of the error
+// If this returns true, you are *not* safe to cast the error to a NoSuchObjectError
 func IsNoSuchObjectError(err error) bool {
 	if err == nil {
 		return false
 	}
 
 	_, ok := err.(*errNoSuchObject)
-	return ok
+	return ok || ldap.IsErrorWithCode(err, ldap.LDAPResultNoSuchObject)
 }
 
 func NewEntryNotFoundError(baseDN, filter string) error {

--- a/pkg/auth/ldaputil/ldapclient/interfaces.go
+++ b/pkg/auth/ldaputil/ldapclient/interfaces.go
@@ -1,0 +1,10 @@
+package ldapclient
+
+import "gopkg.in/ldap.v2"
+
+// Config knows how to connect to an LDAP server and can describe which server it is connecting to
+type Config interface {
+	Connect() (client ldap.Client, err error)
+	GetBindCredentials() (bindDN, bindPassword string)
+	Host() string
+}

--- a/pkg/auth/ldaputil/query.go
+++ b/pkg/auth/ldaputil/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/glog"
 	"gopkg.in/ldap.v2"
 
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
@@ -151,7 +152,7 @@ func (o *LDAPQueryOnAttribute) buildAttributeQuery(attributeValue string,
 
 // QueryForUniqueEntry queries for an LDAP entry with the given searchRequest. The query is expected
 // to return one unqiue result. If this is not the case, errors are raised
-func QueryForUniqueEntry(clientConfig *LDAPClientConfig, query *ldap.SearchRequest) (*ldap.Entry, error) {
+func QueryForUniqueEntry(clientConfig ldapclient.Config, query *ldap.SearchRequest) (*ldap.Entry, error) {
 	result, err := QueryForEntries(clientConfig, query)
 	if err != nil {
 		return nil, err
@@ -186,18 +187,20 @@ func formatResult(results []*ldap.Entry) string {
 }
 
 // QueryForEntries queries for LDAP with the given searchRequest
-func QueryForEntries(clientConfig *LDAPClientConfig, query *ldap.SearchRequest) ([]*ldap.Entry, error) {
+func QueryForEntries(clientConfig ldapclient.Config, query *ldap.SearchRequest) ([]*ldap.Entry, error) {
 	connection, err := clientConfig.Connect()
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to the LDAP server: %v", err)
 	}
 	defer connection.Close()
 
-	if _, err := clientConfig.Bind(connection); err != nil {
-		return nil, fmt.Errorf("could not bind to the LDAP server: %v", err)
+	if bindDN, bindPassword := clientConfig.GetBindCredentials(); len(bindDN) > 0 {
+		if err := connection.Bind(bindDN, bindPassword); err != nil {
+			return nil, fmt.Errorf("could not bind to the LDAP server: %v", err)
+		}
 	}
 
-	glog.V(4).Infof("searching LDAP server %v://%v at dn=%q with scope %v for %s requesting %v", clientConfig.Scheme, clientConfig.Host, query.BaseDN, query.Scope, query.Filter, query.Attributes)
+	glog.V(4).Infof("searching LDAP server with config %v with dn=%q and scope %v for %s requesting %v", clientConfig, query.BaseDN, query.Scope, query.Filter, query.Attributes)
 	searchResult, err := connection.Search(query)
 	if err != nil {
 		if ldap.IsErrorWithCode(err, ldap.LDAPResultNoSuchObject) {

--- a/pkg/auth/ldaputil/query_test.go
+++ b/pkg/auth/ldaputil/query_test.go
@@ -1,10 +1,12 @@
 package ldaputil
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
 	"gopkg.in/ldap.v2"
 )
 
@@ -192,5 +194,67 @@ func TestNewSearchRequest(t *testing.T) {
 			t.Errorf("%s: did not correctly create search request:\n\texpected:\n%#v\n\tgot:\n%#v",
 				testCase.name, testCase.expectedRequest, request)
 		}
+	}
+}
+
+// TestErrNoSuchObject tests that our LDAP search correctly wraps the LDAP server error
+func TestErrNoSuchObject(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		searchRequest *ldap.SearchRequest
+		expectedError error
+	}{
+		{
+			name: "valid search",
+			searchRequest: &ldap.SearchRequest{
+				BaseDN: "uid=john,o=users,dc=example,dc=com",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "invalid search",
+			searchRequest: &ldap.SearchRequest{
+				BaseDN: "ou=groups,dc=example,dc=com",
+			},
+			expectedError: &errNoSuchObject{baseDN: "ou=groups,dc=example,dc=com"},
+		},
+	}
+	for _, testCase := range testCases {
+		testClient := testclient.NewMatchingSearchErrorClient(testclient.New(),
+			"ou=groups,dc=example,dc=com",
+			ldap.NewError(ldap.LDAPResultNoSuchObject, errors.New("")),
+		)
+		testConfig := testclient.NewConfig(testClient)
+		if _, err := QueryForEntries(testConfig, testCase.searchRequest); !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: error did not match:\n\texpected:\n\t%v\n\tgot:\n\t%v", testCase.name, testCase.expectedError, err)
+		}
+	}
+}
+
+// TestErrEntryNotFound checks that we wrap a zero-length list of results correctly if we search for a unique entry
+func TestErrEntryNotFound(t *testing.T) {
+	testConfig := testclient.NewConfig(testclient.New())
+	testSearchRequest := &ldap.SearchRequest{
+		BaseDN:       "dc=example,dc=com",
+		Scope:        ldap.ScopeWholeSubtree,
+		DerefAliases: int(DefaultDerefAliases),
+		SizeLimit:    DefaultSizeLimit,
+		TimeLimit:    DefaultTimeLimit,
+		TypesOnly:    DefaultTypesOnly,
+		Filter:       "(objectClass=*)",
+		Attributes:   append(DefaultAttributes),
+		Controls:     DefaultControls,
+	}
+
+	expectedErr := &errEntryNotFound{baseDN: "dc=example,dc=com", filter: "(objectClass=*)"}
+
+	// test that a unique search errors on no result
+	if _, err := QueryForUniqueEntry(testConfig, testSearchRequest); !reflect.DeepEqual(err, expectedErr) {
+		t.Errorf("query for unique entry did not get correct error:\n\texpected:\n\t%v\n\tgot:\n\t%v", expectedErr, err)
+	}
+
+	// test that a non-unique search doesn't error
+	if _, err := QueryForEntries(testConfig, testSearchRequest); !reflect.DeepEqual(err, nil) {
+		t.Errorf("query for entries did not get correct error:\n\texpected:\n\t%v\n\tgot:\n\t%v", nil, err)
 	}
 }

--- a/pkg/auth/ldaputil/testclient/testclient.go
+++ b/pkg/auth/ldaputil/testclient/testclient.go
@@ -1,0 +1,145 @@
+package testclient
+
+import (
+	"crypto/tls"
+
+	"gopkg.in/ldap.v2"
+)
+
+// Fake is a mock client for an LDAP server
+// The following methods define safe defaults for the return values. In order to adapt this test client
+// for a specific test, anonymously include it and override the method being tested. In the over-riden
+// method, if you are not covering all method calls with your override, defer to the parent for handling.
+type Fake struct {
+	SimpleBindResponse     *ldap.SimpleBindResult
+	PasswordModifyResponse *ldap.PasswordModifyResult
+	SearchResponse         *ldap.SearchResult
+}
+
+var _ ldap.Client = &Fake{}
+
+// NewTestClient returns a new test client with safe default return values
+func New() *Fake {
+	return &Fake{
+		SimpleBindResponse: &ldap.SimpleBindResult{
+			Controls: []ldap.Control{},
+		},
+		PasswordModifyResponse: &ldap.PasswordModifyResult{
+			GeneratedPassword: "",
+		},
+		SearchResponse: &ldap.SearchResult{
+			Entries:   []*ldap.Entry{},
+			Referrals: []string{},
+			Controls:  []ldap.Control{},
+		},
+	}
+}
+
+// Start starts the LDAP connection
+func (c *Fake) Start() {
+	return
+}
+
+// StartTLS begins a TLS-wrapped LDAP connection
+func (c *Fake) StartTLS(config *tls.Config) error {
+	return nil
+}
+
+// Close closes an LDAP connection
+func (c *Fake) Close() {
+	return
+}
+
+// Bind binds to the LDAP server with a bind DN and password
+func (c *Fake) Bind(username, password string) error {
+	return nil
+}
+
+// SimpleBind binds to the LDAP server using the Simple Bind mechanism
+func (c *Fake) SimpleBind(simpleBindRequest *ldap.SimpleBindRequest) (*ldap.SimpleBindResult, error) {
+	return c.SimpleBindResponse, nil
+}
+
+// Add forwards an addition request to the LDAP server
+func (c *Fake) Add(addRequest *ldap.AddRequest) error {
+	return nil
+}
+
+// Del forwards a deletion request to the LDAP server
+func (c *Fake) Del(delRequest *ldap.DelRequest) error {
+	return nil
+}
+
+// Modify forwards a modification request to the LDAP server
+func (c *Fake) Modify(modifyRequest *ldap.ModifyRequest) error {
+	return nil
+}
+
+// Compare ... ?
+func (c *Fake) Compare(dn, attribute, value string) (bool, error) {
+	return false, nil
+}
+
+// PasswordModify forwards a password modify request to the LDAP server
+func (c *Fake) PasswordModify(passwordModifyRequest *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+	return c.PasswordModifyResponse, nil
+}
+
+// Search forwards a search request to the LDAP server
+func (c *Fake) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	return c.SearchResponse, nil
+}
+
+// SearchWithPaging forwards a search request to the LDAP server and pages the response
+func (c *Fake) SearchWithPaging(searchRequest *ldap.SearchRequest, pagingSize uint32) (*ldap.SearchResult, error) {
+	return c.SearchResponse, nil
+}
+
+// NewMatchingSearchErrorClient returns a new MatchingSeachError client sitting on top of the parent
+// client. This client returns the given error when a search base DN matches the given base DN, and
+// defers to the parent otherwise.
+func NewMatchingSearchErrorClient(parent ldap.Client, baseDN string, returnErr error) ldap.Client {
+	return &MatchingSearchErrClient{
+		Client:    parent,
+		BaseDN:    baseDN,
+		ReturnErr: returnErr,
+	}
+}
+
+// MatchingSearchErrClient returns the ReturnErr on every Search() where the search base DN matches the given DN
+// or defers the search to the parent client
+type MatchingSearchErrClient struct {
+	ldap.Client
+	BaseDN    string
+	ReturnErr error
+}
+
+func (c *MatchingSearchErrClient) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if searchRequest.BaseDN == c.BaseDN {
+		return nil, c.ReturnErr
+	}
+	return c.Client.Search(searchRequest)
+}
+
+// NewDNMappingClient returns a new DNMappingClient sitting on top of the parent client. This client returns the
+// ldap entries mapped to with this DN in its' internal DN map, or defers to the parent if the DN is not mapped.
+func NewDNMappingClient(parent ldap.Client, DNMapping map[string][]*ldap.Entry) ldap.Client {
+	return &DNMappingClient{
+		Client:    parent,
+		DNMapping: DNMapping,
+	}
+}
+
+// DNMappingClient returns the LDAP entry mapped to by the base dn given, or if no mapping happens, defers to the parent
+type DNMappingClient struct {
+	ldap.Client
+	DNMapping map[string][]*ldap.Entry
+}
+
+func (c *DNMappingClient) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if entries, exists := c.DNMapping[searchRequest.BaseDN]; exists {
+		return &ldap.SearchResult{Entries: entries}, nil
+	}
+
+	return c.Client.Search(searchRequest)
+}

--- a/pkg/auth/ldaputil/testclient/testclientconfig.go
+++ b/pkg/auth/ldaputil/testclient/testclientconfig.go
@@ -1,0 +1,30 @@
+package testclient
+
+import (
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	"gopkg.in/ldap.v2"
+)
+
+// fakeConfig regurgitates internal state in order to conform to Config
+type fakeConfig struct {
+	client ldap.Client
+}
+
+// NewConfig creates a new Config impl that regurgitates the given data
+func NewConfig(client ldap.Client) ldapclient.Config {
+	return &fakeConfig{
+		client: client,
+	}
+}
+
+func (c *fakeConfig) Connect() (ldap.Client, error) {
+	return c.client, nil
+}
+
+func (c *fakeConfig) GetBindCredentials() (string, string) {
+	return "", ""
+}
+
+func (c *fakeConfig) Host() string {
+	return ""
+}

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
@@ -6,11 +6,12 @@ import (
 	"gopkg.in/ldap.v2"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
-func NewAugmentedADLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
+func NewAugmentedADLDAPInterface(clientConfig ldapclient.Config,
 	userQuery ldaputil.LDAPQuery,
 	groupMembershipAttributes []string,
 	userNameAttributes []string,

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
@@ -8,11 +8,12 @@ import (
 	"gopkg.in/ldap.v2"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewADLDAPInterface builds a new ADLDAPInterface using a schema-appropriate config
-func NewADLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
+func NewADLDAPInterface(clientConfig ldapclient.Config,
 	userQuery ldaputil.LDAPQuery,
 	groupMembershipAttributes []string,
 	userNameAttributes []string) *ADLDAPInterface {
@@ -33,7 +34,7 @@ func NewADLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
 // - LDAPGroupLister
 type ADLDAPInterface struct {
 	// clientConfig holds LDAP connection information
-	clientConfig *ldaputil.LDAPClientConfig
+	clientConfig ldapclient.Config
 
 	// userQuery holds the information necessary to make an LDAP query for all first-class user entries on the LDAP server
 	userQuery ldaputil.LDAPQuery

--- a/pkg/cmd/experimental/syncgroups/cli/ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/ad.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/ad"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
@@ -11,7 +12,7 @@ import (
 var _ SyncBuilder = &ADSyncBuilder{}
 
 type ADSyncBuilder struct {
-	ClientConfig *ldaputil.LDAPClientConfig
+	ClientConfig ldapclient.Config
 	Config       *api.ActiveDirectoryConfig
 
 	adLDAPInterface *ad.ADLDAPInterface

--- a/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/ad"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
@@ -11,7 +12,7 @@ import (
 var _ SyncBuilder = &AugmentedADSyncBuilder{}
 
 type AugmentedADSyncBuilder struct {
-	ClientConfig *ldaputil.LDAPClientConfig
+	ClientConfig ldapclient.Config
 	Config       *api.AugmentedActiveDirectoryConfig
 
 	augmentedADLDAPInterface *ad.AugmentedADLDAPInterface

--- a/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
+++ b/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/rfc2307"
@@ -11,7 +12,7 @@ import (
 var _ SyncBuilder = &RFC2307SyncBuilder{}
 
 type RFC2307SyncBuilder struct {
-	ClientConfig *ldaputil.LDAPClientConfig
+	ClientConfig ldapclient.Config
 	Config       *api.RFC2307Config
 
 	rfc2307LDAPInterface *rfc2307.LDAPInterface

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -317,7 +317,7 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 
 	// populate schema-independent syncer fields
 	syncer := &syncgroups.LDAPGroupSyncer{
-		Host:        clientConfig.Host,
+		Host:        clientConfig.Host(),
 		GroupClient: o.GroupInterface,
 		DryRun:      !o.Confirm,
 
@@ -329,7 +329,7 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 	case GroupSyncSourceOpenShift:
 		// when your source of ldapGroupUIDs is from an openshift group, the mapping of ldapGroupUID to openshift group name is logically
 		// pinned by the existing mapping.
-		listerMapper, err := o.GetOpenShiftGroupListerMapper(syncBuilder, clientConfig)
+		listerMapper, err := o.GetOpenShiftGroupListerMapper(clientConfig.Host())
 		if err != nil {
 			return err
 		}
@@ -378,16 +378,16 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 
 }
 
-func (o *SyncGroupsOptions) GetOpenShiftGroupListerMapper(syncBuilder SyncBuilder, clientConfig *ldaputil.LDAPClientConfig) (interfaces.LDAPGroupListerNameMapper, error) {
+func (o *SyncGroupsOptions) GetOpenShiftGroupListerMapper(host string) (interfaces.LDAPGroupListerNameMapper, error) {
 	if o.Source != GroupSyncSourceOpenShift {
 		return nil, errors.New("openshift is not a valid group source for this config")
 	}
 
 	if len(o.Whitelist) != 0 {
-		return syncgroups.NewOpenShiftGroupLister(o.Whitelist, o.Blacklist, clientConfig.Host, o.GroupInterface), nil
+		return syncgroups.NewOpenShiftGroupLister(o.Whitelist, o.Blacklist, host, o.GroupInterface), nil
 	}
 
-	return syncgroups.NewAllOpenShiftGroupLister(o.Blacklist, clientConfig.Host, o.GroupInterface), nil
+	return syncgroups.NewAllOpenShiftGroupLister(o.Blacklist, host, o.GroupInterface), nil
 }
 
 func (o *SyncGroupsOptions) GetLDAPGroupLister(syncBuilder SyncBuilder) (interfaces.LDAPGroupLister, error) {

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
@@ -8,11 +8,12 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
-func NewLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
+func NewLDAPInterface(clientConfig ldapclient.Config,
 	groupQuery ldaputil.LDAPQueryOnAttribute,
 	groupNameAttributes []string,
 	groupMembershipAttributes []string,
@@ -39,7 +40,7 @@ func NewLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
 // - LDAPGroupLister
 type LDAPInterface struct {
 	// clientConfig holds LDAP connection information
-	clientConfig *ldaputil.LDAPClientConfig
+	clientConfig ldapclient.Config
 
 	// groupQuery holds the information necessary to make an LDAP query for a specific
 	// first-class group entry on the LDAP server

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -500,7 +500,7 @@ func (c *AuthConfig) getPasswordAuthenticator(identityProvider configapi.Identit
 
 		opts := ldappassword.Options{
 			URL:                  url,
-			ClientConfig:         *clientConfig,
+			ClientConfig:         clientConfig,
 			UserAttributeDefiner: ldaputil.NewLDAPUserAttributeDefiner(provider.Attributes),
 		}
 		return ldappassword.New(identityProvider.Name, opts, identityMapper)


### PR DESCRIPTION
This allows us to easily mock out the LDAP client for unit-testing. Currently not feature-complete and up to the developer to correctly compose/layer fake clients on top of each other, determine when to delegate to a parent, etc.

Depends on https://github.com/openshift/origin/pull/5615

/cc @deads2k @liggitt 