### PR TITLE
allow api server only for some integration tests

### DIFF
--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -80,7 +80,7 @@ func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T
 }
 
 func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
-	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/external_kube_test.go
+++ b/test/integration/external_kube_test.go
@@ -68,7 +68,7 @@ func TestExternalKube(t *testing.T) {
 	cluster2MasterConfig.DNSConfig = nil
 
 	// Start cluster 2 (without clearing etcd) and get admin client configs and clients
-	cluster2Options := testserver.TestOptions{DeleteAllEtcdKeys: false}
+	cluster2Options := testserver.TestOptions{DeleteAllEtcdKeys: false, EnableControllers: true}
 	cluster2AdminConfigFile, err := testserver.StartConfiguredMasterWithOptions(cluster2MasterConfig, cluster2Options)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -134,7 +134,7 @@ func TestServiceAccountAuthorization(t *testing.T) {
 	cluster2MasterConfig.DNSConfig = nil
 
 	// Start cluster 2 (without clearing etcd) and get admin client configs and clients
-	cluster2Options := testserver.TestOptions{DeleteAllEtcdKeys: false}
+	cluster2Options := testserver.TestOptions{DeleteAllEtcdKeys: false, EnableControllers: true}
 	cluster2AdminConfigFile, err := testserver.StartConfiguredMasterWithOptions(cluster2MasterConfig, cluster2Options)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/4278

Integration tests were starting before controllers initialized.  This isn't the behavior that most expected.  It is possible to limit the scope of this change, but I think that most integration tests assume that the server's controllers are running.
