### PR TITLE
Allow in-cluster config for oc

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/helpers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/helpers.go
@@ -31,6 +31,14 @@ func init() {
 	redactedBytes = []byte(string(sDec))
 }
 
+// IsConfigEmpty returns true if the config is empty.
+func IsConfigEmpty(config *Config) bool {
+	return len(config.AuthInfos) == 0 && len(config.Clusters) == 0 && len(config.Contexts) == 0 &&
+		len(config.CurrentContext) == 0 &&
+		len(config.Preferences.Extensions) == 0 && !config.Preferences.Colors &&
+		len(config.Extensions) == 0
+}
+
 // MinifyConfig read the current context and uses that to keep only the relevant pieces of config
 // This is useful for making secrets based on kubeconfig files
 func MinifyConfig(config *Config) error {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/types.go
@@ -24,6 +24,7 @@ import (
 // Top level config objects and all values required for proper functioning are not "omitempty".  Any truly optional piece of config is allowed to be omitted.
 
 // Config holds the information needed to build connect to remote kubernetes clusters as a given user
+// IMPORTANT if you add fields to this struct, please update IsConfigEmpty()
 type Config struct {
 	// Legacy field from pkg/api/types.go TypeMeta.
 	// TODO(jlowdermilk): remove this after eliminating downstream dependencies.
@@ -44,6 +45,7 @@ type Config struct {
 	Extensions map[string]*runtime.EmbeddedObject `json:"extensions,omitempty"`
 }
 
+// IMPORTANT if you add fields to this struct, please update IsConfigEmpty()
 type Preferences struct {
 	Colors bool `json:"colors,omitempty"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/client_config.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/client_config.go
@@ -233,7 +233,11 @@ func (config DirectClientConfig) ConfirmUsable() error {
 	validationErrors := make([]error, 0)
 	validationErrors = append(validationErrors, validateAuthInfo(config.getAuthInfoName(), config.getAuthInfo())...)
 	validationErrors = append(validationErrors, validateClusterInfo(config.getClusterName(), config.getCluster())...)
-
+	// when direct client config is specified, and our only error is that no server is defined, we should
+	// return a standard "no config" error
+	if len(validationErrors) == 1 && validationErrors[0] == ErrEmptyCluster {
+		return newErrConfigurationInvalid([]error{ErrEmptyConfig})
+	}
 	return newErrConfigurationInvalid(validationErrors)
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/validation.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/validation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -27,7 +28,12 @@ import (
 	"k8s.io/kubernetes/pkg/util/validation"
 )
 
-var ErrNoContext = errors.New("no context chosen")
+var (
+	ErrNoContext   = errors.New("no context chosen")
+	ErrEmptyConfig = errors.New("no configuration has been provided")
+	// message is for consistency with old behavior
+	ErrEmptyCluster = errors.New("cluster has no server defined")
+)
 
 type errContextNotFound struct {
 	ContextName string
@@ -47,6 +53,16 @@ func IsContextNotFound(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "context was not found for specified context")
+}
+
+// IsEmptyConfig returns true if the provided error indicates the provided configuration
+// is empty.
+func IsEmptyConfig(err error) bool {
+	switch t := err.(type) {
+	case errConfigurationInvalid:
+		return len(t) == 1 && t[0] == ErrEmptyConfig
+	}
+	return err == ErrEmptyConfig
 }
 
 // errConfigurationInvalid is a set of errors indicating the configuration is invalid.
@@ -88,6 +104,10 @@ func IsConfigurationInvalid(err error) bool {
 func Validate(config clientcmdapi.Config) error {
 	validationErrors := make([]error, 0)
 
+	if clientcmdapi.IsConfigEmpty(&config) {
+		return newErrConfigurationInvalid([]error{ErrEmptyConfig})
+	}
+
 	if len(config.CurrentContext) != 0 {
 		if _, exists := config.Contexts[config.CurrentContext]; !exists {
 			validationErrors = append(validationErrors, &errContextNotFound{config.CurrentContext})
@@ -113,6 +133,10 @@ func Validate(config clientcmdapi.Config) error {
 // but no errors in the sections requested or referenced.  It does not return early so that it can find as many errors as possible.
 func ConfirmUsable(config clientcmdapi.Config, passedContextName string) error {
 	validationErrors := make([]error, 0)
+
+	if clientcmdapi.IsConfigEmpty(&config) {
+		return newErrConfigurationInvalid([]error{ErrEmptyConfig})
+	}
 
 	var contextName string
 	if len(passedContextName) != 0 {
@@ -142,6 +166,10 @@ func ConfirmUsable(config clientcmdapi.Config, passedContextName string) error {
 // validateClusterInfo looks for conflicts and errors in the cluster info
 func validateClusterInfo(clusterName string, clusterInfo clientcmdapi.Cluster) []error {
 	validationErrors := make([]error, 0)
+
+	if reflect.DeepEqual(clientcmdapi.Cluster{}, clusterInfo) {
+		return []error{ErrEmptyCluster}
+	}
 
 	if len(clusterInfo.Server) == 0 {
 		if len(clusterName) == 0 {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/validation_test.go
@@ -87,7 +87,7 @@ func TestConfirmUsableEmptyConfig(t *testing.T) {
 	config := clientcmdapi.NewConfig()
 	test := configValidationTest{
 		config:                 config,
-		expectedErrorSubstring: []string{"no context chosen"},
+		expectedErrorSubstring: []string{"invalid configuration: no configuration has been provided"},
 	}
 
 	test.testConfirmUsable("", t)
@@ -96,7 +96,7 @@ func TestConfirmUsableMissingConfig(t *testing.T) {
 	config := clientcmdapi.NewConfig()
 	test := configValidationTest{
 		config:                 config,
-		expectedErrorSubstring: []string{"context was not found for"},
+		expectedErrorSubstring: []string{"invalid configuration: no configuration has been provided"},
 	}
 
 	test.testConfirmUsable("not-here", t)
@@ -104,7 +104,8 @@ func TestConfirmUsableMissingConfig(t *testing.T) {
 func TestValidateEmptyConfig(t *testing.T) {
 	config := clientcmdapi.NewConfig()
 	test := configValidationTest{
-		config: config,
+		config:                 config,
+		expectedErrorSubstring: []string{"invalid configuration: no configuration has been provided"},
 	}
 
 	test.testConfig(t)
@@ -125,6 +126,18 @@ func TestIsContextNotFound(t *testing.T) {
 
 	err := Validate(*config)
 	if !IsContextNotFound(err) {
+		t.Errorf("Expected context not found, but got %v", err)
+	}
+	if !IsConfigurationInvalid(err) {
+		t.Errorf("Expected configuration invalid, but got %v", err)
+	}
+}
+
+func TestIsEmptyConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+
+	err := Validate(*config)
+	if !IsEmptyConfig(err) {
 		t.Errorf("Expected context not found, but got %v", err)
 	}
 	if !IsConfigurationInvalid(err) {
@@ -177,7 +190,7 @@ func TestValidateEmptyClusterInfo(t *testing.T) {
 	config.Clusters["empty"] = &clientcmdapi.Cluster{}
 	test := configValidationTest{
 		config:                 config,
-		expectedErrorSubstring: []string{"no server found for"},
+		expectedErrorSubstring: []string{"cluster has no server defined"},
 	}
 
 	test.testCluster("empty", t)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
@@ -320,6 +320,11 @@ func NewOrDie(c *Config) *Client {
 // running inside a pod running on kuberenetes. It will return an error if
 // called from a process not running in a kubernetes environment.
 func InClusterConfig() (*Config, error) {
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if len(host) == 0 || len(port) == 0 {
+		return nil, fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
+	}
+
 	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountTokenKey)
 	if err != nil {
 		return nil, err
@@ -334,7 +339,7 @@ func InClusterConfig() (*Config, error) {
 
 	return &Config{
 		// TODO: switch to using cluster DNS.
-		Host:            "https://" + net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")),
+		Host:            "https://" + net.JoinHostPort(host, port),
 		BearerToken:     string(token),
 		TLSClientConfig: tlsClientConfig,
 	}, nil

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -187,7 +187,12 @@ atomic-enterprise start \
 	"${NODE_CONFIG_DIR}/node-config.yaml"
 
 # test client not configured
-[ "$(oc get services 2>&1 | grep 'Error in configuration')" ]
+[ "$(oc get services 2>&1 | grep 'No configuration file found, please login')" ]
+unused_port="33333"
+# setting env bypasses the not configured message
+[ "$(KUBERNETES_MASTER=http://${API_HOST}:${unused_port} oc get services 2>&1 | grep 'did you specify the right host or port')" ]
+# setting --server bypasses the not configured message
+[ "$(oc get services --server=http://${API_HOST}:${unused_port} 2>&1 | grep 'did you specify the right host or port')" ]
 
 # Set KUBERNETES_MASTER for oc from now on
 export KUBERNETES_MASTER="${API_SCHEME}://${API_HOST}:${API_PORT}"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -65,7 +65,7 @@ function configure_os_server {
 	# find the same IP that openshift start will bind to.	This allows access from pods that have to talk back to master
 	if [[ -z "${ALL_IP_ADDRESSES-}" ]]; then
 		ALL_IP_ADDRESSES="$(openshift start --print-ip)"
-		SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},localhost"
+		SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},localhost,172.30.0.1"
 
 		while read -r IP_ADDRESS
 		do

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -137,6 +137,25 @@ oc login -u e2e-user
 oc project test
 oc whoami
 
+echo "[INFO] Running a CLI command in a container using the service account"
+echo "[INFO] WARNING: Tests are set to not fail, dockererized container is writing an invalid ca.crt"
+set +e
+oc policy add-role-to-user view -z default
+out=$(oc run cli-with-token --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 2>&1)
+echo $out
+[ "$(echo $out | grep 'Using in-cluster configuration')" ]
+[ "$(echo $out | grep 'In project test')" ]
+oc delete pod cli-with-token
+out=$(oc run cli-with-token-2 --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never -- cli whoami --loglevel=4 2>&1)
+echo $out
+[ "$(echo $out | grep 'system:serviceaccount:test:default')" ]
+oc delete pod cli-with-token-2
+out=$(oc run kubectl-with-token --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never --command -- kubectl get pods --loglevel=4 2>&1)
+echo $out
+[ "$(echo $out | grep 'Using in-cluster configuration')" ]
+[ "$(echo $out | grep 'kubectl-with-token')" ]
+set -e
+
 echo "[INFO] Streaming the logs from a deployment twice..."
 oc create -f test/fixtures/failing-dc.yaml
 tryuntil oc get rc/failing-dc-1


### PR DESCRIPTION
Because we set the default env value to empty, we can't use the default
in cluster config for 'oc' (when you run inside a container, oc works).
It's really important for container integration scenarios that oc uses
the service account token by default, just like kubeconfig.

Regression from upstream kubectl behavior, blocks a significant amount of
real integrations inside containers.