### PR TITLE
Web console: Fix edge case scaling to 0 replicas

### DIFF
--- a/assets/app/scripts/directives/overviewDeployment.js
+++ b/assets/app/scripts/directives/overviewDeployment.js
@@ -94,7 +94,10 @@ angular.module('openshiftConsole')
             });
 
             modalInstance.result.then(function() {
-              $scope.desiredReplicas--;
+              // It's possible $scope.desiredReplicas was set to null if
+              // rc.spec.replicas changed since the dialog was shown, so call
+              // getDesiredReplicas() again.
+              $scope.desiredReplicas = $scope.getDesiredReplicas() - 1;
               scale();
             });
 


### PR DESCRIPTION
Fix a problem where the web console can request -1 replicas when scaling from 2 to 0 quickly. This happens when `rc.spec.replicas` changes after the confirmation dialog is shown, but before Scale Down is clicked.

@jwforres PTAL