### PR TITLE
Prevent creating infinite build loops via oc new-build

### DIFF
--- a/pkg/generate/app/errors.go
+++ b/pkg/generate/app/errors.go
@@ -3,6 +3,8 @@ package app
 import (
 	"bytes"
 	"fmt"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
 // ErrNoMatch is the error returned by new-app when no match is found for a
@@ -53,3 +55,13 @@ The argument %[1]q could apply to the following Docker images or OpenShift image
 // ErrNameRequired is the error returned by new-app when a name cannot be
 // suggested and the user needs to provide one explicitly.
 var ErrNameRequired = fmt.Errorf("you must specify a name for your app")
+
+// CircularOutputReferenceError is the error returned by new-app when the input
+// and output image stream tags are identical.
+type CircularOutputReferenceError struct {
+	Reference imageapi.DockerImageReference
+}
+
+func (e CircularOutputReferenceError) Error() string {
+	return fmt.Sprintf("the input and output image stream tags are identical (%q)", e.Reference.DockerClientDefaults())
+}

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -186,6 +186,24 @@ func (p *Pipeline) NeedsDeployment(env Environment, labels map[string]string) er
 	return nil
 }
 
+// Validate checks for logical errors in the pipeline.
+func (p *Pipeline) Validate() error {
+	if p == nil || p.Build == nil {
+		return nil
+	}
+	input, output := p.Build.Input, p.Build.Output
+	if input == nil || output == nil {
+		return nil
+	}
+	if input.AsImageStream && output.AsImageStream && input.Reference.Equal(output.Reference) {
+		// If the build input and output image stream tags are the same, given that
+		// build configs created by new-app/new-build have an image change trigger,
+		// this setup would cause an infinite build loop, most likely unintentionaly.
+		return CircularOutputReferenceError{Reference: output.Reference}
+	}
+	return nil
+}
+
 // Objects converts all the components in the pipeline into runtime objects.
 func (p *Pipeline) Objects(accept, objectAccept Acceptor) (Objects, error) {
 	objects := Objects{}

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -106,6 +106,15 @@ func ParseDockerImageReference(spec string) (DockerImageReference, error) {
 	return ref, nil
 }
 
+// Equal returns true if the other DockerImageReference is equivalent to the
+// reference r. The comparison applies defaults to the Docker image reference,
+// so that e.g., "foobar" equals "docker.io/library/foobar:latest".
+func (r DockerImageReference) Equal(other DockerImageReference) bool {
+	defaultedRef := r.DockerClientDefaults()
+	otherDefaultedRef := other.DockerClientDefaults()
+	return defaultedRef == otherDefaultedRef
+}
+
 // DockerClientDefaults sets the default values used by the Docker client.
 func (r DockerImageReference) DockerClientDefaults() DockerImageReference {
 	if len(r.Namespace) == 0 {

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -1011,3 +1011,82 @@ func TestResolveImageID(t *testing.T) {
 		}
 	}
 }
+
+func TestDockerImageReferenceEquality(t *testing.T) {
+	equalityTests := []struct {
+		a, b    DockerImageReference
+		isEqual bool
+	}{
+		{
+			a:       DockerImageReference{},
+			b:       DockerImageReference{},
+			isEqual: true,
+		},
+		{
+			a: DockerImageReference{
+				Name: "openshift",
+			},
+			b: DockerImageReference{
+				Name: "openshift",
+			},
+			isEqual: true,
+		},
+		{
+			a: DockerImageReference{
+				Name: "openshift",
+			},
+			b: DockerImageReference{
+				Name: "openshift3",
+			},
+			isEqual: false,
+		},
+		{
+			a: DockerImageReference{
+				Name: "openshift",
+			},
+			b: DockerImageReference{
+				Registry:  DockerDefaultRegistry,
+				Namespace: DockerDefaultNamespace,
+				Name:      "openshift",
+				Tag:       DefaultImageTag,
+			},
+			isEqual: true,
+		},
+		{
+			a: DockerImageReference{
+				Name: "openshift",
+			},
+			b: DockerImageReference{
+				Registry:  DockerDefaultRegistry,
+				Namespace: DockerDefaultNamespace,
+				Name:      "openshift",
+				Tag:       "v1.0",
+			},
+			isEqual: false,
+		},
+		{
+			a: DockerImageReference{
+				Name: "openshift",
+			},
+			b: DockerImageReference{
+				Registry:  DockerDefaultRegistry,
+				Namespace: DockerDefaultNamespace,
+				Name:      "openshift",
+				Tag:       DefaultImageTag,
+				ID:        "d0a28ab59a",
+			},
+			isEqual: false,
+		},
+	}
+	for i, test := range equalityTests {
+		if isEqual := test.a.Equal(test.b); isEqual != test.isEqual {
+			t.Errorf("test %d: %#v.Equal(%#v) = %t; want %t",
+				i, test.a, test.b, isEqual, test.isEqual)
+		}
+		// commutativeness sanity check
+		if x, y := test.a.Equal(test.b), test.b.Equal(test.a); x != y {
+			t.Errorf("test %[1]d: %[2]q.Equal(%[3]q) = %[4]t != %[3]q.Equal(%[2]q) = %[5]t",
+				i, test.a, test.b, x, y)
+		}
+	}
+}

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -97,7 +97,7 @@ os::cmd::expect_success 'oc delete all -l app=ruby'
 
 # check new-build
 os::cmd::expect_failure_and_text 'oc new-build mysql -o yaml' 'you must specify at least one source repository URL'
-os::cmd::expect_success_and_text 'oc new-build mysql --binary -o yaml' 'type: Binary'
+os::cmd::expect_success_and_text 'oc new-build mysql --binary -o yaml --to mysql:bin' 'type: Binary'
 os::cmd::expect_success_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --strategy=docker -o yaml' 'type: Docker'
 os::cmd::expect_failure_and_text 'oc new-build mysql https://github.com/openshift/ruby-hello-world --binary' 'specifying binary builds and source repositories at the same time is not allowed'
 


### PR DESCRIPTION
Make `oc new-build` return an error when input and output image stream tags point to the same reference, e.g.:
```
$ oc new-build -D $'FROM centos\nRUN yum install -y httpd'
error: the input and output image stream tags are identical ("docker.io/library/centos:latest"), please specify a different output reference with --to
```

And if the user explicitly provides the output with the `--to` flag, instead of an error, there will be just a warning:
```
$ oc new-build -D $'FROM centos\nRUN yum install -y httpd' --to centos    
--> WARNING: the input and output image stream tags are identical ("docker.io/library/centos:latest") 
--> Found Docker image c96eeb9 (6 weeks old) from Docker Hub for "centos"                         
    * An image stream will be created as "centos:latest" that will track this image               
    * A Docker build using a predefined Dockerfile will be created                                
      * The resulting image will be pushed to image stream "centos:latest"                        
      * Every time "centos:latest" changes a new build will be triggered                          
--> Creating resources with label build=centos ...                                                
    ImageStream "centos" created                                                                  
    BuildConfig "centos" created                                                                  
--> Success                                                                                       
    Build configuration "centos" created and build triggered.                                     
    Run 'oc logs -f bc/centos' to stream the build progress.                                      
```

Fixes #5072.
Fixes #4730.