### PR TITLE
debug healthz wait flakes

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -105,6 +105,9 @@ echo "[INFO] Create certificates for the OpenShift server to ${MASTER_CONFIG_DIR
 # find the same IP that openshift start will bind to.  This allows access from pods that have to talk back to master
 SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},$(openshift start --print-ip),localhost"
 
+# display any existing OpenShift processes
+check_for_running_openshift
+
 openshift admin ca create-master-certs \
   --overwrite=false \
   --cert-dir="${MASTER_CONFIG_DIR}" \

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -66,6 +66,10 @@ popd &>/dev/null
 os::log::start_system_logger
 
 configure_os_server
+
+check_for_running_openshift
+check_for_running_etcd
+
 openshift start etcd --config=${MASTER_CONFIG_DIR}/master-config.yaml &> ${LOG_DIR}/etcd.log &
 
 wait_for_url "http://${API_HOST}:${ETCD_PORT}/version" "etcd: " 0.25 160


### PR DESCRIPTION
Adding some extra debugging to try and reproduce the flakes in https://github.com/openshift/origin/issues/6031.

I was unable to reproduce it locally without running a test script, pausing, and rerunning the same script in another window.  This is attempting to list the parent processes that started the openshift command that seems to be causing the failure so I can see what isn't cleaning up nicely

cc @stevekuznetsov @deads2k @php-coder 