### PR TITLE
Start SDN controller after running kubelet

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -680,12 +680,12 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "0f33df18b9747ebfe2c337f2bf4443b520a8f2ab"
+			"Rev": "8a7e17c0c3eea529955229dfd7b4baefad56633b"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "0f33df18b9747ebfe2c337f2bf4443b520a8f2ab"
+			"Rev": "8a7e17c0c3eea529955229dfd7b4baefad56633b"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/pkg/netutils/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/golang/glog"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
@@ -24,21 +25,26 @@ func GenerateDefaultGateway(sna *net.IPNet) net.IP {
 	return net.IPv4(ip[0], ip[1], ip[2], ip[3]|0x1)
 }
 
+// Return Host IP Networks
+// Ignores provided interfaces and filters loopback and non IPv4 addrs.
 func GetHostIPNetworks(skipInterfaces []string) ([]*net.IPNet, error) {
 	hostInterfaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
 	}
+
+	skipInterfaceMap := make(map[string]bool)
+	for _, ifaceName := range skipInterfaces {
+		skipInterfaceMap[ifaceName] = true
+	}
+
 	errList := []error{}
 	var hostIPNets []*net.IPNet
-
-CheckValidInterfaces:
 	for _, iface := range hostInterfaces {
-		for _, skipIface := range skipInterfaces {
-			if skipIface == iface.Name {
-				continue CheckValidInterfaces
-			}
+		if skipInterfaceMap[iface.Name] {
+			continue
 		}
+
 		ifAddrs, err := iface.Addrs()
 		if err != nil {
 			errList = append(errList, err)
@@ -50,8 +56,9 @@ CheckValidInterfaces:
 				errList = append(errList, err)
 				continue
 			}
-			// Skip IP addrs that doesn't belong to IPv4
-			if ip.To4() != nil {
+
+			// Skip loopback and non IPv4 addrs
+			if !ip.IsLoopback() && ip.To4() != nil {
 				hostIPNets = append(hostIPNets, ipNet)
 			}
 		}
@@ -67,12 +74,19 @@ func GetNodeIP(nodeName string) (string, error) {
 			return "", fmt.Errorf("Failed to lookup IP address for node %s: %v", nodeName, err)
 		}
 		for _, addr := range addrs {
-			if addr.String() != "127.0.0.1" {
-				ip = addr
-				break
+			// Skip loopback and non IPv4 addrs
+			if addr.IsLoopback() || addr.To4() == nil {
+				glog.V(5).Infof("Skipping loopback/non-IPv4 addr: %q for node %s", addr.String(), nodeName)
+				continue
 			}
+			ip = addr
+			break
 		}
+	} else if ip.IsLoopback() || ip.To4() == nil {
+		glog.V(5).Infof("Skipping loopback/non-IPv4 addr: %q for node %s", ip.String(), nodeName)
+		ip = nil
 	}
+
 	if ip == nil || len(ip.String()) == 0 {
 		return "", fmt.Errorf("Failed to obtain IP address from node name: %s", nodeName)
 	}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/common.go
@@ -224,14 +224,19 @@ func (oc *OvsController) markPodNetworkReady() {
 }
 
 func (oc *OvsController) WaitForPodNetworkReady() error {
-	timeout := 2 * time.Minute
-	select {
-	case <-oc.podNetworkReady:
+	logInterval := 10 * time.Second
+	numIntervals := 12 // timeout: 2 mins
+
+	for i := 0; i < numIntervals; i++ {
+		select {
 		// Wait for StartNode() to finish SDN setup
-	case <-time.After(timeout):
-		return fmt.Errorf("SDN pod network is not ready(timeout: %v)", timeout)
+		case <-oc.podNetworkReady:
+			return nil
+		case <-time.After(logInterval):
+			log.Infof("Waiting for SDN pod network to be ready...")
+		}
 	}
-	return nil
+	return fmt.Errorf("SDN pod network is not ready(timeout: 2 mins)")
 }
 
 func (oc *OvsController) Stop() {

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/plugin.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/plugin.go
@@ -85,9 +85,7 @@ func (plugin *ovsPlugin) getExecutable() string {
 }
 
 func (plugin *ovsPlugin) Init(host knetwork.Host) error {
-	err := plugin.WaitForPodNetworkReady()
-	glog.V(5).Infof("Init network plugin, error: %v", err)
-	return err
+	return nil
 }
 
 func (plugin *ovsPlugin) Name() string {
@@ -99,6 +97,11 @@ func (plugin *ovsPlugin) Name() string {
 }
 
 func (plugin *ovsPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) error {
+	err := plugin.WaitForPodNetworkReady()
+	if err != nil {
+		return err
+	}
+
 	var vnidstr string
 	if plugin.multitenant {
 		vnid, found := plugin.VNIDMap[namespace]

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -262,12 +262,10 @@ func RunSDNController(config *kubernetes.NodeConfig, nodeConfig configapi.NodeCo
 	if controller != nil {
 		config.KubeletConfig.NetworkPlugins = append(config.KubeletConfig.NetworkPlugins, controller)
 
-		go func() {
-			err := controller.StartNode(nodeConfig.NetworkConfig.MTU)
-			if err != nil {
-				glog.Fatalf("SDN Node failed: %v", err)
-			}
-		}()
+		err := controller.StartNode(nodeConfig.NetworkConfig.MTU)
+		if err != nil {
+			glog.Fatalf("SDN Node failed: %v", err)
+		}
 	}
 
 	return endpointFilter
@@ -280,11 +278,11 @@ func StartNode(nodeConfig configapi.NodeConfig) error {
 	}
 	glog.Infof("Starting node %s (%s)", config.KubeletServer.HostnameOverride, version.Get().String())
 
-	endpointFilter := RunSDNController(config, nodeConfig)
 	config.EnsureVolumeDir()
 	config.EnsureDocker(docker.NewHelper())
-	config.RunProxy(endpointFilter)
 	config.RunKubelet()
+	endpointFilter := RunSDNController(config, nodeConfig)
+	config.RunProxy(endpointFilter)
 
 	return nil
 }


### PR DESCRIPTION
On the openshift node,
 (a) SDN needs subnet which is assigned by openshift master
 (b) Master can only assign subnet after kubelet registers the node.
 (c) On a fresh openshift install, (a) and (b) are in deadlock as SDN will not
     proceed without subnet and kubelet will not register the node as
     it is blocked on network plugin intialization to finish.

So the fix:
 - Block SDN initialization to finish at pod setup time.
 - Run kubelet first and it registers the node if needed and
   pods may block for sdn initialization (async op).
 - Run SDN controller (doesn't need to run asynchronously) after kubelet,
   it gets the subnet, does the needed setup and marks sdn as ready.

Origin is broken with https://github.com/openshift/origin/pull/6202 and I did not find this issue during my testing as my node in the dev cluster was already registered with old code.