### PR TITLE
Web console: Warn about problems with routes

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -132,6 +132,7 @@
         <script src="scripts/services/storage.js"></script>
         <script src="scripts/services/constants.js"></script>
         <script src="scripts/services/limits.js"></script>
+        <script src="scripts/services/routes.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>

--- a/assets/app/scripts/controllers/route.js
+++ b/assets/app/scripts/controllers/route.js
@@ -35,6 +35,7 @@ angular.module('openshiftConsole')
       .get($routeParams.project)
       .then(_.spread(function(project, context) {
         $scope.project = project;
+
         DataService.get("routes", $routeParams.route, context).then(
           // success
           function(route) {
@@ -61,6 +62,11 @@ angular.module('openshiftConsole')
               details: "Reason: " + $filter('getErrorDetails')(e)
             };
           });
+
+        // Watch services to display route warnings.
+        watches.push(DataService.watch("services", context, function(services) {
+          $scope.services = services.by("metadata.name");
+        }));
 
         $scope.$on('$destroy', function(){
           DataService.unwatchAll(watches);

--- a/assets/app/scripts/controllers/routes.js
+++ b/assets/app/scripts/controllers/routes.js
@@ -37,6 +37,11 @@ angular.module('openshiftConsole')
           updateFilterWarning();
         }));
 
+        // Watch services to display route warnings.
+        watches.push(DataService.watch("services", context, function(services) {
+          $scope.services = services.by("metadata.name");
+        }));
+
         function updateFilterWarning() {
           if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.routes)  && !$.isEmptyObject($scope.unfilteredRoutes)) {
             $scope.alerts["routes"] = {

--- a/assets/app/scripts/directives/popups.js
+++ b/assets/app/scripts/directives/popups.js
@@ -15,11 +15,19 @@ angular.module('openshiftConsole')
               // If dynamic-content attr is set at all, even if it hasn't evaluated to a value
               if (attrs.dynamicContent || attrs.dynamicContent === "") {
                 $scope.$watch('dynamicContent', function() {
-                  $(element)
-                    .attr("data-content", $scope.dynamicContent)
-                    .popover("destroy")
-                    .popover();                
-                });                  
+                  $(element).popover("destroy");
+                  // Destroy is asynchronous. Wait for it to complete before updating content.
+                  // See https://github.com/twbs/bootstrap/issues/16376
+                  //     https://github.com/twbs/bootstrap/issues/15607
+                  //     http://stackoverflow.com/questions/27238938/bootstrap-popover-destroy-recreate-works-only-every-second-time
+                  // Destroy calls hide, which takes 150ms to complete.
+                  //     https://github.com/twbs/bootstrap/blob/87121181c8a4b63192865587381d4b8ada8de30c/js/tooltip.js#L31
+                  setTimeout(function() {
+                    $(element)
+                      .attr("data-content", $scope.dynamicContent)
+                      .popover();
+                  }, 200);
+                });
               }
               $(element).popover();
               break;
@@ -27,11 +35,19 @@ angular.module('openshiftConsole')
               // If dynamic-content attr is set at all, even if it hasn't evaluated to a value
               if (attrs.dynamicContent || attrs.dynamicContent === "") {
                 $scope.$watch('dynamicContent', function() {
-                  $(element)
-                    .attr("title", $scope.dynamicContent)
-                    .tooltip("destroy")
-                    .tooltip();                
-                });                  
+                  $(element).tooltip("destroy");
+                  // Destroy is asynchronous. Wait for it to complete before updating content.
+                  // See https://github.com/twbs/bootstrap/issues/16376
+                  //     https://github.com/twbs/bootstrap/issues/15607
+                  //     http://stackoverflow.com/questions/27238938/bootstrap-popover-destroy-recreate-works-only-every-second-time
+                  // Destroy calls hide, which takes 150ms to complete.
+                  //     https://github.com/twbs/bootstrap/blob/87121181c8a4b63192865587381d4b8ada8de30c/js/tooltip.js#L31
+                  setTimeout(function() {
+                    $(element)
+                      .attr("title", $scope.dynamicContent)
+                      .tooltip();
+                  }, 200);
+                });
               }
               $(element).tooltip();
               break;
@@ -52,17 +68,28 @@ angular.module('openshiftConsole')
       scope: {
         pod: '='
       },
-      link: function($scope, element) {
+      link: function($scope) {
         var warnings = podWarningsFilter($scope.pod);
-        var content = "";
-        angular.forEach(warnings, function(warning) {
-          content += warning.message + "<br>";
-        });       
-        $('.pficon-warning-triangle-o', element)
-          .attr("data-content", content)
-          .popover("destroy")
-          .popover();
+        $scope.content = warnings.join('<br>');
       },
-      templateUrl: 'views/directives/_pod-warnings.html'
+      templateUrl: 'views/directives/_warnings-popover.html'
+    };
+  })
+  .directive('routeWarnings', function(RoutesService) {
+    return {
+      restrict: 'E',
+      scope: {
+        route: '=',
+        service: '='
+      },
+      link: function($scope) {
+        var updateWarnings = function() {
+          var warnings = RoutesService.getRouteWarnings($scope.route, $scope.service);
+          $scope.content = warnings.join('<br>');
+        };
+        $scope.$watch('route', updateWarnings, true);
+        $scope.$watch('service', updateWarnings, true);
+      },
+      templateUrl: 'views/directives/_warnings-popover.html'
     };
   });

--- a/assets/app/scripts/services/routes.js
+++ b/assets/app/scripts/services/routes.js
@@ -1,0 +1,87 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("RoutesService", function() {
+    var isPortNamed = function(port) {
+      return angular.isString(port);
+    };
+
+    var getServicePortForRoute = function(targetPort, service) {
+      return _.find(service.spec.ports, function(servicePort) {
+        if (isPortNamed(targetPort)) {
+          // When using a named port in the route target port, it refers to the service port.
+          return servicePort.name === targetPort;
+        }
+
+        // Otherwise it refers to the container port (the service target port).
+        // If service target port is a string, we won't be able to correlate the route port.
+        return servicePort.targetPort === targetPort;
+      });
+    };
+
+    var addRouteTargetWarnings = function(route, service, warnings) {
+      // Has the service been deleted?
+      if (!service) {
+        warnings.push('Routes to service "' + route.spec.to.name + '", but service does not exist.');
+        return;
+      }
+
+      var targetPort = route.spec.port ? route.spec.port.targetPort : null;
+      if (!targetPort) {
+        if (service.spec.ports.length > 1) {
+          warnings.push('Route has no target port, but service "' + service.metadata.name + '" has multiple ports. ' +
+                       'The route will round robin traffic across all exposed ports on the service.');
+        }
+
+        // Nothing else to check.
+        return;
+      }
+
+      // Warn when service doesn't have a port that matches target port.
+      var servicePort = getServicePortForRoute(targetPort, service);
+      if (!servicePort) {
+        if (isPortNamed(targetPort)) {
+          warnings.push('Route target port is set to "' + targetPort + '", but service "' + service.metadata.name + '" has no port with that name.');
+        } else {
+          warnings.push('Route target port is set to "' + targetPort + '", but service "' + service.metadata.name + '" does not expose that port.');
+        }
+      }
+    };
+
+    var addTLSWarnings = function(route, warnings) {
+      if (!route.spec.tls) {
+        return;
+      }
+
+      if (!route.spec.tls.termination) {
+        warnings.push('Route has a TLS configuration, but no TLS termination type is specified. TLS will not be enabled until a termination type is set.');
+      }
+
+      if (route.spec.tls.termination === 'passthrough' && route.spec.path) {
+        warnings.push('Route path "' + route.spec.path + '" will be ignored since the route uses passthrough termination.');
+      }
+    };
+
+    return {
+      // Gets warnings about a route.
+      //
+      // Parameters:
+      //   route   - the route (required)
+      //   service - the service routed to
+      //             If null, assumes service does not exist.
+      //
+      // Returns: Array of warning messages.
+      getRouteWarnings: function(route, service) {
+        var warnings = [];
+
+        if (route.spec.to.kind === 'Service') {
+          addRouteTargetWarnings(route, service, warnings);
+        }
+        addTLSWarnings(route, warnings);
+
+        return warnings;
+      },
+
+      getServicePortForRoute: getServicePortForRoute
+    };
+  });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -928,3 +928,8 @@ h1 small.meta, .build-config-summary .meta {
   font-family: @font-family-monospace;
   white-space: pre-wrap;
 }
+
+.warnings-popover {
+  cursor: help;
+  vertical-align: middle;
+}

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -34,7 +34,7 @@
                   </ul>
                 </div>
                 <span ng-if="pod | isTroubledPod">
-                  <pod-warnings pod="pod" style="vertical-align: middle;"></pod-warnings>
+                  <pod-warnings pod="pod"></pod-warnings>
                 </span>
                 <small class="meta">created <relative-timestamp timestamp="pod.metadata.creationTimestamp"></relative-timestamp></small>
               </h1>

--- a/assets/app/views/browse/route.html
+++ b/assets/app/views/browse/route.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+<project-page>
 
   <!-- Middle section -->
   <div class="middle-section">
@@ -12,6 +12,10 @@
           <div ng-if="route">
             <h1>
               {{route.metadata.name}}
+              <route-warnings ng-if="route.spec.to.kind !== 'Service' || services"
+                              route="route"
+                              service="services[route.spec.to.name]">
+              </route-warnings>
               <small class="meta">created <relative-timestamp timestamp="route.metadata.creationTimestamp"></relative-timestamp></small>
               <div class="pull-right dropdown">
                 <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
@@ -58,16 +62,20 @@
                     <span ng-if="route.spec.path">{{route.spec.path}}</span>
                     <span ng-if="!route.spec.path"><em>none</em></span>
                   </dd>
-                  <dt>Routes to:</dt>
+                  <dt>{{route.spec.to.kind || "Routes to"}}:</dt>
                   <dd>
-                    {{route.spec.to.kind}}
                     <a ng-href="{{route.spec.to.name | navigateResourceURL : route.spec.to.kind : route.metadata.namespace}}">{{route.spec.to.name}}</a>
                   </dd>
                   <dt>Target Port:</dt>
                   <dd>
-                    <span ng-if="route.spec.port">{{route.spec.port.targetPort}}</span>
-                    <span ng-if="!route.spec.port"><em>any</em></span>
+                    <span ng-if="route.spec.port.targetPort">
+                      {{route.spec.port.targetPort}}
+                    </span>
+                    <span ng-if="!route.spec.port.targetPort"><em>any</em></span>
                   </dd>
+                  <div ng-if="route.spec.port.targetPort && route.spec.to.kind === 'Service' && (route | routeTargetPortMapping : services[route.spec.to.name])" class="help-block">
+                    This target port will route to {{route | routeTargetPortMapping : services[route.spec.to.name]}}.
+                  </div>
                 </dl>
                 <div style="margin-bottom: 10px;">
                   <h4>TLS Settings</h4>
@@ -107,4 +115,4 @@
       </div><!-- /middle-content -->
     </div><!-- /middle-container -->
   </div><!-- /middle-section -->
-  </project-page>
+</project-page>

--- a/assets/app/views/browse/routes.html
+++ b/assets/app/views/browse/routes.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+<project-page>
 
   <!-- Middle section -->
   <div class="middle-section">
@@ -39,7 +39,13 @@
                 </tbody>
                 <tbody ng-repeat="route in routes | orderObjectsByDate : true">
                   <tr>
-                    <td data-title="Name"><a href="{{route | navigateResourceURL}}">{{route.metadata.name}}</a></td>
+                    <td data-title="Name">
+                      <a href="{{route | navigateResourceURL}}">{{route.metadata.name}}</a>
+                      <route-warnings ng-if="route.spec.to.kind !== 'Service' || services"
+                                      route="route"
+                                      service="services[route.spec.to.name]">
+                      </route-warnings>
+                    </td>
                     <td data-title="Hostname">
                       <div ng-if="(route | isWebRoute)" class="word-break">
                         <a href="{{route | routeWebURL}}" target="_blank">{{route | routeLabel}}</a>
@@ -54,7 +60,14 @@
                     </td>
                     <!-- Add non-breaking space to empty cells. Otherwise, table-mobile layout is broken. -->
                     <td data-title="Target Port">
-                      {{route.spec.port.targetPort}}
+                      <span ng-if="route.spec.port.targetPort">
+                        <span ng-if="route.spec.to.kind !== 'Service'">{{route.spec.port.targetPort}}</span>
+                        <!-- Show the short display port in the table, but the long in the title attr. -->
+                        <span ng-if="route.spec.to.kind === 'Service'"
+                              ng-attr-title="{{route | routeTargetPortMapping : services[route.spec.to.name]}}">
+                          {{route.spec.port.targetPort}}
+                        </span>
+                      </span>
                       <span ng-if="!route.spec.port.targetPort">&nbsp;</span>
                     </td>
                     <!-- Use shorter Termination title for table-mobile to avoid overlapping text. -->
@@ -71,4 +84,4 @@
       </div><!-- /middle-content -->
     </div><!-- /middle-container -->
   </div><!-- /middle-section -->
-  </project-page>
+</project-page>

--- a/assets/app/views/directives/_pod-warnings.html
+++ b/assets/app/views/directives/_pod-warnings.html
@@ -1,3 +1,0 @@
-<span class="pod-warnings">
-  <span class="pficon pficon-warning-triangle-o" title="" data-toggle="popover" data-placement="right" data-trigger="hover" data-html="true"></span>
-</span>

--- a/assets/app/views/directives/_warnings-popover.html
+++ b/assets/app/views/directives/_warnings-popover.html
@@ -1,0 +1,12 @@
+<span ng-if="content">
+  <span
+    dynamic-content="{{content}}"
+    data-toggle="popover"
+    data-placement="right"
+    data-trigger="hover"
+    data-html="true"
+    class="pficon pficon-warning-triangle-o warnings-popover"
+    aria-hidden="true">
+  </span>
+  <span class="sr-only">{{content}}</span>
+</span>

--- a/assets/app/views/pods.html
+++ b/assets/app/views/pods.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+<project-page>
 
   <!-- Middle section -->
   <div class="middle-section">
@@ -39,7 +39,7 @@
                     <td data-title="Name">
                       <a href="{{pod | navigateResourceURL}}">{{pod.metadata.name}}</a>
                       <span ng-if="pod | isTroubledPod">
-                        <pod-warnings pod="pod" style="vertical-align: middle;"></pod-warnings>
+                        <pod-warnings pod="pod"></pod-warnings>
                       </span>
                     </td>
                     <td data-title="Status">
@@ -60,4 +60,4 @@
       </div><!-- /middle-content -->
     </div><!-- /middle-container -->
   </div><!-- /middle-section -->
-  </project-page>
+</project-page>

--- a/assets/test/spec/services/routesSpec.js
+++ b/assets/test/spec/services/routesSpec.js
@@ -1,0 +1,156 @@
+"use strict";
+
+describe("ApplicationGenerator", function(){
+  var RoutesService;
+
+  beforeEach(function(){
+    inject(function(_RoutesService_){
+      RoutesService = _RoutesService_;
+    });
+  });
+
+  describe("#getRouteWarnings", function(){
+    var routeTemplate = {
+      kind: "Route",
+      apiVersion: 'v1',
+      metadata: {
+        name: "ruby-hello-world",
+        labels : {
+          "app": "ruby-hello-world"
+        },
+        annotations: {
+          "openshift.io/generated-by": "OpenShiftWebConsole"
+        }
+      },
+      spec: {
+        to: {
+          kind: "Service",
+          name: "frontend"
+        },
+        host: "www.example.com"
+      }
+    };
+
+    var serviceTemplate = {
+      kind: "Service",
+      apiVersion: "v1",
+      metadata: {
+        name: "frontend",
+        labels : {
+          app : "ruby-hello-world"
+        },
+        annotations: {
+          "openshift.io/generated-by": "OpenShiftWebConsole"
+        }
+      },
+      spec: {
+        ports: [{
+          port: 8080,
+          targetPort : 8080,
+          protocol: "TCP",
+          name: "8080-tcp"
+        }],
+        selector: {
+          "deploymentconfig": "ruby-hello-world"
+        }
+      }
+    };
+
+    it("should warn if service has been deleted", function() {
+      var warnings = RoutesService.getRouteWarnings(routeTemplate, null);
+      expect(warnings).toEqual(['Routes to service "frontend", but service does not exist.']);
+    });
+
+    it("should warn if route has no target port for multi-port service", function() {
+      var route = angular.copy(routeTemplate);
+      var service = angular.copy(serviceTemplate);
+      service.spec.ports.push({
+        port: 8081,
+        targetPort: 8081,
+        protocol: "TCP",
+        name: "8081-tcp"
+      });
+      var warnings = RoutesService.getRouteWarnings(route, service);
+      expect(warnings).toEqual(['Route has no target port, but service "frontend" has multiple ports. ' +
+        'The route will round robin traffic across all exposed ports on the service.']);
+    });
+
+    it("should warn if route has named target port not in service", function() {
+      var route = angular.copy(routeTemplate);
+      route.spec.port = {
+        targetPort: "http"
+      };
+      var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
+      expect(warnings).toEqual(['Route target port is set to "http", but service "frontend" has no port with that name.']);
+    });
+
+    it("should warn if route has target port number that's not a service target port", function() {
+      var route = angular.copy(routeTemplate);
+      route.spec.port = {
+        targetPort: 80
+      };
+      var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
+      expect(warnings).toEqual(['Route target port is set to "80", but service "frontend" does not expose that port.']);
+    });
+
+    it("should warn if route has TLS configuration, but no termination type", function() {
+      var route = angular.copy(routeTemplate);
+      route.spec.tls = {
+        certificate: "dummy-cert",
+        key: "dummy-key"
+      };
+      var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
+      expect(warnings).toEqual(['Route has a TLS configuration, but no TLS termination type is specified. TLS will not be enabled until a termination type is set.']);
+    });
+
+    it("should warn if route uses passthrough termination with a path", function() {
+      var route = angular.copy(routeTemplate);
+      route.spec.path = '/test';
+      route.spec.tls = {
+        termination: 'passthrough'
+      };
+      var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
+      expect(warnings).toEqual(['Route path "/test" will be ignored since the route uses passthrough termination.']);
+    });
+
+    it("should not warn if there are no problems", function() {
+      var route = angular.copy(routeTemplate);
+      route.spec.port = {
+        targetPort: "8080-tcp"
+      };
+      route.spec.tls = {
+        termination: "edge"
+      };
+      var service = angular.copy(serviceTemplate);
+      service.spec.ports.push({
+        port: 8081,
+        targetPort: 8081,
+        protocol: "TCP",
+        name: "8081-tcp"
+      });
+      var warnings = RoutesService.getRouteWarnings(route, serviceTemplate);
+      expect(warnings.length).toEqual(0);
+    });
+
+    it("should warn about multiple problems", function() {
+      var route = angular.copy(routeTemplate);
+      // Missing TLS termination.
+      route.spec.tls = {
+        certificate: "dummy-cert",
+        key: "dummy-key"
+      };
+
+      var service = angular.copy(serviceTemplate);
+      // Missing target port for multi-port service.
+      service.spec.ports.push({
+        port: 8081,
+        targetPort: 8081,
+        protocol: "TCP",
+        name: "8081-tcp"
+      });
+
+      var warnings = RoutesService.getRouteWarnings(route, service);
+      expect(warnings.length).toEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
Warn when the route's service is deleted or it has problems with target port.
Warn about inconsistent TLS configuration.
Show service and container port under target port on route page.

Fixes #6162 
Fixes #6346
See also #6265

This is how it looks, similar to pod warnings. I have not added warnings to the overview (yet?).

Route page:

![screen_shot_2015-12-16_at_4_32_15_pm](https://cloud.githubusercontent.com/assets/1167259/11854596/d91df9e4-a412-11e5-9704-7100577b8362.png)

Routes table:

![screen_shot_2015-12-16_at_4_32_07_pm](https://cloud.githubusercontent.com/assets/1167259/11854608/e903f39a-a412-11e5-8ca7-c12c7cef7e6e.png)

Named port fixes for web console route creation will be a separate PR.

@liggitt @jwforres 
