### PR TITLE
Fix router panic

### DIFF
--- a/pkg/router/controller/unique_host.go
+++ b/pkg/router/controller/unique_host.go
@@ -87,7 +87,7 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 
 	// ensure hosts can only be claimed by one namespace at a time
 	// TODO: this could be abstracted above this layer?
-	if old, ok := p.hostToRoute[host]; ok {
+	if old, ok := p.hostToRoute[host]; ok && len(old) > 0 {
 		oldest := old[0]
 
 		// multiple paths can be added from the namespace of the oldest route
@@ -153,7 +153,11 @@ func (p *UniqueHost) HandleRoute(eventType watch.EventType, route *routeapi.Rout
 						next = append(next, old[i])
 					}
 				}
-				p.hostToRoute[host] = next
+				if len(next) > 0 {
+					p.hostToRoute[host] = next
+				} else {
+					delete(p.hostToRoute, host)
+				}
 			}
 		}
 		delete(p.routeToHost, routeName)


### PR DESCRIPTION
If only one route was registered for a host, got deleted, and then
added back again, the cache that ensures unique hosts would panic
due to an index out of range. This commit fixes the panic by ensuring
that when the last route for a host is removed then the entry for that
host is also removed from the cache.

Found somewhere in the mailing list
```
E1110 22:24:14.854713       1 util.go:82] Recovered from panic: "index out of range" (runtime error: index out of range)
/go/src/github.com/openshift/origin/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go:76
/go/src/github.com/openshift/origin/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go:64
/usr/lib/golang/src/runtime/asm_amd64.s:402
/usr/lib/golang/src/runtime/panic.go:387
/usr/lib/golang/src/runtime/panic.go:12
/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/router/controller/unique_host.go:91
/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/router/controller/controller.go:83
/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/router/controller/controller.go:45
/go/src/github.com/openshift/origin/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go:125
/go/src/github.com/openshift/origin/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go:126
/go/src/github.com/openshift/origin/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go:109
/usr/lib/golang/src/runtime/asm_amd64.s:2232
```

@pweil- @ramr PTAL