### PR TITLE
add APIGroup to role describer

### DIFF
--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -980,7 +980,7 @@ func DescribePolicy(policy *authorizationapi.Policy) (string, error) {
 	})
 }
 
-const policyRuleHeadings = "Verbs\tResources\tResource Names\tNon-Resource URLs\tExtension"
+const policyRuleHeadings = "Verbs\tNon-Resource URLs\tExtension\tResource Names\tAPI Groups\tResources"
 
 func describePolicyRule(out *tabwriter.Writer, rule authorizationapi.PolicyRule, indent string) {
 	extensionString := ""
@@ -994,12 +994,14 @@ func describePolicyRule(out *tabwriter.Writer, rule authorizationapi.PolicyRule,
 		}
 	}
 
-	fmt.Fprintf(out, indent+"%v\t%v\t%v\t%v\t%v\n",
+	fmt.Fprintf(out, indent+"%v\t%v\t%v\t%v\t%v\t%v\n",
 		rule.Verbs.List(),
-		rule.Resources.List(),
-		rule.ResourceNames.List(),
 		rule.NonResourceURLs.List(),
-		extensionString)
+		extensionString,
+		rule.ResourceNames.List(),
+		rule.APIGroups,
+		rule.Resources.List(),
+	)
 }
 
 // RoleDescriber generates information about a Project


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5758

I added `APIGroup` to roles, but neglected to update the describer.  This adds the information to that display.