### PR TITLE
Check Docker-Distribution-API-Version header in v2 check

### DIFF
--- a/pkg/dockerregistry/client.go
+++ b/pkg/dockerregistry/client.go
@@ -312,8 +312,12 @@ func (c *connection) checkV2() (bool, error) {
 	case code >= 300 || resp.StatusCode < 200:
 		return false, nil
 	}
+	if len(resp.Header.Get("Docker-Distribution-API-Version")) == 0 {
+		glog.V(5).Infof("Registry v2 API at %s did not have a Docker-Distribution-API-Version header", base.String())
+		return false, nil
+	}
+
 	glog.V(5).Infof("Found registry v2 API at %s", base.String())
-	// TODO: check Docker-Distribution-API-Version?
 	return true, nil
 }
 

--- a/test/integration/dockerregistryclient_test.go
+++ b/test/integration/dockerregistryclient_test.go
@@ -129,9 +129,7 @@ func TestRegistryClientQuayIOImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = conn.ImageByTag("coreos", "etcd", "latest")
-	if err != nil {
-		t.Skip("SKIPPING: unexpected error from quay.io: %v", err)
-		//t.Errorf("unexpected error: %v", err)
+	if _, err := conn.ImageByTag("coreos", "etcd", "latest"); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Guard against servers that return non-json for the /v2/ check like
quay.io started doing today.  Reverts skipping quay.io