### PR TITLE
CLI logs: fix command name in help

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -490,21 +490,21 @@ Print the logs for a resource.
 [options="nowrap"]
 ----
   # Start streaming the logs of the most recent build of the openldap build config.
-  $ logs openshift cli -f bc/openldap
+  $ openshift cli logs -f bc/openldap
 
   # Start streaming the logs of the latest deployment of the mysql deployment config.
-  $ logs openshift cli -f dc/mysql
+  $ openshift cli logs -f dc/mysql
 
   # Get the logs of the first deployment for the mysql deployment config. Note that logs
   # from older deployments may not exist either because the deployment was successful
   # or due to deployment pruning or manual deletion of the deployment.
-  $ logs openshift cli --version=1 dc/mysql
+  $ openshift cli logs --version=1 dc/mysql
 
   # Return a snapshot of ruby-container logs from pod backend.
-  $ logs openshift cli backend -c ruby-container
+  $ openshift cli logs backend -c ruby-container
 
   # Start streaming of ruby-container logs from pod backend.
-  $ logs openshift cli -f pod/backend -c ruby-container
+  $ openshift cli logs -f pod/backend -c ruby-container
 ----
 ====
 

--- a/pkg/cmd/cli/cmd/logs.go
+++ b/pkg/cmd/cli/cmd/logs.go
@@ -67,7 +67,7 @@ func NewCmdLogs(name, parent string, f *clientcmd.Factory, out io.Writer) *cobra
 	cmd := kcmd.NewCmdLog(f.Factory, out)
 	cmd.Short = "Print the logs for a resource."
 	cmd.Long = logsLong
-	cmd.Example = fmt.Sprintf(logsExample, name+" "+parent)
+	cmd.Example = fmt.Sprintf(logsExample, parent+" "+name)
 	cmd.SuggestFor = []string{"builds", "deployments"}
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		cmdutil.CheckErr(o.Complete(f, out, cmd, args))


### PR DESCRIPTION
command name is inverted in example text