### PR TITLE
Tidy --validate

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -279,7 +279,7 @@ func GetFlagDuration(cmd *cobra.Command, flag string) time.Duration {
 }
 
 func AddValidateFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("validate", false, "If true, use a schema to validate the input before sending it")
+	cmd.Flags().Bool("validate", true, "If true, use a schema to validate the input before sending it")
 	cmd.Flags().String("schema-cache-dir", fmt.Sprintf("~/%s/%s", clientcmd.RecommendedHomeDir, clientcmd.RecommendedSchemaName), fmt.Sprintf("If non-empty, load/store cached API schemas in this directory, default is '$HOME/%s/%s'", clientcmd.RecommendedHomeDir, clientcmd.RecommendedSchemaName))
 }
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -173,6 +173,14 @@ func changeSharedFlagDefaults(rootCmd *cobra.Command) {
 			showAllFlag.Changed = false
 			showAllFlag.Usage = "When printing, show all resources (false means hide terminated pods.)"
 		}
+
+		// we want to disable the --validate flag by default when we're running kube commands from oc.  We want to make sure
+		// that we're only getting the upstream --validate flags, so check both the flag and the usage
+		if validateFlag := currCmd.Flags().Lookup("validate"); (validateFlag != nil) && (validateFlag.Usage == "If true, use a schema to validate the input before sending it") {
+			validateFlag.DefValue = "false"
+			validateFlag.Value.Set("false")
+			validateFlag.Changed = false
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5235

This makes sure that we only set `--validate` to false by default for `oc` not, for the `kubectl` we build.

@kargakis ptal
@liggitt 1.1.1?