### PR TITLE
[WIP] pubsub replacement of AlertsMessageService

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -132,6 +132,7 @@
     <script src="bower_components/kubernetes-object-describer/dist/object-describer.js"></script>
     <script src="bower_components/openshift-object-describer/dist/object-describer.js"></script>
     <script src="bower_components/bootstrap-hover-dropdown/bootstrap-hover-dropdown.min.js"></script>
+    <script src="bower_components/angular-simple-pubsub/pubsub.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -21,7 +21,8 @@ angular
     'kubernetesUI',
     'ui.bootstrap',
     'patternfly.charts',
-    'openshiftConsoleTemplates'
+    'openshiftConsoleTemplates',
+    'pubsub'
   ])
   .constant("mainNavTabs", [])  // even though its not really a "constant", it has to be created as a constant and not a value
                          // or it can't be referenced during module config

--- a/assets/app/scripts/controllers/buildConfig.js
+++ b/assets/app/scripts/controllers/buildConfig.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('BuildConfigController', function ($scope, $routeParams, DataService, ProjectsService, BuildsService, $filter, LabelFilter) {
+  .controller('BuildConfigController', function ($scope, $routeParams, DataService, ProjectsService, BuildsService, $filter, LabelFilter, pubsub) {
     $scope.projectName = $routeParams.project;
     $scope.buildConfig = null;
     $scope.builds = {};
@@ -40,10 +40,10 @@ angular.module('openshiftConsole')
             // If we found the item successfully, watch for changes on it
             watches.push(DataService.watchObject("buildconfigs", $routeParams.buildconfig, context, function(buildConfig, action) {
               if (action === "DELETED") {
-                $scope.alerts["deleted"] = {
+                pubsub.publish('alert', {
                   type: "warning",
                   message: "This build configuration has been deleted."
-                };
+                });
               }
               $scope.buildConfig = buildConfig;
             }));
@@ -51,11 +51,11 @@ angular.module('openshiftConsole')
           // failure
           function(e) {
             $scope.loaded = true;
-            $scope.alerts["load"] = {
+            pubsub.publish('alert', {
               type: "error",
               message: "The build configuration details could not be loaded.",
               details: "Reason: " + $filter('getErrorDetails')(e)
-            };
+            });
           }
         );
 

--- a/assets/app/scripts/directives/alerts.js
+++ b/assets/app/scripts/directives/alerts.js
@@ -1,11 +1,40 @@
 'use strict';
+/* jshint expr: true */
 
 angular.module('openshiftConsole')
-  .directive('alerts', function() {
+  .directive('alerts', function(pubsub) {
     return {
       restrict: 'E',
-      scope: {
-        alerts: '='
+      scope: true,
+      controller: function($scope, $timeout) {
+        $scope.alerts = [];
+        var events = [
+          pubsub.subscribe('alert', function(data) {
+            var index = ($scope.alerts.push(data) -1);
+            if(data.duration) {
+              $timeout(function() {
+                $scope.alerts.splice(index, 1);
+              }, data.duration);
+            }
+          }),
+          pubsub.subscribe('alerts.clear', function() {
+            $scope.alerts = [];
+          })
+        ];
+
+        // TODO: prob good to configure w/an attribute:
+        // <alert clear-on-route-change> (shorter :)
+        // would be useful if <alerts> was a DOM node persistent across pages.
+        $scope.$on('$routeChangeStart', function() {
+          $scope.alerts = [];
+        });
+
+        $scope.$on('$destroy', function() {
+          _.each(events, function(evt) {
+            evt && evt.unsubscribe && evt.unsubscribe();
+          });
+        });
+
       },
       templateUrl: 'views/_alerts.html'
     };

--- a/assets/app/scripts/directives/deleteButton.js
+++ b/assets/app/scripts/directives/deleteButton.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .directive("deleteButton", function ($modal, $location, $filter, hashSizeFilter, DataService, AlertMessageService, Navigate, Logger) {
+  .directive("deleteButton", function ($modal, $location, $filter, hashSizeFilter, DataService, AlertMessageService, Navigate, Logger, pubsub) {
     return {
       restrict: "E",
       scope: {
@@ -39,12 +39,9 @@ angular.module("openshiftConsole")
             DataService.delete(resourceType + 's', resourceName, context)
             .then(function() {
               if (resourceType !== 'project') {
-                AlertMessageService.addAlert({
-                  name: resourceName,
-                  data: {
-                    type: "success",
-                    message: formattedResource + " was marked for deletion."
-                  }
+                pubsub.publishAsync('alert', {
+                  type: "success",
+                  message: formattedResource + " was marked for deletion."
                 });
                 Navigate.toResourceList(resourceType, projectName);
               }
@@ -54,12 +51,9 @@ angular.module("openshiftConsole")
                 }
                 else if ($location.path().indexOf('settings') > '-1') {
                   var homeRedirect = URI('/');
-                  AlertMessageService.addAlert({
-                    name: resourceName,
-                    data: {
-                      type: "success",
-                      message: formattedResource + " was marked for deletion."
-                    }
+                  pubsub.publishAsync('alert', {
+                    type: "success",
+                    message: formattedResource + " was marked for deletion."
                   });
                   $location.url(homeRedirect);
                 }
@@ -67,11 +61,11 @@ angular.module("openshiftConsole")
             })
             .catch(function(err) {
               // called if failure to delete
-              scope.alerts[resourceName] = {
+              pubsub.publishAsync('alert', {
                 type: "error",
                 message: formattedResource + "\'" + " could not be deleted.",
                 details: $filter('getErrorDetails')(err)
-              };
+              });
               Logger.error(formattedResource + " could not be deleted.", err);
             });
           });

--- a/assets/app/scripts/services/alertMessage.js
+++ b/assets/app/scripts/services/alertMessage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module("openshiftConsole")
-  .service("AlertMessageService", function(){
+  .service("AlertMessageService", function() {
     var alerts = [];
     return {
       addAlert: function(alert) {

--- a/assets/app/views/_alerts.html
+++ b/assets/app/views/_alerts.html
@@ -1,18 +1,30 @@
 <div ng-repeat="alert in alerts">
   <div ng-switch="alert.type">
-    <div ng-switch-when="error" class="alert alert-danger">
+    <div ng-switch-when="error" class="alert alert-danger" ng-class="{'alert-dismissable': alert.dismissable}">
+      <button ng-if="alert.dismissable" type="button" class="close" data-dismiss="alert" aria-hidden="true">
+        <span class="pficon pficon-close"></span>
+      </button>
       <span class="pficon pficon-error-circle-o"></span>
       <strong ng-if="alert.message" style="margin-right: 5px;">{{alert.message}}</strong><span ng-if="alert.details">{{alert.details}}</span>
-    </div>  
-    <div ng-switch-when="warning" class="alert alert-warning">
+    </div>
+    <div ng-switch-when="warning" class="alert alert-warning" ng-class="{'alert-dismissable': alert.dismissable}">
+      <button ng-if="alert.dismissable" type="button" class="close" data-dismiss="alert" aria-hidden="true">
+        <span class="pficon pficon-close"></span>
+      </button>
       <span class="pficon pficon-warning-triangle-o"></span>
       <strong ng-if="alert.message" style="margin-right: 5px;">{{alert.message}}</strong><span ng-if="alert.details">{{alert.details}}</span>
-    </div>  
-    <div ng-switch-when="success" class="alert alert-success">
+    </div>
+    <div ng-switch-when="success" class="alert alert-success" ng-class="{'alert-dismissable': alert.dismissable}">
+      <button ng-if="alert.dismissable" type="button" class="close" data-dismiss="alert" aria-hidden="true">
+        <span class="pficon pficon-close"></span>
+      </button>
       <span class="pficon pficon-ok"></span>
       <strong ng-if="alert.message" style="margin-right: 5px;">{{alert.message}}</strong><span ng-if="alert.details">{{alert.details}}</span><a ng-if="alert.link" class="alert-link" href="{{alert.link}}">{{alert.linkText || "View details"}}</a>
-    </div>  
-    <div ng-switch-default class="alert alert-info">
+    </div>
+    <div ng-switch-default class="alert alert-info" ng-class="{'alert-dismissable': alert.dismissable}">
+      <button ng-if="alert.dismissable" type="button" class="close" data-dismiss="alert" aria-hidden="true">
+        <span class="pficon pficon-close"></span>
+      </button>
       <span class="pficon pficon-info"></span>
       <strong ng-if="alert.message" style="margin-right: 5px;">{{alert.message}}</strong><span ng-if="alert.details">{{alert.details}}</span>
     </div>

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -31,7 +31,8 @@
     "kubernetes-container-terminal": "0.0.7",
     "openshift-object-describer": "1.1.1",
     "layout.attrs": "1.1.2",
-    "bootstrap-hover-dropdown": "~2.1.3"
+    "bootstrap-hover-dropdown": "~2.1.3",
+    "angular-simple-pubsub": "~1.0.4"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",


### PR DESCRIPTION
- eliminates AlertsMessageService
- allows the alert directive to listen for events, eliminating need for controller handling `$scope.alerts`
- adds `dismissable` property to alerts, allowing user to dismiss w/icon ([see patternfly reference](https://www.patternfly.org/widgets/#alerts))
- adds `duration` property to alerts, allowing auto dismiss after timeout
- `pubsub.publish` for immediate alert
- `pubsub.publishAsync` for delay, such as route change, before creating alert

Quick example, if all properties used:
```javascript
 pubsub.publish('alert', {
        type: "error",
        message: "Oh no, a bad thing.",
        details: "Reason: bad stuff happened.",
        dismissable: true,  // user can click 'x' to say 'go away!'
        duration: 10000     // or we will eliminate after 10 seconds automatically
});
```
@spadgett @jwforres for thoughts 