### PR TITLE
Improve dev cluster provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,6 +126,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Start an OpenShift cluster
     # Currently this only works with the (default) VirtualBox provider.
 
+    # Tag configuration as stale when provisioning a dev cluster to
+    # ensure that nodes can wait for fresh configuration to be generated.
+    if ARGV[0] =~ /^up|provision$/i and not ARGV.include?("--no-provision")
+      system('test -d ./openshift.local.config && touch ./openshift.local.config/.stale')
+    end
+
     instance_prefix = "openshift"
 
     # The number of minions to provision.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     "cpus"              => ENV['OPENSHIFT_NUM_CPUS'] || 2,
     "memory"            => ENV['OPENSHIFT_MEMORY'] || 2560,
     "fixup_net_udev"    => ENV['OPENSHIFT_FIXUP_NET_UDEV'] || true,
+    "skip_build"        => ENV['OPENSHIFT_SKIP_BUILD'] || false,
     "sync_folders_type" => nil,
     "master_ip"         => ENV['OPENSHIFT_MASTER_IP'] || "10.245.2.2",
     "minion_ip_base"    => ENV['OPENSHIFT_MINION_IP_BASE'] || "10.245.2.",
@@ -151,12 +152,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if network_plugin != ''
       network_plugin = "-n #{network_plugin}"
     end
+    skip_build = ''
+    if vagrant_openshift_config['skip_build']
+      skip_build = '-s'
+    end
 
     # OpenShift master
     config.vm.define "#{VM_NAME_PREFIX}master" do |config|
       config.vm.box = kube_box[kube_os]["name"]
       config.vm.box_url = kube_box[kube_os]["box_url"]
-      config.vm.provision "shell", inline: "/bin/bash -x /vagrant/contrib/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{network_plugin} #{fixup_net_udev}"
+      config.vm.provision "shell", inline: "/bin/bash -x /vagrant/contrib/vagrant/provision-master.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} #{network_plugin} #{fixup_net_udev} #{skip_build}"
       config.vm.network "private_network", ip: "#{master_ip}"
       config.vm.hostname = "openshift-master"
       config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']
@@ -169,7 +174,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         minion_ip = minion_ips[n]
         minion.vm.box = kube_box[kube_os]["name"]
         minion.vm.box_url = kube_box[kube_os]["box_url"]
-        minion.vm.provision "shell", inline: "/bin/bash -x /vagrant/contrib/vagrant/provision-node.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} -i #{minion_index} #{network_plugin} #{fixup_net_udev}"
+        minion.vm.provision "shell", inline: "/bin/bash -x /vagrant/contrib/vagrant/provision-node.sh #{master_ip} #{num_minion} #{minion_ips_str} #{instance_prefix} -i #{minion_index} #{network_plugin} #{fixup_net_udev} #{skip_build}"
         minion.vm.network "private_network", ip: "#{minion_ip}"
         minion.vm.hostname = "openshift-minion-#{minion_index}"
         config.vm.synced_folder ".", "/vagrant", type: vagrant_openshift_config['sync_folders_type']

--- a/contrib/vagrant/provision-config.sh
+++ b/contrib/vagrant/provision-config.sh
@@ -69,6 +69,7 @@ NODE_IPS=(${NODE_IPS//,/ })
 if [ "${CONFIG_ROOT}" = "/" ]; then
   CONFIG_ROOT=""
 fi
+DEPLOYED_CONFIG_ROOT="/"
 NETWORK_PLUGIN=$(os::provision::get-network-plugin "${NETWORK_PLUGIN}" \
   "${DIND_MANAGEMENT_SCRIPT:-false}")
 MASTER_NAME="${INSTANCE_PREFIX}-master"

--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -28,19 +28,23 @@ fi
 os::provision::init-certs "${CONFIG_ROOT}" "${NETWORK_PLUGIN}" \
   "${MASTER_NAME}" "${MASTER_IP}" NODE_NAMES NODE_IPS
 
+os::provision::copy-config "${CONFIG_ROOT}"
+
 echo "Launching openshift daemons"
 NODE_LIST=$(os::provision::join , ${NODE_NAMES[@]})
 cmd="/usr/bin/openshift start master --loglevel=${LOG_LEVEL} \
  --master=https://${MASTER_IP}:8443 --nodes=${NODE_LIST} \
  --network-plugin=${NETWORK_PLUGIN}"
-os::provision::start-os-service "openshift-master" "OpenShift Master" "${cmd}"
+os::provision::start-os-service "openshift-master" "OpenShift Master" \
+    "${cmd}" "${DEPLOYED_CONFIG_ROOT}"
 
 if [ "${SDN_NODE}" = "true" ]; then
-  os::provision::start-node-service "${CONFIG_ROOT}" "${SDN_NODE_NAME}"
+  os::provision::start-node-service "${DEPLOYED_CONFIG_ROOT}" \
+      "${SDN_NODE_NAME}"
 
   # Disable scheduling for the sdn node - it's purpose is only to ensure
   # pod network connectivity on the master.
-  os::provision::disable-sdn-node "${CONFIG_ROOT}" "${SDN_NODE_NAME}"
+  os::provision::disable-sdn-node "${DEPLOYED_CONFIG_ROOT}" "${SDN_NODE_NAME}"
 fi
 
-os::provision::set-os-env "${ORIGIN_ROOT}" "${CONFIG_ROOT}"
+os::provision::set-os-env "${ORIGIN_ROOT}" "${DEPLOYED_CONFIG_ROOT}"

--- a/contrib/vagrant/provision-node.sh
+++ b/contrib/vagrant/provision-node.sh
@@ -13,12 +13,14 @@ if ! os::provision::in-container; then
   os::provision::wait-for-node-config "${CONFIG_ROOT}" "${NODE_NAME}"
 fi
 
+os::provision::copy-config "${CONFIG_ROOT}"
+
 # openshift is assumed to have been built before node deployment
 os::provision::install-cmds "${ORIGIN_ROOT}"
 
 os::provision::install-sdn "${ORIGIN_ROOT}"
 
 echo "Launching openshift daemon"
-os::provision::start-node-service "${CONFIG_ROOT}" "${NODE_NAME}"
+os::provision::start-node-service "${DEPLOYED_CONFIG_ROOT}" "${NODE_NAME}"
 
-os::provision::set-os-env "${ORIGIN_ROOT}" "${CONFIG_ROOT}"
+os::provision::set-os-env "${ORIGIN_ROOT}" "${DEPLOYED_CONFIG_ROOT}"

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -81,6 +81,9 @@ os::provision::init-certs() {
   local volumes_dir="/var/lib/openshift.local.volumes"
   local cert_dir="${server_config_dir}/master"
 
+  # Clear stale configuration
+  rm -rf "${server_config_dir}"
+
   pushd "${config_root}" > /dev/null
 
   # Master certs
@@ -334,7 +337,8 @@ os::provision::wait-for-node-config() {
   local msg="node configuration file"
   local config_file=$(os::provision::get-node-config "${config_root}" \
     "${node_name}")
-  local condition="test -f ${config_file}"
+  local condition="test ! -f ${config_root}/openshift.local.config/.stale -a \
+-f ${config_file}"
   os::provision::wait-for-condition "${msg}" "${condition}" \
     "${OS_WAIT_FOREVER}"
 }

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -229,7 +229,7 @@ os::provision::start-os-service() {
   local unit_name=$1
   local description=$2
   local exec_start=$3
-  local work_dir=${4:-${CONFIG_ROOT}/}
+  local work_dir=$4
 
   local dind_env_var=
   if os::provision::in-container; then
@@ -258,19 +258,24 @@ EOF
   systemctl start "${unit_name}.service"
 }
 
-os::provision::start-node-service() {
+os::provision::copy-config() {
   local config_root=$1
-  local node_name=$2
 
   # Copy over the certificates directory so that each node has a copy.
   cp -r "${config_root}/openshift.local.config" /
   if [ -d /home/vagrant ]; then
     chown -R vagrant.vagrant /openshift.local.config
   fi
+}
+
+os::provision::start-node-service() {
+  local config_root=$1
+  local node_name=$2
 
   cmd="/usr/bin/openshift start node --loglevel=${LOG_LEVEL} \
 --config=$(os::provision::get-node-config ${config_root} ${node_name})"
-  os::provision::start-os-service "openshift-node" "OpenShift Node" "${cmd}" /
+  os::provision::start-os-service "openshift-node" "OpenShift Node" "${cmd}" \
+      "${config_root}"
 }
 
 OS_WAIT_FOREVER=-1


### PR DESCRIPTION
- prevent dev cluster deploy from using stale config
- use local storage instead of nfs for etcd datastore
- optionally skip go builds during cluster provisioning