### PR TITLE
Add success line to dry run

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -226,6 +226,7 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 		}
 	}
 	if config.DryRun {
+		fmt.Fprintf(out, "--> Success (DRY RUN)\n")
 		return nil
 	}
 

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -164,6 +164,7 @@ func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, in io.Rea
 		}
 	}
 	if config.DryRun {
+		fmt.Fprintf(out, "--> Success (DRY RUN)\n")
 		return nil
 	}
 


### PR DESCRIPTION
Whenever `oc new-app` and `new-build` are run with "--dry-run", the output would end abruptly without the "success" message that shows in the non-dry-run execution.

I propose to add a success line with a dry run notice, pretty much line `rsync` does.

Non-dry-run output:

```
[vagrant@openshiftdev origin]$ oc new-build -D "FROM centos:7"
--> Found Docker image 0e23418 (7 weeks old) from Docker Hub for "centos:7"
    * An image stream will be created as "centos:7" that will track this image
    * A Docker build using a predefined Dockerfile will be created
      * The resulting image will be pushed to image stream "centos:latest"
      * Every time "centos:7" changes a new build will be triggered
--> Creating resources with label build=centos ...
    ImageStream "centos" created
    BuildConfig "centos" created
--> Success
    Build configuration "centos" created and build triggered.
    Run 'oc logs -f bc/centos' to stream the build progress.
```

Dry-run output with the new success message:

```
[vagrant@openshiftdev origin]$ oc new-build -D "FROM centos:7" --dry-run
--> Found Docker image 0e23418 (7 weeks old) from Docker Hub for "centos:7"
    * An image stream will be created as "centos:7" that will track this image
    * A Docker build using a predefined Dockerfile will be created
      * The resulting image will be pushed to image stream "centos:latest"
      * Every time "centos:7" changes a new build will be triggered
--> Creating resources with label build=centos ...
--> Success (DRY RUN)
```