### PR TITLE
New kibana archive log link on log tab for build & pod

### DIFF
--- a/assets/.jshintrc
+++ b/assets/.jshintrc
@@ -31,6 +31,7 @@
     "URI": false,
     "ZeroClipboard": false,
     "$": false,
-    "_" : false
+    "_" : false,
+    "URITemplate": false
   }
 }

--- a/assets/app/scripts/services/logLinks.js
+++ b/assets/app/scripts/services/logLinks.js
@@ -50,10 +50,28 @@ angular.module('openshiftConsole')
         newTab(params);
       };
 
-      // Not currently used.
-      // new tab: path/to/current?view=textonly
-      var textOnlyLink = function() {
-        newTab({view: 'textonly'});
+      // broken up for readability:
+      var template = new URITemplate([
+        "/#/discover?",
+        "_g=(",
+          "time:(from:now-7y%2Fy,mode:relative,to:now)",
+        ")",
+        "&_a=(",
+          "columns:!(_source),",
+          "index:'{namespace}.*',",
+          "query:(",
+            "query_string:(",
+              "analyze_wildcard:!t,",
+              "query:'kubernetes_pod_name: {podname} %26%26 kubernetes_namespace_name: {namespace}'",
+            ")",
+          "),",
+          "sort:!(time,desc)",
+        ")",
+        "&console_back_link={backlink}"
+      ].join(''));
+
+      var archiveUri = function(opts) {
+        return template.expand(opts);
       };
 
       return {
@@ -62,7 +80,7 @@ angular.module('openshiftConsole')
         scrollTo: scrollTo,
         newTab: newTab,
         chromelessLink: chromelessLink,
-        textOnlyLink: textOnlyLink
+        archiveUri: archiveUri
       };
     }
   ]);

--- a/assets/app/scripts/services/logLinks.js
+++ b/assets/app/scripts/services/logLinks.js
@@ -54,10 +54,15 @@ angular.module('openshiftConsole')
       var template = new URITemplate([
         "/#/discover?",
         "_g=(",
-          "time:(from:now-7y%2Fy,mode:relative,to:now)",
+          "time:(",
+            "from:now-1w,",
+            "mode:relative,",
+            "to:now",
+          ")",
         ")",
         "&_a=(",
-          "columns:!(_source),",
+          //"columns:!(_source),",
+          "columns:!(kubernetes_container_name,{containername}),",
           "index:'{namespace}.*',",
           "query:(",
             "query_string:(",
@@ -67,8 +72,12 @@ angular.module('openshiftConsole')
           "),",
           "sort:!(time,desc)",
         ")",
-        "&console_back_link={backlink}"
+        // NOTE: slightly older versions of kibana require openshift_ prefix, not console_
+        "#console_container_name={containername}",
+        // backlink should be encoded.  passing URI.encode(backlink) should be sufficient
+        "&console_back_url={backlink}"
       ].join(''));
+
 
       var archiveUri = function(opts) {
         return template.expand(opts);

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -2,6 +2,18 @@
     <span>Current log from {{start}}&nbsp;</span>
     <span ng-if="end">to {{end}}</span>
   </div>
+
+  <div row main-axis="end" ng-if="canViewArchive">
+    <form
+      ng-if="canViewArchive"
+      action="{{kibanaAuthUrl}}"
+      method="POST" target="_blank">
+      <input type="hidden" name="redirect" value="{{archiveLocation}}">
+      <input type="hidden" name="access_token" value="{{access_token}}">
+      <button class="btn btn-sm btn-primary">View Archive</button>
+    </form>
+  </div>
+
   <div ng-if="largeLog" class="log-size-warning">
     <span class="pficon pficon-info" aria-hidden="true"></span>
     Only the previous {{options.tailLines || 1000}} log lines and new log

--- a/assets/app/views/directives/logs/_log-viewer.html
+++ b/assets/app/views/directives/logs/_log-viewer.html
@@ -1,17 +1,18 @@
-  <div class="log-timestamp" ng-if="!chromeless && start">
-    <span>Current log from {{start}}&nbsp;</span>
-    <span ng-if="end">to {{end}}</span>
-  </div>
-
-  <div row main-axis="end" ng-if="canViewArchive">
-    <form
-      ng-if="canViewArchive"
-      action="{{kibanaAuthUrl}}"
-      method="POST" target="_blank">
-      <input type="hidden" name="redirect" value="{{archiveLocation}}">
-      <input type="hidden" name="access_token" value="{{access_token}}">
-      <button class="btn btn-sm btn-primary">View Archive</button>
-    </form>
+  <div row class="log-timestamp" ng-if="!chromeless && start">
+    <div>
+      <span>Current log from {{start}}&nbsp;</span>
+      <span ng-if="end">to {{end}}</span>
+    </div>
+    <div flex></div>
+    <div ng-if="kibanaAuthUrl">
+      <form
+        action="{{kibanaAuthUrl}}"
+        method="POST">
+        <input type="hidden" name="redirect" value="{{archiveLocation}}">
+        <input type="hidden" name="access_token" value="{{access_token}}">
+        <button class="btn btn-sm btn-primary">View Archive</button>
+      </form>
+    </div>
   </div>
 
   <div ng-if="largeLog" class="log-size-warning">
@@ -19,18 +20,17 @@
     Only the previous {{options.tailLines || 1000}} log lines and new log
     messages will be displayed because of the large log size.
   </div>
-  <div ng-if="!chromeless">
-    <div class="row">
-      <div ng-if="status" class="col-md-6 col-sm-12 status">
-        <span>Status:&nbsp;&nbsp;</span>
-        <status-icon status="status"></status-icon>
-        <span>&nbsp;&nbsp;{{status}}</span>
-      </div>
-      <div class="log-link-external col-md-6 col-sm-12">
-        <a href=""  ng-click="goChromeless(options)">
-          Open full view of log<i class="fa fa-external-link"></i>
-        </a>
-      </div>
+
+  <div class="row" ng-if="!chromeless">
+    <div ng-if="status" class="col-md-6 col-sm-12 status">
+      <span>Status:&nbsp;&nbsp;</span>
+      <status-icon status="status"></status-icon>
+      <span>&nbsp;&nbsp;{{status}}</span>
+    </div>
+    <div class="log-link-external col-md-6 col-sm-12 text-right">
+      <a href=""  ng-click="goChromeless(options)">
+        Open full view of log<i class="fa fa-external-link"></i>
+      </a>
     </div>
   </div>
 


### PR DESCRIPTION
This is a work in progress as we are still ironing out details around linking out to Kibana. 

- Use $sce.trustAsResourceUrl in logViewer directive to whitelist link to archives in kibana
- Multiple archive link options in _log-viewer, multiple archive tpl fns to generate kibana link
- Link archive tlp 3rd example (testing)

There are comments pointing out some things still being worked on @spadgett @jwforres 