### PR TITLE
Fixed push to scaled registry with nfs

### DIFF
--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/layer.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/layer.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/docker/distribution"
 	ctxu "github.com/docker/distribution/context"
@@ -48,9 +49,36 @@ type layerHandler struct {
 // GetLayer fetches the binary data from backend storage returns it in the
 // response.
 func (lh *layerHandler) GetLayer(w http.ResponseWriter, r *http.Request) {
+	var (
+		layer distribution.Layer
+		err   error
+	)
+
 	ctxu.GetLogger(lh).Debug("GetImageLayer")
 	layers := lh.Repository.Layers()
-	layer, err := layers.Fetch(lh.Digest)
+
+	// On NFS, recently pushed layer by another registry instance may be unseen to us
+	// for a second. Retry the fetch few times.
+Loop:
+	for retries := 0; ; retries++ {
+		layer, err = layers.Fetch(lh.Digest)
+		if err == nil {
+			if retries > 0 {
+				ctxu.GetLogger(lh).Debugf("(*layerHandler).GetLayer: layer fetched after %d failed attempts", retries)
+			}
+			break Loop
+		}
+		switch err.(type) {
+		case distribution.ErrUnknownLayer:
+			if retries > 10 {
+				ctxu.GetLogger(lh).Debugf("(*layerHandler).GetLayer: failed fetching layer after %d attempts", retries)
+				break Loop
+			}
+			time.Sleep(100 * time.Millisecond * time.Duration(retries+1))
+		default:
+			break Loop
+		}
+	}
 
 	if err != nil {
 		switch err := err.(type) {

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/layerupload.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/handlers/layerupload.go
@@ -171,6 +171,9 @@ func (luh *layerUploadHandler) PatchLayerData(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Flush the upload layer data before sending a reponse
+	defer luh.Upload.Close()
+
 	ct := r.Header.Get("Content-Type")
 	if ct != "" && ct != "application/octet-stream" {
 		w.WriteHeader(http.StatusBadRequest)

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/layerwriter.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/layerwriter.go
@@ -79,8 +79,26 @@ func (lw *layerWriter) Finish(dgst digest.Digest) (distribution.Layer, error) {
 
 	}
 
-	if err := lw.moveLayer(canonical); err != nil {
-		// TODO(stevvooe): Cleanup?
+	// On NFS filesystem file attributes are cached on client. File may
+	// not exist (os.Stat failes with NotExist) few seconds after the write
+	// has been completed.
+	for retries := 0; ; retries++ {
+		err := lw.moveLayer(canonical)
+		if err == nil {
+			if retries > 0 {
+				ctxu.GetLogger(lw.layerStore.repository.ctx).Debugf("(*layerWriter).Finish: layer moved after %d failed attempts", retries)
+			}
+			break
+		}
+		switch err.(type) {
+		case storagedriver.PathNotFoundError:
+			if retries < 50 {
+				time.Sleep(100 * time.Millisecond * time.Duration(retries+1))
+				continue
+			} else {
+				ctxu.GetLogger(lw.layerStore.repository.ctx).Debugf("(*layerWriter).Finish: failed moving layer after %d attempts", retries)
+			}
+		}
 		return nil, err
 	}
 
@@ -93,7 +111,25 @@ func (lw *layerWriter) Finish(dgst digest.Digest) (distribution.Layer, error) {
 		return nil, err
 	}
 
-	return lw.layerStore.Fetch(canonical)
+	// Fetch layer with a retry. Fetch may fail after an upload of big layer on NFS.
+	for retries := 0; ; retries++ {
+		layer, fetchErr := lw.layerStore.Fetch(canonical)
+		if fetchErr == nil {
+			if retries > 0 {
+				ctxu.GetLogger(lw.layerStore.repository.ctx).Debugf("(*layerWriter).Finish: layer fetched after %d failed attempts", retries)
+			}
+			return layer, nil
+		}
+		switch fetchErr.(type) {
+		case distribution.ErrUnknownLayer:
+			if retries < 3 {
+				time.Sleep(100 * time.Millisecond * time.Duration(retries+1))
+				continue
+			}
+		}
+		err = fetchErr
+	}
+	return nil, err
 }
 
 // Cancel the layer upload process.
@@ -298,8 +334,13 @@ func (lw *layerWriter) validateLayer(dgst digest.Digest) (digest.Digest, error) 
 	)
 
 	if lw.resumableDigester != nil {
+		offset := lw.size
+		if offset < lw.offset {
+			// we're probably on NFS where file attributes are cached on client
+			offset = lw.offset
+		}
 		// Restore the hasher state to the end of the upload.
-		if err := lw.resumeHashAt(lw.size); err != nil {
+		if err := lw.resumeHashAt(offset); err != nil {
 			return "", err
 		}
 
@@ -345,7 +386,7 @@ func (lw *layerWriter) validateLayer(dgst digest.Digest) (digest.Digest, error) 
 	}
 
 	if !verified {
-		ctxu.GetLoggerWithField(lw.layerStore.repository.ctx, "canonical", dgst).
+		ctxu.GetLoggerWithField(lw.layerStore.repository.ctx, "canonical", canonical).
 			Errorf("canonical digest does match provided digest")
 		return "", distribution.ErrLayerInvalidDigest{
 			Digest: dgst,

--- a/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/layerwriter.go
+++ b/Godeps/_workspace/src/github.com/docker/distribution/registry/storage/layerwriter.go
@@ -294,6 +294,8 @@ func (lw *layerWriter) resumeHashAt(offset int64) error {
 			return err
 		}
 
+		defer fr.Close()
+
 		if _, err = fr.Seek(int64(lw.resumableDigester.Len()), os.SEEK_SET); err != nil {
 			return fmt.Errorf("unable to seek to layer reader offset %d: %s", lw.resumableDigester.Len(), err)
 		}
@@ -374,6 +376,8 @@ func (lw *layerWriter) validateLayer(dgst digest.Digest) (digest.Digest, error) 
 		if err != nil {
 			return "", err
 		}
+
+		defer fr.Close()
 
 		tr := io.TeeReader(fr, digester)
 


### PR DESCRIPTION
Original PR: #5749

```
On NFS it takes some time for filesystem changes to propagate to other
instances. Several operations need to be retried until successful.

Resolves rhbz#1277356
```

This breaks out the backport to it's own commit and adds logging if the new retries pass their limits.