### PR TITLE
Improve web console scaling

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -207,6 +207,7 @@
         <script src="scripts/directives/oscImageSummary.js"></script>
         <script src="scripts/directives/oscKeyValues.js"></script>
         <script src="scripts/directives/oscRouting.js"></script>
+        <script src="scripts/directives/replicas.js"></script>
         <script src="scripts/directives/resources.js"></script>
         <script src="scripts/directives/overviewDeployment.js"></script>
         <script src="scripts/directives/nav.js"></script>

--- a/assets/app/scripts/controllers/deploymentConfig.js
+++ b/assets/app/scripts/controllers/deploymentConfig.js
@@ -182,9 +182,21 @@ angular.module('openshiftConsole')
           }
         };
 
+        $scope.scale = function(replicas) {
+          var showScalingError = function(result) {
+            $scope.alerts = $scope.alerts || {};
+            $scope.alerts["scale"] = {
+              type: "error",
+              message: "An error occurred scaling the deployment config.",
+              details: $filter('getErrorDetails')(result)
+            };
+          };
+
+          DeploymentsService.scaleDC($scope.deploymentConfig, replicas).then(_.noop, showScalingError);
+        };
+
         $scope.$on('$destroy', function(){
           DataService.unwatchAll(watches);
         });
-
     }));
   });

--- a/assets/app/scripts/directives/overviewDeployment.js
+++ b/assets/app/scripts/directives/overviewDeployment.js
@@ -10,6 +10,8 @@ angular.module('openshiftConsole')
         deploymentConfigId: '=',
         deploymentConfigMissing: '=',
         deploymentConfigDifferentService: '=',
+        deploymentConfig: '=',
+        scalable: '=',
 
         // Nested podTemplate fields
         imagesByDockerReference: '=',
@@ -27,27 +29,28 @@ angular.module('openshiftConsole')
           $scope.desiredReplicas = null;
         });
 
-        // Debounce scaling so multiple clicks within 500 milliseconds only
-        // result in one request.
+        // Debounce scaling so multiple clicks within 500 milliseconds only result in one request.
         var scale = _.debounce(function () {
           if (!angular.isNumber($scope.desiredReplicas)) {
             return;
           }
 
-          DeploymentsService.scale($scope.rc, $scope.desiredReplicas, $scope).then(
-            // success, no need for a message since the UI updates immediately
-            _.noop,
-            // failure
-            function(result) {
-              $scope.alerts = $scope.alerts || {};
-              $scope.desiredReplicas = null;
-              $scope.alerts["scale"] =
-                {
-                  type: "error",
-                  message: "An error occurred scaling the deployment.",
-                  details: $filter('getErrorDetails')(result)
-                };
-            });
+          var showScalingError = function(result) {
+            $scope.alerts = $scope.alerts || {};
+            $scope.desiredReplicas = null;
+            $scope.alerts["scale"] =
+              {
+                type: "error",
+                message: "An error occurred scaling the deployment.",
+                details: $filter('getErrorDetails')(result)
+              };
+          };
+
+          if ($scope.deploymentConfig) {
+            DeploymentsService.scaleDC($scope.deploymentConfig, $scope.desiredReplicas).then(_.noop, showScalingError);
+          } else {
+            DeploymentsService.scaleRC($scope.rc, $scope.desiredReplicas).then(_.noop, showScalingError);
+          }
         }, 500);
 
         $scope.viewPodsForDeployment = function(deployment) {
@@ -62,12 +65,20 @@ angular.module('openshiftConsole')
         };
 
         $scope.scaleUp = function() {
+          if (!$scope.scalable) {
+            return;
+          }
+
           $scope.desiredReplicas = $scope.getDesiredReplicas();
           $scope.desiredReplicas++;
           scale();
         };
 
         $scope.scaleDown = function() {
+          if (!$scope.scalable) {
+            return;
+          }
+
           $scope.desiredReplicas = $scope.getDesiredReplicas();
           if ($scope.desiredReplicas === 0) {
             return;

--- a/assets/app/scripts/directives/replicas.js
+++ b/assets/app/scripts/directives/replicas.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .directive('replicas', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        status: "=?",
+        spec: "=",
+        disableScaling: "=?",
+        scaleFn: "&?"
+      },
+      templateUrl: 'views/directives/replicas.html',
+      link: function(scope) {
+        scope.model = {
+          editing: false
+        };
+
+        scope.scale = function() {
+          if (scope.form.scaling.$valid) {
+            scope.scaleFn({ replicas: scope.model.desired });
+            scope.model.editing = false;
+          }
+        };
+
+        scope.cancel = function() {
+          scope.model.editing = false;
+        };
+      }
+    };
+  });

--- a/assets/app/scripts/filters/date.js
+++ b/assets/app/scripts/filters/date.js
@@ -63,21 +63,16 @@ angular.module('openshiftConsole')
       return moment().subtract(amt, unit).diff(moment(timestamp)) < 0;
     };
   })
-  .filter('orderObjectsByDate', function() {
+  .filter('orderObjectsByDate', function(toArrayFilter) {
     return function(items, reverse) {
-      var filtered = [];
-      angular.forEach(items, function(item) {
-        filtered.push(item);
-      });
-      filtered.sort(function (a, b) {
+      items = toArrayFilter(items);
+      items.sort(function (a, b) {
         if (!a.metadata || !a.metadata.creationTimestamp || !b.metadata || !b.metadata.creationTimestamp) {
           throw "orderObjectsByDate expects all objects to have the field metadata.creationTimestamp";
         }
-        return moment(a.metadata.creationTimestamp).diff(moment(b.metadata.creationTimestamp));
+        var diff = moment(a.metadata.creationTimestamp).diff(moment(b.metadata.creationTimestamp));
+        return reverse ? diff * -1 : diff;
       });
-      if(reverse) {
-        filtered.reverse();
-      }
-      return filtered;
+      return items;
     };
   });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -746,10 +746,6 @@ select:invalid {
   width: 60px;
 }
 
-.deployment .replicas-form input {
-  display: inline-block;
-}
-
 .action-button {
   color: @gray-light;
   cursor: pointer;

--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -7,6 +7,7 @@
   deploymentConfigId               - String. Optional. If present, indicates this replication controller came from a deployment.
   deploymentConfigMissing          - Boolean. Optional.
   deploymentConfigDifferentService - Boolean. Optional.
+  deploymentConfig                 - Object. Required for scaling deployments.
 
   imagesByDockerReference - map[dockerReference][]Image. Optional.
   builds                  - map[buildId]build. Optional.
@@ -103,7 +104,12 @@
           <div flex></div>
           <div column>
             <div>
-              <a href="" ng-click="scaleUp()" title="Scale up" role="button">
+              <a href=""
+                 ng-click="scaleUp()"
+                 title="Scale up"
+                 ng-class="{ disabled: !scalable }"
+                 ng-attr-title="{{!scalable ? undefined : 'Scale down'}}"
+                 ng-attr-aria-disabled="{{!scalable ? 'true' : undefined}}">
                 <i class="fa fa-chevron-up"></i>
                 <span class="sr-only">Scale up</span>
               </a>
@@ -112,9 +118,9 @@
               <!-- Remove the title when disabled because the not-allowed styled cursor overlaps the tooltip on some browsers. -->
               <a href=""
                  ng-click="scaleDown()"
-                 ng-class="{ disabled: getDesiredReplicas() === 0 }"
-                 ng-attr-title="{{(getDesiredReplicas() === 0) ? undefined : 'Scale down'}}"
-                 ng-attr-aria-disabled="{{(getDesiredReplicas() === 0) ? 'true' : undefined}}"
+                 ng-class="{ disabled: !scalable || getDesiredReplicas() === 0 }"
+                 ng-attr-title="{{(!scalable || getDesiredReplicas() === 0) ? undefined : 'Scale down'}}"
+                 ng-attr-aria-disabled="{{(!scalable || getDesiredReplicas() === 0) ? 'true' : undefined}}"
                  role="button">
                 <i class="fa fa-chevron-down"></i>
                 <span class="sr-only">Scale down</span>

--- a/assets/app/views/browse/_deployment-details.html
+++ b/assets/app/views/browse/_deployment-details.html
@@ -30,16 +30,16 @@
       <button ng-show="(deployment | deploymentIsInProgress) && !deployment.metadata.deletionTimestamp" type="button" ng-click="cancelRunningDeployment(deployment)" class="btn btn-default btn-xs">Cancel</button>
     </span>
   </dd>
-  <dt ng-if="deployment | isDeployment">Deployment config:</dt>
-  <dd ng-if="deployment | isDeployment">
+  <dt ng-if-start="deployment | isDeployment">Deployment config:</dt>
+  <dd ng-if-end>
     <a href="{{deploymentConfigName | navigateResourceURL : 'DeploymentConfig' : deployment.metadata.namespace}}">{{deploymentConfigName}}</a>
   </dd>
-  <dt ng-if="deployment | annotation:'deploymentStatusReason'">Status reason:</dt>
-  <dd ng-if="deployment | annotation:'deploymentStatusReason'">
+  <dt ng-if-start="deployment | annotation:'deploymentStatusReason'">Status reason:</dt>
+  <dd ng-if-end>
     {{deployment | annotation:'deploymentStatusReason'}}
   </dd>
-  <dt ng-if="deployment | deploymentIsInProgress">Duration:</dt>
-  <dd ng-if="deployment | deploymentIsInProgress">
+  <dt ng-if-start="deployment | deploymentIsInProgress">Duration:</dt>
+  <dd ng-if-end>
     <span ng-switch="deployment | deploymentStatus" class="hide-ng-leave">
       <span ng-switch-when="Running">running for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
       <span ng-switch-default>waiting for <duration-until-now timestamp="deployment.metadata.creationTimestamp"></duration-until-now></span>
@@ -52,47 +52,12 @@
   </dd>
   <dt>Replicas:</dt>
   <dd>
-    <div ng-show="!replicas.editing">
-      {{deployment.status.replicas}} current / {{deployment.spec.replicas}} desired
-      <a href="" title="Edit" class="action-button" ng-click="replicas.desired = deployment.spec.replicas; replicas.editing = true">
-        <i class="icon icon-pencil" style="margin-left: 5px;"></i>
-        <span class="sr-only">Edit</span>
-      </a>
-    </div>
-    <div ng-show="replicas.editing">
-      <form name="replicas.form" ng-submit="scale()" class="replicas-form">
-        <span ng-class="{'has-error': replicas.form.$invalid}">
-          <input type="number"
-                 name="desired"
-                 ng-model="replicas.desired"
-                 ng-required="true"
-                 min="0"
-                 ng-pattern="/^\-?\d+$/"
-                 focus-when="{{replicas.editing}}"
-                 select-on-focus
-                 class="form-control input-number">
-        </span>
-        <a href="" title="Scale" class="action-button" ng-click="scale()">
-          <i class="icon icon-ok action-button" style="margin-left: 5px;"></i>
-          <span class="sr-only">Scale</span>
-        </a>
-        <a href="" title="Cancel" class="action-button" ng-click="cancelScale()">
-          <i class="icon icon-remove action-button" style="margin-left: 5px;"></i>
-          <span class="sr-only">Cancel</span>
-        </a>
-        <div ng-if="replicas.form.$invalid" class="has-error">
-          <div ng-if="replicas.form.desired.$error.required" class="help-block">
-            A value for replicas is required.
-          </div>
-          <div ng-if="replicas.form.desired.$error.pattern" class="help-block">
-            Replicas must be a whole number.
-          </div>
-          <div ng-if="replicas.form.desired.$error.min" class="help-block">
-            Replicas can't be negative.
-          </div>
-        </div>
-      </form>
-    </div>
+    <!-- Enable scaling if this is a plain replication controller or it's the active deployment. -->
+    <replicas status="deployment.status.replicas"
+              spec="deployment.spec.replicas"
+              disable-scaling="(deployment | isDeployment) && !deploymentConfigMissing && (!isActive || !deploymentConfig)"
+              scale-fn="scale(replicas)">
+    </replicas>
   </dd>
   <annotations annotations="deployment.metadata.annotations"></annotations>
 </dl>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -77,7 +77,7 @@
               <dd ng-repeat="(selectorLabel, selectorValue) in deploymentConfig.spec.selector">{{selectorLabel}}={{selectorValue}}<span ng-show="!$last">, </span></dd>
               <dt>Replicas:</dt>
               <dd>
-                {{deploymentConfig.spec.replicas}}
+                <replicas spec="deploymentConfig.spec.replicas" scale-fn="scale(replicas)"></replicas>
               </dd>
               <dt>Pod template:</dt>
               <dd>&nbsp;</dd>

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -3,12 +3,23 @@
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>
     <div ng-if="!loaded">Loading...</div>
-    <div ng-if="deployment" class="deployment">
+    <div ng-if="deployment">
       <div class="row">
         <div class="col-md-12">
           <div class="tile">
             <h1>
               {{deployment.metadata.name}}
+              <span
+                ng-if="deploymentConfigMissing"
+                class="pficon pficon-warning-triangle-o"
+                style="cursor: help; vertical-align: middle;"
+                data-toggle="tooltip"
+                data-placement="right"
+                data-trigger="hover"
+                title="The deployment's deployment config is missing."
+                aria-hidden="true">
+              </span>
+              <span ng-if="deploymentConfigMissing" class="sr-only">Warning: The deployment's deployment config is missing.</span>
               <small class="meta">created <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></small>
               <div class="pull-right dropdown">
                 <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>

--- a/assets/app/views/directives/replicas.html
+++ b/assets/app/views/directives/replicas.html
@@ -1,0 +1,47 @@
+<div ng-show="!model.editing">
+  <span ng-if="status === undefined">{{spec}}</span>
+  <span ng-if="status !== undefined">{{status}} current / {{spec}} desired</span>
+  <a href="" title="Edit" class="action-button" ng-if="!disableScaling && scaleFn" ng-click="model.desired = spec; model.editing = true">
+    <i class="icon icon-pencil" style="margin-left: 5px;"></i>
+    <span class="sr-only">Edit</span>
+  </a>
+</div>
+<div ng-show="!disableScaling && model.editing">
+  <form name="form.scaling" ng-submit="scale()" class="form-inline">
+    <span ng-class="{'has-error': form.scaling.$invalid}">
+      <input type="number"
+             name="desired"
+             ng-model="model.desired"
+             ng-required="true"
+             min="0"
+             ng-pattern="/^\-?\d+$/"
+             focus-when="{{model.editing}}"
+             select-on-focus
+             class="input-number">
+    </span>
+    <a href=""
+       title="Scale"
+       class="action-button"
+       ng-attr-aria-disabled="{{form.scaling.$invalid ? 'true' : undefined}}"
+       ng-click="scale()"
+       role="button">
+      <i class="icon icon-ok" style="margin-left: 5px;"></i>
+      <span class="sr-only">Scale</span>
+    </a>
+    <a href="" title="Cancel" class="action-button" ng-click="cancel()" role="button">
+      <i class="icon icon-remove" style="margin-left: 5px;"></i>
+      <span class="sr-only">Cancel</span>
+    </a>
+    <div ng-if="form.scaling.$invalid" class="has-error">
+      <div ng-if="form.scaling.desired.$error.required" class="help-block">
+        A value for replicas is required.
+      </div>
+      <div ng-if="form.scaling.desired.$error.pattern" class="help-block">
+        Replicas must be a whole number.
+      </div>
+      <div ng-if="form.scaling.desired.$error.min" class="help-block">
+        Replicas can't be negative.
+      </div>
+    </div>
+  </form>
+</div>

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -176,6 +176,8 @@
                 deployment-config-id="deploymentConfigId"
                 deployment-config-missing="deploymentConfigs && !deploymentConfigs[deploymentConfigId]"
                 deployment-config-different-service="deploymentConfigs[deploymentConfigId] && !deploymentConfigsByService[serviceId][deploymentConfigId]"
+                deployment-config="deploymentConfigs[deploymentConfigId]"
+                scalable="isScalable(deployment, deploymentConfigId)"
                 images-by-docker-reference="imagesByDockerReference"
                 builds="builds"
                 pods="podsByDeployment[deployment.metadata.name]"
@@ -223,6 +225,7 @@
               deployment-config-id="deploymentConfigId"
               deployment-config-missing="deploymentConfigs && !deploymentConfigs[deploymentConfigId]"
               deployment-config-different-service="deploymentConfigs[deploymentConfigId] && !deploymentConfigsByService[''][deploymentConfigId]"
+              scalable="true"
               images-by-docker-reference="imagesByDockerReference"
               builds="builds"
               pods="podsByDeployment[deployment.metadata.name]">


### PR DESCRIPTION
https://trello.com/c/hdJYeLdx

- Scale the deployment config rather than the replication controller for deployments
- Only allow scaling of the most recent in progress or complete deployment on the overview
- Add scaling controls to the deployment config page
- Hide scaling controls on the deployment page when it has a deployment config

Fixes #5926 
Depends on #5875 

- [x] Move edit replicas input into a directive that can be reused between deployment config and vanilla replication controller pages
- [x] Rebase when #5875 lands
- [x] Edit DC rather than scale subresource (currently, no web console API group support for `experimental/v1beta1`)
- [x] Allow scaling latest active deployment on deployment page

/cc @jwforres @ironcladlou 