### PR TITLE
remove buildstrategy and buildsource type field

### DIFF
--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -944,7 +944,6 @@ func deepCopy_api_BuildRequest(in buildapi.BuildRequest, out *buildapi.BuildRequ
 }
 
 func deepCopy_api_BuildSource(in buildapi.BuildSource, out *buildapi.BuildSource, c *conversion.Cloner) error {
-	out.Type = in.Type
 	if in.Binary != nil {
 		out.Binary = new(buildapi.BinaryBuildSource)
 		if err := deepCopy_api_BinaryBuildSource(*in.Binary, out.Binary, c); err != nil {
@@ -1051,7 +1050,6 @@ func deepCopy_api_BuildStatus(in buildapi.BuildStatus, out *buildapi.BuildStatus
 }
 
 func deepCopy_api_BuildStrategy(in buildapi.BuildStrategy, out *buildapi.BuildStrategy, c *conversion.Cloner) error {
-	out.Type = in.Type
 	if in.DockerStrategy != nil {
 		out.DockerStrategy = new(buildapi.DockerBuildStrategy)
 		if err := deepCopy_api_DockerBuildStrategy(*in.DockerStrategy, out.DockerStrategy, c); err != nil {
@@ -1270,7 +1268,6 @@ func deepCopy_api_SourceControlUser(in buildapi.SourceControlUser, out *buildapi
 }
 
 func deepCopy_api_SourceRevision(in buildapi.SourceRevision, out *buildapi.SourceRevision, c *conversion.Cloner) error {
-	out.Type = in.Type
 	if in.Git != nil {
 		out.Git = new(buildapi.GitSourceRevision)
 		if err := deepCopy_api_GitSourceRevision(*in.Git, out.Git, c); err != nil {

--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -204,7 +204,6 @@ func TestGraph(t *testing.T) {
 			},
 			BuildSpec: buildapi.BuildSpec{
 				Strategy: buildapi.BuildStrategy{
-					Type: buildapi.SourceBuildStrategyType,
 					SourceStrategy: &buildapi.SourceBuildStrategy{
 						From: kapi.ObjectReference{Kind: "ImageStreamTag", Name: "test:base-image"},
 					},

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1339,8 +1339,7 @@ func autoconvert_api_BuildRequest_To_v1_BuildRequest(in *buildapi.BuildRequest, 
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(apiv1.SourceRevision)
-		if err := convert_api_SourceRevision_To_v1_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
@@ -1397,7 +1396,6 @@ func autoconvert_api_BuildSource_To_v1_BuildSource(in *buildapi.BuildSource, out
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildSource))(in)
 	}
-	out.Type = apiv1.BuildSourceType(in.Type)
 	if in.Binary != nil {
 		out.Binary = new(apiv1.BinaryBuildSource)
 		if err := convert_api_BinaryBuildSource_To_v1_BinaryBuildSource(in.Binary, out.Binary, s); err != nil {
@@ -1432,27 +1430,22 @@ func autoconvert_api_BuildSource_To_v1_BuildSource(in *buildapi.BuildSource, out
 	return nil
 }
 
-func convert_api_BuildSource_To_v1_BuildSource(in *buildapi.BuildSource, out *apiv1.BuildSource, s conversion.Scope) error {
-	return autoconvert_api_BuildSource_To_v1_BuildSource(in, out, s)
-}
-
 func autoconvert_api_BuildSpec_To_v1_BuildSpec(in *buildapi.BuildSpec, out *apiv1.BuildSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := convert_api_BuildSource_To_v1_BuildSource(&in.Source, &out.Source, s); err != nil {
+	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(apiv1.SourceRevision)
-		if err := convert_api_SourceRevision_To_v1_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := convert_api_BuildStrategy_To_v1_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
@@ -1517,7 +1510,6 @@ func autoconvert_api_BuildStrategy_To_v1_BuildStrategy(in *buildapi.BuildStrateg
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildStrategy))(in)
 	}
-	out.Type = apiv1.BuildStrategyType(in.Type)
 	if in.DockerStrategy != nil {
 		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
 			return err
@@ -1540,10 +1532,6 @@ func autoconvert_api_BuildStrategy_To_v1_BuildStrategy(in *buildapi.BuildStrateg
 		out.CustomStrategy = nil
 	}
 	return nil
-}
-
-func convert_api_BuildStrategy_To_v1_BuildStrategy(in *buildapi.BuildStrategy, out *apiv1.BuildStrategy, s conversion.Scope) error {
-	return autoconvert_api_BuildStrategy_To_v1_BuildStrategy(in, out, s)
 }
 
 func autoconvert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy(in *buildapi.BuildTriggerPolicy, out *apiv1.BuildTriggerPolicy, s conversion.Scope) error {
@@ -1770,7 +1758,6 @@ func autoconvert_api_SourceRevision_To_v1_SourceRevision(in *buildapi.SourceRevi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.SourceRevision))(in)
 	}
-	out.Type = apiv1.BuildSourceType(in.Type)
 	if in.Git != nil {
 		out.Git = new(apiv1.GitSourceRevision)
 		if err := convert_api_GitSourceRevision_To_v1_GitSourceRevision(in.Git, out.Git, s); err != nil {
@@ -1780,10 +1767,6 @@ func autoconvert_api_SourceRevision_To_v1_SourceRevision(in *buildapi.SourceRevi
 		out.Git = nil
 	}
 	return nil
-}
-
-func convert_api_SourceRevision_To_v1_SourceRevision(in *buildapi.SourceRevision, out *apiv1.SourceRevision, s conversion.Scope) error {
-	return autoconvert_api_SourceRevision_To_v1_SourceRevision(in, out, s)
 }
 
 func autoconvert_api_WebHookTrigger_To_v1_WebHookTrigger(in *buildapi.WebHookTrigger, out *apiv1.WebHookTrigger, s conversion.Scope) error {
@@ -2068,8 +2051,7 @@ func autoconvert_v1_BuildRequest_To_api_BuildRequest(in *apiv1.BuildRequest, out
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(buildapi.SourceRevision)
-		if err := convert_v1_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
@@ -2126,7 +2108,7 @@ func autoconvert_v1_BuildSource_To_api_BuildSource(in *apiv1.BuildSource, out *b
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1.BuildSource))(in)
 	}
-	out.Type = buildapi.BuildSourceType(in.Type)
+	// in.Type has no peer in out
 	if in.Binary != nil {
 		out.Binary = new(buildapi.BinaryBuildSource)
 		if err := convert_v1_BinaryBuildSource_To_api_BinaryBuildSource(in.Binary, out.Binary, s); err != nil {
@@ -2161,27 +2143,22 @@ func autoconvert_v1_BuildSource_To_api_BuildSource(in *apiv1.BuildSource, out *b
 	return nil
 }
 
-func convert_v1_BuildSource_To_api_BuildSource(in *apiv1.BuildSource, out *buildapi.BuildSource, s conversion.Scope) error {
-	return autoconvert_v1_BuildSource_To_api_BuildSource(in, out, s)
-}
-
 func autoconvert_v1_BuildSpec_To_api_BuildSpec(in *apiv1.BuildSpec, out *buildapi.BuildSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := convert_v1_BuildSource_To_api_BuildSource(&in.Source, &out.Source, s); err != nil {
+	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(buildapi.SourceRevision)
-		if err := convert_v1_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := convert_v1_BuildStrategy_To_api_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
@@ -2246,7 +2223,7 @@ func autoconvert_v1_BuildStrategy_To_api_BuildStrategy(in *apiv1.BuildStrategy, 
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1.BuildStrategy))(in)
 	}
-	out.Type = buildapi.BuildStrategyType(in.Type)
+	// in.Type has no peer in out
 	if in.DockerStrategy != nil {
 		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
 			return err
@@ -2269,10 +2246,6 @@ func autoconvert_v1_BuildStrategy_To_api_BuildStrategy(in *apiv1.BuildStrategy, 
 		out.CustomStrategy = nil
 	}
 	return nil
-}
-
-func convert_v1_BuildStrategy_To_api_BuildStrategy(in *apiv1.BuildStrategy, out *buildapi.BuildStrategy, s conversion.Scope) error {
-	return autoconvert_v1_BuildStrategy_To_api_BuildStrategy(in, out, s)
 }
 
 func autoconvert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *apiv1.BuildTriggerPolicy, out *buildapi.BuildTriggerPolicy, s conversion.Scope) error {
@@ -2499,7 +2472,7 @@ func autoconvert_v1_SourceRevision_To_api_SourceRevision(in *apiv1.SourceRevisio
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1.SourceRevision))(in)
 	}
-	out.Type = buildapi.BuildSourceType(in.Type)
+	// in.Type has no peer in out
 	if in.Git != nil {
 		out.Git = new(buildapi.GitSourceRevision)
 		if err := convert_v1_GitSourceRevision_To_api_GitSourceRevision(in.Git, out.Git, s); err != nil {
@@ -2509,10 +2482,6 @@ func autoconvert_v1_SourceRevision_To_api_SourceRevision(in *apiv1.SourceRevisio
 		out.Git = nil
 	}
 	return nil
-}
-
-func convert_v1_SourceRevision_To_api_SourceRevision(in *apiv1.SourceRevision, out *buildapi.SourceRevision, s conversion.Scope) error {
-	return autoconvert_v1_SourceRevision_To_api_SourceRevision(in, out, s)
 }
 
 func autoconvert_v1_WebHookTrigger_To_api_WebHookTrigger(in *apiv1.WebHookTrigger, out *buildapi.WebHookTrigger, s conversion.Scope) error {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1348,8 +1348,7 @@ func autoconvert_api_BuildRequest_To_v1beta3_BuildRequest(in *buildapi.BuildRequ
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(apiv1beta3.SourceRevision)
-		if err := convert_api_SourceRevision_To_v1beta3_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
@@ -1406,7 +1405,6 @@ func autoconvert_api_BuildSource_To_v1beta3_BuildSource(in *buildapi.BuildSource
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildSource))(in)
 	}
-	out.Type = apiv1beta3.BuildSourceType(in.Type)
 	if in.Binary != nil {
 		out.Binary = new(apiv1beta3.BinaryBuildSource)
 		if err := convert_api_BinaryBuildSource_To_v1beta3_BinaryBuildSource(in.Binary, out.Binary, s); err != nil {
@@ -1441,27 +1439,22 @@ func autoconvert_api_BuildSource_To_v1beta3_BuildSource(in *buildapi.BuildSource
 	return nil
 }
 
-func convert_api_BuildSource_To_v1beta3_BuildSource(in *buildapi.BuildSource, out *apiv1beta3.BuildSource, s conversion.Scope) error {
-	return autoconvert_api_BuildSource_To_v1beta3_BuildSource(in, out, s)
-}
-
 func autoconvert_api_BuildSpec_To_v1beta3_BuildSpec(in *buildapi.BuildSpec, out *apiv1beta3.BuildSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := convert_api_BuildSource_To_v1beta3_BuildSource(&in.Source, &out.Source, s); err != nil {
+	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(apiv1beta3.SourceRevision)
-		if err := convert_api_SourceRevision_To_v1beta3_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := convert_api_BuildStrategy_To_v1beta3_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
@@ -1526,7 +1519,6 @@ func autoconvert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *buildapi.BuildSt
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildStrategy))(in)
 	}
-	out.Type = apiv1beta3.BuildStrategyType(in.Type)
 	if in.DockerStrategy != nil {
 		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
 			return err
@@ -1549,10 +1541,6 @@ func autoconvert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *buildapi.BuildSt
 		out.CustomStrategy = nil
 	}
 	return nil
-}
-
-func convert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *buildapi.BuildStrategy, out *apiv1beta3.BuildStrategy, s conversion.Scope) error {
-	return autoconvert_api_BuildStrategy_To_v1beta3_BuildStrategy(in, out, s)
 }
 
 func autoconvert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy(in *buildapi.BuildTriggerPolicy, out *apiv1beta3.BuildTriggerPolicy, s conversion.Scope) error {
@@ -1779,7 +1767,6 @@ func autoconvert_api_SourceRevision_To_v1beta3_SourceRevision(in *buildapi.Sourc
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.SourceRevision))(in)
 	}
-	out.Type = apiv1beta3.BuildSourceType(in.Type)
 	if in.Git != nil {
 		out.Git = new(apiv1beta3.GitSourceRevision)
 		if err := convert_api_GitSourceRevision_To_v1beta3_GitSourceRevision(in.Git, out.Git, s); err != nil {
@@ -1789,10 +1776,6 @@ func autoconvert_api_SourceRevision_To_v1beta3_SourceRevision(in *buildapi.Sourc
 		out.Git = nil
 	}
 	return nil
-}
-
-func convert_api_SourceRevision_To_v1beta3_SourceRevision(in *buildapi.SourceRevision, out *apiv1beta3.SourceRevision, s conversion.Scope) error {
-	return autoconvert_api_SourceRevision_To_v1beta3_SourceRevision(in, out, s)
 }
 
 func autoconvert_api_WebHookTrigger_To_v1beta3_WebHookTrigger(in *buildapi.WebHookTrigger, out *apiv1beta3.WebHookTrigger, s conversion.Scope) error {
@@ -2077,8 +2060,7 @@ func autoconvert_v1beta3_BuildRequest_To_api_BuildRequest(in *apiv1beta3.BuildRe
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(buildapi.SourceRevision)
-		if err := convert_v1beta3_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
@@ -2135,7 +2117,7 @@ func autoconvert_v1beta3_BuildSource_To_api_BuildSource(in *apiv1beta3.BuildSour
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1beta3.BuildSource))(in)
 	}
-	out.Type = buildapi.BuildSourceType(in.Type)
+	// in.Type has no peer in out
 	if in.Binary != nil {
 		out.Binary = new(buildapi.BinaryBuildSource)
 		if err := convert_v1beta3_BinaryBuildSource_To_api_BinaryBuildSource(in.Binary, out.Binary, s); err != nil {
@@ -2170,27 +2152,22 @@ func autoconvert_v1beta3_BuildSource_To_api_BuildSource(in *apiv1beta3.BuildSour
 	return nil
 }
 
-func convert_v1beta3_BuildSource_To_api_BuildSource(in *apiv1beta3.BuildSource, out *buildapi.BuildSource, s conversion.Scope) error {
-	return autoconvert_v1beta3_BuildSource_To_api_BuildSource(in, out, s)
-}
-
 func autoconvert_v1beta3_BuildSpec_To_api_BuildSpec(in *apiv1beta3.BuildSpec, out *buildapi.BuildSpec, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1beta3.BuildSpec))(in)
 	}
 	out.ServiceAccount = in.ServiceAccount
-	if err := convert_v1beta3_BuildSource_To_api_BuildSource(&in.Source, &out.Source, s); err != nil {
+	if err := s.Convert(&in.Source, &out.Source, 0); err != nil {
 		return err
 	}
 	if in.Revision != nil {
-		out.Revision = new(buildapi.SourceRevision)
-		if err := convert_v1beta3_SourceRevision_To_api_SourceRevision(in.Revision, out.Revision, s); err != nil {
+		if err := s.Convert(&in.Revision, &out.Revision, 0); err != nil {
 			return err
 		}
 	} else {
 		out.Revision = nil
 	}
-	if err := convert_v1beta3_BuildStrategy_To_api_BuildStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
 		return err
 	}
 	if err := s.Convert(&in.Output, &out.Output, 0); err != nil {
@@ -2255,7 +2232,7 @@ func autoconvert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *apiv1beta3.Build
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1beta3.BuildStrategy))(in)
 	}
-	out.Type = buildapi.BuildStrategyType(in.Type)
+	// in.Type has no peer in out
 	if in.DockerStrategy != nil {
 		if err := s.Convert(&in.DockerStrategy, &out.DockerStrategy, 0); err != nil {
 			return err
@@ -2278,10 +2255,6 @@ func autoconvert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *apiv1beta3.Build
 		out.CustomStrategy = nil
 	}
 	return nil
-}
-
-func convert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *apiv1beta3.BuildStrategy, out *buildapi.BuildStrategy, s conversion.Scope) error {
-	return autoconvert_v1beta3_BuildStrategy_To_api_BuildStrategy(in, out, s)
 }
 
 func autoconvert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *apiv1beta3.BuildTriggerPolicy, out *buildapi.BuildTriggerPolicy, s conversion.Scope) error {
@@ -2508,7 +2481,7 @@ func autoconvert_v1beta3_SourceRevision_To_api_SourceRevision(in *apiv1beta3.Sou
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*apiv1beta3.SourceRevision))(in)
 	}
-	out.Type = buildapi.BuildSourceType(in.Type)
+	// in.Type has no peer in out
 	if in.Git != nil {
 		out.Git = new(buildapi.GitSourceRevision)
 		if err := convert_v1beta3_GitSourceRevision_To_api_GitSourceRevision(in.Git, out.Git, s); err != nil {
@@ -2518,10 +2491,6 @@ func autoconvert_v1beta3_SourceRevision_To_api_SourceRevision(in *apiv1beta3.Sou
 		out.Git = nil
 	}
 	return nil
-}
-
-func convert_v1beta3_SourceRevision_To_api_SourceRevision(in *apiv1beta3.SourceRevision, out *buildapi.SourceRevision, s conversion.Scope) error {
-	return autoconvert_v1beta3_SourceRevision_To_api_SourceRevision(in, out, s)
 }
 
 func autoconvert_v1beta3_WebHookTrigger_To_api_WebHookTrigger(in *apiv1beta3.WebHookTrigger, out *buildapi.WebHookTrigger, s conversion.Scope) error {

--- a/pkg/build/admission/admission_test.go
+++ b/pkg/build/admission/admission_test.go
@@ -32,7 +32,7 @@ func TestBuildAdmission(t *testing.T) {
 	}{
 		{
 			name:             "allowed source build",
-			object:           testBuild(buildapi.SourceBuildStrategyType),
+			object:           testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
 			kind:             "Build",
 			resource:         buildsResource,
 			reviewResponse:   reviewResponse(true, ""),
@@ -42,7 +42,7 @@ func TestBuildAdmission(t *testing.T) {
 		{
 			name:             "allowed source build clone",
 			object:           testBuildRequest("buildname"),
-			responseObject:   testBuild(buildapi.SourceBuildStrategyType),
+			responseObject:   testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
 			kind:             "Build",
 			resource:         buildsResource,
 			subResource:      "clone",
@@ -52,7 +52,7 @@ func TestBuildAdmission(t *testing.T) {
 		},
 		{
 			name:             "denied docker build",
-			object:           testBuild(buildapi.DockerBuildStrategyType),
+			object:           testBuild(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
 			kind:             "Build",
 			resource:         buildsResource,
 			reviewResponse:   reviewResponse(false, "cannot create build of type docker build"),
@@ -62,7 +62,7 @@ func TestBuildAdmission(t *testing.T) {
 		{
 			name:             "denied docker build clone",
 			object:           testBuildRequest("buildname"),
-			responseObject:   testBuild(buildapi.DockerBuildStrategyType),
+			responseObject:   testBuild(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
 			kind:             "Build",
 			resource:         buildsResource,
 			subResource:      "clone",
@@ -72,7 +72,7 @@ func TestBuildAdmission(t *testing.T) {
 		},
 		{
 			name:             "allowed custom build",
-			object:           testBuild(buildapi.CustomBuildStrategyType),
+			object:           testBuild(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
 			kind:             "Build",
 			resource:         buildsResource,
 			reviewResponse:   reviewResponse(true, ""),
@@ -81,7 +81,7 @@ func TestBuildAdmission(t *testing.T) {
 		},
 		{
 			name:             "allowed build config",
-			object:           testBuildConfig(buildapi.DockerBuildStrategyType),
+			object:           testBuildConfig(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
 			kind:             "BuildConfig",
 			resource:         buildConfigsResource,
 			reviewResponse:   reviewResponse(true, ""),
@@ -90,7 +90,7 @@ func TestBuildAdmission(t *testing.T) {
 		},
 		{
 			name:             "allowed build config instantiate",
-			responseObject:   testBuildConfig(buildapi.DockerBuildStrategyType),
+			responseObject:   testBuildConfig(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
 			object:           testBuildRequest("buildname"),
 			kind:             "BuildConfig",
 			resource:         buildConfigsResource,
@@ -101,7 +101,7 @@ func TestBuildAdmission(t *testing.T) {
 		},
 		{
 			name:             "forbidden build config",
-			object:           testBuildConfig(buildapi.CustomBuildStrategyType),
+			object:           testBuildConfig(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
 			kind:             "BuildConfig",
 			resource:         buildConfigsResource,
 			reviewResponse:   reviewResponse(false, ""),
@@ -110,7 +110,7 @@ func TestBuildAdmission(t *testing.T) {
 		},
 		{
 			name:             "forbidden build config instantiate",
-			responseObject:   testBuildConfig(buildapi.CustomBuildStrategyType),
+			responseObject:   testBuildConfig(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
 			object:           testBuildRequest("buildname"),
 			kind:             "BuildConfig",
 			resource:         buildConfigsResource,
@@ -182,29 +182,25 @@ func fakeClient(expectedResource string, reviewResponse *authorizationapi.Subjec
 	return fake
 }
 
-func testBuild(strategy buildapi.BuildStrategyType) *buildapi.Build {
+func testBuild(strategy buildapi.BuildStrategy) *buildapi.Build {
 	return &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "test-build",
 		},
 		Spec: buildapi.BuildSpec{
-			Strategy: buildapi.BuildStrategy{
-				Type: strategy,
-			},
+			Strategy: strategy,
 		},
 	}
 }
 
-func testBuildConfig(strategy buildapi.BuildStrategyType) *buildapi.BuildConfig {
+func testBuildConfig(strategy buildapi.BuildStrategy) *buildapi.BuildConfig {
 	return &buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "test-buildconfig",
 		},
 		Spec: buildapi.BuildConfigSpec{
 			BuildSpec: buildapi.BuildSpec{
-				Strategy: buildapi.BuildStrategy{
-					Type: strategy,
-				},
+				Strategy: strategy,
 			},
 		},
 	}

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -166,24 +166,8 @@ const (
 	StatusReasonExceededRetryTimeout = "ExceededRetryTimeout"
 )
 
-// BuildSourceType is the type of SCM used.
-type BuildSourceType string
-
-// Valid values for BuildSourceType.
-const (
-	//BuildSourceGit instructs a build to use a Git source control repository as the build input.
-	BuildSourceGit BuildSourceType = "Git"
-	// BuildSourceDockerfile uses a Dockerfile as the start of a build
-	BuildSourceDockerfile BuildSourceType = "Dockerfile"
-	// BuildSourceBinary indicates the build will accept a Binary file as input.
-	BuildSourceBinary BuildSourceType = "Binary"
-)
-
 // BuildSource is the input used for the build.
 type BuildSource struct {
-	// Type of build input to accept
-	Type BuildSourceType
-
 	// Binary builds accept a binary as their input. The binary is generally assumed to be a tar,
 	// gzipped tar, or zip file depending on the strategy. For Docker builds, this is the build
 	// context and an optional Dockerfile may be specified to override any Dockerfile in the
@@ -229,9 +213,6 @@ type BinaryBuildSource struct {
 
 // SourceRevision is the revision or commit information from the source for the build
 type SourceRevision struct {
-	// Type of the build source
-	Type BuildSourceType
-
 	// Git contains information about git-based build source
 	Git *GitSourceRevision
 }
@@ -278,9 +259,6 @@ type SourceControlUser struct {
 
 // BuildStrategy contains the details of how to perform a build.
 type BuildStrategy struct {
-	// Type is the kind of build strategy.
-	Type BuildStrategyType
-
 	// DockerStrategy holds the parameters to the Docker build strategy.
 	DockerStrategy *DockerBuildStrategy
 
@@ -293,19 +271,6 @@ type BuildStrategy struct {
 
 // BuildStrategyType describes a particular way of performing a build.
 type BuildStrategyType string
-
-// Valid values for BuildStrategyType.
-const (
-	// DockerBuildStrategyType performs builds using a Dockerfile.
-	DockerBuildStrategyType BuildStrategyType = "Docker"
-
-	// SourceBuildStrategyType performs builds build using Source To Images with a Git repository
-	// and a builder image.
-	SourceBuildStrategyType BuildStrategyType = "Source"
-
-	// CustomBuildStrategyType performs builds using custom builder Docker image.
-	CustomBuildStrategyType BuildStrategyType = "Custom"
-)
 
 const (
 	// CustomBuildStrategyBaseImageKey is the environment variable that indicates the base image to be used when
@@ -526,10 +491,7 @@ type BuildConfigList struct {
 
 // GenericWebHookEvent is the payload expected for a generic webhook post
 type GenericWebHookEvent struct {
-	// Type is the type of source repository
-	Type BuildSourceType
-
-	// Git is the git information if the Type is BuildSourceGit
+	// Git is the git information, if any.
 	Git *GitInfo
 }
 

--- a/pkg/build/api/util.go
+++ b/pkg/build/api/util.go
@@ -11,3 +11,35 @@ const (
 func GetBuildPodName(build *Build) string {
 	return namer.GetPodName(build.Name, BuildPodSuffix)
 }
+
+func StrategyType(strategy BuildStrategy) string {
+	switch {
+	case strategy.DockerStrategy != nil:
+		return "Docker"
+	case strategy.CustomStrategy != nil:
+		return "Custom"
+	case strategy.SourceStrategy != nil:
+		return "Source"
+	}
+	return ""
+}
+
+func SourceType(source BuildSource) string {
+	var sourceType string
+	if source.Git != nil {
+		sourceType = "Git"
+	}
+	if source.Dockerfile != nil {
+		if len(sourceType) != 0 {
+			sourceType = sourceType + ","
+		}
+		sourceType = sourceType + "Dockerfile"
+	}
+	if source.Binary != nil {
+		if len(sourceType) != 0 {
+			sourceType = sourceType + ","
+		}
+		sourceType = sourceType + "Binary"
+	}
+	return sourceType
+}

--- a/pkg/build/api/v1/conversion.go
+++ b/pkg/build/api/v1/conversion.go
@@ -113,6 +113,69 @@ func convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy(in *BuildTriggerPol
 	return nil
 }
 
+func convert_api_SourceRevision_To_v1_SourceRevision(in *newer.SourceRevision, out *SourceRevision, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	out.Type = BuildSourceGit
+	return nil
+}
+
+func convert_v1_SourceRevision_To_api_SourceRevision(in *SourceRevision, out *newer.SourceRevision, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_BuildSource_To_v1_BuildSource(in *newer.BuildSource, out *BuildSource, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	switch {
+	// it is legal for a buildsource to have both a git+dockerfile source, but in v1 that was represented
+	// as type git.
+	case in.Git != nil:
+		out.Type = BuildSourceGit
+	// it is legal for a buildsource to have both a binary+dockerfile source, but in v1 that was represented
+	// as type binary.
+	case in.Binary != nil:
+		out.Type = BuildSourceBinary
+	case in.Dockerfile != nil:
+		out.Type = BuildSourceDockerfile
+	}
+	return nil
+}
+
+func convert_v1_BuildSource_To_api_BuildSource(in *BuildSource, out *newer.BuildSource, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_BuildStrategy_To_v1_BuildStrategy(in *newer.BuildStrategy, out *BuildStrategy, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	switch {
+	case in.SourceStrategy != nil:
+		out.Type = SourceBuildStrategyType
+	case in.DockerStrategy != nil:
+		out.Type = DockerBuildStrategyType
+	case in.CustomStrategy != nil:
+		out.Type = CustomBuildStrategyType
+	}
+	return nil
+}
+
+func convert_v1_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer.BuildStrategy, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	return nil
+}
+
 func init() {
 	err := kapi.Scheme.AddDefaultingFuncs(
 		func(strategy *BuildStrategy) {
@@ -159,6 +222,12 @@ func init() {
 		convert_api_BuildOutput_To_v1_BuildOutput,
 		convert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
 		convert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy,
+		convert_v1_SourceRevision_To_api_SourceRevision,
+		convert_api_SourceRevision_To_v1_SourceRevision,
+		convert_v1_BuildSource_To_api_BuildSource,
+		convert_api_BuildSource_To_v1_BuildSource,
+		convert_v1_BuildStrategy_To_api_BuildStrategy,
+		convert_api_BuildStrategy_To_v1_BuildStrategy,
 	)
 
 	if err := kapi.Scheme.AddFieldLabelConversionFunc("v1", "Build",

--- a/pkg/build/api/v1beta3/conversion.go
+++ b/pkg/build/api/v1beta3/conversion.go
@@ -121,6 +121,68 @@ func convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy(in *newer.Buil
 	return nil
 }
 
+func convert_v1beta3_SourceRevision_To_api_SourceRevision(in *SourceRevision, out *newer.SourceRevision, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_SourceRevision_To_v1beta3_SourceRevision(in *newer.SourceRevision, out *SourceRevision, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	out.Type = BuildSourceGit
+	return nil
+}
+
+func convert_v1beta3_BuildSource_To_api_BuildSource(in *BuildSource, out *newer.BuildSource, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_BuildSource_To_v1beta3_BuildSource(in *newer.BuildSource, out *BuildSource, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	switch {
+	// it is legal for a buildsource to have both a git+dockerfile source, but in v1 that was represented
+	// as type git.
+	case in.Git != nil:
+		out.Type = BuildSourceGit
+	// it is legal for a buildsource to have both a binary+dockerfile source, but in v1 that was represented
+	// as type binary.
+	case in.Binary != nil:
+		out.Type = BuildSourceBinary
+	case in.Dockerfile != nil:
+		out.Type = BuildSourceDockerfile
+	}
+	return nil
+}
+
+func convert_v1beta3_BuildStrategy_To_api_BuildStrategy(in *BuildStrategy, out *newer.BuildStrategy, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_BuildStrategy_To_v1beta3_BuildStrategy(in *newer.BuildStrategy, out *BuildStrategy, s conversion.Scope) error {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+		return err
+	}
+	switch {
+	case in.SourceStrategy != nil:
+		out.Type = SourceBuildStrategyType
+	case in.DockerStrategy != nil:
+		out.Type = DockerBuildStrategyType
+	case in.CustomStrategy != nil:
+		out.Type = CustomBuildStrategyType
+	}
+	return nil
+}
 func init() {
 	err := kapi.Scheme.AddDefaultingFuncs(
 		func(strategy *BuildStrategy) {
@@ -167,6 +229,12 @@ func init() {
 		convert_api_BuildOutput_To_v1beta3_BuildOutput,
 		convert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
 		convert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy,
+		convert_v1beta3_SourceRevision_To_api_SourceRevision,
+		convert_api_SourceRevision_To_v1beta3_SourceRevision,
+		convert_v1beta3_BuildSource_To_api_BuildSource,
+		convert_api_BuildSource_To_v1beta3_BuildSource,
+		convert_v1beta3_BuildStrategy_To_api_BuildStrategy,
+		convert_api_BuildStrategy_To_v1beta3_BuildStrategy,
 	)
 
 	// Add field conversion funcs.

--- a/pkg/build/builder/common.go
+++ b/pkg/build/builder/common.go
@@ -38,7 +38,7 @@ func buildInfo(build *api.Build) []KeyValue {
 			kv = append(kv, KeyValue{"OPENSHIFT_BUILD_COMMIT", build.Spec.Revision.Git.Commit})
 		}
 	}
-	if build.Spec.Strategy.Type == api.SourceBuildStrategyType {
+	if build.Spec.Strategy.SourceStrategy != nil {
 		env := build.Spec.Strategy.SourceStrategy.Env
 		for _, e := range env {
 			kv = append(kv, KeyValue{e.Name, e.Value})
@@ -96,7 +96,6 @@ func updateBuildRevision(c client.BuildInterface, build *api.Build, sourceInfo *
 		return
 	}
 	build.Spec.Revision = &api.SourceRevision{
-		Type: api.BuildSourceGit,
 		Git: &api.GitSourceRevision{
 			Commit:  sourceInfo.CommitID,
 			Message: sourceInfo.Message,

--- a/pkg/build/builder/common_test.go
+++ b/pkg/build/builder/common_test.go
@@ -23,7 +23,6 @@ func TestBuildInfo(t *testing.T) {
 				},
 			},
 			Strategy: api.BuildStrategy{
-				Type: api.SourceBuildStrategyType,
 				SourceStrategy: &api.SourceBuildStrategy{
 					Env: []kapi.EnvVar{
 						{Name: "RAILS_ENV", Value: "production"},

--- a/pkg/build/builder/sti_test.go
+++ b/pkg/build/builder/sti_test.go
@@ -89,12 +89,10 @@ func makeBuild() *api.Build {
 	return &api.Build{
 		Spec: api.BuildSpec{
 			Source: api.BuildSource{
-				Type: api.BuildSourceGit,
 				Git: &api.GitBuildSource{
 					URI: "http://localhost/123",
 				}},
 			Strategy: api.BuildStrategy{
-				Type: api.SourceBuildStrategyType,
 				SourceStrategy: &api.SourceBuildStrategy{
 					From: kapi.ObjectReference{
 						Kind: "DockerImage",

--- a/pkg/build/controller/config_controller_test.go
+++ b/pkg/build/controller/config_controller_test.go
@@ -82,7 +82,6 @@ func (i *testInstantiator) Instantiate(namespace string, request *buildapi.Build
 func baseBuildConfig() *buildapi.BuildConfig {
 	bc := &buildapi.BuildConfig{}
 	bc.Name = "testBuildConfig"
-	bc.Spec.BuildSpec.Strategy.Type = buildapi.SourceBuildStrategyType
 	bc.Spec.BuildSpec.Strategy.SourceStrategy = &buildapi.SourceBuildStrategy{}
 	bc.Spec.BuildSpec.Strategy.SourceStrategy.From.Name = "builderimage:latest"
 	bc.Spec.BuildSpec.Strategy.SourceStrategy.From.Kind = "ImageStreamTag"

--- a/pkg/build/controller/controller.go
+++ b/pkg/build/controller/controller.go
@@ -153,7 +153,7 @@ func (bc *BuildController) nextBuildPhase(build *buildapi.Build) error {
 	podSpec, err := bc.BuildStrategy.CreateBuildPod(buildCopy)
 	if err != nil {
 		build.Status.Reason = buildapi.StatusReasonCannotCreateBuildPodSpec
-		return fmt.Errorf("failed to create a build pod spec with strategy %q: %v", build.Spec.Strategy.Type, err)
+		return fmt.Errorf("failed to create a build pod spec for build %s/%s: %v", build.Namespace, build.Name, err)
 	}
 	glog.V(4).Infof("Pod %s for build %s/%s is about to be created", podSpec.Name, build.Namespace, build.Name)
 

--- a/pkg/build/controller/controller_test.go
+++ b/pkg/build/controller/controller_test.go
@@ -119,14 +119,12 @@ func mockBuild(phase buildapi.BuildPhase, output buildapi.BuildOutput) *buildapi
 		},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://my.build.com/the/build/Dockerfile",
 				},
 				ContextDir: "contextimage",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: output,

--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -335,16 +335,17 @@ type typeBasedFactoryStrategy struct {
 func (f *typeBasedFactoryStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod, error) {
 	var pod *kapi.Pod
 	var err error
-	switch build.Spec.Strategy.Type {
-	case buildapi.DockerBuildStrategyType:
+	switch {
+	case build.Spec.Strategy.DockerStrategy != nil:
 		pod, err = f.DockerBuildStrategy.CreateBuildPod(build)
-	case buildapi.SourceBuildStrategyType:
+	case build.Spec.Strategy.SourceStrategy != nil:
 		pod, err = f.SourceBuildStrategy.CreateBuildPod(build)
-	case buildapi.CustomBuildStrategyType:
+	case build.Spec.Strategy.CustomStrategy != nil:
 		pod, err = f.CustomBuildStrategy.CreateBuildPod(build)
 	default:
-		return nil, fmt.Errorf("no supported build strategy defined for Build %s/%s with type %s", build.Namespace, build.Name, build.Spec.Strategy.Type)
+		return nil, fmt.Errorf("no supported build strategy defined for Build %s/%s", build.Namespace, build.Name)
 	}
+
 	if pod != nil {
 		if pod.Annotations == nil {
 			pod.Annotations = map[string]string{}

--- a/pkg/build/controller/image_change_controller_test.go
+++ b/pkg/build/controller/image_change_controller_test.go
@@ -309,7 +309,6 @@ func mockBuildConfig(baseImage, triggerImage, repoName, repoTag string) *buildap
 		Spec: buildapi.BuildConfigSpec{
 			BuildSpec: buildapi.BuildSpec{
 				Strategy: buildapi.BuildStrategy{
-					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{
 						From: &kapi.ObjectReference{
 							Kind: "ImageStreamTag",

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -118,7 +118,6 @@ func mockCustomBuild(forcePull bool) *buildapi.Build {
 				Git: &buildapi.GitSourceRevision{},
 			},
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://my.build.com/the/dockerbuild/Dockerfile",
 					Ref: "master",
@@ -127,7 +126,6 @@ func mockCustomBuild(forcePull bool) *buildapi.Build {
 				SourceSecret: &kapi.LocalObjectReference{Name: "secretFoo"},
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type: buildapi.CustomBuildStrategyType,
 				CustomStrategy: &buildapi.CustomBuildStrategy{
 					From: kapi.ObjectReference{
 						Kind: "DockerImage",

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -113,7 +113,6 @@ func mockDockerBuild() *buildapi.Build {
 				SourceSecret: &kapi.LocalObjectReference{Name: "secretFoo"},
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type: buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{
 					PullSecret: &kapi.LocalObjectReference{Name: "bar"},
 					Env: []kapi.EnvVar{

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -161,7 +161,6 @@ func mockSTIBuild() *buildapi.Build {
 				SourceSecret: &kapi.LocalObjectReference{Name: "fooSecret"},
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type: buildapi.SourceBuildStrategyType,
 				SourceStrategy: &buildapi.SourceBuildStrategy{
 					From: kapi.ObjectReference{
 						Kind: "DockerImage",

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -49,8 +49,8 @@ func setupDockerSocket(podSpec *kapi.Pod) {
 func setupBuildEnv(build *buildapi.Build, pod *kapi.Pod) error {
 	vars := []kapi.EnvVar{}
 
-	switch build.Spec.Source.Type {
-	case buildapi.BuildSourceGit:
+	switch {
+	case build.Spec.Source.Git != nil:
 		vars = append(vars, kapi.EnvVar{Name: "SOURCE_URI", Value: build.Spec.Source.Git.URI})
 		vars = append(vars, kapi.EnvVar{Name: "SOURCE_REF", Value: build.Spec.Source.Git.Ref})
 	default:

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -211,7 +211,6 @@ func TestInstantiateWithImageTrigger(t *testing.T) {
 			Spec: buildapi.BuildConfigSpec{
 				BuildSpec: buildapi.BuildSpec{
 					Strategy: buildapi.BuildStrategy{
-						Type: buildapi.SourceBuildStrategyType,
 						SourceStrategy: &buildapi.SourceBuildStrategy{
 							From: kapi.ObjectReference{
 								Name: "image3:tag3",
@@ -340,7 +339,6 @@ func TestFindImageTrigger(t *testing.T) {
 		Spec: buildapi.BuildConfigSpec{
 			BuildSpec: buildapi.BuildSpec{
 				Strategy: buildapi.BuildStrategy{
-					Type: buildapi.SourceBuildStrategyType,
 					SourceStrategy: &buildapi.SourceBuildStrategy{
 						From: kapi.ObjectReference{
 							Name: "image3:tag3",
@@ -550,7 +548,6 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 			BuildSpec: buildapi.BuildSpec{
 				Source: source,
 				Revision: &buildapi.SourceRevision{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitSourceRevision{
 						Commit: "1234",
 					},
@@ -565,7 +562,6 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 		},
 	}
 	revision := &buildapi.SourceRevision{
-		Type: buildapi.BuildSourceGit,
 		Git: &buildapi.GitSourceRevision{
 			Commit: "abcd",
 		},
@@ -624,7 +620,6 @@ func TestGenerateBuildWithImageTagForSourceStrategyImageRepository(t *testing.T)
 			BuildSpec: buildapi.BuildSpec{
 				Source: source,
 				Revision: &buildapi.SourceRevision{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitSourceRevision{
 						Commit: "1234",
 					},
@@ -703,7 +698,6 @@ func TestGenerateBuildWithImageTagForDockerStrategyImageRepository(t *testing.T)
 			BuildSpec: buildapi.BuildSpec{
 				Source: source,
 				Revision: &buildapi.SourceRevision{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitSourceRevision{
 						Commit: "1234",
 					},
@@ -781,7 +775,6 @@ func TestGenerateBuildWithImageTagForCustomStrategyImageRepository(t *testing.T)
 			BuildSpec: buildapi.BuildSpec{
 				Source: source,
 				Revision: &buildapi.SourceRevision{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitSourceRevision{
 						Commit: "1234",
 					},
@@ -858,7 +851,6 @@ func TestGenerateBuildFromBuild(t *testing.T) {
 		Spec: buildapi.BuildSpec{
 			Source: source,
 			Revision: &buildapi.SourceRevision{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitSourceRevision{
 					Commit: "1234",
 				},
@@ -891,7 +883,6 @@ func TestGenerateBuildFromBuildWithBuildConfig(t *testing.T) {
 		Spec: buildapi.BuildSpec{
 			Source: source,
 			Revision: &buildapi.SourceRevision{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitSourceRevision{
 					Commit: "1234",
 				},
@@ -907,7 +898,6 @@ func TestGenerateBuildFromBuildWithBuildConfig(t *testing.T) {
 		Spec: buildapi.BuildSpec{
 			Source: source,
 			Revision: &buildapi.SourceRevision{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitSourceRevision{
 					Commit: "1234",
 				},
@@ -1228,7 +1218,6 @@ func mockResources() kapi.ResourceRequirements {
 
 func mockDockerStrategyForNilImage() buildapi.BuildStrategy {
 	return buildapi.BuildStrategy{
-		Type: buildapi.DockerBuildStrategyType,
 		DockerStrategy: &buildapi.DockerBuildStrategy{
 			NoCache: true,
 		},
@@ -1237,7 +1226,6 @@ func mockDockerStrategyForNilImage() buildapi.BuildStrategy {
 
 func mockDockerStrategyForDockerImage(name string) buildapi.BuildStrategy {
 	return buildapi.BuildStrategy{
-		Type: buildapi.DockerBuildStrategyType,
 		DockerStrategy: &buildapi.DockerBuildStrategy{
 			NoCache: true,
 			From: &kapi.ObjectReference{
@@ -1250,7 +1238,6 @@ func mockDockerStrategyForDockerImage(name string) buildapi.BuildStrategy {
 
 func mockDockerStrategyForImageRepository() buildapi.BuildStrategy {
 	return buildapi.BuildStrategy{
-		Type: buildapi.DockerBuildStrategyType,
 		DockerStrategy: &buildapi.DockerBuildStrategy{
 			NoCache: true,
 			From: &kapi.ObjectReference{
@@ -1264,7 +1251,6 @@ func mockDockerStrategyForImageRepository() buildapi.BuildStrategy {
 
 func mockCustomStrategyForDockerImage(name string) buildapi.BuildStrategy {
 	return buildapi.BuildStrategy{
-		Type: buildapi.CustomBuildStrategyType,
 		CustomStrategy: &buildapi.CustomBuildStrategy{
 			From: kapi.ObjectReference{
 				Kind: "DockerImage",
@@ -1276,7 +1262,6 @@ func mockCustomStrategyForDockerImage(name string) buildapi.BuildStrategy {
 
 func mockCustomStrategyForImageRepository() buildapi.BuildStrategy {
 	return buildapi.BuildStrategy{
-		Type: buildapi.CustomBuildStrategyType,
 		CustomStrategy: &buildapi.CustomBuildStrategy{
 			From: kapi.ObjectReference{
 				Kind:      "ImageStreamTag",
@@ -1304,7 +1289,6 @@ func mockBuild(source buildapi.BuildSource, strategy buildapi.BuildStrategy, out
 		Spec: buildapi.BuildSpec{
 			Source: source,
 			Revision: &buildapi.SourceRevision{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitSourceRevision{
 					Commit: "1234",
 				},
@@ -1399,7 +1383,6 @@ func mockBuildGenerator() *BuildGenerator {
 func TestGenerateBuildFromConfigWithSecrets(t *testing.T) {
 	source := mocks.MockSource()
 	revision := &buildapi.SourceRevision{
-		Type: buildapi.BuildSourceGit,
 		Git: &buildapi.GitSourceRevision{
 			Commit: "abcd",
 		},

--- a/pkg/build/generator/test/mocks.go
+++ b/pkg/build/generator/test/mocks.go
@@ -72,7 +72,6 @@ func MockBuildConfig(source buildapi.BuildSource, strategy buildapi.BuildStrateg
 			BuildSpec: buildapi.BuildSpec{
 				Source: source,
 				Revision: &buildapi.SourceRevision{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitSourceRevision{
 						Commit: "1234",
 					},
@@ -86,7 +85,6 @@ func MockBuildConfig(source buildapi.BuildSource, strategy buildapi.BuildStrateg
 
 func MockSource() buildapi.BuildSource {
 	return buildapi.BuildSource{
-		Type: buildapi.BuildSourceGit,
 		Git: &buildapi.GitBuildSource{
 			URI: "http://test.repository/namespace/name",
 			Ref: "test-tag",
@@ -96,7 +94,6 @@ func MockSource() buildapi.BuildSource {
 
 func MockSourceStrategyForImageRepository() buildapi.BuildStrategy {
 	return buildapi.BuildStrategy{
-		Type: buildapi.SourceBuildStrategyType,
 		SourceStrategy: &buildapi.SourceBuildStrategy{
 			From: kapi.ObjectReference{
 				Kind:      "ImageStreamTag",

--- a/pkg/build/registry/build/strategy_test.go
+++ b/pkg/build/registry/build/strategy_test.go
@@ -22,14 +22,12 @@ func TestBuildStrategy(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://github.com/my/repository",
 				},
 				ContextDir: "context",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: buildapi.BuildOutput{
@@ -66,14 +64,12 @@ func TestBuildDecorator(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://github.com/my/repository",
 				},
 				ContextDir: "context",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: buildapi.BuildOutput{

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -30,14 +30,12 @@ func TestBuildConfigStrategy(t *testing.T) {
 			},
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitBuildSource{
 						URI: "http://github.com/my/repository",
 					},
 					ContextDir: "context",
 				},
 				Strategy: buildapi.BuildStrategy{
-					Type:           buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
 				Output: buildapi.BuildOutput{

--- a/pkg/build/registry/buildconfiginstantiate/rest.go
+++ b/pkg/build/registry/buildconfiginstantiate/rest.go
@@ -126,7 +126,6 @@ func (h *binaryInstantiateHandler) handle(r io.Reader) (runtime.Object, error) {
 	request.Name = h.name
 	if len(h.options.Commit) > 0 {
 		request.Revision = &buildapi.SourceRevision{
-			Type: buildapi.BuildSourceGit,
 			Git: &buildapi.GitSourceRevision{
 				Committer: buildapi.SourceControlUser{
 					Name:  h.options.CommitterName,

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -31,21 +31,12 @@ func GetBuildName(pod *kapi.Pod) string {
 // GetImageStreamForStrategy returns the ImageStream[Tag/Image] ObjectReference associated
 // with the BuildStrategy.
 func GetImageStreamForStrategy(strategy buildapi.BuildStrategy) *kapi.ObjectReference {
-	switch strategy.Type {
-	case buildapi.SourceBuildStrategyType:
-		if strategy.SourceStrategy == nil {
-			return nil
-		}
+	switch {
+	case strategy.SourceStrategy != nil:
 		return &strategy.SourceStrategy.From
-	case buildapi.DockerBuildStrategyType:
-		if strategy.DockerStrategy == nil {
-			return nil
-		}
+	case strategy.DockerStrategy != nil:
 		return strategy.DockerStrategy.From
-	case buildapi.CustomBuildStrategyType:
-		if strategy.CustomStrategy == nil {
-			return nil
-		}
+	case strategy.CustomStrategy != nil:
 		return &strategy.CustomStrategy.From
 	default:
 		return nil

--- a/pkg/build/webhook/controller_test.go
+++ b/pkg/build/webhook/controller_test.go
@@ -20,7 +20,6 @@ func (*okBuildConfigGetter) Get(namespace, name string) (*api.BuildConfig, error
 		Spec: api.BuildConfigSpec{
 			BuildSpec: api.BuildSpec{
 				Strategy: api.BuildStrategy{
-					Type: "Source",
 					SourceStrategy: &api.SourceBuildStrategy{
 						From: kapi.ObjectReference{
 							Kind: "DockerImage",
@@ -259,7 +258,6 @@ func TestInvokeWebhookOK(t *testing.T) {
 		Spec: api.BuildConfigSpec{
 			BuildSpec: api.BuildSpec{
 				Strategy: api.BuildStrategy{
-					Type: "Source",
 					SourceStrategy: &api.SourceBuildStrategy{
 						From: kapi.ObjectReference{
 							Kind: "DockerImage",

--- a/pkg/build/webhook/generic/generic.go
+++ b/pkg/build/webhook/generic/generic.go
@@ -65,8 +65,7 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 			for _, ref := range data.Git.Refs {
 				if webhook.GitRefMatches(ref.Ref, git.Ref) {
 					revision = &api.SourceRevision{
-						Type: api.BuildSourceGit,
-						Git:  &ref.GitSourceRevision,
+						Git: &ref.GitSourceRevision,
 					}
 					return revision, true, nil
 				}
@@ -79,8 +78,7 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 			return nil, false, nil
 		}
 		revision = &api.SourceRevision{
-			Type: api.BuildSourceGit,
-			Git:  &data.Git.GitSourceRevision,
+			Git: &data.Git.GitSourceRevision,
 		}
 	}
 	return revision, true, nil

--- a/pkg/build/webhook/generic/generic_test.go
+++ b/pkg/build/webhook/generic/generic_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 var mockBuildStrategy = api.BuildStrategy{
-	Type: "STI",
 	SourceStrategy: &api.SourceBuildStrategy{
 		From: kapi.ObjectReference{
 			Name: "repository/image",
@@ -127,7 +126,6 @@ func TestExtractWithEmptyPayload(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						Ref: "master",
 					},
@@ -163,7 +161,6 @@ func TestExtractWithUnmatchedRefGitPayload(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						Ref: "asdfkasdfasdfasdfadsfkjhkhkh",
 					},
@@ -200,7 +197,6 @@ func TestExtractWithGitPayload(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						Ref: "master",
 					},
@@ -237,7 +233,6 @@ func TestExtractWithGitRefsPayload(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						Ref: "master",
 					},
@@ -274,7 +269,6 @@ func TestExtractWithUnmatchedGitRefsPayload(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						Ref: "other",
 					},
@@ -311,7 +305,7 @@ func TestGitlabPush(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
+					Git: &api.GitBuildSource{},
 				},
 				Strategy: mockBuildStrategy,
 			},
@@ -343,7 +337,7 @@ func TestNonJsonPush(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
+					Git: &api.GitBuildSource{},
 				},
 				Strategy: mockBuildStrategy,
 			},
@@ -382,7 +376,6 @@ func TestExtractWithUnmarshalError(t *testing.T) {
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						Ref: "other",
 					},

--- a/pkg/build/webhook/github/github.go
+++ b/pkg/build/webhook/github/github.go
@@ -72,7 +72,6 @@ func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *h
 	}
 
 	revision = &api.SourceRevision{
-		Type: api.BuildSourceGit,
 		Git: &api.GitSourceRevision{
 			Commit:    event.HeadCommit.ID,
 			Author:    event.HeadCommit.Author,

--- a/pkg/build/webhook/github/github_test.go
+++ b/pkg/build/webhook/github/github_test.go
@@ -29,7 +29,6 @@ func (c *okBuildConfigGetter) Get(namespace, name string) (*api.BuildConfig, err
 			},
 			BuildSpec: api.BuildSpec{
 				Source: api.BuildSource{
-					Type: api.BuildSourceGit,
 					Git: &api.GitBuildSource{
 						URI: "git://github.com/my/repo.git",
 					},
@@ -41,7 +40,6 @@ func (c *okBuildConfigGetter) Get(namespace, name string) (*api.BuildConfig, err
 }
 
 var mockBuildStrategy = api.BuildStrategy{
-	Type: "STI",
 	SourceStrategy: &api.SourceBuildStrategy{
 		From: kapi.ObjectReference{
 			Kind: "DockerImage",
@@ -221,7 +219,6 @@ func setup(t *testing.T, filename, eventType string) *testContext {
 				},
 				BuildSpec: api.BuildSpec{
 					Source: api.BuildSource{
-						Type: api.BuildSourceGit,
 						Git: &api.GitBuildSource{
 							URI: "git://github.com/my/repo.git",
 						},

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -189,7 +189,6 @@ func RunStartBuild(f *clientcmd.Factory, in io.Reader, out io.Writer, cmd *cobra
 	}
 	if len(commit) > 0 {
 		request.Revision = &buildapi.SourceRevision{
-			Type: buildapi.BuildSourceGit,
 			Git: &buildapi.GitSourceRevision{
 				Commit: commit,
 			},
@@ -552,8 +551,7 @@ func RunStartBuildWebHook(f *clientcmd.Factory, out io.Writer, webhook string, p
 func hookEventFromPostReceive(repo git.Repository, path, postReceivePath string) (*buildapi.GenericWebHookEvent, error) {
 	// TODO: support other types of refs
 	event := &buildapi.GenericWebHookEvent{
-		Type: buildapi.BuildSourceGit,
-		Git:  &buildapi.GitInfo{},
+		Git: &buildapi.GitInfo{},
 	}
 
 	// attempt to extract a post receive body

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -172,18 +172,8 @@ type BuildConfigDescriber struct {
 	host string
 }
 
-// TODO: remove when internal SourceBuildStrategyType is refactored to "Source"
-func describeStrategy(strategyType buildapi.BuildStrategyType) buildapi.BuildStrategyType {
-	if strategyType == buildapi.SourceBuildStrategyType {
-		strategyType = buildapi.BuildStrategyType("Source")
-	}
-	return strategyType
-}
-
 func describeBuildSpec(p buildapi.BuildSpec, out *tabwriter.Writer) {
-	formatString(out, "Strategy", describeStrategy(p.Strategy.Type))
-
-	formatString(out, "Source Type", p.Source.Type)
+	formatString(out, "Strategy", buildapi.StrategyType(p.Strategy))
 	if p.Source.Dockerfile != nil {
 		if len(strings.TrimSpace(*p.Source.Dockerfile)) == 0 {
 			formatString(out, "Dockerfile", "")
@@ -225,12 +215,12 @@ func describeBuildSpec(p buildapi.BuildSpec, out *tabwriter.Writer) {
 		}
 	}
 
-	switch p.Strategy.Type {
-	case buildapi.DockerBuildStrategyType:
+	switch {
+	case p.Strategy.DockerStrategy != nil:
 		describeDockerStrategy(p.Strategy.DockerStrategy, out)
-	case buildapi.SourceBuildStrategyType:
+	case p.Strategy.SourceStrategy != nil:
 		describeSourceStrategy(p.Strategy.SourceStrategy, out)
-	case buildapi.CustomBuildStrategyType:
+	case p.Strategy.CustomStrategy != nil:
 		describeCustomStrategy(p.Strategy.CustomStrategy, out)
 	}
 
@@ -246,7 +236,7 @@ func describeBuildSpec(p buildapi.BuildSpec, out *tabwriter.Writer) {
 		formatString(out, "Push Secret", p.Output.PushSecret.Name)
 	}
 
-	if p.Revision != nil && p.Revision.Type == buildapi.BuildSourceGit && p.Revision.Git != nil {
+	if p.Revision != nil && p.Revision.Git != nil {
 		buildDescriber := &BuildDescriber{}
 
 		formatString(out, "Git Commit", p.Revision.Git.Commit)

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -218,7 +218,7 @@ func printBuild(build *buildapi.Build, w io.Writer, withNamespace, wide, showAll
 	if len(build.Status.Reason) > 0 {
 		status = fmt.Sprintf("%s (%s)", status, build.Status.Reason)
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", build.Name, describeStrategy(build.Spec.Strategy.Type), from, status, created, duration)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", build.Name, buildapi.StrategyType(build.Spec.Strategy), from, status, created, duration)
 	return err
 }
 
@@ -242,8 +242,8 @@ func describeSourceShort(spec buildapi.BuildSpec) string {
 		if rev := describeSourceGitRevision(spec); len(rev) != 0 {
 			from = fmt.Sprintf("%s@%s", from, rev)
 		}
-	case len(source.Type) > 0:
-		from = string(source.Type)
+	default:
+		from = buildapi.SourceType(source)
 	}
 	return from
 }
@@ -277,8 +277,8 @@ func printBuildList(buildList *buildapi.BuildList, w io.Writer, withNamespace, w
 }
 
 func printBuildConfig(bc *buildapi.BuildConfig, w io.Writer, withNamespace, wide, showAll bool, columnLabels []string) error {
-	if bc.Spec.Strategy.Type == buildapi.CustomBuildStrategyType {
-		_, err := fmt.Fprintf(w, "%s\t%v\t%s\t%d\n", bc.Name, describeStrategy(bc.Spec.Strategy.Type), bc.Spec.Strategy.CustomStrategy.From.Name, bc.Status.LastVersion)
+	if bc.Spec.Strategy.CustomStrategy != nil {
+		_, err := fmt.Fprintf(w, "%s\t%v\t%s\t%d\n", bc.Name, buildapi.StrategyType(bc.Spec.Strategy), bc.Spec.Strategy.CustomStrategy.From.Name, bc.Status.LastVersion)
 		return err
 	}
 
@@ -289,7 +289,7 @@ func printBuildConfig(bc *buildapi.BuildConfig, w io.Writer, withNamespace, wide
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w, "%s\t%v\t%s\t%d\n", bc.Name, describeStrategy(bc.Spec.Strategy.Type), from, bc.Status.LastVersion)
+	_, err := fmt.Fprintf(w, "%s\t%v\t%s\t%d\n", bc.Name, buildapi.StrategyType(bc.Spec.Strategy), from, bc.Status.LastVersion)
 	return err
 }
 

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -437,15 +437,15 @@ func describeImageTagInPipeline(image graphview.ImageTagLocation, namespace stri
 }
 
 func describeBuildInPipeline(build *buildapi.BuildConfig, baseImage graphview.ImageTagLocation) string {
-	switch build.Spec.Strategy.Type {
-	case buildapi.DockerBuildStrategyType:
+	switch {
+	case build.Spec.Strategy.DockerStrategy != nil:
 		// TODO: handle case where no source repo
 		source, ok := describeSourceInPipeline(&build.Spec.Source)
 		if !ok {
 			return fmt.Sprintf("bc/%s unconfigured docker build - no source set", build.Name)
 		}
 		return fmt.Sprintf("bc/%s docker build of %s", build.Name, source)
-	case buildapi.SourceBuildStrategyType:
+	case build.Spec.Strategy.SourceStrategy != nil:
 		source, ok := describeSourceInPipeline(&build.Spec.Source)
 		if !ok {
 			return fmt.Sprintf("bc/%s unconfigured source build", build.Name)
@@ -454,7 +454,7 @@ func describeBuildInPipeline(build *buildapi.BuildConfig, baseImage graphview.Im
 			return fmt.Sprintf("bc/%s %s; no image set", build.Name, source)
 		}
 		return fmt.Sprintf("bc/%s builds %s with %s", build.Name, source, baseImage.ImageSpec())
-	case buildapi.CustomBuildStrategyType:
+	case build.Spec.Strategy.CustomStrategy != nil:
 		source, ok := describeSourceInPipeline(&build.Spec.Source)
 		if !ok {
 			return fmt.Sprintf("bc/%s custom build ", build.Name)
@@ -602,14 +602,14 @@ func buildTimestamp(build *buildapi.Build) unversioned.Time {
 }
 
 func describeSourceInPipeline(source *buildapi.BuildSource) (string, bool) {
-	switch source.Type {
-	case buildapi.BuildSourceDockerfile:
-		return "Dockerfile", true
-	case buildapi.BuildSourceGit:
+	switch {
+	case source.Git != nil:
 		if len(source.Git.Ref) == 0 {
 			return source.Git.URI, true
 		}
 		return fmt.Sprintf("%s#%s", source.Git.URI, source.Git.Ref), true
+	case source.Dockerfile != nil:
+		return "Dockerfile", true
 	}
 	return "", false
 }

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -139,11 +139,9 @@ func (r *SourceRef) BuildSource() (*buildapi.BuildSource, []buildapi.BuildTrigge
 	source := &buildapi.BuildSource{}
 
 	if len(r.DockerfileContents) != 0 {
-		source.Type = buildapi.BuildSourceDockerfile
 		source.Dockerfile = &r.DockerfileContents
 	}
 	if r.URL != nil {
-		source.Type = buildapi.BuildSourceGit
 		source.Git = &buildapi.GitBuildSource{
 			URI: urlWithoutRef(*r.URL),
 			Ref: r.Ref,
@@ -151,7 +149,6 @@ func (r *SourceRef) BuildSource() (*buildapi.BuildSource, []buildapi.BuildTrigge
 		source.ContextDir = r.ContextDir
 	}
 	if r.Binary {
-		source.Type = buildapi.BuildSourceBinary
 		source.Binary = &buildapi.BinaryBuildSource{}
 	}
 	return source, triggers
@@ -176,13 +173,11 @@ func (s *BuildStrategyRef) BuildStrategy(env Environment) (*buildapi.BuildStrate
 			triggers = s.Base.BuildTriggers()
 		}
 		return &buildapi.BuildStrategy{
-			Type:           buildapi.DockerBuildStrategyType,
 			DockerStrategy: strategy,
 		}, triggers
 	}
 
 	return &buildapi.BuildStrategy{
-		Type: buildapi.SourceBuildStrategyType,
 		SourceStrategy: &buildapi.SourceBuildStrategy{
 			From: s.Base.ObjectReference(),
 			Env:  env.List(),

--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -494,8 +494,6 @@ func addBuildsToGraph(g graph.Graph, builds *buildapi.BuildList) {
 // to the image specified by strategy.from, as long as the image is managed by
 // OpenShift.
 func addBuildStrategyImageReferencesToGraph(g graph.Graph, strategy buildapi.BuildStrategy, predecessor gonum.Node) {
-	glog.V(4).Infof("Examining build strategy with type %q", strategy.Type)
-
 	from := buildutil.GetImageStreamForStrategy(strategy)
 	if from == nil {
 		glog.V(4).Infof("Unable to determine 'from' reference - skipping")

--- a/pkg/image/prune/imagepruner_test.go
+++ b/pkg/image/prune/imagepruner_test.go
@@ -257,7 +257,7 @@ func bcList(bcs ...buildapi.BuildConfig) buildapi.BuildConfigList {
 	}
 }
 
-func bc(namespace, name string, strategyType buildapi.BuildStrategyType, fromKind, fromNamespace, fromName string) buildapi.BuildConfig {
+func bc(namespace, name, strategyType, fromKind, fromNamespace, fromName string) buildapi.BuildConfig {
 	return buildapi.BuildConfig{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: namespace,
@@ -275,7 +275,7 @@ func buildList(builds ...buildapi.Build) buildapi.BuildList {
 	}
 }
 
-func build(namespace, name string, strategyType buildapi.BuildStrategyType, fromKind, fromNamespace, fromName string) buildapi.Build {
+func build(namespace, name, strategyType, fromKind, fromNamespace, fromName string) buildapi.Build {
 	return buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{
 			Namespace: namespace,
@@ -285,14 +285,12 @@ func build(namespace, name string, strategyType buildapi.BuildStrategyType, from
 	}
 }
 
-func buildSpec(strategyType buildapi.BuildStrategyType, fromKind, fromNamespace, fromName string) buildapi.BuildSpec {
+func buildSpec(strategyType, fromKind, fromNamespace, fromName string) buildapi.BuildSpec {
 	spec := buildapi.BuildSpec{
-		Strategy: buildapi.BuildStrategy{
-			Type: strategyType,
-		},
+		Strategy: buildapi.BuildStrategy{},
 	}
 	switch strategyType {
-	case buildapi.SourceBuildStrategyType:
+	case "source":
 		spec.Strategy.SourceStrategy = &buildapi.SourceBuildStrategy{
 			From: kapi.ObjectReference{
 				Kind:      fromKind,
@@ -300,7 +298,7 @@ func buildSpec(strategyType buildapi.BuildStrategyType, fromKind, fromNamespace,
 				Name:      fromName,
 			},
 		}
-	case buildapi.DockerBuildStrategyType:
+	case "docker":
 		spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{
 			From: &kapi.ObjectReference{
 				Kind:      fromKind,
@@ -308,7 +306,7 @@ func buildSpec(strategyType buildapi.BuildStrategyType, fromKind, fromNamespace,
 				Name:      fromName,
 			},
 		}
-	case buildapi.CustomBuildStrategyType:
+	case "custom":
 		spec.Strategy.CustomStrategy = &buildapi.CustomBuildStrategy{
 			From: kapi.ObjectReference{
 				Kind:      fromKind,
@@ -494,62 +492,62 @@ func TestImagePruning(t *testing.T) {
 		},
 		"referenced by bc - sti - ImageStreamImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			bcs:               bcList(bc("foo", "bc1", buildapi.SourceBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			bcs:               bcList(bc("foo", "bc1", "source", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by bc - docker - ImageStreamImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			bcs:               bcList(bc("foo", "bc1", buildapi.DockerBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			bcs:               bcList(bc("foo", "bc1", "docker", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by bc - custom - ImageStreamImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			bcs:               bcList(bc("foo", "bc1", buildapi.CustomBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			bcs:               bcList(bc("foo", "bc1", "custom", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by bc - sti - DockerImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			bcs:               bcList(bc("foo", "bc1", buildapi.SourceBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			bcs:               bcList(bc("foo", "bc1", "source", "DockerImage", "foo", registryURL+"/foo/bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by bc - docker - DockerImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			bcs:               bcList(bc("foo", "bc1", buildapi.DockerBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			bcs:               bcList(bc("foo", "bc1", "docker", "DockerImage", "foo", registryURL+"/foo/bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by bc - custom - DockerImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			bcs:               bcList(bc("foo", "bc1", buildapi.CustomBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			bcs:               bcList(bc("foo", "bc1", "custom", "DockerImage", "foo", registryURL+"/foo/bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by build - sti - ImageStreamImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			builds:            buildList(build("foo", "build1", buildapi.SourceBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			builds:            buildList(build("foo", "build1", "source", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by build - docker - ImageStreamImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			builds:            buildList(build("foo", "build1", buildapi.DockerBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			builds:            buildList(build("foo", "build1", "docker", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by build - custom - ImageStreamImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			builds:            buildList(build("foo", "build1", buildapi.CustomBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			builds:            buildList(build("foo", "build1", "custom", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by build - sti - DockerImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			builds:            buildList(build("foo", "build1", buildapi.SourceBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			builds:            buildList(build("foo", "build1", "source", "DockerImage", "foo", registryURL+"/foo/bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by build - docker - DockerImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			builds:            buildList(build("foo", "build1", buildapi.DockerBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			builds:            buildList(build("foo", "build1", "docker", "DockerImage", "foo", registryURL+"/foo/bar@id")),
 			expectedDeletions: []string{},
 		},
 		"referenced by build - custom - DockerImage - don't prune": {
 			images:            imageList(image("id", registryURL+"/foo/bar@id")),
-			builds:            buildList(build("foo", "build1", buildapi.CustomBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			builds:            buildList(build("foo", "build1", "custom", "DockerImage", "foo", registryURL+"/foo/bar@id")),
 			expectedDeletions: []string{},
 		},
 		"image stream - keep most recent n images": {
@@ -624,8 +622,8 @@ func TestImagePruning(t *testing.T) {
 			rcs:                    rcList(rc("foo", "rc1", registryURL+"/foo/bar@id2")),
 			pods:                   podList(pod("foo", "pod1", kapi.PodRunning, registryURL+"/foo/bar@id2")),
 			dcs:                    dcList(dc("foo", "rc1", registryURL+"/foo/bar@id")),
-			bcs:                    bcList(bc("foo", "bc1", buildapi.SourceBuildStrategyType, "DockerImage", "foo", registryURL+"/foo/bar@id")),
-			builds:                 buildList(build("foo", "build1", buildapi.CustomBuildStrategyType, "ImageStreamImage", "foo", "bar@id")),
+			bcs:                    bcList(bc("foo", "bc1", "source", "DockerImage", "foo", registryURL+"/foo/bar@id")),
+			builds:                 buildList(build("foo", "build1", "custom", "ImageStreamImage", "foo", "bar@id")),
 			expectedDeletions:      []string{},
 			expectedUpdatedStreams: []string{},
 		},

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -47,14 +47,12 @@ func TestAdmissionExists(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://github.com/my/repository",
 				},
 				ContextDir: "context",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: buildapi.BuildOutput{
@@ -94,14 +92,12 @@ func TestAdmissionLifecycle(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "other"},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://github.com/my/repository",
 				},
 				ContextDir: "context",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: buildapi.BuildOutput{

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -110,8 +110,8 @@ func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *te
 	}
 }
 
-func buildStrategyTypes() []buildapi.BuildStrategyType {
-	return []buildapi.BuildStrategyType{buildapi.DockerBuildStrategyType, buildapi.SourceBuildStrategyType, buildapi.CustomBuildStrategyType}
+func buildStrategyTypes() []string {
+	return []string{"source", "docker", "custom"}
 }
 
 func setupBuildStrategyTest(t *testing.T) (clusterAdminClient, projectAdminClient, projectEditorClient *client.Client) {
@@ -202,37 +202,34 @@ func removeBuildStrategyPrivileges(t *testing.T, clusterRoleInterface client.Clu
 
 }
 
-func strategyForType(strategy buildapi.BuildStrategyType) buildapi.BuildStrategy {
+func strategyForType(strategy string) buildapi.BuildStrategy {
 	buildStrategy := buildapi.BuildStrategy{}
-	buildStrategy.Type = strategy
 	switch strategy {
-	case buildapi.DockerBuildStrategyType:
+	case "docker":
 		buildStrategy.DockerStrategy = &buildapi.DockerBuildStrategy{}
-	case buildapi.CustomBuildStrategyType:
+	case "custom":
 		buildStrategy.CustomStrategy = &buildapi.CustomBuildStrategy{}
 		buildStrategy.CustomStrategy.From.Name = "builderimage:latest"
-	case buildapi.SourceBuildStrategyType:
+	case "source":
 		buildStrategy.SourceStrategy = &buildapi.SourceBuildStrategy{}
 		buildStrategy.SourceStrategy.From.Name = "builderimage:latest"
 	}
 	return buildStrategy
 }
 
-func createBuild(t *testing.T, buildInterface client.BuildInterface, strategy buildapi.BuildStrategyType) (*buildapi.Build, error) {
+func createBuild(t *testing.T, buildInterface client.BuildInterface, strategy string) (*buildapi.Build, error) {
 	build := &buildapi.Build{}
 	build.GenerateName = strings.ToLower(string(strategy)) + "-build-"
 	build.Spec.Strategy = strategyForType(strategy)
-	build.Spec.Source.Type = buildapi.BuildSourceGit
 	build.Spec.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
 
 	return buildInterface.Create(build)
 }
 
-func createBuildConfig(t *testing.T, buildConfigInterface client.BuildConfigInterface, strategy buildapi.BuildStrategyType) (*buildapi.BuildConfig, error) {
+func createBuildConfig(t *testing.T, buildConfigInterface client.BuildConfigInterface, strategy string) (*buildapi.BuildConfig, error) {
 	buildConfig := &buildapi.BuildConfig{}
 	buildConfig.GenerateName = strings.ToLower(string(strategy)) + "-buildconfig-"
 	buildConfig.Spec.Strategy = strategyForType(strategy)
-	buildConfig.Spec.Source.Type = buildapi.BuildSourceGit
 	buildConfig.Spec.Source.Git = &buildapi.GitBuildSource{URI: "example.org"}
 
 	return buildConfigInterface.Create(buildConfig)

--- a/test/integration/buildcfgclient_test.go
+++ b/test/integration/buildcfgclient_test.go
@@ -133,14 +133,12 @@ func mockBuildConfig() *buildapi.BuildConfig {
 			},
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitBuildSource{
 						URI: "http://my.docker/build",
 					},
 					ContextDir: "context",
 				},
 				Strategy: buildapi.BuildStrategy{
-					Type:           buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
 				Output: buildapi.BuildOutput{
@@ -179,14 +177,12 @@ func TestBuildConfigClient(t *testing.T) {
 		Spec: buildapi.BuildConfigSpec{
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitBuildSource{
 						URI: "http://my.docker/build",
 					},
 					ContextDir: "context",
 				},
 				Strategy: buildapi.BuildStrategy{
-					Type:           buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{},
 				},
 				Output: buildapi.BuildOutput{

--- a/test/integration/buildclient_test.go
+++ b/test/integration/buildclient_test.go
@@ -151,14 +151,12 @@ func mockBuild() *buildapi.Build {
 		},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://my.docker/build",
 				},
 				ContextDir: "context",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: buildapi.BuildOutput{

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -382,24 +382,25 @@ func runImageChangeTriggerTest(t *testing.T, clusterAdminClient *client.Client, 
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild := event.Object.(*buildapi.Build)
-	switch newBuild.Spec.Strategy.Type {
-	case buildapi.SourceBuildStrategyType:
-		if newBuild.Spec.Strategy.SourceStrategy.From.Name != "registry:8080/openshift/test-image-trigger:"+tag {
+	strategy := newBuild.Spec.Strategy
+	switch {
+	case strategy.SourceStrategy != nil:
+		if strategy.SourceStrategy.From.Name != "registry:8080/openshift/test-image-trigger:"+tag {
 			i, _ := clusterAdminClient.ImageStreams(testutil.Namespace()).Get(imageStream.Name)
 			bc, _ := clusterAdminClient.BuildConfigs(testutil.Namespace()).Get(config.Name)
-			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:"+tag, newBuild.Spec.Strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[0].ImageChange)
+			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:"+tag, strategy.SourceStrategy.From.Name, i, bc.Spec.Triggers[0].ImageChange)
 		}
-	case buildapi.DockerBuildStrategyType:
-		if newBuild.Spec.Strategy.DockerStrategy.From.Name != "registry:8080/openshift/test-image-trigger:"+tag {
+	case strategy.DockerStrategy != nil:
+		if strategy.DockerStrategy.From.Name != "registry:8080/openshift/test-image-trigger:"+tag {
 			i, _ := clusterAdminClient.ImageStreams(testutil.Namespace()).Get(imageStream.Name)
 			bc, _ := clusterAdminClient.BuildConfigs(testutil.Namespace()).Get(config.Name)
-			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:"+tag, newBuild.Spec.Strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[0].ImageChange)
+			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:"+tag, strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[0].ImageChange)
 		}
-	case buildapi.CustomBuildStrategyType:
-		if newBuild.Spec.Strategy.CustomStrategy.From.Name != "registry:8080/openshift/test-image-trigger:"+tag {
+	case strategy.CustomStrategy != nil:
+		if strategy.CustomStrategy.From.Name != "registry:8080/openshift/test-image-trigger:"+tag {
 			i, _ := clusterAdminClient.ImageStreams(testutil.Namespace()).Get(imageStream.Name)
 			bc, _ := clusterAdminClient.BuildConfigs(testutil.Namespace()).Get(config.Name)
-			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:"+tag, newBuild.Spec.Strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[0].ImageChange)
+			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\ntrigger is %s\n", "registry:8080/openshift/test-image-trigger:"+tag, strategy.CustomStrategy.From.Name, i, bc.Spec.Triggers[0].ImageChange)
 		}
 	}
 	// Wait for an update on the specific build that was added
@@ -475,24 +476,25 @@ WaitLoop2:
 		t.Fatalf("expected watch event type %s, got %s", e, a)
 	}
 	newBuild = event.Object.(*buildapi.Build)
-	switch newBuild.Spec.Strategy.Type {
-	case buildapi.SourceBuildStrategyType:
-		if newBuild.Spec.Strategy.SourceStrategy.From.Name != "registry:8080/openshift/test-image-trigger:ref-2-random" {
+	strategy = newBuild.Spec.Strategy
+	switch {
+	case strategy.SourceStrategy != nil:
+		if strategy.SourceStrategy.From.Name != "registry:8080/openshift/test-image-trigger:ref-2-random" {
 			i, _ := clusterAdminClient.ImageStreams(testutil.Namespace()).Get(imageStream.Name)
 			bc, _ := clusterAdminClient.BuildConfigs(testutil.Namespace()).Get(config.Name)
-			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-2-random", newBuild.Spec.Strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[3].ImageChange)
+			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-2-random", strategy.SourceStrategy.From.Name, i, bc.Spec.Triggers[3].ImageChange)
 		}
-	case buildapi.DockerBuildStrategyType:
-		if newBuild.Spec.Strategy.DockerStrategy.From.Name != "registry:8080/openshift/test-image-trigger:ref-2-random" {
+	case strategy.DockerStrategy != nil:
+		if strategy.DockerStrategy.From.Name != "registry:8080/openshift/test-image-trigger:ref-2-random" {
 			i, _ := clusterAdminClient.ImageStreams(testutil.Namespace()).Get(imageStream.Name)
 			bc, _ := clusterAdminClient.BuildConfigs(testutil.Namespace()).Get(config.Name)
-			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-2-random", newBuild.Spec.Strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[3].ImageChange)
+			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-2-random", strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[3].ImageChange)
 		}
-	case buildapi.CustomBuildStrategyType:
-		if newBuild.Spec.Strategy.CustomStrategy.From.Name != "registry:8080/openshift/test-image-trigger:ref-2-random" {
+	case strategy.CustomStrategy != nil:
+		if strategy.CustomStrategy.From.Name != "registry:8080/openshift/test-image-trigger:ref-2-random" {
 			i, _ := clusterAdminClient.ImageStreams(testutil.Namespace()).Get(imageStream.Name)
 			bc, _ := clusterAdminClient.BuildConfigs(testutil.Namespace()).Get(config.Name)
-			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-2-random", newBuild.Spec.Strategy.DockerStrategy.From.Name, i, bc.Spec.Triggers[3].ImageChange)
+			t.Fatalf("Expected build with base image %s, got %s\n, imagerepo is %v\trigger is %s\n", "registry:8080/openshift/test-image-trigger:ref-2-random", strategy.CustomStrategy.From.Name, i, bc.Spec.Triggers[3].ImageChange)
 		}
 	}
 
@@ -748,10 +750,8 @@ func configChangeBuildConfig() *buildapi.BuildConfig {
 	bc := &buildapi.BuildConfig{}
 	bc.Name = "testcfgbc"
 	bc.Namespace = testutil.Namespace()
-	bc.Spec.BuildSpec.Source.Type = buildapi.BuildSourceGit
 	bc.Spec.BuildSpec.Source.Git = &buildapi.GitBuildSource{}
 	bc.Spec.BuildSpec.Source.Git.URI = "git://github.com/openshift/ruby-hello-world.git"
-	bc.Spec.BuildSpec.Strategy.Type = buildapi.DockerBuildStrategyType
 	bc.Spec.BuildSpec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{}
 	configChangeTrigger := buildapi.BuildTriggerPolicy{Type: buildapi.ConfigChangeBuildTriggerType}
 	bc.Spec.Triggers = append(bc.Spec.Triggers, configChangeTrigger)

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -117,14 +117,12 @@ func TestProjectMustExist(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "default"},
 		Spec: buildapi.BuildSpec{
 			Source: buildapi.BuildSource{
-				Type: buildapi.BuildSourceGit,
 				Git: &buildapi.GitBuildSource{
 					URI: "http://github.com/my/repository",
 				},
 				ContextDir: "context",
 			},
 			Strategy: buildapi.BuildStrategy{
-				Type:           buildapi.DockerBuildStrategyType,
 				DockerStrategy: &buildapi.DockerBuildStrategy{},
 			},
 			Output: buildapi.BuildOutput{

--- a/test/integration/webhookgithub_test.go
+++ b/test/integration/webhookgithub_test.go
@@ -296,14 +296,12 @@ func mockBuildConfigImageParms(imageName, imageStream, imageTag string) *buildap
 			},
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitBuildSource{
 						URI: "http://my.docker/build",
 					},
 					ContextDir: "context",
 				},
 				Strategy: buildapi.BuildStrategy{
-					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{
 						From: &kapi.ObjectReference{
 							Kind: "DockerImage",
@@ -338,14 +336,12 @@ func mockBuildConfigImageStreamParms(imageName, imageStream, imageTag string) *b
 			},
 			BuildSpec: buildapi.BuildSpec{
 				Source: buildapi.BuildSource{
-					Type: buildapi.BuildSourceGit,
 					Git: &buildapi.GitBuildSource{
 						URI: "http://my.docker/build",
 					},
 					ContextDir: "context",
 				},
 				Strategy: buildapi.BuildStrategy{
-					Type: buildapi.SourceBuildStrategyType,
 					SourceStrategy: &buildapi.SourceBuildStrategy{
 						From: kapi.ObjectReference{
 							Kind: "ImageStreamTag",


### PR DESCRIPTION
remove build-related type fields from internal api
    
BuildSpec.Source.Type
BuildSpec.Strategy.Type
BuildRequest.Revision.Type
GenericWebHookEvent.Type
    
Code should instead check for non-nil values to determine the type.
This allows for multiple inputs to be used simultaneously (eg
more than one source input)
