### PR TITLE
stop oc export from exporting SA secrets that aren't round-trippable

### DIFF
--- a/pkg/cmd/cli/cmd/exporter_test.go
+++ b/pkg/cmd/cli/cmd/exporter_test.go
@@ -10,10 +10,14 @@ import (
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	deploytest "github.com/openshift/origin/pkg/deploy/api/test"
 	imageapi "github.com/openshift/origin/pkg/image/api"
+	osautil "github.com/openshift/origin/pkg/serviceaccounts/util"
 )
 
 func TestExport(t *testing.T) {
 	exporter := &defaultExporter{}
+
+	baseSA := &kapi.ServiceAccount{}
+	baseSA.Name = "my-sa"
 
 	tests := []struct {
 		name        string
@@ -80,6 +84,68 @@ func TestExport(t *testing.T) {
 					Tags: map[string]imageapi.TagEventList{},
 				},
 			},
+			expectedErr: nil,
+		},
+		{
+			name: "remove unexportable SA secrets",
+			object: &kapi.ServiceAccount{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: baseSA.Name,
+				},
+				ImagePullSecrets: []kapi.LocalObjectReference{
+					{Name: osautil.GetDockercfgSecretNamePrefix(baseSA) + "-foo"},
+					{Name: "another-pull-secret"},
+				},
+				Secrets: []kapi.ObjectReference{
+					{Name: osautil.GetDockercfgSecretNamePrefix(baseSA) + "-foo"},
+					{Name: osautil.GetTokenSecretNamePrefix(baseSA) + "-foo"},
+					{Name: "another-mountable-secret"},
+				},
+			},
+			expectedObj: &kapi.ServiceAccount{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: baseSA.Name,
+				},
+				ImagePullSecrets: []kapi.LocalObjectReference{
+					{Name: "another-pull-secret"},
+				},
+				Secrets: []kapi.ObjectReference{
+					{Name: "another-mountable-secret"},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "do not remove unexportable SA secrets with exact",
+			object: &kapi.ServiceAccount{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: baseSA.Name,
+				},
+				ImagePullSecrets: []kapi.LocalObjectReference{
+					{Name: osautil.GetDockercfgSecretNamePrefix(baseSA) + "-foo"},
+					{Name: "another-pull-secret"},
+				},
+				Secrets: []kapi.ObjectReference{
+					{Name: osautil.GetDockercfgSecretNamePrefix(baseSA) + "-foo"},
+					{Name: osautil.GetTokenSecretNamePrefix(baseSA) + "-foo"},
+					{Name: "another-mountable-secret"},
+				},
+			},
+			expectedObj: &kapi.ServiceAccount{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: baseSA.Name,
+				},
+				ImagePullSecrets: []kapi.LocalObjectReference{
+					{Name: osautil.GetDockercfgSecretNamePrefix(baseSA) + "-foo"},
+					{Name: "another-pull-secret"},
+				},
+				Secrets: []kapi.ObjectReference{
+					{Name: osautil.GetDockercfgSecretNamePrefix(baseSA) + "-foo"},
+					{Name: osautil.GetTokenSecretNamePrefix(baseSA) + "-foo"},
+					{Name: "another-mountable-secret"},
+				},
+			},
+			exact:       true,
 			expectedErr: nil,
 		},
 	}

--- a/pkg/serviceaccounts/util/helpers.go
+++ b/pkg/serviceaccounts/util/helpers.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/openshift/origin/pkg/util/namer"
+)
+
+const (
+	// These constants are here to create a name that is short enough to survive chopping by generate name
+	maxNameLength             = 63
+	randomLength              = 5
+	maxSecretPrefixNameLength = maxNameLength - randomLength
+)
+
+func GetDockercfgSecretNamePrefix(serviceAccount *kapi.ServiceAccount) string {
+	return namer.GetName(serviceAccount.Name, "dockercfg-", maxSecretPrefixNameLength)
+}
+
+// GetTokenSecretNamePrefix creates the prefix used for the generated SA token secret. This is compatible with kube up until
+// long names, at which point we hash the SA name and leave the "token-" intact.  Upstream clips the value and generates a random
+// string.
+// TODO fix the upstream implementation to be more like this.
+func GetTokenSecretNamePrefix(serviceAccount *kapi.ServiceAccount) string {
+	return namer.GetName(serviceAccount.Name, "token-", maxSecretPrefixNameLength)
+}

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -12,6 +12,11 @@ os::log::install_errexit
 
 oc new-app -f examples/sample-app/application-template-stibuild.json --name=sample
 
+# this checks to make sure that the generated tokens and dockercfg secrets are excluded by default
+# and included when --exact is requested
+oc export sa/default --template='{{ .secrets }}' | grep -q "<no value>"
+oc export sa/default --exact --template='{{ .secrets }}' | grep "default-token"
+
 [ "$(oc export all --all-namespaces)" ]
 # make sure the deprecated flag doesn't fail
 [ "$(oc export all --all)" ]


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5189.

This simply extends the pre-existing exclusion mechanism.  Opened https://trello.com/c/pqGl8CVe/546-api-types-should-be-able-to-express-do-not-export for the rest.

@kargakis ptal