### PR TITLE
added test-cmd test wrapper functions and tests

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# This utility file contains functions that wrap commands to be tested. All wrapper functions run commands
+# in a sub-shell and redirect all output. Tests in test-cmd *must* use these functions for testing.
+
+# We assume ${OS_ROOT} is set
+source "${OS_ROOT}/hack/text.sh" # text manipulation functions
+
+# expect_success runs the cmd and expects an exit code of 0
+function os::cmd::expect_success() {
+	if [[ $# -ne 1 ]]; then echo "os::cmd::expect_success expects only one argumment, got $#"; exit 1; fi
+	cmd=$1
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}"
+}
+
+# expect_failure runs the cmd and expects a non-zero exit code
+function os::cmd::expect_failure() {
+	if [[ $# -ne 1 ]]; then echo "os::cmd::expect_failure expects only one argumment, got $#"; exit 1; fi
+	cmd=$1
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::failure_func"
+}
+
+# expect_success_and_text runs the cmd and expects an exit code of 0
+# as well as running a grep test to find the given string in the output
+function os::cmd::expect_success_and_text() {
+	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_success_and_text expects two argumments, got $#"; exit 1; fi
+	cmd=$1
+	expected_text=$2
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::success_func" "${expected_text}"
+}
+
+# expect_failure_and_text runs the cmd and expects a non-zero exit code
+# as well as running a grep test to find the given string in the output
+function os::cmd::expect_failure_and_text() {
+	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_failure_and_text expects two argumments, got $#"; exit 1; fi
+	cmd=$1
+	expected_text=$2
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::failure_func" "${expected_text}"
+}
+
+# expect_success_and_not_text runs the cmd and expects an exit code of 0
+# as well as running a grep test to ensure the given string is not in the output
+function os::cmd::expect_success_and_not_text() {
+	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_success_and_not_text expects two argumments, got $#"; exit 1; fi
+	cmd=$1
+	expected_text=$2
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::success_func" "${expected_text}" "os::cmd::internal::failure_func"
+}
+
+# expect_failure_and_not_text runs the cmd and expects a non-zero exit code
+# as well as running a grep test to ensure the given string is not in the output
+function os::cmd::expect_failure_and_not_text() {
+	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_failure_and_not_text expects two argumments, got $#"; exit 1; fi
+	cmd=$1
+	expected_text=$2
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::failure_func" "${expected_text}" "os::cmd::internal::failure_func"
+}
+
+# expect_code runs the cmd and expects a given exit code
+function os::cmd::expect_code() {
+	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_code expects two argumments, got $#"; fi
+	cmd=$1
+	expected_cmd_code=$2
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::specific_code_func ${expected_cmd_code}"
+}
+
+# expect_code_and_text runs the cmd and expects the given exit code
+# as well as running a grep test to find the given string in the output
+function os::cmd::expect_code_and_text() {
+	if [[ $# -ne 3 ]]; then echo "os::cmd::expect_code_and_text expects three argumments, got $#"; fi
+	cmd=$1
+	expected_cmd_code=$2
+	expected_text=$3
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::specific_code_func ${expected_cmd_code}" "${expected_text}"
+}
+
+# expect_code_and_not_text runs the cmd and expects the given exit code
+# as well as running a grep test to ensure the given string is not in the output
+function os::cmd::expect_code_and_not_text() {
+	if [[ $# -ne 3 ]]; then echo "os::cmd::expect_code_and_not_text expects three argumments, got $#"; fi
+	cmd=$1
+	expected_cmd_code=$2
+	expected_text=$3
+
+	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::specific_code_func ${expected_cmd_code}" "${expected_text}" "os::cmd::internal::failure_func"
+}
+
+# Functions in the os::cmd::internal namespace are discouraged from being used outside of os::cmd
+
+# In order to harvest stderr and stdout at the same time into different buckets, we need to stick them into files 
+# in an intermediate step
+os_cmd_internal_tmpdir="/tmp/openshift/test/cmd"
+os_cmd_internal_tmpout="${os_cmd_internal_tmpdir}/tmp_stdout.log"
+os_cmd_internal_tmperr="${os_cmd_internal_tmpdir}/tmp_stderr.log"
+
+# os::cmd::internal::expect_exit_code_and_text runs the provided test command and expects a specific 
+# exit code from that command as well as the success of a specified `grep` invocation. Output from the 
+# command to be tested is suppressed unless either `VERBOSE=1` or the test fails. This function bypasses
+# any error exiting settings or traps set by upstream callers by masking the return code of the command 
+# with the return code of setting the result variable on failure.
+function os::cmd::internal::expect_exit_code_run_grep() {
+	cmd=$1
+	# default expected cmd code to 0 for success
+	cmd_eval_func=${2:-os::cmd::internal::success_func}
+	# default to nothing 
+	grep_args=${3:-} 
+	# default expected test code to 0 for success
+	test_eval_func=${4:-os::cmd::internal::success_func}
+
+	os::cmd::internal::init_tempdir
+
+	echo "Running  ${cmd}..."
+	
+	cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
+	cmd_succeeded=$( ${cmd_eval_func} "${cmd_result}"; echo $? )
+
+	test_result=0
+	if [[ -n "${grep_args}" ]]; then
+		test_result=$( os::cmd::internal::run_collecting_output 'os::cmd::internal::get_results | grep -Eq "${grep_args}"'; echo $? )
+		
+	fi
+	test_succeeded=$( ${test_eval_func} "${test_result}"; echo $? )
+
+	os::text::clear_last_line
+
+	if (( cmd_succeeded && test_succeeded )); then
+
+		os::text::print_green_bold "SUCCESS: ${cmd}"
+		if [[ -n ${VERBOSE-} ]]; then
+			os::cmd::internal::print_results
+		fi
+		return 0
+	else
+		cause=$(os::cmd::internal::assemble_causes "${cmd_succeeded}" "${test_succeeded}")
+		
+		os::text::print_red_bold "FAILURE: ${cmd}: ${cause}"
+		os::text::print_red "$(os::cmd::internal::print_results)"
+		return 1
+	fi
+}
+
+# os::cmd::internal::init_tempdir initializes the temporary directory 
+function os::cmd::internal::init_tempdir() {
+	mkdir -p "${os_cmd_internal_tmpdir}"
+	rm -f "${os_cmd_internal_tmpdir}"/tmp_std{out,err}.log
+}
+
+# os::cmd::internal::run_collecting_output runs the command given, piping stdout and stderr into
+# the given files, and returning the exit code of the command
+function os::cmd::internal::run_collecting_output() {
+	cmd=$1
+
+	local result=
+	$( eval "${cmd}" 1>>"${os_cmd_internal_tmpout}" 2>>"${os_cmd_internal_tmperr}" ) || result=$?
+	result=${result:-0} # if we haven't set result yet, the command succeeded
+
+	return "${result}"
+} 
+
+# os::cmd::internal::success_func determines if the input exit code denotes success
+# this function returns 0 for false and 1 for true to be compatible with arithmetic tests
+function os::cmd::internal::success_func() {
+	exit_code=$1
+
+	# use a negated test to get output correct for (( ))
+	[[ "${exit_code}" -ne "0" ]]
+	return $?
+}
+
+# os::cmd::internal::failure_func determines if the input exit code denotes failure
+# this function returns 0 for false and 1 for true to be compatible with arithmetic tests
+function os::cmd::internal::failure_func() {
+	exit_code=$1
+
+	# use a negated test to get output correct for (( ))
+	[[ "${exit_code}" -eq "0" ]]
+	return $?
+}
+
+# os::cmd::internal::specific_code_func determines if the input exit code matches the given code
+# this function returns 0 for false and 1 for true to be compatible with arithmetic tests
+function os::cmd::internal::specific_code_func() {
+	expected_code=$1
+	exit_code=$2
+
+	# use a negated test to get output correct for (( ))
+	[[ "${exit_code}" -ne "${expected_code}" ]]
+	return $?
+}
+
+# os::cmd::internal::get_results prints the stderr and stdout files
+function os::cmd::internal::get_results() {
+	cat "${os_cmd_internal_tmpout}" "${os_cmd_internal_tmperr}"
+}
+
+# os::cmd::internal::print_results pretty-prints the stderr and stdout files
+function os::cmd::internal::print_results() {
+	if [[ -s "${os_cmd_internal_tmpout}" ]]; then 
+		echo "Standard output from the command:"
+		cat "${os_cmd_internal_tmpout}"
+	else 
+		echo "There was no output from the command."                                      																																																																																																																
+	fi	
+
+	if [[ -s "${os_cmd_internal_tmperr}" ]]; then 
+		echo "Standard error from the command:"
+		cat "${os_cmd_internal_tmperr}"
+	else 
+		echo "There was no error output from the command."                                      																																																																																																																
+	fi	
+}
+
+# os::cmd::internal::assemble_causes determines from the two input booleans which part of the test
+# failed and generates a nice delimited list of failure causes
+function os::cmd::internal::assemble_causes() {
+	cmd_succeeded=$1
+	test_succeeded=$2
+
+	causes=()
+	if (( ! cmd_succeeded )); then
+		causes+=("the command returned the wrong error code")
+	fi
+	if (( ! test_succeeded )); then
+		causes+=("the output content test failed")
+	fi
+
+	list=$(printf '; %s' "${causes[@]}")
+	echo "${list:2}"
+}

--- a/hack/cmd_util_test.sh
+++ b/hack/cmd_util_test.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# This file ensures that the helper functions in util.sh behave as expected
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -x
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/cmd_util.sh"
+os::log::install_errexit
+
+mkdir -p /tmp/openshift/origin/test/cmd/
+JUNIT_OUTPUT_FILE=/tmp/openshift-cmd/junit_output.txt
+
+# set verbosity so we can see that command output renders correctly
+VERBOSE=1
+
+# positive tests
+os::cmd::expect_success 'exit 0'
+
+os::cmd::expect_failure 'exit 10'
+
+os::cmd::expect_success_and_text 'printf "hello" && exit 0' 'hello'
+
+os::cmd::expect_failure_and_text 'printf "hello" && exit 19' 'hello'
+
+os::cmd::expect_success_and_not_text 'echo "goodbye" && exit 0' 'hello'
+
+os::cmd::expect_failure_and_not_text 'echo "goodbye" && exit 19' 'hello'
+
+os::cmd::expect_code 'exit 195' '195'
+
+os::cmd::expect_code_and_text 'echo "hello" && exit 213' '213' 'hello'
+
+os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 213' '213' 'hello'
+
+echo "positive tests: ok"
+
+# negative tests
+
+if os::cmd::expect_success 'exit 1'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure 'exit 0'; then
+	exit 1
+fi
+
+if os::cmd::expect_success_and_text 'echo "goodbye" && exit 0' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_success_and_text 'echo "hello" && exit 1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_success_and_text 'echo "goodbye" && exit 1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure_and_text 'echo "goodbye" && exit 1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure_and_text 'echo "hello" && exit 0' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure_and_text 'echo "goodbye" && exit 0' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_success_and_not_text 'echo "hello" && exit 0' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_success_and_not_text 'echo "goodbye" && exit 1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_success_and_not_text 'echo "hello" && exit 1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure_and_not_text 'echo "goodbye" && exit 0' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure_and_not_text 'echo "hello" && exit 1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_failure_and_not_text 'echo "hello" && exit 0' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_code 'exit 1' '200'; then
+	exit 1
+fi
+
+if os::cmd::expect_code_and_text 'echo "hello" && exit 0' '1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_code_and_text 'echo "goodbye" && exit 1' '1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_code_and_text 'echo "goodbye" && exit 0' '1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 0' '1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_code_and_not_text 'echo "hello" && exit 1' '1' 'hello'; then
+	exit 1
+fi
+
+if os::cmd::expect_code_and_not_text 'echo "hello" && exit 0' '1' 'hello'; then
+	exit 1
+fi
+
+echo "negative tests: ok"
+
+# complex input tests
+
+# pipes
+os::cmd::expect_success 'echo "hello" | grep hello'
+
+os::cmd::expect_success 'echo "-1" | xargs ls'
+
+# variables
+VAR=hello
+os::cmd::expect_success_and_text 'echo $(echo "${VAR}")' 'hello'
+unset VAR
+
+# semicolon
+os::cmd::expect_success 'echo "hello"; pwd'
+
+# spaces in strings
+os::cmd::expect_success_and_text 'echo "-v marker"' 'v marker'
+
+# curly braces
+os::cmd::expect_success_and_text 'ls "${OS_ROOT}"/hack/update-generated-co{n,m}*.sh' 'completions'
+
+os::cmd::expect_success_and_text 'ls "${OS_ROOT}"/hack/update-generated-co{n,m}*.sh' 'conversions'
+
+# integer arithmetic
+os::cmd::expect_success_and_text 'if (( 1 )); then echo "hello"; fi' 'hello'
+
+os::cmd::expect_success_and_text 'echo $(( 1 - 20 ))' '\-19' # we need to escape for grep
+
+# redirects
+os::cmd::expect_failure_and_text 'grep' 'for more information'
+
+os::cmd::expect_success_and_not_text 'pwd 1>/dev/null' '.' 
+
+os::cmd::expect_failure_and_not_text 'grep 2>/dev/null' '.'
+
+# here document/string
+os::cmd::expect_success 'grep hello <<EOF
+hello
+EOF
+'
+
+os::cmd::expect_success 'grep hello <<< hello'
+
+echo "complex tests: ok"
+
+
+# test for output correctness
+
+# expect_code
+output=$(os::cmd::expect_code 'exit 0' '0')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_code 'exit 1' '0') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+
+output=$(os::cmd::expect_code 'exit 1' '1')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_code 'exit 0' '1') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+
+output=$(os::cmd::expect_code 'exit 99' '99')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_code 'exit 1' '99') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+
+# expect_success
+output=$(os::cmd::expect_success 'exit 0')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_success 'exit 1') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+
+# expect_failure
+output=$(os::cmd::expect_failure 'exit 1')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_failure 'exit 0') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+
+# expect_code_and_text
+output=$(os::cmd::expect_code_and_text 'echo "hello" && exit 0' '0' 'hello')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_code_and_text 'echo "hello" && exit 1' '0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'hello' 
+
+output=$(os::cmd::expect_code_and_text 'echo "goodbye" && exit 0' '0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the output content test failed' 
+echo "${output}" | grep -q 'goodbye' 
+
+output=$(os::cmd::expect_code_and_text 'echo "goodbye" && exit 1' '0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q '; the output content test failed' 
+echo "${output}" | grep -q 'goodbye' 
+
+# expect_success_and_text
+output=$(os::cmd::expect_success_and_text 'echo "hello" && exit 0' 'hello')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_success_and_text 'echo "hello" && exit 1' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'hello' 
+
+output=$(os::cmd::expect_success_and_text 'echo "goodbye" && exit 0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the output content test failed' 
+echo "${output}" | grep -q 'goodbye' 
+
+output=$(os::cmd::expect_success_and_text 'echo "goodbye" && exit 1' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q '; the output content test failed' 
+echo "${output}" | grep -q 'goodbye' 
+
+# expect_failure_and_text
+output=$(os::cmd::expect_failure_and_text 'echo "hello" && exit 1' 'hello')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_failure_and_text 'echo "hello" && exit 0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'hello' 
+
+output=$(os::cmd::expect_failure_and_text 'echo "goodbye" && exit 1' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the output content test failed' 
+echo "${output}" | grep -q 'goodbye' 
+
+output=$(os::cmd::expect_failure_and_text 'echo "goodbye" && exit 0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q '; the output content test failed' 
+echo "${output}" | grep -q 'goodbye' 
+
+# expect_code_and_not_text
+output=$(os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 0' '0' 'hello')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 1' '0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'goodbye' 
+
+output=$(os::cmd::expect_code_and_not_text 'echo "hello" && exit 0' '0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the output content test failed' 
+echo "${output}" | grep -q 'hello' 
+
+output=$(os::cmd::expect_code_and_not_text 'echo "hello" && exit 1' '0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q '; the output content test failed' 
+echo "${output}" | grep -q 'hello' 
+
+# expect_success_and_not_text
+output=$(os::cmd::expect_success_and_not_text 'echo "goodbye" && exit 0' 'hello')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_success_and_not_text 'echo "goodbye" && exit 1' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'goodbye' 
+
+output=$(os::cmd::expect_success_and_not_text 'echo "hello" && exit 0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the output content test failed' 
+echo "${output}" | grep -q 'hello' 
+
+output=$(os::cmd::expect_success_and_not_text 'echo "hello" && exit 1' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q '; the output content test failed' 
+echo "${output}" | grep -q 'hello' 
+
+# expect_failure_and_not_text
+output=$(os::cmd::expect_failure_and_not_text 'echo "goodbye" && exit 1' 'hello')
+echo "${output}" | grep -q 'SUCCESS' 
+
+output=$(os::cmd::expect_failure_and_not_text 'echo "goodbye" && exit 0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q 'goodbye' 
+
+output=$(os::cmd::expect_failure_and_not_text 'echo "hello" && exit 1' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the output content test failed' 
+echo "${output}" | grep -q 'hello' 
+
+output=$(os::cmd::expect_failure_and_not_text 'echo "hello" && exit 0' 'hello') || true
+echo "${output}" | grep -q 'FAILURE' 
+echo "${output}" | grep -q 'the command returned the wrong error code' 
+echo "${output}" | grep -q '; the output content test failed' 
+echo "${output}" | grep -q 'hello' 
+
+echo "output tests: ok"
+
+rm -rf /tmp/openshift-cmd/

--- a/hack/text.sh
+++ b/hack/text.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# This file contains helpful aliases for manipulating the output text to the terminal as
+# well as functions for one-command augmented printing.
+
+shopt -s expand_aliases
+
+# The following aliases provide more readable accessors to `tput`
+alias  os::text::reset='tput sgr0'
+alias   os::text::bold='tput bold'
+alias    os::text::red='tput setaf 1'
+alias  os::text::green='tput setaf 2'
+alias   os::text::blue='tput setaf 4'
+alias os::text::yellow='tput setaf 11'
+
+# os::text::clear_last_line clears the text from the last line of output to the
+# terminal and leaves the cursor on that line to allow for overwriting that text
+alias os::text::clear_last_line='tput cuu 1; tput el'
+
+# The following functions wrap the above aliases to allow one-command printing of augmented text
+
+# os::text::print_bold prints all input in bold text
+function os::text::print_bold() {
+	os::text::bold
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_red prints all input in red text
+function os::text::print_red() {
+	os::text::red
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_red_bold prints all input in bold red text
+function os::text::print_red_bold() {
+	os::text::red
+	os::text::bold
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_green prints all input in green text
+function os::text::print_green() {
+	os::text::green
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_green_bold prints all input in bold green text
+function os::text::print_green_bold() {
+	os::text::green
+	os::text::bold
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_blue prints all input in blue text
+function os::text::print_blue() {
+	os::text::blue
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_blue_bold prints all input in bold blue text
+function os::text::print_blue_bold() {
+	os::text::blue
+	os::text::bold
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_yellow prints all input in yellow text
+function os::text::print_yellow() {
+	os::text::yellow
+	echo "${*}"
+	os::text::reset
+}
+
+# os::text::print_yellow_bold prints all input in bold yellow text
+function os::text::print_yellow_bold() {
+	os::text::yellow
+	os::text::bold
+	echo "${*}"
+	os::text::reset
+}


### PR DESCRIPTION
I've added the following high-level wrapper functions for tests and a test file that ensures correct function:

* `expect_{success,failure} $cmd` - run `$cmd` and expect a `{0,1}` result code
* `expect_{success,failure}_and_text $cmd $text` - run `$cmd` and expect a `{0,1}` result code as well as `$text` in the output 
* `expect_{success,failure}_and_not_text $cmd $text` - run `$cmd` and expect a `{0,1}` result code as well as the absence of `$text` in the output 

Non-`1` result codes can be covered with more general test functions:
* `expect_code  $cmd $code` - run `$cmd` and expect `$code`
* `expect_code_and_text $cmd $code $text` - run `$cmd` and expect `$code` as well as `$text` in the output
* `expect_code_and_not_text $cmd $code $text` - run `$cmd` and expect `$code` as well as the absence of `$text` in the output

All `$text` tests are done using `grep -E`, with negated searches using `-v`. All test wrapper functions honor `VERBOSE=1` in order to always print the output of the test, otherwise output is only printed on a failure.

We can remove the test suite for these wrappers. It's not pretty or optimized but was useful when writing them. I'd appreciate feedback on where these utility functions should live, currently I have them in `test/cmd/util.sh`

Begins to address https://github.com/openshift/origin/issues/4929. We can use the following translations:

| Original Construct              | Wrapper Function To Use                                                                                      |
|-----------------------------------|------------------------------------------------------------------------------------------------------|
| `cmd`                                  | `expect_success $cmd`                                                                                         |
| `cmd | grep $text`               |  `expect_{success,failure}_and_text  $cmd $text` :exclamation:                           |
| `[ $( $cmd | grep $text ) ]`   |   "                                                                                                                           |
| `[ $( $cmd ) ]`                      |  `expect_{success,failure}_and_text  $cmd "."` :exclamation: :question:               |
| `[ -n $( $cmd ) ]`                  |  "                                                                                                                            |
| `[ ! $( $cmd | grep $text ) ]` | `expect_{success,failure}_and_not_text $cmd $text`:exclamation:                       |
| `[ ! $( $cmd ) ]`                    | `expect_{success,failure}_and_not_text $cmd "."` :exclamation: :grey_question: |
| `[ -z $( $cmd ) ]`                  |  "                                                                                                                             |

:exclamation: This will be difficult as currently the return code of `$cmd` is masked.
:question: Currently I believe this is testing that the output of this to `stdout` is not null. Is this what we really want?
:grey_question: Currently I believe this is testing that the output of this to `stdout` is null. Is this what we really want?

/cc @deads2k @liggitt @smarterclayton 

