### PR TITLE
[RPMS] Patch AOS tuned-profiles manpage for naming differences

### DIFF
--- a/contrib/tuned/man/tuned-profiles-origin-node.7
+++ b/contrib/tuned/man/tuned-profiles-origin-node.7
@@ -18,26 +18,26 @@
 .\" * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\" */
 .\" 
-.TH TUNED_PROFILES_OPENSHIFT_NODE "7" "12 Feb 2015" "OpenShift" "tuned"
+.TH TUNED_PROFILES_ORIGIN_NODE "7" "12 Feb 2015" "OpenShift" "tuned-profiles-origin-node"
 .SH NAME
-tuned\-profiles\-openshift-node - description of profiles provided for OpenShift
+tuned\-profiles\-origin-node - description of profiles provided for OpenShift
 
 .SH DESCRIPTION
 These profiles are provided for OpenShift nodes. They provide performance
 optimizations for OpenShift Nodes running on either bare metal
-(openshift-node-host) or virtual machines (openshift-node-guest).
+(origin-node-host) or virtual machines (origin-node-guest).
 
 .SH PROFILES
 The following profiles are provided:
 
 .TP
-.BI "openshift-node\-host"
+.BI "origin-node\-host"
 Profile optimized for OpenShift hosts (bare metal). It is based on throughput\-performance
 profile. It additionally increases SELinux AVC cache, PID limit and tunes
 netfilter connections tracking.
 
 .TP
-.BI "openshift-node\-guest"
+.BI "origin-node\-guest"
 Profile optimized for virtual OpenShift guests. It is based on virtual\-guest
 profile. It additionally increases SELinux AVC cache, PID limit and tunes
 netfilter connections tracking.

--- a/origin.spec
+++ b/origin.spec
@@ -252,7 +252,15 @@ install -d -m 0755 %{buildroot}%{_prefix}/lib/tuned/%{name}-node-{guest,host}
 install -m 0644 contrib/tuned/origin-node-guest/tuned.conf %{buildroot}%{_prefix}/lib/tuned/%{name}-node-guest/tuned.conf
 install -m 0644 contrib/tuned/origin-node-host/tuned.conf %{buildroot}%{_prefix}/lib/tuned/%{name}-node-host/tuned.conf
 install -d -m 0755 %{buildroot}%{_mandir}/man7
+
+# Patch the manpage for tuned profiles on aos
+%if "%{dist}" == ".el7aos"
+%{__sed} -e 's|origin-node|atomic-openshift-node|g' \
+ -e 's|ORIGIN_NODE|ATOMIC_OPENSHIFT_NODE|' \
+ contrib/tuned/man/tuned-profiles-origin-node.7 > %{buildroot}%{_mandir}/man7/tuned-profiles-%{name}-node.7
+%else
 install -m 0644 contrib/tuned/man/tuned-profiles-origin-node.7 %{buildroot}%{_mandir}/man7/tuned-profiles-%{name}-node.7
+%endif
 
 mkdir -p %{buildroot}%{_sharedstatedir}/origin
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1284506