### PR TITLE
removed tryuntil from test-cmd

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -128,8 +128,6 @@ function os::cmd::try_until_text() {
 	local duration=${3:-minute}
 	local interval=${4:-0.2}
 
-	echo os::cmd::internal::run_until_text "${cmd}" "${text}" "${duration}" "${interval}"
-
 	os::cmd::internal::run_until_text "${cmd}" "${text}" "${duration}" "${interval}"
 }
 

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -31,9 +31,9 @@ os::cmd::expect_success 'oc delete pods hello-openshift'
 echo "pods: ok"
 
 os::cmd::expect_success_and_text 'oc create -f examples/hello-openshift/hello-pod.json -o name' 'pod/hello-openshift'
-os::cmd::expect_success "tryuntil 'oc label pod/hello-openshift acustom=label'" # can race against scheduling and status updates
+os::cmd::try_until_success 'oc label pod/hello-openshift acustom=label' # can race against scheduling and status updates
 os::cmd::expect_success_and_text 'oc describe pod/hello-openshift' 'acustom=label'
-os::cmd::expect_success "tryuntil 'oc annotate pod/hello-openshift foo=bar'" # can race against scheduling and status updates
+os::cmd::try_until_success 'oc annotate pod/hello-openshift foo=bar' # can race against scheduling and status updates
 os::cmd::expect_success_and_text 'oc get -o yaml pod/hello-openshift' 'foo: bar'
 os::cmd::expect_success 'oc delete pods -l acustom=label'
 os::cmd::expect_failure 'oc get pod/hello-openshift'

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -68,7 +68,7 @@ sleep 1
 os::cmd::expect_success 'oc delete all --all'
 
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l app=dockerbuild | oc create -f -'
-tryuntil "os::cmd::expect_success 'oc get rc/database-1'"
+os::cmd::try_until_success 'oc get rc/database-1'
 
 os::cmd::expect_success 'oc rollback database --to-version=1 -o=yaml'
 os::cmd::expect_success 'oc rollback dc/database --to-version=1 -o=yaml'

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -18,13 +18,13 @@ os::cmd::expect_failure 'oc new-app unknownhubimage -o yaml'
 # verify we can generate a Docker image based component "mongodb" directly
 os::cmd::expect_success_and_text 'oc new-app mongo -o yaml' 'library/mongo'
 # the local image repository takes precedence over the Docker Hub "mysql" image
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mysql:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mysql:5.5'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mysql:5.6'"
+os::cmd::try_until_success 'oc get imagestreamtags mysql:latest'
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5'
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6'
 os::cmd::expect_success_and_text 'oc new-app mysql -o yaml' 'mysql'
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags php:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags php:5.5'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags php:5.6'"
+os::cmd::try_until_success 'oc get imagestreamtags php:latest'
+os::cmd::try_until_success 'oc get imagestreamtags php:5.5'
+os::cmd::try_until_success 'oc get imagestreamtags php:5.6'
 
 # check label creation
 os::cmd::expect_success 'oc new-app php mysql -l no-source=php-mysql'
@@ -58,32 +58,32 @@ os::cmd::expect_failure 'oc new-app -S --template=nodejs'
 os::cmd::expect_failure 'oc new-app -S --template=perl'
 # check search - filtered, exact matches
 # make sure the imagestreams are imported first.
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mongodb:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mongodb:2.4'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mongodb:2.6'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mysql:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mysql:5.5'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags mysql:5.6'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags nodejs:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags nodejs:0.10'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags perl:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags perl:5.16'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags perl:5.20'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags php:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags php:5.5'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags php:5.6'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags postgresql:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags postgresql:9.2'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags postgresql:9.4'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags python:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags python:2.7'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags python:3.3'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags python:3.4'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags ruby:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags ruby:2.0'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags ruby:2.2'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags wildfly:latest'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags wildfly:8.1'"
+os::cmd::try_until_success 'oc get imagestreamtags mongodb:latest'
+os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.4'
+os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.6'
+os::cmd::try_until_success 'oc get imagestreamtags mysql:latest'
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5'
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6'
+os::cmd::try_until_success 'oc get imagestreamtags nodejs:latest'
+os::cmd::try_until_success 'oc get imagestreamtags nodejs:0.10'
+os::cmd::try_until_success 'oc get imagestreamtags perl:latest'
+os::cmd::try_until_success 'oc get imagestreamtags perl:5.16'
+os::cmd::try_until_success 'oc get imagestreamtags perl:5.20'
+os::cmd::try_until_success 'oc get imagestreamtags php:latest'
+os::cmd::try_until_success 'oc get imagestreamtags php:5.5'
+os::cmd::try_until_success 'oc get imagestreamtags php:5.6'
+os::cmd::try_until_success 'oc get imagestreamtags postgresql:latest'
+os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.2'
+os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.4'
+os::cmd::try_until_success 'oc get imagestreamtags python:latest'
+os::cmd::try_until_success 'oc get imagestreamtags python:2.7'
+os::cmd::try_until_success 'oc get imagestreamtags python:3.3'
+os::cmd::try_until_success 'oc get imagestreamtags python:3.4'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:latest'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2'
+os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
+os::cmd::try_until_success 'oc get imagestreamtags wildfly:8.1'
 
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mongodb' "Tags:\s+2.4, 2.6, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mysql' "Tags:\s+5.5, 5.6, latest"
@@ -139,11 +139,11 @@ os::cmd::expect_success 'oc create -f test/fixtures/installable-stream.yaml'
 project=$(oc project -q)
 os::cmd::expect_success 'oc policy add-role-to-user edit test-user'
 os::cmd::expect_success 'oc login -u test-user -p anything'
-os::cmd::expect_success "tryuntil 'oc project ${project}'"
+os::cmd::try_until_success 'oc project ${project}'
 
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags installable:file'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags installable:token'"
-os::cmd::expect_success "tryuntil 'oc get imagestreamtags installable:serviceaccount'"
+os::cmd::try_until_success 'oc get imagestreamtags installable:file'
+os::cmd::try_until_success 'oc get imagestreamtags installable:token'
+os::cmd::try_until_success 'oc get imagestreamtags installable:serviceaccount'
 os::cmd::expect_failure 'oc new-app installable:file'
 os::cmd::expect_failure_and_text 'oc new-app installable:file' 'requires that you grant the image access'
 os::cmd::expect_failure_and_text 'oc new-app installable:serviceaccount' "requires an 'installer' service account with project editor access"

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -10,9 +10,9 @@ source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
 # This test validates secret interaction
-[ "$(oc secrets new foo --type=blah makefile=Makefile 2>&1 | grep 'error: unknown secret type "blah"')" ]
-oc secrets new foo --type=blah makefile=Makefile --confirm
-oc get secrets/foo -o jsonpath={.type} | grep 'blah'
+os::cmd::expect_failure_and_text 'oc secrets new foo --type=blah makefile=Makefile' 'error: unknown secret type "blah"'
+os::cmd::expect_success 'oc secrets new foo --type=blah makefile=Makefile --confirm'
+os::cmd::expect_success_and_text 'oc get secrets/foo -o jsonpath={.type}' 'blah'
 
 os::cmd::expect_success 'oc secrets new-dockercfg dockercfg --docker-username=sample-user --docker-password=sample-password --docker-email=fake@example.org'
 # can't use a go template here because the output needs to be base64 decoded.  base64 isn't installed by default in all distros


### PR DESCRIPTION
@deads2k There were some remaining cases where `tryuntil` had not been handled correctly because `os::cmd` didn't have a replacement yet when the updates merged. This cleans them up.