### PR TITLE
Use RunAsAny by default

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
@@ -271,22 +271,13 @@ func defaultHostNetworkPorts(containers *[]Container) {
 	}
 }
 
-// Default SCCs for new fields.  Defaults are based on the RunAsUser type if not explicitly set.
-// If the SCC allows RunAsAny UID then the FSGroup/SupGroups will default to RunAsAny.  Otherwise
-// default to MustRunAs with namespace allocation.
+// Default SCCs for new fields.  FSGroup and SupplementalGroups are
+// set to the RunAsAny strategy if they are unset on the scc.
 func defaultSecurityContextConstraints(scc *SecurityContextConstraints) {
 	if len(scc.FSGroup.Type) == 0 {
-		if scc.RunAsUser.Type == RunAsUserStrategyRunAsAny {
-			scc.FSGroup.Type = FSGroupStrategyRunAsAny
-		} else {
-			scc.FSGroup.Type = FSGroupStrategyMustRunAs
-		}
+		scc.FSGroup.Type = FSGroupStrategyRunAsAny
 	}
 	if len(scc.SupplementalGroups.Type) == 0 {
-		if scc.RunAsUser.Type == RunAsUserStrategyRunAsAny {
-			scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
-		} else {
-			scc.SupplementalGroups.Type = SupplementalGroupsStrategyMustRunAs
-		}
+		scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
@@ -588,7 +588,7 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
 			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
 		},
-		"default fsgroup mustRunAs": {
+		"default fsgroup runAsAny with mustRunAs UID strat": {
 			scc: &versioned.SecurityContextConstraints{
 				RunAsUser: versioned.RunAsUserStrategyOptions{
 					Type: versioned.RunAsUserStrategyMustRunAsRange,
@@ -597,10 +597,10 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 					Type: versioned.SupplementalGroupsStrategyMustRunAs,
 				},
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedFSGroup:  versioned.FSGroupStrategyRunAsAny,
 			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
 		},
-		"default sup group mustRunAs": {
+		"default sup group runAsAny with mustRunAs UID strat": {
 			scc: &versioned.SecurityContextConstraints{
 				RunAsUser: versioned.RunAsUserStrategyOptions{
 					Type: versioned.RunAsUserStrategyMustRunAsRange,
@@ -610,7 +610,7 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 				},
 			},
 			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
 		},
 	}
 	for k, v := range tests {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults.go
@@ -220,22 +220,13 @@ func defaultSecurityContext(container *Container) {
 	}
 }
 
-// Default SCCs for new fields.  Defaults are based on the RunAsUser type if not explicitly set.
-// If the SCC allows RunAsAny UID then the FSGroup/SupGroups will default to RunAsAny.  Otherwise
-// default to MustRunAs with namespace allocation.
+// Default SCCs for new fields.  FSGroup and SupplementalGroups are
+// set to the RunAsAny strategy if they are unset on the scc.
 func defaultSecurityContextConstraints(scc *SecurityContextConstraints) {
 	if len(scc.FSGroup.Type) == 0 {
-		if scc.RunAsUser.Type == RunAsUserStrategyRunAsAny {
-			scc.FSGroup.Type = FSGroupStrategyRunAsAny
-		} else {
-			scc.FSGroup.Type = FSGroupStrategyMustRunAs
-		}
+		scc.FSGroup.Type = FSGroupStrategyRunAsAny
 	}
 	if len(scc.SupplementalGroups.Type) == 0 {
-		if scc.RunAsUser.Type == RunAsUserStrategyRunAsAny {
-			scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
-		} else {
-			scc.SupplementalGroups.Type = SupplementalGroupsStrategyMustRunAs
-		}
+		scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults_test.go
@@ -512,7 +512,7 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
 			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
 		},
-		"default fsgroup mustRunAs": {
+		"default fsgroup runAsAny with mustRunAs UID strat": {
 			scc: &versioned.SecurityContextConstraints{
 				RunAsUser: versioned.RunAsUserStrategyOptions{
 					Type: versioned.RunAsUserStrategyMustRunAsRange,
@@ -521,10 +521,10 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 					Type: versioned.SupplementalGroupsStrategyMustRunAs,
 				},
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
+			expectedFSGroup:  versioned.FSGroupStrategyRunAsAny,
 			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
 		},
-		"default sup group mustRunAs": {
+		"default sup group runAsAny with mustRunAs UID strat": {
 			scc: &versioned.SecurityContextConstraints{
 				RunAsUser: versioned.RunAsUserStrategyOptions{
 					Type: versioned.RunAsUserStrategyMustRunAsRange,
@@ -534,7 +534,7 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 				},
 			},
 			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
 		},
 	}
 	for k, v := range tests {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -49,13 +49,11 @@ New Fields:
   1.  allowHostPorts - defaults to false.  You may wish to change this to true on any privileged SCCs or
   [reset your default SCCs](https://docs.openshift.org/latest/admin_guide/manage_scc.html#updating-the-default-security-context-constraints)
   which will set this field to true for the privileged SCC and false for the restricted SCC.
-  1.  fsGroup - if the strategy type is unset this field will default based on the runAsUser strategy.
-  If runAsUser is set to RunAsAny this field will also be set to RunAsAny.  If the strategy type is
-  any other value this field will default to MustRunAs and look to the namespace for [annotation
+  1.  fsGroup - if the strategy type is unset this field will default to RunAsAny.  For more information 
+   about using fsGroup with annotations please see [annotation
   configuration](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#understanding-pre-allocated-values-and-security-context-constraints).
-  1.  supplementalGroups - if the strategy type is unset this field will default based on the runAsUser strategy.
-  If runAsUser is set to RunAsAny this field will also be set to RunAsAny.  If the strategy type is
-  any other value this field will default to MustRunAs and look to the namespace for [annotation
+  1.  supplementalGroups - if the strategy type is unset this field will default to RunAsAny.  For more information 
+  about using supplementalGroups with annotations please see [annotation
   configuration](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#understanding-pre-allocated-values-and-security-context-constraints).
   1.  priority - defaults to nil for existing SCCs.  Please refer to the
   [SCC Documentation](https://docs.openshift.org/latest/architecture/additional_concepts/authorization.html#security-context-constraints)

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -12,7 +12,7 @@ const (
 
 	// SecurityContextConstraintRestricted is used as the name for the system default restricted scc.
 	SecurityContextConstraintRestricted     = "restricted"
-	SecurityContextConstraintRestrictedDesc = "restricted denys access to all host features and requires pods to be run with a UID, SELinux context, fs group, and supplemental groups that are allocated to the namespace.  This is the most restrictive SCC."
+	SecurityContextConstraintRestrictedDesc = "restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC."
 
 	// SecurityContextConstraintNonRoot is used as the name for the system default non-root scc.
 	SecurityContextConstraintNonRoot     = "nonroot"
@@ -25,7 +25,7 @@ const (
 	// SecurityContextConstraintHostNS is used as the name for the system default scc
 	// that grants access to all host ns features.
 	SecurityContextConstraintHostNS     = "hostaccess"
-	SecurityContextConstraintHostNSDesc = "hostaccess allows access to all host namespaces but still requires pods to be run with a UID, SELinux context, fs group, and supplemental groups that are allocated to the namespace. WARNING: this SCC allows host access to namespaces, file systems, and PIDS.  It should only be used by trusted pods.  Grant with caution."
+	SecurityContextConstraintHostNSDesc = "hostaccess allows access to all host namespaces but still requires pods to be run with a UID and SELinux context that are allocated to the namespace. WARNING: this SCC allows host access to namespaces, file systems, and PIDS.  It should only be used by trusted pods.  Grant with caution."
 
 	// SecurityContextConstraintsAnyUID is used as the name for the system default scc that
 	// grants access to run as any uid but is still restricted to specific SELinux contexts.
@@ -97,20 +97,10 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				Type: kapi.RunAsUserStrategyMustRunAsNonRoot,
 			},
 			FSGroup: kapi.FSGroupStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.FSGroupStrategyMustRunAs,
+				Type: kapi.FSGroupStrategyRunAsAny,
 			},
 			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.SupplementalGroupsStrategyMustRunAs,
+				Type: kapi.SupplementalGroupsStrategyRunAsAny,
 			},
 		},
 		// SecurityContextConstraintHostMount is the same as the restricted scc but allows host mounts.
@@ -136,20 +126,10 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				Type: kapi.RunAsUserStrategyMustRunAsRange,
 			},
 			FSGroup: kapi.FSGroupStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.FSGroupStrategyMustRunAs,
+				Type: kapi.FSGroupStrategyRunAsAny,
 			},
 			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.SupplementalGroupsStrategyMustRunAs,
+				Type: kapi.SupplementalGroupsStrategyRunAsAny,
 			},
 		},
 		// SecurityContextConstraintHostNS allows access to everything except privileged on the host
@@ -179,20 +159,10 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				Type: kapi.RunAsUserStrategyMustRunAsRange,
 			},
 			FSGroup: kapi.FSGroupStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.FSGroupStrategyMustRunAs,
+				Type: kapi.FSGroupStrategyRunAsAny,
 			},
 			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.SupplementalGroupsStrategyMustRunAs,
+				Type: kapi.SupplementalGroupsStrategyRunAsAny,
 			},
 		},
 		// SecurityContextConstraintRestricted allows no host access and allocates UIDs and SELinux.
@@ -216,20 +186,10 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				Type: kapi.RunAsUserStrategyMustRunAsRange,
 			},
 			FSGroup: kapi.FSGroupStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.FSGroupStrategyMustRunAs,
+				Type: kapi.FSGroupStrategyRunAsAny,
 			},
 			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
-				// This strategy requires that annotations on the namespace which will be populated
-				// by the admission controller.  Admission will first look for the SupplementalGroupsAnnotation
-				// on the namespace and if it is unable to find that annotation it will attempt
-				// to use the UIDRangeAnnotation.  If neither annotation exists then creation
-				// of the strategy will fail.
-				Type: kapi.SupplementalGroupsStrategyMustRunAs,
+				Type: kapi.SupplementalGroupsStrategyRunAsAny,
 			},
 		},
 		// SecurityContextConstraintsAnyUID allows no host access and allocates SELinux.


### PR DESCRIPTION
There have been issues found showing that changing the default cluster behavior to set FSGroups will adversely affect some of our example images and an unknown number of customer images.  This PR changes the default strategies for cluster SCCs to RunAsAny for FSGroup and SupplementalGroups to retain backwards compatible behavior.

Note: while SupplementalGroups technically doesn't need to be changed it seems best to make the behavior consistent for now.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1279744

@liggitt @pmorie @bparees @danmcp @ncdc 