### PR TITLE
Bug1277038 - Differ between `oc env` updates(removes/adds) the resource(s) envvars and when it doesnt 

### DIFF
--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -56,7 +56,11 @@ os::cmd::expect_success_and_text 'oc env dc/test-deployment-config --list' 'H=h'
 os::cmd::expect_success_and_not_text 'oc env dc/test-deployment-config --list' 'A=a'
 os::cmd::expect_success_and_not_text 'oc env dc/test-deployment-config --list' 'C=c'
 os::cmd::expect_success_and_not_text 'oc env dc/test-deployment-config --list' 'G=g'
+os::cmd::expect_success_and_text 'oc env dc/test-deployment-config TEST=bar' 'not updated'
+os::cmd::expect_success_and_text 'oc env dc/test-deployment-config BAR-' 'not updated'
 echo "env: ok"
+
+
 os::cmd::expect_success 'oc deploy test-deployment-config'
 os::cmd::expect_success 'oc deploy dc/test-deployment-config'
 os::cmd::expect_success 'oc delete deploymentConfigs test-deployment-config'


### PR DESCRIPTION
When adding/removing envvars with `oc env` cmd, differ between states when the command actually updates the resource(s) and when it doesnt.
Eg: When updating resource by adding the envvar with a value that is already present in the resource, or removing a envvar that is not present, the printed output will look accordingly:
`replicationcontroller "database-1" nothing to update`
instead of 
`replicationcontroller "database-1" updated`

+ added a TC

Wasnt sure if we also wanna print due to which envar the resource wasnt updated (eg1. removing envvar thats not present in the resource || updating envar with the same value), since we would have to revrite some parts of the `env.go` and will end up with dup. messages in case user would want to update all rcs/dc with wrong envars(eg1).

@fabianofranz thoughts ?