### PR TITLE
Update config of dind cluster image registry

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -103,9 +103,9 @@ function check-selinux() {
   fi
 }
 
-IMAGE_REPO="${OPENSHIFT_DIND_IMAGE_REPO:-}"
-IMAGE_TAG="${OPENSHIFT_DIND_IMAGE_TAG:-}"
-DIND_IMAGE="${IMAGE_REPO}openshift/dind${IMAGE_TAG}"
+IMAGE_REGISTRY="${OPENSHIFT_TEST_IMAGE_REGISTRY:-}"
+IMAGE_TAG="${OPENSHIFT_TEST_IMAGE_TAG:-}"
+DIND_IMAGE="${IMAGE_REGISTRY}openshift/dind${IMAGE_TAG}"
 BUILD_IMAGES="${OPENSHIFT_DIND_BUILD_IMAGES:-1}"
 
 function build-image() {
@@ -122,12 +122,12 @@ function build-images() {
   # separation of image build from cluster creation.
   if [ "${BUILD_IMAGES}" = "1" ]; then
     echo "Building container images"
-    if [ "${IMAGE_REPO}" != "" ]; then
+    if [ -n "${IMAGE_REGISTRY}" ]; then
       # Failure to cache is assumed to not be worth failing the build.
       ${DOCKER_CMD} pull "${DIND_IMAGE}" || true
     fi
     build-image "${ORIGIN_ROOT}/images/dind" "${DIND_IMAGE}"
-    if [ "${IMAGE_REPO}" != "" ]; then
+    if [ -n "${IMAGE_REGISTRY}" ]; then
       ${DOCKER_CMD} push "${DIND_IMAGE}" || true
     fi
   fi


### PR DESCRIPTION
vagrant-openshift will soon support setting
OPENSHIFT_TEST_IMAGE_REGISTRY to a test-local registry to allow image
caching across job runs.