### PR TITLE
UPSTREAM: docker/distribution: <carry>: fixed a push to scaled registry on NFS

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/layerupload.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/layerupload.go
@@ -171,6 +171,9 @@ func (luh *layerUploadHandler) PatchLayerData(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Flush the upload layer data before sending a reponse
+	defer luh.Upload.Close()
+
 	ct := r.Header.Get("Content-Type")
 	if ct != "" && ct != "application/octet-stream" {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
On NFS it takes some time for filesystem changes to propagate to other
instances. Several operations need to be retried until successful.

Resolves rhbz#1277356