### PR TITLE
Prevent route from overflowing box in mobile Safari

### DIFF
--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -88,11 +88,11 @@
         margin: 4px 0 6px;
       }
       .component {
+        // prevent content from overflowing the parent in Safari
+        width: 100%;
         @media (min-width: @screen-sm-min) {
           // assign flex properties when >768 for proper layout then .component divs will stack at mobile by default
           .flex(@columns: 1);
-          // needed to enable truncation on Safari
-          width: 100%;
         }
         h2,h3 {
           margin: 0 0 5px;


### PR DESCRIPTION
Apply the same fix as #5440, but at all screen widths.

/cc @jwforres @sg00dwin 