### PR TITLE
add reconcile-cluster-role arg for specifying specific roles

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -98,6 +98,14 @@ oadm policy reconcile-cluster-roles
 [ ! "$(oc get clusterrole/cluster-status)" ]
 oadm policy reconcile-cluster-roles --confirm
 oc get clusterrole/cluster-status
+# check the reconcile again with a specific cluster role name
+oc delete clusterrole/cluster-status
+[ ! "$(oc get clusterrole/cluster-status)" ]
+oadm policy reconcile-cluster-roles cluster-admin --confirm 
+[ ! "$(oc get clusterrole/cluster-status)" ]
+oadm policy reconcile-cluster-roles clusterrole/cluster-status --confirm
+oc get clusterrole/cluster-status
+
 oc replace --force -f ./test/fixtures/basic-user.json
 # display shows customized labels/annotations
 [ "$(oadm policy reconcile-cluster-roles | grep custom-label)" ]


### PR DESCRIPTION
This adds support for specifying a specific set of cluster roles to reconcile.  Its necessary for making the upgrade path for infrastructure SAs easier to manage moving forward.

@liggitt @pweil- This is the only one I absolutely need, but if you agree in principle I'll add the same arguments to the reconcile command.