### PR TITLE
refactored LDAP rfc2307 ldapinterface

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -431,8 +431,7 @@
 		},
 		{
 			"ImportPath": "github.com/go-ldap/ldap",
-			"Comment": "v1-22-gc265aaa",
-			"Rev": "c265aaa27b1c60c66f6d4695c6f33eb8b28989ad"
+			"Rev": "71555ef0e2f6f27e05878527b32030134d4f8774"
 		},
 		{
 			"ImportPath": "github.com/godbus/dbus",

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/.travis.yml
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/.travis.yml
@@ -2,11 +2,14 @@ language: go
 go:
     - 1.2
     - 1.3
+    - 1.4
+    - 1.5
     - tip
+go_import_path: gopkg.in/ldap.v2
 install:
     - go get gopkg.in/asn1-ber.v1
-    - go get gopkg.in/ldap.v1
+    - go get gopkg.in/ldap.v2
     - go get code.google.com/p/go.tools/cmd/cover || go get golang.org/x/tools/cmd/cover
     - go build -v ./...
 script:
-    - go test -v -cover ./...
+    - go test -v -cover ./... 

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/README.md
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/README.md
@@ -1,8 +1,20 @@
-[![GoDoc](https://godoc.org/gopkg.in/ldap.v1?status.svg)](https://godoc.org/gopkg.in/ldap.v1) [![Build Status](https://travis-ci.org/go-ldap/ldap.svg)](https://travis-ci.org/go-ldap/ldap)
+[![GoDoc](https://godoc.org/gopkg.in/ldap.v1?status.svg)](https://godoc.org/gopkg.in/ldap.v1)
+[![Build Status](https://travis-ci.org/go-ldap/ldap.svg)](https://travis-ci.org/go-ldap/ldap)
 
 # Basic LDAP v3 functionality for the GO programming language.
 
-## Required Librarys: 
+## Install
+
+For the latest version use:
+
+    go get gopkg.in/ldap.v2
+
+Import the latest version with:
+
+    import "gopkg.in/ldap.v2"
+
+
+## Required Libraries:
 
  - gopkg.in/asn1-ber.v1
 
@@ -14,6 +26,9 @@
  - Compiling string filters to LDAP filters
  - Paging Search Results
  - Modify Requests / Responses
+ - Add Requests / Responses
+ - Delete Requests / Responses
+ - Better Unicode support
 
 ## Examples:
 
@@ -26,23 +41,15 @@
 
 ## TODO:
 
- - Add Requests / Responses
- - Delete Requests / Responses
- - Modify DN Requests / Responses
- - Compare Requests / Responses
- - Implement Tests / Benchmarks
+ - [x] Add Requests / Responses
+ - [x] Delete Requests / Responses
+ - [x] Modify DN Requests / Responses
+ - [ ] Compare Requests / Responses
+ - [ ] Implement Tests / Benchmarks
+
+
 
 ---
-This feature is disabled at the moment, because in some cases the "Search Request Done" packet will be handled before the last "Search Request Entry":
-
- - Mulitple internal goroutines to handle network traffic
-        Makes library goroutine safe
-        Can perform multiple search requests at the same time and return
-        the results to the proper goroutine. All requests are blocking requests,
-        so the goroutine does not need special handling
-
----
-
 The Go gopher was designed by Renee French. (http://reneefrench.blogspot.com/)
 The design is licensed under the Creative Commons 3.0 Attributions license.
 Read this article for more details: http://blog.golang.org/gopher

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/add.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/add.go
@@ -1,0 +1,104 @@
+//
+// https://tools.ietf.org/html/rfc4511
+//
+// AddRequest ::= [APPLICATION 8] SEQUENCE {
+//      entry           LDAPDN,
+//      attributes      AttributeList }
+//
+// AttributeList ::= SEQUENCE OF attribute Attribute
+
+package ldap
+
+import (
+	"errors"
+	"log"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+type Attribute struct {
+	attrType string
+	attrVals []string
+}
+
+func (a *Attribute) encode() *ber.Packet {
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Attribute")
+	seq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, a.attrType, "Type"))
+	set := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSet, nil, "AttributeValue")
+	for _, value := range a.attrVals {
+		set.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, value, "Vals"))
+	}
+	seq.AppendChild(set)
+	return seq
+}
+
+type AddRequest struct {
+	dn         string
+	attributes []Attribute
+}
+
+func (a AddRequest) encode() *ber.Packet {
+	request := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationAddRequest, nil, "Add Request")
+	request.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, a.dn, "DN"))
+	attributes := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Attributes")
+	for _, attribute := range a.attributes {
+		attributes.AppendChild(attribute.encode())
+	}
+	request.AppendChild(attributes)
+	return request
+}
+
+func (a *AddRequest) Attribute(attrType string, attrVals []string) {
+	a.attributes = append(a.attributes, Attribute{attrType: attrType, attrVals: attrVals})
+}
+
+func NewAddRequest(dn string) *AddRequest {
+	return &AddRequest{
+		dn: dn,
+	}
+
+}
+
+func (l *Conn) Add(addRequest *AddRequest) error {
+	messageID := l.nextMessageID()
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Request")
+	packet.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, messageID, "MessageID"))
+	packet.AppendChild(addRequest.encode())
+
+	l.Debug.PrintPacket(packet)
+
+	channel, err := l.sendMessage(packet)
+	if err != nil {
+		return err
+	}
+	if channel == nil {
+		return NewError(ErrorNetwork, errors.New("ldap: could not send message"))
+	}
+	defer l.finishMessage(messageID)
+
+	l.Debug.Printf("%d: waiting for response", messageID)
+	packet = <-channel
+	l.Debug.Printf("%d: got response %p", messageID, packet)
+	if packet == nil {
+		return NewError(ErrorNetwork, errors.New("ldap: could not retrieve message"))
+	}
+
+	if l.Debug {
+		if err := addLDAPDescriptions(packet); err != nil {
+			return err
+		}
+		ber.PrintPacket(packet)
+	}
+
+	if packet.Children[1].Tag == ApplicationAddResponse {
+		resultCode, resultDescription := getLDAPResultCode(packet)
+		if resultCode != 0 {
+			return NewError(resultCode, errors.New(resultDescription))
+		}
+	} else {
+		log.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+	}
+
+	l.Debug.Printf("%d: returning", messageID)
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/client.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/client.go
@@ -1,0 +1,23 @@
+package ldap
+
+import "crypto/tls"
+
+// Client knows how to interact with an LDAP server
+type Client interface {
+	Start()
+	StartTLS(config *tls.Config) error
+	Close()
+
+	Bind(username, password string) error
+	SimpleBind(simpleBindRequest *SimpleBindRequest) (*SimpleBindResult, error)
+
+	Add(addRequest *AddRequest) error
+	Del(delRequest *DelRequest) error
+	Modify(modifyRequest *ModifyRequest) error
+
+	Compare(dn, attribute, value string) (bool, error)
+	PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*PasswordModifyResult, error)
+
+	Search(searchRequest *SearchRequest) (*SearchResult, error)
+	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
+}

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/conn.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/conn.go
@@ -8,11 +8,12 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"gopkg.in/asn1-ber.v1"
 	"log"
 	"net"
 	"sync"
 	"time"
+
+	"gopkg.in/asn1-ber.v1"
 )
 
 const (
@@ -52,6 +53,8 @@ type Conn struct {
 	outstandingRequests uint
 	messageMutex        sync.Mutex
 }
+
+var _ Client = &Conn{}
 
 // DefaultTimeout is a package-level variable that sets the timeout value
 // used for the Dial and DialTLS methods.
@@ -176,7 +179,7 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 		ber.PrintPacket(packet)
 	}
 
-	if packet.Children[1].Children[0].Value.(int64) == LDAPResultSuccess {
+	if resultCode, message := getLDAPResultCode(packet); resultCode == LDAPResultSuccess {
 		conn := tls.Client(l.conn, config)
 
 		if err := conn.Handshake(); err != nil {
@@ -187,11 +190,7 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 		l.isTLS = true
 		l.conn = conn
 	} else {
-		// https://tools.ietf.org/html/rfc4511#section-4.1.9
-		// Children[1].Children[2] is the diagnosticMessage which is guaranteed to exist.
-		return NewError(
-			uint8(packet.Children[1].Children[0].Value.(int64)),
-			fmt.Errorf("ldap: cannot StartTLS (%s)", packet.Children[1].Children[2].Value.(string)))
+		return NewError(resultCode, fmt.Errorf("ldap: cannot StartTLS (%s)", message))
 	}
 	go l.reader()
 

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/control.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/control.go
@@ -16,11 +16,13 @@ const (
 	ControlTypeBeheraPasswordPolicy   = "1.3.6.1.4.1.42.2.27.8.5.1"
 	ControlTypeVChuPasswordMustChange = "2.16.840.1.113730.3.4.4"
 	ControlTypeVChuPasswordWarning    = "2.16.840.1.113730.3.4.5"
+	ControlTypeManageDsaIT            = "2.16.840.1.113730.3.4.2"
 )
 
 var ControlTypeMap = map[string]string{
 	ControlTypePaging:               "Paging",
 	ControlTypeBeheraPasswordPolicy: "Password Policy - Behera Draft",
+	ControlTypeManageDsaIT:          "Manage DSA IT",
 }
 
 type Control interface {
@@ -163,6 +165,36 @@ func (c *ControlVChuPasswordWarning) String() string {
 		ControlTypeVChuPasswordWarning,
 		false,
 		c.Expire)
+}
+
+type ControlManageDsaIT struct {
+	Criticality bool
+}
+
+func (c *ControlManageDsaIT) GetControlType() string {
+	return ControlTypeManageDsaIT
+}
+
+func (c *ControlManageDsaIT) Encode() *ber.Packet {
+	//FIXME
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeManageDsaIT, "Control Type ("+ControlTypeMap[ControlTypeManageDsaIT]+")"))
+	if c.Criticality {
+		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
+	}
+	return packet
+}
+
+func (c *ControlManageDsaIT) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)  Criticality: %t",
+		ControlTypeMap[ControlTypeManageDsaIT],
+		ControlTypeManageDsaIT,
+		c.Criticality)
+}
+
+func NewControlManageDsaIT(Criticality bool) *ControlManageDsaIT {
+	return &ControlManageDsaIT{Criticality: Criticality}
 }
 
 func FindControl(controls []Control, controlType string) Control {

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/del.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/del.go
@@ -1,0 +1,79 @@
+//
+// https://tools.ietf.org/html/rfc4511
+//
+// DelRequest ::= [APPLICATION 10] LDAPDN
+
+package ldap
+
+import (
+	"errors"
+	"log"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+type DelRequest struct {
+	DN       string
+	Controls []Control
+}
+
+func (d DelRequest) encode() *ber.Packet {
+	request := ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationDelRequest, d.DN, "Del Request")
+	request.Data.Write([]byte(d.DN))
+	return request
+}
+
+func NewDelRequest(DN string,
+	Controls []Control) *DelRequest {
+	return &DelRequest{
+		DN:       DN,
+		Controls: Controls,
+	}
+}
+
+func (l *Conn) Del(delRequest *DelRequest) error {
+	messageID := l.nextMessageID()
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Request")
+	packet.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, messageID, "MessageID"))
+	packet.AppendChild(delRequest.encode())
+	if delRequest.Controls != nil {
+		packet.AppendChild(encodeControls(delRequest.Controls))
+	}
+
+	l.Debug.PrintPacket(packet)
+
+	channel, err := l.sendMessage(packet)
+	if err != nil {
+		return err
+	}
+	if channel == nil {
+		return NewError(ErrorNetwork, errors.New("ldap: could not send message"))
+	}
+	defer l.finishMessage(messageID)
+
+	l.Debug.Printf("%d: waiting for response", messageID)
+	packet = <-channel
+	l.Debug.Printf("%d: got response %p", messageID, packet)
+	if packet == nil {
+		return NewError(ErrorNetwork, errors.New("ldap: could not retrieve message"))
+	}
+
+	if l.Debug {
+		if err := addLDAPDescriptions(packet); err != nil {
+			return err
+		}
+		ber.PrintPacket(packet)
+	}
+
+	if packet.Children[1].Tag == ApplicationDelResponse {
+		resultCode, resultDescription := getLDAPResultCode(packet)
+		if resultCode != 0 {
+			return NewError(resultCode, errors.New(resultDescription))
+		}
+	} else {
+		log.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+	}
+
+	l.Debug.Printf("%d: returning", messageID)
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/dn.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/dn.go
@@ -47,17 +47,17 @@ package ldap
 
 import (
 	"bytes"
+	enchex "encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
-	enchex "encoding/hex"
 
 	ber "gopkg.in/asn1-ber.v1"
 )
 
 type AttributeTypeAndValue struct {
-	Type       string
-	Value      string
+	Type  string
+	Value string
 }
 
 type RelativeDN struct {
@@ -71,7 +71,7 @@ type DN struct {
 func ParseDN(str string) (*DN, error) {
 	dn := new(DN)
 	dn.RDNs = make([]*RelativeDN, 0)
-	rdn := new (RelativeDN)
+	rdn := new(RelativeDN)
 	rdn.Attributes = make([]*AttributeTypeAndValue, 0)
 	buffer := bytes.Buffer{}
 	attribute := new(AttributeTypeAndValue)
@@ -115,7 +115,7 @@ func ParseDN(str string) (*DN, error) {
 				index := strings.IndexAny(str[i:], ",+")
 				data := str
 				if index > 0 {
-				  data = str[i:i+index]
+					data = str[i : i+index]
 				} else {
 					data = str[i:]
 				}
@@ -126,7 +126,7 @@ func ParseDN(str string) (*DN, error) {
 				}
 				packet := ber.DecodePacket(raw_ber)
 				buffer.WriteString(packet.Data.String())
-				i += len(data)-1
+				i += len(data) - 1
 			}
 		} else if char == ',' || char == '+' {
 			// We're done with this RDN or value, push it

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/dn_test.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/dn_test.go
@@ -1,38 +1,40 @@
-package ldap
+package ldap_test
 
 import (
 	"reflect"
 	"testing"
+
+	"gopkg.in/ldap.v2"
 )
 
 func TestSuccessfulDNParsing(t *testing.T) {
-	testcases := map[string]DN {
-		"": DN{[]*RelativeDN{}},
-		"cn=Jim\\2C \\22Hasse Hö\\22 Hansson!,dc=dummy,dc=com": DN{[]*RelativeDN{
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"cn", "Jim, \"Hasse Hö\" Hansson!"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"dc", "dummy"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"dc", "com"}, }},}},
-		"UID=jsmith,DC=example,DC=net": DN{[]*RelativeDN{
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"UID", "jsmith"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "example"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "net"}, }},}},
-		"OU=Sales+CN=J. Smith,DC=example,DC=net": DN{[]*RelativeDN{
-			&RelativeDN{[]*AttributeTypeAndValue{
-				&AttributeTypeAndValue{"OU", "Sales"},
-				&AttributeTypeAndValue{"CN", "J. Smith"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "example"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "net"}, }},}},
-		"1.3.6.1.4.1.1466.0=#04024869": DN{[]*RelativeDN{
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"},}},}},
-		"1.3.6.1.4.1.1466.0=#04024869,DC=net": DN{[]*RelativeDN{
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"},}},
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "net"}, }},}},
-		"CN=Lu\\C4\\8Di\\C4\\87": DN{[]*RelativeDN{
-			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"CN", "Lučić"},}},}},
+	testcases := map[string]ldap.DN{
+		"": ldap.DN{[]*ldap.RelativeDN{}},
+		"cn=Jim\\2C \\22Hasse Hö\\22 Hansson!,dc=dummy,dc=com": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"cn", "Jim, \"Hasse Hö\" Hansson!"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"dc", "dummy"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"dc", "com"}}}}},
+		"UID=jsmith,DC=example,DC=net": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"UID", "jsmith"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "example"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
+		"OU=Sales+CN=J. Smith,DC=example,DC=net": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{
+				&ldap.AttributeTypeAndValue{"OU", "Sales"},
+				&ldap.AttributeTypeAndValue{"CN", "J. Smith"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "example"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
+		"1.3.6.1.4.1.1466.0=#04024869": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"}}}}},
+		"1.3.6.1.4.1.1466.0=#04024869,DC=net": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
+		"CN=Lu\\C4\\8Di\\C4\\87": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"CN", "Lučić"}}}}},
 	}
 
 	for test, answer := range testcases {
-		dn, err := ParseDN(test)
+		dn, err := ldap.ParseDN(test)
 		if err != nil {
 			t.Errorf(err.Error())
 			continue
@@ -49,16 +51,16 @@ func TestSuccessfulDNParsing(t *testing.T) {
 }
 
 func TestErrorDNParsing(t *testing.T) {
-	testcases := map[string]string {
-		"*": "DN ended with incomplete type, value pair",
-		"cn=Jim\\0Test": "Failed to decode escaped character: encoding/hex: invalid byte: U+0054 'T'",
-		"cn=Jim\\0": "Got corrupted escaped character",
+	testcases := map[string]string{
+		"*":               "DN ended with incomplete type, value pair",
+		"cn=Jim\\0Test":   "Failed to decode escaped character: encoding/hex: invalid byte: U+0054 'T'",
+		"cn=Jim\\0":       "Got corrupted escaped character",
 		"DC=example,=net": "DN ended with incomplete type, value pair",
-		"1=#0402486": "Failed to decode BER encoding: encoding/hex: odd length hex string",
+		"1=#0402486":      "Failed to decode BER encoding: encoding/hex: odd length hex string",
 	}
 
 	for test, answer := range testcases {
-		_, err := ParseDN(test)
+		_, err := ldap.ParseDN(test)
 		if err == nil {
 			t.Errorf("Expected %s to fail parsing but succeeded\n", test)
 		} else if err.Error() != answer {
@@ -66,5 +68,3 @@ func TestErrorDNParsing(t *testing.T) {
 		}
 	}
 }
-
-

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/error.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/error.go
@@ -1,0 +1,137 @@
+package ldap
+
+import (
+	"fmt"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+// LDAP Result Codes
+const (
+	LDAPResultSuccess                      = 0
+	LDAPResultOperationsError              = 1
+	LDAPResultProtocolError                = 2
+	LDAPResultTimeLimitExceeded            = 3
+	LDAPResultSizeLimitExceeded            = 4
+	LDAPResultCompareFalse                 = 5
+	LDAPResultCompareTrue                  = 6
+	LDAPResultAuthMethodNotSupported       = 7
+	LDAPResultStrongAuthRequired           = 8
+	LDAPResultReferral                     = 10
+	LDAPResultAdminLimitExceeded           = 11
+	LDAPResultUnavailableCriticalExtension = 12
+	LDAPResultConfidentialityRequired      = 13
+	LDAPResultSaslBindInProgress           = 14
+	LDAPResultNoSuchAttribute              = 16
+	LDAPResultUndefinedAttributeType       = 17
+	LDAPResultInappropriateMatching        = 18
+	LDAPResultConstraintViolation          = 19
+	LDAPResultAttributeOrValueExists       = 20
+	LDAPResultInvalidAttributeSyntax       = 21
+	LDAPResultNoSuchObject                 = 32
+	LDAPResultAliasProblem                 = 33
+	LDAPResultInvalidDNSyntax              = 34
+	LDAPResultAliasDereferencingProblem    = 36
+	LDAPResultInappropriateAuthentication  = 48
+	LDAPResultInvalidCredentials           = 49
+	LDAPResultInsufficientAccessRights     = 50
+	LDAPResultBusy                         = 51
+	LDAPResultUnavailable                  = 52
+	LDAPResultUnwillingToPerform           = 53
+	LDAPResultLoopDetect                   = 54
+	LDAPResultNamingViolation              = 64
+	LDAPResultObjectClassViolation         = 65
+	LDAPResultNotAllowedOnNonLeaf          = 66
+	LDAPResultNotAllowedOnRDN              = 67
+	LDAPResultEntryAlreadyExists           = 68
+	LDAPResultObjectClassModsProhibited    = 69
+	LDAPResultAffectsMultipleDSAs          = 71
+	LDAPResultOther                        = 80
+
+	ErrorNetwork            = 200
+	ErrorFilterCompile      = 201
+	ErrorFilterDecompile    = 202
+	ErrorDebugging          = 203
+	ErrorUnexpectedMessage  = 204
+	ErrorUnexpectedResponse = 205
+)
+
+var LDAPResultCodeMap = map[uint8]string{
+	LDAPResultSuccess:                      "Success",
+	LDAPResultOperationsError:              "Operations Error",
+	LDAPResultProtocolError:                "Protocol Error",
+	LDAPResultTimeLimitExceeded:            "Time Limit Exceeded",
+	LDAPResultSizeLimitExceeded:            "Size Limit Exceeded",
+	LDAPResultCompareFalse:                 "Compare False",
+	LDAPResultCompareTrue:                  "Compare True",
+	LDAPResultAuthMethodNotSupported:       "Auth Method Not Supported",
+	LDAPResultStrongAuthRequired:           "Strong Auth Required",
+	LDAPResultReferral:                     "Referral",
+	LDAPResultAdminLimitExceeded:           "Admin Limit Exceeded",
+	LDAPResultUnavailableCriticalExtension: "Unavailable Critical Extension",
+	LDAPResultConfidentialityRequired:      "Confidentiality Required",
+	LDAPResultSaslBindInProgress:           "Sasl Bind In Progress",
+	LDAPResultNoSuchAttribute:              "No Such Attribute",
+	LDAPResultUndefinedAttributeType:       "Undefined Attribute Type",
+	LDAPResultInappropriateMatching:        "Inappropriate Matching",
+	LDAPResultConstraintViolation:          "Constraint Violation",
+	LDAPResultAttributeOrValueExists:       "Attribute Or Value Exists",
+	LDAPResultInvalidAttributeSyntax:       "Invalid Attribute Syntax",
+	LDAPResultNoSuchObject:                 "No Such Object",
+	LDAPResultAliasProblem:                 "Alias Problem",
+	LDAPResultInvalidDNSyntax:              "Invalid DN Syntax",
+	LDAPResultAliasDereferencingProblem:    "Alias Dereferencing Problem",
+	LDAPResultInappropriateAuthentication:  "Inappropriate Authentication",
+	LDAPResultInvalidCredentials:           "Invalid Credentials",
+	LDAPResultInsufficientAccessRights:     "Insufficient Access Rights",
+	LDAPResultBusy:                         "Busy",
+	LDAPResultUnavailable:                  "Unavailable",
+	LDAPResultUnwillingToPerform:           "Unwilling To Perform",
+	LDAPResultLoopDetect:                   "Loop Detect",
+	LDAPResultNamingViolation:              "Naming Violation",
+	LDAPResultObjectClassViolation:         "Object Class Violation",
+	LDAPResultNotAllowedOnNonLeaf:          "Not Allowed On Non Leaf",
+	LDAPResultNotAllowedOnRDN:              "Not Allowed On RDN",
+	LDAPResultEntryAlreadyExists:           "Entry Already Exists",
+	LDAPResultObjectClassModsProhibited:    "Object Class Mods Prohibited",
+	LDAPResultAffectsMultipleDSAs:          "Affects Multiple DSAs",
+	LDAPResultOther:                        "Other",
+}
+
+func getLDAPResultCode(packet *ber.Packet) (code uint8, description string) {
+	if len(packet.Children) >= 2 {
+		response := packet.Children[1]
+		if response.ClassType == ber.ClassApplication && response.TagType == ber.TypeConstructed && len(response.Children) >= 3 {
+			// Children[1].Children[2] is the diagnosticMessage which is guaranteed to exist as seen here: https://tools.ietf.org/html/rfc4511#section-4.1.9
+			return uint8(response.Children[0].Value.(int64)), response.Children[2].Value.(string)
+		}
+	}
+
+	return ErrorNetwork, "Invalid packet format"
+}
+
+type Error struct {
+	Err        error
+	ResultCode uint8
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("LDAP Result Code %d %q: %s", e.ResultCode, LDAPResultCodeMap[e.ResultCode], e.Err.Error())
+}
+
+func NewError(resultCode uint8, err error) error {
+	return &Error{ResultCode: resultCode, Err: err}
+}
+
+func IsErrorWithCode(err error, desiredResultCode uint8) bool {
+	if err == nil {
+		return false
+	}
+
+	serverError, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+
+	return serverError.ResultCode == desiredResultCode
+}

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/example_test.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/example_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/go-ldap/ldap"
+	"gopkg.in/ldap.v2"
 )
 
-// ExampleConn_Bind demonstrats how to bind a connection to an ldap user
+// ExampleConn_Bind demonstrates how to bind a connection to an ldap user
 // allowing access to restricted attrabutes that user has access to
 func ExampleConn_Bind() {
 	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/filter.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/filter.go
@@ -5,9 +5,12 @@
 package ldap
 
 import (
+	"bytes"
+	hexpac "encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"gopkg.in/asn1-ber.v1"
 )
@@ -116,22 +119,22 @@ func DecompileFilter(packet *ber.Packet) (ret string, err error) {
 	case FilterEqualityMatch:
 		ret += ber.DecodeString(packet.Children[0].Data.Bytes())
 		ret += "="
-		ret += ber.DecodeString(packet.Children[1].Data.Bytes())
+		ret += EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes()))
 	case FilterGreaterOrEqual:
 		ret += ber.DecodeString(packet.Children[0].Data.Bytes())
 		ret += ">="
-		ret += ber.DecodeString(packet.Children[1].Data.Bytes())
+		ret += EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes()))
 	case FilterLessOrEqual:
 		ret += ber.DecodeString(packet.Children[0].Data.Bytes())
 		ret += "<="
-		ret += ber.DecodeString(packet.Children[1].Data.Bytes())
+		ret += EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes()))
 	case FilterPresent:
 		ret += ber.DecodeString(packet.Data.Bytes())
 		ret += "=*"
 	case FilterApproxMatch:
 		ret += ber.DecodeString(packet.Children[0].Data.Bytes())
 		ret += "~="
-		ret += ber.DecodeString(packet.Children[1].Data.Bytes())
+		ret += EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes()))
 	}
 
 	ret += ")"
@@ -155,57 +158,73 @@ func compileFilterSet(filter string, pos int, parent *ber.Packet) (int, error) {
 }
 
 func compileFilter(filter string, pos int) (*ber.Packet, int, error) {
-	var packet *ber.Packet
-	var err error
+	var (
+		packet *ber.Packet
+		err    error
+	)
 
 	defer func() {
 		if r := recover(); r != nil {
 			err = NewError(ErrorFilterCompile, errors.New("ldap: error compiling filter"))
 		}
 	}()
-
 	newPos := pos
-	switch filter[pos] {
+
+	currentRune, currentWidth := utf8.DecodeRuneInString(filter[newPos:])
+
+	switch currentRune {
+	case utf8.RuneError:
+		return nil, 0, NewError(ErrorFilterCompile, fmt.Errorf("ldap: error reading rune at position %d", newPos))
 	case '(':
-		packet, newPos, err = compileFilter(filter, pos+1)
+		packet, newPos, err = compileFilter(filter, pos+currentWidth)
 		newPos++
 		return packet, newPos, err
 	case '&':
 		packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterAnd, nil, FilterMap[FilterAnd])
-		newPos, err = compileFilterSet(filter, pos+1, packet)
+		newPos, err = compileFilterSet(filter, pos+currentWidth, packet)
 		return packet, newPos, err
 	case '|':
 		packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterOr, nil, FilterMap[FilterOr])
-		newPos, err = compileFilterSet(filter, pos+1, packet)
+		newPos, err = compileFilterSet(filter, pos+currentWidth, packet)
 		return packet, newPos, err
 	case '!':
 		packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterNot, nil, FilterMap[FilterNot])
 		var child *ber.Packet
-		child, newPos, err = compileFilter(filter, pos+1)
+		child, newPos, err = compileFilter(filter, pos+currentWidth)
 		packet.AppendChild(child)
 		return packet, newPos, err
 	default:
 		attribute := ""
 		condition := ""
-		for newPos < len(filter) && filter[newPos] != ')' {
+		for newPos < len(filter) {
+			currentRune, currentWidth = utf8.DecodeRuneInString(filter[newPos:])
+			if currentRune == ')' {
+				break
+			}
+			if currentRune == utf8.RuneError {
+				return packet, newPos, NewError(ErrorFilterCompile, fmt.Errorf("ldap: error reading rune at position %d", newPos))
+			}
+
+			nextRune, nextWidth := utf8.DecodeRuneInString(filter[newPos+currentWidth:])
+
 			switch {
 			case packet != nil:
-				condition += fmt.Sprintf("%c", filter[newPos])
-			case filter[newPos] == '=':
+				condition += fmt.Sprintf("%c", currentRune)
+			case currentRune == '=':
 				packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterEqualityMatch, nil, FilterMap[FilterEqualityMatch])
-			case filter[newPos] == '>' && filter[newPos+1] == '=':
+			case currentRune == '>' && nextRune == '=':
 				packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterGreaterOrEqual, nil, FilterMap[FilterGreaterOrEqual])
-				newPos++
-			case filter[newPos] == '<' && filter[newPos+1] == '=':
+				newPos += nextWidth // we're skipping the next character as well
+			case currentRune == '<' && nextRune == '=':
 				packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterLessOrEqual, nil, FilterMap[FilterLessOrEqual])
-				newPos++
-			case filter[newPos] == '~' && filter[newPos+1] == '=':
+				newPos += nextWidth // we're skipping the next character as well
+			case currentRune == '~' && nextRune == '=':
 				packet = ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterApproxMatch, nil, FilterMap[FilterLessOrEqual])
-				newPos++
+				newPos += nextWidth // we're skipping the next character as well
 			case packet == nil:
-				attribute += fmt.Sprintf("%c", filter[newPos])
+				attribute += fmt.Sprintf("%c", currentRune)
 			}
-			newPos++
+			newPos += currentWidth
 		}
 		if newPos == len(filter) {
 			err = NewError(ErrorFilterCompile, errors.New("ldap: unexpected end of filter"))
@@ -242,11 +261,34 @@ func compileFilter(filter string, pos int) (*ber.Packet, int, error) {
 			}
 			packet.AppendChild(seq)
 		default:
+			var buffer bytes.Buffer
+			for i := 0; i < len(condition); i++ {
+				// Check for escaped hex characters and convert them to their literal value for transport.
+				if condition[i] == '\\' {
+					// http://tools.ietf.org/search/rfc4515
+					// \ (%x5C) is not a valid character unless it is followed by two HEX characters due to not
+					// being a member of UTF1SUBSET.
+					if i+2 > len(condition) {
+						err = NewError(ErrorFilterCompile, errors.New("ldap: missing characters for escape in filter"))
+						return packet, newPos, err
+					}
+					if escByte, decodeErr := hexpac.DecodeString(condition[i+1 : i+3]); decodeErr != nil {
+						err = NewError(ErrorFilterCompile, errors.New("ldap: invalid characters for escape in filter"))
+						return packet, newPos, err
+					} else {
+						buffer.WriteByte(escByte[0])
+						i += 2 // +1 from end of loop, so 3 total for \xx.
+					}
+				} else {
+					buffer.WriteString(string(condition[i]))
+				}
+			}
+
 			packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, attribute, "Attribute"))
-			packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, condition, "Condition"))
+			packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, buffer.String(), "Condition"))
 		}
 
-		newPos++
+		newPos += currentWidth
 		return packet, newPos, err
 	}
 }

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/filter_test.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/filter_test.go
@@ -1,50 +1,157 @@
-package ldap
+package ldap_test
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/asn1-ber.v1"
+	"gopkg.in/ldap.v2"
 )
 
 type compileTest struct {
-	filterStr  string
-	filterType int
+	filterStr string
+
+	expectedFilter string
+	expectedType   int
+	expectedErr    string
 }
 
 var testFilters = []compileTest{
-	compileTest{filterStr: "(&(sn=Miller)(givenName=Bob))", filterType: FilterAnd},
-	compileTest{filterStr: "(|(sn=Miller)(givenName=Bob))", filterType: FilterOr},
-	compileTest{filterStr: "(!(sn=Miller))", filterType: FilterNot},
-	compileTest{filterStr: "(sn=Miller)", filterType: FilterEqualityMatch},
-	compileTest{filterStr: "(sn=Mill*)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=*Mill)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=*Mill*)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=*i*le*)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=Mi*l*r)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=Mi*le*)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn=*i*ler)", filterType: FilterSubstrings},
-	compileTest{filterStr: "(sn>=Miller)", filterType: FilterGreaterOrEqual},
-	compileTest{filterStr: "(sn<=Miller)", filterType: FilterLessOrEqual},
-	compileTest{filterStr: "(sn=*)", filterType: FilterPresent},
-	compileTest{filterStr: "(sn~=Miller)", filterType: FilterApproxMatch},
+	compileTest{
+		filterStr:      "(&(sn=Miller)(givenName=Bob))",
+		expectedFilter: "(&(sn=Miller)(givenName=Bob))",
+		expectedType:   ldap.FilterAnd,
+	},
+	compileTest{
+		filterStr:      "(|(sn=Miller)(givenName=Bob))",
+		expectedFilter: "(|(sn=Miller)(givenName=Bob))",
+		expectedType:   ldap.FilterOr,
+	},
+	compileTest{
+		filterStr:      "(!(sn=Miller))",
+		expectedFilter: "(!(sn=Miller))",
+		expectedType:   ldap.FilterNot,
+	},
+	compileTest{
+		filterStr:      "(sn=Miller)",
+		expectedFilter: "(sn=Miller)",
+		expectedType:   ldap.FilterEqualityMatch,
+	},
+	compileTest{
+		filterStr:      "(sn=Mill*)",
+		expectedFilter: "(sn=Mill*)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn=*Mill)",
+		expectedFilter: "(sn=*Mill)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn=*Mill*)",
+		expectedFilter: "(sn=*Mill*)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn=*i*le*)",
+		expectedFilter: "(sn=*i*le*)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn=Mi*l*r)",
+		expectedFilter: "(sn=Mi*l*r)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn=Mi*le*)",
+		expectedFilter: "(sn=Mi*le*)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn=*i*ler)",
+		expectedFilter: "(sn=*i*ler)",
+		expectedType:   ldap.FilterSubstrings,
+	},
+	compileTest{
+		filterStr:      "(sn>=Miller)",
+		expectedFilter: "(sn>=Miller)",
+		expectedType:   ldap.FilterGreaterOrEqual,
+	},
+	compileTest{
+		filterStr:      "(sn<=Miller)",
+		expectedFilter: "(sn<=Miller)",
+		expectedType:   ldap.FilterLessOrEqual,
+	},
+	compileTest{
+		filterStr:      "(sn=*)",
+		expectedFilter: "(sn=*)",
+		expectedType:   ldap.FilterPresent,
+	},
+	compileTest{
+		filterStr:      "(sn~=Miller)",
+		expectedFilter: "(sn~=Miller)",
+		expectedType:   ldap.FilterApproxMatch,
+	},
+	compileTest{
+		filterStr:      `(objectGUID='\fc\fe\a3\ab\f9\90N\aaGm\d5I~\d12)`,
+		expectedFilter: `(objectGUID='\fc\fe\a3\ab\f9\90N\aaGm\d5I~\d12)`,
+		expectedType:   ldap.FilterEqualityMatch,
+	},
+	compileTest{
+		filterStr:      `(objectGUID=абвгдеёжзийклмнопрстуфхцчшщъыьэюя)`,
+		expectedFilter: `(objectGUID=\c3\90\c2\b0\c3\90\c2\b1\c3\90\c2\b2\c3\90\c2\b3\c3\90\c2\b4\c3\90\c2\b5\c3\91\c2\91\c3\90\c2\b6\c3\90\c2\b7\c3\90\c2\b8\c3\90\c2\b9\c3\90\c2\ba\c3\90\c2\bb\c3\90\c2\bc\c3\90\c2\bd\c3\90\c2\be\c3\90\c2\bf\c3\91\c2\80\c3\91\c2\81\c3\91\c2\82\c3\91\c2\83\c3\91\c2\84\c3\91\c2\85\c3\91\c2\86\c3\91\c2\87\c3\91\c2\88\c3\91\c2\89\c3\91\c2\8a\c3\91\c2\8b\c3\91\c2\8c\c3\91\c2\8d\c3\91\c2\8e\c3\91\c2\8f)`,
+		expectedType:   ldap.FilterEqualityMatch,
+	},
+	compileTest{
+		filterStr:      `(objectGUID=함수목록)`,
+		expectedFilter: `(objectGUID=\c3\ad\c2\95\c2\a8\c3\ac\c2\88\c2\98\c3\ab\c2\aa\c2\a9\c3\ab\c2\a1\c2\9d)`,
+		expectedType:   ldap.FilterEqualityMatch,
+	},
+	compileTest{
+		filterStr:      `(objectGUID=`,
+		expectedFilter: ``,
+		expectedType:   0,
+		expectedErr:    "unexpected end of filter",
+	},
+	compileTest{
+		filterStr:      `(objectGUID=함수목록`,
+		expectedFilter: ``,
+		expectedType:   0,
+		expectedErr:    "unexpected end of filter",
+	},
 	// compileTest{ filterStr: "()", filterType: FilterExtensibleMatch },
+}
+
+var testInvalidFilters = []string{
+	`(objectGUID=\zz)`,
+	`(objectGUID=\a)`,
 }
 
 func TestFilter(t *testing.T) {
 	// Test Compiler and Decompiler
 	for _, i := range testFilters {
-		filter, err := CompileFilter(i.filterStr)
+		filter, err := ldap.CompileFilter(i.filterStr)
 		if err != nil {
-			t.Errorf("Problem compiling %s - %s", i.filterStr, err.Error())
-		} else if filter.Tag != ber.Tag(i.filterType) {
-			t.Errorf("%q Expected %q got %q", i.filterStr, FilterMap[uint64(i.filterType)], FilterMap[uint64(filter.Tag)])
+			if i.expectedErr == "" || !strings.Contains(err.Error(), i.expectedErr) {
+				t.Errorf("Problem compiling '%s' - '%v' (expected error to contain '%v')", i.filterStr, err, i.expectedErr)
+			}
+		} else if filter.Tag != ber.Tag(i.expectedType) {
+			t.Errorf("%q Expected %q got %q", i.filterStr, ldap.FilterMap[uint64(i.expectedType)], ldap.FilterMap[uint64(filter.Tag)])
 		} else {
-			o, err := DecompileFilter(filter)
+			o, err := ldap.DecompileFilter(filter)
 			if err != nil {
 				t.Errorf("Problem compiling %s - %s", i.filterStr, err.Error())
-			} else if i.filterStr != o {
-				t.Errorf("%q expected, got %q", i.filterStr, o)
+			} else if i.expectedFilter != o {
+				t.Errorf("%q expected, got %q", i.expectedFilter, o)
 			}
+		}
+	}
+}
+
+func TestInvalidFilter(t *testing.T) {
+	for _, filterStr := range testInvalidFilters {
+		if _, err := ldap.CompileFilter(filterStr); err == nil {
+			t.Errorf("Problem compiling %s - expected err", filterStr)
 		}
 	}
 }
@@ -61,7 +168,7 @@ func BenchmarkFilterCompile(b *testing.B) {
 	maxIdx := len(filters)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		CompileFilter(filters[i%maxIdx])
+		ldap.CompileFilter(filters[i%maxIdx])
 	}
 }
 
@@ -71,12 +178,12 @@ func BenchmarkFilterDecompile(b *testing.B) {
 
 	// Test Compiler and Decompiler
 	for idx, i := range testFilters {
-		filters[idx], _ = CompileFilter(i.filterStr)
+		filters[idx], _ = ldap.CompileFilter(i.filterStr)
 	}
 
 	maxIdx := len(filters)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		DecompileFilter(filters[i%maxIdx])
+		ldap.DecompileFilter(filters[i%maxIdx])
 	}
 }

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/ldap.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/ldap.go
@@ -6,7 +6,6 @@ package ldap
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -58,98 +57,6 @@ var ApplicationMap = map[uint8]string{
 	ApplicationSearchResultReference: "Search Result Reference",
 	ApplicationExtendedRequest:       "Extended Request",
 	ApplicationExtendedResponse:      "Extended Response",
-}
-
-// LDAP Result Codes
-const (
-	LDAPResultSuccess                      = 0
-	LDAPResultOperationsError              = 1
-	LDAPResultProtocolError                = 2
-	LDAPResultTimeLimitExceeded            = 3
-	LDAPResultSizeLimitExceeded            = 4
-	LDAPResultCompareFalse                 = 5
-	LDAPResultCompareTrue                  = 6
-	LDAPResultAuthMethodNotSupported       = 7
-	LDAPResultStrongAuthRequired           = 8
-	LDAPResultReferral                     = 10
-	LDAPResultAdminLimitExceeded           = 11
-	LDAPResultUnavailableCriticalExtension = 12
-	LDAPResultConfidentialityRequired      = 13
-	LDAPResultSaslBindInProgress           = 14
-	LDAPResultNoSuchAttribute              = 16
-	LDAPResultUndefinedAttributeType       = 17
-	LDAPResultInappropriateMatching        = 18
-	LDAPResultConstraintViolation          = 19
-	LDAPResultAttributeOrValueExists       = 20
-	LDAPResultInvalidAttributeSyntax       = 21
-	LDAPResultNoSuchObject                 = 32
-	LDAPResultAliasProblem                 = 33
-	LDAPResultInvalidDNSyntax              = 34
-	LDAPResultAliasDereferencingProblem    = 36
-	LDAPResultInappropriateAuthentication  = 48
-	LDAPResultInvalidCredentials           = 49
-	LDAPResultInsufficientAccessRights     = 50
-	LDAPResultBusy                         = 51
-	LDAPResultUnavailable                  = 52
-	LDAPResultUnwillingToPerform           = 53
-	LDAPResultLoopDetect                   = 54
-	LDAPResultNamingViolation              = 64
-	LDAPResultObjectClassViolation         = 65
-	LDAPResultNotAllowedOnNonLeaf          = 66
-	LDAPResultNotAllowedOnRDN              = 67
-	LDAPResultEntryAlreadyExists           = 68
-	LDAPResultObjectClassModsProhibited    = 69
-	LDAPResultAffectsMultipleDSAs          = 71
-	LDAPResultOther                        = 80
-
-	ErrorNetwork            = 200
-	ErrorFilterCompile      = 201
-	ErrorFilterDecompile    = 202
-	ErrorDebugging          = 203
-	ErrorUnexpectedMessage  = 204
-	ErrorUnexpectedResponse = 205
-)
-
-var LDAPResultCodeMap = map[uint8]string{
-	LDAPResultSuccess:                      "Success",
-	LDAPResultOperationsError:              "Operations Error",
-	LDAPResultProtocolError:                "Protocol Error",
-	LDAPResultTimeLimitExceeded:            "Time Limit Exceeded",
-	LDAPResultSizeLimitExceeded:            "Size Limit Exceeded",
-	LDAPResultCompareFalse:                 "Compare False",
-	LDAPResultCompareTrue:                  "Compare True",
-	LDAPResultAuthMethodNotSupported:       "Auth Method Not Supported",
-	LDAPResultStrongAuthRequired:           "Strong Auth Required",
-	LDAPResultReferral:                     "Referral",
-	LDAPResultAdminLimitExceeded:           "Admin Limit Exceeded",
-	LDAPResultUnavailableCriticalExtension: "Unavailable Critical Extension",
-	LDAPResultConfidentialityRequired:      "Confidentiality Required",
-	LDAPResultSaslBindInProgress:           "Sasl Bind In Progress",
-	LDAPResultNoSuchAttribute:              "No Such Attribute",
-	LDAPResultUndefinedAttributeType:       "Undefined Attribute Type",
-	LDAPResultInappropriateMatching:        "Inappropriate Matching",
-	LDAPResultConstraintViolation:          "Constraint Violation",
-	LDAPResultAttributeOrValueExists:       "Attribute Or Value Exists",
-	LDAPResultInvalidAttributeSyntax:       "Invalid Attribute Syntax",
-	LDAPResultNoSuchObject:                 "No Such Object",
-	LDAPResultAliasProblem:                 "Alias Problem",
-	LDAPResultInvalidDNSyntax:              "Invalid DN Syntax",
-	LDAPResultAliasDereferencingProblem:    "Alias Dereferencing Problem",
-	LDAPResultInappropriateAuthentication:  "Inappropriate Authentication",
-	LDAPResultInvalidCredentials:           "Invalid Credentials",
-	LDAPResultInsufficientAccessRights:     "Insufficient Access Rights",
-	LDAPResultBusy:                         "Busy",
-	LDAPResultUnavailable:                  "Unavailable",
-	LDAPResultUnwillingToPerform:           "Unwilling To Perform",
-	LDAPResultLoopDetect:                   "Loop Detect",
-	LDAPResultNamingViolation:              "Naming Violation",
-	LDAPResultObjectClassViolation:         "Object Class Violation",
-	LDAPResultNotAllowedOnNonLeaf:          "Not Allowed On Non Leaf",
-	LDAPResultNotAllowedOnRDN:              "Not Allowed On RDN",
-	LDAPResultEntryAlreadyExists:           "Entry Already Exists",
-	LDAPResultObjectClassModsProhibited:    "Object Class Mods Prohibited",
-	LDAPResultAffectsMultipleDSAs:          "Affects Multiple DSAs",
-	LDAPResultOther:                        "Other",
 }
 
 // Ldap Behera Password Policy Draft 10 (https://tools.ietf.org/html/draft-behera-ldap-password-policy-10)
@@ -318,8 +225,8 @@ func addRequestDescriptions(packet *ber.Packet) {
 }
 
 func addDefaultLDAPResponseDescriptions(packet *ber.Packet) {
-	resultCode := packet.Children[1].Children[0].Value.(int64)
-	packet.Children[1].Children[0].Description = "Result Code (" + LDAPResultCodeMap[uint8(resultCode)] + ")"
+	resultCode, _ := getLDAPResultCode(packet)
+	packet.Children[1].Children[0].Description = "Result Code (" + LDAPResultCodeMap[resultCode] + ")"
 	packet.Children[1].Children[1].Description = "Matched DN"
 	packet.Children[1].Children[2].Description = "Error Message"
 	if len(packet.Children[1].Children) > 3 {
@@ -341,30 +248,6 @@ func DebugBinaryFile(fileName string) error {
 	ber.PrintPacket(packet)
 
 	return nil
-}
-
-type Error struct {
-	Err        error
-	ResultCode uint8
-}
-
-func (e *Error) Error() string {
-	return fmt.Sprintf("LDAP Result Code %d %q: %s", e.ResultCode, LDAPResultCodeMap[e.ResultCode], e.Err.Error())
-}
-
-func NewError(resultCode uint8, err error) error {
-	return &Error{ResultCode: resultCode, Err: err}
-}
-
-func getLDAPResultCode(packet *ber.Packet) (code uint8, description string) {
-	if len(packet.Children) >= 2 {
-		response := packet.Children[1]
-		if response.ClassType == ber.ClassApplication && response.TagType == ber.TypeConstructed && len(response.Children) >= 3 {
-			return uint8(response.Children[0].Value.(int64)), response.Children[2].Value.(string)
-		}
-	}
-
-	return ErrorNetwork, "Invalid packet format"
 }
 
 var hex = "0123456789abcdef"

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/ldap_test.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/ldap_test.go
@@ -1,9 +1,11 @@
-package ldap
+package ldap_test
 
 import (
 	"crypto/tls"
 	"fmt"
 	"testing"
+
+	"gopkg.in/ldap.v2"
 )
 
 var ldapServer = "ldap.itd.umich.edu"
@@ -21,7 +23,7 @@ var attributes = []string{
 
 func TestDial(t *testing.T) {
 	fmt.Printf("TestDial: starting...\n")
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -32,7 +34,7 @@ func TestDial(t *testing.T) {
 
 func TestDialTLS(t *testing.T) {
 	fmt.Printf("TestDialTLS: starting...\n")
-	l, err := DialTLS("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapTLSPort), &tls.Config{InsecureSkipVerify: true})
+	l, err := ldap.DialTLS("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapTLSPort), &tls.Config{InsecureSkipVerify: true})
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -43,7 +45,7 @@ func TestDialTLS(t *testing.T) {
 
 func TestStartTLS(t *testing.T) {
 	fmt.Printf("TestStartTLS: starting...\n")
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -58,16 +60,16 @@ func TestStartTLS(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	fmt.Printf("TestSearch: starting...\n")
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 	if err != nil {
 		t.Errorf(err.Error())
 		return
 	}
 	defer l.Close()
 
-	searchRequest := NewSearchRequest(
+	searchRequest := ldap.NewSearchRequest(
 		baseDN,
-		ScopeWholeSubtree, DerefAlways, 0, 0, false,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
 		filter[0],
 		attributes,
 		nil)
@@ -83,16 +85,16 @@ func TestSearch(t *testing.T) {
 
 func TestSearchStartTLS(t *testing.T) {
 	fmt.Printf("TestSearchStartTLS: starting...\n")
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 	if err != nil {
 		t.Errorf(err.Error())
 		return
 	}
 	defer l.Close()
 
-	searchRequest := NewSearchRequest(
+	searchRequest := ldap.NewSearchRequest(
 		baseDN,
-		ScopeWholeSubtree, DerefAlways, 0, 0, false,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
 		filter[0],
 		attributes,
 		nil)
@@ -123,7 +125,7 @@ func TestSearchStartTLS(t *testing.T) {
 
 func TestSearchWithPaging(t *testing.T) {
 	fmt.Printf("TestSearchWithPaging: starting...\n")
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -136,9 +138,9 @@ func TestSearchWithPaging(t *testing.T) {
 		return
 	}
 
-	searchRequest := NewSearchRequest(
+	searchRequest := ldap.NewSearchRequest(
 		baseDN,
-		ScopeWholeSubtree, DerefAlways, 0, 0, false,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
 		filter[2],
 		attributes,
 		nil)
@@ -151,10 +153,10 @@ func TestSearchWithPaging(t *testing.T) {
 	fmt.Printf("TestSearchWithPaging: %s -> num of entries = %d\n", searchRequest.Filter, len(sr.Entries))
 }
 
-func searchGoroutine(t *testing.T, l *Conn, results chan *SearchResult, i int) {
-	searchRequest := NewSearchRequest(
+func searchGoroutine(t *testing.T, l *ldap.Conn, results chan *ldap.SearchResult, i int) {
+	searchRequest := ldap.NewSearchRequest(
 		baseDN,
-		ScopeWholeSubtree, DerefAlways, 0, 0, false,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
 		filter[i],
 		attributes,
 		nil)
@@ -169,17 +171,17 @@ func searchGoroutine(t *testing.T, l *Conn, results chan *SearchResult, i int) {
 
 func testMultiGoroutineSearch(t *testing.T, TLS bool, startTLS bool) {
 	fmt.Printf("TestMultiGoroutineSearch: starting...\n")
-	var l *Conn
+	var l *ldap.Conn
 	var err error
 	if TLS {
-		l, err = DialTLS("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapTLSPort), &tls.Config{InsecureSkipVerify: true})
+		l, err = ldap.DialTLS("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapTLSPort), &tls.Config{InsecureSkipVerify: true})
 		if err != nil {
 			t.Errorf(err.Error())
 			return
 		}
 		defer l.Close()
 	} else {
-		l, err = Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+		l, err = ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 		if err != nil {
 			t.Errorf(err.Error())
 			return
@@ -195,9 +197,9 @@ func testMultiGoroutineSearch(t *testing.T, TLS bool, startTLS bool) {
 		}
 	}
 
-	results := make([]chan *SearchResult, len(filter))
+	results := make([]chan *ldap.SearchResult, len(filter))
 	for i := range filter {
-		results[i] = make(chan *SearchResult)
+		results[i] = make(chan *ldap.SearchResult)
 		go searchGoroutine(t, l, results[i], i)
 	}
 	for i := range filter {
@@ -217,17 +219,17 @@ func TestMultiGoroutineSearch(t *testing.T) {
 }
 
 func TestEscapeFilter(t *testing.T) {
-	if got, want := EscapeFilter("a\x00b(c)d*e\\f"), `a\00b\28c\29d\2ae\5cf`; got != want {
+	if got, want := ldap.EscapeFilter("a\x00b(c)d*e\\f"), `a\00b\28c\29d\2ae\5cf`; got != want {
 		t.Errorf("Got %s, expected %s", want, got)
 	}
-	if got, want := EscapeFilter("Lučić"), `Lu\c4\8di\c4\87`; got != want {
+	if got, want := ldap.EscapeFilter("Lučić"), `Lu\c4\8di\c4\87`; got != want {
 		t.Errorf("Got %s, expected %s", want, got)
 	}
 }
 
 func TestCompare(t *testing.T) {
 	fmt.Printf("TestCompare: starting...\n")
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -243,5 +245,5 @@ func TestCompare(t *testing.T) {
 		return
 	}
 
-	fmt.Printf("TestCompare: -> num of entries = %d\n", sr)
+	fmt.Printf("TestCompare: -> %v\n", sr)
 }

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/search.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/search.go
@@ -132,16 +132,6 @@ func (e *Entry) GetRawAttributeValue(attribute string) []byte {
 	return values[0]
 }
 
-func (e *Entry) String() string {
-	dn := "DN: " + e.DN
-	attrs := ""
-	for _, attr := range e.Attributes {
-		attrs += "Attr[" + attr.Name + "]: " + strings.Join(attr.Values, " ") + " "
-	}
-
-	return "{" + dn + " " + attrs + "}"
-}
-
 func (e *Entry) Print() {
 	fmt.Printf("DN: %s\n", e.DN)
 	for _, attr := range e.Attributes {

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/search.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/search.go
@@ -62,6 +62,7 @@ package ldap
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"gopkg.in/asn1-ber.v1"
@@ -91,6 +92,26 @@ var DerefMap = map[int]string{
 	DerefInSearching:    "DerefInSearching",
 	DerefFindingBaseObj: "DerefFindingBaseObj",
 	DerefAlways:         "DerefAlways",
+}
+
+// NewEntry returns an Entry object with the specified distinguished name and attribute key-value pairs
+// the map of attributes is accessed in alphabetical order of the keys in order to ensure that, for the
+// same input map of attributes, the output entry will contain the same order of attributes
+func NewEntry(dn string, attributes map[string][]string) *Entry {
+	var attributeNames []string
+	for attributeName := range attributes {
+		attributeNames = append(attributeNames, attributeName)
+	}
+	sort.Strings(attributeNames)
+
+	var encodedAttributes []*EntryAttribute
+	for _, attributeName := range attributeNames {
+		encodedAttributes = append(encodedAttributes, NewEntryAttribute(attributeName, attributes[attributeName]))
+	}
+	return &Entry{
+		DN:         dn,
+		Attributes: encodedAttributes,
+	}
 }
 
 type Entry struct {
@@ -144,6 +165,23 @@ func (e *Entry) PrettyPrint(indent int) {
 	for _, attr := range e.Attributes {
 		attr.PrettyPrint(indent + 2)
 	}
+}
+
+// NewEntryAttribute returns a new EntryAttribute with the desired key-value pair
+func NewEntryAttribute(name string, values []string) *EntryAttribute {
+	return &EntryAttribute{
+		Name:       name,
+		Values:     values,
+		ByteValues: representAsBytes(values),
+	}
+}
+
+func representAsBytes(values []string) [][]byte {
+	var bytes [][]byte
+	for _, value := range values {
+		bytes = append(bytes, []byte(value))
+	}
+	return bytes
 }
 
 type EntryAttribute struct {

--- a/Godeps/_workspace/src/github.com/go-ldap/ldap/search_test.go
+++ b/Godeps/_workspace/src/github.com/go-ldap/ldap/search_test.go
@@ -1,0 +1,31 @@
+package ldap
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestNewEntry tests that repeated calls to NewEntry return the same value with the same input
+func TestNewEntry(t *testing.T) {
+	dn := "testDN"
+	attributes := map[string][]string{
+		"alpha":   {"value"},
+		"beta":    {"value"},
+		"gamma":   {"value"},
+		"delta":   {"value"},
+		"epsilon": {"value"},
+	}
+	exectedEntry := NewEntry(dn, attributes)
+
+	iteration := 0
+	for {
+		if iteration == 100 {
+			break
+		}
+		testEntry := NewEntry(dn, attributes)
+		if !reflect.DeepEqual(exectedEntry, testEntry) {
+			t.Fatalf("consequent calls to NewEntry did not yield the same result:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", exectedEntry, testEntry)
+		}
+		iteration = iteration + 1
+	}
+}

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -5264,6 +5264,25 @@ _openshift_ex_sync-groups()
     must_have_one_noun=()
 }
 
+_openshift_ex_prune-groups()
+{
+    last_command="openshift_ex_prune-groups"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--blacklist=")
+    flags+=("--confirm")
+    flags+=("--sync-config=")
+    flags+=("--whitelist=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _openshift_ex_options()
 {
     last_command="openshift_ex_options"
@@ -5289,6 +5308,7 @@ _openshift_ex()
     commands+=("build-chain")
     commands+=("diagnostics")
     commands+=("sync-groups")
+    commands+=("prune-groups")
     commands+=("options")
 
     flags=()

--- a/pkg/auth/ldaputil/client.go
+++ b/pkg/auth/ldaputil/client.go
@@ -8,10 +8,11 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/go-ldap/ldap"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 )
 
-// NewLDAPClientConfig returns a new LDAPClientConfig
-func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (*LDAPClientConfig, error) {
+// NewLDAPClientConfig returns a new LDAP client config
+func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (ldapclient.Config, error) {
 	url, err := ParseURL(URL)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing URL: %v", err)
@@ -26,64 +27,63 @@ func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (*
 		tlsConfig.RootCAs = roots
 	}
 
-	return &LDAPClientConfig{
-		Scheme:       url.Scheme,
-		Host:         url.Host,
-		BindDN:       bindDN,
-		BindPassword: bindPassword,
-		Insecure:     insecure,
-		TLSConfig:    tlsConfig,
+	return &ldapClientConfig{
+		scheme:       url.Scheme,
+		host:         url.Host,
+		bindDN:       bindDN,
+		bindPassword: bindPassword,
+		insecure:     insecure,
+		tlsConfig:    tlsConfig,
 	}, nil
 }
 
-// LDAPClientConfig holds information for connecting to an LDAP server
-type LDAPClientConfig struct {
-	// Scheme is the LDAP connection scheme, either ldap or ldaps
-	Scheme Scheme
-	// Host is the host:port of the LDAP server
-	Host string
-	// BindDN is an optional DN to bind with during the search phase.
-	BindDN string
-	// BindPassword is an optional password to bind with during the search phase.
-	BindPassword string
-	// Insecure specifies if TLS is required for the connection. If true, either an ldap://... URL or
+// ldapClientConfig holds information for connecting to an LDAP server
+type ldapClientConfig struct {
+	// scheme is the LDAP connection scheme, either ldap or ldaps
+	scheme Scheme
+	// host is the host:port of the LDAP server
+	host string
+	// bindDN is an optional DN to bind with during the search phase.
+	bindDN string
+	// bindPassword is an optional password to bind with during the search phase.
+	bindPassword string
+	// insecure specifies if TLS is required for the connection. If true, either an ldap://... URL or
 	// StartTLS must be supported by the server
-	Insecure bool
-	// TLSConfig holds the TLS options. Only used when Insecure=false
-	TLSConfig *tls.Config
+	insecure bool
+	// tlsConfig holds the TLS options. Only used when insecure=false
+	tlsConfig *tls.Config
 }
 
-func (l LDAPClientConfig) String() string {
-	return fmt.Sprintf("{Scheme: %v Host: %v BindDN: %v len(BindPassword: %v Insecure: %v}", l.Scheme, l.Host, l.BindDN, len(l.BindPassword), l.Insecure)
-}
+// ldapClientConfig is an ldapclient.Config
+var _ ldapclient.Config = &ldapClientConfig{}
 
 // Connect returns an established LDAP connection, or an error if the connection could not
 // be made (or successfully upgraded to TLS). If no error is returned, the caller is responsible for
 // closing the connection
-func (l *LDAPClientConfig) Connect() (*ldap.Conn, error) {
-	tlsConfig := l.TLSConfig
+func (l *ldapClientConfig) Connect() (ldap.Client, error) {
+	tlsConfig := l.tlsConfig
 
 	// Ensure tlsConfig specifies the server we're connecting to
 	if tlsConfig != nil && !tlsConfig.InsecureSkipVerify && len(tlsConfig.ServerName) == 0 {
 		// Add to a copy of the tlsConfig to avoid mutating the original
 		c := *tlsConfig
-		if host, _, err := net.SplitHostPort(l.Host); err == nil {
+		if host, _, err := net.SplitHostPort(l.host); err == nil {
 			c.ServerName = host
 		} else {
-			c.ServerName = l.Host
+			c.ServerName = l.host
 		}
 		tlsConfig = &c
 	}
 
-	switch l.Scheme {
+	switch l.scheme {
 	case SchemeLDAP:
-		con, err := ldap.Dial("tcp", l.Host)
+		con, err := ldap.Dial("tcp", l.host)
 		if err != nil {
 			return nil, err
 		}
 
 		// If an insecure connection is desired, we're done
-		if l.Insecure {
+		if l.insecure {
 			return con, nil
 		}
 
@@ -98,23 +98,22 @@ func (l *LDAPClientConfig) Connect() (*ldap.Conn, error) {
 		return con, nil
 
 	case SchemeLDAPS:
-		return ldap.DialTLS("tcp", l.Host, tlsConfig)
+		return ldap.DialTLS("tcp", l.host, tlsConfig)
 
 	default:
-		return nil, fmt.Errorf("unsupported scheme %q", l.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %q", l.scheme)
 	}
 }
 
-// Bind binds to a given LDAP connection if a bind DN and password were given.
-// Bind returns whether a bind occured and whether an error occurred
-func (l *LDAPClientConfig) Bind(connection *ldap.Conn) (bound bool, err error) {
-	if len(l.BindDN) > 0 {
-		if err := connection.Bind(l.BindDN, l.BindPassword); err != nil {
-			return false, err
-		} else {
-			return true, nil
-		}
-	}
+func (l *ldapClientConfig) GetBindCredentials() (string, string) {
+	return l.bindDN, l.bindPassword
+}
 
-	return false, nil
+func (l *ldapClientConfig) Host() string {
+	return l.host
+}
+
+// String implements Stringer for debugging purposes
+func (l *ldapClientConfig) String() string {
+	return fmt.Sprintf("{Scheme: %v Host: %v BindDN: %v len(BbindPassword): %v Insecure: %v}", l.scheme, l.host, l.bindDN, len(l.bindPassword), l.insecure)
 }

--- a/pkg/auth/ldaputil/errors.go
+++ b/pkg/auth/ldaputil/errors.go
@@ -1,0 +1,75 @@
+package ldaputil
+
+import "fmt"
+
+func NewNoSuchObjectError(baseDN string) error {
+	return &errNoSuchObject{baseDN: baseDN}
+}
+
+// errNoSuchObject is an error that occurs when a base DN for a search refers to an object that does not exist
+type errNoSuchObject struct {
+	baseDN string
+}
+
+// Error returns the error string for the invalid base DN query error
+func (e *errNoSuchObject) Error() string {
+	return fmt.Sprintf("search for entry with base dn=%q refers to a non-existent entry", e.baseDN)
+}
+
+func IsNoSuchObjectError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errNoSuchObject)
+	return ok
+}
+
+func NewEntryNotFoundError(baseDN, filter string) error {
+	return &errEntryNotFound{baseDN: baseDN, filter: filter}
+}
+
+// errEntryNotFound is an error that occurs when trying to find a specific entry fails.
+type errEntryNotFound struct {
+	baseDN string
+	filter string
+}
+
+// Error returns the error string for the entry not found error
+func (e *errEntryNotFound) Error() string {
+	return fmt.Sprintf("search for entry with base dn=%q and filter %q did not return any results", e.baseDN, e.filter)
+}
+
+func IsEntryNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errEntryNotFound)
+	return ok
+}
+
+func NewQueryOutOfBoundsError(queryDN, baseDN string) error {
+	return &errQueryOutOfBounds{baseDN: baseDN, queryDN: queryDN}
+}
+
+// errQueryOutOfBounds is an error that occurs when trying to search by DN for an entry that exists
+// outside of the tree specified with the BaseDN for search.
+type errQueryOutOfBounds struct {
+	baseDN  string
+	queryDN string
+}
+
+// Error returns the error string for the out-of-bounds query
+func (q *errQueryOutOfBounds) Error() string {
+	return fmt.Sprintf("search for entry with dn=%q would search outside of the base dn specified (dn=%q)", q.queryDN, q.baseDN)
+}
+
+func IsQueryOutOfBoundsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errQueryOutOfBounds)
+	return ok
+}

--- a/pkg/auth/ldaputil/ldapclient/interfaces.go
+++ b/pkg/auth/ldaputil/ldapclient/interfaces.go
@@ -1,0 +1,10 @@
+package ldapclient
+
+import "github.com/go-ldap/ldap"
+
+// Config knows how to connect to an LDAP server and can describe which server it is connecting to
+type Config interface {
+	Connect() (client ldap.Client, err error)
+	GetBindCredentials() (bindDN, bindPassword string)
+	Host() string
+}

--- a/pkg/auth/ldaputil/testclient/testclient.go
+++ b/pkg/auth/ldaputil/testclient/testclient.go
@@ -1,0 +1,143 @@
+package testclient
+
+import (
+	"crypto/tls"
+
+	"github.com/go-ldap/ldap"
+)
+
+// Fake is a mock client for an LDAP server
+// The following methods define safe defaults for the return values. In order to adapt this test client
+// for a specific test, anonymously include it and override the method being tested. In the over-riden
+// method, if you are not covering all method calls with your override, defer to the parent for handling.
+type Fake struct {
+	SimpleBindResponse     *ldap.SimpleBindResult
+	PasswordModifyResponse *ldap.PasswordModifyResult
+	SearchResponse         *ldap.SearchResult
+}
+
+// NewTestClient returns a new test client with safe default return values
+func New() *Fake {
+	return &Fake{
+		SimpleBindResponse: &ldap.SimpleBindResult{
+			Controls: []ldap.Control{},
+		},
+		PasswordModifyResponse: &ldap.PasswordModifyResult{
+			GeneratedPassword: "",
+		},
+		SearchResponse: &ldap.SearchResult{
+			Entries:   []*ldap.Entry{},
+			Referrals: []string{},
+			Controls:  []ldap.Control{},
+		},
+	}
+}
+
+// Start starts the LDAP connection
+func (c *Fake) Start() {
+	return
+}
+
+// StartTLS begins a TLS-wrapped LDAP connection
+func (c *Fake) StartTLS(config *tls.Config) error {
+	return nil
+}
+
+// Close closes an LDAP connection
+func (c *Fake) Close() {
+	return
+}
+
+// Bind binds to the LDAP server with a bind DN and password
+func (c *Fake) Bind(username, password string) error {
+	return nil
+}
+
+// SimpleBind binds to the LDAP server using the Simple Bind mechanism
+func (c *Fake) SimpleBind(simpleBindRequest *ldap.SimpleBindRequest) (*ldap.SimpleBindResult, error) {
+	return c.SimpleBindResponse, nil
+}
+
+// Add forwards an addition request to the LDAP server
+func (c *Fake) Add(addRequest *ldap.AddRequest) error {
+	return nil
+}
+
+// Del forwards a deletion request to the LDAP server
+func (c *Fake) Del(delRequest *ldap.DelRequest) error {
+	return nil
+}
+
+// Modify forwards a modification request to the LDAP server
+func (c *Fake) Modify(modifyRequest *ldap.ModifyRequest) error {
+	return nil
+}
+
+// Compare ... ?
+func (c *Fake) Compare(dn, attribute, value string) (bool, error) {
+	return false, nil
+}
+
+// PasswordModify forwards a password modify request to the LDAP server
+func (c *Fake) PasswordModify(passwordModifyRequest *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+	return c.PasswordModifyResponse, nil
+}
+
+// Search forwards a search request to the LDAP server
+func (c *Fake) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	return c.SearchResponse, nil
+}
+
+// SearchWithPaging forwards a search request to the LDAP server and pages the response
+func (c *Fake) SearchWithPaging(searchRequest *ldap.SearchRequest, pagingSize uint32) (*ldap.SearchResult, error) {
+	return c.SearchResponse, nil
+}
+
+// NewMatchingSearchErrorClient returns a new MatchingSeachError client sitting on top of the parent
+// client. This client returns the given error when a search base DN matches the given base DN, and
+// defers to the parent otherwise.
+func NewMatchingSearchErrorClient(parent ldap.Client, baseDN string, returnErr error) ldap.Client {
+	return &MatchingSearchErrClient{
+		Client:    parent,
+		BaseDN:    baseDN,
+		ReturnErr: returnErr,
+	}
+}
+
+// MatchingSearchErrClient returns the ReturnErr on every Search() where the search base DN matches the given DN
+// or defers the search to the parent client
+type MatchingSearchErrClient struct {
+	ldap.Client
+	BaseDN    string
+	ReturnErr error
+}
+
+func (c *MatchingSearchErrClient) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if searchRequest.BaseDN == c.BaseDN {
+		return nil, c.ReturnErr
+	}
+	return c.Client.Search(searchRequest)
+}
+
+// NewDNMappingClient returns a new DNMappingClient sitting on top of the parent client. This client returns the
+// ldap entries mapped to with this DN in its' internal DN map, or defers to the parent if the DN is not mapped.
+func NewDNMappingClient(parent ldap.Client, DNMapping map[string][]*ldap.Entry) ldap.Client {
+	return &DNMappingClient{
+		Client:    parent,
+		DNMapping: DNMapping,
+	}
+}
+
+// DNMappingClient returns the LDAP entry mapped to by the base dn given, or if no mapping happens, defers to the parent
+type DNMappingClient struct {
+	ldap.Client
+	DNMapping map[string][]*ldap.Entry
+}
+
+func (c *DNMappingClient) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if entries, exists := c.DNMapping[searchRequest.BaseDN]; exists {
+		return &ldap.SearchResult{Entries: entries}, nil
+	}
+
+	return c.Client.Search(searchRequest)
+}

--- a/pkg/auth/ldaputil/testclient/testclientconfig.go
+++ b/pkg/auth/ldaputil/testclient/testclientconfig.go
@@ -1,0 +1,30 @@
+package testclient
+
+import (
+	"github.com/go-ldap/ldap"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+)
+
+// fakeConfig regurgitates internal state in order to conform to Config
+type fakeConfig struct {
+	client ldap.Client
+}
+
+// NewConfig creates a new Config impl that regurgitates the given data
+func NewConfig(client ldap.Client) ldapclient.Config {
+	return &fakeConfig{
+		client: client,
+	}
+}
+
+func (c *fakeConfig) Connect() (ldap.Client, error) {
+	return c.client, nil
+}
+
+func (c *fakeConfig) GetBindCredentials() (string, string) {
+	return "", ""
+}
+
+func (c *fakeConfig) Host() string {
+	return ""
+}

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
@@ -6,8 +6,8 @@ import (
 	"github.com/go-ldap/ldap"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
@@ -28,10 +28,6 @@ func NewAugmentedADLDAPInterface(clientConfig ldapclient.Config,
 
 // LDAPInterface extracts the member list of an LDAP user entry from an LDAP server
 // with first-class LDAP entries for users and group.  Group membership is on the user. The LDAPInterface is *NOT* thread-safe.
-// The LDAPInterface satisfies:
-// - LDAPMemberExtractor
-// - LDAPGroupGetter
-// - LDAPGroupLister
 type AugmentedADLDAPInterface struct {
 	*ADLDAPInterface
 
@@ -41,12 +37,14 @@ type AugmentedADLDAPInterface struct {
 	// groupNameAttributes defines which attributes on an LDAP group entry will be interpreted as its name to use for an OpenShift group
 	groupNameAttributes []string
 
+	// cachedGroups holds the result of group queries for later reference, indexed on group UID
+	// e.g. this will map an LDAP group UID to the LDAP entry returned from the query made using it
 	cachedGroups map[string]*ldap.Entry
 }
 
-var _ ldapinterfaces.LDAPMemberExtractor = &AugmentedADLDAPInterface{}
-var _ ldapinterfaces.LDAPGroupGetter = &AugmentedADLDAPInterface{}
-var _ ldapinterfaces.LDAPGroupLister = &AugmentedADLDAPInterface{}
+var _ interfaces.LDAPMemberExtractor = &AugmentedADLDAPInterface{}
+var _ interfaces.LDAPGroupGetter = &AugmentedADLDAPInterface{}
+var _ interfaces.LDAPGroupLister = &AugmentedADLDAPInterface{}
 
 // GroupFor returns an LDAP group entry for the given group UID by searching the internal cache
 // of the LDAPInterface first, then sending an LDAP query if the cache did not contain the entry.

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/groupdetector"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
@@ -75,4 +76,10 @@ func (e *AugmentedADLDAPInterface) requiredGroupAttributes() []string {
 	allAttributes.Insert(e.groupQuery.QueryAttribute)         // this is used for extracting the group UID (otherwise an entry isn't self-describing)
 
 	return allAttributes.List()
+}
+
+// Exists determines if a group idenified with it's LDAP group UID exists on the LDAP server
+func (e *AugmentedADLDAPInterface) Exists(ldapGroupUID string) (bool, error) {
+	groupDetector := groupdetector.NewCompoundDetector(groupdetector.NewGroupBasedDetector(e), groupdetector.NewMemberBasedDetector(e))
+	return groupDetector.Exists(ldapGroupUID)
 }

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
-func NewAugmentedADLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
+func NewAugmentedADLDAPInterface(clientConfig ldapclient.Config,
 	userQuery ldaputil.LDAPQuery,
 	groupMembershipAttributes []string,
 	userNameAttributes []string,

--- a/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface_test.go
+++ b/pkg/cmd/experimental/syncgroups/ad/augmented_ldapinterface_test.go
@@ -1,0 +1,114 @@
+package ad
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-ldap/ldap"
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
+)
+
+const (
+	groupsBaseDN     string = "ou=groups,dc=example,dc=com"
+	groupsBaseFilter string = "objectClass=groupOfNames"
+
+	testGroupDN string = "cn=testGroup," + groupsBaseDN
+)
+
+func newTestAugmentedADLDAPInterface(client ldap.Client) *AugmentedADLDAPInterface {
+	// below are common test implementations of LDAPInterface fields
+	userQuery := ldaputil.LDAPQuery{
+		BaseDN:       usersBaseDN,
+		Scope:        ldaputil.ScopeWholeSubtree,
+		DerefAliases: ldaputil.DerefAliasesAlways,
+		TimeLimit:    0,
+		Filter:       usersBaseFilter,
+	}
+	groupMembershipAttributes := []string{"memberOf"}
+	userNameAttributes := []string{"email"}
+	groupQuery := ldaputil.LDAPQueryOnAttribute{
+		LDAPQuery: ldaputil.LDAPQuery{
+			BaseDN:       groupsBaseDN,
+			Scope:        ldaputil.ScopeWholeSubtree,
+			DerefAliases: ldaputil.DerefAliasesAlways,
+			TimeLimit:    0,
+			Filter:       groupsBaseFilter,
+		},
+		QueryAttribute: "dn",
+	}
+	groupNameAttributes := []string{"cn"}
+
+	return NewAugmentedADLDAPInterface(testclient.NewConfig(client),
+		userQuery,
+		groupMembershipAttributes,
+		userNameAttributes,
+		groupQuery,
+		groupNameAttributes)
+}
+
+// newDefaultTestGroup returns a new LDAP entry with the following characteristics:
+// dn: cn=testGroup,ou=groups,dc=example,dc=com
+// cn: testGroup
+func newDefaultTestGroup() *ldap.Entry {
+	return ldap.NewEntry(testGroupDN, map[string][]string{"cn": {"testGroup"}})
+}
+
+func TestGroupEntryFor(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		cacheSeed      map[string]*ldap.Entry
+		client         ldap.Client
+		baseDNOverride string
+		expectedError  error
+		expectedEntry  *ldap.Entry
+	}{
+		{
+			name: "cached entries",
+			cacheSeed: map[string]*ldap.Entry{
+				testGroupDN: newDefaultTestGroup(),
+			},
+			expectedError: nil,
+			expectedEntry: newDefaultTestGroup(),
+		},
+		{
+			name:           "search request error",
+			baseDNOverride: "otherBaseDN",
+			expectedError:  ldaputil.NewQueryOutOfBoundsError(testGroupDN, "otherBaseDN"),
+			expectedEntry:  nil,
+		},
+		{
+			name:          "search error",
+			client:        testclient.NewMatchingSearchErrorClient(testclient.New(), testGroupDN, searchErr),
+			expectedError: searchErr,
+			expectedEntry: nil,
+		},
+		{
+			name: "no error",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					testGroupDN: {newDefaultTestGroup()},
+				},
+			),
+			expectedError: nil,
+			expectedEntry: newDefaultTestGroup(),
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestAugmentedADLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.cachedGroups = testCase.cacheSeed
+		}
+		if len(testCase.baseDNOverride) > 0 {
+			ldapInterface.groupQuery.BaseDN = testCase.baseDNOverride
+		}
+		entry, err := ldapInterface.GroupEntryFor(testGroupDN)
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(entry, testCase.expectedEntry) {
+			t.Errorf("%s: incorrect members returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedEntry, entry)
+		}
+	}
+}

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/groupdetector"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
@@ -149,4 +150,9 @@ func (e *ADLDAPInterface) requiredUserAttributes() []string {
 	allAttributes.Insert(e.groupMembershipAttributes...)
 
 	return allAttributes.List()
+}
+
+// Exists determines if a group idenified with it's LDAP group UID exists on the LDAP server
+func (e *ADLDAPInterface) Exists(ldapGrouUID string) (bool, error) {
+	return groupdetector.NewMemberBasedDetector(e).Exists(ldapGrouUID)
 }

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 )
 
 // NewADLDAPInterface builds a new ADLDAPInterface using a schema-appropriate config
-func NewADLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
+func NewADLDAPInterface(clientConfig ldapclient.Config,
 	userQuery ldaputil.LDAPQuery,
 	groupMembershipAttributes []string,
 	userNameAttributes []string) *ADLDAPInterface {
@@ -33,7 +34,7 @@ func NewADLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
 // - LDAPGroupLister
 type ADLDAPInterface struct {
 	// clientConfig holds LDAP connection information
-	clientConfig *ldaputil.LDAPClientConfig
+	clientConfig ldapclient.Config
 
 	// userQuery holds the information necessary to make an LDAP query for all first-class user entries on the LDAP server
 	userQuery ldaputil.LDAPQuery

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface.go
@@ -8,8 +8,8 @@ import (
 	"github.com/go-ldap/ldap"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewADLDAPInterface builds a new ADLDAPInterface using a schema-appropriate config

--- a/pkg/cmd/experimental/syncgroups/ad/ldapinterface_test.go
+++ b/pkg/cmd/experimental/syncgroups/ad/ldapinterface_test.go
@@ -1,0 +1,215 @@
+package ad
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/go-ldap/ldap"
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
+)
+
+var searchErr error = errors.New("generic search error")
+
+const (
+	defaultFilter   string = "(objectClass=*)"
+	usersBaseDN     string = "ou=users,dc=example,dc=com"
+	usersBaseFilter string = "objectClass=inetOrgPerson"
+
+	testUserDN         string = "cn=testUser," + usersBaseDN
+	testSecondUserDN   string = "cn=testUser2," + usersBaseDN
+	testGroupUID       string = "testGroup"
+	testSecondGroupUID string = "testSecondGroup"
+)
+
+func newTestADLDAPInterface(client ldap.Client) *ADLDAPInterface {
+	// below are common test implementations of LDAPInterface fields
+	userQuery := ldaputil.LDAPQuery{
+		BaseDN:       usersBaseDN,
+		Scope:        ldaputil.ScopeWholeSubtree,
+		DerefAliases: ldaputil.DerefAliasesAlways,
+		TimeLimit:    0,
+		Filter:       usersBaseFilter,
+	}
+	groupMembershipAttributes := []string{"memberOf"}
+	userNameAttributes := []string{"email"}
+
+	return NewADLDAPInterface(testclient.NewConfig(client),
+		userQuery,
+		groupMembershipAttributes,
+		userNameAttributes)
+}
+
+// newDefaultTestUser returns a new LDAP entry with the following characteristics:
+// dn: cn=testUser,ou=users,dc=example,dc=com
+// cn: testUser
+// email: testEmail
+// memberOf: testGroup
+func newDefaultTestUser() *ldap.Entry {
+	return ldap.NewEntry(testUserDN, map[string][]string{"cn": {"testUser"}, "email": {"testEmail"}, "memberOf": {testGroupUID}})
+}
+
+// newDefaultTestUser returns a new LDAP entry with the following characteristics:
+// dn: cn=testUser2,ou=users,dc=example,dc=com
+// cn: testUser2
+// email: testEmail
+// memberOf: testSecondGroup
+func newVariantTestUser() *ldap.Entry {
+	return ldap.NewEntry(testUserDN, map[string][]string{"cn": {"testUser2"}, "email": {"testEmail"}, "memberOf": {testSecondGroupUID}})
+}
+
+func TestExtractMembers(t *testing.T) {
+	// we don't have a test case for an error on a bad search request as search request errors can only occur if
+	// the search attribute is the DN, and we do not allow DN to be a group UID for this schema
+	var testCases = []struct {
+		name            string
+		cacheSeed       map[string][]*ldap.Entry
+		client          ldap.Client
+		expectedError   error
+		expectedMembers []*ldap.Entry
+	}{
+		{
+			name: "members cached",
+			cacheSeed: map[string][]*ldap.Entry{
+				testGroupUID: {newDefaultTestUser()},
+			},
+			expectedError:   nil,
+			expectedMembers: []*ldap.Entry{newDefaultTestUser()},
+		},
+		{
+			name:            "user query error",
+			client:          testclient.NewMatchingSearchErrorClient(testclient.New(), usersBaseDN, searchErr),
+			expectedError:   searchErr,
+			expectedMembers: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					usersBaseDN: {newDefaultTestUser()},
+				},
+			),
+			expectedError:   nil,
+			expectedMembers: []*ldap.Entry{newDefaultTestUser()},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestADLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.ldapGroupToLDAPMembers = testCase.cacheSeed
+		}
+		members, err := ldapInterface.ExtractMembers(testGroupUID)
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(members, testCase.expectedMembers) {
+			t.Errorf("%s: incorrect members returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedMembers, members)
+		}
+	}
+}
+
+func TestListGroups(t *testing.T) {
+	client := testclient.NewDNMappingClient(
+		testclient.New(),
+		map[string][]*ldap.Entry{
+			usersBaseDN: {newDefaultTestUser()},
+		},
+	)
+	ldapInterface := newTestADLDAPInterface(client)
+	groups, err := ldapInterface.ListGroups()
+	if !reflect.DeepEqual(err, nil) {
+		t.Errorf("listing groups: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", nil, err)
+	}
+	if !reflect.DeepEqual(groups, []string{testGroupUID}) {
+		t.Errorf("listing groups: incorrect group list:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", []string{testGroupUID}, groups)
+	}
+}
+
+func TestPopulateCache(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		cacheSeed        map[string][]*ldap.Entry
+		searchDNOverride string
+		client           ldap.Client
+		expectedError    error
+		expectedCache    map[string][]*ldap.Entry
+	}{
+		{
+			name: "cache already populated",
+			cacheSeed: map[string][]*ldap.Entry{
+				testGroupUID: {newDefaultTestUser()},
+			},
+			expectedError: nil,
+			expectedCache: map[string][]*ldap.Entry{
+				testGroupUID: {newDefaultTestUser()},
+			},
+		},
+		{
+			name:          "user query error",
+			client:        testclient.NewMatchingSearchErrorClient(testclient.New(), usersBaseDN, searchErr),
+			expectedError: searchErr,
+			expectedCache: make(map[string][]*ldap.Entry), // won't be nil but will be empty
+		},
+		{
+			name: "cache populated correctly",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					usersBaseDN: {newDefaultTestUser()},
+				},
+			),
+			expectedError: nil,
+			expectedCache: map[string][]*ldap.Entry{
+				testGroupUID: {newDefaultTestUser()},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestADLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.ldapGroupToLDAPMembers = testCase.cacheSeed
+			ldapInterface.cacheFullyPopulated = true
+		}
+		err := ldapInterface.populateCache()
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(testCase.expectedCache, ldapInterface.ldapGroupToLDAPMembers) {
+			t.Errorf("%s: incorrect cache state:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedCache, ldapInterface.ldapGroupToLDAPMembers)
+		}
+	}
+}
+
+// TestPopulateCacheAfterExtractMembers ensures that the cache is only listed as fully populated after a
+// populateCache call and not after a partial fill from an ExtractMembers call
+func TestPopulateCacheAfterExtractMembers(t *testing.T) {
+	client := testclient.NewDNMappingClient(
+		testclient.New(),
+		map[string][]*ldap.Entry{
+			usersBaseDN: {newDefaultTestUser()},
+		},
+	)
+	ldapInterface := newTestADLDAPInterface(client)
+	_, err := ldapInterface.ExtractMembers(testGroupUID)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// both queries use the same BaseDN so we change what the client returns to simulate not applying the group-specific filter
+	client.(*testclient.DNMappingClient).DNMapping[usersBaseDN] = []*ldap.Entry{newDefaultTestUser(), newVariantTestUser()}
+
+	expectedCache := map[string][]*ldap.Entry{
+		testGroupUID:       {newDefaultTestUser()},
+		testSecondGroupUID: {newVariantTestUser()},
+	}
+
+	err = ldapInterface.populateCache()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(expectedCache, ldapInterface.ldapGroupToLDAPMembers) {
+		t.Errorf("incorrect cache state:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", expectedCache, ldapInterface.ldapGroupToLDAPMembers)
+	}
+}

--- a/pkg/cmd/experimental/syncgroups/cli/ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/ad.go
@@ -9,32 +9,32 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-var _ SyncBuilder = &ADSyncBuilder{}
+var _ SyncBuilder = &ADBuilder{}
 
-type ADSyncBuilder struct {
+type ADBuilder struct {
 	ClientConfig ldapclient.Config
 	Config       *api.ActiveDirectoryConfig
 
 	adLDAPInterface *ad.ADLDAPInterface
 }
 
-func (b *ADSyncBuilder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
+func (b *ADBuilder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
 	return b.getADLDAPInterface()
 }
 
-func (b *ADSyncBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error) {
+func (b *ADBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error) {
 	return &syncgroups.DNLDAPGroupNameMapper{}, nil
 }
 
-func (b *ADSyncBuilder) GetUserNameMapper() (interfaces.LDAPUserNameMapper, error) {
+func (b *ADBuilder) GetUserNameMapper() (interfaces.LDAPUserNameMapper, error) {
 	return syncgroups.NewUserNameMapper(b.Config.UserNameAttributes), nil
 }
 
-func (b *ADSyncBuilder) GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error) {
+func (b *ADBuilder) GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error) {
 	return b.getADLDAPInterface()
 }
 
-func (b *ADSyncBuilder) getADLDAPInterface() (*ad.ADLDAPInterface, error) {
+func (b *ADBuilder) getADLDAPInterface() (*ad.ADLDAPInterface, error) {
 	if b.adLDAPInterface != nil {
 		return b.adLDAPInterface, nil
 	}

--- a/pkg/cmd/experimental/syncgroups/cli/ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/ad.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ SyncBuilder = &ADBuilder{}
+var _ PruneBuilder = &ADBuilder{}
 
 type ADBuilder struct {
 	ClientConfig ldapclient.Config
@@ -45,4 +46,8 @@ func (b *ADBuilder) getADLDAPInterface() (*ad.ADLDAPInterface, error) {
 	}
 	return ad.NewADLDAPInterface(b.ClientConfig,
 		userQuery, b.Config.GroupMembershipAttributes, b.Config.UserNameAttributes), nil
+}
+
+func (b *ADBuilder) GetGroupDetector() (interfaces.LDAPGroupDetector, error) {
+	return b.getADLDAPInterface()
 }

--- a/pkg/cmd/experimental/syncgroups/cli/ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/ad.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/ad"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
@@ -11,7 +12,7 @@ import (
 var _ SyncBuilder = &ADSyncBuilder{}
 
 type ADSyncBuilder struct {
-	ClientConfig *ldaputil.LDAPClientConfig
+	ClientConfig ldapclient.Config
 	Config       *api.ActiveDirectoryConfig
 
 	adLDAPInterface *ad.ADLDAPInterface

--- a/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ SyncBuilder = &AugmentedADBuilder{}
+var _ PruneBuilder = &AugmentedADBuilder{}
 
 type AugmentedADBuilder struct {
 	ClientConfig ldapclient.Config
@@ -58,4 +59,8 @@ func (b *AugmentedADBuilder) getAugmentedADLDAPInterface() (*ad.AugmentedADLDAPI
 	return ad.NewAugmentedADLDAPInterface(b.ClientConfig,
 		userQuery, b.Config.GroupMembershipAttributes, b.Config.UserNameAttributes,
 		groupQuery, b.Config.GroupNameAttributes), nil
+}
+
+func (b *AugmentedADBuilder) GetGroupDetector() (interfaces.LDAPGroupDetector, error) {
+	return b.getAugmentedADLDAPInterface()
 }

--- a/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
@@ -9,20 +9,20 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-var _ SyncBuilder = &AugmentedADSyncBuilder{}
+var _ SyncBuilder = &AugmentedADBuilder{}
 
-type AugmentedADSyncBuilder struct {
+type AugmentedADBuilder struct {
 	ClientConfig ldapclient.Config
 	Config       *api.AugmentedActiveDirectoryConfig
 
 	augmentedADLDAPInterface *ad.AugmentedADLDAPInterface
 }
 
-func (b *AugmentedADSyncBuilder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
+func (b *AugmentedADBuilder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
 	return b.getAugmentedADLDAPInterface()
 }
 
-func (b *AugmentedADSyncBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error) {
+func (b *AugmentedADBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error) {
 	ldapInterface, err := b.getAugmentedADLDAPInterface()
 	if err != nil {
 		return nil, err
@@ -34,15 +34,15 @@ func (b *AugmentedADSyncBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameM
 	return nil, nil
 }
 
-func (b *AugmentedADSyncBuilder) GetUserNameMapper() (interfaces.LDAPUserNameMapper, error) {
+func (b *AugmentedADBuilder) GetUserNameMapper() (interfaces.LDAPUserNameMapper, error) {
 	return syncgroups.NewUserNameMapper(b.Config.UserNameAttributes), nil
 }
 
-func (b *AugmentedADSyncBuilder) GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error) {
+func (b *AugmentedADBuilder) GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error) {
 	return b.getAugmentedADLDAPInterface()
 }
 
-func (b *AugmentedADSyncBuilder) getAugmentedADLDAPInterface() (*ad.AugmentedADLDAPInterface, error) {
+func (b *AugmentedADBuilder) getAugmentedADLDAPInterface() (*ad.AugmentedADLDAPInterface, error) {
 	if b.augmentedADLDAPInterface != nil {
 		return b.augmentedADLDAPInterface, nil
 	}

--- a/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
+++ b/pkg/cmd/experimental/syncgroups/cli/augmented_ad.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/ad"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
@@ -11,7 +12,7 @@ import (
 var _ SyncBuilder = &AugmentedADSyncBuilder{}
 
 type AugmentedADSyncBuilder struct {
-	ClientConfig *ldaputil.LDAPClientConfig
+	ClientConfig ldapclient.Config
 	Config       *api.AugmentedActiveDirectoryConfig
 
 	augmentedADLDAPInterface *ad.AugmentedADLDAPInterface

--- a/pkg/cmd/experimental/syncgroups/cli/interfaces.go
+++ b/pkg/cmd/experimental/syncgroups/cli/interfaces.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+// SyncBuilder describes an object that can build all the schema-specific parts of an LDAPGroupSyncer
+type SyncBuilder interface {
+	GetGroupLister() (interfaces.LDAPGroupLister, error)
+	GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error)
+	GetUserNameMapper() (interfaces.LDAPUserNameMapper, error)
+	GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error)
+}
+
+// GroupNameRestrictions desribes an object that holds blacklists and whitelists
+type GroupNameRestrictions interface {
+	GetWhitelist() []string
+	GetBlacklist() []string
+}
+
+// OpenShiftGroupNameRestrictions describes an object that holds blacklists and whitelists as well as
+// a client that can retrieve OpenShift groups to satisfy those lists
+type OpenShiftGroupNameRestrictions interface {
+	GroupNameRestrictions
+	GetClient() client.GroupInterface
+}
+
+// MappedNameRestrictions describes an object that holds user name mappings for a group sync job
+type MappedNameRestrictions interface {
+	GetGroupNameMappings() map[string]string
+}

--- a/pkg/cmd/experimental/syncgroups/cli/interfaces.go
+++ b/pkg/cmd/experimental/syncgroups/cli/interfaces.go
@@ -13,6 +13,13 @@ type SyncBuilder interface {
 	GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error)
 }
 
+// PruneBuilder describes an object that can build all the schema-specific parts of an LDAPGroupPruner
+type PruneBuilder interface {
+	GetGroupLister() (interfaces.LDAPGroupLister, error)
+	GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error)
+	GetGroupDetector() (interfaces.LDAPGroupDetector, error)
+}
+
 // GroupNameRestrictions desribes an object that holds blacklists and whitelists
 type GroupNameRestrictions interface {
 	GetWhitelist() []string

--- a/pkg/cmd/experimental/syncgroups/cli/prunegroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/prunegroups.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kerrs "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
+	"github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/api/validation"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	PruneGroupsRecommendedName = "prune-groups"
+
+	pruneGroupsLong = `
+Prune OpenShift Groups referencing missing records on from an external provider.
+
+In order to prune OpenShift Group records using those from an external provider, determine which Groups you wish
+to prune. For instance, all or some groups may be selected from the current Groups stored in OpenShift that have
+been synced previously. Any combination of a literal whitelist, a whitelist file and a blacklist file is supported.
+The path to a sync configuration file that was used for syncing the groups in question is required in order to 
+describe how data is requested from the external record store. Default behavior is to prune all OpenShift groups 
+for which the external record does not exist.
+`
+	pruneGroupsExamples = `  # Prune all orphaned groups 
+  $ %[1]s --sync-config=/path/to/ldap-sync-config.yaml
+
+  # Prune all orphaned groups except the ones from the blacklist file
+  $ %[1]s --blacklist=/path/to/blacklist.txt --sync-config=/path/to/ldap-sync-config.yaml
+
+  # Prune all orphaned groups from a list of specific groups specified in a whitelist file
+  $ %[1]s --whitelist=/path/to/whitelist.txt --sync-config=/path/to/ldap-sync-config.yaml
+
+  # Prune all orphaned groups from a list of specific groups specified in a whitelist
+  $ %[1]s groups/group_name groups/other_name --sync-config=/path/to/ldap-sync-config.yaml
+`
+)
+
+type PruneGroupsOptions struct {
+	// Config is the LDAP sync config read from file
+	Config *api.LDAPSyncConfig
+
+	// Whitelist are the names of OpenShift group or LDAP group UIDs to use for syncing
+	Whitelist []string
+
+	// Blacklist are the names of OpenShift group or LDAP group UIDs to exclude
+	Blacklist []string
+
+	// Confirm determines whether or not to write to OpenShift
+	Confirm bool
+
+	// GroupsInterface is the interface used to interact with OpenShift Group objects
+	GroupInterface osclient.GroupInterface
+
+	// Stderr is the writer to write warnings and errors to
+	Stderr io.Writer
+
+	// Out is the writer to write output to
+	Out io.Writer
+}
+
+func NewPruneGroupsOptions() *PruneGroupsOptions {
+	return &PruneGroupsOptions{
+		Stderr:    os.Stderr,
+		Whitelist: []string{},
+	}
+}
+
+func NewCmdPruneGroups(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	options := NewPruneGroupsOptions()
+	options.Out = out
+
+	whitelistFile := ""
+	blacklistFile := ""
+	configFile := ""
+
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s [WHITELIST] [--whitelist=WHITELIST-FILE] [--blacklist=BLACKLIST-FILE] --sync-config=CONFIG-SOURCE", name),
+		Short:   "Prune OpenShift groups referencing missing records on an external provider.",
+		Long:    pruneGroupsLong,
+		Example: fmt.Sprintf(pruneGroupsExamples, fullName),
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Complete(whitelistFile, blacklistFile, configFile, args, f); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(c, err.Error()))
+			}
+
+			if err := options.Validate(); err != nil {
+				cmdutil.CheckErr(cmdutil.UsageError(c, err.Error()))
+			}
+
+			err := options.Run(c, f)
+			if err != nil {
+				if aggregate, ok := err.(kerrs.Aggregate); ok {
+					for _, err := range aggregate.Errors() {
+						fmt.Printf("%s\n", err)
+					}
+					os.Exit(1)
+				}
+			}
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringVar(&whitelistFile, "whitelist", whitelistFile, "path to the group whitelist file")
+	cmd.Flags().StringVar(&blacklistFile, "blacklist", whitelistFile, "path to the group blacklist file")
+	// TODO(deads): enable this once we're able to support string slice elements that have commas
+	// cmd.Flags().StringSliceVar(&options.Blacklist, "blacklist-group", options.Blacklist, "group to blacklist")
+	cmd.Flags().StringVar(&configFile, "sync-config", configFile, "path to the sync config")
+	cmd.Flags().BoolVar(&options.Confirm, "confirm", false, "if true, modify OpenShift groups; if false, display groups")
+
+	return cmd
+}
+
+func (o *PruneGroupsOptions) Complete(whitelistFile, blacklistFile, configFile string, args []string, f *clientcmd.Factory) error {
+	var err error
+	o.Whitelist, err = buildNameList(GroupSyncSourceOpenShift, args, whitelistFile)
+	if err != nil {
+		return err
+	}
+
+	o.Blacklist, err = buildNameList(GroupSyncSourceOpenShift, []string{}, blacklistFile)
+	if err != nil {
+		return err
+	}
+
+	o.Config, err = decodeSyncConfigFromFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	osClient, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	o.GroupInterface = osClient.Groups()
+
+	return nil
+}
+
+func (o *PruneGroupsOptions) Validate() error {
+	results := validation.ValidateLDAPSyncConfig(o.Config)
+	if o.GroupInterface == nil {
+		results.Errors = append(results.Errors, fmt.Errorf("an OpenShift group client is required"))
+	}
+	// TODO(skuznets): pretty-print validation results
+	if len(results.Errors) > 0 {
+		return fmt.Errorf("validation of LDAP sync config failed: %v", kerrs.NewAggregate([]error(results.Errors)))
+	}
+	return nil
+}
+
+// Run creates the GroupSyncer specified and runs it to sync groups
+// the arguments are only here because its the only way to get the printer we need
+func (o *PruneGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
+	clientConfig, err := ldaputil.NewLDAPClientConfig(o.Config.URL, o.Config.BindDN, o.Config.BindPassword, o.Config.CA, o.Config.Insecure)
+	if err != nil {
+		return fmt.Errorf("could not determine LDAP client configuration: %v", err)
+	}
+
+	pruneBuilder, err := buildPruneBuilder(clientConfig, o.Config.RFC2307Config, o.Config.ActiveDirectoryConfig, o.Config.AugmentedActiveDirectoryConfig)
+	if err != nil {
+		return err
+	}
+
+	// populate schema-independent pruner fields
+	pruner := &syncgroups.LDAPGroupPruner{
+		Host:        clientConfig.Host(),
+		GroupClient: o.GroupInterface,
+		DryRun:      !o.Confirm,
+
+		Out: o.Out,
+		Err: os.Stderr,
+	}
+
+	listerMapper, err := getOpenShiftGroupListerMapper(clientConfig.Host(), o)
+	if err != nil {
+		return err
+	}
+	pruner.GroupLister = listerMapper
+	pruner.GroupNameMapper = listerMapper
+
+	pruner.GroupDetector, err = pruneBuilder.GetGroupDetector()
+	if err != nil {
+		return err
+	}
+
+	// Now we run the pruner and report any errors
+	pruneErrors := pruner.Prune()
+	return kerrs.NewAggregate(pruneErrors)
+
+}
+
+func buildPruneBuilder(clientConfig ldapclient.Config, rfc2307 *api.RFC2307Config, ad *api.ActiveDirectoryConfig, augmentedAD *api.AugmentedActiveDirectoryConfig) (PruneBuilder, error) {
+	switch {
+	case rfc2307 != nil:
+		return &RFC2307Builder{ClientConfig: clientConfig, Config: rfc2307}, nil
+	case ad != nil:
+		return &ADBuilder{ClientConfig: clientConfig, Config: ad}, nil
+	case augmentedAD != nil:
+		return &AugmentedADBuilder{ClientConfig: clientConfig, Config: augmentedAD}, nil
+	default:
+		return nil, errors.New("invalid sync config type")
+	}
+}
+
+// The following getters ensure that PruneGroupsOptions satisfies the name restriction interfaces
+
+func (o *PruneGroupsOptions) GetWhitelist() []string {
+	return o.Whitelist
+}
+
+func (o *PruneGroupsOptions) GetBlacklist() []string {
+	return o.Blacklist
+}
+
+func (o *PruneGroupsOptions) GetClient() osclient.GroupInterface {
+	return o.GroupInterface
+}
+
+func (o *PruneGroupsOptions) GetGroupNameMappings() map[string]string {
+	return o.Config.LDAPGroupUIDToOpenShiftGroupNameMapping
+}

--- a/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
+++ b/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/rfc2307"
@@ -11,7 +12,7 @@ import (
 var _ SyncBuilder = &RFC2307SyncBuilder{}
 
 type RFC2307SyncBuilder struct {
-	ClientConfig *ldaputil.LDAPClientConfig
+	ClientConfig ldapclient.Config
 	Config       *api.RFC2307Config
 
 	rfc2307LDAPInterface *rfc2307.LDAPInterface

--- a/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
+++ b/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
@@ -9,20 +9,20 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-var _ SyncBuilder = &RFC2307SyncBuilder{}
+var _ SyncBuilder = &RFC2307Builder{}
 
-type RFC2307SyncBuilder struct {
+type RFC2307Builder struct {
 	ClientConfig ldapclient.Config
 	Config       *api.RFC2307Config
 
 	rfc2307LDAPInterface *rfc2307.LDAPInterface
 }
 
-func (b *RFC2307SyncBuilder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
+func (b *RFC2307Builder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
 	return b.getRFC2307LDAPInterface()
 }
 
-func (b *RFC2307SyncBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error) {
+func (b *RFC2307Builder) GetGroupNameMapper() (interfaces.LDAPGroupNameMapper, error) {
 	ldapInterface, err := b.getRFC2307LDAPInterface()
 	if err != nil {
 		return nil, err
@@ -34,15 +34,15 @@ func (b *RFC2307SyncBuilder) GetGroupNameMapper() (interfaces.LDAPGroupNameMappe
 	return nil, nil
 }
 
-func (b *RFC2307SyncBuilder) GetUserNameMapper() (interfaces.LDAPUserNameMapper, error) {
+func (b *RFC2307Builder) GetUserNameMapper() (interfaces.LDAPUserNameMapper, error) {
 	return syncgroups.NewUserNameMapper(b.Config.UserNameAttributes), nil
 }
 
-func (b *RFC2307SyncBuilder) GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error) {
+func (b *RFC2307Builder) GetGroupMemberExtractor() (interfaces.LDAPMemberExtractor, error) {
 	return b.getRFC2307LDAPInterface()
 }
 
-func (b *RFC2307SyncBuilder) getRFC2307LDAPInterface() (*rfc2307.LDAPInterface, error) {
+func (b *RFC2307Builder) getRFC2307LDAPInterface() (*rfc2307.LDAPInterface, error) {
 	if b.rfc2307LDAPInterface != nil {
 		return b.rfc2307LDAPInterface, nil
 	}

--- a/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
+++ b/pkg/cmd/experimental/syncgroups/cli/rfc2307.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ SyncBuilder = &RFC2307Builder{}
+var _ PruneBuilder = &RFC2307Builder{}
 
 type RFC2307Builder struct {
 	ClientConfig ldapclient.Config
@@ -58,4 +59,8 @@ func (b *RFC2307Builder) getRFC2307LDAPInterface() (*rfc2307.LDAPInterface, erro
 	return rfc2307.NewLDAPInterface(b.ClientConfig,
 		groupQuery, b.Config.GroupNameAttributes, b.Config.GroupMembershipAttributes,
 		userQuery, b.Config.UserNameAttributes), nil
+}
+
+func (b *RFC2307Builder) GetGroupDetector() (interfaces.LDAPGroupDetector, error) {
+	return b.getRFC2307LDAPInterface()
 }

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -86,7 +86,7 @@ type SyncGroupsOptions struct {
 	// Blacklist are the names of OpenShift group or LDAP group UIDs to exclude
 	Blacklist []string
 
-	// Confirm determines whether not to write to openshift
+	// Confirm determines whether or not to write to OpenShift
 	Confirm bool
 
 	// GroupsInterface is the interface used to interact with OpenShift Group objects
@@ -144,7 +144,7 @@ func NewCmdSyncGroups(name, fullName string, f *clientcmd.Factory, out io.Writer
 
 	cmd.Flags().StringVar(&whitelistFile, "whitelist", whitelistFile, "path to the group whitelist file")
 	cmd.Flags().StringVar(&blacklistFile, "blacklist", whitelistFile, "path to the group blacklist file")
-	// TODO enable this we're able to support string slice elements that have commas
+	// TODO(deads): enable this once we're able to support string slice elements that have commas
 	// cmd.Flags().StringSliceVar(&options.Blacklist, "blacklist-group", options.Blacklist, "group to blacklist")
 	cmd.Flags().StringVar(&configFile, "sync-config", configFile, "path to the sync config")
 	cmd.Flags().StringVar(&typeArg, "type", typeArg, "type of group used to locate LDAP group UIDs: "+strings.Join(AllowedSourceTypes, ","))

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -317,7 +317,7 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 
 	// populate schema-independent syncer fields
 	syncer := &syncgroups.LDAPGroupSyncer{
-		Host:        clientConfig.Host,
+		Host:        clientConfig.Host(),
 		GroupClient: o.GroupInterface,
 		DryRun:      !o.Confirm,
 
@@ -329,7 +329,7 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 	case GroupSyncSourceOpenShift:
 		// when your source of ldapGroupUIDs is from an openshift group, the mapping of ldapGroupUID to openshift group name is logically
 		// pinned by the existing mapping.
-		listerMapper, err := o.GetOpenShiftGroupListerMapper(syncBuilder, clientConfig)
+		listerMapper, err := o.GetOpenShiftGroupListerMapper(clientConfig.Host())
 		if err != nil {
 			return err
 		}
@@ -378,16 +378,16 @@ func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error 
 
 }
 
-func (o *SyncGroupsOptions) GetOpenShiftGroupListerMapper(syncBuilder SyncBuilder, clientConfig *ldaputil.LDAPClientConfig) (interfaces.LDAPGroupListerNameMapper, error) {
+func (o *SyncGroupsOptions) GetOpenShiftGroupListerMapper(host string) (interfaces.LDAPGroupListerNameMapper, error) {
 	if o.Source != GroupSyncSourceOpenShift {
 		return nil, errors.New("openshift is not a valid group source for this config")
 	}
 
 	if len(o.Whitelist) != 0 {
-		return syncgroups.NewOpenShiftGroupLister(o.Whitelist, o.Blacklist, clientConfig.Host, o.GroupInterface), nil
+		return syncgroups.NewOpenShiftGroupLister(o.Whitelist, o.Blacklist, host, o.GroupInterface), nil
 	}
 
-	return syncgroups.NewAllOpenShiftGroupLister(o.Blacklist, clientConfig.Host, o.GroupInterface), nil
+	return syncgroups.NewAllOpenShiftGroupLister(o.Blacklist, host, o.GroupInterface), nil
 }
 
 func (o *SyncGroupsOptions) GetLDAPGroupLister(syncBuilder SyncBuilder) (interfaces.LDAPGroupLister, error) {

--- a/pkg/cmd/experimental/syncgroups/groupdetector/groupdetector.go
+++ b/pkg/cmd/experimental/syncgroups/groupdetector/groupdetector.go
@@ -1,0 +1,86 @@
+package groupdetector
+
+import (
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+// NewGroupBasedDetector returns an LDAPGroupDetector that determines group existence based on
+// the presence of a first-class group entry in LDAP as found by an LDAPGroupGetter
+func NewGroupBasedDetector(groupGetter interfaces.LDAPGroupGetter) interfaces.LDAPGroupDetector {
+	return &GroupBasedDetector{groupGetter: groupGetter}
+}
+
+// GroupBasedDetector is an LDAPGroupDetector that determines group existence based on
+// the presence of a first-class group entry in LDAP as found by an LDAPGroupGetter
+type GroupBasedDetector struct {
+	groupGetter interfaces.LDAPGroupGetter
+}
+
+func (l *GroupBasedDetector) Exists(ldapGroupUID string) (bool, error) {
+	_, err := l.groupGetter.GroupEntryFor(ldapGroupUID)
+	if ldaputil.IsQueryOutOfBoundsError(err) || ldaputil.IsEntryNotFoundError(err) || ldaputil.IsNoSuchObjectError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// NewMemberBasedDetector returns an LDAPGroupDetector that determines group existence based on
+// the presence of a non-zero number of first-class member entries in LDAP as found by an LDAPMemberExtractor
+func NewMemberBasedDetector(memberExtractor interfaces.LDAPMemberExtractor) interfaces.LDAPGroupDetector {
+	return &MemberBasedDetector{memberExtractor: memberExtractor}
+}
+
+// MemberBasedDetector is an LDAPGroupDetector that determines group existence based on
+// the presence of a non-zero number of first-class member entries in LDAP as found by an LDAPMemberExtractor
+type MemberBasedDetector struct {
+	memberExtractor interfaces.LDAPMemberExtractor
+}
+
+func (l *MemberBasedDetector) Exists(ldapGrouUID string) (bool, error) {
+	members, err := l.memberExtractor.ExtractMembers(ldapGrouUID)
+	if ldaputil.IsQueryOutOfBoundsError(err) || ldaputil.IsEntryNotFoundError(err) || ldaputil.IsNoSuchObjectError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if len(members) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// NewCompoundDetector returns an LDAPGroupDetector that subsumes some other LDAPGroupDetectors
+// and determines that a group exists if any of the subsumed detectors determine that it does.
+// If any of the subordinate detectors generate an error determining existance, the search is abandoned
+// and the error returned. All detectors must successfully determine existance.
+func NewCompoundDetector(locators ...interfaces.LDAPGroupDetector) interfaces.LDAPGroupDetector {
+	return &CompoundDetector{locators: locators}
+}
+
+// CompoundDetector is an LDAPGroupDetector that subsumes some other LDAPGroupDetectors
+// and determines that a group exists if any of the subsumed detectors determine that it does.
+// If any of the subordinate detectors generate an error determining existance, the search is abandoned
+// and the error returned. All detectors must successfully determine existance.
+type CompoundDetector struct {
+	locators []interfaces.LDAPGroupDetector
+}
+
+func (l *CompoundDetector) Exists(ldapGrouUID string) (bool, error) {
+	conclusion := false
+	for _, locator := range l.locators {
+		opinion, err := locator.Exists(ldapGrouUID)
+		if err != nil {
+			return false, err
+		}
+		conclusion = conclusion || opinion
+	}
+	return conclusion, nil
+}

--- a/pkg/cmd/experimental/syncgroups/groupdetector/groupdetector_test.go
+++ b/pkg/cmd/experimental/syncgroups/groupdetector/groupdetector_test.go
@@ -1,0 +1,246 @@
+package groupdetector
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/go-ldap/ldap"
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+func TestGroupBasedDetectorExists(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		groupGetter    interfaces.LDAPGroupGetter
+		expectedErr    error
+		expectedExists bool
+	}{
+		{
+			name:           "out of bounds error",
+			groupGetter:    &errOutOfBoundsGetterExtractor{},
+			expectedErr:    nil,
+			expectedExists: false,
+		},
+		{
+			name:           "entry not found error",
+			groupGetter:    &errEntryNotFoundGetterExtractor{},
+			expectedErr:    nil,
+			expectedExists: false,
+		},
+		{
+			name:           "no such object error",
+			groupGetter:    &errNoSuchObjectGetterExtractor{},
+			expectedErr:    nil,
+			expectedExists: false,
+		},
+		{
+			name:           "generic error",
+			groupGetter:    &genericErrGetterExtractor{},
+			expectedErr:    genericError,
+			expectedExists: false,
+		},
+		{
+			name:           "no error",
+			groupGetter:    &puppetGetterExtractor{},
+			expectedErr:    nil,
+			expectedExists: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		locator := NewGroupBasedDetector(testCase.groupGetter)
+		exists, err := locator.Exists("ldapGroupUID")
+		if !reflect.DeepEqual(err, testCase.expectedErr) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedErr, err)
+		}
+		if exists != testCase.expectedExists {
+			t.Errorf("%s: incorrect existence check: expected %v, got %v", testCase.name, testCase.expectedExists, exists)
+		}
+	}
+}
+
+func TestMemberBasedDetectorExists(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		memberExtractor interfaces.LDAPMemberExtractor
+		expectedErr     error
+		expectedExists  bool
+	}{
+		{
+			name:            "out of bounds error",
+			memberExtractor: &errOutOfBoundsGetterExtractor{},
+			expectedErr:     nil,
+			expectedExists:  false,
+		},
+		{
+			name:            "entry not found error",
+			memberExtractor: &errEntryNotFoundGetterExtractor{},
+			expectedErr:     nil,
+			expectedExists:  false,
+		},
+		{
+			name:            "no such object error",
+			memberExtractor: &errNoSuchObjectGetterExtractor{},
+			expectedErr:     nil,
+			expectedExists:  false,
+		},
+		{
+			name:            "generic error",
+			memberExtractor: &genericErrGetterExtractor{},
+			expectedErr:     genericError,
+			expectedExists:  false,
+		},
+		{
+			name:            "no error, no entries",
+			memberExtractor: &puppetGetterExtractor{},
+			expectedErr:     nil,
+			expectedExists:  false,
+		},
+		{
+			name:            "no error, has entries",
+			memberExtractor: &puppetGetterExtractor{returnVal: []*ldap.Entry{dummyEntry}},
+			expectedErr:     nil,
+			expectedExists:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		locator := NewMemberBasedDetector(testCase.memberExtractor)
+		exists, err := locator.Exists("ldapGroupUID")
+		if !reflect.DeepEqual(err, testCase.expectedErr) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedErr, err)
+		}
+		if exists != testCase.expectedExists {
+			t.Errorf("%s: incorrect existence check: expected %v, got %v", testCase.name, testCase.expectedExists, exists)
+		}
+	}
+}
+
+func TestCompoundDetectorExists(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		locators       []interfaces.LDAPGroupDetector
+		expectedErr    error
+		expectedExists bool
+	}{
+		{
+			name: "none fail to locate",
+			locators: []interfaces.LDAPGroupDetector{
+				NewGroupBasedDetector(&puppetGetterExtractor{}),
+				NewMemberBasedDetector(&puppetGetterExtractor{returnVal: []*ldap.Entry{dummyEntry}}),
+			},
+			expectedErr:    nil,
+			expectedExists: true,
+		},
+		{
+			name: "one fails to locate",
+			locators: []interfaces.LDAPGroupDetector{
+				NewGroupBasedDetector(&puppetGetterExtractor{}),
+				NewMemberBasedDetector(&puppetGetterExtractor{returnVal: []*ldap.Entry{dummyEntry}}),
+			},
+			expectedErr:    nil,
+			expectedExists: true,
+		},
+		{
+			name: "all fail to locate",
+			locators: []interfaces.LDAPGroupDetector{
+				NewGroupBasedDetector(&errEntryNotFoundGetterExtractor{}),
+				NewMemberBasedDetector(&errOutOfBoundsGetterExtractor{}),
+			},
+			expectedErr:    nil,
+			expectedExists: false,
+		},
+		{
+			name: "one errors",
+			locators: []interfaces.LDAPGroupDetector{
+				NewGroupBasedDetector(&puppetGetterExtractor{}),
+				NewMemberBasedDetector(&genericErrGetterExtractor{}),
+			},
+			expectedErr:    genericError,
+			expectedExists: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		locator := NewCompoundDetector(testCase.locators...)
+		exists, err := locator.Exists("ldapGroupUID")
+		if !reflect.DeepEqual(err, testCase.expectedErr) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedErr, err)
+		}
+		if exists != testCase.expectedExists {
+			t.Errorf("%s: incorrect existence check: expected %v, got %v", testCase.name, testCase.expectedExists, exists)
+		}
+	}
+}
+
+var dummyEntry *ldap.Entry = &ldap.Entry{DN: "dn"}
+
+// puppetGetterExtractor is a GroupGetter and a MemberExtractor that generates no errors and returns
+// whatever LDAP entries are given to it
+type puppetGetterExtractor struct {
+	returnVal []*ldap.Entry
+}
+
+func (g *puppetGetterExtractor) GroupEntryFor(ldapGroupUID string) (*ldap.Entry, error) {
+	if len(g.returnVal) > 0 {
+		return g.returnVal[0], nil
+	}
+	return nil, nil
+}
+
+func (g *puppetGetterExtractor) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
+	if len(g.returnVal) > 0 {
+		return g.returnVal, nil
+	}
+	return nil, nil
+}
+
+// the following generators are both GroupGetters and MemberExtractors that generate specific errors
+// whenever their corresponding methods are called. They are used for the tests for this package
+
+var outOfBoundsError error = ldaputil.NewQueryOutOfBoundsError("baseDN", "queryDN")
+var entryNotFoundError error = ldaputil.NewEntryNotFoundError("baseDN", "filter")
+var noSuchObjectError error = ldaputil.NewNoSuchObjectError("baseDN")
+var genericError error = errors.New("generic error")
+
+type errOutOfBoundsGetterExtractor struct{}
+
+func (g *errOutOfBoundsGetterExtractor) GroupEntryFor(ldapGroupUID string) (*ldap.Entry, error) {
+	return nil, outOfBoundsError
+}
+
+func (g *errOutOfBoundsGetterExtractor) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
+	return nil, outOfBoundsError
+}
+
+type errEntryNotFoundGetterExtractor struct{}
+
+func (g *errEntryNotFoundGetterExtractor) GroupEntryFor(ldapGroupUID string) (*ldap.Entry, error) {
+	return nil, entryNotFoundError
+}
+
+func (g *errEntryNotFoundGetterExtractor) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
+	return nil, entryNotFoundError
+}
+
+type errNoSuchObjectGetterExtractor struct{}
+
+func (g *errNoSuchObjectGetterExtractor) GroupEntryFor(ldapGroupUID string) (*ldap.Entry, error) {
+	return nil, noSuchObjectError
+}
+
+func (g *errNoSuchObjectGetterExtractor) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
+	return nil, noSuchObjectError
+}
+
+type genericErrGetterExtractor struct{}
+
+func (g *genericErrGetterExtractor) GroupEntryFor(ldapGroupUID string) (*ldap.Entry, error) {
+	return nil, genericError
+}
+
+func (g *genericErrGetterExtractor) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
+	return nil, genericError
+}

--- a/pkg/cmd/experimental/syncgroups/grouppruner.go
+++ b/pkg/cmd/experimental/syncgroups/grouppruner.go
@@ -1,0 +1,86 @@
+package syncgroups
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+// GroupPruner runs a prune job on Groups
+type GroupPruner interface {
+	Prune() (errors []error)
+}
+
+// LDAPGroupPruner prunes Groups referencing records on an external LDAP server
+type LDAPGroupPruner struct {
+	// Lists all groups to be synced
+	GroupLister interfaces.LDAPGroupLister
+	// Fetches a group and extracts object metainformation and membership list from a group
+	GroupDetector interfaces.LDAPGroupDetector
+	// Maps an LDAP group enrty to an OpenShift Group's Name
+	GroupNameMapper interfaces.LDAPGroupNameMapper
+	// Allows the Pruner to search for OpenShift Groups
+	GroupClient client.GroupInterface
+	// Host stores the address:port of the LDAP server
+	Host string
+	// DryRun indicates that no changes should be made.
+	DryRun bool
+
+	// Out is used to provide output while the sync job is happening
+	Out io.Writer
+	Err io.Writer
+}
+
+var _ GroupPruner = &LDAPGroupPruner{}
+
+// Prune allows the LDAPGroupPruner to be a GroupPruner
+func (s *LDAPGroupPruner) Prune() []error {
+	var errors []error
+
+	// determine what to sync
+	glog.V(1).Infof("LDAPGroupPruner listing groups to prune with %v", s.GroupLister)
+	ldapGroupUIDs, err := s.GroupLister.ListGroups()
+	if err != nil {
+		errors = append(errors, err)
+		return errors
+	}
+	glog.V(1).Infof("LDAPGroupPruner will attempt to prune ldapGroupUIDs %v", ldapGroupUIDs)
+
+	for _, ldapGroupUID := range ldapGroupUIDs {
+		glog.V(1).Infof("Checking LDAP group %v", ldapGroupUID)
+
+		exists, err := s.GroupDetector.Exists(ldapGroupUID)
+		if err != nil {
+			fmt.Fprintf(s.Err, "Error determining LDAP group existence for group %q: %v.\n", ldapGroupUID, err)
+			errors = append(errors, err)
+			continue
+		}
+		if exists {
+			continue
+		}
+
+		// if the LDAP entry that was previously used to create the group doesn't exist, prune it
+		groupName, err := s.GroupNameMapper.GroupNameFor(ldapGroupUID)
+		if err != nil {
+			fmt.Fprintf(s.Err, "Error determining OpenShift group name for LDAP group %q: %v.\n", ldapGroupUID, err)
+			errors = append(errors, err)
+			continue
+		}
+
+		if !s.DryRun {
+			if err := s.GroupClient.Delete(groupName); err != nil {
+				fmt.Fprintf(s.Err, "Error pruning OpenShift group %q: %v.\n", groupName, err)
+				errors = append(errors, err)
+				continue
+			}
+		}
+
+		fmt.Fprintf(s.Out, "group/%s\n", groupName)
+	}
+
+	return errors
+}

--- a/pkg/cmd/experimental/syncgroups/grouppruner_test.go
+++ b/pkg/cmd/experimental/syncgroups/grouppruner_test.go
@@ -1,0 +1,153 @@
+package syncgroups
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	"github.com/openshift/origin/pkg/client/testclient"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+func TestGoodPrune(t *testing.T) {
+	testGroupPruner, tc := newTestPruner()
+	errs := testGroupPruner.Prune()
+	for _, err := range errs {
+		t.Errorf("unexpected prune error: %v", err)
+	}
+
+	checkClientForDeletedGroups(tc, []string{"os" + Group2UID}, t)
+}
+
+func TestListFailsForPrune(t *testing.T) {
+	testGroupPruner, tc := newTestPruner()
+	listErr := errors.New("error during listing")
+	testGroupPruner.GroupLister.(*TestGroupLister).err = listErr
+
+	errs := testGroupPruner.Prune()
+	if len(errs) != 1 {
+		t.Errorf("unexpected prune errors: %v", errs)
+
+	} else if errs[0] != listErr {
+		t.Errorf("incorrect prune error:\n\twanted:\n\t%v\n\tgot:\n\t%v\n", listErr, errs[0])
+	}
+
+	deletedGroups := extractDeletedGroups(tc)
+	if len(deletedGroups) != 0 {
+		t.Errorf("expected no groups to be deleted, got: %v", deletedGroups)
+	}
+}
+
+// TestLocateFails tests that a failure locating a group does not fail the entire prune job, or cause it to prune that group
+func TestLocateFails(t *testing.T) {
+	testGroupPruner, tc := newTestPruner()
+	locateErr := fmt.Errorf("error during location for group: %s", Group1UID)
+	testGroupPruner.GroupDetector.(*TestGroupDetector).SourceOfErrors[Group1UID] = locateErr
+
+	errs := testGroupPruner.Prune()
+	if len(errs) != 1 {
+		t.Errorf("unexpected prune errors: %v", errs)
+
+	} else if errs[0] != locateErr {
+		t.Errorf("incorrect prune error:\n\twanted:\n\t%v\n\tgot:\n\t%v\n", locateErr, errs[0])
+	}
+
+	checkClientForDeletedGroups(tc, []string{"os" + Group2UID}, t)
+}
+
+// TestDeleteFails tests that a prune failure doesn't fail the entire job
+func TestDeleteFails(t *testing.T) {
+	testGroupPruner, tc := newTestPruner()
+	deleteErr := fmt.Errorf("failed to delete group: %s", "os"+Group1UID)
+	tc.PrependReactor("delete", "groups", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		deleteAction := action.(ktestclient.DeleteAction)
+		if deleteAction.GetName() == "os"+Group1UID {
+			return true, nil, deleteErr
+		}
+		return false, nil, nil
+	})
+	testGroupPruner.GroupDetector.(*TestGroupDetector).SourceOfTruth[Group1UID] = false
+
+	errs := testGroupPruner.Prune()
+	if len(errs) != 1 {
+		t.Errorf("unexpected prune error: %v", errs)
+
+	} else if errs[0] != deleteErr {
+		t.Errorf("incorrect prune error:\n\twanted:\n\t%v\n\tgot:\n\t%v\n", deleteErr, errs[0])
+	}
+
+	// although the first delete will fail, the event is still registered
+	// we are interested in seeing that both delete actions happen
+	checkClientForDeletedGroups(tc, []string{"os" + Group1UID, "os" + Group2UID}, t)
+}
+
+func checkClientForDeletedGroups(tc *testclient.Fake, expectedGroups []string, t *testing.T) {
+	actualGroups := sets.NewString(extractDeletedGroups(tc)...)
+	wantedGroups := sets.NewString(expectedGroups...)
+
+	if !actualGroups.Equal(wantedGroups) {
+		t.Errorf("did not delete correct groups:\n\twanted:\n\t%v\n\tgot:\n\t%v\n", wantedGroups, actualGroups)
+	}
+}
+
+func extractDeletedGroups(tc *testclient.Fake) []string {
+	ret := []string{}
+	for _, genericAction := range tc.Actions() {
+		switch action := genericAction.(type) {
+		case ktestclient.DeleteAction:
+			ret = append(ret, action.GetName())
+		}
+	}
+
+	return ret
+}
+
+func newTestPruner() (*LDAPGroupPruner, *testclient.Fake) {
+	tc := testclient.NewSimpleFake()
+	tc.PrependReactor("delete", "groups", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, nil
+	})
+
+	return &LDAPGroupPruner{
+		GroupLister:     newTestLister(),
+		GroupDetector:   newTestGroupDetector(),
+		GroupNameMapper: newTestGroupNameMapper(),
+		GroupClient:     tc.Groups(),
+		Host:            newTestHost(),
+		Out:             ioutil.Discard,
+		Err:             ioutil.Discard,
+	}, tc
+
+}
+
+func newTestGroupDetector() interfaces.LDAPGroupDetector {
+	return &TestGroupDetector{
+		SourceOfTruth: map[string]bool{
+			Group1UID: true,
+			Group2UID: false,
+			Group3UID: true,
+		},
+		SourceOfErrors: map[string]error{
+			Group1UID: nil,
+			Group2UID: nil,
+			Group3UID: nil,
+		},
+	}
+}
+
+var _ interfaces.LDAPGroupDetector = &TestGroupDetector{}
+
+type TestGroupDetector struct {
+	SourceOfTruth  map[string]bool
+	SourceOfErrors map[string]error
+}
+
+func (l *TestGroupDetector) Exists(ldapGroupUID string) (bool, error) {
+	status, exists := l.SourceOfTruth[ldapGroupUID]
+	return status && exists, l.SourceOfErrors[ldapGroupUID]
+}

--- a/pkg/cmd/experimental/syncgroups/groupsyncer.go
+++ b/pkg/cmd/experimental/syncgroups/groupsyncer.go
@@ -19,7 +19,7 @@ import (
 
 // GroupSyncer runs a Sync job on Groups
 type GroupSyncer interface {
-	Sync() (errors []error)
+	Sync() ([]*userapi.Group, []error)
 }
 
 // LDAPGroupSyncer sync Groups with records on an external LDAP server
@@ -43,6 +43,8 @@ type LDAPGroupSyncer struct {
 	Out io.Writer
 	Err io.Writer
 }
+
+var _ GroupSyncer = &LDAPGroupSyncer{}
 
 // Sync allows the LDAPGroupSyncer to be a GroupSyncer
 func (s *LDAPGroupSyncer) Sync() ([]*userapi.Group, []error) {

--- a/pkg/cmd/experimental/syncgroups/interfaces/errors.go
+++ b/pkg/cmd/experimental/syncgroups/interfaces/errors.go
@@ -4,21 +4,25 @@ import (
 	"fmt"
 )
 
-type MemberLookupError struct {
-	LDAPGroupUID string
-	LDAPUserUID  string
-	CausedBy     error
+func NewMemberLookupError(ldapGroupUID, ldapUserUID string, causedBy error) error {
+	return &memberLookupError{ldapGroupUID: ldapGroupUID, ldapUserUID: ldapUserUID, causedBy: causedBy}
 }
 
-func (e *MemberLookupError) Error() string {
-	return fmt.Sprintf("membership lookup for user %q in group %q failed because of %q", e.LDAPUserUID, e.LDAPGroupUID, e.CausedBy.Error())
+type memberLookupError struct {
+	ldapGroupUID string
+	ldapUserUID  string
+	causedBy     error
 }
 
-func IsMemberLookupError(e error) bool {
+func (e *memberLookupError) Error() string {
+	return fmt.Sprintf("membership lookup for user %q in group %q failed because of %q", e.ldapUserUID, e.ldapGroupUID, e.causedBy.Error())
+}
+
+func IsmemberLookupError(e error) bool {
 	if e == nil {
 		return false
 	}
 
-	_, ok := e.(*MemberLookupError)
+	_, ok := e.(*memberLookupError)
 	return ok
 }

--- a/pkg/cmd/experimental/syncgroups/interfaces/interfaces.go
+++ b/pkg/cmd/experimental/syncgroups/interfaces/interfaces.go
@@ -35,3 +35,8 @@ type LDAPGroupListerNameMapper interface {
 	LDAPGroupLister
 	LDAPGroupNameMapper
 }
+
+// LDAPGroupDetector determines if a group identified by an LDAP group UID exists on the LDAP server
+type LDAPGroupDetector interface {
+	Exists(ldapGroupUID string) (exists bool, err error)
+}

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
-	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
@@ -27,31 +27,25 @@ func NewLDAPInterface(clientConfig ldapclient.Config,
 		groupMembershipAttributes: groupMembershipAttributes,
 		userQuery:                 userQuery,
 		userNameAttributes:        userNameAttributes,
-		cachedUsers:               make(map[string]*ldap.Entry),
-		cachedGroups:              make(map[string]*ldap.Entry),
+		cachedUsers:               map[string]*ldap.Entry{},
+		cachedGroups:              map[string]*ldap.Entry{},
 	}
 }
 
 // LDAPInterface extracts the member list of an LDAP group entry from an LDAP server
 // with first-class LDAP entries for groups. The LDAPInterface is *NOT* thread-safe.
-// The LDAPInterface satisfies:
-// - LDAPMemberExtractor
-// - LDAPGroupGetter
-// - LDAPGroupLister
 type LDAPInterface struct {
 	// clientConfig holds LDAP connection information
 	clientConfig ldapclient.Config
 
-	// groupQuery holds the information necessary to make an LDAP query for a specific
-	// first-class group entry on the LDAP server
+	// groupQuery holds the information necessary to make an LDAP query for a specific first-class group entry on the LDAP server
 	groupQuery ldaputil.LDAPQueryOnAttribute
 	// groupNameAttributes defines which attributes on an LDAP group entry will be interpreted as its name to use for an OpenShift group
 	groupNameAttributes []string
 	// groupMembershipAttributes defines which attributes on an LDAP group entry will be interpreted as its members ldapUserUID
 	groupMembershipAttributes []string
 
-	// userQuery holds the information necessary to make an LDAP query for a specific
-	// first-class user entry on the LDAP server
+	// userQuery holds the information necessary to make an LDAP query for a specific first-class user entry on the LDAP server
 	userQuery ldaputil.LDAPQueryOnAttribute
 	// UserNameAttributes defines which attributes on an LDAP user entry will be interpreted as its' name
 	userNameAttributes []string
@@ -64,13 +58,10 @@ type LDAPInterface struct {
 	cachedUsers map[string]*ldap.Entry
 }
 
-var _ ldapinterfaces.LDAPMemberExtractor = &LDAPInterface{}
-var _ ldapinterfaces.LDAPGroupGetter = &LDAPInterface{}
-var _ ldapinterfaces.LDAPGroupLister = &LDAPInterface{}
-
-func (e *LDAPInterface) String() string {
-	return fmt.Sprintf("%#v", e)
-}
+// The LDAPInterface must conform to the following interfaces
+var _ interfaces.LDAPMemberExtractor = &LDAPInterface{}
+var _ interfaces.LDAPGroupGetter = &LDAPInterface{}
+var _ interfaces.LDAPGroupLister = &LDAPInterface{}
 
 // ExtractMembers returns the LDAP member entries for a group specified with a ldapGroupUID
 func (e *LDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, error) {
@@ -91,7 +82,7 @@ func (e *LDAPInterface) ExtractMembers(ldapGroupUID string) ([]*ldap.Entry, erro
 	for _, ldapMemberUID := range ldapMemberUIDs {
 		memberEntry, err := e.userEntryFor(ldapMemberUID)
 		if err != nil {
-			return nil, &ldapinterfaces.MemberLookupError{LDAPGroupUID: ldapGroupUID, LDAPUserUID: ldapMemberUID, CausedBy: err}
+			return nil, interfaces.NewMemberLookupError(ldapGroupUID, ldapMemberUID, err)
 		}
 		members = append(members, memberEntry)
 	}
@@ -169,7 +160,7 @@ func (e *LDAPInterface) ListGroups() ([]string, error) {
 		// cache groups returned from the server for later
 		ldapGroupUID := ldaputil.GetAttributeValue(group, []string{e.groupQuery.QueryAttribute})
 		if len(ldapGroupUID) == 0 {
-			return nil, fmt.Errorf("unable to find LDAP group UID for %v", group)
+			return nil, fmt.Errorf("unable to find LDAP group UID for %s", group)
 		}
 		e.cachedGroups[ldapGroupUID] = group
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/groupdetector"
 	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
 )
 
@@ -189,4 +190,9 @@ func (e *LDAPInterface) requiredUserAttributes() []string {
 	allAttributes.Insert(e.userQuery.QueryAttribute)         // this is used for extracting the user UID (otherwise an entry isn't self-describing)
 
 	return allAttributes.List()
+}
+
+// Exists determines if a group idenified with it's LDAP group UID exists on the LDAP server
+func (e *LDAPInterface) Exists(ldapGroupUID string) (bool, error) {
+	return groupdetector.NewGroupBasedDetector(e).Exists(ldapGroupUID)
 }

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	ldapinterfaces "github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
 )
 
 // NewLDAPInterface builds a new LDAPInterface using a schema-appropriate config
-func NewLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
+func NewLDAPInterface(clientConfig ldapclient.Config,
 	groupQuery ldaputil.LDAPQueryOnAttribute,
 	groupNameAttributes []string,
 	groupMembershipAttributes []string,
@@ -39,7 +40,7 @@ func NewLDAPInterface(clientConfig *ldaputil.LDAPClientConfig,
 // - LDAPGroupLister
 type LDAPInterface struct {
 	// clientConfig holds LDAP connection information
-	clientConfig *ldaputil.LDAPClientConfig
+	clientConfig ldapclient.Config
 
 	// groupQuery holds the information necessary to make an LDAP query for a specific
 	// first-class group entry on the LDAP server

--- a/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface_test.go
+++ b/pkg/cmd/experimental/syncgroups/rfc2307/ldapinterface_test.go
@@ -1,0 +1,307 @@
+package rfc2307
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/go-ldap/ldap"
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+	"github.com/openshift/origin/pkg/auth/ldaputil/testclient"
+	"github.com/openshift/origin/pkg/cmd/experimental/syncgroups/interfaces"
+)
+
+var searchErr error = errors.New("generic search error")
+
+const (
+	defaultFilter    string = "(objectClass=*)"
+	groupsBaseDN     string = "ou=groups,dc=example,dc=com"
+	groupsBaseFilter string = "objectClass=groupOfNames"
+	usersBaseDN      string = "ou=users,dc=example,dc=com"
+	usersBaseFilter  string = "objectClass=inetOrgPerson"
+
+	testGroupDN string = "cn=testGroup," + groupsBaseDN
+	testUserDN  string = "cn=testUser," + usersBaseDN
+)
+
+func newTestLDAPInterface(client ldap.Client) *LDAPInterface {
+	// below are common test implementations of LDAPInterface fields
+	groupQuery := ldaputil.LDAPQueryOnAttribute{
+		LDAPQuery: ldaputil.LDAPQuery{
+			BaseDN:       groupsBaseDN,
+			Scope:        ldaputil.ScopeWholeSubtree,
+			DerefAliases: ldaputil.DerefAliasesAlways,
+			TimeLimit:    0,
+			Filter:       groupsBaseFilter,
+		},
+		QueryAttribute: "dn",
+	}
+	groupNameAttributes := []string{"cn"}
+	groupMembershipAttributes := []string{"member"}
+	userQuery := ldaputil.LDAPQueryOnAttribute{
+		LDAPQuery: ldaputil.LDAPQuery{
+			BaseDN:       usersBaseDN,
+			Scope:        ldaputil.ScopeWholeSubtree,
+			DerefAliases: ldaputil.DerefAliasesAlways,
+			TimeLimit:    0,
+			Filter:       usersBaseFilter,
+		},
+		QueryAttribute: "dn",
+	}
+	userNameAttributes := []string{"email"}
+
+	return NewLDAPInterface(testclient.NewConfig(client),
+		groupQuery,
+		groupNameAttributes,
+		groupMembershipAttributes,
+		userQuery,
+		userNameAttributes)
+}
+
+// newDefaultTestUser returns a new LDAP entry with the following characteristics:
+// dn: cn=testUser,ou=users,dc=example,dc=com
+// cn: testUser
+// email: testEmail
+func newDefaultTestUser() *ldap.Entry {
+	return ldap.NewEntry(testUserDN, map[string][]string{"cn": {"testUser"}, "email": {"testEmail"}})
+}
+
+// newDefaultTestGroup returns a new LDAP entry with the following characteristics:
+// dn: cn=testGroup,ou=groups,dc=example,dc=com
+// cn: testGroup
+// member: cn=testUser,ou=users,dc=example,dc=com
+func newDefaultTestGroup() *ldap.Entry {
+	return ldap.NewEntry(testGroupDN, map[string][]string{"cn": {"testGroup"}, "member": {testUserDN}})
+}
+
+// newVariantTestGroup returns a new LDAP entry with the following characteristics:
+// dn: cn=testGroup,ou=groups,dc=example,dc=com
+// member: cn=testUser,ou=users,dc=example,dc=com
+// NOTE: this group does NOT have a common name
+func newVariantTestGroup() *ldap.Entry {
+	return ldap.NewEntry(testGroupDN, map[string][]string{"member": {testUserDN}})
+}
+
+func TestExtractMembers(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		client          ldap.Client
+		expectedError   error
+		expectedMembers []*ldap.Entry
+	}{
+		{
+			name:            "group lookup errors",
+			client:          testclient.NewMatchingSearchErrorClient(testclient.New(), testGroupDN, searchErr),
+			expectedError:   searchErr,
+			expectedMembers: nil,
+		},
+		{
+			name: "member lookup errors",
+			// this is a nested test client, the first nest tries to error on the user DN
+			// the second nest attempts to give back from the DN mapping
+			// the third nest is the default "safe" impl from ldaputil
+			client: testclient.NewMatchingSearchErrorClient(
+				testclient.NewDNMappingClient(
+					testclient.New(),
+					map[string][]*ldap.Entry{
+						testGroupDN: {newDefaultTestGroup()},
+					},
+				),
+				testUserDN,
+				searchErr,
+			),
+			expectedError:   interfaces.NewMemberLookupError(testGroupDN, testUserDN, searchErr),
+			expectedMembers: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					testGroupDN: {newDefaultTestGroup()},
+					testUserDN:  {newDefaultTestUser()},
+				},
+			),
+			expectedError:   nil,
+			expectedMembers: []*ldap.Entry{newDefaultTestUser()},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		members, err := ldapInterface.ExtractMembers(testGroupDN)
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(members, testCase.expectedMembers) {
+			t.Errorf("%s: incorrect members returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedMembers, members)
+		}
+	}
+}
+
+func TestGroupEntryFor(t *testing.T) {
+	var testCases = []struct {
+		name                string
+		cacheSeed           map[string]*ldap.Entry
+		queryBaseDNOverride string
+		client              ldap.Client
+		expectedError       error
+		expectedEntry       *ldap.Entry
+	}{
+		{
+			name:          "cached get",
+			cacheSeed:     map[string]*ldap.Entry{testGroupDN: newDefaultTestGroup()},
+			expectedError: nil,
+			expectedEntry: newDefaultTestGroup(),
+		},
+		{
+			name:                "search request failure",
+			queryBaseDNOverride: "otherBaseDN",
+			expectedError:       ldaputil.NewQueryOutOfBoundsError(testGroupDN, "otherBaseDN"),
+			expectedEntry:       nil,
+		},
+		{
+			name:          "query failure",
+			client:        testclient.NewMatchingSearchErrorClient(testclient.New(), testGroupDN, searchErr),
+			expectedError: searchErr,
+			expectedEntry: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					testGroupDN: {newDefaultTestGroup()},
+				},
+			),
+			expectedError: nil,
+			expectedEntry: newDefaultTestGroup(),
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.cachedGroups = testCase.cacheSeed
+		}
+		if len(testCase.queryBaseDNOverride) > 0 {
+			ldapInterface.groupQuery.BaseDN = testCase.queryBaseDNOverride
+		}
+		entry, err := ldapInterface.GroupEntryFor(testGroupDN)
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(entry, testCase.expectedEntry) {
+			t.Errorf("%s: incorrect entry returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedEntry, entry)
+		}
+	}
+}
+
+func TestListGroups(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		client            ldap.Client
+		groupUIDAttribute string
+		expectedError     error
+		expectedGroups    []string
+	}{
+		{
+			name:           "query errors",
+			client:         testclient.NewMatchingSearchErrorClient(testclient.New(), groupsBaseDN, searchErr),
+			expectedError:  searchErr,
+			expectedGroups: nil,
+		},
+		{
+			name: "no UID on entry",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					groupsBaseDN: {newVariantTestGroup()},
+				},
+			),
+			groupUIDAttribute: "cn",
+			expectedError:     fmt.Errorf("unable to find LDAP group UID for %s", newVariantTestGroup()),
+			expectedGroups:    nil,
+		},
+		{
+			name: "no error",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					groupsBaseDN: {newDefaultTestGroup()},
+				},
+			),
+			expectedError:  nil,
+			expectedGroups: []string{testGroupDN},
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		if len(testCase.groupUIDAttribute) > 0 {
+			ldapInterface.groupQuery.QueryAttribute = testCase.groupUIDAttribute
+		}
+		groupNames, err := ldapInterface.ListGroups()
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(groupNames, testCase.expectedGroups) {
+			t.Errorf("%s: incorrect entry returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedGroups, groupNames)
+		}
+	}
+}
+
+func TestUserEntryFor(t *testing.T) {
+	var testCases = []struct {
+		name                string
+		cacheSeed           map[string]*ldap.Entry
+		queryBaseDNOverride string
+		client              ldap.Client
+		expectedError       error
+		expectedEntry       *ldap.Entry
+	}{
+		{
+			name:          "cached get",
+			cacheSeed:     map[string]*ldap.Entry{testUserDN: newDefaultTestUser()},
+			expectedError: nil,
+			expectedEntry: newDefaultTestUser(),
+		},
+		{
+			name:                "search request failure",
+			queryBaseDNOverride: "otherBaseDN",
+			expectedError:       ldaputil.NewQueryOutOfBoundsError(testUserDN, "otherBaseDN"),
+			expectedEntry:       nil,
+		},
+		{
+			name:          "query failure",
+			client:        testclient.NewMatchingSearchErrorClient(testclient.New(), testUserDN, searchErr),
+			expectedError: searchErr,
+			expectedEntry: nil,
+		},
+		{
+			name: "no errors",
+			client: testclient.NewDNMappingClient(
+				testclient.New(),
+				map[string][]*ldap.Entry{
+					testUserDN: {newDefaultTestUser()},
+				},
+			),
+			expectedError: nil,
+			expectedEntry: newDefaultTestUser(),
+		},
+	}
+	for _, testCase := range testCases {
+		ldapInterface := newTestLDAPInterface(testCase.client)
+		if len(testCase.cacheSeed) > 0 {
+			ldapInterface.cachedUsers = testCase.cacheSeed
+		}
+		if len(testCase.queryBaseDNOverride) > 0 {
+			ldapInterface.userQuery.BaseDN = testCase.queryBaseDNOverride
+		}
+		entry, err := ldapInterface.userEntryFor(testUserDN)
+		if !reflect.DeepEqual(err, testCase.expectedError) {
+			t.Errorf("%s: incorrect error returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedError, err)
+		}
+		if !reflect.DeepEqual(entry, testCase.expectedEntry) {
+			t.Errorf("%s: incorrect entry returned:\n\texpected:\n\t%v\n\tgot:\n\t%v\n", testCase.name, testCase.expectedEntry, entry)
+		}
+	}
+}

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -157,6 +157,7 @@ func newExperimentalCommand(name, fullName string) *cobra.Command {
 	experimental.AddCommand(buildchain.NewCmdBuildChain(name, fullName+" "+buildchain.BuildChainRecommendedCommandName, f, out))
 	experimental.AddCommand(diagnostics.NewCommandDiagnostics("diagnostics", fullName+" diagnostics", out))
 	experimental.AddCommand(syncgroups.NewCmdSyncGroups(syncgroups.SyncGroupsRecommendedName, fullName+" "+syncgroups.SyncGroupsRecommendedName, f, out))
+	experimental.AddCommand(syncgroups.NewCmdPruneGroups(syncgroups.PruneGroupsRecommendedName, fullName+" "+syncgroups.PruneGroupsRecommendedName, f, out))
 	experimental.AddCommand(cmd.NewCmdOptions(out))
 	return experimental
 }

--- a/pkg/cmd/server/api/validation/ldap.go
+++ b/pkg/cmd/server/api/validation/ldap.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-func ValidateLDAPSyncConfig(config api.LDAPSyncConfig) ValidationResults {
+func ValidateLDAPSyncConfig(config *api.LDAPSyncConfig) ValidationResults {
 	validationResults := ValidateLDAPClientConfig(config.URL, config.BindDN, config.BindPassword, config.CA, config.Insecure)
 
 	schemaConfigsFound := []string{}

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -500,7 +500,7 @@ func (c *AuthConfig) getPasswordAuthenticator(identityProvider configapi.Identit
 
 		opts := ldappassword.Options{
 			URL:                  url,
-			ClientConfig:         *clientConfig,
+			ClientConfig:         clientConfig,
 			UserAttributeDefiner: ldaputil.NewLDAPUserAttributeDefiner(provider.Attributes),
 		}
 		return ldappassword.New(identityProvider.Name, opts, identityMapper)

--- a/test/extended/authentication/ldap/ad/valid_all_ldap_sync_prune.txt
+++ b/test/extended/authentication/ldap/ad/valid_all_ldap_sync_prune.txt
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: group1
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group1
+users:
+- person1smith@example.com
+- person2smith@example.com
+- person3smith@example.com
+- person4smith@example.com
+- person5smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: group3
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group3
+users:
+- person1smith@example.com
+- person5smith@example.com

--- a/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_prune.txt
+++ b/test/extended/authentication/ldap/augmented-ad/valid_all_ldap_sync_prune.txt
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group1,ou=groups,ou=adextended,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: extended-group1
+users:
+- person1smith@example.com
+- person2smith@example.com
+- person3smith@example.com
+- person4smith@example.com
+- person5smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group3,ou=groups,ou=adextended,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: extended-group3
+users:
+- person1smith@example.com
+- person5smith@example.com

--- a/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_prune.txt
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_prune.txt
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group1
+users:
+- person1smith@example.com
+- person2smith@example.com
+- person3smith@example.com
+- person4smith@example.com
+- person5smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group3,ou=groups,ou=rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group3
+users:
+- person1smith@example.com
+- person5smith@example.com


### PR DESCRIPTION
Originally some of these methods were necessary because the work was not being done in `ldaputil` to create the `SearchRequests`. Now that the search process is more self-contained, these methods are not necessary and can be subsumed by their parents.

Depends on https://github.com/openshift/origin/pull/5709

/cc @deads2k @liggitt 