### PR TITLE
Oc sometimes fails against Kube servers.

### DIFF
--- a/docs/man/man1/oadm-build-chain.1
+++ b/docs/man/man1/oadm-build-chain.1
@@ -93,7 +93,7 @@ default namespace will be used respectively.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca-create-key-pair.1
+++ b/docs/man/man1/oadm-ca-create-key-pair.1
@@ -97,7 +97,7 @@ oadm ca create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.public.key \-\
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca-create-master-certs.1
+++ b/docs/man/man1/oadm-ca-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca-create-server-cert.1
+++ b/docs/man/man1/oadm-ca-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca-create-signer-cert.1
+++ b/docs/man/man1/oadm-ca-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca-decrypt.1
+++ b/docs/man/man1/oadm-ca-decrypt.1
@@ -84,7 +84,7 @@ Decrypt data encrypted with "oadm ca encrypt"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca-encrypt.1
+++ b/docs/man/man1/oadm-ca-encrypt.1
@@ -88,7 +88,7 @@ Encrypt data with AES\-256\-CBC encryption
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ca.1
+++ b/docs/man/man1/oadm-ca.1
@@ -70,7 +70,7 @@ Manage certificates and keys
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-completion.1
+++ b/docs/man/man1/oadm-completion.1
@@ -71,7 +71,7 @@ completion of oadm commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-current-context.1
+++ b/docs/man/man1/oadm-config-current-context.1
@@ -70,7 +70,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-set-context.1
+++ b/docs/man/man1/oadm-config-set-context.1
@@ -77,7 +77,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-set-credentials.1
+++ b/docs/man/man1/oadm-config-set-credentials.1
@@ -104,7 +104,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-set.1
+++ b/docs/man/man1/oadm-config-set.1
@@ -78,7 +78,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-unset.1
+++ b/docs/man/man1/oadm-config-unset.1
@@ -71,7 +71,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-use-context.1
+++ b/docs/man/man1/oadm-config-use-context.1
@@ -70,7 +70,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config-view.1
+++ b/docs/man/man1/oadm-config-view.1
@@ -122,7 +122,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-config.1
+++ b/docs/man/man1/oadm-config.1
@@ -81,7 +81,7 @@ Reference:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-cordon.1
+++ b/docs/man/man1/oadm-cordon.1
@@ -70,7 +70,7 @@ Mark node as unschedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-api-client-config.1
+++ b/docs/man/man1/oadm-create-api-client-config.1
@@ -114,7 +114,7 @@ master as the provided user.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-bootstrap-policy-file.1
+++ b/docs/man/man1/oadm-create-bootstrap-policy-file.1
@@ -80,7 +80,7 @@ Create the default bootstrap policy
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-bootstrap-project-template.1
+++ b/docs/man/man1/oadm-create-bootstrap-project-template.1
@@ -107,7 +107,7 @@ Create a bootstrap project template
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-error-template.1
+++ b/docs/man/man1/oadm-create-error-template.1
@@ -90,7 +90,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-key-pair.1
+++ b/docs/man/man1/oadm-create-key-pair.1
@@ -97,7 +97,7 @@ oadm create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.public.key \-\-pr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-kubeconfig.1
+++ b/docs/man/man1/oadm-create-kubeconfig.1
@@ -114,7 +114,7 @@ users:
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-login-template.1
+++ b/docs/man/man1/oadm-create-login-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-master-certs.1
+++ b/docs/man/man1/oadm-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-node-config.1
+++ b/docs/man/man1/oadm-create-node-config.1
@@ -146,7 +146,7 @@ Create a configuration bundle for a node
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-provider-selection-template.1
+++ b/docs/man/man1/oadm-create-provider-selection-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-server-cert.1
+++ b/docs/man/man1/oadm-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-create-signer-cert.1
+++ b/docs/man/man1/oadm-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-diagnostics.1
+++ b/docs/man/man1/oadm-diagnostics.1
@@ -153,7 +153,7 @@ AnalyzeLogs ClusterRegistry ClusterRoleBindings ClusterRoles ClusterRouter Confi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-drain.1
+++ b/docs/man/man1/oadm-drain.1
@@ -103,7 +103,7 @@ will make the node schedulable again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-groups-add-users.1
+++ b/docs/man/man1/oadm-groups-add-users.1
@@ -73,7 +73,7 @@ This command will append unique users to the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-groups-new.1
+++ b/docs/man/man1/oadm-groups-new.1
@@ -73,7 +73,7 @@ This command will create a new group with an optional list of users.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-groups-prune.1
+++ b/docs/man/man1/oadm-groups-prune.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-groups-remove-users.1
+++ b/docs/man/man1/oadm-groups-remove-users.1
@@ -73,7 +73,7 @@ This command will remove users from the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-groups-sync.1
+++ b/docs/man/man1/oadm-groups-sync.1
@@ -132,7 +132,7 @@ LDAP query templates.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-groups.1
+++ b/docs/man/man1/oadm-groups.1
@@ -73,7 +73,7 @@ Groups are sets of users that can be used when describing policy.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-ipfailover.1
+++ b/docs/man/man1/oadm-ipfailover.1
@@ -145,7 +145,7 @@ value that matches the number of nodes for the given labeled selector.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-manage-node.1
+++ b/docs/man/man1/oadm-manage-node.1
@@ -148,7 +148,7 @@ list\-pods: List all/selected pods on given/selected nodes. It can list the outp
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-migrate-image-references.1
+++ b/docs/man/man1/oadm-migrate-image-references.1
@@ -130,7 +130,7 @@ streams requires administrative privileges.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-migrate-storage.1
+++ b/docs/man/man1/oadm-migrate-storage.1
@@ -121,7 +121,7 @@ WARNING: This is a slow command and will put significant load on an API server. 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-migrate.1
+++ b/docs/man/man1/oadm-migrate.1
@@ -73,7 +73,7 @@ These commands assist administrators in performing preventative maintenance on a
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-new-project.1
+++ b/docs/man/man1/oadm-new-project.1
@@ -97,7 +97,7 @@ to restrict which nodes pods in this project can be scheduled to.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-options.1
+++ b/docs/man/man1/oadm-options.1
@@ -67,7 +67,7 @@ oadm options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-overwrite-policy.1
+++ b/docs/man/man1/oadm-overwrite-policy.1
@@ -84,7 +84,7 @@ Reset the policy to the default values
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-pod-network-isolate-projects.1
+++ b/docs/man/man1/oadm-pod-network-isolate-projects.1
@@ -79,7 +79,7 @@ Allows projects to isolate their network from other projects when using the redh
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-pod-network-join-projects.1
+++ b/docs/man/man1/oadm-pod-network-join-projects.1
@@ -83,7 +83,7 @@ Allows projects to join existing project network when using the redhat/openshift
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-pod-network-make-projects-global.1
+++ b/docs/man/man1/oadm-pod-network-make-projects-global.1
@@ -79,7 +79,7 @@ Allows projects to access all pods in the cluster and vice versa when using the 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-pod-network.1
+++ b/docs/man/man1/oadm-pod-network.1
@@ -73,7 +73,7 @@ This command provides common pod network operations for administrators.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-add-cluster-role-to-group.1
+++ b/docs/man/man1/oadm-policy-add-cluster-role-to-group.1
@@ -70,7 +70,7 @@ Add a role to groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-add-cluster-role-to-user.1
+++ b/docs/man/man1/oadm-policy-add-cluster-role-to-user.1
@@ -70,7 +70,7 @@ Add a role to users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-add-role-to-group.1
+++ b/docs/man/man1/oadm-policy-add-role-to-group.1
@@ -76,7 +76,7 @@ Add a role to groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-add-role-to-user.1
+++ b/docs/man/man1/oadm-policy-add-role-to-user.1
@@ -80,7 +80,7 @@ Add a role to users or serviceaccounts for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-add-scc-to-group.1
+++ b/docs/man/man1/oadm-policy-add-scc-to-group.1
@@ -70,7 +70,7 @@ Add groups to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-add-scc-to-user.1
+++ b/docs/man/man1/oadm-policy-add-scc-to-user.1
@@ -76,7 +76,7 @@ Add users or serviceaccount to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-reconcile-cluster-role-bindings.1
+++ b/docs/man/man1/oadm-policy-reconcile-cluster-role-bindings.1
@@ -127,7 +127,7 @@ You can see which recommended cluster role bindings have changed by choosing an 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-reconcile-cluster-roles.1
+++ b/docs/man/man1/oadm-policy-reconcile-cluster-roles.1
@@ -122,7 +122,7 @@ You can see which cluster roles have recommended changed by choosing an output t
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-reconcile-sccs.1
+++ b/docs/man/man1/oadm-policy-reconcile-sccs.1
@@ -126,7 +126,7 @@ You can see which cluster SCCs have recommended changes by choosing an output ty
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-cluster-role-from-group.1
+++ b/docs/man/man1/oadm-policy-remove-cluster-role-from-group.1
@@ -70,7 +70,7 @@ Remove a role from groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-cluster-role-from-user.1
+++ b/docs/man/man1/oadm-policy-remove-cluster-role-from-user.1
@@ -70,7 +70,7 @@ Remove a role from users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-group.1
+++ b/docs/man/man1/oadm-policy-remove-group.1
@@ -70,7 +70,7 @@ Remove group from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-role-from-group.1
+++ b/docs/man/man1/oadm-policy-remove-role-from-group.1
@@ -76,7 +76,7 @@ Remove a role from groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-role-from-user.1
+++ b/docs/man/man1/oadm-policy-remove-role-from-user.1
@@ -80,7 +80,7 @@ Remove a role from users for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-scc-from-group.1
+++ b/docs/man/man1/oadm-policy-remove-scc-from-group.1
@@ -70,7 +70,7 @@ Remove group from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-scc-from-user.1
+++ b/docs/man/man1/oadm-policy-remove-scc-from-user.1
@@ -76,7 +76,7 @@ Remove user from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-remove-user.1
+++ b/docs/man/man1/oadm-policy-remove-user.1
@@ -70,7 +70,7 @@ Remove user from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy-who-can.1
+++ b/docs/man/man1/oadm-policy-who-can.1
@@ -76,7 +76,7 @@ List who can perform the specified action on a resource
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-policy.1
+++ b/docs/man/man1/oadm-policy.1
@@ -79,7 +79,7 @@ and 'scc'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-prune-builds.1
+++ b/docs/man/man1/oadm-prune-builds.1
@@ -96,7 +96,7 @@ By default, the prune operation performs a dry run making no changes to internal
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-prune-deployments.1
+++ b/docs/man/man1/oadm-prune-deployments.1
@@ -96,7 +96,7 @@ A \-\-confirm flag is needed for changes to be effective.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-prune-groups.1
+++ b/docs/man/man1/oadm-prune-groups.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-prune-images.1
+++ b/docs/man/man1/oadm-prune-images.1
@@ -100,7 +100,7 @@ images.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-prune.1
+++ b/docs/man/man1/oadm-prune.1
@@ -74,7 +74,7 @@ the system by removing them.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-registry.1
+++ b/docs/man/man1/oadm-registry.1
@@ -172,7 +172,7 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-router.1
+++ b/docs/man/man1/oadm-router.1
@@ -213,7 +213,7 @@ you have failover protection.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-taint.1
+++ b/docs/man/man1/oadm-taint.1
@@ -134,7 +134,7 @@ Currently taint can only apply to node.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-top-images.1
+++ b/docs/man/man1/oadm-top-images.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-top-imagestreams.1
+++ b/docs/man/man1/oadm-top-imagestreams.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-top.1
+++ b/docs/man/man1/oadm-top.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-uncordon.1
+++ b/docs/man/man1/oadm-uncordon.1
@@ -70,7 +70,7 @@ Mark node as schedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm-version.1
+++ b/docs/man/man1/oadm-version.1
@@ -70,7 +70,7 @@ Display client and server versions.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oadm.1
+++ b/docs/man/man1/oadm.1
@@ -74,7 +74,7 @@ actions involve interaction with the command\-line client as well.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-build-chain.1
+++ b/docs/man/man1/oc-adm-build-chain.1
@@ -93,7 +93,7 @@ default namespace will be used respectively.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca-create-key-pair.1
+++ b/docs/man/man1/oc-adm-ca-create-key-pair.1
@@ -97,7 +97,7 @@ oc adm ca create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.public.key \
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca-create-master-certs.1
+++ b/docs/man/man1/oc-adm-ca-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca-create-server-cert.1
+++ b/docs/man/man1/oc-adm-ca-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca-create-signer-cert.1
+++ b/docs/man/man1/oc-adm-ca-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca-decrypt.1
+++ b/docs/man/man1/oc-adm-ca-decrypt.1
@@ -84,7 +84,7 @@ Decrypt data encrypted with "oc adm ca encrypt"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca-encrypt.1
+++ b/docs/man/man1/oc-adm-ca-encrypt.1
@@ -88,7 +88,7 @@ Encrypt data with AES\-256\-CBC encryption
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ca.1
+++ b/docs/man/man1/oc-adm-ca.1
@@ -70,7 +70,7 @@ Manage certificates and keys
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-completion.1
+++ b/docs/man/man1/oc-adm-completion.1
@@ -71,7 +71,7 @@ completion of oc adm commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-current-context.1
+++ b/docs/man/man1/oc-adm-config-current-context.1
@@ -70,7 +70,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-set-context.1
+++ b/docs/man/man1/oc-adm-config-set-context.1
@@ -77,7 +77,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-set-credentials.1
+++ b/docs/man/man1/oc-adm-config-set-credentials.1
@@ -104,7 +104,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-set.1
+++ b/docs/man/man1/oc-adm-config-set.1
@@ -78,7 +78,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-unset.1
+++ b/docs/man/man1/oc-adm-config-unset.1
@@ -71,7 +71,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-use-context.1
+++ b/docs/man/man1/oc-adm-config-use-context.1
@@ -70,7 +70,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config-view.1
+++ b/docs/man/man1/oc-adm-config-view.1
@@ -122,7 +122,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-config.1
+++ b/docs/man/man1/oc-adm-config.1
@@ -81,7 +81,7 @@ Reference:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-cordon.1
+++ b/docs/man/man1/oc-adm-cordon.1
@@ -70,7 +70,7 @@ Mark node as unschedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-api-client-config.1
+++ b/docs/man/man1/oc-adm-create-api-client-config.1
@@ -114,7 +114,7 @@ master as the provided user.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-bootstrap-policy-file.1
+++ b/docs/man/man1/oc-adm-create-bootstrap-policy-file.1
@@ -80,7 +80,7 @@ Create the default bootstrap policy
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-bootstrap-project-template.1
+++ b/docs/man/man1/oc-adm-create-bootstrap-project-template.1
@@ -107,7 +107,7 @@ Create a bootstrap project template
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-error-template.1
+++ b/docs/man/man1/oc-adm-create-error-template.1
@@ -90,7 +90,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-key-pair.1
+++ b/docs/man/man1/oc-adm-create-key-pair.1
@@ -97,7 +97,7 @@ oc adm create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.public.key \-\-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-kubeconfig.1
+++ b/docs/man/man1/oc-adm-create-kubeconfig.1
@@ -114,7 +114,7 @@ users:
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-login-template.1
+++ b/docs/man/man1/oc-adm-create-login-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-master-certs.1
+++ b/docs/man/man1/oc-adm-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-node-config.1
+++ b/docs/man/man1/oc-adm-create-node-config.1
@@ -146,7 +146,7 @@ Create a configuration bundle for a node
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-provider-selection-template.1
+++ b/docs/man/man1/oc-adm-create-provider-selection-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-server-cert.1
+++ b/docs/man/man1/oc-adm-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-create-signer-cert.1
+++ b/docs/man/man1/oc-adm-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-diagnostics.1
+++ b/docs/man/man1/oc-adm-diagnostics.1
@@ -153,7 +153,7 @@ AnalyzeLogs ClusterRegistry ClusterRoleBindings ClusterRoles ClusterRouter Confi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-drain.1
+++ b/docs/man/man1/oc-adm-drain.1
@@ -103,7 +103,7 @@ will make the node schedulable again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-groups-add-users.1
+++ b/docs/man/man1/oc-adm-groups-add-users.1
@@ -73,7 +73,7 @@ This command will append unique users to the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-groups-new.1
+++ b/docs/man/man1/oc-adm-groups-new.1
@@ -73,7 +73,7 @@ This command will create a new group with an optional list of users.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-groups-prune.1
+++ b/docs/man/man1/oc-adm-groups-prune.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-groups-remove-users.1
+++ b/docs/man/man1/oc-adm-groups-remove-users.1
@@ -73,7 +73,7 @@ This command will remove users from the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-groups-sync.1
+++ b/docs/man/man1/oc-adm-groups-sync.1
@@ -132,7 +132,7 @@ LDAP query templates.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-groups.1
+++ b/docs/man/man1/oc-adm-groups.1
@@ -73,7 +73,7 @@ Groups are sets of users that can be used when describing policy.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-ipfailover.1
+++ b/docs/man/man1/oc-adm-ipfailover.1
@@ -145,7 +145,7 @@ value that matches the number of nodes for the given labeled selector.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-manage-node.1
+++ b/docs/man/man1/oc-adm-manage-node.1
@@ -148,7 +148,7 @@ list\-pods: List all/selected pods on given/selected nodes. It can list the outp
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-migrate-image-references.1
+++ b/docs/man/man1/oc-adm-migrate-image-references.1
@@ -130,7 +130,7 @@ streams requires administrative privileges.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-migrate-storage.1
+++ b/docs/man/man1/oc-adm-migrate-storage.1
@@ -121,7 +121,7 @@ WARNING: This is a slow command and will put significant load on an API server. 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-migrate.1
+++ b/docs/man/man1/oc-adm-migrate.1
@@ -73,7 +73,7 @@ These commands assist administrators in performing preventative maintenance on a
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-new-project.1
+++ b/docs/man/man1/oc-adm-new-project.1
@@ -97,7 +97,7 @@ to restrict which nodes pods in this project can be scheduled to.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-options.1
+++ b/docs/man/man1/oc-adm-options.1
@@ -67,7 +67,7 @@ oc adm options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-overwrite-policy.1
+++ b/docs/man/man1/oc-adm-overwrite-policy.1
@@ -84,7 +84,7 @@ Reset the policy to the default values
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-pod-network-isolate-projects.1
+++ b/docs/man/man1/oc-adm-pod-network-isolate-projects.1
@@ -79,7 +79,7 @@ Allows projects to isolate their network from other projects when using the redh
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-pod-network-join-projects.1
+++ b/docs/man/man1/oc-adm-pod-network-join-projects.1
@@ -83,7 +83,7 @@ Allows projects to join existing project network when using the redhat/openshift
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-pod-network-make-projects-global.1
+++ b/docs/man/man1/oc-adm-pod-network-make-projects-global.1
@@ -79,7 +79,7 @@ Allows projects to access all pods in the cluster and vice versa when using the 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-pod-network.1
+++ b/docs/man/man1/oc-adm-pod-network.1
@@ -73,7 +73,7 @@ This command provides common pod network operations for administrators.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-add-cluster-role-to-group.1
+++ b/docs/man/man1/oc-adm-policy-add-cluster-role-to-group.1
@@ -70,7 +70,7 @@ Add a role to groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-add-cluster-role-to-user.1
+++ b/docs/man/man1/oc-adm-policy-add-cluster-role-to-user.1
@@ -70,7 +70,7 @@ Add a role to users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-add-role-to-group.1
+++ b/docs/man/man1/oc-adm-policy-add-role-to-group.1
@@ -76,7 +76,7 @@ Add a role to groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-add-role-to-user.1
+++ b/docs/man/man1/oc-adm-policy-add-role-to-user.1
@@ -80,7 +80,7 @@ Add a role to users or serviceaccounts for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-add-scc-to-group.1
+++ b/docs/man/man1/oc-adm-policy-add-scc-to-group.1
@@ -70,7 +70,7 @@ Add groups to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-add-scc-to-user.1
+++ b/docs/man/man1/oc-adm-policy-add-scc-to-user.1
@@ -76,7 +76,7 @@ Add users or serviceaccount to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-reconcile-cluster-role-bindings.1
+++ b/docs/man/man1/oc-adm-policy-reconcile-cluster-role-bindings.1
@@ -127,7 +127,7 @@ You can see which recommended cluster role bindings have changed by choosing an 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-reconcile-cluster-roles.1
+++ b/docs/man/man1/oc-adm-policy-reconcile-cluster-roles.1
@@ -122,7 +122,7 @@ You can see which cluster roles have recommended changed by choosing an output t
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-reconcile-sccs.1
+++ b/docs/man/man1/oc-adm-policy-reconcile-sccs.1
@@ -126,7 +126,7 @@ You can see which cluster SCCs have recommended changes by choosing an output ty
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-cluster-role-from-group.1
+++ b/docs/man/man1/oc-adm-policy-remove-cluster-role-from-group.1
@@ -70,7 +70,7 @@ Remove a role from groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-cluster-role-from-user.1
+++ b/docs/man/man1/oc-adm-policy-remove-cluster-role-from-user.1
@@ -70,7 +70,7 @@ Remove a role from users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-group.1
+++ b/docs/man/man1/oc-adm-policy-remove-group.1
@@ -70,7 +70,7 @@ Remove group from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-role-from-group.1
+++ b/docs/man/man1/oc-adm-policy-remove-role-from-group.1
@@ -76,7 +76,7 @@ Remove a role from groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-role-from-user.1
+++ b/docs/man/man1/oc-adm-policy-remove-role-from-user.1
@@ -80,7 +80,7 @@ Remove a role from users for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-scc-from-group.1
+++ b/docs/man/man1/oc-adm-policy-remove-scc-from-group.1
@@ -70,7 +70,7 @@ Remove group from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-scc-from-user.1
+++ b/docs/man/man1/oc-adm-policy-remove-scc-from-user.1
@@ -76,7 +76,7 @@ Remove user from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-remove-user.1
+++ b/docs/man/man1/oc-adm-policy-remove-user.1
@@ -70,7 +70,7 @@ Remove user from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy-who-can.1
+++ b/docs/man/man1/oc-adm-policy-who-can.1
@@ -76,7 +76,7 @@ List who can perform the specified action on a resource
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-policy.1
+++ b/docs/man/man1/oc-adm-policy.1
@@ -79,7 +79,7 @@ and 'scc'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-prune-builds.1
+++ b/docs/man/man1/oc-adm-prune-builds.1
@@ -96,7 +96,7 @@ By default, the prune operation performs a dry run making no changes to internal
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-prune-deployments.1
+++ b/docs/man/man1/oc-adm-prune-deployments.1
@@ -96,7 +96,7 @@ A \-\-confirm flag is needed for changes to be effective.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-prune-groups.1
+++ b/docs/man/man1/oc-adm-prune-groups.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-prune-images.1
+++ b/docs/man/man1/oc-adm-prune-images.1
@@ -100,7 +100,7 @@ images.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-prune.1
+++ b/docs/man/man1/oc-adm-prune.1
@@ -74,7 +74,7 @@ the system by removing them.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-registry.1
+++ b/docs/man/man1/oc-adm-registry.1
@@ -172,7 +172,7 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-router.1
+++ b/docs/man/man1/oc-adm-router.1
@@ -213,7 +213,7 @@ you have failover protection.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-taint.1
+++ b/docs/man/man1/oc-adm-taint.1
@@ -134,7 +134,7 @@ Currently taint can only apply to node.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-top-images.1
+++ b/docs/man/man1/oc-adm-top-images.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-top-imagestreams.1
+++ b/docs/man/man1/oc-adm-top-imagestreams.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-top.1
+++ b/docs/man/man1/oc-adm-top.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm-uncordon.1
+++ b/docs/man/man1/oc-adm-uncordon.1
@@ -70,7 +70,7 @@ Mark node as schedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-adm.1
+++ b/docs/man/man1/oc-adm.1
@@ -66,7 +66,7 @@ actions involve interaction with the command\-line client as well.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-annotate.1
+++ b/docs/man/man1/oc-annotate.1
@@ -147,7 +147,7 @@ Run 'oc types' for a list of valid resources.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-apply.1
+++ b/docs/man/man1/oc-apply.1
@@ -103,7 +103,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-attach.1
+++ b/docs/man/man1/oc-attach.1
@@ -88,7 +88,7 @@ terminal session. Can be used to debug containers and invoke interactive command
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-autoscale.1
+++ b/docs/man/man1/oc-autoscale.1
@@ -152,7 +152,7 @@ increase or decrease number of pods deployed within the system as needed.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-build-logs.1
+++ b/docs/man/man1/oc-build-logs.1
@@ -80,7 +80,7 @@ DEPRECATED: This command has been moved to "oc logs"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-cancel-build.1
+++ b/docs/man/man1/oc-cancel-build.1
@@ -88,7 +88,7 @@ the build and the time the build is terminated.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-cluster-down.1
+++ b/docs/man/man1/oc-cluster-down.1
@@ -80,7 +80,7 @@ same machine using the \-\-docker\-machine argument.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-cluster-up.1
+++ b/docs/man/man1/oc-cluster-up.1
@@ -152,7 +152,7 @@ A public hostname can also be specified for the server with the \-\-public\-host
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-cluster.1
+++ b/docs/man/man1/oc-cluster.1
@@ -88,7 +88,7 @@ routing suffix, use the \-\-routing\-suffix flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-completion.1
+++ b/docs/man/man1/oc-completion.1
@@ -71,7 +71,7 @@ completion of oc commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-current-context.1
+++ b/docs/man/man1/oc-config-current-context.1
@@ -70,7 +70,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-set-context.1
+++ b/docs/man/man1/oc-config-set-context.1
@@ -77,7 +77,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-set-credentials.1
+++ b/docs/man/man1/oc-config-set-credentials.1
@@ -104,7 +104,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-set.1
+++ b/docs/man/man1/oc-config-set.1
@@ -78,7 +78,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-unset.1
+++ b/docs/man/man1/oc-config-unset.1
@@ -71,7 +71,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-use-context.1
+++ b/docs/man/man1/oc-config-use-context.1
@@ -70,7 +70,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config-view.1
+++ b/docs/man/man1/oc-config-view.1
@@ -122,7 +122,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-config.1
+++ b/docs/man/man1/oc-config.1
@@ -81,7 +81,7 @@ Reference:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-convert.1
+++ b/docs/man/man1/oc-convert.1
@@ -137,7 +137,7 @@ to change to output destination.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-clusterresourcequota.1
+++ b/docs/man/man1/oc-create-clusterresourcequota.1
@@ -91,7 +91,7 @@ Cluster resource quota objects defined quota restrictions that span multiple pro
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-configmap.1
+++ b/docs/man/man1/oc-create-configmap.1
@@ -143,7 +143,7 @@ symlinks, devices, pipes, etc).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-deploymentconfig.1
+++ b/docs/man/man1/oc-create-deploymentconfig.1
@@ -83,7 +83,7 @@ Deployment configs define the template for a pod and manages deploying new image
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-identity.1
+++ b/docs/man/man1/oc-create-identity.1
@@ -112,7 +112,7 @@ to allow logging in with the created identity.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-imagestream.1
+++ b/docs/man/man1/oc-create-imagestream.1
@@ -80,7 +80,7 @@ access controlled destination that you can push images to.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-namespace.1
+++ b/docs/man/man1/oc-create-namespace.1
@@ -123,7 +123,7 @@ Create a namespace with the specified name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-policybinding.1
+++ b/docs/man/man1/oc-create-policybinding.1
@@ -76,7 +76,7 @@ Create a policy binding that references the policy in the targetted namespace.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-quota.1
+++ b/docs/man/man1/oc-create-quota.1
@@ -131,7 +131,7 @@ Create a resourcequota with the specified name, hard limits and optional scopes
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-route-edge.1
+++ b/docs/man/man1/oc-create-route-edge.1
@@ -120,7 +120,7 @@ generated route should expose via the \-\-service flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-route-passthrough.1
+++ b/docs/man/man1/oc-create-route-passthrough.1
@@ -100,7 +100,7 @@ generated route should expose via the \-\-service flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-route-reencrypt.1
+++ b/docs/man/man1/oc-create-route-reencrypt.1
@@ -121,7 +121,7 @@ is needed for reencrypt routes, specify one with the \-\-dest\-ca\-cert flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-route.1
+++ b/docs/man/man1/oc-create-route.1
@@ -74,7 +74,7 @@ If you wish to create unsecured routes, see "oc expose \-h"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-secret-docker-registry.1
+++ b/docs/man/man1/oc-create-secret-docker-registry.1
@@ -158,7 +158,7 @@ by creating a dockercfg secret and attaching it to your service account.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-secret-generic.1
+++ b/docs/man/man1/oc-create-secret-generic.1
@@ -147,7 +147,7 @@ symlinks, devices, pipes, etc).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-secret-tls.1
+++ b/docs/man/man1/oc-create-secret-tls.1
@@ -134,7 +134,7 @@ The public/private key pair must exist before hand. The public key certificate m
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-secret.1
+++ b/docs/man/man1/oc-create-secret.1
@@ -70,7 +70,7 @@ Create a secret using specified subcommand.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-serviceaccount.1
+++ b/docs/man/man1/oc-create-serviceaccount.1
@@ -127,7 +127,7 @@ Create a service account with the specified name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-user.1
+++ b/docs/man/man1/oc-create-user.1
@@ -116,7 +116,7 @@ to allow logging in as the created user.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create-useridentitymapping.1
+++ b/docs/man/man1/oc-create-useridentitymapping.1
@@ -106,7 +106,7 @@ to create a useridentitymapping object.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-create.1
+++ b/docs/man/man1/oc-create.1
@@ -107,7 +107,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-debug.1
+++ b/docs/man/man1/oc-debug.1
@@ -174,7 +174,7 @@ the shell.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-delete.1
+++ b/docs/man/man1/oc-delete.1
@@ -128,7 +128,7 @@ will be lost along with the rest of the resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-deploy.1
+++ b/docs/man/man1/oc-deploy.1
@@ -127,7 +127,7 @@ If no options are given, shows information about the latest deployment.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-describe.1
+++ b/docs/man/man1/oc-describe.1
@@ -96,7 +96,7 @@ given resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-edit.1
+++ b/docs/man/man1/oc-edit.1
@@ -125,7 +125,7 @@ saved copy to include the latest resource version.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-env.1
+++ b/docs/man/man1/oc-env.1
@@ -124,7 +124,7 @@ DEPRECATED: This command has been moved to "oc set env"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-ex-dockerbuild.1
+++ b/docs/man/man1/oc-ex-dockerbuild.1
@@ -93,7 +93,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-ex.1
+++ b/docs/man/man1/oc-ex.1
@@ -67,7 +67,7 @@ oc ex \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-exec.1
+++ b/docs/man/man1/oc-exec.1
@@ -88,7 +88,7 @@ Execute a command in a container
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-explain.1
+++ b/docs/man/man1/oc-explain.1
@@ -86,7 +86,7 @@ resourcequotas (quota), namespaces (ns) or endpoints (ep).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-export.1
+++ b/docs/man/man1/oc-export.1
@@ -148,7 +148,7 @@ to generate the API structure for a template to which you can add parameters and
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-expose.1
+++ b/docs/man/man1/oc-expose.1
@@ -192,7 +192,7 @@ labels from the object it exposes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-extract.1
+++ b/docs/man/man1/oc-extract.1
@@ -128,7 +128,7 @@ with \-\-to=DIRECTORY.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-get.1
+++ b/docs/man/man1/oc-get.1
@@ -152,7 +152,7 @@ If you want an even more detailed view, use 'oc describe'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-idle.1
+++ b/docs/man/man1/oc-idle.1
@@ -102,7 +102,7 @@ associated resources by scaling them back up to their previous scale.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-import-app.json.1
+++ b/docs/man/man1/oc-import-app.json.1
@@ -113,7 +113,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-import-docker-compose.1
+++ b/docs/man/man1/oc-import-docker-compose.1
@@ -109,7 +109,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-import-image.1
+++ b/docs/man/man1/oc-import-image.1
@@ -92,7 +92,7 @@ spec.Tags may have tag and image information imported.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-import.1
+++ b/docs/man/man1/oc-import.1
@@ -73,7 +73,7 @@ These commands assist in bringing existing applications into OpenShift.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-label.1
+++ b/docs/man/man1/oc-label.1
@@ -146,7 +146,7 @@ resource\-version will be used.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-login.1
+++ b/docs/man/man1/oc-login.1
@@ -91,7 +91,7 @@ prompt for user input as needed.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-logout.1
+++ b/docs/man/man1/oc-logout.1
@@ -83,7 +83,7 @@ After logging out, if you want to log back into the server use 'oc login'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-logs.1
+++ b/docs/man/man1/oc-logs.1
@@ -126,7 +126,7 @@ logs of the last attempt.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-new-app.1
+++ b/docs/man/man1/oc-new-app.1
@@ -185,7 +185,7 @@ You can use 'oc status' to check the progress.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-new-build.1
+++ b/docs/man/man1/oc-new-build.1
@@ -174,7 +174,7 @@ You can use 'oc status' to check the progress.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-new-project.1
+++ b/docs/man/man1/oc-new-project.1
@@ -91,7 +91,7 @@ After your project is created it will become the default project in your config.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-observe.1
+++ b/docs/man/man1/oc-observe.1
@@ -246,7 +246,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-options.1
+++ b/docs/man/man1/oc-options.1
@@ -67,7 +67,7 @@ oc options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-patch.1
+++ b/docs/man/man1/oc-patch.1
@@ -103,7 +103,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-add-role-to-group.1
+++ b/docs/man/man1/oc-policy-add-role-to-group.1
@@ -76,7 +76,7 @@ Add a role to groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-add-role-to-user.1
+++ b/docs/man/man1/oc-policy-add-role-to-user.1
@@ -80,7 +80,7 @@ Add a role to users or serviceaccounts for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-can-i.1
+++ b/docs/man/man1/oc-policy-can-i.1
@@ -92,7 +92,7 @@ Check whether an action is allowed
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-remove-group.1
+++ b/docs/man/man1/oc-policy-remove-group.1
@@ -70,7 +70,7 @@ Remove group from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-remove-role-from-group.1
+++ b/docs/man/man1/oc-policy-remove-role-from-group.1
@@ -76,7 +76,7 @@ Remove a role from groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-remove-role-from-user.1
+++ b/docs/man/man1/oc-policy-remove-role-from-user.1
@@ -80,7 +80,7 @@ Remove a role from users for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-remove-user.1
+++ b/docs/man/man1/oc-policy-remove-user.1
@@ -70,7 +70,7 @@ Remove user from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy-who-can.1
+++ b/docs/man/man1/oc-policy-who-can.1
@@ -76,7 +76,7 @@ List who can perform the specified action on a resource
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-policy.1
+++ b/docs/man/man1/oc-policy.1
@@ -70,7 +70,7 @@ Manage authorization policy
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-port-forward.1
+++ b/docs/man/man1/oc-port-forward.1
@@ -76,7 +76,7 @@ Forward 1 or more local ports to a pod
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-process.1
+++ b/docs/man/man1/oc-process.1
@@ -114,7 +114,7 @@ output to the create command over STDIN (using the '\-f \-' option) or redirect 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-project.1
+++ b/docs/man/man1/oc-project.1
@@ -88,7 +88,7 @@ command.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-projects.1
+++ b/docs/man/man1/oc-projects.1
@@ -80,7 +80,7 @@ command.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-proxy.1
+++ b/docs/man/man1/oc-proxy.1
@@ -116,7 +116,7 @@ Run a proxy to the API server
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-replace.1
+++ b/docs/man/man1/oc-replace.1
@@ -123,7 +123,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rollback.1
+++ b/docs/man/man1/oc-rollback.1
@@ -120,7 +120,7 @@ will be.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rollout-history.1
+++ b/docs/man/man1/oc-rollout-history.1
@@ -88,7 +88,7 @@ by using the \-\-revision flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rollout-pause.1
+++ b/docs/man/man1/oc-rollout-pause.1
@@ -84,7 +84,7 @@ Use \\"%[1]s rollout resume\\" to resume a paused resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rollout-resume.1
+++ b/docs/man/man1/oc-rollout-resume.1
@@ -84,7 +84,7 @@ resource, we allow it to be reconciled again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rollout-undo.1
+++ b/docs/man/man1/oc-rollout-undo.1
@@ -104,7 +104,7 @@ will be.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rollout.1
+++ b/docs/man/man1/oc-rollout.1
@@ -70,7 +70,7 @@ Manage deployments.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rsh.1
+++ b/docs/man/man1/oc-rsh.1
@@ -103,7 +103,7 @@ directly.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-rsync.1
+++ b/docs/man/man1/oc-rsync.1
@@ -120,7 +120,7 @@ for the copy.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-run.1
+++ b/docs/man/man1/oc-run.1
@@ -204,7 +204,7 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-scale.1
+++ b/docs/man/man1/oc-scale.1
@@ -118,7 +118,7 @@ desired replicas in the configuration template.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-add.1
+++ b/docs/man/man1/oc-secrets-add.1
@@ -76,7 +76,7 @@ DEPRECATED: This command has been moved to "oc secrets link"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-link.1
+++ b/docs/man/man1/oc-secrets-link.1
@@ -79,7 +79,7 @@ Linking a secret enables a service account to automatically use that secret for 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-new-basicauth.1
+++ b/docs/man/man1/oc-secrets-new-basicauth.1
@@ -131,7 +131,7 @@ this information by creating a 'basicauth' secret and attaching it to your servi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-new-dockercfg.1
+++ b/docs/man/man1/oc-secrets-new-dockercfg.1
@@ -134,7 +134,7 @@ by creating a dockercfg secret and attaching it to your service account.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-new-sshauth.1
+++ b/docs/man/man1/oc-secrets-new-sshauth.1
@@ -123,7 +123,7 @@ provide this information by creating a 'sshauth' secret and attaching it to your
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-new.1
+++ b/docs/man/man1/oc-secrets-new.1
@@ -120,7 +120,7 @@ using with all valid keys in that directory.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets-unlink.1
+++ b/docs/man/man1/oc-secrets-unlink.1
@@ -73,7 +73,7 @@ If a secret is no longer valid for a pod, build or image pull, you may unlink it
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-secrets.1
+++ b/docs/man/man1/oc-secrets.1
@@ -75,7 +75,7 @@ Docker registries.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-serviceaccounts-get-token.1
+++ b/docs/man/man1/oc-serviceaccounts-get-token.1
@@ -78,7 +78,7 @@ itself were making the actions.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-serviceaccounts-new-token.1
+++ b/docs/man/man1/oc-serviceaccounts-new-token.1
@@ -87,7 +87,7 @@ be applied to any created token so that tokens created with this command can be 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-serviceaccounts.1
+++ b/docs/man/man1/oc-serviceaccounts.1
@@ -73,7 +73,7 @@ Service accounts allow system components to access the API.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-build-hook.1
+++ b/docs/man/man1/oc-set-build-hook.1
@@ -147,7 +147,7 @@ arguments to the image's entrypoint (default).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-deployment-hook.1
+++ b/docs/man/man1/oc-set-deployment-hook.1
@@ -172,7 +172,7 @@ the abort policy, because at that point the deployment has already happened.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-env.1
+++ b/docs/man/man1/oc-set-env.1
@@ -137,7 +137,7 @@ syntax.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-probe.1
+++ b/docs/man/man1/oc-set-probe.1
@@ -183,7 +183,7 @@ to fail.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-route-backends.1
+++ b/docs/man/man1/oc-set-route-backends.1
@@ -160,7 +160,7 @@ Not all routers may support multiple or weighted backends.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-triggers.1
+++ b/docs/man/man1/oc-set-triggers.1
@@ -169,7 +169,7 @@ and generic). The config change trigger for a build config will only trigger the
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set-volumes.1
+++ b/docs/man/man1/oc-set-volumes.1
@@ -191,7 +191,7 @@ For descriptions on other volume types, see
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-set.1
+++ b/docs/man/man1/oc-set.1
@@ -73,7 +73,7 @@ These commands help you make changes to existing application resources.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-start-build.1
+++ b/docs/man/man1/oc-start-build.1
@@ -141,7 +141,7 @@ base image changes will use the source specified on the build config.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-status.1
+++ b/docs/man/man1/oc-status.1
@@ -94,7 +94,7 @@ graph in DOT format that is suitable for use by the "dot" command.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-tag.1
+++ b/docs/man/man1/oc-tag.1
@@ -109,7 +109,7 @@ Docker images.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-types.1
+++ b/docs/man/man1/oc-types.1
@@ -220,7 +220,7 @@ For more, see
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-version.1
+++ b/docs/man/man1/oc-version.1
@@ -70,7 +70,7 @@ Display client and server versions.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-volumes.1
+++ b/docs/man/man1/oc-volumes.1
@@ -156,7 +156,7 @@ DEPRECATED: This command has been moved to "oc set volume"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc-whoami.1
+++ b/docs/man/man1/oc-whoami.1
@@ -81,7 +81,7 @@ user context.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/oc.1
+++ b/docs/man/man1/oc.1
@@ -75,7 +75,7 @@ cluster under the 'adm' subcommand.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-build-chain.1
+++ b/docs/man/man1/openshift-admin-build-chain.1
@@ -93,7 +93,7 @@ default namespace will be used respectively.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca-create-key-pair.1
+++ b/docs/man/man1/openshift-admin-ca-create-key-pair.1
@@ -97,7 +97,7 @@ openshift admin ca create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.pub
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca-create-master-certs.1
+++ b/docs/man/man1/openshift-admin-ca-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca-create-server-cert.1
+++ b/docs/man/man1/openshift-admin-ca-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca-create-signer-cert.1
+++ b/docs/man/man1/openshift-admin-ca-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca-decrypt.1
+++ b/docs/man/man1/openshift-admin-ca-decrypt.1
@@ -84,7 +84,7 @@ Decrypt data encrypted with "openshift admin ca encrypt"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca-encrypt.1
+++ b/docs/man/man1/openshift-admin-ca-encrypt.1
@@ -88,7 +88,7 @@ Encrypt data with AES\-256\-CBC encryption
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ca.1
+++ b/docs/man/man1/openshift-admin-ca.1
@@ -70,7 +70,7 @@ Manage certificates and keys
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-completion.1
+++ b/docs/man/man1/openshift-admin-completion.1
@@ -71,7 +71,7 @@ completion of openshift admin commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-current-context.1
+++ b/docs/man/man1/openshift-admin-config-current-context.1
@@ -70,7 +70,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-set-context.1
+++ b/docs/man/man1/openshift-admin-config-set-context.1
@@ -77,7 +77,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-set-credentials.1
+++ b/docs/man/man1/openshift-admin-config-set-credentials.1
@@ -104,7 +104,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-set.1
+++ b/docs/man/man1/openshift-admin-config-set.1
@@ -78,7 +78,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-unset.1
+++ b/docs/man/man1/openshift-admin-config-unset.1
@@ -71,7 +71,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-use-context.1
+++ b/docs/man/man1/openshift-admin-config-use-context.1
@@ -70,7 +70,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config-view.1
+++ b/docs/man/man1/openshift-admin-config-view.1
@@ -122,7 +122,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-config.1
+++ b/docs/man/man1/openshift-admin-config.1
@@ -81,7 +81,7 @@ Reference:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-cordon.1
+++ b/docs/man/man1/openshift-admin-cordon.1
@@ -70,7 +70,7 @@ Mark node as unschedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-api-client-config.1
+++ b/docs/man/man1/openshift-admin-create-api-client-config.1
@@ -114,7 +114,7 @@ master as the provided user.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-bootstrap-policy-file.1
+++ b/docs/man/man1/openshift-admin-create-bootstrap-policy-file.1
@@ -80,7 +80,7 @@ Create the default bootstrap policy
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-bootstrap-project-template.1
+++ b/docs/man/man1/openshift-admin-create-bootstrap-project-template.1
@@ -107,7 +107,7 @@ Create a bootstrap project template
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-error-template.1
+++ b/docs/man/man1/openshift-admin-create-error-template.1
@@ -90,7 +90,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-key-pair.1
+++ b/docs/man/man1/openshift-admin-create-key-pair.1
@@ -97,7 +97,7 @@ openshift admin create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.public
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-kubeconfig.1
+++ b/docs/man/man1/openshift-admin-create-kubeconfig.1
@@ -114,7 +114,7 @@ users:
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-login-template.1
+++ b/docs/man/man1/openshift-admin-create-login-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-master-certs.1
+++ b/docs/man/man1/openshift-admin-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-node-config.1
+++ b/docs/man/man1/openshift-admin-create-node-config.1
@@ -146,7 +146,7 @@ Create a configuration bundle for a node
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-provider-selection-template.1
+++ b/docs/man/man1/openshift-admin-create-provider-selection-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-server-cert.1
+++ b/docs/man/man1/openshift-admin-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-create-signer-cert.1
+++ b/docs/man/man1/openshift-admin-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-diagnostics.1
+++ b/docs/man/man1/openshift-admin-diagnostics.1
@@ -153,7 +153,7 @@ AnalyzeLogs ClusterRegistry ClusterRoleBindings ClusterRoles ClusterRouter Confi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-drain.1
+++ b/docs/man/man1/openshift-admin-drain.1
@@ -103,7 +103,7 @@ will make the node schedulable again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-groups-add-users.1
+++ b/docs/man/man1/openshift-admin-groups-add-users.1
@@ -73,7 +73,7 @@ This command will append unique users to the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-groups-new.1
+++ b/docs/man/man1/openshift-admin-groups-new.1
@@ -73,7 +73,7 @@ This command will create a new group with an optional list of users.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-groups-prune.1
+++ b/docs/man/man1/openshift-admin-groups-prune.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-groups-remove-users.1
+++ b/docs/man/man1/openshift-admin-groups-remove-users.1
@@ -73,7 +73,7 @@ This command will remove users from the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-groups-sync.1
+++ b/docs/man/man1/openshift-admin-groups-sync.1
@@ -132,7 +132,7 @@ LDAP query templates.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-groups.1
+++ b/docs/man/man1/openshift-admin-groups.1
@@ -73,7 +73,7 @@ Groups are sets of users that can be used when describing policy.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-ipfailover.1
+++ b/docs/man/man1/openshift-admin-ipfailover.1
@@ -145,7 +145,7 @@ value that matches the number of nodes for the given labeled selector.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-manage-node.1
+++ b/docs/man/man1/openshift-admin-manage-node.1
@@ -148,7 +148,7 @@ list\-pods: List all/selected pods on given/selected nodes. It can list the outp
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-migrate-image-references.1
+++ b/docs/man/man1/openshift-admin-migrate-image-references.1
@@ -130,7 +130,7 @@ streams requires administrative privileges.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-migrate-storage.1
+++ b/docs/man/man1/openshift-admin-migrate-storage.1
@@ -121,7 +121,7 @@ WARNING: This is a slow command and will put significant load on an API server. 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-migrate.1
+++ b/docs/man/man1/openshift-admin-migrate.1
@@ -73,7 +73,7 @@ These commands assist administrators in performing preventative maintenance on a
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-new-project.1
+++ b/docs/man/man1/openshift-admin-new-project.1
@@ -97,7 +97,7 @@ to restrict which nodes pods in this project can be scheduled to.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-options.1
+++ b/docs/man/man1/openshift-admin-options.1
@@ -67,7 +67,7 @@ openshift admin options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-overwrite-policy.1
+++ b/docs/man/man1/openshift-admin-overwrite-policy.1
@@ -84,7 +84,7 @@ Reset the policy to the default values
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-pod-network-isolate-projects.1
+++ b/docs/man/man1/openshift-admin-pod-network-isolate-projects.1
@@ -79,7 +79,7 @@ Allows projects to isolate their network from other projects when using the redh
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-pod-network-join-projects.1
+++ b/docs/man/man1/openshift-admin-pod-network-join-projects.1
@@ -83,7 +83,7 @@ Allows projects to join existing project network when using the redhat/openshift
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-pod-network-make-projects-global.1
+++ b/docs/man/man1/openshift-admin-pod-network-make-projects-global.1
@@ -79,7 +79,7 @@ Allows projects to access all pods in the cluster and vice versa when using the 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-pod-network.1
+++ b/docs/man/man1/openshift-admin-pod-network.1
@@ -73,7 +73,7 @@ This command provides common pod network operations for administrators.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-add-cluster-role-to-group.1
+++ b/docs/man/man1/openshift-admin-policy-add-cluster-role-to-group.1
@@ -70,7 +70,7 @@ Add a role to groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-add-cluster-role-to-user.1
+++ b/docs/man/man1/openshift-admin-policy-add-cluster-role-to-user.1
@@ -70,7 +70,7 @@ Add a role to users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-add-role-to-group.1
+++ b/docs/man/man1/openshift-admin-policy-add-role-to-group.1
@@ -76,7 +76,7 @@ Add a role to groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-add-role-to-user.1
+++ b/docs/man/man1/openshift-admin-policy-add-role-to-user.1
@@ -80,7 +80,7 @@ Add a role to users or serviceaccounts for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-add-scc-to-group.1
+++ b/docs/man/man1/openshift-admin-policy-add-scc-to-group.1
@@ -70,7 +70,7 @@ Add groups to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-add-scc-to-user.1
+++ b/docs/man/man1/openshift-admin-policy-add-scc-to-user.1
@@ -76,7 +76,7 @@ Add users or serviceaccount to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-reconcile-cluster-role-bindings.1
+++ b/docs/man/man1/openshift-admin-policy-reconcile-cluster-role-bindings.1
@@ -127,7 +127,7 @@ You can see which recommended cluster role bindings have changed by choosing an 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-reconcile-cluster-roles.1
+++ b/docs/man/man1/openshift-admin-policy-reconcile-cluster-roles.1
@@ -122,7 +122,7 @@ You can see which cluster roles have recommended changed by choosing an output t
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-reconcile-sccs.1
+++ b/docs/man/man1/openshift-admin-policy-reconcile-sccs.1
@@ -126,7 +126,7 @@ You can see which cluster SCCs have recommended changes by choosing an output ty
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-cluster-role-from-group.1
+++ b/docs/man/man1/openshift-admin-policy-remove-cluster-role-from-group.1
@@ -70,7 +70,7 @@ Remove a role from groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-cluster-role-from-user.1
+++ b/docs/man/man1/openshift-admin-policy-remove-cluster-role-from-user.1
@@ -70,7 +70,7 @@ Remove a role from users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-group.1
+++ b/docs/man/man1/openshift-admin-policy-remove-group.1
@@ -70,7 +70,7 @@ Remove group from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-role-from-group.1
+++ b/docs/man/man1/openshift-admin-policy-remove-role-from-group.1
@@ -76,7 +76,7 @@ Remove a role from groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-role-from-user.1
+++ b/docs/man/man1/openshift-admin-policy-remove-role-from-user.1
@@ -80,7 +80,7 @@ Remove a role from users for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-scc-from-group.1
+++ b/docs/man/man1/openshift-admin-policy-remove-scc-from-group.1
@@ -70,7 +70,7 @@ Remove group from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-scc-from-user.1
+++ b/docs/man/man1/openshift-admin-policy-remove-scc-from-user.1
@@ -76,7 +76,7 @@ Remove user from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-remove-user.1
+++ b/docs/man/man1/openshift-admin-policy-remove-user.1
@@ -70,7 +70,7 @@ Remove user from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy-who-can.1
+++ b/docs/man/man1/openshift-admin-policy-who-can.1
@@ -76,7 +76,7 @@ List who can perform the specified action on a resource
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-policy.1
+++ b/docs/man/man1/openshift-admin-policy.1
@@ -79,7 +79,7 @@ and 'scc'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-prune-builds.1
+++ b/docs/man/man1/openshift-admin-prune-builds.1
@@ -96,7 +96,7 @@ By default, the prune operation performs a dry run making no changes to internal
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-prune-deployments.1
+++ b/docs/man/man1/openshift-admin-prune-deployments.1
@@ -96,7 +96,7 @@ A \-\-confirm flag is needed for changes to be effective.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-prune-groups.1
+++ b/docs/man/man1/openshift-admin-prune-groups.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-prune-images.1
+++ b/docs/man/man1/openshift-admin-prune-images.1
@@ -100,7 +100,7 @@ images.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-prune.1
+++ b/docs/man/man1/openshift-admin-prune.1
@@ -74,7 +74,7 @@ the system by removing them.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-registry.1
+++ b/docs/man/man1/openshift-admin-registry.1
@@ -172,7 +172,7 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-router.1
+++ b/docs/man/man1/openshift-admin-router.1
@@ -213,7 +213,7 @@ you have failover protection.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-taint.1
+++ b/docs/man/man1/openshift-admin-taint.1
@@ -134,7 +134,7 @@ Currently taint can only apply to node.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-top-images.1
+++ b/docs/man/man1/openshift-admin-top-images.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-top-imagestreams.1
+++ b/docs/man/man1/openshift-admin-top-imagestreams.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-top.1
+++ b/docs/man/man1/openshift-admin-top.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin-uncordon.1
+++ b/docs/man/man1/openshift-admin-uncordon.1
@@ -70,7 +70,7 @@ Mark node as schedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-admin.1
+++ b/docs/man/man1/openshift-admin.1
@@ -66,7 +66,7 @@ actions involve interaction with the command\-line client as well.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-build-chain.1
+++ b/docs/man/man1/openshift-cli-adm-build-chain.1
@@ -93,7 +93,7 @@ default namespace will be used respectively.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca-create-key-pair.1
+++ b/docs/man/man1/openshift-cli-adm-ca-create-key-pair.1
@@ -97,7 +97,7 @@ openshift cli adm ca create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.p
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca-create-master-certs.1
+++ b/docs/man/man1/openshift-cli-adm-ca-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca-create-server-cert.1
+++ b/docs/man/man1/openshift-cli-adm-ca-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca-create-signer-cert.1
+++ b/docs/man/man1/openshift-cli-adm-ca-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca-decrypt.1
+++ b/docs/man/man1/openshift-cli-adm-ca-decrypt.1
@@ -84,7 +84,7 @@ Decrypt data encrypted with "openshift cli adm ca encrypt"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca-encrypt.1
+++ b/docs/man/man1/openshift-cli-adm-ca-encrypt.1
@@ -88,7 +88,7 @@ Encrypt data with AES\-256\-CBC encryption
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ca.1
+++ b/docs/man/man1/openshift-cli-adm-ca.1
@@ -70,7 +70,7 @@ Manage certificates and keys
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-completion.1
+++ b/docs/man/man1/openshift-cli-adm-completion.1
@@ -71,7 +71,7 @@ completion of openshift cli adm commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-current-context.1
+++ b/docs/man/man1/openshift-cli-adm-config-current-context.1
@@ -70,7 +70,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-set-context.1
+++ b/docs/man/man1/openshift-cli-adm-config-set-context.1
@@ -77,7 +77,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-set-credentials.1
+++ b/docs/man/man1/openshift-cli-adm-config-set-credentials.1
@@ -104,7 +104,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-set.1
+++ b/docs/man/man1/openshift-cli-adm-config-set.1
@@ -78,7 +78,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-unset.1
+++ b/docs/man/man1/openshift-cli-adm-config-unset.1
@@ -71,7 +71,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-use-context.1
+++ b/docs/man/man1/openshift-cli-adm-config-use-context.1
@@ -70,7 +70,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config-view.1
+++ b/docs/man/man1/openshift-cli-adm-config-view.1
@@ -122,7 +122,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-config.1
+++ b/docs/man/man1/openshift-cli-adm-config.1
@@ -81,7 +81,7 @@ Reference:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-cordon.1
+++ b/docs/man/man1/openshift-cli-adm-cordon.1
@@ -70,7 +70,7 @@ Mark node as unschedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-api-client-config.1
+++ b/docs/man/man1/openshift-cli-adm-create-api-client-config.1
@@ -114,7 +114,7 @@ master as the provided user.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-bootstrap-policy-file.1
+++ b/docs/man/man1/openshift-cli-adm-create-bootstrap-policy-file.1
@@ -80,7 +80,7 @@ Create the default bootstrap policy
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-bootstrap-project-template.1
+++ b/docs/man/man1/openshift-cli-adm-create-bootstrap-project-template.1
@@ -107,7 +107,7 @@ Create a bootstrap project template
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-error-template.1
+++ b/docs/man/man1/openshift-cli-adm-create-error-template.1
@@ -90,7 +90,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-key-pair.1
+++ b/docs/man/man1/openshift-cli-adm-create-key-pair.1
@@ -97,7 +97,7 @@ openshift cli adm create\-key\-pair \-\-public\-key=$CONFIG/serviceaccounts.publ
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-kubeconfig.1
+++ b/docs/man/man1/openshift-cli-adm-create-kubeconfig.1
@@ -114,7 +114,7 @@ users:
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-login-template.1
+++ b/docs/man/man1/openshift-cli-adm-create-login-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-master-certs.1
+++ b/docs/man/man1/openshift-cli-adm-create-master-certs.1
@@ -159,7 +159,7 @@ for certain configuration changes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-node-config.1
+++ b/docs/man/man1/openshift-cli-adm-create-node-config.1
@@ -146,7 +146,7 @@ Create a configuration bundle for a node
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-provider-selection-template.1
+++ b/docs/man/man1/openshift-cli-adm-create-provider-selection-template.1
@@ -91,7 +91,7 @@ oauthConfig:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-server-cert.1
+++ b/docs/man/man1/openshift-cli-adm-create-server-cert.1
@@ -122,7 +122,7 @@ cat cloudapps.crt cloudapps.key $CA/ca.crt > cloudapps.router.pem
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-create-signer-cert.1
+++ b/docs/man/man1/openshift-cli-adm-create-signer-cert.1
@@ -92,7 +92,7 @@ Create a self\-signed CA key/cert for signing certificates used by server compon
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-diagnostics.1
+++ b/docs/man/man1/openshift-cli-adm-diagnostics.1
@@ -153,7 +153,7 @@ AnalyzeLogs ClusterRegistry ClusterRoleBindings ClusterRoles ClusterRouter Confi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-drain.1
+++ b/docs/man/man1/openshift-cli-adm-drain.1
@@ -103,7 +103,7 @@ will make the node schedulable again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-groups-add-users.1
+++ b/docs/man/man1/openshift-cli-adm-groups-add-users.1
@@ -73,7 +73,7 @@ This command will append unique users to the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-groups-new.1
+++ b/docs/man/man1/openshift-cli-adm-groups-new.1
@@ -73,7 +73,7 @@ This command will create a new group with an optional list of users.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-groups-prune.1
+++ b/docs/man/man1/openshift-cli-adm-groups-prune.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-groups-remove-users.1
+++ b/docs/man/man1/openshift-cli-adm-groups-remove-users.1
@@ -73,7 +73,7 @@ This command will remove users from the list of members for a group.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-groups-sync.1
+++ b/docs/man/man1/openshift-cli-adm-groups-sync.1
@@ -132,7 +132,7 @@ LDAP query templates.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-groups.1
+++ b/docs/man/man1/openshift-cli-adm-groups.1
@@ -73,7 +73,7 @@ Groups are sets of users that can be used when describing policy.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-ipfailover.1
+++ b/docs/man/man1/openshift-cli-adm-ipfailover.1
@@ -145,7 +145,7 @@ value that matches the number of nodes for the given labeled selector.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-manage-node.1
+++ b/docs/man/man1/openshift-cli-adm-manage-node.1
@@ -148,7 +148,7 @@ list\-pods: List all/selected pods on given/selected nodes. It can list the outp
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-migrate-image-references.1
+++ b/docs/man/man1/openshift-cli-adm-migrate-image-references.1
@@ -130,7 +130,7 @@ streams requires administrative privileges.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-migrate-storage.1
+++ b/docs/man/man1/openshift-cli-adm-migrate-storage.1
@@ -121,7 +121,7 @@ WARNING: This is a slow command and will put significant load on an API server. 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-migrate.1
+++ b/docs/man/man1/openshift-cli-adm-migrate.1
@@ -73,7 +73,7 @@ These commands assist administrators in performing preventative maintenance on a
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-new-project.1
+++ b/docs/man/man1/openshift-cli-adm-new-project.1
@@ -97,7 +97,7 @@ to restrict which nodes pods in this project can be scheduled to.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-options.1
+++ b/docs/man/man1/openshift-cli-adm-options.1
@@ -67,7 +67,7 @@ openshift cli adm options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-overwrite-policy.1
+++ b/docs/man/man1/openshift-cli-adm-overwrite-policy.1
@@ -84,7 +84,7 @@ Reset the policy to the default values
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-pod-network-isolate-projects.1
+++ b/docs/man/man1/openshift-cli-adm-pod-network-isolate-projects.1
@@ -79,7 +79,7 @@ Allows projects to isolate their network from other projects when using the redh
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-pod-network-join-projects.1
+++ b/docs/man/man1/openshift-cli-adm-pod-network-join-projects.1
@@ -83,7 +83,7 @@ Allows projects to join existing project network when using the redhat/openshift
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-pod-network-make-projects-global.1
+++ b/docs/man/man1/openshift-cli-adm-pod-network-make-projects-global.1
@@ -79,7 +79,7 @@ Allows projects to access all pods in the cluster and vice versa when using the 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-pod-network.1
+++ b/docs/man/man1/openshift-cli-adm-pod-network.1
@@ -73,7 +73,7 @@ This command provides common pod network operations for administrators.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-add-cluster-role-to-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-add-cluster-role-to-group.1
@@ -70,7 +70,7 @@ Add a role to groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-add-cluster-role-to-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-add-cluster-role-to-user.1
@@ -70,7 +70,7 @@ Add a role to users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-add-role-to-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-add-role-to-group.1
@@ -76,7 +76,7 @@ Add a role to groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-add-role-to-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-add-role-to-user.1
@@ -80,7 +80,7 @@ Add a role to users or serviceaccounts for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-add-scc-to-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-add-scc-to-group.1
@@ -70,7 +70,7 @@ Add groups to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-add-scc-to-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-add-scc-to-user.1
@@ -76,7 +76,7 @@ Add users or serviceaccount to a security context constraint
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-reconcile-cluster-role-bindings.1
+++ b/docs/man/man1/openshift-cli-adm-policy-reconcile-cluster-role-bindings.1
@@ -127,7 +127,7 @@ You can see which recommended cluster role bindings have changed by choosing an 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-reconcile-cluster-roles.1
+++ b/docs/man/man1/openshift-cli-adm-policy-reconcile-cluster-roles.1
@@ -122,7 +122,7 @@ You can see which cluster roles have recommended changed by choosing an output t
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-reconcile-sccs.1
+++ b/docs/man/man1/openshift-cli-adm-policy-reconcile-sccs.1
@@ -126,7 +126,7 @@ You can see which cluster SCCs have recommended changes by choosing an output ty
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-cluster-role-from-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-cluster-role-from-group.1
@@ -70,7 +70,7 @@ Remove a role from groups for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-cluster-role-from-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-cluster-role-from-user.1
@@ -70,7 +70,7 @@ Remove a role from users for all projects in the cluster
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-group.1
@@ -70,7 +70,7 @@ Remove group from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-role-from-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-role-from-group.1
@@ -76,7 +76,7 @@ Remove a role from groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-role-from-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-role-from-user.1
@@ -80,7 +80,7 @@ Remove a role from users for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-scc-from-group.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-scc-from-group.1
@@ -70,7 +70,7 @@ Remove group from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-scc-from-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-scc-from-user.1
@@ -76,7 +76,7 @@ Remove user from scc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-remove-user.1
+++ b/docs/man/man1/openshift-cli-adm-policy-remove-user.1
@@ -70,7 +70,7 @@ Remove user from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy-who-can.1
+++ b/docs/man/man1/openshift-cli-adm-policy-who-can.1
@@ -76,7 +76,7 @@ List who can perform the specified action on a resource
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-policy.1
+++ b/docs/man/man1/openshift-cli-adm-policy.1
@@ -79,7 +79,7 @@ and 'scc'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-prune-builds.1
+++ b/docs/man/man1/openshift-cli-adm-prune-builds.1
@@ -96,7 +96,7 @@ By default, the prune operation performs a dry run making no changes to internal
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-prune-deployments.1
+++ b/docs/man/man1/openshift-cli-adm-prune-deployments.1
@@ -96,7 +96,7 @@ A \-\-confirm flag is needed for changes to be effective.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-prune-groups.1
+++ b/docs/man/man1/openshift-cli-adm-prune-groups.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-prune-images.1
+++ b/docs/man/man1/openshift-cli-adm-prune-images.1
@@ -100,7 +100,7 @@ images.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-prune.1
+++ b/docs/man/man1/openshift-cli-adm-prune.1
@@ -74,7 +74,7 @@ the system by removing them.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-registry.1
+++ b/docs/man/man1/openshift-cli-adm-registry.1
@@ -172,7 +172,7 @@ NOTE: This command is intended to simplify the tasks of setting up a Docker regi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-router.1
+++ b/docs/man/man1/openshift-cli-adm-router.1
@@ -213,7 +213,7 @@ you have failover protection.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-taint.1
+++ b/docs/man/man1/openshift-cli-adm-taint.1
@@ -134,7 +134,7 @@ Currently taint can only apply to node.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-top-images.1
+++ b/docs/man/man1/openshift-cli-adm-top-images.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-top-imagestreams.1
+++ b/docs/man/man1/openshift-cli-adm-top-imagestreams.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-top.1
+++ b/docs/man/man1/openshift-cli-adm-top.1
@@ -74,7 +74,7 @@ usage statistics.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm-uncordon.1
+++ b/docs/man/man1/openshift-cli-adm-uncordon.1
@@ -70,7 +70,7 @@ Mark node as schedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-adm.1
+++ b/docs/man/man1/openshift-cli-adm.1
@@ -66,7 +66,7 @@ actions involve interaction with the command\-line client as well.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-annotate.1
+++ b/docs/man/man1/openshift-cli-annotate.1
@@ -147,7 +147,7 @@ Run 'openshift cli types' for a list of valid resources.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-apply.1
+++ b/docs/man/man1/openshift-cli-apply.1
@@ -103,7 +103,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-attach.1
+++ b/docs/man/man1/openshift-cli-attach.1
@@ -88,7 +88,7 @@ terminal session. Can be used to debug containers and invoke interactive command
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-autoscale.1
+++ b/docs/man/man1/openshift-cli-autoscale.1
@@ -152,7 +152,7 @@ increase or decrease number of pods deployed within the system as needed.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-build-logs.1
+++ b/docs/man/man1/openshift-cli-build-logs.1
@@ -80,7 +80,7 @@ DEPRECATED: This command has been moved to "openshift cli logs"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-cancel-build.1
+++ b/docs/man/man1/openshift-cli-cancel-build.1
@@ -88,7 +88,7 @@ the build and the time the build is terminated.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-cluster-down.1
+++ b/docs/man/man1/openshift-cli-cluster-down.1
@@ -80,7 +80,7 @@ same machine using the \-\-docker\-machine argument.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-cluster-up.1
+++ b/docs/man/man1/openshift-cli-cluster-up.1
@@ -152,7 +152,7 @@ A public hostname can also be specified for the server with the \-\-public\-host
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-cluster.1
+++ b/docs/man/man1/openshift-cli-cluster.1
@@ -88,7 +88,7 @@ routing suffix, use the \-\-routing\-suffix flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-completion.1
+++ b/docs/man/man1/openshift-cli-completion.1
@@ -71,7 +71,7 @@ completion of openshift cli commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-current-context.1
+++ b/docs/man/man1/openshift-cli-config-current-context.1
@@ -70,7 +70,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-set-context.1
+++ b/docs/man/man1/openshift-cli-config-set-context.1
@@ -77,7 +77,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-set-credentials.1
+++ b/docs/man/man1/openshift-cli-config-set-credentials.1
@@ -104,7 +104,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-set.1
+++ b/docs/man/man1/openshift-cli-config-set.1
@@ -78,7 +78,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-unset.1
+++ b/docs/man/man1/openshift-cli-config-unset.1
@@ -71,7 +71,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-use-context.1
+++ b/docs/man/man1/openshift-cli-config-use-context.1
@@ -70,7 +70,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config-view.1
+++ b/docs/man/man1/openshift-cli-config-view.1
@@ -122,7 +122,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-config.1
+++ b/docs/man/man1/openshift-cli-config.1
@@ -81,7 +81,7 @@ Reference:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-convert.1
+++ b/docs/man/man1/openshift-cli-convert.1
@@ -137,7 +137,7 @@ to change to output destination.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-clusterresourcequota.1
+++ b/docs/man/man1/openshift-cli-create-clusterresourcequota.1
@@ -91,7 +91,7 @@ Cluster resource quota objects defined quota restrictions that span multiple pro
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-configmap.1
+++ b/docs/man/man1/openshift-cli-create-configmap.1
@@ -143,7 +143,7 @@ symlinks, devices, pipes, etc).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-deploymentconfig.1
+++ b/docs/man/man1/openshift-cli-create-deploymentconfig.1
@@ -83,7 +83,7 @@ Deployment configs define the template for a pod and manages deploying new image
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-identity.1
+++ b/docs/man/man1/openshift-cli-create-identity.1
@@ -112,7 +112,7 @@ to allow logging in with the created identity.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-imagestream.1
+++ b/docs/man/man1/openshift-cli-create-imagestream.1
@@ -80,7 +80,7 @@ access controlled destination that you can push images to.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-namespace.1
+++ b/docs/man/man1/openshift-cli-create-namespace.1
@@ -123,7 +123,7 @@ Create a namespace with the specified name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-policybinding.1
+++ b/docs/man/man1/openshift-cli-create-policybinding.1
@@ -76,7 +76,7 @@ Create a policy binding that references the policy in the targetted namespace.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-quota.1
+++ b/docs/man/man1/openshift-cli-create-quota.1
@@ -131,7 +131,7 @@ Create a resourcequota with the specified name, hard limits and optional scopes
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-route-edge.1
+++ b/docs/man/man1/openshift-cli-create-route-edge.1
@@ -120,7 +120,7 @@ generated route should expose via the \-\-service flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-route-passthrough.1
+++ b/docs/man/man1/openshift-cli-create-route-passthrough.1
@@ -100,7 +100,7 @@ generated route should expose via the \-\-service flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-route-reencrypt.1
+++ b/docs/man/man1/openshift-cli-create-route-reencrypt.1
@@ -121,7 +121,7 @@ is needed for reencrypt routes, specify one with the \-\-dest\-ca\-cert flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-route.1
+++ b/docs/man/man1/openshift-cli-create-route.1
@@ -74,7 +74,7 @@ If you wish to create unsecured routes, see "openshift cli expose \-h"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-secret-docker-registry.1
+++ b/docs/man/man1/openshift-cli-create-secret-docker-registry.1
@@ -158,7 +158,7 @@ by creating a dockercfg secret and attaching it to your service account.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-secret-generic.1
+++ b/docs/man/man1/openshift-cli-create-secret-generic.1
@@ -147,7 +147,7 @@ symlinks, devices, pipes, etc).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-secret-tls.1
+++ b/docs/man/man1/openshift-cli-create-secret-tls.1
@@ -134,7 +134,7 @@ The public/private key pair must exist before hand. The public key certificate m
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-secret.1
+++ b/docs/man/man1/openshift-cli-create-secret.1
@@ -70,7 +70,7 @@ Create a secret using specified subcommand.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-serviceaccount.1
+++ b/docs/man/man1/openshift-cli-create-serviceaccount.1
@@ -127,7 +127,7 @@ Create a service account with the specified name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-user.1
+++ b/docs/man/man1/openshift-cli-create-user.1
@@ -116,7 +116,7 @@ to allow logging in as the created user.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create-useridentitymapping.1
+++ b/docs/man/man1/openshift-cli-create-useridentitymapping.1
@@ -106,7 +106,7 @@ to create a useridentitymapping object.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-create.1
+++ b/docs/man/man1/openshift-cli-create.1
@@ -107,7 +107,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-debug.1
+++ b/docs/man/man1/openshift-cli-debug.1
@@ -174,7 +174,7 @@ the shell.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-delete.1
+++ b/docs/man/man1/openshift-cli-delete.1
@@ -128,7 +128,7 @@ will be lost along with the rest of the resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-deploy.1
+++ b/docs/man/man1/openshift-cli-deploy.1
@@ -127,7 +127,7 @@ If no options are given, shows information about the latest deployment.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-describe.1
+++ b/docs/man/man1/openshift-cli-describe.1
@@ -96,7 +96,7 @@ given resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-edit.1
+++ b/docs/man/man1/openshift-cli-edit.1
@@ -125,7 +125,7 @@ saved copy to include the latest resource version.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-env.1
+++ b/docs/man/man1/openshift-cli-env.1
@@ -124,7 +124,7 @@ DEPRECATED: This command has been moved to "openshift cli set env"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-ex-dockerbuild.1
+++ b/docs/man/man1/openshift-cli-ex-dockerbuild.1
@@ -93,7 +93,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-ex.1
+++ b/docs/man/man1/openshift-cli-ex.1
@@ -67,7 +67,7 @@ openshift cli ex \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-exec.1
+++ b/docs/man/man1/openshift-cli-exec.1
@@ -88,7 +88,7 @@ Execute a command in a container
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-explain.1
+++ b/docs/man/man1/openshift-cli-explain.1
@@ -86,7 +86,7 @@ resourcequotas (quota), namespaces (ns) or endpoints (ep).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-export.1
+++ b/docs/man/man1/openshift-cli-export.1
@@ -148,7 +148,7 @@ to generate the API structure for a template to which you can add parameters and
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-expose.1
+++ b/docs/man/man1/openshift-cli-expose.1
@@ -192,7 +192,7 @@ labels from the object it exposes.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-extract.1
+++ b/docs/man/man1/openshift-cli-extract.1
@@ -128,7 +128,7 @@ with \-\-to=DIRECTORY.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-get.1
+++ b/docs/man/man1/openshift-cli-get.1
@@ -152,7 +152,7 @@ If you want an even more detailed view, use 'openshift cli describe'.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-idle.1
+++ b/docs/man/man1/openshift-cli-idle.1
@@ -102,7 +102,7 @@ associated resources by scaling them back up to their previous scale.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-import-app.json.1
+++ b/docs/man/man1/openshift-cli-import-app.json.1
@@ -113,7 +113,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-import-docker-compose.1
+++ b/docs/man/man1/openshift-cli-import-docker-compose.1
@@ -109,7 +109,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-import-image.1
+++ b/docs/man/man1/openshift-cli-import-image.1
@@ -92,7 +92,7 @@ spec.Tags may have tag and image information imported.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-import.1
+++ b/docs/man/man1/openshift-cli-import.1
@@ -73,7 +73,7 @@ These commands assist in bringing existing applications into OpenShift.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-label.1
+++ b/docs/man/man1/openshift-cli-label.1
@@ -146,7 +146,7 @@ resource\-version will be used.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-login.1
+++ b/docs/man/man1/openshift-cli-login.1
@@ -91,7 +91,7 @@ prompt for user input as needed.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-logout.1
+++ b/docs/man/man1/openshift-cli-logout.1
@@ -83,7 +83,7 @@ After logging out, if you want to log back into the server use 'openshift cli lo
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-logs.1
+++ b/docs/man/man1/openshift-cli-logs.1
@@ -126,7 +126,7 @@ logs of the last attempt.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-new-app.1
+++ b/docs/man/man1/openshift-cli-new-app.1
@@ -185,7 +185,7 @@ You can use 'openshift cli status' to check the progress.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-new-build.1
+++ b/docs/man/man1/openshift-cli-new-build.1
@@ -174,7 +174,7 @@ You can use 'openshift cli status' to check the progress.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-new-project.1
+++ b/docs/man/man1/openshift-cli-new-project.1
@@ -91,7 +91,7 @@ After your project is created it will become the default project in your config.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-observe.1
+++ b/docs/man/man1/openshift-cli-observe.1
@@ -246,7 +246,7 @@ Experimental: This command is under active development and may change without no
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-options.1
+++ b/docs/man/man1/openshift-cli-options.1
@@ -67,7 +67,7 @@ openshift cli options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-patch.1
+++ b/docs/man/man1/openshift-cli-patch.1
@@ -103,7 +103,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-add-role-to-group.1
+++ b/docs/man/man1/openshift-cli-policy-add-role-to-group.1
@@ -76,7 +76,7 @@ Add a role to groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-add-role-to-user.1
+++ b/docs/man/man1/openshift-cli-policy-add-role-to-user.1
@@ -80,7 +80,7 @@ Add a role to users or serviceaccounts for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-can-i.1
+++ b/docs/man/man1/openshift-cli-policy-can-i.1
@@ -92,7 +92,7 @@ Check whether an action is allowed
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-remove-group.1
+++ b/docs/man/man1/openshift-cli-policy-remove-group.1
@@ -70,7 +70,7 @@ Remove group from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-remove-role-from-group.1
+++ b/docs/man/man1/openshift-cli-policy-remove-role-from-group.1
@@ -76,7 +76,7 @@ Remove a role from groups for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-remove-role-from-user.1
+++ b/docs/man/man1/openshift-cli-policy-remove-role-from-user.1
@@ -80,7 +80,7 @@ Remove a role from users for the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-remove-user.1
+++ b/docs/man/man1/openshift-cli-policy-remove-user.1
@@ -70,7 +70,7 @@ Remove user from the current project
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy-who-can.1
+++ b/docs/man/man1/openshift-cli-policy-who-can.1
@@ -76,7 +76,7 @@ List who can perform the specified action on a resource
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-policy.1
+++ b/docs/man/man1/openshift-cli-policy.1
@@ -70,7 +70,7 @@ Manage authorization policy
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-port-forward.1
+++ b/docs/man/man1/openshift-cli-port-forward.1
@@ -76,7 +76,7 @@ Forward 1 or more local ports to a pod
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-process.1
+++ b/docs/man/man1/openshift-cli-process.1
@@ -114,7 +114,7 @@ output to the create command over STDIN (using the '\-f \-' option) or redirect 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-project.1
+++ b/docs/man/man1/openshift-cli-project.1
@@ -88,7 +88,7 @@ command.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-projects.1
+++ b/docs/man/man1/openshift-cli-projects.1
@@ -80,7 +80,7 @@ command.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-proxy.1
+++ b/docs/man/man1/openshift-cli-proxy.1
@@ -116,7 +116,7 @@ Run a proxy to the API server
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-replace.1
+++ b/docs/man/man1/openshift-cli-replace.1
@@ -123,7 +123,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rollback.1
+++ b/docs/man/man1/openshift-cli-rollback.1
@@ -120,7 +120,7 @@ will be.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rollout-history.1
+++ b/docs/man/man1/openshift-cli-rollout-history.1
@@ -88,7 +88,7 @@ by using the \-\-revision flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rollout-pause.1
+++ b/docs/man/man1/openshift-cli-rollout-pause.1
@@ -84,7 +84,7 @@ Use \\"%[1]s rollout resume\\" to resume a paused resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rollout-resume.1
+++ b/docs/man/man1/openshift-cli-rollout-resume.1
@@ -84,7 +84,7 @@ resource, we allow it to be reconciled again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rollout-undo.1
+++ b/docs/man/man1/openshift-cli-rollout-undo.1
@@ -104,7 +104,7 @@ will be.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rollout.1
+++ b/docs/man/man1/openshift-cli-rollout.1
@@ -70,7 +70,7 @@ Manage deployments.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rsh.1
+++ b/docs/man/man1/openshift-cli-rsh.1
@@ -103,7 +103,7 @@ directly.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-rsync.1
+++ b/docs/man/man1/openshift-cli-rsync.1
@@ -120,7 +120,7 @@ for the copy.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-run.1
+++ b/docs/man/man1/openshift-cli-run.1
@@ -204,7 +204,7 @@ foreground for an interactive container execution.  You may pass 'run/v1' to
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-scale.1
+++ b/docs/man/man1/openshift-cli-scale.1
@@ -118,7 +118,7 @@ desired replicas in the configuration template.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-add.1
+++ b/docs/man/man1/openshift-cli-secrets-add.1
@@ -76,7 +76,7 @@ DEPRECATED: This command has been moved to "openshift cli secrets link"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-link.1
+++ b/docs/man/man1/openshift-cli-secrets-link.1
@@ -79,7 +79,7 @@ Linking a secret enables a service account to automatically use that secret for 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-new-basicauth.1
+++ b/docs/man/man1/openshift-cli-secrets-new-basicauth.1
@@ -131,7 +131,7 @@ this information by creating a 'basicauth' secret and attaching it to your servi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-new-dockercfg.1
+++ b/docs/man/man1/openshift-cli-secrets-new-dockercfg.1
@@ -134,7 +134,7 @@ by creating a dockercfg secret and attaching it to your service account.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-new-sshauth.1
+++ b/docs/man/man1/openshift-cli-secrets-new-sshauth.1
@@ -123,7 +123,7 @@ provide this information by creating a 'sshauth' secret and attaching it to your
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-new.1
+++ b/docs/man/man1/openshift-cli-secrets-new.1
@@ -120,7 +120,7 @@ using with all valid keys in that directory.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets-unlink.1
+++ b/docs/man/man1/openshift-cli-secrets-unlink.1
@@ -73,7 +73,7 @@ If a secret is no longer valid for a pod, build or image pull, you may unlink it
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-secrets.1
+++ b/docs/man/man1/openshift-cli-secrets.1
@@ -75,7 +75,7 @@ Docker registries.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-serviceaccounts-get-token.1
+++ b/docs/man/man1/openshift-cli-serviceaccounts-get-token.1
@@ -78,7 +78,7 @@ itself were making the actions.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-serviceaccounts-new-token.1
+++ b/docs/man/man1/openshift-cli-serviceaccounts-new-token.1
@@ -87,7 +87,7 @@ be applied to any created token so that tokens created with this command can be 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-serviceaccounts.1
+++ b/docs/man/man1/openshift-cli-serviceaccounts.1
@@ -73,7 +73,7 @@ Service accounts allow system components to access the API.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-build-hook.1
+++ b/docs/man/man1/openshift-cli-set-build-hook.1
@@ -147,7 +147,7 @@ arguments to the image's entrypoint (default).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-deployment-hook.1
+++ b/docs/man/man1/openshift-cli-set-deployment-hook.1
@@ -172,7 +172,7 @@ the abort policy, because at that point the deployment has already happened.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-env.1
+++ b/docs/man/man1/openshift-cli-set-env.1
@@ -137,7 +137,7 @@ syntax.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-probe.1
+++ b/docs/man/man1/openshift-cli-set-probe.1
@@ -183,7 +183,7 @@ to fail.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-route-backends.1
+++ b/docs/man/man1/openshift-cli-set-route-backends.1
@@ -160,7 +160,7 @@ Not all routers may support multiple or weighted backends.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-triggers.1
+++ b/docs/man/man1/openshift-cli-set-triggers.1
@@ -169,7 +169,7 @@ and generic). The config change trigger for a build config will only trigger the
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set-volumes.1
+++ b/docs/man/man1/openshift-cli-set-volumes.1
@@ -191,7 +191,7 @@ For descriptions on other volume types, see
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-set.1
+++ b/docs/man/man1/openshift-cli-set.1
@@ -73,7 +73,7 @@ These commands help you make changes to existing application resources.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-start-build.1
+++ b/docs/man/man1/openshift-cli-start-build.1
@@ -141,7 +141,7 @@ base image changes will use the source specified on the build config.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-status.1
+++ b/docs/man/man1/openshift-cli-status.1
@@ -94,7 +94,7 @@ graph in DOT format that is suitable for use by the "dot" command.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-tag.1
+++ b/docs/man/man1/openshift-cli-tag.1
@@ -109,7 +109,7 @@ Docker images.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-types.1
+++ b/docs/man/man1/openshift-cli-types.1
@@ -220,7 +220,7 @@ For more, see
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-volumes.1
+++ b/docs/man/man1/openshift-cli-volumes.1
@@ -156,7 +156,7 @@ DEPRECATED: This command has been moved to "openshift cli set volume"
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli-whoami.1
+++ b/docs/man/man1/openshift-cli-whoami.1
@@ -81,7 +81,7 @@ user context.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-cli.1
+++ b/docs/man/man1/openshift-cli.1
@@ -67,7 +67,7 @@ cluster under the 'adm' subcommand.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-build-chain.1
+++ b/docs/man/man1/openshift-ex-build-chain.1
@@ -93,7 +93,7 @@ default namespace will be used respectively.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-config-patch.1
+++ b/docs/man/man1/openshift-ex-config-patch.1
@@ -80,7 +80,7 @@ Patch the master\-config.yaml or node\-config.yaml
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-config.1
+++ b/docs/man/man1/openshift-ex-config.1
@@ -70,7 +70,7 @@ Manage cluster configuration files like master\-config.yaml.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-diagnostics.1
+++ b/docs/man/man1/openshift-ex-diagnostics.1
@@ -153,7 +153,7 @@ AnalyzeLogs ClusterRegistry ClusterRoleBindings ClusterRoles ClusterRouter Confi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-ipfailover.1
+++ b/docs/man/man1/openshift-ex-ipfailover.1
@@ -145,7 +145,7 @@ value that matches the number of nodes for the given labeled selector.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-options.1
+++ b/docs/man/man1/openshift-ex-options.1
@@ -67,7 +67,7 @@ openshift ex options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-prune-groups.1
+++ b/docs/man/man1/openshift-ex-prune-groups.1
@@ -97,7 +97,7 @@ flag.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-sync-groups.1
+++ b/docs/man/man1/openshift-ex-sync-groups.1
@@ -132,7 +132,7 @@ LDAP query templates.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-validate-master-config.1
+++ b/docs/man/man1/openshift-ex-validate-master-config.1
@@ -73,7 +73,7 @@ This command validates that a configuration file intended to be used for a maste
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-validate-node-config.1
+++ b/docs/man/man1/openshift-ex-validate-node-config.1
@@ -73,7 +73,7 @@ This command validates that a configuration file intended to be used for a node 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex-validate.1
+++ b/docs/man/man1/openshift-ex-validate.1
@@ -73,7 +73,7 @@ The commands here allow administrators to validate the integrity of configuratio
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-ex.1
+++ b/docs/man/man1/openshift-ex.1
@@ -62,7 +62,7 @@ The commands grouped here are under development and may change without notice.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-infra-f5-router.1
+++ b/docs/man/man1/openshift-infra-f5-router.1
@@ -145,7 +145,7 @@ that you must have a cluster\-wide administrative role to view all namespaces.
     The interval at which the route list should be fully refreshed
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-infra-router.1
+++ b/docs/man/man1/openshift-infra-router.1
@@ -145,7 +145,7 @@ that you must have a cluster\-wide administrative role to view all namespaces.
     The interval at which the route list should be fully refreshed
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-annotate.1
+++ b/docs/man/man1/openshift-kube-annotate.1
@@ -260,7 +260,7 @@ Possible resources include (case insensitive):
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-api-versions.1
+++ b/docs/man/man1/openshift-kube-api-versions.1
@@ -182,7 +182,7 @@ Print the supported API versions on the server, in the form of "group/version".
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-apply.1
+++ b/docs/man/man1/openshift-kube-apply.1
@@ -217,7 +217,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-attach.1
+++ b/docs/man/man1/openshift-kube-attach.1
@@ -196,7 +196,7 @@ Attach to a process that is already running inside an existing container.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-autoscale.1
+++ b/docs/man/man1/openshift-kube-autoscale.1
@@ -263,7 +263,7 @@ An autoscaler can automatically increase or decrease number of pods deployed wit
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-cluster-info-dump.1
+++ b/docs/man/man1/openshift-kube-cluster-info-dump.1
@@ -203,7 +203,7 @@ based on namespace and pod name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-cluster-info.1
+++ b/docs/man/man1/openshift-kube-cluster-info.1
@@ -189,7 +189,7 @@ To further debug and diagnose cluster problems, use 'kubectl cluster\-info dump'
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-completion.1
+++ b/docs/man/man1/openshift-kube-completion.1
@@ -186,7 +186,7 @@ completion of kubectl commands.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-current-context.1
+++ b/docs/man/man1/openshift-kube-config-current-context.1
@@ -182,7 +182,7 @@ Displays the current\-context
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-set-context.1
+++ b/docs/man/man1/openshift-kube-config-set-context.1
@@ -189,7 +189,7 @@ Specifying a name that already exists will merge new fields on top of existing v
     Require server version to match client version
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-set-credentials.1
+++ b/docs/man/man1/openshift-kube-config-set-credentials.1
@@ -216,7 +216,7 @@ Bearer token and basic auth are mutually exclusive.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-set.1
+++ b/docs/man/man1/openshift-kube-config-set.1
@@ -190,7 +190,7 @@ PROPERTY\_VALUE is the new value you wish to set. Binary fields such as 'certifi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-unset.1
+++ b/docs/man/man1/openshift-kube-config-unset.1
@@ -183,7 +183,7 @@ PROPERTY\_NAME is a dot delimited name where each token represents either a attr
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-use-context.1
+++ b/docs/man/man1/openshift-kube-config-use-context.1
@@ -182,7 +182,7 @@ Sets the current\-context in a kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config-view.1
+++ b/docs/man/man1/openshift-kube-config-view.1
@@ -234,7 +234,7 @@ You can use \-\-output jsonpath={...} to extract specific values using a jsonpat
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-config.1
+++ b/docs/man/man1/openshift-kube-config.1
@@ -190,7 +190,7 @@ The loading order follows these rules:
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-convert.1
+++ b/docs/man/man1/openshift-kube-convert.1
@@ -249,7 +249,7 @@ to change to output destination.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-cordon.1
+++ b/docs/man/man1/openshift-kube-cordon.1
@@ -182,7 +182,7 @@ Mark node as unschedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-configmap.1
+++ b/docs/man/man1/openshift-kube-create-configmap.1
@@ -255,7 +255,7 @@ symlinks, devices, pipes, etc).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-namespace.1
+++ b/docs/man/man1/openshift-kube-create-namespace.1
@@ -235,7 +235,7 @@ Create a namespace with the specified name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-quota.1
+++ b/docs/man/man1/openshift-kube-create-quota.1
@@ -243,7 +243,7 @@ Create a resourcequota with the specified name, hard limits and optional scopes
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-secret-docker-registry.1
+++ b/docs/man/man1/openshift-kube-create-secret-docker-registry.1
@@ -270,7 +270,7 @@ by creating a dockercfg secret and attaching it to your service account.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-secret-generic.1
+++ b/docs/man/man1/openshift-kube-create-secret-generic.1
@@ -259,7 +259,7 @@ symlinks, devices, pipes, etc).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-secret-tls.1
+++ b/docs/man/man1/openshift-kube-create-secret-tls.1
@@ -246,7 +246,7 @@ The public/private key pair must exist before hand. The public key certificate m
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-secret.1
+++ b/docs/man/man1/openshift-kube-create-secret.1
@@ -182,7 +182,7 @@ Create a secret using specified subcommand.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create-serviceaccount.1
+++ b/docs/man/man1/openshift-kube-create-serviceaccount.1
@@ -239,7 +239,7 @@ Create a service account with the specified name.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-create.1
+++ b/docs/man/man1/openshift-kube-create.1
@@ -219,7 +219,7 @@ JSON and YAML formats are accepted.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-delete.1
+++ b/docs/man/man1/openshift-kube-delete.1
@@ -239,7 +239,7 @@ will be lost along with the rest of the resource.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-describe.1
+++ b/docs/man/man1/openshift-kube-describe.1
@@ -222,7 +222,7 @@ componentstatuses (cs), endpoints (ep), and secrets.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-drain.1
+++ b/docs/man/man1/openshift-kube-drain.1
@@ -215,7 +215,7 @@ will make the node schedulable again.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-edit.1
+++ b/docs/man/man1/openshift-kube-edit.1
@@ -237,7 +237,7 @@ saved copy to include the latest resource version.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-exec.1
+++ b/docs/man/man1/openshift-kube-exec.1
@@ -200,7 +200,7 @@ Execute a command in a container.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-explain.1
+++ b/docs/man/man1/openshift-kube-explain.1
@@ -199,7 +199,7 @@ componentstatuses (cs), endpoints (ep), and secrets.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-expose.1
+++ b/docs/man/man1/openshift-kube-expose.1
@@ -304,7 +304,7 @@ Possible resources include (case insensitive):
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-get.1
+++ b/docs/man/man1/openshift-kube-get.1
@@ -270,7 +270,7 @@ of the \-\-template flag, you can filter the attributes of the fetched resource(
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-label.1
+++ b/docs/man/man1/openshift-kube-label.1
@@ -256,7 +256,7 @@ If \-\-resource\-version is specified, then updates will use this resource versi
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-logs.1
+++ b/docs/man/man1/openshift-kube-logs.1
@@ -224,7 +224,7 @@ Print the logs for a container in a pod. If the pod has only one container, the 
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-namespace.1
+++ b/docs/man/man1/openshift-kube-namespace.1
@@ -185,7 +185,7 @@ namespace has been superseded by the context.namespace field of .kubeconfig file
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-options.1
+++ b/docs/man/man1/openshift-kube-options.1
@@ -179,7 +179,7 @@ openshift kube options \-
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-patch.1
+++ b/docs/man/man1/openshift-kube-patch.1
@@ -219,7 +219,7 @@ Please refer to the models in
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-port-forward.1
+++ b/docs/man/man1/openshift-kube-port-forward.1
@@ -188,7 +188,7 @@ Forward one or more local ports to a pod.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-proxy.1
+++ b/docs/man/man1/openshift-kube-proxy.1
@@ -249,7 +249,7 @@ The above lets you 'curl localhost:8001/custom/api/v1/pods'
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-replace.1
+++ b/docs/man/man1/openshift-kube-replace.1
@@ -241,7 +241,7 @@ Please refer to the models in
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rolling-update.1
+++ b/docs/man/man1/openshift-kube-rolling-update.1
@@ -272,7 +272,7 @@ existing replication controller and overwrite at least one (common) label in its
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rollout-history.1
+++ b/docs/man/man1/openshift-kube-rollout-history.1
@@ -196,7 +196,7 @@ View previous rollout revisions and configurations.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rollout-pause.1
+++ b/docs/man/man1/openshift-kube-rollout-pause.1
@@ -197,7 +197,7 @@ Currently only deployments support being paused.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rollout-resume.1
+++ b/docs/man/man1/openshift-kube-rollout-resume.1
@@ -197,7 +197,7 @@ Currently only deployments support being resumed.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rollout-status.1
+++ b/docs/man/man1/openshift-kube-rollout-status.1
@@ -192,7 +192,7 @@ Watch the status of current rollout, until it's done.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rollout-undo.1
+++ b/docs/man/man1/openshift-kube-rollout-undo.1
@@ -196,7 +196,7 @@ Rollback to a previous rollout.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-rollout.1
+++ b/docs/man/man1/openshift-kube-rollout.1
@@ -182,7 +182,7 @@ Manages a deployment using subcommands like "kubectl rollout undo deployment/abc
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-run.1
+++ b/docs/man/man1/openshift-kube-run.1
@@ -312,7 +312,7 @@ Creates a deployment or job to manage the created container(s).
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-scale.1
+++ b/docs/man/man1/openshift-kube-scale.1
@@ -226,7 +226,7 @@ scale is sent to the server.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-set-image.1
+++ b/docs/man/man1/openshift-kube-set-image.1
@@ -243,7 +243,7 @@ Possible resources include (case insensitive):
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-set.1
+++ b/docs/man/man1/openshift-kube-set.1
@@ -185,7 +185,7 @@ These commands help you make changes to existing application resources.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-stop.1
+++ b/docs/man/man1/openshift-kube-stop.1
@@ -228,7 +228,7 @@ If the resource is scalable it will be scaled to 0 before deletion.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-taint.1
+++ b/docs/man/man1/openshift-kube-taint.1
@@ -246,7 +246,7 @@ Currently taint can only apply to node.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-uncordon.1
+++ b/docs/man/man1/openshift-kube-uncordon.1
@@ -182,7 +182,7 @@ Mark node as schedulable.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube-version.1
+++ b/docs/man/man1/openshift-kube-version.1
@@ -188,7 +188,7 @@ Print the client and server version information.
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/docs/man/man1/openshift-kube.1
+++ b/docs/man/man1/openshift-kube.1
@@ -178,7 +178,7 @@ Find more information at
     If present, the namespace scope for this CLI request.
 
 .PP
-\fB\-\-server\fP=""
+\fB\-s\fP, \fB\-\-server\fP=""
     The address and port of the Kubernetes API server
 
 .PP

--- a/pkg/cmd/util/clientcmd/clientconfig.go
+++ b/pkg/cmd/util/clientcmd/clientconfig.go
@@ -18,6 +18,10 @@ func DefaultClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 	overrideFlags.ContextOverrideFlags.Namespace.ShortName = "n"
 	overrideFlags.AuthOverrideFlags.Username.LongName = ""
 	overrideFlags.AuthOverrideFlags.Password.LongName = ""
+
+	// for compatibility with kubernetes, it is still provided
+	overrideFlags.ClusterOverrideFlags.APIServer.ShortName = "s"
+
 	clientcmd.BindOverrideFlags(overrides, flags, overrideFlags)
 	cobra.MarkFlagFilename(flags, overrideFlags.AuthOverrideFlags.ClientCertificate.LongName)
 	cobra.MarkFlagFilename(flags, overrideFlags.AuthOverrideFlags.ClientKey.LongName)

--- a/pkg/cmd/util/clientcmd/clientconfig_test.go
+++ b/pkg/cmd/util/clientcmd/clientconfig_test.go
@@ -1,0 +1,70 @@
+package clientcmd
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestUpstreamFlagConsistency(t *testing.T) {
+	osflags := pflag.NewFlagSet("test", pflag.ExitOnError)
+	_ = DefaultClientConfig(osflags)
+	kflags := pflag.NewFlagSet("test", pflag.ExitOnError)
+	_ = kcmdutil.DefaultClientConfig(kflags)
+
+	// ensure we are consistent with the flags for upstream
+	kflags.VisitAll(func(kflag *pflag.Flag) {
+		fmt.Println(kflag.Name)
+		osflag := osflags.Lookup(kflag.Name)
+		if osflag == nil {
+			switch kflag.Name {
+			case "kubeconfig", "username", "password":
+				// we remove kubeconfig, username, password
+			default:
+				t.Errorf("%s present in Kubernetes default flags but not Origin", kflag.Name)
+			}
+			return
+		}
+		switch kflag.Name {
+		case "certificate-authority", "client-certificate", "client-key":
+			// we add annotations for certificate-authority, client-certificate, client-key
+			delete(osflag.Annotations, cobra.BashCompFilenameExt)
+		}
+		if e, a := kflag.Annotations, osflag.Annotations; !api.Semantic.DeepEqual(e, a) {
+			t.Errorf("%s: annotations: expected %v, got %v", kflag.Name, e, a)
+		}
+		if e, a := kflag.DefValue, osflag.DefValue; e != a {
+			t.Errorf("%s: default value: expected %q, got %q", kflag.Name, e, a)
+		}
+		if e, a := kflag.Deprecated, osflag.Deprecated; e != a {
+			t.Errorf("%s: deprecated: expected %q, got %q", kflag.Name, e, a)
+		}
+		if e, a := kflag.Hidden, osflag.Hidden; e != a {
+			t.Errorf("%s: hidden: expected %t, got %t", kflag.Name, e, a)
+		}
+		if e, a := kflag.NoOptDefVal, osflag.NoOptDefVal; e != a {
+			t.Errorf("%s: no opt default value: expected %q, got %q", kflag.Name, e, a)
+		}
+		// we override shorthand for namespace
+		if kflag.Name == "namespace" {
+			if e, a := "n", osflag.Shorthand; e != a {
+				t.Errorf("%s: shorthand: expected %q, got %q", kflag.Name, e, a)
+			}
+		} else {
+			if e, a := kflag.Shorthand, osflag.Shorthand; e != a {
+				t.Errorf("%s: shorthand: expected %q, got %q", kflag.Name, e, a)
+			}
+		}
+		if e, a := kflag.ShorthandDeprecated, osflag.ShorthandDeprecated; e != a {
+			t.Errorf("%s: shorthand deprecated: expected %q, got %q", kflag.Name, e, a)
+		}
+		if e, a := kflag.Usage, osflag.Usage; e != a {
+			t.Errorf("%s: usage: expected %q, got %q", kflag.Name, e, a)
+		}
+	})
+}


### PR DESCRIPTION
Support -s shorthand for --server

To support kubectl as a symlink to openshift, make sure we don't try to get clients for Origin resources when the target is a Kube resource. This fixes logs, scale, delete, and attach. Note: "kubectl get all" is still broken.

For trello card https://trello.com/c/hHiMIkxJ/222-integration-tests-for-kubernetes-built-from-origin