### PR TITLE
UPSTREAM: 16277: Fixed resetting last scale time in HPA status

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal.go
@@ -163,6 +163,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpa extensions.HorizontalPodA
 		CurrentReplicas:                 currentReplicas,
 		DesiredReplicas:                 desiredReplicas,
 		CurrentCPUUtilizationPercentage: currentUtilization,
+		LastScaleTime:                   hpa.Status.LastScaleTime,
 	}
 	if rescale {
 		now := unversioned.NewTime(now)


### PR DESCRIPTION
Cherry picked from kubernetes/kubernetes#16277

Prevents the HPA from scaling more frequently than expected by preserving the LastScaleTime across updates that don't trigger a rescale.