### PR TITLE
added support for recursive testing using test-go

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -69,6 +69,10 @@ or an individual package unit test with:
 
     $ hack/test-go.sh pkg/build
 
+or an individual package and all packages nested under it:
+
+    $ hack/test-go.sh pkg/build/...
+
 To run only a certain regex of tests in a package, use:
 
     $ hack/test-go.sh pkg/build -test.run=SynchronizeBuildRunning

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -21,7 +21,7 @@ os::build::setup_env
 
 find_test_dirs() {
   cd "${OS_ROOT}"
-  find . -not \( \
+  find $1 -not \( \
       \( \
         -wholename './Godeps' \
         -o -wholename './_output' \
@@ -78,11 +78,16 @@ fi
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 60s}
 
 if [ "${1-}" != "" ]; then
-  test_packages="$OS_GO_PACKAGE/$1"
+  if [[ "${1}" == *"/..." ]]; then
+    # if the package name ends with /... they are intending a recursive test
+    test_packages=$(find_test_dirs "${1:0:(-4)}")
+  else
+    test_packages="$OS_GO_PACKAGE/$1"
+  fi
 elif [ -n "$TEST_KUBE" ]; then
-  test_packages=`find_test_dirs; special_upstream_test_dirs; find_upstream_test_dirs`
+  test_packages=`find_test_dirs "."; special_upstream_test_dirs; find_upstream_test_dirs`
 else
-  test_packages=`find_test_dirs; special_upstream_test_dirs`
+  test_packages=`find_test_dirs "."; special_upstream_test_dirs`
 fi
 
 if [ -n "$PRINT_PACKAGES" ]; then


### PR DESCRIPTION
@deads2k @smarterclayton 

Fixes https://github.com/openshift/origin/issues/6295#issuecomment-164447442

Example:
```sh
$ hack/test-go.sh pkg/auth/authenticator/
?   	github.com/openshift/origin/pkg/auth/authenticator	[no test files]
hack/test-go.sh took 0 seconds
$ hack/test-go.sh pkg/auth/authenticator/...
ok  	github.com/openshift/origin/pkg/auth/authenticator/anonymous	0.006s
ok  	github.com/openshift/origin/pkg/auth/authenticator/challenger/passwordchallenger	0.004s
ok  	github.com/openshift/origin/pkg/auth/authenticator/password/basicauthpassword	0.004s
ok  	github.com/openshift/origin/pkg/auth/authenticator/password/htpasswd	0.284s
ok  	github.com/openshift/origin/pkg/auth/authenticator/password/keystonepassword	0.006s
ok  	github.com/openshift/origin/pkg/auth/authenticator/request/basicauthrequest	0.003s
ok  	github.com/openshift/origin/pkg/auth/authenticator/request/bearertoken	0.004s
ok  	github.com/openshift/origin/pkg/auth/authenticator/request/headerrequest	0.011s
ok  	github.com/openshift/origin/pkg/auth/authenticator/request/unionrequest	0.024s
ok  	github.com/openshift/origin/pkg/auth/authenticator/request/x509request	0.005s
ok  	github.com/openshift/origin/pkg/auth/authenticator/token/cache	0.006s
hack/test-go.sh took 11 seconds
```