### PR TITLE
Use assets/config.local.js if present for development config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.project
 /.vagrant
 /cpu.pprof
+/assets/app/config.local.js
 /assets/nbproject
 /examples/sample-app/openshift.local.*
 /examples/sample-app/logs/openshift.log

--- a/assets/Gruntfile.js
+++ b/assets/Gruntfile.js
@@ -57,6 +57,10 @@ module.exports = function (grunt) {
         files: ['extensions/extensions.js', 'extensions/extensions.css'],
         tasks: ['copy:extensions']
       },
+      localConfig: {
+        files: ['<%= yeoman.app %>/config.local.js'],
+        tasks: ['copy:localConfig']
+      },
       gruntfile: {
         files: ['Gruntfile.js']
       },
@@ -67,6 +71,7 @@ module.exports = function (grunt) {
         files: [
           '<%= yeoman.app %>/{,*/}*.html',
           '.tmp/styles/{,*/}*.css',
+          '.tmp/config.js',
           '.tmp/scripts/extensions.js',
           '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
         ]
@@ -474,6 +479,18 @@ module.exports = function (grunt) {
           src: 'extensions.css',
           dest: '.tmp/styles'
         }]
+      },
+      // config.local.js is for local customizations if it exists.
+      localConfig: {
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.app %>',
+          src: 'config.local.js',
+          dest: '.tmp',
+          rename: function(path, name) {
+            return path + '/config.js';
+          }
+        }]
       }
     },
 
@@ -482,7 +499,8 @@ module.exports = function (grunt) {
       server: [
         'less:development',
         'copy:styles',
-        'copy:extensions'
+        'copy:extensions',
+        'copy:localConfig'
       ],
       test: [
         'less:development'

--- a/assets/README.md
+++ b/assets/README.md
@@ -41,6 +41,14 @@ The supported log levels are:
 
 Note: currently most of our logging either goes to INFO or ERROR
 
+#### Local configuration
+
+`assets/app/config.js` is the default configuration file for web console
+development. If you need to change the configuration, for example, to point to
+a different API server, copy `assets/app/config.js` to
+`assets/app/config.local.js` and edit the copy. `assets/app/config.local.js` is
+not tracked and will be used instead if it exists.
+
 #### Before opening a pull request
 1. If needed, run `hack/build-assets.sh` to update bindata.go
 2. Run the spec tests with `hack/test-assets.sh`

--- a/assets/app/config.js
+++ b/assets/app/config.js
@@ -1,6 +1,9 @@
 // This is the default configuration for the dev mode of the web console.
 // A generated version of this config is created at run-time when running
-// the web console from the openshift binary
+// the web console from the openshift binary.
+//
+// To change configuration for local development, copy this file to
+// assets/app/config.local.js and edit the copy.
 window.OPENSHIFT_CONFIG = {
   api: {
     openshift: {
@@ -59,7 +62,7 @@ window.OPENSHIFT_CONFIG = {
     k8s: {
       hostPort: "localhost:8443",
       prefixes: {
-      	"v1": "/api"
+        "v1": "/api"
       },
       resources: {
         "bindings": true,
@@ -94,10 +97,10 @@ window.OPENSHIFT_CONFIG = {
     }
   },
   auth: {
-  	oauth_authorize_uri: "https://localhost:8443/oauth/authorize",
-  	oauth_redirect_base: "https://localhost:9000",
-  	oauth_client_id: "openshift-web-console",
-  	logout_uri: ""
+    oauth_authorize_uri: "https://localhost:8443/oauth/authorize",
+    oauth_redirect_base: "https://localhost:9000",
+    oauth_client_id: "openshift-web-console",
+    logout_uri: ""
   },
   loggingURL: "",
   metricsURL: ""


### PR DESCRIPTION
Make it easier to modify options like metrics URL, logging URL, and API server hostname for web console development.

@jwforres @benjaminapetersen 