### PR TITLE
Add to project catalog legend and accessibility fixes

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -397,8 +397,20 @@ label.checkbox {
 
 // Make sure icons are the same size so headings align.
 .add-to-project {
+  .catalog-legend {
+    dd {
+      margin-bottom: 5px;
+    }
+    .fa, .pficon {
+      width: 12px;
+      margin-right: 5px;
+      text-align: center;
+    }
+  }
+
   .filter-group {
     line-height: 1.75;
+    margin: 15px 0 10px;
     .search-input, .btn-group {
       display: inline-block;
       margin-bottom: 10px;
@@ -410,13 +422,21 @@ label.checkbox {
         width: 400px;
       }
     }
-    .filter-btn {
-      margin-right: 5px;
+  }
+  @media (min-width:@screen-sm-min) {
+    // Line up the description and filter controls with left column tiles.
+    .catalog-header-left {
+      padding-right: 10px;
     }
-    @media (min-width: @screen-sm-min) {
-      .filter-msg {
-        display: inline-block;
-      }
+    // Line up catalog with right column tiles.
+    .catalog-legend {
+      padding-left: 15px;
+    }
+  }
+  @media (min-width:@screen-md-min) {
+    // Line up the description and filter controls with left column tiles.
+    .catalog-header-left {
+      padding-right: 15px;
     }
   }
 }

--- a/assets/app/styles/_tile.less
+++ b/assets/app/styles/_tile.less
@@ -34,42 +34,6 @@
       color: @link-hover-color;
     }
   }
-  .tile-table {
-    display: table;
-    width: 100%;
-    height: 48px;
-    .box-sizing(border-box);
-    .tile-table-cell {
-      display: table-cell;
-      vertical-align: top;
-      &:first-child {
-        width:55px;
-
-        img {
-          max-width: @tileHeadingIconFontSize;
-          max-height: 78px;
-        }
-      }
-      > p {
-        margin-bottom: 5px;
-        line-height: @line-height-base / 1.25;
-      }
-      &.template-icon {
-        text-align: center;
-      }
-    }
-    .font-icon.logo, .font-icon {
-      font-size: @tileHeadingIconFontSize;
-      line-height: normal;
-      text-shadow: 0 0 4px #FFFFFF;
-      opacity: .38;
-      vertical-align: bottom;
-    }
-    + p {
-      margin-top: 3px;
-      font-size: inherit;
-    }
-  }
   &.tile-compact {
     margin-bottom: 12px;
   }
@@ -105,7 +69,7 @@
         text-decoration: none;
       }
     }
-    .tile-table-cell > .font-icon, .font-icon.logo {
+    .font-icon.logo {
       opacity: .75;
     }
   }
@@ -113,12 +77,10 @@
 
 .tile-flex {
   .box-shadow-hover-transition;
-  div:nth-child(3n) {
-    .fa, .pficon {
-      cursor: help;
-      font-size: @font-size-base;
-      opacity: .38;
-    }
+  .tile-badge-icon {
+    cursor: help;
+    font-size: @font-size-base;
+    opacity: .38;
   }
   .image-icon, .template-icon {
     width: 30px;
@@ -127,7 +89,7 @@
     opacity: .38;
   }
   &:hover {
-    .image-icon, .template-icon, div:nth-child(3n) .font-icon {
+    .image-icon, .template-icon, .tile-badge-icon {
       opacity: .75;
     }
     a.tile-target {

--- a/assets/app/views/catalog/_image.html
+++ b/assets/app/views/catalog/_image.html
@@ -20,19 +20,24 @@
         <label style="margin-right: 5px;">Version:</label>
         {{version}}
       </div>
-      <a href="" ng-click="filterTag(tag)" ng-repeat="tag in (imageStream | imageStreamTagTags : imageTag)" class="tag small">
+      <a href=""
+         ng-click="filterTag(tag)"
+         ng-repeat="tag in (imageStream | imageStreamTagTags : imageTag)"
+         ng-attr-title="Filter by tag {{tag}}"
+         class="tag small">
         {{tag}}
       </a>
     </div>
     <!-- Unset title attribute to prevent two tooltips. -->
     <div title="" ng-if="isBuilder">
       <i
-        class="pficon pficon-image"
+        class="pficon pficon-image tile-badge-icon"
         aria-hidden="true"
         data-toggle="tooltip"
         data-placement="bottom"
         data-container="body"
-        data-original-title="This image can build source code."></i>
+        data-original-title="Builder Image"></i>
+      <span class="sr-only">Builder Image</span>
     </div>
   </div>
 </div>

--- a/assets/app/views/catalog/_template.html
+++ b/assets/app/views/catalog/_template.html
@@ -18,9 +18,24 @@
         <label style="margin-right: 5px;">Version:</label>
         {{template | annotation : 'version'}}
       </div>
-      <a href="" ng-click="filterTag(tag)" ng-repeat="tag in (template | tags)" class="tag small">
+      <a href=""
+         ng-click="filterTag(tag)"
+         ng-repeat="tag in (template | tags)"
+         ng-attr-title="Filter by tag {{tag}}"
+         class="tag small">
         {{tag}}
       </a>
+    </div>
+    <!-- Unset title attribute to prevent two tooltips. -->
+    <div title="">
+      <i
+        class="fa fa-bolt tile-badge-icon"
+        aria-hidden="true"
+        data-toggle="tooltip"
+        data-placement="bottom"
+        data-container="body"
+        data-original-title="Template"></i>
+      <span class="sr-only">Template</span>
     </div>
   </div>
 </div>

--- a/assets/app/views/create.html
+++ b/assets/app/views/create.html
@@ -33,37 +33,63 @@
           <div ng-show="!emptyCatalog">
             <h1>Select Image or Template</h1>
 
-            <p>Choose from web frameworks, databases, and other components.</p>
+            <div class="row">
+              <!-- Right padding to line up cleanly with the left column tiles. -->
+              <div class="col-sm-6 catalog-header-left">
+                Choose from web frameworks, databases, and other components to
+                add content to your project.
 
-            <div class="filter-group">
-              <!-- Add a hidden label for screen readers. -->
-              <label for="search" class="sr-only">Filter by keyword</label>
-              <input
-                 ng-model="filter.keyword"
-                 autofocus
-                 type="search"
-                 id="search"
-                 placeholder="Filter by keyword"
-                 class="search-input form-control"
-                 autocorrect="off"
-                 autocapitalize="off"
-                 spellcheck="false">
+                <div class="filter-group">
+                  <!-- Add a hidden label for screen readers. -->
+                  <label for="search" class="sr-only">Filter by keyword</label>
+                  <!-- Pull the filter right so the input and dropdown button
+                       can use 100% width on the same line. -->
+                  <div uib-dropdown uib-keyboard-nav class="btn-group pull-right">
+                    <button class="dropdown-toggle" data-toggle="dropdown" role="menu">
+                      Browse
+                      <span class="caret" aria-hidden="true"></span>
+                    </button>
+                    <ul class="uib-dropdown-menu">
+                      <li ng-repeat="tag in categoryTags" role="menuitem">
+                        <a href="" ng-click="filter.tag = tag">{{tag}}</a>
+                      </li>
+                    </ul>
+                  </div>
 
-              <!-- Filter by tag -->
-              <div uib-dropdown uib-keyboard-nav class="filter-btn btn-group">
-                <button class="dropdown-toggle" data-toggle="dropdown" role="menu">
-                  Browse
-                  <span class="caret"></span>
-                </button>
-                <ul class="uib-dropdown-menu">
-                  <li ng-repeat="tag in categoryTags" role="menuitem">
-                    <a href="" ng-click="filter.tag = tag">{{tag}}</a>
-                  </li>
-                </ul>
+                  <!-- Use the remaining space for the input. -->
+                  <div style="overflow: hidden; padding-right: 10px;">
+                    <input
+                       ng-model="filter.keyword"
+                       autofocus
+                       type="search"
+                       id="search"
+                       placeholder="Filter by keyword"
+                       class="search-input form-control"
+                       autocorrect="off"
+                       autocapitalize="off"
+                       spellcheck="false"
+                       style="width: 100%;">
+                   </div>
+
+                  <div ng-if="filter.tag">
+                    Tagged with {{filter.tag}}.
+                    <a href="" ng-click="filter.tag = ''">See all tags</a>
+                  </div>
+                </div>
               </div>
-              <div ng-if="filter.tag" class="filter-msg">
-                Tagged with {{filter.tag}}.
-                <a href="" ng-click="filter.tag = ''">See all tags</a>
+
+              <!-- Legend -->
+              <div class="col-sm-6 catalog-legend">
+                <dl aria-hidden="true" class="text-muted">
+                  <dt>
+                    <i class="pficon pficon-image"></i> Builder Image
+                  </dt>
+                  <dd>Builds images from source code in a Git repository.</dd>
+                  <dt>
+                    <i class="fa fa-bolt"></i> Template
+                  </dt>
+                  <dd>Creates a predefined set of resources.</dd>
+                </dl>
               </div>
             </div>
 


### PR DESCRIPTION
- Add builder image icon legend to catalog
- Add sr-only text for builder image icon
- Add title text to filter by tag links
- Fix hover style for builder image icon
- Replace `nth-child` styles with `tile-badge-icon` class
- Remove unused `tile-table` CSS styles

![openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/11477170/b73f0c98-9754-11e5-88c0-e11cc019e2b5.png)

Fixes #4917
See also #5988

/cc @jwforres @sg00dwin 