### PR TITLE
Show 'none' when there is no builder image

### DIFF
--- a/assets/app/views/browse/_build-details.html
+++ b/assets/app/views/browse/_build-details.html
@@ -36,7 +36,7 @@
         <dt>Build strategy:</dt>
         <dd>{{build.spec.strategy.type}}</dd>
         <dt>Builder image:</dt>
-        <dd class="truncate">{{(build | buildStrategy).from | imageObjectRef : build.metadata.namespace}}</dd>
+        <dd class="truncate">{{(build | buildStrategy).from | imageObjectRef : build.metadata.namespace}}<span ng-if="!(build | buildStrategy).from"><em>none</em></span></dd>
         <dt>Source type:</dt>
         <dd>{{build.spec.source.type}}</dd>
         <dt ng-if-start="build.spec.source.git.uri">Source repo:</dt>


### PR DESCRIPTION
Using 'truncate' when the tag is empty causes the next `<dd>` contents to be shifted up, and the labels will point to the wrong piece of information.
Furthermore, we already show 'none' in multiple other places in the Web Console in similar contexts.

Fixes #6364.