### PR TITLE
[RPMs] Add requires on git

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -96,6 +96,7 @@ Obsoletes:      tuned-profiles-openshift-node < %{package_refector_version}
 %package clients
 Summary:        %{product_name} Client binaries for Linux
 Obsoletes:      openshift-clients < %{package_refector_version}
+Requires:       git
 
 %description clients
 %{summary}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1286743

`oc new-app` relies on presence of the `git` binary