### PR TITLE
UPSTREAM: 18522: Close web socket watches correctly

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/watch.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/apiserver/watch.go
@@ -94,6 +94,7 @@ type WatchServer struct {
 
 // HandleWS implements a websocket handler.
 func (w *WatchServer) HandleWS(ws *websocket.Conn) {
+	defer ws.Close()
 	done := make(chan struct{})
 	go func() {
 		var unused interface{}


### PR DESCRIPTION
Fixes #6125 

The websocket library will close the underlying net connection, but it is up to the handler function to call Close() on the websocket connection itself, sending the final websocket frame.

We were already doing this for websocket-based log streaming and exec. This adds it to websocket-based watches.

Upstream PR in https://github.com/kubernetes/kubernetes/pull/18522