### PR TITLE
Allow name generation on rolebindings

### DIFF
--- a/pkg/authorization/registry/rolebinding/strategy.go
+++ b/pkg/authorization/registry/rolebinding/strategy.go
@@ -40,7 +40,7 @@ func (strategy) AllowUnconditionalUpdate() bool {
 }
 
 func (s strategy) GenerateName(base string) string {
-	return base
+	return kapi.SimpleNameGenerator.GenerateName(base)
 }
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.


### PR DESCRIPTION
@deads2k not a 1.1 blocker, but noticed this while working on other things. Still
need the "allow easy rolebinding without guessing name" stuff.