### PR TITLE
Extended tests for HPA with DeploymentConfigs

### DIFF
--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -113,6 +113,13 @@ if [[ -z ${TEST_ONLY+x} ]]; then
   wait_for_registry
   CREATE_ROUTER_CERT=1 install_router
 
+  echo "[INFO] Installing heapster"
+  oc --namespace=openshift-infra create -f test/extended/fixtures/metrics-sa.yaml
+  oadm policy add-role-to-user edit system:serviceaccount:openshift-infra:metrics-deployer --namespace=openshift-infra
+  oadm policy add-cluster-role-to-user cluster-reader system:serviceaccount:openshift-infra:heapster
+  oc --namespace=openshift-infra secrets new metrics-deployer nothing=/dev/null
+  oc --namespace=openshift-infra process -f test/extended/fixtures/metrics.yaml -v HAWKULAR_METRICS_HOSTNAME=not.needed,MASTER_URL=${MASTER_ADDR} | oc --namespace=openshift-infra create -f -
+
   echo "[INFO] Creating image streams"
   oc create -n openshift -f examples/image-streams/image-streams-centos7.json --config="${ADMIN_KUBECONFIG}"
 fi

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/images"
+	_ "github.com/openshift/origin/test/extended/pod_autoscaling"
 	_ "github.com/openshift/origin/test/extended/router"
 	_ "github.com/openshift/origin/test/extended/security"
 

--- a/test/extended/fixtures/metrics-sa.yaml
+++ b/test/extended/fixtures/metrics-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-deployer
+secrets:
+- name: metrics-deployer
+

--- a/test/extended/fixtures/metrics.yaml
+++ b/test/extended/fixtures/metrics.yaml
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: "v1"
+kind: "Template"
+metadata:
+  name: metrics-deployer-template
+  annotations:
+    description: "Template for deploying the required Metrics integration. Requires cluster-admin 'metrics-deployer' service account and 'metrics-deployer' secret."
+    tags: "infrastructure"
+labels:
+  metrics-infra: deployer
+  provider: openshift
+  component: deployer
+objects:
+-
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    generateName: metrics-deployer-
+  spec:
+    containers:
+    - image: ${IMAGE_PREFIX}metrics-deployer:${IMAGE_VERSION}
+      name: deployer
+      volumeMounts:
+      - name: secret
+        mountPath: /secret
+        readOnly: true
+      - name: empty
+        mountPath: /etc/deploy
+      env:
+        - name: PROJECT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: IMAGE_PREFIX
+          value: ${IMAGE_PREFIX}
+        - name: IMAGE_VERSION
+          value: ${IMAGE_VERSION}
+        - name: PUBLIC_MASTER_URL
+          value: ${PUBLIC_MASTER_URL}
+        - name: MASTER_URL
+          value: ${MASTER_URL}
+        - name: REDEPLOY
+          value: ${REDEPLOY}
+        - name: USE_PERSISTENT_STORAGE
+          value: ${USE_PERSISTENT_STORAGE}
+        - name: HAWKULAR_METRICS_HOSTNAME
+          value: ${HAWKULAR_METRICS_HOSTNAME}
+        - name: CASSANDRA_NODES
+          value: ${CASSANDRA_NODES}
+        - name: CASSANDRA_PV_SIZE
+          value: ${CASSANDRA_PV_SIZE}
+        - name: METRIC_DURATION
+          value: ${METRIC_DURATION}
+    dnsPolicy: ClusterFirst
+    restartPolicy: Never
+    serviceAccount: metrics-deployer
+    volumes:
+    - name: empty
+      emptyDir: {}
+    - name: secret
+      secret:
+        secretName: metrics-deployer
+parameters:
+-
+  description: 'Specify prefix for metrics components; e.g. for "openshift/origin-metrics-deployer:v1.1", set prefix "openshift/origin-"'
+  name: IMAGE_PREFIX
+  value: "openshift/origin-"
+-
+  description: 'Specify version for metrics components; e.g. for "openshift/origin-metrics-deployer:v1.1", set version "v1.1"'
+  name: IMAGE_VERSION
+  value: latest
+-
+  description: "Internal URL for the master, for authentication retrieval"
+  name: MASTER_URL
+  value: "https://kubernetes.default.svc:443"
+-
+  description: "External hostname where clients will reach Hawkular Metrics"
+  name: HAWKULAR_METRICS_HOSTNAME
+  required: true
+-
+  description: "If set to true the deployer will try and delete all the existing components before trying to redeploy."
+  name: REDEPLOY
+  value: "false"
+-
+  description: "Set to true for persistent storage, set to false to use non persistent storage"
+  name: USE_PERSISTENT_STORAGE
+  value: "true"
+-
+  description: "The number of Cassandra Nodes to deploy for the initial cluster"
+  name: CASSANDRA_NODES
+  value: "1"
+-
+  description: "The persistent volume size for each of the Cassandra nodes"
+  name: CASSANDRA_PV_SIZE
+  value: "1Gi"
+-
+  description: "How many days metrics should be stored for."
+  name: METRIC_DURATION
+  value: "7"

--- a/test/extended/fixtures/test-basic-deploymentconfig.yaml
+++ b/test/extended/fixtures/test-basic-deploymentconfig.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    name: frontend
+  strategy:
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        name: frontend
+    spec:
+      containers:
+      - image: openshift/ruby-hello-world
+        imagePullPolicy: IfNotPresent
+        name: webserver
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 500m
+        terminationMessagePath: /dev/termination-log
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  triggers: []
+

--- a/test/extended/pod_autoscaling/deployment.go
+++ b/test/extended/pod_autoscaling/deployment.go
@@ -1,0 +1,149 @@
+package pod_autoscaling
+
+import (
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	exapi "k8s.io/kubernetes/pkg/apis/extensions"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+var _ = g.Describe("Horizontal Pod Autoscaling: DeploymentConfigs", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                      = exutil.NewCLI("hpa-tests", exutil.KubeConfigPath())
+		deploymentConfigFixture = exutil.FixturePath("fixtures", "test-basic-deploymentconfig.yaml")
+		dcName                  = "frontend"
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("creating the DeploymentConfig")
+		err := oc.Run("create").Args("-f", deploymentConfigFixture).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should scale the deployment when it is complete", func() {
+		err := oc.Run("deploy").Args(dcName, "--latest").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rcClient := oc.KubeREST().ReplicationControllers(oc.Namespace())
+		err = exutil.WaitForADeployment(rcClient, dcName, exutil.CheckDeploymentCompletedFunc, exutil.CheckDeploymentFailedFunc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("creating a new HPA targeted at 80% CPU consumption")
+		scaler := exapi.HorizontalPodAutoscaler{
+			ObjectMeta: kapi.ObjectMeta{Name: "frontend-scaler"},
+			Spec: exapi.HorizontalPodAutoscalerSpec{
+				ScaleRef: exapi.SubresourceReference{
+					Kind:        "DeploymentConfig",
+					Name:        dcName,
+					APIVersion:  "v1",
+					Subresource: "scale",
+				},
+				MaxReplicas:    6,
+				CPUUtilization: &exapi.CPUTargetUtilization{TargetPercentage: 80},
+			},
+		}
+		_, err = oc.KubeREST().Extensions().HorizontalPodAutoscalers(oc.Namespace()).Create(&scaler)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForRCToBeScaled(rcClient, deployutil.DeploymentNameForConfigVersion(dcName, 1), 1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should only scale the most recent deployment", func() {
+		err := oc.Run("deploy").Args(dcName, "--latest").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rcClient := oc.KubeREST().ReplicationControllers(oc.Namespace())
+		err = exutil.WaitForADeployment(rcClient, dcName, exutil.CheckDeploymentCompletedFunc, exutil.CheckDeploymentFailedFunc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("deploy").Args(dcName, "--latest").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = exutil.WaitForADeployment(rcClient, dcName, exutil.CheckDeploymentCompletedFunc, exutil.CheckDeploymentFailedFunc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("creating a new HPA targeted at 80% CPU consumption")
+		scaler := exapi.HorizontalPodAutoscaler{
+			ObjectMeta: kapi.ObjectMeta{Name: "frontend-scaler"},
+			Spec: exapi.HorizontalPodAutoscalerSpec{
+				ScaleRef: exapi.SubresourceReference{
+					Kind:        "DeploymentConfig",
+					Name:        dcName,
+					APIVersion:  "v1",
+					Subresource: "scale",
+				},
+				MaxReplicas:    6,
+				CPUUtilization: &exapi.CPUTargetUtilization{TargetPercentage: 80},
+			},
+		}
+		_, err = oc.KubeREST().Extensions().HorizontalPodAutoscalers(oc.Namespace()).Create(&scaler)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForRCToBeScaled(rcClient, deployutil.DeploymentNameForConfigVersion(dcName, 1), 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForRCToBeScaled(rcClient, deployutil.DeploymentNameForConfigVersion(dcName, 2), 1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should not scale a failed or incomplete deployment", func() {
+		err := oc.Run("deploy").Args(dcName, "--latest").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rcClient := oc.KubeREST().ReplicationControllers(oc.Namespace())
+		err = exutil.WaitForADeployment(rcClient, dcName, exutil.CheckDeploymentCompletedFunc, exutil.CheckDeploymentFailedFunc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// update the deployment to mark it as failed
+		rc, err := rcClient.Get(deployutil.DeploymentNameForConfigVersion(dcName, 1))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		rc.Annotations[deployapi.DeploymentStatusAnnotation] = string(deployapi.DeploymentStatusFailed)
+		_, err = rcClient.Update(rc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("creating a new HPA targeted at 80% CPU consumption")
+		scaler := exapi.HorizontalPodAutoscaler{
+			ObjectMeta: kapi.ObjectMeta{Name: "frontend-scaler"},
+			Spec: exapi.HorizontalPodAutoscalerSpec{
+				ScaleRef: exapi.SubresourceReference{
+					Kind:        "DeploymentConfig",
+					Name:        dcName,
+					APIVersion:  "v1",
+					Subresource: "scale",
+				},
+				MaxReplicas:    6,
+				CPUUtilization: &exapi.CPUTargetUtilization{TargetPercentage: 80},
+			},
+		}
+		_, err = oc.KubeREST().Extensions().HorizontalPodAutoscalers(oc.Namespace()).Create(&scaler)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// this needs to be "wait till RC *could* be scaled (check last scale time?)
+		err = waitForRCToBeScaled(rcClient, deployutil.DeploymentNameForConfigVersion(dcName, 1), 1)
+		o.Expect(err).To(o.Equal(wait.ErrWaitTimeout))
+	})
+})
+
+func waitForRCToBeScaled(c kclient.ReplicationControllerInterface, rcName string, target int) error {
+	return wait.PollImmediate(20*time.Second, 3*time.Minute, func() (bool, error) {
+		if rc, err := c.Get(rcName); err != nil {
+			return false, err
+		} else if rc.Spec.Replicas == target {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}


### PR DESCRIPTION
This commit adds extended tests for testing scaling
DeploymentConfigs with HorizontalPodAutoscalers.

It makes the core test setup include installing
heapster into the cluster from the origin-metrics
repository.

Fixes #5595
