### PR TITLE
Fixes attach example

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
@@ -38,7 +38,7 @@ const (
 $ kubectl attach 123456-7890
 
 # Get output from ruby-container from pod 123456-7890
-$ kubectl attach 123456-7890 -c ruby-container date
+$ kubectl attach 123456-7890 -c ruby-container
 
 # Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
 # and sends stdout/stderr from 'bash' back to the client

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -43,7 +43,7 @@ Attach to a running container.
   $ openshift cli attach 123456-7890
 
   # Get output from ruby-container from pod 123456-7890
-  $ openshift cli attach 123456-7890 -c ruby-container date
+  $ openshift cli attach 123456-7890 -c ruby-container
 
   # Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780
   # and sends stdout/stderr from 'bash' back to the client

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -343,7 +343,7 @@ terminal session. Can be used to debug containers and invoke interactive command
   $ %[1]s attach 123456-7890
 
   # Get output from ruby-container from pod 123456-7890
-  $ %[1]s attach 123456-7890 -c ruby-container date
+  $ %[1]s attach 123456-7890 -c ruby-container
 
   # Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-780
   # and sends stdout/stderr from 'bash' back to the client


### PR DESCRIPTION
Fixes example in `oc attach`, it's not supposed to receive more than one argument (POD).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1257889

