### PR TITLE
add namespace to field selectors

### DIFF
--- a/pkg/authorization/api/fields.go
+++ b/pkg/authorization/api/fields.go
@@ -22,7 +22,8 @@ func ClusterPolicyBindingToSelectableFields(policyBinding *ClusterPolicyBinding)
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func PolicyToSelectableFields(policy *Policy) fields.Set {
 	return fields.Set{
-		"metadata.name": policy.Name,
+		"metadata.name":      policy.Name,
+		"metadata.namespace": policy.Namespace,
 	}
 }
 
@@ -31,6 +32,7 @@ func PolicyToSelectableFields(policy *Policy) fields.Set {
 func PolicyBindingToSelectableFields(policyBinding *PolicyBinding) fields.Set {
 	return fields.Set{
 		"metadata.name":       policyBinding.Name,
+		"metadata.namespace":  policyBinding.Namespace,
 		"policyRef.namespace": policyBinding.PolicyRef.Namespace,
 	}
 }
@@ -39,7 +41,8 @@ func PolicyBindingToSelectableFields(policyBinding *PolicyBinding) fields.Set {
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func RoleToSelectableFields(role *Role) fields.Set {
 	return fields.Set{
-		"metadata.name": role.Name,
+		"metadata.name":      role.Name,
+		"metadata.namespace": role.Namespace,
 	}
 }
 
@@ -47,6 +50,7 @@ func RoleToSelectableFields(role *Role) fields.Set {
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func RoleBindingToSelectableFields(roleBinding *RoleBinding) fields.Set {
 	return fields.Set{
-		"metadata.name": roleBinding.Name,
+		"metadata.name":      roleBinding.Name,
+		"metadata.namespace": roleBinding.Namespace,
 	}
 }

--- a/pkg/build/api/fields.go
+++ b/pkg/build/api/fields.go
@@ -6,9 +6,10 @@ import "k8s.io/kubernetes/pkg/fields"
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func BuildToSelectableFields(build *Build) fields.Set {
 	return fields.Set{
-		"metadata.name": build.Name,
-		"status":        string(build.Status.Phase),
-		"podName":       GetBuildPodName(build),
+		"metadata.name":      build.Name,
+		"metadata.namespace": build.Namespace,
+		"status":             string(build.Status.Phase),
+		"podName":            GetBuildPodName(build),
 	}
 }
 
@@ -16,6 +17,7 @@ func BuildToSelectableFields(build *Build) fields.Set {
 // changes to the returned keys require registering conversions for existing versions using Scheme.AddFieldLabelConversionFunc
 func BuildConfigToSelectableFields(buildConfig *BuildConfig) fields.Set {
 	return fields.Set{
-		"metadata.name": buildConfig.Name,
+		"metadata.name":      buildConfig.Name,
+		"metadata.namespace": buildConfig.Namespace,
 	}
 }

--- a/pkg/deploy/api/fields.go
+++ b/pkg/deploy/api/fields.go
@@ -5,6 +5,7 @@ import "k8s.io/kubernetes/pkg/fields"
 // DeploymentConfigToSelectableFields returns a label set that represents the object
 func DeploymentConfigToSelectableFields(deploymentConfig *DeploymentConfig) fields.Set {
 	return fields.Set{
-		"metadata.name": deploymentConfig.Name,
+		"metadata.name":      deploymentConfig.Name,
+		"metadata.namespace": deploymentConfig.Namespace,
 	}
 }

--- a/pkg/image/api/fields.go
+++ b/pkg/image/api/fields.go
@@ -5,7 +5,8 @@ import "k8s.io/kubernetes/pkg/fields"
 // ImageToSelectableFields returns a label set that represents the object.
 func ImageToSelectableFields(image *Image) fields.Set {
 	return fields.Set{
-		"metadata.name": image.Name,
+		"metadata.name":      image.Name,
+		"metadata.namespace": image.Namespace,
 	}
 }
 
@@ -13,6 +14,7 @@ func ImageToSelectableFields(image *Image) fields.Set {
 func ImageStreamToSelectableFields(ir *ImageStream) fields.Set {
 	return fields.Set{
 		"metadata.name":                ir.Name,
+		"metadata.namespace":           ir.Namespace,
 		"spec.dockerImageRepository":   ir.Spec.DockerImageRepository,
 		"status.dockerImageRepository": ir.Status.DockerImageRepository,
 	}

--- a/pkg/route/api/fields.go
+++ b/pkg/route/api/fields.go
@@ -5,9 +5,10 @@ import "k8s.io/kubernetes/pkg/fields"
 // RouteToSelectableFields returns a label set that represents the object
 func RouteToSelectableFields(route *Route) fields.Set {
 	return fields.Set{
-		"metadata.name": route.Name,
-		"spec.path":     route.Spec.Path,
-		"spec.host":     route.Spec.Host,
-		"spec.to.name":  route.Spec.To.Name,
+		"metadata.name":      route.Name,
+		"metadata.namespace": route.Namespace,
+		"spec.path":          route.Spec.Path,
+		"spec.host":          route.Spec.Host,
+		"spec.to.name":       route.Spec.To.Name,
 	}
 }


### PR DESCRIPTION
Companion PR for https://github.com/kubernetes/kubernetes/pull/17986

Add namespace to v1 field selectors

Changed:

1. Policy
1. PolicyBinding
1. Build
1. BuildConfig
1. DeploymentConfig
1. Image
1. ImageStream
1. Route
1. Role
1. RoleBinding

Unchanged:

1. all v1beta3 pieces in anticipation that they will go away
1. ClusterPolicy
1. ClusterPolicyBinding
1. OAuthAccessToken
1. OAuthAuthorizeToken
1. OAuthClient
1. OAuthClientAuthorization
1. Project
1. ClusterNetwork
1. HostSubnet
1. NetNamespace
1. Group
1. Identity
1. User

@derekwaynecarr @liggitt 