### PR TITLE
Prompt before scaling deployments to 0 in UI

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -190,6 +190,7 @@
         <script src="scripts/controllers/util/logout.js"></script>
         <script src="scripts/controllers/create.js"></script>
         <script src="scripts/controllers/createProject.js"></script>
+        <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/directives/date.js"></script>
         <script src="scripts/directives/deleteButton.js"></script>

--- a/assets/app/scripts/controllers/modals/confirmScale.js
+++ b/assets/app/scripts/controllers/modals/confirmScale.js
@@ -1,0 +1,23 @@
+'use strict';
+/* jshint unused: false */
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:ConfirmScaleController
+ * @description
+ * # ConfirmScaleController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('ConfirmScaleController', function ($scope, $modalInstance, resource, type) {
+    $scope.resource = resource;
+    $scope.type = type;
+
+    $scope.confirmScale = function() {
+      $modalInstance.close('confirmScale');
+    };
+
+    $scope.cancel = function() {
+      $modalInstance.dismiss('cancel');
+    };
+  });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -692,7 +692,7 @@ a.action-button {
   }
 }
 
-.modal-resource-delete {
+.modal-resource-delete, .modal-confirm-scale {
   background-color: @gray-lighter;
   h1 {
     font-size: 21px;

--- a/assets/app/views/_overview-deployment.html
+++ b/assets/app/views/_overview-deployment.html
@@ -87,6 +87,15 @@
               ng-click="viewPodsForDeployment(rc)"
               ng-class="{ clickable: (pods | hashSize) > 0 }">
           </pod-status-chart>
+
+          <!-- Add a link for screen readers. -->
+          <a href=""
+             class="sr-only"
+             ng-click="viewPodsForDeployment(rc)"
+             ng-if="(pods | hashSize) > 0"
+             role="button">
+             View pods for {{rc | displayName}}
+          </a>
         </div>
 
         <div column class="scaling-controls">
@@ -94,7 +103,7 @@
           <div flex></div>
           <div column>
             <div>
-              <a href="" ng-click="scaleUp()" title="Scale up">
+              <a href="" ng-click="scaleUp()" title="Scale up" role="button">
                 <i class="fa fa-chevron-up"></i>
                 <span class="sr-only">Scale up</span>
               </a>
@@ -104,7 +113,9 @@
               <a href=""
                  ng-click="scaleDown()"
                  ng-class="{ disabled: getDesiredReplicas() === 0 }"
-                 ng-attr-title="{{(getDesiredReplicas() === 0) ? undefined : 'Scale down'}}">
+                 ng-attr-title="{{(getDesiredReplicas() === 0) ? undefined : 'Scale down'}}"
+                 ng-attr-aria-disabled="{{(getDesiredReplicas() === 0) ? 'true' : undefined}}"
+                 role="button">
                 <i class="fa fa-chevron-down"></i>
                 <span class="sr-only">Scale down</span>
               </a>

--- a/assets/app/views/modals/confirmScale.html
+++ b/assets/app/views/modals/confirmScale.html
@@ -1,0 +1,13 @@
+<div class="modal-confirm-scale">
+  <div class="modal-body">
+    <h1>Scale down {{type}} <strong>{{resource | displayName}}</strong>?</h1>
+    <p>
+      Are you sure you want to scale <strong>{{resource | displayName}}</strong> to 0
+      replicas? This will stop all pods for the {{type}}.
+    </p>
+  </div>
+  <div class="modal-footer">
+      <button class="btn btn-lg btn-danger" type="button" ng-click="confirmScale()">Scale Down</button>
+      <button class="btn btn-lg btn-default" type="button" ng-click="cancel()">Cancel</button>
+  </div>
+</div>


### PR DESCRIPTION
Using the same modal style as we do for delete.

<img width="647" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/11501887/740ad05e-9805-11e5-952e-5b87463f258d.png">

Fixes #6098

Also adds an `sr-only` link for pod status and an `aria-disabled` attribute for the scale down link (see #5988).