### PR TITLE
Handle openshift.io/build-config.name label as well as buildconfig

### DIFF
--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -162,7 +162,7 @@ func TestGraph(t *testing.T) {
 		{
 			ObjectMeta: kapi.ObjectMeta{
 				Name:              "build1-1-abc",
-				Labels:            map[string]string{buildapi.DeprecatedBuildConfigLabel: "build1"},
+				Labels:            map[string]string{buildapi.BuildConfigLabelDeprecated: "build1"},
 				CreationTimestamp: unversioned.NewTime(now.Add(-10 * time.Second)),
 			},
 			Status: buildapi.BuildStatus{
@@ -172,7 +172,7 @@ func TestGraph(t *testing.T) {
 		{
 			ObjectMeta: kapi.ObjectMeta{
 				Name:              "build1-2-abc",
-				Labels:            map[string]string{buildapi.DeprecatedBuildConfigLabel: "build1"},
+				Labels:            map[string]string{buildapi.BuildConfigLabelDeprecated: "build1"},
 				CreationTimestamp: unversioned.NewTime(now.Add(-5 * time.Second)),
 			},
 			Status: buildapi.BuildStatus{
@@ -182,7 +182,7 @@ func TestGraph(t *testing.T) {
 		{
 			ObjectMeta: kapi.ObjectMeta{
 				Name:              "build1-3-abc",
-				Labels:            map[string]string{buildapi.DeprecatedBuildConfigLabel: "build1"},
+				Labels:            map[string]string{buildapi.BuildConfigLabelDeprecated: "build1"},
 				CreationTimestamp: unversioned.NewTime(now.Add(-15 * time.Second)),
 			},
 			Status: buildapi.BuildStatus{

--- a/pkg/build/api/helpers.go
+++ b/pkg/build/api/helpers.go
@@ -17,3 +17,36 @@ func BuildToPodLogOptions(opts *BuildLogOptions) *kapi.PodLogOptions {
 		LimitBytes:   opts.LimitBytes,
 	}
 }
+
+// PredicateFunc is testing an argument and decides does it meet some criteria or not.
+// It can be used for filtering elements based on some conditions.
+type PredicateFunc func(interface{}) bool
+
+// FilterBuilds returns array of builds that satisfies predicate function.
+func FilterBuilds(builds []Build, predicate PredicateFunc) []Build {
+	if len(builds) == 0 {
+		return builds
+	}
+
+	result := make([]Build, 0)
+	for _, build := range builds {
+		if predicate(build) {
+			result = append(result, build)
+		}
+	}
+
+	return result
+}
+
+// ByBuildConfigLabelPredicate matches all builds that have build config label with specified value.
+func ByBuildConfigLabelPredicate(labelValue string) PredicateFunc {
+	return func(arg interface{}) bool {
+		return (hasBuildConfigLabel(arg.(Build), BuildConfigLabel, labelValue) ||
+			hasBuildConfigLabel(arg.(Build), BuildConfigLabelDeprecated, labelValue))
+	}
+}
+
+func hasBuildConfigLabel(build Build, labelName, labelValue string) bool {
+	value, ok := build.Labels[labelName]
+	return ok && value == labelValue
+}

--- a/pkg/build/api/helpers_test.go
+++ b/pkg/build/api/helpers_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"strings"
+)
+
+func TestFilterBuilds_withEmptyArray(t *testing.T) {
+	actual := FilterBuilds([]Build{}, nil)
+	assertThatArrayIsEmpty(t, actual)
+}
+
+func TestFilterBuilds_withAllElementsAccepted(t *testing.T) {
+	expected := []Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "build1-abc",
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "build2-abc",
+			},
+		},
+	}
+
+	alwaysTruePredicate := func(arg interface{}) bool {
+		return true
+	}
+
+	actual := FilterBuilds(expected, alwaysTruePredicate)
+	assertThatArraysAreEquals(t, actual, expected)
+}
+
+func TestFilterBuilds_withFilteredElements(t *testing.T) {
+	input := []Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "skip1-abc",
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "build2-abc",
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name: "skip3-abc",
+			},
+		},
+	}
+
+	expected := []Build{input[1]}
+
+	skipByNamePrefixPredicate := func(arg interface{}) bool {
+		return !strings.HasPrefix(arg.(Build).Name, "skip")
+	}
+
+	actual := FilterBuilds(input, skipByNamePrefixPredicate)
+	assertThatArraysAreEquals(t, actual, expected)
+}
+
+func TestByBuildConfigLabelPredicate_withBuildConfigLabel(t *testing.T) {
+	input := []Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build1-abc",
+				Labels: map[string]string{BuildConfigLabel: "foo"},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build2-abc",
+				Labels: map[string]string{"bar": "baz"},
+			},
+		},
+	}
+
+	expected := []Build{input[0]}
+
+	actual := FilterBuilds(input, ByBuildConfigLabelPredicate("foo"))
+	assertThatArraysAreEquals(t, actual, expected)
+
+	actual = FilterBuilds(input, ByBuildConfigLabelPredicate("not-foo"))
+	assertThatArrayIsEmpty(t, actual)
+}
+
+func TestByBuildConfigLabelPredicate_withBuildConfigLabelDeprecated(t *testing.T) {
+	input := []Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build1-abc",
+				Labels: map[string]string{BuildConfigLabelDeprecated: "foo"},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build2-abc",
+				Labels: map[string]string{"bar": "baz"},
+			},
+		},
+	}
+
+	expected := []Build{input[0]}
+
+	actual := FilterBuilds(input, ByBuildConfigLabelPredicate("foo"))
+	assertThatArraysAreEquals(t, actual, expected)
+
+	actual = FilterBuilds(input, ByBuildConfigLabelPredicate("not-foo"))
+	assertThatArrayIsEmpty(t, actual)
+}
+
+func TestByBuildConfigLabelPredicate_withBothBuildConfigLabels(t *testing.T) {
+	input := []Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build1-abc",
+				Labels: map[string]string{BuildConfigLabel: "foo"},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build2-abc",
+				Labels: map[string]string{"bar": "baz"},
+			},
+		},
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build3-abc",
+				Labels: map[string]string{BuildConfigLabelDeprecated: "foo"},
+			},
+		},
+	}
+
+	expected := []Build{input[0], input[2]}
+
+	actual := FilterBuilds(input, ByBuildConfigLabelPredicate("foo"))
+	assertThatArraysAreEquals(t, actual, expected)
+
+	actual = FilterBuilds(input, ByBuildConfigLabelPredicate("not-foo"))
+	assertThatArrayIsEmpty(t, actual)
+}
+
+func TestByBuildConfigLabelPredicate_withoutBuildConfigLabels(t *testing.T) {
+	input := []Build{
+		{
+			ObjectMeta: kapi.ObjectMeta{
+				Name:   "build1-abc",
+				Labels: map[string]string{"bar": "baz"},
+			},
+		},
+	}
+
+	actual := FilterBuilds(input, ByBuildConfigLabelPredicate("not-foo"))
+	assertThatArrayIsEmpty(t, actual)
+}
+
+func assertThatArraysAreEquals(t *testing.T, expected, actual []Build) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %v\ngot: %v", expected, actual)
+	}
+}
+
+func assertThatArrayIsEmpty(t *testing.T, array []Build) {
+	if len(array) != 0 {
+		t.Errorf("expected empty array, got %v", array)
+	}
+}

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -407,9 +407,9 @@ const (
 	// BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig
 	// on which the Build is based.
 	BuildConfigLabel = "openshift.io/build-config.name"
-	// DeprecatedBuildConfigLabel was used as BuildConfigLabel before adding namespaces.
+	// BuildConfigLabelDeprecated was used as BuildConfigLabel before adding namespaces.
 	// We keep it for backward compatibility.
-	DeprecatedBuildConfigLabel = "buildconfig"
+	BuildConfigLabelDeprecated = "buildconfig"
 )
 
 // BuildConfig is a template which can be used to create new builds.

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -351,7 +351,7 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 	if build.Labels == nil {
 		build.Labels = make(map[string]string)
 	}
-	build.Labels[buildapi.DeprecatedBuildConfigLabel] = bcCopy.Name
+	build.Labels[buildapi.BuildConfigLabelDeprecated] = bcCopy.Name
 	build.Labels[buildapi.BuildConfigLabel] = bcCopy.Name
 
 	builderSecrets, err := g.FetchServiceAccountSecrets(bc.Namespace, serviceAccount)

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -601,7 +601,7 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 	if build.Labels[buildapi.BuildConfigLabel] != bc.Name {
 		t.Errorf("Build does not contain labels from BuildConfig")
 	}
-	if build.Labels[buildapi.DeprecatedBuildConfigLabel] != bc.Name {
+	if build.Labels[buildapi.BuildConfigLabelDeprecated] != bc.Name {
 		t.Errorf("Build does not contain labels from BuildConfig")
 	}
 	if build.Status.Config.Name != bc.Name || build.Status.Config.Namespace != bc.Namespace || build.Status.Config.Kind != "BuildConfig" {

--- a/pkg/build/graph/helpers.go
+++ b/pkg/build/graph/helpers.go
@@ -53,7 +53,10 @@ func belongsToBuildConfig(config *buildapi.BuildConfig, b *buildapi.Build) bool 
 	if b.Labels == nil {
 		return false
 	}
-	if b.Labels[buildapi.DeprecatedBuildConfigLabel] == config.Name {
+	if b.Labels[buildapi.BuildConfigLabel] == config.Name {
+		return true
+	}
+	if b.Labels[buildapi.BuildConfigLabelDeprecated] == config.Name {
 		return true
 	}
 	return false

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -377,10 +377,11 @@ func (d *BuildConfigDescriber) Describe(namespace, name string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	buildList, err := d.Builds(namespace).List(labels.SelectorFromSet(labels.Set{buildapi.DeprecatedBuildConfigLabel: name}), fields.Everything())
+	buildList, err := d.Builds(namespace).List(labels.Everything(), fields.Everything())
 	if err != nil {
 		return "", err
 	}
+	buildList.Items = buildapi.FilterBuilds(buildList.Items, buildapi.ByBuildConfigLabelPredicate(name))
 
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, buildConfig.ObjectMeta)

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -261,11 +261,11 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 			if !ok {
 				return nil, errors.New("provided options object is not a BuildLogOptions")
 			}
-			buildsForBCSelector := labels.SelectorFromSet(map[string]string{buildapi.DeprecatedBuildConfigLabel: t.Name})
-			builds, err := oc.Builds(t.Namespace).List(buildsForBCSelector, fields.Everything())
+			builds, err := oc.Builds(t.Namespace).List(labels.Everything(), fields.Everything())
 			if err != nil {
 				return nil, err
 			}
+			builds.Items = buildapi.FilterBuilds(builds.Items, buildapi.ByBuildConfigLabelPredicate(t.Name))
 			if len(builds.Items) == 0 {
 				return nil, fmt.Errorf("no builds found for %s", t.Name)
 			}


### PR DESCRIPTION
I've updated code with to handle new label in the same fashion as old one.

@bparees @mfojtik PTAL

Actually these changes should be made during the fix of #4810