### PR TITLE
Verify the installed rpms in images

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -12,6 +12,11 @@ FROM centos:centos7
 # base images land
 RUN yum swap -y -- remove systemd-container\* -- install systemd systemd-libs
 
-RUN yum install -y git tar wget hostname sysvinit-tools util-linux bsdtar epel-release \
-    socat ethtool device-mapper iptables && \
-    yum clean all
+# The install_and_verify.sh script installs packages using yum and verifies that
+# the packages were really installed and not skipped.
+RUN echo -e "#!/bin/sh -ex\nyum install --setopt=tsflags=nodocs -y \"\$@\" && \
+      yum clean all && rpm -V \"\$@\"" > /usr/bin/install_and_verify.sh && \
+      chmod +x /usr/bin/install_and_verify.sh
+
+RUN install_and_verify.sh git tar wget hostname sysvinit-tools util-linux bsdtar \
+                 epel-release socat ethtool device-mapper iptables

--- a/images/base/Dockerfile.rhel7
+++ b/images/base/Dockerfile.rhel7
@@ -6,5 +6,10 @@
 #
 FROM rhel7
 
-RUN yum install -y git tar wget socat hostname sysvinit-tools util-linux ethtool bsdtar && \
-    yum clean all
+# The install_and_verify.sh script installs packages using yum and verifies that
+# the packages were really installed and not skipped.
+RUN echo -e "#!/bin/sh -ex\nyum install --setopt=tsflags=nodocs -y \"\$@\" && \
+      yum clean all && rpm -V \"\$@\"" > /usr/bin/install_and_verify.sh && \
+      chmod +x /usr/bin/install_and_verify.sh
+
+RUN install_and_verify.sh git tar wget socat hostname sysvinit-tools util-linux ethtool bsdtar

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -21,8 +21,10 @@ VOLUME ["/run", "/tmp"]
 RUN yum -y update && yum -y install git golang hg tar make \
   hostname bind-utils iproute iputils which procps-ng openssh-server \
   # Node-specific packages
-  docker openvswitch bridge-utils ethtool \
-  && yum clean all
+  docker openvswitch bridge-utils ethtool && \
+  rpm -V git golang hg tar make hostname bind-utils iproute iputils which \
+         procps-ng openssh-server docker openvswitch bridge-utils ethtool && \
+  yum clean all
 
 # sshd should be enabled as needed
 RUN systemctl disable sshd.service

--- a/images/dockerregistry/Dockerfile
+++ b/images/dockerregistry/Dockerfile
@@ -6,8 +6,7 @@
 #
 FROM openshift/origin-base
 
-RUN yum install -y tree findutils epel-release && \
-    yum clean all
+RUN install_and_verify.sh tree findutils epel-release
 
 # The registry doesn't require a privileged user.
 USER 1001

--- a/images/ipfailover/keepalived/Dockerfile
+++ b/images/ipfailover/keepalived/Dockerfile
@@ -5,8 +5,7 @@
 #
 FROM openshift/origin-base
 
-RUN yum -y install kmod keepalived iproute psmisc nc net-tools && \
-    yum clean all
+RUN install_and_verify.sh kmod keepalived iproute psmisc nmap-ncat net-tools
 
 ADD conf/ /var/lib/openshift/ipfailover/keepalived/conf/
 ADD lib/  /var/lib/openshift/ipfailover/keepalived/lib/

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -14,10 +14,10 @@ MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
 # to run in another container
 
 ADD https://copr.fedoraproject.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo /etc/yum.repos.d/
-RUN yum install -y libmnl libnetfilter_conntrack openvswitch \
+
+RUN install_and_verify.sh libmnl libnetfilter_conntrack openvswitch \
     libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
-    binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
-    && yum clean all
+    binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus
 
 RUN mkdir -p \
     /usr/lib/systemd/system/origin-node.service.d \

--- a/images/openvswitch/Dockerfile
+++ b/images/openvswitch/Dockerfile
@@ -4,18 +4,13 @@
 # The standard name for this image is openshift/openvswitch
 #
 
-FROM centos:centos7
+FROM openshift/origin-base
 
 MAINTAINER Scott Dodson <sdodson@redhat.com>
 
 ADD https://copr.fedoraproject.org/coprs/maxamillion/origin-next/repo/epel-7/maxamillion-origin-next-epel-7.repo /etc/yum.repos.d/
 
-# TODO: systemd update from centos 7.1 -> 7.2 is broken, remove this once 7.2
-# base images land
-RUN yum swap -y -- remove systemd-container\* -- install systemd systemd-libs
-
-RUN yum install -y openvswitch \
-    && yum clean all
+RUN install_and_verify.sh openvswitch
 
 ADD  scripts/* /usr/local/bin/
 RUN chmod +x /usr/local/bin/*

--- a/images/release/Dockerfile
+++ b/images/release/Dockerfile
@@ -6,7 +6,8 @@
 #
 FROM openshift/origin-base
 
-RUN yum install -y zip hg golang golang-pkg-darwin-amd64 golang-pkg-windows-amd64 golang-pkg-linux-386 && yum clean all
+RUN install_and_verify.sh zip golang golang-pkg-darwin-amd64 \
+                   golang-pkg-windows-amd64 golang-pkg-linux-386
 
 ENV GOPATH /go
 

--- a/images/router/haproxy-base/Dockerfile
+++ b/images/router/haproxy-base/Dockerfile
@@ -11,12 +11,11 @@ FROM openshift/origin-base
 #       this is temporary and should be removed when the container is switch to an empty-dir
 #       with gid support.
 #
-RUN yum -y install haproxy && \
+RUN install_and_verify.sh haproxy && \
     mkdir -p /var/lib/containers/router/{certs,cacerts} && \
     mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_edge_http_expose,os_edge_http_redirect}.map,haproxy.config} && \
-    chmod -R 777 /var && \
-    yum clean all
+    chmod -R 777 /var
 
 ADD conf/ /var/lib/haproxy/conf/
 # add the dummy cert to the app cert directory as well to avoid errors with default config


### PR DESCRIPTION
This PR will add the `rpm -V ` command to verify that all packages we intended to install were successfully installed. The `yum install -y` can skip the packages that cannot be installed for whatever reason. This has potential to produce broken images.

Additionally I added `nodoc` option to save few kilobytes from the image ;-)