### PR TITLE
UPSTREAM: 14182: Distinguish image registry unavailable and pull failure

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/container/runtime.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/container/runtime.go
@@ -45,6 +45,9 @@ var (
 
 	// Required Image is absent on host and PullPolicy is NeverPullImage
 	ErrImageNeverPull = errors.New("ErrImageNeverPull")
+
+	// Get http error when pulling image from registry
+	RegistryUnavailable = errors.New("RegistryUnavailable")
 )
 
 var ErrRunContainer = errors.New("RunContainerError")

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/docker.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/docker.go
@@ -130,7 +130,7 @@ func filterHTTPError(err error, image string) error {
 		jerr.Code == http.StatusServiceUnavailable ||
 		jerr.Code == http.StatusGatewayTimeout) {
 		glog.V(2).Infof("Pulling image %q failed: %v", image, err)
-		return fmt.Errorf("image pull failed for %s because the registry is temporarily unavailable.", image)
+		return kubecontainer.RegistryUnavailable
 	} else {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/docker_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubelet/dockertools/docker_test.go
@@ -257,7 +257,7 @@ func TestPullWithJSONError(t *testing.T) {
 		"Bad gateway": {
 			"ubuntu",
 			&jsonmessage.JSONError{Code: 502, Message: "<!doctype html>\n<html class=\"no-js\" lang=\"\">\n    <head>\n  </head>\n    <body>\n   <h1>Oops, there was an error!</h1>\n        <p>We have been contacted of this error, feel free to check out <a href=\"http://status.docker.com/\">status.docker.com</a>\n           to see if there is a bigger issue.</p>\n\n    </body>\n</html>"},
-			"because the registry is temporarily unavailable",
+			kubecontainer.RegistryUnavailable.Error(),
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
This is a prerequisite to serial image pulling in Kubelet.

@smarterclayton @liggitt 