### PR TITLE
Add bash auto-completion for oc, oadm, and openshift to the environments created by Vagrant

### DIFF
--- a/contrib/vagrant/provision-dind.sh
+++ b/contrib/vagrant/provision-dind.sh
@@ -6,7 +6,7 @@ ORIGIN_ROOT=${1:-/vagrant}
 
 yum install -y deltarpm
 yum update -y
-yum install -y docker-io go git
+yum install -y docker-io go git bash-completion
 
 # It should be safe to bypass security to access docker in a dev
 # environment.  This also allows bash completion, which doesn't work

--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -128,6 +128,9 @@ os::provision::set-os-env() {
   fi
   os::provision::set-bash-env "${origin_root}" "${config_root}" \
 "/root/${file_target}"
+
+  # Make symlinks to the bash completions for the openshift commands
+  ln -s ${origin_root}/contrib/completions/bash/* /etc/bash_completion.d/
 }
 
 os::provision::get-admin-config() {
@@ -215,7 +218,7 @@ os::provision::install-pkgs() {
   if ! os::provision::in-container; then
     yum install -y deltarpm
     yum update -y
-    yum install -y docker-io git golang e2fsprogs hg net-tools bridge-utils which ethtool
+    yum install -y docker-io git golang e2fsprogs hg net-tools bridge-utils which ethtool bash-completion
 
     systemctl enable docker
     systemctl start docker


### PR DESCRIPTION
This patch makes the vagrant images pull in the bash-completions rpm and adds a symbolic link from /etc/bash_completions.d to the completions in the source tree mounted through /vagrant.  After doing this all of the OpenShift commands auto-complete correctly when the DinD and the Dev Cluster.