### PR TITLE
Fix vagrant provisioning

### DIFF
--- a/contrib/node/install-sdn.sh
+++ b/contrib/node/install-sdn.sh
@@ -2,8 +2,7 @@
 
 os::util::install-sdn() {
   local deployed_root=$1
-  local target=$2
-  target=${target:-/usr}
+  local target=${2:-/usr}
   if [ ! -d ${target} ]; then
     mkdir -p ${target}
   fi


### PR DESCRIPTION
Vagrant provisioning reliably fails for me with:

    ==> master: + os::util::install-sdn /vagrant
    ==> master: + local deployed_root=/vagrant
    ==> master: /vagrant/contrib/vagrant/provision-util.sh: line 123: $2: unbound variable

This seems to be an unnoticed pseudo-merge conflict between #4707 (which added "set -o nounset" to the provisioning scripts) and #5442 (which added a new function which sometimes refers to an unset variable)

@sdodson 