### PR TITLE
added junitreport tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ test-int-plus: build
 endif
 test-int-plus:
 	hack/test-cmd.sh
+	hack/test-tools.sh
 	KUBE_RACE=" " hack/test-integration-docker.sh
 	hack/test-end-to-end-docker.sh
 ifeq ($(EXTENDED),true)

--- a/hack/test-tools.sh
+++ b/hack/test-tools.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This command runs any exposed integration tests for the developer tools
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+STARTTIME=$(date +%s)
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+cd "${OS_ROOT}"
+source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/cmd_util.sh"
+os::log::install_errexit
+
+for tool in ${OS_ROOT}/tools/*; do
+	test_file=${tool}/test/integration.sh
+	if [ -e ${test_file} ]; then
+		# if the tool exposes an integration test, run it
+		os::cmd::expect_success "${test_file}"
+	fi
+done
+
+echo "test-tools: ok"

--- a/tools/junitreport/.gitignore
+++ b/tools/junitreport/.gitignore
@@ -1,0 +1,1 @@
+junitreport

--- a/tools/junitreport/README.md
+++ b/tools/junitreport/README.md
@@ -1,0 +1,47 @@
+# junitreport
+
+`junitreport` is a tool that allows for the consumption of test output in order to create jUnit XML.
+
+## Installation
+
+In order to build and install `junitreport`, from the root of the OpenShift Origin repository, run `hack/build-go.sh tools/junitreport`. 
+
+## Usage 
+
+`junitreport` can read the output of different types of tests. Specify which output is being read with `--type=<type>`. Supported test output types currently include `'gotest'`, for `go test` output. The default test type is `'gotest'`. 
+
+`junitreport` can output flat or nested test suites. To choose which type of output to use, set `--suites=<type>` to either `'flat'` or `'nested'`. The default suite output structure is `'flat'`. When creating nested test suites, `junitreport` will use `/` as the delimeter between suite names: `github.com/maintainer/repository/suite` will be parsed as a hierarchy of `github.com`, `github.com/maintainer`, *etc.* If you are requesting nested test suite output but do not want the root suite(s) to be as general as `github.com`, for example, set `--roots=<root suite names>` to be a comma-delimited list of the names of the suites you wish to use as roots. If the parser encounters a package outside of those roots, it will ignore it. This allows a user to provide a root suite and only collect data for children of that root from a larger data set.
+
+Ensure that the output you are feeding `junitreport` is free of extraneous text - any lines that are not test/suite declarations, metadata, or results are interpreted as test output. Text that you do not expect to see in Jenkins, for example, while looking at the output of a failed test should not be included in the input to `junitreport`.
+
+Currently, `junitreport` does not support the parsing of parallel test output.
+
+### Examples
+
+To parse the output of `go test` into a flat collection of test suites:
+
+```sh
+
+$ go test -v -cover ./... | junitreport > report.xml
+```
+
+To parse the output of `go test` into a nested collection of test suites rooted at `github.com/maintainer`:
+
+```sh
+
+$ go test -v -cover ./... | junitreport --suites=nested --roots=github.com/maintainer > report.xml
+```
+
+### Testing
+
+`junitreport` has unit tests as well as integration tests. To run the unit tests from the `junitreport` root directory:
+
+```sh
+$ go test -v -cover ./...
+```
+
+To run the integration tests from the `junitreport` root directory:
+
+```sh
+$ test/integration.sh
+```

--- a/tools/junitreport/junitreport.go
+++ b/tools/junitreport/junitreport.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/cmd"
+)
+
+var (
+	// parserType is a flag that holds the type of parser to use
+	parserType string
+
+	// builderType is a flag that holds the type of builder to use
+	builderType string
+
+	// rootSuites is a flag that holds the comma-delimited list of root suite names
+	rootSuites string
+
+	// testOutputFile is a flag that holds the path to the file containing test output
+	testOutputFile string
+)
+
+const (
+	defaultParserType     = "gotest"
+	defaultBuilderType    = "flat"
+	defaultTestOutputFile = "/dev/stdin"
+)
+
+func init() {
+	flag.StringVar(&parserType, "type", defaultParserType, "which type of test output to parse")
+	flag.StringVar(&builderType, "suites", defaultBuilderType, "which test suite structure to use")
+	flag.StringVar(&rootSuites, "roots", "", "comma-delimited list of root suite names")
+	flag.StringVar(&testOutputFile, "f", defaultTestOutputFile, "the path to the file containing test output to consume")
+}
+
+const (
+	junitReportUsageLong = `Consume test output to create jUnit XML files and summarize jUnit XML files.
+
+%[1]s consumes test output through Stdin and creates jUnit XML files. Currently, only the output of 'go test'
+is supported. jUnit XML can be build with nested or flat test suites. Sub-trees of test suites can be selected
+when using the nested test-suites representation to only build XML for some subset of the test output. This
+parser is greedy, so all output not directly related to a test suite is considered test case output.
+`
+
+	junitReportUsage = `Usage:
+  %[1]s [--type=TEST-OUTPUT-TYPE] [--suites=SUITE-TYPE] [-f=FILE]
+  %[1]s [-f=FILE] summarize
+`
+
+	junitReportExamples = `Examples:
+  # Consume 'go test' output to create a jUnit XML file
+  $ go test -v -cover ./... | %[1]s > report.xml
+
+  # Consume 'go test' output from a file to create a jUnit XML file
+  $ %[1]s -f testoutput.txt > report.xml
+
+  # Consume 'go test' output to create a jUnit XML file with nested test suites
+  $ go test -v -cover ./... | junitreport --suites=nested > report.xml
+
+  # Consume 'go test' output to create a jUnit XML file with nested test suites rooted at 'github.com/maintainer'
+  $ go test -v -cover ./... | junitreport --suites=nested --roots=github.com/maintainer > report.xml
+
+  # Describe failures and skipped tests in an existing jUnit XML file
+  $ cat report.xml | %[1]s summarize
+`
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, junitReportUsageLong+"\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, junitReportUsage+"\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, junitReportExamples+"\n", os.Args[0])
+		fmt.Fprintln(os.Stderr, "Options:")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	flag.Parse()
+
+	var rootSuiteNames []string
+	if len(rootSuites) > 0 {
+		rootSuiteNames = strings.Split(rootSuites, ",")
+	}
+
+	var input io.Reader
+	if testOutputFile == defaultTestOutputFile {
+		input = os.Stdin
+	} else {
+		file, err := os.Open(testOutputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading input file: %v\n", err)
+		}
+		defer file.Close()
+		input = file
+	}
+
+	arguments := flag.Args()
+	// If we are asked to summarize an XML file, that is all we do
+	if len(arguments) == 1 && arguments[0] == "summarize" {
+		summary, err := cmd.Summarize(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error summarizing jUnit XML file: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprint(os.Stdout, summary)
+		os.Exit(0)
+	}
+	if len(arguments) > 1 {
+		fmt.Fprintf(os.Stderr, "Incorrect usage of %[1]s, see '%[1]s --help' for more details.\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	// Otherwise, we get ready to parse and generate XML output.
+	options := cmd.JUnitReportOptions{
+		Input:  input,
+		Output: os.Stdout,
+	}
+
+	err := options.Complete(builderType, parserType, rootSuiteNames)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing flags: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = options.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating output: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tools/junitreport/pkg/api/string.go
+++ b/tools/junitreport/pkg/api/string.go
@@ -1,0 +1,37 @@
+package api
+
+import "fmt"
+
+// This file implements Stringer for the API types for ease of debugging
+
+func (t *TestSuites) String() string {
+	return fmt.Sprintf("Test Suites with suites: %s.", t.Suites)
+}
+
+func (t *TestSuite) String() string {
+	childDescriptions := []string{}
+	for _, child := range t.Children {
+		childDescriptions = append(childDescriptions, child.String())
+	}
+	return fmt.Sprintf("Test Suite %q with properties: %s, %d test cases, of which %d failed and %d were skipped: %s, and children: %s.", t.Name, t.Properties, t.NumTests, t.NumFailed, t.NumSkipped, t.TestCases, childDescriptions)
+}
+
+func (t *TestCase) String() string {
+	var result, message, output string
+	result = "passed"
+	if t.SkipMessage != nil {
+		result = "skipped"
+		message = t.SkipMessage.Message
+	}
+	if t.FailureOutput != nil {
+		result = "failed"
+		message = t.FailureOutput.Message
+		output = t.FailureOutput.Output
+	}
+
+	return fmt.Sprintf("Test Case %q %s after %f seconds with message %q and output %q.", t.Name, result, t.Duration, message, output)
+}
+
+func (p *TestSuiteProperty) String() string {
+	return fmt.Sprintf("%q=%q", p.Name, p.Value)
+}

--- a/tools/junitreport/pkg/api/test_case.go
+++ b/tools/junitreport/pkg/api/test_case.go
@@ -1,0 +1,30 @@
+package api
+
+import "time"
+
+// SetDuration sets the runtime duration of the test case
+func (t *TestCase) SetDuration(duration string) error {
+	parsedDuration, err := time.ParseDuration(duration)
+	if err != nil {
+		return err
+	}
+
+	// we round to the millisecond on duration
+	t.Duration = float64(int(parsedDuration.Seconds()*1000)) / 1000
+	return nil
+}
+
+// MarkSkipped marks the test as skipped with the given message
+func (t *TestCase) MarkSkipped(message string) {
+	t.SkipMessage = &SkipMessage{
+		Message: message,
+	}
+}
+
+// MarkFailed marks the test as failed with the given message and output
+func (t *TestCase) MarkFailed(message, output string) {
+	t.FailureOutput = &FailureOutput{
+		Message: message,
+		Output:  output,
+	}
+}

--- a/tools/junitreport/pkg/api/test_suite.go
+++ b/tools/junitreport/pkg/api/test_suite.go
@@ -1,0 +1,41 @@
+package api
+
+import "time"
+
+// AddProperty adds a property to the test suite
+func (t *TestSuite) AddProperty(name, value string) {
+	t.Properties = append(t.Properties, &TestSuiteProperty{Name: name, Value: value})
+}
+
+// AddTestCase adds a test case to the test suite and updates test suite metrics as necessary
+func (t *TestSuite) AddTestCase(testCase *TestCase) {
+	t.NumTests += 1
+
+	if testCase.SkipMessage != nil {
+		t.NumSkipped += 1
+	}
+
+	if testCase.FailureOutput != nil {
+		t.NumFailed += 1
+	}
+
+	t.Duration += testCase.Duration
+	// we round to the millisecond on duration
+	t.Duration = float64(int(t.Duration*1000)) / 1000
+
+	t.TestCases = append(t.TestCases, testCase)
+}
+
+// SetDuration sets the duration of the test suite if this value is not calculated by aggregating the durations
+// of all of the substituent test cases. This should *not* be used if the total duration of the test suite is
+// calculated as that sum, as AddTestCase will handle that case.
+func (t *TestSuite) SetDuration(duration string) error {
+	parsedDuration, err := time.ParseDuration(duration)
+	if err != nil {
+		return err
+	}
+
+	// we round to the millisecond on duration
+	t.Duration = float64(int(parsedDuration.Seconds()*1000)) / 1000
+	return nil
+}

--- a/tools/junitreport/pkg/api/types.go
+++ b/tools/junitreport/pkg/api/types.go
@@ -1,0 +1,98 @@
+package api
+
+import "encoding/xml"
+
+// The below types are directly marshalled into XML. The types correspond to jUnit
+// XML schema, but do not contain all valid fields. For instance, the class name
+// field for test cases is omitted, as this concept does not directly apply to Go.
+// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+
+// TestSuites represents a flat collection of jUnit test suites.
+type TestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	// Suites are the jUnit test suites held in this collection
+	Suites []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuite represents a single jUnit test suite, potentially holding child suites.
+type TestSuite struct {
+	XMLName xml.Name `xml:"testsuite"`
+
+	// Name is the name of the test suite
+	Name string `xml:"name,attr"`
+
+	// NumTests records the number of tests in the TestSuite
+	NumTests uint `xml:"tests,attr"`
+
+	// NumSkipped records the number of skipped tests in the suite
+	NumSkipped uint `xml:"skipped,attr"`
+
+	// NumFailed records the number of failed tests in the suite
+	NumFailed uint `xml:"failures,attr"`
+
+	// Duration is the time taken in seconds to run all tests in the suite
+	Duration float64 `xml:"time,attr"`
+
+	// Properties holds other properties of the test suite as a mapping of name to value
+	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+
+	// TestCases are the test cases contained in the test suite
+	TestCases []*TestCase `xml:"testcase"`
+
+	// Children holds nested test suites
+	Children []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuiteProperty contains a mapping of a property name to a value
+type TestSuiteProperty struct {
+	XMLName xml.Name `xml:"propery"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// TestCase represents a jUnit test case
+type TestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+
+	// Name is the name of the test case
+	Name string `xml:"name,attr"`
+
+	// Duration is the time taken in seconds to run the test
+	Duration float64 `xml:"time,attr"`
+
+	// SkipMessage holds the reason why the test was skipped
+	SkipMessage *SkipMessage `xml:"skipped"`
+
+	// FailureOutput holds the output from a failing test
+	FailureOutput *FailureOutput `xml:"failure"`
+}
+
+// SkipMessage holds a message explaining why a test was skipped
+type SkipMessage struct {
+	XMLName xml.Name `xml:"skipped"`
+
+	// Message explains why the test was skipped
+	Message string `xml:"message,attr"`
+}
+
+// FailureOutput holds the output from a failing test
+type FailureOutput struct {
+	XMLName xml.Name `xml:"failure"`
+
+	// Message holds the failure message from the test
+	Message string `xml:"message,attr"`
+
+	// Output holds verbose failure output from the test
+	Output string `xml:",chardata"`
+}
+
+// TestResult is the result of a test case
+type TestResult string
+
+const (
+	TestResultPass TestResult = "pass"
+	TestResultSkip TestResult = "skip"
+	TestResultFail TestResult = "fail"
+)

--- a/tools/junitreport/pkg/builder/flat/test_suites_builder.go
+++ b/tools/junitreport/pkg/builder/flat/test_suites_builder.go
@@ -1,0 +1,30 @@
+package flat
+
+import (
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder"
+)
+
+// NewTestSuitesBuilder returns a new flat test suites builder. All test suites consumed
+// by this builder will be added to a flat list of suites - no suites will be children of other suites
+func NewTestSuitesBuilder() builder.TestSuitesBuilder {
+	return &flatTestSuitesBuilder{
+		testSuites: &api.TestSuites{},
+	}
+}
+
+// flatTestSuitesBuilder is a test suites builder that does not nest suites
+type flatTestSuitesBuilder struct {
+	testSuites *api.TestSuites
+}
+
+// AddSuite adds a test suite to the test suites collection being built
+func (b *flatTestSuitesBuilder) AddSuite(suite *api.TestSuite) error {
+	b.testSuites.Suites = append(b.testSuites.Suites, suite)
+	return nil
+}
+
+// Build releases the test suites collection being built at whatever current state it is in
+func (b *flatTestSuitesBuilder) Build() *api.TestSuites {
+	return b.testSuites
+}

--- a/tools/junitreport/pkg/builder/flat/test_suites_builder_test.go
+++ b/tools/junitreport/pkg/builder/flat/test_suites_builder_test.go
@@ -1,0 +1,75 @@
+package flat
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+func TestAddSuite(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		seedSuites     *api.TestSuites
+		suitesToAdd    []*api.TestSuite
+		expectedSuites *api.TestSuites
+	}{
+		{
+			name: "empty",
+			suitesToAdd: []*api.TestSuite{
+				{
+					Name: "testSuite",
+				},
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "testSuite",
+					},
+				},
+			},
+		},
+		{
+			name: "populated",
+			seedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "testSuite",
+					},
+				},
+			},
+			suitesToAdd: []*api.TestSuite{
+				{
+					Name: "testSuite2",
+				},
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "testSuite",
+					},
+					{
+						Name: "testSuite2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		builder := NewTestSuitesBuilder()
+		if testCase.seedSuites != nil {
+			builder.(*flatTestSuitesBuilder).testSuites = testCase.seedSuites
+		}
+
+		for _, suite := range testCase.suitesToAdd {
+			if err := builder.AddSuite(suite); err != nil {
+				t.Errorf("%s: unexpected error adding test suite: %v", testCase.name, err)
+			}
+		}
+
+		if expected, actual := testCase.expectedSuites, builder.Build(); !reflect.DeepEqual(expected, actual) {
+			t.Errorf("%s: did not correctly add suites:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, expected, actual)
+		}
+	}
+}

--- a/tools/junitreport/pkg/builder/interfaces.go
+++ b/tools/junitreport/pkg/builder/interfaces.go
@@ -1,0 +1,12 @@
+package builder
+
+import "github.com/openshift/origin/tools/junitreport/pkg/api"
+
+// TestSuitesBuilder knows how to aggregate data to form a collection of test suites.
+type TestSuitesBuilder interface {
+	// AddSuite adds a test suite to the collection
+	AddSuite(suite *api.TestSuite) error
+
+	// Build retuns the built structure
+	Build() *api.TestSuites
+}

--- a/tools/junitreport/pkg/builder/nested/test_suites_builder.go
+++ b/tools/junitreport/pkg/builder/nested/test_suites_builder.go
@@ -1,0 +1,181 @@
+package nested
+
+import (
+	"strings"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder"
+	"github.com/openshift/origin/tools/junitreport/pkg/errors"
+)
+
+// NewTestSuitesBuilder returns a new nested test suites builder. All test suites consumed by
+// this builder will be added to a multitree of suites rooted at the suites with the given names.
+func NewTestSuitesBuilder(rootSuiteNames []string) builder.TestSuitesBuilder {
+	rootSuites := []*api.TestSuite{}
+	for _, name := range rootSuiteNames {
+		rootSuites = append(rootSuites, &api.TestSuite{Name: name})
+	}
+
+	return &nestedTestSuitesBuilder{
+		restrictedRoots: len(rootSuites) > 0, // i given they are the only roots allowed
+		testSuites: &api.TestSuites{
+			Suites: rootSuites,
+		},
+	}
+}
+
+const (
+	// TestSuiteNameDelimiter is the default delimeter for test suite names
+	TestSuiteNameDelimiter = "/"
+)
+
+// nestedTestSuitesBuilder is a test suites builder that nests suites under a root suite
+type nestedTestSuitesBuilder struct {
+	// restrictedRoots determines if the builder is able to add new roots to the tree or if all
+	// new suits are to be added only if they are leaves of the original set of roots created
+	// by the constructor
+	restrictedRoots bool
+
+	testSuites *api.TestSuites
+}
+
+// AddSuite adds a test suite to the test suites collection being built if the suite is not in
+// the collection, otherwise it overwrites the current record of the suite in the collection. In
+// both cases, it updates the metrics of any parent suites to include those of the new suite. If
+// the parent of the test suite to be added is found in the collection, the test suite is added
+// as a child of that suite. Otherwise, parent suites are created by successively removing one
+// layer of package specificity until the root name is found. For instance, if the suite named
+// "root/package/subpackage/subsubpackage" were to be added to an empty collection, the suites
+// named "root", "root/package", and "root/package/subpackage" would be created and added first,
+// then the suite could be added as a child of the latter parent package. If roots are restricted,
+// then test suites to be added are asssumed to be nested under one of the root suites created by
+// the constructor method and the attempted addition of a suite not rooted in those suites will
+// fail silently to allow for selective tree-building given a root.
+func (b *nestedTestSuitesBuilder) AddSuite(suite *api.TestSuite) error {
+	if recordedSuite := b.findSuite(suite.Name); recordedSuite != nil {
+		// if we are trying to add a suite that already exists, we just need to overwrite our
+		// current record with the data in the new suite to be added
+		recordedSuite.NumTests = suite.NumTests
+		recordedSuite.NumSkipped = suite.NumSkipped
+		recordedSuite.NumFailed = suite.NumFailed
+		recordedSuite.Duration = suite.Duration
+		recordedSuite.Properties = suite.Properties
+		recordedSuite.TestCases = suite.TestCases
+		recordedSuite.Children = suite.Children
+		return nil
+	}
+
+	if err := b.addToParent(suite); err != nil {
+		if errors.IsSuiteOutOfBoundsError(err) {
+			// if we were trying to add something out of bounds, we ignore the request but do not
+			// throw an error so we can selectively build sub-trees with a set of specified roots
+			return nil
+		}
+		return err
+	}
+
+	b.updateMetrics(suite)
+
+	return nil
+}
+
+// addToParent will find or create the parent for the test suite and add the given suite as a child
+func (b *nestedTestSuitesBuilder) addToParent(child *api.TestSuite) error {
+	name := child.Name
+	if !b.isChildOfRoots(name) && b.restrictedRoots {
+		// if we were asked to add a new test suite that isn't a child of any current root,
+		// and we aren't allowed to add new roots, we can't fulfill this request
+		return errors.NewSuiteOutOfBoundsError(name)
+	}
+
+	parentName := getParentName(name)
+	if len(parentName) == 0 {
+		// this suite does not have a parent, we just need to add it as a root
+		b.testSuites.Suites = append(b.testSuites.Suites, child)
+		return nil
+	}
+
+	parent := b.findSuite(parentName)
+	if parent == nil {
+		// no parent is currently registered, we need to create it and add it to the tree
+		parent = &api.TestSuite{
+			Name:     parentName,
+			Children: []*api.TestSuite{child},
+		}
+
+		return b.addToParent(parent)
+	}
+
+	parent.Children = append(parent.Children, child)
+	return nil
+}
+
+// getParentName returns the name of the parent package, if it exists in the multitree
+func getParentName(name string) string {
+	if !strings.Contains(name, TestSuiteNameDelimiter) {
+		return ""
+	}
+
+	delimeterIndex := strings.LastIndex(name, TestSuiteNameDelimiter)
+	return name[0:delimeterIndex]
+}
+
+func (b *nestedTestSuitesBuilder) isChildOfRoots(name string) bool {
+	for _, rootSuite := range b.testSuites.Suites {
+		if strings.HasPrefix(name, rootSuite.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// findSuite finds a test suite in a collection of test suites
+func (b *nestedTestSuitesBuilder) findSuite(name string) *api.TestSuite {
+	return findSuite(b.testSuites.Suites, name)
+}
+
+// findSuite walks a test suite tree to find a test suite with the given name
+func findSuite(suites []*api.TestSuite, name string) *api.TestSuite {
+	for _, suite := range suites {
+		if suite.Name == name {
+			return suite
+		}
+
+		if strings.HasPrefix(name, suite.Name) {
+			return findSuite(suite.Children, name)
+		}
+	}
+
+	return nil
+}
+
+// updateMetrics updates the metrics for all parents of a test suite
+func (b *nestedTestSuitesBuilder) updateMetrics(newSuite *api.TestSuite) {
+	updateMetrics(b.testSuites.Suites, newSuite)
+}
+
+// updateMetrics walks a test suite tree to update metrics of parents of the given suite
+func updateMetrics(suites []*api.TestSuite, newSuite *api.TestSuite) {
+	for _, suite := range suites {
+		if suite.Name == newSuite.Name || !strings.HasPrefix(newSuite.Name, suite.Name) {
+			// if we're considering the suite itself or another suite that is not a pure
+			// prefix of the new suite, we are not considering a parent suite and therefore
+			// do not need to update any metrics
+			continue
+		}
+
+		suite.NumTests += newSuite.NumTests
+		suite.NumSkipped += newSuite.NumSkipped
+		suite.NumFailed += newSuite.NumFailed
+		suite.Duration += newSuite.Duration
+		// we round to the millisecond on duration
+		suite.Duration = float64(int(suite.Duration*1000)) / 1000
+
+		updateMetrics(suite.Children, newSuite)
+	}
+}
+
+// Build releases the test suites collection being built at whatever current state it is in
+func (b *nestedTestSuitesBuilder) Build() *api.TestSuites {
+	return b.testSuites
+}

--- a/tools/junitreport/pkg/builder/nested/test_suites_builder_test.go
+++ b/tools/junitreport/pkg/builder/nested/test_suites_builder_test.go
@@ -1,0 +1,182 @@
+package nested
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+func TestGetParentName(t *testing.T) {
+	var testCases = []struct {
+		name               string
+		testName           string
+		expectedParentName string
+	}{
+		{
+			name:               "no parent",
+			testName:           "root",
+			expectedParentName: "",
+		},
+		{
+			name:               "one parent",
+			testName:           "root/package",
+			expectedParentName: "root",
+		},
+		{
+			name:               "many parents",
+			testName:           "root/package/subpackage/etc",
+			expectedParentName: "root/package/subpackage",
+		},
+	}
+
+	for _, testCase := range testCases {
+		if actual, expected := getParentName(testCase.testName), testCase.expectedParentName; actual != expected {
+			t.Errorf("%s: did not get correct parent name for test name: expected: %q, got %q", testCase.name, expected, actual)
+		}
+	}
+}
+
+func TestAddSuite(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		rootSuiteNames []string
+		seedSuites     *api.TestSuites
+		suiteToAdd     *api.TestSuite
+		expectedSuites *api.TestSuites
+	}{
+		{
+			name: "empty adding root",
+			suiteToAdd: &api.TestSuite{
+				Name: "root",
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "root",
+					},
+				},
+			},
+		},
+		{
+			name: "empty adding child",
+			suiteToAdd: &api.TestSuite{
+				Name: "root/child",
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "root",
+						Children: []*api.TestSuite{
+							{
+								Name: "root/child",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "empty with bounds, adding out of bounds",
+			rootSuiteNames: []string{"someotherroot"},
+			suiteToAdd: &api.TestSuite{
+				Name: "root/child",
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "someotherroot",
+					},
+				},
+			},
+		},
+		{
+			name: "populated adding child",
+			seedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "root",
+					},
+				},
+			},
+			suiteToAdd: &api.TestSuite{
+				Name: "root/child",
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "root",
+						Children: []*api.TestSuite{
+							{
+								Name: "root/child",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "empty with bounds, adding in bounds",
+			rootSuiteNames: []string{"root"},
+			suiteToAdd: &api.TestSuite{
+				Name: "root/child/grandchild",
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name: "root",
+						Children: []*api.TestSuite{
+							{
+								Name: "root/child",
+								Children: []*api.TestSuite{
+									{
+										Name: "root/child/grandchild",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "populated overwriting record",
+			seedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "root",
+						NumTests: 3,
+					},
+				},
+			},
+			suiteToAdd: &api.TestSuite{
+				Name:     "root",
+				NumTests: 4,
+			},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "root",
+						NumTests: 4,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		builder := NewTestSuitesBuilder(testCase.rootSuiteNames)
+
+		if testCase.seedSuites != nil {
+			builder.(*nestedTestSuitesBuilder).testSuites = testCase.seedSuites
+		}
+
+		if err := builder.AddSuite(testCase.suiteToAdd); err != nil {
+			t.Errorf("%s: unexpected error adding suite to suites: %v", testCase.name, err)
+		}
+
+		if actual, expected := builder.Build(), testCase.expectedSuites; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: did not get correct test suites after addition of test suite:\n\texpected:\n\t%s,\n\tgot\n\t%s", testCase.name, expected, actual)
+		}
+	}
+}

--- a/tools/junitreport/pkg/cmd/junitreport.go
+++ b/tools/junitreport/pkg/cmd/junitreport.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"io"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/builder"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder/flat"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser/gotest"
+)
+
+type testSuitesBuilderType string
+
+const (
+	flatBuilderType   testSuitesBuilderType = "flat"
+	nestedBuilderType testSuitesBuilderType = "nested"
+)
+
+var supportedBuilderTypes = []testSuitesBuilderType{flatBuilderType, nestedBuilderType}
+
+type testParserType string
+
+const (
+	goTestParserType testParserType = "gotest"
+)
+
+var supportedTestParserTypes = []testParserType{goTestParserType}
+
+type JUnitReportOptions struct {
+	// BuilderType is the type of test suites builder to use
+	BuilderType testSuitesBuilderType
+
+	// RootSuiteNames is a list of root suites to be used for nested test suite output if
+	// the root suite is to be more specific than the suite name without any suite delimeters
+	// i.e. if `github.com/owner/repo` is to be used instead of `github.com`
+	RootSuiteNames []string
+
+	// ParserType is the parser type that will be used to parse test output
+	ParserType testParserType
+
+	// Input is the reader for the test output to be parsed
+	Input io.Reader
+
+	// Output is the writer for the file to which the XML is written
+	Output io.Writer
+}
+
+func (o *JUnitReportOptions) Complete(builderType, parserType string, rootSuiteNames []string) error {
+	switch testSuitesBuilderType(builderType) {
+	case flatBuilderType:
+		o.BuilderType = flatBuilderType
+	case nestedBuilderType:
+		o.BuilderType = nestedBuilderType
+	default:
+		return fmt.Errorf("unrecognized test suites builder type: got %s, expected one of %v", builderType, supportedBuilderTypes)
+	}
+
+	switch testParserType(parserType) {
+	case goTestParserType:
+		o.ParserType = goTestParserType
+	default:
+		return fmt.Errorf("unrecognized test parser type: got %s, expected one of %v", parserType, supportedTestParserTypes)
+	}
+
+	o.RootSuiteNames = rootSuiteNames
+
+	return nil
+}
+
+func (o *JUnitReportOptions) Run() error {
+	var builder builder.TestSuitesBuilder
+	switch o.BuilderType {
+	case flatBuilderType:
+		builder = flat.NewTestSuitesBuilder()
+	case nestedBuilderType:
+		builder = nested.NewTestSuitesBuilder(o.RootSuiteNames)
+	}
+
+	var testParser parser.TestOutputParser
+	switch o.ParserType {
+	case goTestParserType:
+		testParser = gotest.NewParser(builder)
+	}
+
+	testSuites, err := testParser.Parse(bufio.NewScanner(o.Input))
+	if err != nil {
+		return err
+	}
+
+	_, err = io.WriteString(o.Output, xml.Header)
+	if err != nil {
+		return fmt.Errorf("error writing XML header to file: %v", err)
+	}
+
+	encoder := xml.NewEncoder(o.Output)
+	encoder.Indent("", "\t") // no prefix, indent with tabs
+
+	if err := encoder.Encode(testSuites); err != nil {
+		return fmt.Errorf("error encoding test suites to XML: %v", err)
+	}
+
+	_, err = io.WriteString(o.Output, "\n")
+	if err != nil {
+		return fmt.Errorf("error writing last newline to file: %v", err)
+	}
+
+	return nil
+}

--- a/tools/junitreport/pkg/cmd/summarize.go
+++ b/tools/junitreport/pkg/cmd/summarize.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+// Summarize reads the input into a TestSuites structure and summarizes the tests contained within,
+// bringing attention to tests that did not succeed.
+func Summarize(input io.Reader) (string, error) {
+	var testSuites api.TestSuites
+	if err := xml.NewDecoder(input).Decode(&testSuites); err != nil {
+		return "", err
+	}
+
+	var summary bytes.Buffer
+	var numTests, numFailed, numSkipped uint
+	var duration float64
+	for _, testSuite := range testSuites.Suites {
+		numTests += testSuite.NumTests
+		numFailed += testSuite.NumFailed
+		numSkipped += testSuite.NumSkipped
+		duration += testSuite.Duration
+	}
+
+	verb := "were"
+	if numSkipped == 1 {
+		verb = "was"
+	}
+	summary.WriteString(fmt.Sprintf("Of %d tests executed in %.3fs, %d succeeded, %d failed, and %d %s skipped.\n\n", numTests, duration, (numTests - numFailed - numSkipped), numFailed, numSkipped, verb))
+
+	for _, testSuite := range testSuites.Suites {
+		summarizeTests(testSuite, &summary)
+	}
+
+	return summary.String(), nil
+}
+
+func summarizeTests(testSuite *api.TestSuite, summary *bytes.Buffer) {
+	for _, testCase := range testSuite.TestCases {
+		if testCase.FailureOutput != nil {
+			summary.WriteString(fmt.Sprintf("In suite %q, test case %q failed:\n%s\n\n", testSuite.Name, testCase.Name, testCase.FailureOutput.Output))
+		}
+		if testCase.SkipMessage != nil {
+			summary.WriteString(fmt.Sprintf("In suite %q, test case %q was skipped:\n%s\n\n", testSuite.Name, testCase.Name, testCase.SkipMessage.Message))
+		}
+	}
+
+	for _, childSuite := range testSuite.Children {
+		summarizeTests(childSuite, summary)
+	}
+}

--- a/tools/junitreport/pkg/errors/errors.go
+++ b/tools/junitreport/pkg/errors/errors.go
@@ -1,0 +1,31 @@
+package errors
+
+import "fmt"
+
+// NewSuiteOutOfBoundsError returns a new SuiteOutOfBounds error for the given suite name
+func NewSuiteOutOfBoundsError(name string) error {
+	return &suiteOutOfBoundsError{
+		suiteName: name,
+	}
+}
+
+// suiteOutOfBoundsError describes the failure to place a test suite into a test suite tree because the suite
+// in question is not a child of any suite in the tree
+type suiteOutOfBoundsError struct {
+	suiteName string
+}
+
+func (e *suiteOutOfBoundsError) Error() string {
+	return fmt.Sprintf("the test suite %q could not be placed under any existing roots in the tree", e.suiteName)
+}
+
+// IsSuiteOutOfBoundsError determines if the given error was raised because a suite could not be placed
+// in the test suite tree
+func IsSuiteOutOfBoundsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*suiteOutOfBoundsError)
+	return ok
+}

--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -1,0 +1,130 @@
+package gotest
+
+import (
+	"regexp"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+func newTestDataParser() testDataParser {
+	return testDataParser{
+		// testStartPattern matches the line in verbose `go test` output that marks the declaration of a test.
+		// The first submatch of this regex is the name of the test
+		testStartPattern: regexp.MustCompile(`=== RUN\s+(.+)$`),
+
+		// testResultPattern matches the line in verbose `go test` output that marks the result of a test.
+		// The first submatch of this regex is the result of the test (PASS, FAIL, or SKIP)
+		// The second submatch of this regex is the name of the test
+		// The third submatch of this regex is the time taken in seconds for the test to finish
+		testResultPattern: regexp.MustCompile(`--- (PASS|FAIL|SKIP):\s+(.+)\s+\((\d+\.\d+)(s| seconds)\)`),
+	}
+}
+
+type testDataParser struct {
+	testStartPattern  *regexp.Regexp
+	testResultPattern *regexp.Regexp
+}
+
+// MarksBeginning determines if the line marks the begining of a test case
+func (p *testDataParser) MarksBeginning(line string) bool {
+	return p.testStartPattern.MatchString(line)
+}
+
+// ExtractName extracts the name of the test case from test output line
+func (p *testDataParser) ExtractName(line string) (string, bool) {
+	if matches := p.testStartPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[1]) > 0 {
+		return matches[1], true
+	}
+
+	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[2]) > 0 {
+		return matches[2], true
+	}
+
+	return "", false
+}
+
+// ExtractResult extracts the test result from a test output line
+func (p *testDataParser) ExtractResult(line string) (api.TestResult, bool) {
+	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[1]) > 0 {
+		switch matches[1] {
+		case "PASS":
+			return api.TestResultPass, true
+		case "SKIP":
+			return api.TestResultSkip, true
+		case "FAIL":
+			return api.TestResultFail, true
+		}
+	}
+	return "", false
+}
+
+// ExtractDuration extracts the test duration from a test output line
+func (p *testDataParser) ExtractDuration(line string) (string, bool) {
+	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 2 && len(matches[3]) > 0 {
+		return matches[3] + "s", true
+	}
+	return "", false
+}
+
+func newTestSuiteDataParser() testSuiteDataParser {
+	return testSuiteDataParser{
+		// coverageOutputPattern matches coverage output on a single line.
+		// The first submatch of this regex is the percent coverage
+		coverageOutputPattern: regexp.MustCompile(`coverage:\s+(\d+\.\d+)\% of statements`),
+
+		// packageResultPattern matches the `go test` output for the end of a package.
+		// The first submatch of this regex matches the result of the test (ok or FAIL)
+		// The second submatch of this regex matches the name of the package
+		// The third submatch of this regex matches the time taken in seconds for tests in the package to finish
+		// The sixth (optional) submatch of this regex is the percent coverage
+		packageResultPattern: regexp.MustCompile(`(ok|FAIL)\s+(.+)[\s\t]+(\d+\.\d+(s| seconds))([\s\t]+coverage:\s+(\d+\.\d+)\% of statements)?`),
+	}
+}
+
+type testSuiteDataParser struct {
+	coverageOutputPattern *regexp.Regexp
+	packageResultPattern  *regexp.Regexp
+}
+
+// ExtractName extracts the name of the test suite from a test output line
+func (p *testSuiteDataParser) ExtractName(line string) (string, bool) {
+	if matches := p.packageResultPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[2]) > 0 {
+		return matches[2], true
+	}
+	return "", false
+}
+
+// ExtractDuration extracts the package duration from a test output line
+func (p *testSuiteDataParser) ExtractDuration(line string) (string, bool) {
+	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 2 && len(resultMatches[3]) > 0 {
+		return resultMatches[3], true
+	}
+	return "", false
+}
+
+const (
+	coveragePropertyName string = "coverage.statements.pct"
+)
+
+// ExtractProperties extracts any metadata properties of the test suite from a test output line
+func (p *testSuiteDataParser) ExtractProperties(line string) (map[string]string, bool) {
+	// the only test suite properties that Go testing can create are coverage values, which can either
+	// be present on their own line or in the package result line
+	if matches := p.coverageOutputPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[1]) > 0 {
+		return map[string]string{
+			coveragePropertyName: matches[1],
+		}, true
+	}
+
+	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 5 && len(resultMatches[6]) > 0 {
+		return map[string]string{
+			coveragePropertyName: resultMatches[6],
+		}, true
+	}
+	return map[string]string{}, false
+}
+
+// MarksCompletion determines if the line marks the completion of a test suite
+func (p *testSuiteDataParser) MarksCompletion(line string) bool {
+	return p.packageResultPattern.MatchString(line)
+}

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -1,0 +1,306 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+func TestMarksTestBeginning(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		testLine string
+	}{
+		{
+			name:     "basic",
+			testLine: "=== RUN TestName",
+		},
+		{
+			name:     "numeric",
+			testLine: "=== RUN 1234",
+		},
+		{
+			name:     "url",
+			testLine: "=== RUN github.com/maintainer/repository/package/file",
+		},
+		{
+			name:     "failed print",
+			testLine: "some other text=== RUN github.com/maintainer/repository/package/file",
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestDataParser()
+
+		if !parser.MarksBeginning(testCase.testLine) {
+			t.Errorf("%s: did not correctly determine that line %q marked test beginning", testCase.name, testCase.testLine)
+		}
+	}
+}
+
+func TestExtractTestName(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		testLine     string
+		expectedName string
+	}{
+		{
+			name:         "basic start",
+			testLine:     "=== RUN TestName",
+			expectedName: "TestName",
+		},
+		{
+			name:         "numeric",
+			testLine:     "=== RUN 1234",
+			expectedName: "1234",
+		},
+		{
+			name:         "url",
+			testLine:     "=== RUN github.com/maintainer/repository/package/file",
+			expectedName: "github.com/maintainer/repository/package/file",
+		},
+		{
+			name:         "basic end",
+			testLine:     "--- PASS: Test (0.10 seconds)",
+			expectedName: "Test",
+		},
+		{
+			name:         "go1.5.1 timing",
+			testLine:     "--- PASS: TestTwo (0.03s)",
+			expectedName: "TestTwo",
+		},
+		{
+			name:         "skip",
+			testLine:     "--- SKIP: Test (0.10 seconds)",
+			expectedName: "Test",
+		},
+		{
+			name:         "fail",
+			testLine:     "--- FAIL: Test (0.10 seconds)",
+			expectedName: "Test",
+		},
+		{
+			name:         "failed print",
+			testLine:     "some other text--- FAIL: Test (0.10 seconds)",
+			expectedName: "Test",
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestDataParser()
+
+		actual, contained := parser.ExtractName(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract name from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedName != actual {
+			t.Errorf("%s: did not correctly extract name from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedName, actual)
+		}
+	}
+}
+
+func TestExtractResult(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		testLine       string
+		expectedResult api.TestResult
+	}{
+		{
+			name:           "basic",
+			testLine:       "--- PASS: Test (0.10 seconds)",
+			expectedResult: api.TestResultPass,
+		},
+		{
+			name:           "go1.5.1 timing",
+			testLine:       "--- PASS: TestTwo (0.03s)",
+			expectedResult: api.TestResultPass,
+		},
+		{
+			name:           "skip",
+			testLine:       "--- SKIP: Test (0.10 seconds)",
+			expectedResult: api.TestResultSkip,
+		},
+		{
+			name:           "fail",
+			testLine:       "--- FAIL: Test (0.10 seconds)",
+			expectedResult: api.TestResultFail,
+		},
+		{
+			name:           "failed print",
+			testLine:       "some other text--- FAIL: Test (0.10 seconds)",
+			expectedResult: api.TestResultFail,
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestDataParser()
+
+		actual, contained := parser.ExtractResult(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract result from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedResult != actual {
+			t.Errorf("%s: did not correctly extract result from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedResult, actual)
+		}
+	}
+}
+
+func TestExtractDuration(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		testLine         string
+		expectedDuration string
+	}{
+		{
+			name:             "basic",
+			testLine:         "--- PASS: Test (0.10 seconds)",
+			expectedDuration: "0.10s", // we make the conversion to time.Duration-parseable units internally
+		},
+		{
+			name:             "go1.5.1 timing",
+			testLine:         "--- PASS: TestTwo (0.03s)",
+			expectedDuration: "0.03s",
+		},
+		{
+			name:             "failed print",
+			testLine:         "some other text--- PASS: TestTwo (0.03s)",
+			expectedDuration: "0.03s",
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestDataParser()
+
+		actual, contained := parser.ExtractDuration(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract duration from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedDuration != actual {
+			t.Errorf("%s: did not correctly extract duration from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedDuration, actual)
+		}
+	}
+}
+
+func TestExtractSuiteName(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		testLine     string
+		expectedName string
+	}{
+		{
+			name: "basic",
+			testLine: "ok  	package/name 0.160s",
+			expectedName: "package/name",
+		},
+		{
+			name: "go 1.5.1",
+			testLine: "ok  	package/name	0.160s",
+			expectedName: "package/name",
+		},
+		{
+			name: "numeric",
+			testLine: "ok  	1234 0.160s",
+			expectedName: "1234",
+		},
+		{
+			name: "url",
+			testLine: "ok  	github.com/maintainer/repository/package/file 0.160s",
+			expectedName: "github.com/maintainer/repository/package/file",
+		},
+		{
+			name: "with coverage",
+			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			expectedName: "package/name",
+		},
+		{
+			name: "failed print",
+			testLine: `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
+			expectedName: "package/name",
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestSuiteDataParser()
+
+		actual, contained := parser.ExtractName(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract name from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedName != actual {
+			t.Errorf("%s: did not correctly extract suite name from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedName, actual)
+		}
+	}
+}
+
+func TestSuiteProperties(t *testing.T) {
+	var testCases = []struct {
+		name               string
+		testLine           string
+		expectedProperties map[string]string
+	}{
+		{
+			name:               "basic",
+			testLine:           `coverage: 10.0% of statements`,
+			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
+		},
+		{
+			name: "with package declaration",
+			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
+		},
+		{
+			name:               "failed print",
+			testLine:           `some other textcoverage: 10.0% of statements`,
+			expectedProperties: map[string]string{coveragePropertyName: "10.0"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestSuiteDataParser()
+
+		actual, contained := parser.ExtractProperties(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract properties from line %q", testCase.name, testCase.testLine)
+		}
+		if !reflect.DeepEqual(testCase.expectedProperties, actual) {
+			t.Errorf("%s: did not correctly extract properties from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedProperties, actual)
+		}
+	}
+}
+
+func TestMarksCompletion(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		testLine string
+	}{
+		{
+			name: "basic",
+			testLine: "ok  	package/name 0.160s",
+		},
+		{
+			name: "numeric",
+			testLine: "ok  	1234 0.160s",
+		},
+		{
+			name: "url",
+			testLine: "ok  	github.com/maintainer/repository/package/file 0.160s",
+		},
+		{
+			name: "with coverage",
+			testLine: `ok  	package/name 0.400s  coverage: 10.0% of statements`,
+		},
+		{
+			name: "failed print",
+			testLine: `some other textok  	package/name 0.400s  coverage: 10.0% of statements`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := newTestSuiteDataParser()
+
+		if !parser.MarksCompletion(testCase.testLine) {
+			t.Errorf("%s: did not correctly determine that line %q marked the end of a suite", testCase.name, testCase.testLine)
+		}
+	}
+}

--- a/tools/junitreport/pkg/parser/gotest/parser.go
+++ b/tools/junitreport/pkg/parser/gotest/parser.go
@@ -1,0 +1,106 @@
+package gotest
+
+import (
+	"bufio"
+	"strings"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser"
+)
+
+// NewParser returns a new parser that's capable of parsing Go unit test output
+func NewParser(builder builder.TestSuitesBuilder) parser.TestOutputParser {
+	return &testOutputParser{
+		builder:     builder,
+		testParser:  newTestDataParser(),
+		suiteParser: newTestSuiteDataParser(),
+	}
+}
+
+type testOutputParser struct {
+	builder     builder.TestSuitesBuilder
+	testParser  testDataParser
+	suiteParser testSuiteDataParser
+}
+
+// Parse parses `go test -v` output into test suites. Test output from `go test -v` is not bookmarked for packages, so
+// the parsing strategy is to advance line-by-line, building up a slice of test cases until a package declaration is found,
+// at which point all tests cases are added to that package and the process can start again.
+func (p *testOutputParser) Parse(input *bufio.Scanner) (*api.TestSuites, error) {
+	currentSuite := &api.TestSuite{}
+	var currentTest *api.TestCase
+	var currentTestResult api.TestResult
+	var currentTestOutput []string
+
+	for input.Scan() {
+		line := input.Text()
+		isTestOutput := true
+
+		if p.testParser.MarksBeginning(line) || p.suiteParser.MarksCompletion(line) {
+			if currentTest != nil {
+				// we can't mark the test as failed or skipped until we have all of the test output, which we don't know
+				// we have until we see the next test or the beginning of suite output, so we add it here
+				output := strings.Join(currentTestOutput, "\n")
+				switch currentTestResult {
+				case api.TestResultSkip:
+					currentTest.MarkSkipped(output)
+				case api.TestResultFail:
+					currentTest.MarkFailed("", output)
+				}
+
+				currentSuite.AddTestCase(currentTest)
+			}
+			currentTest = &api.TestCase{}
+			currentTestResult = api.TestResultFail
+			currentTestOutput = []string{}
+		}
+
+		if name, matched := p.testParser.ExtractName(line); matched {
+			currentTest.Name = name
+		}
+
+		if result, matched := p.testParser.ExtractResult(line); matched {
+			currentTestResult = result
+		}
+
+		if duration, matched := p.testParser.ExtractDuration(line); matched {
+			if err := currentTest.SetDuration(duration); err != nil {
+				return nil, err
+			}
+		}
+
+		if properties, matched := p.suiteParser.ExtractProperties(line); matched {
+			for name := range properties {
+				currentSuite.AddProperty(name, properties[name])
+			}
+			isTestOutput = false
+		}
+
+		if name, matched := p.suiteParser.ExtractName(line); matched {
+			currentSuite.Name = name
+			isTestOutput = false
+		}
+
+		if duration, matched := p.suiteParser.ExtractDuration(line); matched {
+			if err := currentSuite.SetDuration(duration); err != nil {
+				return nil, err
+			}
+		}
+
+		if p.suiteParser.MarksCompletion(line) {
+			p.builder.AddSuite(currentSuite)
+
+			currentSuite = &api.TestSuite{}
+			currentTest = nil
+			isTestOutput = false
+		}
+
+		// we want to associate any line not directly related to a test suite with a test case to ensure we capture all output
+		if isTestOutput {
+			currentTestOutput = append(currentTestOutput, line)
+		}
+	}
+
+	return p.builder.Build(), nil
+}

--- a/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
@@ -1,0 +1,369 @@
+package gotest
+
+import (
+	"bufio"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder/flat"
+)
+
+// TestFlatParse tests that parsing the `go test` output in the test directory with a flat builder works as expected
+func TestFlatParse(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		testFile       string
+		expectedSuites *api.TestSuites
+	}{
+		{
+			name:     "basic",
+			testFile: "1.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.16,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "failure",
+			testFile: "2.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package/name",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  0.15,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.`,
+								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.13,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "skip",
+			testFile: "3.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:       "package/name",
+						NumTests:   2,
+						NumSkipped: 1,
+						Duration:   0.15,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+								SkipMessage: &api.SkipMessage{
+									Message: `=== RUN TestOne
+--- SKIP: TestOne (0.02 seconds)
+	file_test.go:11: Skip message`,
+								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.13,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "go 1.4",
+			testFile: "4.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.16,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "multiple suites",
+			testFile: "5.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name1",
+						NumTests: 2,
+						Duration: 0.16,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+					{
+						Name:      "package/name2",
+						NumTests:  2,
+						Duration:  0.15,
+						NumFailed: 1,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.`,
+								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.13,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "coverage statement",
+			testFile: "6.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.16,
+						Properties: []*api.TestSuiteProperty{
+							{
+								Name:  "coverage.statements.pct",
+								Value: "13.37",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "coverage statement in package result",
+			testFile: "7.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.16,
+						Properties: []*api.TestSuiteProperty{
+							{
+								Name:  "coverage.statements.pct",
+								Value: "10.0",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "go 1.5",
+			testFile: "8.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.05,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.03,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nested ",
+			testFile: "9.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.05,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.03,
+							},
+						},
+					},
+					{
+						Name:       "package/name/nested",
+						NumTests:   2,
+						NumFailed:  1,
+						NumSkipped: 1,
+						Duration:   0.05,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== RUN   TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.`,
+								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.03,
+								SkipMessage: &api.SkipMessage{
+									Message: `=== RUN   TestTwo
+--- SKIP: TestTwo (0.03 seconds)
+	file_test.go:11: Skip message
+PASS`,
+								},
+							},
+						},
+					},
+					{
+						Name:     "package/other/nested",
+						NumTests: 2,
+						Duration: 0.3,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.1,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.2,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test case timing doesn't add to test suite timing",
+			testFile: "10.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 2.16,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := NewParser(flat.NewTestSuitesBuilder())
+
+		testFile := "./../../../test/gotest/testdata/" + testCase.testFile
+
+		reader, err := os.Open(testFile)
+		if err != nil {
+			t.Errorf("%s: unexpected error opening file %q: %v", testCase.name, testFile, err)
+			continue
+		}
+		testSuites, err := parser.Parse(bufio.NewScanner(reader))
+		if err != nil {
+			t.Errorf("%s: unexpected error parsing file: %v", testCase.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
+			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
+		}
+	}
+}

--- a/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
@@ -1,0 +1,486 @@
+package gotest
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
+)
+
+// TestNestedParse tests that parsing the `go test` output in the test directory with a nested builder works as expected
+func TestNestedParse(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		testFile       string
+		rootSuiteNames []string
+		expectedSuites *api.TestSuites
+	}{
+		{
+			name:     "basic",
+			testFile: "1.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 0.16,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 0.16,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "basic with restricted root",
+			testFile:       "1.txt",
+			rootSuiteNames: []string{"package/name"},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.16,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "failure",
+			testFile: "2.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  0.15,
+						Children: []*api.TestSuite{
+							{
+								Name:      "package/name",
+								NumTests:  2,
+								NumFailed: 1,
+								Duration:  0.15,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.02,
+										FailureOutput: &api.FailureOutput{
+											Output: `=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.`,
+										},
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.13,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "skip",
+			testFile: "3.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:       "package",
+						NumTests:   2,
+						NumSkipped: 1,
+						Duration:   0.15,
+						Children: []*api.TestSuite{
+							{
+								Name:       "package/name",
+								NumTests:   2,
+								NumSkipped: 1,
+								Duration:   0.15,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.02,
+										SkipMessage: &api.SkipMessage{
+											Message: `=== RUN TestOne
+--- SKIP: TestOne (0.02 seconds)
+	file_test.go:11: Skip message`,
+										},
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.13,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "go 1.4",
+			testFile: "4.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 0.16,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 0.16,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "multiple suites",
+			testFile: "5.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package",
+						NumTests:  4,
+						NumFailed: 1,
+						Duration:  0.31,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name1",
+								NumTests: 2,
+								Duration: 0.16,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+							{
+								Name:      "package/name2",
+								NumTests:  2,
+								Duration:  0.15,
+								NumFailed: 1,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.02,
+										FailureOutput: &api.FailureOutput{
+											Output: `=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.`,
+										},
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.13,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "coverage statement",
+			testFile: "6.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 0.16,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 0.16,
+								Properties: []*api.TestSuiteProperty{
+									{
+										Name:  "coverage.statements.pct",
+										Value: "13.37",
+									},
+								},
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "coverage statement in package result",
+			testFile: "7.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 0.16,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 0.16,
+								Properties: []*api.TestSuiteProperty{
+									{
+										Name:  "coverage.statements.pct",
+										Value: "10.0",
+									},
+								},
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "go 1.5",
+			testFile: "8.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 0.05,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 0.05,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.02,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.03,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nested ",
+			testFile: "9.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:       "package",
+						NumTests:   6,
+						NumFailed:  1,
+						NumSkipped: 1,
+						Duration:   0.4,
+						Children: []*api.TestSuite{
+							{
+								Name:       "package/name",
+								NumTests:   4,
+								NumFailed:  1,
+								NumSkipped: 1,
+								Duration:   0.1,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.02,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.03,
+									},
+								},
+								Children: []*api.TestSuite{
+
+									{
+										Name:       "package/name/nested",
+										NumTests:   2,
+										NumFailed:  1,
+										NumSkipped: 1,
+										Duration:   0.05,
+										TestCases: []*api.TestCase{
+											{
+												Name:     "TestOne",
+												Duration: 0.02,
+												FailureOutput: &api.FailureOutput{
+													Output: `=== RUN   TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.`,
+												},
+											},
+											{
+												Name:     "TestTwo",
+												Duration: 0.03,
+												SkipMessage: &api.SkipMessage{
+													Message: `=== RUN   TestTwo
+--- SKIP: TestTwo (0.03 seconds)
+	file_test.go:11: Skip message
+PASS`, // we include this line greedily even though it does not belong to the test
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name:     "package/other",
+								NumTests: 2,
+								Duration: 0.3,
+								Children: []*api.TestSuite{
+
+									{
+										Name:     "package/other/nested",
+										NumTests: 2,
+										Duration: 0.3,
+										TestCases: []*api.TestCase{
+											{
+												Name:     "TestOne",
+												Duration: 0.1,
+											},
+											{
+												Name:     "TestTwo",
+												Duration: 0.2,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "test case timing doesn't add to test suite timing",
+			testFile: "10.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 2.16,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 2.16,
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := NewParser(nested.NewTestSuitesBuilder(testCase.rootSuiteNames))
+
+		testFile := "./../../../test/gotest/testdata/" + testCase.testFile
+
+		reader, err := os.Open(testFile)
+		if err != nil {
+			t.Errorf("%s: unexpected error opening file %q: %v", testCase.name, testFile, err)
+			continue
+		}
+		testSuites, err := parser.Parse(bufio.NewScanner(reader))
+		if err != nil {
+			t.Errorf("%s: unexpected error parsing file: %v", testCase.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
+			fmt.Println(util.ObjectGoPrintDiff(testSuites, testCase.expectedSuites))
+			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
+		}
+	}
+}

--- a/tools/junitreport/pkg/parser/interfaces.go
+++ b/tools/junitreport/pkg/parser/interfaces.go
@@ -1,0 +1,12 @@
+package parser
+
+import (
+	"bufio"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+// TestOutputParser knows how to parse test output to create a collection of test suites
+type TestOutputParser interface {
+	Parse(input *bufio.Scanner) (*api.TestSuites, error)
+}

--- a/tools/junitreport/pkg/parser/stack/interfaces.go
+++ b/tools/junitreport/pkg/parser/stack/interfaces.go
@@ -1,0 +1,39 @@
+package stack
+
+import "github.com/openshift/origin/tools/junitreport/pkg/api"
+
+// TestDataParser knows how to take raw test data and extract the useful information from it
+type TestDataParser interface {
+	// MarksBeginning determines if the line marks the begining of a test case
+	MarksBeginning(line string) bool
+
+	// ExtractName extracts the name of the test case from test output lines
+	ExtractName(line string) (name string, succeeded bool)
+
+	// ExtractResult extracts the test result from a test output line
+	ExtractResult(line string) (result api.TestResult, succeeded bool)
+
+	// ExtractDuration extracts the test duration from a test output line
+	ExtractDuration(line string) (duration string, succeeded bool)
+
+	// ExtractMessage extracts a message (e.g. for signalling why a failure or skip occured) from a test output line
+	ExtractMessage(line string) (message string, succeeded bool)
+
+	// MarksCompletion determines if the line marks the completion of a test case
+	MarksCompletion(line string) bool
+}
+
+// TestSuiteDataParser knows how to take raw test suite data and extract the useful information from it
+type TestSuiteDataParser interface {
+	// MarksBeginning determines if the line marks the begining of a test suite
+	MarksBeginning(line string) bool
+
+	// ExtractName extracts the name of the test suite from a test output line
+	ExtractName(line string) (name string, succeeded bool)
+
+	// ExtractProperties extracts any metadata properties of the test suite from a test output line
+	ExtractProperties(line string) (properties map[string]string, succeeded bool)
+
+	// MarksCompletion determines if the line marks the completion of a test suite
+	MarksCompletion(line string) bool
+}

--- a/tools/junitreport/pkg/parser/stack/parser.go
+++ b/tools/junitreport/pkg/parser/stack/parser.go
@@ -1,0 +1,125 @@
+package stack
+
+import (
+	"bufio"
+	"strings"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser"
+)
+
+// NewParser returns a new parser that's capable of parsing Go unit test output
+func NewParser(builder builder.TestSuitesBuilder, testParser TestDataParser, suiteParser TestSuiteDataParser) parser.TestOutputParser {
+	return &testOutputParser{
+		builder:     builder,
+		testParser:  testParser,
+		suiteParser: suiteParser,
+	}
+}
+
+// testOutputParser uses a stack to parse test output. Critical assumptions that this parser makes are:
+//   1 - packages may be nested but tests may not
+//   2 - no package declarations will occur within the boundaries of a test
+//   3 - all tests and packages are fully bounded by a start and result line
+//   4 - if a package or test declaration occurs after the start of a package but before it's result,
+//       the sub-package's or member test's result line will occur before that of the parent package
+//       i.e. any test or package overlap will necessarily mean that one package's lines are a superset
+//       of any lines of tests or other packages overlapping with it
+//   5 - any text in the input file that doesn't match the parser regex is necessarily the output of the
+//       current test being built
+type testOutputParser struct {
+	builder builder.TestSuitesBuilder
+
+	testParser  TestDataParser
+	suiteParser TestSuiteDataParser
+}
+
+// Parse parses output syntax of a specific class, the assumptions of which are outlined in the struct definition.
+// The specific boundary markers and metadata encodings are free to vary as long as regex can be build to extract them
+// from test output.
+func (p *testOutputParser) Parse(input *bufio.Scanner) (*api.TestSuites, error) {
+	inProgress := NewTestSuiteStack()
+
+	var currentTest *api.TestCase
+	var currentResult api.TestResult
+	var currentOutput []string
+	var currentMessage string
+
+	for input.Scan() {
+		line := input.Text()
+		isTestOutput := true
+
+		if p.testParser.MarksBeginning(line) {
+			currentTest = &api.TestCase{}
+			currentResult = api.TestResultFail
+			currentOutput = []string{}
+			currentMessage = ""
+		}
+
+		if name, contained := p.testParser.ExtractName(line); contained {
+			currentTest.Name = name
+		}
+
+		if result, contained := p.testParser.ExtractResult(line); contained {
+			currentResult = result
+		}
+
+		if duration, contained := p.testParser.ExtractDuration(line); contained {
+			if err := currentTest.SetDuration(duration); err != nil {
+				return nil, err
+			}
+		}
+
+		if message, contained := p.testParser.ExtractMessage(line); contained {
+			currentMessage = message
+		}
+
+		if p.testParser.MarksCompletion(line) {
+			// if we have finished the current test case, we finalize our current test, add it to the package
+			// at the head of our in progress package stack, and clear our current test record.
+			output := strings.Join(currentOutput, "\n")
+
+			switch currentResult {
+			case api.TestResultSkip:
+				currentTest.MarkSkipped(currentMessage)
+			case api.TestResultFail:
+				currentTest.MarkFailed(currentMessage, output)
+			}
+
+			inProgress.Peek().AddTestCase(currentTest)
+			currentTest = &api.TestCase{}
+		}
+
+		if p.suiteParser.MarksBeginning(line) {
+			// if we encounter the beginning of a suite, we create a new suite to be considered and
+			// add it to the head of our in progress package stack
+			inProgress.Push(&api.TestSuite{})
+			isTestOutput = false
+		}
+
+		if name, contained := p.suiteParser.ExtractName(line); contained {
+			inProgress.Peek().Name = name
+			isTestOutput = false
+		}
+
+		if properties, contained := p.suiteParser.ExtractProperties(line); contained {
+			for propertyName := range properties {
+				inProgress.Peek().AddProperty(propertyName, properties[propertyName])
+			}
+			isTestOutput = false
+		}
+
+		if p.suiteParser.MarksCompletion(line) {
+			// if we encounter the end of a suite, we remove the suite at the head of the in progress stack
+			p.builder.AddSuite(inProgress.Pop())
+			isTestOutput = false
+		}
+
+		// we want to associate every line other than those directly involved with test suites as output of a test case
+		if isTestOutput {
+			currentOutput = append(currentOutput, line)
+		}
+	}
+	return p.builder.Build(), nil
+}

--- a/tools/junitreport/pkg/parser/stack/stack.go
+++ b/tools/junitreport/pkg/parser/stack/stack.go
@@ -1,0 +1,73 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+// TestSuiteStack is a data structure that holds api.TestSuite objects in a LIFO
+type TestSuiteStack interface {
+	// Push adds the testSuite to the top of the LIFO
+	Push(pkg *api.TestSuite)
+	// Pop removes the head of the LIFO and returns it
+	Pop() *api.TestSuite
+	// Peek returns a reference to the head of the LIFO without removing it
+	Peek() *api.TestSuite
+	// IsEmpty determines if the stack has any members
+	IsEmpty() bool
+}
+
+// NewTestSuiteStack returns a new TestSuiteStack
+func NewTestSuiteStack() TestSuiteStack {
+	return &testSuiteStack{
+		head: nil,
+	}
+}
+
+// testSuiteStack is an implementation of a TestSuiteStack using a linked list
+type testSuiteStack struct {
+	head *testSuiteNode
+}
+
+// Push adds the testSuite to the top of the LIFO
+func (s *testSuiteStack) Push(data *api.TestSuite) {
+	newNode := &testSuiteNode{
+		Member: data,
+		Next:   s.head,
+	}
+	s.head = newNode
+}
+
+// Pop removes the head of the LIFO and returns it
+func (s *testSuiteStack) Pop() *api.TestSuite {
+	if s.IsEmpty() {
+		return nil
+	}
+	oldNode := s.head
+	s.head = s.head.Next
+	return oldNode.Member
+}
+
+// Peek returns a reference to the head of the LIFO without removing it
+func (s *testSuiteStack) Peek() *api.TestSuite {
+	if s.IsEmpty() {
+		return nil
+	}
+	return s.head.Member
+}
+
+// IsEmpty determines if the stack has any members
+func (s *testSuiteStack) IsEmpty() bool {
+	return s.head == nil
+}
+
+// testSuiteNode is a node in a singly-linked list
+type testSuiteNode struct {
+	Member *api.TestSuite
+	Next   *testSuiteNode
+}
+
+func (n *testSuiteNode) String() string {
+	return fmt.Sprintf("{Member: %s, Next: %s}", n.Member, n.Next.String())
+}

--- a/tools/junitreport/pkg/parser/stack/stack_test.go
+++ b/tools/junitreport/pkg/parser/stack/stack_test.go
@@ -1,0 +1,179 @@
+package stack
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+func TestPush(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		stackSeed       *testSuiteNode
+		testSuiteToPush *api.TestSuite
+		expectedStack   *testSuiteNode
+	}{
+		{
+			name:            "push on empty stack",
+			stackSeed:       nil,
+			testSuiteToPush: newTestSuite("test"),
+			expectedStack:   newTestSuiteNode(newTestSuite("test"), nil),
+		},
+		{
+			name:            "push on existing stack",
+			stackSeed:       newTestSuiteNode(newTestSuite("test"), nil),
+			testSuiteToPush: newTestSuite("test2"),
+			expectedStack:   newTestSuiteNode(newTestSuite("test2"), newTestSuiteNode(newTestSuite("test"), nil)),
+		},
+		{
+			name:            "push on deep stack",
+			stackSeed:       newTestSuiteNode(newTestSuite("test2"), newTestSuiteNode(newTestSuite("test3"), nil)),
+			testSuiteToPush: newTestSuite("test1"),
+			expectedStack:   newTestSuiteNode(newTestSuite("test1"), newTestSuiteNode(newTestSuite("test2"), newTestSuiteNode(newTestSuite("test3"), nil))),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testStack := &testSuiteStack{
+			head: testCase.stackSeed,
+		}
+		testStack.Push(testCase.testSuiteToPush)
+
+		if !reflect.DeepEqual(testStack.head, testCase.expectedStack) {
+			t.Errorf("%s: did not get correct stack state after push:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", testCase.name, testCase.expectedStack, testStack.head)
+		}
+	}
+}
+
+func TestPop(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		stackSeed         *testSuiteNode
+		expectedTestSuite *api.TestSuite
+		expectedStack     *testSuiteNode
+	}{
+		{
+			name:              "pop on empty stack",
+			stackSeed:         nil,
+			expectedTestSuite: nil,
+			expectedStack:     nil,
+		},
+		{
+			name:              "pop on existing stack",
+			stackSeed:         newTestSuiteNode(newTestSuite("test"), nil),
+			expectedTestSuite: newTestSuite("test"),
+			expectedStack:     nil,
+		},
+		{
+			name:              "pop on deep stack",
+			stackSeed:         newTestSuiteNode(newTestSuite("test"), newTestSuiteNode(newTestSuite("test2"), nil)),
+			expectedTestSuite: newTestSuite("test"),
+			expectedStack:     newTestSuiteNode(newTestSuite("test2"), nil),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testStack := &testSuiteStack{
+			head: testCase.stackSeed,
+		}
+		testSuite := testStack.Pop()
+		if !reflect.DeepEqual(testSuite, testCase.expectedTestSuite) {
+			t.Errorf("%s: did not get correct package from pop:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", testCase.name, testCase.expectedTestSuite, testSuite)
+		}
+		if !reflect.DeepEqual(testStack.head, testCase.expectedStack) {
+			t.Errorf("%s: did not get correct stack state after pop:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", testCase.name, testCase.expectedStack, testStack.head)
+		}
+	}
+}
+
+func TestPeek(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		stackSeed         *testSuiteNode
+		expectedTestSuite *api.TestSuite
+		expectedStack     *testSuiteNode
+	}{
+		{
+			name:              "peek on empty stack",
+			stackSeed:         nil,
+			expectedTestSuite: nil,
+			expectedStack:     nil,
+		},
+		{
+			name:              "peek on existing stack",
+			stackSeed:         newTestSuiteNode(newTestSuite("test"), nil),
+			expectedTestSuite: newTestSuite("test"),
+			expectedStack:     newTestSuiteNode(newTestSuite("test"), nil),
+		},
+		{
+			name:              "peek on deep stack",
+			stackSeed:         newTestSuiteNode(newTestSuite("test"), newTestSuiteNode(newTestSuite("test2"), nil)),
+			expectedTestSuite: newTestSuite("test"),
+			expectedStack:     newTestSuiteNode(newTestSuite("test"), newTestSuiteNode(newTestSuite("test2"), nil)),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testStack := &testSuiteStack{
+			head: testCase.stackSeed,
+		}
+		testSuite := testStack.Peek()
+		if !reflect.DeepEqual(testSuite, testCase.expectedTestSuite) {
+			t.Errorf("%s: did not get correct package from pop:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", testCase.name, testCase.expectedTestSuite, testSuite)
+		}
+		if !reflect.DeepEqual(testStack.head, testCase.expectedStack) {
+			t.Errorf("%s: did not get correct stack state after pop:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", testCase.name, testCase.expectedStack, testStack.head)
+		}
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		stackSeed     *testSuiteNode
+		expectedState bool
+		expectedStack *testSuiteNode
+	}{
+		{
+			name:          "isempty on empty stack",
+			stackSeed:     nil,
+			expectedState: true,
+			expectedStack: nil,
+		},
+		{
+			name:          "isempty on existing stack",
+			stackSeed:     newTestSuiteNode(newTestSuite("test"), nil),
+			expectedState: false,
+			expectedStack: newTestSuiteNode(newTestSuite("test"), nil),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testStack := &testSuiteStack{
+			head: testCase.stackSeed,
+		}
+		state := testStack.IsEmpty()
+
+		if state != testCase.expectedState {
+			t.Errorf("%s: did not get correct stack emptiness after push: expected: %t got: %t\n", testCase.name, testCase.expectedState, state)
+		}
+
+		if !reflect.DeepEqual(testStack.head, testCase.expectedStack) {
+			t.Errorf("%s: did not get correct stack state after push:\n\texpected:\n\t%s\n\tgot:\n\t%s\n", testCase.name, testCase.expectedStack, testStack.head)
+		}
+	}
+}
+
+func newTestSuite(name string) *api.TestSuite {
+	return &api.TestSuite{
+		Name: name,
+	}
+}
+
+func newTestSuiteNode(testSuite *api.TestSuite, next *testSuiteNode) *testSuiteNode {
+	return &testSuiteNode{
+		Member: testSuite,
+		Next:   next,
+	}
+}

--- a/tools/junitreport/test/gotest/reports/10_flat.xml
+++ b/tools/junitreport/test/gotest/reports/10_flat.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="2.16">
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/10_nested.xml
+++ b/tools/junitreport/test/gotest/reports/10_nested.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="2.16">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="2.16">
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/1_flat.xml
+++ b/tools/junitreport/test/gotest/reports/1_flat.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/1_nested.xml
+++ b/tools/junitreport/test/gotest/reports/1_nested.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/1_nested_restricted.xml
+++ b/tools/junitreport/test/gotest/reports/1_nested_restricted.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/2_flat.xml
+++ b/tools/junitreport/test/gotest/reports/2_flat.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="1" time="0.15">
+		<testcase name="TestOne" time="0.02">
+			<failure message="">=== RUN TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+		</testcase>
+		<testcase name="TestTwo" time="0.13"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/2_nested.xml
+++ b/tools/junitreport/test/gotest/reports/2_nested.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="1" time="0.15">
+		<testsuite name="package/name" tests="2" skipped="0" failures="1" time="0.15">
+			<testcase name="TestOne" time="0.02">
+				<failure message="">=== RUN TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+			</testcase>
+			<testcase name="TestTwo" time="0.13"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/3_flat.xml
+++ b/tools/junitreport/test/gotest/reports/3_flat.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="1" failures="0" time="0.15">
+		<testcase name="TestOne" time="0.02">
+			<skipped message="=== RUN TestOne&#xA;--- SKIP: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Skip message"></skipped>
+		</testcase>
+		<testcase name="TestTwo" time="0.13"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/3_nested.xml
+++ b/tools/junitreport/test/gotest/reports/3_nested.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="1" failures="0" time="0.15">
+		<testsuite name="package/name" tests="2" skipped="1" failures="0" time="0.15">
+			<testcase name="TestOne" time="0.02">
+				<skipped message="=== RUN TestOne&#xA;--- SKIP: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Skip message"></skipped>
+			</testcase>
+			<testcase name="TestTwo" time="0.13"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/4_flat.xml
+++ b/tools/junitreport/test/gotest/reports/4_flat.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/4_nested.xml
+++ b/tools/junitreport/test/gotest/reports/4_nested.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/5_flat.xml
+++ b/tools/junitreport/test/gotest/reports/5_flat.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name1" tests="2" skipped="0" failures="0" time="0.16">
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+	<testsuite name="package/name2" tests="2" skipped="0" failures="1" time="0.15">
+		<testcase name="TestOne" time="0.02">
+			<failure message="">=== RUN TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+		</testcase>
+		<testcase name="TestTwo" time="0.13"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/5_nested.xml
+++ b/tools/junitreport/test/gotest/reports/5_nested.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="4" skipped="0" failures="1" time="0.31">
+		<testsuite name="package/name1" tests="2" skipped="0" failures="0" time="0.16">
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+		<testsuite name="package/name2" tests="2" skipped="0" failures="1" time="0.15">
+			<testcase name="TestOne" time="0.02">
+				<failure message="">=== RUN TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+			</testcase>
+			<testcase name="TestTwo" time="0.13"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/6_flat.xml
+++ b/tools/junitreport/test/gotest/reports/6_flat.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+		<propery name="coverage.statements.pct" value="13.37"></propery>
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/6_nested.xml
+++ b/tools/junitreport/test/gotest/reports/6_nested.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+			<propery name="coverage.statements.pct" value="13.37"></propery>
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/7_flat.xml
+++ b/tools/junitreport/test/gotest/reports/7_flat.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+		<propery name="coverage.statements.pct" value="10.0"></propery>
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/7_nested.xml
+++ b/tools/junitreport/test/gotest/reports/7_nested.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+			<propery name="coverage.statements.pct" value="10.0"></propery>
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/8_flat.xml
+++ b/tools/junitreport/test/gotest/reports/8_flat.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.05">
+		<testcase name="TestOne" time="0.02"></testcase>
+		<testcase name="TestTwo" time="0.03"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/8_nested.xml
+++ b/tools/junitreport/test/gotest/reports/8_nested.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.05">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.05">
+			<testcase name="TestOne" time="0.02"></testcase>
+			<testcase name="TestTwo" time="0.03"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/9_flat.xml
+++ b/tools/junitreport/test/gotest/reports/9_flat.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.05">
+		<testcase name="TestOne" time="0.02"></testcase>
+		<testcase name="TestTwo" time="0.03"></testcase>
+	</testsuite>
+	<testsuite name="package/name/nested" tests="2" skipped="1" failures="1" time="0.05">
+		<testcase name="TestOne" time="0.02">
+			<failure message="">=== RUN   TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+		</testcase>
+		<testcase name="TestTwo" time="0.03">
+			<skipped message="=== RUN   TestTwo&#xA;--- SKIP: TestTwo (0.03 seconds)&#xA;&#x9;file_test.go:11: Skip message&#xA;PASS"></skipped>
+		</testcase>
+	</testsuite>
+	<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="0.3">
+		<testcase name="TestOne" time="0.1"></testcase>
+		<testcase name="TestTwo" time="0.2"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/9_nested.xml
+++ b/tools/junitreport/test/gotest/reports/9_nested.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="6" skipped="1" failures="1" time="0.4">
+		<testsuite name="package/name" tests="4" skipped="1" failures="1" time="0.1">
+			<testcase name="TestOne" time="0.02"></testcase>
+			<testcase name="TestTwo" time="0.03"></testcase>
+			<testsuite name="package/name/nested" tests="2" skipped="1" failures="1" time="0.05">
+				<testcase name="TestOne" time="0.02">
+					<failure message="">=== RUN   TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+				</testcase>
+				<testcase name="TestTwo" time="0.03">
+					<skipped message="=== RUN   TestTwo&#xA;--- SKIP: TestTwo (0.03 seconds)&#xA;&#x9;file_test.go:11: Skip message&#xA;PASS"></skipped>
+				</testcase>
+			</testsuite>
+		</testsuite>
+		<testsuite name="package/other" tests="2" skipped="0" failures="0" time="0.3">
+			<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="0.3">
+				<testcase name="TestOne" time="0.1"></testcase>
+				<testcase name="TestTwo" time="0.2"></testcase>
+			</testsuite>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/9_nested_restricted.xml
+++ b/tools/junitreport/test/gotest/reports/9_nested_restricted.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="4" skipped="1" failures="1" time="0.1">
+		<testcase name="TestOne" time="0.02"></testcase>
+		<testcase name="TestTwo" time="0.03"></testcase>
+		<testsuite name="package/name/nested" tests="2" skipped="1" failures="1" time="0.05">
+			<testcase name="TestOne" time="0.02">
+				<failure message="">=== RUN   TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+			</testcase>
+			<testcase name="TestTwo" time="0.03">
+				<skipped message="=== RUN   TestTwo&#xA;--- SKIP: TestTwo (0.03 seconds)&#xA;&#x9;file_test.go:11: Skip message&#xA;PASS"></skipped>
+			</testcase>
+		</testsuite>
+	</testsuite>
+	<testsuite name="package/other" tests="2" skipped="0" failures="0" time="0.3">
+		<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="0.3">
+			<testcase name="TestOne" time="0.1"></testcase>
+			<testcase name="TestTwo" time="0.2"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/summaries/10_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/10_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 2.160s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/1_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/1_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.160s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/2_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/2_summary.txt
@@ -1,0 +1,10 @@
+Of 2 tests executed in 0.150s, 1 succeeded, 1 failed, and 0 were skipped.
+
+In suite "package/name", test case "TestOne" failed:
+=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+

--- a/tools/junitreport/test/gotest/summaries/3_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/3_summary.txt
@@ -1,0 +1,7 @@
+Of 2 tests executed in 0.150s, 1 succeeded, 0 failed, and 1 was skipped.
+
+In suite "package/name", test case "TestOne" was skipped:
+=== RUN TestOne
+--- SKIP: TestOne (0.02 seconds)
+	file_test.go:11: Skip message
+

--- a/tools/junitreport/test/gotest/summaries/4_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/4_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.160s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/5_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/5_summary.txt
@@ -1,0 +1,10 @@
+Of 4 tests executed in 0.310s, 3 succeeded, 1 failed, and 0 were skipped.
+
+In suite "package/name2", test case "TestOne" failed:
+=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+

--- a/tools/junitreport/test/gotest/summaries/6_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/6_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.160s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/7_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/7_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.160s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/8_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/8_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.050s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/9_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/9_summary.txt
@@ -1,0 +1,16 @@
+Of 6 tests executed in 0.400s, 4 succeeded, 1 failed, and 1 was skipped.
+
+In suite "package/name/nested", test case "TestOne" failed:
+=== RUN   TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+
+In suite "package/name/nested", test case "TestTwo" was skipped:
+=== RUN   TestTwo
+--- SKIP: TestTwo (0.03 seconds)
+	file_test.go:11: Skip message
+PASS
+

--- a/tools/junitreport/test/gotest/testdata/1.txt
+++ b/tools/junitreport/test/gotest/testdata/1.txt
@@ -1,0 +1,6 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10 seconds)
+PASS
+ok  	package/name 0.160s

--- a/tools/junitreport/test/gotest/testdata/10.txt
+++ b/tools/junitreport/test/gotest/testdata/10.txt
@@ -1,0 +1,6 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10 seconds)
+PASS
+ok  	package/name 2.160s

--- a/tools/junitreport/test/gotest/testdata/2.txt
+++ b/tools/junitreport/test/gotest/testdata/2.txt
@@ -1,0 +1,11 @@
+=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+=== RUN TestTwo
+--- PASS: TestTwo (0.13 seconds)
+FAIL
+exit status 1
+FAIL	package/name 0.150s

--- a/tools/junitreport/test/gotest/testdata/3.txt
+++ b/tools/junitreport/test/gotest/testdata/3.txt
@@ -1,0 +1,7 @@
+=== RUN TestOne
+--- SKIP: TestOne (0.02 seconds)
+	file_test.go:11: Skip message
+=== RUN TestTwo
+--- PASS: TestTwo (0.13 seconds)
+PASS
+ok	package/name 0.150s

--- a/tools/junitreport/test/gotest/testdata/4.txt
+++ b/tools/junitreport/test/gotest/testdata/4.txt
@@ -1,0 +1,6 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06s)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10s)
+PASS
+ok  	package/name	0.160s

--- a/tools/junitreport/test/gotest/testdata/5.txt
+++ b/tools/junitreport/test/gotest/testdata/5.txt
@@ -1,0 +1,17 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10 seconds)
+PASS
+ok  	package/name1 0.160s
+=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+=== RUN TestTwo
+--- PASS: TestTwo (0.13 seconds)
+FAIL
+exit status 1
+FAIL	package/name2 0.150s

--- a/tools/junitreport/test/gotest/testdata/6.txt
+++ b/tools/junitreport/test/gotest/testdata/6.txt
@@ -1,0 +1,7 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10 seconds)
+PASS
+coverage: 13.37% of statements
+ok  	package/name 0.160s

--- a/tools/junitreport/test/gotest/testdata/7.txt
+++ b/tools/junitreport/test/gotest/testdata/7.txt
@@ -1,0 +1,6 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10 seconds)
+PASS
+ok  	package/name 0.160s  coverage: 10.0% of statements

--- a/tools/junitreport/test/gotest/testdata/8.txt
+++ b/tools/junitreport/test/gotest/testdata/8.txt
@@ -1,0 +1,6 @@
+=== RUN   TestOne
+--- PASS: TestOne (0.02s)
+=== RUN   TestTwo
+--- PASS: TestTwo (0.03s)
+PASS
+ok  	package/name	0.050s

--- a/tools/junitreport/test/gotest/testdata/9.txt
+++ b/tools/junitreport/test/gotest/testdata/9.txt
@@ -1,0 +1,23 @@
+=== RUN   TestOne
+--- PASS: TestOne (0.02s)
+=== RUN   TestTwo
+--- PASS: TestTwo (0.03s)
+PASS
+ok  	package/name	0.050s
+=== RUN   TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+=== RUN   TestTwo
+--- SKIP: TestTwo (0.03 seconds)
+	file_test.go:11: Skip message
+PASS
+ok  	package/name/nested	0.050s
+=== RUN   TestOne
+--- PASS: TestOne (0.1s)
+=== RUN   TestTwo
+--- PASS: TestTwo (0.2s)
+PASS
+ok  	package/other/nested	0.300s

--- a/tools/junitreport/test/integration.sh
+++ b/tools/junitreport/test/integration.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# This file runs the integration tests for the `junitreport` binary to ensure that correct jUnit XML is produced.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+JUNITREPORT_ROOT=$(dirname "${BASH_SOURCE}")/..
+pushd "${JUNITREPORT_ROOT}" > /dev/null
+
+TMPDIR="/tmp/junitreport/test/integration"
+mkdir -p "${TMPDIR}"
+
+echo "[INFO] Building junitreport binary for testing..."
+go build .
+
+for suite in test/*/; do
+	suite_name=$( basename ${suite} )
+	echo "[INFO] Testing suite ${suite_name}..."
+
+	WORKINGDIR="${TMPDIR}/${suite_name}"
+	mkdir -p "${WORKINGDIR}"
+
+	# test every case with flat and nested suites
+	for test in ${suite}/testdata/*.txt; do
+		test_name=$( basename ${test} | grep -Po ".+(?=\.txt)" )
+
+		cat "${test}" | ./junitreport -type "${suite_name}" -suites flat > "${WORKINGDIR}/${test_name}_flat.xml"
+		if ! diff "${suite}/reports/${test_name}_flat.xml" "${WORKINGDIR}/${test_name}_flat.xml"; then
+			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for flat suite builder."
+			exit 1
+		fi
+
+		cat "${test}" | ./junitreport -type "${suite_name}" -suites nested > "${WORKINGDIR}/${test_name}_nested.xml"
+		if ! diff "${suite}/reports/${test_name}_nested.xml" "${WORKINGDIR}/${test_name}_nested.xml"; then
+			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for nested suite builder."
+			exit 1
+		fi
+
+		cat "${WORKINGDIR}/${test_name}_flat.xml" | ./junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
+		if ! diff "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
+			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize flat XML."
+		fi
+
+		cat "${WORKINGDIR}/${test_name}_nested.xml" | ./junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
+		if ! diff "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
+			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize nested XML."
+		fi
+	done
+
+	echo "[PASS] Test output type passed: ${suite_name}"
+done
+
+echo "[INFO] Testing restricted roots with nested suites..."
+# test some cases with nested suites and given roots
+cat "test/gotest/testdata/1.txt" | ./junitreport -type gotest -suites nested -roots package/name > "${TMPDIR}/gotest/1_nested_restricted.xml"
+if ! diff "test/gotest/reports/1_nested_restricted.xml" "${TMPDIR}/gotest/1_nested_restricted.xml"; then
+	echo "[FAIL] Test '1' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name'."
+	exit 1
+fi
+
+cat "test/gotest/testdata/9.txt" | ./junitreport -type gotest -suites nested -roots package/name,package/other > "${TMPDIR}/gotest/9_nested_restricted.xml"
+if ! diff "test/gotest/reports/9_nested_restricted.xml" "${TMPDIR}/gotest/9_nested_restricted.xml"; then
+	echo "[FAIL] Test '9' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name,package/other'."
+	exit 1
+fi
+echo "[PASS] Suite passed: restricted roots"
+
+echo "[PASS] junitreport testing successful"
+popd > /dev/null


### PR DESCRIPTION
# junitreport

`junitreport` is a tool that allows for the consumption of test output in order to create jUnit XML.

## Installation

In order to build and install `junitreport`, from the root of the OpenShift Origin repository, run `hack/buil-go.sh cmd/junitreport`. 

## Usage 

`junitreport` can read the output of different types of tests. Specify which output is being read with `--type=<type>`. Supported test output types currently include `'gotest'`, for `go test` output. The default test type is `'gotest'`. 

`junitreport` can output flat or nested test suites. To choose which type of output to use, set `--suites=<type>` to either `'flat'` or `'nested'`. The default suite output structure is `'flat'`. When creating nested test suites, `junitreport` will use `/` as the delimeter between suite names: `github.com/maintainer/repository/suite` will be parsed as a hierarchy of `github.com`, `github.com/maintainer`, *etc.* If you are requesting nested test suite output but do not want the root suite(s) to be as general as `github.com`, for example, set `--roots=<root suite names>` to be a comma-delimited list of the names of the suites you wish to use as roots. If the parser encounters a package outside of those roots, it will ignore it. This allows a user to provide a root suite and only collect data for children of that root from a larger data set.

Ensure that the output you are feeding `junitreport` is free of extraneous text - any lines that are not test/suite declarations, metadata, or results are interpreted as test output. Text that you do not expect to see in Jenkins, for example, while looking at the output of a failed test should not be included in the input to `junitreport`.

### Examples

To parse the output of `go test` into a flat collection of test suites:

```sh

$ go test -v -cover ./... | junitreport > report.xml
```

To parse the output of `go test` into a nested collection of test suites rooted at `github.com/maintainer`:

```sh

$ go test -v -cover ./... | junitreport --suites=nested --roots=github.com/maintainer > report.xml
```