### PR TITLE
UPSTREAM: 14881: fix delta fifo & various fakes for go1.5.1

### DIFF
--- a/pkg/build/controller/factory/factory.go
+++ b/pkg/build/controller/factory/factory.go
@@ -118,7 +118,7 @@ func (factory *BuildControllerFactory) Create() controller.RunnableController {
 // CreateDeleteController constructs a BuildDeleteController
 func (factory *BuildControllerFactory) CreateDeleteController() controller.RunnableController {
 	client := ControllerClient{factory.KubeClient, factory.OSClient}
-	queue := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, nil, nil)
+	queue := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, nil, keyListerGetter{})
 	cache.NewReflector(&buildDeleteLW{client, queue}, &buildapi.Build{}, queue, 5*time.Minute).RunUntil(factory.Stop)
 
 	buildDeleteController := &buildcontroller.BuildDeleteController{
@@ -206,11 +206,34 @@ func (factory *BuildPodControllerFactory) Create() controller.RunnableController
 	}
 }
 
+// keyListerGetter is a dummy implementation of a KeyListerGetter
+// which always returns a fake object and true for gets, and
+// returns no items for list.  This forces the DeltaFIFO queue
+// to always queue delete events it receives from etcd.  Our
+// client will properly handle duplicated events and this is more
+// efficient than maintaining a local cache of all the build pods
+// so the DeltaFIFO can perform a proper diff.
+type keyListerGetter struct {
+	client osclient.Interface
+}
+
+// ListKeys is a dummy implementation of a KeyListerGetter interface returning
+// empty string array; used only to force DeltaFIFO to always queue delete events.
+func (keyListerGetter) ListKeys() []string {
+	return []string{}
+}
+
+// GetByKey is a dummy implementation of a KeyListerGetter interface returning
+// always "", true, nil; used only to force DeltaFIFO to always queue delete events.
+func (keyListerGetter) GetByKey(key string) (interface{}, bool, error) {
+	return "", true, nil
+}
+
 // CreateDeleteController constructs a BuildPodDeleteController
 func (factory *BuildPodControllerFactory) CreateDeleteController() controller.RunnableController {
 
 	client := ControllerClient{factory.KubeClient, factory.OSClient}
-	queue := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, nil, nil)
+	queue := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, nil, keyListerGetter{})
 	cache.NewReflector(&buildPodDeleteLW{client, queue}, &kapi.Pod{}, queue, 5*time.Minute).RunUntil(factory.Stop)
 
 	buildPodDeleteController := &buildcontroller.BuildPodDeleteController{


### PR DESCRIPTION
This is re-submission of the upstream patch which must be included before next rebase lands. This was previously submitted by @deads2k in #5339, this adds @bparees patch on top of it. 

Ben, frankly said I'm moderately happy with that solution of yours, but it works. I'd rather us switch to using `framework.Informer` for that, but that keeps internal cache you don't want in return (similarly to  [this](https://github.com/openshift/origin/pull/6230/files#diff-54ebade8eae1319de4596fd6f5f1f612R354)). 