### PR TITLE
Web console: display and attach persistent volume claims

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -166,6 +166,7 @@
         <script src="scripts/services/deployments.js"></script>
         <script src="scripts/services/imagestreams.js"></script>
         <script src="scripts/services/metrics.js"></script>
+        <script src="scripts/services/storage.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>
@@ -183,6 +184,8 @@
         <script src="scripts/controllers/service.js"></script>
         <script src="scripts/controllers/routes.js"></script>
         <script src="scripts/controllers/route.js"></script>
+        <script src="scripts/controllers/storage.js"></script>
+        <script src="scripts/controllers/persistentVolumeClaim.js"></script>
         <script src="scripts/controllers/create/createFromImage.js"></script>
         <script src="scripts/controllers/create/nextSteps.js"></script>
         <script src="scripts/controllers/newfromtemplate.js"></script>
@@ -195,6 +198,7 @@
         <script src="scripts/controllers/create.js"></script>
         <script src="scripts/controllers/createProject.js"></script>
         <script src="scripts/controllers/createRoute.js"></script>
+        <script src="scripts/controllers/attachPVC.js"></script>
         <script src="scripts/controllers/modals/confirmScale.js"></script>
         <script src="scripts/controllers/modals/deleteModal.js"></script>
         <script src="scripts/controllers/modals/editModal.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -70,6 +70,7 @@ angular
       .subPath("Pods", "pods", builder.join(templatePath, 'pods.html'))
       .subPath("Routes", "routes", builder.join(templatePath, 'browse/routes.html'))
       .subPath("Services", "services", builder.join(templatePath, 'services.html'))
+      .subPath("Storage", "storage", builder.join(templatePath, 'storage.html'))
       .build();
     tab.icon = "sitemap";
     tabs.push(tab);
@@ -195,6 +196,14 @@ angular
         templateUrl: 'views/browse/service.html',
         controller: 'ServiceController'
       })
+      .when('/project/:project/browse/storage', {
+        templateUrl: 'views/storage.html',
+        controller: 'StorageController'
+      })
+      .when('/project/:project/browse/persistentvolumeclaims/:pvc', {
+        templateUrl: 'views/browse/persistent-volume-claim.html',
+        controller: 'PersistentVolumeClaimController'
+      })
       .when('/project/:project/browse/routes', {
         templateUrl: 'views/browse/routes.html',
         controller: 'RoutesController'
@@ -206,6 +215,10 @@ angular
       .when('/project/:project/createRoute', {
         templateUrl: 'views/createRoute.html',
         controller: 'CreateRouteController'
+      })
+      .when('/project/:project/attachPVC', {
+        templateUrl: 'views/attachPVC.html',
+        controller: 'AttachPVCController'
       })
       .when('/project/:project/create', {
         templateUrl: 'views/create.html',

--- a/assets/app/scripts/controllers/attachPVC.js
+++ b/assets/app/scripts/controllers/attachPVC.js
@@ -1,0 +1,275 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreateRouteController
+ * @description
+ * # CreateRouteController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('AttachPVCController', function ($filter, $routeParams, $scope, $window, StorageService, DataService, Navigate, ProjectsService) {
+    $scope.alerts = {};
+    $scope.renderOptions = {
+      hideFilterWidget: true
+    };
+
+    $scope.projectName = $routeParams.project;
+    $scope.deploymentConfigName = $routeParams.deploymentconfig;
+    $scope.deploymentName = $routeParams.deployment;
+
+    $scope.attach = {
+      deploymentConfig: null,
+      deployment: null,
+      persistentVolumeClaim: null,
+      volumeName: null,
+      mountPath: null,
+      containers: {
+        all: true,
+        individual: {}
+      }
+    };
+
+    $scope.breadcrumbs = [
+      {
+        title: $routeParams.project,
+        link: "project/" + $routeParams.project
+      },
+      {
+        title: "Attach Storage"
+      }
+    ];
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+
+        var orderByDisplayName = $filter('orderByDisplayName');
+        var getErrorDetails = $filter('getErrorDetails');
+        var navigateResourceURL = $filter('navigateResourceURL');
+        var generateName = $filter('generateName');
+
+        var displayError = function(errorMessage, errorDetails) {
+          $scope.disableInputs = true;
+          $scope.alerts['attach-persistent-volume-claim'] = {
+            type: "error",
+            message: errorMessage,
+            details: errorDetails
+          };
+        };
+
+        // check parameters validity
+        var validateRouteParams = function() {
+          if ($scope.deploymentConfigName && $scope.deploymentName) {
+            Navigate.toErrorPage("Deployment and deployment config can't be both provided provided.");
+          }
+          if (!$scope.deploymentConfigName && !$scope.deploymentName) {
+            Navigate.toErrorPage("A deployment or deployment config must be provided.");
+          }
+        };
+
+        // load resources required to show the page (list of pvcs and deployment or deployment config)
+        var load = function() {
+          if ($scope.deploymentConfigName) {
+            DataService.get("deploymentconfigs", $scope.deploymentConfigName, context).then(
+              function(deploymentConfig) {
+                angular.forEach(deploymentConfig.spec.template.spec.containers, function(container) {
+                  $scope.attach.containers.individual[container.name] = true;
+                });
+                $scope.attach.deploymentConfig = deploymentConfig;
+                rebuildBreadcrumb();
+              },
+              function(e) {
+                displayError("The deployment config could not be loaded.", getErrorDetails(e));
+              }
+            );
+          }
+
+          if ($scope.deploymentName) {
+            DataService.get("replicationcontrollers", $scope.deploymentName, context).then(
+              function(deployment) {
+                angular.forEach(deployment.spec.template.spec.containers, function(container) {
+                  $scope.attach.containers.individual[container.name] = true;
+                });
+                $scope.attach.deployment = deployment;
+                rebuildBreadcrumb();
+              },
+              function(e) {
+                displayError("The deployment could not be loaded.", getErrorDetails(e));
+              }
+            );
+          }
+
+          DataService.list("persistentvolumeclaims", context, 
+            function(pvcs) {
+              $scope.pvcs = orderByDisplayName(pvcs.by("metadata.name"));
+              if ($scope.pvcs.length) {
+                if (!$scope.attach.persistentVolumeClaim) {
+                  $scope.attach.persistentVolumeClaim = $scope.pvcs[0];
+                }
+              }
+            },
+            function(e) {
+              displayError("The persistent volume claims could not be loaded.", getErrorDetails(e));
+            }
+          );
+        };
+
+        var isVolumeNameUsed = function(name, podTemplate) {
+          if (podTemplate.spec.volumes) {
+            for (var i = 0; i < podTemplate.spec.volumes.length; i++) {
+              var volume = podTemplate.spec.volumes[i];
+              if (volume.name === name) {
+                $scope.isVolumeNameUsed = true;
+                return true;
+              }
+            }
+          }
+          $scope.isVolumeNameUsed = false;
+          return false;
+        };
+
+        var isVolumeMountPathUsed = function(name, mountPath, podTemplate) {
+          if (podTemplate.spec.containers) {
+            for (var i = 0; i < podTemplate.spec.containers.length; i++) {
+              var container = podTemplate.spec.containers[i];
+              if ($scope.attach.containers.all || $scope.attach.containers.individual[container.name]) {
+                if (container.volumeMounts) {
+                  for (var j = 0; j < container.volumeMounts.length; j++) {
+                    var volumeMount = container.volumeMounts[j];
+                    if (volumeMount.mountPath === mountPath && name !== volumeMount.Name) {
+                      $scope.isVolumeMountPathUsed = true;
+                      return true;
+                    }
+                  }
+                }
+              }
+            }          
+          }
+          $scope.isVolumeMountPathUsed = false;
+          return false;
+        };
+
+        // breadcrumb must react depending on what we are attaching to (deployment or dc)
+        var rebuildBreadcrumb = function() {
+          $scope.breadcrumbs.splice(1, 0, {
+            title: "Deployments",
+            link: "project/" + $routeParams.project + "/browse/deployments"
+          });
+
+          var deploymentConfig = $scope.attach.deploymentConfig;
+          if (deploymentConfig) {
+            $scope.breadcrumbs.splice(2, 0, {
+              title: deploymentConfig.metadata.name,
+              link: navigateResourceURL(deploymentConfig)
+            });
+          }
+
+          var deployment = $scope.attach.deployment;
+          if (deployment) {
+            var deploymentVersion = $filter("annotation")(deployment, "deploymentVersion");
+            $scope.breadcrumbs.splice(2, 0, {
+              title: deploymentVersion ? "#" + deploymentVersion : deployment.metadata.name
+            });
+            var deploymentDeploymentConfigName = $filter("annotation")(deployment, "deploymentConfig");
+            if (deploymentDeploymentConfigName) {
+              $scope.breadcrumbs[2].link = navigateResourceURL(deployment);
+              $scope.breadcrumbs.splice(2, 0, {
+                title: deploymentDeploymentConfigName,
+                link: navigateResourceURL(deploymentDeploymentConfigName, "deploymentConfig", $routeParams.project)
+              });
+            }
+          }
+        };
+
+        validateRouteParams();
+        load();
+
+        $scope.containerToAttachProvided = function() {
+          if ($scope.attach.containers.all) {
+            return true;
+          }
+          for (var key in $scope.attach.containers.individual) {
+            if ($scope.attach.containers.individual[key] === true) {
+              return true;
+            }
+          }
+          return false;
+        };
+
+        $scope.attachPVC = function() {
+          $scope.disableInputs = true;
+
+          if ($scope.attachPVCForm.$valid) {
+            // generate a volume name if not provided
+            if (!$scope.attach.volumeName) {
+              $scope.attach.volumeName = generateName("volume-");
+            }
+
+            var deploymentConfig = $scope.attach.deploymentConfig;
+            var deployment = $scope.attach.deployment;
+            var podTemplate = deploymentConfig ? deploymentConfig.spec.template : deployment.spec.template;
+
+            var persistentVolumeClaim = $scope.attach.persistentVolumeClaim;
+            var name = $scope.attach.volumeName;
+            var mountPath = $scope.attach.mountPath;
+
+            // check the volume name wanted was not yet used in this pod template
+            if (isVolumeNameUsed(name, podTemplate)) {
+              $scope.disableInputs = false;
+              return;
+            }
+
+            if (mountPath) {
+              // if we want to mount, check if the mount path is unique in this pod template 
+              if (isVolumeMountPathUsed(name, mountPath, podTemplate)) {
+                $scope.disableInputs = false;
+                return;
+              }
+
+              // for each container in the pod spec, add the new volume mount
+              angular.forEach(podTemplate.spec.containers, function(container) {
+                if ($scope.attach.containers.all || $scope.attach.containers.individual[container.name]) {
+                  var newVolumeMount = StorageService.createVolumeMount(name, mountPath);
+                  if (!container.volumeMounts) {
+                    container.volumeMounts = [];
+                  }
+                  container.volumeMounts.push(newVolumeMount);
+                }
+              });
+            }
+
+            // add the new volume to the pod template
+            var newVolume = StorageService.createVolume(name, persistentVolumeClaim);
+            if (!podTemplate.spec.volumes) {
+              podTemplate.spec.volumes = [];
+            }
+            podTemplate.spec.volumes.push(newVolume);
+            $scope.alerts = {};
+
+            // save deployment or deployment config
+            if (deploymentConfig) {
+              DataService.update("deploymentconfigs", deploymentConfig.metadata.name, deploymentConfig, context).then(
+                function() {
+                  $window.history.back();
+                },
+                function(result) {
+                  displayError("An error occurred attaching the persistent volume claim to deployment config.", getErrorDetails(result));
+                }
+              );
+            }
+            if (deployment) {
+              DataService.update("replicationcontrollers", deployment.metadata.name, deployment, context).then(
+                function() {
+                  $window.history.back();
+                },
+                function(result) {
+                  displayError("An error occurred attaching the persistent volume claim to deployment.", getErrorDetails(result));
+                }
+              );
+            }
+          }
+        };
+    }));
+  });

--- a/assets/app/scripts/controllers/persistentVolumeClaim.js
+++ b/assets/app/scripts/controllers/persistentVolumeClaim.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:StorageController
+ * @description
+ * # StorageController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('PersistentVolumeClaimController', function ($scope, $routeParams, DataService, ProjectsService, $filter) {
+    $scope.projectName = $routeParams.project;
+    $scope.pvc = null;
+    $scope.alerts = {};
+    $scope.renderOptions = $scope.renderOptions || {};
+    $scope.renderOptions.hideFilterWidget = true;
+    $scope.breadcrumbs = [
+      {
+        title: "Persistent Volume Claims",
+        link: "project/" + $routeParams.project + "/browse/storage"
+      },
+      {
+        title: $routeParams.pvc
+      }
+    ];
+
+    var watches = [];
+  
+    ProjectsService
+    .get($routeParams.project)
+    .then(_.spread(function(project, context) {
+      $scope.project = project;
+      DataService.get("persistentvolumeclaims", $routeParams.pvc, context).then(
+        // success
+        function(pvc) {
+          $scope.loaded = true;
+          $scope.pvc = pvc;
+
+          // If we found the item successfully, watch for changes on it
+          watches.push(DataService.watchObject("persistentvolumeclaims", $routeParams.pvc, context, function(pvc, action) {
+            if (action === "DELETED") {
+              $scope.alerts["deleted"] = {
+                type: "warning",
+                message: "This persistent volume claim has been deleted."
+              };
+            }
+            $scope.pvc = pvc;
+          }));
+        },
+        // failure
+        function(e) {
+          $scope.loaded = true;
+          $scope.alerts["load"] = {
+            type: "error",
+            message: "The persistent volume claim details could not be loaded.",
+            details: "Reason: " + $filter('getErrorDetails')(e)
+          };
+        }
+      );
+
+      $scope.$on('$destroy', function(){
+        DataService.unwatchAll(watches);
+      });
+
+    }));
+});

--- a/assets/app/scripts/controllers/storage.js
+++ b/assets/app/scripts/controllers/storage.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:StorageController
+ * @description
+ * # StorageController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('StorageController', function ($routeParams, $scope, AlertMessageService, DataService, ProjectsService, $filter, LabelFilter, Logger) {
+    $scope.projectName = $routeParams.project;
+    $scope.pvcs = {};
+    $scope.unfilteredPVCs = {};
+    $scope.labelSuggestions = {};
+    $scope.alerts = $scope.alerts || {};
+    $scope.emptyMessage = "Loading...";
+
+    // get and clear any alerts
+    AlertMessageService.getAlerts().forEach(function(alert) {
+      $scope.alerts[alert.name] = alert.data;
+    });
+    AlertMessageService.clearAlerts();
+
+    var watches = [];
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+         watches.push(DataService.watch("persistentvolumeclaims", context, function(pvcs) {
+          $scope.unfilteredPVCs = pvcs.by("metadata.name");
+          LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredPVCs, $scope.labelSuggestions);
+          LabelFilter.setLabelSuggestions($scope.labelSuggestions);
+          $scope.pvcs = LabelFilter.getLabelSelector().select($scope.unfilteredPVCs);
+          $scope.emptyMessage = "No persistent volume claims to show";
+          updateFilterWarning();
+          Logger.log("pvcs (subscribe)", $scope.unfilteredPVCs);
+        }));
+
+        function updateFilterWarning() {
+          if (!LabelFilter.getLabelSelector().isEmpty() && $.isEmptyObject($scope.pvcs)  && !$.isEmptyObject($scope.unfilteredPVCs)) {
+            $scope.alerts["storage"] = {
+              type: "warning",
+              details: "The active filters are hiding all persistent volume claims."
+            };
+          }
+          else {
+            delete $scope.alerts["storage"];
+          }
+        }
+
+        LabelFilter.onActiveFiltersChanged(function(labelSelector) {
+          // trigger a digest loop
+          $scope.$apply(function() {
+            $scope.pvcs = labelSelector.select($scope.unfilteredPVCs);
+            updateFilterWarning();
+          });
+        });
+
+        $scope.$on('$destroy', function(){
+          DataService.unwatchAll(watches);
+        });
+
+      }));
+  });

--- a/assets/app/scripts/directives/resources.js
+++ b/assets/app/scripts/directives/resources.js
@@ -125,4 +125,14 @@ angular.module('openshiftConsole')
         };
       }
     };
+  })
+  .directive('volumes', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        volumes: '=',
+        namespace: '='
+      },
+      templateUrl: 'views/_volumes.html'
+    };
   });

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -108,7 +108,7 @@ angular.module('openshiftConsole')
       var amount = split[1];
       var unit = split[2];
       switch(type) {
-        case "memory":
+        case "memory", "storage":
           unit += "B";
           break;
         case "cpu":
@@ -140,6 +140,8 @@ angular.module('openshiftConsole')
           return "http://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#deployment-operations";
         case "route-types":
           return "https://docs.openshift.org/latest/architecture/core_concepts/routes.html#route-types";
+        case "persistent_volumes":
+          return "https://docs.openshift.org/latest/dev_guide/persistent_volumes.html";
         default:
           return "http://docs.openshift.org/latest/welcome/index.html";
       }
@@ -340,5 +342,52 @@ angular.module('openshiftConsole')
   .filter('navigateResourceURL', function(Navigate) {
     return function(resource, kind, namespace) {
       return Navigate.resourceURL(resource, kind, namespace);
+    };
+  })
+  .filter('join', function() {
+    return function(array, separator) {
+      if (!separator) {
+        separator = ',';
+      }
+      return array.join(separator);
+    };
+  })
+  .filter('generateName', function() {
+    return function(prefix, length) {
+      if (!prefix) {
+        prefix = "";
+      }
+      if (!length) {
+        length = 5;
+      }
+      var randomString = Math.round((Math.pow(36, length + 1) - Math.random() * Math.pow(36, length))).toString(36).slice(1);
+      return prefix + randomString;
+    };
+  })
+  .filter('accessModes', function() {
+    return function(value, format) {
+      if (!value) {
+        return value;
+      }  
+      var accessModes = [];
+      angular.forEach(value, function(item) {
+        var accessModeString;
+        var longForm = format === "long";
+        switch(item) {
+          case "ReadWriteOnce":
+            accessModeString = longForm ? "RWO (Read-Write-Once)" : "Read-Write-Once";
+            break;
+          case "ReadOnlyMany":
+            accessModeString = longForm ? "ROX (Read-Only-Many)" : "Read-Only-Many";
+            break;
+          case "ReadWriteMany":
+            accessModeString = longForm ? "RWX (Read-Write-Many)" : "Read-Write-Many";
+            break;
+          default:
+            accessModeString = item;
+        }
+        accessModes.push(accessModeString);
+      });
+      return _.uniq(accessModes);
     };
   });

--- a/assets/app/scripts/services/navigate.js
+++ b/assets/app/scripts/services/navigate.js
@@ -126,7 +126,8 @@ angular.module("openshiftConsole")
           'pod': 'pods',
           'replicationcontroller': 'deployments',
           'route': 'routes',
-          'service': 'services'
+          'service': 'services',
+          'persistentvolumeclaim': 'storage'
         };
 
         var redirect = URI.expand("project/{projectName}/browse/{browsePath}", {

--- a/assets/app/scripts/services/storage.js
+++ b/assets/app/scripts/services/storage.js
@@ -1,0 +1,21 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("StorageService", function() {
+    return {
+      createVolume: function(name, persistentVolumeClaim) {
+        return {
+          name: name,
+          persistentVolumeClaim: {
+            claimName: persistentVolumeClaim.metadata.name
+          }
+        };
+      },
+      createVolumeMount: function(name, mountPath) {
+        return {
+          name: name,
+          mountPath: mountPath
+        };
+      }
+    };
+  });

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -445,7 +445,8 @@ label.checkbox {
   font-size: 128px;
 }
 
-.create-route-icon {
+.create-route-icon,
+.create-storage-icon {
   padding-top: 0;
   text-align: right;
 }

--- a/assets/app/styles/_tables.less
+++ b/assets/app/styles/_tables.less
@@ -44,6 +44,15 @@
     }
   }
 }
+
+.table-borderless>tbody>tr>th, 
+.table-borderless>tfoot>tr>th, 
+.table-borderless>thead>tr>td, 
+.table-borderless>tbody>tr>td, 
+.table-borderless>tfoot>tr>td {
+  border-top: none; 
+}
+
 @media (max-width: @screen-xs-max) {
   .table-mobile {
     border-top: 2px solid @table-border-color;

--- a/assets/app/views/_volumes.html
+++ b/assets/app/views/_volumes.html
@@ -1,0 +1,50 @@
+<!--
+  Expects the following variables:
+  volumes
+  namespace
+ -->
+<div ng-repeat="volume in volumes">
+  <h5 style="margin-bottom:0;">{{volume.name}}</h5>
+  <dl class="dl-horizontal left">
+    <div ng-if="volume.secret">
+      <dt>Type:</dt>
+      <dd>secret</dd>
+      <dt>Secret name:</dt>
+      <dd>{{volume.secret.secretName}}</dd>
+    </div>
+    <div ng-if="volume.persistentVolumeClaim">
+      <dt>Type:</dt>
+      <dd>persistent volume claim</dd>
+      <dt>Claim name:</dt>
+      <dd><a ng-href="{{volume.persistentVolumeClaim.claimName | navigateResourceURL : 'PersistentVolumeClaim' : namespace}}">{{volume.persistentVolumeClaim.claimName}}</a></dd>
+      <dt>Mode:</dt>
+      <dd>
+        <span ng-if="volume.persistentVolumeClaim.readOnly">read-only</span>
+        <span ng-if="!volume.persistentVolumeClaim.readOnly">read-write</span>
+      </dd>
+    </div>
+    <div ng-if="volume.hostPath">
+      <dt>Type:</dt>
+      <dd>host path</dd>
+      <dt>Path:</dt>
+      <dd>{{volume.hostPath.path}}</dd>
+    </div>
+    <div ng-if="volume.emptyDir">
+      <dt>Type:</dt>
+      <dd>empty dir</dd>
+      <dt>Medium:</dt>
+      <dd>
+        <span ng-if="!volume.emptyDir.medium">node's default</span>
+        <span ng-if="volume.emptyDir.medium">{{volume.emptyDir.medium}}</span>
+      </dd>
+    </div>
+    <div ng-if="volume.gitRepo">
+      <dt>Type:</dt>
+      <dd>git repo</dd>
+      <dt>Repository:</dt>
+      <dd>{{volume.gitRepo.repository}}</dd>
+      <dt ng-if-start="volume.gitRepo.revision">Revision:</dt>
+      <dd ng-if-end>{{volume.gitRepo.revision}}</dd>
+    </div>
+  </dl>
+</div> 

--- a/assets/app/views/attachPVC.html
+++ b/assets/app/views/attachPVC.html
@@ -1,0 +1,172 @@
+<div class="content">
+  <div class="container">
+    <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+    <div class="row">
+      <div class="col-md-12">
+        <alerts alerts="alerts"></alerts>
+        <div ng-show="!pvcs || !(attach.deploymentConfig || attach.deployment)">Loading...</div>
+
+        <div ng-show="pvcs && !pvcs.length && (attach.deploymentConfig || attach.deployment)" class="empty-state-message empty-state-full-page">
+          <h2 class="text-center">No persistent volume claims.</h2>
+
+          <p class="gutter-top">
+            A <b>persistent volume claim</b> is required to attach to this 
+            <span ng-if="attach.deploymentConfig">deployment config,</span>
+            <span ng-if="attach.deployment">deployment,</span>
+            but none are loaded on this project.
+          </p>
+
+          <p>
+            To claim storage from a persistent volume, refer to the documentation on <a ng-href="{{'persistent_volumes' | helpLink}}">using persistent volumes</a>.
+          </p>
+
+          <p ng-if="attach.deploymentConfig"><a href="{{attach.deploymentConfig | navigateResourceURL}}">Back to deployment config</a></p>
+          <p ng-if="attach.deployment"><a href="{{attach.deployment | navigateResourceURL}}">Back to deployment</a></p>
+        </div>
+
+        <div class="row" ng-show="pvcs && pvcs.length && (attach.deploymentConfig || attach.deployment)">        
+          <div class="create-storage-icon col-md-2 gutter-top hidden-sm hidden-xs">
+            <span class="fa fa-hdd-o icon-xl"></span>
+          </div>
+
+          <div class="col-md-8">
+            <h1>Attach Storage</h1>
+            <div>
+              <span class="help-block">
+                Attach an existing persistent volume claim to the template of 
+                <span ng-if="attach.deploymentConfig">deployment config <b>{{attach.deploymentConfig.metadata.name}}</b>.</span>
+                <span ng-if="attach.deployment">deployment <b>{{attach.deployment.metadata.name}}</b>.</span>
+              </span>
+            </div>
+            <form name="attachPVCForm">
+              <fieldset ng-disabled="disableInputs">
+                <div class="form-group">
+                  <label for="persistentVolumeClaim" class="required">Persistent volume claim</label>
+                  <div>
+                    <span id="persistent-volume-claim-help" class="help-block">Select the persistent volume claim to attach to.</span>
+                  </div>
+                  <table style="margin-bottom:0;background-color:transparent;" class="table table-condensed table-borderless">
+                    <tbody>
+                      <tr ng-repeat="pvc in pvcs track by (pvc | uid)">
+                        <td style="padding-left:0;">
+                          <input 
+                            type="radio"
+                            name="persistentVolumeClaim"
+                            ng-model="attach.persistentVolumeClaim"
+                            ng-value="pvc"
+                            aria-describedby="pvc-help">
+                        </td>
+                        <td><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
+                        <td ng-if="pvc.spec.volumeName">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</td>
+                        <td ng-if="!pvc.spec.volumeName">{{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}</td>
+                        <td>({{pvc.spec.accessModes | accessModes | join}})</td>
+                        <td>
+                          {{pvc.status.phase}}
+                          <span ng-if="pvc.spec.volumeName">
+                            to volume <strong>{{pvc.spec.volumeName}}</strong>
+                          </span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <h3>Volume</h3>
+                <div>
+                  <span class="help-block">
+                    Specify details about how volumes are going to be mounted inside containers.
+                  </span>
+                </div>
+
+                <div class="form-group">
+                  <label for="route-name">Mount path</label>
+                  <input
+                      id="mount-path"
+                      class="form-control"
+                      type="text"
+                      name="mountPath"
+                      ng-model="attach.mountPath"
+                      ng-pattern="/^\/.*$/"
+                      placeholder="example: /data"
+                      autocorrect="off"
+                      autocapitalize="off"
+                      spellcheck="false"
+                      aria-describedby="mount-path-help">
+                  <div>
+                    <span id="mount-path-help" class="help-block">Mount path for the volume inside the container. If not specified, the volume will not be mounted automatically.</span>
+                  </div>
+                  <div class="has-error" ng-show="attachPVCForm.mountPath.$error.pattern && attachPVCForm.mountPath.$touched">
+                    <span class="help-block">
+                      Mount path must be a valid path to a directory starting with <code>/</code>.
+                    </span>
+                  </div>
+                  <div class="has-error" ng-show="isVolumeMountPathUsed">
+                    <span class="help-block">
+                      Volume mount in that path already exists. Please choose another mount path.
+                    </span>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="volume-name">Volume name</label>
+                  <input
+                      id="volume-path"
+                      class="form-control"
+                      type="text"
+                      name="volumeName"
+                      ng-model="attach.volumeName"
+                      placeholder="(generated if empty)"
+                      autocorrect="off"
+                      autocapitalize="off"
+                      spellcheck="false"
+                      aria-describedby="volume-name-help">
+                  <div>
+                    <span id="volume-name-help" class="help-block">Unique name used to identify this volume. If not specified, a volume name is generated.</span>
+                  </div>
+                </div>
+                <div class="has-error" ng-show="isVolumeNameUsed">
+                  <span class="help-block">
+                    Volume name already exists. Please choose another name.
+                  </span>
+                </div>
+
+                <div ng-show="attach.containers.all">
+                  The volume will be mounted into all containers. You can <a href=""
+                    ng-click="attach.containers.all = false">select specific containers</a> instead.
+                </div>
+
+                <div ng-show="!attach.containers.all" class="form-group">
+                  <h3>Containers</h3>
+                  <div>
+                    <span class="help-block">
+                      Attach the volume to the following containers:
+                    </span>
+                  </div>
+                  <div class="checkbox" ng-repeat="container in (attach.deployment.spec.template.spec.containers || attach.deploymentConfig.spec.template.spec.containers)">
+                    <label>
+                      <input type="checkbox" ng-model="attach.containers.individual[container.name]">
+                      <b>{{container.name}}</b> from image <i>{{container.image}}</i>
+                    </label>
+                  </div>
+                  <div class="has-error" ng-show="!containerToAttachProvided()">
+                    <span class="help-block">
+                      You must select at least one container.
+                    </span>
+                  </div>
+                </div>
+
+                <div class="button-group gutter-top gutter-bottom">
+                  <button type="submit"
+                      class="btn btn-primary btn-lg"
+                      ng-click="attachPVC()"
+                      ng-disabled="attachPVCForm.$invalid || disableInputs || !attachPVC || !containerToAttachProvided()">Attach</button>
+                  <a class="btn btn-default btn-lg" role="button" href="#" back>Cancel</a>
+                </div>
+              </fieldset>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/app/views/browse/_deployment-details.html
+++ b/assets/app/views/browse/_deployment-details.html
@@ -68,4 +68,7 @@
     images-by-docker-reference="imagesByDockerReference"
     builds="builds"
     detailed="true"></pod-template>
+    <h4 style="margin-top: 20px;">Volumes</h4>
+    <a ng-href="project/{{project.metadata.name}}/attachPVC?deployment={{deployment.metadata.name}}">Attach storage</a>
+    <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
 </div>

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -48,52 +48,9 @@
         detailed="true">
       </pod-template>
       <div ng-if="pod.spec.volumes.length">
-        <h3 style="margin-top: 20px;">Volumes</h3>
-        <div ng-repeat="volume in pod.spec.volumes">
-          <h4>{{volume.name}}</h4>
-          <dl class="dl-horizontal left">
-            <div ng-if="volume.secret">
-              <dt>Type:</dt>
-              <dd>secret</dd>
-              <dt>Secret name:</dt>
-              <dd>{{volume.secret.secretName}}</dd>
-            </div>
-            <div ng-if="volume.persistentVolumeClaim">
-              <dt>Type:</dt>
-              <dd>persistent volume claim</dd>
-              <dt>Claim name:</dt>
-              <dd>{{volume.persistentVolumeClaim.claimName}}</dd>
-              <dt>Mode:</dt>
-              <dd>
-                <span ng-if="volume.persistentVolumeClaim.readOnly">read-only</span>
-                <span ng-if="!volume.persistentVolumeClaim.readOnly">read-write</span>
-              </dd>
-            </div>
-            <div ng-if="volume.hostPath">
-              <dt>Type:</dt>
-              <dd>host path</dd>
-              <dt>Path:</dt>
-              <dd>{{volume.hostPath.path}}</dd>
-            </div>
-            <div ng-if="volume.emptyDir">
-              <dt>Type:</dt>
-              <dd>empty dir</dd>
-              <dt>Medium:</dt>
-              <dd>
-                <span ng-if="!volume.emptyDir.medium">node's default</span>
-                <span ng-if="volume.emptyDir.medium">{{volume.emptyDir.medium}}</span>
-              </dd>
-            </div>
-            <div ng-if="volume.gitRepo">
-              <dt>Type:</dt>
-              <dd>git repo</dd>
-              <dt>Repository:</dt>
-              <dd>{{volume.gitRepo.repository}}</dd>
-              <dt ng-if-start="volume.gitRepo.revision">Revision:</dt>
-              <dd ng-if-end>{{volume.gitRepo.revision}}</dd>
-            </div>
-          </dl>
-        </div>    
+        <h4 style="margin-top: 20px;">Volumes</h4>
+        <a ng-if="pod | annotation:'deploymentConfig'" ng-href="project/{{project.metadata.name}}/attachPVC?deploymentconfig={{pod | annotation:'deploymentConfig'}}">Attach storage and redeploy</a>
+        <volumes volumes="pod.spec.volumes" namespace="project.metadata.name"></volumes>
       </div>
     </div>
   </div>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -87,6 +87,9 @@
                     builds="builds"
                     detailed="true"></pod-template>
             </dl>
+            <h4 style="margin-top: 20px;">Volumes</h4>
+            <a ng-href="project/{{project.metadata.name}}/attachPVC?deploymentconfig={{deploymentConfig.metadata.name}}">Attach storage</a>
+            <volumes volumes="deploymentConfig.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
           </div>
           <div class="col-lg-6">
             <h3>Triggers</h3>

--- a/assets/app/views/browse/persistent-volume-claim.html
+++ b/assets/app/views/browse/persistent-volume-claim.html
@@ -1,0 +1,72 @@
+<div class="content">
+  <project-page>
+    <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+    <alerts alerts="alerts"></alerts>
+    <div ng-if="!loaded">Loading...</div>
+    <div ng-if="pvc">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="tile">
+            <h1>
+              {{pvc.metadata.name}}
+              <small class="meta" ng-if="!pvc.spec.volumeName">
+                  <span ng-if="pvc.spec.resources.requests['storage']">
+                    waiting for {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}} allocation,
+                  </span>
+                  <span ng-if="!pvc.spec.resources.requests['storage']">waiting for allocation,</span>
+              </small>
+              <small class="meta">created <relative-timestamp timestamp="pvc.metadata.creationTimestamp"></relative-timestamp></small>
+              <div class="pull-right dropdown">
+                <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
+                <ul class="dropdown-menu actions action-button">
+                  <li>
+                    <edit-link
+                      resource="pvc"
+                      kind="persistentvolumeclaims"
+                      alerts="alerts">
+                    </edit-link>
+                  </li>
+                  <li>
+                    <delete-link
+                      resource-type="persistentvolumeclaim"
+                      type-display-name="Persistent Volume Claim"
+                      resource-name="{{pvc.metadata.name}}"
+                      project-name="{{pvc.metadata.namespace}}"
+                      alerts="alerts">
+                    </delete-link>
+                  </li>
+                </ul>
+              </div>
+            </h1>
+            <div class="resource-details">
+              <dl class="dl-horizontal left">
+                <dt>Status:</dt>
+                <dd>
+                  <status-icon status="pvc.status.phase" disable-animation></status-icon>
+                  {{pvc.status.phase}}
+                  <span ng-if="pvc.spec.volumeName">to volume <strong>{{pvc.spec.volumeName}}</strong></span>
+                </dd>
+                <dt ng-if="pvc.spec.volumeName">Capacity:</dt>
+                <dd ng-if="pvc.spec.volumeName">
+                  <span ng-if="pvc.status.capacity['storage']">
+                    allocated {{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}
+                  </span>
+                  <span ng-if="!pvc.status.capacity['storage']">allocated unknown size</span>
+                </dd>
+                <dt>Requested Capacity:</dt>
+                <dd>
+                  <span ng-if="pvc.spec.resources.requests['storage']">
+                    {{pvc.spec.resources.requests['storage'] | usageWithUnits: 'storage'}}
+                  </span>
+                  <span ng-if="!pvc.spec.resources.requests['storage']"><em>none</em></span>
+                </dd>
+                <dt>Access Modes:</dt>
+                <dd>{{pvc.spec.accessModes | accessModes:'long' | join}}</dd>
+              </dl>
+            </div>
+          </div> <!-- /tile -->
+        </div> <!-- /col -->
+      </div> <!-- /row -->
+    </div>
+  </project-page>
+</div>

--- a/assets/app/views/directives/_status-icon.html
+++ b/assets/app/views/directives/_status-icon.html
@@ -8,6 +8,7 @@
   <span ng-switch-when="Pending" class="spinner spinner-xs spinner-inline" aria-hidden="true"></span>
   <span ng-switch-when="Running" class="fa fa-refresh" ng-class="{'fa-spin' : spinning }" aria-hidden="true"></span>
   <span ng-switch-when="Succeeded" class="fa fa-check text-success" aria-hidden="true"></span>
+  <span ng-switch-when="Bound" class="fa fa-check text-success" aria-hidden="true"></span>
   <span ng-switch-when="Terminated" class="fa fa-times text-danger" aria-hidden="true"></span>
   <span ng-switch-when="Unknown" class="fa fa-question text-danger" aria-hidden="true"></span>
   <span ng-switch-default class="fa fa-question text-danger" aria-hidden="true"></span>

--- a/assets/app/views/storage.html
+++ b/assets/app/views/storage.html
@@ -1,0 +1,46 @@
+<div class="content">
+  <project-page>
+    <div>
+      <div class="page-header page-header-bleed-right">
+        <h1>Storage</h1>
+      </div>
+      <alerts alerts="alerts"></alerts>
+      <h2>Persistent Volume Claims</h2>
+      <table class="table table-bordered table-hover table-mobile">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Capacity</th>
+            <th>Access Modes</th>
+            <th>Age</th>
+          </tr>
+        </thead>
+        <tbody ng-if="(pvcs | hashSize) == 0">
+          <tr><td colspan="5"><em>{{emptyMessage}}</em></td></tr>
+        </tbody>
+        <tbody ng-repeat="pvc in pvcs | orderObjectsByDate : true">
+          <tr>
+            <td data-title="Name"><a ng-href="{{pvc | navigateResourceURL}}">{{pvc.metadata.name}}</a></td>
+            <td data-title="Status">
+              <status-icon status="pvc.status.phase" disable-animation></status-icon>
+              {{pvc.status.phase}}
+              <span ng-if="pvc.spec.volumeName">to volume <strong>{{pvc.spec.volumeName}}</strong></span>
+            </td>
+            <td data-title="Capacity">
+              <span ng-if="pvc.spec.volumeName">
+                <span ng-if="pvc.status.capacity['storage']">{{pvc.status.capacity['storage'] | usageWithUnits: 'storage'}}</span>
+                <span ng-if="!pvc.status.capacity['storage']">unknown</span>
+              </span>
+              <span ng-if="!pvc.spec.volumeName">
+                <span>-</span>
+              </span>
+            </td>
+            <td data-title="Access Modes">{{pvc.spec.accessModes | accessModes:'long' | join}}</td>
+            <td data-title="Age"><relative-timestamp timestamp="pvc.metadata.creationTimestamp" drop-suffix="true"></relative-timestamp></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </project-page>
+</div>


### PR DESCRIPTION
~~Code is **not yet ready for review** but I'm opening this for design feedback.~~ PTAL @jwforres @ajacobs21e @spadgett @benjaminapetersen 

List all existing persistent volume claims, this is under *Browse/Storage*. The "Status" column represents the fulfilment of a claim against actual volumes in the cluster. You can click a claim to see the detail page with a little more information.

~~[deprecated screenshot](https://cloud.githubusercontent.com/assets/158611/11859716/eefae26c-a454-11e5-83e0-072ce7021c14.png)~~ (scroll down for the most up-to-date)

Now how do we attach an existing persistent volume claim to pods? Volumes allow you to attach a pvc to *any resource that declares a pod spec*, so deployment configs, deployments (replication controllers in practice), etc. It does not seem possible to attach to a pod directly, and attaching to a deployment does not seem to make much sense (will not cause a new deployment so I think the pods would only be affected if a redeployment occurs). So I'm only supporting attaching to deployment configs at the moment, but other kinds can be added easily. 

I'm doing this in the deployment config details page using the *Attach persistent volume claim* link (similar to how it's done in *Create route*). Volumes were not yet present in the deployment config details page, so I added it mostly with the same design it's displayed in pod details, but together with the "Template" section (since it's not volumes *of the deployment config*, but of the template that will result in the dc's pods).

~~[deprecated screenshot](https://cloud.githubusercontent.com/assets/158611/11859720/f73ae314-a454-11e5-9d83-2a7474163430.png)~~ (scroll down for the most up-to-date)

Here is where you attach an existing persistent volume claim to a deployment config. I'm not particularly happy with the dropdown for the pvcs, it would be interesting to have more information (probably capacity, status and access modes) instead of just the name, so that it's more clear to users what's the pvc they are attaching to. What would you suggest, maybe radios? Also, it's still missing a few simple inputs (mount path, volume name, etc).

~~[deprecated screenshot](https://cloud.githubusercontent.com/assets/158611/11859721/fcc58bf4-a454-11e5-92b4-11e1b4eb155b.png)~~
