### PR TITLE
avoid: no such file error in test-cmd

### DIFF
--- a/hack/test-cmd_util.sh
+++ b/hack/test-cmd_util.sh
@@ -333,5 +333,3 @@ echo "${output}" | grep -q '; the output content test failed'
 echo "${output}" | grep -q 'hello' 
 
 echo "output tests: ok"
-
-rm -rf /tmp/openshift-cmd/


### PR DESCRIPTION
Without this update, you get 
```
hack/test-cmd.sh: line 153: /tmp/openshift-cmd/MdEn/logs/openshift.log: No such file or directory
```

When running `hack/test-cmd.sh`.  I don't understand how the test and merge are still running (this always dies locally), but since they're still moving ahead I'll just [merge].

@liggitt if you want a posthumous look