### PR TITLE
Persistent Volume recycling config

### DIFF
--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -132,6 +132,9 @@ func attemptToLoadRecycler(path string, config *volume.VolumeConfig) error {
 	if err != nil {
 		return err
 	}
+	if len(recyclerPod.Spec.Volumes) != 1 {
+		return fmt.Errorf("Recycler pod is expected to have exactly 1 volume to scrub, but found %d", len(recyclerPod.Spec.Volumes))
+	}
 	config.RecyclerPodTemplate = recyclerPod
 	glog.V(5).Infof("Recycler set to %s/%s", config.RecyclerPodTemplate.Namespace, config.RecyclerPodTemplate.Name)
 	return nil

--- a/pkg/cmd/server/kubernetes/master.go
+++ b/pkg/cmd/server/kubernetes/master.go
@@ -24,6 +24,7 @@ import (
 	resourcequotacontroller "k8s.io/kubernetes/pkg/controller/resourcequota"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/host_path"
 	"k8s.io/kubernetes/pkg/volume/nfs"
@@ -85,15 +86,28 @@ func (c *MasterConfig) RunPersistentVolumeClaimRecycler(recyclerImageName string
 	defaultScrubPod.Spec.Containers[0].SecurityContext = &kapi.SecurityContext{RunAsUser: &uid}
 	defaultScrubPod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 
+	volumeConfig := c.ControllerManager.VolumeConfigFlags
 	hostPathConfig := volume.VolumeConfig{
-		RecyclerMinimumTimeout:   30,
-		RecyclerTimeoutIncrement: 30,
+		RecyclerMinimumTimeout:   volumeConfig.PersistentVolumeRecyclerMinimumTimeoutHostPath,
+		RecyclerTimeoutIncrement: volumeConfig.PersistentVolumeRecyclerIncrementTimeoutHostPath,
 		RecyclerPodTemplate:      defaultScrubPod,
 	}
+
+	if len(volumeConfig.PersistentVolumeRecyclerPodTemplateFilePathHostPath) != 0 {
+		if err := attemptToLoadRecycler(volumeConfig.PersistentVolumeRecyclerPodTemplateFilePathHostPath, &hostPathConfig); err != nil {
+			glog.Fatalf("Could not create hostpath recycler pod from file %s: %+v", volumeConfig.PersistentVolumeRecyclerPodTemplateFilePathHostPath, err)
+		}
+	}
 	nfsConfig := volume.VolumeConfig{
-		RecyclerMinimumTimeout:   180,
-		RecyclerTimeoutIncrement: 30,
+		RecyclerMinimumTimeout:   volumeConfig.PersistentVolumeRecyclerMinimumTimeoutNFS,
+		RecyclerTimeoutIncrement: volumeConfig.PersistentVolumeRecyclerIncrementTimeoutNFS,
 		RecyclerPodTemplate:      defaultScrubPod,
+	}
+
+	if len(volumeConfig.PersistentVolumeRecyclerPodTemplateFilePathNFS) != 0 {
+		if err := attemptToLoadRecycler(volumeConfig.PersistentVolumeRecyclerPodTemplateFilePathNFS, &nfsConfig); err != nil {
+			glog.Fatalf("Could not create NFS recycler pod from file %s: %+v", volumeConfig.PersistentVolumeRecyclerPodTemplateFilePathNFS, err)
+		}
 	}
 
 	allPlugins := []volume.VolumePlugin{}
@@ -105,6 +119,22 @@ func (c *MasterConfig) RunPersistentVolumeClaimRecycler(recyclerImageName string
 		glog.Fatalf("Could not start Persistent Volume Recycler: %+v", err)
 	}
 	recycler.Run()
+}
+
+// attemptToLoadRecycler tries decoding a pod from a filepath for use as a recycler for a volume.
+// If a path is not set as a CLI flag, no load will be attempted and no error returned.
+// If a path is set and the pod was successfully loaded, the recycler pod will be set on the config and no error returned.
+// Any failed attempt to load the recycler pod will return an error.
+// TODO: make this func re-usable upstream and use downstream.  No need to duplicate this function.
+func attemptToLoadRecycler(path string, config *volume.VolumeConfig) error {
+	glog.V(5).Infof("Attempting to load recycler pod file from %s", path)
+	recyclerPod, err := io.LoadPodFromFile(path)
+	if err != nil {
+		return err
+	}
+	config.RecyclerPodTemplate = recyclerPod
+	glog.V(5).Infof("Recycler set to %s/%s", config.RecyclerPodTemplate.Namespace, config.RecyclerPodTemplate.Name)
+	return nil
 }
 
 // RunReplicationController starts the Kubernetes replication controller sync loop


### PR DESCRIPTION
Original PR here: https://github.com/openshift/origin/pull/5171

That PR wanted a specific service account for the recycler (we've got one now) and all config was rolled into #5217, which was not merged.

This PR re-adds the ability to configure the recycler and allow override of the recycler pod.

@liggitt @pweil- 