### PR TITLE
DNSServer: fail if unable to listen to requested port

### DIFF
--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -162,8 +162,7 @@ func (c *MasterConfig) RunDNSServer() {
 	}
 
 	if ok, err := cmdutil.TryListen(c.Options.DNSConfig.BindNetwork, c.Options.DNSConfig.BindAddress); !ok {
-		glog.Warningf("Could not start DNS: %v", err)
-		return
+		glog.Fatalf("Could not start DNS: %v", err)
 	}
 
 	go func() {


### PR DESCRIPTION
If we are unable to listen to the requested address for the DNS server we should fail just like if we cannot start run the ListenAndServer command below it.

Resolves https://github.com/openshift/origin/issues/6184#event-482721382

@smarterclayton @liggitt 