### PR TITLE
hack/util.sh(delete_large_and_empty_logs): optimize find usage.

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -488,11 +488,9 @@ function dump_container_logs()
 # delete_large_and_empty_logs deletes empty logs and logs over 20MB
 function delete_large_and_empty_logs()
 {
-	# clean up zero byte log files
+	# Clean up zero byte log files
 	# Clean up large log files so they don't end up on jenkins
-	find ${ARTIFACT_DIR} -name *.log -size +20M -exec -exec rm -f {} \;
-	find ${LOG_DIR} -name *.log -size +20M -exec -exec rm -f {} \;
-	find ${LOG_DIR} -name *.log -size 0 -exec rm -f {} \;
+	find "${ARTIFACT_DIR}" "${LOG_DIR}" -type f -name '*.log' \( -empty -or -size +20M \) -delete
 }
 
 ######


### PR DESCRIPTION
I made minor improvements to the `delete_large_and_empty_logs` function:

1) quoted dir names
2) replaced `-exec rm -f {} \;` by `-delete` (also remove doubled `-exec`)
3) added `-type f`
4) replaced `-size 0` by `-empty`
5) quoted `-name` argument
6) combine 3 find calls into one (I believe that it make this function faster because we don't scan the disk twice) (thank you @rhcarvalho!)

@bparees @smarterclayton PTAL