### PR TITLE
Reduce number of tick labels in metrics sparkline

### DIFF
--- a/assets/app/scripts/directives/metrics.js
+++ b/assets/app/scripts/directives/metrics.js
@@ -81,7 +81,9 @@ angular.module('openshiftConsole')
               },
               tick: {
                 count: 30,
-                culling: true,
+                culling: {
+                  max: 7
+                },
                 fit: true,
                 type: 'timeseries',
                 format: '%H:%M'


### PR DESCRIPTION
Fixes #5829

Mobile:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/11068375/fc1ff78e-879e-11e5-8022-f4a14e5acaf2.png)

Desktop:

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/11068493/8a84ab46-879f-11e5-86b6-1623b6af266f.png)

@jwforres 