### PR TITLE
Let users select log content without line numbers

### DIFF
--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -11,13 +11,19 @@ angular.module('openshiftConsole')
     'logLinks',
     function($sce, $timeout, $window, AuthService, APIDiscovery, DataService, logLinks) {
 
-      // Create a template for each log line that we clone below.
-      var logLineTemplate = $('<div row class="log-line"/>');
-      $('<div class="log-line-number"><div row flex main-axis="end"></div></div>').appendTo(logLineTemplate);
-      $('<div flex class="log-line-text"/>').appendTo(logLineTemplate);
-
       // Keep a reference the DOM node rather than the jQuery object for cloneNode.
-      logLineTemplate = logLineTemplate.get(0);
+      var logLineTemplate =
+        $('<tr class="log-line">' +
+          '<td class="log-line-number"></td>' +
+          '<td class="log-line-text"></td>' +
+          '</tr>').get(0);
+      var buildLogLineNode = function(lineNumber, text) {
+        var line = logLineTemplate.cloneNode(true);
+        line.firstChild.appendChild(document.createTextNode(lineNumber));
+        line.lastChild.appendChild(document.createTextNode(text));
+
+        return line;
+      };
 
       return {
         restrict: 'AE',
@@ -154,13 +160,8 @@ angular.module('openshiftConsole')
               var lastLineNumber = 0;
               var addLine = function(text) {
                 lastLineNumber++;
-
                 // Append the line to the document fragment buffer.
-                var line = logLineTemplate.cloneNode(true);
-                line.childNodes[0].childNodes[0].appendChild(document.createTextNode(lastLineNumber));
-                line.lastChild.appendChild(document.createTextNode(text));
-                buffer.appendChild(line);
-
+                buffer.appendChild(buildLogLineNode(lastLineNumber, text));
                 update();
               };
 

--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -65,19 +65,13 @@
   .log-view-output {
     font-size: 12px;
     padding: 30px 0 30px;
-    &:before {
-      content: '';
-      display: block;
-      height: 100%;
-      width: 1px;
-      background-color: lighten(@log-bg-color, 10%);
-      top: 0;
-      left: 60px;
-      position: absolute;
-    }
     .ellipsis-loader {
       // Give space between log output and loader
       margin-top: 30px;
+    }
+    table {
+      table-layout: fixed;
+      width: 100%;
     }
   }
 }
@@ -100,18 +94,22 @@
   }
 }
 .log-line-number {
-  .flex(@columns: 0 0 60px); // set width of number column
+  .unselectable();
+  border-right: 1px lighten(@log-bg-color, 10%) solid;
+  padding-right: 10px;
+  text-align: right;
+  vertical-align: top;
+  white-space: nowrap;
+  width: 60px;
   &:hover, &:focus {
     background-color: lighten(@log-bg-color, 13%);
     color: @link-hover-color-bright;
-  }
-  div {
-    padding-right: 10px;
   }
 }
 .log-line-text {
   padding: 0 10px;
   white-space: pre-wrap;
+  width: 100%;
   .word-break();
 }
 .log-chromeless {

--- a/assets/app/styles/_mixins.less
+++ b/assets/app/styles/_mixins.less
@@ -52,4 +52,8 @@
   background-image: linear-gradient(@angle, @color 25%, transparent 25%, transparent 50%, @color 50%, @color 75%, transparent 75%, transparent);
 }
 
-
+.unselectable() {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}

--- a/assets/app/views/directives/logs/_log-formatted.html
+++ b/assets/app/views/directives/logs/_log-formatted.html
@@ -19,7 +19,9 @@
       </a>
     </div>
     <div flex column class="log-view-output">
-      <div id="logContent"></div>
+      <table>
+        <tbody id="logContent"></tbody>
+      </table>
       <div row main-axis="center">
         <ellipsis-loader ng-show="loading"></ellipsis-loader>
       </div>


### PR DESCRIPTION
Add a mixin for browser prefixed user-select: none styles. Switch to a table for log content so user-select works properly in Safari.

/cc @jwforres 