### PR TITLE
Secrets in containerized nodes are wrong due to encoding

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/io/writer.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/io/writer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package io
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -49,6 +50,7 @@ func (writer *StdWriter) WriteFile(filename string, data []byte, perm os.FileMod
 type NsenterWriter struct {
 }
 
+// TODO: should take a writer, not []byte
 func (writer *NsenterWriter) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	cmd := "nsenter"
 	base_args := []string{
@@ -56,10 +58,11 @@ func (writer *NsenterWriter) WriteFile(filename string, data []byte, perm os.Fil
 		"--",
 	}
 
-	echo_args := append(base_args, "sh", "-c",
-		fmt.Sprintf("echo %q | cat > %s", data, filename))
+	echo_args := append(base_args, "sh", "-c", fmt.Sprintf("cat > %s", filename))
 	glog.V(5).Infof("Command to write data to file: %v %v", cmd, echo_args)
-	outputBytes, err := exec.Command(cmd, echo_args...).CombinedOutput()
+	command := exec.Command(cmd, echo_args...)
+	command.Stdin = bytes.NewBuffer(data)
+	outputBytes, err := command.CombinedOutput()
 	if err != nil {
 		glog.Errorf("Output from writing to %q: %v", filename, string(outputBytes))
 		return err

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -138,8 +138,6 @@ oc project test
 oc whoami
 
 echo "[INFO] Running a CLI command in a container using the service account"
-echo "[INFO] WARNING: Tests are set to not fail, dockererized container is writing an invalid ca.crt"
-set +e
 oc policy add-role-to-user view -z default
 out=$(oc run cli-with-token --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 2>&1)
 echo $out
@@ -154,7 +152,6 @@ out=$(oc run kubectl-with-token --attach --env=POD_NAMESPACE=test --image=opensh
 echo $out
 [ "$(echo $out | grep 'Using in-cluster configuration')" ]
 [ "$(echo $out | grep 'kubectl-with-token')" ]
-set -e
 
 echo "[INFO] Streaming the logs from a deployment twice..."
 oc create -f test/fixtures/failing-dc.yaml


### PR DESCRIPTION
The upstream "fix" for writing secrets onto disk while containerized improperly mangled the content of the node.

@liggitt this is candidate because of containerized.