### PR TITLE
refactored test/cmd/volumes to use helper methods

### DIFF
--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -6,33 +6,34 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
 # This test validates the 'volume' command
 
-oc create -f test/integration/fixtures/test-deployment-config.json
+os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-config.json'
 
-[ "$(oc volume dc/test-deployment-config --list | grep vol1)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol0 -m /opt5)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol2 --type=emptydir -m /opt)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol1 --type=secret --secret-name='$ecret' -m /data 2>&1 | grep overwrite)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol1 --type=emptyDir -m /data --overwrite)" ]
-[ "$(oc volume dc/test-deployment-config --add -m /opt 2>&1 | grep exists)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby' --overwrite 2>&1 | grep warning)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby*' --overwrite)" ]
-[ "$(oc volume dc/test-deployment-config --list --name=vol2 | grep /etc)" ]
-[ "$(oc volume dc/test-deployment-config --add --name=vol3 -o yaml | grep vol3)" ]
-[ "$(oc volume dc/test-deployment-config --list --name=vol3 2>&1 | grep 'not found')" ]
-[ "$(oc volume dc/test-deployment-config --remove 2>&1 | grep confirm)" ]
-[ "$(oc volume dc/test-deployment-config --remove --name=vol2)" ]
-[ ! "$(oc volume dc/test-deployment-config --list | grep vol2)" ]
-[ "$(oc volume dc/test-deployment-config --remove --confirm)" ]
-[ ! "$(oc volume dc/test-deployment-config --list | grep vol1)" ]
+os::cmd::expect_success_and_text 'oc volume dc/test-deployment-config --list' 'vol1'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --add --name=vol0 -m /opt5'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --add --name=vol2 --type=emptydir -m /opt'
+os::cmd::expect_failure_and_text "oc volume dc/test-deployment-config --add --name=vol1 --type=secret --secret-name='\$ecret' -m /data" 'overwrite to replace'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --add --name=vol1 --type=emptyDir -m /data --overwrite'
+os::cmd::expect_failure_and_text 'oc volume dc/test-deployment-config --add -m /opt' "'/opt' already exists"
+os::cmd::expect_success_and_text "oc volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby' --overwrite" 'does not have any containers'
+os::cmd::expect_success "oc volume dc/test-deployment-config --add --name=vol2 -m /etc -c 'ruby*' --overwrite"
+os::cmd::expect_success_and_text 'oc volume dc/test-deployment-config --list --name=vol2' 'mounted at /etc'
+os::cmd::expect_success_and_text 'oc volume dc/test-deployment-config --add --name=vol3 -o yaml' 'name: vol3'
+os::cmd::expect_failure_and_text 'oc volume dc/test-deployment-config --list --name=vol3' 'volume "vol3" not found'
+os::cmd::expect_failure_and_text 'oc volume dc/test-deployment-config --remove' 'confirm for removing more than one volume'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --remove --name=vol2'
+os::cmd::expect_success_and_not_text 'oc volume dc/test-deployment-config --list' 'vol2'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --remove --confirm'
+os::cmd::expect_success_and_not_text 'oc volume dc/test-deployment-config --list' 'vol1'
 
-[ "$(oc get pvc --no-headers | wc -l)" -eq 0 ]
-oc volume dc/test-deployment-config --add --mount-path=/other --claim-size=1G
-oc volume dc/test-deployment-config --add --mount-path=/second --type=pvc --claim-size=1G --claim-mode=rwo
-[ "$(oc get pvc --no-headers | wc -l)" -eq 2 ]
+os::cmd::expect_success_and_text 'oc get pvc --no-headers | wc -l' '0'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --add --mount-path=/other --claim-size=1G'
+os::cmd::expect_success 'oc volume dc/test-deployment-config --add --mount-path=/second --type=pvc --claim-size=1G --claim-mode=rwo'
+os::cmd::expect_success_and_text 'oc get pvc --no-headers | wc -l' '2'
 
-oc delete dc/test-deployment-config
+os::cmd::expect_success 'oc delete dc/test-deployment-config'
 echo "volumes: ok"


### PR DESCRIPTION
/cc @deads2k @smarterclayton 

The intent here needs to be reviewed - as it stands many commands had their exit code masked by `grep` so I am guessing as to what the exit code should be - if the command was failing as written, I expected failure.

~~Since @smarterclayton blew away history with the move to compartmentalize test suites, I don't know who owns these tests. Please tag them for review.~~