### PR TITLE
Create sourcable bash env as part of dind cluster deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /assets/nbproject
 /examples/sample-app/openshift.local.*
 /examples/sample-app/logs/openshift.log
+/dind-*.rc
 *.swp
 .vimrc
 .vagrant-openshift.json*

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -232,6 +232,21 @@ ${DEPLOYED_CONFIG_ROOT}"
       ${DOCKER_CMD} exec -t "${cid}" systemctl start sshd
     fi
   done
+
+  local rc_file="dind-${INSTANCE_PREFIX}.rc"
+  local admin_config=$(os::provision::get-admin-config ${CONFIG_ROOT})
+  echo "export KUBECONFIG=${admin_config}
+export PATH=\$PATH:${ORIGIN_ROOT}/_output/local/bin/linux/amd64" > "${rc_file}"
+
+  if [ "${KUBECONFIG:-}" != "${admin_config}" ]; then
+    echo ""
+    echo "Before invoking the openshift cli, make sure to source the
+cluster's rc file to configure the bash environment:
+
+  $ . ${rc_file}
+  $ oc get nodes
+"
+  fi
 }
 
 function stop() {


### PR DESCRIPTION
Deploying a dind cluster on a vm provisioned by vagrant will be
assured of having KUBECONFIG and PATH set correctly in the vm.  For
manual dind deployment (e.g. to an arbitrary docker instance), this
change adds an rc file that can be sourced to configure the
environment for accessing the cluster with the openshift cli.