### PR TITLE
SCMAuth: use local proxy when password length exceeds 255 chars

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -66,6 +66,8 @@ function configure_os_server {
 	if [[ -z "${ALL_IP_ADDRESSES-}" ]]; then
 		ALL_IP_ADDRESSES="$(openshift start --print-ip)"
 		SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},localhost,172.30.0.1"
+                SERVER_HOSTNAME_LIST="${SERVER_HOSTNAME_LIST},kubernetes.default.svc.cluster.local,kubernetes.default.svc,kubernetes.default,kubernetes"
+                SERVER_HOSTNAME_LIST="${SERVER_HOSTNAME_LIST},openshift.default.svc.cluster.local,openshift.default.svc,openshift.default,openshift"
 
 		while read -r IP_ADDRESS
 		do

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -50,6 +50,7 @@ func run(builderFactory factoryFunc) {
 				glog.Fatalf("Cannot setup secret file for accessing private repository: %v", err)
 			}
 			if sourceURL != nil {
+				build.Annotations[bld.OriginalSourceURLAnnotationKey] = build.Spec.Source.Git.URI
 				build.Spec.Source.Git.URI = sourceURL.String()
 			}
 		}

--- a/pkg/build/builder/cmd/scmauth/password.go
+++ b/pkg/build/builder/cmd/scmauth/password.go
@@ -3,21 +3,29 @@ package scmauth
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/golang/glog"
+
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/util/file"
 )
 
 const (
-	DefaultUsername      = "builder"
-	UsernamePasswordName = "password"
-	UsernameSecret       = "username"
-	PasswordSecret       = "password"
-	TokenSecret          = "token"
-	UserPassGitConfig    = `# credential git config
+	DefaultUsername       = "builder"
+	UsernamePasswordName  = "password"
+	UsernameSecret        = "username"
+	PasswordSecret        = "password"
+	TokenSecret           = "token"
+	curlPasswordThreshold = 255
+	proxyHost             = "127.0.0.1:8080"
+	UserPassGitConfig     = `# credential git config
 [credential]
    helper = store --file=%s
 `
@@ -51,7 +59,8 @@ func (u UsernamePassword) Setup(baseDir string) (*url.URL, error) {
 	}
 
 	// Determine overrides
-	overrideSourceURL, gitconfigURL, err := doSetup(u.SourceURL, usernameSecret, passwordSecret, tokenSecret)
+	overrideFn := longPasswordOverride(baseDir, removeCredentials)
+	overrideSourceURL, gitconfigURL, err := doSetup(u.SourceURL, usernameSecret, passwordSecret, tokenSecret, overrideFn)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +89,24 @@ func (u UsernamePassword) Setup(baseDir string) (*url.URL, error) {
 	return overrideSourceURL, nil
 }
 
-func doSetup(sourceURL url.URL, usernameSecret, passwordSecret, tokenSecret string) (*url.URL, *url.URL, error) {
+type overrideURLFunc func(sourceURL *url.URL, username, password string) (*url.URL, error)
+
+func removeCredentials(sourceURL *url.URL, username, password string) (*url.URL, error) {
+	overrideURL := *sourceURL
+	overrideURL.User = nil
+	return &overrideURL, nil
+}
+
+func longPasswordOverride(dir string, overrideFn overrideURLFunc) overrideURLFunc {
+	return func(sourceURL *url.URL, username, password string) (*url.URL, error) {
+		if len(password) > curlPasswordThreshold {
+			return startProxy(dir, sourceURL, username, password)
+		}
+		return overrideFn(sourceURL, username, password)
+	}
+}
+
+func doSetup(sourceURL url.URL, usernameSecret, passwordSecret, tokenSecret string, overrideURLFn overrideURLFunc) (*url.URL, *url.URL, error) {
 	// Extract auth from the source URL
 	urlUsername := ""
 	urlPassword := ""
@@ -114,15 +140,16 @@ func doSetup(sourceURL url.URL, usernameSecret, passwordSecret, tokenSecret stri
 		username = DefaultUsername
 	}
 
-	// Remove user/pw from the source url
-	overrideSourceURL := sourceURL
-	overrideSourceURL.User = nil
+	overrideSourceURL, err := overrideURLFn(&sourceURL, username, password)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Set user/pw in the config url
 	configURL := sourceURL
 	configURL.User = url.UserPassword(username, password)
 
-	return &overrideSourceURL, &configURL, nil
+	return overrideSourceURL, &configURL, nil
 }
 
 // Name returns the name of this auth method.
@@ -154,4 +181,79 @@ func readSecret(baseDir, fileName string) (string, error) {
 		return "", nil
 	}
 	return lines[0], nil
+}
+
+type basicAuthTransport struct {
+	transport http.RoundTripper
+	username  string
+	password  string
+}
+
+func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(t.username, t.password)
+	// Ensure that the Host header has the value of the real git server
+	// and not the local proxy.
+	req.Host = req.URL.Host
+	if glog.V(8) {
+		glog.Infof("Proxying request to URL %q", req.URL.String())
+		if reqdump, err := httputil.DumpRequestOut(req, false); err == nil {
+			glog.Infof("Request:\n%s\n", string(reqdump))
+		}
+	}
+	resp, err := t.transport.RoundTrip(req)
+	if glog.V(8) {
+		if err != nil {
+			glog.Infof("Proxy RoundTrip error: %#v", err)
+		} else {
+			if respdump, err := httputil.DumpResponse(resp, false); err == nil {
+				glog.Infof("Response:\n%s\n", string(respdump))
+			}
+		}
+	}
+	return resp, err
+}
+
+func startProxy(dir string, sourceURL *url.URL, username, password string) (*url.URL, error) {
+
+	// Setup the targetURL of the proxy to be the host of the original URL
+	targetURL := &url.URL{
+		Scheme: sourceURL.Scheme,
+		Host:   sourceURL.Host,
+	}
+	proxyHandler := httputil.NewSingleHostReverseProxy(targetURL)
+
+	// The baseTransport will either be the default transport or a
+	// transport with the appropriate TLSConfig if a ca.crt is present.
+	baseTransport := http.DefaultTransport
+
+	// Check whether a CA cert is available and use it if it is.
+	caCertFile := filepath.Join(dir, "ca.crt")
+	_, err := os.Stat(caCertFile)
+	if err == nil && sourceURL.Scheme == "https" {
+		baseTransport, err = cmdutil.TransportFor(caCertFile, "", "")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Build a basic auth RoundTripper for use by the proxy
+	authTransport := &basicAuthTransport{
+		username:  username,
+		password:  password,
+		transport: baseTransport,
+	}
+	proxyHandler.Transport = authTransport
+
+	// Start the proxy go-routine
+	go func() {
+		log.Fatal(http.ListenAndServe(proxyHost, proxyHandler))
+	}()
+
+	// The new URL will use the proxy endpoint
+	proxyURL := *sourceURL
+	proxyURL.User = nil
+	proxyURL.Host = proxyHost
+	proxyURL.Scheme = "http"
+
+	return &proxyURL, nil
 }

--- a/pkg/build/builder/cmd/scmauth/password_test.go
+++ b/pkg/build/builder/cmd/scmauth/password_test.go
@@ -86,7 +86,7 @@ func TestPassword(t *testing.T) {
 
 	for k, tc := range testcases {
 		u, _ := url.Parse(tc.URL)
-		sourceURL, configURL, err := doSetup(*u, tc.Username, tc.Password, tc.Token)
+		sourceURL, configURL, err := doSetup(*u, tc.Username, tc.Password, tc.Token, removeCredentials)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 			continue

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -8,6 +8,8 @@ import (
 	"github.com/openshift/origin/pkg/build/api"
 )
 
+const OriginalSourceURLAnnotationKey = "openshift.io/original-source-url"
+
 // A KeyValue can be used to build ordered lists of key-value pairs.
 type KeyValue struct {
 	Key   string
@@ -22,7 +24,11 @@ func buildInfo(build *api.Build) []KeyValue {
 		{"OPENSHIFT_BUILD_NAMESPACE", build.Namespace},
 	}
 	if build.Spec.Source.Git != nil {
-		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_SOURCE", build.Spec.Source.Git.URI})
+		sourceURL := build.Spec.Source.Git.URI
+		if originalURL, ok := build.Annotations[OriginalSourceURLAnnotationKey]; ok {
+			sourceURL = originalURL
+		}
+		kv = append(kv, KeyValue{"OPENSHIFT_BUILD_SOURCE", sourceURL})
 		if build.Spec.Source.Git.Ref != "" {
 			kv = append(kv, KeyValue{"OPENSHIFT_BUILD_REFERENCE", build.Spec.Source.Git.Ref})
 		}

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"path/filepath"
+	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -30,13 +31,15 @@ var _ = g.Describe("builds: parallel: gitauth: Check build for private source re
 		gitPassword                   = "gituserpassword"
 		buildConfigName               = "gitauthtest"
 		sourceURLTemplate             = "https://gitserver.%s/ruby-hello-world"
+		sourceURLTemplateTokenAuth    = "https://gitserver-tokenauth.%s/ruby-hello-world"
 	)
 
 	var (
-		gitServerFixture = exutil.FixturePath("fixtures", "test-gitserver.yaml")
-		testBuildFixture = exutil.FixturePath("fixtures", "test-auth-build.yaml")
-		oc               = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
-		caCertPath       = filepath.Join(filepath.Dir(exutil.KubeConfigPath()), "ca.crt")
+		gitServerFixture          = exutil.FixturePath("fixtures", "test-gitserver.yaml")
+		gitServerTokenAuthFixture = exutil.FixturePath("fixtures", "test-gitserver-tokenauth.yaml")
+		testBuildFixture          = exutil.FixturePath("fixtures", "test-auth-build.yaml")
+		oc                        = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
+		caCertPath                = filepath.Join(filepath.Dir(exutil.KubeConfigPath()), "ca.crt")
 	)
 
 	g.JustBeforeEach(func() {
@@ -45,51 +48,78 @@ var _ = g.Describe("builds: parallel: gitauth: Check build for private source re
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
+	testGitAuth := func(gitServerYaml, urlTemplate string, secretFunc func() string) {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		g.By("obtaining the configured API server host from config")
+		adminClientConfig, err := testutil.GetClusterAdminClientConfig(exutil.KubeConfigPath())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		hostURL, err := url.Parse(adminClientConfig.Host)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		host, err := hostname(hostURL.Host)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		routeSuffix := fmt.Sprintf("%s.%s", host, hostNameSuffix)
+
+		g.By(fmt.Sprintf("calling oc new-app -f %q -p ROUTE_SUFFIX=%s", gitServerYaml, routeSuffix))
+		err = oc.Run("new-app").Args("-f", gitServerYaml, "-p", fmt.Sprintf("ROUTE_SUFFIX=%s", routeSuffix)).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("expecting the deployment of the gitserver to be in the Complete phase")
+		err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), gitServerDeploymentConfigName,
+			exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		sourceSecretName := secretFunc()
+
+		sourceURL := fmt.Sprintf(urlTemplate, routeSuffix)
+		g.By(fmt.Sprintf("creating a new BuildConfig by calling oc new-app -f %q -p SOURCE_SECRET=%s,SOURCE_URL=%s",
+			testBuildFixture, sourceSecretName, sourceURL))
+		err = oc.Run("new-app").Args("-f", testBuildFixture, "-p", fmt.Sprintf("SOURCE_SECRET=%s,SOURCE_URL=%s",
+			sourceSecretName, sourceURL)).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("starting a test build")
+		buildName, err := oc.Run("start-build").Args(buildConfigName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("expecting build %s to complete successfully", buildName))
+		err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+
 	g.Describe("Build using a username, password, and CA certificate", func() {
 		g.It("should create a new build using the internal gitserver", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+			testGitAuth(gitServerFixture, sourceURLTemplate, func() string {
+				g.By(fmt.Sprintf("creating a new secret for the gitserver by calling oc secrets new-basicauth %s --username=%s --password=%s --cacert=%s",
+					sourceSecretName, gitUserName, gitPassword, caCertPath))
+				err := oc.Run("secrets").
+					Args("new-basicauth", sourceSecretName,
+					fmt.Sprintf("--username=%s", gitUserName),
+					fmt.Sprintf("--password=%s", gitPassword),
+					fmt.Sprintf("--ca-cert=%s", caCertPath)).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				return sourceSecretName
+			})
+		})
+	})
 
-			g.By("obtaining the configured API server host from config")
-			adminClientConfig, err := testutil.GetClusterAdminClientConfig(exutil.KubeConfigPath())
-			o.Expect(err).NotTo(o.HaveOccurred())
-			hostURL, err := url.Parse(adminClientConfig.Host)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			host, err := hostname(hostURL.Host)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			routeSuffix := fmt.Sprintf("%s.%s", host, hostNameSuffix)
+	g.Describe("Build using a service account token and CA certificate", func() {
+		g.It("should create a new build using the internal gitserver", func() {
+			testGitAuth(gitServerTokenAuthFixture, sourceURLTemplateTokenAuth, func() string {
+				g.By("assigning the edit role to the builder service account")
+				err := oc.Run("policy").Args("add-role-to-user", "edit", "--serviceaccount=builder").Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By(fmt.Sprintf("calling oc new-app -f %q -p ROUTE_SUFFIX=%s", gitServerFixture, routeSuffix))
-			err = oc.Run("new-app").Args("-f", gitServerFixture, "-p", fmt.Sprintf("ROUTE_SUFFIX=%s", routeSuffix)).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("expecting the deployment of the gitserver to be in the Complete phase")
-			err = exutil.WaitForADeployment(oc.KubeREST().ReplicationControllers(oc.Namespace()), gitServerDeploymentConfigName,
-				exutil.CheckDeploymentCompletedFn, exutil.CheckDeploymentFailedFn)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By(fmt.Sprintf("creating a new secret for the gitserver by calling oc secrets new-basicauth %s --username=%s --password=%s --cacert=%s",
-				sourceSecretName, gitUserName, gitPassword, caCertPath))
-			err = oc.Run("secrets").
-				Args("new-basicauth", sourceSecretName,
-				fmt.Sprintf("--username=%s", gitUserName),
-				fmt.Sprintf("--password=%s", gitPassword),
-				fmt.Sprintf("--ca-cert=%s", caCertPath)).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			sourceURL := fmt.Sprintf(sourceURLTemplate, routeSuffix)
-			g.By(fmt.Sprintf("creating a new BuildConfig by calling oc new-app -f %q -p SOURCE_SECRET=%s,SOURCE_URL=%s",
-				testBuildFixture, sourceSecretName, sourceURL))
-			err = oc.Run("new-app").Args("-f", testBuildFixture, "-p", fmt.Sprintf("SOURCE_SECRET=%s,SOURCE_URL=%s",
-				sourceSecretName, sourceURL)).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("starting a test build")
-			buildName, err := oc.Run("start-build").Args(buildConfigName).Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By(fmt.Sprintf("expecting build %s to complete successfully", buildName))
-			err = exutil.WaitForABuild(oc.REST().Builds(oc.Namespace()), buildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn)
-			o.Expect(err).NotTo(o.HaveOccurred())
+				g.By("getting the token secret name for the builder service account")
+				sa, err := oc.KubeREST().ServiceAccounts(oc.Namespace()).Get("builder")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				for _, s := range sa.Secrets {
+					if strings.Contains(s.Name, "token") {
+						return s.Name
+					}
+				}
+				return ""
+			})
 		})
 	})
 })

--- a/test/extended/fixtures/test-gitserver-tokenauth.yaml
+++ b/test/extended/fixtures/test-gitserver-tokenauth.yaml
@@ -59,7 +59,7 @@ objects:
           # stored in this app.
           # TOOD: support HTTPS
           - name: PUBLIC_URL
-            value: http://gitserver.$(POD_NAMESPACE).svc.cluster.local:8080
+            value: http://gitserver-tokenauth.$(POD_NAMESPACE).svc.cluster.local:8080
           # The directory to store Git repositories in. If not backed
           # by a persistent volume, repositories will be lost when
           # deployments occur. Use INITIAL_GIT_CLONE and AUTOLINK_*
@@ -94,8 +94,8 @@ objects:
           # should be used to authorize against the server. The value
           # '-' will use the pod's service account.
           # May not be used in combination with REQUIRE_GIT_AUTH
-          #- name: REQUIRE_SERVER_AUTH
-          #  value: "-"
+          - name: REQUIRE_SERVER_AUTH
+            value: "-"
           
           # The namespace to check authorization against when
           # REQUIRE_SERVICE_AUTH is used. Users must have 'get' on
@@ -105,8 +105,8 @@ objects:
           # Require BASIC authentication with a username and password
           # to push or pull.
           # May not be used in combination with REQUIRE_SERVER_AUTH
-          - name: REQUIRE_GIT_AUTH
-            value: gituser:gituserpassword
+          #- name: REQUIRE_GIT_AUTH
+          #  value: gituser:gituserpassword
 
           # Autolinking:
           #
@@ -158,7 +158,7 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: gitserver
+    name: gitserver-tokenauth
     labels:
       app: gitserver
   spec:
@@ -170,13 +170,13 @@ objects:
 - apiVersion: v1
   kind: Route
   metadata:
-    name: gitserver
+    name: gitserver-tokenauth
     labels:
       app: gitserver
   spec:
-    host: gitserver.${ROUTE_SUFFIX}
+    host: gitserver-tokenauth.${ROUTE_SUFFIX}
     tls:
       termination: edge
     to:
       kind: Service
-      name: gitserver
+      name: gitserver-tokenauth


### PR DESCRIPTION
This is a workaround to fix the limitation that libcurl currently has in RHEL and CentOS with passwords exceeding 255 characters. A fix will be available most likely in RHEL 7.3.