### PR TITLE
Bug 1277046 - fixed tagging ImageStreamImage

### DIFF
--- a/pkg/image/registry/imagestream/strategy.go
+++ b/pkg/image/registry/imagestream/strategy.go
@@ -229,29 +229,11 @@ func tagReferenceToTagEvent(stream *api.ImageStream, tagRef api.TagReference, ta
 		}, nil
 
 	case "ImageStreamImage":
-		ref, err := api.DockerImageReferenceForStream(stream)
-		if err != nil {
-			return nil, err
-		}
-
-		resolvedIDs := api.ResolveImageID(stream, tagOrID)
-		switch len(resolvedIDs) {
-		case 1:
-			ref.ID = resolvedIDs.List()[0]
-			return &api.TagEvent{
-				Created:              unversioned.Now(),
-				DockerImageReference: ref.String(),
-				Image:                ref.ID,
-			}, nil
-		case 0:
-			return nil, fmt.Errorf("no images match the prefix %q", tagOrID)
-		default:
-			return nil, fmt.Errorf("multiple images match the prefix %q: %s", tagOrID, strings.Join(resolvedIDs.List(), ", "))
-		}
+		return api.ResolveImageID(stream, tagOrID)
 	case "ImageStreamTag":
 		return api.LatestTaggedImage(stream, tagOrID), nil
 	default:
-		return nil, fmt.Errorf("invalid from.kind %q: it must be ImageStreamImage or ImageStreamTag", tagRef.From.Kind)
+		return nil, fmt.Errorf("invalid from.kind %q: it must be DockerImage, ImageStreamImage or ImageStreamTag", tagRef.From.Kind)
 	}
 }
 

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -696,7 +696,7 @@ func TestTagsChanged(t *testing.T) {
 			},
 		},
 		"object reference to image stream image in same stream": {
-			stream: "registry:5000/ns/stream",
+			stream: "internalregistry:5000/ns/stream",
 			tags: map[string]api.TagReference{
 				"t1": {
 					From: &kapi.ObjectReference{
@@ -729,6 +729,45 @@ func TestTagsChanged(t *testing.T) {
 						{
 							DockerImageReference: "registry:5000/ns/stream@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 							Image:                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						},
+					},
+				},
+			},
+		},
+		"object reference to image stream image in same stream (bad digest)": {
+			stream: "internalregistry:5000/ns/stream",
+			tags: map[string]api.TagReference{
+				"t1": {
+					From: &kapi.ObjectReference{
+						Kind: "ImageStreamImage",
+						Name: "stream@12345",
+					},
+				},
+			},
+			existingTagHistory: map[string]api.TagEventList{
+				"other": {
+					Items: []api.TagEvent{
+						{
+							DockerImageReference: "registry:5000/ns/stream:12345",
+							Image:                "12345",
+						},
+					},
+				},
+			},
+			expectedTagHistory: map[string]api.TagEventList{
+				"t1": {
+					Items: []api.TagEvent{
+						{
+							DockerImageReference: "registry:5000/ns/stream:12345",
+							Image:                "12345",
+						},
+					},
+				},
+				"other": {
+					Items: []api.TagEvent{
+						{
+							DockerImageReference: "registry:5000/ns/stream:12345",
+							Image:                "12345",
 						},
 					},
 				},


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1277046.

The general take-away is we were unnecessarily expanding docker spec to point to internal registry, instead of pointing to the pull spec from the tag which is the source of the new tag.

@miminar ptal
@ncdc fyi