### PR TITLE
Use minutes instead of seconds where possible.

### DIFF
--- a/test/extended/builds/start_build.go
+++ b/test/extended/builds/start_build.go
@@ -160,7 +160,7 @@ var _ = g.Describe("builds: parallel: oc start-build", func() {
 
 			g.By("getting the build name")
 			var buildName string
-			wait.Poll(time.Duration(100*time.Millisecond), time.Duration(60*time.Second), func() (bool, error) {
+			wait.Poll(time.Duration(100*time.Millisecond), 1*time.Minute, func() (bool, error) {
 				out, err := oc.Run("get").
 					Args("build", "--template", "{{ (index .items 0).metadata.name }}").Output()
 				// Give it second chance in case the build resource was not created yet

--- a/test/extended/images/helper.go
+++ b/test/extended/images/helper.go
@@ -25,7 +25,7 @@ func GetImageLabels(c client.ImageStreamImageInterface, imageRepoName, imageRef 
 
 // RunInPodContainer will run provided command in the specified pod container.
 func RunInPodContainer(oc *exutil.CLI, selector labels.Selector, cmd []string) error {
-	pods, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), selector, exutil.CheckPodIsRunningFn, 1, 120*time.Second)
+	pods, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), selector, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/test/extended/images/s2i_perl.go
+++ b/test/extended/images/s2i_perl.go
@@ -38,7 +38,7 @@ var _ = g.Describe("images: s2i: perl", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			assertPageCountIs := func(i int) {
-				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 120*time.Second)
+				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				result, err := CheckPageContains(oc, "dancer-mysql-example", "", pageCountFn(i))
@@ -63,7 +63,7 @@ var _ = g.Describe("images: s2i: perl", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("scale").Args("rc", dcName, "--replicas=0").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitUntilPodIsGone(oc.KubeREST().Pods(oc.Namespace()), pods.Items[0].Name, 60*time.Second)
+			err = exutil.WaitUntilPodIsGone(oc.KubeREST().Pods(oc.Namespace()), pods.Items[0].Name, 1*time.Minute)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("scale").Args("rc", dcName, "--replicas=1").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/s2i_php.go
+++ b/test/extended/images/s2i_php.go
@@ -38,7 +38,7 @@ var _ = g.Describe("images: s2i: php", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			assertPageCountIs := func(i int) {
-				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 120*time.Second)
+				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				result, err := CheckPageContains(oc, "cakephp-mysql-example", "", pageCountFn(i))

--- a/test/extended/images/s2i_python.go
+++ b/test/extended/images/s2i_python.go
@@ -38,7 +38,7 @@ var _ = g.Describe("images: s2i: python", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			assertPageCountIs := func(i int) {
-				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 120*time.Second)
+				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				result, err := CheckPageContains(oc, "django-ex", "", pageCountFn(i))
@@ -63,7 +63,7 @@ var _ = g.Describe("images: s2i: python", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("scale").Args("rc", dcName, "--replicas=0").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitUntilPodIsGone(oc.KubeREST().Pods(oc.Namespace()), pods.Items[0].Name, 60*time.Second)
+			err = exutil.WaitUntilPodIsGone(oc.KubeREST().Pods(oc.Namespace()), pods.Items[0].Name, 1*time.Minute)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("scale").Args("rc", dcName, "--replicas=1").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/s2i_ruby.go
+++ b/test/extended/images/s2i_ruby.go
@@ -37,7 +37,7 @@ var _ = g.Describe("images: s2i: ruby", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			assertPageContent := func(content string) {
-				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 120*time.Second)
+				_, err := exutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), dcLabel, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				result, err := CheckPageContains(oc, "rails-postgresql-example", "", content)
@@ -62,7 +62,7 @@ var _ = g.Describe("images: s2i: ruby", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("scale").Args("rc", dcName, "--replicas=0").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitUntilPodIsGone(oc.KubeREST().Pods(oc.Namespace()), pods.Items[0].Name, 60*time.Second)
+			err = exutil.WaitUntilPodIsGone(oc.KubeREST().Pods(oc.Namespace()), pods.Items[0].Name, 1*time.Minute)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = oc.Run("scale").Args("rc", dcName, "--replicas=1").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/job/controller.go
+++ b/test/extended/job/controller.go
@@ -24,7 +24,7 @@ var _ = g.Describe("Job", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By(fmt.Sprintf("Waiting for pod..."))
-			podNames, err := exeutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), exeutil.ParseLabelsOrDie("app=pi"), exeutil.CheckPodIsSucceededFn, 1, 120*time.Second)
+			podNames, err := exeutil.WaitForPods(oc.KubeREST().Pods(oc.Namespace()), exeutil.ParseLabelsOrDie("app=pi"), exeutil.CheckPodIsSucceededFn, 1, 2*time.Minute)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(len(podNames)).Should(o.Equal(1))
 			podName := podNames[0]

--- a/test/extended/util/db_image_helpers.go
+++ b/test/extended/util/db_image_helpers.go
@@ -275,7 +275,7 @@ func WaitUntilUp(oc *CLI, d Database, timeout time.Duration) error {
 // WaitUntilAllHelpersAreUp waits until all helpers are ready to serve requests
 func WaitUntilAllHelpersAreUp(oc *CLI, helpers []Database) error {
 	for _, m := range helpers {
-		if err := WaitUntilUp(oc, m, 180*time.Second); err != nil {
+		if err := WaitUntilUp(oc, m, 3*time.Minute); err != nil {
 			return err
 		}
 	}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -125,7 +125,7 @@ func WaitForBuilderAccount(c kclient.ServiceAccountsInterface) error {
 		}
 		return false, nil
 	}
-	return wait.Poll(time.Duration(100*time.Millisecond), time.Duration(60*time.Second), waitFn)
+	return wait.Poll(time.Duration(100*time.Millisecond), 1*time.Minute, waitFn)
 }
 
 // WaitForAnImageStream waits for an ImageStream to fulfill the isOK function


### PR DESCRIPTION
IMHO it's a bit easier to understand when you see `time.Minute` instead of `60*time.Second`. So, I did such replacements in tests. Interesting to hear your opinions, maybe it's not worth it.

PTAL @rhcarvalho @mnagy @bparees
