### PR TITLE
Fix race between Kubelet initialization and plugin creation

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -680,12 +680,12 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "8a7e17c0c3eea529955229dfd7b4baefad56633b"
+			"Rev": "e7f0d8be285f73c896ff19455bd03d5189cbe5e6"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins",
 			"Comment": "v0.1-164-g9d342eb",
-			"Rev": "8a7e17c0c3eea529955229dfd7b4baefad56633b"
+			"Rev": "e7f0d8be285f73c896ff19455bd03d5189cbe5e6"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/api/types.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/api/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
+	pconfig "k8s.io/kubernetes/pkg/proxy/config"
 )
 
 type EventType string
@@ -85,4 +86,9 @@ type OsdnPlugin interface {
 
 	StartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error
 	StartNode(mtu uint) error
+}
+
+type FilteringEndpointsConfigHandler interface {
+	pconfig.EndpointsConfigHandler
+	SetBaseEndpointsHandler(base pconfig.EndpointsConfigHandler)
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/common.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
@@ -20,6 +21,7 @@ import (
 type PluginHooks interface {
 	PluginStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error
 	PluginStartNode(mtu uint) error
+	UpdatePod(namespace string, name string, id kubetypes.DockerID) error
 }
 
 type OvsController struct {
@@ -46,8 +48,6 @@ type FlowController interface {
 
 	AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error
 	DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error
-
-	UpdatePod(namespace, podName, containerID string, netID uint) error
 }
 
 // Called by plug factory functions to initialize the generic plugin instance

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/factory/factory.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/factory/factory.go
@@ -7,14 +7,13 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	oskserver "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 )
 
 // Call by higher layers to create the plugin instance
-func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, oskserver.FilteringEndpointsConfigHandler, error) {
+func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
 	switch strings.ToLower(pluginType) {
 	case ovs.SingleTenantPluginName():
 		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), false, hostname, selfIP)

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -4,10 +4,8 @@ set -e
 lock_file=/var/lock/openshift-sdn.lock
 
 action=$1
-pod_namespace=$2
-pod_name=$3
-net_container=$4
-tenant_id=$5
+net_container=$2
+tenant_id=$3
 
 lockwrap() {
     (
@@ -55,18 +53,17 @@ add_ovs_flows() {
 
     case $tenant_id in
 	-1) # single-tenant plugin
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=100,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=100,arp,nw_dst=${ipaddr},actions=output:${ovs_port}"
+	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=goto_table:6"
 	    ;;
 
 	0)  # multi-tenant plugin, admin namespace
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
+	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:5"
+	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=7,priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
 	    ;;
 
 	*)  # multi-tenant plugin, normal namespace
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
+	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:5"
+	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=7,priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
 	    ;;
     esac
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/bin/openshift-sdn-ovs-setup.sh
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/bin/openshift-sdn-ovs-setup.sh
@@ -74,9 +74,9 @@ function setup_required() {
         return 0
     fi
     if [ "$multitenant" = "true" ]; then
-	flow_rule='NXM_NX_TUN_IPV4'
+	flow_rule='table=3.*NXM_NX_TUN_ID'
     else
-	flow_rule='table=0.*arp'
+	flow_rule='table=3.*goto_table:9'
     fi
     if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q $flow_rule; then
         return 0
@@ -127,57 +127,65 @@ function setup() {
     ip link set vovsbr txqueuelen 0
     brctl addif lbr0 vlinuxbr
 
+    ovs-vsctl del-port br0 vovsbr || true
+    ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=3
+
+    # Table 0; VXLAN filtering; the first rule sends un-tunnelled packets
+    # to table 1. Additional per-node rules are filled in by controller.go
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0, tun_src=0.0.0.0, actions=goto_table:1"
+    # eg, "table=0, tun_src=${remote_node}, actions=goto_table:1"
+
+    # Table 1; learn MAC addresses and continue with table 2
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=1, actions=learn(table=9, priority=200, hard_timeout=900, NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[], load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[], output:NXM_OF_IN_PORT[]), goto_table:2"
+
+    # Table 2; initial dispatch
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=200, arp, actions=goto_table:9"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=1, actions=goto_table:3" # vxlan0
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=2, actions=goto_table:6" # tun0
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=3, actions=goto_table:6" # vovsbr
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=0, actions=goto_table:4"              # container
+
+    # Table 3; incoming from vxlan
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=3, priority=200, ip, nw_dst=${local_subnet_gateway}, actions=output:2"
     if [ "$multitenant" = "true" ]; then
-	ovs-vsctl del-port br0 vovsbr || true
-	ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=3
-
-	# Table 0; learn MAC addresses and continue with table 1
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=0, actions=learn(table=8, priority=200, hard_timeout=900, NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[], load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[], output:NXM_OF_IN_PORT[]), goto_table:1"
-
-	# Table 1; initial dispatch
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=1, arp, actions=goto_table:8"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=1, in_port=1, actions=goto_table:2" # vxlan0
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=1, in_port=2, actions=goto_table:5" # tun0
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=1, in_port=3, actions=goto_table:5" # vovsbr
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=1, actions=goto_table:3"            # container
-
-	# Table 2; incoming from vxlan
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, arp, actions=goto_table:8"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=200, ip, nw_dst=${local_subnet_gateway}, actions=output:2"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, tun_id=0, actions=goto_table:5"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, ip, nw_dst=${local_subnet_cidr}, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:6"
-
-	# Table 3; incoming from container; filled in by openshift-sdn-ovs
-
-	# Table 4; services; mostly filled in by controller.go
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=200, reg0=0, ip, nw_dst=${service_network_cidr}, actions=output:2"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=100, ip, nw_dst=${service_network_cidr}, actions=drop"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=0, actions=goto_table:5"
-
-	# Table 5; general routing
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=200, ip, nw_dst=${local_subnet_gateway}, actions=output:2"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=150, ip, nw_dst=${local_subnet_cidr}, actions=goto_table:6"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=100, ip, nw_dst=${cluster_network_cidr}, actions=goto_table:7"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=0, ip, actions=output:2"
-
-	# Table 6; to local container; mostly filled in by openshift-sdn-ovs
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=200, ip, reg0=0, actions=goto_table:8"
-
-	# Table 7; to remote container; filled in by controller.go
-
-	# Table 8; MAC dispatch / ARP, filled in by Table 0's learn() rule
-	# and with per-node vxlan ARP rules by controller.go
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=8, priority=0, arp, actions=flood"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=3, priority=100, ip, nw_dst=${local_subnet_cidr}, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:7"
     else
-	ovs-vsctl del-port br0 vovsbr || true
-	ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=9
-
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=100,arp,nw_dst=${local_subnet_gateway},actions=output:2"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=100,ip,nw_dst=${local_subnet_gateway},actions=output:2"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=75,ip,nw_dst=${local_subnet_cidr},actions=output:9"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=75,arp,nw_dst=${local_subnet_cidr},actions=output:9"
-	ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,priority=50,actions=output:2"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=3, priority=100, ip, nw_dst=${local_subnet_cidr}, actions=goto_table:9"
     fi
+
+    # Table 4; incoming from container; filled in by openshift-sdn-ovs
+    # eg, single-tenant: "table=4, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, goto_table:6"
+    # multitenant: "table=4, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
+
+    # Table 5; service isolation; mostly filled in by controller.go
+    if [ "$multitenant" = "true" ]; then
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=200, reg0=0, ip, nw_dst=${service_network_cidr}, actions=output:2"
+	# eg, "table=5, priority=200, ${service_proto}, nw_dst=${service_ip}, tp_dst=${service_port}, actions=output:2"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=100, ip, nw_dst=${service_network_cidr}, actions=drop"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=5, priority=0, actions=goto_table:6"
+    fi
+
+    # Table 6; general routing
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=200, ip, nw_dst=${local_subnet_gateway}, actions=output:2"
+    if [ "$multitenant" = "true" ]; then
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=150, ip, reg0=0, nw_dst=${local_subnet_cidr}, actions=goto_table:9"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=150, ip, nw_dst=${local_subnet_cidr}, actions=goto_table:7"
+    else
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=150, ip, nw_dst=${local_subnet_cidr}, actions=goto_table:9"
+    fi
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=100, ip, nw_dst=${cluster_network_cidr}, actions=goto_table:8"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=0, ip, actions=output:2"
+
+    # Table 7; to local container with isolation; filled in by openshift-sdn-ovs
+    # eg, "table=7, priority=100, ip, nw_dst=${ipaddr}, reg0=${tenant_id}, actions=output:${ovs_port}"
+
+    # Table 8; to remote container; filled in by controller.go
+    # eg, "table=8, priority=100, ip, nw_dst=${remote_subnet_cidr}, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31], set_field:${remote_node_ip}->tun_dst,output:1"
+
+    # Table 9; MAC dispatch / ARP, filled in by Table 0's learn() rule
+    # and with per-node vxlan ARP rules by controller.go
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=9, priority=0, arp, actions=flood"
+    # eg, "table=9, priority=100, arp, nw_dst=${remote_subnet_cidr}, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31], set_field:${remote_node_ip}->tun_dst,output:1"
 
     # setup tun address
     ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev ${TUN}

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/controller.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/ovs/controller.go
@@ -58,21 +58,23 @@ func (c *FlowController) AddOFRules(nodeIP, nodeSubnetCIDR, localIP string) erro
 	}
 
 	glog.V(5).Infof("AddOFRules for %s", nodeIP)
-
-	var iprule, arprule string
 	cookie := generateCookie(nodeIP)
-	if c.multitenant {
-		iprule = fmt.Sprintf("table=7,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
-		arprule = fmt.Sprintf("table=8,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
-	} else {
-		iprule = fmt.Sprintf("table=0,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
-		arprule = fmt.Sprintf("table=0,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
+
+	inrule := fmt.Sprintf("table=0,cookie=0x%s,tun_src=%s,actions=goto_table:1", cookie, nodeIP)
+	out, err := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", inrule).CombinedOutput()
+	if err != nil {
+		glog.Errorf("Error adding flow %q: %s (%v)", inrule, out, err)
+		return err
 	}
-	out, err := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
+
+	iprule := fmt.Sprintf("table=8,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
+	out, err = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
 	if err != nil {
 		glog.Errorf("Error adding flow %q: %s (%v)", iprule, out, err)
 		return err
 	}
+
+	arprule := fmt.Sprintf("table=9,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, nodeSubnetCIDR, nodeIP)
 	out, err = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
 	if err != nil {
 		glog.Errorf("Error adding flow %q: %s (%v)", arprule, out, err)
@@ -134,7 +136,7 @@ func (c *FlowController) DelServiceOFRules(netID uint, IP string, protocol api.S
 }
 
 func generateBaseServiceRule(IP string, protocol api.ServiceProtocol, port uint) string {
-	return fmt.Sprintf("table=4,%s,nw_dst=%s,tp_dst=%d", strings.ToLower(string(protocol)), IP, port)
+	return fmt.Sprintf("table=5,%s,nw_dst=%s,tp_dst=%d", strings.ToLower(string(protocol)), IP, port)
 }
 
 func generateAddServiceRule(netID uint, IP string, protocol api.ServiceProtocol, port uint) string {
@@ -148,14 +150,4 @@ func generateAddServiceRule(netID uint, IP string, protocol api.ServiceProtocol,
 
 func generateDelServiceRule(IP string, protocol api.ServiceProtocol, port uint) string {
 	return generateBaseServiceRule(IP, protocol, port)
-}
-
-func (c *FlowController) UpdatePod(namespace, podName, containerID string, netID uint) error {
-	if !c.multitenant {
-		return nil
-	}
-
-	out, err := exec.Command("openshift-sdn-ovs", "update", namespace, podName, containerID, fmt.Sprint(netID)).CombinedOutput()
-	glog.V(5).Infof("UpdatePod network plugin output: %s, %v", string(out), err)
-	return err
 }

--- a/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/vnids.go
+++ b/Godeps/_workspace/src/github.com/openshift/openshift-sdn/plugins/osdn/vnids.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -222,7 +223,7 @@ func (oc *OvsController) updatePodNetwork(namespace string, netID, oldNetID uint
 		return err
 	}
 	for _, pod := range pods {
-		err := oc.flowController.UpdatePod(pod.Namespace, pod.Name, pod.ContainerID, netID)
+		err := oc.pluginHooks.UpdatePod(pod.Namespace, pod.Name, kubetypes.DockerID(pod.ContainerID))
 		if err != nil {
 			return err
 		}

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -8,7 +8,7 @@ set -o pipefail
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
   echo "Unknown go version '${GO_VERSION}', skipping gofmt."
   exit 0
 fi


### PR DESCRIPTION
Because kubelet is started from a goroutine, sometimes it might
try to initialize network plugins before openshift-node has had
a chance to add the plugin to kubelet's list.  That causes the
openshift node process to exit with:

"Network plugin redhat/openshift-ovs-subnet not found."

Fixes: 0ba1e2c2811ea9b2951bc2163fcac9db647903b7