### PR TITLE
increase wait time on imagestreams

### DIFF
--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -73,7 +73,7 @@ os::cmd::expect_success 'oc get bc'
 os::cmd::expect_success 'oc get builds'
 
 # make sure the imagestream has the latest tag before starting a build or the build will immediately fail.
-os::cmd::try_until_text 'oc get is ruby-22-centos7' 'latest'
+os::cmd::try_until_text 'oc get is ruby-22-centos7' 'latest' $(( 2 * minute ))
 
 REAL_OUTPUT_TO=$(oc get bc/ruby-sample-build --template='{{ .spec.output.to.name }}')
 os::cmd::expect_success "oc patch bc/ruby-sample-build -p '{\"spec\":{\"output\":{\"to\":{\"name\":\"different:tag1\"}}}}'"

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -46,7 +46,7 @@ os::cmd::expect_success_and_text "oc get imageStreams mysql --template='{{.statu
 os::cmd::expect_success_and_text "oc get imageStreams postgresql --template='{{.status.dockerImageRepository}}'" 'postgresql'
 os::cmd::expect_success_and_text "oc get imageStreams mongodb --template='{{.status.dockerImageRepository}}'" 'mongodb'
 # verify the image repository had its tags populated
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
+os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest' $(( 2 * minute ))
 os::cmd::expect_success_and_text "oc get imageStreams wildfly --template='{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}'" '[0-9]{4}\-[0-9]{2}\-[0-9]{2}' # expect a date like YYYY-MM-DD
 os::cmd::expect_success_and_text 'oc get istag' 'wildfly'
 os::cmd::expect_success 'oc annotate istag/wildfly:latest foo=bar'
@@ -63,8 +63,8 @@ os::cmd::expect_failure 'oc get imageStreams nodejs'
 os::cmd::expect_failure 'oc get imageStreams postgresql'
 os::cmd::expect_failure 'oc get imageStreams mongodb'
 os::cmd::expect_failure 'oc get imageStreams wildfly'
-os::cmd::try_until_success 'oc get imagestreamTags mysql:5.5'
-os::cmd::try_until_success 'oc get imagestreamTags mysql:5.6'
+os::cmd::try_until_success 'oc get imagestreamTags mysql:5.5' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamTags mysql:5.6' $(( 2 * minute ))
 os::cmd::expect_success_and_text "oc get imagestreams mysql --template='{{ index .metadata.annotations \"openshift.io/image.dockerRepositoryCheck\"}}'" '[0-9]{4}\-[0-9]{2}\-[0-9]{2}' # expect a date like YYYY-MM-DD
 os::cmd::expect_success 'oc describe istag/mysql:latest'
 os::cmd::expect_success_and_text 'oc describe istag/mysql:latest' 'Environment:'

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -17,15 +17,16 @@ os::cmd::expect_failure 'oc new-app unknownhubimage -o yaml'
 os::cmd::expect_success_and_text 'oc new-app mongo -o yaml' 'library/mongo'
 # the local image repository takes precedence over the Docker Hub "mysql" image
 os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
-os::cmd::try_until_success 'oc get imagestreamtags mysql:latest'
-os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5'
-os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6'
+os::cmd::try_until_success 'oc get imagestreamtags mysql:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6' $(( 2 * minute ))
 os::cmd::expect_success_and_not_text 'oc new-app mysql -o yaml' 'library/mysql'
 
 # check label creation
-os::cmd::try_until_success 'oc get imagestreamtags php:latest'
-os::cmd::try_until_success 'oc get imagestreamtags php:5.5'
-os::cmd::try_until_success 'oc get imagestreamtags php:5.6'
+os::cmd::try_until_success 'oc get imagestreamtags php:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags php:5.5' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags php:5.6' $(( 2 * minute ))
+
 os::cmd::expect_success 'oc new-app php mysql -l no-source=php-mysql'
 os::cmd::expect_success 'oc delete all -l no-source=php-mysql'
 os::cmd::expect_success 'oc new-app php mysql'
@@ -57,32 +58,32 @@ os::cmd::expect_failure 'oc new-app -S --template=nodejs'
 os::cmd::expect_failure 'oc new-app -S --template=perl'
 # check search - filtered, exact matches
 # make sure the imagestreams are imported first.
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:latest'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.4'
-os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.6'
-os::cmd::try_until_success 'oc get imagestreamtags mysql:latest'
-os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5'
-os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6'
-os::cmd::try_until_success 'oc get imagestreamtags nodejs:latest'
-os::cmd::try_until_success 'oc get imagestreamtags nodejs:0.10'
-os::cmd::try_until_success 'oc get imagestreamtags perl:latest'
-os::cmd::try_until_success 'oc get imagestreamtags perl:5.16'
-os::cmd::try_until_success 'oc get imagestreamtags perl:5.20'
-os::cmd::try_until_success 'oc get imagestreamtags php:latest'
-os::cmd::try_until_success 'oc get imagestreamtags php:5.5'
-os::cmd::try_until_success 'oc get imagestreamtags php:5.6'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:latest'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.2'
-os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.4'
-os::cmd::try_until_success 'oc get imagestreamtags python:latest'
-os::cmd::try_until_success 'oc get imagestreamtags python:2.7'
-os::cmd::try_until_success 'oc get imagestreamtags python:3.3'
-os::cmd::try_until_success 'oc get imagestreamtags python:3.4'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:latest'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
-os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest'
-os::cmd::try_until_success 'oc get imagestreamtags wildfly:8.1'
+os::cmd::try_until_success 'oc get imagestreamtags mongodb:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.4' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mongodb:2.6' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mysql:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags nodejs:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags nodejs:0.10' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags perl:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags perl:5.16' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags perl:5.20' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags php:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags php:5.5' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags php:5.6' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags postgresql:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.2' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags postgresql:9.4' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags python:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags python:2.7' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags python:3.3' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags python:3.4' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags ruby:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags ruby:2.2' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags wildfly:latest' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags wildfly:8.1' $(( 2 * minute ))
 
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mongodb' "Tags:\s+2.4, 2.6, latest"
 os::cmd::expect_success_and_text 'oc new-app --search --image-stream=mysql' "Tags:\s+5.5, 5.6, latest"
@@ -140,9 +141,9 @@ os::cmd::expect_success 'oc policy add-role-to-user edit test-user'
 os::cmd::expect_success 'oc login -u test-user -p anything'
 os::cmd::try_until_success 'oc project ${project}'
 
-os::cmd::try_until_success 'oc get imagestreamtags installable:file'
-os::cmd::try_until_success 'oc get imagestreamtags installable:token'
-os::cmd::try_until_success 'oc get imagestreamtags installable:serviceaccount'
+os::cmd::try_until_success 'oc get imagestreamtags installable:file' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags installable:token' $(( 2 * minute ))
+os::cmd::try_until_success 'oc get imagestreamtags installable:serviceaccount' $(( 2 * minute ))
 os::cmd::expect_failure 'oc new-app installable:file'
 os::cmd::expect_failure_and_text 'oc new-app installable:file' 'requires that you grant the image access'
 os::cmd::expect_failure_and_text 'oc new-app installable:serviceaccount' "requires an 'installer' service account with project editor access"


### PR DESCRIPTION
This is a band-aid so we flake less often while a real fix is made. All waits now allow 2 minutes until timeout.
@bparees @deads2k FYI