### PR TITLE
Prevent early exit on install-assets failure

### DIFF
--- a/hack/install-assets.sh
+++ b/hack/install-assets.sh
@@ -18,8 +18,8 @@ function cmd() {
   echo "[install-assets] ${cmd}"
   rc="0"
   while [[ "$tries" -gt 0 ]]; do
-    $cmd &> ${log_file}
-    rc=$?
+    rc="0"
+    $cmd &> ${log_file} || rc=$?
     [[ "$rc" == "0" ]] && return 0
     ((tries--))
   done


### PR DESCRIPTION
assign rc inside the loop, so a successful run of $cmd leaves it holding "0"
assign rc in an || so a failure of $cmd doesn't exit the script (because of `set -e`)