### PR TITLE
extended tests for docker and sti bc with no outputname defined

### DIFF
--- a/test/extended/builds/build_no_outputname.go
+++ b/test/extended/builds/build_no_outputname.go
@@ -1,0 +1,44 @@
+package builds
+
+import (
+	"fmt"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: no name specified for the output image", func() {
+	defer g.GinkgoRecover()
+	var (
+		dockerImageFixture = filepath.Join("fixtures", "test-docker-no-outputname.json")
+		s2iImageFixture    = filepath.Join("fixtures", "test-sti-no-outputname.json")
+		oc                 = exutil.NewCLI("build-no-outputname", exutil.KubeConfigPath())
+	)
+
+	g.Describe("building from templates", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		g.It(fmt.Sprintf("should create an image from %q docker template without an output image reference defined", dockerImageFixture), func() {
+			err := oc.Run("create").Args("-f", dockerImageFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting build to pass without an output image reference specified")
+			out, err := oc.Run("start-build").Args("test-docker", "--follow", "--wait").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(out).Should(o.ContainSubstring(`Build does not have an Output defined, no output image was pushed to a registry.`))
+		})
+
+		g.It(fmt.Sprintf("should create an image from %q S2i template without an output image reference defined", s2iImageFixture), func() {
+			err := oc.Run("create").Args("-f", s2iImageFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting build to pass without an output image reference specified")
+			out, err := oc.Run("start-build").Args("test-sti", "--follow", "--wait").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(out).Should(o.ContainSubstring(`Build does not have an Output defined, no output image was pushed to a registry.`))
+		})
+	})
+})

--- a/test/extended/fixtures/test-docker-no-outputname.json
+++ b/test/extended/fixtures/test-docker-no-outputname.json
@@ -1,0 +1,35 @@
+{
+  "kind":"BuildConfig",
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"test-docker",
+    "labels":{
+      "name":"test-docker"
+    }
+  },
+  "spec":{
+    "triggers":[],
+    "source":{
+      "type":"Git",
+      "git":{
+        "uri":"https://github.com/openshift/origin"
+      },
+      "contextDir":"test/extended/fixtures/test-build-app"
+    },
+    "strategy":{
+      "type":"Docker",
+      "env": [
+        {
+          "name": "BUILD_LOGLEVEL",
+          "value": "5"
+        }
+      ],
+      "dockerStrategy":{
+        "from":{
+          "kind":"DockerImage",
+          "name":"openshift/ruby-20-centos7"
+        }
+      }
+    }
+  }
+}

--- a/test/extended/fixtures/test-sti-no-outputname.json
+++ b/test/extended/fixtures/test-sti-no-outputname.json
@@ -1,0 +1,35 @@
+{
+"kind":"BuildConfig",
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"test-sti",
+    "labels":{
+      "name":"test-sti"
+    }
+  },
+  "spec":{
+    "triggers":[],
+    "source":{
+      "type":"Git",
+      "git":{
+        "uri":"https://github.com/openshift/origin"
+      },
+      "contextDir":"test/extended/fixtures/test-build-app"
+    },
+    "strategy":{
+      "type":"Source",
+      "env": [
+        {
+          "name": "BUILD_LOGLEVEL",
+          "value": "5"
+        }
+      ],
+      "sourceStrategy":{
+        "from":{
+          "kind":"DockerImage",
+          "name":"openshift/ruby-20-centos7"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
extended tests that verify that the build is valid without and Output.To.Name defined in the buildconfig.
this is an addon to https://github.com/openshift/origin/pull/5071