### PR TITLE
Added unit testing for LDAP group sync

### DIFF
--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
@@ -1,13 +1,13 @@
 package ad
 
 import (
-	"k8s.io/kubernetes/pkg/util/sets"
-
 	"gopkg.in/ldap.v2"
+
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
@@ -28,10 +28,6 @@ func NewAugmentedADLDAPInterface(clientConfig ldapclient.Config,
 
 // LDAPInterface extracts the member list of an LDAP user entry from an LDAP server
 // with first-class LDAP entries for users and group.  Group membership is on the user. The LDAPInterface is *NOT* thread-safe.
-// The LDAPInterface satisfies:
-// - LDAPMemberExtractor
-// - LDAPGroupGetter
-// - LDAPGroupLister
 type AugmentedADLDAPInterface struct {
 	*ADLDAPInterface
 
@@ -41,12 +37,14 @@ type AugmentedADLDAPInterface struct {
 	// groupNameAttributes defines which attributes on an LDAP group entry will be interpreted as its name to use for an OpenShift group
 	groupNameAttributes []string
 
+	// cachedGroups holds the result of group queries for later reference, indexed on group UID
+	// e.g. this will map an LDAP group UID to the LDAP entry returned from the query made using it
 	cachedGroups map[string]*ldap.Entry
 }
 
-var _ ldapinterfaces.LDAPMemberExtractor = &AugmentedADLDAPInterface{}
-var _ ldapinterfaces.LDAPGroupGetter = &AugmentedADLDAPInterface{}
-var _ ldapinterfaces.LDAPGroupLister = &AugmentedADLDAPInterface{}
+var _ interfaces.LDAPMemberExtractor = &AugmentedADLDAPInterface{}
+var _ interfaces.LDAPGroupGetter = &AugmentedADLDAPInterface{}
+var _ interfaces.LDAPGroupLister = &AugmentedADLDAPInterface{}
 
 // GroupFor returns an LDAP group entry for the given group UID by searching the internal cache
 // of the LDAPInterface first, then sending an LDAP query if the cache did not contain the entry.

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface_test.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface_test.go
@@ -1,0 +1,108 @@
+package ad
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"gopkg.in/ldap.v2"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
+)
+
+func newTestAugmentedADLDAPInterface(client ldap.Client) *AugmentedADLDAPInterface {
+	// below are common test implementations of LDAPInterface fields
+	userQuery := ldaputil.LDAPQuery{
+		BaseDN:       "ou=users,dc=example,dc=com",
+		Scope:        ldaputil.ScopeWholeSubtree,
+		DerefAliases: ldaputil.DerefAliasesAlways,
+		TimeLimit:    0,
+		Filter:       "objectClass=inetOrgPerson",
+	}
+	groupMembershipAttributes := []string{"memberOf"}
+	userNameAttributes := []string{"cn"}
+	groupQuery := ldaputil.LDAPQueryOnAttribute{
+		LDAPQuery: ldaputil.LDAPQuery{
+			BaseDN:       "ou=groups,dc=example,dc=com",
+			Scope:        ldaputil.ScopeWholeSubtree,
+			DerefAliases: ldaputil.DerefAliasesAlways,
+			TimeLimit:    0,
+			Filter:       "objectClass=groupOfNames",
+		},
+		QueryAttribute: "dn",
+	}
+	groupNameAttributes := []string{"cn"}
+
+	return NewAugmentedADLDAPInterface(testclient.NewConfig(client),
+		userQuery,
+		groupMembershipAttributes,
+		userNameAttributes,
+		groupQuery,
+		groupNameAttributes)
+}
+
+// newDefaultTestGroup returns a new LDAP entry with the given CN
+func newTestGroup(CN string) *ldap.Entry {
+	return ldap.NewEntry(fmt.Sprintf("cn=%s,ou=groups,dc=example,dc=com", CN), map[string][]string{"cn": {CN}})
+}
+
+func TestGroupEntryFor(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		cacheSeed      map[string]*ldap.Entry
+		client         ldap.Client
+		baseDNOverride string
+		expectedError  error
+		expectedEntry  *ldap.Entry
+	}{
+		{
+			name: "cached entries",
+			cacheSeed: map[string]*ldap.Entry{
+				"cn=testGroup,ou=groups,dc=example,dc=com": newTestGroup("testGroup"),
+			},
+			expectedError: nil,
+			expectedEntry: newTestGroup("testGroup"),
+		},
+		{
+			name:           "search request error",
+			baseDNOverride: "otherBaseDN",
+			expectedError:  ldaputil.NewQueryOutOfBoundsError("cn=testGroup,ou=groups,dc=example,dc=com", "otherBaseDN"),
+			expectedEntry:  nil,
+		},
+		{
+			name:          "search error",
+			client:        testclient.NewMatchingSearchErrorClient(testclient.New(), "cn=testGroup,ou=groups,dc=example,dc=com", errors.New("generic search error")),
+			expectedError: errors.New("generic search error"),
+			expectedEntry: nil,
+		},
+		{
+			name: "no error",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"cn=testGroup,ou=groups,dc=example,dc=com": {newTestGroup("testGroup")},
+				},
+			),
+			expectedError: nil,
+			expectedEntry: newTestGroup("testGroup"),
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestAugmentedADLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.cachedGroups = testCase.cacheSeed
+		}
+		if len(testCase.baseDNOverride) > 0 {
+			ldapInterface.groupQuery.BaseDN = testCase.baseDNOverride
+		}
+		entry, err := ldapInterface.GroupEntryFor("cn=testGroup,ou=groups,dc=example,dc=com")
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(entry, testCase.expectedEntry) {
+			t.Errorf("%s: incorrect members returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedEntry, entry)
+		}
+	}
+}

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
@@ -3,13 +3,13 @@ package ad
 import (
 	"reflect"
 
-	"k8s.io/kubernetes/pkg/util/sets"
-
 	"gopkg.in/ldap.v2"
+
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewADLDAPInterface builds a new ADLDAPInterface using a schema-appropriate config
@@ -29,9 +29,6 @@ func NewADLDAPInterface(clientConfig ldapclient.Config,
 
 // ADLDAPInterface extracts the member list of an LDAP group entry from an LDAP server
 // with first-class LDAP entries for user only. The ADLDAPInterface is *NOT* thread-safe.
-// The ADLDAPInterface satisfies:
-// - LDAPMemberExtractor
-// - LDAPGroupLister
 type ADLDAPInterface struct {
 	// clientConfig holds LDAP connection information
 	clientConfig ldapclient.Config
@@ -43,12 +40,17 @@ type ADLDAPInterface struct {
 	// UserNameAttributes defines which attributes on an LDAP user entry will be interpreted as its name
 	userNameAttributes []string
 
-	cachePopulated         bool
+	// cacheFullyPopulated determines if the cache has been fully populated
+	// populateCache() will populate it fully, specific calls to ExtractMembers() will not
+	cacheFullyPopulated bool
+	// ldapGroupToLDAPMembers holds the result of user queries for later reference, indexed on group UID
+	// e.g. this will map all LDAP users to the LDAP group UID whose entry returned them
 	ldapGroupToLDAPMembers map[string][]*ldap.Entry
 }
 
-var _ ldapinterfaces.LDAPMemberExtractor = &ADLDAPInterface{}
-var _ ldapinterfaces.LDAPGroupLister = &ADLDAPInterface{}
+// The LDAPInterface must conform to the following interfaces
+var _ interfaces.LDAPMemberExtractor = &ADLDAPInterface{}
+var _ interfaces.LDAPGroupLister = &ADLDAPInterface{}
 
 // ExtractMembers returns the LDAP member entries for a group specified with a ldapGroupUID
 func (e *ADLDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
@@ -74,9 +76,7 @@ func (e *ADLDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, er
 			return nil, err
 		}
 
-		for i := range currEntries {
-			currEntry := currEntries[i]
-
+		for _, currEntry := range currEntries {
 			if !isEntryPresent(usersInGroup, currEntry) {
 				usersInGroup = append(usersInGroup, currEntry)
 			}
@@ -101,7 +101,7 @@ func (e *ADLDAPInterface) ListGroups() ([]string, error) {
 // populateCache queries all users to build a map of all the groups.  If the cache has already been
 // populated, this is a no-op.
 func (e *ADLDAPInterface) populateCache() error {
-	if e.cachePopulated {
+	if e.cacheFullyPopulated {
 		return nil
 	}
 
@@ -112,8 +112,7 @@ func (e *ADLDAPInterface) populateCache() error {
 		return err
 	}
 
-	for i := range userEntries {
-		userEntry := userEntries[i]
+	for _, userEntry := range userEntries {
 		if userEntry == nil {
 			continue
 		}
@@ -130,7 +129,7 @@ func (e *ADLDAPInterface) populateCache() error {
 			}
 		}
 	}
-	e.cachePopulated = true
+	e.cacheFullyPopulated = true
 
 	return nil
 }

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface_test.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface_test.go
@@ -1,0 +1,202 @@
+package ad
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"gopkg.in/ldap.v2"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
+)
+
+func newTestADLDAPInterface(client ldap.Client) *ADLDAPInterface {
+	// below are common test implementations of LDAPInterface fields
+	userQuery := ldaputil.LDAPQuery{
+		BaseDN:       "ou=users,dc=example,dc=com",
+		Scope:        ldaputil.ScopeWholeSubtree,
+		DerefAliases: ldaputil.DerefAliasesAlways,
+		TimeLimit:    0,
+		Filter:       "objectClass=inetOrgPerson",
+	}
+	groupMembershipAttributes := []string{"memberOf"}
+	userNameAttributes := []string{"cn"}
+
+	return NewADLDAPInterface(testclient.NewConfig(client),
+		userQuery,
+		groupMembershipAttributes,
+		userNameAttributes)
+}
+
+// newTestUser(testUserDN, testUserCN, testGroupUID) returns a new LDAP entry with the given CN,
+// as a member of the given group
+func newTestUser(CN, groupUID string) *ldap.Entry {
+	return ldap.NewEntry(fmt.Sprintf("cn=%s,ou=users,dc=example,dc=com", CN), map[string][]string{"cn": {CN}, "memberOf": {groupUID}})
+}
+
+func TestExtractMembers(t *testing.T) {
+	// we don't have a test case for an error on a bad search request as search request errors can only occur if
+	// the search attribute is the DN, and we do not allow DN to be a group UID for this schema
+	var testCases = []struct {
+		name            string
+		cacheSeed       map[string][]*ldap.Entry
+		client          ldap.Client
+		expectedError   error
+		expectedMembers []*ldap.Entry
+	}{
+		{
+			name: "members cached",
+			cacheSeed: map[string][]*ldap.Entry{
+				"testGroup": {newTestUser("testUser", "testGroup")},
+			},
+			expectedError:   nil,
+			expectedMembers: []*ldap.Entry{newTestUser("testUser", "testGroup")},
+		},
+		{
+			name: "user query error",
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.New(),
+				"ou=users,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError:   errors.New("generic search error"),
+			expectedMembers: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"ou=users,dc=example,dc=com": {newTestUser("testUser", "testGroup")},
+				},
+			),
+			expectedError:   nil,
+			expectedMembers: []*ldap.Entry{newTestUser("testUser", "testGroup")},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestADLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.ldapGroupToLDAPMembers = testCase.cacheSeed
+		}
+		members, err := ldapInterface.ExtractMembers("testGroup")
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(members, testCase.expectedMembers) {
+			t.Errorf("%s: incorrect members returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedMembers, members)
+		}
+	}
+}
+
+func TestListGroups(t *testing.T) {
+	client := testclient.NewDNMappingClient(
+		testclient.New(),
+		map[string][]*ldap.Entry{
+			"ou=users,dc=example,dc=com": {newTestUser("testUser", "testGroup")},
+		},
+	)
+	ldapInterface := newTestADLDAPInterface(client)
+	groups, err := ldapInterface.ListGroups()
+	if !reflect.DeepEqual(err, nil) {
+		t.Errorf("listing groups: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", nil, err)
+	}
+	if !reflect.DeepEqual(groups, []string{"testGroup"}) {
+		t.Errorf("listing groups: incorrect group list:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", []string{"testGroup"}, groups)
+	}
+}
+
+func TestPopulateCache(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		cacheSeed        map[string][]*ldap.Entry
+		searchDNOverride string
+		client           ldap.Client
+		expectedError    error
+		expectedCache    map[string][]*ldap.Entry
+	}{
+		{
+			name: "cache already populated",
+			cacheSeed: map[string][]*ldap.Entry{
+				"testGroup": {newTestUser("testUser", "testGroup")},
+			},
+			expectedError: nil,
+			expectedCache: map[string][]*ldap.Entry{
+				"testGroup": {newTestUser("testUser", "testGroup")},
+			},
+		},
+		{
+			name: "user query error",
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.New(),
+				"ou=users,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError: errors.New("generic search error"),
+			expectedCache: make(map[string][]*ldap.Entry), // won't be nil but will be empty
+		},
+		{
+			name: "cache populated correctly",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"ou=users,dc=example,dc=com": {newTestUser("testUser", "testGroup")},
+				},
+			),
+			expectedError: nil,
+			expectedCache: map[string][]*ldap.Entry{
+				"testGroup": {newTestUser("testUser", "testGroup")},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestADLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.ldapGroupToLDAPMembers = testCase.cacheSeed
+			ldapInterface.cacheFullyPopulated = true
+		}
+		err := ldapInterface.populateCache()
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(testCase.expectedCache, ldapInterface.ldapGroupToLDAPMembers) {
+			t.Errorf("%s: incorrect cache state:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedCache, ldapInterface.ldapGroupToLDAPMembers)
+		}
+	}
+}
+
+// TestPopulateCacheAfterExtractMembers ensures that the cache is only listed as fully populated after a
+// populateCache call and not after a partial fill from an ExtractMembers call
+func TestPopulateCacheAfterExtractMembers(t *testing.T) {
+	client := testclient.NewDNMappingClient(
+		testclient.New(),
+		map[string][]*ldap.Entry{
+			"ou=users,dc=example,dc=com": {newTestUser("testUser", "testGroup")},
+		},
+	)
+	ldapInterface := newTestADLDAPInterface(client)
+	_, err := ldapInterface.ExtractMembers("testGroup")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// both queries use the same BaseDN so we change what the client returns to simulate not applying the group-specific filter
+	client.(*testclient.DNMappingClient).DNMapping["ou=users,dc=example,dc=com"] = []*ldap.Entry{
+		newTestUser("testUser", "testGroup"),
+		newTestUser("testUser2", "testGroup2")}
+
+	expectedCache := map[string][]*ldap.Entry{
+		"testGroup":  {newTestUser("testUser", "testGroup")},
+		"testGroup2": {newTestUser("testUser2", "testGroup2")},
+	}
+
+	err = ldapInterface.populateCache()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(expectedCache, ldapInterface.ldapGroupToLDAPMembers) {
+		t.Errorf("incorrect cache state:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", expectedCache, ldapInterface.ldapGroupToLDAPMembers)
+	}
+}

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -86,7 +86,7 @@ type SyncGroupsOptions struct {
 	// Blacklist are the names of OpenShift group or LDAP group UIDs to exclude
 	Blacklist []string
 
-	// Confirm determines whether not to write to openshift
+	// Confirm determines whether or not to write to OpenShift
 	Confirm bool
 
 	// GroupsInterface is the interface used to interact with OpenShift Group objects
@@ -144,7 +144,7 @@ func NewCmdSyncGroups(name, fullName string, f *clientcmd.Factory, out io.Writer
 
 	cmd.Flags().StringVar(&whitelistFile, "whitelist", whitelistFile, "path to the group whitelist file")
 	cmd.Flags().StringVar(&blacklistFile, "blacklist", whitelistFile, "path to the group blacklist file")
-	// TODO enable this we're able to support string slice elements that have commas
+	// TODO: enable this once we're able to support string slice elements that have commas
 	// cmd.Flags().StringSliceVar(&options.Blacklist, "blacklist-group", options.Blacklist, "group to blacklist")
 	cmd.Flags().StringVar(&configFile, "sync-config", configFile, "path to the sync config")
 	cmd.Flags().StringVar(&typeArg, "type", typeArg, "type of group used to locate LDAP group UIDs: "+strings.Join(AllowedSourceTypes, ","))

--- a/pkg/cmd/experimental/syncgroups/groupsyncer.go
+++ b/pkg/cmd/experimental/syncgroups/groupsyncer.go
@@ -19,7 +19,8 @@ import (
 
 // GroupSyncer runs a Sync job on Groups
 type GroupSyncer interface {
-	Sync() (errors []error)
+	// Sync syncs groups in OpenShift with records from an external source
+	Sync() (groupsAffected []*userapi.Group, errors []error)
 }
 
 // LDAPGroupSyncer sync Groups with records on an external LDAP server
@@ -43,6 +44,8 @@ type LDAPGroupSyncer struct {
 	Out io.Writer
 	Err io.Writer
 }
+
+var _ GroupSyncer = &LDAPGroupSyncer{}
 
 // Sync allows the LDAPGroupSyncer to be a GroupSyncer
 func (s *LDAPGroupSyncer) Sync() ([]*userapi.Group, []error) {

--- a/pkg/cmd/experimental/syncgroups/interfaces/errors.go
+++ b/pkg/cmd/experimental/syncgroups/interfaces/errors.go
@@ -4,21 +4,25 @@ import (
 	"fmt"
 )
 
-type MemberLookupError struct {
-	LDAPGroupUID string
-	LDAPUserUID  string
-	CausedBy     error
+func NewMemberLookupError(ldapGroupUID, ldapUserUID string, causedBy error) error {
+	return &memberLookupError{ldapGroupUID: ldapGroupUID, ldapUserUID: ldapUserUID, causedBy: causedBy}
 }
 
-func (e *MemberLookupError) Error() string {
-	return fmt.Sprintf("membership lookup for user %q in group %q failed because of %q", e.LDAPUserUID, e.LDAPGroupUID, e.CausedBy.Error())
+type memberLookupError struct {
+	ldapGroupUID string
+	ldapUserUID  string
+	causedBy     error
 }
 
-func IsMemberLookupError(e error) bool {
+func (e *memberLookupError) Error() string {
+	return fmt.Sprintf("membership lookup for user %q in group %q failed because of %q", e.ldapUserUID, e.ldapGroupUID, e.causedBy.Error())
+}
+
+func IsmemberLookupError(e error) bool {
 	if e == nil {
 		return false
 	}
 
-	_, ok := e.(*MemberLookupError)
+	_, ok := e.(*memberLookupError)
 	return ok
 }

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
@@ -27,31 +27,25 @@ func NewLDAPInterface(clientConfig ldapclient.Config,
 		groupMembershipAttributes: groupMembershipAttributes,
 		userQuery:                 userQuery,
 		userNameAttributes:        userNameAttributes,
-		cachedUsers:               make(map[string]*ldap.Entry),
-		cachedGroups:              make(map[string]*ldap.Entry),
+		cachedUsers:               map[string]*ldap.Entry{},
+		cachedGroups:              map[string]*ldap.Entry{},
 	}
 }
 
 // LDAPInterface extracts the member list of an LDAP group entry from an LDAP server
 // with first-class LDAP entries for groups. The LDAPInterface is *NOT* thread-safe.
-// The LDAPInterface satisfies:
-// - LDAPMemberExtractor
-// - LDAPGroupGetter
-// - LDAPGroupLister
 type LDAPInterface struct {
 	// clientConfig holds LDAP connection information
 	clientConfig ldapclient.Config
 
-	// groupQuery holds the information necessary to make an LDAP query for a specific
-	// first-class group entry on the LDAP server
+	// groupQuery holds the information necessary to make an LDAP query for a specific first-class group entry on the LDAP server
 	groupQuery ldaputil.LDAPQueryOnAttribute
 	// groupNameAttributes defines which attributes on an LDAP group entry will be interpreted as its name to use for an OpenShift group
 	groupNameAttributes []string
 	// groupMembershipAttributes defines which attributes on an LDAP group entry will be interpreted as its members ldapUserUID
 	groupMembershipAttributes []string
 
-	// userQuery holds the information necessary to make an LDAP query for a specific
-	// first-class user entry on the LDAP server
+	// userQuery holds the information necessary to make an LDAP query for a specific first-class user entry on the LDAP server
 	userQuery ldaputil.LDAPQueryOnAttribute
 	// UserNameAttributes defines which attributes on an LDAP user entry will be interpreted as its' name
 	userNameAttributes []string
@@ -64,13 +58,10 @@ type LDAPInterface struct {
 	cachedUsers map[string]*ldap.Entry
 }
 
-var _ ldapinterfaces.LDAPMemberExtractor = &LDAPInterface{}
-var _ ldapinterfaces.LDAPGroupGetter = &LDAPInterface{}
-var _ ldapinterfaces.LDAPGroupLister = &LDAPInterface{}
-
-func (e *LDAPInterface) String() string {
-	return fmt.Sprintf("%#v", e)
-}
+// The LDAPInterface must conform to the following interfaces
+var _ interfaces.LDAPMemberExtractor = &LDAPInterface{}
+var _ interfaces.LDAPGroupGetter = &LDAPInterface{}
+var _ interfaces.LDAPGroupLister = &LDAPInterface{}
 
 // ExtractMembers returns the LDAP member entries for a group specified with a ldapGroupUID
 func (e *LDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
@@ -91,7 +82,7 @@ func (e *LDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, erro
 	for _, ldapMemberUID := range ldapMemberUIDs {
 		memberEntry, err := e.userEntryFor(ldapMemberUID)
 		if err != nil {
-			return nil, &ldapinterfaces.MemberLookupError{LDAPGroupUID: ldapGroupUID, LDAPUserUID: ldapMemberUID, CausedBy: err}
+			return nil, interfaces.NewMemberLookupError(ldapGroupUID, ldapMemberUID, err)
 		}
 		members = append(members, memberEntry)
 	}
@@ -169,7 +160,7 @@ func (e *LDAPInterface) ListGroups() ([]string, error) {
 		// cache groups returned from the server for later
 		ldapGroupUID := ldaputil.GetAttributeValue(group, []string{e.groupQuery.QueryAttribute})
 		if len(ldapGroupUID) == 0 {
-			return nil, fmt.Errorf("unable to find LDAP group UID for %v", group)
+			return nil, fmt.Errorf("unable to find LDAP group UID for %s", group)
 		}
 		e.cachedGroups[ldapGroupUID] = group
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface_test.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface_test.go
@@ -1,0 +1,305 @@
+package rfc2307
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"gopkg.in/ldap.v2"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+func newTestLDAPInterface(client ldap.Client) *LDAPInterface {
+	// below are common test implementations of LDAPInterface fields
+	groupQuery := ldaputil.LDAPQueryOnAttribute{
+		LDAPQuery: ldaputil.LDAPQuery{
+			BaseDN:       "ou=groups,dc=example,dc=com",
+			Scope:        ldaputil.ScopeWholeSubtree,
+			DerefAliases: ldaputil.DerefAliasesAlways,
+			TimeLimit:    0,
+			Filter:       "objectClass=groupOfNames",
+		},
+		QueryAttribute: "dn",
+	}
+	groupNameAttributes := []string{"cn"}
+	groupMembershipAttributes := []string{"member"}
+	userQuery := ldaputil.LDAPQueryOnAttribute{
+		LDAPQuery: ldaputil.LDAPQuery{
+			BaseDN:       "ou=users,dc=example,dc=com",
+			Scope:        ldaputil.ScopeWholeSubtree,
+			DerefAliases: ldaputil.DerefAliasesAlways,
+			TimeLimit:    0,
+			Filter:       "objectClass=inetOrgPerson",
+		},
+		QueryAttribute: "dn",
+	}
+	userNameAttributes := []string{"cn"}
+
+	return NewLDAPInterface(testclient.NewConfig(client),
+		groupQuery,
+		groupNameAttributes,
+		groupMembershipAttributes,
+		userQuery,
+		userNameAttributes)
+}
+
+// newTestUser returns a new LDAP entry with the CN
+func newTestUser(CN string) *ldap.Entry {
+	return ldap.NewEntry(fmt.Sprintf("cn=%s,ou=users,dc=example,dc=com", CN), map[string][]string{"cn": {CN}})
+}
+
+// newTestGroup returns a new LDAP entry with the given CN and member
+func newTestGroup(CN, member string) *ldap.Entry {
+	DN := fmt.Sprintf("cn=%s,ou=groups,dc=example,dc=com", CN)
+	if len(CN) > 0 {
+		return ldap.NewEntry(DN, map[string][]string{"cn": {CN}, "member": {member}})
+	} else {
+		// no CN
+		return ldap.NewEntry(DN, map[string][]string{"member": {member}})
+	}
+}
+
+func TestExtractMembers(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		client          ldap.Client
+		expectedError   error
+		expectedMembers []*ldap.Entry
+	}{
+		{
+			name: "group lookup errors",
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.New(),
+				"cn=testGroup,ou=groups,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError:   errors.New("generic search error"),
+			expectedMembers: nil,
+		},
+		{
+			name: "member lookup errors",
+			// this is a nested test client, the first nest tries to error on the user DN
+			// the second nest attempts to give back from the DN mapping
+			// the third nest is the default "safe" impl from ldaputil
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.NewDNMappingClient(
+					testclient.New(),
+					map[string][]*ldap.Entry{
+						"cn=testGroup,ou=groups,dc=example,dc=com": {newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com")},
+					},
+				),
+				"cn=testUser,ou=users,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError:   interfaces.NewMemberLookupError("cn=testGroup,ou=groups,dc=example,dc=com", "cn=testUser,ou=users,dc=example,dc=com", errors.New("generic search error")),
+			expectedMembers: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"cn=testGroup,ou=groups,dc=example,dc=com": {newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com")},
+					"cn=testUser,ou=users,dc=example,dc=com":   {newTestUser("testUser")},
+				},
+			),
+			expectedError:   nil,
+			expectedMembers: []*ldap.Entry{newTestUser("testUser")},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		members, err := ldapInterface.ExtractMembers("cn=testGroup,ou=groups,dc=example,dc=com")
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(members, testCase.expectedMembers) {
+			t.Errorf("%s: incorrect members returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedMembers, members)
+		}
+	}
+}
+
+func TestGroupEntryFor(t *testing.T) {
+	var testCases = []struct {
+		name                string
+		cacheSeed           map[string]*ldap.Entry
+		queryBaseDNOverride string
+		client              ldap.Client
+		expectedError       error
+		expectedEntry       *ldap.Entry
+	}{
+		{
+			name:          "cached get",
+			cacheSeed:     map[string]*ldap.Entry{"cn=testGroup,ou=groups,dc=example,dc=com": newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com")},
+			expectedError: nil,
+			expectedEntry: newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com"),
+		},
+		{
+			name:                "search request failure",
+			queryBaseDNOverride: "otherBaseDN",
+			expectedError:       ldaputil.NewQueryOutOfBoundsError("cn=testGroup,ou=groups,dc=example,dc=com", "otherBaseDN"),
+			expectedEntry:       nil,
+		},
+		{
+			name: "query failure",
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.New(),
+				"cn=testGroup,ou=groups,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError: errors.New("generic search error"),
+			expectedEntry: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"cn=testGroup,ou=groups,dc=example,dc=com": {newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com")},
+				},
+			),
+			expectedError: nil,
+			expectedEntry: newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com"),
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.cachedGroups = testCase.cacheSeed
+		}
+		if len(testCase.queryBaseDNOverride) > 0 {
+			ldapInterface.groupQuery.BaseDN = testCase.queryBaseDNOverride
+		}
+		entry, err := ldapInterface.GroupEntryFor("cn=testGroup,ou=groups,dc=example,dc=com")
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(entry, testCase.expectedEntry) {
+			t.Errorf("%s: incorrect entry returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedEntry, entry)
+		}
+	}
+}
+
+func TestListGroups(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		client            ldap.Client
+		groupUIDAttribute string
+		expectedError     error
+		expectedGroups    []string
+	}{
+		{
+			name: "query errors",
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.New(),
+				"ou=groups,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError:  errors.New("generic search error"),
+			expectedGroups: nil,
+		},
+		{
+			name: "no UID on entry",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"ou=groups,dc=example,dc=com": {newTestGroup("", "cn=testUser,ou=users,dc=example,dc=com")},
+				},
+			),
+			groupUIDAttribute: "cn",
+			expectedError:     fmt.Errorf("unable to find LDAP group UID for %s", newTestGroup("", "cn=testUser,ou=users,dc=example,dc=com")),
+			expectedGroups:    nil,
+		},
+		{
+			name: "no error",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"ou=groups,dc=example,dc=com": {newTestGroup("testGroup", "cn=testUser,ou=users,dc=example,dc=com")},
+				},
+			),
+			expectedError:  nil,
+			expectedGroups: []string{"cn=testGroup,ou=groups,dc=example,dc=com"},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		if len(testCase.groupUIDAttribute) > 0 {
+			ldapInterface.groupQuery.QueryAttribute = testCase.groupUIDAttribute
+		}
+		groupNames, err := ldapInterface.ListGroups()
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(groupNames, testCase.expectedGroups) {
+			t.Errorf("%s: incorrect entry returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedGroups, groupNames)
+		}
+	}
+}
+
+func TestUserEntryFor(t *testing.T) {
+	var testCases = []struct {
+		name                string
+		cacheSeed           map[string]*ldap.Entry
+		queryBaseDNOverride string
+		client              ldap.Client
+		expectedError       error
+		expectedEntry       *ldap.Entry
+	}{
+		{
+			name: "cached get",
+			cacheSeed: map[string]*ldap.Entry{
+				"cn=testUser,ou=users,dc=example,dc=com": newTestUser("testUser"),
+			},
+			expectedError: nil,
+			expectedEntry: newTestUser("testUser"),
+		},
+		{
+			name:                "search request failure",
+			queryBaseDNOverride: "otherBaseDN",
+			expectedError:       ldaputil.NewQueryOutOfBoundsError("cn=testUser,ou=users,dc=example,dc=com", "otherBaseDN"),
+			expectedEntry:       nil,
+		},
+		{
+			name: "query failure",
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.New(),
+				"cn=testUser,ou=users,dc=example,dc=com",
+				errors.New("generic search error"),
+			),
+			expectedError: errors.New("generic search error"),
+			expectedEntry: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					"cn=testUser,ou=users,dc=example,dc=com": {newTestUser("testUser")},
+				},
+			),
+			expectedError: nil,
+			expectedEntry: newTestUser("testUser"),
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.cachedUsers = testCase.cacheSeed
+		}
+		if len(testCase.queryBaseDNOverride) > 0 {
+			ldapInterface.userQuery.BaseDN = testCase.queryBaseDNOverride
+		}
+		entry, err := ldapInterface.userEntryFor("cn=testUser,ou=users,dc=example,dc=com")
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(entry, testCase.expectedEntry) {
+			t.Errorf("%s: incorrect entry returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedEntry, entry)
+		}
+	}
+}


### PR DESCRIPTION
Addresses technical debt left over for the 3.1 push for LDAP group sync.

Depends on #5616
Depends on UPSTREAM https://github.com/go-ldap/ldap/pull/38

/cc @deads2k @liggitt 