### PR TITLE
UPSTREAM: 17920: Fix frequent kubernetes endpoint updates during cluster start

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/controller.go
@@ -291,9 +291,14 @@ func (c *Controller) ReconcileEndpoints(serviceName string, ip net.IP, endpointP
 	return c.EndpointRegistry.UpdateEndpoints(ctx, e)
 }
 
-// Determine if the endpoint is in the format ReconcileEndpoints expect (one subset,
-// correct ports, N IP addresses); and if the specified IP address is present and
-// the correct number of ip addresses are found.
+// Determine if the endpoint is in the format ReconcileEndpoints expects.
+//
+// Return values:
+// * formatCorrect is true if exactly one subset is found.
+// * ipCorrect is true when current master's IP is found and the number
+//     of addresses is less than or equal to the master count.
+// * portsCorrect is true when endpoint ports exactly match provided ports.
+//     portsCorrect is only evaluated when reconcilePorts is set to true.
 func checkEndpointSubsetFormat(e *api.Endpoints, ip string, ports []api.EndpointPort, count int, reconcilePorts bool) (formatCorrect bool, ipCorrect bool, portsCorrect bool) {
 	if len(e.Subsets) != 1 {
 		return false, false, false
@@ -313,7 +318,7 @@ func checkEndpointSubsetFormat(e *api.Endpoints, ip string, ports []api.Endpoint
 	}
 	for _, addr := range sub.Addresses {
 		if addr.IP == ip {
-			ipCorrect = len(sub.Addresses) == count
+			ipCorrect = len(sub.Addresses) <= count
 			break
 		}
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/controller_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/controller_test.go
@@ -161,6 +161,54 @@ func TestReconcileEndpoints(t *testing.T) {
 			},
 		},
 		{
+			testName:          "existing endpoints satisfy and endpoint addresses length less than master count",
+			serviceName:       "foo",
+			ip:                "4.3.2.2",
+			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			additionalMasters: 3,
+			endpoints: &api.EndpointsList{
+				Items: []api.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []api.EndpointSubset{{
+						Addresses: []api.EndpointAddress{
+							{IP: "4.3.2.1"},
+							{IP: "4.3.2.2"},
+						},
+						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					}},
+				}},
+			},
+			expectUpdate: nil,
+		},
+		{
+			testName:          "existing endpoints current IP missing and address length less than master count",
+			serviceName:       "foo",
+			ip:                "4.3.2.2",
+			endpointPorts:     []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			additionalMasters: 3,
+			endpoints: &api.EndpointsList{
+				Items: []api.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets: []api.EndpointSubset{{
+						Addresses: []api.EndpointAddress{
+							{IP: "4.3.2.1"},
+						},
+						Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+					}},
+				}},
+			},
+			expectUpdate: &api.Endpoints{
+				ObjectMeta: om("foo"),
+				Subsets: []api.EndpointSubset{{
+					Addresses: []api.EndpointAddress{
+						{IP: "4.3.2.1"},
+						{IP: "4.3.2.2"},
+					},
+					Ports: []api.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+				}},
+			},
+		},
+		{
 			testName:      "existing endpoints wrong name",
 			serviceName:   "foo",
 			ip:            "1.2.3.4",


### PR DESCRIPTION
checkEndpointSubsetFormat ensures that
1. the current master's IP is in the list of addresses
2. the number of IPs in the list exactly matches the master count

This is problematic while masters are in the process of starting because it causes frequent updates to the kubernetes endpoints until all masters have started and added themselves to the list.

checkEndpointSubsetFormat should report success if the current master's IP is found and the count of addresses is less than or equal to the expected count.

Resolves #6073 
@liggitt 