### PR TITLE
Implement submodule init/update in s2i

### DIFF
--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -20,6 +20,7 @@ type KeyValue struct {
 type GitClient interface {
 	CloneWithOptions(dir string, url string, opts git.CloneOptions) error
 	Checkout(dir string, ref string) error
+	SubmoduleUpdate(dir string, init, recursive bool) error
 	ListRemote(url string, args ...string) (string, string, error)
 	GetInfo(location string) (*git.SourceInfo, []error)
 }

--- a/pkg/generate/app/test/fakegit.go
+++ b/pkg/generate/app/test/fakegit.go
@@ -7,11 +7,12 @@ import (
 )
 
 type FakeGit struct {
-	RootDir        string
-	GitURL         string
-	Ref            string
-	CloneCalled    bool
-	CheckoutCalled bool
+	RootDir               string
+	GitURL                string
+	Ref                   string
+	CloneCalled           bool
+	CheckoutCalled        bool
+	SubmoduleUpdateCalled bool
 }
 
 func (g *FakeGit) GetRootDir(dir string) (string, error) {
@@ -47,6 +48,11 @@ func (g *FakeGit) CloneMirror(source, target string) error {
 
 func (g *FakeGit) Checkout(dir string, ref string) error {
 	g.CheckoutCalled = true
+	return nil
+}
+
+func (g *FakeGit) SubmoduleUpdate(dir string, init, recurse bool) error {
+	g.SubmoduleUpdateCalled = true
 	return nil
 }
 

--- a/pkg/generate/git/repository.go
+++ b/pkg/generate/git/repository.go
@@ -28,6 +28,7 @@ type Repository interface {
 	CloneMirror(dir string, url string) error
 	Fetch(dir string) error
 	Checkout(dir string, ref string) error
+	SubmoduleUpdate(dir string, init, recursive bool) error
 	Archive(dir, ref, format string, w io.Writer) error
 	Init(dir string, bare bool) error
 	AddRemote(dir string, name, url string) error
@@ -225,6 +226,20 @@ func (r *repository) Archive(location, ref, format string, w io.Writer) error {
 // Checkout switches to the given ref for the git repository
 func (r *repository) Checkout(location string, ref string) error {
 	_, _, err := r.git(nil, location, "checkout", ref)
+	return err
+}
+
+// SubmoduleUpdate updates submodules, optionally recursively
+func (r *repository) SubmoduleUpdate(location string, init, recursive bool) error {
+	updateArgs := []string{"submodule", "update"}
+	if init {
+		updateArgs = append(updateArgs, "--init")
+	}
+	if recursive {
+		updateArgs = append(updateArgs, "--recursive")
+	}
+
+	_, _, err := r.git(nil, location, updateArgs...)
 	return err
 }
 


### PR DESCRIPTION
This adds support for checking out the correct submodules and submodule versions by removing recursive clone in favor of post-checkout submodule init and update.

The git equivalent before:

```
git clone --recursive repo
git checkout branch
```

This would leave the submodules at the "master" branch version.

The git equivalent with this patch:

```
git clone repo
git checkout branch
git submodule init
git submodule update
```

This ensures the correct submodules and submodule versions are checked out.

This patch requires openshift/source-to-image#353. The associated issue is #5910.

Note that this patch and associated tests will fail until the required source-to-image patch is merged and the version pin updated in this repo.