### PR TITLE
to add a job test to extended test

### DIFF
--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -41,7 +41,6 @@ SKIP_TESTS=(
   kube-ui                 # Not installed by default
   DaemonRestart           # Experimental mode not enabled yet
   "Daemon set"            # Experimental mode not enabled yet
-  Job                     # Not enabled yet
   "deployment should"     # Not enabled yet
   Ingress                 # Not enabled yet
 

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/images"
+	_ "github.com/openshift/origin/test/extended/job"
 	_ "github.com/openshift/origin/test/extended/router"
 	_ "github.com/openshift/origin/test/extended/security"
 

--- a/test/extended/fixtures/job-controller.yaml
+++ b/test/extended/fixtures/job-controller.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Job
+metadata:
+  name: pi
+spec:
+  selector:
+    matchLabels:
+      app: pi
+  template:
+    metadata:
+      name: pi
+      labels:
+        app: pi
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(100)"]
+      restartPolicy: Never

--- a/test/extended/job/controller.go
+++ b/test/extended/job/controller.go
@@ -1,0 +1,47 @@
+package job
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exeutil "github.com/openshift/origin/test/extended/util"
+	kapiextensions "k8s.io/kubernetes/pkg/apis/extensions"
+)
+
+var _ = g.Describe("Job", func() {
+	defer g.GinkgoRecover()
+	var (
+		configPath = exeutil.FixturePath("fixtures", "job-controller.yaml")
+		oc         = exeutil.NewCLI("job-controller", exeutil.KubeConfigPath())
+	)
+	g.Describe("controller", func() {
+		g.It("should create and run a job in user project", func() {
+			oc.SetOutputDir(exeutil.TestContext.OutputDir)
+			g.By(fmt.Sprintf("creating a job from %q", configPath))
+			err := oc.Run("create").Args("-f", configPath).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("Waiting for pod..."))
+			podNames, err := exeutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), exeutil.ParseLabelsOrDie("app=pi"), exeutil.CheckPodIsSucceededFunc, 1, 120*time.Second)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(len(podNames)).Should(o.Equal(1))
+			podName := podNames[0]
+
+			g.By("retrieving logs from pod " + podName)
+			logs, err := oc.Run("logs").Args(podName).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(logs).Should(o.Equal("3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068"))
+
+			g.By("checking job status")
+			jobs, err := oc.KubeREST().Jobs(oc.Namespace()).List(exeutil.ParseLabelsOrDie("app=pi"), nil)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			o.Expect(len(jobs.Items)).Should(o.Equal(1))
+			job := jobs.Items[0]
+			o.Expect(len(job.Status.Conditions)).Should(o.Equal(1))
+			o.Expect(job.Status.Conditions[0].Type).Should(o.Equal(kapiextensions.JobComplete))
+		})
+	})
+})

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -297,6 +297,11 @@ var CheckPodIsRunningFunc = func(pod kapi.Pod) bool {
 	return pod.Status.Phase == kapi.PodRunning
 }
 
+// CheckPodIsSucceededFunc returns true if the pod status is "Succdeded"
+var CheckPodIsSucceededFunc = func(pod kapi.Pod) bool {
+	return pod.Status.Phase == kapi.PodSucceeded
+}
+
 // WaitUntilPodIsGone waits until the named Pod will disappear
 func WaitUntilPodIsGone(c kclient.PodInterface, podName string, timeout time.Duration) error {
 	return wait.Poll(1*time.Second, timeout, func() (bool, error) {


### PR DESCRIPTION
@soltysh @deads2k this PR is for
 https://github.com/openshift/origin/issues/5538 
Enables Upstream `Job` e2e test 
and add a basic test job creation (following https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/jobs.md)

Thanks to have a look.