### PR TITLE
Remove hook directory by default in gitserver example

### DIFF
--- a/examples/gitserver/gitserver.yaml
+++ b/examples/gitserver/gitserver.yaml
@@ -58,10 +58,11 @@ items:
           # to remove the need to use a persistent volume.
           - name: GIT_HOME
             value: /var/lib/git
+
           # The directory to use as the default hook directory for any
           # cloned or autolinked directories.
           - name: HOOK_PATH
-            value: /var/lib/git-hooks
+          # value: /var/lib/git-hooks
 
           # Authentication and authorization
 


### PR DESCRIPTION
BuildConfigs currently created by the gitserver post-receive hook are not quiet there yet. We need service account authentication to work (https://github.com/openshift/origin/pull/5908) and we need to be able to set the secret of the buildconfig when generating it in new-app. In the meantime, we won't use git hooks by default.

Fixes bz 1252822