### PR TITLE
Fix alignment of icon on settings page by overriding patternfly rule

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -81,6 +81,9 @@ html, body {
   }
   .page-header {
     margin-top: 22px;
+    .actions {
+      margin-top: 0;
+    }
   }
 }
 #header-logo {


### PR DESCRIPTION
<img width="293" alt="alignment" src="https://cloud.githubusercontent.com/assets/1874151/11188829/d8d19290-8c5a-11e5-8a6e-a9e341968246.png">
