### PR TITLE
tito builder/tagger cleanup

### DIFF
--- a/.tito/lib/origin/builder/__init__.py
+++ b/.tito/lib/origin/builder/__init__.py
@@ -4,77 +4,95 @@ Code for building Origin
 
 import sys
 
-from tito.common import (get_latest_commit, get_latest_tagged_version, check_tag_exists,
-        run_command, get_script_path, find_spec_file, get_spec_version_and_release, munge_specfile)
+from tito.common import (
+    get_latest_commit,
+    get_latest_tagged_version,
+    check_tag_exists,
+    run_command,
+    find_spec_file,
+    get_spec_version_and_release,
+    munge_specfile
+)
+
 from tito.builder import Builder
 
 class OriginBuilder(Builder):
-  """
-  builder which defines 'commit' as the git hash prior to building
+    """
+    builder which defines 'commit' as the git hash prior to building
 
-  Used For:
-    - Packages that want to know the commit in all situations
-  """
+    Used For:
+        - Packages that want to know the commit in all situations
+    """
 
-  def _get_rpmbuild_dir_options(self):
-      git_hash = get_latest_commit()
-      cmd = '. ./hack/common.sh ; echo $(os::build::ldflags)'
-      ldflags = run_command('bash -c \'%s\''  % (cmd) )
+    def _get_rpmbuild_dir_options(self):
+        git_hash = get_latest_commit()
+        cmd = '. ./hack/common.sh ; echo $(os::build::ldflags)'
+        ldflags = run_command("bash -c '{0}'".format(cmd))
 
-      return ('--define "_topdir %s" --define "_sourcedir %s" --define "_builddir %s" '
-            '--define "_srcrpmdir %s" --define "_rpmdir %s" --define "ldflags %s" '
-            '--define "commit %s" ' % (
-                self.rpmbuild_dir,
-                self.rpmbuild_sourcedir, self.rpmbuild_builddir,
-                self.rpmbuild_basedir, self.rpmbuild_basedir,
-                ldflags, git_hash))
+        return ('--define "_topdir %s" --define "_sourcedir %s" --define "_builddir %s" '
+                '--define "_srcrpmdir %s" --define "_rpmdir %s" --define "ldflags %s" '
+                '--define "commit %s" ' % (
+                    self.rpmbuild_dir,
+                    self.rpmbuild_sourcedir, self.rpmbuild_builddir,
+                    self.rpmbuild_basedir, self.rpmbuild_basedir,
+                    ldflags, git_hash))
 
-  def _setup_test_specfile(self):
-      if self.test and not self.ran_setup_test_specfile:
-          # If making a test rpm we need to get a little crazy with the spec
-          # file we're building off. (note that this is a temp copy of the
-          # spec) Swap out the actual release for one that includes the git
-          # SHA1 we're building for our test package:
-          sha = self.git_commit_id[:7]
-          fullname = "%s-%s" % (self.project_name, self.display_version)
-          munge_specfile(
-              self.spec_file,
-              sha,
-              self.commit_count,
-              fullname,
-              self.tgz_filename,
-          )
-          # Custom Openshift v3 stuff follows, everything above is the standard
-          # builder
-          cmd = '. ./hack/common.sh ; echo $(os::build::ldflags)'
-          ldflags = run_command('bash -c \'%s\''  % (cmd) )
-          update_ldflags = "sed -i 's|^%%global ldflags .*$|%%global ldflags %s|' %s" % \
-            (ldflags, self.spec_file)
-          output = run_command(update_ldflags)
+    def _setup_test_specfile(self):
+        if self.test and not self.ran_setup_test_specfile:
+            # If making a test rpm we need to get a little crazy with the spec
+            # file we're building off. (note that this is a temp copy of the
+            # spec) Swap out the actual release for one that includes the git
+            # SHA1 we're building for our test package:
+            sha = self.git_commit_id[:7]
+            fullname = "{0}-{1}".format(self.project_name, self.display_version)
+            munge_specfile(
+                self.spec_file,
+                sha,
+                self.commit_count,
+                fullname,
+                self.tgz_filename,
+            )
+            # Custom Openshift v3 stuff follows, everything above is the standard
+            # builder
+            cmd = '. ./hack/common.sh ; echo $(os::build::ldflags)'
+            ldflags = run_command("bash -c '{0}'".format(cmd))
+            print("LDFLAGS::{0}".format(ldflags))
+            update_ldflags = \
+                    "sed -i 's|^%%global ldflags .*$|%%global ldflags {0}|' {1}".format(
+                        ' '.join([ldflag.strip() for ldflag in ldflags.split()]),
+                        self.spec_file
+                    )
+            # FIXME - output is never used
+            output = run_command(update_ldflags)
 
-          self.build_version += ".git." + str(self.commit_count) + "." + str(self.git_commit_id[:7])
-          self.ran_setup_test_specfile = True
+            self.build_version += ".git." + \
+                str(self.commit_count) + \
+                "." + \
+                str(self.git_commit_id[:7])
+            self.ran_setup_test_specfile = True
 
-  def _get_build_version(self):
-      """
-      Figure out the git tag and version-release we're building.
-      """
-      # Determine which package version we should build:
-      build_version = None
-      if self.build_tag:
-          build_version = self.build_tag[len(self.project_name + "-"):]
-      else:
-          build_version = get_latest_tagged_version(self.project_name)
-          if build_version is None:
-              if not self.test:
-                  error_out(["Unable to lookup latest package info.",
-                          "Perhaps you need to tag first?"])
-              sys.stderr.write("WARNING: unable to lookup latest package "
-                  "tag, building untagged test project\n")
-              build_version = get_spec_version_and_release(self.start_dir,
-                  find_spec_file(in_dir=self.start_dir))
-          self.build_tag = "v%s" % (build_version)
+    def _get_build_version(self):
+        """
+        Figure out the git tag and version-release we're building.
+        """
+        # Determine which package version we should build:
+        build_version = None
+        if self.build_tag:
+            build_version = self.build_tag[len(self.project_name + "-"):]
+        else:
+            build_version = get_latest_tagged_version(self.project_name)
+            if build_version is None:
+                if not self.test:
+                    error_out(["Unable to lookup latest package info.",
+                            "Perhaps you need to tag first?"])
+                sys.stderr.write("WARNING: unable to lookup latest package "
+                    "tag, building untagged test project\n")
+                build_version = get_spec_version_and_release(self.start_dir,
+                    find_spec_file(in_dir=self.start_dir))
+            self.build_tag = "v{0}".format(build_version)
 
-      if not self.test:
-          check_tag_exists(self.build_tag, offline=self.offline)
-      return build_version
+        if not self.test:
+            check_tag_exists(self.build_tag, offline=self.offline)
+        return build_version
+
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:

--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -4,201 +4,218 @@ Code for tagging Origin packages
 
 import os
 import re
-import rpm
 import shutil
 import subprocess
 import tempfile
 import textwrap
-import sys
 
-from tito.common import (get_latest_commit, run_command,
-        get_latest_tagged_version, increase_version, increase_zstream,
-        get_spec_version_and_release, tag_exists_locally, tag_exists_remotely,
-        head_points_to_tag, undo_tag, tito_config_dir)
-#, get_spec_version_and_release
+from tito.common import (
+    find_git_root,
+    get_latest_commit,
+    run_command,
+    get_latest_tagged_version,
+    tag_exists_locally,
+    tag_exists_remotely,
+    head_points_to_tag,
+    undo_tag,
+    tito_config_dir,
+)
+
 from tito.compat import write
 from tito.tagger import VersionTagger
 from tito.exception import TitoException
 
 
 class OriginTagger(VersionTagger):
-  """
-  Origin custom tagger. This tagger has several deviations from normal
-  the normal tito tagger.
+    """
+    Origin custom tagger. This tagger has several deviations from normal
+    the normal tito tagger.
 
-  ** Rather than versions being tagged %{name}-%{version}-%{release} they're
-  tagged as v%{version} in order to preserve compatibility with origin build
-  processes. This means you really should not attempt to use the release field
-  for anything useful, it should probably always remain zero.
+    ** Rather than versions being tagged %{name}-%{version}-%{release} they're
+    tagged as v%{version} in order to preserve compatibility with origin build
+    processes. This means you really should not attempt to use the release field
+    for anything useful, it should probably always remain zero.
 
-  ** RPM specfile global commit is updated with the git hash, this may be
-  relevant and popular with other golang projects, so TODO: submit to tito
-  upstream.
+    ** RPM specfile global commit is updated with the git hash, this may be
+    relevant and popular with other golang projects, so TODO: submit to tito
+    upstream.
 
-  Requires that your commit global is written on one single line like this:
+    Requires that your commit global is written on one single line like this:
 
-  %global commit 460abe2a3abe0fa22ac96c551fe71c0fc36f7475
+    %global commit 460abe2a3abe0fa22ac96c551fe71c0fc36f7475
 
-  ** RPM specfile global ldflags is updated with os::build::ldflags as generated
-  by importing hack/common.sh this absolutely depends on the non standard
-  version tagging outlined above. This is 100% openshift specific
+    ** RPM specfile global ldflags is updated with os::build::ldflags as generated
+    by importing hack/common.sh this absolutely depends on the non standard
+    version tagging outlined above. This is 100% openshift specific
 
-  Requires that your ldflags global is written on one single line like this:
-  %global ldflags -X foo -X bar
+    Requires that your ldflags global is written on one single line like this:
+    %global ldflags -X foo -X bar
 
-  NOTE: Does not work with --use-version as tito does not provide a way to
-  override the forced version tagger, see
-  https://github.com/dgoodwin/tito/pull/163
+    NOTE: Does not work with --use-version as tito does not provide a way to
+    override the forced version tagger, see
+    https://github.com/dgoodwin/tito/pull/163
 
 
-  Used For:
+    Used For:
     - Origin, probably not much else
-  """
-
-  def _tag_release(self):
     """
-    Tag a new release of the package, add specfile global named commit. (ie:
-    x.y.z-r+1) and ldflags from hack/common.sh os::build::ldflags
-    """
-    self._make_changelog()
-    new_version = self._bump_version()
-    new_version = re.sub(r"-.*","",new_version)
-    git_hash = get_latest_commit()
-    update_commit = "sed -i 's/^%%global commit .*$/%%global commit %s/' %s" % \
-      (git_hash, self.spec_file)
-    output = run_command(update_commit)
 
-    cmd = '. ./hack/common.sh ; echo $(os::build::ldflags)'
-    ldflags = run_command('bash -c \'%s\''  % (cmd) )
-    # hack/common.sh will tell us that the tree is dirty because tito has
-    # already mucked with things, but lets not consider the tree to be dirty
-    ldflags = ldflags.replace('-dirty','')
-    update_ldflags = "sed -i 's|^%%global ldflags .*$|%%global ldflags %s|' %s" % \
-           (ldflags, self.spec_file)
-    output = run_command(update_ldflags)
+    def _tag_release(self):
+        """
+        Tag a new release of the package, add specfile global named commit.
+        (ie: x.y.z-r+1) and ldflags from hack/common.sh os::build::ldflags
+        """
+        self._make_changelog()
+        new_version = self._bump_version()
+        new_version = re.sub(r"-.*", "", new_version)
+        git_hash = get_latest_commit()
+        update_commit = \
+            "sed -i 's/^%%global commit .*$/%%global commit {0}/' {1}".format(
+                git_hash,
+                self.spec_file
+            )
+        output = run_command(update_commit)
 
-    self._check_tag_does_not_exist(self._get_new_tag(new_version))
-    self._update_changelog(new_version)
-    self._update_package_metadata(new_version)
+        cmd = '. ./hack/common.sh ; echo $(os::build::ldflags)'
+        ldflags = run_command('bash -c \'{0}\''.format(cmd))
+        # hack/common.sh will tell us that the tree is dirty because tito has
+        # already mucked with things, but lets not consider the tree to be
+        # dirty
+        ldflags = ldflags.replace('-dirty', '')
+        update_ldflags = \
+            "sed -i 's|^%%global ldflags .*$|%%global ldflags {0}|' {1}".format(
+                ldflags,
+                self.spec_file
+            )
+        # FIXME - this output is never used
+        output = run_command(update_ldflags)
 
-  def _get_new_tag(self, new_version):
-      """ Returns the actual tag we'll be creating. """
-      return "v%s" % (new_version)
+        self._check_tag_does_not_exist(self._get_new_tag(new_version))
+        self._update_changelog(new_version)
+        self._update_package_metadata(new_version)
 
-  def get_latest_tagged_version(package_name):
-      """
-      Return the latest git tag for this package in the current branch.
-      Uses the info in .tito/packages/package-name.
+    def _get_new_tag(self, new_version):
+        """ Returns the actual tag we'll be creating. """
+        return "v{0}".format(new_version)
 
-      Returns None if file does not exist.
-      """
-      git_root = find_git_root()
-      rel_eng_dir = os.path.join(git_root, tito_config_dir())
-      file_path = "%s/packages/%s" % (rel_eng_dir, package_name)
-      debug("Getting latest package info from: %s" % file_path)
-      if not os.path.exists(file_path):
-          return None
+    def get_latest_tagged_version(package_name):
+        """
+        Return the latest git tag for this package in the current branch.
+        Uses the info in .tito/packages/package-name.
 
-      output = run_command("awk '{ print $1 ; exit }' %s" % file_path)
-      if output is None or output.strip() == "":
-          error_out("Error looking up latest tagged version in: %s" % file_path)
+        Returns None if file does not exist.
+        """
+        git_root = find_git_root()
+        rel_eng_dir = os.path.join(git_root, tito_config_dir())
+        file_path = "{0}/packages/{1}".format(rel_eng_dir, package_name)
+        debug("Getting latest package info from: {0}".format(file_path))
+        if not os.path.exists(file_path):
+            return None
 
-      return output
+        output = run_command("awk '{ print $1 ; exit }' {0}".format(file_path))
+        if output is None or output.strip() == "":
+            error_out("Error looking up latest tagged version in: {0}".format(file_path))
 
-  def _make_changelog(self):
-      """
-      Create a new changelog entry in the spec, with line items from git
-      """
-      if self._no_auto_changelog:
-          debug("Skipping changelog generation.")
-          return
+        return output
 
-      in_f = open(self.spec_file, 'r')
-      out_f = open(self.spec_file + ".new", 'w')
+    def _make_changelog(self):
+        """
+        Create a new changelog entry in the spec, with line items from git
+        """
+        if self._no_auto_changelog:
+            debug("Skipping changelog generation.")
+            return
 
-      found_changelog = False
-      for line in in_f.readlines():
-          out_f.write(line)
+        in_f = open(self.spec_file, 'r')
+        out_f = open(self.spec_file + ".new", 'w')
 
-          if not found_changelog and line.startswith("%changelog"):
-              found_changelog = True
+        found_changelog = False
+        for line in in_f.readlines():
+            out_f.write(line)
 
-              old_version = get_latest_tagged_version(self.project_name)
+            if not found_changelog and line.startswith("%changelog"):
+                found_changelog = True
 
-              # don't die if this is a new package with no history
-              if old_version is not None:
-                  last_tag = "v%s" % (old_version)
-                  output = self._generate_default_changelog(last_tag)
-              else:
-                  output = self._new_changelog_msg
+                old_version = get_latest_tagged_version(self.project_name)
 
-              fd, name = tempfile.mkstemp()
-              write(fd, "# Create your changelog entry below:\n")
-              if self.git_email is None or (('HIDE_EMAIL' in self.user_config) and
-                      (self.user_config['HIDE_EMAIL'] not in ['0', ''])):
-                  header = "* %s %s\n" % (self.today, self.git_user)
-              else:
-                  header = "* %s %s <%s>\n" % (self.today, self.git_user,
-                     self.git_email)
+                # don't die if this is a new package with no history
+                if old_version is not None:
+                    last_tag = "v%s" % (old_version)
+                    output = self._generate_default_changelog(last_tag)
+                else:
+                    output = self._new_changelog_msg
 
-              write(fd, header)
+                fd, name = tempfile.mkstemp()
+                write(fd, "# Create your changelog entry below:\n")
+                if self.git_email is None or \
+                        (('HIDE_EMAIL' in self.user_config) and
+                        (self.user_config['HIDE_EMAIL'] not in ['0', ''])):
+                    header = "* {0} {1}\n".format(self.today, self.git_user)
+                else:
+                    header = "* {0} {1} <{2}>\n".format(
+                        self.today,
+                        self.git_user,
+                        self.git_email
+                    )
 
-              for cmd_out in output.split("\n"):
-                  write(fd, "- ")
-                  write(fd, "\n  ".join(textwrap.wrap(cmd_out, 77)))
-                  write(fd, "\n")
+                write(fd, header)
 
-              write(fd, "\n")
+                for cmd_out in output.split("\n"):
+                    write(fd, "- ")
+                    write(fd, "\n  ".join(textwrap.wrap(cmd_out, 77)))
+                    write(fd, "\n")
 
-              if not self._accept_auto_changelog:
-                  # Give the user a chance to edit the generated changelog:
-                  editor = 'vi'
-                  if "EDITOR" in os.environ:
-                      editor = os.environ["EDITOR"]
-                  subprocess.call(editor.split() + [name])
+                write(fd, "\n")
 
-              os.lseek(fd, 0, 0)
-              file = os.fdopen(fd)
+                if not self._accept_auto_changelog:
+                    # Give the user a chance to edit the generated changelog:
+                    editor = 'vi'
+                    if "EDITOR" in os.environ:
+                        editor = os.environ["EDITOR"]
+                    subprocess.call(editor.split() + [name])
 
-              for line in file.readlines():
-                  if not line.startswith("#"):
-                      out_f.write(line)
+                os.lseek(fd, 0, 0)
+                file = os.fdopen(fd)
 
-              output = file.read()
+                for line in file.readlines():
+                    if not line.startswith("#"):
+                        out_f.write(line)
 
-              file.close()
-              os.unlink(name)
+                output = file.read()
 
-      if not found_changelog:
-          print("WARNING: no %changelog section find in spec file. Changelog entry was not appended.")
+                file.close()
+                os.unlink(name)
 
-      in_f.close()
-      out_f.close()
+        if not found_changelog:
+            print("WARNING: no %%changelog section find in spec file. Changelog entry was not appended.")
 
-      shutil.move(self.spec_file + ".new", self.spec_file)
+        in_f.close()
+        out_f.close()
 
-  def _undo(self):
-      """
-      Undo the most recent tag.
+        shutil.move(self.spec_file + ".new", self.spec_file)
 
-      Tag commit must be the most recent commit, and the tag must not
-      exist in the remote git repo, otherwise we report and error out.
-      """
-      tag = "v%s" % (get_latest_tagged_version(self.project_name))
-      print("Undoing tag: %s" % tag)
-      if not tag_exists_locally(tag):
-          raise TitoException(
-              "Cannot undo tag that does not exist locally.")
-      if not self.offline and tag_exists_remotely(tag):
-          raise TitoException("Cannot undo tag that has been pushed.")
+    def _undo(self):
+        """
+        Undo the most recent tag.
 
-      # Tag must be the most recent commit.
-      if not head_points_to_tag(tag):
-          raise TitoException("Cannot undo if tag is not the most recent commit.")
+        Tag commit must be the most recent commit, and the tag must not
+        exist in the remote git repo, otherwise we report and error out.
+        """
+        tag = "v{0}".format(get_latest_tagged_version(self.project_name))
+        print("Undoing tag: {0}".format(tag))
+        if not tag_exists_locally(tag):
+            raise TitoException(
+                "Cannot undo tag that does not exist locally.")
+        if not self.offline and tag_exists_remotely(tag):
+            raise TitoException("Cannot undo tag that has been pushed.")
 
-      # Everything looks good:
-      print
-      undo_tag(tag)
+        # Tag must be the most recent commit.
+        if not head_points_to_tag(tag):
+            raise TitoException("Cannot undo if tag is not the most recent commit.")
+
+        # Everything looks good:
+        print
+        undo_tag(tag)
 
 # This won't do anything until tito supports configuring the forcedversion tagger
 # See https://github.com/dgoodwin/tito/pull/163
@@ -219,3 +236,5 @@ class OriginForceVersionTagger(OriginTagger):
         self._update_changelog(new_version)
         self._update_setup_py(new_version)
         self._update_package_metadata(new_version)
+
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:


### PR DESCRIPTION
This is mostly just clean up to make the code more [pep8](https://www.python.org/dev/peps/pep-0008/) friendly

    - don't use mixed spacing tab width
    - string formatting
    - add vim modeline for sanity
    - handle/remove possible newlines from ldflags