### PR TITLE
Add additional route settings to UI

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -190,6 +190,7 @@
         <script src="scripts/controllers/util/logout.js"></script>
         <script src="scripts/controllers/create.js"></script>
         <script src="scripts/controllers/createProject.js"></script>
+        <script src="scripts/controllers/createRoute.js"></script>
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/directives/date.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -193,6 +193,10 @@ angular
         templateUrl: 'views/browse/route.html',
         controller: 'RouteController'
       })
+      .when('/project/:project/createRoute', {
+        templateUrl: 'views/createRoute.html',
+        controller: 'CreateRouteController'
+      })
       .when('/project/:project/create', {
         templateUrl: 'views/create.html'
       })

--- a/assets/app/scripts/controllers/createRoute.js
+++ b/assets/app/scripts/controllers/createRoute.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreateRouteController
+ * @description
+ * # CreateRouteController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CreateRouteController', function ($filter, $routeParams, $scope, $window, ApplicationGenerator, DataService, Navigate, ProjectsService) {
+    $scope.alerts = {};
+    $scope.renderOptions = {
+      hideFilterWidget: true
+    };
+    $scope.projectName = $routeParams.project;
+    $scope.serviceName = $routeParams.service;
+
+    // Prefill route name with the service name.
+    $scope.routing = {
+      name: $scope.serviceName || ""
+    };
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+
+        var updatePortOptions = function(service) {
+          if (!service) {
+            return;
+          }
+
+          $scope.routing.portOptions = _.map(service.spec.ports, function(portMapping) {
+            return {
+              containerPort: portMapping.targetPort,
+              protocol: portMapping.protocol
+            };
+          });
+
+          if ($scope.routing.portOptions.length) {
+            $scope.routing.targetPort = $scope.routing.portOptions[0];
+          }
+        };
+
+        var labels = {},
+            orderByDisplayName = $filter('orderByDisplayName');
+        if ($scope.serviceName) {
+          DataService.get("services", $scope.serviceName, context).then(function(service) {
+            updatePortOptions(service);
+            labels = angular.copy(service.metadata.labels);
+          });
+        } else {
+          // Prompt the user for the service.
+          DataService.list("services", context, function(services) {
+            $scope.services = orderByDisplayName(services.by("metadata.name"));
+            if (!$scope.routing.service && $scope.services.length) {
+              $scope.routing.service = $scope.services[0];
+            }
+            $scope.$watch('routing.service', function() {
+              updatePortOptions($scope.routing.service);
+              labels = angular.copy($scope.routing.service.metadata.labels);
+            });
+          });
+        }
+
+        $scope.createRoute = function() {
+          $scope.disableInputs = true;
+          if ($scope.createRouteForm.$valid) {
+            var serviceName = $scope.serviceName || $scope.routing.service.metadata.name;
+            var route = ApplicationGenerator.createRoute($scope.routing, serviceName, labels);
+            DataService.create('routes', null, route, context)
+              .then(function() { // Success
+                // Return to the previous page
+                $window.history.back();
+              }, function(result) { // Failure
+                $scope.disableInputs = false;
+                $scope.alerts['create-route'] = {
+                  type: "error",
+                  message: "An error occurred creating the route.",
+                  details: $filter('getErrorDetails')(result)
+                };
+              });
+          }
+        };
+    }));
+  });

--- a/assets/app/scripts/directives/oscFileInput.js
+++ b/assets/app/scripts/directives/oscFileInput.js
@@ -5,16 +5,18 @@ angular.module('openshiftConsole')
     return {
       restrict: 'E',
       scope: {
-        name: "@",
         model: "=",
-        required: "="
+        required: "=",
+        disabled: "=ngDisabled",
+        helpText: "@?"
       },
       templateUrl: 'views/directives/osc-file-input.html',
       link: function(scope, element){
+        scope.helpID = _.uniqueId('help-');
         scope.supportsFileUpload = (window.File && window.FileReader && window.FileList && window.Blob);
         scope.uploadError = false;
         $(element).change(function(){
-          var file = $('input[type=file]',this)[0].files[0];
+          var file = $('input[type=file]', this)[0].files[0];
           var reader = new FileReader();
           reader.onloadend = function(){
             scope.$apply(function(){
@@ -25,10 +27,9 @@ angular.module('openshiftConsole')
           reader.onerror = function(e){
             scope.supportsFileUpload = false;
             scope.uploadError = true;
-            Logger.error(e);
+            Logger.error("Could not read file", e);
           };
-//          reader.readAsBinaryString(file);
-          reader.onerror();
+          reader.readAsText(file);
         });
       }
     };

--- a/assets/app/scripts/directives/oscRouting.js
+++ b/assets/app/scripts/directives/oscRouting.js
@@ -2,21 +2,27 @@
 
 angular.module("openshiftConsole")
   /**
-   * Provides a widget for entering route information
-   * 
-   * model:     The model for the input.  The model will either use or add the
-   *            following keys:
-   *                      {
-   *                        uri:  "",
-   *                        customCerts:  false, //true|false
-   *                        certificate: "",
-   *                        key: "",
-   *                        caCertificate: ""
-   *                      }
-   * uri-disabled:  An expression that will make the URI text input
-   *                disabled.  Enabled by default
-   * security-model:  A model of the custom certificate and private key in
-   *                      the form of: 
+   * Widget for entering route information
+   *
+   * model:
+   *   The model for the input. The model will either use or add the following keys:
+   *     {
+   *       name: "",
+   *       host: "",
+   *       path: "",
+   *       tls.termination: "",
+   *       tls.insecureEdgeTerminationPolicy: "",
+   *       tls.certificate: "",
+   *       tls.key: "",
+   *       tls.caCertificate: "",
+   *       tls.destinationCACertificate: ""
+   *     }
+   *
+   * showNameInput:
+   *   Whether to prompt the user for a route name (default: false)
+   *
+   * routingDisabled:
+   *   An expression that will disable the form (default: false)
    */
   .directive("oscRouting", function(){
     return {
@@ -24,12 +30,34 @@ angular.module("openshiftConsole")
       restrict: 'E',
       scope: {
         route: "=model",
-        uriDisabled: "=",
-        uriRequired: "="
+        showNameInput: "=",
+        routingDisabled: "="
       },
       templateUrl: 'views/directives/osc-routing.html',
       link: function(scope, element, attrs, formCtl){
         scope.form = formCtl;
+
+        var showCertificateWarning = function() {
+          if (!scope.route.tls) {
+            return false;
+          }
+
+          if (scope.route.tls.termination && scope.route.tls.termination !== 'passthrough') {
+            return false;
+          }
+
+          // Check if any certificate or key is set with an incompatible termination.
+          return scope.route.tls.certificate ||
+                 scope.route.tls.key ||
+                 scope.route.tls.caCertificate ||
+                 scope.route.tls.destinationCACertificate;
+        };
+
+        // Show a warning if previously-set certificates won't be used because
+        // the TLS termination is now incompatible.
+        scope.$watch('route.tls.termination', function() {
+          scope.showCertificatesNotUsedWarning = showCertificateWarning();
+        });
       }
     };
   });

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -138,6 +138,8 @@ angular.module('openshiftConsole')
           return "http://docs.openshift.org/latest/dev_guide/builds.html#starting-a-build";
         case "deployment-operations":
           return "http://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#deployment-operations";
+        case "route-types":
+          return "https://docs.openshift.org/latest/architecture/core_concepts/routes.html#route-types";
         default:
           return "http://docs.openshift.org/latest/welcome/index.html";
       }

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -95,6 +95,15 @@ angular.module("openshiftConsole")
       return resources;
     };
 
+    // Public method for creating a route.
+    // Expects routeOptions from the osc-routing directive.
+    scope.createRoute = function(routeOptions, serviceName, labels) {
+      return scope._generateRoute({
+        labels: labels || {},
+        routing: angular.extend({ include: true }, routeOptions)
+      }, routeOptions.name, serviceName);
+    };
+
     scope._generateRoute = function(input, name, serviceName){
       if(!input.routing.include) {
         return null;
@@ -116,10 +125,43 @@ angular.module("openshiftConsole")
         }
       };
 
+      if (input.routing.host) {
+        route.spec.host = input.routing.host;
+      }
+
+      if (input.routing.path) {
+        route.spec.path = input.routing.path;
+      }
+
       if (input.routing.targetPort) {
         route.spec.port = {
           targetPort: input.routing.targetPort.containerPort
         };
+      }
+
+      var tls = input.routing.tls;
+      if (tls && tls.termination) {
+        route.spec.tls = {
+          termination: tls.termination
+        };
+
+        if (tls.termination !== 'passthrough') {
+          if (tls.termination === 'edge' && tls.insecureEdgeTerminationPolicy) {
+            route.spec.tls.insecureEdgeTerminationPolicy = tls.insecureEdgeTerminationPolicy;
+          }
+          if (tls.certificate) {
+            route.spec.tls.certificate = tls.certificate;
+          }
+          if (tls.key) {
+            route.spec.tls.key = tls.key;
+          }
+          if (tls.caCertificate) {
+            route.spec.tls.caCertificate = tls.caCertificate;
+          }
+          if (tls.destinationCACertificate && tls.termination === 'reencrypt') {
+            route.spec.tls.destinationCACertificate = tls.destinationCACertificate;
+          }
+        }
       }
 
       return route;

--- a/assets/app/styles/_components.less
+++ b/assets/app/styles/_components.less
@@ -108,22 +108,27 @@
           line-height: @line-height-base;
           .align-self(@align: left);
           color: @gray-light;
-          @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max), (max-width: 380px) {
+          @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
             // block display multiple port mappings at specific widths to prevent breaking of layout, but also prevent wrapping when not needed
-            // 380px is the min width at which 2 port mappings can be displayed inline without extending beyond their box, so stack them when viewport is <380
             .port-mappings {
               display: block;
             }
           }
         }
-
+        .add-route-link {
+          text-transform: none;
+        }
         @media (max-width: @screen-sm-min) {
+          // display side-by-side at mobile resolutions
+          .port-mappings, .add-route-link {
+            display: inline-block;
+            margin-right: 5px;
+          }
           &.meta-data {
             /* Left align for vertical layout at small sizes */
             text-align: left;
           }
         }
-
       }
     }
     &.service {

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -322,6 +322,12 @@ label.checkbox {
   font-weight: normal;
 }
 
+.form-group .checkbox {
+  // Use the default form-group margin for consistency. Otherwise the
+  // checkboxes are closer than other form elements.
+  margin-bottom: inherit;
+}
+
 // Make sure icons are the same size so headings align.
 .add-to-project {
   .filter-group {
@@ -346,6 +352,15 @@ label.checkbox {
       }
     }
   }
+}
+
+.icon-xl {
+  font-size: 128px;
+}
+
+.create-route-icon {
+  padding-top: 0;
+  text-align: right;
 }
 
 .create-from-template,
@@ -490,9 +505,6 @@ label.checkbox {
         // float: right;
         text-align: right;
       }
-    }
-    .form-control-md {
-      width: @create-form-md-width;
     }
     .labels .form-group {
       // Show name/value fields like labels and env vars side by side at wide screen sizes.

--- a/assets/app/views/browse/route.html
+++ b/assets/app/views/browse/route.html
@@ -41,10 +41,10 @@
                   <span ng-if="route.spec.to.kind != 'Service'">{{route.spec.to.name}}</span>
                   <span ng-if="route.spec.to.kind == 'Service'"><a href="{{route | navigateResourceURL}}">{{route.spec.to.name}}</a></span>
                 </dd>
-                <dt>Port:</dt>
+                <dt>Target Port:</dt>
                 <dd>
                   <span ng-if="route.spec.port">{{route.spec.port.targetPort}}</span>
-                  <span ng-if="!route.spec.port">any</span>
+                  <span ng-if="!route.spec.port"><em>any</em></span>
                 </dd>
               </dl>
               <div style="margin-bottom: 10px;">
@@ -52,6 +52,8 @@
                 <dl class="dl-horizontal left" ng-if="route.spec.tls">
                   <dt>Termination type:</dt>
                   <dd>{{route.spec.tls.termination}}</dd>
+                  <dt ng-if-start="route.spec.tls.termination === 'edge'">Insecure Traffic:</dt>
+                  <dd ng-if-end>{{route.spec.tls.insecureEdgeTerminationPolicy || 'None'}}</dd>
                   <dt>Certificate:</dt>
                   <dd>
                     <span ng-if="route.spec.tls.certificate" click-to-reveal><pre class="clipped">{{route.spec.tls.certificate}}</pre></span>

--- a/assets/app/views/browse/routes.html
+++ b/assets/app/views/browse/routes.html
@@ -2,6 +2,9 @@
   <project-page>
     <div ng-controller="RoutesController">
       <div class="page-header page-header-bleed-right">
+        <div class="actions pull-right">
+          <a ng-href="project/{{project.metadata.name}}/createRoute" class="btn btn-default">Create Route</a>
+        </div>
         <h1>Routes</h1>
       </div>
       <alerts alerts="alerts"></alerts>
@@ -10,8 +13,9 @@
           <tr>
             <th>Name</th>
             <th>Hostname</th>
-            <th>Routes to</th>
-            <th>Age</th>
+            <th>Routes To</th>
+            <th>Target Port</th>
+            <th>TLS Termination</th>
           </tr>
         </thead>
         <tbody ng-if="(routes | hashSize) == 0">
@@ -28,15 +32,20 @@
                 {{route | routeLabel}}
               </div>
             </td>
-            <td data-title="Routes to">
-              <span>{{route.spec.to.kind}}: </span>
-              <span ng-if="route.spec.to.kind != 'Service'">{{route.spec.to.name}}</span>
-              <span ng-if="route.spec.to.kind == 'Service'">
-                <a ng-href="{{route.spec.to.name | navigateResourceURL : 'Service': route.metadata.namespace}}">{{route.spec.to.name}}</a>
-                <span ng-if="route.spec.port.targetPort"> on port {{route.spec.port.targetPort}}</span>
-              </span>
+            <td data-title="Routes To">
+              <span ng-if="route.spec.to.kind !== 'Service'">{{route.spec.to.kind}}: {{route.spec.to.name}}</span>
+              <span ng-if="route.spec.to.kind === 'Service'"><a ng-href="{{route.spec.to.name | navigateResourceURL : 'Service': route.metadata.namespace}}">{{route.spec.to.name}}</a></span>
             </td>
-            <td data-title="Age"><relative-timestamp timestamp="route.metadata.creationTimestamp" drop-suffix="true"></relative-timestamp></td>
+            <!-- Add non-breaking space to empty cells. Otherwise, table-mobile layout is broken. -->
+            <td data-title="Target Port">
+              {{route.spec.port.targetPort}}
+              <span ng-if="!route.spec.port.targetPort">&nbsp;</span>
+            </td>
+            <!-- Use shorter Termination title for table-mobile to avoid overlapping text. -->
+            <td data-title="Termination">
+              {{route.spec.tls.termination}}
+              <span ng-if="!route.spec.tls.termination">&nbsp;</span>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -68,7 +68,8 @@
                   </tbody>
                 </table>
               </div>
-              <dl class="dl-horizontal left">
+              <!-- No bottom margin so Create Route link is close to content. -->
+              <dl class="dl-horizontal left" style="margin-bottom: 0;">
                 <dt>Routes:</dt>
                 <dd>
                   <span ng-if="!routesForService.length"><em>none</em></span>
@@ -79,6 +80,9 @@
                   </span>
                 </dd>
               </dl>
+              <div class="gutter-bottom">
+                <a ng-href="project/{{project.metadata.name}}/createRoute?service={{service.metadata.name}}">Create route</a>
+              </div>
               <annotations annotations="service.metadata.annotations"></annotations>
             </div>
           </div> <!-- /tile -->

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -39,7 +39,7 @@
                               name="appname"
                               ng-change="nameTaken = false"
                               ng-blur="shouldValidateName = form.appname.$dirty"
-                              class="form-control form-control-md"
+                              class="form-control"
                               autocorrect="off"
                               autocapitalize="off"
                               spellcheck="false">
@@ -82,7 +82,7 @@
                         ref: {{image.metadata.annotations.sampleRef}}</span><span ng-if="image.metadata.annotations.sampleContextDir">,
                         context dir: {{image.metadata.annotations.sampleContextDir}}</span>
                       <a href="" ng-click="fillSampleRepo()"
-                        style="margin-left: 3px;">Try it<i class="fa fa-level-up" style="margin-left: 3px; font-size: 17px;"></i></a>
+                        style="margin-left: 3px;" class="nowrap">Try it<i class="fa fa-level-up" style="margin-left: 3px; font-size: 17px;"></i></a>
                     </div>
                     <div class="has-error" ng-show="form.sourceUrl.$error.required && form.sourceUrl.$dirty">
                       <span class="help-block">A Git repository URL is required.</span>
@@ -92,7 +92,7 @@
                     </div>
                   </div>
 
-                  <div click-to-reveal link-text="Show advanced build and deployment options">
+                  <div click-to-reveal link-text="Show advanced routing, build, and deployment options">
                     <div class="form-group">
                       <label for="gitref">Git Reference</label>
                       <div>
@@ -104,7 +104,7 @@
                           autocorrect="off"
                           autocapitalize="off"
                           spellcheck="false"
-                          class="form-control form-control-md">
+                          class="form-control">
                       </div>
                       <div class="help-block">Optional branch, tag, or commit.</div>
                     </div>
@@ -119,7 +119,7 @@
                           autocorrect="off"
                           autocapitalize="off"
                           spellcheck="false"
-                          class="form-control form-control-md">
+                          class="form-control">
                       </div>
                       <div class="help-block">Optional subdirectory for the application source code, used as the context directory for the build.</div> </div>
 
@@ -132,35 +132,16 @@
                       can-toggle="false"
                       ng-if="routing.portOptions.length"
                       >
-                      <div ng-hide="$parent.expand">
-                        <div>
-                          <label>Create a route to the application: </label>
-                          <span>{{routing | yesNo}}</span>
-                        </div>
+                      <div class="form-group checkbox">
+                        <label>
+                          <input type="checkbox" ng-model="routing.include">
+                          Create a route to the application
+                        </label>
                       </div>
-                      <div ng-show="$parent.expand">
-                        <div class="form-group checkbox">
-                          <label>
-                            <input type="checkbox" ng-model="routing.include">
-                              Create a route to the application
-                              <span class="help action-inline">
-                                <i class="pficon pficon-help" data-toggle="tooltip" data-placement="right" data-original-title="Additional routes with alternative configuration options (security, TLS termination, etc) can be added using the oc command."></i>
-                              </span>
-                          </label>
-
-                        </div>
-                        <div class="form-group">
-                          <label for="routeTargetPort">Target port:</label>
-                          <span ng-if="routing.portOptions.length === 1">{{routing.portOptions[0].containerPort}}/{{routing.portOptions[0].protocol}}</span>
-                          <select
-                              id="routeTargetPort"
-                              ng-if="routing.portOptions.length > 1"
-                              ng-model="routing.targetPort"
-                              ng-options="(portSpec.containerPort + '/' + portSpec.protocol) for portSpec in routing.portOptions"
-                              ng-disabled="!routing.include">
-                          </select>
-                        </div>
-                      </div>
+                      <osc-routing
+                        model="routing"
+                        routing-disabled="!routing.include">
+                      </osc-routing>
                     </osc-form-section>
 
                     <!-- /routing -->

--- a/assets/app/views/createRoute.html
+++ b/assets/app/views/createRoute.html
@@ -1,0 +1,60 @@
+<div class="content">
+  <div class="container">
+    <div class="col-md-12">
+      <ol class="breadcrumb">
+        <li><a href="{{projectName | projectOverviewURL}}">{{(project | displayName) || projectName}}</a></li>
+        <li class="active"><strong>Create Route</strong></li>
+      </ol>
+      <alerts alerts="alerts"></alerts>
+      <div class="row">
+        <div class="create-route-icon col-md-2 gutter-top hidden-sm hidden-xs">
+          <span class="pficon pficon-route icon-xl"></span>
+        </div>
+        <div class="col-md-8">
+          <h1>Create Route</h1>
+          <div>
+            <span class="help-block">
+              Routing is a way to make your application publicly visible.
+              <span ng-if="serviceName">Create a route to expose service {{serviceName}}.</span>
+              <span ng-if="!serviceName">Select a service to expose and enter route details.</span>
+            </span>
+          </div>
+          <div ng-show="!serviceName && !services">Loading...</div>
+          <div ng-show="serviceName || services">
+            <form name="createRouteForm">
+              <fieldset ng-disabled="disableInputs">
+                <div ng-if="!serviceName" class="form-group">
+                  <label for="service-select" class="required">Service</label>
+                  <select
+                      id="service-select"
+                      ng-model="routing.service"
+                      ng-options="service as service.metadata.name for service in services track by (service | uid)"
+                      required
+                      class="form-control"
+                      aria-describedby="service-help">
+                  </select>
+                  <div>
+                    <span id="service-help" class="help-block">Service to route to.</span>
+                  </div>
+                  <div ng-if="!services.length" class="has-error">
+                    <span class="help-block">There are no services in your project to expose with a route.</span>
+                  </div>
+                </div>
+
+                <osc-routing model="routing" show-name-input="true"></osc-routing>
+                <div class="button-group gutter-top gutter-bottom">
+                  <button type="submit"
+                      class="btn btn-primary btn-lg"
+                      ng-click="createRoute()"
+                      ng-disabled="createRouteForm.$invalid || disableInputs || !createRoute"
+                      value="">Create</button>
+                  <a class="btn btn-default btn-lg" href="#" back>Cancel</a>
+                </div>
+              </fieldset>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/app/views/directives/osc-file-input.html
+++ b/assets/app/views/directives/osc-file-input.html
@@ -1,26 +1,30 @@
-<div class="form-group">
-  <div class="input-group">
-    <span class="input-group-btn">
-        <span class="btn btn-default btn-file" ng-show="supportsFileUpload">
-            Browse&hellip; <input type="file"
-                                  class="form-control" 
-                            >
-        </span>
+<div class="input-group">
+  <input
+      type="text"
+      class="form-control"
+      ng-model="fileName"
+      readonly
+      ng-show="supportsFileUpload"
+      ng-disabled="disabled"
+      ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
+  <span class="input-group-btn">
+    <span class="btn btn-default btn-file" ng-show="supportsFileUpload" ng-attr-disabled="{{ disabled || undefined }}">
+      Browse&hellip;
+      <input type="file" ng-disabled="disabled" class="form-control">
     </span>
-    <input type="text" class="form-control" 
-           ng-model="fileName" 
-           readonly 
-           ng-show="supportsFileUpload">
-  </div>
-  <textarea class="form-control"
-            name="{{name}}"
-            rows="8"
-            ng-hide="supportsFileUpload"
-            ng-model="model"
-            ng-required="required"
-  >
-  </textarea>
-  <div class="has-error" ng-show="uploadError">
-    <span class="help-block">There was an error reading the file.  Please copy the file content into the text area.</span>
-  </div>
+  </span>
+</div>
+<textarea class="form-control"
+    rows="8"
+    ng-hide="supportsFileUpload"
+    ng-model="model"
+    ng-required="required"
+    ng-disabled="disabled"
+    ng-attr-aria-describedby="{{helpText ? helpID : undefined}}">
+</textarea>
+<div ng-if="helpText">
+  <span ng-attr-id="{{helpID}}" class="help-block">{{::helpText}}</span>
+</div>
+<div class="has-error" ng-show="uploadError">
+  <span class="help-block">There was an error reading the file. Please copy the file content into the text area.</span>
 </div>

--- a/assets/app/views/directives/osc-routing.html
+++ b/assets/app/views/directives/osc-routing.html
@@ -1,83 +1,216 @@
 <ng-form name="routeForm">
-  <div class="row">
-    <div class="col-sm-offset-1 col-md-offset-1 col-md-11 col-sm-11">
+  <fieldset ng-disabled="routingDisabled">
 
+    <!-- Name -->
+    <div ng-show="showNameInput" class="form-group">
+      <label for="route-name" class="required">Name</label>
+      <!-- regex, maxlength from k8s.io/kubernetes/pkg/util/validation/validation.go -->
+      <input
+          id="route-name"
+          class="form-control"
+          type="text"
+          name="name"
+          ng-model="route.name"
+          ng-required="showNameInput"
+          ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/"
+          ng-maxlength="63"
+          ng-minlength="2"
+          placeholder="my-route"
+          select-on-focus
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-describedby="route-name-help">
+      <div>
+        <span id="route-name-help" class="help-block">A unique name for the route within the project.</span>
+      </div>
+      <div class="has-error" ng-show="routeForm.name.$error.pattern && routeForm.name.$touched && !routingDisabled">
+        <span class="help-block">
+          Route names may only contain lower-case letters, numbers, and dashes.
+          They may not start or end with a dash.
+        </span>
+      </div>
+    </div>
+
+    <!-- Host -->
+    <div class="form-group">
+      <label for="host">Hostname</label>
+      <!-- regex, maxlength from k8s.io/kubernetes/pkg/util/validation/validation.go -->
+      <input
+          id="host"
+          class="form-control"
+          type="text"
+          name="host"
+          ng-model="route.host"
+          ng-pattern="/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/"
+          ng-maxlength="253"
+          placeholder="www.example.com"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-describedby="route-host-help">
+      <div>
+        <span id="route-host-help" class="help-block">
+          Public hostname for the route. If not specified, a hostname is generated.
+        </span>
+      </div>
+      <div class="has-error" ng-show="routeForm.host.$error.pattern && routeForm.host.$touched && !routingDisabled">
+        <span class="help-block">
+          Hostname must consist of lower-case letters, numbers, periods, and
+          hyphens. It must start and end with a letter or number.
+        </span>
+      </div>
+    </div>
+
+    <!-- Path -->
+    <div class="form-group">
+      <label for="path">Path</label>
+      <input
+          id="path"
+          class="form-control"
+          type="text"
+          name="path"
+          ng-model="route.path"
+          ng-pattern="/^\/.*$/"
+          ng-disabled="route.tls.termination === 'passthrough'"
+          placeholder="/"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-describedby="route-path-help">
+      <div>
+        <span id="route-path-help" class="help-block">
+          Path that the router watches to route traffic to the service.
+        </span>
+      </div>
+      <div class="has-error" ng-show="routeForm.path.$error.pattern && routeForm.path.$touched && !routingDisabled">
+        <span class="help-block">
+          Path must start with <code>/</code>
+        </span>
+      </div>
+      <div class="has-warning" ng-show="route.path && route.tls.termination === 'passthrough'">
+        <span class="help-block">
+          Path value will not be used. Paths cannot be set for passthrough TLS.
+        </span>
+      </div>
+    </div>
+
+    <!-- Target Port -->
+    <div ng-if="route.portOptions.length" class="form-group">
+      <label for="routeTargetPort">Target Port</label>
+      <select
+          id="routeTargetPort"
+          ng-if="route.portOptions.length"
+          ng-model="route.targetPort"
+          ng-options="(portSpec.containerPort + '/' + portSpec.protocol) for portSpec in route.portOptions"
+          class="form-control"
+          aria-describedby="target-port-help">
+      </select>
+      <div>
+        <span id="target-port-help" class="help-block">
+          Container port that the service should direct traffic to.
+        </span>
+      </div>
+    </div>
+
+    <div>
+      <a href=""
+        ng-click="showSecureRouteOptions = true"
+        ng-show="!showSecureRouteOptions">Show options for secured routes</a>
+    </div>
+
+    <div ng-show="showSecureRouteOptions">
+      <h3>Route Type</h3>
+      <div>
+        <span class="help-block">
+          Routes can be secured using several TLS termination types for serving certificates.
+        </span>
+      </div>
+
+      <!-- TLS Termination -->
       <div class="form-group">
-        <label class="radio-inline">
-          <input type="radio" value="http,https" ng-model="route.protocol"> Both
-        </label>
-        <label class="radio-inline">
-          <input type="radio" value="http" ng-model="route.protocol"> http://
-        </label>
-        <label class="radio-inline">
-          <input type="radio" value="https" ng-model="route.protocol"> https:// 
-        </label> 
-      </div>
-      <input class="uri-input form-control" type="text" name="routeUri"
-           ng-model="route.uri" 
-           ng-pattern="/^[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/"
-           ng-model-options="{ debounce: 500 }"
-           ng-disabled="uriDisabled"
-           >
-      <div class="has-error" ng-show="routeForm.routeUri.$error.pattern && !uriDisabled">
-        <span class="help-block">Please enter a valid uri for this route.</span>
-      </div>
-    </div>
-  </div><!-- /row -->
-  <div class="row">
-    <div class="col-sm-offset-1 col-md-offset-1 col-md-11 col-sm-11">
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" 
-                 ng-model="route.customCerts" 
-                 > 
-          Provide my own certificates and private keys
-        </label>
-      </div>
-    </div>
-  </div><!-- /row -->
-  <div ng-class="fade" ng-show="route.customCerts">
-    <div class="row">
-      <div class="col-sm-offset-1 col-md-offset-1 col-md-2 col-sm-2">
-          <label>Certificate</label>
-      </div>
-      <div class="col-md-9 col-sm-9">
-        <osc-file-input
-            name="certificate"
-            model="route.certificate"
-            required="route.customCerts"
-            >
-        </osc-file-input>
-      </div>
-    </div><!-- /row -->
-    <div class="row">
-      <div class="col-sm-offset-1 col-md-offset-1 col-md-2 col-sm-2">
-          <label>Private Key</label>
-      </div>
-      <div class="col-md-9 col-sm-9">
-        <osc-file-input
-            name="privatekey"
-            model="route.key" 
-            required="route.customCerts"
-            >
-        </osc-file-input>
-      </div>
-    </div><!-- /row -->
-    <div class="row">
-      <div class="col-sm-offset-1 col-md-offset-1 col-md-2 col-sm-2">
-          <label>CA Certificate</label>
-      </div>
-      <div class="col-md-9 col-sm-9">
-        <osc-file-input
-            name="cacert"
-            model="route.caCertificate" 
-            required="route.customCerts"
-            >
-        </osc-file-input>
-        <div class="has-error" ng-show="route.customCerts && (routeForm.certificate.$invalid ||routeForm.privatekey.$invalid ||routeForm.cacert.$invalid)">
-            <span class="help-block">A certificate, private key and CA certificate are required when providing your own certs.</span>
+        <label>TLS Termination</label>
+        <select ng-model="route.tls.termination" class="form-control">
+          <option value="">None</option>
+          <option value="edge">Edge</option>
+          <option value="passthrough">Passthrough</option>
+          <option value="reencrypt">Re-encrypt</option>
+        </select>
+        <div class="learn-more-block help-block">
+          <a href="{{'route-types' | helpLink}}" target="_blank">Learn more <i class="fa fa-external-link"></i></a>
         </div>
       </div>
-    </div><!-- /row -->
-  </div>
+
+      <!-- Insecure Edge Termination Policy -->
+      <div class="form-group">
+        <label>Insecure Traffic</label>
+        <select
+            ng-model="route.tls.insecureEdgeTerminationPolicy"
+            ng-disabled="route.tls.termination !== 'edge'"
+            class="form-control"
+            aria-describedby="route-insecure-policy-help">
+          <option value="">None</option>
+          <option value="Allow">Allow</option>
+          <option value="Redirect">Redirect</option>
+        </select>
+        <div>
+          <span id="route-insecure-policy-help" class="help-block">
+            Policy for traffic on insecure schemes like HTTP for edge termination.
+          </span>
+        </div>
+      </div>
+
+      <!-- Key and Certificates -->
+      <h3>Certificates</h3>
+      <div>
+        <span class="help-block">
+          TLS certificates for edge and re-encrypt termination. If not
+          specified, the router's default certificate is used.
+        </span>
+      </div>
+      <div ng-if="showCertificatesNotUsedWarning" class="has-warning">
+        <span class="help-block">
+          The certificate or key you've set will not be used.
+          <span ng-if="!route.tls.termination">
+            The route is unsecured.
+          </span>
+          <span ng-if="route.tls.termination === 'passthrough'">
+            Custom certificates cannot be used with passthrough termination.
+          </span>
+        </span>
+      </div>
+      <fieldset ng-disabled="!route.tls.termination || route.tls.termination === 'passthrough'">
+        <div>
+          <div class="form-group">
+            <label>Certificate</label>
+            <osc-file-input model="route.tls.certificate" help-text="The PEM format certificate."></osc-file-input>
+          </div>
+          <div class="form-group">
+            <label>Private Key</label>
+            <osc-file-input model="route.tls.key" help-text="The PEM format key."></osc-file-input>
+          </div>
+          <div class="form-group">
+            <label>CA Certificate</label>
+            <osc-file-input model="route.tls.caCertificate" help-text="The PEM format CA certificate."></osc-file-input>
+          </div>
+          <div class="form-group">
+            <label>Destination CA Certificate</label>
+            <osc-file-input
+                model="route.tls.destinationCACertificate"
+                help-text="The PEM format CA certificate to validate the endpoint certificate for re-encrypt termination."
+                ng-disabled="route.tls.termination !== 'reencrypt'">
+            </osc-file-input>
+            <!-- Show a warning if the value won't be used, but only if we're
+                 not already showing the generic certificate warning above. -->
+            <div ng-if="route.tls.destinationCACertificate && route.tls.termination !== 'reencrypt' && !showCertificatesNotUsedWarning" class="has-warning">
+              <span class="help-block">
+                The destination CA certificate will not be used. Destination CA
+                certificates are only used for re-encrypt termination.
+              </span>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </fieldset>
 </ng-form>

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -32,7 +32,7 @@
           </p>
 
           <p class="gutter-top">
-            <a href="project/{{projectName}}/create" class="btn btn-lg btn-primary">
+            <a ng-href="project/{{projectName}}/create" class="btn btn-lg btn-primary">
               Add to Project
             </a>
           </p>
@@ -102,9 +102,7 @@
                   </span>
                   <span class="small" ng-if="otherRoutes">
                     (and
-                    <a href="{{service | navigateResourceURL}}">
-                      {{otherRoutes}} other {{(otherRoutes == 1) ? 'route' : 'routes'}}
-                    </a>)
+                    <a href="{{service | navigateResourceURL}}">{{otherRoutes}} other {{(otherRoutes == 1) ? 'route' : 'routes'}}</a>)
                   </span>
                 </h2>
 
@@ -116,7 +114,7 @@
               </div>
 
               <div class="component meta-data">
-                <div ng-if="numPorts">
+                <span ng-if="numPorts">
                   <!--
                   Show only the first two ports if there are many since we don't have much space here.
                   The full list is visible elsewhere.
@@ -129,6 +127,9 @@
                   <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
                     and {{numRemaining}} {{numRemaining == 1 ? "other" : "others"}}
                   </span>
+                </span>
+                <div ng-if="!displayRouteByService[serviceId]" class="component-label add-route-link">
+                  <a ng-href="project/{{project.metadata.name}}/createRoute?service={{service.metadata.name}}">Create Route</a>
                 </div>
               </div>
             </div>

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -24,8 +24,17 @@ describe("ApplicationGenerator", function(){
       routing: {
         include: true,
         targetPort: {
-          containerPort: 80,
-          protocol: "TCP"
+          containerPort: 443,
+          protocol: "TCP",
+        },
+        host: "www.example.com",
+        path: "/test",
+        tls: {
+          termination: "edge",
+          insecureEdgeTerminationPolicy: "Redirect",
+          certificate: "dummy-cert",
+          key: "dummy-key",
+          caCertificate: "dummy-ca-cert"
         }
       },
       buildConfig: {
@@ -178,8 +187,17 @@ describe("ApplicationGenerator", function(){
             kind: "Service",
             name: "theServiceName"
           },
+          host: "www.example.com",
+          path: "/test",
           port: {
-            targetPort: 80
+            targetPort: 443
+          },
+          tls: {
+            termination: "edge",
+            insecureEdgeTerminationPolicy: "Redirect",
+            certificate: "dummy-cert",
+            key: "dummy-key",
+            caCertificate: "dummy-ca-cert"
           }
         }
       });


### PR DESCRIPTION
https://trello.com/c/WSVk6KQk

* Adds support for creating secure routs during the create flow.
* Adds support creating routes for existing services.

Fixes #6093

TODO:

- [x] Supporting adding routes from browse routes page
- [x] Re-use labels from service when creating route like `oc expose`
- [x] Rebase when #6084 merges for new project service name
- [x] Fix `spec` typos

Routing section during create flow: 

<img width="774" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11379415/4190765c-92be-11e5-877b-25d48183af6b.png">

After clicking "Show options for secure routes":

<img width="778" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11379431/57f321e2-92be-11e5-936d-5f2c33fc4450.png">

Fields are enabled and disabled depending on termination type. (Selecting Passthrough disables the Path field, etc.).

Add route from overview:

<img width="732" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11379467/7cde70ba-92be-11e5-95a5-35f3d01a4dc2.png">

Add route from service page:

<img width="696" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11379489/93dff25c-92be-11e5-8b8a-6eccbe697a80.png">

Create route from routes page:

<img width="875" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11379512/ac5b4c46-92be-11e5-9503-11ecd4e0a496.png">

Standalone add route page:

<img width="812" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11379532/c4f33188-92be-11e5-96be-73ddefed6d45.png">


/cc @jwforres @jcantrill 