### PR TITLE
don't show context nicknames that users don't recognize

### DIFF
--- a/pkg/cmd/cli/config/smart_merge.go
+++ b/pkg/cmd/cli/config/smart_merge.go
@@ -81,9 +81,9 @@ func GetContextNicknameFromConfig(namespace string, clientCfg *client.Config) (s
 	return namespace + "/" + clusterNick + "/" + userInfo.Name, nil
 }
 
-func GetContextNickname(namespace, clusterNick, userNick string) (string, error) {
+func GetContextNickname(namespace, clusterNick, userNick string) string {
 	tokens := strings.SplitN(userNick, "/", 2)
-	return namespace + "/" + clusterNick + "/" + tokens[0], nil
+	return namespace + "/" + clusterNick + "/" + tokens[0]
 }
 
 // CreateConfig takes a clientCfg and builds a config (kubeconfig style) from it.

--- a/pkg/cmd/server/admin/create_kubeconfig.go
+++ b/pkg/cmd/server/admin/create_kubeconfig.go
@@ -158,10 +158,7 @@ func (o CreateKubeConfigOptions) CreateKubeConfig() (*clientcmdapi.Config, error
 	if err != nil {
 		return nil, err
 	}
-	contextNick, err := cliconfig.GetContextNickname(o.ContextNamespace, clusterNick, userNick)
-	if err != nil {
-		return nil, err
-	}
+	contextNick := cliconfig.GetContextNickname(o.ContextNamespace, clusterNick, userNick)
 
 	credentials := make(map[string]*clientcmdapi.AuthInfo)
 	credentials[userNick] = &clientcmdapi.AuthInfo{
@@ -184,10 +181,7 @@ func (o CreateKubeConfigOptions) CreateKubeConfig() (*clientcmdapi.Config, error
 		if err != nil {
 			return nil, err
 		}
-		publicContextNick, err := cliconfig.GetContextNickname(o.ContextNamespace, publicClusterNick, userNick)
-		if err != nil {
-			return nil, err
-		}
+		publicContextNick := cliconfig.GetContextNickname(o.ContextNamespace, publicClusterNick, userNick)
 
 		clusters[publicClusterNick] = &clientcmdapi.Cluster{
 			Server: o.PublicAPIServerURL,


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4030.

```
$ oc project
Using project "default" on server "https://172.28.128.4:8443".
```

Users don't need to know about contexts unless they are using a custom one.

@fabianofranz ptal.