### PR TITLE
UPSTREAM: 17567: handle the HEAD verb correctly for authorization

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers.go
@@ -502,7 +502,7 @@ func (r *RequestInfoResolver) GetRequestInfo(req *http.Request) (RequestInfo, er
 		switch req.Method {
 		case "POST":
 			requestInfo.Verb = "create"
-		case "GET":
+		case "GET", "HEAD":
 			requestInfo.Verb = "get"
 		case "PUT":
 			requestInfo.Verb = "update"

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/handlers_test.go
@@ -222,7 +222,9 @@ func TestGetAPIRequestInfo(t *testing.T) {
 
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
+		{"HEAD", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/pods", "list", "api", "", "v1", api.NamespaceAll, "pods", "", "", []string{"pods"}},
+		{"HEAD", "/api/v1/pods", "list", "api", "", "v1", api.NamespaceAll, "pods", "", "", []string{"pods"}},
 		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "foo", []string{"pods", "foo"}},
 		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "", []string{"pods"}},
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/5973
Upstream: https://github.com/kubernetes/kubernetes/pull/17567

Treats `HEAD` as http `GET` (`get` or `list`) for authorization.