### PR TITLE
CLI usability - proposed aliases

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -1759,9 +1759,9 @@ _oc_env()
     must_have_one_noun=()
 }
 
-_oc_volume()
+_oc_volumes()
 {
-    last_command="oc_volume"
+    last_command="oc_volumes"
     commands=()
 
     flags=()
@@ -5358,7 +5358,7 @@ _oc()
     commands+=("describe")
     commands+=("edit")
     commands+=("env")
-    commands+=("volume")
+    commands+=("volumes")
     commands+=("label")
     commands+=("annotate")
     commands+=("expose")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -6486,9 +6486,9 @@ _openshift_cli_env()
     must_have_one_noun=()
 }
 
-_openshift_cli_volume()
+_openshift_cli_volumes()
 {
-    last_command="openshift_cli_volume"
+    last_command="openshift_cli_volumes"
     commands=()
 
     flags=()
@@ -10085,7 +10085,7 @@ _openshift_cli()
     commands+=("describe")
     commands+=("edit")
     commands+=("env")
-    commands+=("volume")
+    commands+=("volumes")
     commands+=("label")
     commands+=("annotate")
     commands+=("expose")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -1031,7 +1031,7 @@ An introduction to concepts and types
 ====
 
 
-== oc volume
+== oc volumes
 Update volume on a resource with a pod template
 
 ====

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -67,6 +67,7 @@ func NewCmdProject(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.
 		Short:   "Switch to another project",
 		Long:    projectLong,
 		Example: fmt.Sprintf(projectExample, fullName),
+		Aliases: []string{"projects"},
 		Run: func(cmd *cobra.Command, args []string) {
 			options.PathOptions = cliconfig.NewPathOptions(cmd)
 

--- a/pkg/cmd/cli/cmd/volume.go
+++ b/pkg/cmd/cli/cmd/volume.go
@@ -137,10 +137,11 @@ func NewCmdVolume(fullName string, f *clientcmd.Factory, out, errOut io.Writer) 
 	addOpts := &AddVolumeOptions{}
 	opts := &VolumeOptions{AddOpts: addOpts}
 	cmd := &cobra.Command{
-		Use:     "volume RESOURCE/NAME --add|--remove|--list",
+		Use:     "volumes RESOURCE/NAME --add|--remove|--list",
 		Short:   "Update volume on a resource with a pod template",
 		Long:    volumeLong,
 		Example: fmt.Sprintf(volumeExample, fullName),
+		Aliases: []string{"volume"},
 		Run: func(cmd *cobra.Command, args []string) {
 			addOpts.TypeChanged = cmd.Flag("type").Changed
 

--- a/pkg/cmd/cli/secrets/subcommand.go
+++ b/pkg/cmd/cli/secrets/subcommand.go
@@ -37,10 +37,11 @@ Docker registries.`
 func NewCmdSecrets(name, fullName string, f *clientcmd.Factory, reader io.Reader, out io.Writer, ocEditFullName string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
-		Use:   name,
-		Short: "Manage secrets",
-		Long:  secretsLong,
-		Run:   cmdutil.DefaultSubCommandRun(out),
+		Use:     name,
+		Short:   "Manage secrets",
+		Long:    secretsLong,
+		Aliases: []string{"secret"},
+		Run:     cmdutil.DefaultSubCommandRun(out),
 	}
 
 	newSecretFullName := fullName + " " + NewSecretRecommendedCommandName

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -88,6 +88,10 @@ os::cmd::expect_success_and_text 'openshift kubectl get --help' 'Display one or 
 os::cmd::expect_success_and_text 'openshift start --help' 'Start an all-in-one server'
 os::cmd::expect_success_and_text 'openshift start master --help' 'Start a master'
 os::cmd::expect_success_and_text 'openshift start node --help' 'Start a node'
+os::cmd::expect_success_and_text 'oc project --help' 'Switch to another project'
+os::cmd::expect_success_and_text 'oc projects --help' 'Switch to another project'
+os::cmd::expect_success_and_text 'openshift cli project --help' 'Switch to another project'
+os::cmd::expect_success_and_text 'openshift cli projects --help' 'Switch to another project'
 os::cmd::expect_success_and_text 'oc get --help' 'oc'
 
 # help for given command through help command must be consistent
@@ -97,10 +101,14 @@ os::cmd::expect_success_and_text 'openshift help kubectl get' 'Display one or ma
 os::cmd::expect_success_and_text 'openshift help start' 'Start an all-in-one server'
 os::cmd::expect_success_and_text 'openshift help start master' 'Start a master'
 os::cmd::expect_success_and_text 'openshift help start node' 'Start a node'
+os::cmd::expect_success_and_text 'oc help project' 'Switch to another project'
+os::cmd::expect_success_and_text 'oc help projects' 'Switch to another project'
 # TODO: fix these tests
 # os::cmd::expect_success_and_text 'openshift cli help update' 'Update a resource'
 # os::cmd::expect_success_and_text 'openshift cli help replace' 'Replace a resource'
 # os::cmd::expect_success_and_text 'openshift cli help patch' 'Update field\(s\) of a resource'
+# os::cmd::expect_success_and_text 'openshift cli help project' 'Switch to another project'
+# os::cmd::expect_success_and_text 'openshift cli help projects' 'Switch to another project'
 
 # runnable commands with required flags must error consistently
 os::cmd::expect_failure_and_text 'oc get' 'Required resource not specified'

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -60,4 +60,12 @@ os::cmd::expect_success 'oc secrets add serviceaccounts/deployer secrets/basicau
 # make sure we can add as as pull secret and mount secret at once
 os::cmd::expect_success 'oc secrets add serviceaccounts/deployer secrets/basicauth secrets/sshauth --for=pull,mount'
 
+# command alias
+os::cmd::expect_success 'oc secret --help'
+os::cmd::expect_success 'oc secret new --help'
+os::cmd::expect_success 'oc secret new-dockercfg --help'
+os::cmd::expect_success 'oc secret new-basicauth --help'
+os::cmd::expect_success 'oc secret new-sshauth --help'
+os::cmd::expect_success 'oc secret add --help'
+
 echo "secrets: ok"

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -35,5 +35,9 @@ os::cmd::expect_success 'oc volume dc/test-deployment-config --add --mount-path=
 os::cmd::expect_success 'oc volume dc/test-deployment-config --add --mount-path=/second --type=pvc --claim-size=1G --claim-mode=rwo'
 os::cmd::expect_success_and_text 'oc get pvc --no-headers | wc -l' '2'
 
+# command alias
+os::cmd::expect_success 'oc volumes --help'
+os::cmd::expect_success 'oc volumes dc/test-deployment-config --list'
+
 os::cmd::expect_success 'oc delete dc/test-deployment-config'
 echo "volumes: ok"


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4226

Adds a few aliases for supporting both singular *and* plural forms in some commands:

```
volume/volumes
config/configs
project/projects
secret/secrets
```

Perfect back compat maintained.