### PR TITLE
eliminate double bc reporting in status

### DIFF
--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -354,7 +354,7 @@ func describeDeploymentConfigTrigger(dc *deployapi.DeploymentConfig) string {
 func describeStandaloneBuildGroup(pipeline graphview.ImagePipeline, namespace string) []string {
 	switch {
 	case pipeline.Build != nil:
-		lines := []string{fmt.Sprintf("%s %s", pipeline.Build.ResourceString(), describeBuildInPipeline(pipeline.Build.BuildConfig, pipeline.BaseImage))}
+		lines := []string{describeBuildInPipeline(pipeline.Build.BuildConfig, pipeline.BaseImage)}
 		if pipeline.Image != nil {
 			lines = append(lines, fmt.Sprintf("pushes to %s", describeImageTagInPipeline(pipeline.Image, namespace)))
 		}
@@ -397,26 +397,26 @@ func describeBuildInPipeline(build *buildapi.BuildConfig, baseImage graphview.Im
 		// TODO: handle case where no source repo
 		source, ok := describeSourceInPipeline(&build.Spec.Source)
 		if !ok {
-			return fmt.Sprintf("unconfigured docker build bc/%s - no source set", build.Name)
+			return fmt.Sprintf("bc/%s unconfigured docker build - no source set", build.Name)
 		}
-		return fmt.Sprintf("docker build of %s through bc/%s", source, build.Name)
+		return fmt.Sprintf("bc/%s docker build of %s", build.Name, source)
 	case buildapi.SourceBuildStrategyType:
 		source, ok := describeSourceInPipeline(&build.Spec.Source)
 		if !ok {
-			return fmt.Sprintf("unconfigured source build bc/%s", build.Name)
+			return fmt.Sprintf("bc/%s unconfigured source build", build.Name)
 		}
 		if baseImage == nil {
-			return fmt.Sprintf("%s through bc/%s; no image set", source, build.Name)
+			return fmt.Sprintf("bc/%s %s; no image set", build.Name, source)
 		}
-		return fmt.Sprintf("builds %s with %s through bc/%s", source, baseImage.ImageSpec(), build.Name)
+		return fmt.Sprintf("bc/%s builds %s with %s", build.Name, source, baseImage.ImageSpec())
 	case buildapi.CustomBuildStrategyType:
 		source, ok := describeSourceInPipeline(&build.Spec.Source)
 		if !ok {
-			return fmt.Sprintf("custom build bc/%s ", build.Name)
+			return fmt.Sprintf("bc/%s custom build ", build.Name)
 		}
-		return fmt.Sprintf("custom build of %s through bc/%s", source, build.Name)
+		return fmt.Sprintf("bc/%s custom build of %s", build.Name, source)
 	default:
-		return fmt.Sprintf("unrecognized build bc/%s", build.Name)
+		return fmt.Sprintf("bc/%s unrecognized build", build.Name)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5360

New output looks like:

```
[deads@deads-dev-01 origin]$ oc new-project one
[deads@deads-dev-01 origin]$ oc new-build openshift/nodejs-010-
[deads@deads-dev-01 origin]$ oc status
In project one on server https://localhost:8443

bc/nodejs-ex builds https://github.com/openshift/nodejs-ex.git with one/nodejs-010-centos7:latest
  #1 build new for 1 seconds (can't push to image)
```

```
[deads@deads-dev-01 origin]$ oc new-project two
[deads@deads-dev-01 origin]$ oc new-app https://github.com/openshift/ruby-hello-world
[deads@deads-dev-01 origin]$ oc status
In project two on server https://localhost:8443

svc/ruby-hello-world - 172.30.126.54:8080
  dc/ruby-hello-world deploys imagestreamtag/ruby-hello-world:latest <-
    bc/ruby-hello-world docker build of https://github.com/openshift/ruby-hello-world 
      #1 build new for 1 seconds (can't push to image)
    #1 deployment waiting on image or update
```

@kargakis ptal