### PR TITLE
[WIP][DO_NOT_MERGE] Resurrect extension-points in web console

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -132,6 +132,8 @@
     <script src="bower_components/kubernetes-object-describer/dist/object-describer.js"></script>
     <script src="bower_components/openshift-object-describer/dist/object-describer.js"></script>
     <script src="bower_components/bootstrap-hover-dropdown/bootstrap-hover-dropdown.min.js"></script>
+    <script src="bower_components/angular-extension-registry/dist/angular-extension-registry.min.js"></script>
+    <script src="bower_components/angular-extension-registry/dist/compiled-templates.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -225,6 +227,15 @@
         <script src="scripts/directives/affix.js"></script>
         <script src="scripts/services/logLinks.js"></script>
         <!-- endbuild -->
+
+        <!-- extension manager demo -->
+        <link rel="stylesheet" href="scripts/_extensions/build_details/style.css" />
+        <script src="scripts/_extensions/build_details/route.js"></script>
+        <script src="scripts/_extensions/build_details/stub.js"></script>
+        <script src="scripts/_extensions/build_details/service.js"></script>
+        <script src="scripts/_extensions/build_details/controller.js"></script>
+        <script src="scripts/_extensions/build_details/extension.js"></script>
+        <!-- /extension manager demo -->
 
     <!-- Load any extensions last. -->
     <script src="scripts/extensions.js"></script>

--- a/assets/app/scripts/_extensions/build_details/controller.js
+++ b/assets/app/scripts/_extensions/build_details/controller.js
@@ -1,0 +1,39 @@
+'use strict';
+
+angular.module('openshiftConsole')
+    .controller('GitRepoController', function($filter, $http, $scope, $routeParams, ProjectsService, DataService, Git, GitApiStub) {
+          $scope.projectName = $routeParams.project;
+          $scope.renderOptions = {
+            hideFilterWidget: true
+          };
+
+          ProjectsService
+            .get($routeParams.project)
+            .then(_.spread(function(project, context) {
+              $scope.project = project;
+
+              DataService
+                .get("builds", $routeParams.build, context)
+                .then(function(build) {
+                  $scope.build = build;
+
+                  if(!Git.uri.for.commits(build)) {
+                    return;
+                  };
+
+                  Git                   // real API call
+                  //GitApiStub          // stub, to avoid hitting github's rate limit
+                    .get(Git.uri.for.commits(build))
+                    .then(function(request) {
+                      $scope.githubLinks = request.data;
+                    },function() {
+                      $scope.alerts['error'] = {
+                        type: "error",
+                        message: "Error",
+                        details: "We're sorry, but something went wrong."
+                      };
+                    });
+                });
+            }));
+
+        });

--- a/assets/app/scripts/_extensions/build_details/extension.js
+++ b/assets/app/scripts/_extensions/build_details/extension.js
@@ -1,0 +1,58 @@
+'use strict';
+
+angular
+    .module('openshiftConsole')
+    .run([
+        '$q',
+        '$timeout',
+        'extensionInput',
+        'Git',
+        'GitApiStub',
+        function($q, $timeout, extensionInput, Git, GitApiStub) {
+            var template = _.template([
+                                '<div>',
+                                    '<h3>Github Activity</h3>',
+                                    '<table>',
+                                        '<tr>',
+                                            '<td>',
+                                                '<strong>Latest Commit Message to source repo: &nbsp;&nbsp;&nbsp;</strong>',
+                                            '</td>',
+                                            '<td>',
+                                                '<%= message %> &nbsp;&nbsp;',
+                                            '</td>',
+                                            '<td>',
+                                                '<a href="<%= route %>">View more </a>',
+                                            '</td>',
+                                        '</tr>',
+                                    '</table>',
+                                '</div>'
+                            ].join(''));
+
+            extensionInput.register('build_details', _.spread(function(build, buildConfigName) {
+                var uri =   build.spec &&
+                            build.spec.source &&
+                            build.spec.source.git &&
+                            build.spec.source.git.uri,
+                    route = URI('project')
+                            .segment(build.metadata.namespace)
+                            .segment('browse')
+                            .segment('builds')
+                            .segment(buildConfigName)
+                            .segment(build.metadata.name)
+                            .segment('gitrepo')
+                            .toString();
+
+                return uri ?
+                          Git            // real API call
+                          //GitApiStub   // stub, to avoid hitting github's rate limit
+                            .get(Git.uri.for.commits(build))
+                            .then(function(request) {
+                              return {
+                                type: 'html',
+                                html: template({ route: route, githubUri: uri, message: _.first(request.data).commit.message })
+                              };
+                            }) :
+                            null;
+            }));
+    }
+  ]);

--- a/assets/app/scripts/_extensions/build_details/route.js
+++ b/assets/app/scripts/_extensions/build_details/route.js
@@ -1,0 +1,16 @@
+'use strict';
+
+angular.module('openshiftConsole')
+    // add a route to support
+    .config([
+        '$routeProvider',
+        function($routeProvider) {
+            // TODO: register a route to a page that will show the last commits
+            // for the github repo
+            $routeProvider
+                .when('/project/:project/browse/builds/:buildconfig/:build/gitrepo', {
+                    templateUrl: 'scripts/_extensions/build_details/view.html',
+                    controller: 'GitRepoController'
+                })
+        }
+    ])

--- a/assets/app/scripts/_extensions/build_details/service.js
+++ b/assets/app/scripts/_extensions/build_details/service.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('Git', function($http) {
+    return {
+      uri: {
+        for: {
+          commits: function(build) {
+            var gitUri = build.spec &&
+                     build.spec.source &&
+                     build.spec.source.git &&
+                     build.spec.source.git.uri,
+            segments = URI(gitUri).suffix('').segment(),
+            apiUri = URI('https://api.github.com')
+                      .segment('repos');
+
+            _.each(segments, function(segment) {
+              apiUri.segment(segment);
+            });
+            apiUri.segment('commits');
+            return apiUri;
+          }
+        }
+      },
+      get: function(apiUri) {
+        return $http({
+                  url: apiUri
+                });
+      }
+    }
+  });

--- a/assets/app/scripts/_extensions/build_details/stub.js
+++ b/assets/app/scripts/_extensions/build_details/stub.js
@@ -1,0 +1,115 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .factory('GitApiStub', function($q) {
+    return {
+      get: function() {
+        // Fake data of same format as Github's api, but with some dummy values injected
+        return $q.when({
+                  data: [
+                    {
+                        "sha": "123456789012345",
+                        "commit": {
+                          "author": {
+                            "name": "John Doe",
+                            "email": "jdoe@users.noreply.github.com",
+                            "date": "2015-12-02T12:54:13Z"
+                          },
+                          "message": "Merge pull request #49 from jdoe/bump_version\n\nmove hello world example to ruby-22 image",
+                          "url": "https://api.github.com/repos/jdoe/stuff-and-things/git/commits/123456789012345",
+                          "comment_count": 0
+                        },
+                        "url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/123456789012345",
+                        "html_url": "https://github.com/jdoe/stuff-and-things/commit/123456789012345",
+                        "comments_url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/123456789012345/comments",
+                        "author": {
+                          "login": "jdoe",
+                          "id": 1234567,
+                          "avatar_url": "https://avatars.githubusercontent.com/u/1234567?v=3",
+                          "gravatar_id": "",
+                          "url": "https://api.github.com/users/jdoe",
+                          "html_url": "https://github.com/jdoe",
+                          "repos_url": "https://api.github.com/users/jdoe/repos",
+                          "events_url": "https://api.github.com/users/jdoe/events{/privacy}",
+                          "received_events_url": "https://api.github.com/users/jdoe/received_events",
+                          "type": "User",
+                          "site_admin": false
+                        },
+                        "committer": {
+                          "login": "jdoe",
+                          "id": 1234567,
+                          "avatar_url": "https://avatars.githubusercontent.com/u/1234567?v=3",
+                          "gravatar_id": "",
+                          "url": "https://api.github.com/users/jdoe",
+                          "html_url": "https://github.com/jdoe",
+                          "repos_url": "https://api.github.com/users/jdoe/repos",
+                          "type": "User"
+                        },
+                        "parents": [
+                          {
+                            "sha": "12345123451234512345",
+                            "url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/12345123451234512345",
+                            "html_url": "https://github.com/jdoe/stuff-and-things/commit/12345123451234512345"
+                          },
+                          {
+                            "sha": "09876543210987654321",
+                            "url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/09876543210987654321",
+                            "html_url": "https://github.com/jdoe/stuff-and-things/commit/09876543210987654321"
+                          }
+                        ]
+                      },{
+                        "sha": "123456789012345",
+                        "commit": {
+                          "author": {
+                            "name": "John Doe",
+                            "email": "jdoe@users.noreply.github.com",
+                            "date": "2015-12-02T12:54:13Z"
+                          },
+                          "message": "Merge pull request #49 from jdoe/bump_version\n\nmove hello world example to ruby-22 image",
+                          "url": "https://api.github.com/repos/jdoe/stuff-and-things/git/commits/123456789012345",
+                          "comment_count": 0
+                        },
+                        "url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/123456789012345",
+                        "html_url": "https://github.com/jdoe/stuff-and-things/commit/123456789012345",
+                        "comments_url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/123456789012345/comments",
+                        "author": {
+                          "login": "jdoe",
+                          "id": 1234567,
+                          "avatar_url": "https://avatars.githubusercontent.com/u/1234567?v=3",
+                          "gravatar_id": "",
+                          "url": "https://api.github.com/users/jdoe",
+                          "html_url": "https://github.com/jdoe",
+                          "repos_url": "https://api.github.com/users/jdoe/repos",
+                          "events_url": "https://api.github.com/users/jdoe/events{/privacy}",
+                          "received_events_url": "https://api.github.com/users/jdoe/received_events",
+                          "type": "User",
+                          "site_admin": false
+                        },
+                        "committer": {
+                          "login": "jdoe",
+                          "id": 1234567,
+                          "avatar_url": "https://avatars.githubusercontent.com/u/1234567?v=3",
+                          "gravatar_id": "",
+                          "url": "https://api.github.com/users/jdoe",
+                          "html_url": "https://github.com/jdoe",
+                          "repos_url": "https://api.github.com/users/jdoe/repos",
+                          "type": "User"
+                        },
+                        "parents": [
+                          {
+                            "sha": "12345123451234512345",
+                            "url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/12345123451234512345",
+                            "html_url": "https://github.com/jdoe/stuff-and-things/commit/12345123451234512345"
+                          },
+                          {
+                            "sha": "09876543210987654321",
+                            "url": "https://api.github.com/repos/jdoe/stuff-and-things/commits/09876543210987654321",
+                            "html_url": "https://github.com/jdoe/stuff-and-things/commit/09876543210987654321"
+                          }
+                        ]
+                      }
+                    ]
+                });
+    }
+  }
+});

--- a/assets/app/scripts/_extensions/build_details/style.css
+++ b/assets/app/scripts/_extensions/build_details/style.css
@@ -1,0 +1,4 @@
+#git .sha { width: 25%;}
+#git .author { width: 15%;}
+#git .date { width: 15%;}
+#git .message {width: 45%;}

--- a/assets/app/scripts/_extensions/build_details/view.html
+++ b/assets/app/scripts/_extensions/build_details/view.html
@@ -1,0 +1,38 @@
+<div class="content">
+  <project-page>
+    <breadcrumbs breadcrumbs="[{}]"></breadcrumbs>
+    <alerts></alerts>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="tile">
+          <h1>{{build.metadata.name}} Git Commits</h1>
+
+          <table id="git" class="table table-bordered table-hover table-mobile">
+          <thead>
+            <tr>
+              <th class="sha">SHA</th>
+              <th class="author">Author</th>
+              <th class="date">Date</th>
+              <th class="message">Message</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="gitLink in githubLinks">
+              <td class="sha">
+                <a href="{{gitLink.html_url}}" target="_blank">
+                  <span class="truncate">{{gitLink.sha}}</span>
+                </a>
+              </td>
+              <td class="author">
+                <a href="mailto:{{gitLink.commit.author.email}}">{{gitLink.commit.author.name}}</a>
+              </td>
+              <td class="date">{{gitLink.commit.author.date | date : short }}</td>
+              <td class="message">{{gitLink.commit.message}}</td>
+            </tr>
+          </tbody>
+
+        </div>
+      </div>
+    </div>
+  </project-page>
+</div>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -21,7 +21,8 @@ angular
     'kubernetesUI',
     'ui.bootstrap',
     'patternfly.charts',
-    'openshiftConsoleTemplates'
+    'openshiftConsoleTemplates',
+    'extension-registry'
   ])
   .constant("mainNavTabs", [])  // even though its not really a "constant", it has to be created as a constant and not a value
                          // or it can't be referenced during module config

--- a/assets/app/styles/__extension.prototype.less
+++ b/assets/app/styles/__extension.prototype.less
@@ -1,0 +1,11 @@
+.extension-pod {
+  border: 1px solid #0099d3;
+  color: #0099d3;
+  background: #F2F2F2;
+  padding: 2px;
+  margin: 2px;
+  border-radius: 4px
+}
+.extension-pod:hover {
+  background: #C1DEE8;
+}

--- a/assets/app/styles/main.less
+++ b/assets/app/styles/main.less
@@ -82,3 +82,7 @@
 @import "_tile.less";
 @import "_topology.less";
 @import "_log.less";
+
+
+/* extension registry prototype */
+@import "__extension.prototype.less";

--- a/assets/app/views/_pod-template.html
+++ b/assets/app/views/_pod-template.html
@@ -10,10 +10,10 @@
       <div class="component-label">Container: {{container.name}}</div>
       <div row ng-if="container.image" class="pod-template-image icon-row">
         <div>
-          <span class="pficon pficon-image" aria-hidden="true"></span> 
+          <span class="pficon pficon-image" aria-hidden="true"></span>
         </div>
         <div flex>
-          Image: 
+          Image:
           <span ng-if="!imagesByDockerReference[container.image]">{{container.image | imageStreamName}}</span>
           <span ng-if="imagesByDockerReference[container.image]">
             <a ng-href="{{imagesByDockerReference[container.image].imageStreamName | navigateResourceURL : 'ImageStream' : imagesByDockerReference[container.image].imageStreamNamespace}}">{{container.image | imageStreamName}}</a>
@@ -25,7 +25,7 @@
         <div row class="icon-row" ng-if="build = (image | buildForImage : builds)">
           <div>
             <span class="fa fa-refresh" aria-hidden="true"></span>
-          </div> 
+          </div>
           <div flex>Build:
             <a ng-href="{{build | navigateResourceURL}}">
               <span ng-if="(build | annotation : 'buildNumber')">#{{build | annotation : 'buildNumber'}}</span>
@@ -56,7 +56,7 @@
                 </span>
               </span>
             </span>
-          </div>         
+          </div>
         </div>
       </div>
 
@@ -70,7 +70,7 @@
             <span class="nowrap">{{port.containerPort}}/{{port.protocol}}<span ng-if="port.name">&thinsp;({{port.name}})</span><span ng-if="port.hostPort">&thinsp;<span class="port-icon">&#8594;</span>&thinsp;{{port.hostPort}}</span></span><span ng-if="!$last">, </span>
           </span>
         </div>
-      </div> 
+      </div>
 
       <div row ng-if="detailed" ng-repeat="mount in container.volumeMounts" class="icon-row">
         <div>
@@ -84,8 +84,19 @@
         </div>
       </div>
 
+      <!--
+        Current extension manager component
+      -->
       <div hawtio-extension name="container-links"></div>
-
+      <!--
+        prototype extension management component
+      -->
+      <div
+        extension-output
+        extension-name="pod_template"
+        extension-types="text link select html"
+        extension-args="container"
+        extension-limit="3"></div>
     </div>
   </div>
 </div>

--- a/assets/app/views/browse/_build-details.html
+++ b/assets/app/views/browse/_build-details.html
@@ -60,4 +60,14 @@
     </div>
   </div>
   <annotations annotations="build.metadata.annotations"></annotations>
+  <!--
+    prototype extension management component
+    - args passed should have a consistent schema, need to do some thinking here
+  -->
+  <div
+    extension-output
+    extension-name="build_details"
+    extension-types="text link select html"
+    extension-args="[ build, buildConfigName ]"
+    extension-limit="3"></div>
 </div>

--- a/assets/bower.json
+++ b/assets/bower.json
@@ -31,7 +31,8 @@
     "kubernetes-container-terminal": "0.0.7",
     "openshift-object-describer": "1.1.1",
     "layout.attrs": "1.1.2",
-    "bootstrap-hover-dropdown": "~2.1.3"
+    "bootstrap-hover-dropdown": "~2.1.3",
+    "angular-extension-registry": "git://github.com/benjaminapetersen/angular-extension-registry.git"
   },
   "devDependencies": {
     "angular-mocks": "1.3.8",

--- a/assets/extensions/extensions.js
+++ b/assets/extensions/extensions.js
@@ -9,3 +9,5 @@
  *
  * You can modify this file to test extensions in a development environment.
  */
+console.info('HELLO', 'world');
+console.log('from the extensions/', 'extensions.js', 'file');


### PR DESCRIPTION
Per the hack day demo, here is code for review should we want to pick this back up at some point.

- Adds [angular-extension-registry](https://github.com/benjaminapetersen/angular-extension-registry) to web console. Can view the README.md to get the gory details of how it works.
- This PR includes my hack demo code for reference, but we would obviously eliminate this.

Things needed if we decide to complete this feature:
- [ ] Decide where we would want to inject extension points & what data is appropriate to expose as args
- [ ] Decide what issues [in the module](https://github.com/benjaminapetersen/angular-extension-registry) we feel are necessary to resolve before we use it. 

@jwforres @spadgett 
