### PR TITLE
Clean up extension API resources on namespace delete

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -65,7 +65,7 @@ echo
 
 # setup the test dirs
 export ETCD_DIR=${BASETMPDIR}/etcd
-etcdlog="${ETCD_DIR}/etcd.log"
+etcdlog="${BASETMPDIR}/etcd.log"
 testdir="${OS_ROOT}/_output/testbin/${package}"
 name="$(basename ${testdir})"
 testexec="${testdir}/${name}.test"
@@ -74,11 +74,13 @@ mkdir -p "${ETCD_DIR}"
 
 # build the test executable (cgo must be disabled to have the symbol table available)
 pushd "${testdir}" &>/dev/null
+echo "Building test executable..."
 CGO_ENABLED=0 go test -c -tags="${tags}" "${OS_GO_PACKAGE}/${package}"
 popd &>/dev/null
 
 
 # Start etcd
+echo "Starting etcd..."
 etcd -name test -data-dir ${ETCD_DIR} \
  --listen-peer-urls http://${ETCD_HOST}:${ETCD_PEER_PORT} \
  --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} \
@@ -111,12 +113,12 @@ function exectest() {
 
 	if [[ ${result} -eq 0 ]]; then
 		tput setaf 2 # green
-		echo "ok			$1"
+		echo "ok      $1"
 		tput sgr0		# reset
 		exit 0
 	else
 		tput setaf 1 # red
-		echo "failed	$1"
+		echo "failed  $1"
 		tput sgr0		# reset
 		echo "${out}"
 		exit 1

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -63,8 +63,9 @@ func (c *MasterConfig) InstallAPI(container *restful.Container) []string {
 
 // RunNamespaceController starts the Kubernetes Namespace Manager
 func (c *MasterConfig) RunNamespaceController() {
-	// TODO: Add OR c.ControllerManager.EnableDeploymentController once we have upstream deployments
-	experimentalMode := c.ControllerManager.EnableExperimental
+	// we now have several of the kube "experimental" pieces enabled in Origin, so this needs to be
+	// enabled whenever we have the "experimental" APIs enabled.
+	experimentalMode := c.Master.EnableExp
 	namespaceController := namespacecontroller.NewNamespaceController(c.KubeClient, experimentalMode, c.ControllerManager.NamespaceSyncPeriod)
 	namespaceController.Run()
 }

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -216,6 +216,9 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 		},
 	}
 
+	// set for consistency -- Origin only used m.EnableExp
+	cmserver.EnableExperimental = m.EnableExp
+
 	if options.DNSConfig != nil {
 		_, dnsPortStr, err := net.SplitHostPort(options.DNSConfig.BindAddress)
 		if err != nil {

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -551,8 +551,10 @@ func startControllers(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) erro
 		kc.RunNodeController()
 		kc.RunScheduler()
 		kc.RunReplicationController(rcClient)
-		kc.RunJobController(jobClient)
-		kc.RunHPAController(hpaOClient, hpaKClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace)
+		if kc.Master.EnableExp {
+			kc.RunJobController(jobClient)
+			kc.RunHPAController(hpaOClient, hpaKClient, oc.Options.PolicyConfig.OpenShiftInfrastructureNamespace)
+		}
 		kc.RunEndpointController()
 		kc.RunNamespaceController()
 		kc.RunPersistentVolumeClaimBinder()

--- a/test/integration/extensions_api_deletion_test.go
+++ b/test/integration/extensions_api_deletion_test.go
@@ -1,0 +1,108 @@
+// +build integration,etcd
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	expapi "k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+func TestExtensionsAPIDeletion(t *testing.T) {
+	const projName = "ext-deletion-proj"
+
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// create the containing project
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+		t.Fatalf("unexpected error creating the project: %v", err)
+	}
+	projectAdminClient, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	if err != nil {
+		t.Fatalf("unexpected error getting project admin client: %v", err)
+	}
+	// TODO: switch to checking "list","horizontalpodautoscalers" once SAR supports API groups
+	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", "pods", true); err != nil {
+		t.Fatalf("unexpected error waiting for policy update: %v", err)
+	}
+
+	// create the extensions resources as the project admin
+	hpa := expapi.HorizontalPodAutoscaler{
+		ObjectMeta: kapi.ObjectMeta{Name: "test-hpa"},
+		Spec: expapi.HorizontalPodAutoscalerSpec{
+			ScaleRef:       expapi.SubresourceReference{Kind: "DeploymentConfig", Name: "frontend", APIVersion: "v1", Subresource: "scale"},
+			MaxReplicas:    10,
+			CPUUtilization: &expapi.CPUTargetUtilization{TargetPercentage: 10},
+		},
+	}
+	if _, err := projectAdminKubeClient.Extensions().HorizontalPodAutoscalers(projName).Create(&hpa); err != nil {
+		t.Fatalf("unexpected error creating the HPA object: %v", err)
+	}
+
+	job := expapi.Job{
+		ObjectMeta: kapi.ObjectMeta{Name: "test-job"},
+		Spec: expapi.JobSpec{
+			Selector: &expapi.PodSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			Template: kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+				Spec: kapi.PodSpec{
+					Containers:    []kapi.Container{{Name: "baz", Image: "run"}},
+					RestartPolicy: kapi.RestartPolicyOnFailure,
+				},
+			},
+		},
+	}
+	if _, err := projectAdminKubeClient.Extensions().Jobs(projName).Create(&job); err != nil {
+		t.Fatalf("unexpected error creating the job object: %v", err)
+	}
+
+	if err := clusterAdminClient.Projects().Delete(projName); err != nil {
+		t.Fatalf("unexpected error deleting the project: %v", err)
+	}
+	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := clusterAdminKubeClient.Namespaces().Get(projName)
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatalf("unexpected error while waiting for project to delete: %v", err)
+	}
+
+	if _, err := clusterAdminKubeClient.Extensions().HorizontalPodAutoscalers(projName).Get(hpa.Name); err == nil {
+		t.Fatalf("HPA object was still present after project was deleted!")
+	} else if !errors.IsNotFound(err) {
+		t.Fatalf("Error trying to get deleted HPA object (not a not-found error): %v", err)
+	}
+	if _, err := clusterAdminKubeClient.Extensions().Jobs(projName).Get(job.Name); err == nil {
+		t.Fatalf("Job object was still present after project was deleted!")
+	} else if !errors.IsNotFound(err) {
+		t.Fatalf("Error trying to get deleted Job object (not a not-found error): %v", err)
+	}
+}

--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -1,0 +1,90 @@
+// +build integration,etcd
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+	expapi "k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+func TestExtensionsAPIDisabled(t *testing.T) {
+	const projName = "ext-disabled-proj"
+
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Disable all extensions API versions
+	masterConfig.KubernetesMasterConfig.DisabledAPIGroupVersions = map[string][]string{"extensions": {"*"}}
+
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// create the containing project
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+		t.Fatalf("unexpected error creating the project: %v", err)
+	}
+	projectAdminClient, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	if err != nil {
+		t.Fatalf("unexpected error getting project admin client: %v", err)
+	}
+	// TODO: switch to checking "list","horizontalpodautoscalers" once SAR supports API groups
+	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", "pods", true); err != nil {
+		t.Fatalf("unexpected error waiting for policy update: %v", err)
+	}
+
+	// make sure extensions API objects cannot be listed or created
+	if _, err := projectAdminKubeClient.Extensions().HorizontalPodAutoscalers(projName).List(labels.Everything(), fields.Everything()); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error listing HPA, got %v", err)
+	}
+	if _, err := projectAdminKubeClient.Extensions().HorizontalPodAutoscalers(projName).Create(&expapi.HorizontalPodAutoscaler{}); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error creating HPA, got %v", err)
+	}
+	if _, err := projectAdminKubeClient.Extensions().Jobs(projName).List(labels.Everything(), fields.Everything()); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error listing jobs, got %v", err)
+	}
+	if _, err := projectAdminKubeClient.Extensions().Jobs(projName).Create(&expapi.Job{}); !errors.IsNotFound(err) {
+		t.Fatalf("expected NotFound error creating job, got %v", err)
+	}
+
+	if err := clusterAdminClient.Projects().Delete(projName); err != nil {
+		t.Fatalf("unexpected error deleting the project: %v", err)
+	}
+	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := clusterAdminKubeClient.Namespaces().Get(projName)
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatalf("unexpected error while waiting for project to delete: %v", err)
+	}
+}

--- a/test/integration/web_console_extensions_test.go
+++ b/test/integration/web_console_extensions_test.go
@@ -19,7 +19,7 @@ import (
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
-func TestExtensions(t *testing.T) {
+func TestWebConsoleExtensions(t *testing.T) {
 	// Create a temporary directory.
 	tmpDir, err := ioutil.TempDir("", "extensions")
 	if err != nil {


### PR DESCRIPTION
This commit sets "experimentalMode" on the Namespace controller to
always be true, so that it will always try to delete the
"experimental" resources like HPAs, Jobs, etc.

Fixes bug 1278259
Fixes #5747 