### PR TITLE
Fix typo in example `oc run` command.

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -796,7 +796,7 @@ Run a particular image on the cluster.
   $ oc run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
 
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
-  $ oc run -i -tty nginx --image=nginx --restart=Never
+  $ oc run -i --tty nginx --image=nginx --restart=Never
 ----
 ====
 


### PR DESCRIPTION
-tty is not an option. --tty is.