### PR TITLE
Copy config to dev cluster master's local storage

### DIFF
--- a/contrib/vagrant/provision-node.sh
+++ b/contrib/vagrant/provision-node.sh
@@ -13,9 +13,15 @@ if ! os::provision::in-container; then
   os::provision::wait-for-node-config "${CONFIG_ROOT}" "${NODE_NAME}"
 fi
 
+# Copy configuration to local storage because each node's openshift
+# service uses the configuration path as a working directory and it is
+# not desirable for nodes to share a working directory.
+DEPLOYED_CONFIG_ROOT="/"
+os::provision::copy-config "${CONFIG_ROOT}"
+
 # Binaries are expected to have been built by the time node
 # configuration is available.
-os::provision::base-install "${ORIGIN_ROOT}" "${CONFIG_ROOT}"
+os::provision::base-install "${ORIGIN_ROOT}" "${DEPLOYED_CONFIG_ROOT}"
 
 echo "Launching openshift daemon"
-os::provision::start-node-service "${CONFIG_ROOT}" "${NODE_NAME}"
+os::provision::start-node-service "${DEPLOYED_CONFIG_ROOT}" "${NODE_NAME}"

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -276,7 +276,7 @@ os::provision::start-os-service() {
   local unit_name=$1
   local description=$2
   local exec_start=$3
-  local work_dir=${4:-${CONFIG_ROOT}/}
+  local work_dir=$4
 
   local dind_env_var=
   if os::provision::in-container; then
@@ -305,19 +305,24 @@ EOF
   systemctl start "${unit_name}.service"
 }
 
-os::provision::start-node-service() {
+os::provision::copy-config() {
   local config_root=$1
-  local node_name=$2
 
   # Copy over the certificates directory so that each node has a copy.
   cp -r "${config_root}/openshift.local.config" /
   if [ -d /home/vagrant ]; then
     chown -R vagrant.vagrant /openshift.local.config
   fi
+}
+
+os::provision::start-node-service() {
+  local config_root=$1
+  local node_name=$2
 
   cmd="/usr/bin/openshift start node --loglevel=${LOG_LEVEL} \
 --config=$(os::provision::get-node-config ${config_root} ${node_name})"
-  os::provision::start-os-service "openshift-node" "OpenShift Node" "${cmd}" /
+  os::provision::start-os-service "openshift-node" "OpenShift Node" "${cmd}" \
+      "${config_root}"
 }
 
 OS_WAIT_FOREVER=-1


### PR DESCRIPTION
By default openshift's etcd instance stores data as a peer to the
cluster configuration (e.g. /vagrant/openshift.local.etcd).  When this
path is an nfs mount, various lock-related errors are possible.  This
change copies the configuration to local storage to ensure that etcd's
backing store will not be subject to the possibility of nfs-related lock
failures.