### PR TITLE
Accept CamelCase versions of TLS config

### DIFF
--- a/pkg/route/api/v1/conversion.go
+++ b/pkg/route/api/v1/conversion.go
@@ -12,6 +12,16 @@ func init() {
 		func(obj *RouteSpec) {
 			obj.To.Kind = "Service"
 		},
+		func(obj *TLSConfig) {
+			switch obj.Termination {
+			case TLSTerminationType("Reencrypt"):
+				obj.Termination = TLSTerminationReencrypt
+			case TLSTerminationType("Edge"):
+				obj.Termination = TLSTerminationEdge
+			case TLSTerminationType("Passthrough"):
+				obj.Termination = TLSTerminationPassthrough
+			}
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/route/api/v1/conversion_test.go
+++ b/pkg/route/api/v1/conversion_test.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"testing"
 
+	kapi "k8s.io/kubernetes/pkg/api"
+
 	"github.com/openshift/origin/pkg/route/api"
 	testutil "github.com/openshift/origin/test/util/api"
 )
@@ -14,4 +16,22 @@ func TestFieldSelectorConversions(t *testing.T) {
 		// Ensure previously supported labels have conversions. DO NOT REMOVE THINGS FROM THIS LIST
 		"spec.host", "spec.path", "spec.to.name",
 	)
+}
+
+func TestSupportingCamelConstants(t *testing.T) {
+	for k, v := range map[TLSTerminationType]api.TLSTerminationType{
+		"Reencrypt":   api.TLSTerminationReencrypt,
+		"Edge":        api.TLSTerminationEdge,
+		"Passthrough": api.TLSTerminationPassthrough,
+	} {
+		obj := &TLSConfig{Termination: k}
+		out := &api.TLSConfig{}
+		if err := kapi.Scheme.Convert(obj, out); err != nil {
+			t.Errorf("%s: did not convert: %v", k, err)
+			continue
+		}
+		if out.Termination != v {
+			t.Errorf("%s: did not default termination: %#v", k, out)
+		}
+	}
 }


### PR DESCRIPTION
API consumers should be able to send `Reentrypt` instead of `reencrypt` and have their code work.

@ramr @pweil-