### PR TITLE
Rename project service to ProjectsService, update existing uses

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -146,7 +146,7 @@
         <script src="scripts/services/auth.js"></script>
         <script src="scripts/services/data.js"></script>
         <script src="scripts/services/discovery.js"></script>
-        <script src="scripts/services/project.js"></script>
+        <script src="scripts/services/projects.js"></script>
         <script src="scripts/services/applicationGenerator.js"></script>
         <script src="scripts/services/alertMessage.js"></script>
         <script src="scripts/services/login.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -115,7 +115,8 @@ angular
         templateUrl: 'views/builds.html'
       })
       .when('/project/:project/browse/builds/:buildconfig', {
-        templateUrl: 'views/browse/build-config.html'
+        templateUrl: 'views/browse/build-config.html',
+        controller: 'BuildConfigController'
       })
       .when('/project/:project/browse/builds/:buildconfig/:build', {
         templateUrl: function(params) {
@@ -130,13 +131,15 @@ angular
       // For when a build is missing a buildconfig label
       // Needs to still be prefixed with browse/builds so the secondary nav active state is correct
       .when('/project/:project/browse/builds-noconfig/:build', {
-        templateUrl: 'views/browse/build.html'
+        templateUrl: 'views/browse/build.html',
+        controller: 'BuildController'
       })
       .when('/project/:project/browse/deployments', {
         templateUrl: 'views/deployments.html'
       })
       .when('/project/:project/browse/deployments/:deploymentconfig', {
-        templateUrl: 'views/browse/deployment-config.html'
+        templateUrl: 'views/browse/deployment-config.html',
+        controller: 'DeploymentConfigController'
       })
       .when('/project/:project/browse/deployments/:deploymentconfig/:deployment', {
         templateUrl: function(params) {
@@ -160,7 +163,8 @@ angular
         templateUrl: 'views/images.html'
       })
       .when('/project/:project/browse/images/:image', {
-        templateUrl: 'views/browse/image.html'
+        templateUrl: 'views/browse/image.html',
+        controller: 'ImageController'
       })
       .when('/project/:project/browse/pods', {
         templateUrl: 'views/pods.html'
@@ -179,14 +183,16 @@ angular
         templateUrl: 'views/services.html'
       })
       .when('/project/:project/browse/services/:service', {
-        templateUrl: 'views/browse/service.html'
+        templateUrl: 'views/browse/service.html',
+        controller: 'ServiceController'
       })
       .when('/project/:project/browse/routes', {
         templateUrl: 'views/browse/routes.html'
       })
       .when('/project/:project/browse/routes/:route', {
-        templateUrl: 'views/browse/route.html'
-      })      
+        templateUrl: 'views/browse/route.html',
+        controller: 'RouteController'
+      })
       .when('/project/:project/create', {
         templateUrl: 'views/create.html'
       })

--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -7,13 +7,15 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('BuildController', function ($scope, $routeParams, DataService, project, BuildsService, $filter) {
+  .controller('BuildController', function ($scope, $routeParams, DataService, ProjectsService, BuildsService, $filter) {
+    $scope.projectName = $routeParams.project;
     $scope.build = null;
     $scope.buildConfigName = $routeParams.buildconfig;
     $scope.builds = {};
     $scope.alerts = {};
-    $scope.renderOptions = $scope.renderOptions || {};
-    $scope.renderOptions.hideFilterWidget = true;
+    $scope.renderOptions = {
+      hideFilterWidget: true
+    };
     $scope.breadcrumbs = [
       {
         title: "Builds",
@@ -40,95 +42,92 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      var context = {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      };
-      angular.extend($scope, context);
-      // FIXME: DataService.createStream() requires a scope with a
-      // projectPromise rather than just a namespace, so we have to pass the
-      // context into the log-viewer directive.
-      $scope.logContext = context;
-      DataService.get("builds", $routeParams.build, $scope).then(
-        // success
-        function(build) {
-          $scope.loaded = true;
-          $scope.build = build;
-          var buildNumber = $filter("annotation")(build, "buildNumber");
-          if (buildNumber) {
-            $scope.breadcrumbs[2].title = "#" + buildNumber;
-          }
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("builds", $routeParams.build, $scope, function(build, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This build has been deleted."
-              };
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        // FIXME: DataService.createStream() requires a scope with a
+        // projectPromise rather than just a namespace, so we have to pass the
+        // context into the log-viewer directive.
+        $scope.logContext = context;
+        DataService.get("builds", $routeParams.build, context).then(
+          // success
+          function(build) {
+            $scope.loaded = true;
             $scope.build = build;
-          }));
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The build details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
+            var buildNumber = $filter("annotation")(build, "buildNumber");
+            if (buildNumber) {
+              $scope.breadcrumbs[2].title = "#" + buildNumber;
+            }
 
-      watches.push(DataService.watch("builds", $scope, function(builds, action, build) {
-        $scope.builds = {};
-        // TODO we should send the ?labelSelector=buildconfig=<name> on the API request
-        // to only load the buildconfig's builds, but this requires some DataService changes
-        var allBuilds = builds.by("metadata.name");
-        angular.forEach(allBuilds, function(build, name) {
-          if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
-            $scope.builds[name] = build;
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("builds", $routeParams.build, context, function(build, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This build has been deleted."
+                };
+              }
+              $scope.build = build;
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The build details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
           }
+        );
+
+        watches.push(DataService.watch("builds", context, function(builds, action, build) {
+          $scope.builds = {};
+          // TODO we should send the ?labelSelector=buildconfig=<name> on the API request
+          // to only load the buildconfig's builds, but this requires some DataService changes
+          var allBuilds = builds.by("metadata.name");
+          angular.forEach(allBuilds, function(build, name) {
+            if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
+              $scope.builds[name] = build;
+            }
+          });
+
+          var buildConfigName;
+          var buildName;
+          if (build) {
+            buildConfigName = build.metadata.labels.buildconfig;
+            buildName = build.metadata.name;
+          }
+
+          if (!action) {
+            // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
+            $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.builds);
+          } else if (action === 'ADDED'){
+            // When new build id instantiated/cloned associate him to his buildConfig and add him into buildConfigBuildsInProgress structure.
+            $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
+            $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
+          } else if (action === 'MODIFIED'){
+            // After the build ends remove him from the buildConfigBuildsInProgress structure.
+            if (!$filter('isIncompleteBuild')(build)){
+              delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
+            }
+          }
+        }));
+        $scope.startBuild = function(buildConfigName) {
+          BuildsService.startBuild(buildConfigName, context, $scope);
+        };
+
+        $scope.cancelBuild = function(build, buildConfigName) {
+          BuildsService.cancelBuild(build, buildConfigName, context, $scope);
+        };
+
+        $scope.cloneBuild = function(buildName) {
+          BuildsService.cloneBuild(buildName, context, $scope);
+        };
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
         });
-
-        var buildConfigName;
-        var buildName;
-        if (build) {
-          buildConfigName = build.metadata.labels.buildconfig;
-          buildName = build.metadata.name;
-        }
-
-        if (!action) {
-          // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
-          $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.builds);
-        } else if (action === 'ADDED'){
-          // When new build id instantiated/cloned associate him to his buildConfig and add him into buildConfigBuildsInProgress structure.
-          $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
-          $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
-        } else if (action === 'MODIFIED'){
-          // After the build ends remove him from the buildConfigBuildsInProgress structure.
-          if (!$filter('isIncompleteBuild')(build)){
-            delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-          }
-        }
       }));
-    });
-
-    $scope.startBuild = function(buildConfigName) {
-      BuildsService.startBuild(buildConfigName, $scope);
-    };
-
-    $scope.cancelBuild = function(build, buildConfigName) {
-      BuildsService.cancelBuild(build, buildConfigName, $scope);
-    };
-
-    $scope.cloneBuild = function(buildName) {
-      BuildsService.cloneBuild(buildName, $scope);
-    };
-
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
   });

--- a/assets/app/scripts/controllers/buildConfig.js
+++ b/assets/app/scripts/controllers/buildConfig.js
@@ -7,7 +7,8 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('BuildConfigController', function ($scope, $routeParams, DataService, project, BuildsService, $filter, LabelFilter) {
+  .controller('BuildConfigController', function ($scope, $routeParams, DataService, ProjectsService, BuildsService, $filter, LabelFilter) {
+    $scope.projectName = $routeParams.project;
     $scope.buildConfig = null;
     $scope.builds = {};
     $scope.unfilteredBuilds = {};
@@ -26,119 +27,119 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      angular.extend($scope, {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      });
-      DataService.get("buildconfigs", $routeParams.buildconfig, $scope).then(
-        // success
-        function(buildConfig) {
-          $scope.loaded = true;
-          $scope.buildConfig = buildConfig;
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("buildconfigs", $routeParams.buildconfig, $scope, function(buildConfig, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This build configuration has been deleted."
-              }; 
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        DataService.get("buildconfigs", $routeParams.buildconfig, context).then(
+          // success
+          function(buildConfig) {
+            $scope.loaded = true;
             $scope.buildConfig = buildConfig;
-          }));           
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The build configuration details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
 
-      watches.push(DataService.watch("builds", $scope, function(builds, action, build) {
-        $scope.emptyMessage = "No builds to show";
-        // TODO we should send the ?labelSelector=buildconfig=<name> on the API request
-        // to only load the buildconfig's builds, but this requires some DataService changes  
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("buildconfigs", $routeParams.buildconfig, context, function(buildConfig, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This build configuration has been deleted."
+                };
+              }
+              $scope.buildConfig = buildConfig;
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The build configuration details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
+          }
+        );
 
-        if (!action) {
-          $scope.unfilteredBuilds = {};
-          var allBuilds = builds.by("metadata.name");
-          angular.forEach(allBuilds, function(build, name) {
-            if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
-              $scope.unfilteredBuilds[name] = build;
+        watches.push(DataService.watch("builds", context, function(builds, action, build) {
+          $scope.emptyMessage = "No builds to show";
+          // TODO we should send the ?labelSelector=buildconfig=<name> on the API request
+          // to only load the buildconfig's builds, but this requires some DataService changes
+
+          if (!action) {
+            $scope.unfilteredBuilds = {};
+            var allBuilds = builds.by("metadata.name");
+            angular.forEach(allBuilds, function(build, name) {
+              if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
+                $scope.unfilteredBuilds[name] = build;
+              }
+            });
+
+            // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
+            $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.unfilteredBuilds);
+          } else if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
+            var buildName = build.metadata.name;
+            var buildConfigName = $routeParams.buildconfig;
+            switch (action) {
+              case 'ADDED':
+              case 'MODIFIED':
+                $scope.unfilteredBuilds[buildName] = build;
+                // After the build ends remove him from the buildConfigBuildsInProgress structure.
+                if ($filter('isIncompleteBuild')(build)){
+                  $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
+                  $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
+                } else if ($scope.buildConfigBuildsInProgress[buildConfigName]) {
+                  delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
+                }
+                break;
+              case 'DELETED':
+                delete $scope.unfilteredBuilds[buildName];
+                if ($scope.buildConfigBuildsInProgress[buildConfigName]){
+                  delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
+                }
+                break;
             }
-          });
+          }
 
-          // Loading of the page that will create buildConfigBuildsInProgress structure, which will associate running build to his buildConfig.
-          $scope.buildConfigBuildsInProgress = BuildsService.associateRunningBuildToBuildConfig($scope.unfilteredBuilds);
-        } else if (build.metadata.labels && build.metadata.labels.buildconfig === $routeParams.buildconfig) {
-          var buildName = build.metadata.name;
-          var buildConfigName = $routeParams.buildconfig;
-          switch (action) {
-            case 'ADDED':
-            case 'MODIFIED':
-              $scope.unfilteredBuilds[buildName] = build;
-              // After the build ends remove him from the buildConfigBuildsInProgress structure.
-              if ($filter('isIncompleteBuild')(build)){
-                $scope.buildConfigBuildsInProgress[buildConfigName] = $scope.buildConfigBuildsInProgress[buildConfigName] || {};
-                $scope.buildConfigBuildsInProgress[buildConfigName][buildName] = build;
-              } else if ($scope.buildConfigBuildsInProgress[buildConfigName]) {
-                delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-              }
-              break;
-            case 'DELETED':
-              delete $scope.unfilteredBuilds[buildName];
-              if ($scope.buildConfigBuildsInProgress[buildConfigName]){
-                delete $scope.buildConfigBuildsInProgress[buildConfigName][buildName];
-              }
-              break;
+          $scope.builds = LabelFilter.getLabelSelector().select($scope.unfilteredBuilds);
+          updateFilterWarning();
+          LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuilds, $scope.labelSuggestions);
+          LabelFilter.setLabelSuggestions($scope.labelSuggestions);
+        }));
+
+        function updateFilterWarning() {
+          if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.builds) && !$.isEmptyObject($scope.unfilteredBuilds)) {
+            $scope.alerts["builds"] = {
+              type: "warning",
+              details: "The active filters are hiding all builds."
+            };
+          }
+          else {
+            delete $scope.alerts["builds"];
           }
         }
-        
-        $scope.builds = LabelFilter.getLabelSelector().select($scope.unfilteredBuilds); 
-        updateFilterWarning();
-        LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuilds, $scope.labelSuggestions);
-        LabelFilter.setLabelSuggestions($scope.labelSuggestions);    
-      }));
-    });
 
-    function updateFilterWarning() {
-      if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.builds) && !$.isEmptyObject($scope.unfilteredBuilds)) {
-        $scope.alerts["builds"] = {
-          type: "warning",
-          details: "The active filters are hiding all builds."
+        LabelFilter.onActiveFiltersChanged(function(labelSelector) {
+          // trigger a digest loop
+          $scope.$apply(function() {
+            $scope.builds = labelSelector.select($scope.unfilteredBuilds);
+            updateFilterWarning();
+          });
+        });
+
+        $scope.startBuild = function(buildConfigName) {
+          BuildsService.startBuild(buildConfigName, context, $scope);
         };
-      }
-      else {
-        delete $scope.alerts["builds"];
-      }
-    }
 
-    LabelFilter.onActiveFiltersChanged(function(labelSelector) {
-      // trigger a digest loop
-      $scope.$apply(function() {
-        $scope.builds = labelSelector.select($scope.unfilteredBuilds);
-        updateFilterWarning();
-      });
-    });    
+        $scope.cancelBuild = function(build, buildConfigName) {
+          BuildsService.cancelBuild(build, buildConfigName, context, $scope);
+        };
 
-    $scope.startBuild = function(buildConfigName) {
-      BuildsService.startBuild(buildConfigName, $scope);
-    };
+        $scope.cloneBuild = function(buildName) {
+          BuildsService.cloneBuild(buildName, context, $scope);
+        };
 
-    $scope.cancelBuild = function(build, buildConfigName) {
-      BuildsService.cancelBuild(build, buildConfigName, $scope);
-    };
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
 
-    $scope.cloneBuild = function(buildName) {
-      BuildsService.cloneBuild(buildName, $scope);
-    };
-
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
+    }));
   });

--- a/assets/app/scripts/controllers/builds.js
+++ b/assets/app/scripts/controllers/builds.js
@@ -69,7 +69,7 @@ angular.module('openshiftConsole')
       $scope.unfilteredBuildConfigs = buildConfigs.by("metadata.name");
       LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuildConfigs, $scope.labelSuggestions);
       LabelFilter.setLabelSuggestions($scope.labelSuggestions);
-      $scope.buildConfigs = LabelFilter.getLabelSelector().select($scope.unfilteredBuildConfigs);      
+      $scope.buildConfigs = LabelFilter.getLabelSelector().select($scope.unfilteredBuildConfigs);
       associateBuildsToBuildConfig();
       updateFilterWarning();
       Logger.log("buildconfigs (subscribe)", $scope.buildConfigs);
@@ -130,15 +130,15 @@ angular.module('openshiftConsole')
     }
 
     $scope.startBuild = function(buildConfigName) {
-      BuildsService.startBuild(buildConfigName, $scope);
+      BuildsService.startBuild(buildConfigName, $scope, $scope); // FIXME
     };
 
     $scope.cancelBuild = function(build, buildConfigName) {
-      BuildsService.cancelBuild(build, buildConfigName, $scope);
+      BuildsService.cancelBuild(build, buildConfigName, $scope, $scope); // FIXME
     };
 
     $scope.cloneBuild = function(buildName) {
-      BuildsService.cloneBuild(buildName, $scope);
+      BuildsService.cloneBuild(buildName, $scope, $scope); // FIXME
     };
 
     LabelFilter.onActiveFiltersChanged(function(labelSelector) {

--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -7,7 +7,8 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('DeploymentController', function ($scope, $routeParams, DataService, project, DeploymentsService, ImageStreamResolver, $filter) {
+  .controller('DeploymentController', function ($scope, $routeParams, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter) {
+    $scope.projectName = $routeParams.project;
     $scope.deployment = null;
     $scope.deploymentConfig = null;
     $scope.deployments = {};
@@ -15,10 +16,10 @@ angular.module('openshiftConsole')
     $scope.imageStreams = {};
     $scope.imagesByDockerReference = {};
     $scope.imageStreamImageRefByDockerReference = {}; // lets us determine if a particular container's docker image reference belongs to an imageStream
-    $scope.builds = {};     
+    $scope.builds = {};
     $scope.alerts = {};
-    $scope.renderOptions = $scope.renderOptions || {};    
-    $scope.renderOptions.hideFilterWidget = true;    
+    $scope.renderOptions = $scope.renderOptions || {};
+    $scope.renderOptions.hideFilterWidget = true;
     $scope.breadcrumbs = [
       {
         title: "Deployments",
@@ -51,167 +52,166 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      var context = {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      };
-      angular.extend($scope, context);
-      // FIXME: DataService.createStream() requires a scope with a
-      // projectPromise rather than just a namespace, so we have to pass the
-      // context into the log-viewer directive.
-      $scope.logContext = context;
-      DataService.get("replicationcontrollers", $routeParams.deployment || $routeParams.replicationcontroller, $scope).then(
-        // success
-        function(deployment) {
-          $scope.loaded = true;
-          $scope.deployment = deployment;
-          var deploymentVersion = $filter("annotation")(deployment, "deploymentVersion");
-          if (deploymentVersion) {
-            $scope.breadcrumbs[2].title = "#" + deploymentVersion;
-            $scope.logOptions.version = deploymentVersion;
-          }
-          $scope.deploymentConfigName = $filter("annotation") (deployment, "deploymentConfig");
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("replicationcontrollers", $routeParams.deployment || $routeParams.replicationcontroller, $scope, function(deployment, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: $routeParams.deployment ? "This deployment has been deleted." : "This replication controller has been deleted."
-              }; 
-            }
-            $scope.deployment = deployment;
-          }));          
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: $routeParams.deployment ? "The deployment details could not be loaded." : "The replication controller details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
-
-      if ($routeParams.deploymentconfig) {
-        DataService.get("deploymentconfigs", $routeParams.deploymentconfig, $scope).then(
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        // FIXME: DataService.createStream() requires a scope with a
+        // projectPromise rather than just a namespace, so we have to pass the
+        // context into the log-viewer directive.
+        $scope.logContext = context;
+        DataService.get("replicationcontrollers", $routeParams.deployment || $routeParams.replicationcontroller, context).then(
           // success
-          function(deploymentConfig) {
-            $scope.deploymentConfig = deploymentConfig;
+          function(deployment) {
+            $scope.loaded = true;
+            $scope.deployment = deployment;
+            var deploymentVersion = $filter("annotation")(deployment, "deploymentVersion");
+            if (deploymentVersion) {
+              $scope.breadcrumbs[2].title = "#" + deploymentVersion;
+              $scope.logOptions.version = deploymentVersion;
+            }
+            $scope.deploymentConfigName = $filter("annotation") (deployment, "deploymentConfig");
+
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("replicationcontrollers", $routeParams.deployment || $routeParams.replicationcontroller, context, function(deployment, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: $routeParams.deployment ? "This deployment has been deleted." : "This replication controller has been deleted."
+                };
+              }
+              $scope.deployment = deployment;
+            }));
           },
           // failure
           function(e) {
+            $scope.loaded = true;
             $scope.alerts["load"] = {
               type: "error",
-              message: "The deployment configuration details could not be loaded.",
+              message: $routeParams.deployment ? "The deployment details could not be loaded." : "The replication controller details could not be loaded.",
               details: "Reason: " + $filter('getErrorDetails')(e)
             };
           }
-        );      
-      }
+        );
 
-      function extractPodTemplates() {
-        angular.forEach($scope.deployments, function(deployment, deploymentId){
-          $scope.podTemplates[deploymentId] = deployment.spec.template;
-        });
-      }
-
-      watches.push(DataService.watch("replicationcontrollers", $scope, function(deployments, action, deployment) {
-        $scope.deployments = deployments.by("metadata.name");
-        extractPodTemplates();
-        ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-        $scope.emptyMessage = "No deployments to show";
-        $scope.deploymentsByDeploymentConfig = DeploymentsService.associateDeploymentsToDeploymentConfig($scope.deployments);
-
-        var deploymentConfigName;
-        var deploymentName;
-        if (deployment) {
-          deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');
-          deploymentName = deployment.metadata.name;
-        }
-        if (!action) {
-          // Loading of the page that will create deploymentConfigDeploymentsInProgress structure, which will associate running deployment to his deploymentConfig.
-          $scope.deploymentConfigDeploymentsInProgress = DeploymentsService.associateRunningDeploymentToDeploymentConfig($scope.deploymentsByDeploymentConfig);
-        } else if (action === 'ADDED' || (action === 'MODIFIED' && ['New', 'Pending', 'Running'].indexOf($filter('deploymentStatus')(deployment)) > -1)) {
-          // When new deployment id instantiated/cloned, or in case of a retry, associate him to his deploymentConfig and add him into deploymentConfigDeploymentsInProgress structure.
-          $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] = $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] || {};
-          $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName] = deployment;
-        } else if (action === 'MODIFIED') {
-          // After the deployment ends remove him from the deploymentConfigDeploymentsInProgress structure.
-          var status = $filter('deploymentStatus')(deployment);
-          if (status === "Complete" || status === "Failed"){
-            delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
-          }
-        }
-
-        // Extract the causes from the encoded deployment config
-        if (deployment) {
-          if (action !== "DELETED") {
-            deployment.causes = $filter('deploymentCauses')(deployment);
-          }
-        }
-        else {
-          angular.forEach($scope.deployments, function(deployment) {
-            deployment.causes = $filter('deploymentCauses')(deployment);
-          });
-        }        
-      }));
-
-      // Sets up subscription for imageStreams
-      watches.push(DataService.watch("imagestreams", $scope, function(imageStreams) {
-        $scope.imageStreams = imageStreams.by("metadata.name");
-        ImageStreamResolver.buildDockerRefMapForImageStreams($scope.imageStreams, $scope.imageStreamImageRefByDockerReference);
-        ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-        Logger.log("imagestreams (subscribe)", $scope.imageStreams);
-      }));
-
-      watches.push(DataService.watch("builds", $scope, function(builds) {
-        $scope.builds = builds.by("metadata.name");
-        Logger.log("builds (subscribe)", $scope.builds);
-      }));
-    });
-
-    $scope.startLatestDeployment = function(deploymentConfig) {
-      DeploymentsService.startLatestDeployment(deploymentConfig, $scope);
-    };
-
-    $scope.retryFailedDeployment = function(deployment) {
-      DeploymentsService.retryFailedDeployment(deployment, $scope);
-    };
-
-    $scope.rollbackToDeployment = function(deployment, changeScaleSettings, changeStrategy, changeTriggers) {
-      DeploymentsService.rollbackToDeployment(deployment, changeScaleSettings, changeStrategy, changeTriggers, $scope);
-    };
-
-    $scope.cancelRunningDeployment = function(deployment) {
-      DeploymentsService.cancelRunningDeployment(deployment, $scope);
-    };
-
-    $scope.scale = function() {
-      if ($scope.replicas.form.$valid) {
-        DeploymentsService.scale($scope.deployment, $scope.replicas.desired).then(
-          // success, no need for a message since the UI updates immediately
-          _.noop,
-          // failure
-          function(result) {
-            $scope.alerts["scale"] =
-              {
+        if ($routeParams.deploymentconfig) {
+          DataService.get("deploymentconfigs", $routeParams.deploymentconfig, context).then(
+            // success
+            function(deploymentConfig) {
+              $scope.deploymentConfig = deploymentConfig;
+            },
+            // failure
+            function(e) {
+              $scope.alerts["load"] = {
                 type: "error",
-                message: "An error occurred scaling the deployment.",
-                details: $filter('getErrorDetails')(result)
+                message: "The deployment configuration details could not be loaded.",
+                details: "Reason: " + $filter('getErrorDetails')(e)
               };
+            }
+          );
+        }
+
+        function extractPodTemplates() {
+          angular.forEach($scope.deployments, function(deployment, deploymentId){
+            $scope.podTemplates[deploymentId] = deployment.spec.template;
           });
-        $scope.replicas.editing = false;
-      }
-    };
+        }
 
-    $scope.cancelScale = function() {
-      $scope.replicas.editing = false;
-    };
+        watches.push(DataService.watch("replicationcontrollers", context, function(deployments, action, deployment) {
+          $scope.deployments = deployments.by("metadata.name");
+          extractPodTemplates();
+          ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
+          $scope.emptyMessage = "No deployments to show";
+          $scope.deploymentsByDeploymentConfig = DeploymentsService.associateDeploymentsToDeploymentConfig($scope.deployments);
 
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
+          var deploymentConfigName;
+          var deploymentName;
+          if (deployment) {
+            deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');
+            deploymentName = deployment.metadata.name;
+          }
+          if (!action) {
+            // Loading of the page that will create deploymentConfigDeploymentsInProgress structure, which will associate running deployment to his deploymentConfig.
+            $scope.deploymentConfigDeploymentsInProgress = DeploymentsService.associateRunningDeploymentToDeploymentConfig($scope.deploymentsByDeploymentConfig);
+          } else if (action === 'ADDED' || (action === 'MODIFIED' && ['New', 'Pending', 'Running'].indexOf($filter('deploymentStatus')(deployment)) > -1)) {
+            // When new deployment id instantiated/cloned, or in case of a retry, associate him to his deploymentConfig and add him into deploymentConfigDeploymentsInProgress structure.
+            $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] = $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] || {};
+            $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName] = deployment;
+          } else if (action === 'MODIFIED') {
+            // After the deployment ends remove him from the deploymentConfigDeploymentsInProgress structure.
+            var status = $filter('deploymentStatus')(deployment);
+            if (status === "Complete" || status === "Failed"){
+              delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
+            }
+          }
+
+          // Extract the causes from the encoded deployment config
+          if (deployment) {
+            if (action !== "DELETED") {
+              deployment.causes = $filter('deploymentCauses')(deployment);
+            }
+          }
+          else {
+            angular.forEach($scope.deployments, function(deployment) {
+              deployment.causes = $filter('deploymentCauses')(deployment);
+            });
+          }
+        }));
+
+        // Sets up subscription for imageStreams
+        watches.push(DataService.watch("imagestreams", context, function(imageStreams) {
+          $scope.imageStreams = imageStreams.by("metadata.name");
+          ImageStreamResolver.buildDockerRefMapForImageStreams($scope.imageStreams, $scope.imageStreamImageRefByDockerReference);
+          ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
+          Logger.log("imagestreams (subscribe)", $scope.imageStreams);
+        }));
+
+        watches.push(DataService.watch("builds", context, function(builds) {
+          $scope.builds = builds.by("metadata.name");
+          Logger.log("builds (subscribe)", $scope.builds);
+        }));
+
+        $scope.startLatestDeployment = function(deploymentConfig) {
+          DeploymentsService.startLatestDeployment(deploymentConfig, context, $scope);
+        };
+
+        $scope.retryFailedDeployment = function(deployment) {
+          DeploymentsService.retryFailedDeployment(deployment, context, $scope);
+        };
+
+        $scope.rollbackToDeployment = function(deployment, changeScaleSettings, changeStrategy, changeTriggers) {
+          DeploymentsService.rollbackToDeployment(deployment, changeScaleSettings, changeStrategy, changeTriggers, context, $scope);
+        };
+
+        $scope.cancelRunningDeployment = function(deployment) {
+          DeploymentsService.cancelRunningDeployment(deployment, context, $scope);
+        };
+
+        $scope.scale = function() {
+          if ($scope.replicas.form.$valid) {
+            DeploymentsService.scale($scope.deployment, $scope.replicas.desired).then(
+              // success, no need for a message since the UI updates immediately
+              _.noop,
+              // failure
+              function(result) {
+                $scope.alerts["scale"] =
+                  {
+                    type: "error",
+                    message: "An error occurred scaling the deployment.",
+                    details: $filter('getErrorDetails')(result)
+                  };
+              });
+            $scope.replicas.editing = false;
+          }
+        };
+
+        $scope.cancelScale = function() {
+          $scope.replicas.editing = false;
+        };
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
+
+    }));
   });

--- a/assets/app/scripts/controllers/deploymentConfig.js
+++ b/assets/app/scripts/controllers/deploymentConfig.js
@@ -7,21 +7,22 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('DeploymentConfigController', function ($scope, $routeParams, DataService, project, DeploymentsService, ImageStreamResolver, $filter, LabelFilter) {
+  .controller('DeploymentConfigController', function ($scope, $routeParams, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter, LabelFilter) {
+    $scope.projectName = $routeParams.project;
     $scope.deploymentConfig = null;
     $scope.deployments = {};
     $scope.unfilteredDeployments = {};
     $scope.imageStreams = {};
     $scope.imagesByDockerReference = {};
     $scope.imageStreamImageRefByDockerReference = {}; // lets us determine if a particular container's docker image reference belongs to an imageStream
-    $scope.builds = {};         
-    $scope.labelSuggestions = {};    
+    $scope.builds = {};
+    $scope.labelSuggestions = {};
     // TODO we should add this back in and show the pod template on this page
     //$scope.podTemplates = {};
     //$scope.imageStreams = {};
     //$scope.imagesByDockerReference = {};
     //$scope.imageStreamImageRefByDockerReference = {}; // lets us determine if a particular container's docker image reference belongs to an imageStream
-    //$scope.builds = {};   
+    //$scope.builds = {};
     $scope.alerts = {};
     $scope.breadcrumbs = [
       {
@@ -36,134 +37,134 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      angular.extend($scope, {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      });
-      DataService.get("deploymentconfigs", $routeParams.deploymentconfig, $scope).then(
-        // success
-        function(deploymentConfig) {
-          $scope.loaded = true;
-          $scope.deploymentConfig = deploymentConfig;
-          ImageStreamResolver.fetchReferencedImageStreamImages([deploymentConfig.spec.template], $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("deploymentconfigs", $routeParams.deploymentconfig, $scope, function(deploymentConfig, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This deployment configuration has been deleted."
-              }; 
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        DataService.get("deploymentconfigs", $routeParams.deploymentconfig, context).then(
+          // success
+          function(deploymentConfig) {
+            $scope.loaded = true;
             $scope.deploymentConfig = deploymentConfig;
-            ImageStreamResolver.fetchReferencedImageStreamImages([deploymentConfig.spec.template], $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-          }));          
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The deployment configuration details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
+            ImageStreamResolver.fetchReferencedImageStreamImages([deploymentConfig.spec.template], $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
 
-      // TODO we should add this back in and show the pod template on this page
-      // function extractPodTemplates() {
-      //   angular.forEach($scope.deployments, function(deployment, deploymentId){
-      //     $scope.podTemplates[deploymentId] = deployment.spec.template;
-      //   });
-      // }
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("deploymentconfigs", $routeParams.deploymentconfig, context, function(deploymentConfig, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This deployment configuration has been deleted."
+                };
+              }
+              $scope.deploymentConfig = deploymentConfig;
+              ImageStreamResolver.fetchReferencedImageStreamImages([deploymentConfig.spec.template], $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The deployment configuration details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
+          }
+        );
 
-      watches.push(DataService.watch("replicationcontrollers", $scope, function(deployments, action, deployment) { 
         // TODO we should add this back in and show the pod template on this page
-        // extractPodTemplates();
-        // ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-        $scope.emptyMessage = "No deployments to show";
- 
-        if (!action) {
-          var deploymentsByDeploymentConfig = DeploymentsService.associateDeploymentsToDeploymentConfig(deployments.by("metadata.name"));
-          $scope.unfilteredDeployments = deploymentsByDeploymentConfig[$routeParams.deploymentconfig] || {};
-          angular.forEach($scope.unfilteredDeployments, function(deployment) {
-            deployment.causes = $filter('deploymentCauses')(deployment);
-          });
-          // Loading of the page that will create deploymentConfigDeploymentsInProgress structure, which will associate running deployment to his deploymentConfig.
-          $scope.deploymentConfigDeploymentsInProgress = DeploymentsService.associateRunningDeploymentToDeploymentConfig(deploymentsByDeploymentConfig);
-        } else if (DeploymentsService.deploymentBelongsToConfig(deployment, $routeParams.deploymentconfig)) {
-          var deploymentName = deployment.metadata.name;
-          var deploymentConfigName = $routeParams.deploymentconfig;
-          switch (action) {
-            case 'ADDED':
-            case 'MODIFIED':
-              $scope.unfilteredDeployments[deploymentName] = deployment;
-              // When deployment is retried, associate him to his deploymentConfig and add him into deploymentConfigDeploymentsInProgress structure.
-              if ($filter('deploymentIsInProgress')(deployment)){
-                $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] = $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] || {};
-                $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName] = deployment;                
-              } else if ($scope.deploymentConfigDeploymentsInProgress[deploymentConfigName]) { // After the deployment ends remove him from the deploymentConfigDeploymentsInProgress structure.
-                delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
-              }
+        // function extractPodTemplates() {
+        //   angular.forEach($scope.deployments, function(deployment, deploymentId){
+        //     $scope.podTemplates[deploymentId] = deployment.spec.template;
+        //   });
+        // }
+
+        watches.push(DataService.watch("replicationcontrollers", context, function(deployments, action, deployment) {
+          // TODO we should add this back in and show the pod template on this page
+          // extractPodTemplates();
+          // ImageStreamResolver.fetchReferencedImageStreamImages($scope.podTemplates, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
+          $scope.emptyMessage = "No deployments to show";
+
+          if (!action) {
+            var deploymentsByDeploymentConfig = DeploymentsService.associateDeploymentsToDeploymentConfig(deployments.by("metadata.name"));
+            $scope.unfilteredDeployments = deploymentsByDeploymentConfig[$routeParams.deploymentconfig] || {};
+            angular.forEach($scope.unfilteredDeployments, function(deployment) {
               deployment.causes = $filter('deploymentCauses')(deployment);
-              break;
-            case 'DELETED':
-              delete $scope.unfilteredDeployments[deploymentName];
-              if ($scope.deploymentConfigDeploymentsInProgress[deploymentConfigName]) {
-                delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
-              }
-              break;
+            });
+            // Loading of the page that will create deploymentConfigDeploymentsInProgress structure, which will associate running deployment to his deploymentConfig.
+            $scope.deploymentConfigDeploymentsInProgress = DeploymentsService.associateRunningDeploymentToDeploymentConfig(deploymentsByDeploymentConfig);
+          } else if (DeploymentsService.deploymentBelongsToConfig(deployment, $routeParams.deploymentconfig)) {
+            var deploymentName = deployment.metadata.name;
+            var deploymentConfigName = $routeParams.deploymentconfig;
+            switch (action) {
+              case 'ADDED':
+              case 'MODIFIED':
+                $scope.unfilteredDeployments[deploymentName] = deployment;
+                // When deployment is retried, associate him to his deploymentConfig and add him into deploymentConfigDeploymentsInProgress structure.
+                if ($filter('deploymentIsInProgress')(deployment)){
+                  $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] = $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName] || {};
+                  $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName] = deployment;
+                } else if ($scope.deploymentConfigDeploymentsInProgress[deploymentConfigName]) { // After the deployment ends remove him from the deploymentConfigDeploymentsInProgress structure.
+                  delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
+                }
+                deployment.causes = $filter('deploymentCauses')(deployment);
+                break;
+              case 'DELETED':
+                delete $scope.unfilteredDeployments[deploymentName];
+                if ($scope.deploymentConfigDeploymentsInProgress[deploymentConfigName]) {
+                  delete $scope.deploymentConfigDeploymentsInProgress[deploymentConfigName][deploymentName];
+                }
+                break;
+            }
+          }
+
+          $scope.deployments = LabelFilter.getLabelSelector().select($scope.unfilteredDeployments);
+          updateFilterWarning();
+          LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredDeployments, $scope.labelSuggestions);
+          LabelFilter.setLabelSuggestions($scope.labelSuggestions);
+        }));
+
+        watches.push(DataService.watch("imagestreams", context, function(imageStreams) {
+          $scope.imageStreams = imageStreams.by("metadata.name");
+          ImageStreamResolver.buildDockerRefMapForImageStreams($scope.imageStreams, $scope.imageStreamImageRefByDockerReference);
+          // If the dep config has been loaded already
+          if ($scope.deploymentConfig) {
+            ImageStreamResolver.fetchReferencedImageStreamImages([$scope.deploymentConfig.spec.template], $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
+          }
+          Logger.log("imagestreams (subscribe)", $scope.imageStreams);
+        }));
+
+        watches.push(DataService.watch("builds", context, function(builds) {
+          $scope.builds = builds.by("metadata.name");
+          Logger.log("builds (subscribe)", $scope.builds);
+        }));
+
+        function updateFilterWarning() {
+          if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.deployments) && !$.isEmptyObject($scope.unfilteredDeployments)) {
+            $scope.alerts["deployments"] = {
+              type: "warning",
+              details: "The active filters are hiding all deployments."
+            };
+          }
+          else {
+            delete $scope.alerts["deployments"];
           }
         }
 
-        $scope.deployments = LabelFilter.getLabelSelector().select($scope.unfilteredDeployments);      
-        updateFilterWarning();
-        LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredDeployments, $scope.labelSuggestions);
-        LabelFilter.setLabelSuggestions($scope.labelSuggestions);
-      }));
+        LabelFilter.onActiveFiltersChanged(function(labelSelector) {
+          // trigger a digest loop
+          $scope.$apply(function() {
+            $scope.deployments = labelSelector.select($scope.unfilteredDeployments);
+            updateFilterWarning();
+          });
+        });
 
-      watches.push(DataService.watch("imagestreams", $scope, function(imageStreams) {
-        $scope.imageStreams = imageStreams.by("metadata.name");
-        ImageStreamResolver.buildDockerRefMapForImageStreams($scope.imageStreams, $scope.imageStreamImageRefByDockerReference);
-        // If the dep config has been loaded already
-        if ($scope.deploymentConfig) {
-          ImageStreamResolver.fetchReferencedImageStreamImages([$scope.deploymentConfig.spec.template], $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-        }
-        Logger.log("imagestreams (subscribe)", $scope.imageStreams);
-      }));
-
-      watches.push(DataService.watch("builds", $scope, function(builds) {
-        $scope.builds = builds.by("metadata.name");
-        Logger.log("builds (subscribe)", $scope.builds);
-      }));
-    });
-
-    function updateFilterWarning() {
-      if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.deployments) && !$.isEmptyObject($scope.unfilteredDeployments)) {
-        $scope.alerts["deployments"] = {
-          type: "warning",
-          details: "The active filters are hiding all deployments."
+        $scope.startLatestDeployment = function(deploymentConfig) {
+          DeploymentsService.startLatestDeployment(deploymentConfig, context, $scope);
         };
-      }
-      else {
-        delete $scope.alerts["deployments"];
-      }
-    }
 
-    LabelFilter.onActiveFiltersChanged(function(labelSelector) {
-      // trigger a digest loop
-      $scope.$apply(function() {
-        $scope.deployments = labelSelector.select($scope.unfilteredDeployments);
-        updateFilterWarning();
-      });
-    }); 
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
 
-    $scope.startLatestDeployment = function(deploymentConfig) {
-      DeploymentsService.startLatestDeployment(deploymentConfig, $scope);
-    };
-
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
+    }));
   });

--- a/assets/app/scripts/controllers/image.js
+++ b/assets/app/scripts/controllers/image.js
@@ -7,13 +7,14 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('ImageController', function ($scope, $routeParams, DataService, project, $filter, ImageStreamsService) {
+  .controller('ImageController', function ($scope, $routeParams, DataService, ProjectsService, $filter, ImageStreamsService) {
+    $scope.projectName = $routeParams.project;
     $scope.imageStream = null;
     $scope.tagsByName = {};
     $scope.tagShowOlder = {};
     $scope.alerts = {};
-    $scope.renderOptions = $scope.renderOptions || {};    
-    $scope.renderOptions.hideFilterWidget = true;    
+    $scope.renderOptions = $scope.renderOptions || {};
+    $scope.renderOptions.hideFilterWidget = true;
     $scope.breadcrumbs = [
       {
         title: "Image Streams",
@@ -26,42 +27,41 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      angular.extend($scope, {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      });
-      DataService.get("imagestreams", $routeParams.image, $scope).then(
-        // success
-        function(imageStream) {
-          $scope.loaded = true;
-          $scope.imageStream = imageStream;
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("imagestreams", $routeParams.image, $scope, function(imageStream, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This image stream has been deleted."
-              }; 
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        DataService.get("imagestreams", $routeParams.image, context).then(
+          // success
+          function(imageStream) {
+            $scope.loaded = true;
             $scope.imageStream = imageStream;
-            $scope.tagsByName = ImageStreamsService.tagsByName($scope.imageStream);
-          }));          
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The image stream details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
-    });
 
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    }); 
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("imagestreams", $routeParams.image, context, function(imageStream, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This image stream has been deleted."
+                };
+              }
+              $scope.imageStream = imageStream;
+              $scope.tagsByName = ImageStreamsService.tagsByName($scope.imageStream);
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The image stream details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
+          });
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
+
+      }));
   });

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -7,7 +7,8 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('PodController', function ($scope, $routeParams, $timeout, DataService, project, $filter, ImageStreamResolver, MetricsService) {
+  .controller('PodController', function ($scope, $routeParams, $timeout, DataService, ProjectsService, $filter, ImageStreamResolver, MetricsService) {
+    $scope.projectName = $routeParams.project;
     $scope.pod = null;
     $scope.imageStreams = {};
     $scope.imagesByDockerReference = {};
@@ -41,75 +42,74 @@ angular.module('openshiftConsole')
       $scope.metricsAvailable = available;
     });
 
-    project.get($routeParams.project).then(function(resp) {
-      var context = {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      };
-      angular.extend($scope, context);
-      // FIXME: DataService.createStream() requires a scope with a
-      // projectPromise rather than just a namespace, so we have to pass the
-      // context into the log-viewer directive.
-      $scope.logContext = context;
-      DataService.get("pods", $routeParams.pod, $scope).then(
-        // success
-        function(pod) {
-          $scope.loaded = true;
-          $scope.pod = pod;
-          $scope.logOptions.container = $routeParams.container || pod.spec.containers[0].name;
-          var pods = {};
-          pods[pod.metadata.name] = pod;
-          ImageStreamResolver.fetchReferencedImageStreamImages(pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("pods", $routeParams.pod, $scope, function(pod, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This pod has been deleted."
-              };
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        // FIXME: DataService.createStream() requires a scope with a
+        // projectPromise rather than just a namespace, so we have to pass the
+        // context into the log-viewer directive.
+        $scope.logContext = context;
+        DataService.get("pods", $routeParams.pod, context).then(
+          // success
+          function(pod) {
+            $scope.loaded = true;
             $scope.pod = pod;
-          }));
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The pod details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
+            $scope.logOptions.container = $routeParams.container || pod.spec.containers[0].name;
+            var pods = {};
+            pods[pod.metadata.name] = pod;
+            ImageStreamResolver.fetchReferencedImageStreamImages(pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
 
-      // Sets up subscription for imageStreams
-      watches.push(DataService.watch("imagestreams", $scope, function(imageStreams) {
-        $scope.imageStreams = imageStreams.by("metadata.name");
-        ImageStreamResolver.buildDockerRefMapForImageStreams($scope.imageStreams, $scope.imageStreamImageRefByDockerReference);
-        ImageStreamResolver.fetchReferencedImageStreamImages($scope.pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, $scope);
-        Logger.log("imagestreams (subscribe)", $scope.imageStreams);
-      }));
-
-      watches.push(DataService.watch("builds", $scope, function(builds) {
-        $scope.builds = builds.by("metadata.name");
-        Logger.log("builds (subscribe)", $scope.builds);
-      }));
-    });
-
-    $scope.containersRunning = function(containerStatuses) {
-      var running = 0;
-      if (containerStatuses) {
-        containerStatuses.forEach(function(v) {
-          if (v.state && v.state.running) {
-            running++;
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("pods", $routeParams.pod, context, function(pod, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This pod has been deleted."
+                };
+              }
+              $scope.pod = pod;
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The pod details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
           }
-        });
-      }
-      return running;
-    };
+        );
 
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
+        // Sets up subscription for imageStreams
+        watches.push(DataService.watch("imagestreams", context, function(imageStreams) {
+          $scope.imageStreams = imageStreams.by("metadata.name");
+          ImageStreamResolver.buildDockerRefMapForImageStreams($scope.imageStreams, $scope.imageStreamImageRefByDockerReference);
+          ImageStreamResolver.fetchReferencedImageStreamImages($scope.pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);
+          Logger.log("imagestreams (subscribe)", $scope.imageStreams);
+        }));
+
+        watches.push(DataService.watch("builds", context, function(builds) {
+          $scope.builds = builds.by("metadata.name");
+          Logger.log("builds (subscribe)", $scope.builds);
+        }));
+
+        $scope.containersRunning = function(containerStatuses) {
+          var running = 0;
+          if (containerStatuses) {
+            containerStatuses.forEach(function(v) {
+              if (v.state && v.state.running) {
+                running++;
+              }
+            });
+          }
+          return running;
+        };
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
+
+    }));
   });

--- a/assets/app/scripts/controllers/route.js
+++ b/assets/app/scripts/controllers/route.js
@@ -7,11 +7,12 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('RouteController', function ($scope, $routeParams, DataService, project, $filter) {
+  .controller('RouteController', function ($scope, $routeParams, DataService, ProjectsService, $filter) {
+    $scope.projectName = $routeParams.project;
     $scope.route = null;
     $scope.alerts = {};
-    $scope.renderOptions = $scope.renderOptions || {};    
-    $scope.renderOptions.hideFilterWidget = true;    
+    $scope.renderOptions = $scope.renderOptions || {};
+    $scope.renderOptions.hideFilterWidget = true;
     $scope.breadcrumbs = [
       {
         title: "Routes",
@@ -24,41 +25,40 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      angular.extend($scope, {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      });
-      DataService.get("routes", $routeParams.route, $scope).then(
-        // success
-        function(route) {
-          $scope.loaded = true;
-          $scope.route = route;
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("routes", $routeParams.route, $scope, function(route, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This route has been deleted."
-              }; 
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        DataService.get("routes", $routeParams.route, context).then(
+          // success
+          function(route) {
+            $scope.loaded = true;
             $scope.route = route;
-          }));          
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The route details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
-    });
 
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("routes", $routeParams.route, context, function(route, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This route has been deleted."
+                };
+              }
+              $scope.route = route;
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The route details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
+          });
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
+
+      }));
   });

--- a/assets/app/scripts/controllers/service.js
+++ b/assets/app/scripts/controllers/service.js
@@ -7,11 +7,12 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('ServiceController', function ($scope, $routeParams, DataService, project, $filter) {
+  .controller('ServiceController', function ($scope, $routeParams, DataService, ProjectsService, $filter) {
+    $scope.projectName = $routeParams.project;
     $scope.service = null;
     $scope.alerts = {};
-    $scope.renderOptions = $scope.renderOptions || {};    
-    $scope.renderOptions.hideFilterWidget = true;    
+    $scope.renderOptions = $scope.renderOptions || {};
+    $scope.renderOptions.hideFilterWidget = true;
     $scope.breadcrumbs = [
       {
         title: "Services",
@@ -24,53 +25,53 @@ angular.module('openshiftConsole')
 
     var watches = [];
 
-    project.get($routeParams.project).then(function(resp) {
-      angular.extend($scope, {
-        project: resp[0],
-        projectPromise: resp[1].projectPromise
-      });
-      DataService.get("services", $routeParams.service, $scope).then(
-        // success
-        function(service) {
-          $scope.loaded = true;
-          $scope.service = service;
-
-          // If we found the item successfully, watch for changes on it
-          watches.push(DataService.watchObject("services", $routeParams.service, $scope, function(service, action) {
-            if (action === "DELETED") {
-              $scope.alerts["deleted"] = {
-                type: "warning",
-                message: "This service has been deleted."
-              }; 
-            }
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        DataService.get("services", $routeParams.service, context).then(
+          // success
+          function(service) {
+            $scope.loaded = true;
             $scope.service = service;
-          }));          
-        },
-        // failure
-        function(e) {
-          $scope.loaded = true;
-          $scope.alerts["load"] = {
-            type: "error",
-            message: "The service details could not be loaded.",
-            details: "Reason: " + $filter('getErrorDetails')(e)
-          };
-        }
-      );
 
-      watches.push(DataService.watch("routes", $scope, function(routes) {
-        $scope.routesForService = [];
-        angular.forEach(routes.by("metadata.name"), function(route) {
-          if (route.spec.to.kind === "Service" &&
-              route.spec.to.name === $routeParams.service) {
-            $scope.routesForService.push(route);
+            // If we found the item successfully, watch for changes on it
+            watches.push(DataService.watchObject("services", $routeParams.service, context, function(service, action) {
+              if (action === "DELETED") {
+                $scope.alerts["deleted"] = {
+                  type: "warning",
+                  message: "This service has been deleted."
+                };
+              }
+              $scope.service = service;
+            }));
+          },
+          // failure
+          function(e) {
+            $scope.loaded = true;
+            $scope.alerts["load"] = {
+              type: "error",
+              message: "The service details could not be loaded.",
+              details: "Reason: " + $filter('getErrorDetails')(e)
+            };
           }
+        );
+
+        watches.push(DataService.watch("routes", context, function(routes) {
+          $scope.routesForService = [];
+          angular.forEach(routes.by("metadata.name"), function(route) {
+            if (route.spec.to.kind === "Service" &&
+                route.spec.to.name === $routeParams.service) {
+              $scope.routesForService.push(route);
+            }
+          });
+
+          Logger.log("routes (subscribe)", $scope.routesByService);
+        }));
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
         });
 
-        Logger.log("routes (subscribe)", $scope.routesByService);
-      }));
-    });
-
-    $scope.$on('$destroy', function(){
-      DataService.unwatchAll(watches);
-    });
+    }));
   });

--- a/assets/app/scripts/directives/deleteButton.js
+++ b/assets/app/scripts/directives/deleteButton.js
@@ -13,11 +13,6 @@ angular.module("openshiftConsole")
       },
       templateUrl: "views/directives/delete-button.html",
       link: function(scope, element, attrs) {
-        // make resource types available in the modal
-        scope.resourceType = attrs.resourceType;
-        scope.resourceName = attrs.resourceName;
-        scope.projectName = attrs.projectName;
-        scope.displayName = attrs.displayName;
 
         if (attrs.resourceType === 'project') {
           scope.isProject = true;
@@ -39,8 +34,9 @@ angular.module("openshiftConsole")
             var resourceName = scope.resourceName;
             var projectName = scope.projectName;
             var formattedResource = $filter('humanizeResourceType')(resourceType) + ' ' + "\'"  + (scope.displayName ? scope.displayName : resourceName) + "\'";
+            var context = (scope.resourceType === 'project') ? {} : {namespace: scope.projectName};
 
-            DataService.delete(resourceType + 's', resourceName, scope.$parent)
+            DataService.delete(resourceType + 's', resourceName, context)
             .then(function() {
               if (resourceType !== 'project') {
                 AlertMessageService.addAlert({

--- a/assets/app/scripts/services/builds.js
+++ b/assets/app/scripts/services/builds.js
@@ -5,7 +5,7 @@ angular.module("openshiftConsole")
     function BuildsService() {}
 
     // Function which will 'instantiate' new build from given buildConfigName
-    BuildsService.prototype.startBuild = function(buildConfigName, $scope) {
+    BuildsService.prototype.startBuild = function(buildConfigName, context, $scope) {
       var req = {
         kind: "BuildRequest",
         apiVersion: "v1",
@@ -13,10 +13,10 @@ angular.module("openshiftConsole")
           name: buildConfigName
         }
       };
-      DataService.create("buildconfigs/instantiate", buildConfigName, req, $scope).then(
+      DataService.create("buildconfigs/instantiate", buildConfigName, req, context).then(
         function(build) { //success
             $scope.alerts = $scope.alerts || {};
-            $scope.alerts["create"] = 
+            $scope.alerts["create"] =
               {
                 type: "success",
                 message: "Build " + build.metadata.name + " has started.",
@@ -25,7 +25,7 @@ angular.module("openshiftConsole")
         },
         function(result) { //failure
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["create"] = 
+          $scope.alerts["create"] =
             {
               type: "error",
               message: "An error occurred while starting the build.",
@@ -35,13 +35,13 @@ angular.module("openshiftConsole")
       );
     };
 
-    BuildsService.prototype.cancelBuild = function(build, buildConfigName, $scope) {
+    BuildsService.prototype.cancelBuild = function(build, buildConfigName, context, $scope) {
       var canceledBuild = angular.copy(build);
       canceledBuild.status.cancelled = true;
-      DataService.update("builds", canceledBuild.metadata.name, canceledBuild, $scope).then(
+      DataService.update("builds", canceledBuild.metadata.name, canceledBuild, context).then(
         function() {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["cancel"] = 
+          $scope.alerts["cancel"] =
             {
               type: "success",
               message: "Cancelling build " + build.metadata.name + " of " + buildConfigName + "."
@@ -49,7 +49,7 @@ angular.module("openshiftConsole")
         },
         function(result) {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["cancel"] = 
+          $scope.alerts["cancel"] =
             {
               type: "error",
               message: "An error occurred cancelling the build.",
@@ -60,7 +60,7 @@ angular.module("openshiftConsole")
     };
 
     // Function which will 'clone' build from given buildName
-    BuildsService.prototype.cloneBuild = function(buildName, $scope) {
+    BuildsService.prototype.cloneBuild = function(buildName, context, $scope) {
       var req = {
         kind: "BuildRequest",
         apiVersion: "v1",
@@ -68,10 +68,10 @@ angular.module("openshiftConsole")
           name: buildName
         }
       };
-      DataService.create("builds/clone", buildName, req, $scope).then(
+      DataService.create("builds/clone", buildName, req, context).then(
         function(build) { //success
             $scope.alerts = $scope.alerts || {};
-            $scope.alerts["rebuild"] = 
+            $scope.alerts["rebuild"] =
             {
               type: "success",
               message: "Build " + buildName + " is being rebuilt as " + build.metadata.name + ".",
@@ -80,7 +80,7 @@ angular.module("openshiftConsole")
         },
         function(result) { //failure
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["rebuild"] = 
+          $scope.alerts["rebuild"] =
             {
               type: "error",
               message: "An error occurred while rerunning the build.",
@@ -101,6 +101,6 @@ angular.module("openshiftConsole")
       });
       return buildConfigBuildsInProgress;
     };
-    
+
     return new BuildsService();
   });

--- a/assets/app/scripts/services/deployments.js
+++ b/assets/app/scripts/services/deployments.js
@@ -4,7 +4,7 @@ angular.module("openshiftConsole")
   .factory("DeploymentsService", function(DataService, $filter, LabelFilter){
     function DeploymentsService() {}
 
-    DeploymentsService.prototype.startLatestDeployment = function(deploymentConfig, $scope) {
+    DeploymentsService.prototype.startLatestDeployment = function(deploymentConfig, context, $scope) {
       // increase latest version by one so starts new deployment based on latest
       var req = {
         kind: "DeploymentConfig",
@@ -19,10 +19,10 @@ angular.module("openshiftConsole")
       req.status.latestVersion++;
 
       // update the deployment config
-      DataService.update("deploymentconfigs", deploymentConfig.metadata.name, req, $scope).then(
+      DataService.update("deploymentconfigs", deploymentConfig.metadata.name, req, context).then(
         function() {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["deploy"] = 
+          $scope.alerts["deploy"] =
             {
               type: "success",
               message: "Deployment #" + req.status.latestVersion + " of " + deploymentConfig.metadata.name + " has started.",
@@ -30,7 +30,7 @@ angular.module("openshiftConsole")
         },
         function(result) {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["deploy"] = 
+          $scope.alerts["deploy"] =
             {
               type: "error",
               message: "An error occurred while starting the deployment.",
@@ -40,14 +40,14 @@ angular.module("openshiftConsole")
       );
     };
 
-    DeploymentsService.prototype.retryFailedDeployment = function(deployment, $scope) {
+    DeploymentsService.prototype.retryFailedDeployment = function(deployment, context, $scope) {
       var req = angular.copy(deployment);
       var deploymentName = deployment.metadata.name;
       var deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');
       // TODO: we need a "retry" api endpoint so we don't have to do this manually
 
       // delete the deployer pod as well as the deployment hooks pods, if any
-      DataService.list("pods", $scope, function(list) {
+      DataService.list("pods", context, function(list) {
         var pods = list.by("metadata.name");
         var deleteDeployerPod = function(pod) {
           var deployerPodForAnnotation = $filter('annotationName')('deployerPodFor');
@@ -57,8 +57,8 @@ angular.module("openshiftConsole")
                 Logger.info("Deployer pod " + pod.metadata.name + " deleted");
               },
               function(result) {
-                $scope.alerts = $scope.alerts || {};                
-                $scope.alerts["retrydeployer"] = 
+                $scope.alerts = $scope.alerts || {};
+                $scope.alerts["retrydeployer"] =
                   {
                     type: "error",
                     message: "An error occurred while deleting the deployer pod.",
@@ -80,10 +80,10 @@ angular.module("openshiftConsole")
       delete req.metadata.annotations[deploymentCancelledAnnotation];
 
       // update the deployment
-      DataService.update("replicationcontrollers", deploymentName, req, $scope).then(
+      DataService.update("replicationcontrollers", deploymentName, req, context).then(
         function() {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["retry"] = 
+          $scope.alerts["retry"] =
             {
               type: "success",
               message: "Retrying deployment " + deploymentName + " of " + deploymentConfigName + ".",
@@ -91,7 +91,7 @@ angular.module("openshiftConsole")
         },
         function(result) {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["retry"] = 
+          $scope.alerts["retry"] =
             {
               type: "error",
               message: "An error occurred while retrying the deployment.",
@@ -101,9 +101,9 @@ angular.module("openshiftConsole")
       );
     };
 
-    DeploymentsService.prototype.rollbackToDeployment = function(deployment, changeScaleSettings, changeStrategy, changeTriggers, $scope) {
+    DeploymentsService.prototype.rollbackToDeployment = function(deployment, changeScaleSettings, changeStrategy, changeTriggers, context, $scope) {
       var deploymentName = deployment.metadata.name;
-      var deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');        
+      var deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');
       // put together a new rollback request
       var req = {
         kind: "DeploymentConfigRollback",
@@ -121,14 +121,14 @@ angular.module("openshiftConsole")
 
       // TODO: we need a "rollback" api endpoint so we don't have to do this manually
 
-      // create the deployment config rollback 
-      DataService.create("deploymentconfigrollbacks", null, req, $scope).then(
+      // create the deployment config rollback
+      DataService.create("deploymentconfigrollbacks", null, req, context).then(
         function(newDeploymentConfig) {
           // update the deployment config based on the one returned by the rollback
-          DataService.update("deploymentconfigs", deploymentConfigName, newDeploymentConfig, $scope).then(
+          DataService.update("deploymentconfigs", deploymentConfigName, newDeploymentConfig, context).then(
             function(rolledBackDeploymentConfig) {
               $scope.alerts = $scope.alerts || {};
-              $scope.alerts["rollback"] = 
+              $scope.alerts["rollback"] =
                 {
                   type: "success",
                   message: "Deployment #" + rolledBackDeploymentConfig.status.latestVersion + " is rolling back " + deploymentConfigName + " to " + deploymentName + ".",
@@ -136,7 +136,7 @@ angular.module("openshiftConsole")
             },
             function(result) {
               $scope.alerts = $scope.alerts || {};
-              $scope.alerts["rollback"] = 
+              $scope.alerts["rollback"] =
                 {
                   type: "error",
                   message: "An error occurred while rolling back the deployment.",
@@ -146,8 +146,8 @@ angular.module("openshiftConsole")
           );
         },
         function(result) {
-          $scope.alerts = $scope.alerts || {};          
-          $scope.alerts["rollback"] = 
+          $scope.alerts = $scope.alerts || {};
+          $scope.alerts["rollback"] =
             {
               type: "error",
               message: "An error occurred while rolling back the deployment.",
@@ -157,9 +157,9 @@ angular.module("openshiftConsole")
       );
     };
 
-    DeploymentsService.prototype.cancelRunningDeployment = function(deployment, $scope) {
+    DeploymentsService.prototype.cancelRunningDeployment = function(deployment, context, $scope) {
       var deploymentName = deployment.metadata.name;
-      var deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');        
+      var deploymentConfigName = $filter('annotation')(deployment, 'deploymentConfig');
       var req = angular.copy(deployment);
 
       // TODO: we need a "cancel" api endpoint so we don't have to do this manually
@@ -171,10 +171,10 @@ angular.module("openshiftConsole")
       req.metadata.annotations[deploymentStatusReasonAnnotation] = "The deployment was cancelled by the user";
 
       // update the deployment with cancellation annotations
-      DataService.update("replicationcontrollers", deploymentName, req, $scope).then(
+      DataService.update("replicationcontrollers", deploymentName, req, context).then(
         function() {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["cancel"] = 
+          $scope.alerts["cancel"] =
             {
               type: "success",
               message: "Cancelling deployment " + deploymentName + " of " + deploymentConfigName + ".",
@@ -182,7 +182,7 @@ angular.module("openshiftConsole")
         },
         function(result) {
           $scope.alerts = $scope.alerts || {};
-          $scope.alerts["cancel"] = 
+          $scope.alerts["cancel"] =
             {
               type: "error",
               message: "An error occurred while cancelling the deployment.",

--- a/assets/app/scripts/services/projects.js
+++ b/assets/app/scripts/services/projects.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('openshiftConsole')
-  .factory('project', [
+  .factory('ProjectsService', [
     '$location',
     '$q',
     '$routeParams',
@@ -13,17 +13,22 @@ angular.module('openshiftConsole')
           return  AuthService
                     .withUser()
                     .then(function() {
+                      // basic compatibility w/previous impl with a controller
                       var context = {
                         // TODO: swap $.Deferred() for $q.defer()
+                        projectPromise: $.Deferred(),
                         projectName: projectName,
-                        projectPromise: $.Deferred()
+                        project: undefined
                       };
                       return DataService
-                              .get('projects', context.projectName, context, {errorNotification: false})
+                              .get('projects', projectName, context, {errorNotification: false})
                               .then(function(project) {
+                                context.project = project;
+                                // backwards compat
                                 context.projectPromise.resolve(project);
                                 // TODO: ideally would just return project, but DataService expects
-                                // context.projectPromise as a separate Deferred at this point.
+                                // context.projectPromise as a separate Deferred at this point
+                                // and ties mutliple requests together via this obj
                                 return [project, context];
                               }, function(e) {
                                 context.projectPromise.reject(e);
@@ -50,7 +55,6 @@ angular.module('openshiftConsole')
         };
     }
   ]);
-
 
 
 

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -1,4 +1,4 @@
-<div ng-controller="BuildConfigController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -1,4 +1,4 @@
-<div ng-controller="BuildController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -1,4 +1,4 @@
-<div ng-controller="DeploymentConfigController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -12,7 +12,7 @@
               <small class="meta">created <relative-timestamp timestamp="deployment.metadata.creationTimestamp"></relative-timestamp></small>
             </h1>
             <labels ng-if="deploymentConfigName" labels="deployment.metadata.labels" clickable="true" kind="deployments" title-kind="deployments for deployment config {{deploymentConfigName}}" project-name="{{deployment.metadata.namespace}}" limit="3" navigate-url="project/{{deployment.metadata.namespace}}/browse/deployments/{{deploymentConfigName}}"></labels>
-            <labels ng-if="!deploymentConfigName" labels="deployment.metadata.labels" clickable="true" kind="deployments" project-name="{{deployment.metadata.namespace}}" limit="3"></labels> 
+            <labels ng-if="!deploymentConfigName" labels="deployment.metadata.labels" clickable="true" kind="deployments" project-name="{{deployment.metadata.namespace}}" limit="3"></labels>
             <tabset>
               <tab active="selectedTab.details">
                 <tab-heading>Details</tab-heading>

--- a/assets/app/views/browse/image.html
+++ b/assets/app/views/browse/image.html
@@ -1,4 +1,4 @@
-<div ng-controller="ImageController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>
@@ -6,11 +6,11 @@
     <div class="tile" ng-if="imageStream">
       <h1>
         {{imageStream.metadata.name}}
-        <delete-button 
+        <delete-button
           class="pull-right fa-lg"
-          resource-type="imagestream" 
-          resource-name="{{imageStream.metadata.name}}" 
-          project-name="{{imageStream.metadata.namespace}}" 
+          resource-type="imagestream"
+          resource-name="{{imageStream.metadata.name}}"
+          project-name="{{imageStream.metadata.namespace}}"
           alerts="alerts">
         </delete-button>
         <small class="meta">created <relative-timestamp timestamp="imageStream.metadata.creationTimestamp"></relative-timestamp></small>
@@ -41,7 +41,7 @@
           <tr ng-repeat-start="tag in tagsByName | orderBy : 'name'">
             <td>{{tag.name}}</td>
             <td>
-              <!-- this value can get long when its an ImageStreamImage. Use max width and class truncate to elide some 
+              <!-- this value can get long when its an ImageStreamImage. Use max width and class truncate to elide some
                    of the SHA1 for long values. They can still be copied even when elided. -->
               <div style="max-width: 400px;" class="truncate">
                 <span ng-if="!tag.spec.from"><em>pushed</em></span>
@@ -64,7 +64,7 @@
                   <span ng-if="!tag.spec.from">Not yet synced</span>
                   <!-- We have no idea why in this case -->
                   <span ng-if="tag.spec.from">Unresolved</span>
-                </div>              
+                </div>
               </div>
               <div ng-if="tag.status">
                 <span ng-if="tag.status.items.length && tag.status.items[0].image">
@@ -85,7 +85,7 @@
               <div ng-if="tag.status.items.length && tag.status.items[0].dockerImageReference" style="max-width: 400px;" class="truncate"
                      ng-attr-title="{{tag.items[0].dockerImageReference}}">
                  {{tag.status.items[0].dockerImageReference}}
-              </div>              
+              </div>
             </td>
           </tr>
           <tr ng-repeat="item in tag.status.items" ng-if="tagShowOlder[tag.name] && !$first && item.image">
@@ -101,7 +101,7 @@
               <div ng-if="item.dockerImageReference" style="max-width: 400px;" class="truncate"
                      ng-attr-title="{{item.dockerImageReference}}">
                  {{item.dockerImageReference}}
-              </div>              
+              </div>
             </td>
           </tr>
           <tr ng-repeat-end style="display: none;"></tr>

--- a/assets/app/views/browse/route.html
+++ b/assets/app/views/browse/route.html
@@ -1,4 +1,4 @@
-<div ng-controller="RouteController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -1,4 +1,4 @@
-<div ng-controller="ServiceController" class="content">
+<div class="content">
   <project-page>
     <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
     <alerts alerts="alerts"></alerts>
@@ -9,11 +9,11 @@
           <div class="tile">
             <h1>
               {{service.metadata.name}}
-              <delete-button 
+              <delete-button
                 class="pull-right fa-lg"
-                resource-type="service" 
-                resource-name="{{service.metadata.name}}" 
-                project-name="{{service.metadata.namespace}}" 
+                resource-type="service"
+                resource-name="{{service.metadata.name}}"
+                project-name="{{service.metadata.namespace}}"
                 alerts="alerts">
               </delete-button>
               <small class="meta">created <relative-timestamp timestamp="service.metadata.creationTimestamp"></relative-timestamp></small>
@@ -79,7 +79,7 @@
                   </span>
                 </dd>
               </dl>
-              <annotations annotations="service.metadata.annotations"></annotations>            
+              <annotations annotations="service.metadata.annotations"></annotations>
             </div>
           </div> <!-- /tile -->
         </div> <!-- /col -->


### PR DESCRIPTION
@jwforres @spadgett this is pt3 of [breaking down this PR](https://github.com/openshift/origin/pull/5953).  In this one I'm renaming project to ProjectsService & updating all the controllers using it already.  I'm creating one more PR that updates all of the controllers where ProjectsService will be newly introduced.