### PR TITLE
Prevent dev cluster deploy from using stale config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,6 +127,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Start an OpenShift cluster
     # Currently this only works with the (default) VirtualBox provider.
 
+    # Tag configuration as stale when provisioning a dev cluster to
+    # ensure that nodes can wait for fresh configuration to be generated.
+    if ARGV[0] =~ /^up|provision$/i and not ARGV.include?("--no-provision")
+      system('test -d ./openshift.local.config && touch ./openshift.local.config/.stale')
+    end
+
     instance_prefix = "openshift"
 
     # The number of minions to provision.

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -109,6 +109,10 @@ os::provision::init-certs() {
   done
 
   popd > /dev/null
+
+  # Indicate to nodes that it's safe to begin provisioning by removing
+  # the stale marker.
+  rm -f ${config_root}/openshift.local.config/.stale
 }
 
 os::provision::set-os-env() {
@@ -353,7 +357,8 @@ os::provision::wait-for-node-config() {
   local msg="node configuration file"
   local config_file=$(os::provision::get-node-config "${config_root}" \
     "${node_name}")
-  local condition="test -f ${config_file}"
+  local condition="test ! -f ${config_root}/openshift.local.config/.stale -a \
+-f ${config_file}"
   os::provision::wait-for-condition "${msg}" "${condition}" \
     "${OS_WAIT_FOREVER}"
 }


### PR DESCRIPTION
When a dev cluster is deployed with vagrant, the nodes wait for their
configuration to be created.  If stale configuration is already present,
they may use that configuration before the master has a chance to
generate new configuration.  This change marks existing configuration as
stale at the beginning of provisioning to avoid that possiblity.