### PR TITLE
Transfer ImagePullSecrets to deployment hook pods

### DIFF
--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -218,6 +218,12 @@ func makeHookPod(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationCont
 		}
 	}
 
+	// Transfer image pull secrets from the pod spec.
+	imagePullSecrets := []kapi.LocalObjectReference{}
+	for _, pullSecret := range deployment.Spec.Template.Spec.ImagePullSecrets {
+		imagePullSecrets = append(imagePullSecrets, kapi.LocalObjectReference{Name: pullSecret.Name})
+	}
+
 	pod := &kapi.Pod{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: namer.GetPodName(deployment.Name, label),
@@ -243,8 +249,9 @@ func makeHookPod(hook *deployapi.LifecycleHook, deployment *kapi.ReplicationCont
 			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
 			// Setting the node selector on the hook pod so that it is created
 			// on the same set of nodes as the deployment pods.
-			NodeSelector:  deployment.Spec.Template.Spec.NodeSelector,
-			RestartPolicy: restartPolicy,
+			NodeSelector:     deployment.Spec.Template.Spec.NodeSelector,
+			RestartPolicy:    restartPolicy,
+			ImagePullSecrets: imagePullSecrets,
 		},
 	}
 

--- a/pkg/deploy/strategy/support/lifecycle_test.go
+++ b/pkg/deploy/strategy/support/lifecycle_test.go
@@ -239,6 +239,11 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 							},
 						},
 					},
+					ImagePullSecrets: []kapi.LocalObjectReference{
+						{
+							Name: "secret-1",
+						},
+					},
 				},
 			},
 		},
@@ -287,6 +292,11 @@ func TestHookExecutor_makeHookPod(t *testing.T) {
 									kapi.ResourceMemory: resource.MustParse("10M"),
 								},
 							},
+						},
+					},
+					ImagePullSecrets: []kapi.LocalObjectReference{
+						{
+							Name: "secret-1",
 						},
 					},
 				},
@@ -495,6 +505,11 @@ func deployment(name, namespace string) *kapi.ReplicationController {
 						},
 						RestartPolicy: kapi.RestartPolicyAlways,
 						DNSPolicy:     kapi.DNSClusterFirst,
+						ImagePullSecrets: []kapi.LocalObjectReference{
+							{
+								Name: "secret-1",
+							},
+						},
 					},
 					ObjectMeta: kapi.ObjectMeta{
 						Labels: map[string]string{"a": "b"},


### PR DESCRIPTION
Transfer ImagePullSecrets from the deployment pod spec to hook pods
so that hook pods can pull from private registries.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1277898