### PR TITLE
Added readiness probe for Router

### DIFF
--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -329,14 +329,20 @@ func generateProbeConfigForRoute(cfg *RouterConfig, ports []kapi.ContainerPort) 
 	var probe *kapi.Probe
 
 	if cfg.Type == "haproxy-router" {
-		probe = &kapi.Probe{
-			Handler: kapi.Handler{
-				TCPSocket: &kapi.TCPSocketAction{
-					Port: kutil.IntOrString{
-						IntVal: ports[0].ContainerPort,
-					},
+		probe = &kapi.Probe{}
+		if cfg.StatsPort > 0 {
+			probe.Handler.HTTPGet = &kapi.HTTPGetAction{
+				Path: "/healthz",
+				Port: kutil.IntOrString{
+					IntVal: cfg.StatsPort,
 				},
-			},
+			}
+		} else {
+			probe.Handler.TCPSocket = &kapi.TCPSocketAction{
+				Port: kutil.IntOrString{
+					IntVal: ports[0].ContainerPort,
+				},
+			}
 		}
 	}
 

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -180,6 +180,7 @@ oc get scc privileged -o yaml | sed '/users:/ a\
 [ "$(oadm router -o yaml --credentials="${KUBECONFIG}" --service-account=router -n default | egrep 'image:.*-haproxy-router:')" ]
 oadm router --credentials="${KUBECONFIG}" --images="${USE_IMAGES}" --service-account=router -n default
 [ "$(oadm router -n default | grep 'service exists')" ]
+[ "$(oc get dc/router -o yaml -n default | grep 'readinessProbe')" ]
 echo "router: ok"
 
 # Test running a registry


### PR DESCRIPTION
Uses the same endpoint as liveness probe does.

Partially addresses #5900

Signed-off-by: Michal Minar <miminar@redhat.com>