### PR TITLE
Implement BuildConfig reaper

### DIFF
--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -411,6 +411,9 @@ const (
 	// BuildConfigLabelDeprecated was used as BuildConfigLabel before adding namespaces.
 	// We keep it for backward compatibility.
 	BuildConfigLabelDeprecated = "buildconfig"
+	// BuildConfigPausedAnnotation is an annotation that marks a BuildConfig as paused.
+	// New Builds cannot be instantiated from a paused BuildConfig.
+	BuildConfigPausedAnnotation = "openshift.io/build-config.paused"
 )
 
 // BuildConfig is a template which can be used to create new builds.

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -322,7 +322,7 @@ func (factory *BuildConfigControllerFactory) Create() controller.RunnableControl
 		RetryManager: controller.NewQueueRetryManager(
 			queue,
 			cache.MetaNamespaceKeyFunc,
-			retryFunc("BuildConfig", nil),
+			retryFunc("BuildConfig", buildcontroller.IsFatal),
 			kutil.NewTokenBucketRateLimiter(1, 10)),
 		Handle: func(obj interface{}) error {
 			bc := obj.(*buildapi.BuildConfig)

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -81,6 +81,26 @@ func TestInstantiateRetry(t *testing.T) {
 }
 */
 
+func TestInstantiateDeletingError(t *testing.T) {
+	generator := BuildGenerator{Client: Client{
+		GetBuildConfigFunc: func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {
+			bc := &buildapi.BuildConfig{
+				ObjectMeta: kapi.ObjectMeta{
+					Annotations: map[string]string{
+						buildapi.BuildConfigPausedAnnotation: "true",
+					},
+				},
+			}
+			return bc, nil
+		},
+	}}
+
+	_, err := generator.Instantiate(kapi.NewDefaultContext(), &buildapi.BuildRequest{})
+	if err == nil || !strings.Contains(err.Error(), "BuildConfig is paused") {
+		t.Errorf("Expected error, got different %v", err)
+	}
+}
+
 func TestInstantiateGetBuildConfigError(t *testing.T) {
 	generator := BuildGenerator{Client: Client{
 		GetBuildConfigFunc: func(ctx kapi.Context, name string) (*buildapi.BuildConfig, error) {

--- a/pkg/build/reaper/doc.go
+++ b/pkg/build/reaper/doc.go
@@ -1,0 +1,2 @@
+// Package reaper implements the Reaper interface for buildConfigs
+package reaper

--- a/pkg/build/reaper/reaper.go
+++ b/pkg/build/reaper/reaper.go
@@ -1,0 +1,122 @@
+package reaper
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/kubectl"
+	kutilerrors "k8s.io/kubernetes/pkg/util/errors"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/util"
+)
+
+// NewBuildConfigReaper returns a new reaper for buildConfigs
+func NewBuildConfigReaper(oc *client.Client) kubectl.Reaper {
+	return &BuildConfigReaper{oc: oc, pollInterval: kubectl.Interval, timeout: kubectl.Timeout}
+}
+
+// BuildConfigReaper implements the Reaper interface for buildConfigs
+type BuildConfigReaper struct {
+	oc                    client.Interface
+	pollInterval, timeout time.Duration
+}
+
+// Stop deletes the build configuration and all of the associated builds.
+func (reaper *BuildConfigReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *kapi.DeleteOptions) (string, error) {
+	noBcFound := false
+	noBuildFound := true
+
+	// Add deletion pending annotation to the build config
+	err := unversioned.RetryOnConflict(unversioned.DefaultRetry, func() error {
+		bc, err := reaper.oc.BuildConfigs(namespace).Get(name)
+		if kerrors.IsNotFound(err) {
+			noBcFound = true
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		// Ignore if the annotation already exists
+		if strings.ToLower(bc.Annotations[buildapi.BuildConfigPausedAnnotation]) == "true" {
+			return nil
+		}
+
+		// Set the annotation and update
+		if err := util.AddObjectAnnotations(bc, map[string]string{buildapi.BuildConfigPausedAnnotation: "true"}); err != nil {
+			return err
+		}
+		_, err = reaper.oc.BuildConfigs(namespace).Update(bc)
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Warn the user if the BuildConfig won't get deleted after this point.
+	bcDeleted := false
+	defer func() {
+		if !bcDeleted {
+			glog.Warningf("BuildConfig %s/%s will not be deleted because not all associated builds could be deleted. You can try re-running the command or removing them manually", namespace, name)
+		}
+	}()
+
+	// Collect builds related to the config.
+	builds, err := reaper.oc.Builds(namespace).List(buildutil.BuildConfigSelector(name), nil)
+	if err != nil {
+		return "", err
+	}
+	errList := []error{}
+	for _, build := range builds.Items {
+		noBuildFound = false
+		if err := reaper.oc.Builds(namespace).Delete(build.Name); err != nil {
+			glog.Warningf("Cannot delete Build %s/%s: %v", build.Namespace, build.Name, err)
+			if !kerrors.IsNotFound(err) {
+				errList = append(errList, err)
+			}
+		}
+	}
+
+	// Collect deprecated builds related to the config.
+	// TODO: Delete this block after BuildConfigLabelDeprecated is removed.
+	builds, err = reaper.oc.Builds(namespace).List(buildutil.BuildConfigSelectorDeprecated(name), nil)
+	if err != nil {
+		return "", err
+	}
+	for _, build := range builds.Items {
+		noBuildFound = false
+		if err := reaper.oc.Builds(namespace).Delete(build.Name); err != nil {
+			glog.Warningf("Cannot delete Build %s/%s: %v", build.Namespace, build.Name, err)
+			if !kerrors.IsNotFound(err) {
+				errList = append(errList, err)
+			}
+		}
+	}
+
+	// Aggregate all errors
+	if len(errList) > 0 {
+		return "", kutilerrors.NewAggregate(errList)
+	}
+
+	// Finally we can delete the BuildConfig
+	if !noBcFound {
+		if err := reaper.oc.BuildConfigs(namespace).Delete(name); err != nil {
+			return "", err
+		}
+	}
+	bcDeleted = true
+
+	if noBcFound && noBuildFound {
+		return "", kerrors.NewNotFound("BuildConfig", name)
+	}
+
+	return fmt.Sprintf("%s stopped", name), nil
+}

--- a/pkg/build/reaper/reaper_test.go
+++ b/pkg/build/reaper/reaper_test.go
@@ -1,0 +1,194 @@
+package reaper
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildutil "github.com/openshift/origin/pkg/build/util"
+	"github.com/openshift/origin/pkg/client/testclient"
+)
+
+func makeBuildConfig(version int, deleting bool) *buildapi.BuildConfig {
+	ret := &buildapi.BuildConfig{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:        "config",
+			Namespace:   "default",
+			Annotations: make(map[string]string),
+		},
+		Spec: buildapi.BuildConfigSpec{},
+		Status: buildapi.BuildConfigStatus{
+			LastVersion: version,
+		},
+	}
+	if deleting {
+		ret.Annotations[buildapi.BuildConfigPausedAnnotation] = "true"
+	}
+	return ret
+}
+
+func makeBuild(version int) buildapi.Build {
+	return buildapi.Build{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      fmt.Sprintf("build-%d", version),
+			Namespace: "default",
+			Labels:    map[string]string{buildapi.BuildConfigLabel: "config"},
+		},
+	}
+}
+
+func makeDeprecatedBuild(version int) buildapi.Build {
+	return buildapi.Build{
+		ObjectMeta: kapi.ObjectMeta{
+			Name:      fmt.Sprintf("build-%d", version),
+			Namespace: "default",
+			Labels:    map[string]string{buildapi.BuildConfigLabelDeprecated: "config"},
+		},
+	}
+}
+
+func makeBuildList(version int) *buildapi.BuildList {
+	if version%2 != 0 {
+		panic("version needs be even")
+	}
+	list := &buildapi.BuildList{}
+	for i := 1; i <= version; i += 2 {
+		list.Items = append(list.Items, makeBuild(i))
+		list.Items = append(list.Items, makeDeprecatedBuild(i+1))
+	}
+	return list
+}
+
+func newBuildListFake(objects ...runtime.Object) *testclient.Fake {
+	fake := testclient.NewSimpleFake(objects...)
+	fake.PrependReactor("list", "builds", func(action ktestclient.Action) (handled bool, ret runtime.Object, err error) {
+		selector := action.(ktestclient.ListAction).GetListRestrictions().Labels
+		retList := &buildapi.BuildList{}
+		for _, obj := range objects {
+			list, ok := obj.(*buildapi.BuildList)
+			if !ok {
+				continue
+			}
+			for _, build := range list.Items {
+				if selector.Matches(labels.Set(build.Labels)) {
+					retList.Items = append(retList.Items, build)
+				}
+			}
+		}
+		return true, retList, nil
+	})
+	return fake
+}
+
+func actionsAreEqual(a, b ktestclient.Action) bool {
+	if reflect.DeepEqual(a, b) {
+		return true
+	}
+	// If it's an update action, we will take a better look at the object
+	if a.GetVerb() == "update" && b.GetVerb() == "update" &&
+		a.GetNamespace() == b.GetNamespace() &&
+		a.GetResource() == b.GetResource() &&
+		a.GetSubresource() == b.GetSubresource() {
+		ret := reflect.DeepEqual(a.(ktestclient.UpdateAction).GetObject(), b.(ktestclient.UpdateAction).GetObject())
+		return ret
+	}
+	return false
+}
+
+func TestStop(t *testing.T) {
+	notFound := func() runtime.Object {
+		return &(kerrors.NewNotFound("BuildConfig", "config").(*kerrors.StatusError).ErrStatus)
+	}
+
+	tests := map[string]struct {
+		oc       *testclient.Fake
+		expected []ktestclient.Action
+		err      bool
+	}{
+		"simple stop": {
+			oc: newBuildListFake(makeBuildConfig(0, false)),
+			expected: []ktestclient.Action{
+				ktestclient.NewGetAction("buildconfigs", "default", "config"),
+				ktestclient.NewUpdateAction("buildconfigs", "default", makeBuildConfig(0, true)),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelector("config"), nil),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelectorDeprecated("config"), nil),
+				ktestclient.NewDeleteAction("buildconfigs", "default", "config"),
+			},
+			err: false,
+		},
+		"multiple builds": {
+			oc: newBuildListFake(makeBuildConfig(4, false), makeBuildList(4)),
+			expected: []ktestclient.Action{
+				ktestclient.NewGetAction("buildconfigs", "default", "config"),
+				ktestclient.NewUpdateAction("buildconfigs", "default", makeBuildConfig(4, true)),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelector("config"), nil),
+				ktestclient.NewDeleteAction("builds", "default", "build-1"),
+				ktestclient.NewDeleteAction("builds", "default", "build-3"),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelectorDeprecated("config"), nil),
+				ktestclient.NewDeleteAction("builds", "default", "build-2"),
+				ktestclient.NewDeleteAction("builds", "default", "build-4"),
+				ktestclient.NewDeleteAction("buildconfigs", "default", "config"),
+			},
+			err: false,
+		},
+		"no config, some builds": {
+			oc: newBuildListFake(makeBuildList(2)),
+			expected: []ktestclient.Action{
+				ktestclient.NewGetAction("buildconfigs", "default", "config"),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelector("config"), nil),
+				ktestclient.NewDeleteAction("builds", "default", "build-1"),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelectorDeprecated("config"), nil),
+				ktestclient.NewDeleteAction("builds", "default", "build-2"),
+			},
+			err: false,
+		},
+		"no config, no builds": {
+			oc: testclient.NewSimpleFake(notFound()),
+			expected: []ktestclient.Action{
+				ktestclient.NewGetAction("buildconfigs", "default", "config"),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelector("config"), nil),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelectorDeprecated("config"), nil),
+			},
+			err: true,
+		},
+		"config, no builds": {
+			oc: testclient.NewSimpleFake(makeBuildConfig(0, false)),
+			expected: []ktestclient.Action{
+				ktestclient.NewGetAction("buildconfigs", "default", "config"),
+				ktestclient.NewUpdateAction("buildconfigs", "default", makeBuildConfig(0, true)),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelector("config"), nil),
+				ktestclient.NewListAction("builds", "default", buildutil.BuildConfigSelectorDeprecated("config"), nil),
+				ktestclient.NewDeleteAction("buildconfigs", "default", "config"),
+			},
+			err: false,
+		},
+	}
+
+	for testName, test := range tests {
+		reaper := &BuildConfigReaper{oc: test.oc, pollInterval: time.Millisecond, timeout: time.Millisecond}
+		_, err := reaper.Stop("default", "config", 1*time.Second, nil)
+
+		if !test.err && err != nil {
+			t.Errorf("%s: unexpected error: %v", testName, err)
+		}
+		if test.err && err == nil {
+			t.Errorf("%s: expected an error", testName)
+		}
+		if len(test.oc.Actions()) != len(test.expected) {
+			t.Fatalf("%s: unexpected actions: %v, expected %v", testName, test.oc.Actions(), test.expected)
+		}
+		for j, actualAction := range test.oc.Actions() {
+			if !actionsAreEqual(actualAction, test.expected[j]) {
+				t.Errorf("%s: unexpected action: %v, expected %v", testName, actualAction, test.expected[j])
+			}
+		}
+	}
+}

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
 )
@@ -69,4 +70,16 @@ func IsBuildComplete(build *buildapi.Build) bool {
 // for the config that has the provided name
 func BuildNameForConfigVersion(name string, version int) string {
 	return fmt.Sprintf("%s-%d", name, version)
+}
+
+// BuildConfigSelector returns a label Selector which can be used to find all
+// builds for a BuildConfig.
+func BuildConfigSelector(name string) labels.Selector {
+	return labels.Set{buildapi.BuildConfigLabel: name}.AsSelector()
+}
+
+// BuildConfigSelectorDeprecated returns a label Selector which can be used to find
+// all builds for a BuildConfig that use the deprecated labels.
+func BuildConfigSelectorDeprecated(name string) labels.Selector {
+	return labels.Set{buildapi.BuildConfigLabelDeprecated: name}.AsSelector()
 }

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/api/latest"
 	authorizationreaper "github.com/openshift/origin/pkg/authorization/reaper"
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	buildreaper "github.com/openshift/origin/pkg/build/reaper"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
@@ -226,6 +227,8 @@ func NewFactory(clientConfig kclientcmd.ClientConfig) *Factory {
 				client.RoleBindingsNamespacer(oc),
 				kclient.SecurityContextConstraintsInterface(kc),
 			), nil
+		case "BuildConfig":
+			return buildreaper.NewBuildConfigReaper(oc), nil
 		}
 		return kReaperFunc(mapping)
 	}

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -1,0 +1,60 @@
+package builds
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("builds: deleting buildconfig", func() {
+	defer g.GinkgoRecover()
+	var (
+		buildFixture = exutil.FixturePath("..", "extended", "fixtures", "test-build.json")
+		oc           = exutil.NewCLI("cli-start-build", exutil.KubeConfigPath())
+	)
+
+	g.JustBeforeEach(func() {
+		g.By("waiting for builder service account")
+		err := exutil.WaitForBuilderAccount(oc.KubeREST().ServiceAccounts(oc.Namespace()))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.Run("create").Args("-f", buildFixture).Execute()
+	})
+
+	g.Describe("oc delete buildconfig", func() {
+		g.It("should start builds and delete the buildconfig", func() {
+			var (
+				err    error
+				builds [4]string
+			)
+
+			g.By("starting multiple builds")
+			for i := range builds {
+				builds[i], err = oc.Run("start-build").Args("sample-build").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			g.By("deleting the buildconfig")
+			err = oc.Run("delete").Args("bc/sample-build").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for builds to clear")
+			err = wait.Poll(3*time.Second, 3*time.Minute, func() (bool, error) {
+				out, err := oc.Run("get").Args("-o", "name", "builds").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if len(out) == 0 {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err == wait.ErrWaitTimeout {
+				g.Fail("timed out waiting for builds to clear")
+			}
+		})
+
+	})
+})

--- a/test/extended/fixtures/test-custom-build.json
+++ b/test/extended/fixtures/test-custom-build.json
@@ -15,9 +15,9 @@
       "customStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "172.30.17.104:5000/foo/bar"
+          "name": ""
         },
-        "exposeDockerSocket": true
+        "exposeDockerSocket": false
       }
     },
     "output": {


### PR DESCRIPTION
The reaper will delete all builds associated with the BC.

This is another shot at #5080. That one was closed, but after discussion at #5208, it became necessary to return to the previous attempt. Differences from #5080 are that we now handle deprecated labels, I've added unit tests and also extended tests from #5208.