### PR TITLE
Bug1281928 - fix image stream tagging for DockerImage type images.

### DIFF
--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -341,6 +341,8 @@ func (o TagOptions) RunTag() error {
 				switch o.sourceKind {
 				case "DockerImage":
 					targetRef.From.Name = localRef.String()
+					// for external image we need to force re-import to fetch its metadata
+					delete(target.Annotations, imageapi.DockerImageRepositoryCheckAnnotation)
 				default:
 					targetRef.From.Name = localRef.NameString()
 					targetRef.From.Namespace = o.ref.Namespace


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1281928.

This reverts certain changes from #4853, epecially regarding image stream mapping for DockerImage types. This still needs more work, because with current changes I'm getting double tags created which may result in double builds. The idea is to import tags from external registry (since we provide that functionality right now) for images tagged with `oc tag` command. This way we wouldn't have to revert the aforementioned changes and still have reasonable output. Still investigating...