### PR TITLE
Set registry service's session affinity

### DIFF
--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -298,6 +298,17 @@ func RunCmdRegistry(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg
 			},
 		}
 		objects = app.AddServices(objects, true)
+
+		// Set registry service's sessionAffinity to ClientIP to prevent push
+		// failures due to a use of poorly consistent storage shared by
+		// multiple replicas.
+		for _, obj := range objects {
+			switch t := obj.(type) {
+			case *kapi.Service:
+				t.Spec.SessionAffinity = kapi.ServiceAffinityClientIP
+			}
+		}
+
 		// TODO: label all created objects with the same label
 		list := &kapi.List{Items: objects}
 

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -171,6 +171,7 @@ echo "router: ok"
 [ "$(oadm registry -o yaml --credentials="${KUBECONFIG}" | egrep 'image:.*-docker-registry')" ]
 oadm registry --credentials="${KUBECONFIG}" --images="${USE_IMAGES}"
 [ "$(oadm registry | grep 'service exists')" ]
+[ "$(oc describe svc/docker-registry | grep 'Session Affinity:\s*ClientIP')" ]
 echo "registry: ok"
 
 # Test building a dependency tree


### PR DESCRIPTION
Use `ClientIP` session affinity for registry service. This prevents
errors during a push when multiple replicas share poorly consistent
storage volume such as NFS.

Resolves #5795