### PR TITLE
custom Dockerfile path for the docker build

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14855,6 +14855,10 @@
      "forcePull": {
       "type": "boolean",
       "description": "forces the source build to pull the image if true"
+     },
+     "dockerfilePath": {
+      "type": "string",
+      "description": "path of the Dockerfile to use for building the Docker image, relative to the contextDir, if set"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1181,6 +1181,7 @@ func deepCopy_api_DockerBuildStrategy(in buildapi.DockerBuildStrategy, out *buil
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1638,6 +1638,7 @@ func autoconvert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy(in *buildapi.
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 
@@ -2352,6 +2353,7 @@ func autoconvert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy(in *apiv1.Doc
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1207,6 +1207,7 @@ func deepCopy_v1_DockerBuildStrategy(in apiv1.DockerBuildStrategy, out *apiv1.Do
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1647,6 +1647,7 @@ func autoconvert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy(in *buil
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 
@@ -2361,6 +2362,7 @@ func autoconvert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy(in *apiv
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1215,6 +1215,7 @@ func deepCopy_v1beta3_DockerBuildStrategy(in apiv1beta3.DockerBuildStrategy, out
 		out.Env = nil
 	}
 	out.ForcePull = in.ForcePull
+	out.DockerfilePath = in.DockerfilePath
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -326,6 +326,10 @@ type DockerBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool
+
+	// DockerfilePath is the path of the Dockerfile that will be used to build the Docker image,
+	// relative to the root of the context (contextDir).
+	DockerfilePath string
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -309,6 +309,10 @@ type DockerBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool `json:"forcePull,omitempty" description:"forces the source build to pull the image if true"`
+
+	// DockerfilePath is the path of the Dockerfile that will be used to build the Docker image,
+	// relative to the root of the context (contextDir).
+	DockerfilePath string `json:"dockerfilePath,omitempty" description:"path of the Dockerfile to use for building the Docker image, relative to the contextDir, if set"`
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -299,6 +299,10 @@ type DockerBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool `json:"forcePull,omitempty" description:"forces the source build to pull the image if true"`
+
+	// DockerfilePath is the path of the Dockerfile that will be used to build the Docker image,
+	// relative to the root of the context (contextDir).
+	DockerfilePath string `json:"dockerfilePath,omitempty" description:"path of the Dockerfile to use for building the Docker image, relative to the contextDir, if set"`
 }
 
 // SourceBuildStrategy defines input parameters specific to an Source build.

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -355,6 +355,22 @@ func validateDockerStrategy(strategy *buildapi.DockerBuildStrategy) fielderrors.
 	}
 
 	allErrs = append(allErrs, validateSecretRef(strategy.PullSecret).Prefix("pullSecret")...)
+
+	if len(strategy.DockerfilePath) != 0 {
+		cleaned := path.Clean(strategy.DockerfilePath)
+		switch {
+		case strings.HasPrefix(cleaned, "/"):
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("dockerfilePath", strategy.DockerfilePath, "dockerfilePath must not be an absolute path"))
+		case strings.HasPrefix(cleaned, ".."):
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("dockerfilePath", strategy.DockerfilePath, "dockerfilePath must not start with .."))
+		default:
+			if cleaned == "." {
+				cleaned = ""
+			}
+			strategy.DockerfilePath = cleaned
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -1,14 +1,21 @@
 package builder
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/builder/parser"
+	"github.com/fsouza/go-dockerclient"
 	kapi "k8s.io/kubernetes/pkg/api"
 
+	"github.com/openshift/origin/pkg/build/api"
+	"github.com/openshift/origin/pkg/generate/git"
 	"github.com/openshift/origin/pkg/util/docker/dockerfile"
+	"github.com/openshift/source-to-image/pkg/tar"
 )
 
 func TestInsertEnvAfterFrom(t *testing.T) {
@@ -126,6 +133,122 @@ RUN echo "hello world"
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("test[%d]: replaceLastFrom(node, %+v) = %+v; want %+v", i, test.image, got, want)
 			t.Logf("resulting Dockerfile:\n%s", dockerfile.ParseTreeToDockerfile(got))
+		}
+	}
+}
+
+// TestDockerfilePath validates that we can use a Dockefile with a custom name, and in a sub-directory
+func TestDockerfilePath(t *testing.T) {
+	tests := []struct {
+		contextDir     string
+		dockerfilePath string
+		dockerStrategy *api.DockerBuildStrategy
+	}{
+		// default Dockerfile path
+		{
+			dockerfilePath: "Dockerfile",
+			dockerStrategy: &api.DockerBuildStrategy{},
+		},
+		// custom Dockerfile path in the root context
+		{
+			dockerfilePath: "mydockerfile",
+			dockerStrategy: &api.DockerBuildStrategy{
+				DockerfilePath: "mydockerfile",
+			},
+		},
+		// custom Dockerfile path in a sub directory
+		{
+			dockerfilePath: "dockerfiles/mydockerfile",
+			dockerStrategy: &api.DockerBuildStrategy{
+				DockerfilePath: "dockerfiles/mydockerfile",
+			},
+		},
+		// custom Dockerfile path in a sub directory
+		// with a contextDir
+		{
+			contextDir:     "somedir",
+			dockerfilePath: "dockerfiles/mydockerfile",
+			dockerStrategy: &api.DockerBuildStrategy{
+				DockerfilePath: "dockerfiles/mydockerfile",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		buildDir, err := ioutil.TempDir("", "dockerfile-path")
+		if err != nil {
+			t.Errorf("failed to create tmpdir: %v", err)
+			continue
+		}
+		absoluteDockerfilePath := filepath.Join(buildDir, test.contextDir, test.dockerfilePath)
+		dockerfileContent := "FROM openshift/origin-base"
+		if err = os.MkdirAll(filepath.Dir(absoluteDockerfilePath), os.FileMode(0750)); err != nil {
+			t.Errorf("failed to create directory %s: %v", filepath.Dir(absoluteDockerfilePath), err)
+			continue
+		}
+		if err = ioutil.WriteFile(absoluteDockerfilePath, []byte(dockerfileContent), os.FileMode(0644)); err != nil {
+			t.Errorf("failed to write dockerfile to %s: %v", absoluteDockerfilePath, err)
+			continue
+		}
+
+		build := &api.Build{
+			Spec: api.BuildSpec{
+				Source: api.BuildSource{
+					Git: &api.GitBuildSource{
+						URI: "http://github.com/openshift/origin.git",
+					},
+					ContextDir: test.contextDir,
+				},
+				Strategy: api.BuildStrategy{
+					DockerStrategy: test.dockerStrategy,
+				},
+				Output: api.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "test/test-result:latest",
+					},
+				},
+			},
+		}
+
+		dockerClient := &FakeDocker{
+			buildImageFunc: func(opts docker.BuildImageOptions) error {
+				if opts.Dockerfile != test.dockerfilePath {
+					t.Errorf("Unexpected dockerfile path: %s (expected: %s)", opts.Dockerfile, test.dockerfilePath)
+				}
+				return nil
+			},
+		}
+
+		dockerBuilder := &DockerBuilder{
+			dockerClient: dockerClient,
+			build:        build,
+			gitClient:    git.NewRepository(),
+			tar:          tar.New(),
+		}
+
+		// this will validate that the Dockerfile is readable
+		// and append some labels to the Dockerfile
+		if err = dockerBuilder.addBuildParameters(buildDir); err != nil {
+			t.Errorf("failed to add build parameters: %v", err)
+			continue
+		}
+
+		// check that our Dockerfile has been modified
+		dockerfileData, err := ioutil.ReadFile(absoluteDockerfilePath)
+		if err != nil {
+			t.Errorf("failed to read dockerfile %s: %v", absoluteDockerfilePath, err)
+			continue
+		}
+		if !strings.Contains(string(dockerfileData), dockerfileContent) {
+			t.Errorf("Updated Dockerfile content does not contains the original Dockerfile content.\n\nOriginal content:\n%s\n\nUpdated content:\n%s\n", dockerfileContent, string(dockerfileData))
+			continue
+		}
+
+		// check that the docker client is called with the right Dockerfile parameter
+		if err = dockerBuilder.dockerBuild(buildDir); err != nil {
+			t.Errorf("failed to build: %v", err)
+			continue
 		}
 	}
 }

--- a/pkg/build/builder/dockerutil.go
+++ b/pkg/build/builder/dockerutil.go
@@ -83,7 +83,7 @@ func removeImage(client DockerClient, name string) error {
 }
 
 // buildImage invokes a docker build on a particular directory
-func buildImage(client DockerClient, dir string, noCache bool, tag string, tar tar.Tar, pullAuth *docker.AuthConfigurations, forcePull bool) error {
+func buildImage(client DockerClient, dir string, dockerfilePath string, noCache bool, tag string, tar tar.Tar, pullAuth *docker.AuthConfigurations, forcePull bool) error {
 	// TODO: be able to pass a stream directly to the Docker build to avoid the double temp hit
 	r, w := io.Pipe()
 	go func() {
@@ -100,6 +100,7 @@ func buildImage(client DockerClient, dir string, noCache bool, tag string, tar t
 		RmTmpContainer: true,
 		OutputStream:   os.Stdout,
 		InputStream:    r,
+		Dockerfile:     dockerfilePath,
 		NoCache:        noCache,
 		Pull:           forcePull,
 	}

--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -13,7 +13,7 @@ type FakeDocker struct {
 }
 
 func (d *FakeDocker) BuildImage(opts docker.BuildImageOptions) error {
-	if d.pushImageFunc != nil {
+	if d.buildImageFunc != nil {
 		return d.buildImageFunc(opts)
 	}
 	return nil


### PR DESCRIPTION
This PR allows to customize the name of the Dockerfile file in a docker build, similar to the '--file' option of the 'docker build' command.

our use case for this feature is to have different builds for a single codebase, resulting in different "applications". We already use different Dockerfiles for that, with the help of 'docker build --file', but it is not yet supported in openshift.

for the moment I only changed the API and the docker build. If you validate those changes and the naming, I'll go ahead and change the newapp / newbuild code to support a '--dockerfilePath' option, and the generate/dockerfile package to support a custom Dockerfile path (instead of the hardcoded "Dockerfile")