### PR TITLE
Fix --to-docker missing namespace bug

### DIFF
--- a/pkg/generate/app/imageref.go
+++ b/pkg/generate/app/imageref.go
@@ -217,13 +217,15 @@ func (r *ImageRef) BuildOutput() (*buildapi.BuildOutput, error) {
 		return nil, err
 	}
 	kind := "ImageStreamTag"
+	name := imageapi.JoinImageStreamTag(imageRepo.Name, r.Reference.Tag)
 	if !r.AsImageStream {
 		kind = "DockerImage"
+		name = r.Reference.String()
 	}
 	return &buildapi.BuildOutput{
 		To: &kapi.ObjectReference{
 			Kind: kind,
-			Name: imageapi.JoinImageStreamTag(imageRepo.Name, r.Reference.Tag),
+			Name: name,
 		},
 	}, nil
 }

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -19,6 +19,8 @@ cat "${OS_ROOT}/Dockerfile" | oc new-build -D - --name=test
 oc get bc/test
 oc new-build --dockerfile=$'FROM centos:7\nRUN yum install -y httpd'
 oc get bc/centos
+oc new-build -D $'FROM openshift/origin:v1.1' --to-docker
+[[ $(oc get bc/origin --template '{{with .spec.output.to}}{{.kind}} {{.name}}{{end}}') == "DockerImage openshift/origin:latest" ]]
 oc delete all --all
 
 oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -


### PR DESCRIPTION
`oc new-build <source> --to-docker` incorrectly removed the namespace
part of the Docker image reference, eventually causing builds to push to
the wrong spec.