### PR TITLE
Increase contrast of web console log text

### DIFF
--- a/assets/app/styles/_log.less
+++ b/assets/app/styles/_log.less
@@ -87,10 +87,10 @@
   }
 }
 .log-line {
-  color: lighten(@log-bg-color, 62%);
+  color: #d1d1d1;
   &:hover {
     background-color: lighten(@log-bg-color, 8%);
-    color: lighten(@log-bg-color, 80%);
+    color: #ededed;
   }
 }
 .log-line-number {
@@ -101,10 +101,6 @@
   vertical-align: top;
   white-space: nowrap;
   width: 60px;
-  &:hover, &:focus {
-    background-color: lighten(@log-bg-color, 13%);
-    color: @link-hover-color-bright;
-  }
 }
 .log-line-text {
   padding: 0 10px;


### PR DESCRIPTION
Use grays from the patternfly palette. Don't use a blue color when hovering over a line number since that makes it look clickable.

Fixes #6336

![openshift_web_console_and_openshift_web_console](https://cloud.githubusercontent.com/assets/1167259/11842863/67adb2e2-a3d4-11e5-9b5f-2f398c482077.png)

@jwforres @thoraxe 