### PR TITLE
Allow to pass extra args to server in extended test and mute config loading messages

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -238,7 +237,6 @@ func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.V(3).Infoln("Config loaded from file", filename)
 
 	// set LocationOfOrigin on every Cluster, User, and Context
 	for key, obj := range config.AuthInfos {

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -141,6 +141,11 @@ function start_os_server {
 	echo "[INFO] Using images:              ${USE_IMAGES}"
 	echo "[INFO] MasterIP is:               ${MASTER_ADDR}"
 
+	SERVER_ARGS=${SERVER_ARGS:-""}
+	if [ ! -z "${SERVER_ARGS}" ]; then
+		echo "[INFO] Server arguments:          ${SERVER_ARGS}"
+	fi
+
 	mkdir -p ${LOG_DIR}
 
 	echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
@@ -149,7 +154,7 @@ function start_os_server {
 	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start \
 	 --master-config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --node-config=${NODE_CONFIG_DIR}/node-config.yaml \
-	 --loglevel=4 \
+	 --loglevel=4 "${SERVER_ARGS}" \
 	&>"${LOG_DIR}/openshift.log" &
 	export OS_PID=$!
 


### PR DESCRIPTION
This PR will:

* mute messages like this:
```console
I1211 10:53:21.257617   26640 loader.go:241] Config loaded from file /tmp/openshift-extended-tests/core/openshift.local.config/master/admin.kubeconfig
```
* allow to pass `SERVER_ARGS` into `./test/extended/core.sh` with additional arguments to `openshift start` (like `--latest-images`)