### PR TITLE
Add template parameter output formatting

### DIFF
--- a/pkg/util/stringreplace/object.go
+++ b/pkg/util/stringreplace/object.go
@@ -9,11 +9,11 @@ import (
 // VisitObjectStrings visits recursively all string fields in the object and call the
 // visitor function on them. The visitor function can be used to modify the
 // value of the string fields.
-func VisitObjectStrings(obj interface{}, visitor func(string) string) {
+func VisitObjectStrings(obj interface{}, visitor func(string) interface{}) {
 	visitValue(reflect.ValueOf(obj), visitor)
 }
 
-func visitValue(v reflect.Value, visitor func(string) string) {
+func visitValue(v reflect.Value, visitor func(string) interface{}) {
 	switch v.Kind() {
 
 	case reflect.Ptr:
@@ -44,7 +44,7 @@ func visitValue(v reflect.Value, visitor func(string) string) {
 			glog.Infof("Unable to set String value '%v'", v)
 			return
 		}
-		v.SetString(visitor(v.String()))
+		v.SetString(visitor(v.String()).(string))
 
 	default:
 		glog.V(5).Infof("Unknown field type '%s': %v", v.Kind(), v)
@@ -52,7 +52,7 @@ func visitValue(v reflect.Value, visitor func(string) string) {
 }
 
 // visitUnsettableValues creates a copy of the object you want to modify and returns the modified result
-func visitUnsettableValues(typeOf reflect.Type, original reflect.Value, visitor func(string) string) reflect.Value {
+func visitUnsettableValues(typeOf reflect.Type, original reflect.Value, visitor func(string) interface{}) reflect.Value {
 	val := reflect.New(typeOf).Elem()
 	existing := original
 	// if the value type is interface, we must resolve it to a concrete value prior to setting it back.


### PR DESCRIPTION
POC, which resolves #3946

```
"replicas":"${MY_REPLICA_COUNT | int}"
```

the pipe syntax would only be allowed if the parameter was the entire value (you couldn't do `"${FOO | int}${BAR | int}"`

Possible transformations:

* `int`, for replicas, etc. converted using http://golang.org/pkg/strconv/#ParseInt (with base 10 and bitsize 53?)

  ```
  "${FOO | int}"  -> 1
  ```

* `float`, for fractional quota limits. converted using http://golang.org/pkg/strconv/#ParseFloat (with bitsize 64?)

  ```
  "${FOO | float}" -> 1.5
  ```

* `bool`, useful for pod options like hostNetwork, etc. converted using http://golang.org/pkg/strconv/#ParseBool

  ```
  "${FOO | bool}" -> true
  ```

* `base64`, for any binary-encoded data, which is base64 encoded in the API:

  ```
  "${FOO | base64}" -> "SGVsbG8gd29ybGQ="
  ```

For the conversion cases, we'd have to define what happens in error cases, either the template processing fails, or a default value (probably empty, so `0`, `0.0`, `false`, respectively) is used. I think my preference would be to fail processing in conversion error cases