### PR TITLE
Enhance status for deploymentconfigs

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -21797,16 +21797,36 @@
      "latestVersion": {
       "type": "integer",
       "format": "int64",
-      "description": "LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig is out of sync."
-     },
-     "details": {
-      "$ref": "v1.DeploymentDetails",
-      "description": "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger"
+      "description": "LatestVersion is used to determine whether the current deployment associated with a deployment config is out of sync."
      },
      "observedGeneration": {
       "type": "integer",
       "format": "int64",
-      "description": "ObservedGeneration is the most recent generation observed by the controller."
+      "description": "ObservedGeneration is the most recent generation observed by the deployment config controller."
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the total number of pods targeted by this deployment config."
+     },
+     "updatedReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config that have the desired template spec."
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "AvailableReplicas is the total number of available pods targeted by this deployment config."
+     },
+     "unavailableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "UnavailableReplicas is the total number of unavailable pods targeted by this deployment config."
+     },
+     "details": {
+      "$ref": "v1.DeploymentDetails",
+      "description": "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger"
      }
     }
    },

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -344,9 +344,10 @@ func (c *MasterConfig) RunDeployerPodController() {
 func (c *MasterConfig) RunDeploymentConfigController() {
 	dcInfomer := c.Informers.DeploymentConfigs().Informer()
 	rcInformer := c.Informers.ReplicationControllers().Informer()
+	podInformer := c.Informers.Pods().Informer()
 	osclient, kclient := c.DeploymentConfigControllerClients()
 
-	controller := deployconfigcontroller.NewDeploymentConfigController(dcInfomer, rcInformer, osclient, kclient, c.EtcdHelper.Codec())
+	controller := deployconfigcontroller.NewDeploymentConfigController(dcInfomer, rcInformer, podInformer, osclient, kclient, c.EtcdHelper.Codec())
 	// TODO: Make the stop channel actually work.
 	stopCh := make(chan struct{})
 	// TODO: Make the number of workers configurable.

--- a/pkg/deploy/api/deep_copy_generated.go
+++ b/pkg/deploy/api/deep_copy_generated.go
@@ -184,6 +184,11 @@ func DeepCopy_api_DeploymentConfigSpec(in DeploymentConfigSpec, out *DeploymentC
 
 func DeepCopy_api_DeploymentConfigStatus(in DeploymentConfigStatus, out *DeploymentConfigStatus, c *conversion.Cloner) error {
 	out.LatestVersion = in.LatestVersion
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
 	if in.Details != nil {
 		in, out := in.Details, &out.Details
 		*out = new(DeploymentDetails)
@@ -193,7 +198,6 @@ func DeepCopy_api_DeploymentConfigStatus(in DeploymentConfigStatus, out *Deploym
 	} else {
 		out.Details = nil
 	}
-	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/deploy/api/helpers.go
+++ b/pkg/deploy/api/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -32,7 +33,18 @@ func ScaleFromConfig(dc *DeploymentConfig) *extensions.Scale {
 		ObjectMeta: kapi.ObjectMeta{
 			Name:              dc.Name,
 			Namespace:         dc.Namespace,
+			UID:               dc.UID,
+			ResourceVersion:   dc.ResourceVersion,
 			CreationTimestamp: dc.CreationTimestamp,
+		},
+		Spec: extensions.ScaleSpec{
+			Replicas: dc.Spec.Replicas,
+		},
+		Status: extensions.ScaleStatus{
+			Replicas: dc.Status.Replicas,
+			Selector: &unversioned.LabelSelector{
+				MatchLabels: dc.Spec.Selector,
+			},
 		},
 	}
 }

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -325,14 +325,23 @@ type DeploymentConfigSpec struct {
 
 // DeploymentConfigStatus represents the current deployment state.
 type DeploymentConfigStatus struct {
-	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
-	// is out of sync.
+	// LatestVersion is used to determine whether the current deployment associated with a deployment
+	// config is out of sync.
 	LatestVersion int64
+	// ObservedGeneration is the most recent generation observed by the deployment config controller.
+	ObservedGeneration int64
+	// Replicas is the total number of pods targeted by this deployment config.
+	Replicas int32
+	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
+	// that have the desired template spec.
+	UpdatedReplicas int32
+	// AvailableReplicas is the total number of available pods targeted by this deployment config.
+	AvailableReplicas int32
+	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
+	UnavailableReplicas int32
 	// Details are the reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails
-	// ObservedGeneration is the most recent generation observed by the controller.
-	ObservedGeneration int64
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.

--- a/pkg/deploy/api/v1/conversion_generated.go
+++ b/pkg/deploy/api/v1/conversion_generated.go
@@ -420,6 +420,11 @@ func Convert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in *deploy_api.
 
 func autoConvert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *DeploymentConfigStatus, out *deploy_api.DeploymentConfigStatus, s conversion.Scope) error {
 	out.LatestVersion = in.LatestVersion
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
 	if in.Details != nil {
 		in, out := &in.Details, &out.Details
 		*out = new(deploy_api.DeploymentDetails)
@@ -429,7 +434,6 @@ func autoConvert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *Dep
 	} else {
 		out.Details = nil
 	}
-	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -439,6 +443,11 @@ func Convert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *Deploym
 
 func autoConvert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(in *deploy_api.DeploymentConfigStatus, out *DeploymentConfigStatus, s conversion.Scope) error {
 	out.LatestVersion = in.LatestVersion
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
 	if in.Details != nil {
 		in, out := &in.Details, &out.Details
 		*out = new(DeploymentDetails)
@@ -448,7 +457,6 @@ func autoConvert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(in *dep
 	} else {
 		out.Details = nil
 	}
-	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/deploy/api/v1/deep_copy_generated.go
+++ b/pkg/deploy/api/v1/deep_copy_generated.go
@@ -183,6 +183,11 @@ func DeepCopy_v1_DeploymentConfigSpec(in DeploymentConfigSpec, out *DeploymentCo
 
 func DeepCopy_v1_DeploymentConfigStatus(in DeploymentConfigStatus, out *DeploymentConfigStatus, c *conversion.Cloner) error {
 	out.LatestVersion = in.LatestVersion
+	out.ObservedGeneration = in.ObservedGeneration
+	out.Replicas = in.Replicas
+	out.UpdatedReplicas = in.UpdatedReplicas
+	out.AvailableReplicas = in.AvailableReplicas
+	out.UnavailableReplicas = in.UnavailableReplicas
 	if in.Details != nil {
 		in, out := in.Details, &out.Details
 		*out = new(DeploymentDetails)
@@ -192,7 +197,6 @@ func DeepCopy_v1_DeploymentConfigStatus(in DeploymentConfigStatus, out *Deployme
 	} else {
 		out.Details = nil
 	}
-	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/deploy/api/v1/swagger_doc.go
+++ b/pkg/deploy/api/v1/swagger_doc.go
@@ -94,10 +94,14 @@ func (DeploymentConfigSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentConfigStatus = map[string]string{
-	"":                   "DeploymentConfigStatus represents the current deployment state.",
-	"latestVersion":      "LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig is out of sync.",
-	"details":            "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger",
-	"observedGeneration": "ObservedGeneration is the most recent generation observed by the controller.",
+	"":                    "DeploymentConfigStatus represents the current deployment state.",
+	"latestVersion":       "LatestVersion is used to determine whether the current deployment associated with a deployment config is out of sync.",
+	"observedGeneration":  "ObservedGeneration is the most recent generation observed by the deployment config controller.",
+	"replicas":            "Replicas is the total number of pods targeted by this deployment config.",
+	"updatedReplicas":     "UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config that have the desired template spec.",
+	"availableReplicas":   "AvailableReplicas is the total number of available pods targeted by this deployment config.",
+	"unavailableReplicas": "UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.",
+	"details":             "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger",
 }
 
 func (DeploymentConfigStatus) SwaggerDoc() map[string]string {

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -282,14 +282,23 @@ type DeploymentConfigSpec struct {
 
 // DeploymentConfigStatus represents the current deployment state.
 type DeploymentConfigStatus struct {
-	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
-	// is out of sync.
+	// LatestVersion is used to determine whether the current deployment associated with a deployment
+	// config is out of sync.
 	LatestVersion int64 `json:"latestVersion,omitempty"`
+	// ObservedGeneration is the most recent generation observed by the deployment config controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Replicas is the total number of pods targeted by this deployment config.
+	Replicas int32 `json:"replicas,omitempty"`
+	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
+	// that have the desired template spec.
+	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
+	// AvailableReplicas is the total number of available pods targeted by this deployment config.
+	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
+	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
+	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty"`
 	// Details are the reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails `json:"details,omitempty"`
-	// ObservedGeneration is the most recent generation observed by the controller.
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -297,14 +297,23 @@ type DeploymentConfigSpec struct {
 }
 
 type DeploymentConfigStatus struct {
-	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
-	// is out of sync.
+	// LatestVersion is used to determine whether the current deployment associated with a deployment
+	// config is out of sync.
 	LatestVersion int64 `json:"latestVersion,omitempty"`
+	// ObservedGeneration is the most recent generation observed by the deployment config controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Replicas is the total number of pods targeted by this deployment config.
+	Replicas int32 `json:"replicas,omitempty"`
+	// UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config
+	// that have the desired template spec.
+	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
+	// AvailableReplicas is the total number of available pods targeted by this deployment config.
+	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
+	// UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.
+	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty"`
 	// The reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails `json:"details,omitempty"`
-	// ObservedGeneration is the most recent generation observed by the controller.
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.

--- a/pkg/deploy/controller/deploymentconfig/controller_test.go
+++ b/pkg/deploy/controller/deploymentconfig/controller_test.go
@@ -670,7 +670,20 @@ func TestHandleScenarios(t *testing.T) {
 			2*time.Minute,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		)
-		c := NewDeploymentConfigController(dcInformer, rcInformer, oc, kc, codec)
+		podInformer := framework.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options kapi.ListOptions) (runtime.Object, error) {
+					return kc.Pods(kapi.NamespaceAll).List(options)
+				},
+				WatchFunc: func(options kapi.ListOptions) (watch.Interface, error) {
+					return kc.Pods(kapi.NamespaceAll).Watch(options)
+				},
+			},
+			&kapi.Pod{},
+			2*time.Minute,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		)
+		c := NewDeploymentConfigController(dcInformer, rcInformer, podInformer, oc, kc, codec)
 
 		for i := range toStore {
 			c.rcStore.Add(&toStore[i])

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -189,6 +189,33 @@ var _ = g.Describe("deploymentconfigs", func() {
 		})
 	})
 
+	g.Describe("with enhanced status", func() {
+		g.It("should include various info in status [Conformance]", func() {
+			resource, name, err := createFixture(oc, simpleDeploymentFixture)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying the deployment is marked complete")
+			o.Expect(waitForLatestCondition(oc, name, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
+
+			g.By("verifying that status.replicas is set")
+			replicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.replicas}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(replicas).To(o.ContainSubstring("2"))
+			g.By("verifying that status.updatedReplicas is set")
+			updatedReplicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.updatedReplicas}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(updatedReplicas).To(o.ContainSubstring("2"))
+			g.By("verifying that status.availableReplicas is set")
+			availableReplicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.availableReplicas}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(availableReplicas).To(o.ContainSubstring("2"))
+			g.By("verifying that status.unavailableReplicas is set")
+			unavailableReplicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.unavailableReplicas}\"").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(unavailableReplicas).To(o.ContainSubstring("0"))
+		})
+	})
+
 	g.Describe("with custom deployments", func() {
 		g.It("should run the custom deployment steps [Conformance]", func() {
 			out, err := oc.Run("create").Args("-f", customDeploymentFixture).Output()


### PR DESCRIPTION
Add various status fields for enhancing user experience. The fields are
also required for round-tripping upstream Deployments.

@ironcladlou @openshift/api-review  PTAL

Fixes https://github.com/openshift/origin/issues/5918
Part of https://trello.com/c/Mljldox7/643-5-deployments-downstream-support-for-upstream-features

@mfojtik @pweil- fyi