### PR TITLE
Verify upstream commits in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ verify:
 else
 verify: build
 endif
+	hack/verify-upstream-commits.sh
 	hack/verify-gofmt.sh
 	hack/verify-govet.sh
 	hack/verify-generated-deep-copies.sh

--- a/cmd/rebasehelpers/commitchecker/commitchecker.go
+++ b/cmd/rebasehelpers/commitchecker/commitchecker.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openshift/origin/cmd/rebasehelpers/util"
+)
+
+func main() {
+	var start, end string
+	flag.StringVar(&start, "start", "master", "The start of the revision range for analysis")
+	flag.StringVar(&end, "end", "HEAD", "The end of the revision range for analysis")
+	flag.Parse()
+
+	commits, err := util.CommitsBetween(start, end)
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("ERROR: couldn't find commits from %s..%s: %v\n", start, end, err))
+		os.Exit(1)
+	}
+
+	errs := []string{}
+	for _, validate := range AllValidators {
+		err := validate(commits)
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		os.Stderr.WriteString(strings.Join(errs, "\n\n"))
+		os.Exit(2)
+	}
+}

--- a/cmd/rebasehelpers/commitchecker/validate.go
+++ b/cmd/rebasehelpers/commitchecker/validate.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"text/template"
+
+	"github.com/openshift/origin/cmd/rebasehelpers/util"
+)
+
+var CommitSummaryErrorTemplate = `
+The following UPSTREAM commits have invalid summaries:
+
+{{ range .Commits }}  [{{ .Sha }}] {{ .Summary }}
+{{ end }}
+UPSTREAM commit summaries should look like:
+
+  UPSTREAM: [non-kube-account/repo[/path]: ]<PR number>|'<carry>'|'<drop>': description
+
+UPSTREAM commits which revert previous UPSTREAM commits should look like:
+
+  UPSTREAM: revert: <sha>: <normal upstream format>
+
+UPSTREAM commits are validated against the following regular expression:
+
+  {{ .Pattern }}
+
+Examples of valid summaries:
+
+  UPSTREAM: 12345: An origin change
+  UPSTREAM: docker/docker: 12345: A docker change
+  UPSTREAM: <carry>: A carried kube change
+  UPSTREAM: <drop>: A dropped kube change
+  UPSTREAM: revert: abcd123: docker/docker: 12345: A docker change
+
+`
+
+var AllValidators = []func([]util.Commit) error{
+	ValidateUpstreamCommitsWithoutGodepsChanges,
+	ValidateUpstreamCommitModifiesSingleGodepsRepo,
+	ValidateUpstreamCommitSummaries,
+	ValidateUpstreamCommitModifiesOnlyGodeps,
+	ValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo,
+}
+
+// ValidateUpstreamCommitsWithoutGodepsChanges returns an error if any
+// upstream commits have no Godeps changes.
+func ValidateUpstreamCommitsWithoutGodepsChanges(commits []util.Commit) error {
+	problemCommits := []util.Commit{}
+	for _, commit := range commits {
+		if commit.HasGodepsChanges() && !commit.DeclaresUpstreamChange() {
+			problemCommits = append(problemCommits, commit)
+		}
+	}
+	if len(problemCommits) > 0 {
+		label := "The following commits contain Godeps changes but aren't declared as UPSTREAM:"
+		msg := renderGodepFilesError(label, problemCommits, RenderOnlyGodepsFiles)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+// ValidateUpstreamCommitModifiesSingleGodepsRepo returns an error if any
+// upstream commits have changes that span more than one Godeps repo.
+func ValidateUpstreamCommitModifiesSingleGodepsRepo(commits []util.Commit) error {
+	problemCommits := []util.Commit{}
+	for _, commit := range commits {
+		godepsChanges, err := commit.GodepsReposChanged()
+		if err != nil {
+			return err
+		}
+		if len(godepsChanges) > 1 {
+			problemCommits = append(problemCommits, commit)
+		}
+	}
+	if len(problemCommits) > 0 {
+		label := "The following UPSTREAM commits modify more than one repo in their changelist"
+		msg := renderGodepFilesError(label, problemCommits, RenderOnlyGodepsFiles)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+// ValidateUpstreamCommitSummaries ensures that any commits which declare to
+// be upstream match the regular expressions for UPSTREAM summaries.
+func ValidateUpstreamCommitSummaries(commits []util.Commit) error {
+	problemCommits := []util.Commit{}
+	for _, commit := range commits {
+		if commit.DeclaresUpstreamChange() && !commit.MatchesUpstreamSummaryPattern() {
+			problemCommits = append(problemCommits, commit)
+		}
+	}
+	if len(problemCommits) > 0 {
+		tmpl, _ := template.New("problems").Parse(CommitSummaryErrorTemplate)
+		data := struct {
+			Pattern *regexp.Regexp
+			Commits []util.Commit
+		}{
+			Pattern: util.UpstreamSummaryPattern,
+			Commits: problemCommits,
+		}
+		buffer := &bytes.Buffer{}
+		tmpl.Execute(buffer, data)
+		return fmt.Errorf(buffer.String())
+	}
+	return nil
+}
+
+// ValidateUpstreamCommitModifiesOnlyGodeps ensures that any Godeps commits
+// modify ONLY Godeps files.
+func ValidateUpstreamCommitModifiesOnlyGodeps(commits []util.Commit) error {
+	problemCommits := []util.Commit{}
+	for _, commit := range commits {
+		if commit.HasGodepsChanges() && commit.HasNonGodepsChanges() {
+			problemCommits = append(problemCommits, commit)
+		}
+	}
+	if len(problemCommits) > 0 {
+		label := "The following UPSTREAM commits modify files outside Godeps"
+		msg := renderGodepFilesError(label, problemCommits, RenderAllFiles)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+// ValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo ensures that an
+// upstream commit only modifies the Godep repo the summary declares.
+func ValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(commits []util.Commit) error {
+	problemCommits := []util.Commit{}
+	for _, commit := range commits {
+		if commit.DeclaresUpstreamChange() {
+			declaredRepo, err := commit.DeclaredUpstreamRepo()
+			if err != nil {
+				return err
+			}
+			reposChanged, err := commit.GodepsReposChanged()
+			if err != nil {
+				return err
+			}
+			for _, changedRepo := range reposChanged {
+				if changedRepo != declaredRepo {
+					fmt.Printf("changedRepo=%s, declaredRepo=%s\n", changedRepo, declaredRepo)
+					problemCommits = append(problemCommits, commit)
+				}
+			}
+		}
+	}
+	if len(problemCommits) > 0 {
+		label := "The following UPSTREAM commits modify Godeps repos other than the repo the commit declares"
+		msg := renderGodepFilesError(label, problemCommits, RenderAllFiles)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+type CommitFilesRenderOption int
+
+const (
+	RenderNoFiles CommitFilesRenderOption = iota
+	RenderOnlyGodepsFiles
+	RenderOnlyNonGodepsFiles
+	RenderAllFiles
+)
+
+// renderGodepFilesError formats commits and their file lists into readable
+// output prefixed with label.
+func renderGodepFilesError(label string, commits []util.Commit, opt CommitFilesRenderOption) string {
+	msg := fmt.Sprintf("%s:\n\n", label)
+	for _, commit := range commits {
+		msg += fmt.Sprintf("[%s] %s\n", commit.Sha, commit.Summary)
+		if opt == RenderNoFiles {
+			continue
+		}
+		for _, file := range commit.Files {
+			if opt == RenderAllFiles ||
+				(opt == RenderOnlyGodepsFiles && file.HasGodepsChanges()) ||
+				(opt == RenderOnlyNonGodepsFiles && !file.HasGodepsChanges()) {
+				msg += fmt.Sprintf("  - %s\n", file)
+			}
+		}
+	}
+	return msg
+}

--- a/cmd/rebasehelpers/commitchecker/validate_test.go
+++ b/cmd/rebasehelpers/commitchecker/validate_test.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/cmd/rebasehelpers/util"
+)
+
+func TestValidateUpstreamCommitsWithoutGodepsChanges(t *testing.T) {
+	tests := []struct {
+		name          string
+		commits       []util.Commit
+		errorExpected bool
+	}{
+		{
+			name: "test 1",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "commit 2",
+					Files:   []util.File{"Godeps/file1", "pkg/file2"},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			name: "test 2",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: commit 2",
+					Files:   []util.File{"Godeps/file1", "pkg/file2"},
+				},
+			},
+			errorExpected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Logf("evaluating test %q", test.name)
+		err := ValidateUpstreamCommitsWithoutGodepsChanges(test.commits)
+		if err != nil {
+			if test.errorExpected {
+				t.Logf("got expected error:\n%s", err)
+				continue
+			} else {
+				t.Fatalf("unexpected error:\n%s", err)
+			}
+		} else {
+			if test.errorExpected {
+				t.Fatalf("expected an error, got none")
+			}
+		}
+	}
+}
+
+func TestValidateUpstreamCommitModifiesSingleGodepsRepo(t *testing.T) {
+	tests := []struct {
+		name          string
+		commits       []util.Commit
+		errorExpected bool
+	}{
+		{
+			name: "test 1",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "commit 2",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+		{
+			name: "test 2",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: commit 2",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+						"Godeps/_workspace/src/github.com/coreos/etcd/file",
+					},
+				},
+				{
+					Sha:     "aaa0002",
+					Summary: "UPSTREAM: commit 3",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/heapster/file1",
+						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
+					},
+				},
+			},
+			errorExpected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Logf("evaluating test %q", test.name)
+		err := ValidateUpstreamCommitModifiesSingleGodepsRepo(test.commits)
+		if err != nil {
+			if test.errorExpected {
+				t.Logf("got expected error:\n%s", err)
+				continue
+			} else {
+				t.Fatalf("unexpected error:\n%s", err)
+			}
+		} else {
+			if test.errorExpected {
+				t.Fatalf("expected an error, got none")
+			}
+		}
+	}
+}
+
+func TestValidateUpstreamCommitModifiesOnlyGodeps(t *testing.T) {
+	tests := []struct {
+		name          string
+		commits       []util.Commit
+		errorExpected bool
+	}{
+		{
+			name: "test 1",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: commit 2",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+						"pkg/some_file",
+					},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			name: "test 2",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: commit 2",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Logf("evaluating test %q", test.name)
+		err := ValidateUpstreamCommitModifiesOnlyGodeps(test.commits)
+		if err != nil {
+			if test.errorExpected {
+				t.Logf("got expected error:\n%s", err)
+				continue
+			} else {
+				t.Fatalf("unexpected error:\n%s", err)
+			}
+		} else {
+			if test.errorExpected {
+				t.Fatalf("expected an error, got none")
+			}
+		}
+	}
+}
+
+func TestValidateUpstreamCommitSummaries(t *testing.T) {
+	tests := []struct {
+		summary string
+		valid   bool
+	}{
+		{valid: true, summary: "UPSTREAM: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: k8s.io/heapster: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: github.com/coreos/etcd: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: github.com/coreos/etcd: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: k8s.io/heapster: 12345: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: github.com/coreos/etcd: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: github.com/coreos/etcd: <drop>: a change"},
+		{valid: false, summary: "UPSTREAM: whoopsie daisy"},
+	}
+	for _, test := range tests {
+		commit := util.Commit{Summary: test.summary, Sha: "abcd000"}
+		err := ValidateUpstreamCommitSummaries([]util.Commit{commit})
+		if err != nil {
+			if test.valid {
+				t.Fatalf("unexpected error:\n%s", err)
+			} else {
+				t.Logf("got expected error:\n%s", err)
+			}
+		} else {
+			if !test.valid {
+				t.Fatalf("expected an error, got none; summary: %s", test.summary)
+			}
+		}
+	}
+}
+
+func TestValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(t *testing.T) {
+	tests := []struct {
+		name          string
+		commits       []util.Commit
+		errorExpected bool
+	}{
+		{
+			name: "test 1",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0000",
+					Summary: "commit 1",
+					Files:   []util.File{"file1", "pkg/file2"},
+				},
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: github.com/coreos/etcd: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
+					},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			name: "test 2",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: github.com/coreos/etcd: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
+						"Godeps/_workspace/src/github.com/coreos/etcd/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+		{
+			name: "test three segments",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: github.com/coreos/etcd: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/github.com/coreos/etcd/a/file1",
+						"Godeps/_workspace/src/github.com/coreos/etcd/b/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+		{
+			name: "test 3",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+		{
+			name: "test 4",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
+						"Godeps/_workspace/src/github.com/coreos/etcd/file2",
+					},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			name: "test 5",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: revert: abcd000: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+		{
+			name: "test 6",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: revert: abcd000: github.com/coreos/etcd: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
+						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
+					},
+				},
+			},
+			errorExpected: true,
+		},
+		{
+			name: "test 7",
+			commits: []util.Commit{
+				{
+					Sha:     "aaa0001",
+					Summary: "UPSTREAM: revert: abcd000: github.com/coreos/etcd: 12345: a change",
+					Files: []util.File{
+						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
+						"Godeps/_workspace/src/github.com/coreos/etcd/file2",
+					},
+				},
+			},
+			errorExpected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Logf("evaluating test %q", test.name)
+		err := ValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(test.commits)
+		if err != nil {
+			if test.errorExpected {
+				t.Logf("got expected error:\n%s", err)
+				continue
+			} else {
+				t.Fatalf("unexpected error:\n%s", err)
+			}
+		} else {
+			if test.errorExpected {
+				t.Fatalf("expected an error, got none")
+			}
+		}
+	}
+}

--- a/cmd/rebasehelpers/util/git.go
+++ b/cmd/rebasehelpers/util/git.go
@@ -1,0 +1,218 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var UpstreamSummaryPattern = regexp.MustCompile(`UPSTREAM: (revert: [a-f0-9]{7,}: )?(([\w\.-]+\/[\w-]+)(\/[\w-]+)?: )?([0-9]{4,}:|<carry>:|<drop>:)`)
+
+// supportedHosts maps source hosts to the number of path segments that
+// represent the account/repo for that host. This is necessary because we
+// can't tell just by looking at an import path whether the repo is identified
+// by the first 2 or 3 path segments.
+//
+// If dependencies are introduced from new hosts, they'll need to be added
+// here.
+var SupportedHosts = map[string]int{
+	"bitbucket.org":     3,
+	"code.google.com":   3,
+	"github.com":        3,
+	"golang.org":        3,
+	"google.golang.org": 2,
+	"gopkg.in":          2,
+	"k8s.io":            2,
+	"speter.net":        2,
+}
+
+type Commit struct {
+	Sha     string
+	Summary string
+	Files   []File
+}
+
+func (c Commit) DeclaresUpstreamChange() bool {
+	return strings.HasPrefix(strings.ToLower(c.Summary), "upstream")
+}
+
+func (c Commit) MatchesUpstreamSummaryPattern() bool {
+	return UpstreamSummaryPattern.MatchString(c.Summary)
+}
+
+func (c Commit) DeclaredUpstreamRepo() (string, error) {
+	if !c.DeclaresUpstreamChange() {
+		return "", fmt.Errorf("commit declares no upstream changes")
+	}
+	if !c.MatchesUpstreamSummaryPattern() {
+		return "", fmt.Errorf("commit doesn't match the upstream commit summary pattern")
+	}
+	groups := UpstreamSummaryPattern.FindStringSubmatch(c.Summary)
+	repo := groups[3]
+	if len(repo) == 0 {
+		repo = "k8s.io/kubernetes"
+	}
+	// Do a simple special casing for repos which use 3 path segments to
+	// identify the repo. The only repos ever seen use either 2 or 3 so don't
+	// bother trying to make it too generic.
+	segments := -1
+	for host, count := range SupportedHosts {
+		if strings.HasPrefix(repo, host) {
+			segments = count
+			break
+		}
+	}
+	if segments == -1 {
+		fmt.Printf("commit modifies unsupported repo %q\n", repo)
+		return "", fmt.Errorf("commit modifies unsupported repo %q", repo)
+	}
+	fmt.Printf("repo=%s, segments=%d\n", repo, segments)
+	if segments == 3 {
+		repo += groups[4]
+	}
+	return repo, nil
+}
+
+func (c Commit) HasGodepsChanges() bool {
+	for _, file := range c.Files {
+		if file.HasGodepsChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Commit) HasNonGodepsChanges() bool {
+	for _, file := range c.Files {
+		if !file.HasGodepsChanges() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Commit) GodepsReposChanged() ([]string, error) {
+	repos := map[string]struct{}{}
+	for _, file := range c.Files {
+		if !file.HasGodepsChanges() {
+			continue
+		}
+		repo, err := file.GodepsRepoChanged()
+		if err != nil {
+			return nil, fmt.Errorf("problem with file %q in commit %s: %s", file, c.Sha, err)
+		}
+		repos[repo] = struct{}{}
+	}
+	changed := []string{}
+	for repo := range repos {
+		changed = append(changed, repo)
+	}
+	return changed, nil
+}
+
+type File string
+
+func (f File) HasGodepsChanges() bool {
+	return strings.HasPrefix(string(f), "Godeps")
+}
+
+func (f File) GodepsRepoChanged() (string, error) {
+	if !f.HasGodepsChanges() {
+		return "", fmt.Errorf("file doesn't appear to be a Godeps change")
+	}
+	// Find the _workspace path segment index.
+	workspaceIdx := -1
+	parts := strings.Split(string(f), string(os.PathSeparator))
+	for i, part := range parts {
+		if part == "_workspace" {
+			workspaceIdx = i
+			break
+		}
+	}
+	// Godeps path struture assumption: Godeps/_workspace/src/...
+	if workspaceIdx == -1 || len(parts) < (workspaceIdx+3) {
+		return "", fmt.Errorf("file doesn't appear to be a Godeps workspace path")
+	}
+	// Deal with repos which could be identified by either 2 or 3 path segments.
+	host := parts[workspaceIdx+2]
+	segments := -1
+	for supportedHost, count := range SupportedHosts {
+		if host == supportedHost {
+			segments = count
+			break
+		}
+	}
+	if segments == -1 {
+		return "", fmt.Errorf("file modifies an unsupported repo host %q", host)
+	}
+	switch segments {
+	case 2:
+		return fmt.Sprintf("%s/%s", host, parts[workspaceIdx+3]), nil
+	case 3:
+		return fmt.Sprintf("%s/%s/%s", host, parts[workspaceIdx+3], parts[workspaceIdx+4]), nil
+	}
+	return "", fmt.Errorf("file modifies an unsupported repo host %q", host)
+}
+
+func CommitsBetween(a, b string) ([]Commit, error) {
+	commits := []Commit{}
+	stdout, _, err := run("git", "log", "--oneline", fmt.Sprintf("%s..%s", a, b))
+	if err != nil {
+		return nil, fmt.Errorf("error executing git log: %s", err)
+	}
+	for _, log := range strings.Split(stdout, "\n") {
+		if len(log) == 0 {
+			continue
+		}
+		commit, err := NewCommitFromOnelineLog(log)
+		if err != nil {
+			return nil, err
+		}
+		commits = append(commits, commit)
+	}
+	return commits, nil
+}
+
+func NewCommitFromOnelineLog(log string) (Commit, error) {
+	var commit Commit
+	parts := strings.Split(log, " ")
+	if len(parts) < 2 {
+		return commit, fmt.Errorf("invalid log entry: %s", log)
+	}
+	commit.Sha = parts[0]
+	commit.Summary = strings.Join(parts[1:], " ")
+	files, err := filesInCommit(commit.Sha)
+	if err != nil {
+		return commit, err
+	}
+	commit.Files = files
+	return commit, nil
+}
+
+func filesInCommit(sha string) ([]File, error) {
+	files := []File{}
+	stdout, _, err := run("git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+	if err != nil {
+		return nil, err
+	}
+	for _, filename := range strings.Split(stdout, "\n") {
+		if len(filename) == 0 {
+			continue
+		}
+		files = append(files, File(filename))
+	}
+	return files, nil
+}
+
+func run(args ...string) (string, string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -638,3 +638,11 @@ os::build::gen-docs() {
 
   echo "Assets generated in ${dest}"
 }
+
+# os::build::find-binary locates a locally built binary for the current
+# platform and returns the path to the binary.
+os::build::find-binary() {
+  local bin="$1"
+  local path=$( (ls -t _output/local/bin/$(os::build::host_platform)/${bin}) 2>/dev/null || true | head -1 )
+  echo "$path"
+}

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -18,7 +18,7 @@ fi
 "${OS_ROOT}/hack/build-go.sh" cmd/genbashcomp
 
 # Find binary
-genbashcomp=$( (ls -t _output/local/bin/${platform}/genbashcomp) 2>/dev/null || true | head -1 )
+genbashcomp="$(os::build::find-binary genbashcomp)"
 
 if [[ ! "$genbashcomp" ]]; then
   {

--- a/hack/update-generated-docs.sh
+++ b/hack/update-generated-docs.sh
@@ -12,7 +12,7 @@ source "${OS_ROOT}/hack/common.sh"
 "${OS_ROOT}/hack/build-go.sh" cmd/gendocs
 
 # Find binary
-gendocs=$( (ls -t _output/local/bin/$(os::build::host_platform)/gendocs) 2>/dev/null || true | head -1 )
+gendocs="$(os::build::find-binary gendocs)"
 
 if [[ -z "$gendocs" ]]; then
   {

--- a/hack/verify-generated-conversions.sh
+++ b/hack/verify-generated-conversions.sh
@@ -20,7 +20,7 @@ else
   echo "$buildout" | sed 's/^/   /'
 fi
 
-genconversion="${OS_ROOT}/_output/local/bin/$(os::build::host_platform)/genconversion"
+genconversion="$(os::build::find-binary genconversion)"
 
 echo "   Verifying genconversion binary..."
 if [[ ! -x "$genconversion" ]]; then

--- a/hack/verify-generated-deep-copies.sh
+++ b/hack/verify-generated-deep-copies.sh
@@ -20,7 +20,7 @@ else
   echo "$buildout" | sed 's/^/   /'
 fi
 
-gendeepcopy="${OS_ROOT}/_output/local/bin/$(os::build::host_platform)/gendeepcopy"
+gendeepcopy="$(os::build::find-binary gendeepcopy)"
 
 echo "   Verifying gendeepcopy binary..."
 if [[ ! -x "$gendeepcopy" ]]; then

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+
+"${OS_ROOT}/hack/build-go.sh" cmd/rebasehelpers/commitchecker
+
+# Find binary
+commitchecker="$(os::build::find-binary commitchecker)"
+echo "===== Verifying UPSTREAM Commits ====="
+$commitchecker
+echo "SUCCESS: All commits are valid."


### PR DESCRIPTION
Add UPSTREAM/godeps commit validation during the Makefile `verify` task.

Part of https://trello.com/c/noaPjUWG.