### PR TITLE
[RPMs] Cleanup kubeplugin path from old sdn-ovs installs

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -3,6 +3,8 @@
 %global gopath      %{_datadir}/gocode
 %global import_path github.com/openshift/origin
 %global sdn_import_path github.com/openshift/openshift-sdn
+# The following should only be used for cleanup of sdn-ovs upgrades
+%global kube_plugin_path /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet
 
 # docker_version is the version of docker requires by packages
 %global docker_version 1.8.2
@@ -393,6 +395,14 @@ fi
 %{_bindir}/openshift-sdn-ovs-setup.sh
 %{_unitdir}/%{name}-node.service.d/openshift-sdn-ovs.conf
 %{_unitdir}/docker.service.d/docker-sdn-ovs.conf
+
+%posttrans sdn-ovs
+# This path was installed by older packages but the directory wasn't owned by
+# RPM so we need to clean it up otherwise kubelet throws an error trying to
+# load the directory as a plugin
+if [ -d %{kube_plugin_path} ]; then
+  rmdir %{kube_plugin_path}
+fi
 
 %files -n tuned-profiles-%{name}-node
 %defattr(-,root,root,-)


### PR DESCRIPTION
Older SDN packaging dropped a kube plugin into /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet/openshift-ovs-subnet however newer packaging doesn't. When upgrading the file is removed, however the directory /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet is not removed because the RPM didn't properly own that directory.

Based on my reading of http://fedoraproject.org/wiki/Packaging:ScriptletSnippets#Scriptlet_Ordering a %posttrans is the safest place to do this cleanup as it happens after the old package is removed.

I've also scanned all the files to look for places where we're not properly owning directories we're placing files into. The only one I found was the redistributable clients directories.

The error before fixing this is
```
Dec 09 17:18:19 ose3-master.example.com atomic-openshift-node[12214]: F1209 17:18:19.061149 12214 node.go:159] failed to create kubelet: [network plugin "redhat/openshift-ovs-subnet" was registered more than once, Network plugin "redhat/openshift-ovs-subnet" failed init: Invalid exec plugin. Executable 'redhat/openshift-ovs-subnet' does not have correct permissions.]
```