### PR TITLE
Minor commit validation fixes

### DIFF
--- a/cmd/rebasehelpers/commitchecker/commitchecker.go
+++ b/cmd/rebasehelpers/commitchecker/commitchecker.go
@@ -21,9 +21,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO: Filter out bump commits for now until we decide how to deal with
+	// them correctly.
+	nonbumpCommits := []util.Commit{}
+	for _, commit := range commits {
+		if commit.DeclaresUpstreamChange() &&
+			!strings.HasPrefix(commit.Summary, "bump(") {
+			nonbumpCommits = append(nonbumpCommits, commit)
+		}
+	}
+
 	errs := []string{}
 	for _, validate := range AllValidators {
-		err := validate(commits)
+		err := validate(nonbumpCommits)
 		if err != nil {
 			errs = append(errs, err.Error())
 		}

--- a/cmd/rebasehelpers/commitchecker/validate_test.go
+++ b/cmd/rebasehelpers/commitchecker/validate_test.go
@@ -208,14 +208,14 @@ func TestValidateUpstreamCommitSummaries(t *testing.T) {
 		{valid: true, summary: "UPSTREAM: k8s.io/heapster: 12345: a change"},
 		{valid: true, summary: "UPSTREAM: <carry>: a change"},
 		{valid: true, summary: "UPSTREAM: <drop>: a change"},
-		{valid: true, summary: "UPSTREAM: github.com/coreos/etcd: <carry>: a change"},
-		{valid: true, summary: "UPSTREAM: github.com/coreos/etcd: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: coreos/etcd: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: coreos/etcd: <drop>: a change"},
 		{valid: true, summary: "UPSTREAM: revert: abcd123: 12345: a change"},
 		{valid: true, summary: "UPSTREAM: revert: abcd123: k8s.io/heapster: 12345: a change"},
 		{valid: true, summary: "UPSTREAM: revert: abcd123: <carry>: a change"},
 		{valid: true, summary: "UPSTREAM: revert: abcd123: <drop>: a change"},
-		{valid: true, summary: "UPSTREAM: revert: abcd123: github.com/coreos/etcd: <carry>: a change"},
-		{valid: true, summary: "UPSTREAM: revert: abcd123: github.com/coreos/etcd: <drop>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: coreos/etcd: <carry>: a change"},
+		{valid: true, summary: "UPSTREAM: revert: abcd123: coreos/etcd: <drop>: a change"},
 		{valid: false, summary: "UPSTREAM: whoopsie daisy"},
 	}
 	for _, test := range tests {
@@ -251,7 +251,7 @@ func TestValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(t *testing.T) {
 				},
 				{
 					Sha:     "aaa0001",
-					Summary: "UPSTREAM: github.com/coreos/etcd: 12345: a change",
+					Summary: "UPSTREAM: coreos/etcd: 12345: a change",
 					Files: []util.File{
 						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
 						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
@@ -266,7 +266,7 @@ func TestValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(t *testing.T) {
 			commits: []util.Commit{
 				{
 					Sha:     "aaa0001",
-					Summary: "UPSTREAM: github.com/coreos/etcd: 12345: a change",
+					Summary: "UPSTREAM: coreos/etcd: 12345: a change",
 					Files: []util.File{
 						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
 						"Godeps/_workspace/src/github.com/coreos/etcd/file2",
@@ -280,7 +280,7 @@ func TestValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(t *testing.T) {
 			commits: []util.Commit{
 				{
 					Sha:     "aaa0001",
-					Summary: "UPSTREAM: github.com/coreos/etcd: 12345: a change",
+					Summary: "UPSTREAM: coreos/etcd: 12345: a change",
 					Files: []util.File{
 						"Godeps/_workspace/src/github.com/coreos/etcd/a/file1",
 						"Godeps/_workspace/src/github.com/coreos/etcd/b/file2",
@@ -336,7 +336,7 @@ func TestValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(t *testing.T) {
 			commits: []util.Commit{
 				{
 					Sha:     "aaa0001",
-					Summary: "UPSTREAM: revert: abcd000: github.com/coreos/etcd: 12345: a change",
+					Summary: "UPSTREAM: revert: abcd000: coreos/etcd: 12345: a change",
 					Files: []util.File{
 						"Godeps/_workspace/src/k8s.io/kubernetes/file1",
 						"Godeps/_workspace/src/k8s.io/kubernetes/file2",
@@ -350,7 +350,7 @@ func TestValidateUpstreamCommitModifiesOnlyDeclaredGodepRepo(t *testing.T) {
 			commits: []util.Commit{
 				{
 					Sha:     "aaa0001",
-					Summary: "UPSTREAM: revert: abcd000: github.com/coreos/etcd: 12345: a change",
+					Summary: "UPSTREAM: revert: abcd000: coreos/etcd: 12345: a change",
 					Files: []util.File{
 						"Godeps/_workspace/src/github.com/coreos/etcd/file1",
 						"Godeps/_workspace/src/github.com/coreos/etcd/file2",

--- a/cmd/rebasehelpers/util/git.go
+++ b/cmd/rebasehelpers/util/git.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var UpstreamSummaryPattern = regexp.MustCompile(`UPSTREAM: (revert: [a-f0-9]{7,}: )?(([\w\.-]+\/[\w-]+)(\/[\w-]+)?: )?([0-9]{4,}:|<carry>:|<drop>:)`)
+var UpstreamSummaryPattern = regexp.MustCompile(`UPSTREAM: (revert: [a-f0-9]{7,}: )?(([\w\.-]+\/[\w-]+)?: )?(\d+:|<carry>:|<drop>:)`)
 
 // supportedHosts maps source hosts to the number of path segments that
 // represent the account/repo for that host. This is necessary because we
@@ -54,24 +54,6 @@ func (c Commit) DeclaredUpstreamRepo() (string, error) {
 	repo := groups[3]
 	if len(repo) == 0 {
 		repo = "k8s.io/kubernetes"
-	}
-	// Do a simple special casing for repos which use 3 path segments to
-	// identify the repo. The only repos ever seen use either 2 or 3 so don't
-	// bother trying to make it too generic.
-	segments := -1
-	for host, count := range SupportedHosts {
-		if strings.HasPrefix(repo, host) {
-			segments = count
-			break
-		}
-	}
-	if segments == -1 {
-		fmt.Printf("commit modifies unsupported repo %q\n", repo)
-		return "", fmt.Errorf("commit modifies unsupported repo %q", repo)
-	}
-	fmt.Printf("repo=%s, segments=%d\n", repo, segments)
-	if segments == 3 {
-		repo += groups[4]
 	}
 	return repo, nil
 }

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -17,6 +17,7 @@ cd "${OS_ROOT}"
 repo="${UPSTREAM_REPO:-k8s.io/kubernetes}"
 package="${UPSTREAM_PACKAGE:-pkg/api}"
 UPSTREAM_REPO_LOCATION="${UPSTREAM_REPO_LOCATION:-../../../${repo}}"
+pr="$1"
 
 if [[ "$#" -ne 1 ]]; then
   echo "You must supply a pull request by number or a Git range in the upstream ${repo} project" 1>&2
@@ -40,7 +41,7 @@ os::build::require_clean_tree
 remote="${UPSTREAM_REMOTE:-origin}"
 git fetch ${remote}
 
-selector="$(os::build::commit_range $1 ${remote}/master)"
+selector="$(os::build::commit_range $pr ${remote}/master)"
 
 if [[ -z "${NO_REBASE-}" ]]; then
   echo "++ Generating patch for ${selector} onto ${lastrev} ..." 2>&1
@@ -80,9 +81,14 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
+commit_message="UPSTREAM: $pr: Cherry-picked"
+if [ "$repo" != "k8s.io/kubernetes" ]; then
+  commit_message="UPSTREAM: $repo: $pr: Cherry-picked"
+fi
+
 set -o errexit
 git add .
-git commit -m "UPSTREAM: $1: " > /dev/null
+git commit -m "$commit_message" > /dev/null
 git commit --amend
 echo 2>&1
 echo "++ Done" 2>&1


### PR DESCRIPTION
Minor commit validation fixes.

* Update hack/cherry-pick.sh to produce valid commit summaries
* Improve validation examples
* Remove validation debugging output
* Ignore bump commits (for now)
* Allow unqualified non-kube repo references