### PR TITLE
allow unknown secret types

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -4049,6 +4049,7 @@ _oc_secrets_new()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--confirm")
     flags+=("--no-headers")
     flags+=("--output=")
     two_word_flags+=("-o")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -8776,6 +8776,7 @@ _openshift_cli_secrets_new()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--confirm")
     flags+=("--no-headers")
     flags+=("--output=")
     two_word_flags+=("-o")

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -9,6 +9,9 @@ source "${OS_ROOT}/hack/util.sh"
 os::log::install_errexit
 
 # This test validates secret interaction
+[ "$(oc secrets new foo --type=blah makefile=Makefile 2>&1 | grep 'error: unknown secret type "blah"')" ]
+oc secrets new foo --type=blah makefile=Makefile --confirm
+oc get secrets/foo -o jsonpath={.type} | grep 'blah'
 
 oc secrets new-dockercfg dockercfg --docker-username=sample-user --docker-password=sample-password --docker-email=fake@example.org
 # can't use a go template here because the output needs to be base64 decoded.  base64 isn't installed by default in all distros


### PR DESCRIPTION
We need to allow secrets of unknown types so that we can handle new types as they are created upstream.  We can't do any checking of file validity if we don't recognize the type, so this pull requires a flag.

Found this while looking at the new image pull secret format.