### PR TITLE
add requester username to project template

### DIFF
--- a/pkg/project/api/types.go
+++ b/pkg/project/api/types.go
@@ -53,4 +53,7 @@ const (
 	// ProjectNodeSelector is an annotation that holds the node selector;
 	// the node selector annotation determines which nodes will have pods from this project scheduled to them
 	ProjectNodeSelector = "openshift.io/node-selector"
+	// ProjectRequester is the username that requested a given project.  Its not guaranteed to be present,
+	// but it is set by the default project template.
+	ProjectRequester = "openshift.io/requester"
 )

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -67,8 +67,10 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 
 	projectName := projectRequest.Name
 	projectAdmin := ""
+	projectRequester := ""
 	if userInfo, exists := kapi.UserFrom(ctx); exists {
 		projectAdmin = userInfo.GetName()
+		projectRequester = userInfo.GetName()
 	}
 
 	template, err := r.getTemplate()
@@ -86,6 +88,8 @@ func (r *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 			template.Parameters[i].Value = projectRequest.DisplayName
 		case ProjectNameParam:
 			template.Parameters[i].Value = projectName
+		case ProjectRequesterParam:
+			template.Parameters[i].Value = projectRequester
 		}
 	}
 

--- a/pkg/project/registry/projectrequest/delegated/sample_template.go
+++ b/pkg/project/registry/projectrequest/delegated/sample_template.go
@@ -16,10 +16,11 @@ const (
 	ProjectDisplayNameParam = "PROJECT_DISPLAYNAME"
 	ProjectDescriptionParam = "PROJECT_DESCRIPTION"
 	ProjectAdminUserParam   = "PROJECT_ADMIN_USER"
+	ProjectRequesterParam   = "PROJECT_REQUESTING_USER"
 )
 
 var (
-	parameters = []string{ProjectNameParam, ProjectDisplayNameParam, ProjectDescriptionParam, ProjectAdminUserParam}
+	parameters = []string{ProjectNameParam, ProjectDisplayNameParam, ProjectDescriptionParam, ProjectAdminUserParam, ProjectRequesterParam}
 )
 
 func DefaultTemplate() *templateapi.Template {
@@ -33,6 +34,7 @@ func DefaultTemplate() *templateapi.Template {
 	project.Annotations = map[string]string{
 		projectapi.ProjectDescription: "${" + ProjectDescriptionParam + "}",
 		projectapi.ProjectDisplayName: "${" + ProjectDisplayNameParam + "}",
+		projectapi.ProjectRequester:   "${" + ProjectRequesterParam + "}",
 	}
 	ret.Objects = append(ret.Objects, project)
 

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -78,6 +78,14 @@ func TestUnprivilegedNewProject(t *testing.T) {
 
 	waitForProject(t, valerieOpenshiftClient, "new-project", 5*time.Second, 10)
 
+	actualProject, err := valerieOpenshiftClient.Projects().Get("new-project")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if e, a := "valerie", actualProject.Annotations[projectapi.ProjectRequester]; e != a {
+		t.Errorf("incorrect project requester: expected %v, got %v", e, a)
+	}
+
 	if err := requestProject.Run(); !kapierrors.IsAlreadyExists(err) {
 		t.Fatalf("expected an already exists error, but got %v", err)
 	}


### PR DESCRIPTION
Add an `openshift.io/requester` annotation to our default project template.

This requires updates to documentation (I think) for the additional parameter we provide.

@stevekuznetsov  please review and open the doc pull.