### PR TITLE
Copy volume mounts to hook pods

### DIFF
--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -237,6 +237,13 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 									kapi.ResourceMemory: resource.MustParse("10M"),
 								},
 							},
+							VolumeMounts: []kapi.VolumeMount{
+								{
+									Name:      "volume-2",
+									ReadOnly:  true,
+									MountPath: "/mnt/volume-2",
+								},
+							},
 						},
 					},
 				},
@@ -476,6 +483,13 @@ func deployment(name, namespace string) *kapi.ReplicationController {
 									Limits: kapi.ResourceList{
 										kapi.ResourceCPU:    resource.MustParse("10"),
 										kapi.ResourceMemory: resource.MustParse("10M"),
+									},
+								},
+								VolumeMounts: []kapi.VolumeMount{
+									{
+										Name:      "volume-2",
+										ReadOnly:  true,
+										MountPath: "/mnt/volume-2",
 									},
 								},
 							},


### PR DESCRIPTION
Copy volume mounts to hook pods matching any volumes which were also
copied to the hook pod. Otherwise the mapped volumes are inaccessible
to the hook container.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1270187