### PR TITLE
bump(github.com/openshift/openshift-sdn) d5965ee039bb85c5ec9ef7f455a8…

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -685,12 +685,12 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "cb0e352cd7591ace30d592d4f82685d2bcd38a04"
+			"Rev": "d5965ee039bb85c5ec9ef7f455a8c03ac0ff0214"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "cb0e352cd7591ace30d592d4f82685d2bcd38a04"
+			"Rev": "d5965ee039bb85c5ec9ef7f455a8c03ac0ff0214"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/multitenant/plugins.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/multitenant/plugins.go
@@ -52,11 +52,8 @@ func (plugin *MultitenantPlugin) SetUpPod(namespace string, name string, id kube
 }
 
 func (plugin *MultitenantPlugin) TearDownPod(namespace string, name string, id kubeletTypes.DockerID) error {
-	vnid, found := plugin.OvsController.VNIDMap[namespace]
-	if !found {
-		return fmt.Errorf("Error fetching VNID for namespace: %s", namespace)
-	}
-	out, err := utilexec.New().Command(plugin.getExecutable(), tearDownCmd, namespace, name, string(id), strconv.FormatUint(uint64(vnid), 10)).CombinedOutput()
+	// The script's teardown functionality doesn't need the VNID
+	out, err := utilexec.New().Command(plugin.getExecutable(), tearDownCmd, namespace, name, string(id), "-1").CombinedOutput()
 	glog.V(5).Infof("TearDownPod 'multitenant' network plugin output: %s, %v", string(out), err)
 	return err
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1277383, which if you enable the multitenant plugin and did this sequence:

oc new-project foobar
oc create <some pod>
oc delete project foobar
(or if for some other reason, openshift decided to terminate the pod after the node received the NetNamespace deletion event from the master)

would leave stale OVS rules and a veth pair on the OVS bridge.