### PR TITLE
Retry build logs in start build when waiting for build

### DIFF
--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -30,6 +30,7 @@ import (
 	osutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/generate/git"
+	"github.com/openshift/origin/pkg/util/errors"
 	"github.com/openshift/source-to-image/pkg/tar"
 )
 
@@ -251,19 +252,33 @@ func RunStartBuild(f *clientcmd.Factory, in io.Reader, out io.Writer, cmd *cobra
 	if follow {
 		wg.Add(1)
 		go func() {
-			defer wg.Done()
+			// if --wait option is set, then don't wait for logs to finish streaming
+			// but wait for the build to reach its final state
+			if waitForComplete {
+				wg.Done()
+			} else {
+				defer wg.Done()
+			}
 			opts := buildapi.BuildLogOptions{
 				Follow: true,
 				NoWait: false,
 			}
-			rd, err := client.BuildLogs(namespace).Get(newBuild.Name, opts).Stream()
-			if err != nil {
-				fmt.Fprintf(cmd.Out(), "error getting logs: %v\n", err)
-				return
-			}
-			defer rd.Close()
-			if _, err = io.Copy(out, rd); err != nil {
-				fmt.Fprintf(cmd.Out(), "error streaming logs: %v\n", err)
+			for {
+				rd, err := client.BuildLogs(namespace).Get(newBuild.Name, opts).Stream()
+				if err != nil {
+					// if --wait options is set, then retry the connection to build logs
+					// when we hit the timeout.
+					if waitForComplete && errors.IsTimeoutErr(err) {
+						continue
+					}
+					fmt.Fprintf(cmd.Out(), "error getting logs: %v\n", err)
+					return
+				}
+				defer rd.Close()
+				if _, err = io.Copy(out, rd); err != nil {
+					fmt.Fprintf(cmd.Out(), "error streaming logs: %v\n", err)
+				}
+				break
 			}
 		}()
 	}

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -2,7 +2,10 @@ package errors
 
 import "strings"
 
-import kapierrors "k8s.io/kubernetes/pkg/api/errors"
+import (
+	kapierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
 
 // TolerateNotFoundError tolerates 'not found' errors
 func TolerateNotFoundError(err error) error {
@@ -24,4 +27,13 @@ func ErrorToSentence(err error) string {
 		msg = msg + "."
 	}
 	return msg
+}
+
+// IsTimeoutErr returns true if the error indicates timeout
+func IsTimeoutErr(err error) bool {
+	e, ok := err.(*kapierrors.StatusError)
+	if !ok {
+		return false
+	}
+	return e.ErrStatus.Reason == unversioned.StatusReasonTimeout
 }


### PR DESCRIPTION
When a build is started using `start-build --follow --wait` the `--follow` option will timeout after 10 seconds if the logs don't come. That will leave `--wait` to wait till the build fail/succeed but it won't show any logs anymore.

This PR will retry the attempt to retrieve the logs when these options are specified together. That means, if you specify `--wait` we retry the `--follow` after timeout until we get the logs or the build fails.

The `--wait` option mean that we will wait for the build to reach its final state (Complete/Error) so retrying the logs makes sense to me.