### PR TITLE
Use service port name as route targetPort in 'oc expose service'

### DIFF
--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -119,8 +119,10 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 			supportsTCP := false
 			for _, port := range svc.Spec.Ports {
 				if port.Protocol == kapi.ProtocolTCP {
-					// Pass service target port as the route port
-					cmd.Flags().Set("port", port.TargetPort.String())
+					if len(port.Name) > 0 {
+						// Pass service port name as the route target port, if it is named
+						cmd.Flags().Set("target-port", port.Name)
+					}
 					supportsTCP = true
 					break
 				}

--- a/pkg/route/generator/generate_test.go
+++ b/pkg/route/generator/generate_test.go
@@ -23,6 +23,8 @@ func TestGenerateRoute(t *testing.T) {
 				"name":         "test",
 				"default-name": "someservice",
 				"port":         "80",
+				"ports":        "80,443",
+				"target-port":  "svcportname",
 				"hostname":     "www.example.com",
 			},
 			expected: routeapi.Route{
@@ -40,7 +42,7 @@ func TestGenerateRoute(t *testing.T) {
 					Port: &routeapi.RoutePort{
 						TargetPort: util.IntOrString{
 							Kind:   util.IntstrString,
-							StrVal: "80",
+							StrVal: "svcportname",
 						},
 					},
 				},
@@ -51,6 +53,7 @@ func TestGenerateRoute(t *testing.T) {
 				"labels":       "foo=bar",
 				"name":         "test",
 				"default-name": "someservice",
+				"port":         "80",
 				"ports":        "80,443",
 				"hostname":     "www.example.com",
 			},
@@ -65,12 +68,6 @@ func TestGenerateRoute(t *testing.T) {
 					Host: "www.example.com",
 					To: api.ObjectReference{
 						Name: "someservice",
-					},
-					Port: &routeapi.RoutePort{
-						TargetPort: util.IntOrString{
-							Kind:   util.IntstrString,
-							StrVal: "80",
-						},
 					},
 				},
 			},

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -68,7 +68,8 @@ os::cmd::expect_success 'oc create -f test/integration/fixtures/test-service.jso
 os::cmd::expect_failure 'oc expose service frontend --create-external-load-balancer'
 os::cmd::expect_failure 'oc expose service frontend --port=40 --type=NodePort'
 os::cmd::expect_success 'oc expose service frontend'
-os::cmd::expect_success_and_text 'oc get route frontend' 'name=frontend'
+os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.to.name}}'" "frontend"           # routes to correct service
+os::cmd::expect_success_and_text "oc get route frontend --output-version=v1 --template='{{.spec.port.targetPort}}'" "<no value>" # no target port for services with unnamed ports
 os::cmd::expect_success 'oc delete svc,route -l name=frontend'
 # Test that external services are exposable
 os::cmd::expect_success 'oc create -f test/fixtures/external-service.yaml'
@@ -79,7 +80,7 @@ os::cmd::expect_success 'oc delete svc external'
 # Expose multiport service and verify we set a port in the route
 os::cmd::expect_success 'oc create -f test/fixtures/multiport-service.yaml'
 os::cmd::expect_success 'oc expose svc/frontend --name route-with-set-port'
-os::cmd::expect_success "os::util::get_object_assert 'route route-with-set-port' '{{.spec.port.targetPort}}' '8080'"
+os::cmd::expect_success_and_text "oc get route route-with-set-port --template='{{.spec.port.targetPort}}' --output-version=v1" "web"
 echo "expose: ok"
 
 os::cmd::expect_success 'oc delete all --all'


### PR DESCRIPTION
Fixes #6265

There are 6 possible scenarios for services with ports we will hit in `oc expose`
1. 1 unnamed service port -> numbered container port
2. 1 unnamed service port -> named container port
3. 1 named service port -> numbered container port
4. 1 named service port -> named container port
5. 2+ named service ports -> numbered container port
6. 2+ named service ports -> named container port

Whenever a service port is named (cases 3,4,5,6), we should use the name as the route targetPort

When a service port is unnamed (which means it is the only port), we could try to set a targetPort that will point to the right containers, or we could omit the targetPort and let the route "round-robin" to the single port. In case 1 (numbered container port), we could set a numbered targetPort, but the route would break if the service was edited to set a different targetPort. In case 2 (named container port), we have no choice but to round-robin (container port names aren't available in the endpoints).

This PR updates `oc expose service <svc>` to generate a route that has a named targetPort when possible, and no targetPort otherwise.