### PR TITLE
warn on missing log and metric URLs for console

### DIFF
--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -317,12 +317,16 @@ func ValidateAssetConfig(config *api.AssetConfig) ValidationResults {
 		if _, loggingURLErrs := ValidateSecureURL(config.LoggingPublicURL, "loggingPublicURL"); len(loggingURLErrs) > 0 {
 			validationResults.AddErrors(loggingURLErrs...)
 		}
+	} else {
+		validationResults.AddWarnings(fielderrors.NewFieldInvalid("loggingPublicURL", "", "required to view aggregated container logs in the console"))
 	}
 
 	if len(config.MetricsPublicURL) > 0 {
 		if _, metricsURLErrs := ValidateSecureURL(config.MetricsPublicURL, "metricsPublicURL"); len(metricsURLErrs) > 0 {
 			validationResults.AddErrors(metricsURLErrs...)
 		}
+	} else {
+		validationResults.AddWarnings(fielderrors.NewFieldInvalid("metricsPublicURL", "", "required to view cluster metrics in the console"))
 	}
 
 	for i, scriptFile := range config.ExtensionScripts {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5038.

@spadgett Looks like someone did most of the work after your pull merged. Can you confirm that the text is accurate? 

Also, I was expecting to see information about enabling these settings here https://docs.openshift.org/latest/admin_guide/cluster_metrics.html and here https://docs.openshift.org/latest/admin_guide/aggregate_logging.html.  Am I looking in the wrong spot?

@liggitt Adds server config messages for things admins probably want.