### PR TITLE
deployapi: Refactor internal objects to match versioned

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -16076,7 +16076,7 @@
      },
      "from": {
       "$ref": "v1.ObjectReference",
-      "description": "a reference to an ImageRepository, ImageStream, or ImageStreamTag to watch for changes"
+      "description": "a reference to an ImageStreamTag to watch for changes"
      },
      "lastTriggeredImage": {
       "type": "string",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1324,8 +1324,11 @@ func deepCopy_api_DeploymentCause(in deployapi.DeploymentCause, out *deployapi.D
 }
 
 func deepCopy_api_DeploymentCauseImageTrigger(in deployapi.DeploymentCauseImageTrigger, out *deployapi.DeploymentCauseImageTrigger, c *conversion.Cloner) error {
-	out.RepositoryName = in.RepositoryName
-	out.Tag = in.Tag
+	if newVal, err := c.DeepCopy(in.From); err != nil {
+		return err
+	} else {
+		out.From = newVal.(pkgapi.ObjectReference)
+	}
 	return nil
 }
 
@@ -1340,27 +1343,11 @@ func deepCopy_api_DeploymentConfig(in deployapi.DeploymentConfig, out *deployapi
 	} else {
 		out.ObjectMeta = newVal.(pkgapi.ObjectMeta)
 	}
-	if in.Triggers != nil {
-		out.Triggers = make([]deployapi.DeploymentTriggerPolicy, len(in.Triggers))
-		for i := range in.Triggers {
-			if err := deepCopy_api_DeploymentTriggerPolicy(in.Triggers[i], &out.Triggers[i], c); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Triggers = nil
-	}
-	if err := deepCopy_api_DeploymentTemplate(in.Template, &out.Template, c); err != nil {
+	if err := deepCopy_api_DeploymentConfigSpec(in.Spec, &out.Spec, c); err != nil {
 		return err
 	}
-	out.LatestVersion = in.LatestVersion
-	if in.Details != nil {
-		out.Details = new(deployapi.DeploymentDetails)
-		if err := deepCopy_api_DeploymentDetails(*in.Details, out.Details, c); err != nil {
-			return err
-		}
-	} else {
-		out.Details = nil
+	if err := deepCopy_api_DeploymentConfigStatus(in.Status, &out.Status, c); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1411,6 +1398,54 @@ func deepCopy_api_DeploymentConfigRollbackSpec(in deployapi.DeploymentConfigRoll
 	out.IncludeTemplate = in.IncludeTemplate
 	out.IncludeReplicationMeta = in.IncludeReplicationMeta
 	out.IncludeStrategy = in.IncludeStrategy
+	return nil
+}
+
+func deepCopy_api_DeploymentConfigSpec(in deployapi.DeploymentConfigSpec, out *deployapi.DeploymentConfigSpec, c *conversion.Cloner) error {
+	if err := deepCopy_api_DeploymentStrategy(in.Strategy, &out.Strategy, c); err != nil {
+		return err
+	}
+	if in.Triggers != nil {
+		out.Triggers = make([]deployapi.DeploymentTriggerPolicy, len(in.Triggers))
+		for i := range in.Triggers {
+			if err := deepCopy_api_DeploymentTriggerPolicy(in.Triggers[i], &out.Triggers[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Triggers = nil
+	}
+	out.Replicas = in.Replicas
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
+	if in.Template != nil {
+		if newVal, err := c.DeepCopy(in.Template); err != nil {
+			return err
+		} else {
+			out.Template = newVal.(*pkgapi.PodTemplateSpec)
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func deepCopy_api_DeploymentConfigStatus(in deployapi.DeploymentConfigStatus, out *deployapi.DeploymentConfigStatus, c *conversion.Cloner) error {
+	out.LatestVersion = in.LatestVersion
+	if in.Details != nil {
+		out.Details = new(deployapi.DeploymentDetails)
+		if err := deepCopy_api_DeploymentDetails(*in.Details, out.Details, c); err != nil {
+			return err
+		}
+	} else {
+		out.Details = nil
+	}
 	return nil
 }
 
@@ -1539,18 +1574,6 @@ func deepCopy_api_DeploymentStrategy(in deployapi.DeploymentStrategy, out *deplo
 	return nil
 }
 
-func deepCopy_api_DeploymentTemplate(in deployapi.DeploymentTemplate, out *deployapi.DeploymentTemplate, c *conversion.Cloner) error {
-	if err := deepCopy_api_DeploymentStrategy(in.Strategy, &out.Strategy, c); err != nil {
-		return err
-	}
-	if newVal, err := c.DeepCopy(in.ControllerTemplate); err != nil {
-		return err
-	} else {
-		out.ControllerTemplate = newVal.(pkgapi.ReplicationControllerSpec)
-	}
-	return nil
-}
-
 func deepCopy_api_DeploymentTriggerImageChangeParams(in deployapi.DeploymentTriggerImageChangeParams, out *deployapi.DeploymentTriggerImageChangeParams, c *conversion.Cloner) error {
 	out.Automatic = in.Automatic
 	if in.ContainerNames != nil {
@@ -1561,13 +1584,11 @@ func deepCopy_api_DeploymentTriggerImageChangeParams(in deployapi.DeploymentTrig
 	} else {
 		out.ContainerNames = nil
 	}
-	out.RepositoryName = in.RepositoryName
 	if newVal, err := c.DeepCopy(in.From); err != nil {
 		return err
 	} else {
 		out.From = newVal.(pkgapi.ObjectReference)
 	}
-	out.Tag = in.Tag
 	out.LastTriggeredImage = in.LastTriggeredImage
 	return nil
 }
@@ -2908,11 +2929,12 @@ func init() {
 		deepCopy_api_DeploymentConfigList,
 		deepCopy_api_DeploymentConfigRollback,
 		deepCopy_api_DeploymentConfigRollbackSpec,
+		deepCopy_api_DeploymentConfigSpec,
+		deepCopy_api_DeploymentConfigStatus,
 		deepCopy_api_DeploymentDetails,
 		deepCopy_api_DeploymentLog,
 		deepCopy_api_DeploymentLogOptions,
 		deepCopy_api_DeploymentStrategy,
-		deepCopy_api_DeploymentTemplate,
 		deepCopy_api_DeploymentTriggerImageChangeParams,
 		deepCopy_api_DeploymentTriggerPolicy,
 		deepCopy_api_ExecNewPodHook,

--- a/pkg/api/graph/graphview/veneering_test.go
+++ b/pkg/api/graph/graphview/veneering_test.go
@@ -145,13 +145,13 @@ func TestBareBCGroup(t *testing.T) {
 	coveredNodes.Insert(coveredByBCs.List()...)
 
 	if e, a := 0, len(serviceGroups); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected %v services, got %v", e, a)
 	}
 	if e, a := 0, len(bareDCPipelines); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected %v deploymentConfigs, got %v", e, a)
 	}
 	if e, a := 1, len(bareBCPipelines); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected %v buildConfigs, got %v", e, a)
 	}
 }
 
@@ -259,38 +259,35 @@ func TestGraph(t *testing.T) {
 	})
 	deploygraph.EnsureDeploymentConfigNode(g, &deployapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{Namespace: "other", Name: "deploy1"},
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			{
-				ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
-					From:           kapi.ObjectReference{Namespace: "default", Name: "other"},
-					ContainerNames: []string{"1", "2"},
-					Tag:            "tag1",
+		Spec: deployapi.DeploymentConfigSpec{
+			Triggers: []deployapi.DeploymentTriggerPolicy{
+				{
+					ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
+						From:           kapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "default", Name: "other:tag1"},
+						ContainerNames: []string{"1", "2"},
+					},
 				},
 			},
-		},
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: map[string]string{
-							"deploymentconfig": "deploy1",
-							"env":              "prod",
-						},
+			Template: &kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{
+					Labels: map[string]string{
+						"deploymentconfig": "deploy1",
+						"env":              "prod",
 					},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:  "1",
-								Image: "mycustom/repo/image",
-							},
-							{
-								Name:  "2",
-								Image: "mycustom/repo/image2",
-							},
-							{
-								Name:  "3",
-								Image: "mycustom/repo/image3",
-							},
+				},
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{
+							Name:  "1",
+							Image: "mycustom/repo/image",
+						},
+						{
+							Name:  "2",
+							Image: "mycustom/repo/image2",
+						},
+						{
+							Name:  "3",
+							Image: "mycustom/repo/image3",
 						},
 					},
 				},
@@ -299,21 +296,19 @@ func TestGraph(t *testing.T) {
 	})
 	deploygraph.EnsureDeploymentConfigNode(g, &deployapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{Namespace: "default", Name: "deploy2"},
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: map[string]string{
-							"deploymentconfig": "deploy2",
-							"env":              "dev",
-						},
+		Spec: deployapi.DeploymentConfigSpec{
+			Template: &kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{
+					Labels: map[string]string{
+						"deploymentconfig": "deploy2",
+						"env":              "dev",
 					},
-					Spec: kapi.PodSpec{
-						Containers: []kapi.Container{
-							{
-								Name:  "1",
-								Image: "someother/image:v1",
-							},
+				},
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{
+							Name:  "1",
+							Image: "someother/image:v1",
 						},
 					},
 				},

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -2498,6 +2498,70 @@ func convert_v1_WebHookTrigger_To_api_WebHookTrigger(in *apiv1.WebHookTrigger, o
 	return autoconvert_v1_WebHookTrigger_To_api_WebHookTrigger(in, out, s)
 }
 
+func autoconvert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(in *deployapi.CustomDeploymentStrategyParams, out *deployapiv1.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.CustomDeploymentStrategyParams))(in)
+	}
+	out.Image = in.Image
+	if in.Environment != nil {
+		out.Environment = make([]pkgapiv1.EnvVar, len(in.Environment))
+		for i := range in.Environment {
+			if err := convert_api_EnvVar_To_v1_EnvVar(&in.Environment[i], &out.Environment[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Environment = nil
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(in *deployapi.CustomDeploymentStrategyParams, out *deployapiv1.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_api_DeploymentCause_To_v1_DeploymentCause(in *deployapi.DeploymentCause, out *deployapiv1.DeploymentCause, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentCause))(in)
+	}
+	out.Type = deployapiv1.DeploymentTriggerType(in.Type)
+	if in.ImageTrigger != nil {
+		out.ImageTrigger = new(deployapiv1.DeploymentCauseImageTrigger)
+		if err := convert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger(in.ImageTrigger, out.ImageTrigger, s); err != nil {
+			return err
+		}
+	} else {
+		out.ImageTrigger = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentCause_To_v1_DeploymentCause(in *deployapi.DeploymentCause, out *deployapiv1.DeploymentCause, s conversion.Scope) error {
+	return autoconvert_api_DeploymentCause_To_v1_DeploymentCause(in, out, s)
+}
+
+func autoconvert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger(in *deployapi.DeploymentCauseImageTrigger, out *deployapiv1.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentCauseImageTrigger))(in)
+	}
+	if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger(in *deployapi.DeploymentCauseImageTrigger, out *deployapiv1.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	return autoconvert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger(in, out, s)
+}
+
 func autoconvert_api_DeploymentConfig_To_v1_DeploymentConfig(in *deployapi.DeploymentConfig, out *deployapiv1.DeploymentConfig, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*deployapi.DeploymentConfig))(in)
@@ -2508,11 +2572,17 @@ func autoconvert_api_DeploymentConfig_To_v1_DeploymentConfig(in *deployapi.Deplo
 	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	// in.Triggers has no peer in out
-	// in.Template has no peer in out
-	// in.LatestVersion has no peer in out
-	// in.Details has no peer in out
+	if err := convert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
 	return nil
+}
+
+func convert_api_DeploymentConfig_To_v1_DeploymentConfig(in *deployapi.DeploymentConfig, out *deployapiv1.DeploymentConfig, s conversion.Scope) error {
+	return autoconvert_api_DeploymentConfig_To_v1_DeploymentConfig(in, out, s)
 }
 
 func autoconvert_api_DeploymentConfigList_To_v1_DeploymentConfigList(in *deployapi.DeploymentConfigList, out *deployapiv1.DeploymentConfigList, s conversion.Scope) error {
@@ -2528,7 +2598,7 @@ func autoconvert_api_DeploymentConfigList_To_v1_DeploymentConfigList(in *deploya
 	if in.Items != nil {
 		out.Items = make([]deployapiv1.DeploymentConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := convert_api_DeploymentConfig_To_v1_DeploymentConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2575,6 +2645,89 @@ func autoconvert_api_DeploymentConfigRollbackSpec_To_v1_DeploymentConfigRollback
 
 func convert_api_DeploymentConfigRollbackSpec_To_v1_DeploymentConfigRollbackSpec(in *deployapi.DeploymentConfigRollbackSpec, out *deployapiv1.DeploymentConfigRollbackSpec, s conversion.Scope) error {
 	return autoconvert_api_DeploymentConfigRollbackSpec_To_v1_DeploymentConfigRollbackSpec(in, out, s)
+}
+
+func autoconvert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in *deployapi.DeploymentConfigSpec, out *deployapiv1.DeploymentConfigSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentConfigSpec))(in)
+	}
+	if err := convert_api_DeploymentStrategy_To_v1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+		return err
+	}
+	if in.Triggers != nil {
+		out.Triggers = make([]deployapiv1.DeploymentTriggerPolicy, len(in.Triggers))
+		for i := range in.Triggers {
+			if err := convert_api_DeploymentTriggerPolicy_To_v1_DeploymentTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Triggers = nil
+	}
+	out.Replicas = in.Replicas
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
+	if in.Template != nil {
+		out.Template = new(pkgapiv1.PodTemplateSpec)
+		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in *deployapi.DeploymentConfigSpec, out *deployapiv1.DeploymentConfigSpec, s conversion.Scope) error {
+	return autoconvert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec(in, out, s)
+}
+
+func autoconvert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(in *deployapi.DeploymentConfigStatus, out *deployapiv1.DeploymentConfigStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentConfigStatus))(in)
+	}
+	out.LatestVersion = in.LatestVersion
+	if in.Details != nil {
+		out.Details = new(deployapiv1.DeploymentDetails)
+		if err := convert_api_DeploymentDetails_To_v1_DeploymentDetails(in.Details, out.Details, s); err != nil {
+			return err
+		}
+	} else {
+		out.Details = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(in *deployapi.DeploymentConfigStatus, out *deployapiv1.DeploymentConfigStatus, s conversion.Scope) error {
+	return autoconvert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus(in, out, s)
+}
+
+func autoconvert_api_DeploymentDetails_To_v1_DeploymentDetails(in *deployapi.DeploymentDetails, out *deployapiv1.DeploymentDetails, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentDetails))(in)
+	}
+	out.Message = in.Message
+	if in.Causes != nil {
+		out.Causes = make([]*deployapiv1.DeploymentCause, len(in.Causes))
+		for i := range in.Causes {
+			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Causes = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentDetails_To_v1_DeploymentDetails(in *deployapi.DeploymentDetails, out *deployapiv1.DeploymentDetails, s conversion.Scope) error {
+	return autoconvert_api_DeploymentDetails_To_v1_DeploymentDetails(in, out, s)
 }
 
 func autoconvert_api_DeploymentLog_To_v1_DeploymentLog(in *deployapi.DeploymentLog, out *deployapiv1.DeploymentLog, s conversion.Scope) error {
@@ -2641,6 +2794,301 @@ func convert_api_DeploymentLogOptions_To_v1_DeploymentLogOptions(in *deployapi.D
 	return autoconvert_api_DeploymentLogOptions_To_v1_DeploymentLogOptions(in, out, s)
 }
 
+func autoconvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *deployapi.DeploymentStrategy, out *deployapiv1.DeploymentStrategy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentStrategy))(in)
+	}
+	out.Type = deployapiv1.DeploymentStrategyType(in.Type)
+	if in.CustomParams != nil {
+		out.CustomParams = new(deployapiv1.CustomDeploymentStrategyParams)
+		if err := convert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams(in.CustomParams, out.CustomParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
+	}
+	if in.RecreateParams != nil {
+		out.RecreateParams = new(deployapiv1.RecreateDeploymentStrategyParams)
+		if err := convert_api_RecreateDeploymentStrategyParams_To_v1_RecreateDeploymentStrategyParams(in.RecreateParams, out.RecreateParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.RecreateParams = nil
+	}
+	if in.RollingParams != nil {
+		if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RollingParams = nil
+	}
+	if err := convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *deployapi.DeploymentStrategy, out *deployapiv1.DeploymentStrategy, s conversion.Scope) error {
+	return autoconvert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in, out, s)
+}
+
+func autoconvert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams(in *deployapi.DeploymentTriggerImageChangeParams, out *deployapiv1.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentTriggerImageChangeParams))(in)
+	}
+	out.Automatic = in.Automatic
+	if in.ContainerNames != nil {
+		out.ContainerNames = make([]string, len(in.ContainerNames))
+		for i := range in.ContainerNames {
+			out.ContainerNames[i] = in.ContainerNames[i]
+		}
+	} else {
+		out.ContainerNames = nil
+	}
+	if err := convert_api_ObjectReference_To_v1_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	out.LastTriggeredImage = in.LastTriggeredImage
+	return nil
+}
+
+func autoconvert_api_DeploymentTriggerPolicy_To_v1_DeploymentTriggerPolicy(in *deployapi.DeploymentTriggerPolicy, out *deployapiv1.DeploymentTriggerPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentTriggerPolicy))(in)
+	}
+	out.Type = deployapiv1.DeploymentTriggerType(in.Type)
+	if in.ImageChangeParams != nil {
+		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImageChangeParams = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentTriggerPolicy_To_v1_DeploymentTriggerPolicy(in *deployapi.DeploymentTriggerPolicy, out *deployapiv1.DeploymentTriggerPolicy, s conversion.Scope) error {
+	return autoconvert_api_DeploymentTriggerPolicy_To_v1_DeploymentTriggerPolicy(in, out, s)
+}
+
+func autoconvert_api_ExecNewPodHook_To_v1_ExecNewPodHook(in *deployapi.ExecNewPodHook, out *deployapiv1.ExecNewPodHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.ExecNewPodHook))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapiv1.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_api_EnvVar_To_v1_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
+	return nil
+}
+
+func convert_api_ExecNewPodHook_To_v1_ExecNewPodHook(in *deployapi.ExecNewPodHook, out *deployapiv1.ExecNewPodHook, s conversion.Scope) error {
+	return autoconvert_api_ExecNewPodHook_To_v1_ExecNewPodHook(in, out, s)
+}
+
+func autoconvert_api_LifecycleHook_To_v1_LifecycleHook(in *deployapi.LifecycleHook, out *deployapiv1.LifecycleHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.LifecycleHook))(in)
+	}
+	out.FailurePolicy = deployapiv1.LifecycleHookFailurePolicy(in.FailurePolicy)
+	if in.ExecNewPod != nil {
+		out.ExecNewPod = new(deployapiv1.ExecNewPodHook)
+		if err := convert_api_ExecNewPodHook_To_v1_ExecNewPodHook(in.ExecNewPod, out.ExecNewPod, s); err != nil {
+			return err
+		}
+	} else {
+		out.ExecNewPod = nil
+	}
+	return nil
+}
+
+func convert_api_LifecycleHook_To_v1_LifecycleHook(in *deployapi.LifecycleHook, out *deployapiv1.LifecycleHook, s conversion.Scope) error {
+	return autoconvert_api_LifecycleHook_To_v1_LifecycleHook(in, out, s)
+}
+
+func autoconvert_api_RecreateDeploymentStrategyParams_To_v1_RecreateDeploymentStrategyParams(in *deployapi.RecreateDeploymentStrategyParams, out *deployapiv1.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.RecreateDeploymentStrategyParams))(in)
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapiv1.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapiv1.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
+}
+
+func convert_api_RecreateDeploymentStrategyParams_To_v1_RecreateDeploymentStrategyParams(in *deployapi.RecreateDeploymentStrategyParams, out *deployapiv1.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_api_RecreateDeploymentStrategyParams_To_v1_RecreateDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams(in *deployapi.RollingDeploymentStrategyParams, out *deployapiv1.RollingDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.RollingDeploymentStrategyParams))(in)
+	}
+	if in.UpdatePeriodSeconds != nil {
+		out.UpdatePeriodSeconds = new(int64)
+		*out.UpdatePeriodSeconds = *in.UpdatePeriodSeconds
+	} else {
+		out.UpdatePeriodSeconds = nil
+	}
+	if in.IntervalSeconds != nil {
+		out.IntervalSeconds = new(int64)
+		*out.IntervalSeconds = *in.IntervalSeconds
+	} else {
+		out.IntervalSeconds = nil
+	}
+	if in.TimeoutSeconds != nil {
+		out.TimeoutSeconds = new(int64)
+		*out.TimeoutSeconds = *in.TimeoutSeconds
+	} else {
+		out.TimeoutSeconds = nil
+	}
+	if err := s.Convert(&in.MaxUnavailable, &out.MaxUnavailable, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.MaxSurge, &out.MaxSurge, 0); err != nil {
+		return err
+	}
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapiv1.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapiv1.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
+}
+
+func autoconvert_v1_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in *deployapiv1.CustomDeploymentStrategyParams, out *deployapi.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.CustomDeploymentStrategyParams))(in)
+	}
+	out.Image = in.Image
+	if in.Environment != nil {
+		out.Environment = make([]pkgapi.EnvVar, len(in.Environment))
+		for i := range in.Environment {
+			if err := convert_v1_EnvVar_To_api_EnvVar(&in.Environment[i], &out.Environment[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Environment = nil
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_v1_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in *deployapiv1.CustomDeploymentStrategyParams, out *deployapi.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_v1_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_v1_DeploymentCause_To_api_DeploymentCause(in *deployapiv1.DeploymentCause, out *deployapi.DeploymentCause, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentCause))(in)
+	}
+	out.Type = deployapi.DeploymentTriggerType(in.Type)
+	if in.ImageTrigger != nil {
+		out.ImageTrigger = new(deployapi.DeploymentCauseImageTrigger)
+		if err := convert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in.ImageTrigger, out.ImageTrigger, s); err != nil {
+			return err
+		}
+	} else {
+		out.ImageTrigger = nil
+	}
+	return nil
+}
+
+func convert_v1_DeploymentCause_To_api_DeploymentCause(in *deployapiv1.DeploymentCause, out *deployapi.DeploymentCause, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentCause_To_api_DeploymentCause(in, out, s)
+}
+
+func autoconvert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in *deployapiv1.DeploymentCauseImageTrigger, out *deployapi.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentCauseImageTrigger))(in)
+	}
+	if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in *deployapiv1.DeploymentCauseImageTrigger, out *deployapi.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in, out, s)
+}
+
 func autoconvert_v1_DeploymentConfig_To_api_DeploymentConfig(in *deployapiv1.DeploymentConfig, out *deployapi.DeploymentConfig, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*deployapiv1.DeploymentConfig))(in)
@@ -2651,9 +3099,17 @@ func autoconvert_v1_DeploymentConfig_To_api_DeploymentConfig(in *deployapiv1.Dep
 	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	// in.Spec has no peer in out
-	// in.Status has no peer in out
+	if err := convert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
 	return nil
+}
+
+func convert_v1_DeploymentConfig_To_api_DeploymentConfig(in *deployapiv1.DeploymentConfig, out *deployapi.DeploymentConfig, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentConfig_To_api_DeploymentConfig(in, out, s)
 }
 
 func autoconvert_v1_DeploymentConfigList_To_api_DeploymentConfigList(in *deployapiv1.DeploymentConfigList, out *deployapi.DeploymentConfigList, s conversion.Scope) error {
@@ -2669,7 +3125,7 @@ func autoconvert_v1_DeploymentConfigList_To_api_DeploymentConfigList(in *deploya
 	if in.Items != nil {
 		out.Items = make([]deployapi.DeploymentConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := convert_v1_DeploymentConfig_To_api_DeploymentConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2716,6 +3172,89 @@ func autoconvert_v1_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollback
 
 func convert_v1_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec(in *deployapiv1.DeploymentConfigRollbackSpec, out *deployapi.DeploymentConfigRollbackSpec, s conversion.Scope) error {
 	return autoconvert_v1_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec(in, out, s)
+}
+
+func autoconvert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *deployapiv1.DeploymentConfigSpec, out *deployapi.DeploymentConfigSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentConfigSpec))(in)
+	}
+	if err := convert_v1_DeploymentStrategy_To_api_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+		return err
+	}
+	if in.Triggers != nil {
+		out.Triggers = make([]deployapi.DeploymentTriggerPolicy, len(in.Triggers))
+		for i := range in.Triggers {
+			if err := convert_v1_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Triggers = nil
+	}
+	out.Replicas = in.Replicas
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
+	if in.Template != nil {
+		out.Template = new(pkgapi.PodTemplateSpec)
+		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *deployapiv1.DeploymentConfigSpec, out *deployapi.DeploymentConfigSpec, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in, out, s)
+}
+
+func autoconvert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *deployapiv1.DeploymentConfigStatus, out *deployapi.DeploymentConfigStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentConfigStatus))(in)
+	}
+	out.LatestVersion = in.LatestVersion
+	if in.Details != nil {
+		out.Details = new(deployapi.DeploymentDetails)
+		if err := convert_v1_DeploymentDetails_To_api_DeploymentDetails(in.Details, out.Details, s); err != nil {
+			return err
+		}
+	} else {
+		out.Details = nil
+	}
+	return nil
+}
+
+func convert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *deployapiv1.DeploymentConfigStatus, out *deployapi.DeploymentConfigStatus, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in, out, s)
+}
+
+func autoconvert_v1_DeploymentDetails_To_api_DeploymentDetails(in *deployapiv1.DeploymentDetails, out *deployapi.DeploymentDetails, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentDetails))(in)
+	}
+	out.Message = in.Message
+	if in.Causes != nil {
+		out.Causes = make([]*deployapi.DeploymentCause, len(in.Causes))
+		for i := range in.Causes {
+			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Causes = nil
+	}
+	return nil
+}
+
+func convert_v1_DeploymentDetails_To_api_DeploymentDetails(in *deployapiv1.DeploymentDetails, out *deployapi.DeploymentDetails, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentDetails_To_api_DeploymentDetails(in, out, s)
 }
 
 func autoconvert_v1_DeploymentLog_To_api_DeploymentLog(in *deployapiv1.DeploymentLog, out *deployapi.DeploymentLog, s conversion.Scope) error {
@@ -2780,6 +3319,233 @@ func autoconvert_v1_DeploymentLogOptions_To_api_DeploymentLogOptions(in *deploya
 
 func convert_v1_DeploymentLogOptions_To_api_DeploymentLogOptions(in *deployapiv1.DeploymentLogOptions, out *deployapi.DeploymentLogOptions, s conversion.Scope) error {
 	return autoconvert_v1_DeploymentLogOptions_To_api_DeploymentLogOptions(in, out, s)
+}
+
+func autoconvert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in *deployapiv1.DeploymentStrategy, out *deployapi.DeploymentStrategy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentStrategy))(in)
+	}
+	out.Type = deployapi.DeploymentStrategyType(in.Type)
+	if in.CustomParams != nil {
+		out.CustomParams = new(deployapi.CustomDeploymentStrategyParams)
+		if err := convert_v1_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in.CustomParams, out.CustomParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
+	}
+	if in.RecreateParams != nil {
+		out.RecreateParams = new(deployapi.RecreateDeploymentStrategyParams)
+		if err := convert_v1_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in.RecreateParams, out.RecreateParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.RecreateParams = nil
+	}
+	if in.RollingParams != nil {
+		if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RollingParams = nil
+	}
+	if err := convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func convert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in *deployapiv1.DeploymentStrategy, out *deployapi.DeploymentStrategy, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in, out, s)
+}
+
+func autoconvert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *deployapiv1.DeploymentTriggerImageChangeParams, out *deployapi.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentTriggerImageChangeParams))(in)
+	}
+	out.Automatic = in.Automatic
+	if in.ContainerNames != nil {
+		out.ContainerNames = make([]string, len(in.ContainerNames))
+		for i := range in.ContainerNames {
+			out.ContainerNames[i] = in.ContainerNames[i]
+		}
+	} else {
+		out.ContainerNames = nil
+	}
+	if err := convert_v1_ObjectReference_To_api_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	out.LastTriggeredImage = in.LastTriggeredImage
+	return nil
+}
+
+func autoconvert_v1_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in *deployapiv1.DeploymentTriggerPolicy, out *deployapi.DeploymentTriggerPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.DeploymentTriggerPolicy))(in)
+	}
+	out.Type = deployapi.DeploymentTriggerType(in.Type)
+	if in.ImageChangeParams != nil {
+		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImageChangeParams = nil
+	}
+	return nil
+}
+
+func convert_v1_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in *deployapiv1.DeploymentTriggerPolicy, out *deployapi.DeploymentTriggerPolicy, s conversion.Scope) error {
+	return autoconvert_v1_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in, out, s)
+}
+
+func autoconvert_v1_ExecNewPodHook_To_api_ExecNewPodHook(in *deployapiv1.ExecNewPodHook, out *deployapi.ExecNewPodHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.ExecNewPodHook))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapi.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_v1_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
+	return nil
+}
+
+func convert_v1_ExecNewPodHook_To_api_ExecNewPodHook(in *deployapiv1.ExecNewPodHook, out *deployapi.ExecNewPodHook, s conversion.Scope) error {
+	return autoconvert_v1_ExecNewPodHook_To_api_ExecNewPodHook(in, out, s)
+}
+
+func autoconvert_v1_LifecycleHook_To_api_LifecycleHook(in *deployapiv1.LifecycleHook, out *deployapi.LifecycleHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.LifecycleHook))(in)
+	}
+	out.FailurePolicy = deployapi.LifecycleHookFailurePolicy(in.FailurePolicy)
+	if in.ExecNewPod != nil {
+		out.ExecNewPod = new(deployapi.ExecNewPodHook)
+		if err := convert_v1_ExecNewPodHook_To_api_ExecNewPodHook(in.ExecNewPod, out.ExecNewPod, s); err != nil {
+			return err
+		}
+	} else {
+		out.ExecNewPod = nil
+	}
+	return nil
+}
+
+func convert_v1_LifecycleHook_To_api_LifecycleHook(in *deployapiv1.LifecycleHook, out *deployapi.LifecycleHook, s conversion.Scope) error {
+	return autoconvert_v1_LifecycleHook_To_api_LifecycleHook(in, out, s)
+}
+
+func autoconvert_v1_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in *deployapiv1.RecreateDeploymentStrategyParams, out *deployapi.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.RecreateDeploymentStrategyParams))(in)
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapi.LifecycleHook)
+		if err := convert_v1_LifecycleHook_To_api_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapi.LifecycleHook)
+		if err := convert_v1_LifecycleHook_To_api_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
+}
+
+func convert_v1_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in *deployapiv1.RecreateDeploymentStrategyParams, out *deployapi.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_v1_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in *deployapiv1.RollingDeploymentStrategyParams, out *deployapi.RollingDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1.RollingDeploymentStrategyParams))(in)
+	}
+	if in.UpdatePeriodSeconds != nil {
+		out.UpdatePeriodSeconds = new(int64)
+		*out.UpdatePeriodSeconds = *in.UpdatePeriodSeconds
+	} else {
+		out.UpdatePeriodSeconds = nil
+	}
+	if in.IntervalSeconds != nil {
+		out.IntervalSeconds = new(int64)
+		*out.IntervalSeconds = *in.IntervalSeconds
+	} else {
+		out.IntervalSeconds = nil
+	}
+	if in.TimeoutSeconds != nil {
+		out.TimeoutSeconds = new(int64)
+		*out.TimeoutSeconds = *in.TimeoutSeconds
+	} else {
+		out.TimeoutSeconds = nil
+	}
+	// in.MaxUnavailable has no peer in out
+	// in.MaxSurge has no peer in out
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapi.LifecycleHook)
+		if err := convert_v1_LifecycleHook_To_api_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapi.LifecycleHook)
+		if err := convert_v1_LifecycleHook_To_api_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
 }
 
 func autoconvert_api_Image_To_v1_Image(in *imageapi.Image, out *imageapiv1.Image, s conversion.Scope) error {
@@ -4904,6 +5670,256 @@ func convert_v1_UserList_To_api_UserList(in *userapiv1.UserList, out *userapi.Us
 	return autoconvert_v1_UserList_To_api_UserList(in, out, s)
 }
 
+func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *pkgapi.AWSElasticBlockStoreVolumeSource, out *pkgapiv1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.AWSElasticBlockStoreVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in *pkgapi.AWSElasticBlockStoreVolumeSource, out *pkgapiv1.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in, out, s)
+}
+
+func autoconvert_api_Capabilities_To_v1_Capabilities(in *pkgapi.Capabilities, out *pkgapiv1.Capabilities, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Capabilities))(in)
+	}
+	if in.Add != nil {
+		out.Add = make([]pkgapiv1.Capability, len(in.Add))
+		for i := range in.Add {
+			out.Add[i] = pkgapiv1.Capability(in.Add[i])
+		}
+	} else {
+		out.Add = nil
+	}
+	if in.Drop != nil {
+		out.Drop = make([]pkgapiv1.Capability, len(in.Drop))
+		for i := range in.Drop {
+			out.Drop[i] = pkgapiv1.Capability(in.Drop[i])
+		}
+	} else {
+		out.Drop = nil
+	}
+	return nil
+}
+
+func convert_api_Capabilities_To_v1_Capabilities(in *pkgapi.Capabilities, out *pkgapiv1.Capabilities, s conversion.Scope) error {
+	return autoconvert_api_Capabilities_To_v1_Capabilities(in, out, s)
+}
+
+func autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *pkgapi.CephFSVolumeSource, out *pkgapiv1.CephFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.CephFSVolumeSource))(in)
+	}
+	if in.Monitors != nil {
+		out.Monitors = make([]string, len(in.Monitors))
+		for i := range in.Monitors {
+			out.Monitors[i] = in.Monitors[i]
+		}
+	} else {
+		out.Monitors = nil
+	}
+	out.User = in.User
+	out.SecretFile = in.SecretFile
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapiv1.LocalObjectReference)
+		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *pkgapi.CephFSVolumeSource, out *pkgapiv1.CephFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in, out, s)
+}
+
+func autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *pkgapi.CinderVolumeSource, out *pkgapiv1.CinderVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.CinderVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in *pkgapi.CinderVolumeSource, out *pkgapiv1.CinderVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in, out, s)
+}
+
+func autoconvert_api_Container_To_v1_Container(in *pkgapi.Container, out *pkgapiv1.Container, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Container))(in)
+	}
+	out.Name = in.Name
+	out.Image = in.Image
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.WorkingDir = in.WorkingDir
+	if in.Ports != nil {
+		out.Ports = make([]pkgapiv1.ContainerPort, len(in.Ports))
+		for i := range in.Ports {
+			if err := convert_api_ContainerPort_To_v1_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapiv1.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_api_EnvVar_To_v1_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	if err := convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.VolumeMounts != nil {
+		out.VolumeMounts = make([]pkgapiv1.VolumeMount, len(in.VolumeMounts))
+		for i := range in.VolumeMounts {
+			if err := convert_api_VolumeMount_To_v1_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.VolumeMounts = nil
+	}
+	if in.LivenessProbe != nil {
+		out.LivenessProbe = new(pkgapiv1.Probe)
+		if err := convert_api_Probe_To_v1_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.LivenessProbe = nil
+	}
+	if in.ReadinessProbe != nil {
+		out.ReadinessProbe = new(pkgapiv1.Probe)
+		if err := convert_api_Probe_To_v1_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.ReadinessProbe = nil
+	}
+	if in.Lifecycle != nil {
+		out.Lifecycle = new(pkgapiv1.Lifecycle)
+		if err := convert_api_Lifecycle_To_v1_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+			return err
+		}
+	} else {
+		out.Lifecycle = nil
+	}
+	out.TerminationMessagePath = in.TerminationMessagePath
+	out.ImagePullPolicy = pkgapiv1.PullPolicy(in.ImagePullPolicy)
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(pkgapiv1.SecurityContext)
+		if err := convert_api_SecurityContext_To_v1_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	out.Stdin = in.Stdin
+	out.StdinOnce = in.StdinOnce
+	out.TTY = in.TTY
+	return nil
+}
+
+func convert_api_Container_To_v1_Container(in *pkgapi.Container, out *pkgapiv1.Container, s conversion.Scope) error {
+	return autoconvert_api_Container_To_v1_Container(in, out, s)
+}
+
+func autoconvert_api_ContainerPort_To_v1_ContainerPort(in *pkgapi.ContainerPort, out *pkgapiv1.ContainerPort, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.ContainerPort))(in)
+	}
+	out.Name = in.Name
+	out.HostPort = in.HostPort
+	out.ContainerPort = in.ContainerPort
+	out.Protocol = pkgapiv1.Protocol(in.Protocol)
+	out.HostIP = in.HostIP
+	return nil
+}
+
+func convert_api_ContainerPort_To_v1_ContainerPort(in *pkgapi.ContainerPort, out *pkgapiv1.ContainerPort, s conversion.Scope) error {
+	return autoconvert_api_ContainerPort_To_v1_ContainerPort(in, out, s)
+}
+
+func autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *pkgapi.DownwardAPIVolumeFile, out *pkgapiv1.DownwardAPIVolumeFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.DownwardAPIVolumeFile))(in)
+	}
+	out.Path = in.Path
+	if err := convert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in *pkgapi.DownwardAPIVolumeFile, out *pkgapiv1.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(in, out, s)
+}
+
+func autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *pkgapi.DownwardAPIVolumeSource, out *pkgapiv1.DownwardAPIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.DownwardAPIVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]pkgapiv1.DownwardAPIVolumeFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in *pkgapi.DownwardAPIVolumeSource, out *pkgapiv1.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in, out, s)
+}
+
+func autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *pkgapi.EmptyDirVolumeSource, out *pkgapiv1.EmptyDirVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.EmptyDirVolumeSource))(in)
+	}
+	out.Medium = pkgapiv1.StorageMedium(in.Medium)
+	return nil
+}
+
+func convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in *pkgapi.EmptyDirVolumeSource, out *pkgapiv1.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in, out, s)
+}
+
 func autoconvert_api_EnvVar_To_v1_EnvVar(in *pkgapi.EnvVar, out *pkgapiv1.EnvVar, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapi.EnvVar))(in)
@@ -4944,6 +5960,213 @@ func convert_api_EnvVarSource_To_v1_EnvVarSource(in *pkgapi.EnvVarSource, out *p
 	return autoconvert_api_EnvVarSource_To_v1_EnvVarSource(in, out, s)
 }
 
+func autoconvert_api_ExecAction_To_v1_ExecAction(in *pkgapi.ExecAction, out *pkgapiv1.ExecAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.ExecAction))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_api_ExecAction_To_v1_ExecAction(in *pkgapi.ExecAction, out *pkgapiv1.ExecAction, s conversion.Scope) error {
+	return autoconvert_api_ExecAction_To_v1_ExecAction(in, out, s)
+}
+
+func autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *pkgapi.FCVolumeSource, out *pkgapiv1.FCVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.FCVolumeSource))(in)
+	}
+	if in.TargetWWNs != nil {
+		out.TargetWWNs = make([]string, len(in.TargetWWNs))
+		for i := range in.TargetWWNs {
+			out.TargetWWNs[i] = in.TargetWWNs[i]
+		}
+	} else {
+		out.TargetWWNs = nil
+	}
+	if in.Lun != nil {
+		out.Lun = new(int)
+		*out.Lun = *in.Lun
+	} else {
+		out.Lun = nil
+	}
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_FCVolumeSource_To_v1_FCVolumeSource(in *pkgapi.FCVolumeSource, out *pkgapiv1.FCVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource(in, out, s)
+}
+
+func autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *pkgapi.FlockerVolumeSource, out *pkgapiv1.FlockerVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.FlockerVolumeSource))(in)
+	}
+	out.DatasetName = in.DatasetName
+	return nil
+}
+
+func convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in *pkgapi.FlockerVolumeSource, out *pkgapiv1.FlockerVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in, out, s)
+}
+
+func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *pkgapi.GCEPersistentDiskVolumeSource, out *pkgapiv1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.GCEPersistentDiskVolumeSource))(in)
+	}
+	out.PDName = in.PDName
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in *pkgapi.GCEPersistentDiskVolumeSource, out *pkgapiv1.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in, out, s)
+}
+
+func autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *pkgapi.GitRepoVolumeSource, out *pkgapiv1.GitRepoVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.GitRepoVolumeSource))(in)
+	}
+	out.Repository = in.Repository
+	out.Revision = in.Revision
+	return nil
+}
+
+func convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in *pkgapi.GitRepoVolumeSource, out *pkgapiv1.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in, out, s)
+}
+
+func autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *pkgapi.GlusterfsVolumeSource, out *pkgapiv1.GlusterfsVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.GlusterfsVolumeSource))(in)
+	}
+	out.EndpointsName = in.EndpointsName
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in *pkgapi.GlusterfsVolumeSource, out *pkgapiv1.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in, out, s)
+}
+
+func autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in *pkgapi.HTTPGetAction, out *pkgapiv1.HTTPGetAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.HTTPGetAction))(in)
+	}
+	out.Path = in.Path
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	out.Host = in.Host
+	out.Scheme = pkgapiv1.URIScheme(in.Scheme)
+	return nil
+}
+
+func convert_api_HTTPGetAction_To_v1_HTTPGetAction(in *pkgapi.HTTPGetAction, out *pkgapiv1.HTTPGetAction, s conversion.Scope) error {
+	return autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction(in, out, s)
+}
+
+func autoconvert_api_Handler_To_v1_Handler(in *pkgapi.Handler, out *pkgapiv1.Handler, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Handler))(in)
+	}
+	if in.Exec != nil {
+		out.Exec = new(pkgapiv1.ExecAction)
+		if err := convert_api_ExecAction_To_v1_ExecAction(in.Exec, out.Exec, s); err != nil {
+			return err
+		}
+	} else {
+		out.Exec = nil
+	}
+	if in.HTTPGet != nil {
+		out.HTTPGet = new(pkgapiv1.HTTPGetAction)
+		if err := convert_api_HTTPGetAction_To_v1_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+			return err
+		}
+	} else {
+		out.HTTPGet = nil
+	}
+	if in.TCPSocket != nil {
+		out.TCPSocket = new(pkgapiv1.TCPSocketAction)
+		if err := convert_api_TCPSocketAction_To_v1_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+			return err
+		}
+	} else {
+		out.TCPSocket = nil
+	}
+	return nil
+}
+
+func convert_api_Handler_To_v1_Handler(in *pkgapi.Handler, out *pkgapiv1.Handler, s conversion.Scope) error {
+	return autoconvert_api_Handler_To_v1_Handler(in, out, s)
+}
+
+func autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *pkgapi.HostPathVolumeSource, out *pkgapiv1.HostPathVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.HostPathVolumeSource))(in)
+	}
+	out.Path = in.Path
+	return nil
+}
+
+func convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in *pkgapi.HostPathVolumeSource, out *pkgapiv1.HostPathVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in, out, s)
+}
+
+func autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *pkgapi.ISCSIVolumeSource, out *pkgapiv1.ISCSIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.ISCSIVolumeSource))(in)
+	}
+	out.TargetPortal = in.TargetPortal
+	out.IQN = in.IQN
+	out.Lun = in.Lun
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in *pkgapi.ISCSIVolumeSource, out *pkgapiv1.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in, out, s)
+}
+
+func autoconvert_api_Lifecycle_To_v1_Lifecycle(in *pkgapi.Lifecycle, out *pkgapiv1.Lifecycle, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Lifecycle))(in)
+	}
+	if in.PostStart != nil {
+		out.PostStart = new(pkgapiv1.Handler)
+		if err := convert_api_Handler_To_v1_Handler(in.PostStart, out.PostStart, s); err != nil {
+			return err
+		}
+	} else {
+		out.PostStart = nil
+	}
+	if in.PreStop != nil {
+		out.PreStop = new(pkgapiv1.Handler)
+		if err := convert_api_Handler_To_v1_Handler(in.PreStop, out.PreStop, s); err != nil {
+			return err
+		}
+	} else {
+		out.PreStop = nil
+	}
+	return nil
+}
+
+func convert_api_Lifecycle_To_v1_Lifecycle(in *pkgapi.Lifecycle, out *pkgapiv1.Lifecycle, s conversion.Scope) error {
+	return autoconvert_api_Lifecycle_To_v1_Lifecycle(in, out, s)
+}
+
 func autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *pkgapi.LocalObjectReference, out *pkgapiv1.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapi.LocalObjectReference))(in)
@@ -4954,6 +6177,20 @@ func autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in *pkgapi.
 
 func convert_api_LocalObjectReference_To_v1_LocalObjectReference(in *pkgapi.LocalObjectReference, out *pkgapiv1.LocalObjectReference, s conversion.Scope) error {
 	return autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference(in, out, s)
+}
+
+func autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *pkgapi.NFSVolumeSource, out *pkgapiv1.NFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.NFSVolumeSource))(in)
+	}
+	out.Server = in.Server
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in *pkgapi.NFSVolumeSource, out *pkgapiv1.NFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in, out, s)
 }
 
 func autoconvert_api_ObjectFieldSelector_To_v1_ObjectFieldSelector(in *pkgapi.ObjectFieldSelector, out *pkgapiv1.ObjectFieldSelector, s conversion.Scope) error {
@@ -5037,6 +6274,153 @@ func convert_api_ObjectReference_To_v1_ObjectReference(in *pkgapi.ObjectReferenc
 	return autoconvert_api_ObjectReference_To_v1_ObjectReference(in, out, s)
 }
 
+func autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *pkgapi.PersistentVolumeClaimVolumeSource, out *pkgapiv1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.PersistentVolumeClaimVolumeSource))(in)
+	}
+	out.ClaimName = in.ClaimName
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in *pkgapi.PersistentVolumeClaimVolumeSource, out *pkgapiv1.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in, out, s)
+}
+
+func autoconvert_api_PodSpec_To_v1_PodSpec(in *pkgapi.PodSpec, out *pkgapiv1.PodSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.PodSpec))(in)
+	}
+	if in.Volumes != nil {
+		out.Volumes = make([]pkgapiv1.Volume, len(in.Volumes))
+		for i := range in.Volumes {
+			if err := convert_api_Volume_To_v1_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Volumes = nil
+	}
+	if in.Containers != nil {
+		out.Containers = make([]pkgapiv1.Container, len(in.Containers))
+		for i := range in.Containers {
+			if err := convert_api_Container_To_v1_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	out.RestartPolicy = pkgapiv1.RestartPolicy(in.RestartPolicy)
+	if in.TerminationGracePeriodSeconds != nil {
+		out.TerminationGracePeriodSeconds = new(int64)
+		*out.TerminationGracePeriodSeconds = *in.TerminationGracePeriodSeconds
+	} else {
+		out.TerminationGracePeriodSeconds = nil
+	}
+	if in.ActiveDeadlineSeconds != nil {
+		out.ActiveDeadlineSeconds = new(int64)
+		*out.ActiveDeadlineSeconds = *in.ActiveDeadlineSeconds
+	} else {
+		out.ActiveDeadlineSeconds = nil
+	}
+	out.DNSPolicy = pkgapiv1.DNSPolicy(in.DNSPolicy)
+	if in.NodeSelector != nil {
+		out.NodeSelector = make(map[string]string)
+		for key, val := range in.NodeSelector {
+			out.NodeSelector[key] = val
+		}
+	} else {
+		out.NodeSelector = nil
+	}
+	out.ServiceAccountName = in.ServiceAccountName
+	out.NodeName = in.NodeName
+	if in.SecurityContext != nil {
+		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	if in.ImagePullSecrets != nil {
+		out.ImagePullSecrets = make([]pkgapiv1.LocalObjectReference, len(in.ImagePullSecrets))
+		for i := range in.ImagePullSecrets {
+			if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ImagePullSecrets = nil
+	}
+	return nil
+}
+
+func autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *pkgapi.PodTemplateSpec, out *pkgapiv1.PodTemplateSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.PodTemplateSpec))(in)
+	}
+	if err := convert_api_ObjectMeta_To_v1_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in *pkgapi.PodTemplateSpec, out *pkgapiv1.PodTemplateSpec, s conversion.Scope) error {
+	return autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in, out, s)
+}
+
+func autoconvert_api_Probe_To_v1_Probe(in *pkgapi.Probe, out *pkgapiv1.Probe, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Probe))(in)
+	}
+	if err := convert_api_Handler_To_v1_Handler(&in.Handler, &out.Handler, s); err != nil {
+		return err
+	}
+	out.InitialDelaySeconds = in.InitialDelaySeconds
+	out.TimeoutSeconds = in.TimeoutSeconds
+	return nil
+}
+
+func convert_api_Probe_To_v1_Probe(in *pkgapi.Probe, out *pkgapiv1.Probe, s conversion.Scope) error {
+	return autoconvert_api_Probe_To_v1_Probe(in, out, s)
+}
+
+func autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *pkgapi.RBDVolumeSource, out *pkgapiv1.RBDVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.RBDVolumeSource))(in)
+	}
+	if in.CephMonitors != nil {
+		out.CephMonitors = make([]string, len(in.CephMonitors))
+		for i := range in.CephMonitors {
+			out.CephMonitors[i] = in.CephMonitors[i]
+		}
+	} else {
+		out.CephMonitors = nil
+	}
+	out.RBDImage = in.RBDImage
+	out.FSType = in.FSType
+	out.RBDPool = in.RBDPool
+	out.RadosUser = in.RadosUser
+	out.Keyring = in.Keyring
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapiv1.LocalObjectReference)
+		if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *pkgapi.RBDVolumeSource, out *pkgapiv1.RBDVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in, out, s)
+}
+
 func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *pkgapi.ResourceRequirements, out *pkgapiv1.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapi.ResourceRequirements))(in)
@@ -5070,6 +6454,506 @@ func autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in *pkgapi.
 
 func convert_api_ResourceRequirements_To_v1_ResourceRequirements(in *pkgapi.ResourceRequirements, out *pkgapiv1.ResourceRequirements, s conversion.Scope) error {
 	return autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements(in, out, s)
+}
+
+func autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in *pkgapi.SELinuxOptions, out *pkgapiv1.SELinuxOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.SELinuxOptions))(in)
+	}
+	out.User = in.User
+	out.Role = in.Role
+	out.Type = in.Type
+	out.Level = in.Level
+	return nil
+}
+
+func convert_api_SELinuxOptions_To_v1_SELinuxOptions(in *pkgapi.SELinuxOptions, out *pkgapiv1.SELinuxOptions, s conversion.Scope) error {
+	return autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions(in, out, s)
+}
+
+func autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *pkgapi.SecretVolumeSource, out *pkgapiv1.SecretVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.SecretVolumeSource))(in)
+	}
+	out.SecretName = in.SecretName
+	return nil
+}
+
+func convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in *pkgapi.SecretVolumeSource, out *pkgapiv1.SecretVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in, out, s)
+}
+
+func autoconvert_api_SecurityContext_To_v1_SecurityContext(in *pkgapi.SecurityContext, out *pkgapiv1.SecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.SecurityContext))(in)
+	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(pkgapiv1.Capabilities)
+		if err := convert_api_Capabilities_To_v1_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(pkgapiv1.SELinuxOptions)
+		if err := convert_api_SELinuxOptions_To_v1_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
+	return nil
+}
+
+func convert_api_SecurityContext_To_v1_SecurityContext(in *pkgapi.SecurityContext, out *pkgapiv1.SecurityContext, s conversion.Scope) error {
+	return autoconvert_api_SecurityContext_To_v1_SecurityContext(in, out, s)
+}
+
+func autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction(in *pkgapi.TCPSocketAction, out *pkgapiv1.TCPSocketAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.TCPSocketAction))(in)
+	}
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_TCPSocketAction_To_v1_TCPSocketAction(in *pkgapi.TCPSocketAction, out *pkgapiv1.TCPSocketAction, s conversion.Scope) error {
+	return autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction(in, out, s)
+}
+
+func autoconvert_api_Volume_To_v1_Volume(in *pkgapi.Volume, out *pkgapiv1.Volume, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Volume))(in)
+	}
+	out.Name = in.Name
+	if err := s.Convert(&in.VolumeSource, &out.VolumeSource, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_Volume_To_v1_Volume(in *pkgapi.Volume, out *pkgapiv1.Volume, s conversion.Scope) error {
+	return autoconvert_api_Volume_To_v1_Volume(in, out, s)
+}
+
+func autoconvert_api_VolumeMount_To_v1_VolumeMount(in *pkgapi.VolumeMount, out *pkgapiv1.VolumeMount, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.VolumeMount))(in)
+	}
+	out.Name = in.Name
+	out.ReadOnly = in.ReadOnly
+	out.MountPath = in.MountPath
+	return nil
+}
+
+func convert_api_VolumeMount_To_v1_VolumeMount(in *pkgapi.VolumeMount, out *pkgapiv1.VolumeMount, s conversion.Scope) error {
+	return autoconvert_api_VolumeMount_To_v1_VolumeMount(in, out, s)
+}
+
+func autoconvert_api_VolumeSource_To_v1_VolumeSource(in *pkgapi.VolumeSource, out *pkgapiv1.VolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.VolumeSource))(in)
+	}
+	if in.HostPath != nil {
+		out.HostPath = new(pkgapiv1.HostPathVolumeSource)
+		if err := convert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+			return err
+		}
+	} else {
+		out.HostPath = nil
+	}
+	if in.EmptyDir != nil {
+		out.EmptyDir = new(pkgapiv1.EmptyDirVolumeSource)
+		if err := convert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.EmptyDir = nil
+	}
+	if in.GCEPersistentDisk != nil {
+		out.GCEPersistentDisk = new(pkgapiv1.GCEPersistentDiskVolumeSource)
+		if err := convert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+			return err
+		}
+	} else {
+		out.GCEPersistentDisk = nil
+	}
+	if in.AWSElasticBlockStore != nil {
+		out.AWSElasticBlockStore = new(pkgapiv1.AWSElasticBlockStoreVolumeSource)
+		if err := convert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+			return err
+		}
+	} else {
+		out.AWSElasticBlockStore = nil
+	}
+	if in.GitRepo != nil {
+		out.GitRepo = new(pkgapiv1.GitRepoVolumeSource)
+		if err := convert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+			return err
+		}
+	} else {
+		out.GitRepo = nil
+	}
+	if in.Secret != nil {
+		out.Secret = new(pkgapiv1.SecretVolumeSource)
+		if err := convert_api_SecretVolumeSource_To_v1_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+			return err
+		}
+	} else {
+		out.Secret = nil
+	}
+	if in.NFS != nil {
+		out.NFS = new(pkgapiv1.NFSVolumeSource)
+		if err := convert_api_NFSVolumeSource_To_v1_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.NFS = nil
+	}
+	if in.ISCSI != nil {
+		out.ISCSI = new(pkgapiv1.ISCSIVolumeSource)
+		if err := convert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+			return err
+		}
+	} else {
+		out.ISCSI = nil
+	}
+	if in.Glusterfs != nil {
+		out.Glusterfs = new(pkgapiv1.GlusterfsVolumeSource)
+		if err := convert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+			return err
+		}
+	} else {
+		out.Glusterfs = nil
+	}
+	if in.PersistentVolumeClaim != nil {
+		out.PersistentVolumeClaim = new(pkgapiv1.PersistentVolumeClaimVolumeSource)
+		if err := convert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+			return err
+		}
+	} else {
+		out.PersistentVolumeClaim = nil
+	}
+	if in.RBD != nil {
+		out.RBD = new(pkgapiv1.RBDVolumeSource)
+		if err := convert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+			return err
+		}
+	} else {
+		out.RBD = nil
+	}
+	if in.Cinder != nil {
+		out.Cinder = new(pkgapiv1.CinderVolumeSource)
+		if err := convert_api_CinderVolumeSource_To_v1_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cinder = nil
+	}
+	if in.CephFS != nil {
+		out.CephFS = new(pkgapiv1.CephFSVolumeSource)
+		if err := convert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.CephFS = nil
+	}
+	if in.Flocker != nil {
+		out.Flocker = new(pkgapiv1.FlockerVolumeSource)
+		if err := convert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+			return err
+		}
+	} else {
+		out.Flocker = nil
+	}
+	if in.DownwardAPI != nil {
+		out.DownwardAPI = new(pkgapiv1.DownwardAPIVolumeSource)
+		if err := convert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+			return err
+		}
+	} else {
+		out.DownwardAPI = nil
+	}
+	if in.FC != nil {
+		out.FC = new(pkgapiv1.FCVolumeSource)
+		if err := convert_api_FCVolumeSource_To_v1_FCVolumeSource(in.FC, out.FC, s); err != nil {
+			return err
+		}
+	} else {
+		out.FC = nil
+	}
+	return nil
+}
+
+func autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *pkgapiv1.AWSElasticBlockStoreVolumeSource, out *pkgapi.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.AWSElasticBlockStoreVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *pkgapiv1.AWSElasticBlockStoreVolumeSource, out *pkgapi.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_Capabilities_To_api_Capabilities(in *pkgapiv1.Capabilities, out *pkgapi.Capabilities, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.Capabilities))(in)
+	}
+	if in.Add != nil {
+		out.Add = make([]pkgapi.Capability, len(in.Add))
+		for i := range in.Add {
+			out.Add[i] = pkgapi.Capability(in.Add[i])
+		}
+	} else {
+		out.Add = nil
+	}
+	if in.Drop != nil {
+		out.Drop = make([]pkgapi.Capability, len(in.Drop))
+		for i := range in.Drop {
+			out.Drop[i] = pkgapi.Capability(in.Drop[i])
+		}
+	} else {
+		out.Drop = nil
+	}
+	return nil
+}
+
+func convert_v1_Capabilities_To_api_Capabilities(in *pkgapiv1.Capabilities, out *pkgapi.Capabilities, s conversion.Scope) error {
+	return autoconvert_v1_Capabilities_To_api_Capabilities(in, out, s)
+}
+
+func autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *pkgapiv1.CephFSVolumeSource, out *pkgapi.CephFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.CephFSVolumeSource))(in)
+	}
+	if in.Monitors != nil {
+		out.Monitors = make([]string, len(in.Monitors))
+		for i := range in.Monitors {
+			out.Monitors[i] = in.Monitors[i]
+		}
+	} else {
+		out.Monitors = nil
+	}
+	out.User = in.User
+	out.SecretFile = in.SecretFile
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapi.LocalObjectReference)
+		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *pkgapiv1.CephFSVolumeSource, out *pkgapi.CephFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *pkgapiv1.CinderVolumeSource, out *pkgapi.CinderVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.CinderVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in *pkgapiv1.CinderVolumeSource, out *pkgapi.CinderVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_Container_To_api_Container(in *pkgapiv1.Container, out *pkgapi.Container, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.Container))(in)
+	}
+	out.Name = in.Name
+	out.Image = in.Image
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.WorkingDir = in.WorkingDir
+	if in.Ports != nil {
+		out.Ports = make([]pkgapi.ContainerPort, len(in.Ports))
+		for i := range in.Ports {
+			if err := convert_v1_ContainerPort_To_api_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapi.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_v1_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	if err := convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.VolumeMounts != nil {
+		out.VolumeMounts = make([]pkgapi.VolumeMount, len(in.VolumeMounts))
+		for i := range in.VolumeMounts {
+			if err := convert_v1_VolumeMount_To_api_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.VolumeMounts = nil
+	}
+	if in.LivenessProbe != nil {
+		out.LivenessProbe = new(pkgapi.Probe)
+		if err := convert_v1_Probe_To_api_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.LivenessProbe = nil
+	}
+	if in.ReadinessProbe != nil {
+		out.ReadinessProbe = new(pkgapi.Probe)
+		if err := convert_v1_Probe_To_api_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.ReadinessProbe = nil
+	}
+	if in.Lifecycle != nil {
+		out.Lifecycle = new(pkgapi.Lifecycle)
+		if err := convert_v1_Lifecycle_To_api_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+			return err
+		}
+	} else {
+		out.Lifecycle = nil
+	}
+	out.TerminationMessagePath = in.TerminationMessagePath
+	out.ImagePullPolicy = pkgapi.PullPolicy(in.ImagePullPolicy)
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(pkgapi.SecurityContext)
+		if err := convert_v1_SecurityContext_To_api_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	out.Stdin = in.Stdin
+	out.StdinOnce = in.StdinOnce
+	out.TTY = in.TTY
+	return nil
+}
+
+func convert_v1_Container_To_api_Container(in *pkgapiv1.Container, out *pkgapi.Container, s conversion.Scope) error {
+	return autoconvert_v1_Container_To_api_Container(in, out, s)
+}
+
+func autoconvert_v1_ContainerPort_To_api_ContainerPort(in *pkgapiv1.ContainerPort, out *pkgapi.ContainerPort, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.ContainerPort))(in)
+	}
+	out.Name = in.Name
+	out.HostPort = in.HostPort
+	out.ContainerPort = in.ContainerPort
+	out.Protocol = pkgapi.Protocol(in.Protocol)
+	out.HostIP = in.HostIP
+	return nil
+}
+
+func convert_v1_ContainerPort_To_api_ContainerPort(in *pkgapiv1.ContainerPort, out *pkgapi.ContainerPort, s conversion.Scope) error {
+	return autoconvert_v1_ContainerPort_To_api_ContainerPort(in, out, s)
+}
+
+func autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *pkgapiv1.DownwardAPIVolumeFile, out *pkgapi.DownwardAPIVolumeFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.DownwardAPIVolumeFile))(in)
+	}
+	out.Path = in.Path
+	if err := convert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *pkgapiv1.DownwardAPIVolumeFile, out *pkgapi.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in, out, s)
+}
+
+func autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *pkgapiv1.DownwardAPIVolumeSource, out *pkgapi.DownwardAPIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.DownwardAPIVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]pkgapi.DownwardAPIVolumeFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *pkgapiv1.DownwardAPIVolumeSource, out *pkgapi.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *pkgapiv1.EmptyDirVolumeSource, out *pkgapi.EmptyDirVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.EmptyDirVolumeSource))(in)
+	}
+	out.Medium = pkgapi.StorageMedium(in.Medium)
+	return nil
+}
+
+func convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *pkgapiv1.EmptyDirVolumeSource, out *pkgapi.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in, out, s)
 }
 
 func autoconvert_v1_EnvVar_To_api_EnvVar(in *pkgapiv1.EnvVar, out *pkgapi.EnvVar, s conversion.Scope) error {
@@ -5112,6 +6996,213 @@ func convert_v1_EnvVarSource_To_api_EnvVarSource(in *pkgapiv1.EnvVarSource, out 
 	return autoconvert_v1_EnvVarSource_To_api_EnvVarSource(in, out, s)
 }
 
+func autoconvert_v1_ExecAction_To_api_ExecAction(in *pkgapiv1.ExecAction, out *pkgapi.ExecAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.ExecAction))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_v1_ExecAction_To_api_ExecAction(in *pkgapiv1.ExecAction, out *pkgapi.ExecAction, s conversion.Scope) error {
+	return autoconvert_v1_ExecAction_To_api_ExecAction(in, out, s)
+}
+
+func autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in *pkgapiv1.FCVolumeSource, out *pkgapi.FCVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.FCVolumeSource))(in)
+	}
+	if in.TargetWWNs != nil {
+		out.TargetWWNs = make([]string, len(in.TargetWWNs))
+		for i := range in.TargetWWNs {
+			out.TargetWWNs[i] = in.TargetWWNs[i]
+		}
+	} else {
+		out.TargetWWNs = nil
+	}
+	if in.Lun != nil {
+		out.Lun = new(int)
+		*out.Lun = *in.Lun
+	} else {
+		out.Lun = nil
+	}
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *pkgapiv1.FCVolumeSource, out *pkgapi.FCVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *pkgapiv1.FlockerVolumeSource, out *pkgapi.FlockerVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.FlockerVolumeSource))(in)
+	}
+	out.DatasetName = in.DatasetName
+	return nil
+}
+
+func convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in *pkgapiv1.FlockerVolumeSource, out *pkgapi.FlockerVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *pkgapiv1.GCEPersistentDiskVolumeSource, out *pkgapi.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.GCEPersistentDiskVolumeSource))(in)
+	}
+	out.PDName = in.PDName
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *pkgapiv1.GCEPersistentDiskVolumeSource, out *pkgapi.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *pkgapiv1.GitRepoVolumeSource, out *pkgapi.GitRepoVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.GitRepoVolumeSource))(in)
+	}
+	out.Repository = in.Repository
+	out.Revision = in.Revision
+	return nil
+}
+
+func convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *pkgapiv1.GitRepoVolumeSource, out *pkgapi.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *pkgapiv1.GlusterfsVolumeSource, out *pkgapi.GlusterfsVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.GlusterfsVolumeSource))(in)
+	}
+	out.EndpointsName = in.EndpointsName
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *pkgapiv1.GlusterfsVolumeSource, out *pkgapi.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in *pkgapiv1.HTTPGetAction, out *pkgapi.HTTPGetAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.HTTPGetAction))(in)
+	}
+	out.Path = in.Path
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	out.Host = in.Host
+	out.Scheme = pkgapi.URIScheme(in.Scheme)
+	return nil
+}
+
+func convert_v1_HTTPGetAction_To_api_HTTPGetAction(in *pkgapiv1.HTTPGetAction, out *pkgapi.HTTPGetAction, s conversion.Scope) error {
+	return autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction(in, out, s)
+}
+
+func autoconvert_v1_Handler_To_api_Handler(in *pkgapiv1.Handler, out *pkgapi.Handler, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.Handler))(in)
+	}
+	if in.Exec != nil {
+		out.Exec = new(pkgapi.ExecAction)
+		if err := convert_v1_ExecAction_To_api_ExecAction(in.Exec, out.Exec, s); err != nil {
+			return err
+		}
+	} else {
+		out.Exec = nil
+	}
+	if in.HTTPGet != nil {
+		out.HTTPGet = new(pkgapi.HTTPGetAction)
+		if err := convert_v1_HTTPGetAction_To_api_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+			return err
+		}
+	} else {
+		out.HTTPGet = nil
+	}
+	if in.TCPSocket != nil {
+		out.TCPSocket = new(pkgapi.TCPSocketAction)
+		if err := convert_v1_TCPSocketAction_To_api_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+			return err
+		}
+	} else {
+		out.TCPSocket = nil
+	}
+	return nil
+}
+
+func convert_v1_Handler_To_api_Handler(in *pkgapiv1.Handler, out *pkgapi.Handler, s conversion.Scope) error {
+	return autoconvert_v1_Handler_To_api_Handler(in, out, s)
+}
+
+func autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *pkgapiv1.HostPathVolumeSource, out *pkgapi.HostPathVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.HostPathVolumeSource))(in)
+	}
+	out.Path = in.Path
+	return nil
+}
+
+func convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in *pkgapiv1.HostPathVolumeSource, out *pkgapi.HostPathVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *pkgapiv1.ISCSIVolumeSource, out *pkgapi.ISCSIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.ISCSIVolumeSource))(in)
+	}
+	out.TargetPortal = in.TargetPortal
+	out.IQN = in.IQN
+	out.Lun = in.Lun
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *pkgapiv1.ISCSIVolumeSource, out *pkgapi.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_Lifecycle_To_api_Lifecycle(in *pkgapiv1.Lifecycle, out *pkgapi.Lifecycle, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.Lifecycle))(in)
+	}
+	if in.PostStart != nil {
+		out.PostStart = new(pkgapi.Handler)
+		if err := convert_v1_Handler_To_api_Handler(in.PostStart, out.PostStart, s); err != nil {
+			return err
+		}
+	} else {
+		out.PostStart = nil
+	}
+	if in.PreStop != nil {
+		out.PreStop = new(pkgapi.Handler)
+		if err := convert_v1_Handler_To_api_Handler(in.PreStop, out.PreStop, s); err != nil {
+			return err
+		}
+	} else {
+		out.PreStop = nil
+	}
+	return nil
+}
+
+func convert_v1_Lifecycle_To_api_Lifecycle(in *pkgapiv1.Lifecycle, out *pkgapi.Lifecycle, s conversion.Scope) error {
+	return autoconvert_v1_Lifecycle_To_api_Lifecycle(in, out, s)
+}
+
 func autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *pkgapiv1.LocalObjectReference, out *pkgapi.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapiv1.LocalObjectReference))(in)
@@ -5122,6 +7213,20 @@ func autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in *pkgapiv
 
 func convert_v1_LocalObjectReference_To_api_LocalObjectReference(in *pkgapiv1.LocalObjectReference, out *pkgapi.LocalObjectReference, s conversion.Scope) error {
 	return autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference(in, out, s)
+}
+
+func autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *pkgapiv1.NFSVolumeSource, out *pkgapi.NFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.NFSVolumeSource))(in)
+	}
+	out.Server = in.Server
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in *pkgapiv1.NFSVolumeSource, out *pkgapi.NFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in, out, s)
 }
 
 func autoconvert_v1_ObjectFieldSelector_To_api_ObjectFieldSelector(in *pkgapiv1.ObjectFieldSelector, out *pkgapi.ObjectFieldSelector, s conversion.Scope) error {
@@ -5205,6 +7310,158 @@ func convert_v1_ObjectReference_To_api_ObjectReference(in *pkgapiv1.ObjectRefere
 	return autoconvert_v1_ObjectReference_To_api_ObjectReference(in, out, s)
 }
 
+func autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *pkgapiv1.PersistentVolumeClaimVolumeSource, out *pkgapi.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.PersistentVolumeClaimVolumeSource))(in)
+	}
+	out.ClaimName = in.ClaimName
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *pkgapiv1.PersistentVolumeClaimVolumeSource, out *pkgapi.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_PodSpec_To_api_PodSpec(in *pkgapiv1.PodSpec, out *pkgapi.PodSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.PodSpec))(in)
+	}
+	if in.Volumes != nil {
+		out.Volumes = make([]pkgapi.Volume, len(in.Volumes))
+		for i := range in.Volumes {
+			if err := convert_v1_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Volumes = nil
+	}
+	if in.Containers != nil {
+		out.Containers = make([]pkgapi.Container, len(in.Containers))
+		for i := range in.Containers {
+			if err := convert_v1_Container_To_api_Container(&in.Containers[i], &out.Containers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	out.RestartPolicy = pkgapi.RestartPolicy(in.RestartPolicy)
+	if in.TerminationGracePeriodSeconds != nil {
+		out.TerminationGracePeriodSeconds = new(int64)
+		*out.TerminationGracePeriodSeconds = *in.TerminationGracePeriodSeconds
+	} else {
+		out.TerminationGracePeriodSeconds = nil
+	}
+	if in.ActiveDeadlineSeconds != nil {
+		out.ActiveDeadlineSeconds = new(int64)
+		*out.ActiveDeadlineSeconds = *in.ActiveDeadlineSeconds
+	} else {
+		out.ActiveDeadlineSeconds = nil
+	}
+	out.DNSPolicy = pkgapi.DNSPolicy(in.DNSPolicy)
+	if in.NodeSelector != nil {
+		out.NodeSelector = make(map[string]string)
+		for key, val := range in.NodeSelector {
+			out.NodeSelector[key] = val
+		}
+	} else {
+		out.NodeSelector = nil
+	}
+	// in.DeprecatedHost has no peer in out
+	out.ServiceAccountName = in.ServiceAccountName
+	// in.DeprecatedServiceAccount has no peer in out
+	out.NodeName = in.NodeName
+	// in.HostNetwork has no peer in out
+	// in.HostPID has no peer in out
+	// in.HostIPC has no peer in out
+	if in.SecurityContext != nil {
+		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	if in.ImagePullSecrets != nil {
+		out.ImagePullSecrets = make([]pkgapi.LocalObjectReference, len(in.ImagePullSecrets))
+		for i := range in.ImagePullSecrets {
+			if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ImagePullSecrets = nil
+	}
+	return nil
+}
+
+func autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *pkgapiv1.PodTemplateSpec, out *pkgapi.PodTemplateSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.PodTemplateSpec))(in)
+	}
+	if err := convert_v1_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in *pkgapiv1.PodTemplateSpec, out *pkgapi.PodTemplateSpec, s conversion.Scope) error {
+	return autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s)
+}
+
+func autoconvert_v1_Probe_To_api_Probe(in *pkgapiv1.Probe, out *pkgapi.Probe, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.Probe))(in)
+	}
+	if err := convert_v1_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
+		return err
+	}
+	out.InitialDelaySeconds = in.InitialDelaySeconds
+	out.TimeoutSeconds = in.TimeoutSeconds
+	return nil
+}
+
+func convert_v1_Probe_To_api_Probe(in *pkgapiv1.Probe, out *pkgapi.Probe, s conversion.Scope) error {
+	return autoconvert_v1_Probe_To_api_Probe(in, out, s)
+}
+
+func autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *pkgapiv1.RBDVolumeSource, out *pkgapi.RBDVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.RBDVolumeSource))(in)
+	}
+	if in.CephMonitors != nil {
+		out.CephMonitors = make([]string, len(in.CephMonitors))
+		for i := range in.CephMonitors {
+			out.CephMonitors[i] = in.CephMonitors[i]
+		}
+	} else {
+		out.CephMonitors = nil
+	}
+	out.RBDImage = in.RBDImage
+	out.FSType = in.FSType
+	out.RBDPool = in.RBDPool
+	out.RadosUser = in.RadosUser
+	out.Keyring = in.Keyring
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapi.LocalObjectReference)
+		if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *pkgapiv1.RBDVolumeSource, out *pkgapi.RBDVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in, out, s)
+}
+
 func autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in *pkgapiv1.ResourceRequirements, out *pkgapi.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapiv1.ResourceRequirements))(in)
@@ -5240,8 +7497,260 @@ func convert_v1_ResourceRequirements_To_api_ResourceRequirements(in *pkgapiv1.Re
 	return autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements(in, out, s)
 }
 
+func autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in *pkgapiv1.SELinuxOptions, out *pkgapi.SELinuxOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.SELinuxOptions))(in)
+	}
+	out.User = in.User
+	out.Role = in.Role
+	out.Type = in.Type
+	out.Level = in.Level
+	return nil
+}
+
+func convert_v1_SELinuxOptions_To_api_SELinuxOptions(in *pkgapiv1.SELinuxOptions, out *pkgapi.SELinuxOptions, s conversion.Scope) error {
+	return autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions(in, out, s)
+}
+
+func autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *pkgapiv1.SecretVolumeSource, out *pkgapi.SecretVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.SecretVolumeSource))(in)
+	}
+	out.SecretName = in.SecretName
+	return nil
+}
+
+func convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in *pkgapiv1.SecretVolumeSource, out *pkgapi.SecretVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in, out, s)
+}
+
+func autoconvert_v1_SecurityContext_To_api_SecurityContext(in *pkgapiv1.SecurityContext, out *pkgapi.SecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.SecurityContext))(in)
+	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(pkgapi.Capabilities)
+		if err := convert_v1_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(pkgapi.SELinuxOptions)
+		if err := convert_v1_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
+	return nil
+}
+
+func convert_v1_SecurityContext_To_api_SecurityContext(in *pkgapiv1.SecurityContext, out *pkgapi.SecurityContext, s conversion.Scope) error {
+	return autoconvert_v1_SecurityContext_To_api_SecurityContext(in, out, s)
+}
+
+func autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction(in *pkgapiv1.TCPSocketAction, out *pkgapi.TCPSocketAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.TCPSocketAction))(in)
+	}
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_TCPSocketAction_To_api_TCPSocketAction(in *pkgapiv1.TCPSocketAction, out *pkgapi.TCPSocketAction, s conversion.Scope) error {
+	return autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction(in, out, s)
+}
+
+func autoconvert_v1_Volume_To_api_Volume(in *pkgapiv1.Volume, out *pkgapi.Volume, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.Volume))(in)
+	}
+	out.Name = in.Name
+	if err := s.Convert(&in.VolumeSource, &out.VolumeSource, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1_Volume_To_api_Volume(in *pkgapiv1.Volume, out *pkgapi.Volume, s conversion.Scope) error {
+	return autoconvert_v1_Volume_To_api_Volume(in, out, s)
+}
+
+func autoconvert_v1_VolumeMount_To_api_VolumeMount(in *pkgapiv1.VolumeMount, out *pkgapi.VolumeMount, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.VolumeMount))(in)
+	}
+	out.Name = in.Name
+	out.ReadOnly = in.ReadOnly
+	out.MountPath = in.MountPath
+	return nil
+}
+
+func convert_v1_VolumeMount_To_api_VolumeMount(in *pkgapiv1.VolumeMount, out *pkgapi.VolumeMount, s conversion.Scope) error {
+	return autoconvert_v1_VolumeMount_To_api_VolumeMount(in, out, s)
+}
+
+func autoconvert_v1_VolumeSource_To_api_VolumeSource(in *pkgapiv1.VolumeSource, out *pkgapi.VolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1.VolumeSource))(in)
+	}
+	if in.HostPath != nil {
+		out.HostPath = new(pkgapi.HostPathVolumeSource)
+		if err := convert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+			return err
+		}
+	} else {
+		out.HostPath = nil
+	}
+	if in.EmptyDir != nil {
+		out.EmptyDir = new(pkgapi.EmptyDirVolumeSource)
+		if err := convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.EmptyDir = nil
+	}
+	if in.GCEPersistentDisk != nil {
+		out.GCEPersistentDisk = new(pkgapi.GCEPersistentDiskVolumeSource)
+		if err := convert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+			return err
+		}
+	} else {
+		out.GCEPersistentDisk = nil
+	}
+	if in.AWSElasticBlockStore != nil {
+		out.AWSElasticBlockStore = new(pkgapi.AWSElasticBlockStoreVolumeSource)
+		if err := convert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+			return err
+		}
+	} else {
+		out.AWSElasticBlockStore = nil
+	}
+	if in.GitRepo != nil {
+		out.GitRepo = new(pkgapi.GitRepoVolumeSource)
+		if err := convert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+			return err
+		}
+	} else {
+		out.GitRepo = nil
+	}
+	if in.Secret != nil {
+		out.Secret = new(pkgapi.SecretVolumeSource)
+		if err := convert_v1_SecretVolumeSource_To_api_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+			return err
+		}
+	} else {
+		out.Secret = nil
+	}
+	if in.NFS != nil {
+		out.NFS = new(pkgapi.NFSVolumeSource)
+		if err := convert_v1_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.NFS = nil
+	}
+	if in.ISCSI != nil {
+		out.ISCSI = new(pkgapi.ISCSIVolumeSource)
+		if err := convert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+			return err
+		}
+	} else {
+		out.ISCSI = nil
+	}
+	if in.Glusterfs != nil {
+		out.Glusterfs = new(pkgapi.GlusterfsVolumeSource)
+		if err := convert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+			return err
+		}
+	} else {
+		out.Glusterfs = nil
+	}
+	if in.PersistentVolumeClaim != nil {
+		out.PersistentVolumeClaim = new(pkgapi.PersistentVolumeClaimVolumeSource)
+		if err := convert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+			return err
+		}
+	} else {
+		out.PersistentVolumeClaim = nil
+	}
+	if in.RBD != nil {
+		out.RBD = new(pkgapi.RBDVolumeSource)
+		if err := convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+			return err
+		}
+	} else {
+		out.RBD = nil
+	}
+	if in.Cinder != nil {
+		out.Cinder = new(pkgapi.CinderVolumeSource)
+		if err := convert_v1_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cinder = nil
+	}
+	if in.CephFS != nil {
+		out.CephFS = new(pkgapi.CephFSVolumeSource)
+		if err := convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.CephFS = nil
+	}
+	if in.Flocker != nil {
+		out.Flocker = new(pkgapi.FlockerVolumeSource)
+		if err := convert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+			return err
+		}
+	} else {
+		out.Flocker = nil
+	}
+	if in.DownwardAPI != nil {
+		out.DownwardAPI = new(pkgapi.DownwardAPIVolumeSource)
+		if err := convert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+			return err
+		}
+	} else {
+		out.DownwardAPI = nil
+	}
+	if in.FC != nil {
+		out.FC = new(pkgapi.FCVolumeSource)
+		if err := convert_v1_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
+			return err
+		}
+	} else {
+		out.FC = nil
+	}
+	// in.Metadata has no peer in out
+	return nil
+}
+
 func init() {
 	err := pkgapi.Scheme.AddGeneratedConversionFuncs(
+		autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1_AWSElasticBlockStoreVolumeSource,
 		autoconvert_api_BinaryBuildRequestOptions_To_v1_BinaryBuildRequestOptions,
 		autoconvert_api_BinaryBuildSource_To_v1_BinaryBuildSource,
 		autoconvert_api_BuildConfigList_To_v1_BuildConfigList,
@@ -5259,6 +7768,9 @@ func init() {
 		autoconvert_api_BuildStrategy_To_v1_BuildStrategy,
 		autoconvert_api_BuildTriggerPolicy_To_v1_BuildTriggerPolicy,
 		autoconvert_api_Build_To_v1_Build,
+		autoconvert_api_Capabilities_To_v1_Capabilities,
+		autoconvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource,
+		autoconvert_api_CinderVolumeSource_To_v1_CinderVolumeSource,
 		autoconvert_api_ClusterNetworkList_To_v1_ClusterNetworkList,
 		autoconvert_api_ClusterNetwork_To_v1_ClusterNetwork,
 		autoconvert_api_ClusterPolicyBindingList_To_v1_ClusterPolicyBindingList,
@@ -5269,22 +7781,47 @@ func init() {
 		autoconvert_api_ClusterRoleBinding_To_v1_ClusterRoleBinding,
 		autoconvert_api_ClusterRoleList_To_v1_ClusterRoleList,
 		autoconvert_api_ClusterRole_To_v1_ClusterRole,
+		autoconvert_api_ContainerPort_To_v1_ContainerPort,
+		autoconvert_api_Container_To_v1_Container,
 		autoconvert_api_CustomBuildStrategy_To_v1_CustomBuildStrategy,
+		autoconvert_api_CustomDeploymentStrategyParams_To_v1_CustomDeploymentStrategyParams,
+		autoconvert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger,
+		autoconvert_api_DeploymentCause_To_v1_DeploymentCause,
 		autoconvert_api_DeploymentConfigList_To_v1_DeploymentConfigList,
 		autoconvert_api_DeploymentConfigRollbackSpec_To_v1_DeploymentConfigRollbackSpec,
 		autoconvert_api_DeploymentConfigRollback_To_v1_DeploymentConfigRollback,
+		autoconvert_api_DeploymentConfigSpec_To_v1_DeploymentConfigSpec,
+		autoconvert_api_DeploymentConfigStatus_To_v1_DeploymentConfigStatus,
 		autoconvert_api_DeploymentConfig_To_v1_DeploymentConfig,
+		autoconvert_api_DeploymentDetails_To_v1_DeploymentDetails,
 		autoconvert_api_DeploymentLogOptions_To_v1_DeploymentLogOptions,
 		autoconvert_api_DeploymentLog_To_v1_DeploymentLog,
+		autoconvert_api_DeploymentStrategy_To_v1_DeploymentStrategy,
+		autoconvert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams,
+		autoconvert_api_DeploymentTriggerPolicy_To_v1_DeploymentTriggerPolicy,
 		autoconvert_api_DockerBuildStrategy_To_v1_DockerBuildStrategy,
+		autoconvert_api_DownwardAPIVolumeFile_To_v1_DownwardAPIVolumeFile,
+		autoconvert_api_DownwardAPIVolumeSource_To_v1_DownwardAPIVolumeSource,
+		autoconvert_api_EmptyDirVolumeSource_To_v1_EmptyDirVolumeSource,
 		autoconvert_api_EnvVarSource_To_v1_EnvVarSource,
 		autoconvert_api_EnvVar_To_v1_EnvVar,
+		autoconvert_api_ExecAction_To_v1_ExecAction,
+		autoconvert_api_ExecNewPodHook_To_v1_ExecNewPodHook,
+		autoconvert_api_FCVolumeSource_To_v1_FCVolumeSource,
+		autoconvert_api_FlockerVolumeSource_To_v1_FlockerVolumeSource,
+		autoconvert_api_GCEPersistentDiskVolumeSource_To_v1_GCEPersistentDiskVolumeSource,
 		autoconvert_api_GitBuildSource_To_v1_GitBuildSource,
+		autoconvert_api_GitRepoVolumeSource_To_v1_GitRepoVolumeSource,
 		autoconvert_api_GitSourceRevision_To_v1_GitSourceRevision,
+		autoconvert_api_GlusterfsVolumeSource_To_v1_GlusterfsVolumeSource,
 		autoconvert_api_GroupList_To_v1_GroupList,
 		autoconvert_api_Group_To_v1_Group,
+		autoconvert_api_HTTPGetAction_To_v1_HTTPGetAction,
+		autoconvert_api_Handler_To_v1_Handler,
+		autoconvert_api_HostPathVolumeSource_To_v1_HostPathVolumeSource,
 		autoconvert_api_HostSubnetList_To_v1_HostSubnetList,
 		autoconvert_api_HostSubnet_To_v1_HostSubnet,
+		autoconvert_api_ISCSIVolumeSource_To_v1_ISCSIVolumeSource,
 		autoconvert_api_IdentityList_To_v1_IdentityList,
 		autoconvert_api_Identity_To_v1_Identity,
 		autoconvert_api_ImageChangeTrigger_To_v1_ImageChangeTrigger,
@@ -5299,9 +7836,12 @@ func init() {
 		autoconvert_api_ImageStream_To_v1_ImageStream,
 		autoconvert_api_Image_To_v1_Image,
 		autoconvert_api_IsPersonalSubjectAccessReview_To_v1_IsPersonalSubjectAccessReview,
+		autoconvert_api_LifecycleHook_To_v1_LifecycleHook,
+		autoconvert_api_Lifecycle_To_v1_Lifecycle,
 		autoconvert_api_LocalObjectReference_To_v1_LocalObjectReference,
 		autoconvert_api_LocalResourceAccessReview_To_v1_LocalResourceAccessReview,
 		autoconvert_api_LocalSubjectAccessReview_To_v1_LocalSubjectAccessReview,
+		autoconvert_api_NFSVolumeSource_To_v1_NFSVolumeSource,
 		autoconvert_api_NetNamespaceList_To_v1_NetNamespaceList,
 		autoconvert_api_NetNamespace_To_v1_NetNamespace,
 		autoconvert_api_OAuthAccessTokenList_To_v1_OAuthAccessTokenList,
@@ -5316,16 +7856,22 @@ func init() {
 		autoconvert_api_ObjectMeta_To_v1_ObjectMeta,
 		autoconvert_api_ObjectReference_To_v1_ObjectReference,
 		autoconvert_api_Parameter_To_v1_Parameter,
+		autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1_PersistentVolumeClaimVolumeSource,
+		autoconvert_api_PodSpec_To_v1_PodSpec,
+		autoconvert_api_PodTemplateSpec_To_v1_PodTemplateSpec,
 		autoconvert_api_PolicyBindingList_To_v1_PolicyBindingList,
 		autoconvert_api_PolicyBinding_To_v1_PolicyBinding,
 		autoconvert_api_PolicyList_To_v1_PolicyList,
 		autoconvert_api_PolicyRule_To_v1_PolicyRule,
 		autoconvert_api_Policy_To_v1_Policy,
+		autoconvert_api_Probe_To_v1_Probe,
 		autoconvert_api_ProjectList_To_v1_ProjectList,
 		autoconvert_api_ProjectRequest_To_v1_ProjectRequest,
 		autoconvert_api_ProjectSpec_To_v1_ProjectSpec,
 		autoconvert_api_ProjectStatus_To_v1_ProjectStatus,
 		autoconvert_api_Project_To_v1_Project,
+		autoconvert_api_RBDVolumeSource_To_v1_RBDVolumeSource,
+		autoconvert_api_RecreateDeploymentStrategyParams_To_v1_RecreateDeploymentStrategyParams,
 		autoconvert_api_ResourceAccessReviewResponse_To_v1_ResourceAccessReviewResponse,
 		autoconvert_api_ResourceAccessReview_To_v1_ResourceAccessReview,
 		autoconvert_api_ResourceRequirements_To_v1_ResourceRequirements,
@@ -5333,24 +7879,33 @@ func init() {
 		autoconvert_api_RoleBinding_To_v1_RoleBinding,
 		autoconvert_api_RoleList_To_v1_RoleList,
 		autoconvert_api_Role_To_v1_Role,
+		autoconvert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams,
 		autoconvert_api_RouteList_To_v1_RouteList,
 		autoconvert_api_RoutePort_To_v1_RoutePort,
 		autoconvert_api_RouteSpec_To_v1_RouteSpec,
 		autoconvert_api_RouteStatus_To_v1_RouteStatus,
 		autoconvert_api_Route_To_v1_Route,
+		autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions,
 		autoconvert_api_SecretSpec_To_v1_SecretSpec,
+		autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
+		autoconvert_api_SecurityContext_To_v1_SecurityContext,
 		autoconvert_api_SourceBuildStrategy_To_v1_SourceBuildStrategy,
 		autoconvert_api_SourceControlUser_To_v1_SourceControlUser,
 		autoconvert_api_SourceRevision_To_v1_SourceRevision,
 		autoconvert_api_SubjectAccessReviewResponse_To_v1_SubjectAccessReviewResponse,
 		autoconvert_api_SubjectAccessReview_To_v1_SubjectAccessReview,
+		autoconvert_api_TCPSocketAction_To_v1_TCPSocketAction,
 		autoconvert_api_TLSConfig_To_v1_TLSConfig,
 		autoconvert_api_TemplateList_To_v1_TemplateList,
 		autoconvert_api_Template_To_v1_Template,
 		autoconvert_api_UserIdentityMapping_To_v1_UserIdentityMapping,
 		autoconvert_api_UserList_To_v1_UserList,
 		autoconvert_api_User_To_v1_User,
+		autoconvert_api_VolumeMount_To_v1_VolumeMount,
+		autoconvert_api_VolumeSource_To_v1_VolumeSource,
+		autoconvert_api_Volume_To_v1_Volume,
 		autoconvert_api_WebHookTrigger_To_v1_WebHookTrigger,
+		autoconvert_v1_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource,
 		autoconvert_v1_BinaryBuildRequestOptions_To_api_BinaryBuildRequestOptions,
 		autoconvert_v1_BinaryBuildSource_To_api_BinaryBuildSource,
 		autoconvert_v1_BuildConfigList_To_api_BuildConfigList,
@@ -5368,6 +7923,9 @@ func init() {
 		autoconvert_v1_BuildStrategy_To_api_BuildStrategy,
 		autoconvert_v1_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
 		autoconvert_v1_Build_To_api_Build,
+		autoconvert_v1_Capabilities_To_api_Capabilities,
+		autoconvert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource,
+		autoconvert_v1_CinderVolumeSource_To_api_CinderVolumeSource,
 		autoconvert_v1_ClusterNetworkList_To_api_ClusterNetworkList,
 		autoconvert_v1_ClusterNetwork_To_api_ClusterNetwork,
 		autoconvert_v1_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList,
@@ -5378,22 +7936,47 @@ func init() {
 		autoconvert_v1_ClusterRoleBinding_To_api_ClusterRoleBinding,
 		autoconvert_v1_ClusterRoleList_To_api_ClusterRoleList,
 		autoconvert_v1_ClusterRole_To_api_ClusterRole,
+		autoconvert_v1_ContainerPort_To_api_ContainerPort,
+		autoconvert_v1_Container_To_api_Container,
 		autoconvert_v1_CustomBuildStrategy_To_api_CustomBuildStrategy,
+		autoconvert_v1_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams,
+		autoconvert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger,
+		autoconvert_v1_DeploymentCause_To_api_DeploymentCause,
 		autoconvert_v1_DeploymentConfigList_To_api_DeploymentConfigList,
 		autoconvert_v1_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec,
 		autoconvert_v1_DeploymentConfigRollback_To_api_DeploymentConfigRollback,
+		autoconvert_v1_DeploymentConfigSpec_To_api_DeploymentConfigSpec,
+		autoconvert_v1_DeploymentConfigStatus_To_api_DeploymentConfigStatus,
 		autoconvert_v1_DeploymentConfig_To_api_DeploymentConfig,
+		autoconvert_v1_DeploymentDetails_To_api_DeploymentDetails,
 		autoconvert_v1_DeploymentLogOptions_To_api_DeploymentLogOptions,
 		autoconvert_v1_DeploymentLog_To_api_DeploymentLog,
+		autoconvert_v1_DeploymentStrategy_To_api_DeploymentStrategy,
+		autoconvert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
+		autoconvert_v1_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy,
 		autoconvert_v1_DockerBuildStrategy_To_api_DockerBuildStrategy,
+		autoconvert_v1_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
+		autoconvert_v1_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
+		autoconvert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
 		autoconvert_v1_EnvVarSource_To_api_EnvVarSource,
 		autoconvert_v1_EnvVar_To_api_EnvVar,
+		autoconvert_v1_ExecAction_To_api_ExecAction,
+		autoconvert_v1_ExecNewPodHook_To_api_ExecNewPodHook,
+		autoconvert_v1_FCVolumeSource_To_api_FCVolumeSource,
+		autoconvert_v1_FlockerVolumeSource_To_api_FlockerVolumeSource,
+		autoconvert_v1_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
 		autoconvert_v1_GitBuildSource_To_api_GitBuildSource,
+		autoconvert_v1_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
 		autoconvert_v1_GitSourceRevision_To_api_GitSourceRevision,
+		autoconvert_v1_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
 		autoconvert_v1_GroupList_To_api_GroupList,
 		autoconvert_v1_Group_To_api_Group,
+		autoconvert_v1_HTTPGetAction_To_api_HTTPGetAction,
+		autoconvert_v1_Handler_To_api_Handler,
+		autoconvert_v1_HostPathVolumeSource_To_api_HostPathVolumeSource,
 		autoconvert_v1_HostSubnetList_To_api_HostSubnetList,
 		autoconvert_v1_HostSubnet_To_api_HostSubnet,
+		autoconvert_v1_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
 		autoconvert_v1_IdentityList_To_api_IdentityList,
 		autoconvert_v1_Identity_To_api_Identity,
 		autoconvert_v1_ImageChangeTrigger_To_api_ImageChangeTrigger,
@@ -5408,9 +7991,12 @@ func init() {
 		autoconvert_v1_ImageStream_To_api_ImageStream,
 		autoconvert_v1_Image_To_api_Image,
 		autoconvert_v1_IsPersonalSubjectAccessReview_To_api_IsPersonalSubjectAccessReview,
+		autoconvert_v1_LifecycleHook_To_api_LifecycleHook,
+		autoconvert_v1_Lifecycle_To_api_Lifecycle,
 		autoconvert_v1_LocalObjectReference_To_api_LocalObjectReference,
 		autoconvert_v1_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
 		autoconvert_v1_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
+		autoconvert_v1_NFSVolumeSource_To_api_NFSVolumeSource,
 		autoconvert_v1_NetNamespaceList_To_api_NetNamespaceList,
 		autoconvert_v1_NetNamespace_To_api_NetNamespace,
 		autoconvert_v1_OAuthAccessTokenList_To_api_OAuthAccessTokenList,
@@ -5425,16 +8011,22 @@ func init() {
 		autoconvert_v1_ObjectMeta_To_api_ObjectMeta,
 		autoconvert_v1_ObjectReference_To_api_ObjectReference,
 		autoconvert_v1_Parameter_To_api_Parameter,
+		autoconvert_v1_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource,
+		autoconvert_v1_PodSpec_To_api_PodSpec,
+		autoconvert_v1_PodTemplateSpec_To_api_PodTemplateSpec,
 		autoconvert_v1_PolicyBindingList_To_api_PolicyBindingList,
 		autoconvert_v1_PolicyBinding_To_api_PolicyBinding,
 		autoconvert_v1_PolicyList_To_api_PolicyList,
 		autoconvert_v1_PolicyRule_To_api_PolicyRule,
 		autoconvert_v1_Policy_To_api_Policy,
+		autoconvert_v1_Probe_To_api_Probe,
 		autoconvert_v1_ProjectList_To_api_ProjectList,
 		autoconvert_v1_ProjectRequest_To_api_ProjectRequest,
 		autoconvert_v1_ProjectSpec_To_api_ProjectSpec,
 		autoconvert_v1_ProjectStatus_To_api_ProjectStatus,
 		autoconvert_v1_Project_To_api_Project,
+		autoconvert_v1_RBDVolumeSource_To_api_RBDVolumeSource,
+		autoconvert_v1_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams,
 		autoconvert_v1_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
 		autoconvert_v1_ResourceAccessReview_To_api_ResourceAccessReview,
 		autoconvert_v1_ResourceRequirements_To_api_ResourceRequirements,
@@ -5442,23 +8034,31 @@ func init() {
 		autoconvert_v1_RoleBinding_To_api_RoleBinding,
 		autoconvert_v1_RoleList_To_api_RoleList,
 		autoconvert_v1_Role_To_api_Role,
+		autoconvert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
 		autoconvert_v1_RouteList_To_api_RouteList,
 		autoconvert_v1_RoutePort_To_api_RoutePort,
 		autoconvert_v1_RouteSpec_To_api_RouteSpec,
 		autoconvert_v1_RouteStatus_To_api_RouteStatus,
 		autoconvert_v1_Route_To_api_Route,
+		autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions,
 		autoconvert_v1_SecretSpec_To_api_SecretSpec,
+		autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
+		autoconvert_v1_SecurityContext_To_api_SecurityContext,
 		autoconvert_v1_SourceBuildStrategy_To_api_SourceBuildStrategy,
 		autoconvert_v1_SourceControlUser_To_api_SourceControlUser,
 		autoconvert_v1_SourceRevision_To_api_SourceRevision,
 		autoconvert_v1_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse,
 		autoconvert_v1_SubjectAccessReview_To_api_SubjectAccessReview,
+		autoconvert_v1_TCPSocketAction_To_api_TCPSocketAction,
 		autoconvert_v1_TLSConfig_To_api_TLSConfig,
 		autoconvert_v1_TemplateList_To_api_TemplateList,
 		autoconvert_v1_Template_To_api_Template,
 		autoconvert_v1_UserIdentityMapping_To_api_UserIdentityMapping,
 		autoconvert_v1_UserList_To_api_UserList,
 		autoconvert_v1_User_To_api_User,
+		autoconvert_v1_VolumeMount_To_api_VolumeMount,
+		autoconvert_v1_VolumeSource_To_api_VolumeSource,
+		autoconvert_v1_Volume_To_api_Volume,
 		autoconvert_v1_WebHookTrigger_To_api_WebHookTrigger,
 	)
 	if err != nil {

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -2507,6 +2507,70 @@ func convert_v1beta3_WebHookTrigger_To_api_WebHookTrigger(in *apiv1beta3.WebHook
 	return autoconvert_v1beta3_WebHookTrigger_To_api_WebHookTrigger(in, out, s)
 }
 
+func autoconvert_api_CustomDeploymentStrategyParams_To_v1beta3_CustomDeploymentStrategyParams(in *deployapi.CustomDeploymentStrategyParams, out *deployapiv1beta3.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.CustomDeploymentStrategyParams))(in)
+	}
+	out.Image = in.Image
+	if in.Environment != nil {
+		out.Environment = make([]pkgapiv1beta3.EnvVar, len(in.Environment))
+		for i := range in.Environment {
+			if err := convert_api_EnvVar_To_v1beta3_EnvVar(&in.Environment[i], &out.Environment[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Environment = nil
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_api_CustomDeploymentStrategyParams_To_v1beta3_CustomDeploymentStrategyParams(in *deployapi.CustomDeploymentStrategyParams, out *deployapiv1beta3.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_api_CustomDeploymentStrategyParams_To_v1beta3_CustomDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_api_DeploymentCause_To_v1beta3_DeploymentCause(in *deployapi.DeploymentCause, out *deployapiv1beta3.DeploymentCause, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentCause))(in)
+	}
+	out.Type = deployapiv1beta3.DeploymentTriggerType(in.Type)
+	if in.ImageTrigger != nil {
+		out.ImageTrigger = new(deployapiv1beta3.DeploymentCauseImageTrigger)
+		if err := convert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger(in.ImageTrigger, out.ImageTrigger, s); err != nil {
+			return err
+		}
+	} else {
+		out.ImageTrigger = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentCause_To_v1beta3_DeploymentCause(in *deployapi.DeploymentCause, out *deployapiv1beta3.DeploymentCause, s conversion.Scope) error {
+	return autoconvert_api_DeploymentCause_To_v1beta3_DeploymentCause(in, out, s)
+}
+
+func autoconvert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger(in *deployapi.DeploymentCauseImageTrigger, out *deployapiv1beta3.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentCauseImageTrigger))(in)
+	}
+	if err := convert_api_ObjectReference_To_v1beta3_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger(in *deployapi.DeploymentCauseImageTrigger, out *deployapiv1beta3.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	return autoconvert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger(in, out, s)
+}
+
 func autoconvert_api_DeploymentConfig_To_v1beta3_DeploymentConfig(in *deployapi.DeploymentConfig, out *deployapiv1beta3.DeploymentConfig, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*deployapi.DeploymentConfig))(in)
@@ -2517,11 +2581,17 @@ func autoconvert_api_DeploymentConfig_To_v1beta3_DeploymentConfig(in *deployapi.
 	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	// in.Triggers has no peer in out
-	// in.Template has no peer in out
-	// in.LatestVersion has no peer in out
-	// in.Details has no peer in out
+	if err := convert_api_DeploymentConfigSpec_To_v1beta3_DeploymentConfigSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_api_DeploymentConfigStatus_To_v1beta3_DeploymentConfigStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
 	return nil
+}
+
+func convert_api_DeploymentConfig_To_v1beta3_DeploymentConfig(in *deployapi.DeploymentConfig, out *deployapiv1beta3.DeploymentConfig, s conversion.Scope) error {
+	return autoconvert_api_DeploymentConfig_To_v1beta3_DeploymentConfig(in, out, s)
 }
 
 func autoconvert_api_DeploymentConfigList_To_v1beta3_DeploymentConfigList(in *deployapi.DeploymentConfigList, out *deployapiv1beta3.DeploymentConfigList, s conversion.Scope) error {
@@ -2537,7 +2607,7 @@ func autoconvert_api_DeploymentConfigList_To_v1beta3_DeploymentConfigList(in *de
 	if in.Items != nil {
 		out.Items = make([]deployapiv1beta3.DeploymentConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := convert_api_DeploymentConfig_To_v1beta3_DeploymentConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2584,6 +2654,89 @@ func autoconvert_api_DeploymentConfigRollbackSpec_To_v1beta3_DeploymentConfigRol
 
 func convert_api_DeploymentConfigRollbackSpec_To_v1beta3_DeploymentConfigRollbackSpec(in *deployapi.DeploymentConfigRollbackSpec, out *deployapiv1beta3.DeploymentConfigRollbackSpec, s conversion.Scope) error {
 	return autoconvert_api_DeploymentConfigRollbackSpec_To_v1beta3_DeploymentConfigRollbackSpec(in, out, s)
+}
+
+func autoconvert_api_DeploymentConfigSpec_To_v1beta3_DeploymentConfigSpec(in *deployapi.DeploymentConfigSpec, out *deployapiv1beta3.DeploymentConfigSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentConfigSpec))(in)
+	}
+	if err := convert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+		return err
+	}
+	if in.Triggers != nil {
+		out.Triggers = make([]deployapiv1beta3.DeploymentTriggerPolicy, len(in.Triggers))
+		for i := range in.Triggers {
+			if err := convert_api_DeploymentTriggerPolicy_To_v1beta3_DeploymentTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Triggers = nil
+	}
+	out.Replicas = in.Replicas
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
+	if in.Template != nil {
+		out.Template = new(pkgapiv1beta3.PodTemplateSpec)
+		if err := convert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentConfigSpec_To_v1beta3_DeploymentConfigSpec(in *deployapi.DeploymentConfigSpec, out *deployapiv1beta3.DeploymentConfigSpec, s conversion.Scope) error {
+	return autoconvert_api_DeploymentConfigSpec_To_v1beta3_DeploymentConfigSpec(in, out, s)
+}
+
+func autoconvert_api_DeploymentConfigStatus_To_v1beta3_DeploymentConfigStatus(in *deployapi.DeploymentConfigStatus, out *deployapiv1beta3.DeploymentConfigStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentConfigStatus))(in)
+	}
+	out.LatestVersion = in.LatestVersion
+	if in.Details != nil {
+		out.Details = new(deployapiv1beta3.DeploymentDetails)
+		if err := convert_api_DeploymentDetails_To_v1beta3_DeploymentDetails(in.Details, out.Details, s); err != nil {
+			return err
+		}
+	} else {
+		out.Details = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentConfigStatus_To_v1beta3_DeploymentConfigStatus(in *deployapi.DeploymentConfigStatus, out *deployapiv1beta3.DeploymentConfigStatus, s conversion.Scope) error {
+	return autoconvert_api_DeploymentConfigStatus_To_v1beta3_DeploymentConfigStatus(in, out, s)
+}
+
+func autoconvert_api_DeploymentDetails_To_v1beta3_DeploymentDetails(in *deployapi.DeploymentDetails, out *deployapiv1beta3.DeploymentDetails, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentDetails))(in)
+	}
+	out.Message = in.Message
+	if in.Causes != nil {
+		out.Causes = make([]*deployapiv1beta3.DeploymentCause, len(in.Causes))
+		for i := range in.Causes {
+			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Causes = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentDetails_To_v1beta3_DeploymentDetails(in *deployapi.DeploymentDetails, out *deployapiv1beta3.DeploymentDetails, s conversion.Scope) error {
+	return autoconvert_api_DeploymentDetails_To_v1beta3_DeploymentDetails(in, out, s)
 }
 
 func autoconvert_api_DeploymentLog_To_v1beta3_DeploymentLog(in *deployapi.DeploymentLog, out *deployapiv1beta3.DeploymentLog, s conversion.Scope) error {
@@ -2650,6 +2803,301 @@ func convert_api_DeploymentLogOptions_To_v1beta3_DeploymentLogOptions(in *deploy
 	return autoconvert_api_DeploymentLogOptions_To_v1beta3_DeploymentLogOptions(in, out, s)
 }
 
+func autoconvert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy(in *deployapi.DeploymentStrategy, out *deployapiv1beta3.DeploymentStrategy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentStrategy))(in)
+	}
+	out.Type = deployapiv1beta3.DeploymentStrategyType(in.Type)
+	if in.CustomParams != nil {
+		out.CustomParams = new(deployapiv1beta3.CustomDeploymentStrategyParams)
+		if err := convert_api_CustomDeploymentStrategyParams_To_v1beta3_CustomDeploymentStrategyParams(in.CustomParams, out.CustomParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
+	}
+	if in.RecreateParams != nil {
+		out.RecreateParams = new(deployapiv1beta3.RecreateDeploymentStrategyParams)
+		if err := convert_api_RecreateDeploymentStrategyParams_To_v1beta3_RecreateDeploymentStrategyParams(in.RecreateParams, out.RecreateParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.RecreateParams = nil
+	}
+	if in.RollingParams != nil {
+		if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RollingParams = nil
+	}
+	if err := convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy(in *deployapi.DeploymentStrategy, out *deployapiv1beta3.DeploymentStrategy, s conversion.Scope) error {
+	return autoconvert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy(in, out, s)
+}
+
+func autoconvert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams(in *deployapi.DeploymentTriggerImageChangeParams, out *deployapiv1beta3.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentTriggerImageChangeParams))(in)
+	}
+	out.Automatic = in.Automatic
+	if in.ContainerNames != nil {
+		out.ContainerNames = make([]string, len(in.ContainerNames))
+		for i := range in.ContainerNames {
+			out.ContainerNames[i] = in.ContainerNames[i]
+		}
+	} else {
+		out.ContainerNames = nil
+	}
+	if err := convert_api_ObjectReference_To_v1beta3_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	out.LastTriggeredImage = in.LastTriggeredImage
+	return nil
+}
+
+func autoconvert_api_DeploymentTriggerPolicy_To_v1beta3_DeploymentTriggerPolicy(in *deployapi.DeploymentTriggerPolicy, out *deployapiv1beta3.DeploymentTriggerPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.DeploymentTriggerPolicy))(in)
+	}
+	out.Type = deployapiv1beta3.DeploymentTriggerType(in.Type)
+	if in.ImageChangeParams != nil {
+		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImageChangeParams = nil
+	}
+	return nil
+}
+
+func convert_api_DeploymentTriggerPolicy_To_v1beta3_DeploymentTriggerPolicy(in *deployapi.DeploymentTriggerPolicy, out *deployapiv1beta3.DeploymentTriggerPolicy, s conversion.Scope) error {
+	return autoconvert_api_DeploymentTriggerPolicy_To_v1beta3_DeploymentTriggerPolicy(in, out, s)
+}
+
+func autoconvert_api_ExecNewPodHook_To_v1beta3_ExecNewPodHook(in *deployapi.ExecNewPodHook, out *deployapiv1beta3.ExecNewPodHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.ExecNewPodHook))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapiv1beta3.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_api_EnvVar_To_v1beta3_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
+	return nil
+}
+
+func convert_api_ExecNewPodHook_To_v1beta3_ExecNewPodHook(in *deployapi.ExecNewPodHook, out *deployapiv1beta3.ExecNewPodHook, s conversion.Scope) error {
+	return autoconvert_api_ExecNewPodHook_To_v1beta3_ExecNewPodHook(in, out, s)
+}
+
+func autoconvert_api_LifecycleHook_To_v1beta3_LifecycleHook(in *deployapi.LifecycleHook, out *deployapiv1beta3.LifecycleHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.LifecycleHook))(in)
+	}
+	out.FailurePolicy = deployapiv1beta3.LifecycleHookFailurePolicy(in.FailurePolicy)
+	if in.ExecNewPod != nil {
+		out.ExecNewPod = new(deployapiv1beta3.ExecNewPodHook)
+		if err := convert_api_ExecNewPodHook_To_v1beta3_ExecNewPodHook(in.ExecNewPod, out.ExecNewPod, s); err != nil {
+			return err
+		}
+	} else {
+		out.ExecNewPod = nil
+	}
+	return nil
+}
+
+func convert_api_LifecycleHook_To_v1beta3_LifecycleHook(in *deployapi.LifecycleHook, out *deployapiv1beta3.LifecycleHook, s conversion.Scope) error {
+	return autoconvert_api_LifecycleHook_To_v1beta3_LifecycleHook(in, out, s)
+}
+
+func autoconvert_api_RecreateDeploymentStrategyParams_To_v1beta3_RecreateDeploymentStrategyParams(in *deployapi.RecreateDeploymentStrategyParams, out *deployapiv1beta3.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.RecreateDeploymentStrategyParams))(in)
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapiv1beta3.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1beta3_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapiv1beta3.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1beta3_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
+}
+
+func convert_api_RecreateDeploymentStrategyParams_To_v1beta3_RecreateDeploymentStrategyParams(in *deployapi.RecreateDeploymentStrategyParams, out *deployapiv1beta3.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_api_RecreateDeploymentStrategyParams_To_v1beta3_RecreateDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams(in *deployapi.RollingDeploymentStrategyParams, out *deployapiv1beta3.RollingDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapi.RollingDeploymentStrategyParams))(in)
+	}
+	if in.UpdatePeriodSeconds != nil {
+		out.UpdatePeriodSeconds = new(int64)
+		*out.UpdatePeriodSeconds = *in.UpdatePeriodSeconds
+	} else {
+		out.UpdatePeriodSeconds = nil
+	}
+	if in.IntervalSeconds != nil {
+		out.IntervalSeconds = new(int64)
+		*out.IntervalSeconds = *in.IntervalSeconds
+	} else {
+		out.IntervalSeconds = nil
+	}
+	if in.TimeoutSeconds != nil {
+		out.TimeoutSeconds = new(int64)
+		*out.TimeoutSeconds = *in.TimeoutSeconds
+	} else {
+		out.TimeoutSeconds = nil
+	}
+	if err := s.Convert(&in.MaxUnavailable, &out.MaxUnavailable, 0); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.MaxSurge, &out.MaxSurge, 0); err != nil {
+		return err
+	}
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapiv1beta3.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1beta3_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapiv1beta3.LifecycleHook)
+		if err := convert_api_LifecycleHook_To_v1beta3_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
+}
+
+func autoconvert_v1beta3_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in *deployapiv1beta3.CustomDeploymentStrategyParams, out *deployapi.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.CustomDeploymentStrategyParams))(in)
+	}
+	out.Image = in.Image
+	if in.Environment != nil {
+		out.Environment = make([]pkgapi.EnvVar, len(in.Environment))
+		for i := range in.Environment {
+			if err := convert_v1beta3_EnvVar_To_api_EnvVar(&in.Environment[i], &out.Environment[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Environment = nil
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in *deployapiv1beta3.CustomDeploymentStrategyParams, out *deployapi.CustomDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_v1beta3_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentCause_To_api_DeploymentCause(in *deployapiv1beta3.DeploymentCause, out *deployapi.DeploymentCause, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentCause))(in)
+	}
+	out.Type = deployapi.DeploymentTriggerType(in.Type)
+	if in.ImageTrigger != nil {
+		out.ImageTrigger = new(deployapi.DeploymentCauseImageTrigger)
+		if err := convert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in.ImageTrigger, out.ImageTrigger, s); err != nil {
+			return err
+		}
+	} else {
+		out.ImageTrigger = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentCause_To_api_DeploymentCause(in *deployapiv1beta3.DeploymentCause, out *deployapi.DeploymentCause, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentCause_To_api_DeploymentCause(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in *deployapiv1beta3.DeploymentCauseImageTrigger, out *deployapi.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentCauseImageTrigger))(in)
+	}
+	if err := convert_v1beta3_ObjectReference_To_api_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in *deployapiv1beta3.DeploymentCauseImageTrigger, out *deployapi.DeploymentCauseImageTrigger, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in, out, s)
+}
+
 func autoconvert_v1beta3_DeploymentConfig_To_api_DeploymentConfig(in *deployapiv1beta3.DeploymentConfig, out *deployapi.DeploymentConfig, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*deployapiv1beta3.DeploymentConfig))(in)
@@ -2660,9 +3108,17 @@ func autoconvert_v1beta3_DeploymentConfig_To_api_DeploymentConfig(in *deployapiv
 	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
 		return err
 	}
-	// in.Spec has no peer in out
-	// in.Status has no peer in out
+	if err := convert_v1beta3_DeploymentConfigSpec_To_api_DeploymentConfigSpec(&in.Spec, &out.Spec, s); err != nil {
+		return err
+	}
+	if err := convert_v1beta3_DeploymentConfigStatus_To_api_DeploymentConfigStatus(&in.Status, &out.Status, s); err != nil {
+		return err
+	}
 	return nil
+}
+
+func convert_v1beta3_DeploymentConfig_To_api_DeploymentConfig(in *deployapiv1beta3.DeploymentConfig, out *deployapi.DeploymentConfig, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentConfig_To_api_DeploymentConfig(in, out, s)
 }
 
 func autoconvert_v1beta3_DeploymentConfigList_To_api_DeploymentConfigList(in *deployapiv1beta3.DeploymentConfigList, out *deployapi.DeploymentConfigList, s conversion.Scope) error {
@@ -2678,7 +3134,7 @@ func autoconvert_v1beta3_DeploymentConfigList_To_api_DeploymentConfigList(in *de
 	if in.Items != nil {
 		out.Items = make([]deployapi.DeploymentConfig, len(in.Items))
 		for i := range in.Items {
-			if err := s.Convert(&in.Items[i], &out.Items[i], 0); err != nil {
+			if err := convert_v1beta3_DeploymentConfig_To_api_DeploymentConfig(&in.Items[i], &out.Items[i], s); err != nil {
 				return err
 			}
 		}
@@ -2725,6 +3181,89 @@ func autoconvert_v1beta3_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRol
 
 func convert_v1beta3_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec(in *deployapiv1beta3.DeploymentConfigRollbackSpec, out *deployapi.DeploymentConfigRollbackSpec, s conversion.Scope) error {
 	return autoconvert_v1beta3_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *deployapiv1beta3.DeploymentConfigSpec, out *deployapi.DeploymentConfigSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentConfigSpec))(in)
+	}
+	if err := convert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
+		return err
+	}
+	if in.Triggers != nil {
+		out.Triggers = make([]deployapi.DeploymentTriggerPolicy, len(in.Triggers))
+		for i := range in.Triggers {
+			if err := convert_v1beta3_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(&in.Triggers[i], &out.Triggers[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Triggers = nil
+	}
+	out.Replicas = in.Replicas
+	if in.Selector != nil {
+		out.Selector = make(map[string]string)
+		for key, val := range in.Selector {
+			out.Selector[key] = val
+		}
+	} else {
+		out.Selector = nil
+	}
+	if in.Template != nil {
+		out.Template = new(pkgapi.PodTemplateSpec)
+		if err := convert_v1beta3_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
+			return err
+		}
+	} else {
+		out.Template = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in *deployapiv1beta3.DeploymentConfigSpec, out *deployapi.DeploymentConfigSpec, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentConfigSpec_To_api_DeploymentConfigSpec(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *deployapiv1beta3.DeploymentConfigStatus, out *deployapi.DeploymentConfigStatus, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentConfigStatus))(in)
+	}
+	out.LatestVersion = in.LatestVersion
+	if in.Details != nil {
+		out.Details = new(deployapi.DeploymentDetails)
+		if err := convert_v1beta3_DeploymentDetails_To_api_DeploymentDetails(in.Details, out.Details, s); err != nil {
+			return err
+		}
+	} else {
+		out.Details = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in *deployapiv1beta3.DeploymentConfigStatus, out *deployapi.DeploymentConfigStatus, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentConfigStatus_To_api_DeploymentConfigStatus(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentDetails_To_api_DeploymentDetails(in *deployapiv1beta3.DeploymentDetails, out *deployapi.DeploymentDetails, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentDetails))(in)
+	}
+	out.Message = in.Message
+	if in.Causes != nil {
+		out.Causes = make([]*deployapi.DeploymentCause, len(in.Causes))
+		for i := range in.Causes {
+			if err := s.Convert(&in.Causes[i], &out.Causes[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Causes = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentDetails_To_api_DeploymentDetails(in *deployapiv1beta3.DeploymentDetails, out *deployapi.DeploymentDetails, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentDetails_To_api_DeploymentDetails(in, out, s)
 }
 
 func autoconvert_v1beta3_DeploymentLog_To_api_DeploymentLog(in *deployapiv1beta3.DeploymentLog, out *deployapi.DeploymentLog, s conversion.Scope) error {
@@ -2789,6 +3328,233 @@ func autoconvert_v1beta3_DeploymentLogOptions_To_api_DeploymentLogOptions(in *de
 
 func convert_v1beta3_DeploymentLogOptions_To_api_DeploymentLogOptions(in *deployapiv1beta3.DeploymentLogOptions, out *deployapi.DeploymentLogOptions, s conversion.Scope) error {
 	return autoconvert_v1beta3_DeploymentLogOptions_To_api_DeploymentLogOptions(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy(in *deployapiv1beta3.DeploymentStrategy, out *deployapi.DeploymentStrategy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentStrategy))(in)
+	}
+	out.Type = deployapi.DeploymentStrategyType(in.Type)
+	if in.CustomParams != nil {
+		out.CustomParams = new(deployapi.CustomDeploymentStrategyParams)
+		if err := convert_v1beta3_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams(in.CustomParams, out.CustomParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.CustomParams = nil
+	}
+	if in.RecreateParams != nil {
+		out.RecreateParams = new(deployapi.RecreateDeploymentStrategyParams)
+		if err := convert_v1beta3_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in.RecreateParams, out.RecreateParams, s); err != nil {
+			return err
+		}
+	} else {
+		out.RecreateParams = nil
+	}
+	if in.RollingParams != nil {
+		if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.RollingParams = nil
+	}
+	if err := convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
+	if in.Annotations != nil {
+		out.Annotations = make(map[string]string)
+		for key, val := range in.Annotations {
+			out.Annotations[key] = val
+		}
+	} else {
+		out.Annotations = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy(in *deployapiv1beta3.DeploymentStrategy, out *deployapi.DeploymentStrategy, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy(in, out, s)
+}
+
+func autoconvert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *deployapiv1beta3.DeploymentTriggerImageChangeParams, out *deployapi.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentTriggerImageChangeParams))(in)
+	}
+	out.Automatic = in.Automatic
+	if in.ContainerNames != nil {
+		out.ContainerNames = make([]string, len(in.ContainerNames))
+		for i := range in.ContainerNames {
+			out.ContainerNames[i] = in.ContainerNames[i]
+		}
+	} else {
+		out.ContainerNames = nil
+	}
+	if err := convert_v1beta3_ObjectReference_To_api_ObjectReference(&in.From, &out.From, s); err != nil {
+		return err
+	}
+	out.LastTriggeredImage = in.LastTriggeredImage
+	return nil
+}
+
+func autoconvert_v1beta3_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in *deployapiv1beta3.DeploymentTriggerPolicy, out *deployapi.DeploymentTriggerPolicy, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.DeploymentTriggerPolicy))(in)
+	}
+	out.Type = deployapi.DeploymentTriggerType(in.Type)
+	if in.ImageChangeParams != nil {
+		if err := s.Convert(&in.ImageChangeParams, &out.ImageChangeParams, 0); err != nil {
+			return err
+		}
+	} else {
+		out.ImageChangeParams = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in *deployapiv1beta3.DeploymentTriggerPolicy, out *deployapi.DeploymentTriggerPolicy, s conversion.Scope) error {
+	return autoconvert_v1beta3_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy(in, out, s)
+}
+
+func autoconvert_v1beta3_ExecNewPodHook_To_api_ExecNewPodHook(in *deployapiv1beta3.ExecNewPodHook, out *deployapi.ExecNewPodHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.ExecNewPodHook))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapi.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_v1beta3_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	out.ContainerName = in.ContainerName
+	if in.Volumes != nil {
+		out.Volumes = make([]string, len(in.Volumes))
+		for i := range in.Volumes {
+			out.Volumes[i] = in.Volumes[i]
+		}
+	} else {
+		out.Volumes = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_ExecNewPodHook_To_api_ExecNewPodHook(in *deployapiv1beta3.ExecNewPodHook, out *deployapi.ExecNewPodHook, s conversion.Scope) error {
+	return autoconvert_v1beta3_ExecNewPodHook_To_api_ExecNewPodHook(in, out, s)
+}
+
+func autoconvert_v1beta3_LifecycleHook_To_api_LifecycleHook(in *deployapiv1beta3.LifecycleHook, out *deployapi.LifecycleHook, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.LifecycleHook))(in)
+	}
+	out.FailurePolicy = deployapi.LifecycleHookFailurePolicy(in.FailurePolicy)
+	if in.ExecNewPod != nil {
+		out.ExecNewPod = new(deployapi.ExecNewPodHook)
+		if err := convert_v1beta3_ExecNewPodHook_To_api_ExecNewPodHook(in.ExecNewPod, out.ExecNewPod, s); err != nil {
+			return err
+		}
+	} else {
+		out.ExecNewPod = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_LifecycleHook_To_api_LifecycleHook(in *deployapiv1beta3.LifecycleHook, out *deployapi.LifecycleHook, s conversion.Scope) error {
+	return autoconvert_v1beta3_LifecycleHook_To_api_LifecycleHook(in, out, s)
+}
+
+func autoconvert_v1beta3_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in *deployapiv1beta3.RecreateDeploymentStrategyParams, out *deployapi.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.RecreateDeploymentStrategyParams))(in)
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapi.LifecycleHook)
+		if err := convert_v1beta3_LifecycleHook_To_api_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapi.LifecycleHook)
+		if err := convert_v1beta3_LifecycleHook_To_api_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in *deployapiv1beta3.RecreateDeploymentStrategyParams, out *deployapi.RecreateDeploymentStrategyParams, s conversion.Scope) error {
+	return autoconvert_v1beta3_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams(in, out, s)
+}
+
+func autoconvert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams(in *deployapiv1beta3.RollingDeploymentStrategyParams, out *deployapi.RollingDeploymentStrategyParams, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*deployapiv1beta3.RollingDeploymentStrategyParams))(in)
+	}
+	if in.UpdatePeriodSeconds != nil {
+		out.UpdatePeriodSeconds = new(int64)
+		*out.UpdatePeriodSeconds = *in.UpdatePeriodSeconds
+	} else {
+		out.UpdatePeriodSeconds = nil
+	}
+	if in.IntervalSeconds != nil {
+		out.IntervalSeconds = new(int64)
+		*out.IntervalSeconds = *in.IntervalSeconds
+	} else {
+		out.IntervalSeconds = nil
+	}
+	if in.TimeoutSeconds != nil {
+		out.TimeoutSeconds = new(int64)
+		*out.TimeoutSeconds = *in.TimeoutSeconds
+	} else {
+		out.TimeoutSeconds = nil
+	}
+	// in.MaxUnavailable has no peer in out
+	// in.MaxSurge has no peer in out
+	if in.UpdatePercent != nil {
+		out.UpdatePercent = new(int)
+		*out.UpdatePercent = *in.UpdatePercent
+	} else {
+		out.UpdatePercent = nil
+	}
+	if in.Pre != nil {
+		out.Pre = new(deployapi.LifecycleHook)
+		if err := convert_v1beta3_LifecycleHook_To_api_LifecycleHook(in.Pre, out.Pre, s); err != nil {
+			return err
+		}
+	} else {
+		out.Pre = nil
+	}
+	if in.Post != nil {
+		out.Post = new(deployapi.LifecycleHook)
+		if err := convert_v1beta3_LifecycleHook_To_api_LifecycleHook(in.Post, out.Post, s); err != nil {
+			return err
+		}
+	} else {
+		out.Post = nil
+	}
+	return nil
 }
 
 func autoconvert_api_Image_To_v1beta3_Image(in *imageapi.Image, out *imageapiv1beta3.Image, s conversion.Scope) error {
@@ -4879,6 +5645,252 @@ func convert_v1beta3_UserList_To_api_UserList(in *userapiv1beta3.UserList, out *
 	return autoconvert_v1beta3_UserList_To_api_UserList(in, out, s)
 }
 
+func autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1beta3_AWSElasticBlockStoreVolumeSource(in *pkgapi.AWSElasticBlockStoreVolumeSource, out *pkgapiv1beta3.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.AWSElasticBlockStoreVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_AWSElasticBlockStoreVolumeSource_To_v1beta3_AWSElasticBlockStoreVolumeSource(in *pkgapi.AWSElasticBlockStoreVolumeSource, out *pkgapiv1beta3.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1beta3_AWSElasticBlockStoreVolumeSource(in, out, s)
+}
+
+func autoconvert_api_Capabilities_To_v1beta3_Capabilities(in *pkgapi.Capabilities, out *pkgapiv1beta3.Capabilities, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Capabilities))(in)
+	}
+	if in.Add != nil {
+		out.Add = make([]pkgapiv1beta3.Capability, len(in.Add))
+		for i := range in.Add {
+			out.Add[i] = pkgapiv1beta3.Capability(in.Add[i])
+		}
+	} else {
+		out.Add = nil
+	}
+	if in.Drop != nil {
+		out.Drop = make([]pkgapiv1beta3.Capability, len(in.Drop))
+		for i := range in.Drop {
+			out.Drop[i] = pkgapiv1beta3.Capability(in.Drop[i])
+		}
+	} else {
+		out.Drop = nil
+	}
+	return nil
+}
+
+func convert_api_Capabilities_To_v1beta3_Capabilities(in *pkgapi.Capabilities, out *pkgapiv1beta3.Capabilities, s conversion.Scope) error {
+	return autoconvert_api_Capabilities_To_v1beta3_Capabilities(in, out, s)
+}
+
+func autoconvert_api_CephFSVolumeSource_To_v1beta3_CephFSVolumeSource(in *pkgapi.CephFSVolumeSource, out *pkgapiv1beta3.CephFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.CephFSVolumeSource))(in)
+	}
+	if in.Monitors != nil {
+		out.Monitors = make([]string, len(in.Monitors))
+		for i := range in.Monitors {
+			out.Monitors[i] = in.Monitors[i]
+		}
+	} else {
+		out.Monitors = nil
+	}
+	out.User = in.User
+	out.SecretFile = in.SecretFile
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapiv1beta3.LocalObjectReference)
+		if err := convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_CephFSVolumeSource_To_v1beta3_CephFSVolumeSource(in *pkgapi.CephFSVolumeSource, out *pkgapiv1beta3.CephFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_CephFSVolumeSource_To_v1beta3_CephFSVolumeSource(in, out, s)
+}
+
+func autoconvert_api_CinderVolumeSource_To_v1beta3_CinderVolumeSource(in *pkgapi.CinderVolumeSource, out *pkgapiv1beta3.CinderVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.CinderVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_CinderVolumeSource_To_v1beta3_CinderVolumeSource(in *pkgapi.CinderVolumeSource, out *pkgapiv1beta3.CinderVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_CinderVolumeSource_To_v1beta3_CinderVolumeSource(in, out, s)
+}
+
+func autoconvert_api_Container_To_v1beta3_Container(in *pkgapi.Container, out *pkgapiv1beta3.Container, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Container))(in)
+	}
+	out.Name = in.Name
+	out.Image = in.Image
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.WorkingDir = in.WorkingDir
+	if in.Ports != nil {
+		out.Ports = make([]pkgapiv1beta3.ContainerPort, len(in.Ports))
+		for i := range in.Ports {
+			if err := convert_api_ContainerPort_To_v1beta3_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapiv1beta3.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_api_EnvVar_To_v1beta3_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	if err := convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.VolumeMounts != nil {
+		out.VolumeMounts = make([]pkgapiv1beta3.VolumeMount, len(in.VolumeMounts))
+		for i := range in.VolumeMounts {
+			if err := convert_api_VolumeMount_To_v1beta3_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.VolumeMounts = nil
+	}
+	if in.LivenessProbe != nil {
+		out.LivenessProbe = new(pkgapiv1beta3.Probe)
+		if err := convert_api_Probe_To_v1beta3_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.LivenessProbe = nil
+	}
+	if in.ReadinessProbe != nil {
+		out.ReadinessProbe = new(pkgapiv1beta3.Probe)
+		if err := convert_api_Probe_To_v1beta3_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.ReadinessProbe = nil
+	}
+	if in.Lifecycle != nil {
+		out.Lifecycle = new(pkgapiv1beta3.Lifecycle)
+		if err := convert_api_Lifecycle_To_v1beta3_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+			return err
+		}
+	} else {
+		out.Lifecycle = nil
+	}
+	out.TerminationMessagePath = in.TerminationMessagePath
+	out.ImagePullPolicy = pkgapiv1beta3.PullPolicy(in.ImagePullPolicy)
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(pkgapiv1beta3.SecurityContext)
+		if err := convert_api_SecurityContext_To_v1beta3_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	out.Stdin = in.Stdin
+	out.StdinOnce = in.StdinOnce
+	out.TTY = in.TTY
+	return nil
+}
+
+func autoconvert_api_ContainerPort_To_v1beta3_ContainerPort(in *pkgapi.ContainerPort, out *pkgapiv1beta3.ContainerPort, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.ContainerPort))(in)
+	}
+	out.Name = in.Name
+	out.HostPort = in.HostPort
+	out.ContainerPort = in.ContainerPort
+	out.Protocol = pkgapiv1beta3.Protocol(in.Protocol)
+	out.HostIP = in.HostIP
+	return nil
+}
+
+func convert_api_ContainerPort_To_v1beta3_ContainerPort(in *pkgapi.ContainerPort, out *pkgapiv1beta3.ContainerPort, s conversion.Scope) error {
+	return autoconvert_api_ContainerPort_To_v1beta3_ContainerPort(in, out, s)
+}
+
+func autoconvert_api_DownwardAPIVolumeFile_To_v1beta3_DownwardAPIVolumeFile(in *pkgapi.DownwardAPIVolumeFile, out *pkgapiv1beta3.DownwardAPIVolumeFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.DownwardAPIVolumeFile))(in)
+	}
+	out.Path = in.Path
+	if err := convert_api_ObjectFieldSelector_To_v1beta3_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_DownwardAPIVolumeFile_To_v1beta3_DownwardAPIVolumeFile(in *pkgapi.DownwardAPIVolumeFile, out *pkgapiv1beta3.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoconvert_api_DownwardAPIVolumeFile_To_v1beta3_DownwardAPIVolumeFile(in, out, s)
+}
+
+func autoconvert_api_DownwardAPIVolumeSource_To_v1beta3_DownwardAPIVolumeSource(in *pkgapi.DownwardAPIVolumeSource, out *pkgapiv1beta3.DownwardAPIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.DownwardAPIVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]pkgapiv1beta3.DownwardAPIVolumeFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_api_DownwardAPIVolumeFile_To_v1beta3_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_api_DownwardAPIVolumeSource_To_v1beta3_DownwardAPIVolumeSource(in *pkgapi.DownwardAPIVolumeSource, out *pkgapiv1beta3.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_DownwardAPIVolumeSource_To_v1beta3_DownwardAPIVolumeSource(in, out, s)
+}
+
+func autoconvert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource(in *pkgapi.EmptyDirVolumeSource, out *pkgapiv1beta3.EmptyDirVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.EmptyDirVolumeSource))(in)
+	}
+	out.Medium = pkgapiv1beta3.StorageMedium(in.Medium)
+	return nil
+}
+
+func convert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource(in *pkgapi.EmptyDirVolumeSource, out *pkgapiv1beta3.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource(in, out, s)
+}
+
 func autoconvert_api_EnvVar_To_v1beta3_EnvVar(in *pkgapi.EnvVar, out *pkgapiv1beta3.EnvVar, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapi.EnvVar))(in)
@@ -4919,6 +5931,213 @@ func convert_api_EnvVarSource_To_v1beta3_EnvVarSource(in *pkgapi.EnvVarSource, o
 	return autoconvert_api_EnvVarSource_To_v1beta3_EnvVarSource(in, out, s)
 }
 
+func autoconvert_api_ExecAction_To_v1beta3_ExecAction(in *pkgapi.ExecAction, out *pkgapiv1beta3.ExecAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.ExecAction))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_api_ExecAction_To_v1beta3_ExecAction(in *pkgapi.ExecAction, out *pkgapiv1beta3.ExecAction, s conversion.Scope) error {
+	return autoconvert_api_ExecAction_To_v1beta3_ExecAction(in, out, s)
+}
+
+func autoconvert_api_FCVolumeSource_To_v1beta3_FCVolumeSource(in *pkgapi.FCVolumeSource, out *pkgapiv1beta3.FCVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.FCVolumeSource))(in)
+	}
+	if in.TargetWWNs != nil {
+		out.TargetWWNs = make([]string, len(in.TargetWWNs))
+		for i := range in.TargetWWNs {
+			out.TargetWWNs[i] = in.TargetWWNs[i]
+		}
+	} else {
+		out.TargetWWNs = nil
+	}
+	if in.Lun != nil {
+		out.Lun = new(int)
+		*out.Lun = *in.Lun
+	} else {
+		out.Lun = nil
+	}
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_FCVolumeSource_To_v1beta3_FCVolumeSource(in *pkgapi.FCVolumeSource, out *pkgapiv1beta3.FCVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_FCVolumeSource_To_v1beta3_FCVolumeSource(in, out, s)
+}
+
+func autoconvert_api_FlockerVolumeSource_To_v1beta3_FlockerVolumeSource(in *pkgapi.FlockerVolumeSource, out *pkgapiv1beta3.FlockerVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.FlockerVolumeSource))(in)
+	}
+	out.DatasetName = in.DatasetName
+	return nil
+}
+
+func convert_api_FlockerVolumeSource_To_v1beta3_FlockerVolumeSource(in *pkgapi.FlockerVolumeSource, out *pkgapiv1beta3.FlockerVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_FlockerVolumeSource_To_v1beta3_FlockerVolumeSource(in, out, s)
+}
+
+func autoconvert_api_GCEPersistentDiskVolumeSource_To_v1beta3_GCEPersistentDiskVolumeSource(in *pkgapi.GCEPersistentDiskVolumeSource, out *pkgapiv1beta3.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.GCEPersistentDiskVolumeSource))(in)
+	}
+	out.PDName = in.PDName
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_GCEPersistentDiskVolumeSource_To_v1beta3_GCEPersistentDiskVolumeSource(in *pkgapi.GCEPersistentDiskVolumeSource, out *pkgapiv1beta3.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_GCEPersistentDiskVolumeSource_To_v1beta3_GCEPersistentDiskVolumeSource(in, out, s)
+}
+
+func autoconvert_api_GitRepoVolumeSource_To_v1beta3_GitRepoVolumeSource(in *pkgapi.GitRepoVolumeSource, out *pkgapiv1beta3.GitRepoVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.GitRepoVolumeSource))(in)
+	}
+	out.Repository = in.Repository
+	out.Revision = in.Revision
+	return nil
+}
+
+func convert_api_GitRepoVolumeSource_To_v1beta3_GitRepoVolumeSource(in *pkgapi.GitRepoVolumeSource, out *pkgapiv1beta3.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_GitRepoVolumeSource_To_v1beta3_GitRepoVolumeSource(in, out, s)
+}
+
+func autoconvert_api_GlusterfsVolumeSource_To_v1beta3_GlusterfsVolumeSource(in *pkgapi.GlusterfsVolumeSource, out *pkgapiv1beta3.GlusterfsVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.GlusterfsVolumeSource))(in)
+	}
+	out.EndpointsName = in.EndpointsName
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_GlusterfsVolumeSource_To_v1beta3_GlusterfsVolumeSource(in *pkgapi.GlusterfsVolumeSource, out *pkgapiv1beta3.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_GlusterfsVolumeSource_To_v1beta3_GlusterfsVolumeSource(in, out, s)
+}
+
+func autoconvert_api_HTTPGetAction_To_v1beta3_HTTPGetAction(in *pkgapi.HTTPGetAction, out *pkgapiv1beta3.HTTPGetAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.HTTPGetAction))(in)
+	}
+	out.Path = in.Path
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	out.Host = in.Host
+	out.Scheme = pkgapiv1beta3.URIScheme(in.Scheme)
+	return nil
+}
+
+func convert_api_HTTPGetAction_To_v1beta3_HTTPGetAction(in *pkgapi.HTTPGetAction, out *pkgapiv1beta3.HTTPGetAction, s conversion.Scope) error {
+	return autoconvert_api_HTTPGetAction_To_v1beta3_HTTPGetAction(in, out, s)
+}
+
+func autoconvert_api_Handler_To_v1beta3_Handler(in *pkgapi.Handler, out *pkgapiv1beta3.Handler, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Handler))(in)
+	}
+	if in.Exec != nil {
+		out.Exec = new(pkgapiv1beta3.ExecAction)
+		if err := convert_api_ExecAction_To_v1beta3_ExecAction(in.Exec, out.Exec, s); err != nil {
+			return err
+		}
+	} else {
+		out.Exec = nil
+	}
+	if in.HTTPGet != nil {
+		out.HTTPGet = new(pkgapiv1beta3.HTTPGetAction)
+		if err := convert_api_HTTPGetAction_To_v1beta3_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+			return err
+		}
+	} else {
+		out.HTTPGet = nil
+	}
+	if in.TCPSocket != nil {
+		out.TCPSocket = new(pkgapiv1beta3.TCPSocketAction)
+		if err := convert_api_TCPSocketAction_To_v1beta3_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+			return err
+		}
+	} else {
+		out.TCPSocket = nil
+	}
+	return nil
+}
+
+func convert_api_Handler_To_v1beta3_Handler(in *pkgapi.Handler, out *pkgapiv1beta3.Handler, s conversion.Scope) error {
+	return autoconvert_api_Handler_To_v1beta3_Handler(in, out, s)
+}
+
+func autoconvert_api_HostPathVolumeSource_To_v1beta3_HostPathVolumeSource(in *pkgapi.HostPathVolumeSource, out *pkgapiv1beta3.HostPathVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.HostPathVolumeSource))(in)
+	}
+	out.Path = in.Path
+	return nil
+}
+
+func convert_api_HostPathVolumeSource_To_v1beta3_HostPathVolumeSource(in *pkgapi.HostPathVolumeSource, out *pkgapiv1beta3.HostPathVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_HostPathVolumeSource_To_v1beta3_HostPathVolumeSource(in, out, s)
+}
+
+func autoconvert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource(in *pkgapi.ISCSIVolumeSource, out *pkgapiv1beta3.ISCSIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.ISCSIVolumeSource))(in)
+	}
+	out.TargetPortal = in.TargetPortal
+	out.IQN = in.IQN
+	out.Lun = in.Lun
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource(in *pkgapi.ISCSIVolumeSource, out *pkgapiv1beta3.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource(in, out, s)
+}
+
+func autoconvert_api_Lifecycle_To_v1beta3_Lifecycle(in *pkgapi.Lifecycle, out *pkgapiv1beta3.Lifecycle, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Lifecycle))(in)
+	}
+	if in.PostStart != nil {
+		out.PostStart = new(pkgapiv1beta3.Handler)
+		if err := convert_api_Handler_To_v1beta3_Handler(in.PostStart, out.PostStart, s); err != nil {
+			return err
+		}
+	} else {
+		out.PostStart = nil
+	}
+	if in.PreStop != nil {
+		out.PreStop = new(pkgapiv1beta3.Handler)
+		if err := convert_api_Handler_To_v1beta3_Handler(in.PreStop, out.PreStop, s); err != nil {
+			return err
+		}
+	} else {
+		out.PreStop = nil
+	}
+	return nil
+}
+
+func convert_api_Lifecycle_To_v1beta3_Lifecycle(in *pkgapi.Lifecycle, out *pkgapiv1beta3.Lifecycle, s conversion.Scope) error {
+	return autoconvert_api_Lifecycle_To_v1beta3_Lifecycle(in, out, s)
+}
+
 func autoconvert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in *pkgapi.LocalObjectReference, out *pkgapiv1beta3.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapi.LocalObjectReference))(in)
@@ -4929,6 +6148,20 @@ func autoconvert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in *pk
 
 func convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in *pkgapi.LocalObjectReference, out *pkgapiv1beta3.LocalObjectReference, s conversion.Scope) error {
 	return autoconvert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in, out, s)
+}
+
+func autoconvert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource(in *pkgapi.NFSVolumeSource, out *pkgapiv1beta3.NFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.NFSVolumeSource))(in)
+	}
+	out.Server = in.Server
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource(in *pkgapi.NFSVolumeSource, out *pkgapiv1beta3.NFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource(in, out, s)
 }
 
 func autoconvert_api_ObjectFieldSelector_To_v1beta3_ObjectFieldSelector(in *pkgapi.ObjectFieldSelector, out *pkgapiv1beta3.ObjectFieldSelector, s conversion.Scope) error {
@@ -5012,6 +6245,153 @@ func convert_api_ObjectReference_To_v1beta3_ObjectReference(in *pkgapi.ObjectRef
 	return autoconvert_api_ObjectReference_To_v1beta3_ObjectReference(in, out, s)
 }
 
+func autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1beta3_PersistentVolumeClaimVolumeSource(in *pkgapi.PersistentVolumeClaimVolumeSource, out *pkgapiv1beta3.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.PersistentVolumeClaimVolumeSource))(in)
+	}
+	out.ClaimName = in.ClaimName
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_PersistentVolumeClaimVolumeSource_To_v1beta3_PersistentVolumeClaimVolumeSource(in *pkgapi.PersistentVolumeClaimVolumeSource, out *pkgapiv1beta3.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1beta3_PersistentVolumeClaimVolumeSource(in, out, s)
+}
+
+func autoconvert_api_PodSpec_To_v1beta3_PodSpec(in *pkgapi.PodSpec, out *pkgapiv1beta3.PodSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.PodSpec))(in)
+	}
+	if in.Volumes != nil {
+		out.Volumes = make([]pkgapiv1beta3.Volume, len(in.Volumes))
+		for i := range in.Volumes {
+			if err := convert_api_Volume_To_v1beta3_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Volumes = nil
+	}
+	if in.Containers != nil {
+		out.Containers = make([]pkgapiv1beta3.Container, len(in.Containers))
+		for i := range in.Containers {
+			if err := s.Convert(&in.Containers[i], &out.Containers[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	out.RestartPolicy = pkgapiv1beta3.RestartPolicy(in.RestartPolicy)
+	if in.TerminationGracePeriodSeconds != nil {
+		out.TerminationGracePeriodSeconds = new(int64)
+		*out.TerminationGracePeriodSeconds = *in.TerminationGracePeriodSeconds
+	} else {
+		out.TerminationGracePeriodSeconds = nil
+	}
+	if in.ActiveDeadlineSeconds != nil {
+		out.ActiveDeadlineSeconds = new(int64)
+		*out.ActiveDeadlineSeconds = *in.ActiveDeadlineSeconds
+	} else {
+		out.ActiveDeadlineSeconds = nil
+	}
+	out.DNSPolicy = pkgapiv1beta3.DNSPolicy(in.DNSPolicy)
+	if in.NodeSelector != nil {
+		out.NodeSelector = make(map[string]string)
+		for key, val := range in.NodeSelector {
+			out.NodeSelector[key] = val
+		}
+	} else {
+		out.NodeSelector = nil
+	}
+	// in.ServiceAccountName has no peer in out
+	// in.NodeName has no peer in out
+	if in.SecurityContext != nil {
+		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	if in.ImagePullSecrets != nil {
+		out.ImagePullSecrets = make([]pkgapiv1beta3.LocalObjectReference, len(in.ImagePullSecrets))
+		for i := range in.ImagePullSecrets {
+			if err := convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ImagePullSecrets = nil
+	}
+	return nil
+}
+
+func autoconvert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec(in *pkgapi.PodTemplateSpec, out *pkgapiv1beta3.PodTemplateSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.PodTemplateSpec))(in)
+	}
+	if err := convert_api_ObjectMeta_To_v1beta3_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec(in *pkgapi.PodTemplateSpec, out *pkgapiv1beta3.PodTemplateSpec, s conversion.Scope) error {
+	return autoconvert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec(in, out, s)
+}
+
+func autoconvert_api_Probe_To_v1beta3_Probe(in *pkgapi.Probe, out *pkgapiv1beta3.Probe, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Probe))(in)
+	}
+	if err := convert_api_Handler_To_v1beta3_Handler(&in.Handler, &out.Handler, s); err != nil {
+		return err
+	}
+	out.InitialDelaySeconds = in.InitialDelaySeconds
+	out.TimeoutSeconds = in.TimeoutSeconds
+	return nil
+}
+
+func convert_api_Probe_To_v1beta3_Probe(in *pkgapi.Probe, out *pkgapiv1beta3.Probe, s conversion.Scope) error {
+	return autoconvert_api_Probe_To_v1beta3_Probe(in, out, s)
+}
+
+func autoconvert_api_RBDVolumeSource_To_v1beta3_RBDVolumeSource(in *pkgapi.RBDVolumeSource, out *pkgapiv1beta3.RBDVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.RBDVolumeSource))(in)
+	}
+	if in.CephMonitors != nil {
+		out.CephMonitors = make([]string, len(in.CephMonitors))
+		for i := range in.CephMonitors {
+			out.CephMonitors[i] = in.CephMonitors[i]
+		}
+	} else {
+		out.CephMonitors = nil
+	}
+	out.RBDImage = in.RBDImage
+	out.FSType = in.FSType
+	out.RBDPool = in.RBDPool
+	out.RadosUser = in.RadosUser
+	out.Keyring = in.Keyring
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapiv1beta3.LocalObjectReference)
+		if err := convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_api_RBDVolumeSource_To_v1beta3_RBDVolumeSource(in *pkgapi.RBDVolumeSource, out *pkgapiv1beta3.RBDVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_RBDVolumeSource_To_v1beta3_RBDVolumeSource(in, out, s)
+}
+
 func autoconvert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(in *pkgapi.ResourceRequirements, out *pkgapiv1beta3.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapi.ResourceRequirements))(in)
@@ -5045,6 +6425,504 @@ func autoconvert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(in *pk
 
 func convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(in *pkgapi.ResourceRequirements, out *pkgapiv1beta3.ResourceRequirements, s conversion.Scope) error {
 	return autoconvert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(in, out, s)
+}
+
+func autoconvert_api_SELinuxOptions_To_v1beta3_SELinuxOptions(in *pkgapi.SELinuxOptions, out *pkgapiv1beta3.SELinuxOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.SELinuxOptions))(in)
+	}
+	out.User = in.User
+	out.Role = in.Role
+	out.Type = in.Type
+	out.Level = in.Level
+	return nil
+}
+
+func convert_api_SELinuxOptions_To_v1beta3_SELinuxOptions(in *pkgapi.SELinuxOptions, out *pkgapiv1beta3.SELinuxOptions, s conversion.Scope) error {
+	return autoconvert_api_SELinuxOptions_To_v1beta3_SELinuxOptions(in, out, s)
+}
+
+func autoconvert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource(in *pkgapi.SecretVolumeSource, out *pkgapiv1beta3.SecretVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.SecretVolumeSource))(in)
+	}
+	out.SecretName = in.SecretName
+	return nil
+}
+
+func convert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource(in *pkgapi.SecretVolumeSource, out *pkgapiv1beta3.SecretVolumeSource, s conversion.Scope) error {
+	return autoconvert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource(in, out, s)
+}
+
+func autoconvert_api_SecurityContext_To_v1beta3_SecurityContext(in *pkgapi.SecurityContext, out *pkgapiv1beta3.SecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.SecurityContext))(in)
+	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(pkgapiv1beta3.Capabilities)
+		if err := convert_api_Capabilities_To_v1beta3_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(pkgapiv1beta3.SELinuxOptions)
+		if err := convert_api_SELinuxOptions_To_v1beta3_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
+	return nil
+}
+
+func convert_api_SecurityContext_To_v1beta3_SecurityContext(in *pkgapi.SecurityContext, out *pkgapiv1beta3.SecurityContext, s conversion.Scope) error {
+	return autoconvert_api_SecurityContext_To_v1beta3_SecurityContext(in, out, s)
+}
+
+func autoconvert_api_TCPSocketAction_To_v1beta3_TCPSocketAction(in *pkgapi.TCPSocketAction, out *pkgapiv1beta3.TCPSocketAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.TCPSocketAction))(in)
+	}
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_TCPSocketAction_To_v1beta3_TCPSocketAction(in *pkgapi.TCPSocketAction, out *pkgapiv1beta3.TCPSocketAction, s conversion.Scope) error {
+	return autoconvert_api_TCPSocketAction_To_v1beta3_TCPSocketAction(in, out, s)
+}
+
+func autoconvert_api_Volume_To_v1beta3_Volume(in *pkgapi.Volume, out *pkgapiv1beta3.Volume, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.Volume))(in)
+	}
+	out.Name = in.Name
+	if err := s.Convert(&in.VolumeSource, &out.VolumeSource, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_api_Volume_To_v1beta3_Volume(in *pkgapi.Volume, out *pkgapiv1beta3.Volume, s conversion.Scope) error {
+	return autoconvert_api_Volume_To_v1beta3_Volume(in, out, s)
+}
+
+func autoconvert_api_VolumeMount_To_v1beta3_VolumeMount(in *pkgapi.VolumeMount, out *pkgapiv1beta3.VolumeMount, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.VolumeMount))(in)
+	}
+	out.Name = in.Name
+	out.ReadOnly = in.ReadOnly
+	out.MountPath = in.MountPath
+	return nil
+}
+
+func convert_api_VolumeMount_To_v1beta3_VolumeMount(in *pkgapi.VolumeMount, out *pkgapiv1beta3.VolumeMount, s conversion.Scope) error {
+	return autoconvert_api_VolumeMount_To_v1beta3_VolumeMount(in, out, s)
+}
+
+func autoconvert_api_VolumeSource_To_v1beta3_VolumeSource(in *pkgapi.VolumeSource, out *pkgapiv1beta3.VolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapi.VolumeSource))(in)
+	}
+	if in.HostPath != nil {
+		out.HostPath = new(pkgapiv1beta3.HostPathVolumeSource)
+		if err := convert_api_HostPathVolumeSource_To_v1beta3_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+			return err
+		}
+	} else {
+		out.HostPath = nil
+	}
+	if in.EmptyDir != nil {
+		out.EmptyDir = new(pkgapiv1beta3.EmptyDirVolumeSource)
+		if err := convert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.EmptyDir = nil
+	}
+	if in.GCEPersistentDisk != nil {
+		out.GCEPersistentDisk = new(pkgapiv1beta3.GCEPersistentDiskVolumeSource)
+		if err := convert_api_GCEPersistentDiskVolumeSource_To_v1beta3_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+			return err
+		}
+	} else {
+		out.GCEPersistentDisk = nil
+	}
+	if in.AWSElasticBlockStore != nil {
+		out.AWSElasticBlockStore = new(pkgapiv1beta3.AWSElasticBlockStoreVolumeSource)
+		if err := convert_api_AWSElasticBlockStoreVolumeSource_To_v1beta3_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+			return err
+		}
+	} else {
+		out.AWSElasticBlockStore = nil
+	}
+	if in.GitRepo != nil {
+		out.GitRepo = new(pkgapiv1beta3.GitRepoVolumeSource)
+		if err := convert_api_GitRepoVolumeSource_To_v1beta3_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+			return err
+		}
+	} else {
+		out.GitRepo = nil
+	}
+	if in.Secret != nil {
+		out.Secret = new(pkgapiv1beta3.SecretVolumeSource)
+		if err := convert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+			return err
+		}
+	} else {
+		out.Secret = nil
+	}
+	if in.NFS != nil {
+		out.NFS = new(pkgapiv1beta3.NFSVolumeSource)
+		if err := convert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.NFS = nil
+	}
+	if in.ISCSI != nil {
+		out.ISCSI = new(pkgapiv1beta3.ISCSIVolumeSource)
+		if err := convert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+			return err
+		}
+	} else {
+		out.ISCSI = nil
+	}
+	if in.Glusterfs != nil {
+		out.Glusterfs = new(pkgapiv1beta3.GlusterfsVolumeSource)
+		if err := convert_api_GlusterfsVolumeSource_To_v1beta3_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+			return err
+		}
+	} else {
+		out.Glusterfs = nil
+	}
+	if in.PersistentVolumeClaim != nil {
+		out.PersistentVolumeClaim = new(pkgapiv1beta3.PersistentVolumeClaimVolumeSource)
+		if err := convert_api_PersistentVolumeClaimVolumeSource_To_v1beta3_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+			return err
+		}
+	} else {
+		out.PersistentVolumeClaim = nil
+	}
+	if in.RBD != nil {
+		out.RBD = new(pkgapiv1beta3.RBDVolumeSource)
+		if err := convert_api_RBDVolumeSource_To_v1beta3_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+			return err
+		}
+	} else {
+		out.RBD = nil
+	}
+	if in.Cinder != nil {
+		out.Cinder = new(pkgapiv1beta3.CinderVolumeSource)
+		if err := convert_api_CinderVolumeSource_To_v1beta3_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cinder = nil
+	}
+	if in.CephFS != nil {
+		out.CephFS = new(pkgapiv1beta3.CephFSVolumeSource)
+		if err := convert_api_CephFSVolumeSource_To_v1beta3_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.CephFS = nil
+	}
+	if in.Flocker != nil {
+		out.Flocker = new(pkgapiv1beta3.FlockerVolumeSource)
+		if err := convert_api_FlockerVolumeSource_To_v1beta3_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+			return err
+		}
+	} else {
+		out.Flocker = nil
+	}
+	if in.DownwardAPI != nil {
+		out.DownwardAPI = new(pkgapiv1beta3.DownwardAPIVolumeSource)
+		if err := convert_api_DownwardAPIVolumeSource_To_v1beta3_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+			return err
+		}
+	} else {
+		out.DownwardAPI = nil
+	}
+	if in.FC != nil {
+		out.FC = new(pkgapiv1beta3.FCVolumeSource)
+		if err := convert_api_FCVolumeSource_To_v1beta3_FCVolumeSource(in.FC, out.FC, s); err != nil {
+			return err
+		}
+	} else {
+		out.FC = nil
+	}
+	return nil
+}
+
+func autoconvert_v1beta3_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *pkgapiv1beta3.AWSElasticBlockStoreVolumeSource, out *pkgapi.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.AWSElasticBlockStoreVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in *pkgapiv1beta3.AWSElasticBlockStoreVolumeSource, out *pkgapi.AWSElasticBlockStoreVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_Capabilities_To_api_Capabilities(in *pkgapiv1beta3.Capabilities, out *pkgapi.Capabilities, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.Capabilities))(in)
+	}
+	if in.Add != nil {
+		out.Add = make([]pkgapi.Capability, len(in.Add))
+		for i := range in.Add {
+			out.Add[i] = pkgapi.Capability(in.Add[i])
+		}
+	} else {
+		out.Add = nil
+	}
+	if in.Drop != nil {
+		out.Drop = make([]pkgapi.Capability, len(in.Drop))
+		for i := range in.Drop {
+			out.Drop[i] = pkgapi.Capability(in.Drop[i])
+		}
+	} else {
+		out.Drop = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_Capabilities_To_api_Capabilities(in *pkgapiv1beta3.Capabilities, out *pkgapi.Capabilities, s conversion.Scope) error {
+	return autoconvert_v1beta3_Capabilities_To_api_Capabilities(in, out, s)
+}
+
+func autoconvert_v1beta3_CephFSVolumeSource_To_api_CephFSVolumeSource(in *pkgapiv1beta3.CephFSVolumeSource, out *pkgapi.CephFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.CephFSVolumeSource))(in)
+	}
+	if in.Monitors != nil {
+		out.Monitors = make([]string, len(in.Monitors))
+		for i := range in.Monitors {
+			out.Monitors[i] = in.Monitors[i]
+		}
+	} else {
+		out.Monitors = nil
+	}
+	out.User = in.User
+	out.SecretFile = in.SecretFile
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapi.LocalObjectReference)
+		if err := convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_CephFSVolumeSource_To_api_CephFSVolumeSource(in *pkgapiv1beta3.CephFSVolumeSource, out *pkgapi.CephFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_CephFSVolumeSource_To_api_CephFSVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_CinderVolumeSource_To_api_CinderVolumeSource(in *pkgapiv1beta3.CinderVolumeSource, out *pkgapi.CinderVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.CinderVolumeSource))(in)
+	}
+	out.VolumeID = in.VolumeID
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_CinderVolumeSource_To_api_CinderVolumeSource(in *pkgapiv1beta3.CinderVolumeSource, out *pkgapi.CinderVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_CinderVolumeSource_To_api_CinderVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_Container_To_api_Container(in *pkgapiv1beta3.Container, out *pkgapi.Container, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.Container))(in)
+	}
+	out.Name = in.Name
+	out.Image = in.Image
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.WorkingDir = in.WorkingDir
+	if in.Ports != nil {
+		out.Ports = make([]pkgapi.ContainerPort, len(in.Ports))
+		for i := range in.Ports {
+			if err := convert_v1beta3_ContainerPort_To_api_ContainerPort(&in.Ports[i], &out.Ports[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Ports = nil
+	}
+	if in.Env != nil {
+		out.Env = make([]pkgapi.EnvVar, len(in.Env))
+		for i := range in.Env {
+			if err := convert_v1beta3_EnvVar_To_api_EnvVar(&in.Env[i], &out.Env[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Env = nil
+	}
+	if err := convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if in.VolumeMounts != nil {
+		out.VolumeMounts = make([]pkgapi.VolumeMount, len(in.VolumeMounts))
+		for i := range in.VolumeMounts {
+			if err := convert_v1beta3_VolumeMount_To_api_VolumeMount(&in.VolumeMounts[i], &out.VolumeMounts[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.VolumeMounts = nil
+	}
+	if in.LivenessProbe != nil {
+		out.LivenessProbe = new(pkgapi.Probe)
+		if err := convert_v1beta3_Probe_To_api_Probe(in.LivenessProbe, out.LivenessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.LivenessProbe = nil
+	}
+	if in.ReadinessProbe != nil {
+		out.ReadinessProbe = new(pkgapi.Probe)
+		if err := convert_v1beta3_Probe_To_api_Probe(in.ReadinessProbe, out.ReadinessProbe, s); err != nil {
+			return err
+		}
+	} else {
+		out.ReadinessProbe = nil
+	}
+	if in.Lifecycle != nil {
+		out.Lifecycle = new(pkgapi.Lifecycle)
+		if err := convert_v1beta3_Lifecycle_To_api_Lifecycle(in.Lifecycle, out.Lifecycle, s); err != nil {
+			return err
+		}
+	} else {
+		out.Lifecycle = nil
+	}
+	out.TerminationMessagePath = in.TerminationMessagePath
+	// in.Privileged has no peer in out
+	out.ImagePullPolicy = pkgapi.PullPolicy(in.ImagePullPolicy)
+	// in.Capabilities has no peer in out
+	if in.SecurityContext != nil {
+		out.SecurityContext = new(pkgapi.SecurityContext)
+		if err := convert_v1beta3_SecurityContext_To_api_SecurityContext(in.SecurityContext, out.SecurityContext, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	out.Stdin = in.Stdin
+	out.StdinOnce = in.StdinOnce
+	out.TTY = in.TTY
+	return nil
+}
+
+func autoconvert_v1beta3_ContainerPort_To_api_ContainerPort(in *pkgapiv1beta3.ContainerPort, out *pkgapi.ContainerPort, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.ContainerPort))(in)
+	}
+	out.Name = in.Name
+	out.HostPort = in.HostPort
+	out.ContainerPort = in.ContainerPort
+	out.Protocol = pkgapi.Protocol(in.Protocol)
+	out.HostIP = in.HostIP
+	return nil
+}
+
+func convert_v1beta3_ContainerPort_To_api_ContainerPort(in *pkgapiv1beta3.ContainerPort, out *pkgapi.ContainerPort, s conversion.Scope) error {
+	return autoconvert_v1beta3_ContainerPort_To_api_ContainerPort(in, out, s)
+}
+
+func autoconvert_v1beta3_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *pkgapiv1beta3.DownwardAPIVolumeFile, out *pkgapi.DownwardAPIVolumeFile, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.DownwardAPIVolumeFile))(in)
+	}
+	out.Path = in.Path
+	if err := convert_v1beta3_ObjectFieldSelector_To_api_ObjectFieldSelector(&in.FieldRef, &out.FieldRef, s); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in *pkgapiv1beta3.DownwardAPIVolumeFile, out *pkgapi.DownwardAPIVolumeFile, s conversion.Scope) error {
+	return autoconvert_v1beta3_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(in, out, s)
+}
+
+func autoconvert_v1beta3_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *pkgapiv1beta3.DownwardAPIVolumeSource, out *pkgapi.DownwardAPIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.DownwardAPIVolumeSource))(in)
+	}
+	if in.Items != nil {
+		out.Items = make([]pkgapi.DownwardAPIVolumeFile, len(in.Items))
+		for i := range in.Items {
+			if err := convert_v1beta3_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile(&in.Items[i], &out.Items[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in *pkgapiv1beta3.DownwardAPIVolumeSource, out *pkgapi.DownwardAPIVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *pkgapiv1beta3.EmptyDirVolumeSource, out *pkgapi.EmptyDirVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.EmptyDirVolumeSource))(in)
+	}
+	out.Medium = pkgapi.StorageMedium(in.Medium)
+	return nil
+}
+
+func convert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in *pkgapiv1beta3.EmptyDirVolumeSource, out *pkgapi.EmptyDirVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in, out, s)
 }
 
 func autoconvert_v1beta3_EnvVar_To_api_EnvVar(in *pkgapiv1beta3.EnvVar, out *pkgapi.EnvVar, s conversion.Scope) error {
@@ -5087,6 +6965,213 @@ func convert_v1beta3_EnvVarSource_To_api_EnvVarSource(in *pkgapiv1beta3.EnvVarSo
 	return autoconvert_v1beta3_EnvVarSource_To_api_EnvVarSource(in, out, s)
 }
 
+func autoconvert_v1beta3_ExecAction_To_api_ExecAction(in *pkgapiv1beta3.ExecAction, out *pkgapi.ExecAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.ExecAction))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_ExecAction_To_api_ExecAction(in *pkgapiv1beta3.ExecAction, out *pkgapi.ExecAction, s conversion.Scope) error {
+	return autoconvert_v1beta3_ExecAction_To_api_ExecAction(in, out, s)
+}
+
+func autoconvert_v1beta3_FCVolumeSource_To_api_FCVolumeSource(in *pkgapiv1beta3.FCVolumeSource, out *pkgapi.FCVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.FCVolumeSource))(in)
+	}
+	if in.TargetWWNs != nil {
+		out.TargetWWNs = make([]string, len(in.TargetWWNs))
+		for i := range in.TargetWWNs {
+			out.TargetWWNs[i] = in.TargetWWNs[i]
+		}
+	} else {
+		out.TargetWWNs = nil
+	}
+	if in.Lun != nil {
+		out.Lun = new(int)
+		*out.Lun = *in.Lun
+	} else {
+		out.Lun = nil
+	}
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_FCVolumeSource_To_api_FCVolumeSource(in *pkgapiv1beta3.FCVolumeSource, out *pkgapi.FCVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_FCVolumeSource_To_api_FCVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_FlockerVolumeSource_To_api_FlockerVolumeSource(in *pkgapiv1beta3.FlockerVolumeSource, out *pkgapi.FlockerVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.FlockerVolumeSource))(in)
+	}
+	out.DatasetName = in.DatasetName
+	return nil
+}
+
+func convert_v1beta3_FlockerVolumeSource_To_api_FlockerVolumeSource(in *pkgapiv1beta3.FlockerVolumeSource, out *pkgapi.FlockerVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_FlockerVolumeSource_To_api_FlockerVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *pkgapiv1beta3.GCEPersistentDiskVolumeSource, out *pkgapi.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.GCEPersistentDiskVolumeSource))(in)
+	}
+	out.PDName = in.PDName
+	out.FSType = in.FSType
+	out.Partition = in.Partition
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in *pkgapiv1beta3.GCEPersistentDiskVolumeSource, out *pkgapi.GCEPersistentDiskVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *pkgapiv1beta3.GitRepoVolumeSource, out *pkgapi.GitRepoVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.GitRepoVolumeSource))(in)
+	}
+	out.Repository = in.Repository
+	out.Revision = in.Revision
+	return nil
+}
+
+func convert_v1beta3_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in *pkgapiv1beta3.GitRepoVolumeSource, out *pkgapi.GitRepoVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *pkgapiv1beta3.GlusterfsVolumeSource, out *pkgapi.GlusterfsVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.GlusterfsVolumeSource))(in)
+	}
+	out.EndpointsName = in.EndpointsName
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in *pkgapiv1beta3.GlusterfsVolumeSource, out *pkgapi.GlusterfsVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_HTTPGetAction_To_api_HTTPGetAction(in *pkgapiv1beta3.HTTPGetAction, out *pkgapi.HTTPGetAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.HTTPGetAction))(in)
+	}
+	out.Path = in.Path
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	out.Host = in.Host
+	out.Scheme = pkgapi.URIScheme(in.Scheme)
+	return nil
+}
+
+func convert_v1beta3_HTTPGetAction_To_api_HTTPGetAction(in *pkgapiv1beta3.HTTPGetAction, out *pkgapi.HTTPGetAction, s conversion.Scope) error {
+	return autoconvert_v1beta3_HTTPGetAction_To_api_HTTPGetAction(in, out, s)
+}
+
+func autoconvert_v1beta3_Handler_To_api_Handler(in *pkgapiv1beta3.Handler, out *pkgapi.Handler, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.Handler))(in)
+	}
+	if in.Exec != nil {
+		out.Exec = new(pkgapi.ExecAction)
+		if err := convert_v1beta3_ExecAction_To_api_ExecAction(in.Exec, out.Exec, s); err != nil {
+			return err
+		}
+	} else {
+		out.Exec = nil
+	}
+	if in.HTTPGet != nil {
+		out.HTTPGet = new(pkgapi.HTTPGetAction)
+		if err := convert_v1beta3_HTTPGetAction_To_api_HTTPGetAction(in.HTTPGet, out.HTTPGet, s); err != nil {
+			return err
+		}
+	} else {
+		out.HTTPGet = nil
+	}
+	if in.TCPSocket != nil {
+		out.TCPSocket = new(pkgapi.TCPSocketAction)
+		if err := convert_v1beta3_TCPSocketAction_To_api_TCPSocketAction(in.TCPSocket, out.TCPSocket, s); err != nil {
+			return err
+		}
+	} else {
+		out.TCPSocket = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_Handler_To_api_Handler(in *pkgapiv1beta3.Handler, out *pkgapi.Handler, s conversion.Scope) error {
+	return autoconvert_v1beta3_Handler_To_api_Handler(in, out, s)
+}
+
+func autoconvert_v1beta3_HostPathVolumeSource_To_api_HostPathVolumeSource(in *pkgapiv1beta3.HostPathVolumeSource, out *pkgapi.HostPathVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.HostPathVolumeSource))(in)
+	}
+	out.Path = in.Path
+	return nil
+}
+
+func convert_v1beta3_HostPathVolumeSource_To_api_HostPathVolumeSource(in *pkgapiv1beta3.HostPathVolumeSource, out *pkgapi.HostPathVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_HostPathVolumeSource_To_api_HostPathVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *pkgapiv1beta3.ISCSIVolumeSource, out *pkgapi.ISCSIVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.ISCSIVolumeSource))(in)
+	}
+	out.TargetPortal = in.TargetPortal
+	out.IQN = in.IQN
+	out.Lun = in.Lun
+	out.FSType = in.FSType
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in *pkgapiv1beta3.ISCSIVolumeSource, out *pkgapi.ISCSIVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_Lifecycle_To_api_Lifecycle(in *pkgapiv1beta3.Lifecycle, out *pkgapi.Lifecycle, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.Lifecycle))(in)
+	}
+	if in.PostStart != nil {
+		out.PostStart = new(pkgapi.Handler)
+		if err := convert_v1beta3_Handler_To_api_Handler(in.PostStart, out.PostStart, s); err != nil {
+			return err
+		}
+	} else {
+		out.PostStart = nil
+	}
+	if in.PreStop != nil {
+		out.PreStop = new(pkgapi.Handler)
+		if err := convert_v1beta3_Handler_To_api_Handler(in.PreStop, out.PreStop, s); err != nil {
+			return err
+		}
+	} else {
+		out.PreStop = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_Lifecycle_To_api_Lifecycle(in *pkgapiv1beta3.Lifecycle, out *pkgapi.Lifecycle, s conversion.Scope) error {
+	return autoconvert_v1beta3_Lifecycle_To_api_Lifecycle(in, out, s)
+}
+
 func autoconvert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in *pkgapiv1beta3.LocalObjectReference, out *pkgapi.LocalObjectReference, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapiv1beta3.LocalObjectReference))(in)
@@ -5097,6 +7182,20 @@ func autoconvert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in *pk
 
 func convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in *pkgapiv1beta3.LocalObjectReference, out *pkgapi.LocalObjectReference, s conversion.Scope) error {
 	return autoconvert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in, out, s)
+}
+
+func autoconvert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource(in *pkgapiv1beta3.NFSVolumeSource, out *pkgapi.NFSVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.NFSVolumeSource))(in)
+	}
+	out.Server = in.Server
+	out.Path = in.Path
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource(in *pkgapiv1beta3.NFSVolumeSource, out *pkgapi.NFSVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource(in, out, s)
 }
 
 func autoconvert_v1beta3_ObjectFieldSelector_To_api_ObjectFieldSelector(in *pkgapiv1beta3.ObjectFieldSelector, out *pkgapi.ObjectFieldSelector, s conversion.Scope) error {
@@ -5180,6 +7279,156 @@ func convert_v1beta3_ObjectReference_To_api_ObjectReference(in *pkgapiv1beta3.Ob
 	return autoconvert_v1beta3_ObjectReference_To_api_ObjectReference(in, out, s)
 }
 
+func autoconvert_v1beta3_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *pkgapiv1beta3.PersistentVolumeClaimVolumeSource, out *pkgapi.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.PersistentVolumeClaimVolumeSource))(in)
+	}
+	out.ClaimName = in.ClaimName
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in *pkgapiv1beta3.PersistentVolumeClaimVolumeSource, out *pkgapi.PersistentVolumeClaimVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_PodSpec_To_api_PodSpec(in *pkgapiv1beta3.PodSpec, out *pkgapi.PodSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.PodSpec))(in)
+	}
+	if in.Volumes != nil {
+		out.Volumes = make([]pkgapi.Volume, len(in.Volumes))
+		for i := range in.Volumes {
+			if err := convert_v1beta3_Volume_To_api_Volume(&in.Volumes[i], &out.Volumes[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Volumes = nil
+	}
+	if in.Containers != nil {
+		out.Containers = make([]pkgapi.Container, len(in.Containers))
+		for i := range in.Containers {
+			if err := s.Convert(&in.Containers[i], &out.Containers[i], 0); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Containers = nil
+	}
+	out.RestartPolicy = pkgapi.RestartPolicy(in.RestartPolicy)
+	if in.TerminationGracePeriodSeconds != nil {
+		out.TerminationGracePeriodSeconds = new(int64)
+		*out.TerminationGracePeriodSeconds = *in.TerminationGracePeriodSeconds
+	} else {
+		out.TerminationGracePeriodSeconds = nil
+	}
+	if in.ActiveDeadlineSeconds != nil {
+		out.ActiveDeadlineSeconds = new(int64)
+		*out.ActiveDeadlineSeconds = *in.ActiveDeadlineSeconds
+	} else {
+		out.ActiveDeadlineSeconds = nil
+	}
+	out.DNSPolicy = pkgapi.DNSPolicy(in.DNSPolicy)
+	if in.NodeSelector != nil {
+		out.NodeSelector = make(map[string]string)
+		for key, val := range in.NodeSelector {
+			out.NodeSelector[key] = val
+		}
+	} else {
+		out.NodeSelector = nil
+	}
+	// in.ServiceAccount has no peer in out
+	// in.Host has no peer in out
+	// in.HostNetwork has no peer in out
+	// in.HostPID has no peer in out
+	// in.HostIPC has no peer in out
+	if in.SecurityContext != nil {
+		if err := s.Convert(&in.SecurityContext, &out.SecurityContext, 0); err != nil {
+			return err
+		}
+	} else {
+		out.SecurityContext = nil
+	}
+	if in.ImagePullSecrets != nil {
+		out.ImagePullSecrets = make([]pkgapi.LocalObjectReference, len(in.ImagePullSecrets))
+		for i := range in.ImagePullSecrets {
+			if err := convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(&in.ImagePullSecrets[i], &out.ImagePullSecrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.ImagePullSecrets = nil
+	}
+	return nil
+}
+
+func autoconvert_v1beta3_PodTemplateSpec_To_api_PodTemplateSpec(in *pkgapiv1beta3.PodTemplateSpec, out *pkgapi.PodTemplateSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.PodTemplateSpec))(in)
+	}
+	if err := convert_v1beta3_ObjectMeta_To_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, s); err != nil {
+		return err
+	}
+	if err := s.Convert(&in.Spec, &out.Spec, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_PodTemplateSpec_To_api_PodTemplateSpec(in *pkgapiv1beta3.PodTemplateSpec, out *pkgapi.PodTemplateSpec, s conversion.Scope) error {
+	return autoconvert_v1beta3_PodTemplateSpec_To_api_PodTemplateSpec(in, out, s)
+}
+
+func autoconvert_v1beta3_Probe_To_api_Probe(in *pkgapiv1beta3.Probe, out *pkgapi.Probe, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.Probe))(in)
+	}
+	if err := convert_v1beta3_Handler_To_api_Handler(&in.Handler, &out.Handler, s); err != nil {
+		return err
+	}
+	out.InitialDelaySeconds = in.InitialDelaySeconds
+	out.TimeoutSeconds = in.TimeoutSeconds
+	return nil
+}
+
+func convert_v1beta3_Probe_To_api_Probe(in *pkgapiv1beta3.Probe, out *pkgapi.Probe, s conversion.Scope) error {
+	return autoconvert_v1beta3_Probe_To_api_Probe(in, out, s)
+}
+
+func autoconvert_v1beta3_RBDVolumeSource_To_api_RBDVolumeSource(in *pkgapiv1beta3.RBDVolumeSource, out *pkgapi.RBDVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.RBDVolumeSource))(in)
+	}
+	if in.CephMonitors != nil {
+		out.CephMonitors = make([]string, len(in.CephMonitors))
+		for i := range in.CephMonitors {
+			out.CephMonitors[i] = in.CephMonitors[i]
+		}
+	} else {
+		out.CephMonitors = nil
+	}
+	out.RBDImage = in.RBDImage
+	out.FSType = in.FSType
+	out.RBDPool = in.RBDPool
+	out.RadosUser = in.RadosUser
+	out.Keyring = in.Keyring
+	if in.SecretRef != nil {
+		out.SecretRef = new(pkgapi.LocalObjectReference)
+		if err := convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(in.SecretRef, out.SecretRef, s); err != nil {
+			return err
+		}
+	} else {
+		out.SecretRef = nil
+	}
+	out.ReadOnly = in.ReadOnly
+	return nil
+}
+
+func convert_v1beta3_RBDVolumeSource_To_api_RBDVolumeSource(in *pkgapiv1beta3.RBDVolumeSource, out *pkgapi.RBDVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_RBDVolumeSource_To_api_RBDVolumeSource(in, out, s)
+}
+
 func autoconvert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(in *pkgapiv1beta3.ResourceRequirements, out *pkgapi.ResourceRequirements, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*pkgapiv1beta3.ResourceRequirements))(in)
@@ -5215,8 +7464,260 @@ func convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(in *pkgapi
 	return autoconvert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(in, out, s)
 }
 
+func autoconvert_v1beta3_SELinuxOptions_To_api_SELinuxOptions(in *pkgapiv1beta3.SELinuxOptions, out *pkgapi.SELinuxOptions, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.SELinuxOptions))(in)
+	}
+	out.User = in.User
+	out.Role = in.Role
+	out.Type = in.Type
+	out.Level = in.Level
+	return nil
+}
+
+func convert_v1beta3_SELinuxOptions_To_api_SELinuxOptions(in *pkgapiv1beta3.SELinuxOptions, out *pkgapi.SELinuxOptions, s conversion.Scope) error {
+	return autoconvert_v1beta3_SELinuxOptions_To_api_SELinuxOptions(in, out, s)
+}
+
+func autoconvert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource(in *pkgapiv1beta3.SecretVolumeSource, out *pkgapi.SecretVolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.SecretVolumeSource))(in)
+	}
+	out.SecretName = in.SecretName
+	return nil
+}
+
+func convert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource(in *pkgapiv1beta3.SecretVolumeSource, out *pkgapi.SecretVolumeSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource(in, out, s)
+}
+
+func autoconvert_v1beta3_SecurityContext_To_api_SecurityContext(in *pkgapiv1beta3.SecurityContext, out *pkgapi.SecurityContext, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.SecurityContext))(in)
+	}
+	if in.Capabilities != nil {
+		out.Capabilities = new(pkgapi.Capabilities)
+		if err := convert_v1beta3_Capabilities_To_api_Capabilities(in.Capabilities, out.Capabilities, s); err != nil {
+			return err
+		}
+	} else {
+		out.Capabilities = nil
+	}
+	if in.Privileged != nil {
+		out.Privileged = new(bool)
+		*out.Privileged = *in.Privileged
+	} else {
+		out.Privileged = nil
+	}
+	if in.SELinuxOptions != nil {
+		out.SELinuxOptions = new(pkgapi.SELinuxOptions)
+		if err := convert_v1beta3_SELinuxOptions_To_api_SELinuxOptions(in.SELinuxOptions, out.SELinuxOptions, s); err != nil {
+			return err
+		}
+	} else {
+		out.SELinuxOptions = nil
+	}
+	if in.RunAsUser != nil {
+		out.RunAsUser = new(int64)
+		*out.RunAsUser = *in.RunAsUser
+	} else {
+		out.RunAsUser = nil
+	}
+	if in.RunAsNonRoot != nil {
+		out.RunAsNonRoot = new(bool)
+		*out.RunAsNonRoot = *in.RunAsNonRoot
+	} else {
+		out.RunAsNonRoot = nil
+	}
+	return nil
+}
+
+func convert_v1beta3_SecurityContext_To_api_SecurityContext(in *pkgapiv1beta3.SecurityContext, out *pkgapi.SecurityContext, s conversion.Scope) error {
+	return autoconvert_v1beta3_SecurityContext_To_api_SecurityContext(in, out, s)
+}
+
+func autoconvert_v1beta3_TCPSocketAction_To_api_TCPSocketAction(in *pkgapiv1beta3.TCPSocketAction, out *pkgapi.TCPSocketAction, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.TCPSocketAction))(in)
+	}
+	if err := s.Convert(&in.Port, &out.Port, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_TCPSocketAction_To_api_TCPSocketAction(in *pkgapiv1beta3.TCPSocketAction, out *pkgapi.TCPSocketAction, s conversion.Scope) error {
+	return autoconvert_v1beta3_TCPSocketAction_To_api_TCPSocketAction(in, out, s)
+}
+
+func autoconvert_v1beta3_Volume_To_api_Volume(in *pkgapiv1beta3.Volume, out *pkgapi.Volume, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.Volume))(in)
+	}
+	out.Name = in.Name
+	if err := s.Convert(&in.VolumeSource, &out.VolumeSource, 0); err != nil {
+		return err
+	}
+	return nil
+}
+
+func convert_v1beta3_Volume_To_api_Volume(in *pkgapiv1beta3.Volume, out *pkgapi.Volume, s conversion.Scope) error {
+	return autoconvert_v1beta3_Volume_To_api_Volume(in, out, s)
+}
+
+func autoconvert_v1beta3_VolumeMount_To_api_VolumeMount(in *pkgapiv1beta3.VolumeMount, out *pkgapi.VolumeMount, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.VolumeMount))(in)
+	}
+	out.Name = in.Name
+	out.ReadOnly = in.ReadOnly
+	out.MountPath = in.MountPath
+	return nil
+}
+
+func convert_v1beta3_VolumeMount_To_api_VolumeMount(in *pkgapiv1beta3.VolumeMount, out *pkgapi.VolumeMount, s conversion.Scope) error {
+	return autoconvert_v1beta3_VolumeMount_To_api_VolumeMount(in, out, s)
+}
+
+func autoconvert_v1beta3_VolumeSource_To_api_VolumeSource(in *pkgapiv1beta3.VolumeSource, out *pkgapi.VolumeSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*pkgapiv1beta3.VolumeSource))(in)
+	}
+	if in.HostPath != nil {
+		out.HostPath = new(pkgapi.HostPathVolumeSource)
+		if err := convert_v1beta3_HostPathVolumeSource_To_api_HostPathVolumeSource(in.HostPath, out.HostPath, s); err != nil {
+			return err
+		}
+	} else {
+		out.HostPath = nil
+	}
+	if in.EmptyDir != nil {
+		out.EmptyDir = new(pkgapi.EmptyDirVolumeSource)
+		if err := convert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource(in.EmptyDir, out.EmptyDir, s); err != nil {
+			return err
+		}
+	} else {
+		out.EmptyDir = nil
+	}
+	if in.GCEPersistentDisk != nil {
+		out.GCEPersistentDisk = new(pkgapi.GCEPersistentDiskVolumeSource)
+		if err := convert_v1beta3_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource(in.GCEPersistentDisk, out.GCEPersistentDisk, s); err != nil {
+			return err
+		}
+	} else {
+		out.GCEPersistentDisk = nil
+	}
+	if in.AWSElasticBlockStore != nil {
+		out.AWSElasticBlockStore = new(pkgapi.AWSElasticBlockStoreVolumeSource)
+		if err := convert_v1beta3_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource(in.AWSElasticBlockStore, out.AWSElasticBlockStore, s); err != nil {
+			return err
+		}
+	} else {
+		out.AWSElasticBlockStore = nil
+	}
+	if in.GitRepo != nil {
+		out.GitRepo = new(pkgapi.GitRepoVolumeSource)
+		if err := convert_v1beta3_GitRepoVolumeSource_To_api_GitRepoVolumeSource(in.GitRepo, out.GitRepo, s); err != nil {
+			return err
+		}
+	} else {
+		out.GitRepo = nil
+	}
+	if in.Secret != nil {
+		out.Secret = new(pkgapi.SecretVolumeSource)
+		if err := convert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource(in.Secret, out.Secret, s); err != nil {
+			return err
+		}
+	} else {
+		out.Secret = nil
+	}
+	if in.NFS != nil {
+		out.NFS = new(pkgapi.NFSVolumeSource)
+		if err := convert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource(in.NFS, out.NFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.NFS = nil
+	}
+	if in.ISCSI != nil {
+		out.ISCSI = new(pkgapi.ISCSIVolumeSource)
+		if err := convert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource(in.ISCSI, out.ISCSI, s); err != nil {
+			return err
+		}
+	} else {
+		out.ISCSI = nil
+	}
+	if in.Glusterfs != nil {
+		out.Glusterfs = new(pkgapi.GlusterfsVolumeSource)
+		if err := convert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource(in.Glusterfs, out.Glusterfs, s); err != nil {
+			return err
+		}
+	} else {
+		out.Glusterfs = nil
+	}
+	if in.PersistentVolumeClaim != nil {
+		out.PersistentVolumeClaim = new(pkgapi.PersistentVolumeClaimVolumeSource)
+		if err := convert_v1beta3_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource(in.PersistentVolumeClaim, out.PersistentVolumeClaim, s); err != nil {
+			return err
+		}
+	} else {
+		out.PersistentVolumeClaim = nil
+	}
+	if in.RBD != nil {
+		out.RBD = new(pkgapi.RBDVolumeSource)
+		if err := convert_v1beta3_RBDVolumeSource_To_api_RBDVolumeSource(in.RBD, out.RBD, s); err != nil {
+			return err
+		}
+	} else {
+		out.RBD = nil
+	}
+	if in.Cinder != nil {
+		out.Cinder = new(pkgapi.CinderVolumeSource)
+		if err := convert_v1beta3_CinderVolumeSource_To_api_CinderVolumeSource(in.Cinder, out.Cinder, s); err != nil {
+			return err
+		}
+	} else {
+		out.Cinder = nil
+	}
+	if in.CephFS != nil {
+		out.CephFS = new(pkgapi.CephFSVolumeSource)
+		if err := convert_v1beta3_CephFSVolumeSource_To_api_CephFSVolumeSource(in.CephFS, out.CephFS, s); err != nil {
+			return err
+		}
+	} else {
+		out.CephFS = nil
+	}
+	if in.Flocker != nil {
+		out.Flocker = new(pkgapi.FlockerVolumeSource)
+		if err := convert_v1beta3_FlockerVolumeSource_To_api_FlockerVolumeSource(in.Flocker, out.Flocker, s); err != nil {
+			return err
+		}
+	} else {
+		out.Flocker = nil
+	}
+	if in.DownwardAPI != nil {
+		out.DownwardAPI = new(pkgapi.DownwardAPIVolumeSource)
+		if err := convert_v1beta3_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource(in.DownwardAPI, out.DownwardAPI, s); err != nil {
+			return err
+		}
+	} else {
+		out.DownwardAPI = nil
+	}
+	if in.FC != nil {
+		out.FC = new(pkgapi.FCVolumeSource)
+		if err := convert_v1beta3_FCVolumeSource_To_api_FCVolumeSource(in.FC, out.FC, s); err != nil {
+			return err
+		}
+	} else {
+		out.FC = nil
+	}
+	// in.Metadata has no peer in out
+	return nil
+}
+
 func init() {
 	err := pkgapi.Scheme.AddGeneratedConversionFuncs(
+		autoconvert_api_AWSElasticBlockStoreVolumeSource_To_v1beta3_AWSElasticBlockStoreVolumeSource,
 		autoconvert_api_BinaryBuildRequestOptions_To_v1beta3_BinaryBuildRequestOptions,
 		autoconvert_api_BinaryBuildSource_To_v1beta3_BinaryBuildSource,
 		autoconvert_api_BuildConfigList_To_v1beta3_BuildConfigList,
@@ -5234,6 +7735,9 @@ func init() {
 		autoconvert_api_BuildStrategy_To_v1beta3_BuildStrategy,
 		autoconvert_api_BuildTriggerPolicy_To_v1beta3_BuildTriggerPolicy,
 		autoconvert_api_Build_To_v1beta3_Build,
+		autoconvert_api_Capabilities_To_v1beta3_Capabilities,
+		autoconvert_api_CephFSVolumeSource_To_v1beta3_CephFSVolumeSource,
+		autoconvert_api_CinderVolumeSource_To_v1beta3_CinderVolumeSource,
 		autoconvert_api_ClusterNetworkList_To_v1beta3_ClusterNetworkList,
 		autoconvert_api_ClusterNetwork_To_v1beta3_ClusterNetwork,
 		autoconvert_api_ClusterPolicyBindingList_To_v1beta3_ClusterPolicyBindingList,
@@ -5244,22 +7748,47 @@ func init() {
 		autoconvert_api_ClusterRoleBinding_To_v1beta3_ClusterRoleBinding,
 		autoconvert_api_ClusterRoleList_To_v1beta3_ClusterRoleList,
 		autoconvert_api_ClusterRole_To_v1beta3_ClusterRole,
+		autoconvert_api_ContainerPort_To_v1beta3_ContainerPort,
+		autoconvert_api_Container_To_v1beta3_Container,
 		autoconvert_api_CustomBuildStrategy_To_v1beta3_CustomBuildStrategy,
+		autoconvert_api_CustomDeploymentStrategyParams_To_v1beta3_CustomDeploymentStrategyParams,
+		autoconvert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger,
+		autoconvert_api_DeploymentCause_To_v1beta3_DeploymentCause,
 		autoconvert_api_DeploymentConfigList_To_v1beta3_DeploymentConfigList,
 		autoconvert_api_DeploymentConfigRollbackSpec_To_v1beta3_DeploymentConfigRollbackSpec,
 		autoconvert_api_DeploymentConfigRollback_To_v1beta3_DeploymentConfigRollback,
+		autoconvert_api_DeploymentConfigSpec_To_v1beta3_DeploymentConfigSpec,
+		autoconvert_api_DeploymentConfigStatus_To_v1beta3_DeploymentConfigStatus,
 		autoconvert_api_DeploymentConfig_To_v1beta3_DeploymentConfig,
+		autoconvert_api_DeploymentDetails_To_v1beta3_DeploymentDetails,
 		autoconvert_api_DeploymentLogOptions_To_v1beta3_DeploymentLogOptions,
 		autoconvert_api_DeploymentLog_To_v1beta3_DeploymentLog,
+		autoconvert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy,
+		autoconvert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams,
+		autoconvert_api_DeploymentTriggerPolicy_To_v1beta3_DeploymentTriggerPolicy,
 		autoconvert_api_DockerBuildStrategy_To_v1beta3_DockerBuildStrategy,
+		autoconvert_api_DownwardAPIVolumeFile_To_v1beta3_DownwardAPIVolumeFile,
+		autoconvert_api_DownwardAPIVolumeSource_To_v1beta3_DownwardAPIVolumeSource,
+		autoconvert_api_EmptyDirVolumeSource_To_v1beta3_EmptyDirVolumeSource,
 		autoconvert_api_EnvVarSource_To_v1beta3_EnvVarSource,
 		autoconvert_api_EnvVar_To_v1beta3_EnvVar,
+		autoconvert_api_ExecAction_To_v1beta3_ExecAction,
+		autoconvert_api_ExecNewPodHook_To_v1beta3_ExecNewPodHook,
+		autoconvert_api_FCVolumeSource_To_v1beta3_FCVolumeSource,
+		autoconvert_api_FlockerVolumeSource_To_v1beta3_FlockerVolumeSource,
+		autoconvert_api_GCEPersistentDiskVolumeSource_To_v1beta3_GCEPersistentDiskVolumeSource,
 		autoconvert_api_GitBuildSource_To_v1beta3_GitBuildSource,
+		autoconvert_api_GitRepoVolumeSource_To_v1beta3_GitRepoVolumeSource,
 		autoconvert_api_GitSourceRevision_To_v1beta3_GitSourceRevision,
+		autoconvert_api_GlusterfsVolumeSource_To_v1beta3_GlusterfsVolumeSource,
 		autoconvert_api_GroupList_To_v1beta3_GroupList,
 		autoconvert_api_Group_To_v1beta3_Group,
+		autoconvert_api_HTTPGetAction_To_v1beta3_HTTPGetAction,
+		autoconvert_api_Handler_To_v1beta3_Handler,
+		autoconvert_api_HostPathVolumeSource_To_v1beta3_HostPathVolumeSource,
 		autoconvert_api_HostSubnetList_To_v1beta3_HostSubnetList,
 		autoconvert_api_HostSubnet_To_v1beta3_HostSubnet,
+		autoconvert_api_ISCSIVolumeSource_To_v1beta3_ISCSIVolumeSource,
 		autoconvert_api_IdentityList_To_v1beta3_IdentityList,
 		autoconvert_api_Identity_To_v1beta3_Identity,
 		autoconvert_api_ImageChangeTrigger_To_v1beta3_ImageChangeTrigger,
@@ -5274,9 +7803,12 @@ func init() {
 		autoconvert_api_ImageStream_To_v1beta3_ImageStream,
 		autoconvert_api_Image_To_v1beta3_Image,
 		autoconvert_api_IsPersonalSubjectAccessReview_To_v1beta3_IsPersonalSubjectAccessReview,
+		autoconvert_api_LifecycleHook_To_v1beta3_LifecycleHook,
+		autoconvert_api_Lifecycle_To_v1beta3_Lifecycle,
 		autoconvert_api_LocalObjectReference_To_v1beta3_LocalObjectReference,
 		autoconvert_api_LocalResourceAccessReview_To_v1beta3_LocalResourceAccessReview,
 		autoconvert_api_LocalSubjectAccessReview_To_v1beta3_LocalSubjectAccessReview,
+		autoconvert_api_NFSVolumeSource_To_v1beta3_NFSVolumeSource,
 		autoconvert_api_NetNamespaceList_To_v1beta3_NetNamespaceList,
 		autoconvert_api_NetNamespace_To_v1beta3_NetNamespace,
 		autoconvert_api_OAuthAccessTokenList_To_v1beta3_OAuthAccessTokenList,
@@ -5291,16 +7823,22 @@ func init() {
 		autoconvert_api_ObjectMeta_To_v1beta3_ObjectMeta,
 		autoconvert_api_ObjectReference_To_v1beta3_ObjectReference,
 		autoconvert_api_Parameter_To_v1beta3_Parameter,
+		autoconvert_api_PersistentVolumeClaimVolumeSource_To_v1beta3_PersistentVolumeClaimVolumeSource,
+		autoconvert_api_PodSpec_To_v1beta3_PodSpec,
+		autoconvert_api_PodTemplateSpec_To_v1beta3_PodTemplateSpec,
 		autoconvert_api_PolicyBindingList_To_v1beta3_PolicyBindingList,
 		autoconvert_api_PolicyBinding_To_v1beta3_PolicyBinding,
 		autoconvert_api_PolicyList_To_v1beta3_PolicyList,
 		autoconvert_api_PolicyRule_To_v1beta3_PolicyRule,
 		autoconvert_api_Policy_To_v1beta3_Policy,
+		autoconvert_api_Probe_To_v1beta3_Probe,
 		autoconvert_api_ProjectList_To_v1beta3_ProjectList,
 		autoconvert_api_ProjectRequest_To_v1beta3_ProjectRequest,
 		autoconvert_api_ProjectSpec_To_v1beta3_ProjectSpec,
 		autoconvert_api_ProjectStatus_To_v1beta3_ProjectStatus,
 		autoconvert_api_Project_To_v1beta3_Project,
+		autoconvert_api_RBDVolumeSource_To_v1beta3_RBDVolumeSource,
+		autoconvert_api_RecreateDeploymentStrategyParams_To_v1beta3_RecreateDeploymentStrategyParams,
 		autoconvert_api_ResourceAccessReviewResponse_To_v1beta3_ResourceAccessReviewResponse,
 		autoconvert_api_ResourceAccessReview_To_v1beta3_ResourceAccessReview,
 		autoconvert_api_ResourceRequirements_To_v1beta3_ResourceRequirements,
@@ -5308,24 +7846,33 @@ func init() {
 		autoconvert_api_RoleBinding_To_v1beta3_RoleBinding,
 		autoconvert_api_RoleList_To_v1beta3_RoleList,
 		autoconvert_api_Role_To_v1beta3_Role,
+		autoconvert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams,
 		autoconvert_api_RouteList_To_v1beta3_RouteList,
 		autoconvert_api_RoutePort_To_v1beta3_RoutePort,
 		autoconvert_api_RouteSpec_To_v1beta3_RouteSpec,
 		autoconvert_api_RouteStatus_To_v1beta3_RouteStatus,
 		autoconvert_api_Route_To_v1beta3_Route,
+		autoconvert_api_SELinuxOptions_To_v1beta3_SELinuxOptions,
 		autoconvert_api_SecretSpec_To_v1beta3_SecretSpec,
+		autoconvert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource,
+		autoconvert_api_SecurityContext_To_v1beta3_SecurityContext,
 		autoconvert_api_SourceBuildStrategy_To_v1beta3_SourceBuildStrategy,
 		autoconvert_api_SourceControlUser_To_v1beta3_SourceControlUser,
 		autoconvert_api_SourceRevision_To_v1beta3_SourceRevision,
 		autoconvert_api_SubjectAccessReviewResponse_To_v1beta3_SubjectAccessReviewResponse,
 		autoconvert_api_SubjectAccessReview_To_v1beta3_SubjectAccessReview,
+		autoconvert_api_TCPSocketAction_To_v1beta3_TCPSocketAction,
 		autoconvert_api_TLSConfig_To_v1beta3_TLSConfig,
 		autoconvert_api_TemplateList_To_v1beta3_TemplateList,
 		autoconvert_api_Template_To_v1beta3_Template,
 		autoconvert_api_UserIdentityMapping_To_v1beta3_UserIdentityMapping,
 		autoconvert_api_UserList_To_v1beta3_UserList,
 		autoconvert_api_User_To_v1beta3_User,
+		autoconvert_api_VolumeMount_To_v1beta3_VolumeMount,
+		autoconvert_api_VolumeSource_To_v1beta3_VolumeSource,
+		autoconvert_api_Volume_To_v1beta3_Volume,
 		autoconvert_api_WebHookTrigger_To_v1beta3_WebHookTrigger,
+		autoconvert_v1beta3_AWSElasticBlockStoreVolumeSource_To_api_AWSElasticBlockStoreVolumeSource,
 		autoconvert_v1beta3_BinaryBuildRequestOptions_To_api_BinaryBuildRequestOptions,
 		autoconvert_v1beta3_BinaryBuildSource_To_api_BinaryBuildSource,
 		autoconvert_v1beta3_BuildConfigList_To_api_BuildConfigList,
@@ -5343,6 +7890,9 @@ func init() {
 		autoconvert_v1beta3_BuildStrategy_To_api_BuildStrategy,
 		autoconvert_v1beta3_BuildTriggerPolicy_To_api_BuildTriggerPolicy,
 		autoconvert_v1beta3_Build_To_api_Build,
+		autoconvert_v1beta3_Capabilities_To_api_Capabilities,
+		autoconvert_v1beta3_CephFSVolumeSource_To_api_CephFSVolumeSource,
+		autoconvert_v1beta3_CinderVolumeSource_To_api_CinderVolumeSource,
 		autoconvert_v1beta3_ClusterNetworkList_To_api_ClusterNetworkList,
 		autoconvert_v1beta3_ClusterNetwork_To_api_ClusterNetwork,
 		autoconvert_v1beta3_ClusterPolicyBindingList_To_api_ClusterPolicyBindingList,
@@ -5353,22 +7903,47 @@ func init() {
 		autoconvert_v1beta3_ClusterRoleBinding_To_api_ClusterRoleBinding,
 		autoconvert_v1beta3_ClusterRoleList_To_api_ClusterRoleList,
 		autoconvert_v1beta3_ClusterRole_To_api_ClusterRole,
+		autoconvert_v1beta3_ContainerPort_To_api_ContainerPort,
+		autoconvert_v1beta3_Container_To_api_Container,
 		autoconvert_v1beta3_CustomBuildStrategy_To_api_CustomBuildStrategy,
+		autoconvert_v1beta3_CustomDeploymentStrategyParams_To_api_CustomDeploymentStrategyParams,
+		autoconvert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger,
+		autoconvert_v1beta3_DeploymentCause_To_api_DeploymentCause,
 		autoconvert_v1beta3_DeploymentConfigList_To_api_DeploymentConfigList,
 		autoconvert_v1beta3_DeploymentConfigRollbackSpec_To_api_DeploymentConfigRollbackSpec,
 		autoconvert_v1beta3_DeploymentConfigRollback_To_api_DeploymentConfigRollback,
+		autoconvert_v1beta3_DeploymentConfigSpec_To_api_DeploymentConfigSpec,
+		autoconvert_v1beta3_DeploymentConfigStatus_To_api_DeploymentConfigStatus,
 		autoconvert_v1beta3_DeploymentConfig_To_api_DeploymentConfig,
+		autoconvert_v1beta3_DeploymentDetails_To_api_DeploymentDetails,
 		autoconvert_v1beta3_DeploymentLogOptions_To_api_DeploymentLogOptions,
 		autoconvert_v1beta3_DeploymentLog_To_api_DeploymentLog,
+		autoconvert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy,
+		autoconvert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
+		autoconvert_v1beta3_DeploymentTriggerPolicy_To_api_DeploymentTriggerPolicy,
 		autoconvert_v1beta3_DockerBuildStrategy_To_api_DockerBuildStrategy,
+		autoconvert_v1beta3_DownwardAPIVolumeFile_To_api_DownwardAPIVolumeFile,
+		autoconvert_v1beta3_DownwardAPIVolumeSource_To_api_DownwardAPIVolumeSource,
+		autoconvert_v1beta3_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
 		autoconvert_v1beta3_EnvVarSource_To_api_EnvVarSource,
 		autoconvert_v1beta3_EnvVar_To_api_EnvVar,
+		autoconvert_v1beta3_ExecAction_To_api_ExecAction,
+		autoconvert_v1beta3_ExecNewPodHook_To_api_ExecNewPodHook,
+		autoconvert_v1beta3_FCVolumeSource_To_api_FCVolumeSource,
+		autoconvert_v1beta3_FlockerVolumeSource_To_api_FlockerVolumeSource,
+		autoconvert_v1beta3_GCEPersistentDiskVolumeSource_To_api_GCEPersistentDiskVolumeSource,
 		autoconvert_v1beta3_GitBuildSource_To_api_GitBuildSource,
+		autoconvert_v1beta3_GitRepoVolumeSource_To_api_GitRepoVolumeSource,
 		autoconvert_v1beta3_GitSourceRevision_To_api_GitSourceRevision,
+		autoconvert_v1beta3_GlusterfsVolumeSource_To_api_GlusterfsVolumeSource,
 		autoconvert_v1beta3_GroupList_To_api_GroupList,
 		autoconvert_v1beta3_Group_To_api_Group,
+		autoconvert_v1beta3_HTTPGetAction_To_api_HTTPGetAction,
+		autoconvert_v1beta3_Handler_To_api_Handler,
+		autoconvert_v1beta3_HostPathVolumeSource_To_api_HostPathVolumeSource,
 		autoconvert_v1beta3_HostSubnetList_To_api_HostSubnetList,
 		autoconvert_v1beta3_HostSubnet_To_api_HostSubnet,
+		autoconvert_v1beta3_ISCSIVolumeSource_To_api_ISCSIVolumeSource,
 		autoconvert_v1beta3_IdentityList_To_api_IdentityList,
 		autoconvert_v1beta3_Identity_To_api_Identity,
 		autoconvert_v1beta3_ImageChangeTrigger_To_api_ImageChangeTrigger,
@@ -5383,9 +7958,12 @@ func init() {
 		autoconvert_v1beta3_ImageStream_To_api_ImageStream,
 		autoconvert_v1beta3_Image_To_api_Image,
 		autoconvert_v1beta3_IsPersonalSubjectAccessReview_To_api_IsPersonalSubjectAccessReview,
+		autoconvert_v1beta3_LifecycleHook_To_api_LifecycleHook,
+		autoconvert_v1beta3_Lifecycle_To_api_Lifecycle,
 		autoconvert_v1beta3_LocalObjectReference_To_api_LocalObjectReference,
 		autoconvert_v1beta3_LocalResourceAccessReview_To_api_LocalResourceAccessReview,
 		autoconvert_v1beta3_LocalSubjectAccessReview_To_api_LocalSubjectAccessReview,
+		autoconvert_v1beta3_NFSVolumeSource_To_api_NFSVolumeSource,
 		autoconvert_v1beta3_NetNamespaceList_To_api_NetNamespaceList,
 		autoconvert_v1beta3_NetNamespace_To_api_NetNamespace,
 		autoconvert_v1beta3_OAuthAccessTokenList_To_api_OAuthAccessTokenList,
@@ -5400,16 +7978,22 @@ func init() {
 		autoconvert_v1beta3_ObjectMeta_To_api_ObjectMeta,
 		autoconvert_v1beta3_ObjectReference_To_api_ObjectReference,
 		autoconvert_v1beta3_Parameter_To_api_Parameter,
+		autoconvert_v1beta3_PersistentVolumeClaimVolumeSource_To_api_PersistentVolumeClaimVolumeSource,
+		autoconvert_v1beta3_PodSpec_To_api_PodSpec,
+		autoconvert_v1beta3_PodTemplateSpec_To_api_PodTemplateSpec,
 		autoconvert_v1beta3_PolicyBindingList_To_api_PolicyBindingList,
 		autoconvert_v1beta3_PolicyBinding_To_api_PolicyBinding,
 		autoconvert_v1beta3_PolicyList_To_api_PolicyList,
 		autoconvert_v1beta3_PolicyRule_To_api_PolicyRule,
 		autoconvert_v1beta3_Policy_To_api_Policy,
+		autoconvert_v1beta3_Probe_To_api_Probe,
 		autoconvert_v1beta3_ProjectList_To_api_ProjectList,
 		autoconvert_v1beta3_ProjectRequest_To_api_ProjectRequest,
 		autoconvert_v1beta3_ProjectSpec_To_api_ProjectSpec,
 		autoconvert_v1beta3_ProjectStatus_To_api_ProjectStatus,
 		autoconvert_v1beta3_Project_To_api_Project,
+		autoconvert_v1beta3_RBDVolumeSource_To_api_RBDVolumeSource,
+		autoconvert_v1beta3_RecreateDeploymentStrategyParams_To_api_RecreateDeploymentStrategyParams,
 		autoconvert_v1beta3_ResourceAccessReviewResponse_To_api_ResourceAccessReviewResponse,
 		autoconvert_v1beta3_ResourceAccessReview_To_api_ResourceAccessReview,
 		autoconvert_v1beta3_ResourceRequirements_To_api_ResourceRequirements,
@@ -5417,23 +8001,31 @@ func init() {
 		autoconvert_v1beta3_RoleBinding_To_api_RoleBinding,
 		autoconvert_v1beta3_RoleList_To_api_RoleList,
 		autoconvert_v1beta3_Role_To_api_Role,
+		autoconvert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
 		autoconvert_v1beta3_RouteList_To_api_RouteList,
 		autoconvert_v1beta3_RoutePort_To_api_RoutePort,
 		autoconvert_v1beta3_RouteSpec_To_api_RouteSpec,
 		autoconvert_v1beta3_RouteStatus_To_api_RouteStatus,
 		autoconvert_v1beta3_Route_To_api_Route,
+		autoconvert_v1beta3_SELinuxOptions_To_api_SELinuxOptions,
 		autoconvert_v1beta3_SecretSpec_To_api_SecretSpec,
+		autoconvert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource,
+		autoconvert_v1beta3_SecurityContext_To_api_SecurityContext,
 		autoconvert_v1beta3_SourceBuildStrategy_To_api_SourceBuildStrategy,
 		autoconvert_v1beta3_SourceControlUser_To_api_SourceControlUser,
 		autoconvert_v1beta3_SourceRevision_To_api_SourceRevision,
 		autoconvert_v1beta3_SubjectAccessReviewResponse_To_api_SubjectAccessReviewResponse,
 		autoconvert_v1beta3_SubjectAccessReview_To_api_SubjectAccessReview,
+		autoconvert_v1beta3_TCPSocketAction_To_api_TCPSocketAction,
 		autoconvert_v1beta3_TLSConfig_To_api_TLSConfig,
 		autoconvert_v1beta3_TemplateList_To_api_TemplateList,
 		autoconvert_v1beta3_Template_To_api_Template,
 		autoconvert_v1beta3_UserIdentityMapping_To_api_UserIdentityMapping,
 		autoconvert_v1beta3_UserList_To_api_UserList,
 		autoconvert_v1beta3_User_To_api_User,
+		autoconvert_v1beta3_VolumeMount_To_api_VolumeMount,
+		autoconvert_v1beta3_VolumeSource_To_api_VolumeSource,
+		autoconvert_v1beta3_Volume_To_api_Volume,
 		autoconvert_v1beta3_WebHookTrigger_To_api_WebHookTrigger,
 	)
 	if err != nil {

--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -285,15 +285,13 @@ func RunCmdRegistry(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg
 					Name:   name,
 					Labels: label,
 				},
-				Triggers: []dapi.DeploymentTriggerPolicy{
-					{Type: dapi.DeploymentTriggerOnConfigChange},
-				},
-				Template: dapi.DeploymentTemplate{
-					ControllerTemplate: kapi.ReplicationControllerSpec{
-						Replicas: cfg.Replicas,
-						Selector: label,
-						Template: podTemplate,
+				Spec: dapi.DeploymentConfigSpec{
+					Replicas: cfg.Replicas,
+					Selector: label,
+					Triggers: []dapi.DeploymentTriggerPolicy{
+						{Type: dapi.DeploymentTriggerOnConfigChange},
 					},
+					Template: podTemplate,
 				},
 			},
 		}

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -590,28 +590,26 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg *
 					Name:   name,
 					Labels: label,
 				},
-				Triggers: []dapi.DeploymentTriggerPolicy{
-					{Type: dapi.DeploymentTriggerOnConfigChange},
-				},
-				Template: dapi.DeploymentTemplate{
+				Spec: dapi.DeploymentConfigSpec{
 					Strategy: dapi.DeploymentStrategy{
 						Type:          dapi.DeploymentStrategyTypeRolling,
 						RollingParams: &dapi.RollingDeploymentStrategyParams{UpdatePercent: &updatePercent},
 					},
-					ControllerTemplate: kapi.ReplicationControllerSpec{
-						Replicas: cfg.Replicas,
-						Selector: label,
-						Template: &kapi.PodTemplateSpec{
-							ObjectMeta: kapi.ObjectMeta{Labels: label},
-							Spec: kapi.PodSpec{
-								SecurityContext: &kapi.PodSecurityContext{
-									HostNetwork: cfg.HostNetwork,
-								},
-								ServiceAccountName: cfg.ServiceAccount,
-								NodeSelector:       nodeSelector,
-								Containers:         containers,
-								Volumes:            volumes,
+					Replicas: cfg.Replicas,
+					Selector: label,
+					Triggers: []dapi.DeploymentTriggerPolicy{
+						{Type: dapi.DeploymentTriggerOnConfigChange},
+					},
+					Template: &kapi.PodTemplateSpec{
+						ObjectMeta: kapi.ObjectMeta{Labels: label},
+						Spec: kapi.PodSpec{
+							SecurityContext: &kapi.PodSecurityContext{
+								HostNetwork: cfg.HostNetwork,
 							},
+							ServiceAccountName: cfg.ServiceAccount,
+							NodeSelector:       nodeSelector,
+							Containers:         containers,
+							Volumes:            volumes,
 						},
 					},
 				},

--- a/pkg/cmd/cli/cmd/deploy_test.go
+++ b/pkg/cmd/cli/cmd/deploy_test.go
@@ -60,7 +60,7 @@ func TestCmdDeploy_latestOk(t *testing.T) {
 			t.Fatalf("expected updated config")
 		}
 
-		if e, a := 2, updatedConfig.LatestVersion; e != a {
+		if e, a := 2, updatedConfig.Status.LatestVersion; e != a {
 			t.Fatalf("expected updated config version %d, got %d", e, a)
 		}
 	}
@@ -292,10 +292,10 @@ func TestDeploy_reenableTriggers(t *testing.T) {
 	})
 
 	config := deploytest.OkDeploymentConfig(1)
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{}
+	config.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{}
 	count := 3
 	for i := 0; i < count; i++ {
-		config.Triggers = append(config.Triggers, mktrigger())
+		config.Spec.Triggers = append(config.Spec.Triggers, mktrigger())
 	}
 
 	o := &DeployOptions{osClient: osClient}
@@ -308,10 +308,10 @@ func TestDeploy_reenableTriggers(t *testing.T) {
 		t.Fatalf("expected an updated config")
 	}
 
-	if e, a := count, len(config.Triggers); e != a {
+	if e, a := count, len(config.Spec.Triggers); e != a {
 		t.Fatalf("expected %d triggers, got %d", e, a)
 	}
-	for _, trigger := range config.Triggers {
+	for _, trigger := range config.Spec.Triggers {
 		if !trigger.ImageChangeParams.Automatic {
 			t.Errorf("expected trigger to be enabled: %#v", trigger.ImageChangeParams)
 		}

--- a/pkg/cmd/cli/cmd/exporter.go
+++ b/pkg/cmd/cli/cmd/exporter.go
@@ -142,10 +142,10 @@ func (e *defaultExporter) Export(obj runtime.Object, exact bool) error {
 
 	case *deployapi.DeploymentConfig:
 		// TODO: when internal refactor is completed use status reset
-		t.LatestVersion = 0
-		t.Details = nil
-		for i := range t.Triggers {
-			if p := t.Triggers[i].ImageChangeParams; p != nil {
+		t.Status.LatestVersion = 0
+		t.Status.Details = nil
+		for i := range t.Spec.Triggers {
+			if p := t.Spec.Triggers[i].ImageChangeParams; p != nil {
 				p.LastTriggeredImage = ""
 			}
 		}

--- a/pkg/cmd/cli/cmd/exporter_test.go
+++ b/pkg/cmd/cli/cmd/exporter_test.go
@@ -33,11 +33,8 @@ func TestExport(t *testing.T) {
 				ObjectMeta: kapi.ObjectMeta{
 					Name: "config",
 				},
-				LatestVersion: 0,
-				Triggers: []deployapi.DeploymentTriggerPolicy{
-					deploytest.OkImageChangeTrigger(),
-				},
-				Template: deploytest.OkDeploymentTemplate(),
+				Spec:   deploytest.OkDeploymentConfigSpec(),
+				Status: deploytest.OkDeploymentConfigStatus(0),
 			},
 			expectedErr: nil,
 		},

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -249,8 +249,8 @@ func (o *RollbackOptions) Run() error {
 	}
 
 	// Print warnings about any image triggers disabled during the rollback.
-	fmt.Fprintf(o.out, "#%d rolled back to %s\n", rolledback.LatestVersion, rollback.Spec.From.Name)
-	for _, trigger := range rolledback.Triggers {
+	fmt.Fprintf(o.out, "#%d rolled back to %s\n", rolledback.Status.LatestVersion, rollback.Spec.From.Name)
+	for _, trigger := range rolledback.Spec.Triggers {
 		disabled := []string{}
 		if trigger.Type == deployapi.DeploymentTriggerOnImageChange && !trigger.ImageChangeParams.Automatic {
 			disabled = append(disabled, trigger.ImageChangeParams.From.Name)
@@ -327,7 +327,7 @@ func (o *RollbackOptions) findTargetDeployment(config *deployapi.DeploymentConfi
 				break
 			}
 		} else {
-			if version < config.LatestVersion && deployutil.DeploymentStatusFor(&deployment) == deployapi.DeploymentStatusComplete {
+			if version < config.Status.LatestVersion && deployutil.DeploymentStatusFor(&deployment) == deployapi.DeploymentStatusComplete {
 				target = &deployment
 				break
 			}

--- a/pkg/cmd/cli/describe/describer_test.go
+++ b/pkg/cmd/cli/describe/describer_test.go
@@ -170,18 +170,17 @@ func TestDeploymentConfigDescriber(t *testing.T) {
 	podList.Items = []kapi.Pod{*mkPod(kapi.PodRunning, 0)}
 	describe()
 
-	config.Triggers = append(config.Triggers, deployapitest.OkConfigChangeTrigger())
+	config.Spec.Triggers = append(config.Spec.Triggers, deployapitest.OkConfigChangeTrigger())
 	describe()
 
-	config.Template.Strategy = deployapitest.OkCustomStrategy()
+	config.Spec.Strategy = deployapitest.OkCustomStrategy()
 	describe()
 
-	config.Triggers[0].ImageChangeParams.RepositoryName = ""
-	config.Triggers[0].ImageChangeParams.From = kapi.ObjectReference{Name: "imageRepo"}
+	config.Spec.Triggers[0].ImageChangeParams.From = kapi.ObjectReference{Name: "imageRepo"}
 	describe()
 
-	config.Template.Strategy = deployapitest.OkStrategy()
-	config.Template.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{
+	config.Spec.Strategy = deployapitest.OkStrategy()
+	config.Spec.Strategy.RecreateParams = &deployapi.RecreateDeploymentStrategyParams{
 		Pre: &deployapi.LifecycleHook{
 			FailurePolicy: deployapi.LifecycleHookFailurePolicyAbort,
 			ExecNewPod: &deployapi.ExecNewPodHook{

--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -453,7 +453,7 @@ func printRouteList(routeList *routeapi.RouteList, w io.Writer, withNamespace, w
 
 func printDeploymentConfig(dc *deployapi.DeploymentConfig, w io.Writer, withNamespace, wide, showAll bool, columnLabels []string) error {
 	triggers := sets.String{}
-	for _, trigger := range dc.Triggers {
+	for _, trigger := range dc.Spec.Triggers {
 		triggers.Insert(string(trigger.Type))
 	}
 	tStr := strings.Join(triggers.List(), ", ")
@@ -463,7 +463,7 @@ func printDeploymentConfig(dc *deployapi.DeploymentConfig, w io.Writer, withName
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w, "%s\t%s\t%v\n", dc.Name, tStr, dc.LatestVersion)
+	_, err := fmt.Fprintf(w, "%s\t%s\t%v\n", dc.Name, tStr, dc.Status.LatestVersion)
 	return err
 }
 

--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -390,7 +390,7 @@ func describeRouteInServiceGroup(routeNode *routegraph.RouteNode) []string {
 }
 
 func describeDeploymentConfigTrigger(dc *deployapi.DeploymentConfig) string {
-	if len(dc.Triggers) == 0 {
+	if len(dc.Spec.Triggers) == 0 {
 		return "(manual)"
 	}
 
@@ -624,10 +624,10 @@ func describeDeployments(dcNode *deploygraph.DeploymentConfigNode, activeDeploym
 
 	if activeDeployment == nil {
 		on, auto := describeDeploymentConfigTriggers(dcNode.DeploymentConfig)
-		if dcNode.DeploymentConfig.LatestVersion == 0 {
+		if dcNode.DeploymentConfig.Status.LatestVersion == 0 {
 			out = append(out, fmt.Sprintf("#1 deployment waiting %s", on))
 		} else if auto {
-			out = append(out, fmt.Sprintf("#%d deployment pending %s", dcNode.DeploymentConfig.LatestVersion, on))
+			out = append(out, fmt.Sprintf("#%d deployment pending %s", dcNode.DeploymentConfig.Status.LatestVersion, on))
 		}
 		// TODO: detect new image available?
 	} else {
@@ -714,7 +714,7 @@ func describePodSummary(rc *kapi.ReplicationController, includeEmpty bool) strin
 
 func describeDeploymentConfigTriggers(config *deployapi.DeploymentConfig) (string, bool) {
 	hasConfig, hasImage := false, false
-	for _, t := range config.Triggers {
+	for _, t := range config.Spec.Triggers {
 		switch t.Type {
 		case deployapi.DeploymentTriggerOnConfigChange:
 			hasConfig = true

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -89,14 +89,14 @@ func NewDeployer(client kclient.Interface) *Deployer {
 		},
 		scaler: scaler,
 		strategyFor: func(config *deployapi.DeploymentConfig) (strategy.DeploymentStrategy, error) {
-			switch config.Template.Strategy.Type {
+			switch config.Spec.Strategy.Type {
 			case deployapi.DeploymentStrategyTypeRecreate:
 				return recreate.NewRecreateDeploymentStrategy(client, latest.Codec), nil
 			case deployapi.DeploymentStrategyTypeRolling:
 				recreate := recreate.NewRecreateDeploymentStrategy(client, latest.Codec)
 				return rolling.NewRollingDeploymentStrategy(config.Namespace, client, latest.Codec, recreate), nil
 			default:
-				return nil, fmt.Errorf("unsupported strategy type: %s", config.Template.Strategy.Type)
+				return nil, fmt.Errorf("unsupported strategy type: %s", config.Spec.Strategy.Type)
 			}
 		},
 	}

--- a/pkg/deploy/api/test/ok.go
+++ b/pkg/deploy/api/test/ok.go
@@ -8,6 +8,24 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
+func OkDeploymentConfigSpec() deployapi.DeploymentConfigSpec {
+	return deployapi.DeploymentConfigSpec{
+		Replicas: 1,
+		Selector: OkSelector(),
+		Strategy: OkStrategy(),
+		Template: OkPodTemplate(),
+		Triggers: []deployapi.DeploymentTriggerPolicy{
+			OkImageChangeTrigger(),
+		},
+	}
+}
+
+func OkDeploymentConfigStatus(version int) deployapi.DeploymentConfigStatus {
+	return deployapi.DeploymentConfigStatus{
+		LatestVersion: version,
+	}
+}
+
 func OkStrategy() deployapi.DeploymentStrategy {
 	return deployapi.DeploymentStrategy{
 		Type: deployapi.DeploymentStrategyTypeRecreate,
@@ -67,21 +85,6 @@ func OkRollingStrategy() deployapi.DeploymentStrategy {
 	}
 }
 
-func OkControllerTemplate() kapi.ReplicationControllerSpec {
-	return kapi.ReplicationControllerSpec{
-		Replicas: 1,
-		Selector: OkSelector(),
-		Template: OkPodTemplate(),
-	}
-}
-
-func OkDeploymentTemplate() deployapi.DeploymentTemplate {
-	return deployapi.DeploymentTemplate{
-		Strategy:           OkStrategy(),
-		ControllerTemplate: OkControllerTemplate(),
-	}
-}
-
 func OkSelector() map[string]string {
 	return map[string]string{"a": "b"}
 }
@@ -131,24 +134,9 @@ func OkImageChangeTrigger() deployapi.DeploymentTriggerPolicy {
 				"container1",
 			},
 			From: kapi.ObjectReference{
-				Kind: "ImageStream",
-				Name: "test-image-stream",
+				Kind: "ImageStreamTag",
+				Name: imageapi.JoinImageStreamTag("test-image-stream", imageapi.DefaultImageTag),
 			},
-			Tag: imageapi.DefaultImageTag,
-		},
-	}
-}
-
-func OkImageChangeTriggerDeprecated() deployapi.DeploymentTriggerPolicy {
-	return deployapi.DeploymentTriggerPolicy{
-		Type: deployapi.DeploymentTriggerOnImageChange,
-		ImageChangeParams: &deployapi.DeploymentTriggerImageChangeParams{
-			Automatic: true,
-			ContainerNames: []string{
-				"container1",
-			},
-			RepositoryName: "registry:8080/repo1:ref1",
-			Tag:            imageapi.DefaultImageTag,
 		},
 	}
 }
@@ -158,10 +146,7 @@ func OkDeploymentConfig(version int) *deployapi.DeploymentConfig {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "config",
 		},
-		LatestVersion: version,
-		Triggers: []deployapi.DeploymentTriggerPolicy{
-			OkImageChangeTrigger(),
-		},
-		Template: OkDeploymentTemplate(),
+		Spec:   OkDeploymentConfigSpec(),
+		Status: OkDeploymentConfigStatus(version),
 	}
 }

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -245,27 +245,44 @@ const DeploymentCancelledAnnotationValue = "true"
 type DeploymentConfig struct {
 	unversioned.TypeMeta
 	kapi.ObjectMeta
+
+	// Spec represents a desired deployment state and how to deploy to it.
+	Spec DeploymentConfigSpec
+
+	// Status represents the current deployment state.
+	Status DeploymentConfigStatus
+}
+
+// DeploymentConfigSpec represents the desired state of the deployment.
+type DeploymentConfigSpec struct {
+	// Strategy describes how a deployment is executed.
+	Strategy DeploymentStrategy
+
 	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
 	// are defined, a new deployment can only occur as a result of an explicit client update to the
 	// DeploymentConfig with a new LatestVersion.
 	Triggers []DeploymentTriggerPolicy
-	// Template represents a desired deployment state and how to deploy it.
-	Template DeploymentTemplate
+
+	// Replicas is the number of desired replicas.
+	Replicas int
+
+	// Selector is a label query over pods that should match the Replicas count.
+	Selector map[string]string
+
+	// Template is the object that describes the pod that will be created if
+	// insufficient replicas are detected. Internally, this takes precedence over a
+	// TemplateRef.
+	Template *kapi.PodTemplateSpec
+}
+
+// DeploymentConfigStatus represents the current deployment state.
+type DeploymentConfigStatus struct {
 	// LatestVersion is used to determine whether the current deployment associated with a DeploymentConfig
 	// is out of sync.
 	LatestVersion int
 	// Details are the reasons for the update to this deployment config.
 	// This could be based on a change made by the user or caused by an automatic trigger
 	Details *DeploymentDetails
-}
-
-// DeploymentTemplate contains all the necessary information to create a deployment from a
-// DeploymentStrategy.
-type DeploymentTemplate struct {
-	// Strategy describes how a deployment is executed.
-	Strategy DeploymentStrategy
-	// ControllerTemplate is the desired replication state the deployment works to materialize.
-	ControllerTemplate kapi.ReplicationControllerSpec
 }
 
 // DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.
@@ -296,17 +313,10 @@ type DeploymentTriggerImageChangeParams struct {
 	Automatic bool
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string
-	// RepositoryName is the identifier for a Docker image repository to watch for changes.
-	// DEPRECATED: will be removed in v1beta3.
-	RepositoryName string
-	// From is a reference to a Docker image repository to watch for changes. This field takes
-	// precedence over RepositoryName, which is deprecated and will be removed in v1beta3. The
-	// Kind may be left blank, in which case it defaults to "ImageRepository". The "Name" is
-	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// From is a reference to an image stream tag to watch for changes. From.Name is the only
+	// required subfield - if From.Namespace is blank, the namespace of the current deployment
 	// trigger will be used.
 	From kapi.ObjectReference
-	// Tag is the name of an image repository tag to watch for changes.
-	Tag string
 	// LastTriggeredImage is the last image to be triggered.
 	LastTriggeredImage string
 }
@@ -329,10 +339,9 @@ type DeploymentCause struct {
 
 // DeploymentCauseImageTrigger contains information about a deployment caused by an image trigger
 type DeploymentCauseImageTrigger struct {
-	// RepositoryName is the identifier for a Docker image repository that was updated.
-	RepositoryName string
-	// Tag is the name of an image repository tag that is now pointing to a new image.
-	Tag string
+	// From is a reference to the changed object which triggered a deployment. The field may have
+	// the kinds DockerImage, ImageStreamTag, or ImageStreamImage.
+	From kapi.ObjectReference
 }
 
 // DeploymentConfigList is a collection of deployment configs.

--- a/pkg/deploy/api/v1/conversion.go
+++ b/pkg/deploy/api/v1/conversion.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/conversion"
@@ -13,200 +14,36 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func convert_v1_DeploymentConfig_To_api_DeploymentConfig(in *DeploymentConfig, out *newer.DeploymentConfig, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Spec, &out.Template, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Spec.Triggers, &out.Triggers, 0); err != nil {
-		return err
-	}
-	out.LatestVersion = in.Status.LatestVersion
-	if err := s.Convert(&in.Status.Details, &out.Details, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_DeploymentConfig_To_v1_DeploymentConfig(in *newer.DeploymentConfig, out *DeploymentConfig, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Template, &out.Spec, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Triggers, &out.Spec.Triggers, 0); err != nil {
-		return err
-	}
-	out.Status.LatestVersion = in.LatestVersion
-	if err := s.Convert(&in.Details, &out.Status.Details, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1_DeploymentConfigSpec_To_api_DeploymentTemplate(in *DeploymentConfigSpec, out *newer.DeploymentTemplate, s conversion.Scope) error {
-	out.ControllerTemplate.Replicas = in.Replicas
-	if in.Selector != nil {
-		out.ControllerTemplate.Selector = make(map[string]string)
-		for k, v := range in.Selector {
-			out.ControllerTemplate.Selector[k] = v
-		}
-	}
-	if in.Template != nil {
-		if err := s.Convert(&in.Template, &out.ControllerTemplate.Template, 0); err != nil {
-			return err
-		}
-	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1_DeploymentStrategy_To_api_DeploymentStrategy(in *DeploymentStrategy, out *newer.DeploymentStrategy, s conversion.Scope) error {
-	if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_DeploymentStrategy_To_v1_DeploymentStrategy(in *newer.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
-	if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_DeploymentTemplate_To_v1_DeploymentConfigSpec(in *newer.DeploymentTemplate, out *DeploymentConfigSpec, s conversion.Scope) error {
-	out.Replicas = in.ControllerTemplate.Replicas
-	if in.ControllerTemplate.Selector != nil {
-		out.Selector = make(map[string]string)
-		for k, v := range in.ControllerTemplate.Selector {
-			out.Selector[k] = v
-		}
-	}
-	if in.ControllerTemplate.Template != nil {
-		if err := s.Convert(&in.ControllerTemplate.Template, &out.Template, 0); err != nil {
-			return err
-		}
-	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
 func convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *DeploymentTriggerImageChangeParams, out *newer.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
-	out.Automatic = in.Automatic
-	out.ContainerNames = make([]string, len(in.ContainerNames))
-	copy(out.ContainerNames, in.ContainerNames)
-	out.LastTriggeredImage = in.LastTriggeredImage
-	if err := s.Convert(&in.From, &out.From, 0); err != nil {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	switch in.From.Kind {
-	case "DockerImage":
-		ref, err := imageapi.ParseDockerImageReference(in.From.Name)
-		if err != nil {
-			return err
-		}
-		out.Tag = ref.Tag
-		ref.Tag, ref.ID = "", ""
-		out.RepositoryName = ref.String()
 	case "ImageStreamTag":
-		name, tag, ok := imageapi.SplitImageStreamTag(in.From.Name)
-		if !ok {
-			return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
+	case "ImageStream", "ImageRepository":
+		out.From.Kind = "ImageStreamTag"
+		if !strings.Contains(out.From.Name, ":") {
+			out.From.Name = imageapi.JoinImageStreamTag(out.From.Name, imageapi.DefaultImageTag)
 		}
-		out.From.Kind = "ImageStream"
-		out.From.Name = name
-		out.Tag = tag
+	default:
+		// Will be handled by validation
 	}
 	return nil
 }
 
 func convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams(in *newer.DeploymentTriggerImageChangeParams, out *DeploymentTriggerImageChangeParams, s conversion.Scope) error {
-	out.Automatic = in.Automatic
-	out.ContainerNames = make([]string, len(in.ContainerNames))
-	copy(out.ContainerNames, in.ContainerNames)
-	out.LastTriggeredImage = in.LastTriggeredImage
-	if err := s.Convert(&in.From, &out.From, 0); err != nil {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	switch in.From.Kind {
-	case "ImageStream":
+	case "ImageStreamTag":
+	case "ImageStream", "ImageRepository":
 		out.From.Kind = "ImageStreamTag"
-		tag := in.Tag
-		if len(tag) == 0 {
-			tag = imageapi.DefaultImageTag
+		if !strings.Contains(out.From.Name, ":") {
+			out.From.Name = imageapi.JoinImageStreamTag(out.From.Name, imageapi.DefaultImageTag)
 		}
-		out.From.Name = fmt.Sprintf("%s:%s", in.From.Name, tag)
-	}
-	return nil
-}
-
-func convert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in *DeploymentCauseImageTrigger, out *newer.DeploymentCauseImageTrigger, s conversion.Scope) error {
-	switch in.From.Kind {
-	case "DockerImage":
-		ref, err := imageapi.ParseDockerImageReference(in.From.Name)
-		if err != nil {
-			return err
-		}
-		out.Tag = ref.Tag
-		ref.Tag, ref.ID = "", ""
-		out.RepositoryName = ref.Minimal().String()
-	}
-	return nil
-}
-
-func convert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger(in *newer.DeploymentCauseImageTrigger, out *DeploymentCauseImageTrigger, s conversion.Scope) error {
-	if len(in.RepositoryName) != 0 {
-		ref, err := imageapi.ParseDockerImageReference(in.RepositoryName)
-		if err != nil {
-			return err
-		}
-		ref.Tag = in.Tag
-		out.From.Kind = "DockerImage"
-		out.From.Name = ref.String()
+	default:
+		// Will be handled by validation
 	}
 	return nil
 }
@@ -288,31 +125,9 @@ func convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategy
 }
 
 func init() {
-	err := api.Scheme.AddDefaultingFuncs(
-		func(obj *DeploymentTriggerImageChangeParams) {
-			if len(obj.From.Kind) == 0 {
-				obj.From.Kind = "ImageStreamTag"
-			}
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	err = api.Scheme.AddConversionFuncs(
-		convert_v1_DeploymentConfig_To_api_DeploymentConfig,
-		convert_api_DeploymentConfig_To_v1_DeploymentConfig,
-
-		convert_v1_DeploymentConfigSpec_To_api_DeploymentTemplate,
-		convert_v1_DeploymentStrategy_To_api_DeploymentStrategy,
-		convert_api_DeploymentStrategy_To_v1_DeploymentStrategy,
-		convert_api_DeploymentTemplate_To_v1_DeploymentConfigSpec,
-
+	err := api.Scheme.AddConversionFuncs(
 		convert_v1_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
 		convert_api_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams,
-
-		convert_v1_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger,
-		convert_api_DeploymentCauseImageTrigger_To_v1_DeploymentCauseImageTrigger,
 
 		convert_v1_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
 		convert_api_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrategyParams,

--- a/pkg/deploy/api/v1/defaults.go
+++ b/pkg/deploy/api/v1/defaults.go
@@ -58,6 +58,11 @@ func init() {
 				}
 			}
 		},
+		func(obj *DeploymentTriggerImageChangeParams) {
+			if len(obj.From.Kind) == 0 {
+				obj.From.Kind = "ImageStreamTag"
+			}
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -224,8 +224,7 @@ type DeploymentConfig struct {
 	Status DeploymentConfigStatus `json:"status" description:"the current state of the latest deployment"`
 }
 
-// DeploymentTemplate contains all the necessary information to create a deployment from a
-// DeploymentStrategy.
+// DeploymentConfigSpec represents the desired state of the deployment.
 type DeploymentConfigSpec struct {
 	// Strategy describes how a deployment is executed.
 	Strategy DeploymentStrategy `json:"strategy" description:"how a deployment is executed"`
@@ -290,11 +289,10 @@ type DeploymentTriggerImageChangeParams struct {
 	Automatic bool `json:"automatic,omitempty" description:"whether detection of a new tag value should trigger a deployment"`
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string `json:"containerNames,omitempty" description:"restricts tag updates to a set of container names in the pod"`
-	// From is a reference to a Docker image repository tag to watch for changes. The
-	// Kind may be left blank, in which case it defaults to "ImageStreamTag". The "Name" is
-	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// From is a reference to an image stream tag to watch for changes. From.Name is the only
+	// required subfield - if From.Namespace is blank, the namespace of the current deployment
 	// trigger will be used.
-	From kapi.ObjectReference `json:"from" description:"a reference to an ImageRepository, ImageStream, or ImageStreamTag to watch for changes"`
+	From kapi.ObjectReference `json:"from" description:"a reference to an ImageStreamTag to watch for changes"`
 	// LastTriggeredImage is the last image to be triggered.
 	LastTriggeredImage string `json:"lastTriggeredImage,omitempty" description:"the last image to be triggered"`
 }

--- a/pkg/deploy/api/v1beta3/conversion.go
+++ b/pkg/deploy/api/v1beta3/conversion.go
@@ -3,6 +3,7 @@ package v1beta3
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/conversion"
@@ -12,200 +13,36 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/api"
 )
 
-func convert_v1beta3_DeploymentConfig_To_api_DeploymentConfig(in *DeploymentConfig, out *newer.DeploymentConfig, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Spec, &out.Template, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Spec.Triggers, &out.Triggers, 0); err != nil {
-		return err
-	}
-	out.LatestVersion = in.Status.LatestVersion
-	if err := s.Convert(&in.Status.Details, &out.Details, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_DeploymentConfig_To_v1beta3_DeploymentConfig(in *newer.DeploymentConfig, out *DeploymentConfig, s conversion.Scope) error {
-	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Template, &out.Spec, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Triggers, &out.Spec.Triggers, 0); err != nil {
-		return err
-	}
-	out.Status.LatestVersion = in.LatestVersion
-	if err := s.Convert(&in.Details, &out.Status.Details, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1beta3_DeploymentConfigSpec_To_api_DeploymentTemplate(in *DeploymentConfigSpec, out *newer.DeploymentTemplate, s conversion.Scope) error {
-	out.ControllerTemplate.Replicas = in.Replicas
-	if in.Selector != nil {
-		out.ControllerTemplate.Selector = make(map[string]string)
-		for k, v := range in.Selector {
-			out.ControllerTemplate.Selector[k] = v
-		}
-	}
-	if in.Template != nil {
-		if err := s.Convert(&in.Template, &out.ControllerTemplate.Template, 0); err != nil {
-			return err
-		}
-	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy(in *DeploymentStrategy, out *newer.DeploymentStrategy, s conversion.Scope) error {
-	if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy(in *newer.DeploymentStrategy, out *DeploymentStrategy, s conversion.Scope) error {
-	if err := s.Convert(&in.Type, &out.Type, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.CustomParams, &out.CustomParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RecreateParams, &out.RecreateParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.RollingParams, &out.RollingParams, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Resources, &out.Resources, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Labels, &out.Labels, 0); err != nil {
-		return err
-	}
-	if err := s.Convert(&in.Annotations, &out.Annotations, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
-func convert_api_DeploymentTemplate_To_v1beta3_DeploymentConfigSpec(in *newer.DeploymentTemplate, out *DeploymentConfigSpec, s conversion.Scope) error {
-	out.Replicas = in.ControllerTemplate.Replicas
-	if in.ControllerTemplate.Selector != nil {
-		out.Selector = make(map[string]string)
-		for k, v := range in.ControllerTemplate.Selector {
-			out.Selector[k] = v
-		}
-	}
-	if in.ControllerTemplate.Template != nil {
-		if err := s.Convert(&in.ControllerTemplate.Template, &out.Template, 0); err != nil {
-			return err
-		}
-	}
-	if err := s.Convert(&in.Strategy, &out.Strategy, 0); err != nil {
-		return err
-	}
-	return nil
-}
-
 func convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams(in *DeploymentTriggerImageChangeParams, out *newer.DeploymentTriggerImageChangeParams, s conversion.Scope) error {
-	out.Automatic = in.Automatic
-	out.ContainerNames = make([]string, len(in.ContainerNames))
-	copy(out.ContainerNames, in.ContainerNames)
-	out.LastTriggeredImage = in.LastTriggeredImage
-	if err := s.Convert(&in.From, &out.From, 0); err != nil {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	switch in.From.Kind {
-	case "DockerImage":
-		ref, err := imageapi.ParseDockerImageReference(in.From.Name)
-		if err != nil {
-			return err
-		}
-		out.Tag = ref.Tag
-		ref.Tag, ref.ID = "", ""
-		out.RepositoryName = ref.String()
 	case "ImageStreamTag":
-		name, tag, ok := imageapi.SplitImageStreamTag(in.From.Name)
-		if !ok {
-			return fmt.Errorf("ImageStreamTag object references must be in the form <name>:<tag>: %s", in.From.Name)
+	case "ImageStream", "ImageRepository":
+		out.From.Kind = "ImageStreamTag"
+		if !strings.Contains(out.From.Name, ":") {
+			out.From.Name = imageapi.JoinImageStreamTag(out.From.Name, imageapi.DefaultImageTag)
 		}
-		out.From.Kind = "ImageStream"
-		out.From.Name = name
-		out.Tag = tag
+	default:
+		// Will be handled by validation
 	}
 	return nil
 }
 
 func convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams(in *newer.DeploymentTriggerImageChangeParams, out *DeploymentTriggerImageChangeParams, s conversion.Scope) error {
-	out.Automatic = in.Automatic
-	out.ContainerNames = make([]string, len(in.ContainerNames))
-	copy(out.ContainerNames, in.ContainerNames)
-	out.LastTriggeredImage = in.LastTriggeredImage
-	if err := s.Convert(&in.From, &out.From, 0); err != nil {
+	if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 		return err
 	}
 	switch in.From.Kind {
-	case "ImageStream":
+	case "ImageStreamTag":
+	case "ImageStream", "ImageRepository":
 		out.From.Kind = "ImageStreamTag"
-		tag := in.Tag
-		if len(tag) == 0 {
-			tag = imageapi.DefaultImageTag
+		if !strings.Contains(out.From.Name, ":") {
+			out.From.Name = imageapi.JoinImageStreamTag(out.From.Name, imageapi.DefaultImageTag)
 		}
-		out.From.Name = fmt.Sprintf("%s:%s", in.From.Name, tag)
-	}
-	return nil
-}
-
-func convert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger(in *DeploymentCauseImageTrigger, out *newer.DeploymentCauseImageTrigger, s conversion.Scope) error {
-	switch in.From.Kind {
-	case "DockerImage":
-		ref, err := imageapi.ParseDockerImageReference(in.From.Name)
-		if err != nil {
-			return err
-		}
-		out.Tag = ref.Tag
-		ref.Tag, ref.ID = "", ""
-		out.RepositoryName = ref.Minimal().String()
-	}
-	return nil
-}
-
-func convert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger(in *newer.DeploymentCauseImageTrigger, out *DeploymentCauseImageTrigger, s conversion.Scope) error {
-	if len(in.RepositoryName) != 0 {
-		ref, err := imageapi.ParseDockerImageReference(in.RepositoryName)
-		if err != nil {
-			return err
-		}
-		ref.Tag = in.Tag
-		out.From.Kind = "DockerImage"
-		out.From.Name = ref.String()
+	default:
+		// Will be handled by validation
 	}
 	return nil
 }
@@ -287,28 +124,10 @@ func convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStr
 }
 
 func init() {
-	err := api.Scheme.AddDefaultingFuncs(
-		func(obj *DeploymentTriggerImageChangeParams) {
-			if len(obj.From.Kind) == 0 {
-				obj.From.Kind = "ImageStreamTag"
-			}
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	err = api.Scheme.AddConversionFuncs(
-		convert_v1beta3_DeploymentConfig_To_api_DeploymentConfig,
-		convert_api_DeploymentConfig_To_v1beta3_DeploymentConfig,
-		convert_v1beta3_DeploymentConfigSpec_To_api_DeploymentTemplate,
-		convert_v1beta3_DeploymentStrategy_To_api_DeploymentStrategy,
-		convert_api_DeploymentStrategy_To_v1beta3_DeploymentStrategy,
-		convert_api_DeploymentTemplate_To_v1beta3_DeploymentConfigSpec,
+	err := api.Scheme.AddConversionFuncs(
 		convert_v1beta3_DeploymentTriggerImageChangeParams_To_api_DeploymentTriggerImageChangeParams,
 		convert_api_DeploymentTriggerImageChangeParams_To_v1beta3_DeploymentTriggerImageChangeParams,
-		convert_v1beta3_DeploymentCauseImageTrigger_To_api_DeploymentCauseImageTrigger,
-		convert_api_DeploymentCauseImageTrigger_To_v1beta3_DeploymentCauseImageTrigger,
+
 		convert_v1beta3_RollingDeploymentStrategyParams_To_api_RollingDeploymentStrategyParams,
 		convert_api_RollingDeploymentStrategyParams_To_v1beta3_RollingDeploymentStrategyParams,
 	)

--- a/pkg/deploy/api/v1beta3/conversion_test.go
+++ b/pkg/deploy/api/v1beta3/conversion_test.go
@@ -12,23 +12,44 @@ import (
 )
 
 func TestTriggerRoundTrip(t *testing.T) {
-	p := DeploymentTriggerImageChangeParams{
-		From: kapiv1beta3.ObjectReference{
-			Kind: "DockerImage",
-			Name: "",
+	tests := []struct {
+		testName   string
+		kind, name string
+	}{
+		{
+			testName: "ImageStream -> ImageStreamTag",
+			kind:     "ImageStream",
+			name:     "golang",
+		},
+		{
+			testName: "ImageStreamTag -> ImageStreamTag",
+			kind:     "ImageStreamTag",
+			name:     "golang:latest",
+		},
+		{
+			testName: "ImageRepository -> ImageStreamTag",
+			kind:     "ImageRepository",
+			name:     "golang",
 		},
 	}
-	out := &newer.DeploymentTriggerImageChangeParams{}
-	if err := kapi.Scheme.Convert(&p, out); err == nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	p.From.Name = "a/b:test"
-	out = &newer.DeploymentTriggerImageChangeParams{}
-	if err := kapi.Scheme.Convert(&p, out); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if out.RepositoryName != "a/b" && out.Tag != "test" {
-		t.Errorf("unexpected output: %#v", out)
+
+	for _, test := range tests {
+		p := DeploymentTriggerImageChangeParams{
+			From: kapiv1beta3.ObjectReference{
+				Kind: test.kind,
+				Name: test.name,
+			},
+		}
+		out := &newer.DeploymentTriggerImageChangeParams{}
+		if err := kapi.Scheme.Convert(&p, out); err != nil {
+			t.Errorf("%s: unexpected error: %v", test.testName, err)
+		}
+		if out.From.Name != "golang:latest" {
+			t.Errorf("%s: unexpected name: %s", test.testName, out.From.Name)
+		}
+		if out.From.Kind != "ImageStreamTag" {
+			t.Errorf("%s: unexpected kind: %s", test.testName, out.From.Kind)
+		}
 	}
 }
 

--- a/pkg/deploy/api/v1beta3/defaults.go
+++ b/pkg/deploy/api/v1beta3/defaults.go
@@ -51,6 +51,11 @@ func init() {
 				}
 			}
 		},
+		func(obj *DeploymentTriggerImageChangeParams) {
+			if len(obj.From.Kind) == 0 {
+				obj.From.Kind = "ImageStreamTag"
+			}
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -304,11 +304,10 @@ type DeploymentTriggerImageChangeParams struct {
 	Automatic bool `json:"automatic,omitempty" description:"whether detection of a new tag value should trigger a deployment"`
 	// ContainerNames is used to restrict tag updates to the specified set of container names in a pod.
 	ContainerNames []string `json:"containerNames,omitempty" description:"restricts tag updates to a set of container names in the pod"`
-	// From is a reference to a Docker image repository tag to watch for changes. The
-	// Kind may be left blank, in which case it defaults to "ImageStreamTag". The "Name" is
-	// the only required subfield - if Namespace is blank, the namespace of the current deployment
+	// From is a reference to an image stream tag to watch for changes. From.Name is the only
+	// required subfield - if From.Namespace is blank, the namespace of the current deployment
 	// trigger will be used.
-	From kapi.ObjectReference `json:"from" description:"a reference to an ImageRepository, ImageStream, or ImageStreamTag to watch for changes"`
+	From kapi.ObjectReference `json:"from" description:"a reference to an ImageStreamTag to watch for changes"`
 	// LastTriggeredImage is the last image to be triggered.
 	LastTriggeredImage string `json:"lastTriggeredImage" description:"the last image to be triggered"`
 }

--- a/pkg/deploy/controller/configchange/controller_test.go
+++ b/pkg/deploy/controller/configchange/controller_test.go
@@ -31,7 +31,7 @@ func TestHandle_newConfigNoTriggers(t *testing.T) {
 	}
 
 	config := deployapitest.OkDeploymentConfig(1)
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{}
+	config.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{}
 	err := controller.Handle(config)
 
 	if err != nil {
@@ -61,7 +61,7 @@ func TestHandle_newConfigTriggers(t *testing.T) {
 	}
 
 	config := deployapitest.OkDeploymentConfig(0)
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
+	config.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
 	err := controller.Handle(config)
 
 	if err != nil {
@@ -72,16 +72,16 @@ func TestHandle_newConfigTriggers(t *testing.T) {
 		t.Fatalf("expected config to be updated")
 	}
 
-	if e, a := 1, updated.LatestVersion; e != a {
+	if e, a := 1, updated.Status.LatestVersion; e != a {
 		t.Fatalf("expected update to latestversion=%d, got %d", e, a)
 	}
 
-	if updated.Details == nil {
+	if updated.Status.Details == nil {
 		t.Fatalf("expected config change details to be set")
-	} else if updated.Details.Causes == nil {
+	} else if updated.Status.Details.Causes == nil {
 		t.Fatalf("expected config change causes to be set")
-	} else if updated.Details.Causes[0].Type != deployapi.DeploymentTriggerOnConfigChange {
-		t.Fatalf("expected config change cause to be set to config change trigger, got %s", updated.Details.Causes[0].Type)
+	} else if updated.Status.Details.Causes[0].Type != deployapi.DeploymentTriggerOnConfigChange {
+		t.Fatalf("expected config change cause to be set to config change trigger, got %s", updated.Status.Details.Causes[0].Type)
 	}
 }
 
@@ -98,14 +98,14 @@ func TestHandle_changeWithTemplateDiff(t *testing.T) {
 			name:           "container name change",
 			changeExpected: true,
 			modify: func(config *deployapi.DeploymentConfig) {
-				config.Template.ControllerTemplate.Template.Spec.Containers[1].Name = "modified"
+				config.Spec.Template.Spec.Containers[1].Name = "modified"
 			},
 		},
 		{
 			name:           "template label change",
 			changeExpected: true,
 			modify: func(config *deployapi.DeploymentConfig) {
-				config.Template.ControllerTemplate.Template.Labels["newkey"] = "value"
+				config.Spec.Template.Labels["newkey"] = "value"
 			},
 		},
 		{
@@ -119,7 +119,7 @@ func TestHandle_changeWithTemplateDiff(t *testing.T) {
 		t.Logf("running scenario: %s", s.name)
 
 		config := deployapitest.OkDeploymentConfig(1)
-		config.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
+		config.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{deployapitest.OkConfigChangeTrigger()}
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 		var updated *deployapi.DeploymentConfig
 
@@ -152,20 +152,20 @@ func TestHandle_changeWithTemplateDiff(t *testing.T) {
 				t.Errorf("expected config to be updated")
 				continue
 			}
-			if e, a := 2, updated.LatestVersion; e != a {
+			if e, a := 2, updated.Status.LatestVersion; e != a {
 				t.Errorf("expected update to latestversion=%d, got %d", e, a)
 			}
 
-			if updated.Details == nil {
+			if updated.Status.Details == nil {
 				t.Errorf("expected config change details to be set")
-			} else if updated.Details.Causes == nil {
+			} else if updated.Status.Details.Causes == nil {
 				t.Errorf("expected config change causes to be set")
-			} else if updated.Details.Causes[0].Type != deployapi.DeploymentTriggerOnConfigChange {
-				t.Errorf("expected config change cause to be set to config change trigger, got %s", updated.Details.Causes[0].Type)
+			} else if updated.Status.Details.Causes[0].Type != deployapi.DeploymentTriggerOnConfigChange {
+				t.Errorf("expected config change cause to be set to config change trigger, got %s", updated.Status.Details.Causes[0].Type)
 			}
 		} else {
 			if updated != nil {
-				t.Errorf("unexpected update to version %d", updated.LatestVersion)
+				t.Errorf("unexpected update to version %d", updated.Status.LatestVersion)
 			}
 		}
 	}

--- a/pkg/deploy/controller/deployment/controller.go
+++ b/pkg/deploy/controller/deployment/controller.go
@@ -204,7 +204,7 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 		return nil, err
 	}
 
-	container, err := c.makeContainer(&deploymentConfig.Template.Strategy)
+	container, err := c.makeContainer(&deploymentConfig.Spec.Strategy)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 					Args:      container.Args,
 					Image:     container.Image,
 					Env:       envVars,
-					Resources: deploymentConfig.Template.Strategy.Resources,
+					Resources: deploymentConfig.Spec.Strategy.Resources,
 				},
 			},
 			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
@@ -251,8 +251,8 @@ func (c *DeploymentController) makeDeployerPod(deployment *kapi.ReplicationContr
 	}
 
 	// MergeInfo will not overwrite values unless the flag OverwriteExistingDstKey is set.
-	util.MergeInto(pod.Labels, deploymentConfig.Template.Strategy.Labels, 0)
-	util.MergeInto(pod.Annotations, deploymentConfig.Template.Strategy.Annotations, 0)
+	util.MergeInto(pod.Labels, deploymentConfig.Spec.Strategy.Labels, 0)
+	util.MergeInto(pod.Annotations, deploymentConfig.Spec.Strategy.Annotations, 0)
 
 	pod.Spec.Containers[0].ImagePullPolicy = kapi.PullIfNotPresent
 

--- a/pkg/deploy/controller/deployment/controller_test.go
+++ b/pkg/deploy/controller/deployment/controller_test.go
@@ -696,9 +696,9 @@ func TestDeployerCustomLabelsAndAnnotations(t *testing.T) {
 	for _, test := range testCases {
 		t.Logf("evaluating test case %s", test.name)
 		config := deploytest.OkDeploymentConfig(1)
-		config.Template.Strategy = test.strategy
-		config.Template.Strategy.Labels = test.labels
-		config.Template.Strategy.Annotations = test.annotations
+		config.Spec.Strategy = test.strategy
+		config.Spec.Strategy.Labels = test.labels
+		config.Spec.Strategy.Annotations = test.annotations
 
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 		podTemplate, err := controller.makeDeployerPod(deployment)

--- a/pkg/deploy/controller/deploymentconfig/controller_test.go
+++ b/pkg/deploy/controller/deploymentconfig/controller_test.go
@@ -593,7 +593,7 @@ func TestHandleScenarios(t *testing.T) {
 		}
 
 		config := deploytest.OkDeploymentConfig(test.newVersion)
-		config.Template.ControllerTemplate.Replicas = test.replicas
+		config.Spec.Replicas = test.replicas
 		err := controller.Handle(config)
 		if err != nil && !test.errExpected {
 			t.Fatalf("unexpected error: %s", err)
@@ -610,7 +610,7 @@ func TestHandleScenarios(t *testing.T) {
 		sort.Sort(deployutil.ByLatestVersionDesc(expectedDeployments))
 		sort.Sort(deployutil.ByLatestVersionDesc(actualDeployments))
 
-		if e, a := test.expectedReplicas, config.Template.ControllerTemplate.Replicas; e != a {
+		if e, a := test.expectedReplicas, config.Spec.Replicas; e != a {
 			t.Errorf("expected config replicas to be %d, got %d", e, a)
 			t.Fatalf("events:\n%s", strings.Join(recorder.Events, "\t\n"))
 		}

--- a/pkg/deploy/generator/config_generator.go
+++ b/pkg/deploy/generator/config_generator.go
@@ -33,7 +33,7 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 	configChanged := false
 	errs := fielderrors.ValidationErrorList{}
 	causes := []*deployapi.DeploymentCause{}
-	for i, trigger := range config.Triggers {
+	for i, trigger := range config.Spec.Triggers {
 		params := trigger.ImageChangeParams
 
 		// Only process image change triggers
@@ -41,29 +41,31 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 			continue
 		}
 
+		name, tag, ok := imageapi.SplitImageStreamTag(params.From.Name)
+		if !ok {
+			f := fmt.Sprintf("triggers[%d].imageChange.from", i)
+			errs = append(errs, fielderrors.NewFieldInvalid(f, name, err.Error()))
+			continue
+		}
+
 		// Find the image repo referred to by the trigger params
 		imageStream, err := g.findImageStream(config, params)
 		if err != nil {
 			f := fmt.Sprintf("triggers[%d].imageChange.from", i)
-			v := params.From.Name
-			if len(params.RepositoryName) > 0 {
-				f = fmt.Sprintf("triggers[%d].imageChange.repositoryName", i)
-				v = params.RepositoryName
-			}
-			errs = append(errs, fielderrors.NewFieldInvalid(f, v, err.Error()))
+			errs = append(errs, fielderrors.NewFieldInvalid(f, name, err.Error()))
 			continue
 		}
 
 		// Find the latest tag event for the trigger tag
-		latestEvent := imageapi.LatestTaggedImage(imageStream, params.Tag)
+		latestEvent := imageapi.LatestTaggedImage(imageStream, tag)
 		if latestEvent == nil {
 			f := fmt.Sprintf("triggers[%d].imageChange.tag", i)
-			errs = append(errs, fielderrors.NewFieldInvalid(f, params.Tag, fmt.Sprintf("no image recorded for %s/%s:%s", imageStream.Namespace, imageStream.Name, params.Tag)))
+			errs = append(errs, fielderrors.NewFieldInvalid(f, tag, fmt.Sprintf("no image recorded for %s/%s:%s", imageStream.Namespace, imageStream.Name, tag)))
 			continue
 		}
 
 		// Update containers
-		template := config.Template.ControllerTemplate.Template
+		template := config.Spec.Template
 		names := sets.NewString(params.ContainerNames...)
 		containerChanged := false
 		for i := range template.Spec.Containers {
@@ -88,8 +90,10 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 				&deployapi.DeploymentCause{
 					Type: deployapi.DeploymentTriggerOnImageChange,
 					ImageTrigger: &deployapi.DeploymentCauseImageTrigger{
-						RepositoryName: latestEvent.DockerImageReference,
-						Tag:            params.Tag,
+						From: kapi.ObjectReference{
+							Name: imageapi.JoinImageStreamTag(imageStream.Name, tag),
+							Kind: "ImageStreamTag",
+						},
 					},
 				})
 		}
@@ -101,37 +105,27 @@ func (g *DeploymentConfigGenerator) Generate(ctx kapi.Context, name string) (*de
 
 	// Bump the version if we updated containers or if this is an initial
 	// deployment
-	if configChanged || config.LatestVersion == 0 {
-		config.Details = &deployapi.DeploymentDetails{
+	if configChanged || config.Status.LatestVersion == 0 {
+		config.Status.Details = &deployapi.DeploymentDetails{
 			Causes: causes,
 		}
-		config.LatestVersion++
+		config.Status.LatestVersion++
 	}
 
 	return config, nil
 }
 
 func (g *DeploymentConfigGenerator) findImageStream(config *deployapi.DeploymentConfig, params *deployapi.DeploymentTriggerImageChangeParams) (*imageapi.ImageStream, error) {
-	// Try to find the repo by ObjectReference
 	if len(params.From.Name) > 0 {
 		namespace := params.From.Namespace
 		if len(namespace) == 0 {
 			namespace = config.Namespace
 		}
-
-		return g.Client.GetImageStream(kapi.WithNamespace(kapi.NewContext(), namespace), params.From.Name)
-	}
-
-	// Fall back to a list based lookup on RepositoryName
-	repos, err := g.Client.ListImageStreams(kapi.WithNamespace(kapi.NewContext(), config.Namespace))
-	if err != nil {
-		return nil, err
-	}
-	for _, repo := range repos.Items {
-		if len(repo.Status.DockerImageRepository) > 0 &&
-			params.RepositoryName == repo.Status.DockerImageRepository {
-			return &repo, nil
+		name, _, ok := imageapi.SplitImageStreamTag(params.From.Name)
+		if !ok {
+			return nil, fmt.Errorf("invalid ImageStreamTag: %s", params.From.Name)
 		}
+		return g.Client.GetImageStream(kapi.WithNamespace(kapi.NewContext(), namespace), name)
 	}
 	return nil, fmt.Errorf("couldn't find image stream for config %s trigger params", deployutil.LabelForDeploymentConfig(config))
 }

--- a/pkg/deploy/generator/generator.go
+++ b/pkg/deploy/generator/generator.go
@@ -28,8 +28,10 @@ func (BasicDeploymentConfigController) Generate(genericParams map[string]interfa
 	case *kapi.ReplicationController:
 		obj = &deployapi.DeploymentConfig{
 			ObjectMeta: t.ObjectMeta,
-			Template: deployapi.DeploymentTemplate{
-				ControllerTemplate: t.Spec,
+			Spec: deployapi.DeploymentConfigSpec{
+				Selector: t.Spec.Selector,
+				Replicas: t.Spec.Replicas,
+				Template: t.Spec.Template,
 			},
 		}
 	default:

--- a/pkg/deploy/graph/nodes/nodes.go
+++ b/pkg/deploy/graph/nodes/nodes.go
@@ -19,8 +19,10 @@ func EnsureDeploymentConfigNode(g osgraph.MutableUniqueGraph, dc *depoyapi.Deplo
 		},
 	).(*DeploymentConfigNode)
 
-	rcSpecNode := kubegraph.EnsureReplicationControllerSpecNode(g, &dc.Template.ControllerTemplate, dcName)
-	g.AddEdge(dcNode, rcSpecNode, osgraph.ContainsEdgeKind)
+	if dc.Spec.Template != nil {
+		podTemplateSpecNode := kubegraph.EnsurePodTemplateSpecNode(g, dc.Spec.Template, dcName)
+		g.AddEdge(dcNode, podTemplateSpecNode, osgraph.ContainsEdgeKind)
+	}
 
 	return dcNode
 }

--- a/pkg/deploy/registry/deployconfig/etcd/etcd.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd.go
@@ -112,11 +112,11 @@ func (r *ScaleREST) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 			CreationTimestamp: deploymentConfig.CreationTimestamp,
 		},
 		Spec: extensions.ScaleSpec{
-			Replicas: deploymentConfig.Template.ControllerTemplate.Replicas,
+			Replicas: deploymentConfig.Spec.Replicas,
 		},
 		Status: extensions.ScaleStatus{
 			Replicas: totalReplicas,
-			Selector: deploymentConfig.Template.ControllerTemplate.Selector,
+			Selector: deploymentConfig.Spec.Selector,
 		},
 	}, nil
 }
@@ -162,7 +162,7 @@ func (r *ScaleREST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object
 			Replicas: scale.Spec.Replicas,
 		},
 		Status: extensions.ScaleStatus{
-			Selector: deploymentConfig.Template.ControllerTemplate.Selector,
+			Selector: deploymentConfig.Spec.Selector,
 		},
 	}
 
@@ -173,8 +173,8 @@ func (r *ScaleREST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object
 		return nil, false, err
 	}
 
-	oldReplicas := deploymentConfig.Template.ControllerTemplate.Replicas
-	deploymentConfig.Template.ControllerTemplate.Replicas = scale.Spec.Replicas
+	oldReplicas := deploymentConfig.Spec.Replicas
+	deploymentConfig.Spec.Replicas = scale.Spec.Replicas
 	if err := r.registry.UpdateDeploymentConfig(ctx, deploymentConfig); err != nil {
 		return nil, false, err
 	}

--- a/pkg/deploy/registry/deployconfig/strategy_test.go
+++ b/pkg/deploy/registry/deployconfig/strategy_test.go
@@ -19,10 +19,7 @@ func TestDeploymentConfigStrategy(t *testing.T) {
 	}
 	deploymentConfig := &deployapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "foo", Namespace: "default"},
-		Template: deployapi.DeploymentTemplate{
-			Strategy:           deploytest.OkStrategy(),
-			ControllerTemplate: deploytest.OkControllerTemplate(),
-		},
+		Spec:       deploytest.OkDeploymentConfigSpec(),
 	}
 	Strategy.PrepareForCreate(deploymentConfig)
 	errs := Strategy.Validate(ctx, deploymentConfig)
@@ -31,10 +28,7 @@ func TestDeploymentConfigStrategy(t *testing.T) {
 	}
 	updatedDeploymentConfig := &deployapi.DeploymentConfig{
 		ObjectMeta: kapi.ObjectMeta{Name: "bar", Namespace: "default"},
-		Template: deployapi.DeploymentTemplate{
-			Strategy:           deploytest.OkStrategy(),
-			ControllerTemplate: deploytest.OkControllerTemplate(),
-		},
+		Spec:       deploytest.OkDeploymentConfigSpec(),
 	}
 	errs = Strategy.ValidateUpdate(ctx, updatedDeploymentConfig, deploymentConfig)
 	if len(errs) == 0 {

--- a/pkg/deploy/registry/deploylog/rest.go
+++ b/pkg/deploy/registry/deploylog/rest.go
@@ -82,7 +82,7 @@ func (r *REST) Get(ctx kapi.Context, name string, opts runtime.Object) (runtime.
 	if err != nil {
 		return nil, errors.NewNotFound("deploymentConfig", name)
 	}
-	desiredVersion := config.LatestVersion
+	desiredVersion := config.Status.LatestVersion
 	if desiredVersion == 0 {
 		return nil, errors.NewBadRequest(fmt.Sprintf("no deployment exists for deploymentConfig %q", config.Name))
 	}
@@ -91,7 +91,7 @@ func (r *REST) Get(ctx kapi.Context, name string, opts runtime.Object) (runtime.
 	switch {
 	case deployLogOpts.Version == nil:
 		// Latest
-	case *deployLogOpts.Version <= 0 || int(*deployLogOpts.Version) > config.LatestVersion:
+	case *deployLogOpts.Version <= 0 || int(*deployLogOpts.Version) > config.Status.LatestVersion:
 		// Invalid version
 		return nil, errors.NewBadRequest(fmt.Sprintf("invalid version for deploymentConfig %q: %d", config.Name, *deployLogOpts.Version))
 	default:

--- a/pkg/deploy/registry/rollback/rollback_generator.go
+++ b/pkg/deploy/registry/rollback/rollback_generator.go
@@ -29,40 +29,40 @@ func (g *RollbackGenerator) GenerateRollback(from, to *deployapi.DeploymentConfi
 
 	// construct the candidate deploymentConfig based on the rollback spec
 	if spec.IncludeTemplate {
-		if err := kapi.Scheme.Convert(&to.Template.ControllerTemplate.Template, &rollback.Template.ControllerTemplate.Template); err != nil {
+		if err := kapi.Scheme.Convert(&to.Spec.Template, &rollback.Spec.Template); err != nil {
 			return nil, fmt.Errorf("couldn't copy template to rollback:: %v", err)
 		}
 	}
 
 	if spec.IncludeReplicationMeta {
-		rollback.Template.ControllerTemplate.Replicas = to.Template.ControllerTemplate.Replicas
-		rollback.Template.ControllerTemplate.Selector = map[string]string{}
-		for k, v := range to.Template.ControllerTemplate.Selector {
-			rollback.Template.ControllerTemplate.Selector[k] = v
+		rollback.Spec.Replicas = to.Spec.Replicas
+		rollback.Spec.Selector = map[string]string{}
+		for k, v := range to.Spec.Selector {
+			rollback.Spec.Selector[k] = v
 		}
 	}
 
 	if spec.IncludeTriggers {
-		if err := kapi.Scheme.Convert(&to.Triggers, &rollback.Triggers); err != nil {
+		if err := kapi.Scheme.Convert(&to.Spec.Triggers, &rollback.Spec.Triggers); err != nil {
 			return nil, fmt.Errorf("couldn't copy triggers to rollback:: %v", err)
 		}
 	}
 
 	if spec.IncludeStrategy {
-		if err := kapi.Scheme.Convert(&to.Template.Strategy, &rollback.Template.Strategy); err != nil {
+		if err := kapi.Scheme.Convert(&to.Spec.Strategy, &rollback.Spec.Strategy); err != nil {
 			return nil, fmt.Errorf("couldn't copy strategy to rollback:: %v", err)
 		}
 	}
 
 	// Disable any image change triggers.
-	for _, trigger := range rollback.Triggers {
+	for _, trigger := range rollback.Spec.Triggers {
 		if trigger.Type == deployapi.DeploymentTriggerOnImageChange {
 			trigger.ImageChangeParams.Automatic = false
 		}
 	}
 
 	// TODO: add a new cause?
-	rollback.LatestVersion++
+	rollback.Status.LatestVersion++
 
 	return rollback, nil
 }

--- a/pkg/deploy/scaler/scale.go
+++ b/pkg/deploy/scaler/scale.go
@@ -51,7 +51,7 @@ func (scaler *DeploymentConfigScaler) Scale(namespace, name string, newSize uint
 		if err != nil {
 			return err
 		}
-		return wait.Poll(waitForReplicas.Interval, waitForReplicas.Timeout, controllerHasSpecifiedReplicas(scaler.clientInterface, rc, dc.Template.ControllerTemplate.Replicas))
+		return wait.Poll(waitForReplicas.Interval, waitForReplicas.Timeout, controllerHasSpecifiedReplicas(scaler.clientInterface, rc, dc.Spec.Replicas))
 	}
 	return nil
 }

--- a/pkg/deploy/scaler/scale_test.go
+++ b/pkg/deploy/scaler/scale_test.go
@@ -43,7 +43,7 @@ func TestScale(t *testing.T) {
 		scaler := NewDeploymentConfigScaler(oc, kc)
 
 		config := deploytest.OkDeploymentConfig(1)
-		config.Template.ControllerTemplate.Replicas = 1
+		config.Spec.Replicas = 1
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 
 		var wait *kubectl.RetryParams
@@ -59,7 +59,7 @@ func TestScale(t *testing.T) {
 			// scale replica count.
 			scale := action.(ktestclient.UpdateAction).GetObject().(*extensions.Scale)
 			scale.Status.Replicas = scale.Spec.Replicas
-			config.Template.ControllerTemplate.Replicas = scale.Spec.Replicas
+			config.Spec.Replicas = scale.Spec.Replicas
 			deployment.Spec.Replicas = scale.Spec.Replicas
 			deployment.Status.Replicas = deployment.Spec.Replicas
 			return true, scale, nil
@@ -76,7 +76,7 @@ func TestScale(t *testing.T) {
 			}
 		}
 
-		if e, a := config.Template.ControllerTemplate.Replicas, deployment.Spec.Replicas; e != a {
+		if e, a := config.Spec.Replicas, deployment.Spec.Replicas; e != a {
 			t.Errorf("expected rc/%s replicas %d, got %d", deployment.Name, e, a)
 		}
 	}

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -75,7 +75,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 		return fmt.Errorf("couldn't decode config from deployment %s: %v", to.Name, err)
 	}
 
-	params := config.Template.Strategy.RecreateParams
+	params := config.Spec.Strategy.RecreateParams
 	retryParams := kubectl.NewRetryParams(s.retryPeriod, s.retryTimeout)
 	waitParams := kubectl.NewRetryParams(s.retryPeriod, s.retryTimeout)
 

--- a/pkg/deploy/strategy/recreate/recreate_test.go
+++ b/pkg/deploy/strategy/recreate/recreate_test.go
@@ -44,7 +44,7 @@ func TestRecreate_initialDeployment(t *testing.T) {
 
 func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
-	config.Template.Strategy.RecreateParams = recreateParams(deployapi.LifecycleHookFailurePolicyAbort, "")
+	config.Spec.Strategy.RecreateParams = recreateParams(deployapi.LifecycleHookFailurePolicyAbort, "")
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	scaler := &scalertest.FakeScaler{}
 
@@ -76,7 +76,7 @@ func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
 
 func TestRecreate_deploymentPreHookFail(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
-	config.Template.Strategy.RecreateParams = recreateParams(deployapi.LifecycleHookFailurePolicyAbort, "")
+	config.Spec.Strategy.RecreateParams = recreateParams(deployapi.LifecycleHookFailurePolicyAbort, "")
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	scaler := &scalertest.FakeScaler{}
 
@@ -106,7 +106,7 @@ func TestRecreate_deploymentPreHookFail(t *testing.T) {
 
 func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
-	config.Template.Strategy.RecreateParams = recreateParams("", deployapi.LifecycleHookFailurePolicyAbort)
+	config.Spec.Strategy.RecreateParams = recreateParams("", deployapi.LifecycleHookFailurePolicyAbort)
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	scaler := &scalertest.FakeScaler{}
 
@@ -138,7 +138,7 @@ func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
 
 func TestRecreate_deploymentPostHookFail(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
-	config.Template.Strategy.RecreateParams = recreateParams("", deployapi.LifecycleHookFailurePolicyAbort)
+	config.Spec.Strategy.RecreateParams = recreateParams("", deployapi.LifecycleHookFailurePolicyAbort)
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	scaler := &scalertest.FakeScaler{}
 

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -100,7 +100,7 @@ func (s *RollingDeploymentStrategy) Deploy(from *kapi.ReplicationController, to 
 		return fmt.Errorf("couldn't decode DeploymentConfig from deployment %s: %v", deployutil.LabelForDeployment(to), err)
 	}
 
-	params := config.Template.Strategy.RollingParams
+	params := config.Spec.Strategy.RollingParams
 	updateAcceptor := s.getUpdateAcceptor(time.Duration(*params.TimeoutSeconds) * time.Second)
 
 	// If there's no prior deployment, delegate to another strategy since the

--- a/pkg/deploy/strategy/rolling/rolling_test.go
+++ b/pkg/deploy/strategy/rolling/rolling_test.go
@@ -39,7 +39,7 @@ func TestRolling_deployInitial(t *testing.T) {
 	}
 
 	config := deploytest.OkDeploymentConfig(1)
-	config.Template.Strategy = deploytest.OkRollingStrategy()
+	config.Spec.Strategy = deploytest.OkRollingStrategy()
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 	err := strategy.Deploy(nil, deployment, 2)
 	if err != nil {
@@ -52,10 +52,10 @@ func TestRolling_deployInitial(t *testing.T) {
 
 func TestRolling_deployRolling(t *testing.T) {
 	latestConfig := deploytest.OkDeploymentConfig(1)
-	latestConfig.Template.Strategy = deploytest.OkRollingStrategy()
+	latestConfig.Spec.Strategy = deploytest.OkRollingStrategy()
 	latest, _ := deployutil.MakeDeployment(latestConfig, kapi.Codec)
 	config := deploytest.OkDeploymentConfig(2)
-	config.Template.Strategy = deploytest.OkRollingStrategy()
+	config.Spec.Strategy = deploytest.OkRollingStrategy()
 	deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 
 	deployments := map[string]*kapi.ReplicationController{
@@ -139,7 +139,7 @@ func TestRolling_deployRolling(t *testing.T) {
 
 func TestRolling_deployRollingHooks(t *testing.T) {
 	config := deploytest.OkDeploymentConfig(1)
-	config.Template.Strategy = deploytest.OkRollingStrategy()
+	config.Spec.Strategy = deploytest.OkRollingStrategy()
 	latest, _ := deployutil.MakeDeployment(config, kapi.Codec)
 
 	var hookError error
@@ -191,7 +191,7 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 
 	for _, tc := range cases {
 		config := deploytest.OkDeploymentConfig(2)
-		config.Template.Strategy.RollingParams = tc.params
+		config.Spec.Strategy.RollingParams = tc.params
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 		deployments[deployment.Name] = deployment
 		hookError = nil
@@ -250,7 +250,7 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 
 	for _, tc := range cases {
 		config := deploytest.OkDeploymentConfig(2)
-		config.Template.Strategy.RollingParams = tc.params
+		config.Spec.Strategy.RollingParams = tc.params
 		deployment, _ := deployutil.MakeDeployment(config, kapi.Codec)
 		hookError = nil
 		if tc.hookShouldFail {

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -103,7 +103,7 @@ func (e *HookExecutor) executeExecNewPod(hook *deployapi.LifecycleHook, deployme
 	}
 
 	// Build a pod spec from the hook config and deployment
-	podSpec, err := makeHookPod(hook, deployment, &config.Template.Strategy, label)
+	podSpec, err := makeHookPod(hook, deployment, &config.Spec.Strategy, label)
 	if err != nil {
 		return err
 	}

--- a/pkg/deploy/util/util_test.go
+++ b/pkg/deploy/util/util_test.go
@@ -72,7 +72,7 @@ func TestMakeDeploymentOk(t *testing.T) {
 	expectedAnnotations := map[string]string{
 		deployapi.DeploymentConfigAnnotation:  config.Name,
 		deployapi.DeploymentStatusAnnotation:  string(deployapi.DeploymentStatusNew),
-		deployapi.DeploymentVersionAnnotation: strconv.Itoa(config.LatestVersion),
+		deployapi.DeploymentVersionAnnotation: strconv.Itoa(config.Status.LatestVersion),
 	}
 
 	for key, expected := range expectedAnnotations {
@@ -84,7 +84,7 @@ func TestMakeDeploymentOk(t *testing.T) {
 	expectedAnnotations = map[string]string{
 		deployapi.DeploymentAnnotation:        deployment.Name,
 		deployapi.DeploymentConfigAnnotation:  config.Name,
-		deployapi.DeploymentVersionAnnotation: strconv.Itoa(config.LatestVersion),
+		deployapi.DeploymentVersionAnnotation: strconv.Itoa(config.Status.LatestVersion),
 	}
 
 	for key, expected := range expectedAnnotations {

--- a/pkg/diagnostics/cluster/router.go
+++ b/pkg/diagnostics/cluster/router.go
@@ -137,7 +137,7 @@ func (d *ClusterRouter) getRouterDC(r types.DiagnosticResult) *osapi.DeploymentC
 }
 
 func (d *ClusterRouter) getRouterPods(dc *osapi.DeploymentConfig, r types.DiagnosticResult) *kapi.PodList {
-	pods, err := d.KubeClient.Pods(kapi.NamespaceDefault).List(labels.SelectorFromSet(dc.Template.ControllerTemplate.Selector), fields.Everything())
+	pods, err := d.KubeClient.Pods(kapi.NamespaceDefault).List(labels.SelectorFromSet(dc.Spec.Selector), fields.Everything())
 	if err != nil {
 		r.Error("DClu2004", err, fmt.Sprintf("Finding pods for '%s' DeploymentConfig failed. This should never happen. Error: (%[2]T) %[2]v", routerName, err))
 		return nil

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -311,19 +311,17 @@ func (r *DeploymentConfigRef) DeploymentConfig() (*deployapi.DeploymentConfig, e
 		ObjectMeta: kapi.ObjectMeta{
 			Name: r.Name,
 		},
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: 1,
-				Selector: selector,
-				Template: &kapi.PodTemplateSpec{
-					ObjectMeta: kapi.ObjectMeta{
-						Labels: selector,
-					},
-					Spec: template,
+		Spec: deployapi.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: selector,
+			Template: &kapi.PodTemplateSpec{
+				ObjectMeta: kapi.ObjectMeta{
+					Labels: selector,
 				},
+				Spec: template,
 			},
+			Triggers: triggers,
 		},
-		Triggers: triggers,
 	}, nil
 }
 

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -908,7 +908,7 @@ func TestRunAll(t *testing.T) {
 				imageStreams = append(imageStreams, tp)
 			case *deployapi.DeploymentConfig:
 				got["deploymentConfig"] = append(got["deploymentConfig"], tp.Name)
-				if podTemplate := tp.Template.ControllerTemplate.Template; podTemplate != nil {
+				if podTemplate := tp.Spec.Template; podTemplate != nil {
 					for _, volume := range podTemplate.Spec.Volumes {
 						if volume.VolumeSource.EmptyDir != nil {
 							gotVolumes[volume.Name] = "EmptyDir"
@@ -923,9 +923,9 @@ func TestRunAll(t *testing.T) {
 					}
 				}
 				if test.config.Labels != nil {
-					if !mapContains(test.config.Labels, tp.Template.ControllerTemplate.Selector) {
+					if !mapContains(test.config.Labels, tp.Spec.Selector) {
 						t.Errorf("%s: did not get expected deployment config rc selector. Expected: %v. Got: %v",
-							test.name, test.config.Labels, tp.Template.ControllerTemplate.Selector)
+							test.name, test.config.Labels, tp.Spec.Selector)
 					}
 				}
 			}

--- a/pkg/generate/app/imageref.go
+++ b/pkg/generate/app/imageref.go
@@ -288,18 +288,17 @@ func (r *ImageRef) DeployableContainer() (container *kapi.Container, triggers []
 		imageChangeParams := &deployapi.DeploymentTriggerImageChangeParams{
 			Automatic:      true,
 			ContainerNames: []string{name},
-			Tag:            tag,
 		}
 		if r.Stream != nil {
 			imageChangeParams.From = kapi.ObjectReference{
-				Kind:      "ImageStream",
-				Name:      r.Stream.Name,
+				Kind:      "ImageStreamTag",
+				Name:      imageapi.JoinImageStreamTag(r.Stream.Name, tag),
 				Namespace: r.Stream.Namespace,
 			}
 		} else {
 			imageChangeParams.From = kapi.ObjectReference{
-				Kind: "ImageStream",
-				Name: name,
+				Kind: "ImageStreamTag",
+				Name: imageapi.JoinImageStreamTag(name, tag),
 			}
 		}
 		triggers = []deployapi.DeploymentTriggerPolicy{

--- a/pkg/generate/app/imageref_test.go
+++ b/pkg/generate/app/imageref_test.go
@@ -100,17 +100,17 @@ func TestSimpleDeploymentConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if config.Name != "origin" || len(config.Triggers) != 2 || config.Template.ControllerTemplate.Template.Spec.Containers[0].Image != image.Reference.String() {
+	if config.Name != "origin" || len(config.Spec.Triggers) != 2 || config.Spec.Template.Spec.Containers[0].Image != image.Reference.String() {
 		t.Errorf("unexpected value: %#v", config)
 	}
-	for _, trigger := range config.Triggers {
+	for _, trigger := range config.Spec.Triggers {
 		if trigger.Type == deployapi.DeploymentTriggerOnImageChange {
 			from := trigger.ImageChangeParams.From
-			if from.Kind != "ImageStream" {
-				t.Errorf("unexpected from kind in image change trigger")
+			if from.Kind != "ImageStreamTag" {
+				t.Errorf("unexpected from.kind in image change trigger: %s", from.Kind)
 			}
-			if from.Name != "origin" && from.Namespace != "openshift" {
-				t.Errorf("unexpected  from name and namespace in image change trigger: %s, %s", from.Name, from.Namespace)
+			if from.Name != "origin:latest" && from.Namespace != "openshift" {
+				t.Errorf("unexpected from.name %q and from.namespace %q in image change trigger", from.Name, from.Namespace)
 			}
 		}
 	}

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -330,12 +330,12 @@ func AddServices(objects Objects, firstPortOnly bool) Objects {
 					Labels:       t.Labels,
 				},
 				Spec: kapi.ServiceSpec{
-					Selector: t.Template.ControllerTemplate.Selector,
+					Selector: t.Spec.Selector,
 				},
 			}
 
 			svcPorts := map[string]struct{}{}
-			for _, container := range t.Template.ControllerTemplate.Template.Spec.Containers {
+			for _, container := range t.Spec.Template.Spec.Containers {
 				ports := sortablePorts(container.Ports)
 				sort.Sort(&ports)
 				for _, p := range ports {

--- a/pkg/generate/app/pipeline_test.go
+++ b/pkg/generate/app/pipeline_test.go
@@ -45,14 +45,12 @@ func fakeDeploymentConfig(name string, containers ...containerDesc) *deployapi.D
 		ObjectMeta: kapi.ObjectMeta{
 			Name: name,
 		},
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: 1,
-				Selector: map[string]string{"name": "test"},
-				Template: &kapi.PodTemplateSpec{
-					Spec: kapi.PodSpec{
-						Containers: specContainers,
-					},
+		Spec: deployapi.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: map[string]string{"name": "test"},
+			Template: &kapi.PodTemplateSpec{
+				Spec: kapi.PodSpec{
+					Containers: specContainers,
 				},
 			},
 		},

--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -459,7 +459,7 @@ func addDeploymentConfigsToGraph(g graph.Graph, dcs *deployapi.DeploymentConfigL
 		dc := &dcs.Items[i]
 		glog.V(4).Infof("Examining DeploymentConfig %s/%s", dc.Namespace, dc.Name)
 		dcNode := deploygraph.EnsureDeploymentConfigNode(g, dc)
-		addPodSpecToGraph(g, &dc.Template.ControllerTemplate.Template.Spec, dcNode)
+		addPodSpecToGraph(g, &dc.Spec.Template.Spec, dcNode)
 	}
 }
 

--- a/pkg/image/prune/imagepruner_test.go
+++ b/pkg/image/prune/imagepruner_test.go
@@ -241,11 +241,9 @@ func dc(namespace, name string, containerImages ...string) deployapi.DeploymentC
 			Namespace: namespace,
 			Name:      name,
 		},
-		Template: deployapi.DeploymentTemplate{
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Template: &kapi.PodTemplateSpec{
-					Spec: podSpec(containerImages...),
-				},
+		Spec: deployapi.DeploymentConfigSpec{
+			Template: &kapi.PodTemplateSpec{
+				Spec: podSpec(containerImages...),
 			},
 		},
 	}

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -170,23 +170,20 @@ func GenerateDeploymentConfig(name string, options *ipfailover.IPFailoverConfigC
 			Name:   name,
 			Labels: selector,
 		},
-		Triggers: []dapi.DeploymentTriggerPolicy{
-			{Type: dapi.DeploymentTriggerOnConfigChange},
-		},
-		Template: dapi.DeploymentTemplate{
+		Spec: dapi.DeploymentConfigSpec{
 			Strategy: dapi.DeploymentStrategy{
 				Type: dapi.DeploymentStrategyTypeRecreate,
 			},
-
 			// TODO: v0.1 requires a manual resize of the
 			//       replicas to match current cluster state.
 			//       In the future, the PerNodeController in
 			//       kubernetes would remove the need for this
 			//       manual intervention.
-			ControllerTemplate: kapi.ReplicationControllerSpec{
-				Replicas: options.Replicas,
-				Selector: selector,
-				Template: podTemplate,
+			Replicas: options.Replicas,
+			Selector: selector,
+			Template: podTemplate,
+			Triggers: []dapi.DeploymentTriggerPolicy{
+				{Type: dapi.DeploymentTriggerOnConfigChange},
 			},
 		},
 	}, nil

--- a/pkg/ipfailover/keepalived/generator_test.go
+++ b/pkg/ipfailover/keepalived/generator_test.go
@@ -95,12 +95,11 @@ func TestGenerateDeploymentConfig(t *testing.T) {
 			t.Errorf("Test case for %s got DeploymentConfig name %v where %v was expected", tc.Name, dc.Name, tc.Name)
 		}
 
-		controller := dc.Template.ControllerTemplate
-		if controller.Replicas != tc.Replicas {
-			t.Errorf("Test case for %s got controller replicas %v where %v was expected", tc.Name, controller.Replicas, tc.Replicas)
+		if dc.Spec.Replicas != tc.Replicas {
+			t.Errorf("Test case for %s got controller replicas %v where %v was expected", tc.Name, dc.Spec.Replicas, tc.Replicas)
 		}
 
-		podSpec := controller.Template.Spec
+		podSpec := dc.Spec.Template.Spec
 		if !podSpec.SecurityContext.HostNetwork {
 			t.Errorf("Test case for %s got HostNetwork disabled where HostNetwork was expected to be enabled", tc.Name)
 		}

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -176,20 +176,20 @@ func AddObjectAnnotations(obj runtime.Object, annotations map[string]string) err
 
 // addDeploymentConfigNestedLabels adds new label(s) to a nested labels of a single DeploymentConfig object
 func addDeploymentConfigNestedLabels(obj *deployapi.DeploymentConfig, labels labels.Set) error {
-	if obj.Template.ControllerTemplate.Template.Labels == nil {
-		obj.Template.ControllerTemplate.Template.Labels = make(map[string]string)
+	if obj.Spec.Template.Labels == nil {
+		obj.Spec.Template.Labels = make(map[string]string)
 	}
-	if err := MergeInto(obj.Template.ControllerTemplate.Template.Labels, labels, OverwriteExistingDstKey); err != nil {
+	if err := MergeInto(obj.Spec.Template.Labels, labels, OverwriteExistingDstKey); err != nil {
 		return fmt.Errorf("unable to add labels to Template.DeploymentConfig.Template.ControllerTemplate.Template: %v", err)
 	}
 	return nil
 }
 
 func addDeploymentConfigNestedAnnotations(obj *deployapi.DeploymentConfig, annotations map[string]string) error {
-	if obj.Template.ControllerTemplate.Template.Annotations == nil {
-		obj.Template.ControllerTemplate.Template.Annotations = make(map[string]string)
+	if obj.Spec.Template.Annotations == nil {
+		obj.Spec.Template.Annotations = make(map[string]string)
 	}
-	if err := MergeInto(obj.Template.ControllerTemplate.Template.Annotations, annotations, OverwriteExistingDstKey); err != nil {
+	if err := MergeInto(obj.Spec.Template.Annotations, annotations, OverwriteExistingDstKey); err != nil {
 		return fmt.Errorf("unable to add annotations to Template.DeploymentConfig.Template.ControllerTemplate.Template: %v", err)
 	}
 	return nil

--- a/pkg/util/labels_test.go
+++ b/pkg/util/labels_test.go
@@ -108,12 +108,10 @@ func TestAddConfigLabels(t *testing.T) {
 				ObjectMeta: kapi.ObjectMeta{
 					Labels: map[string]string{"foo": "first value"},
 				},
-				Template: deployapi.DeploymentTemplate{
-					ControllerTemplate: kapi.ReplicationControllerSpec{
-						Template: &kapi.PodTemplateSpec{
-							ObjectMeta: kapi.ObjectMeta{
-								Labels: map[string]string{"foo": "first value"},
-							},
+				Spec: deployapi.DeploymentConfigSpec{
+					Template: &kapi.PodTemplateSpec{
+						ObjectMeta: kapi.ObjectMeta{
+							Labels: map[string]string{"foo": "first value"},
 						},
 					},
 				},
@@ -156,7 +154,7 @@ func TestAddConfigLabels(t *testing.T) {
 				t.Errorf("Unexpected labels on testCase[%v]. Expected: %#v, got: %#v.", i, e, a)
 			}
 		case *deployapi.DeploymentConfig:
-			if e, a := test.expectedLabels, objType.Template.ControllerTemplate.Template.Labels; !reflect.DeepEqual(e, a) {
+			if e, a := test.expectedLabels, objType.Spec.Template.Labels; !reflect.DeepEqual(e, a) {
 				t.Errorf("Unexpected labels on testCase[%v]. Expected: %#v, got: %#v.", i, e, a)
 			}
 		}

--- a/test/fixtures/app-scenarios/new-project-deployed-app.yaml
+++ b/test/fixtures/app-scenarios/new-project-deployed-app.yaml
@@ -8,7 +8,6 @@ items:
       name: ruby-sample-build
       template: application-template-stibuild
     name: ruby-sample-build
-    namespace: example
   spec:
     output:
       to:
@@ -47,7 +46,6 @@ items:
       name: ruby-sample-build
       template: application-template-stibuild
     name: ruby-sample-build-1
-    namespace: example
   spec:
     output:
       to:
@@ -70,7 +68,7 @@ items:
     config:
       kind: BuildConfig
       name: ruby-sample-build
-      namespace: example
+
     phase: Complete
     startTimestamp: 2015-04-07T04:12:21Z
 - apiVersion: v1beta3
@@ -86,7 +84,6 @@ items:
     labels:
       template: application-template-stibuild
     name: database-2
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -143,7 +140,6 @@ items:
     labels:
       template: application-template-stibuild
     name: database-1
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -194,7 +190,6 @@ items:
     labels:
       template: application-template-stibuild
     name: database
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -245,14 +240,13 @@ items:
       openshift.io/deployment-config.name: frontend
       openshift.io/deployment.phase: Failed
       openshift.io/deployment-config.latest-version: "2"
-      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"frontend","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/frontend","uid":"471f24e3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"346","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ImageChange","imageChangeParams":{"automatic":true,"containerNames":["ruby-helloworld"],"from":{"kind":"ImageRepository","name":"origin-ruby-sample"},"tag":"latest","lastTriggeredImage":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58"}}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"frontend"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld","image":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","ports":[{"containerPort":8080,"protocol":"TCP"}],"env":[{"name":"ADMIN_USERNAME","key":"ADMIN_USERNAME","value":"adminNPX"},{"name":"ADMIN_PASSWORD","key":"ADMIN_PASSWORD","value":"7q1IdEao"},{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"frontend","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ImageChange","imageTrigger":{"repositoryName":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","tag":"latest"}}]}}'
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"frontend","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/frontend","uid":"471f24e3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"346","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ImageChange","imageChangeParams":{"automatic":true,"containerNames":["ruby-helloworld"],"from":{"kind":"ImageStreamTag","name":"origin-ruby-sample:latest"},"tag":"latest","lastTriggeredImage":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58"}}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"frontend"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld","image":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","ports":[{"containerPort":8080,"protocol":"TCP"}],"env":[{"name":"ADMIN_USERNAME","key":"ADMIN_USERNAME","value":"adminNPX"},{"name":"ADMIN_PASSWORD","key":"ADMIN_PASSWORD","value":"7q1IdEao"},{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"frontend","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ImageChange","imageTrigger":{"repositoryName":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","tag":"latest"}}]}}'
       openshift.io/deployment.status-reason: unable to contact server
       pod: deploy-frontend-17mza9
     creationTimestamp: 2015-04-07T04:12:53Z
     labels:
       template: application-template-stibuild
     name: frontend-2
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -307,13 +301,12 @@ items:
       openshift.io/deployment-config.name: frontend
       openshift.io/deployment.phase: Complete
       openshift.io/deployment-config.latest-version: "1"
-      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"frontend","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/frontend","uid":"471f24e3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"346","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ImageChange","imageChangeParams":{"automatic":true,"containerNames":["ruby-helloworld"],"from":{"kind":"ImageRepository","name":"origin-ruby-sample"},"tag":"latest","lastTriggeredImage":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58"}}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"frontend"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld","image":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","ports":[{"containerPort":8080,"protocol":"TCP"}],"env":[{"name":"ADMIN_USERNAME","key":"ADMIN_USERNAME","value":"adminNPX"},{"name":"ADMIN_PASSWORD","key":"ADMIN_PASSWORD","value":"7q1IdEao"},{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"frontend","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ImageChange","imageTrigger":{"repositoryName":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","tag":"latest"}}]}}'
+      openshift.io/encoded-deployment-config: '{"kind":"DeploymentConfig","apiVersion":"v1beta1","metadata":{"name":"frontend","namespace":"test","selfLink":"/osapi/v1beta1/watch/deploymentConfigs/frontend","uid":"471f24e3-dcdc-11e4-968a-080027c5bfa9","resourceVersion":"346","creationTimestamp":"2015-04-07T04:12:17Z","labels":{"template":"application-template-stibuild"}},"triggers":[{"type":"ImageChange","imageChangeParams":{"automatic":true,"containerNames":["ruby-helloworld"],"from":{"kind":"ImageStreamTag","name":"origin-ruby-sample:latest"},"tag":"latest","lastTriggeredImage":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58"}}],"template":{"strategy":{"type":"Recreate"},"controllerTemplate":{"replicas":1,"replicaSelector":{"name":"frontend"},"podTemplate":{"desiredState":{"manifest":{"version":"v1beta2","id":"","volumes":null,"containers":[{"name":"ruby-helloworld","image":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","ports":[{"containerPort":8080,"protocol":"TCP"}],"env":[{"name":"ADMIN_USERNAME","key":"ADMIN_USERNAME","value":"adminNPX"},{"name":"ADMIN_PASSWORD","key":"ADMIN_PASSWORD","value":"7q1IdEao"},{"name":"MYSQL_USER","key":"MYSQL_USER","value":"user1CY"},{"name":"MYSQL_PASSWORD","key":"MYSQL_PASSWORD","value":"FfyXmsGG"},{"name":"MYSQL_DATABASE","key":"MYSQL_DATABASE","value":"root"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"PullIfNotPresent","capabilities":{}}],"restartPolicy":{"always":{}},"dnsPolicy":"ClusterFirst"}},"labels":{"name":"frontend","template":"application-template-stibuild"}}}},"latestVersion":1,"details":{"causes":[{"type":"ImageChange","imageTrigger":{"repositoryName":"172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58","tag":"latest"}}]}}'
       pod: deploy-frontend-17mza9
     creationTimestamp: 2015-04-07T04:12:53Z
     labels:
       template: application-template-stibuild
     name: frontend-1
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -368,7 +361,6 @@ items:
     labels:
       template: application-template-stibuild
     name: frontend
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -415,8 +407,8 @@ items:
         containerNames:
         - ruby-helloworld
         from:
-          kind: ImageRepository
-          name: origin-ruby-sample
+          kind: ImageStreamTag
+          name: origin-ruby-sample:latest
         lastTriggeredImage: 172.30.17.139:5000/test/origin-ruby-sample:73214fafa244cb8abbe55273dac5d237a589a5fc7ac09926a1756a42c21e8a58
       type: ImageChange
   status:
@@ -435,7 +427,6 @@ items:
     labels:
       template: application-template-stibuild
     name: database
-    namespace: example
   spec:
     portalIP: 172.30.17.240
     ports:
@@ -456,7 +447,6 @@ items:
     labels:
       template: application-template-stibuild
     name: frontend
-    namespace: example
   spec:
     portalIP: 172.30.17.154
     ports:
@@ -479,7 +469,6 @@ items:
     labels:
       template: application-template-stibuild
     name: frontend
-    namespace: example
     resourceVersion: "393"
   spec:
     host: frontend-example.router.default.svc.cluster.local

--- a/test/fixtures/app-scenarios/new-project-no-build.yaml
+++ b/test/fixtures/app-scenarios/new-project-no-build.yaml
@@ -5,7 +5,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-example-2
-    namespace: example
   spec:
     output:
       to:
@@ -36,7 +35,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-example-2
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -73,8 +71,8 @@ items:
         containerNames:
         - sinatra-example-2
         from:
-          kind: ImageRepository
-          name: sinatra-example-2
+          kind: ImageStreamTag
+          name: sinatra-example-2:latest
         lastTriggeredImage: ""
       type: ImageChange
   status: {}
@@ -83,7 +81,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:18:56Z
     name: sinatra-example-2
-    namespace: example
   spec: {}
   status:
     dockerImageRepository: ""
@@ -92,7 +89,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-example-2
-    namespace: example
   spec:
     portalIP: 172.30.17.48
     ports:

--- a/test/fixtures/app-scenarios/new-project-one-build.yaml
+++ b/test/fixtures/app-scenarios/new-project-one-build.yaml
@@ -109,8 +109,8 @@ items:
         containerNames:
         - sinatra-example-1
         from:
-          kind: ImageRepository
-          name: sinatra-example-1
+          kind: ImageStreamTag
+          name: sinatra-example-1:latest
         lastTriggeredImage: ""
       type: ImageChange
   status: {}

--- a/test/fixtures/app-scenarios/new-project-two-deployment-configs.yaml
+++ b/test/fixtures/app-scenarios/new-project-two-deployment-configs.yaml
@@ -5,7 +5,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-app-example
-    namespace: example
   spec:
     output:
       to:
@@ -36,7 +35,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:18:56Z
     name: sinatra-app-example
-    namespace: example
   spec: {}
   status:
     dockerImageRepository: ""
@@ -47,7 +45,6 @@ items:
     labels:
       buildconfig: sinatra-app-example
     name: sinatra-app-example-1
-    namespace: example
   spec:
     output:
       to:
@@ -81,7 +78,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-app-example-a
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -118,8 +114,8 @@ items:
         containerNames:
         - sinatra-app-example
         from:
-          kind: ImageRepository
-          name: sinatra-app-example
+          kind: ImageStreamTag
+          name: sinatra-app-example:latest
         lastTriggeredImage: ""
       type: ImageChange
   status: {}
@@ -128,7 +124,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-app-example-b
-    namespace: example
   spec:
     replicas: 1
     selector:
@@ -165,8 +160,8 @@ items:
         containerNames:
         - sinatra-app-example
         from:
-          kind: ImageRepository
-          name: sinatra-app-example
+          kind: ImageStreamTag
+          name: sinatra-app-example:latest
         lastTriggeredImage: ""
       type: ImageChange
   status: {}
@@ -175,7 +170,6 @@ items:
   metadata:
     creationTimestamp: 2015-04-06T21:02:00Z
     name: sinatra-app-example
-    namespace: example
   spec:
     portalIP: 172.30.17.49
     ports:

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -59,7 +59,7 @@ func TestTriggers_manual(t *testing.T) {
 
 	config := deploytest.OkDeploymentConfig(0)
 	config.Namespace = testutil.Namespace()
-	config.Triggers = []deployapi.DeploymentTriggerPolicy{
+	config.Spec.Triggers = []deployapi.DeploymentTriggerPolicy{
 		{
 			Type: deployapi.DeploymentTriggerManual,
 		},
@@ -81,7 +81,7 @@ func TestTriggers_manual(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if config.LatestVersion != 1 {
+		if config.Status.LatestVersion != 1 {
 			t.Fatalf("Generated deployment should have version 1: %#v", config)
 		}
 		t.Logf("config(1): %#v", config)
@@ -199,8 +199,8 @@ waitForNewConfig:
 				newConfig = event.Object.(*deployapi.DeploymentConfig)
 				// Multiple updates to the config can be expected (e.g. status
 				// updates), so wait for a significant update (e.g. version).
-				if newConfig.LatestVersion > 0 {
-					if e, a := updatedPullSpec, newConfig.Template.ControllerTemplate.Template.Spec.Containers[0].Image; e != a {
+				if newConfig.Status.LatestVersion > 0 {
+					if e, a := updatedPullSpec, newConfig.Spec.Template.Spec.Containers[0].Image; e != a {
 						t.Fatalf("unexpected image for pod template container 0; expected %q, got %q", e, a)
 					}
 					break waitForNewConfig
@@ -218,7 +218,7 @@ func TestTriggers_configChange(t *testing.T) {
 
 	config := deploytest.OkDeploymentConfig(0)
 	config.Namespace = testutil.Namespace()
-	config.Triggers[0] = deploytest.OkConfigChangeTrigger()
+	config.Spec.Triggers[0] = deploytest.OkConfigChangeTrigger()
 	var err error
 
 	watch, err := openshift.KubeClient.ReplicationControllers(testutil.Namespace()).Watch(labels.Everything(), fields.Everything(), "0")
@@ -253,7 +253,7 @@ func TestTriggers_configChange(t *testing.T) {
 			return err
 		}
 
-		config.Template.ControllerTemplate.Template.Spec.Containers[0].Env[0].Value = "UPDATED"
+		config.Spec.Template.Spec.Containers[0].Env[0].Value = "UPDATED"
 
 		// before we update the config, we need to update the state of the existing deployment
 		// this is required to be done manually since the deployment and deployer pod controllers are not run in this test


### PR DESCRIPTION
Forked from https://github.com/openshift/origin/pull/6233

@deads2k the PR you asked for.

cc: @ironcladlou @liggitt 

TODO:
- [x] Fix unit tests
- [x] Generate new conversions
- [x] Refactor to use new internal changes everywhere
- [x] Support only imagestreamtags for deployment ICTs (https://github.com/openshift/origin/issues/2511)

Fixes https://github.com/openshift/origin/issues/2511