### PR TITLE
Use new deployment scale endpoint to request a scale event

### DIFF
--- a/pkg/deploy/api/helpers.go
+++ b/pkg/deploy/api/helpers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 // DeploymentToPodLogOptions builds a PodLogOptions object out of a DeploymentLogOptions.
@@ -15,5 +16,16 @@ func DeploymentToPodLogOptions(opts *DeploymentLogOptions) *kapi.PodLogOptions {
 		Timestamps:   opts.Timestamps,
 		TailLines:    opts.TailLines,
 		LimitBytes:   opts.LimitBytes,
+	}
+}
+
+// ScaleFromConfig builds a scale resource out of a deployment config.
+func ScaleFromConfig(dc *DeploymentConfig) *extensions.Scale {
+	return &extensions.Scale{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:              dc.Name,
+			Namespace:         dc.Namespace,
+			CreationTimestamp: dc.CreationTimestamp,
+		},
 	}
 }

--- a/pkg/deploy/scaler/scale_test.go
+++ b/pkg/deploy/scaler/scale_test.go
@@ -49,10 +49,10 @@ func TestScale(t *testing.T) {
 			kc:        ktestclient.NewSimpleFake(mkDeploymentList(1)),
 			expected: []ktestclient.Action{
 				ktestclient.NewGetAction("deploymentconfigs", "default", "foo"),
+				ktestclient.NewUpdateAction("deploymentconfigs/scale", "default", nil),
 			},
 			kexpected: []ktestclient.Action{
 				ktestclient.NewGetAction("replicationcontrollers", "default", "config-1"),
-				ktestclient.NewUpdateAction("replicationcontrollers", "default", nil),
 			},
 			expectedErr: nil,
 		},
@@ -66,11 +66,11 @@ func TestScale(t *testing.T) {
 			kc:              ktestclient.NewSimpleFake(mkDeploymentList(1)),
 			expected: []ktestclient.Action{
 				ktestclient.NewGetAction("deploymentconfigs", "default", "foo"),
+				ktestclient.NewUpdateAction("deploymentconfigs/scale", "default", nil),
 				ktestclient.NewGetAction("deploymentconfigs", "default", "foo"),
 			},
 			kexpected: []ktestclient.Action{
 				ktestclient.NewGetAction("replicationcontrollers", "default", "config-1"),
-				ktestclient.NewUpdateAction("replicationcontrollers", "default", nil),
 				ktestclient.NewGetAction("replicationcontrollers", "default", "config-1"),
 				ktestclient.NewGetAction("replicationcontrollers", "", "config-1"),
 			},

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -40,23 +40,6 @@ oc delete all --all
 sleep 1
 oc delete all --all
 
-oc create -f test/integration/fixtures/test-deployment-config.json
-tryuntil oc get rc/test-deployment-config-1
-# oc deploy test-deployment-config --cancel # TODO: does not block until success
-# oc deploy test-deployment-config --latest
-# tryuntil oc get rc/test-deployment-config-2
-
-# scale rc via deployment configuration
-oc scale dc test-deployment-config --replicas=1
-oc scale dc test-deployment-config --replicas=2 --timeout=10m
-# scale directly
-oc scale rc test-deployment-config-1 --replicas=4
-oc scale rc test-deployment-config-1 --replicas=5 --timeout=10m
-oc delete all --all
-echo "scale: ok"
-
-oc delete all --all
-
 oc process -f examples/sample-app/application-template-dockerbuild.json -l app=dockerbuild | oc create -f -
 tryuntil oc get rc/database-1
 

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -186,6 +186,18 @@ oc logs buildconfigs/ruby-sample-build --loglevel=6
 oc logs buildconfig/ruby-sample-build --loglevel=6
 echo "logs: ok"
 
+echo "[INFO] Starting a deployment to test scaling..."
+oc create -f test/integration/fixtures/test-deployment-config.json
+tryuntil '[ "$(oc get rc/test-deployment-config-1 -o yaml | grep Complete)" ]'
+# scale rc via deployment configuration
+oc scale dc/test-deployment-config --replicas=1
+oc scale dc/test-deployment-config --replicas=2 --timeout=10m
+# scale directly
+oc scale rc/test-deployment-config-1 --replicas=4
+oc scale rc/test-deployment-config-1 --replicas=5 --timeout=10m
+oc delete dc/test-deployment-config
+echo "scale: ok"
+
 
 echo "[INFO] Starting build from ${STI_CONFIG_FILE} with non-existing commit..."
 set +e


### PR DESCRIPTION
Use the new deploymentconfigs/{name}/scale endpooint instead of trying to resolve the latest deployment for a config in the client.

Btw I would love if I could poll the scale subresource (GET dc/%s/scale instead of polling the latest rc) in case of a specified --timeout (which means wait until all pods are up) but [getting the scale](https://github.com/openshift/origin/blob/d81eca744f4f1cc960760876dfb9f9f786eb64e1/pkg/deploy/registry/deployconfig/etcd/etcd.go#L118) of a dc isn't returning the current replicas of the latest. 

@ironcladlou @DirectXMan12 

