### PR TITLE
Allow oc new-build to create a binary scratch build

### DIFF
--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -181,8 +181,10 @@ func RunNewBuild(fullName string, f *clientcmd.Factory, out io.Writer, in io.Rea
 	for _, item := range result.List.Items {
 		switch t := item.(type) {
 		case *buildapi.BuildConfig:
-			fmt.Fprintf(out, "%sBuild configuration %q created and build triggered.\n", indent, t.Name)
-			fmt.Fprintf(out, "%sRun '%s logs -f bc/%s' to stream the build progress.\n", indent, fullName, t.Name)
+			if len(t.Spec.Triggers) > 0 && t.Spec.Source.Binary == nil {
+				fmt.Fprintf(out, "%sBuild configuration %q created and build triggered.\n", indent, t.Name)
+				fmt.Fprintf(out, "%sRun '%s logs -f bc/%s' to stream the build progress.\n", indent, fullName, t.Name)
+			}
 		}
 	}
 

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -166,14 +166,19 @@ type BuildStrategyRef struct {
 // BuildStrategy builds an OpenShift BuildStrategy from a BuildStrategyRef
 func (s *BuildStrategyRef) BuildStrategy(env Environment) (*buildapi.BuildStrategy, []buildapi.BuildTriggerPolicy) {
 	if s.IsDockerBuild {
-		dockerFrom := s.Base.ObjectReference()
+		var triggers []buildapi.BuildTriggerPolicy
+		strategy := &buildapi.DockerBuildStrategy{
+			Env: env.List(),
+		}
+		if s.Base != nil {
+			ref := s.Base.ObjectReference()
+			strategy.From = &ref
+			triggers = s.Base.BuildTriggers()
+		}
 		return &buildapi.BuildStrategy{
-			Type: buildapi.DockerBuildStrategyType,
-			DockerStrategy: &buildapi.DockerBuildStrategy{
-				From: &dockerFrom,
-				Env:  env.List(),
-			},
-		}, s.Base.BuildTriggers()
+			Type:           buildapi.DockerBuildStrategyType,
+			DockerStrategy: strategy,
+		}, triggers
 	}
 
 	return &buildapi.BuildStrategy{

--- a/pkg/generate/app/cmd/describe.go
+++ b/pkg/generate/app/cmd/describe.go
@@ -43,6 +43,8 @@ func extractFirstImageStreamTag(newOnly bool, images ...*app.ImageRef) string {
 func describeLocatedImage(refInput *app.ComponentInput, baseNamespace string) string {
 	match := refInput.ResolvedMatch
 	switch {
+	case match == nil:
+		return ""
 	case match.ImageStream != nil:
 		if image := match.Image; image != nil {
 			shortID := imageapi.ShortDockerImageID(image, 7)
@@ -72,11 +74,16 @@ func describeBuildPipelineWithImage(out io.Writer, ref app.ComponentReference, p
 		fmt.Fprintf(out, "--> %s\n", locatedImage)
 	}
 
-	trackedImage := extractFirstImageStreamTag(true, pipeline.InputImage, pipeline.Image)
-	if len(trackedImage) > 0 {
-		fmt.Fprintf(out, "    * An image stream will be created as %q that will track this image\n", trackedImage)
-	}
-	if pipeline.Build != nil {
+	if pipeline.Build == nil {
+		trackedImage := extractFirstImageStreamTag(true, pipeline.InputImage, pipeline.Image)
+		if len(trackedImage) > 0 {
+			fmt.Fprintf(out, "    * An image stream will be created as %q that will track this image\n", trackedImage)
+		}
+	} else {
+		trackedImage := extractFirstImageStreamTag(true, pipeline.InputImage)
+		if len(trackedImage) > 0 {
+			fmt.Fprintf(out, "    * An image stream will be created as %q that will track the source image\n", trackedImage)
+		}
 		if refInput.Uses != nil && refInput.Uses.Info() != nil {
 			matches := []string{}
 			for _, t := range refInput.Uses.Info().Types {
@@ -137,7 +144,7 @@ func describeBuildPipelineWithImage(out io.Writer, ref app.ComponentReference, p
 			fmt.Fprintf(out, "      You can add persistent volumes later by running 'volume dc/%s --add ...'\n", pipeline.Deployment.Name)
 		}
 	}
-	if match.Image != nil {
+	if match != nil && match.Image != nil {
 		if pipeline.Deployment != nil {
 			ports := sets.NewString()
 			if match.Image.Config != nil {

--- a/pkg/generate/app/componentref.go
+++ b/pkg/generate/app/componentref.go
@@ -82,6 +82,9 @@ func (r ComponentReferences) NeedsSource() (refs ComponentReferences) {
 // ImageComponentRefs returns the list of component references to images
 func (r ComponentReferences) ImageComponentRefs() (refs ComponentReferences) {
 	return r.filter(func(ref ComponentReference) bool {
+		if ref.Input().ScratchImage {
+			return true
+		}
 		return ref.Input() != nil && ref.Input().ResolvedMatch != nil && ref.Input().ResolvedMatch.IsImage()
 	})
 }
@@ -262,6 +265,7 @@ type ComponentInput struct {
 	Value    string
 
 	ExpectToBuild bool
+	ScratchImage  bool
 
 	Uses          *SourceRepository
 	ResolvedMatch *ComponentMatch

--- a/pkg/generate/app/pipeline.go
+++ b/pkg/generate/app/pipeline.go
@@ -56,13 +56,17 @@ func (pb *pipelineBuilder) To(name string) PipelineBuilder {
 // NewBuildPipeline creates a new pipeline with components that are expected to
 // be built.
 func (pb *pipelineBuilder) NewBuildPipeline(from string, resolvedMatch *ComponentMatch, sourceRepository *SourceRepository) (*Pipeline, error) {
-	input, err := InputImageFromMatch(resolvedMatch)
-	if err != nil {
-		return nil, fmt.Errorf("can't build %q: %v", from, err)
-	}
-	if !input.AsImageStream {
-		msg := "Could not find an image stream match for %q. Make sure that a Docker image with that tag is available on the node for the build to succeed."
-		glog.Warningf(msg, resolvedMatch.Value)
+	var input *ImageRef
+	if resolvedMatch != nil {
+		inputImage, err := InputImageFromMatch(resolvedMatch)
+		if err != nil {
+			return nil, fmt.Errorf("can't build %q: %v", from, err)
+		}
+		input = inputImage
+		if !input.AsImageStream {
+			msg := "Could not find an image stream match for %q. Make sure that a Docker image with that tag is available on the node for the build to succeed."
+			glog.Warningf(msg, resolvedMatch.Value)
+		}
 	}
 
 	strategy, source, err := StrategyAndSourceForRepository(sourceRepository, input)

--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -349,10 +349,6 @@ func (e SourceRepositoryEnumerator) Detect(dir string) (*SourceRepositoryInfo, e
 // TODO: user should be able to choose whether to download a remote source ref for
 // more info
 func StrategyAndSourceForRepository(repo *SourceRepository, image *ImageRef) (*BuildStrategyRef, *SourceRef, error) {
-	if image == nil {
-		return nil, nil, fmt.Errorf("an image ref is required to generate a strategy and sourceref")
-	}
-
 	strategy := &BuildStrategyRef{
 		Base:          image,
 		IsDockerBuild: repo.IsDockerBuild(),

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -25,6 +25,15 @@ template='{{with .spec.output.to}}{{.kind}} {{.name}}{{end}}'
 os::cmd::expect_success "oc new-build --dockerfile=\$'FROM centos:7\nRUN yum install -y httpd'"
 os::cmd::expect_success_and_text "oc get bc/centos --template '${template}'" '^ImageStreamTag centos:latest$'
 
+# Build from a binary with no inputs requires name
+os::cmd::expect_failure_and_text "oc new-build --binary" "you must provide a --name"
+
+# Build from a binary with inputs creates a binary build
+os::cmd::expect_success "oc new-build --binary --name=binary-test"
+os::cmd::expect_success_and_text "oc get bc/binary-test" 'Binary'
+
+os::cmd::expect_success 'oc delete is/binary-test bc/binary-test'
+
 # Build from Dockerfile with output to DockerImage
 os::cmd::expect_success "oc new-build -D \$'FROM openshift/origin:v1.1' --to-docker"
 os::cmd::expect_success_and_text "oc get bc/origin --template '${template}'" '^DockerImage library/origin:latest$'


### PR DESCRIPTION
Support `oc new-build --binary --name=test` which creates a build that has no From, is binary, and can build anything with a docker image.