### PR TITLE
Show build trends chart on build config page

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -213,10 +213,11 @@
         <script src="scripts/directives/catalog.js"></script>
         <script src="scripts/directives/oscObjectDescriber.js"></script>
         <script src="scripts/directives/metrics.js"></script>
-		<script src="scripts/directives/logViewer.js"></script>
+        <script src="scripts/directives/logViewer.js"></script>
         <script src="scripts/directives/statusIcon.js"></script>
         <script src="scripts/directives/ellipsisLoader.js"></script>
-		<script src="scripts/directives/podStatusChart.js"></script>
+        <script src="scripts/directives/podStatusChart.js"></script>
+        <script src="scripts/directives/buildTrendsChart.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>

--- a/assets/app/scripts/directives/buildTrendsChart.js
+++ b/assets/app/scripts/directives/buildTrendsChart.js
@@ -1,0 +1,266 @@
+"use strict";
+
+angular.module('openshiftConsole')
+  .directive('buildTrendsChart', function($filter, $location, $rootScope) {
+    return {
+      restrict: 'E',
+      scope: {
+        builds: '='
+      },
+      templateUrl: 'views/_build-trends-chart.html',
+      link: function($scope) {
+        var buildByNumber;
+        var completePhases = ['Complete', 'Failed', 'Cancelled', 'Error'];
+
+        // Simple humanize function that returns an abbreviated duration like "1h 4m" or "2m 4s"
+        // suitable for use on the chart y-axis.
+        var humanize = function(value) {
+          var result = [];
+          var duration = moment.duration(value);
+          var hours = Math.floor(duration.asHours());
+          var minutes = duration.minutes();
+          var seconds = duration.seconds();
+
+          if (!hours && !minutes && !seconds) {
+            return '';
+          }
+
+          if (hours) {
+            result.push(hours + "h");
+          }
+          if (minutes) {
+            result.push(minutes + "m");
+          }
+
+          // Only show seconds if not duration doesn't include hours.
+          // Always show seconds otherwise (even 0s).
+          if (!hours) {
+            result.push(seconds + "s");
+          }
+
+          return result.join(" ");
+        };
+
+        var getStartTimestsamp = function(build) {
+          return build.status.startTimestamp || build.metadata.creationTimestamp;
+        };
+
+        // Chart configuration, see http://c3js.org/reference.html
+        $scope.chartID = _.uniqueId('build-trends-chart-');
+        var config = {
+          bindto: '#' + $scope.chartID,
+          padding: {
+            right: 30
+          },
+          axis: {
+            x: {
+              fit: true,
+              label: {
+                text: 'Build Number',
+                position: 'outer-right'
+              },
+              padding: {
+                bottom: 0
+              },
+              tick: {
+                culling: true,
+                fit: true,
+                format: function(x) {
+                  return '#' + x;
+                }
+              }
+            },
+            y: {
+              label: {
+                text: 'Duration',
+                position: 'outer-top'
+              },
+              min: 0,
+              padding: {
+                left: 0,
+                bottom: 0
+              },
+              tick: {
+                count: 5,
+                culling: true,
+                fit: true,
+                format: humanize
+              }
+            }
+          },
+          bar: {
+            width: {
+              max: 50
+            }
+          },
+          size: {
+            height: 200
+          },
+          tooltip: {
+            format: {
+              title: function(x) {
+                var build = buildByNumber[x];
+                var startTimestamp = getStartTimestsamp(build);
+                return '#' + x + ' (' + moment(startTimestamp).fromNow() + ')';
+              }
+            }
+          },
+          data: {
+            // https://www.patternfly.org/styles/color-palette/
+            colors: {
+              Cancelled: "#d1d1d1",
+              Complete: "#00b9e4",
+              Error: "#393f44",
+              Failed: "#cc0000"
+            },
+            empty: {
+              label: {
+                text: "No Completed Builds"
+              }
+            },
+            onclick: function(d) {
+              var build = buildByNumber[d.x];
+              var url = $filter('navigateResourceURL')(build);
+              if (url) {
+                $rootScope.$apply(function() {
+                  $location.path(url);
+                });
+              }
+            },
+            selection: {
+              enabled: true
+            },
+            type: 'bar'
+          }
+        };
+
+        var updateCompleteBuilds = function() {
+          $scope.completeBuilds = [];
+          var isIncomplete = $filter('isIncompleteBuild');
+          angular.forEach($scope.builds, function(build) {
+            if (!isIncomplete(build)) {
+              $scope.completeBuilds.push(build);
+            }
+          });
+        };
+
+        var numCompleteBuilds = function() {
+          updateCompleteBuilds();
+          return $scope.completeBuilds.length;
+        };
+
+        var annotationFilter = $filter('annotation');
+        var getBuildNumber = function(build) {
+          var buildNumber = annotationFilter(build, 'buildNumber') || parseInt(build.metadata.name.match(/(\d+)$/), 10);
+          if (isNaN(buildNumber)) {
+            return null;
+          }
+
+          return buildNumber;
+        };
+
+        var getDuration = function(build) {
+          var startTimestamp = getStartTimestsamp(build);
+          var endTimestamp = build.status.completionTimestamp;
+          if (!startTimestamp || !endTimestamp) {
+            return 0;
+          }
+
+          return moment(endTimestamp).diff(moment(startTimestamp));
+        };
+
+        var chart, averageDuration, showAverageLine = false;
+        var updateAvgLine = function() {
+          if (averageDuration && showAverageLine) {
+            chart.ygrids([{
+              value: averageDuration,
+              'class': 'build-trends-avg-line'
+            }]);
+          } else {
+            chart.ygrids.remove();
+          }
+        };
+
+        $scope.toggleAvgLine = function() {
+          showAverageLine = !showAverageLine;
+          updateAvgLine();
+        };
+
+        var update = function() {
+          // Keep a map of builds by number so we can find the build later when a data point is clicked.
+          buildByNumber = {};
+          var data = {
+            json: [],
+            keys: {
+              x: 'buildNumber'
+            }
+          };
+
+          var sum = 0, count = 0, foundPhases = {};
+          angular.forEach($scope.completeBuilds, function(build) {
+            var buildNumber = getBuildNumber(build);
+            if (!buildNumber) {
+              return;
+            }
+
+            var duration = getDuration(build);
+
+            // Track the sum and count to calculate the average duration.
+            sum += duration;
+            count++;
+
+            var buildData = {
+              buildNumber: buildNumber
+            };
+            buildData[build.status.phase] = duration;
+            data.json.push(buildData);
+            buildByNumber[buildNumber] = build;
+            foundPhases[build.status.phase] = true;
+          });
+
+          // Show only the last 50 builds.
+          if (data.json.length > 50) {
+            data.json.sort(function(a, b) {
+              return a.buildNumber - b.buildNumber;
+            });
+            data.json = data.json.slice(data.json.length - 50);
+          }
+
+          if (count) {
+            averageDuration = sum / count;
+            $scope.averageDurationText = humanize(averageDuration);
+          } else {
+            averageDuration = null;
+            $scope.averageDurationText = null;
+          }
+
+          // Only show found phases in the legend.
+          var groups = _.filter(completePhases, function(phase) {
+            return foundPhases[phase];
+          });
+          data.keys.value = groups;
+          data.groups = [groups];
+
+          if (!chart) {
+            config.data = angular.extend(data, config.data);
+            chart = c3.generate(config);
+          } else {
+            chart.load(data);
+          }
+
+          // Update average line.
+          updateAvgLine();
+        };
+
+        $scope.$watch(numCompleteBuilds, update);
+
+        $scope.$on('destroy', function() {
+          if (chart) {
+            // http://c3js.org/reference.html#api-destroy
+            chart = chart.destroy();
+          }
+        });
+      }
+    };
+  });
+

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -268,27 +268,77 @@ html, body {
   .btn {
     margin: 10px 0 20px;
   }
+}
+
+.empty-state-full-page {
   @media (min-height: 500px) {
     margin-top: 150px;
   }
 }
 
-  .service-table {
-    border: 0;
-    margin: 10px 0 5px;
-    table {
-      .table;
-      .table-condensed;
-      .text-center;
-      .small;
-      margin-bottom: 0;
-      thead {
-        tr th {
-          .text-center;
-        }
+.service-table {
+  border: 0;
+  margin: 10px 0 5px;
+  table {
+    .table;
+    .table-condensed;
+    .text-center;
+    .small;
+    margin-bottom: 0;
+    thead {
+      tr th {
+        .text-center;
       }
     }
   }
+}
+
+.build-config-summary {
+  .latest-build-status {
+    margin-right: 5px;
+    .status-icon {
+      width: 20px;
+    }
+  }
+  // Indent icon width to align with text above.
+  .latest-build-timestamp {
+    margin-left: 25px;
+  }
+}
+
+// The chart gets too compressed at narrow widths. Use an approach
+// similar to table-responsive on mobile where the user can scroll.
+.build-trends-responsive {
+  width: 100%;
+  margin-top: 20px;
+  overflow: scroll;
+  .build-trends-container {
+    min-width: 600px;
+    height: 235px;
+    // Disable the gray vertical line when hover over a bar.
+    .c3-xgrid-focus {
+      display: none;
+    }
+    .build-trends-avg-line {
+      stroke: #d1d1d1;
+      stroke-dasharray: 8,5;
+      stroke-width: 1;
+    }
+    .avg-duration {
+      margin-right: 30px;
+    }
+    .avg-duration-text {
+      vertical-align: top;
+      // same as c3-legend
+      font-size: 12px;
+    }
+    @media (max-width: @screen-xs-max) {
+      // Show a border at mobile screen widths so it's obvious you can scroll.
+      border: 1px solid #d1d1d1;
+      padding: 10px 0;
+    }
+  }
+}
 
 .pod-metrics {
   .metrics-options {
@@ -802,8 +852,12 @@ labels + .resource-details {
   border-bottom: 1px solid #eee;
 }
 
-h1 small.meta {
+h1 small.meta, .build-config-summary .meta {
   font-size: 12px;
+  @media (max-width: @screen-xs-min) {
+    display: block;
+    margin-top: 5px;
+  }
 }
 
 .action-divider {

--- a/assets/app/views/_build-trends-chart.html
+++ b/assets/app/views/_build-trends-chart.html
@@ -1,0 +1,24 @@
+<!-- aria-hidden since we have the build table below with the same details -->
+<!-- Wrap the content in a scrollable div for mobile -->
+<div class="build-trends-responsive" aria-hidden="true">
+  <div class="build-trends-container">
+    <!-- Build trends chart -->
+    <div ng-attr-id="{{chartID}}" class="build-trends-chart"></div>
+
+    <!-- Average duration -->
+    <div ng-if="averageDurationText" class="avg-duration pull-right">
+      <a href="" ng-click="toggleAvgLine()" title="Toggle average line" role="button" class="action-button">
+        <span class="avg-duration-text text-muted">
+          <svg width="25" height="20">
+            <line class="build-trends-avg-line" x1="0" y1="10" x2="25" y2="10" />
+          </svg>
+          <span style="vertical-align: top;">Average: {{averageDurationText}}</span>
+        </span>
+      </a>
+    </div>
+  </div>
+</div>
+
+<div ng-if="averageDurationText" class="sr-only">
+  Average build duration {{averageDurationText}}
+</div>

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -17,143 +17,205 @@
           <small class="meta">created <relative-timestamp timestamp="buildConfig.metadata.creationTimestamp"></relative-timestamp></small>
         </h1>
         <labels labels="buildConfig.metadata.labels" clickable="true" kind="builds" title-kind="build configs" project-name="{{buildConfig.metadata.namespace}}" limit="3"></labels>
-        <div class="resource-details">
-          <div class="row">
-            <div class="col-lg-6">
-              <h3>Configuration</h3>
-              <dl class="dl-horizontal left">
-                <div>
-                  <dt>Build strategy:</dt>
-                  <dd>{{buildConfig.spec.strategy.type}}</dd>
-                </div>
-                <div ng-switch="buildConfig.spec.strategy.type">
-                  <div ng-switch-when="Source">
-                    <div ng-if="buildConfig.spec.strategy.sourceStrategy.from">
-                      <dt>Builder image:</dt>
-                      <dd>{{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
-                    </div>
-                  </div>
-                  <div ng-switch-when="Docker">
-                    <div ng-if="buildConfig.spec.strategy.dockerStrategy.from">
-                      <dt>Builder image stream:</dt>
-                      <dd>{{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
-                    </div>
-                  </div>
-                  <div ng-switch-when="Custom">
-                    <div ng-if="buildConfig.spec.strategy.customStrategy.from">
-                      <dt>Builder image stream:</dt>
-                      <dd>{{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                      </dd>
-                    </div>
-                  </div>
-                </div>
-                <div ng-if="buildConfig.spec.source">
-                  <div ng-if="buildConfig.spec.source.type == 'Git'">
-                    <dt>Source repo:</dt>
-                    <dd ng-bind-html='buildConfig.spec.source.git.uri | githubLink : buildConfig.spec.source.git.ref : buildConfig.spec.source.contextDir | linky'></dd>
-                    <dt ng-if="buildConfig.spec.source.git.ref">Source ref:</dt>
-                    <dd ng-if="buildConfig.spec.source.git.ref">{{buildConfig.spec.source.git.ref}}</dd>
-                    <dt ng-if="buildConfig.spec.source.contextDir">Source context dir:</dt>
-                    <dd ng-if="buildConfig.spec.source.contextDir">{{buildConfig.spec.source.contextDir}}</dd>
-                  </div>
-                </div>
-                <div ng-if="buildConfig.spec.output.to">
-                  <dt>Output to:</dt>
-                  <dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>
-                </div>
-              </dl>
-              <div ng-if="(buildConfig | buildStrategy).env">
-                <h3>Environment Variables</h3>
-                <dl class="dl-horizontal left">
-                  <dt ng-repeat-start="envVar in (buildConfig | buildStrategy).env">{{envVar.name}}:</dt>
-                  <dd ng-repeat-end>{{envVar.value}}</dd>
-                </dl>
-              </div>
-            </div>
-            <div class="col-lg-6">
-              <h3>Triggers</h3>
-              <dl class="dl-horizontal left">
+        <tabset>
+          <tab>
+            <tab-heading>Summary</tab-heading>
 
-                <div ng-repeat="trigger in buildConfig.spec.triggers">
-                  <div ng-switch="trigger.type">
-                    <div ng-switch-when="GitHub">
-                        <dt>GitHub webhook URL:
-                          <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more
-                          <i class="fa fa-external-link"></i></span></a>
-                        </dt>
-                        <dd>
-                          <span click-to-reveal link-text='Show URL' style="margin-right: 5px;">{{buildConfig.metadata.name | webhookURL : trigger.type : trigger.github.secret : project.metadata.name}}</span>
-                          <copy-to-clipboard-button clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.github.secret : project.metadata.name"></copy-to-clipboard-button>
-                        </dd>
-                    </div>
-                    <div ng-switch-when="Generic">
-                        <dt>Generic webhook URL:
-                          <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more <i class="fa fa-external-link"></i></span></a>
-                        </dt>
-                        <dd>
-                          <span click-to-reveal link-text='Show URL' style="margin-right: 5px;">{{buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic.secret : project.metadata.name}}</span>
-                          <copy-to-clipboard-button clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic.secret : project.metadata.name"></copy-to-clipboard-button>
-                        </dd>
-                    </div>
-                    <div ng-switch-when="ImageChange">
+            <!-- If unfilteredBuilds is undefined, the builds are still loading. -->
+            <div ng-if="!unfilteredBuilds" class="gutter-bottom">Loading...</div>
+
+            <!-- Show an empty state message when there are no builds. -->
+            <div ng-if="unfilteredBuilds && (unfilteredBuilds | hashSize) === 0" class="empty-state-message text-center">
+              <h2>No builds.</h2>
+
+              <p>
+                Start a new build to create an image from
+                <span ng-if="buildConfig.spec.source.type === 'Git'">
+                  source repository
+                  <span ng-bind-html='buildConfig.spec.source.git.uri | githubLink : buildConfig.spec.source.git.ref : buildConfig.spec.source.contextDir | linky'></span>
+                </span>
+                <span ng-if="buildConfig.spec.source.type !== 'Git'">
+                  build configuration {{buildConfig.metadata.name}}.
+                </span>
+              </p>
+
+              <button class="btn btn-primary btn-lg" ng-click="startBuild(buildConfig.metadata.name)">
+                Start Build
+              </button>
+            </div>
+
+            <!-- A filter is hiding all builds (and a message is already displayed above saying that).
+                 Show a simple "No builds." message rather than the full empty state message. -->
+            <div ng-if="(unfilteredBuilds | hashSize) > 0 && (builds | hashSize) === 0">
+              No builds.
+            </div>
+
+            <!-- Show the latest build and a chart of the recent build duration and status. -->
+            <div ng-if="builds && (builds | hashSize) > 0" class="build-config-summary">
+              <div class="actions pull-right">
+                <button class="btn btn-default pull-right" ng-click="startBuild(buildConfig.metadata.name)" ng-disabled="buildConfig.metadata.deletionTimestamp || (buildConfigBuildsInProgress[buildConfig.metadata.name] | hashSize) > 0">Start Build</button>
+              </div>
+
+              <!-- Show the latest build status first. -->
+              <div class="h3" style="margin-bottom: 0;">
+                <span class="latest-build-status">
+                  <status-icon status="latestBuild.status.phase" style="margin-right: 5px;"></status-icon>
+                  Latest build
+                  <!-- Line break comments to prevent whitespace from being underlined on link hover. -->
+                  <a ng-href="{{latestBuild | navigateResourceURL}}"><!--
+                    --><span ng-if="latestBuild | annotation : 'buildNumber'">#{{latestBuild | annotation : 'buildNumber'}}</span><!--
+                    --><span ng-if="!(latestBuild | annotation : 'buildNumber')">{{latestBuild.metadata.name}}</span><!--
+                  --></a>
+                  <span ng-switch="latestBuild.status.phase" class="hide-ng-leave">
+                    <span ng-switch-when="Complete">complete.</span>
+                    <span ng-switch-when="Failed">failed.</span>
+                    <span ng-switch-when="Error">encountered an error.</span>
+                    <span ng-switch-when="Cancelled">was cancelled.</span>
+                    <span ng-switch-default>is {{latestBuild.status.phase | lowercase}}.</span>
+                  </span>
+                </span>
+                <a ng-href="{{latestBuild | navigateResourceURL}}?tab=logs">View Log</a>
+              </div>
+              <div class="latest-build-timestamp meta text-muted">
+                started <relative-timestamp timestamp="latestBuild.status.startTimestamp || latestBuild.metadata.creationTimestamp"></relative-timestamp>
+              </div>
+
+              <build-trends-chart builds="builds"></build-trends-chart>
+            </div>
+          </tab>
+          <tab>
+            <tab-heading>Configuration</tab-heading>
+              <div class="resource-details">
+                <div class="row">
+                  <div class="col-lg-6">
+                    <h3>Configuration</h3>
+                    <dl class="dl-horizontal left">
+                      <div>
+                        <dt>Build strategy:</dt>
+                        <dd>{{buildConfig.spec.strategy.type}}</dd>
+                      </div>
                       <div ng-switch="buildConfig.spec.strategy.type">
-                        <div ng-switch-when="Source" ng-if="buildConfig.spec.strategy.sourceStrategy.from && buildConfig.spec.strategy.sourceStrategy.from.kind!='ImageStreamImage'">
-                          <dt>
-                            New image for:
-                          </dt>
-                          <dd>
-                            Image stream {{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                          </dd>
+                        <div ng-switch-when="Source">
+                          <div ng-if="buildConfig.spec.strategy.sourceStrategy.from">
+                            <dt>Builder image:</dt>
+                            <dd>{{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
+                          </div>
                         </div>
-                        <div ng-switch-when="Docker" ng-if="buildConfig.spec.strategy.dockerStrategy.from && buildConfig.spec.strategy.dockerStrategy.from.kind!='ImageStreamImage'">
-                          <dt>
-                            New image for:
-                          </dt>
-                          <dd>
-                            Image stream {{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                          </dd>
+                        <div ng-switch-when="Docker">
+                          <div ng-if="buildConfig.spec.strategy.dockerStrategy.from">
+                            <dt>Builder image stream:</dt>
+                            <dd>{{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}</dd>
+                          </div>
                         </div>
-                        <div ng-switch-when="Custom" ng-if="buildConfig.spec.strategy.customStrategy.from && buildConfig.spec.strategy.customStrategy.from.kind!='ImageStreamImage'">
-                          <dt>
-                            New image for:
-                          </dt>
-                          <dd>
-                            Image stream {{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
-                          </dd>
+                        <div ng-switch-when="Custom">
+                          <div ng-if="buildConfig.spec.strategy.customStrategy.from">
+                            <dt>Builder image stream:</dt>
+                            <dd>{{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                            </dd>
+                          </div>
+                        </div>
+                      </div>
+                      <div ng-if="buildConfig.spec.source">
+                        <div ng-if="buildConfig.spec.source.type == 'Git'">
+                          <dt>Source repo:</dt>
+                          <dd ng-bind-html='buildConfig.spec.source.git.uri | githubLink : buildConfig.spec.source.git.ref : buildConfig.spec.source.contextDir | linky'></dd>
+                          <dt ng-if="buildConfig.spec.source.git.ref">Source ref:</dt>
+                          <dd ng-if="buildConfig.spec.source.git.ref">{{buildConfig.spec.source.git.ref}}</dd>
+                          <dt ng-if="buildConfig.spec.source.contextDir">Source context dir:</dt>
+                          <dd ng-if="buildConfig.spec.source.contextDir">{{buildConfig.spec.source.contextDir}}</dd>
+                        </div>
+                      </div>
+                      <div ng-if="buildConfig.spec.output.to">
+                        <dt>Output to:</dt>
+                        <dd>{{buildConfig.spec.output.to | imageObjectRef : buildConfig.metadata.namespace}}</dd>
+                      </div>
+                    </dl>
+                    <div ng-if="(buildConfig | buildStrategy).env">
+                      <h3>Environment Variables</h3>
+                      <dl class="dl-horizontal left">
+                        <dt ng-repeat-start="envVar in (buildConfig | buildStrategy).env">{{envVar.name}}:</dt>
+                        <dd ng-repeat-end>{{envVar.value}}</dd>
+                      </dl>
+                    </div>
+                  </div>
+                  <div class="col-lg-6">
+                    <h3>Triggers</h3>
+                    <dl class="dl-horizontal left">
+                    <div ng-repeat="trigger in buildConfig.spec.triggers">
+                      <div ng-switch="trigger.type">
+                        <div ng-switch-when="GitHub">
+                            <dt>GitHub webhook URL:
+                              <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more
+                              <i class="fa fa-external-link"></i></span></a>
+                            </dt>
+                            <dd>
+                              <span click-to-reveal link-text='Show URL' style="margin-right: 5px;">{{buildConfig.metadata.name | webhookURL : trigger.type : trigger.github.secret : project.metadata.name}}</span>
+                              <copy-to-clipboard-button clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.github.secret : project.metadata.name"></copy-to-clipboard-button>
+                            </dd>
+                        </div>
+                        <div ng-switch-when="Generic">
+                            <dt>Generic webhook URL:
+                              <a href="{{'webhooks' | helpLink}}" target="_blank"><span class="learn-more-block">Learn more <i class="fa fa-external-link"></i></span></a>
+                            </dt>
+                            <dd>
+                              <span click-to-reveal link-text='Show URL' style="margin-right: 5px;">{{buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic.secret : project.metadata.name}}</span>
+                              <copy-to-clipboard-button clipboard-text="buildConfig.metadata.name | webhookURL : trigger.type : trigger.generic.secret : project.metadata.name"></copy-to-clipboard-button>
+                            </dd>
+                        </div>
+                        <div ng-switch-when="ImageChange">
+                          <div ng-switch="buildConfig.spec.strategy.type">
+                            <div ng-switch-when="Source" ng-if="buildConfig.spec.strategy.sourceStrategy.from && buildConfig.spec.strategy.sourceStrategy.from.kind!='ImageStreamImage'">
+                              <dt>
+                                New image for:
+                              </dt>
+                              <dd>
+                                Image stream {{buildConfig.spec.strategy.sourceStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                              </dd>
+                            </div>
+                            <div ng-switch-when="Docker" ng-if="buildConfig.spec.strategy.dockerStrategy.from && buildConfig.spec.strategy.dockerStrategy.from.kind!='ImageStreamImage'">
+                              <dt>
+                                New image for:
+                              </dt>
+                              <dd>
+                                Image stream {{buildConfig.spec.strategy.dockerStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                              </dd>
+                            </div>
+                            <div ng-switch-when="Custom" ng-if="buildConfig.spec.strategy.customStrategy.from && buildConfig.spec.strategy.customStrategy.from.kind!='ImageStreamImage'">
+                              <dt>
+                                New image for:
+                              </dt>
+                              <dd>
+                                Image stream {{buildConfig.spec.strategy.customStrategy.from | imageObjectRef : buildConfig.metadata.namespace}}
+                              </dd>
+                            </div>
+                          </div>
+                        </div>
+                        <div ng-switch-when="ConfigChange">
+                          <dt>Config change for:</dt>
+                          <dd>Build config {{buildConfig.metadata.name}}</dd>
+                        </div>
+                        <div ng-switch-default>
+                          <dt>Other trigger:</dt>
+                          <dd>{{trigger.type}}</dd>
                         </div>
                       </div>
                     </div>
-                    <div ng-switch-when="ConfigChange">
-                      <dt>Config change for:</dt>
-                      <dd>Build config {{buildConfig.metadata.name}}</dd>
-                    </div>
-                    <div ng-switch-default>
-                      <dt>Other trigger:</dt>
-                      <dd>{{trigger.type}}</dd>
-                    </div>
-                  </div>
+                    <dt>Manual (CLI):
+                      <a href="{{'start-build' | helpLink}}" target="_blank">
+                        <span class="learn-more-block">Learn more <i class="fa fa-external-link"> </i></span>
+                      </a>
+                    </dt>
+                    <dd>
+                      <code>oc start-build {{buildConfig.metadata.name}} -n {{project.metadata.name}}</code>
+                      <copy-to-clipboard-button clipboard-text="'oc start-build ' + buildConfig.metadata.name + ' -n ' + project.metadata.name"></copy-to-clipboard-button>
+                    </dd>
+                  </dl>
                 </div>
-                <dt>Manual:</dt>
-                <dd>
-                  <span>
-                    <button class="btn btn-default btn-xs" ng-click="startBuild(buildConfig.metadata.name)" ng-disabled="buildConfig.metadata.deletionTimestamp || (buildConfigBuildsInProgress[buildConfig.metadata.name] | hashSize) > 0">Build</button>
-                  </span>
-                </dd>
-                <dt>Manual (CLI):
-                  <a href="{{'start-build' | helpLink}}" target="_blank">
-                    <span class="learn-more-block">Learn more <i class="fa fa-external-link"> </i></span>
-                  </a>
-                </dt>
-                <dd>
-                  <code>oc start-build {{buildConfig.metadata.name}} -n {{project.metadata.name}}</code>
-                  <copy-to-clipboard-button clipboard-text="'oc start-build ' + buildConfig.metadata.name + ' -n ' + project.metadata.name"></copy-to-clipboard-button>
-                </dd>
-
-              </dl>
+              </div>
+              <annotations annotations="buildConfig.metadata.annotations"></annotations>
             </div>
-          </div>
-          <annotations annotations="buildConfig.metadata.annotations"></annotations>
-        </div>
+          </tab>
+        </tabset>
       </div>
     </div><!-- /buildConfig .tile -->
     <div ng-if="loaded">
@@ -168,7 +230,7 @@
         <tbody ng-if="(builds | hashSize) == 0">
           <tr><td colspan="4" data-title="Build"><em>{{emptyMessage}}</em></td></tr>
         </tbody>
-        <tbody ng-repeat="build in builds | orderObjectsByDate : true">
+        <tbody ng-repeat="build in orderedBuilds">
           <tr>
             <td data-title="Build">
               <!-- Build number and link -->

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -9,7 +9,7 @@
         <div class="col-md-12">
           <p ng-if="emptyCatalog && !loaded">Loading...</p>
 
-          <div ng-if="emptyCatalog && loaded && !nonBuilderImages.length" class="empty-state-message">
+          <div ng-if="emptyCatalog && loaded && !nonBuilderImages.length" class="empty-state-message empty-state-full-page">
             <h2 class="text-center">No images or templates.</h2>
 
             <p class="gutter-top">

--- a/assets/app/views/directives/_status-icon.html
+++ b/assets/app/views/directives/_status-icon.html
@@ -1,5 +1,5 @@
 <span ng-switch="status" class="hide-ng-leave status-icon">
-  <span ng-switch-when="Cancelled" class="fa fa-ban text-warning" aria-hidden="true"></span>
+  <span ng-switch-when="Cancelled" class="fa fa-ban text-muted" aria-hidden="true"></span>
   <span ng-switch-when="Complete" class="fa fa-check text-success" aria-hidden="true"></span>
   <span ng-switch-when="Deployed" class="fa fa-check text-success" aria-hidden="true"></span>
   <span ng-switch-when="Error" class="fa fa-times text-danger" aria-hidden="true"></span>

--- a/assets/app/views/projects.html
+++ b/assets/app/views/projects.html
@@ -39,7 +39,7 @@
   </div>
 </div>
 
-<div ng-if="showGetStarted" class="empty-state-message text-center">
+<div ng-if="showGetStarted" class="empty-state-message empty-state-full-page text-center">
   <h1>Welcome to OpenShift.</h1>
 
   <p>


### PR DESCRIPTION
<img width="766" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11066641/0873db34-8797-11e5-8293-e85c50f62298.png">

Hovering over a point shows a tooltip with build details. Clicking a point takes you to the build page.

TODO:

- [x] Change to a bar chart based on user feedback
- [x] Find a place for the start build button
- [x] Don't flash "No builds" as the page loads
- [x] Improve empty state when no builds
- [x] Don't show legend items if not in chart
- [x] View logs link for last build
- [x] Show average line (with legend)
- [x] Show simple "No builds." message if filter is hiding all builds

https://trello.com/c/0kKI9Wvc

Fixes #3994
Fixes #5698

@jwforres 