### PR TITLE
add InsecureSkipVerify flag for LDAP

### DIFF
--- a/pkg/auth/ldaputil/client.go
+++ b/pkg/auth/ldaputil/client.go
@@ -12,13 +12,15 @@ import (
 )
 
 // NewLDAPClientConfig returns a new LDAP client config
-func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecure bool) (ldapclient.Config, error) {
+func NewLDAPClientConfig(URL, bindDN, bindPassword, CA string, insecureSkipVerify bool, insecure bool) (ldapclient.Config, error) {
 	url, err := ParseURL(URL)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing URL: %v", err)
 	}
 
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify,
+	}
 	if len(CA) > 0 {
 		roots, err := util.CertPoolFromFile(CA)
 		if err != nil {

--- a/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
+++ b/pkg/cmd/experimental/syncgroups/cli/syncgroups.go
@@ -311,7 +311,7 @@ func (o *SyncGroupsOptions) Validate() error {
 // Run creates the GroupSyncer specified and runs it to sync groups
 // the arguments are only here because its the only way to get the printer we need
 func (o *SyncGroupsOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
-	clientConfig, err := ldaputil.NewLDAPClientConfig(o.Config.URL, o.Config.BindDN, o.Config.BindPassword, o.Config.CA, o.Config.Insecure)
+	clientConfig, err := ldaputil.NewLDAPClientConfig(o.Config.URL, o.Config.BindDN, o.Config.BindPassword, o.Config.CA, o.Config.InsecureSkipVerify, o.Config.Insecure)
 	if err != nil {
 		return fmt.Errorf("could not determine LDAP client configuration: %v", err)
 	}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -584,6 +584,10 @@ type LDAPPasswordIdentityProvider struct {
 	// Cannot be set to true with a URL scheme of "ldaps://"
 	// If false, "ldaps://" URLs connect using TLS, and "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830
 	Insecure bool
+	// InsecureSkipVerify, if true, indicates that any certificate will be accepted,
+	// regardless of the host name in the certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	InsecureSkipVerify bool
 	// CA is the optional trusted certificate authority bundle to use when making requests to the server
 	// If empty, the default system roots are used
 	CA string
@@ -821,6 +825,10 @@ type LDAPSyncConfig struct {
 	// Cannot be set to true with a URL scheme of "ldaps://"
 	// If false, "ldaps://" URLs connect using TLS, and "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830
 	Insecure bool
+	// InsecureSkipVerify, if true, indicates that any certificate will be accepted,
+	// regardless of the host name in the certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	InsecureSkipVerify bool
 	// CA is the optional trusted certificate authority bundle to use when making requests to the server
 	// If empty, the default system roots are used
 	CA string

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -533,6 +533,10 @@ type LDAPPasswordIdentityProvider struct {
 	// Cannot be set to true with a URL scheme of "ldaps://"
 	// If false, "ldaps://" URLs connect using TLS, and "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830
 	Insecure bool `json:"insecure"`
+	// InsecureSkipVerify, if true, indicates that any certificate will be accepted,
+	// regardless of the host name in the certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	InsecureSkipVerify bool `json:"insecureSkipVerify"`
 	// CA is the optional trusted certificate authority bundle to use when making requests to the server
 	// If empty, the default system roots are used
 	CA string `json:"ca"`
@@ -768,6 +772,10 @@ type LDAPSyncConfig struct {
 	// Cannot be set to true with a URL scheme of "ldaps://"
 	// If false, "ldaps://" URLs connect using TLS, and "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830
 	Insecure bool `json:"insecure"`
+	// InsecureSkipVerify, if true, indicates that any certificate will be accepted,
+	// regardless of the host name in the certificate.
+	// In this mode, TLS is susceptible to man-in-the-middle attacks.
+	InsecureSkipVerify bool
 	// CA is the optional trusted certificate authority bundle to use when making requests to the server
 	// If empty, the default system roots are used
 	CA string `json:"ca"`

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -200,6 +200,7 @@ oauthConfig:
       bindPassword: ""
       ca: ""
       insecure: false
+      insecureSkipVerify: false
       kind: LDAPPasswordIdentityProvider
       url: ""
   - challenge: false

--- a/pkg/cmd/server/api/validation/ldap.go
+++ b/pkg/cmd/server/api/validation/ldap.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ValidateLDAPSyncConfig(config *api.LDAPSyncConfig) ValidationResults {
-	validationResults := ValidateLDAPClientConfig(config.URL, config.BindDN, config.BindPassword, config.CA, config.Insecure)
+	validationResults := ValidateLDAPClientConfig(config.URL, config.BindDN, config.BindPassword, config.CA, config.InsecureSkipVerify, config.Insecure)
 
 	schemaConfigsFound := []string{}
 
@@ -45,7 +45,7 @@ func ValidateLDAPSyncConfig(config *api.LDAPSyncConfig) ValidationResults {
 	return validationResults
 }
 
-func ValidateLDAPClientConfig(url, bindDN, bindPassword, CA string, insecure bool) ValidationResults {
+func ValidateLDAPClientConfig(url, bindDN, bindPassword, CA string, insecureSkipVerify bool, insecure bool) ValidationResults {
 	validationResults := ValidationResults{}
 
 	if len(url) == 0 {
@@ -77,6 +77,10 @@ func ValidateLDAPClientConfig(url, bindDN, bindPassword, CA string, insecure boo
 		if len(CA) > 0 {
 			validationResults.AddErrors(fielderrors.NewFieldInvalid("ca", CA,
 				"Cannot specify a ca with insecure=true"))
+		}
+		if insecureSkipVerify {
+			validationResults.AddErrors(fielderrors.NewFieldInvalid("insecureSkipVerify", insecureSkipVerify,
+				"Cannot set the insecureSkipVerify flag with insecure=true"))
 		}
 	} else {
 		if len(CA) > 0 {

--- a/pkg/cmd/server/api/validation/oauth.go
+++ b/pkg/cmd/server/api/validation/oauth.go
@@ -170,7 +170,7 @@ func ValidateIdentityProvider(identityProvider api.IdentityProvider) ValidationR
 }
 
 func ValidateLDAPIdentityProvider(provider *api.LDAPPasswordIdentityProvider) ValidationResults {
-	validationResults := ValidateLDAPClientConfig(provider.URL, provider.BindDN, provider.BindPassword, provider.CA, provider.Insecure).Prefix("provider")
+	validationResults := ValidateLDAPClientConfig(provider.URL, provider.BindDN, provider.BindPassword, provider.CA, provider.InsecureSkipVerify, provider.Insecure).Prefix("provider")
 
 	// At least one attribute to use as the user id is required
 	if len(provider.Attributes.ID) == 0 {

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -493,6 +493,7 @@ func (c *AuthConfig) getPasswordAuthenticator(identityProvider configapi.Identit
 			provider.BindDN,
 			provider.BindPassword,
 			provider.CA,
+			provider.InsecureSkipVerify,
 			provider.Insecure)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
for tls.Config, to accept any certificate when talking to a TLS-enabled LDAP server