### PR TITLE
Allow a service account installation

### DIFF
--- a/pkg/authorization/api/helpers.go
+++ b/pkg/authorization/api/helpers.go
@@ -124,8 +124,8 @@ func BuildSubjects(users, groups []string, userNameValidator, groupNameValidator
 // StringSubjectsFor returns users and groups for comparison against user.Info.  currentNamespace is used to
 // to create usernames for service accounts where namespace=="".
 func StringSubjectsFor(currentNamespace string, subjects []kapi.ObjectReference) ([]string, []string) {
-	users := []string{}
-	groups := []string{}
+	// these MUST be nil to indicate empty
+	var users, groups []string
 
 	for _, subject := range subjects {
 		switch subject.Kind {
@@ -134,7 +134,9 @@ func StringSubjectsFor(currentNamespace string, subjects []kapi.ObjectReference)
 			if len(subject.Namespace) > 0 {
 				namespace = subject.Namespace
 			}
-			users = append(users, serviceaccount.MakeUsername(namespace, subject.Name))
+			if len(namespace) > 0 {
+				users = append(users, serviceaccount.MakeUsername(namespace, subject.Name))
+			}
 
 		case UserKind, SystemUserKind:
 			users = append(users, subject.Name)

--- a/pkg/generate/app/builder.go
+++ b/pkg/generate/app/builder.go
@@ -86,24 +86,29 @@ func isGeneratorJobImageStreamTag(stream *imageapi.ImageStream, tag string) bool
 
 func parseGenerateTokenAs(value string) (*TokenInput, error) {
 	parts := strings.SplitN(value, ":", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("label %s=%s; expected 'env:<NAME>' or not set", labelGenerateTokenAs, value)
-	}
 	switch parts[0] {
 	case "env":
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("label %s=%s; expected 'env:<NAME>' or not set", labelGenerateTokenAs, value)
+		}
 		name := strings.TrimSpace(parts[1])
 		if len(name) == 0 {
 			return nil, fmt.Errorf("label %s=%s; expected 'env:<NAME>' but name was empty", labelGenerateTokenAs, value)
 		}
 		return &TokenInput{Env: &name}, nil
 	case "file":
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("label %s=%s; expected 'file:<PATH>' or not set", labelGenerateTokenAs, value)
+		}
 		name := strings.TrimSpace(parts[1])
 		if len(name) == 0 {
 			return nil, fmt.Errorf("label %s=%s; expected 'file:<PATH>' but path was empty", labelGenerateTokenAs, value)
 		}
 		return &TokenInput{File: &name}, nil
+	case "serviceaccount":
+		return &TokenInput{ServiceAccount: true}, nil
 	default:
-		return nil, fmt.Errorf("unrecognized value for label %s=%s; expected 'env:<NAME>'", labelGenerateTokenAs, value)
+		return nil, fmt.Errorf("unrecognized value for label %s=%s; expected 'env:<NAME>', 'file:<PATH>', or 'serviceaccount'", labelGenerateTokenAs, value)
 	}
 }
 
@@ -113,8 +118,9 @@ const (
 )
 
 type TokenInput struct {
-	Env  *string
-	File *string
+	Env            *string
+	File           *string
+	ServiceAccount bool
 }
 
 type GeneratorInput struct {

--- a/pkg/generate/app/cmd/describe.go
+++ b/pkg/generate/app/cmd/describe.go
@@ -193,17 +193,26 @@ func describeGeneratedJob(out io.Writer, ref app.ComponentReference, pod *kapi.P
 	fmt.Fprintf(out, "    * Install will run in pod %q\n", localOrRemoteName(pod.ObjectMeta, baseNamespace))
 	switch {
 	case secret != nil:
-		fmt.Fprintf(out, "    * The pod has access to your current session token through the secret %q\n", localOrRemoteName(secret.ObjectMeta, baseNamespace))
-		fmt.Fprintf(out, "    * If you cancel the install, you should delete the secret or log out of your session\n")
+		fmt.Fprintf(out, "    * The pod has access to your current session token through the secret %q.\n", localOrRemoteName(secret.ObjectMeta, baseNamespace))
+		fmt.Fprintf(out, "      If you cancel the install, you should delete the secret or log out of your session.\n")
 	case hasToken && generatorInput.Token.Env != nil:
-		fmt.Fprintf(out, "    * The pod has access to your current session token via environment variable %s\n", *generatorInput.Token.Env)
-		fmt.Fprintf(out, "    * If you cancel the install, you should delete the pod or log out of your session\n")
+		fmt.Fprintf(out, "    * The pod has access to your current session token via environment variable %s.\n", *generatorInput.Token.Env)
+		fmt.Fprintf(out, "      If you cancel the install, you should delete the pod or log out of your session.\n")
+	case hasToken && generatorInput.Token.ServiceAccount:
+		fmt.Fprintf(out, "    * The pod will use the 'installer' service account. If this account does not exist\n")
+		fmt.Fprintf(out, "      with sufficient permissions, you may need to ask a project admin set it up.\n")
 	case hasToken:
-		fmt.Fprintf(out, "    * The pod has access to your current session token. Please delete the pod if you cancel the install\n")
+		fmt.Fprintf(out, "    * The pod has access to your current session token. Please delete the pod if you cancel the install.\n")
 	}
 	if hasToken {
-		fmt.Fprintf(out, "--> WARNING: The pod requires access to your current session token to install this image. Only\n")
-		fmt.Fprintf(out, "      grant access to images whose source you trust. The image will be able to perform any\n")
-		fmt.Fprintf(out, "      action you can take on the cluster.\n")
+		if generatorInput.Token.ServiceAccount {
+			fmt.Fprintf(out, "--> WARNING: The pod requires access to the 'installer' service account to install this\n")
+			fmt.Fprintf(out, "      image. Only grant access to images whose source you trust. The image will be able\n")
+			fmt.Fprintf(out, "      to act as an editor within this project.\n")
+		} else {
+			fmt.Fprintf(out, "--> WARNING: The pod requires access to your current session token to install this image. Only\n")
+			fmt.Fprintf(out, "      grant access to images whose source you trust. The image will be able to perform any\n")
+			fmt.Fprintf(out, "      action you can take on the cluster.\n")
+		}
 	}
 }

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func skipExternalGit(t *testing.T) {
-	if len(os.Getenv("TEST_ASSETS_HEADLESS")) > 0 || len(os.Getenv("SKIP_EXTERNAL_GIT")) > 0 {
+	if len(os.Getenv("SKIP_EXTERNAL_GIT")) > 0 {
 		t.Skip("external Git tests are disabled")
 	}
 }
@@ -214,6 +214,7 @@ func TestBuildTemplates(t *testing.T) {
 		appCfg.Out = &bytes.Buffer{}
 		appCfg.refBuilder = &app.ReferenceBuilder{}
 		appCfg.SetOpenShiftClient(&client.Fake{}, c.namespace)
+		appCfg.KubeClient = ktestclient.NewSimpleFake()
 		appCfg.templateSearcher = fakeTemplateSearcher()
 		appCfg.AddArguments([]string{c.templateName})
 		appCfg.TemplateParameters = util.StringList{}

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -111,7 +111,7 @@ tryuntil oc get imagestreamtags installable:token
 tryuntil oc get imagestreamtags installable:serviceaccount
 [ ! "$(oc new-app installable:file)" ]
 [ "$(oc new-app installable:file 2>&1 | grep 'requires that you grant the image access')" ]
-[ "$(oc new-app installable:serviceaccount 2>&1 | grep "requires that you create the 'installer' service account")" ]
+[ "$(oc new-app installable:serviceaccount 2>&1 | grep "requires an 'installer' service account with project editor access")" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F '/var/run/openshift.secret.token')" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F 'activeDeadlineSeconds: 14400')" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F 'openshift.io/generated-job: "true"')" ]

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -108,13 +108,18 @@ tryuntil oc project "${project}"
 
 tryuntil oc get imagestreamtags installable:file
 tryuntil oc get imagestreamtags installable:token
+tryuntil oc get imagestreamtags installable:serviceaccount
 [ ! "$(oc new-app installable:file)" ]
 [ "$(oc new-app installable:file 2>&1 | grep 'requires that you grant the image access')" ]
+[ "$(oc new-app installable:serviceaccount 2>&1 | grep "requires that you create the 'installer' service account")" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F '/var/run/openshift.secret.token')" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F 'activeDeadlineSeconds: 14400')" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F 'openshift.io/generated-job: "true"')" ]
 [ "$(oc new-app installable:file --grant-install-rights -o yaml | grep -F 'openshift.io/generated-job.for: installable:file')" ]
 [ "$(oc new-app installable:token --grant-install-rights -o yaml | grep -F 'name: TOKEN_ENV')" ]
 [ "$(oc new-app installable:token --grant-install-rights -o yaml | grep -F 'openshift/origin@sha256:')" ]
+[ "$(oc new-app installable:serviceaccount --grant-install-rights -o yaml | grep -F 'serviceAccountName: installer')" ]
+[ "$(oc new-app installable:serviceaccount --grant-install-rights -o yaml | grep -F 'fieldPath: metadata.namespace')" ]
+[ "$(oc new-app installable:serviceaccount --grant-install-rights -o yaml A=B | grep -F 'name: A')" ]
 
 echo "new-app: ok"

--- a/test/fixtures/installable-stream.yaml
+++ b/test/fixtures/installable-stream.yaml
@@ -28,3 +28,10 @@ spec:
     from:
       kind: DockerImage
       name: openshift/origin:v1.0.6
+  - name: serviceaccount
+    annotations:
+      io.openshift.generate.job: "true"
+      io.openshift.generate.token.as: "serviceaccount"
+    from:
+      kind: DockerImage
+      name: openshift/origin:v1.0.6


### PR DESCRIPTION
Allow a service account to be used as the installation target. Can
potentially simplify metrics and logging installation.

@liggitt review please, low impact to other components but potential
better story for integrators