### PR TITLE
Fix flakiness in builds extended tests

### DIFF
--- a/test/extended/builds/sti_env.go
+++ b/test/extended/builds/sti_env.go
@@ -10,15 +10,20 @@ import (
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
-	kapi "k8s.io/kubernetes/pkg/api"
 )
 
 var _ = g.Describe("builds: s2i build with .sti/environment file", func() {
 	defer g.GinkgoRecover()
+	const (
+		buildTestPod     = "build-test-pod"
+		buildTestService = "build-test-svc"
+	)
+
 	var (
-		imageStreamFixture = exutil.FixturePath("..", "integration", "fixtures", "test-image-stream.json")
-		stiEnvBuildFixture = exutil.FixturePath("fixtures", "test-env-build.json")
-		oc                 = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
+		imageStreamFixture   = exutil.FixturePath("..", "integration", "fixtures", "test-image-stream.json")
+		stiEnvBuildFixture   = exutil.FixturePath("fixtures", "test-env-build.json")
+		podAndServiceFixture = exutil.FixturePath("fixtures", "test-build-podsvc.json")
+		oc                   = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
 	)
 
 	g.JustBeforeEach(func() {
@@ -51,24 +56,20 @@ var _ = g.Describe("builds: s2i build with .sti/environment file", func() {
 			imageName, err := exutil.GetDockerImageReference(oc.REST().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("writing the pod definition to a file")
-			pod := exutil.GetPodForContainer(kapi.Container{
-				Image: imageName,
-				Name:  "test",
-			})
-			_, err = oc.KubeREST().Pods(oc.Namespace()).Create(pod)
+			g.By("instantiating a pod and service with the new image")
+			err = oc.Run("new-app").Args("-f", podAndServiceFixture, "-p", "IMAGE_NAME="+imageName).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("expecting the pod to be running")
-			err = oc.KubeFramework().WaitForPodRunning(pod.Name)
+			g.By("waiting for the service to become available")
+			err = oc.KubeFramework().WaitForAnEndpoint(buildTestService)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("expecting the pod container has TEST_ENV variable set")
-			out, err := oc.Run("exec").Args("-p", pod.Name, "--", "curl", "http://0.0.0.0:8080").Output()
+			out, err := oc.Run("exec").Args("-p", buildTestPod, "--", "curl", "http://0.0.0.0:8080").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			if !strings.Contains(out, "success") {
-				e2e.Failf("expected 'success' response when executing curl in %q, got %q", pod.Name, out)
+				e2e.Failf("expected 'success' response when executing curl in %q, got %q", buildTestPod, out)
 			}
 		})
 	})

--- a/test/extended/builds/sti_incremental.go
+++ b/test/extended/builds/sti_incremental.go
@@ -3,21 +3,26 @@ package builds
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e"
 
 	exutil "github.com/openshift/origin/test/extended/util"
-	kapi "k8s.io/kubernetes/pkg/api"
 )
 
 var _ = g.Describe("builds: s2i incremental build with push and pull to authenticated registry", func() {
 	defer g.GinkgoRecover()
+
+	const (
+		buildTestPod     = "build-test-pod"
+		buildTestService = "build-test-svc"
+	)
+
 	var (
-		templateFixture = exutil.FixturePath("fixtures", "incremental-auth-build.json")
-		oc              = exutil.NewCLI("build-sti-env", exutil.KubeConfigPath())
+		templateFixture      = exutil.FixturePath("fixtures", "incremental-auth-build.json")
+		podAndServiceFixture = exutil.FixturePath("fixtures", "test-build-podsvc.json")
+		oc                   = exutil.NewCLI("build-sti-inc", exutil.KubeConfigPath())
 	)
 
 	g.JustBeforeEach(func() {
@@ -54,43 +59,25 @@ var _ = g.Describe("builds: s2i incremental build with push and pull to authenti
 			imageName, err := exutil.GetDockerImageReference(oc.REST().ImageStreams(oc.Namespace()), "internal-image", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("creating a pod for the new image")
-			pod := exutil.GetPodForContainer(kapi.Container{
-				Image: imageName,
-				Name:  "test",
-			})
-			_, err = oc.KubeREST().Pods(oc.Namespace()).Create(pod)
+			g.By("instantiating a pod and service with the new image")
+			err = oc.Run("new-app").Args("-f", podAndServiceFixture, "-p", "IMAGE_NAME="+imageName).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("expecting the pod to be running")
-			err = oc.KubeFramework().WaitForPodRunning(pod.Name)
+			g.By("waiting for the service to become available")
+			err = oc.KubeFramework().WaitForAnEndpoint(buildTestService)
 			o.Expect(err).NotTo(o.HaveOccurred())
-
-			// even though the pod is running, the app isn't always started
-			// so wait until webrick output is complete before curling.
-			logs := ""
-			count := 0
-			maxCount := 30
-			for strings.Contains(logs, "8080") && count < maxCount {
-				logs, _ = oc.Run("logs").Args(pod.Name).Output()
-				time.Sleep(time.Second)
-				count++
-			}
-			if count == maxCount {
-				e2e.Failf("Never saw port 8080 open in pod logs")
-			}
 
 			g.By("expecting the pod container has saved artifacts")
-			out, err := oc.Run("exec").Args("-p", pod.Name, "--", "curl", "http://0.0.0.0:8080").Output()
+			out, err := oc.Run("exec").Args("-p", buildTestPod, "--", "curl", "http://0.0.0.0:8080").Output()
 			if err != nil {
-				logs, _ = oc.Run("logs").Args(pod.Name).Output()
+				logs, _ := oc.Run("logs").Args(buildTestPod).Output()
 				e2e.Failf("Failed to curl in application container: \n%q, pod logs: \n%q", out, logs)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			if !strings.Contains(out, "artifacts exist") {
-				logs, _ = oc.Run("logs").Args(pod.Name).Output()
-				e2e.Failf("Pod %q does not contain expected artifacts: %q\n%q", pod.Name, out, logs)
+				logs, _ := oc.Run("logs").Args(buildTestPod).Output()
+				e2e.Failf("Pod %q does not contain expected artifacts: %q\n%q", buildTestPod, out, logs)
 			}
 		})
 	})

--- a/test/extended/fixtures/test-build-podsvc.json
+++ b/test/extended/fixtures/test-build-podsvc.json
@@ -1,0 +1,56 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "parameters": [
+    {
+      "name": "IMAGE_NAME",
+      "required": true
+    }
+  ],
+  "objects": [
+    {
+      "kind":"Pod",
+      "apiVersion":"v1",
+      "metadata":{
+        "name":"build-test-pod",
+        "labels":{
+          "name":"build-test-pod"
+        }
+      },
+      "spec":{
+        "containers":[
+          {
+            "name":"test",
+            "image":"${IMAGE_NAME}",
+            "readinessProbe": {
+              "httpGet": {
+                "port": 8080
+              }
+            }
+          }
+        ],
+        "dnsPolicy":"ClusterFirst"
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion":"v1",
+      "metadata": {
+        "name":"build-test-svc"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "8080-tcp",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "name": "build-test-pod"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Uses a pod with a readiness probe and a service to determine when the pod is serving content. The service endpoint will be added only when the pod is ready to serve content as determined by the readiness probe.