### PR TITLE
oc: Use object name instead of provided arg in cancel-build

### DIFF
--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -92,11 +92,11 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 		opts := buildapi.BuildLogOptions{
 			NoWait: true,
 		}
-		response, err := client.BuildLogs(namespace).Get(buildName, opts).Do().Raw()
+		response, err := client.BuildLogs(namespace).Get(build.Name, opts).Do().Raw()
 		if err != nil {
-			glog.Errorf("Could not fetch build logs for %s: %v", buildName, err)
+			glog.Errorf("Could not fetch build logs for %s: %v", build.Name, err)
 		} else {
-			glog.Infof("Build logs for %s:\n%v", buildName, string(response))
+			glog.Infof("Build logs for %s:\n%v", build.Name, string(response))
 		}
 	}
 
@@ -104,7 +104,7 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 	for {
 		build.Status.Cancelled = true
 		if _, err = buildClient.Update(build); err != nil && errors.IsConflict(err) {
-			build, err = buildClient.Get(buildName)
+			build, err = buildClient.Get(build.Name)
 			if err != nil {
 				return err
 			}
@@ -115,7 +115,7 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 		}
 		break
 	}
-	fmt.Fprintf(out, "Build %s was cancelled.\n", buildName)
+	fmt.Fprintf(out, "Build %s was cancelled.\n", build.Name)
 
 	// mapper, typer := f.Object()
 	// resourceMapper := &resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: f.ClientMapperForCommand()}
@@ -130,7 +130,7 @@ func RunCancelBuild(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, arg
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(out, "Restarted build %s.\n", buildName)
+		fmt.Fprintf(out, "Restarted build %s.\n", build.Name)
 		fmt.Fprintf(out, "%s\n", newBuild.Name)
 		// fmt.Fprintf(out, "%s\n", newBuild.Name)
 		// info, err := resourceMapper.InfoForObject(newBuild)

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -108,7 +108,7 @@ os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -'
 os::cmd::expect_success "tryuntil 'oc get build/ruby-sample-build-1'"
 # Uses type/name resource syntax to cancel the build and check for proper message
-os::cmd::expect_success "oc cancel-build build/ruby-sample-build-1 | grep 'Build build/ruby-sample-build-1 was cancelled.'"
+os::cmd::expect_success "oc cancel-build build/ruby-sample-build-1 | grep 'Build ruby-sample-build-1 was cancelled.'"
 # Make sure canceling already cancelled build returns proper message
 os::cmd::expect_success "tryuntil $(oc cancel-build build/ruby-sample-build-1 | grep 'A cancellation event was already triggered for the build build/ruby-sample-build-1.')"
 os::cmd::expect_success 'oc delete all --all'


### PR DESCRIPTION
Provided argument can be in the form of either NAME or build/NAME.
There are a few places in cancel-build we haven't hit that should
use only the NAME format.

Fixes https://github.com/openshift/origin/issues/6312

@mfojtik please review