### PR TITLE
Bug1277420 - show friendly prompt when cancelling a completed build

### DIFF
--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -83,7 +83,7 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 	if !ok {
 		return fmt.Errorf("%q is not a valid build", buildName)
 	}
-	if !isBuildCancellable(build) {
+	if !isBuildCancellable(build, out) {
 		return nil
 	}
 
@@ -115,7 +115,7 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 		}
 		break
 	}
-	glog.V(2).Infof("Build %s was cancelled.", buildName)
+	fmt.Fprintf(out, "Build %s was cancelled.\n", buildName)
 
 	// mapper, typer := f.Object()
 	// resourceMapper := &resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: f.ClientMapperForCommand()}
@@ -130,7 +130,7 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 		if err != nil {
 			return err
 		}
-		glog.V(2).Infof("Restarted build %s.", buildName)
+		fmt.Fprintf(out, "Restarted build %s.\n", buildName)
 		fmt.Fprintf(out, "%s\n", newBuild.Name)
 		// fmt.Fprintf(out, "%s\n", newBuild.Name)
 		// info, err := resourceMapper.InfoForObject(newBuild)
@@ -150,17 +150,17 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 }
 
 // isBuildCancellable checks if another cancellation event was triggered, and if the build status is correct.
-func isBuildCancellable(build *buildapi.Build) bool {
+func isBuildCancellable(build *buildapi.Build, out io.Writer) bool {
 	if build.Status.Phase != buildapi.BuildPhaseNew &&
 		build.Status.Phase != buildapi.BuildPhasePending &&
 		build.Status.Phase != buildapi.BuildPhaseRunning {
 
-		glog.V(2).Infof("A build can be cancelled only if it has new/pending/running status.")
+		fmt.Fprintf(out, "A build can be cancelled only if it has new/pending/running status.\n")
 		return false
 	}
 
 	if build.Status.Cancelled {
-		glog.V(2).Infof("A cancellation event was already triggered for the build %s.", build.Name)
+		fmt.Fprintf(out, "A cancellation event was already triggered for the build %s.\n", build.Name)
 		return false
 	}
 	return true

--- a/test/fixtures/failing-bc.json
+++ b/test/fixtures/failing-bc.json
@@ -1,0 +1,55 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "origin-ruby-sample",
+        "creationTimestamp": null
+      },
+      "spec": {},
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-build",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "imageChange",
+            "imageChange": {}
+          }
+        ],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "git://github.com/openshift/ruby-hello-world.git"
+          },
+          "contextDir":"wrong/dir"
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/ruby-20-centos7"
+            }
+          }
+        },
+        "resources": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Based on https://bugzilla.redhat.com/show_bug.cgi?id=1277420

I've remove the verbosity level from all the spots in `cancelbuild.go` since the output of all of them is important for the user.

@fabianofranz PTAL