### PR TITLE
Add commit summary validation to verify task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ verify:
 else
 verify: build
 endif
+	hack/verify-upstream-commits.sh
 	hack/verify-gofmt.sh
 	hack/verify-govet.sh
 	hack/verify-generated-deep-copies.sh

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -7,7 +7,7 @@ set -o pipefail
 cd $(dirname "${BASH_SOURCE}")/..
 
 ok_revert_pat='UPSTREAM: [0-9]{4,}: revert origin [a-f0-9]{7,}:'
-ok_upstream_pat='UPSTREAM: ([0-9]{4,}:|<carry>:|<drop>:)'
+ok_upstream_pat='UPSTREAM: (([a-z0-9-_]+: )?[0-9]{4,}:|<carry>:|<drop>:)'
 
 echo "===== Verifying UPSTREAM Commits ====="
 

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd $(dirname "${BASH_SOURCE}")/..
+
+ok_revert_pat='UPSTREAM: [0-9]{4,}: revert origin [a-f0-9]{7,}:'
+ok_upstream_pat='UPSTREAM: ([0-9]{4,}:|<carry>:|<drop>:)'
+
+echo "===== Verifying UPSTREAM Commits ====="
+
+invalid_commits=()
+
+OLDIFS="$IFS"
+IFS=$'\n'
+while IFS= read -r commit; do
+  summary=$(echo $commit | cut -d ' ' -f 2-)
+  if [[ $summary =~ 'revert' ]]; then
+    if [[ ! $summary =~ $ok_revert_pat ]]; then
+      invalid_commits+=($commit)
+    fi
+  else
+    if [[ ! $summary =~ $ok_upstream_pat ]]; then
+      invalid_commits+=($commit)
+    fi
+  fi
+done < <(git log --oneline master..HEAD | grep -i upstream)
+IFS="$OLDIFS"
+
+if [ "${#invalid_commits[@]}" -gt 0 ]; then
+  echo "FAILURE: The following malformed UPSTREAM commits were detected:"
+  echo ""
+  for commit in "${invalid_commits[@]}"; do
+    echo "  $commit"
+  done
+  echo ""
+  echo "UPSTREAM commits must match one of the following patterns:"
+  echo ""
+  echo "  $ok_upstream_pat"
+  echo "  $ok_revert_pat"
+  exit 1
+fi
+
+echo "SUCCESS: No invalid upstream commits"

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -6,8 +6,8 @@ set -o pipefail
 
 cd $(dirname "${BASH_SOURCE}")/..
 
-ok_revert_pat='UPSTREAM: [0-9]{4,}: revert origin [a-f0-9]{7,}:'
 ok_upstream_pat='UPSTREAM: (([a-z0-9-_]+: )?[0-9]{4,}:|<carry>:|<drop>:)'
+ok_revert_pat='UPSTREAM: revert: [a-f0-9]{7,}: (([a-z0-9-_]+: )?[0-9]{4,}:|<carry>:|<drop>:)'
 
 echo "===== Verifying UPSTREAM Commits ====="
 


### PR DESCRIPTION
Validate any UPSTREAM commits when performing the verify task in
the Makefile. This is to enforce naming conventions for upstream
commits and facilitate more reliable automation.

Part of https://trello.com/c/noaPjUWG