### PR TITLE
Fix build-waiting logic to use polling instead of watcher

### DIFF
--- a/test/extended/images/helper.go
+++ b/test/extended/images/helper.go
@@ -50,7 +50,7 @@ func CheckPageContains(oc *exutil.CLI, endpoint, path, contents string) (bool, e
 		return false, err
 	}
 
-	response, err := exutil.FetchURL(fmt.Sprintf("http://%s/%s", address, path), 60*time.Second)
+	response, err := exutil.FetchURL(fmt.Sprintf("http://%s/%s", address, path), 3*time.Minute)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The watcher logic is prone to not enforcing the timeout. If no event
happens, the build can go on for a very long time.

Enforce the timeout by using polling instead. Also raise the timeout to
30 minutes for very slow builds and make the errors more specific.

@mfojtik: PTAL. In the end I decided against the channel-timeout approach we
discussed because it seemed too complicated and cumbersome compared to this
approach. I know that polling is technically inferior to watching, but this
code is only used in tests after all and I don't see the (probably negligible)
performance gains to be worth the added complexity.

Fixes #5728