### PR TITLE
Use go1.5 when invoking gofmt and go vet as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,12 @@ all build:
 #
 # Example:
 #   make check
-#   make check WHAT=pkg/build GOFLAGS=-v
+#   make check WHAT=pkg/build TESTFLAGS=-v
 check:
 	TEST_KUBE=1 hack/test-go.sh $(WHAT) $(TESTS) $(TESTFLAGS)
 .PHONY: check
 
-# Verify code is properly organized.
+# Verify if code is properly organized.
 #
 # Example:
 #   make verify
@@ -129,7 +129,7 @@ endif
 test-int-plus: export KUBE_COVER= -cover -covermode=atomic
 test-int-plus: export KUBE_RACE=  -race
 ifeq ($(SKIP_BUILD), true)
-test-int-plus: 
+test-int-plus:
 else
 test-int-plus: build
 endif

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -8,7 +8,7 @@ set -o pipefail
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
+if [ ${GO_VERSION[2]} \< "go1.4" ]; then
   echo "Unknown go version '${GO_VERSION}', skipping gofmt."
   exit 0
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
+if [ ${GO_VERSION[2]} \< "go1.4" ]; then
   echo "Unknown go version '${GO_VERSION}', skipping go vet."
   exit 0
 fi


### PR DESCRIPTION
@smarterclayton ptal, since I remember you've had some objections against using go1.5 for gfmt and govet. But from my tests it's working as expected and will allow some of us (using go1.5) to test these stuff locally.