### PR TITLE
bump(github.com/openshift/openshift-sdn) cb0e352cd7591ace30d592d4f82

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -685,12 +685,12 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "1f449c7f0d3cd41314a895ef119f9d25a15b54de"
+			"Rev": "cb0e352cd7591ace30d592d4f82685d2bcd38a04"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "1f449c7f0d3cd41314a895ef119f9d25a15b54de"
+			"Rev": "cb0e352cd7591ace30d592d4f82685d2bcd38a04"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common.go
@@ -3,6 +3,8 @@ package netutils
 import (
 	"encoding/binary"
 	"net"
+
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 func IPToUint32(ip net.IP) uint32 {
@@ -19,4 +21,39 @@ func Uint32ToIP(u uint32) net.IP {
 func GenerateDefaultGateway(sna *net.IPNet) net.IP {
 	ip := sna.IP.To4()
 	return net.IPv4(ip[0], ip[1], ip[2], ip[3]|0x1)
+}
+
+func GetHostIPNetworks(skipInterfaces []string) ([]*net.IPNet, error) {
+	hostInterfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	errList := []error{}
+	var hostIPNets []*net.IPNet
+
+CheckValidInterfaces:
+	for _, iface := range hostInterfaces {
+		for _, skipIface := range skipInterfaces {
+			if skipIface == iface.Name {
+				continue CheckValidInterfaces
+			}
+		}
+		ifAddrs, err := iface.Addrs()
+		if err != nil {
+			errList = append(errList, err)
+			continue
+		}
+		for _, addr := range ifAddrs {
+			ip, ipNet, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				errList = append(errList, err)
+				continue
+			}
+			// Skip IP addrs that doesn't belong to IPv4
+			if ip.To4() != nil {
+				hostIPNets = append(hostIPNets, ipNet)
+			}
+		}
+	}
+	return hostIPNets, kerrors.NewAggregate(errList)
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/api/types.go
@@ -85,8 +85,8 @@ const (
 )
 
 type ServicePort struct {
-	Protocol  ServiceProtocol
-	Port      uint
+	Protocol ServiceProtocol
+	Port     uint
 }
 
 type Service struct {

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/common.go
@@ -97,13 +97,22 @@ func (oc *OvsController) isMultitenant() bool {
 	return is_mt
 }
 
-func (oc *OvsController) validateClusterNetwork(networkCIDR string, subnetsInUse []string) error {
-	_, clusterIPNet, err := net.ParseCIDR(networkCIDR)
+func (oc *OvsController) validateClusterNetwork(networkCIDR string, subnetsInUse []string, hostIPNets []*net.IPNet) error {
+	clusterIP, clusterIPNet, err := net.ParseCIDR(networkCIDR)
 	if err != nil {
 		return fmt.Errorf("Failed to parse network address: %s", networkCIDR)
 	}
 
 	errList := []error{}
+	for _, ipNet := range hostIPNets {
+		if ipNet.Contains(clusterIP) {
+			errList = append(errList, fmt.Errorf("Error: Cluster IP: %s conflicts with host network: %s", clusterIP.String(), ipNet.String()))
+		}
+		if clusterIPNet.Contains(ipNet.IP) {
+			errList = append(errList, fmt.Errorf("Error: Host network with IP: %s conflicts with cluster network: %s", ipNet.IP.String(), networkCIDR))
+		}
+	}
+
 	for _, netStr := range subnetsInUse {
 		subnetIP, _, err := net.ParseCIDR(netStr)
 		if err != nil {
@@ -117,17 +126,26 @@ func (oc *OvsController) validateClusterNetwork(networkCIDR string, subnetsInUse
 	return kerrors.NewAggregate(errList)
 }
 
-func (oc *OvsController) validateServiceNetwork(networkCIDR string) error {
-	_, serviceIPNet, err := net.ParseCIDR(networkCIDR)
+func (oc *OvsController) validateServiceNetwork(networkCIDR string, hostIPNets []*net.IPNet) error {
+	serviceIP, serviceIPNet, err := net.ParseCIDR(networkCIDR)
 	if err != nil {
 		return fmt.Errorf("Failed to parse network address: %s", networkCIDR)
+	}
+
+	errList := []error{}
+	for _, ipNet := range hostIPNets {
+		if ipNet.Contains(serviceIP) {
+			errList = append(errList, fmt.Errorf("Error: Service IP: %s conflicts with host network: %s", ipNet.String(), networkCIDR))
+		}
+		if serviceIPNet.Contains(ipNet.IP) {
+			errList = append(errList, fmt.Errorf("Error: Host network with IP: %s conflicts with service network: %s", ipNet.IP.String(), networkCIDR))
+		}
 	}
 
 	services, _, err := oc.subnetRegistry.GetServices()
 	if err != nil {
 		return err
 	}
-	errList := []error{}
 	for _, svc := range services {
 		if !serviceIPNet.Contains(net.ParseIP(svc.IP)) {
 			errList = append(errList, fmt.Errorf("Error: Existing service with IP: %s is not part of service network: %s", svc.IP, networkCIDR))
@@ -137,11 +155,18 @@ func (oc *OvsController) validateServiceNetwork(networkCIDR string) error {
 }
 
 func (oc *OvsController) validateNetworkConfig(clusterNetworkCIDR, serviceNetworkCIDR string, subnetsInUse []string) error {
+	// TODO: Instead of hardcoding 'tun0' and 'lbr0', get it from common place.
+	// This will ensure both the kube/multitenant scripts and master validations use the same name.
+	hostIPNets, err := netutils.GetHostIPNetworks([]string{"tun0", "lbr0"})
+	if err != nil {
+		return err
+	}
+
 	errList := []error{}
-	if err := oc.validateClusterNetwork(clusterNetworkCIDR, subnetsInUse); err != nil {
+	if err := oc.validateClusterNetwork(clusterNetworkCIDR, subnetsInUse, hostIPNets); err != nil {
 		errList = append(errList, err)
 	}
-	if err := oc.validateServiceNetwork(serviceNetworkCIDR); err != nil {
+	if err := oc.validateServiceNetwork(serviceNetworkCIDR, hostIPNets); err != nil {
 		errList = append(errList, err)
 	}
 	return kerrors.NewAggregate(errList)
@@ -393,7 +418,6 @@ func (oc *OvsController) DeleteNode(nodeName string) error {
 func (oc *OvsController) StartNode(mtu uint) error {
 	err := oc.initSelfSubnet()
 	if err != nil {
-		log.Errorf("Failed to get subnet for this host: %v", err)
 		return err
 	}
 
@@ -537,17 +561,27 @@ func (oc *OvsController) watchVnids(ready chan<- bool, start <-chan string) {
 }
 
 func (oc *OvsController) initSelfSubnet() error {
-	// get subnet for self
-	for {
-		sub, err := oc.subnetRegistry.GetSubnet(oc.hostName)
-		if err != nil {
-			log.Errorf("Could not find an allocated subnet for node %s: %s. Waiting...", oc.hostName, err)
-			time.Sleep(2 * time.Second)
-			continue
+	// timeout: 10 secs
+	retries := 20
+	retryInterval := 500 * time.Millisecond
+
+	var err error
+	var subnet *api.Subnet
+	// Try every retryInterval and bail-out if it exceeds max retries
+	for i := 0; i < retries; i++ {
+		// Get subnet for current node
+		subnet, err = oc.subnetRegistry.GetSubnet(oc.hostName)
+		if err == nil {
+			break
 		}
-		oc.localSubnet = sub
-		return nil
+		log.Warningf("Could not find an allocated subnet for node: %s, Waiting...", oc.hostName)
+		time.Sleep(retryInterval)
 	}
+	if err != nil {
+		return fmt.Errorf("Failed to get subnet for this host: %s, error: %v", oc.hostName, err)
+	}
+	oc.localSubnet = subnet
+	return nil
 }
 
 func (oc *OvsController) watchNodes(ready chan<- bool, start <-chan string) {

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -41,10 +41,12 @@ function docker_network_config() {
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
-
-		systemctl daemon-reload
-		systemctl restart docker.service
-
+		## linux bridge
+		ip link set lbr0 down || true
+		brctl delbr lbr0 || true
+		brctl addbr lbr0
+		ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
+		ip link set lbr0 up
 
 	    if [ ! -f /.dockerinit ]; then
 		# disable iptables for lbr0
@@ -56,6 +58,11 @@ EOF
 		modprobe br_netfilter || true
 		sysctl -w net.bridge.bridge-nf-call-iptables=0
 	    fi
+		# when using --pid=host to run docker container, systemctl inside it refuses
+		# to work because it detects that it's running in chroot. using dbus instead
+		# of systemctl is just a workaround
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.Reload
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.RestartUnit string:'docker.service' string:'replace'
 	    ;;
     esac
 }
@@ -63,9 +70,6 @@ EOF
 function setup_required() {
     ip=$(echo `ip a s lbr0 2>/dev/null|awk '/inet / {print $2}'`)
     if [ "$ip" != "${local_subnet_gateway}/${local_subnet_mask_len}" ]; then
-        return 0
-    fi
-    if ! docker_network_config check; then
         return 0
     fi
     if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q 'table=0.*arp'; then
@@ -115,25 +119,15 @@ function setup() {
     ip link set vovsbr up
     ip link set vlinuxbr txqueuelen 0
     ip link set vovsbr txqueuelen 0
+    brctl addif lbr0 vlinuxbr
 
     ovs-vsctl del-port br0 vovsbr || true
     ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=9
-
-    ## linux bridge
-    ip link set lbr0 down || true
-    brctl delbr lbr0 || true
-    brctl addbr lbr0
-    ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
-    ip link set lbr0 up
-    brctl addif lbr0 vlinuxbr
 
     # setup tun address
     ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev ${TUN}
     ip link set ${TUN} up
     ip route add ${cluster_network_cidr} dev ${TUN} proto kernel scope link
-
-    ## docker
-    docker_network_config update
 
     # Cleanup docker0 since docker won't do it
     ip link set docker0 down || true
@@ -147,11 +141,15 @@ function setup() {
     echo "export OPENSHIFT_CLUSTER_SUBNET=${cluster_network_cidr}" >> "/etc/openshift-sdn/config.env"
 
     # delete unnecessary routes
-    delete_local_subnet_route lbr0
+    delete_local_subnet_route lbr0 || true
     delete_local_subnet_route ${TUN} || true
 }
 
 set +e
+if ! docker_network_config check; then
+  lockwrap docker_network_config update
+fi
+
 if ! setup_required; then
     echo "SDN setup not required."
     exit 140

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -42,8 +42,12 @@ function docker_network_config() {
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
 
-		systemctl daemon-reload
-		systemctl restart docker.service
+		## linux bridge
+		ip link set lbr0 down || true
+		brctl delbr lbr0 || true
+		brctl addbr lbr0
+		ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
+		ip link set lbr0 up
 
 	    if [ ! -f /.dockerinit ]; then
 		# disable iptables for lbr0
@@ -55,6 +59,11 @@ EOF
 		modprobe br_netfilter || true
 		sysctl -w net.bridge.bridge-nf-call-iptables=0
 	    fi
+		# when using --pid=host to run docker container, systemctl inside it refuses
+		# to work because it detects that it's running in chroot. using dbus instead
+		# of systemctl is just a workaround
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.Reload
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.RestartUnit string:'docker.service' string:'replace'
 	    ;;
     esac
 }
@@ -62,9 +71,6 @@ EOF
 function setup_required() {
     ip=$(echo `ip a s lbr0 2>/dev/null|awk '/inet / {print $2}'`)
     if [ "$ip" != "${local_subnet_gateway}/${local_subnet_mask_len}" ]; then
-        return 0
-    fi
-    if ! docker_network_config check; then
         return 0
     fi
     if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q NXM_NX_TUN_IPV4; then
@@ -114,6 +120,7 @@ function setup() {
     ip link set vovsbr up
     ip link set vlinuxbr txqueuelen 0
     ip link set vovsbr txqueuelen 0
+    brctl addif lbr0 vlinuxbr
 
     ovs-vsctl del-port br0 vovsbr || true
     ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=3
@@ -156,21 +163,10 @@ function setup() {
     # and with per-node vxlan ARP rules by multitenant.go
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=8, priority=0, arp, actions=flood"
 
-    ## linux bridge
-    ip link set lbr0 down || true
-    brctl delbr lbr0 || true
-    brctl addbr lbr0
-    ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
-    ip link set lbr0 up
-    brctl addif lbr0 vlinuxbr
-
     # setup tun address
     ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev ${TUN}
     ip link set ${TUN} up
     ip route add ${cluster_network_cidr} dev ${TUN} proto kernel scope link
-
-    ## docker
-    docker_network_config update
 
     # Cleanup docker0 since docker won't do it
     ip link set docker0 down || true
@@ -184,11 +180,15 @@ function setup() {
     echo "export OPENSHIFT_CLUSTER_SUBNET=${cluster_network_cidr}" >> "/etc/openshift-sdn/config.env"
 
     # delete unnecessary routes
-    delete_local_subnet_route lbr0
+    delete_local_subnet_route lbr0 || true
     delete_local_subnet_route ${TUN} || true
 }
 
 set +e
+if ! docker_network_config check; then
+  lockwrap docker_network_config update
+fi
+
 if ! setup_required; then
     echo "SDN setup not required."
     exit 140


### PR DESCRIPTION
Fixes:
- Detect host network conflict with sdn cluster/service network
- Isolate docker bridge initialization to enable containerized installs
- Tolerate missing routes for lbr0 too
- Isolate restarting docker
- Don't loop forever if subnet not found for the node