### PR TITLE
Create proper client packages for mac and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Getting Started
 
 ### Installation
 
+If you have downloaded the client tools, place the included binaries in your PATH.
+
 * For a quick install of Origin, see the [Getting Started Install guide](https://docs.openshift.org/latest/getting_started/administrators.html).
 * For an advanced installation using [Ansible](https://github.com/openshift/openshift-ansible), follow the [Advanced Installation guide](https://docs.openshift.org/latest/install_config/install/advanced_install.html)
 * To build and run from source, see [CONTRIBUTING.adoc](CONTRIBUTING.adoc)

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -28,15 +28,15 @@ if [[ ! -d _output/local/releases ]]; then
 fi
 
 # Extract the release achives to a staging area.
-os::build::detect_local_release_tars "linux-amd64"
+os::build::detect_local_release_tars "linux-64bit"
 
 echo "Building images from release tars for commit ${OS_RELEASE_COMMIT}:"
 echo " primary: $(basename ${OS_PRIMARY_RELEASE_TAR})"
 echo " image:   $(basename ${OS_IMAGE_RELEASE_TAR})"
 
 imagedir="$(mktemp -d 2>/dev/null || mktemp -d -t imagedir.XXXXXX)"
-tar xzpf "${OS_PRIMARY_RELEASE_TAR}" -C "${imagedir}"
-tar xzpf "${OS_IMAGE_RELEASE_TAR}" -C "${imagedir}"
+tar xzpf "${OS_PRIMARY_RELEASE_TAR}" --strip-components=1 -C "${imagedir}"
+tar xzpf "${OS_IMAGE_RELEASE_TAR}" --strip-components=1 -C "${imagedir}"
 
 # Copy primary binaries to the appropriate locations.
 cp -pf "${imagedir}/openshift" images/origin/bin

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -15,10 +15,10 @@ cd "${OS_ROOT}"
 
 # Copy the linux release archives release back to the local _output/local/bin/linux/amd64 directory.
 # TODO: support different OS's?
-os::build::detect_local_release_tars "linux-amd64"
+os::build::detect_local_release_tars "linux-64bit"
 
 mkdir -p "${OS_OUTPUT_BINPATH}/linux/amd64"
-tar mxzf "${OS_PRIMARY_RELEASE_TAR}" -C "${OS_OUTPUT_BINPATH}/linux/amd64"
-tar mxzf "${OS_IMAGE_RELEASE_TAR}" -C "${OS_OUTPUT_BINPATH}/linux/amd64"
+tar mxzf "${OS_PRIMARY_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/linux/amd64"
+tar mxzf "${OS_IMAGE_RELEASE_TAR}" --strip-components=1 -C "${OS_OUTPUT_BINPATH}/linux/amd64"
 
 os::build::make_openshift_binary_symlinks


### PR DESCRIPTION
Give each archive better names.

```
openshift-origin-v1.1-65c2664-linux-64bit.tar.gz
openshift-origin-client-tools-v1.1-65c2664-linux-64bit.tar.gz
openshift-origin-client-tools-v1.1-65c2664-mac.zip
openshift-origin-client-tools-v1.1-65c2664-windows.zip
openshift-origin-client-tools-v1.1-65c2664-linux-32bit.tar.gz
```

Also, adds a root directory to each TAR file.

Fixes #5936