### PR TITLE
better url check, better avoid DialTCP frailities for non-http protocols

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -73,7 +73,7 @@ func fetchSource(dir string, build *api.Build, urlTimeout time.Duration, in io.R
 func checkRemoteGit(url string, timeout time.Duration) error {
 	glog.V(4).Infof("git ls-remote --heads %q", url)
 	cmd := exec.Command("git", "ls-remote", "--heads", url)
-	cmd.Env = []string{"GIT_ASKPASS=/bin/true"}
+	cmd.Env = []string{"GIT_ASKPASS=/bin/true", "GIT_SSH=" + os.Getenv("GIT_SSH")}
 
 	var (
 		out []byte

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -26,7 +26,7 @@ oc get buildConfigs
 oc get bc
 oc get builds
 
-# make sure the imagestream is imported before starting a build or the build will immediately fail.
+# make sure the imagestream has the latest tag before starting a build or the build will immediately fail.
 wait_for_command "oc get is ruby-20-centos7 | grep latest"
 
 REAL_OUTPUT_TO=$(oc get bc/ruby-sample-build --template='{{ .spec.output.to.name }}')


### PR DESCRIPTION
@bparees @csrwng this is the next part (after all git clone spec / url validation fixes) for the issue of doing an ssh based git clone to a provide repo with a user ID other than `git`.

Note: it is quite possible additional changes are needed; in my test the actual `git clone` from the builder is failing (though I can execute the example same `git clone` from the command line).

Either my test/env setup is still a bit off, or the scm auth for ssh private keys is incorrect;  Hopefully I can sync up with @csrwng when I'm back in the office on Thursday and do some compares with him.

With that preamble - PTAL - thx.