### PR TITLE
Fix oadm command in contrib

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -93,7 +93,7 @@ NOTE: Replace "linux/amd64" with the appropriate value for your platform/archite
 
         $ sudo chmod +r openshift.local.config/master/openshift-registry.kubeconfig
         $ sudo chmod +r openshift.local.config/master/admin.kubeconfig
-        $ oadm registry --create --credentials=openshift.local.config/master/openshift-registry.kubeconfig --config=openshift.local.config/master/admin.kubeconfig
+        $ ./oadm registry --create --credentials=openshift.local.config/master/openshift-registry.kubeconfig --config=openshift.local.config/master/admin.kubeconfig
 
 11.  If it is not there already, add the current directory to the $PATH, so you can leverage the OpenShift commands elsewhere.
 


### PR DESCRIPTION
Per some feedback received...the openshift start command assumes you don't have the commands on your path yet and includes `./`.   The oadm step assumes the same (telling you to cd to the directory) but doesn't include `./`.  