### PR TITLE
Don't show build trends chart scrollbars if not needed

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -311,7 +311,7 @@ html, body {
 .build-trends-responsive {
   width: 100%;
   margin-top: 20px;
-  overflow: scroll;
+  overflow: auto;
   .build-trends-container {
     min-width: 600px;
     height: 235px;


### PR DESCRIPTION
The scrollbar was appearing always due to the `overflow: scroll;` style on the parent div.

@jwforres 