### PR TITLE
add role reaper

### DIFF
--- a/pkg/authorization/reaper/cluster_role.go
+++ b/pkg/authorization/reaper/cluster_role.go
@@ -1,0 +1,62 @@
+package reaper
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/labels"
+
+	"github.com/openshift/origin/pkg/client"
+)
+
+func NewClusterRoleReaper(roleClient client.ClusterRolesInterface, clusterBindingClient client.ClusterRoleBindingsInterface, bindingClient client.RoleBindingsNamespacer) kubectl.Reaper {
+	return &ClusterRoleReaper{
+		roleClient:           roleClient,
+		clusterBindingClient: clusterBindingClient,
+		bindingClient:        bindingClient,
+	}
+}
+
+type ClusterRoleReaper struct {
+	roleClient           client.ClusterRolesInterface
+	clusterBindingClient client.ClusterRoleBindingsInterface
+	bindingClient        client.RoleBindingsNamespacer
+}
+
+// Stop on a reaper is actually used for deletion.  In this case, we'll delete referencing clusterroleclusterBindings
+// then delete the clusterrole.
+func (r *ClusterRoleReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *kapi.DeleteOptions) (string, error) {
+	clusterBindings, err := r.clusterBindingClient.ClusterRoleBindings().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return "", err
+	}
+	for _, clusterBinding := range clusterBindings.Items {
+		if clusterBinding.RoleRef.Name == name {
+			if err := r.clusterBindingClient.ClusterRoleBindings().Delete(clusterBinding.Name); err != nil && !kerrors.IsNotFound(err) {
+				glog.Infof("Cannot delete clusterrolebinding/%s: %v", clusterBinding.Name, err)
+			}
+		}
+	}
+
+	namespacedBindings, err := r.bindingClient.RoleBindings(kapi.NamespaceNone).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return "", err
+	}
+	for _, namespacedBinding := range namespacedBindings.Items {
+		if namespacedBinding.RoleRef.Namespace == kapi.NamespaceNone && namespacedBinding.RoleRef.Name == name {
+			if err := r.bindingClient.RoleBindings(namespacedBinding.Namespace).Delete(namespacedBinding.Name); err != nil && !kerrors.IsNotFound(err) {
+				glog.Infof("Cannot delete rolebinding/%s in %s: %v", namespacedBinding.Name, namespacedBinding.Namespace, err)
+			}
+		}
+	}
+
+	if err := r.roleClient.ClusterRoles().Delete(name); err != nil && !kerrors.IsNotFound(err) {
+		return "", err
+	}
+
+	return "", nil
+}

--- a/pkg/authorization/reaper/cluster_role_test.go
+++ b/pkg/authorization/reaper/cluster_role_test.go
@@ -1,0 +1,157 @@
+package reaper
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client/testclient"
+)
+
+func TestClusterRoleReaper(t *testing.T) {
+	tests := []struct {
+		name                string
+		role                *authorizationapi.ClusterRole
+		bindings            []*authorizationapi.ClusterRoleBinding
+		deletedBindingNames []string
+	}{
+		{
+			name: "no bindings",
+			role: &authorizationapi.ClusterRole{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "role",
+				},
+			},
+		},
+		{
+			name: "bindings",
+			role: &authorizationapi.ClusterRole{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "role",
+				},
+			},
+			bindings: []*authorizationapi.ClusterRoleBinding{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name: "binding-1",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role"},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name: "binding-2",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role2"},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name: "binding-3",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role"},
+				},
+			},
+			deletedBindingNames: []string{"binding-1", "binding-3"},
+		},
+	}
+
+	for _, test := range tests {
+		startingObjects := []runtime.Object{}
+		startingObjects = append(startingObjects, test.role)
+		for _, binding := range test.bindings {
+			startingObjects = append(startingObjects, binding)
+		}
+		tc := testclient.NewSimpleFake(startingObjects...)
+
+		actualDeletedBindingNames := []string{}
+		tc.PrependReactor("delete", "clusterrolebindings", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			actualDeletedBindingNames = append(actualDeletedBindingNames, action.(ktestclient.DeleteAction).GetName())
+			return true, nil, nil
+		})
+
+		reaper := NewClusterRoleReaper(tc, tc, tc)
+		_, err := reaper.Stop("", test.role.Name, 0, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+
+		expected := sets.NewString(test.deletedBindingNames...)
+		actuals := sets.NewString(actualDeletedBindingNames...)
+		if !reflect.DeepEqual(expected.List(), actuals.List()) {
+			t.Errorf("%s: expected %v, got %v", test.name, expected.List(), actuals.List())
+		}
+	}
+}
+
+func TestClusterRoleReaperAgainstNamespacedBindings(t *testing.T) {
+	tests := []struct {
+		name                string
+		role                *authorizationapi.ClusterRole
+		bindings            []*authorizationapi.RoleBinding
+		deletedBindingNames []string
+	}{
+		{
+			name: "bindings",
+			role: &authorizationapi.ClusterRole{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "role",
+				},
+			},
+			bindings: []*authorizationapi.RoleBinding{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-1",
+						Namespace: "ns-one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role"},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-2",
+						Namespace: "ns-one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role2"},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-3",
+						Namespace: "ns-one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role"},
+				},
+			},
+			deletedBindingNames: []string{"binding-1", "binding-3"},
+		},
+	}
+
+	for _, test := range tests {
+		startingObjects := []runtime.Object{}
+		startingObjects = append(startingObjects, test.role)
+		for _, binding := range test.bindings {
+			startingObjects = append(startingObjects, binding)
+		}
+		tc := testclient.NewSimpleFake(startingObjects...)
+
+		actualDeletedBindingNames := []string{}
+		tc.PrependReactor("delete", "rolebindings", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			actualDeletedBindingNames = append(actualDeletedBindingNames, action.(ktestclient.DeleteAction).GetName())
+			return true, nil, nil
+		})
+
+		reaper := NewClusterRoleReaper(tc, tc, tc)
+		_, err := reaper.Stop("", test.role.Name, 0, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+
+		expected := sets.NewString(test.deletedBindingNames...)
+		actuals := sets.NewString(actualDeletedBindingNames...)
+		if !reflect.DeepEqual(expected.List(), actuals.List()) {
+			t.Errorf("%s: expected %v, got %v", test.name, expected.List(), actuals.List())
+		}
+	}
+}

--- a/pkg/authorization/reaper/role.go
+++ b/pkg/authorization/reaper/role.go
@@ -1,0 +1,49 @@
+package reaper
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/labels"
+
+	"github.com/openshift/origin/pkg/client"
+)
+
+func NewRoleReaper(roleClient client.RolesNamespacer, bindingClient client.RoleBindingsNamespacer) kubectl.Reaper {
+	return &RoleReaper{
+		roleClient:    roleClient,
+		bindingClient: bindingClient,
+	}
+}
+
+type RoleReaper struct {
+	roleClient    client.RolesNamespacer
+	bindingClient client.RoleBindingsNamespacer
+}
+
+// Stop on a reaper is actually used for deletion.  In this case, we'll delete referencing rolebindings
+// then delete the role.
+func (r *RoleReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *kapi.DeleteOptions) (string, error) {
+	bindings, err := r.bindingClient.RoleBindings(namespace).List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return "", err
+	}
+
+	for _, binding := range bindings.Items {
+		if binding.RoleRef.Namespace == namespace && binding.RoleRef.Name == name {
+			if err := r.bindingClient.RoleBindings(namespace).Delete(binding.Name); err != nil && !kerrors.IsNotFound(err) {
+				glog.Infof("Cannot delete rolebinding/%s: %v", binding.Name, err)
+			}
+		}
+	}
+
+	if err := r.roleClient.Roles(namespace).Delete(name); err != nil && !kerrors.IsNotFound(err) {
+		return "", err
+	}
+
+	return "", nil
+}

--- a/pkg/authorization/reaper/role_test.go
+++ b/pkg/authorization/reaper/role_test.go
@@ -1,0 +1,110 @@
+package reaper
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/api"
+	"github.com/openshift/origin/pkg/client/testclient"
+)
+
+func TestRoleReaper(t *testing.T) {
+	tests := []struct {
+		name                string
+		role                *authorizationapi.Role
+		bindings            []*authorizationapi.RoleBinding
+		deletedBindingNames []string
+	}{
+		{
+			name: "no bindings",
+			role: &authorizationapi.Role{
+				ObjectMeta: kapi.ObjectMeta{
+					Name: "role",
+				},
+			},
+		},
+		{
+			name: "bindings",
+			role: &authorizationapi.Role{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "role",
+					Namespace: "one",
+				},
+			},
+			bindings: []*authorizationapi.RoleBinding{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-1",
+						Namespace: "one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role", Namespace: "one"},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-2",
+						Namespace: "one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role2", Namespace: "one"},
+				},
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-3",
+						Namespace: "one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role", Namespace: "one"},
+				},
+			},
+			deletedBindingNames: []string{"binding-1", "binding-3"},
+		},
+		{
+			name: "bindings in other namespace ignored",
+			role: &authorizationapi.Role{
+				ObjectMeta: kapi.ObjectMeta{
+					Name:      "role",
+					Namespace: "one",
+				},
+			},
+			bindings: []*authorizationapi.RoleBinding{
+				{
+					ObjectMeta: kapi.ObjectMeta{
+						Name:      "binding-1",
+						Namespace: "one",
+					},
+					RoleRef: kapi.ObjectReference{Name: "role"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		startingObjects := []runtime.Object{}
+		startingObjects = append(startingObjects, test.role)
+		for _, binding := range test.bindings {
+			startingObjects = append(startingObjects, binding)
+		}
+		tc := testclient.NewSimpleFake(startingObjects...)
+
+		actualDeletedBindingNames := []string{}
+		tc.PrependReactor("delete", "rolebindings", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+			actualDeletedBindingNames = append(actualDeletedBindingNames, action.(ktestclient.DeleteAction).GetName())
+			return true, nil, nil
+		})
+
+		reaper := NewRoleReaper(tc, tc)
+		_, err := reaper.Stop(test.role.Namespace, test.role.Name, 0, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+
+		expected := sets.NewString(test.deletedBindingNames...)
+		actuals := sets.NewString(actualDeletedBindingNames...)
+		if !reflect.DeepEqual(expected.List(), actuals.List()) {
+			t.Errorf("%s: expected %v, got %v", test.name, expected.List(), actuals.List())
+		}
+	}
+}

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 
 	"github.com/openshift/origin/pkg/api/latest"
+	authorizationreaper "github.com/openshift/origin/pkg/authorization/reaper"
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/client"
@@ -202,8 +203,14 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 			return nil, err
 		}
 
-		if mapping.Kind == "DeploymentConfig" {
+		switch mapping.Kind {
+		case "DeploymentConfig":
 			return deployreaper.NewDeploymentConfigReaper(oc, kc), nil
+		case "Role":
+			return authorizationreaper.NewRoleReaper(oc, oc), nil
+		case "ClusterRole":
+			return authorizationreaper.NewClusterRoleReaper(oc, oc, oc), nil
+
 		}
 		return kReaperFunc(mapping)
 	}

--- a/test/extended/fixtures/roles/policy-clusterroles.yaml
+++ b/test/extended/fixtures/roles/policy-clusterroles.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: basic-user2
+  rules:
+  - apiGroups: null
+    attributeRestrictions: null
+    resourceNames:
+    - "~"
+    resources:
+    - users
+    verbs:
+    - get
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - projectrequests
+    verbs:
+    - list
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - clusterroles
+    verbs:
+    - get
+    - list
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - list
+  - apiGroups: null
+    attributeRestrictions:
+      apiVersion: v1
+      kind: IsPersonalSubjectAccessReview
+    resources:
+    - localsubjectaccessreviews
+    - subjectaccessreviews
+    verbs:
+    - create
+- apiVersion: v1
+  groupNames:
+  - system:authenticated
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: basic-users2
+  roleRef:
+    name: basic-user2
+  subjects:
+  - kind: SystemGroup
+    name: system:authenticated
+  userNames: null
+kind: List
+metadata: {}

--- a/test/extended/fixtures/roles/policy-roles.yaml
+++ b/test/extended/fixtures/roles/policy-roles.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    name: basic-user
+  rules:
+  - apiGroups: null
+    attributeRestrictions: null
+    resourceNames:
+    - "~"
+    resources:
+    - users
+    verbs:
+    - get
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - projectrequests
+    verbs:
+    - list
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - clusterroles
+    verbs:
+    - get
+    - list
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
+    - projects
+    verbs:
+    - list
+  - apiGroups: null
+    attributeRestrictions:
+      apiVersion: v1
+      kind: IsPersonalSubjectAccessReview
+    resources:
+    - localsubjectaccessreviews
+    - subjectaccessreviews
+    verbs:
+    - create
+- apiVersion: v1
+  groupNames:
+  - system:authenticated
+  kind: PolicyBinding
+  metadata:
+    name: "cmd-admin:default"
+  policyRef:
+    namespace: cmd-admin
+- apiVersion: v1
+  groupNames:
+  - system:authenticated
+  kind: RoleBinding
+  metadata:
+    creationTimestamp: null
+    name: basic-users
+  roleRef:
+    name: basic-user
+    namespace: cmd-admin
+  subjects:
+  - kind: SystemGroup
+    name: system:authenticated
+  userNames: null
+kind: List
+metadata: {}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4808.

This cleans up rolebindings that were referencing the deleted role.  Same with cluster rolebindings.  It doesn't try to clean up rolebindings from a cluster-role though, because of the fanout.

@liggitt you may have an interest
@soltysh @ironcladlou you've both written reapers before