### PR TITLE
Implement dynamic provisioners for GCE, AWS and OpenStack/Cinder

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/plugins.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/plugins.go
@@ -29,6 +29,7 @@ import (
 	// Volume plugins
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/aws_ebs"
@@ -92,8 +93,8 @@ func NewVolumeProvisioner(cloud cloudprovider.Interface, flags VolumeConfigFlags
 		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeVolumePlugins())
 		//	case cloud != nil && gce.ProviderName == cloud.ProviderName():
 		//		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeVolumePlugins())
-		//	case cloud != nil && openstack.ProviderName == cloud.ProviderName():
-		//		return getProvisionablePluginFromVolumePlugins(cinder.ProbeVolumePlugins())
+	case cloud != nil && openstack.ProviderName == cloud.ProviderName():
+		return getProvisionablePluginFromVolumePlugins(cinder.ProbeVolumePlugins())
 	}
 	return nil, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/plugins.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/plugins.go
@@ -29,6 +29,7 @@ import (
 	// Volume plugins
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/volume"
@@ -91,8 +92,8 @@ func NewVolumeProvisioner(cloud cloudprovider.Interface, flags VolumeConfigFlags
 		return getProvisionablePluginFromVolumePlugins(host_path.ProbeVolumePlugins(volume.VolumeConfig{}))
 	case cloud != nil && aws_cloud.ProviderName == cloud.ProviderName():
 		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeVolumePlugins())
-		//	case cloud != nil && gce.ProviderName == cloud.ProviderName():
-		//		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeVolumePlugins())
+	case cloud != nil && gce_cloud.ProviderName == cloud.ProviderName():
+		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeVolumePlugins())
 	case cloud != nil && openstack.ProviderName == cloud.ProviderName():
 		return getProvisionablePluginFromVolumePlugins(cinder.ProbeVolumePlugins())
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/plugins.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/plugins.go
@@ -28,6 +28,7 @@ import (
 
 	// Volume plugins
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/aws_ebs"
@@ -87,8 +88,8 @@ func NewVolumeProvisioner(cloud cloudprovider.Interface, flags VolumeConfigFlags
 	switch {
 	case cloud == nil && flags.EnableHostPathProvisioning:
 		return getProvisionablePluginFromVolumePlugins(host_path.ProbeVolumePlugins(volume.VolumeConfig{}))
-		//	case cloud != nil && aws.ProviderName == cloud.ProviderName():
-		//		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeVolumePlugins())
+	case cloud != nil && aws_cloud.ProviderName == cloud.ProviderName():
+		return getProvisionablePluginFromVolumePlugins(aws_ebs.ProbeVolumePlugins())
 		//	case cloud != nil && gce.ProviderName == cloud.ProviderName():
 		//		return getProvisionablePluginFromVolumePlugins(gce_pd.ProbeVolumePlugins())
 		//	case cloud != nil && openstack.ProviderName == cloud.ProviderName():

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
@@ -57,6 +57,11 @@ const TagNameKubernetesCluster = "KubernetesCluster"
 // MaxReadThenCreateRetries sets the maxiumum number of attempts we will make
 const MaxReadThenCreateRetries = 30
 
+// Default volume type for newly created Volumes
+// TODO: Remove when user/admin can configure volume types and thus we don't
+// need hardcoded defaults.
+const DefaultVolumeType = "gp2"
+
 // Abstraction over AWS, to allow mocking/other implementations
 type AWSServices interface {
 	Compute(region string) (EC2, error)
@@ -134,7 +139,8 @@ type EC2Metadata interface {
 }
 
 type VolumeOptions struct {
-	CapacityMB int
+	CapacityGB int
+	Tags       *map[string]string
 }
 
 // Volumes is an interface for managing cloud-provisioned volumes
@@ -1156,15 +1162,15 @@ func (aws *AWSCloud) DetachDisk(instanceName string, diskName string) error {
 }
 
 // Implements Volumes.CreateVolume
-func (aws *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) {
+func (s *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) {
 	// TODO: Should we tag this with the cluster id (so it gets deleted when the cluster does?)
-	// This is only used for testing right now
 
 	request := &ec2.CreateVolumeInput{}
-	request.AvailabilityZone = &aws.availabilityZone
-	volSize := (int64(volumeOptions.CapacityMB) + 1023) / 1024
+	request.AvailabilityZone = &s.availabilityZone
+	volSize := int64(volumeOptions.CapacityGB)
 	request.Size = &volSize
-	response, err := aws.ec2.CreateVolume(request)
+	request.VolumeType = aws.String(DefaultVolumeType)
+	response, err := s.ec2.CreateVolume(request)
 	if err != nil {
 		return "", err
 	}
@@ -1174,6 +1180,28 @@ func (aws *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) 
 
 	volumeName := "aws://" + az + "/" + awsID
 
+	// apply tags
+	if volumeOptions.Tags != nil {
+		tags := []*ec2.Tag{}
+		for k, v := range *volumeOptions.Tags {
+			tag := &ec2.Tag{}
+			tag.Key = aws.String(k)
+			tag.Value = aws.String(v)
+			tags = append(tags, tag)
+		}
+		tagRequest := &ec2.CreateTagsInput{}
+		tagRequest.Resources = []*string{&awsID}
+		tagRequest.Tags = tags
+		if _, err := s.createTags(tagRequest); err != nil {
+			// delete the volume and hope it succeeds
+			delerr := s.DeleteVolume(volumeName)
+			if delerr != nil {
+				// delete did not succeed, we have a stray volume!
+				return "", fmt.Errorf("error tagging volume %s, could not delete the volume: %v", volumeName, delerr)
+			}
+			return "", fmt.Errorf("error tagging volume %s: %v", volumeName, err)
+		}
+	}
 	return volumeName, nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
@@ -1429,6 +1429,28 @@ func (gce *GCECloud) GetZone() (cloudprovider.Zone, error) {
 	}, nil
 }
 
+func (gce *GCECloud) CreateDisk(name string, sizeGb int64) error {
+	diskToCreate := &compute.Disk{
+		Name:   name,
+		SizeGb: sizeGb,
+	}
+	createOp, err := gce.service.Disks.Insert(gce.projectID, gce.zone, diskToCreate).Do()
+	if err != nil {
+		return err
+	}
+
+	return gce.waitForZoneOp(createOp)
+}
+
+func (gce *GCECloud) DeleteDisk(diskToDelete string) error {
+	deleteOp, err := gce.service.Disks.Delete(gce.projectID, gce.zone, diskToDelete).Do()
+	if err != nil {
+		return err
+	}
+
+	return gce.waitForZoneOp(deleteOp)
+}
+
 func (gce *GCECloud) AttachDisk(diskName string, readOnly bool) error {
 	disk, err := gce.getDisk(diskName)
 	if err != nil {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
@@ -958,3 +958,41 @@ func (os *OpenStack) getVolume(diskName string) (volumes.Volume, error) {
 	return volume, err
 }
 
+// Create a volume of given size (in GiB)
+func (os *OpenStack) CreateVolume(size int) (volumeName string, err error) {
+
+	sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+
+	if err != nil || sClient == nil {
+		glog.Errorf("Unable to initialize cinder client for region: %s", os.region)
+		return "", err
+	}
+
+	opts := volumes.CreateOpts{Size: size}
+	vol, err := volumes.Create(sClient, opts).Extract()
+	if err != nil {
+		glog.Errorf("Failed to create a %d GB volume: %v", size, err)
+		return "", err
+	}
+	glog.Infof("Created volume %v", vol.ID)
+	return vol.ID, err
+}
+
+func (os *OpenStack) DeleteVolume(volumeName string) error {
+	sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+
+	if err != nil || sClient == nil {
+		glog.Errorf("Unable to initialize cinder client for region: %s", os.region)
+		return err
+	}
+	err = volumes.Delete(sClient, volumeName).ExtractErr()
+	if err != nil {
+		glog.Errorf("Cannot delete volume %s: %v", volumeName, err)
+	}
+	return err
+}
+

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -198,3 +198,26 @@ func TestZones(t *testing.T) {
 		t.Fatalf("GetZone() returned wrong region (%s)", zone.Region)
 	}
 }
+
+func TestVolumes(t *testing.T) {
+	cfg, ok := configFromEnv()
+	if !ok {
+		t.Skipf("No config found in environment")
+	}
+
+	os, err := newOpenStack(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
+	}
+
+	vol, err := os.CreateVolume(1)
+	if err != nil {
+		t.Fatalf("Cannot create a new Cinder volume: %v", err)
+	}
+
+	err = os.DeleteVolume(vol)
+	if err != nil {
+		t.Fatalf("Cannot delete Cinder volume %s: %v", vol, err)
+	}
+
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_provisioner_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_provisioner_controller.go
@@ -337,6 +337,10 @@ func newProvisioner(plugin volume.ProvisionableVolumePlugin, claim *api.Persiste
 		Capacity:                      claim.Spec.Resources.Requests[api.ResourceName(api.ResourceStorage)],
 		AccessModes:                   claim.Spec.AccessModes,
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
+		CloudTags: &map[string]string{
+			cloudVolumeCreatedForNamespaceTag: claim.Namespace,
+			cloudVolumeCreatedForNameTag:      claim.Name,
+		},
 	}
 
 	provisioner, err := plugin.NewProvisioner(volumeOptions)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/types.go
@@ -30,6 +30,12 @@ const (
 // For example tiers might be gold, silver, and tin and the admin configures what that means for each volume plugin that can provision a volume.
 // Values in the alpha version of this feature are not meaningful, but will be in the full version of this feature.
 	qosProvisioningKey = "volume.alpha.kubernetes.io/storage-class"
+	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
+	// with namespace of a persistent volume claim used to create this volume.
+	cloudVolumeCreatedForNamespaceTag = "kubernetes.io/created-for/pvc/namespace"
+	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
+	// with name of a persistent volume claim used to create this volume.
+	cloudVolumeCreatedForNameTag = "kubernetes.io/created-for/pvc/name"
 )
 
 // persistentVolumeOrderedIndex is a cache.Store that keeps persistent volumes indexed by AccessModes and ordered by storage capacity.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
@@ -45,6 +46,8 @@ type awsElasticBlockStorePlugin struct {
 
 var _ volume.VolumePlugin = &awsElasticBlockStorePlugin{}
 var _ volume.PersistentVolumePlugin = &awsElasticBlockStorePlugin{}
+var _ volume.DeletableVolumePlugin = &awsElasticBlockStorePlugin{}
+var _ volume.ProvisionableVolumePlugin = &awsElasticBlockStorePlugin{}
 
 const (
 	awsElasticBlockStorePluginName = "kubernetes.io/aws-ebs"
@@ -124,12 +127,50 @@ func (plugin *awsElasticBlockStorePlugin) newCleanerInternal(volName string, pod
 	}}, nil
 }
 
+func (plugin *awsElasticBlockStorePlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+	return plugin.newDeleterInternal(spec, &AWSDiskUtil{})
+}
+
+func (plugin *awsElasticBlockStorePlugin) newDeleterInternal(spec *volume.Spec, manager ebsManager) (volume.Deleter, error) {
+	if spec.PersistentVolume != nil && spec.PersistentVolume.Spec.AWSElasticBlockStore == nil {
+		return nil, fmt.Errorf("spec.PersistentVolumeSource.AWSElasticBlockStore is nil")
+	}
+	return &awsElasticBlockStoreDeleter{
+		awsElasticBlockStore: &awsElasticBlockStore{
+			volName:  spec.Name(),
+			volumeID: spec.PersistentVolume.Spec.AWSElasticBlockStore.VolumeID,
+			manager:  manager,
+			plugin:   plugin,
+		}}, nil
+}
+
+func (plugin *awsElasticBlockStorePlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
+	if len(options.AccessModes) == 0 {
+		options.AccessModes = plugin.GetAccessModes()
+	}
+	return plugin.newProvisionerInternal(options, &AWSDiskUtil{})
+}
+
+func (plugin *awsElasticBlockStorePlugin) newProvisionerInternal(options volume.VolumeOptions, manager ebsManager) (volume.Provisioner, error) {
+	return &awsElasticBlockStoreProvisioner{
+		awsElasticBlockStore: &awsElasticBlockStore{
+			manager: manager,
+			plugin:  plugin,
+		},
+		options: options,
+	}, nil
+}
+
 // Abstract interface to PD operations.
 type ebsManager interface {
 	// Attaches the disk to the kubelet's host machine.
 	AttachAndMountDisk(b *awsElasticBlockStoreBuilder, globalPDPath string) error
 	// Detaches the disk from the kubelet's host machine.
 	DetachDisk(c *awsElasticBlockStoreCleaner) error
+	// Creates a volume
+	CreateVolume(provisioner *awsElasticBlockStoreProvisioner) (volumeID string, volumeSizeGB int, err error)
+	// Deletes a volume
+	DeleteVolume(deleter *awsElasticBlockStoreDeleter) error
 }
 
 // awsElasticBlockStore volumes are disk resources provided by Amazon Web Services
@@ -350,4 +391,68 @@ func (c *awsElasticBlockStoreCleaner) TearDownAt(dir string) error {
 		}
 	}
 	return nil
+}
+
+type awsElasticBlockStoreDeleter struct {
+	*awsElasticBlockStore
+}
+
+var _ volume.Deleter = &awsElasticBlockStoreDeleter{}
+
+func (d *awsElasticBlockStoreDeleter) GetPath() string {
+	name := awsElasticBlockStorePluginName
+	return d.plugin.host.GetPodVolumeDir(d.podUID, util.EscapeQualifiedNameForDisk(name), d.volName)
+}
+
+func (d *awsElasticBlockStoreDeleter) Delete() error {
+	return d.manager.DeleteVolume(d)
+}
+
+type awsElasticBlockStoreProvisioner struct {
+	*awsElasticBlockStore
+	options   volume.VolumeOptions
+	namespace string
+}
+
+var _ volume.Provisioner = &awsElasticBlockStoreProvisioner{}
+
+func (c *awsElasticBlockStoreProvisioner) Provision(pv *api.PersistentVolume) error {
+	volumeID, sizeGB, err := c.manager.CreateVolume(c)
+	if err != nil {
+		return err
+	}
+	pv.Spec.PersistentVolumeSource.AWSElasticBlockStore.VolumeID = volumeID
+	pv.Spec.Capacity = api.ResourceList{
+		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
+	}
+	return nil
+}
+
+func (c *awsElasticBlockStoreProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
+	// Provide dummy api.PersistentVolume.Spec, it will be filled in
+	// awsElasticBlockStoreProvisioner.Provision()
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: "pv-aws-",
+			Labels:       map[string]string{},
+			Annotations: map[string]string{
+				"kubernetes.io/createdby": "aws-ebs-dynamic-provisioner",
+			},
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   c.options.AccessModes,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): c.options.Capacity,
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				AWSElasticBlockStore: &api.AWSElasticBlockStoreVolumeSource{
+					VolumeID:  "dummy",
+					FSType:    "ext4",
+					Partition: 0,
+					ReadOnly:  false,
+				},
+			},
+		},
+	}, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package aws_ebs
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -94,6 +97,17 @@ func (fake *fakePDManager) DetachDisk(c *awsElasticBlockStoreCleaner) error {
 	return nil
 }
 
+func (fake *fakePDManager) CreateVolume(c *awsElasticBlockStoreProvisioner) (volumeID string, volumeSizeGB int, err error) {
+	return "test-aws-volume-name", 100, nil
+}
+
+func (fake *fakePDManager) DeleteVolume(cd *awsElasticBlockStoreDeleter) error {
+	if cd.volumeID != "test-aws-volume-name" {
+		return fmt.Errorf("Deleter got unexpected volume name: %s", cd.volumeID)
+	}
+	return nil
+}
+
 func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
@@ -157,6 +171,47 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("TearDown() failed, volume path still exists: %s", path)
 	} else if !os.IsNotExist(err) {
 		t.Errorf("SetUp() failed: %v", err)
+	}
+
+	// Test Provisioner
+	cap := resource.MustParse("100Gi")
+	options := volume.VolumeOptions{
+		Capacity: cap,
+		AccessModes: []api.PersistentVolumeAccessMode{
+			api.ReadWriteOnce,
+		},
+		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
+	}
+	provisioner, err := plug.(*awsElasticBlockStorePlugin).newProvisionerInternal(options, &fakePDManager{})
+	persistentSpec, err := provisioner.NewPersistentVolumeTemplate()
+	if err != nil {
+		t.Errorf("NewPersistentVolumeTemplate() failed: %v", err)
+	}
+
+	// get 2nd Provisioner - persistent volume controller will do the same
+	provisioner, err = plug.(*awsElasticBlockStorePlugin).newProvisionerInternal(options, &fakePDManager{})
+	err = provisioner.Provision(persistentSpec)
+	if err != nil {
+		t.Errorf("Provision() failed: %v", err)
+	}
+
+	if persistentSpec.Spec.PersistentVolumeSource.AWSElasticBlockStore.VolumeID != "test-aws-volume-name" {
+		t.Errorf("Provision() returned unexpected volume ID: %s", persistentSpec.Spec.PersistentVolumeSource.AWSElasticBlockStore.VolumeID)
+	}
+	cap = persistentSpec.Spec.Capacity[api.ResourceStorage]
+	size := cap.Value()
+	if size != 100*1024*1024*1024 {
+		t.Errorf("Provision() returned unexpected volume size: %v", size)
+	}
+
+	// Test Deleter
+	volSpec := &volume.Spec{
+		PersistentVolume: persistentSpec,
+	}
+	deleter, err := plug.(*awsElasticBlockStorePlugin).newDeleterInternal(volSpec, &fakePDManager{})
+	err = deleter.Delete()
+	if err != nil {
+		t.Errorf("Deleter() failed: %v", err)
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
@@ -17,11 +17,15 @@ limitations under the License.
 package cinder
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
@@ -39,6 +43,9 @@ type cinderPlugin struct {
 }
 
 var _ volume.VolumePlugin = &cinderPlugin{}
+var _ volume.PersistentVolumePlugin = &cinderPlugin{}
+var _ volume.DeletableVolumePlugin = &cinderPlugin{}
+var _ volume.ProvisionableVolumePlugin = &cinderPlugin{}
 
 const (
 	cinderVolumePluginName = "kubernetes.io/cinder"
@@ -107,12 +114,64 @@ func (plugin *cinderPlugin) newCleanerInternal(volName string, podUID types.UID,
 		}}, nil
 }
 
+func (plugin *cinderPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+	return plugin.newDeleterInternal(spec, &CinderDiskUtil{})
+}
+
+func (plugin *cinderPlugin) newDeleterInternal(spec *volume.Spec, manager cdManager) (volume.Deleter, error) {
+	if spec.PersistentVolume != nil && spec.PersistentVolume.Spec.Cinder == nil {
+		return nil, fmt.Errorf("spec.PersistentVolumeSource.Cinder is nil")
+	}
+	return &cinderVolumeDeleter{
+		&cinderVolume{
+			volName: spec.Name(),
+			pdName:  spec.PersistentVolume.Spec.Cinder.VolumeID,
+			manager: manager,
+			plugin:  plugin,
+		}}, nil
+}
+
+func (plugin *cinderPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
+	if len(options.AccessModes) == 0 {
+		options.AccessModes = plugin.GetAccessModes()
+	}
+	return plugin.newProvisionerInternal(options, &CinderDiskUtil{})
+}
+
+func (plugin *cinderPlugin) newProvisionerInternal(options volume.VolumeOptions, manager cdManager) (volume.Provisioner, error) {
+	return &cinderVolumeProvisioner{
+		cinderVolume: &cinderVolume{
+			manager: manager,
+			plugin:  plugin,
+		},
+		options: options,
+	}, nil
+}
+
+func (plugin *cinderPlugin) getCloudProvider() (*openstack.OpenStack, error) {
+	cloud := plugin.host.GetCloudProvider()
+	if cloud == nil {
+		glog.Errorf("Cloud provider not initialized properly")
+		return nil, errors.New("Cloud provider not initialized properly")
+	}
+
+	os := cloud.(*openstack.OpenStack)
+	if os == nil {
+		return nil, errors.New("Invalid cloud provider: expected OpenStack")
+	}
+	return os, nil
+}
+
 // Abstract interface to PD operations.
 type cdManager interface {
 	// Attaches the disk to the kubelet's host machine.
 	AttachDisk(builder *cinderVolumeBuilder, globalPDPath string) error
 	// Detaches the disk from the kubelet's host machine.
 	DetachDisk(cleaner *cinderVolumeCleaner) error
+	// Creates a volume
+	CreateVolume(provisioner *cinderVolumeProvisioner) (volumeID string, volumeSizeGB int, err error)
+	// Deletes a volume
+	DeleteVolume(deleter *cinderVolumeDeleter) error
 }
 
 var _ volume.Builder = &cinderVolumeBuilder{}
@@ -286,4 +345,67 @@ func (c *cinderVolumeCleaner) TearDownAt(dir string) error {
 		}
 	}
 	return nil
+}
+
+type cinderVolumeDeleter struct {
+	*cinderVolume
+}
+
+var _ volume.Deleter = &cinderVolumeDeleter{}
+
+func (r *cinderVolumeDeleter) GetPath() string {
+	name := cinderVolumePluginName
+	return r.plugin.host.GetPodVolumeDir(r.podUID, util.EscapeQualifiedNameForDisk(name), r.volName)
+}
+
+func (r *cinderVolumeDeleter) Delete() error {
+	return r.manager.DeleteVolume(r)
+}
+
+type cinderVolumeProvisioner struct {
+	*cinderVolume
+	options volume.VolumeOptions
+}
+
+var _ volume.Provisioner = &cinderVolumeProvisioner{}
+
+func (c *cinderVolumeProvisioner) Provision(pv *api.PersistentVolume) error {
+	volumeID, sizeGB, err := c.manager.CreateVolume(c)
+	if err != nil {
+		return err
+	}
+	pv.Spec.PersistentVolumeSource.Cinder.VolumeID = volumeID
+	pv.Spec.Capacity = api.ResourceList{
+		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
+	}
+	return nil
+}
+
+func (c *cinderVolumeProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
+	// Provide dummy api.PersistentVolume.Spec, it will be filled in
+	// cinderVolumeProvisioner.Provision()
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: "pv-cinder-",
+			Labels:       map[string]string{},
+			Annotations: map[string]string{
+				"kubernetes.io/createdby": "cinder-dynamic-provisioner",
+			},
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   c.options.AccessModes,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): c.options.Capacity,
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				Cinder: &api.CinderVolumeSource{
+					VolumeID: "dummy",
+					FSType:   "ext4",
+					ReadOnly: false,
+				},
+			},
+		},
+	}, nil
+
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package cinder
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
@@ -62,6 +64,17 @@ func (fake *fakePDManager) DetachDisk(c *cinderVolumeCleaner) error {
 	err := os.RemoveAll(globalPath)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (fake *fakePDManager) CreateVolume(c *cinderVolumeProvisioner) (volumeID string, volumeSizeGB int, err error) {
+	return "test-volume-name", 1, nil
+}
+
+func (fake *fakePDManager) DeleteVolume(cd *cinderVolumeDeleter) error {
+	if cd.pdName != "test-volume-name" {
+		return fmt.Errorf("Deleter got unexpected volume name: %s", cd.pdName)
 	}
 	return nil
 }
@@ -129,5 +142,46 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("TearDown() failed, volume path still exists: %s", path)
 	} else if !os.IsNotExist(err) {
 		t.Errorf("SetUp() failed: %v", err)
+	}
+
+	// Test Provisioner
+	cap := resource.MustParse("100Mi")
+	options := volume.VolumeOptions{
+		Capacity: cap,
+		AccessModes: []api.PersistentVolumeAccessMode{
+			api.ReadWriteOnce,
+		},
+		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
+	}
+	provisioner, err := plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{})
+	persistentSpec, err := provisioner.NewPersistentVolumeTemplate()
+	if err != nil {
+		t.Errorf("NewPersistentVolumeTemplate() failed: %v", err)
+	}
+
+	// get 2nd Provisioner - persistent volume controller will do the same
+	provisioner, err = plug.(*cinderPlugin).newProvisionerInternal(options, &fakePDManager{})
+	err = provisioner.Provision(persistentSpec)
+	if err != nil {
+		t.Errorf("Provision() failed: %v", err)
+	}
+
+	if persistentSpec.Spec.PersistentVolumeSource.Cinder.VolumeID != "test-volume-name" {
+		t.Errorf("Provision() returned unexpected volume ID: %s", persistentSpec.Spec.PersistentVolumeSource.Cinder.VolumeID)
+	}
+	cap = persistentSpec.Spec.Capacity[api.ResourceStorage]
+	size := cap.Value()
+	if size != 1024*1024*1024 {
+		t.Errorf("Provision() returned unexpected volume size: %v", size)
+	}
+
+	// Test Deleter
+	volSpec := &volume.Spec{
+		PersistentVolume: persistentSpec,
+	}
+	deleter, err := plug.(*cinderPlugin).newDeleterInternal(volSpec, &fakePDManager{})
+	err = deleter.Delete()
+	if err != nil {
+		t.Errorf("Deleter() failed: %v", err)
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder_util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/cinder/cinder_util.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 type CinderDiskUtil struct{}
@@ -40,12 +40,11 @@ func (util *CinderDiskUtil) AttachDisk(b *cinderVolumeBuilder, globalPDPath stri
 	if b.readOnly {
 		options = append(options, "ro")
 	}
-	cloud := b.plugin.host.GetCloudProvider()
-	if cloud == nil {
-		glog.Errorf("Cloud provider not initialized properly")
-		return errors.New("Cloud provider not initialized properly")
+	cloud, err := b.plugin.getCloudProvider()
+	if err != nil {
+		return err
 	}
-	diskid, err := cloud.(*openstack.OpenStack).AttachDisk(b.pdName)
+	diskid, err := cloud.AttachDisk(b.pdName)
 	if err != nil {
 		return err
 	}
@@ -119,17 +118,48 @@ func (util *CinderDiskUtil) DetachDisk(cd *cinderVolumeCleaner) error {
 	}
 	glog.V(2).Infof("Successfully unmounted main device: %s\n", globalPDPath)
 
-	cloud := cd.plugin.host.GetCloudProvider()
-	if cloud == nil {
-		glog.Errorf("Cloud provider not initialized properly")
-		return errors.New("Cloud provider not initialized properly")
+	cloud, err := cd.plugin.getCloudProvider()
+	if err != nil {
+		return err
 	}
 
-	if err := cloud.(*openstack.OpenStack).DetachDisk(cd.pdName); err != nil {
+	if err = cloud.DetachDisk(cd.pdName); err != nil {
 		return err
 	}
 	glog.V(2).Infof("Successfully detached cinder volume %s", cd.pdName)
 	return nil
+}
+
+func (util *CinderDiskUtil) DeleteVolume(cd *cinderVolumeDeleter) error {
+	cloud, err := cd.plugin.getCloudProvider()
+	if err != nil {
+		return err
+	}
+
+	if err = cloud.DeleteVolume(cd.pdName); err != nil {
+		glog.V(2).Infof("Error deleting cinder volume %s: %v", cd.pdName, err)
+		return err
+	}
+	glog.V(2).Infof("Successfully deleted cinder volume %s", cd.pdName)
+	return nil
+}
+
+func (util *CinderDiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID string, volumeSizeGB int, err error) {
+	cloud, err := c.plugin.getCloudProvider()
+	if err != nil {
+		return "", 0, err
+	}
+
+	volSizeBytes := c.options.Capacity.Value()
+	// Cinder works with gigabytes, convert to GiB with rounding up
+	volSizeGB := int(volume.RoundUpSize(volSizeBytes, 1024*1024*1024))
+	name, err := cloud.CreateVolume(volSizeGB)
+	if err != nil {
+		glog.V(2).Infof("Error creating cinder volume: %v", err)
+		return "", 0, err
+	}
+	glog.V(2).Infof("Successfully created cinder volume %s", name)
+	return name, volSizeGB, nil
 }
 
 type cinderSafeFormatAndMount struct {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
@@ -17,12 +17,14 @@ limitations under the License.
 package gce_pd
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
@@ -41,6 +43,8 @@ type gcePersistentDiskPlugin struct {
 
 var _ volume.VolumePlugin = &gcePersistentDiskPlugin{}
 var _ volume.PersistentVolumePlugin = &gcePersistentDiskPlugin{}
+var _ volume.DeletableVolumePlugin = &gcePersistentDiskPlugin{}
+var _ volume.ProvisionableVolumePlugin = &gcePersistentDiskPlugin{}
 
 const (
 	gcePersistentDiskPluginName = "kubernetes.io/gce-pd"
@@ -122,12 +126,50 @@ func (plugin *gcePersistentDiskPlugin) newCleanerInternal(volName string, podUID
 	}}, nil
 }
 
+func (plugin *gcePersistentDiskPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
+	return plugin.newDeleterInternal(spec, &GCEDiskUtil{})
+}
+
+func (plugin *gcePersistentDiskPlugin) newDeleterInternal(spec *volume.Spec, manager pdManager) (volume.Deleter, error) {
+	if spec.PersistentVolume != nil && spec.PersistentVolume.Spec.GCEPersistentDisk == nil {
+		return nil, fmt.Errorf("spec.PersistentVolumeSource.GCEPersistentDisk is nil")
+	}
+	return &gcePersistentDiskDeleter{
+		gcePersistentDisk: &gcePersistentDisk{
+			volName: spec.Name(),
+			pdName:  spec.PersistentVolume.Spec.GCEPersistentDisk.PDName,
+			manager: manager,
+			plugin:  plugin,
+		}}, nil
+}
+
+func (plugin *gcePersistentDiskPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
+	if len(options.AccessModes) == 0 {
+		options.AccessModes = plugin.GetAccessModes()
+	}
+	return plugin.newProvisionerInternal(options, &GCEDiskUtil{})
+}
+
+func (plugin *gcePersistentDiskPlugin) newProvisionerInternal(options volume.VolumeOptions, manager pdManager) (volume.Provisioner, error) {
+	return &gcePersistentDiskProvisioner{
+		gcePersistentDisk: &gcePersistentDisk{
+			manager: manager,
+			plugin:  plugin,
+		},
+		options: options,
+	}, nil
+}
+
 // Abstract interface to PD operations.
 type pdManager interface {
 	// Attaches the disk to the kubelet's host machine.
 	AttachAndMountDisk(b *gcePersistentDiskBuilder, globalPDPath string) error
 	// Detaches the disk from the kubelet's host machine.
 	DetachDisk(c *gcePersistentDiskCleaner) error
+	// Creates a volume
+	CreateVolume(provisioner *gcePersistentDiskProvisioner) (volumeID string, volumeSizeGB int, err error)
+	// Deletes a volume
+	DeleteVolume(deleter *gcePersistentDiskDeleter) error
 }
 
 // gcePersistentDisk volumes are disk resources provided by Google Compute Engine
@@ -302,4 +344,67 @@ func (c *gcePersistentDiskCleaner) TearDownAt(dir string) error {
 		}
 	}
 	return nil
+}
+
+type gcePersistentDiskDeleter struct {
+	*gcePersistentDisk
+}
+
+var _ volume.Deleter = &gcePersistentDiskDeleter{}
+
+func (d *gcePersistentDiskDeleter) GetPath() string {
+	name := gcePersistentDiskPluginName
+	return d.plugin.host.GetPodVolumeDir(d.podUID, util.EscapeQualifiedNameForDisk(name), d.volName)
+}
+
+func (d *gcePersistentDiskDeleter) Delete() error {
+	return d.manager.DeleteVolume(d)
+}
+
+type gcePersistentDiskProvisioner struct {
+	*gcePersistentDisk
+	options volume.VolumeOptions
+}
+
+var _ volume.Provisioner = &gcePersistentDiskProvisioner{}
+
+func (c *gcePersistentDiskProvisioner) Provision(pv *api.PersistentVolume) error {
+	volumeID, sizeGB, err := c.manager.CreateVolume(c)
+	if err != nil {
+		return err
+	}
+	pv.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName = volumeID
+	pv.Spec.Capacity = api.ResourceList{
+		api.ResourceName(api.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
+	}
+	return nil
+}
+
+func (c *gcePersistentDiskProvisioner) NewPersistentVolumeTemplate() (*api.PersistentVolume, error) {
+	// Provide dummy api.PersistentVolume.Spec, it will be filled in
+	// gcePersistentDiskProvisioner.Provision()
+	return &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			GenerateName: "pv-gce-",
+			Labels:       map[string]string{},
+			Annotations: map[string]string{
+				"kubernetes.io/createdby": "gce-pd-dynamic-provisioner",
+			},
+		},
+		Spec: api.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   c.options.AccessModes,
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): c.options.Capacity,
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				GCEPersistentDisk: &api.GCEPersistentDiskVolumeSource{
+					PDName:    "dummy",
+					FSType:    "ext4",
+					Partition: 0,
+					ReadOnly:  false,
+				},
+			},
+		},
+	}, nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package gce_pd
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/types"
@@ -99,6 +101,17 @@ func (fake *fakePDManager) DetachDisk(c *gcePersistentDiskCleaner) error {
 	return nil
 }
 
+func (fake *fakePDManager) CreateVolume(c *gcePersistentDiskProvisioner) (volumeID string, volumeSizeGB int, err error) {
+	return "test-gce-volume-name", 100, nil
+}
+
+func (fake *fakePDManager) DeleteVolume(cd *gcePersistentDiskDeleter) error {
+	if cd.pdName != "test-gce-volume-name" {
+		return fmt.Errorf("Deleter got unexpected volume name: %s", cd.pdName)
+	}
+	return nil
+}
+
 func TestPlugin(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), volume.NewFakeVolumeHost("/tmp/fake", nil, nil))
@@ -171,6 +184,47 @@ func TestPlugin(t *testing.T) {
 	}
 	if !fakeManager.detachCalled {
 		t.Errorf("Detach watch not called")
+	}
+
+	// Test Provisioner
+	cap := resource.MustParse("100Mi")
+	options := volume.VolumeOptions{
+		Capacity: cap,
+		AccessModes: []api.PersistentVolumeAccessMode{
+			api.ReadWriteOnce,
+		},
+		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
+	}
+	provisioner, err := plug.(*gcePersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
+	persistentSpec, err := provisioner.NewPersistentVolumeTemplate()
+	if err != nil {
+		t.Errorf("NewPersistentVolumeTemplate() failed: %v", err)
+	}
+
+	// get 2nd Provisioner - persistent volume controller will do the same
+	provisioner, err = plug.(*gcePersistentDiskPlugin).newProvisionerInternal(options, &fakePDManager{})
+	err = provisioner.Provision(persistentSpec)
+	if err != nil {
+		t.Errorf("Provision() failed: %v", err)
+	}
+
+	if persistentSpec.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName != "test-gce-volume-name" {
+		t.Errorf("Provision() returned unexpected volume ID: %s", persistentSpec.Spec.PersistentVolumeSource.GCEPersistentDisk.PDName)
+	}
+	cap = persistentSpec.Spec.Capacity[api.ResourceStorage]
+	size := cap.Value()
+	if size != 100*1024*1024*1024 {
+		t.Errorf("Provision() returned unexpected volume size: %v", size)
+	}
+
+	// Test Deleter
+	volSpec := &volume.Spec{
+		PersistentVolume: persistentSpec,
+	}
+	deleter, err := plug.(*gcePersistentDiskPlugin).newDeleterInternal(volSpec, &fakePDManager{})
+	err = deleter.Delete()
+	if err != nil {
+		t.Errorf("Deleter() failed: %v", err)
 	}
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/gce_pd/gce_util.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/operationmanager"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 const (
@@ -118,6 +119,39 @@ func (util *GCEDiskUtil) DetachDisk(c *gcePersistentDiskCleaner) error {
 	// Detach disk, retry if needed.
 	go detachDiskAndVerify(c)
 	return nil
+}
+
+func (util *GCEDiskUtil) DeleteVolume(d *gcePersistentDiskDeleter) error {
+	cloud, err := getCloudProvider()
+	if err != nil {
+		return err
+	}
+
+	if err = cloud.DeleteDisk(d.pdName); err != nil {
+		glog.V(2).Infof("Error deleting GCE PD volume %s: %v", d.pdName, err)
+		return err
+	}
+	glog.V(2).Infof("Successfully deleted GCE PD volume %s", d.pdName)
+	return nil
+}
+
+func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (volumeID string, volumeSizeGB int, err error) {
+	cloud, err := getCloudProvider()
+	if err != nil {
+		return "", 0, err
+	}
+
+	name := fmt.Sprintf("kube-dynamic-%s", util.NewUUID())
+	requestBytes := c.options.Capacity.Value()
+	// GCE works with gigabytes, convert to GiB with rounding up
+	requestGB := volume.RoundUpSize(requestBytes, 1024*1024*1024)
+	err = cloud.CreateDisk(name, int64(requestGB))
+	if err != nil {
+		glog.V(2).Infof("Error creating GCE PD volume: %v", err)
+		return "", 0, err
+	}
+	glog.V(2).Infof("Successfully created GCE PD volume %s", name)
+	return name, int(requestGB), nil
 }
 
 // Attaches the specified persistent disk device to node, verifies that it is attached, and retries if it fails.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/plugins.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/plugins.go
@@ -49,6 +49,8 @@ type VolumeOptions struct {
 	AccessModes []api.PersistentVolumeAccessMode
 	// Reclamation policy for a persistent volume
 	PersistentVolumeReclaimPolicy api.PersistentVolumeReclaimPolicy
+	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
+	CloudTags *map[string]string
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/util.go
@@ -138,3 +138,12 @@ func CalculateTimeoutForVolume(minimumTimeout, timeoutIncrement int, pv *api.Per
 		return timeout
 	}
 }
+
+// RoundUpSize calculates how many allocation units are needed to accomodate
+// a volume of given size. E.g. when user wants 1500MiB volume, while AWS EBS
+// allocates volumes in gibibyte-sized chunks,
+// RoundUpSize(1500 * 1024*1024, 1024*1024*1024) returns '2'
+// (2 GiB is the smallest allocatable volume that can hold 1500MiB)
+func RoundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
+	return (volumeSizeBytes + allocationUnitBytes - 1) / allocationUnitBytes
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/pd.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/test/e2e/pd.go
@@ -338,7 +338,7 @@ func createPD() (string, error) {
 			return "", fmt.Errorf("Provider does not support volumes")
 		}
 		volumeOptions := &aws_cloud.VolumeOptions{}
-		volumeOptions.CapacityMB = 10 * 1024
+		volumeOptions.CapacityGB = 10
 		return volumes.CreateVolume(volumeOptions)
 	}
 }


### PR DESCRIPTION
Merge only after https://github.com/openshift/origin/pull/6291 and all the referenced PRs are merged upstream.

It's rebased version of referenced pull requests. I picked only tiny part of PR#17747, just to get `CreateDisk` and `DeleteDisk`.

Upstream PRs:
* https://github.com/kubernetes/kubernetes/pull/18601
* https://github.com/kubernetes/kubernetes/pull/18607
* https://github.com/kubernetes/kubernetes/pull/17747
* https://github.com/kubernetes/kubernetes/pull/18621