### PR TITLE
added better output to test-end-to-end/core

### DIFF
--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -159,16 +159,16 @@ oc whoami
 echo "[INFO] Running a CLI command in a container using the service account"
 oc policy add-role-to-user view -z default
 out=$(oc run cli-with-token --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never -- cli status --loglevel=4 2>&1)
-echo $out
+echo "${out}"
 [ "$(echo $out | grep 'Using in-cluster configuration')" ]
 [ "$(echo $out | grep 'In project test')" ]
 oc delete pod cli-with-token
 out=$(oc run cli-with-token-2 --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never -- cli whoami --loglevel=4 2>&1)
-echo $out
+echo "${out}"
 [ "$(echo $out | grep 'system:serviceaccount:test:default')" ]
 oc delete pod cli-with-token-2
 out=$(oc run kubectl-with-token --attach --env=POD_NAMESPACE=test --image=openshift/origin:${TAG} --restart=Never --command -- kubectl get pods --loglevel=4 2>&1)
-echo $out
+echo "${out}"
 [ "$(echo $out | grep 'Using in-cluster configuration')" ]
 [ "$(echo $out | grep 'kubectl-with-token')" ]
 


### PR DESCRIPTION
This wraps the `echo` calls for better formatting. 

@smarterclayton @liggitt 