### PR TITLE
pre-set the SA namespaces

### DIFF
--- a/pkg/cmd/admin/policy/modify_roles.go
+++ b/pkg/cmd/admin/policy/modify_roles.go
@@ -248,7 +248,7 @@ func (o *RoleModificationOptions) CompleteUserWithSA(f *clientcmd.Factory, args 
 	o.RoleBindingAccessor = NewLocalRoleBindingAccessor(roleBindingNamespace, osClient)
 
 	for _, sa := range saNames {
-		o.Subjects = append(o.Subjects, kapi.ObjectReference{Name: sa, Kind: "ServiceAccount"})
+		o.Subjects = append(o.Subjects, kapi.ObjectReference{Namespace: roleBindingNamespace, Name: sa, Kind: "ServiceAccount"})
 	}
 
 	return nil

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -70,6 +70,14 @@ oadm policy who-can get pods --all-namespaces
 
 oadm policy add-role-to-group cluster-admin system:unauthenticated
 oadm policy add-role-to-user cluster-admin system:no-user
+oadm policy add-role-to-user admin -z fake-sa
+oc get rolebinding/admins -o jsonpath={.subjects} | grep "fake-sa"
+oadm policy remove-role-from-user admin -z fake-sa
+[ ! "$(oc get rolebinding/admins -o jsonpath={.subjects} | grep 'fake-sa')" ]
+oadm policy add-role-to-user admin -z fake-sa
+oc get rolebinding/admins -o jsonpath={.subjects} | grep "fake-sa"
+oadm policy remove-role-from-user admin "system:serviceaccount:$(oc project -q):fake-sa"
+[ ! "$(oc get rolebinding/admins -o jsonpath={.subjects} | grep 'fake-sa')" ]
 oadm policy remove-role-from-group cluster-admin system:unauthenticated
 oadm policy remove-role-from-user cluster-admin system:no-user
 oadm policy remove-group system:unauthenticated


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1278354

The namespace gets fully qualified during creation so that it is unambiguous.  It happens as part of the serialization that forces "matching" usernames and subjects.  Since the string representation is always qualified, the subject is always qualified.

 