### PR TITLE
Fix client cache

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/clientcache.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/clientcache.go
@@ -68,6 +68,11 @@ func (c *ClientCache) ClientConfigForVersion(version string) (*client.Config, er
 	client.SetKubernetesDefaults(&config)
 	c.configs[version] = &config
 
+	// `version` does not necessarily equal `config.Version`.  However, we know that we call this method again with
+	// `config.Version`, we should get the the config we've just built.
+	config = config
+	c.configs[config.Version] = &config
+
 	return &config, nil
 }
 

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -489,6 +489,11 @@ func (c *clientCache) ClientConfigForVersion(version string) (*kclient.Config, e
 	client.SetOpenShiftDefaults(&config)
 	c.configs[version] = &config
 
+	// `version` does not necessarily equal `config.Version`.  However, we know that we call this method again with
+	// `config.Version`, we should get the the config we've just built.
+	configCopy := config
+	c.configs[config.Version] = &configCopy
+
 	return &config, nil
 }
 

--- a/pkg/cmd/util/clientcmd/factory_test.go
+++ b/pkg/cmd/util/clientcmd/factory_test.go
@@ -32,7 +32,7 @@ func TestClientConfigForVersion(t *testing.T) {
 
 	// First call, negotiate
 	called = 0
-	v1Config, err := clients.ClientConfigForVersion("v1")
+	v1Config, err := clients.ClientConfigForVersion("")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -44,6 +44,19 @@ func TestClientConfigForVersion(t *testing.T) {
 	}
 
 	// Second call, cache
+	called = 0
+	v1Config, err = clients.ClientConfigForVersion("")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if v1Config.Version != "v1" {
+		t.Fatalf("Expected v1, got %v", v1Config.Version)
+	}
+	if called != 0 {
+		t.Fatalf("Expected not be called again getting a config from cache, was called %d additional times", called)
+	}
+
+	// Third call, cached under exactly matching version
 	called = 0
 	v1Config, err = clients.ClientConfigForVersion("v1")
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5820.

When we negotiate for "", the "" value is filled in the clientCache, but we don't also fill the "v1" slot.  The `resource.Builder` then requests a RESTClient for its resource and the cache gets filled again.  This fills in the correct slot.