### PR TITLE
os::cmd improvements

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -8,7 +8,7 @@ source "${OS_ROOT}/hack/text.sh"
 # expect_success runs the cmd and expects an exit code of 0
 function os::cmd::expect_success() {
 	if [[ $# -ne 1 ]]; then echo "os::cmd::expect_success expects only one argument, got $#"; exit 1; fi
-	cmd=$1
+	local cmd=$1
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}"
 }
@@ -16,7 +16,7 @@ function os::cmd::expect_success() {
 # expect_failure runs the cmd and expects a non-zero exit code
 function os::cmd::expect_failure() {
 	if [[ $# -ne 1 ]]; then echo "os::cmd::expect_failure expects only one argument, got $#"; exit 1; fi
-	cmd=$1
+	local cmd=$1
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::failure_func"
 }
@@ -25,8 +25,8 @@ function os::cmd::expect_failure() {
 # as well as running a grep test to find the given string in the output
 function os::cmd::expect_success_and_text() {
 	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_success_and_text expects two arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_text=$2
+	local cmd=$1
+	local expected_text=$2
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::success_func" "${expected_text}"
 }
@@ -35,8 +35,8 @@ function os::cmd::expect_success_and_text() {
 # as well as running a grep test to find the given string in the output
 function os::cmd::expect_failure_and_text() {
 	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_failure_and_text expects two arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_text=$2
+	local cmd=$1
+	local expected_text=$2
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::failure_func" "${expected_text}"
 }
@@ -45,8 +45,8 @@ function os::cmd::expect_failure_and_text() {
 # as well as running a grep test to ensure the given string is not in the output
 function os::cmd::expect_success_and_not_text() {
 	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_success_and_not_text expects two arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_text=$2
+	local cmd=$1
+	local expected_text=$2
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::success_func" "${expected_text}" "os::cmd::internal::failure_func"
 }
@@ -55,8 +55,8 @@ function os::cmd::expect_success_and_not_text() {
 # as well as running a grep test to ensure the given string is not in the output
 function os::cmd::expect_failure_and_not_text() {
 	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_failure_and_not_text expects two arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_text=$2
+	local cmd=$1
+	local expected_text=$2
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::failure_func" "${expected_text}" "os::cmd::internal::failure_func"
 }
@@ -64,8 +64,8 @@ function os::cmd::expect_failure_and_not_text() {
 # expect_code runs the cmd and expects a given exit code
 function os::cmd::expect_code() {
 	if [[ $# -ne 2 ]]; then echo "os::cmd::expect_code expects two arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_cmd_code=$2
+	local cmd=$1
+	local expected_cmd_code=$2
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::specific_code_func ${expected_cmd_code}"
 }
@@ -74,9 +74,9 @@ function os::cmd::expect_code() {
 # as well as running a grep test to find the given string in the output
 function os::cmd::expect_code_and_text() {
 	if [[ $# -ne 3 ]]; then echo "os::cmd::expect_code_and_text expects three arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_cmd_code=$2
-	expected_text=$3
+	local cmd=$1
+	local expected_cmd_code=$2
+	local expected_text=$3
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::specific_code_func ${expected_cmd_code}" "${expected_text}"
 }
@@ -85,9 +85,9 @@ function os::cmd::expect_code_and_text() {
 # as well as running a grep test to ensure the given string is not in the output
 function os::cmd::expect_code_and_not_text() {
 	if [[ $# -ne 3 ]]; then echo "os::cmd::expect_code_and_not_text expects three arguments, got $#"; exit 1; fi
-	cmd=$1
-	expected_cmd_code=$2
-	expected_text=$3
+	local cmd=$1
+	local expected_cmd_code=$2
+	local expected_text=$3
 
 	os::cmd::internal::expect_exit_code_run_grep "${cmd}" "os::cmd::internal::specific_code_func ${expected_cmd_code}" "${expected_text}" "os::cmd::internal::failure_func"
 }
@@ -101,9 +101,9 @@ minute=$(( 60 * second ))
 # the default interval for os::cmd::try_until_success is 200ms
 function os::cmd::try_until_success() {
 	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_success expects at least one arguments, got $#"; exit 1; fi
-	cmd=$1
-	duration=${2:-minute}
-	interval=${3:-0.2}
+	local cmd=$1
+	local duration=${2:-minute}
+	local interval=${3:-0.2}
 
 	os::cmd::internal::run_until_exit_code "${cmd}" "os::cmd::internal::success_func" "${duration}" "${interval}"
 }
@@ -112,9 +112,9 @@ function os::cmd::try_until_success() {
 # the default time-out for os::cmd::try_until_failure is 60 seconds.
 function os::cmd::try_until_failure() {
 	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_success expects at least one argument, got $#"; exit 1; fi
-	cmd=$1
-	duration=${2:-$minute}
-	interval=${3:-0.2}
+	local cmd=$1
+	local duration=${2:-$minute}
+	local interval=${3:-0.2}
 
 	os::cmd::internal::run_until_exit_code "${cmd}" "os::cmd::internal::failure_func" "${duration}" "${interval}"
 }
@@ -123,10 +123,10 @@ function os::cmd::try_until_failure() {
 # the default time-out for os::cmd::try_until_text is 60 seconds.
 function os::cmd::try_until_text() {
 	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_success expects at least two arguments, got $#"; exit 1; fi
-	cmd=$1
-	text=$2
-	duration=${3:-minute}
-	interval=${4:-0.2}
+	local cmd=$1
+	local text=$2
+	local duration=${3:-minute}
+	local interval=${4:-0.2}
 
 	echo os::cmd::internal::run_until_text "${cmd}" "${text}" "${duration}" "${interval}"
 
@@ -147,41 +147,50 @@ os_cmd_internal_tmperr="${os_cmd_internal_tmpdir}/tmp_stderr.log"
 # any error exiting settings or traps set by upstream callers by masking the return code of the command 
 # with the return code of setting the result variable on failure.
 function os::cmd::internal::expect_exit_code_run_grep() {
-	cmd=$1
+	local cmd=$1
 	# default expected cmd code to 0 for success
-	cmd_eval_func=${2:-os::cmd::internal::success_func}
+	local cmd_eval_func=${2:-os::cmd::internal::success_func}
 	# default to nothing 
-	grep_args=${3:-} 
+	local grep_args=${3:-} 
 	# default expected test code to 0 for success
-	test_eval_func=${4:-os::cmd::internal::success_func}
+	local test_eval_func=${4:-os::cmd::internal::success_func}
 
 	os::cmd::internal::init_tempdir
 
-	echo "Running  ${cmd}..."
-	
-	cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
-	cmd_succeeded=$( ${cmd_eval_func} "${cmd_result}"; echo $? )
+	local name=$(os::cmd::internal::describe_call "${cmd}" "${cmd_eval_func}" "${grep_args}" "${test_eval_func}")
+	echo "Running ${name}..."
 
-	test_result=0
+	local start_time=$(os::cmd::internal::seconds_since_epoch)
+
+	local cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
+	local cmd_succeeded=$( ${cmd_eval_func} "${cmd_result}"; echo $? )
+
+	local test_result=0
 	if [[ -n "${grep_args}" ]]; then
 		test_result=$( os::cmd::internal::run_collecting_output 'os::cmd::internal::get_results | grep -Eq "${grep_args}"'; echo $? )
 		
 	fi
-	test_succeeded=$( ${test_eval_func} "${test_result}"; echo $? )
+	local test_succeeded=$( ${test_eval_func} "${test_result}"; echo $? )
 
-	os::text::clear_last_line
+	local end_time=$(os::cmd::internal::seconds_since_epoch)
+	local time_elapsed=$(echo "scale=3; ${end_time} - ${start_time}" | bc | xargs printf '%5.3f') # in decimal seconds, we need leading zeroes for parsing later
+
+	# some commands are multi-line, so we may need to clear more than just the previous line
+	local cmd_length=$(echo "${cmd}" | wc -l)
+	for (( i=0; i<${cmd_length}; i++ )); do
+		os::text::clear_last_line
+	done
 
 	if (( cmd_succeeded && test_succeeded )); then
-
-		os::text::print_green_bold "SUCCESS: ${cmd}"
+		os::text::print_green "SUCCESS after ${time_elapsed}s: ${name}"
 		if [[ -n ${VERBOSE-} ]]; then
 			os::cmd::internal::print_results
 		fi
 		return 0
 	else
-		cause=$(os::cmd::internal::assemble_causes "${cmd_succeeded}" "${test_succeeded}")
+		local cause=$(os::cmd::internal::assemble_causes "${cmd_succeeded}" "${test_succeeded}")
 		
-		os::text::print_red_bold "FAILURE: ${cmd}: ${cause}"
+		os::text::print_red_bold "FAILURE after ${time_elapsed}s: ${name}: ${cause}"
 		os::text::print_red "$(os::cmd::internal::print_results)"
 		return 1
 	fi
@@ -193,14 +202,83 @@ function os::cmd::internal::init_tempdir() {
 	rm -f "${os_cmd_internal_tmpdir}"/tmp_std{out,err}.log
 }
 
+# os::cmd::internal::describe_call determines the file:line of the latest function call made
+# from outside of this file in the call stack, and the name of the function being called from 
+# that line, returning a string describing the call
+function os::cmd::internal::describe_call() {
+	local cmd=$1
+	local cmd_eval_func=$2
+	local grep_args=${3:-}
+	local test_eval_func=${4:-}
+
+	local caller_id=$(os::cmd::internal::determine_caller)
+	local full_name="${caller_id}: executing '${cmd}'"
+
+	local cmd_expectation=$(os::cmd::internal::describe_expectation "${cmd_eval_func}")
+	local full_name="${full_name} expecting ${cmd_expectation}"
+
+	if [[ -n "${grep_args}" ]]; then
+		local text_expecting=
+		case "${test_eval_func}" in
+		"os::cmd::internal::success_func")
+			text_expecting="text" ;;
+		"os::cmd::internal::failure_func")
+			text_expecting="not text" ;;
+		esac
+		full_name="${full_name} and ${text_expecting} '${grep_args}'"
+	fi
+
+	echo "${full_name}"
+}
+
+# os::cmd::internal::determine_caller determines the file and line number of the function call to
+# the outer os::cmd wrapper function
+function os::cmd::internal::determine_caller() {
+	local call_depth=
+	local len_sources="${#BASH_SOURCE[@]}"
+	for (( i=0; i<${len_sources}; i++ )); do
+		if [ ! $(echo "${BASH_SOURCE[i]}" | grep "hack/cmd_util\.sh$") ]; then
+			call_depth=i
+			break
+		fi
+	done
+
+	local caller_file="${BASH_SOURCE[${call_depth}]}"
+	local caller_line="${BASH_LINENO[${call_depth}-1]}"
+	echo "${caller_file}:${caller_line}"
+}
+
+# os::cmd::internal::describe_expectation describes a command return code evaluation function
+function os::cmd::internal::describe_expectation() {
+	local func=$1
+	case "${func}" in
+	"os::cmd::internal::success_func")
+		echo "success" ;;
+	"os::cmd::internal::failure_func")
+		echo "failure" ;;
+	"os::cmd::internal::specific_code_func"*[0-9])
+		local code=$(echo "${func}" | grep -Po "[0-9]+$")
+		echo "exit code ${code}" ;;
+	"")
+		echo "any result"
+	esac
+}
+
+# os::cmd::internal::seconds_since_epoch returns the number of seconds elapsed since the epoch
+# with milli-second precision
+function os::cmd::internal::seconds_since_epoch() {
+	local ns=$(date +%s%N)
+	echo $(bc <<< "scale=3; ${ns}/1000000000")
+}
+
 # os::cmd::internal::run_collecting_output runs the command given, piping stdout and stderr into
 # the given files, and returning the exit code of the command
 function os::cmd::internal::run_collecting_output() {
-	cmd=$1
+	local cmd=$1
 
 	local result=
 	$( eval "${cmd}" 1>>"${os_cmd_internal_tmpout}" 2>>"${os_cmd_internal_tmperr}" ) || result=$?
-	result=${result:-0} # if we haven't set result yet, the command succeeded
+	local result=${result:-0} # if we haven't set result yet, the command succeeded
 
 	return "${result}"
 } 
@@ -208,7 +286,7 @@ function os::cmd::internal::run_collecting_output() {
 # os::cmd::internal::success_func determines if the input exit code denotes success
 # this function returns 0 for false and 1 for true to be compatible with arithmetic tests
 function os::cmd::internal::success_func() {
-	exit_code=$1
+	local exit_code=$1
 
 	# use a negated test to get output correct for (( ))
 	[[ "${exit_code}" -ne "0" ]]
@@ -218,7 +296,7 @@ function os::cmd::internal::success_func() {
 # os::cmd::internal::failure_func determines if the input exit code denotes failure
 # this function returns 0 for false and 1 for true to be compatible with arithmetic tests
 function os::cmd::internal::failure_func() {
-	exit_code=$1
+	local exit_code=$1
 
 	# use a negated test to get output correct for (( ))
 	[[ "${exit_code}" -eq "0" ]]
@@ -228,8 +306,8 @@ function os::cmd::internal::failure_func() {
 # os::cmd::internal::specific_code_func determines if the input exit code matches the given code
 # this function returns 0 for false and 1 for true to be compatible with arithmetic tests
 function os::cmd::internal::specific_code_func() {
-	expected_code=$1
-	exit_code=$2
+	local expected_code=$1
+	local exit_code=$2
 
 	# use a negated test to get output correct for (( ))
 	[[ "${exit_code}" -ne "${expected_code}" ]]
@@ -261,10 +339,10 @@ function os::cmd::internal::print_results() {
 # os::cmd::internal::assemble_causes determines from the two input booleans which part of the test
 # failed and generates a nice delimited list of failure causes
 function os::cmd::internal::assemble_causes() {
-	cmd_succeeded=$1
-	test_succeeded=$2
+	local cmd_succeeded=$1
+	local test_succeeded=$2
 
-	causes=()
+	local causes=()
 	if (( ! cmd_succeeded )); then
 		causes+=("the command returned the wrong error code")
 	fi
@@ -272,7 +350,7 @@ function os::cmd::internal::assemble_causes() {
 		causes+=("the output content test failed")
 	fi
 
-	list=$(printf '; %s' "${causes[@]}")
+	local list=$(printf '; %s' "${causes[@]}")
 	echo "${list:2}"
 }
 
@@ -283,38 +361,50 @@ function os::cmd::internal::assemble_causes() {
 # set by upstream callers by masking the return code of the command with the return code of setting
 # the result variable on failure.
 function os::cmd::internal::run_until_exit_code() {
-	cmd=$1
-	cmd_eval_func=$2
-	duration=$3
-	interval=$4
+	local cmd=$1
+	local cmd_eval_func=$2
+	local duration=$3
+	local interval=$4
 
 	os::cmd::internal::init_tempdir
 
-	echo "Waiting on ${cmd}..."
+	local description=$(os::cmd::internal::describe_call "${cmd}" "${cmd_eval_func}")
+	local duration_seconds=$(echo "scale=3; $(( duration )) / 1000" | bc | xargs printf '%5.3f')
+	local description="${description}; re-trying every ${interval}s until completion or ${duration_seconds}s"
+	echo "Running ${description}..."
 	
-	deadline=$(( $(date +%s000) + $duration ))
+	local start_time=$(os::cmd::internal::seconds_since_epoch)
+
+	local deadline=$(( $(date +%s000) + $duration ))
 	while [ $(date +%s000) -lt $deadline ]; do	
-		cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
-		cmd_succeeded=$( ${cmd_eval_func} "${cmd_result}"; echo $? )
+		local cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
+		local cmd_succeeded=$( ${cmd_eval_func} "${cmd_result}"; echo $? )
 		if (( cmd_succeeded )); then
 			break
 		fi
 		sleep "${interval}"
 	done
 
-	os::text::clear_last_line
+	local end_time=$(os::cmd::internal::seconds_since_epoch)
+	local time_elapsed=$(echo "scale=9; ${end_time} - ${start_time}" | bc | xargs printf '%5.3f') # in decimal seconds, we need leading zeroes for parsing later
+
+	# some commands are multi-line, so we may need to clear more than just the previous line
+	local cmd_length=$(echo "${cmd}" | wc -l)
+	for (( i=0; i<${cmd_length}; i++ )); do
+		os::text::clear_last_line
+	done
 
 	if (( cmd_succeeded )); then
 
-		os::text::print_green_bold "SUCCESS: ${cmd}"
+		os::text::print_green "SUCCESS after ${time_elapsed}s: ${description}"
 		if [[ -n ${VERBOSE-} ]]; then
 			os::cmd::internal::print_results
 		fi
 		return 0
 	else
-		cause=$(os::cmd::internal::assemble_try_until_code_causes "${cmd_succeeded}")
+		local cause=$(os::cmd::internal::assemble_try_until_code_causes "${cmd_succeeded}")
 
-		os::text::print_red_bold "FAILURE: ${cmd}: ${cause}"
+		os::text::print_red_bold "FAILURE after ${time_elapsed}s: ${description}: ${cause}"
 		os::text::print_red "$(os::cmd::internal::print_results)"
 		return 1
 	fi
@@ -323,16 +413,16 @@ function os::cmd::internal::run_until_exit_code() {
 # os::cmd::internal::assemble_try_until_code_causes determines from the input boolean which part of the try untik
 # failed and generates a nice delimited list of failure causes
 function os::cmd::internal::assemble_try_until_code_causes() {
-	cmd_succeeded=$1
+	local cmd_succeeded=$1
 
-	causes=()
+	local causes=()
 	if (( ! cmd_succeeded )); then
 		causes+=("the command returned the wrong error code")
 	else
 		causes+=("the command timed out")
 	fi
 
-	list=$(printf '; %s' "${causes[@]}")
+	local list=$(printf '; %s' "${causes[@]}")
 	echo "${list:2}"
 }
 
@@ -342,20 +432,25 @@ function os::cmd::internal::assemble_try_until_code_causes() {
 # set by upstream callers by masking the return code of the command with the return code of setting
 # the result variable on failure.
 function os::cmd::internal::run_until_text() {
-	cmd=$1
-	text=$2
-	duration=$3
-	interval=$4
+	local cmd=$1
+	local text=$2
+	local duration=$3
+	local interval=$4
 
 	os::cmd::internal::init_tempdir
 
-	echo "Waiting on ${cmd}..."
+	local description=$(os::cmd::internal::describe_call "${cmd}" "" "${text}" "os::cmd::internal::success_func")
+	local duration_seconds=$(echo "scale=3; $(( duration )) / 1000" | bc | xargs printf '%5.3f')
+	local description="${description}; re-trying every ${interval}s until completion or ${duration_seconds}s"
+	echo "Running ${description}..."
 	
-	deadline=$(( $(date +%s000) + $duration ))
+	local start_time=$(os::cmd::internal::seconds_since_epoch)
+	
+	local deadline=$(( $(date +%s000) + $duration ))
 	while [ $(date +%s000) -lt $deadline ]; do	
-		cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
-		test_result=$( os::cmd::internal::run_collecting_output 'os::cmd::internal::get_results | grep -Eq "${text}"'; echo $? )
-		test_succeeded=$( ${test_eval_func} "${test_result}"; echo $? )
+		local cmd_result=$( os::cmd::internal::run_collecting_output "${cmd}"; echo $? )
+		local test_result=$( os::cmd::internal::run_collecting_output 'os::cmd::internal::get_results | grep -Eq "${text}"'; echo $? )
+		local test_succeeded=$( os::cmd::internal::success_func "${test_result}"; echo $? )
 
 		if (( test_succeeded )); then
 			break
@@ -363,19 +458,26 @@ function os::cmd::internal::run_until_text() {
 		sleep "${interval}"
 	done
 
-	os::text::clear_last_line
+	local end_time=$(os::cmd::internal::seconds_since_epoch)
+	local time_elapsed=$(echo "scale=9; ${end_time} - ${start_time}" | bc | xargs printf '%5.3f') # in decimal seconds, we need leading zeroes for parsing later
+
+	# some commands are multi-line, so we may need to clear more than just the previous line
+	local cmd_length=$(echo "${cmd}" | wc -l)
+	for (( i=0; i<${cmd_length}; i++ )); do
+		os::text::clear_last_line
+	done
 
 	if (( test_succeeded )); then
 
-		os::text::print_green_bold "SUCCESS: ${cmd}"
+		os::text::print_green "SUCCESS after ${time_elapsed}s: ${description}"
 		if [[ -n ${VERBOSE-} ]]; then
 			os::cmd::internal::print_results
 		fi
 		return 0
 	else
-		cause=$(os::cmd::internal::assemble_try_until_text_causes "${test_succeeded}")
+		local cause=$(os::cmd::internal::assemble_try_until_text_causes "${test_succeeded}")
 		
-		os::text::print_red_bold "FAILURE: ${cmd}: ${cause}"
+		os::text::print_red_bold "FAILURE after ${time_elapsed}s: ${description}: ${cause}"
 		os::text::print_red "$(os::cmd::internal::print_results)"
 		return 1
 	fi
@@ -384,15 +486,15 @@ function os::cmd::internal::run_until_text() {
 # os::cmd::internal::assemble_try_until_text_causes determines from the input boolean which part of the try untik
 # failed and generates a nice delimited list of failure causes
 function os::cmd::internal::assemble_try_until_text_causes() {
-	test_succeeded=$1
+	local test_succeeded=$1
 
-	causes=()
+	local causes=()
 	if (( ! test_succeeded )); then
 		causes+=("the output content test failed")
 	else
 		causes+=("the command timed out")
 	fi
 
-	list=$(printf '; %s' "${causes[@]}")
+	local list=$(printf '; %s' "${causes[@]}")
 	echo "${list:2}"
 }

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -72,7 +72,7 @@ os::cmd::expect_success_and_text 'oc describe istag/mysql:latest' 'Image Created
 os::cmd::expect_success_and_text 'oc describe istag/mysql:latest' 'Image Name:'
 name=$(oc get istag/mysql:latest --template='{{ .image.metadata.name }}')
 imagename="isimage/mysql@${name:0:15}"
-os::cmd::expect_success 'oc describe "${imagename}"'
+os::cmd::expect_success "oc describe ${imagename}"
 os::cmd::expect_success_and_text "oc describe ${imagename}" 'Environment:'
 os::cmd::expect_success_and_text "oc describe ${imagename}" 'Image Created:'
 os::cmd::expect_success_and_text "oc describe ${imagename}" 'Image Name:'
@@ -87,7 +87,7 @@ echo "import-image: ok"
 os::cmd::expect_success 'oc tag mysql:latest tagtest:tag1 --alias'
 os::cmd::expect_success_and_text "oc get is/tagtest --template='{{(index .spec.tags 0).from.kind}}'" 'ImageStreamTag'
 
-os::cmd::expect_success 'oc tag mysql@${name} tagtest:tag2 --alias'
+os::cmd::expect_success "oc tag mysql@${name} tagtest:tag2 --alias"
 os::cmd::expect_success_and_text "oc get is/tagtest --template='{{(index .spec.tags 1).from.kind}}'" 'ImageStreamImage'
 
 os::cmd::expect_success 'oc tag mysql:notfound tagtest:tag3 --alias'
@@ -99,10 +99,10 @@ os::cmd::expect_success_and_text "oc get is/tagtest --template='{{(index .spec.t
 os::cmd::expect_success 'oc tag --source=istag mysql:latest tagtest:tag5 --alias'
 os::cmd::expect_success_and_text "oc get is/tagtest --template='{{(index .spec.tags 4).from.kind}}'" 'ImageStreamTag'
 
-os::cmd::expect_success 'oc tag --source=imagestreamimage mysql@${name} tagtest:tag6 --alias'
+os::cmd::expect_success "oc tag --source=imagestreamimage mysql@${name} tagtest:tag6 --alias"
 os::cmd::expect_success_and_text "oc get is/tagtest --template='{{(index .spec.tags 5).from.kind}}'" 'ImageStreamImage'
 
-os::cmd::expect_success 'oc tag --source=isimage mysql@${name} tagtest:tag7 --alias'
+os::cmd::expect_success "oc tag --source=isimage mysql@${name} tagtest:tag7 --alias"
 os::cmd::expect_success_and_text "oc get is/tagtest --template='{{(index .spec.tags 6).from.kind}}'" 'ImageStreamImage'
 
 os::cmd::expect_success 'oc tag --source=docker mysql:latest tagtest:tag8 --alias'


### PR DESCRIPTION
#### Better naming conventions in `os::cmd` output
Tests will be internally named better, with the test declaration line looking like:
```
test/cmd/edit.sh:18: executing 'OC_EDITOR=cat oc edit pod/hello-openshift' expecting success and text 'Edit cancelled'...
```
with options:
```
path/to/file.sh:line: executing <cmd> expecting (success|failure|exit code <code>)(and (not) text <text>)?
```

Output will look like:
```
SUCCESS: test/cmd/edit.sh:18: executing 'OC_EDITOR=cat oc edit pod/hello-openshift' expecting success and text 'Edit cancelled'
FAILURE: test/cmd/edit.sh:18: executing 'OC_EDITOR=cat oc edit pod/hello-openshift' expecting success and text 'Edit cancelled': the command returned the wrong error code; the output content test failed
```
with similar options

#### `os::cmd` properly handles multi-line commands - the test declaration and test result (`FAILURE|SUCCESS:`) lines never overlap
#### `os::cmd` reports time elapsed for tests, with sub-second precision so we can see something meaningful for short tests
```
SUCCESS after 0.038322103s: test/cmd/edit.sh:16: executing 'OC_EDITOR=cat oc edit pod/hello-openshift' expecting success and text 'Edit cancelled'
```

#### `os::cmd` only uses `local` variables now to make it impossible for us to interfere with other variables set in the process

@deads2k @liggitt  PTAL

