### PR TITLE
Refactor pkg/generate/app

### DIFF
--- a/pkg/generate/app/errors.go
+++ b/pkg/generate/app/errors.go
@@ -52,4 +52,4 @@ The argument %[1]q could apply to the following Docker images or OpenShift image
 
 // ErrNameRequired is the error returned by new-app when a name cannot be
 // suggested and the user needs to provide one explicitly.
-var ErrNameRequired = fmt.Errorf("you must specify a name for your app with --name")
+var ErrNameRequired = fmt.Errorf("you must specify a name for your app")

--- a/pkg/generate/app/pipeline_test.go
+++ b/pkg/generate/app/pipeline_test.go
@@ -233,12 +233,3 @@ func TestAddServices(t *testing.T) {
 		}
 	}
 }
-
-func TestNewBuildPipeline(t *testing.T) {
-	// If we cannot infer a name from user input, NewBuildPipeline should return
-	// ErrNameRequired.
-	_, err := NewBuildPipeline("test", nil, false, nil, nil, nil)
-	if err != ErrNameRequired {
-		t.Errorf("err = %#v; want %#v", err, ErrNameRequired)
-	}
-}

--- a/pkg/generate/app/uniquenamegenerator.go
+++ b/pkg/generate/app/uniquenamegenerator.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	kvalidation "k8s.io/kubernetes/pkg/util/validation"
+
+	"github.com/openshift/origin/pkg/util/namer"
+)
+
+// the opposite of kuval.DNS1123LabelFmt
+var invalidNameCharactersRegexp = regexp.MustCompile("[^-a-z0-9]")
+
+// A UniqueNameGenerator is able to generate unique names from a given original
+// name.
+type UniqueNameGenerator interface {
+	Generate(NameSuggester) (string, error)
+}
+
+// NewUniqueNameGenerator creates a new UniqueNameGenerator with the given
+// original name.
+func NewUniqueNameGenerator(name string) UniqueNameGenerator {
+	return &uniqueNameGenerator{name, map[string]int{}}
+}
+
+type uniqueNameGenerator struct {
+	originalName string
+	names        map[string]int
+}
+
+// Generate returns a name that is unique within the set of names of this unique
+// name generator. If the generator's original name is empty, a new name will be
+// suggested.
+func (ung *uniqueNameGenerator) Generate(suggester NameSuggester) (string, error) {
+	name := ung.originalName
+	if len(name) == 0 {
+		var ok bool
+		name, ok = suggester.SuggestName()
+		if !ok {
+			return "", ErrNameRequired
+		}
+	}
+	return ung.ensureValidName(name)
+}
+
+// ensureValidName returns a new name based on the name given that is unique in
+// the set of names of this unique name generator.
+func (ung *uniqueNameGenerator) ensureValidName(name string) (string, error) {
+	names := ung.names
+
+	// Ensure that name meets length requirements
+	if len(name) < 2 {
+		return "", fmt.Errorf("invalid name: %s", name)
+	}
+
+	// Make all names lowercase
+	name = strings.ToLower(name)
+
+	// Remove everything except [-0-9a-z]
+	name = invalidNameCharactersRegexp.ReplaceAllString(name, "")
+
+	// Remove leading hyphen(s) that may be introduced by the previous step
+	name = strings.TrimLeft(name, "-")
+
+	if len(name) > kvalidation.DNS1123SubdomainMaxLength {
+		glog.V(4).Infof("Trimming %s to maximum allowable length (%d)\n", name, kvalidation.DNS1123SubdomainMaxLength)
+		name = name[:kvalidation.DNS1123SubdomainMaxLength]
+	}
+
+	count, existing := names[name]
+	if !existing {
+		names[name] = 0
+		return name, nil
+	}
+	count++
+	names[name] = count
+	newName := namer.GetName(name, strconv.Itoa(count), kvalidation.DNS1123SubdomainMaxLength)
+	return newName, nil
+}

--- a/pkg/generate/app/uniquenamegenerator_test.go
+++ b/pkg/generate/app/uniquenamegenerator_test.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	kvalidation "k8s.io/kubernetes/pkg/util/validation"
+
+	"github.com/openshift/origin/pkg/util/namer"
+)
+
+func TestUniqueNameGeneratorNameRequired(t *testing.T) {
+	nameGenerator := NewUniqueNameGenerator("")
+	_, err := nameGenerator.Generate(&ImageRef{})
+	if err != ErrNameRequired {
+		t.Errorf("err = %#v; want %#v", err, ErrNameRequired)
+	}
+}
+
+func TestUniqueNameGeneratorEnsureValidName(t *testing.T) {
+	chars := []byte("abcdefghijk")
+	longBytes := []byte{}
+	for i := 0; i < (kvalidation.DNS1123SubdomainMaxLength + 20); i++ {
+		longBytes = append(longBytes, chars[i%len(chars)])
+	}
+	longName := string(longBytes)
+	tests := []struct {
+		name        string
+		input       []string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:     "duplicate names",
+			input:    []string{"one", "two", "three", "one", "one", "two"},
+			expected: []string{"one", "two", "three", "one-1", "one-2", "two-1"},
+		},
+		{
+			name:     "mixed case names",
+			input:    []string{"One", "ONE", "tWo"},
+			expected: []string{"one", "one-1", "two"},
+		},
+		{
+			name:     "non-standard characters",
+			input:    []string{"Emby.One", "test-_test", "_-_", "@-MyRepo"},
+			expected: []string{"embyone", "test-test", "", "myrepo"},
+		},
+		{
+			name:        "short name",
+			input:       []string{"t"},
+			expectError: true,
+		},
+		{
+			name:  "long name",
+			input: []string{longName, longName, longName},
+			expected: []string{longName[:kvalidation.DNS1123SubdomainMaxLength],
+				namer.GetName(longName[:kvalidation.DNS1123SubdomainMaxLength], "1", kvalidation.DNS1123SubdomainMaxLength),
+				namer.GetName(longName[:kvalidation.DNS1123SubdomainMaxLength], "2", kvalidation.DNS1123SubdomainMaxLength),
+			},
+		},
+	}
+
+tests:
+	for _, test := range tests {
+		result := []string{}
+		nameGenerator := NewUniqueNameGenerator("").(*uniqueNameGenerator)
+		for _, i := range test.input {
+			name, err := nameGenerator.ensureValidName(i)
+			if err != nil && !test.expectError {
+				t.Errorf("%s: unexpected error: %v", test.name, err)
+			}
+			if err == nil && test.expectError {
+				t.Errorf("%s: did not get an error.", test.name)
+			}
+			if err != nil {
+				continue tests
+			}
+			result = append(result, name)
+		}
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("%s: unexpected output. Expected: %#v, Got: %#v", test.name, test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
This is moving code away from `pkg/generate/app/cmd` to `pkg/generate/app` and breaking down big functions into smaller pieces.

Most of this code came to life a few weeks ago during my early work on #5141, but since that one is taking some time to merge, I decided to ship this refactor earlier, so to avoid more rebases with conflicts for me, and to make life easier for those touching those packages now.