### PR TITLE
Prevent deployment status string accumulation

### DIFF
--- a/pkg/deploy/controller/deploymentconfig/controller_test.go
+++ b/pkg/deploy/controller/deploymentconfig/controller_test.go
@@ -493,7 +493,7 @@ func TestFindDetails(t *testing.T) {
 			},
 			expectedDetails: "",
 			expectedLatest:  true,
-			expectedErr:     false,
+			expectedErr:     true,
 		},
 		{
 			name:           "found istag",
@@ -764,7 +764,10 @@ func TestFindDetails(t *testing.T) {
 				},
 			})
 		}
-
+		// This should be recalculated for each scenario.
+		config.Details = &deployapi.DeploymentDetails{
+			Message: "preexisting message",
+		}
 		if test.hasDeployments {
 			existingDeployments.Items = []kapi.ReplicationController{}
 			d := mkdeployment(test.version)


### PR DESCRIPTION
Rebuild the deployment config status from scratch each time to prevent
accumulating the string with old messages. Separate the algorithm into
two parts: one which builds up the context for the details, and one which
renders the context into a string.

Fixes #5706