### PR TITLE
builder: fix basic auth for source repos

### DIFF
--- a/pkg/build/builder/cmd/scmauth/cacert.go
+++ b/pkg/build/builder/cmd/scmauth/cacert.go
@@ -22,17 +22,17 @@ type CACert struct {
 }
 
 // Setup creates a .gitconfig fragment that points to the given ca.crt
-func (s CACert) Setup(baseDir string) (*url.URL, error) {
+func (s CACert) Setup(baseDir string, context SCMAuthContext) error {
 	if strings.ToLower(s.SourceURL.Scheme) != "https" {
-		return nil, nil
+		return nil
 	}
 	gitconfig, err := ioutil.TempFile("", "ca.crt.")
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer gitconfig.Close()
 	gitconfig.WriteString(fmt.Sprintf(CACertConfig, filepath.Join(baseDir, CACertName)))
-	return nil, ensureGitConfigIncludes(gitconfig.Name())
+	return ensureGitConfigIncludes(gitconfig.Name(), context)
 }
 
 // Name returns the name of this auth method.

--- a/pkg/build/builder/cmd/scmauth/cacert_test.go
+++ b/pkg/build/builder/cmd/scmauth/cacert_test.go
@@ -1,0 +1,52 @@
+package scmauth
+
+import (
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestCACertHandles(t *testing.T) {
+	caCert := &CACert{}
+	if !caCert.Handles("ca.crt") {
+		t.Errorf("should handle ca.crt")
+	}
+	if caCert.Handles("username") {
+		t.Errorf("should not handle username")
+	}
+}
+
+func TestCACertSetup(t *testing.T) {
+	context := NewDefaultSCMContext()
+	caCert := &CACert{
+		SourceURL: url.URL{Scheme: "https", Host: "my.host", Path: "git/repo"},
+	}
+	secretDir := secretDir(t, "ca.crt")
+	defer os.RemoveAll(secretDir)
+
+	err := caCert.Setup(secretDir, context)
+	gitConfig, _ := context.Get("GIT_CONFIG")
+	defer cleanupConfig(gitConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	validateConfig(t, gitConfig, "sslCAInfo")
+}
+
+func TestCACertSetupNoSSL(t *testing.T) {
+	context := NewDefaultSCMContext()
+	caCert := &CACert{
+		SourceURL: url.URL{Scheme: "http", Host: "my.host", Path: "git/repo"},
+	}
+	secretDir := secretDir(t, "ca.crt")
+	defer os.RemoveAll(secretDir)
+
+	err := caCert.Setup(secretDir, context)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, gitConfigPresent := context.Get("GIT_CONFIG")
+	if gitConfigPresent {
+		t.Fatalf("git config not expected")
+	}
+}

--- a/pkg/build/builder/cmd/scmauth/context.go
+++ b/pkg/build/builder/cmd/scmauth/context.go
@@ -1,0 +1,56 @@
+package scmauth
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type defaultSCMContext struct {
+	vars        map[string]string
+	overrideURL *url.URL
+}
+
+func NewDefaultSCMContext() *defaultSCMContext {
+	return &defaultSCMContext{
+		vars: make(map[string]string),
+	}
+}
+
+func (c *defaultSCMContext) Get(name string) (string, bool) {
+	value, ok := c.vars[name]
+	return value, ok
+}
+
+// Set will set the value of a variable. If a variable has already been set
+// and the value sent is different, then an error will be returned.
+func (c *defaultSCMContext) Set(name, value string) error {
+	if oldValue, isSet := c.Get(name); isSet && value != oldValue {
+		return fmt.Errorf("cannot set the value of variable %s with value %q. Existing value: %q", name, value, oldValue)
+	}
+	c.vars[name] = value
+	return nil
+}
+
+// SetOverrideURL will set an override URL. If a value has already been set
+// and the URL passed is different, then an error will be returned.
+func (c *defaultSCMContext) SetOverrideURL(u *url.URL) error {
+	if c.overrideURL != nil && c.overrideURL.String() != u.String() {
+		return fmt.Errorf("cannot set the value of overrideURL with value %s. Existing value: %s", c.overrideURL.String(), u.String())
+	}
+	c.overrideURL = u
+	return nil
+}
+
+// OverrideURL returns an override URL if one is set
+func (c *defaultSCMContext) OverrideURL() *url.URL {
+	return c.overrideURL
+}
+
+// Env returns a string slice with variables set on this context
+func (c *defaultSCMContext) Env() []string {
+	env := []string{}
+	for k, v := range c.vars {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}

--- a/pkg/build/builder/cmd/scmauth/context_test.go
+++ b/pkg/build/builder/cmd/scmauth/context_test.go
@@ -1,0 +1,75 @@
+package scmauth
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestContextSet(t *testing.T) {
+	c := NewDefaultSCMContext()
+	err := c.Set("VAR1", "value1")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	c.Set("VAR2", "value2")
+	if v, _ := c.Get("VAR1"); v != "value1" {
+		t.Errorf("unexpected value")
+	}
+	if v, _ := c.Get("VAR2"); v != "value2" {
+		t.Errorf("unexpected value")
+	}
+	if len(c.Env()) != 2 {
+		t.Errorf("unexpected length of Env")
+	}
+}
+
+func TestContextSetExisting(t *testing.T) {
+	c := NewDefaultSCMContext()
+	err := c.Set("VAR1", "value1")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Setting the same value should be ok
+	err = c.Set("VAR1", "value1")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Setting a different value should return an error
+	err = c.Set("VAR1", "value2")
+	if err == nil {
+		t.Errorf("did not get expected error")
+	}
+}
+
+func TestSetOverrideURL(t *testing.T) {
+	c := NewDefaultSCMContext()
+	u, _ := url.Parse("https://my.override.url/test/repo")
+	err := c.SetOverrideURL(u)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	u2 := c.OverrideURL()
+	if u.String() != u2.String() {
+		t.Errorf("did not get the same URL: %v", u2)
+	}
+}
+
+func TestSetOverrideURLExisting(t *testing.T) {
+	c := NewDefaultSCMContext()
+	urlStr := "https://my.override.url/test/repo"
+	u, _ := url.Parse(urlStr)
+	err := c.SetOverrideURL(u)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	sameURL, _ := url.Parse(urlStr)
+	err = c.SetOverrideURL(sameURL)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	differentURL, _ := url.Parse("https://another.url/different/path")
+	err = c.SetOverrideURL(differentURL)
+	if err == nil {
+		t.Errorf("did not get expected error")
+	}
+}

--- a/pkg/build/builder/cmd/scmauth/doc.go
+++ b/pkg/build/builder/cmd/scmauth/doc.go
@@ -1,0 +1,2 @@
+// Package scmauth provides SCM authentication methods based on secret files
+package scmauth

--- a/pkg/build/builder/cmd/scmauth/gitconfig.go
+++ b/pkg/build/builder/cmd/scmauth/gitconfig.go
@@ -1,7 +1,6 @@
 package scmauth
 
 import (
-	"net/url"
 	"path/filepath"
 )
 
@@ -11,8 +10,8 @@ const GitConfigName = ".gitconfig"
 type GitConfig struct{}
 
 // Setup adds the secret .gitconfig as an include to the .gitconfig file to be used in the build
-func (_ GitConfig) Setup(baseDir string) (*url.URL, error) {
-	return nil, ensureGitConfigIncludes(filepath.Join(baseDir, GitConfigName))
+func (_ GitConfig) Setup(baseDir string, context SCMAuthContext) error {
+	return ensureGitConfigIncludes(filepath.Join(baseDir, GitConfigName), context)
 }
 
 // Name returns the name of this auth method.

--- a/pkg/build/builder/cmd/scmauth/gitconfig_test.go
+++ b/pkg/build/builder/cmd/scmauth/gitconfig_test.go
@@ -1,0 +1,34 @@
+package scmauth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGitConfigHandles(t *testing.T) {
+	caCert := &GitConfig{}
+	if !caCert.Handles(".gitconfig") {
+		t.Errorf("should handle .gitconfig")
+	}
+	if caCert.Handles("username") {
+		t.Errorf("should not handle username")
+	}
+	if caCert.Handles("gitconfig") {
+		t.Errorf("should not handle gitconfig")
+	}
+}
+
+func TestGitConfigSetup(t *testing.T) {
+	context := NewDefaultSCMContext()
+	gitConfig := &GitConfig{}
+	secretDir := secretDir(t, ".gitconfig")
+	defer os.RemoveAll(secretDir)
+
+	err := gitConfig.Setup(secretDir, context)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	config, _ := context.Get("GIT_CONFIG")
+	defer cleanupConfig(config)
+	validateConfig(t, config, "test")
+}

--- a/pkg/build/builder/cmd/scmauth/password_test.go
+++ b/pkg/build/builder/cmd/scmauth/password_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+func TestPasswordHandles(t *testing.T) {
+	tests := map[string]bool{
+		"username": true,
+		"user":     false,
+		"token":    true,
+		"ca.crt":   false,
+		"password": true,
+	}
+	up := UsernamePassword{}
+	for k, v := range tests {
+		if a := up.Handles(k); a != v {
+			t.Errorf("unexpected result for %s: %v", k, a)
+		}
+	}
+}
+
 func TestPassword(t *testing.T) {
 
 	testcases := map[string]struct {

--- a/pkg/build/builder/cmd/scmauth/scmauth.go
+++ b/pkg/build/builder/cmd/scmauth/scmauth.go
@@ -14,5 +14,21 @@ type SCMAuth interface {
 
 	// Setup lays down the required files for this authentication method to work.
 	// Returns the the source URL stripped of credentials.
-	Setup(baseDir string) (*url.URL, error)
+	Setup(baseDir string, context SCMAuthContext) error
+}
+
+// SCMAuthContext keeps track of variables needed for SCM authentication.
+// The variables will then be used to invoke git
+type SCMAuthContext interface {
+	// Get returns the value of a variable if previously set on the context and
+	// a boolean indicating whether the variable is set or not
+	Get(name string) (string, bool)
+
+	// Set will set the value of a variable. If a variable has already been set
+	// and the value sent is different, then an error will be returned.
+	Set(name, value string) error
+
+	// SetOverrideURL will set an override URL. If a value has already been set
+	// and the URL passed is different, then an error will be returned.
+	SetOverrideURL(u *url.URL) error
 }

--- a/pkg/build/builder/cmd/scmauth/scmauth_test.go
+++ b/pkg/build/builder/cmd/scmauth/scmauth_test.go
@@ -1,0 +1,79 @@
+package scmauth
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openshift/origin/pkg/util/file"
+)
+
+func secretDir(t *testing.T, files ...string) string {
+	dir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	for _, f := range files {
+		err := ioutil.WriteFile(filepath.Join(dir, f), []byte("test"), 0600)
+		if err != nil {
+			t.Fatalf("error creating test file: %v", err)
+		}
+	}
+	return dir
+}
+
+func cleanupConfig(config string) {
+	if len(config) == 0 {
+		return
+	}
+	lines, err := file.ReadLines(config)
+	if err != nil {
+		// abort cleanup on error
+		return
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "path = ") {
+			continue
+		}
+		cleanupDir(strings.TrimPrefix(line, "path = "))
+	}
+	cleanupDir(filepath.Dir(config))
+}
+
+func cleanupDir(path string) {
+	os.RemoveAll(path)
+}
+
+func validateConfig(t *testing.T, config string, search string) {
+	if len(config) == 0 {
+		return
+	}
+	lines, err := file.ReadLines(config)
+	if err != nil {
+		t.Fatalf("cannot read file %s: %v", config, err)
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "path = ") {
+			continue
+		}
+		includedConfig := strings.TrimPrefix(line, "path = ")
+		validateConfigContent(t, includedConfig, search)
+	}
+}
+
+func validateConfigContent(t *testing.T, config string, search string) {
+	lines, err := file.ReadLines(config)
+	if err != nil {
+		t.Fatalf("cannot read file %s: %v", config, err)
+	}
+	for _, line := range lines {
+		if strings.Contains(line, search) {
+			// search string was found. Test was successful
+			return
+		}
+	}
+
+	t.Errorf("Could not find search string %q in config file %s", search, config)
+}

--- a/pkg/build/builder/cmd/scmauth/scmauths.go
+++ b/pkg/build/builder/cmd/scmauth/scmauths.go
@@ -1,0 +1,73 @@
+package scmauth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+
+	"github.com/golang/glog"
+)
+
+type SCMAuths []SCMAuth
+
+func GitAuths(sourceURL *url.URL) SCMAuths {
+	auths := SCMAuths{
+		&SSHPrivateKey{},
+		&UsernamePassword{SourceURL: *sourceURL},
+		&CACert{SourceURL: *sourceURL},
+		&GitConfig{},
+	}
+	return auths
+}
+
+func (a SCMAuths) present(files []os.FileInfo) SCMAuths {
+	scmAuthsPresent := map[string]SCMAuth{}
+	for _, file := range files {
+		glog.V(3).Infof("Finding auth for %q", file.Name())
+		for _, scmAuth := range a {
+			if scmAuth.Handles(file.Name()) {
+				glog.V(3).Infof("Found SCMAuth %q to handle %q", scmAuth.Name(), file.Name())
+				scmAuthsPresent[scmAuth.Name()] = scmAuth
+			}
+		}
+	}
+	auths := SCMAuths{}
+	for _, auth := range scmAuthsPresent {
+		auths = append(auths, auth)
+	}
+	return auths
+}
+
+func (a SCMAuths) doSetup(secretsDir string) (*defaultSCMContext, error) {
+	context := NewDefaultSCMContext()
+	for _, auth := range a {
+		glog.V(3).Infof("Setting up SCMAuth %q", auth.Name())
+		err := auth.Setup(secretsDir, context)
+		if err != nil {
+			return nil, fmt.Errorf("cannot set up source authentication method %q: %v", auth.Name(), err)
+		}
+	}
+	return context, nil
+
+}
+
+func (a SCMAuths) Setup(secretsDir string) (env []string, overrideURL *url.URL, err error) {
+	files, err := ioutil.ReadDir(secretsDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Filter the list of SCMAuths based on the secret files that are present
+	presentAuths := a.present(files)
+	if len(presentAuths) == 0 {
+		return nil, nil, fmt.Errorf("no auth handler was found for secrets in %s", secretsDir)
+	}
+
+	// Setup the present SCMAuths
+	context, err := presentAuths.doSetup(secretsDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return context.Env(), context.OverrideURL(), nil
+}

--- a/pkg/build/builder/cmd/scmauth/scmauths_test.go
+++ b/pkg/build/builder/cmd/scmauth/scmauths_test.go
@@ -1,0 +1,68 @@
+package scmauth
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type testAuth struct {
+	name string
+}
+
+func (a *testAuth) Name() string {
+	return a.name
+}
+
+func (a *testAuth) Handles(name string) bool {
+	return name == a.name
+}
+
+func (a *testAuth) Setup(baseDir string, context SCMAuthContext) error {
+	context.Set(a.name, "test")
+	return nil
+}
+
+func scmAuths() SCMAuths {
+	return SCMAuths{
+		&testAuth{name: "one"},
+		&testAuth{name: "two"},
+		&testAuth{name: "three"},
+	}
+}
+
+func TestPresent(t *testing.T) {
+	secretDir := secretDir(t, "one", "three")
+	defer os.RemoveAll(secretDir)
+	files, err := ioutil.ReadDir(secretDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := scmAuths().present(files)
+	if len(result) != 2 {
+		t.Errorf("Unexpected result: %#v", result)
+	}
+	// Ensure that two is not present in result
+	for _, a := range result {
+		if a.Name() == "two" {
+			t.Errorf("Found unexpected auth")
+		}
+	}
+}
+
+func TestSetup(t *testing.T) {
+	secretDir := secretDir(t, "one", "two", "three")
+	env, _, err := scmAuths().Setup(secretDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	expectedVars := map[string]struct{}{"one=test": {}, "two=test": {}, "three=test": {}}
+	if len(env) != 3 {
+		t.Errorf("unexpected number of vars")
+	}
+	for _, v := range env {
+		if _, exists := expectedVars[v]; !exists {
+			t.Errorf("Unexpected variable: %s", v)
+		}
+	}
+}

--- a/pkg/build/builder/cmd/scmauth/sshkey.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey.go
@@ -2,8 +2,6 @@ package scmauth
 
 import (
 	"io/ioutil"
-	"net/url"
-	"os"
 	"path/filepath"
 )
 
@@ -14,25 +12,25 @@ type SSHPrivateKey struct{}
 
 // Setup creates a wrapper script for SSH command to be able to use the provided
 // SSH key while accessing private repository.
-func (_ SSHPrivateKey) Setup(baseDir string) (*url.URL, error) {
+func (_ SSHPrivateKey) Setup(baseDir string, context SCMAuthContext) error {
 	script, err := ioutil.TempFile("", "gitssh")
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer script.Close()
 	if err := script.Chmod(0711); err != nil {
-		return nil, err
+		return err
 	}
 	if _, err := script.WriteString("#!/bin/sh\nssh -i " +
 		filepath.Join(baseDir, SSHPrivateKeyMethodName) +
 		" -o StrictHostKeyChecking=false \"$@\"\n"); err != nil {
-		return nil, err
+		return err
 	}
 	// set environment variable to tell git to use the SSH wrapper
-	if err := os.Setenv("GIT_SSH", script.Name()); err != nil {
-		return nil, err
+	if err := context.Set("GIT_SSH", script.Name()); err != nil {
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 // Name returns the name of this auth method.

--- a/pkg/build/builder/cmd/scmauth/sshkey_test.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey_test.go
@@ -1,0 +1,32 @@
+package scmauth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSSHPrivateKeyHandles(t *testing.T) {
+	sshKey := &SSHPrivateKey{}
+	if !sshKey.Handles("ssh-privatekey") {
+		t.Errorf("should handle ssh-privatekey")
+	}
+	if sshKey.Handles("ca.crt") {
+		t.Errorf("should not handle ca.crt")
+	}
+}
+
+func TestSSHPrivateKeySetup(t *testing.T) {
+	context := NewDefaultSCMContext()
+	sshKey := &SSHPrivateKey{}
+	secretDir := secretDir(t, "ssh-privatekey")
+	defer os.RemoveAll(secretDir)
+
+	err := sshKey.Setup(secretDir, context)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	_, isSet := context.Get("GIT_SSH")
+	if !isSet {
+		t.Errorf("GIT_SSH is not set")
+	}
+}

--- a/pkg/build/builder/cmd/scmauth/util.go
+++ b/pkg/build/builder/cmd/scmauth/util.go
@@ -3,14 +3,13 @@ package scmauth
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/openshift/origin/pkg/util/file"
 )
 
-func createGitConfig(includePath string) error {
+func createGitConfig(includePath string, context SCMAuthContext) error {
 	tempDir, err := ioutil.TempDir("", "git")
 	if err != nil {
 		return err
@@ -24,17 +23,21 @@ func createGitConfig(includePath string) error {
 	// therefore the HOME variable needs to be set so git can pick up
 	// .gitconfig from that location. The GIT_CONFIG variable is still used
 	// to track the location of the GIT_CONFIG for multiple SCMAuth objects.
-	os.Setenv("HOME", tempDir)
-	os.Setenv("GIT_CONFIG", gitconfig)
+	if err := context.Set("HOME", tempDir); err != nil {
+		return err
+	}
+	if err := context.Set("GIT_CONFIG", gitconfig); err != nil {
+		return err
+	}
 	return nil
 }
 
 // ensureGitConfigIncludes ensures that the OS env var GIT_CONFIG is set and
 // that it points to a file that has an include statement for the given path
-func ensureGitConfigIncludes(path string) error {
-	gitconfig := os.Getenv("GIT_CONFIG")
-	if gitconfig == "" {
-		return createGitConfig(path)
+func ensureGitConfigIncludes(path string, context SCMAuthContext) error {
+	gitconfig, present := context.Get("GIT_CONFIG")
+	if !present {
+		return createGitConfig(path, context)
 	}
 
 	lines, err := file.ReadLines(gitconfig)
@@ -50,5 +53,5 @@ func ensureGitConfigIncludes(path string) error {
 
 	lines = append(lines, fmt.Sprintf("path = %s", path))
 	content := []byte(strings.Join(lines, "\n"))
-	return ioutil.WriteFile(gitconfig, content, 0644)
+	return ioutil.WriteFile(gitconfig, content, 0600)
 }

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -1,21 +1,27 @@
 package builder
 
 import (
-	"os"
-
 	"github.com/golang/glog"
-	s2iapi "github.com/openshift/source-to-image/pkg/api"
 
 	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/generate/git"
 )
 
 const OriginalSourceURLAnnotationKey = "openshift.io/original-source-url"
 
-// A KeyValue can be used to build ordered lists of key-value pairs.
+// KeyValue can be used to build ordered lists of key-value pairs.
 type KeyValue struct {
 	Key   string
 	Value string
+}
+
+// GitClient performs git operations
+type GitClient interface {
+	CloneWithOptions(dir string, url string, opts git.CloneOptions) error
+	Checkout(dir string, ref string) error
+	ListRemote(url string, args ...string) (string, string, error)
+	GetInfo(location string) (*git.SourceInfo, []error)
 }
 
 // buildInfo returns a slice of KeyValue pairs with build metadata to be
@@ -47,51 +53,7 @@ func buildInfo(build *api.Build) []KeyValue {
 	return kv
 }
 
-// setHTTPProxy sets the system's environment variables to define the HTTP and
-// HTTPS proxies to be used by commands that respect those variables, e.g., git
-// clone performed to fetch source code to be built. It returns the original
-// values of all environment variables that were set.
-func setHTTPProxy(httpProxy, httpsProxy string) map[string]string {
-	originalProxies := make(map[string]string, 4)
-	if httpProxy != "" {
-		glog.V(2).Infof("Setting HTTP_PROXY to %s", httpProxy)
-		originalProxies["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")
-		originalProxies["http_proxy"] = os.Getenv("http_proxy")
-		os.Setenv("HTTP_PROXY", httpProxy)
-		os.Setenv("http_proxy", httpProxy)
-	}
-	if httpsProxy != "" {
-		glog.V(2).Infof("Setting HTTPS_PROXY to %s", httpsProxy)
-		originalProxies["HTTPS_PROXY"] = os.Getenv("HTTPS_PROXY")
-		originalProxies["https_proxy"] = os.Getenv("https_proxy")
-		os.Setenv("HTTPS_PROXY", httpsProxy)
-		os.Setenv("https_proxy", httpsProxy)
-	}
-	return originalProxies
-}
-
-// resetHTTPProxy sets the system's environment variables defined in
-// originalProxies. It should be used to undo the changes made by setHTTPProxy.
-func resetHTTPProxy(originalProxies map[string]string) {
-	if proxy, ok := originalProxies["HTTP_PROXY"]; ok {
-		glog.V(4).Infof("Resetting HTTP_PROXY to %s", proxy)
-		os.Setenv("HTTP_PROXY", proxy)
-	}
-	if proxy, ok := originalProxies["http_proxy"]; ok {
-		glog.V(4).Infof("Resetting http_proxy to %s", proxy)
-		os.Setenv("http_proxy", proxy)
-	}
-	if proxy, ok := originalProxies["HTTPS_PROXY"]; ok {
-		glog.V(4).Infof("Resetting HTTPS_PROXY to %s", proxy)
-		os.Setenv("HTTPS_PROXY", proxy)
-	}
-	if proxy, ok := originalProxies["https_proxy"]; ok {
-		glog.V(4).Infof("Resetting https_proxy to %s", proxy)
-		os.Setenv("https_proxy", proxy)
-	}
-}
-
-func updateBuildRevision(c client.BuildInterface, build *api.Build, sourceInfo *s2iapi.SourceInfo) {
+func updateBuildRevision(c client.BuildInterface, build *api.Build, sourceInfo *git.SourceInfo) {
 	if build.Spec.Revision != nil {
 		return
 	}

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client/testclient"
+	"github.com/openshift/origin/pkg/generate/git"
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/api/validation"
 	s2ibuild "github.com/openshift/source-to-image/pkg/build"
@@ -75,6 +76,7 @@ func makeStiBuilder(
 		"/docker.socket",
 		testclient.NewSimpleFake().Builds(""),
 		makeBuild(),
+		git.NewRepository(),
 		testStiBuilderFactory{getStrategyErr: getStrategyErr, buildError: buildError},
 		testStiConfigValidator{errors: validationErrors},
 	)

--- a/pkg/build/builder/util.go
+++ b/pkg/build/builder/util.go
@@ -59,3 +59,29 @@ func getDockerNetworkMode() stiapi.DockerNetworkMode {
 	}
 	return ""
 }
+
+// MergeEnv will take an existing environment and merge it with a new set of
+// variables. For variables with the same name in both, only the one in the
+// new environment will be kept.
+func MergeEnv(oldEnv, newEnv []string) []string {
+	key := func(e string) string {
+		i := strings.Index(e, "=")
+		if i == -1 {
+			return e
+		}
+		return e[:i]
+	}
+	result := []string{}
+	newVars := map[string]struct{}{}
+	for _, e := range newEnv {
+		newVars[key(e)] = struct{}{}
+	}
+	result = append(result, newEnv...)
+	for _, e := range oldEnv {
+		if _, exists := newVars[key(e)]; exists {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result
+}

--- a/pkg/build/builder/util_test.go
+++ b/pkg/build/builder/util_test.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -41,5 +42,58 @@ func TestCGroups_Ubuntu_Docker1_9(t *testing.T) {
 
 	if containerId != "bfea6eb2d60179355e370a5d277d496eb0fe75d9a5a47c267221e87dbbbbc93b" {
 		t.Errorf("got %s, expected bfea6eb2d60179355e370a5d277d496eb0fe75d9a5a47c267221e87dbbbbc93b", containerId)
+	}
+}
+
+func TestMergeEnv(t *testing.T) {
+	tests := []struct {
+		oldEnv   []string
+		newEnv   []string
+		expected []string
+	}{
+		{
+			oldEnv:   []string{"one=1", "two=2"},
+			newEnv:   []string{"three=3", "four=4"},
+			expected: []string{"one=1", "two=2", "three=3", "four=4"},
+		},
+		{
+			oldEnv:   []string{"one=1", "two=2", "four=4"},
+			newEnv:   []string{"three=3", "four=4=5=6"},
+			expected: []string{"one=1", "two=2", "three=3", "four=4=5=6"},
+		},
+		{
+			oldEnv:   []string{"one=1", "two=2", "three=3"},
+			newEnv:   []string{"two=002", "four=4"},
+			expected: []string{"one=1", "two=002", "three=3", "four=4"},
+		},
+		{
+			oldEnv:   []string{"one=1", "=2"},
+			newEnv:   []string{"=3", "two=2"},
+			expected: []string{"one=1", "=3", "two=2"},
+		},
+		{
+			oldEnv:   []string{"one=1", "two"},
+			newEnv:   []string{"two=2", "three=3"},
+			expected: []string{"one=1", "two=2", "three=3"},
+		},
+	}
+	for _, tc := range tests {
+		result := MergeEnv(tc.oldEnv, tc.newEnv)
+		toCheck := map[string]struct{}{}
+		for _, e := range tc.expected {
+			toCheck[e] = struct{}{}
+		}
+		for _, e := range result {
+			if _, exists := toCheck[e]; !exists {
+				t.Errorf("old = %s, new = %s: %s not expected in result",
+					strings.Join(tc.oldEnv, ","), strings.Join(tc.newEnv, ","), e)
+				continue
+			}
+			delete(toCheck, e)
+		}
+		if len(toCheck) > 0 {
+			t.Errorf("old = %s, new = %s: did not get expected values in result: %#v",
+				strings.Join(tc.oldEnv, ","), strings.Join(tc.newEnv, ","), toCheck)
+		}
 	}
 }

--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -66,7 +66,7 @@ func IsRemoteRepository(s string) bool {
 		return false
 	}
 	gitRepo := git.NewRepository()
-	if err := gitRepo.ListRemote(s); err != nil {
+	if _, _, err := gitRepo.ListRemote(s); err != nil {
 		return false
 	}
 	return true

--- a/pkg/generate/app/test/fakegit.go
+++ b/pkg/generate/app/test/fakegit.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"io"
+
+	"github.com/openshift/origin/pkg/generate/git"
 )
 
 type FakeGit struct {
@@ -25,6 +27,11 @@ func (g *FakeGit) GetRef(dir string) string {
 }
 
 func (g *FakeGit) Clone(dir string, url string) error {
+	g.CloneCalled = true
+	return nil
+}
+
+func (g *FakeGit) CloneWithOptions(dir string, url string, opts git.CloneOptions) error {
 	g.CloneCalled = true
 	return nil
 }
@@ -67,6 +74,10 @@ func (f *FakeGit) ShowFormat(source, ref, format string) (string, error) {
 	return "", nil
 }
 
-func (f *FakeGit) ListRemote(url string) error {
-	return nil
+func (f *FakeGit) ListRemote(url string, args ...string) (string, string, error) {
+	return "", "", nil
+}
+
+func (f *FakeGit) GetInfo(location string) (*git.SourceInfo, []error) {
+	return nil, nil
 }

--- a/pkg/generate/git/git.go
+++ b/pkg/generate/git/git.go
@@ -2,11 +2,12 @@ package git
 
 import (
 	"bufio"
-	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
 	"io"
 	"net/url"
 	"path"
 	"strings"
+
+	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
 )
 
 // ParseRepository parses a string that may be in the Git format (git@) or URL format


### PR DESCRIPTION
If using basic auth to build a source repo, the 'git ls-remote' test will not pass and fail the build. Only the GIT_SSH and GIT_ASKPASS env vars are passed to the process. Other vars such as GIT_CONFIG are needed for basic auth to succeed. This change passes the entire current environment to git ls-remote with the addition of GIT_ASKPASS=/bin/true. GIT_SSH is already part of the outer environment.