### PR TITLE
allow for easier test specification from command-line for test-cmd

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -151,6 +151,11 @@ working against the API. Run it with:
 
     $ hack/test-cmd.sh
 
+This suite comprises many smaller suites, which are found under `test/cmd` and can be run individually by
+specifying them using a regex filter, passed through `grep -E` like with integration tests above:
+
+    $ hack/test-cmd.sh <regex>
+
 ### End-to-End (e2e) Tests
 
 The final test category is end to end tests (e2e) which should verify a long set of flows in the

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you want to run the test suite, make sure you have your environment set up, a
 # run the unit tests
 $ make check
 
-# run a simple server integration test
+# run a command-line integration test suite
 $ hack/test-cmd.sh
 
 # run the integration server test suite

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -9,6 +9,7 @@ set -o pipefail
 
 STARTTIME=$(date +%s)
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+cd "${OS_ROOT}"
 source "${OS_ROOT}/hack/util.sh"
 os::log::install_errexit
 
@@ -48,10 +49,9 @@ trap "cleanup" EXIT
 set -e
 
 function find_tests {
-  cd "${OS_ROOT}"
-  find "${1}" -name '*.sh' | sort -u
+  find "${OS_ROOT}/test/cmd" -name '*.sh' | grep -E "${1}" | sort -u
 }
-tests=( $(find_tests ${1:-test/cmd}) )
+tests=( $(find_tests ${1:-.*}) )
 
 # Setup environment
 


### PR DESCRIPTION
New usage: `hack/test-cmd.sh <regex>`

The filter is implemented the same way that it is for `test-integration` - anything you put in will be thrown into a `grep -E` after all tests are found to filter them. The default filter (if none is given) is `sh`, which matches all tests. This is currently possible by specifying the full path name to the test to run, but that is less user-friendly than just specifying the name of the suite to run.

@deads2k @liggitt @smarterclayton PTAL