### PR TITLE
Web console: Use service port name for route targetPort

### DIFF
--- a/assets/app/scripts/controllers/create/createFromImage.js
+++ b/assets/app/scripts/controllers/create/createFromImage.js
@@ -91,11 +91,19 @@ angular.module("openshiftConsole")
                     scope.deploymentConfig.envVars[pair[0]] = pair[1];
                   });
 
-                  scope.routing.portOptions = ApplicationGenerator.parsePorts(imageStreamTag.image);
-                  if (scope.routing.portOptions.length){
-                    scope.routing.targetPort = scope.routing.portOptions[0];
-                  } else {
+                  var ports = ApplicationGenerator.parsePorts(imageStreamTag.image);
+                  if (ports.length === 0) {
                     scope.routing.include = false;
+                    scope.routing.portOptions = [];
+                  } else {
+                    scope.routing.portOptions = _.map(ports, function(portSpec) {
+                      var servicePort = ApplicationGenerator.getServicePort(portSpec);
+                      return {
+                        port: servicePort.name,
+                        label: servicePort.targetPort + "/" + servicePort.protocol
+                      };
+                    });
+                    scope.routing.targetPort = scope.routing.portOptions[0];
                   }
                 }, function(){
                     Navigate.toErrorPage("Cannot create from source: the specified image could not be retrieved.");

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -86,6 +86,7 @@ angular.module("openshiftConsole")
       var service = scope._generateService(input, input.name, ports);
       if (service) {
         resources.service = service;
+
         // Only attempt to generate a route if there is a service.
         resources.route = scope._generateRoute(input, input.name, resources.service.metadata.name);
       }
@@ -133,7 +134,7 @@ angular.module("openshiftConsole")
 
       if (input.routing.targetPort) {
         route.spec.port = {
-          targetPort: input.routing.targetPort.containerPort
+          targetPort: input.routing.targetPort.port
         };
       }
 
@@ -328,6 +329,16 @@ angular.module("openshiftConsole")
       };
     };
 
+    scope.getServicePort = function(portSpec) {
+      return {
+        port: portSpec.containerPort,
+        targetPort: portSpec.containerPort,
+        protocol: portSpec.protocol,
+        // Use the same naming convention as CLI new-app.
+        name: (portSpec.containerPort + '-' + portSpec.protocol).toLowerCase()
+      };
+    };
+
     scope._generateService  = function(input, serviceName, ports){
       if (!ports || !ports.length) {
         return null;
@@ -345,19 +356,9 @@ angular.module("openshiftConsole")
           selector: {
             deploymentconfig: input.name
           },
-          ports: []
+          ports: _.map(ports, scope.getServicePort)
         }
       };
-
-      angular.forEach(ports, function(port) {
-        service.spec.ports.push({
-          port: port.containerPort,
-          targetPort: port.containerPort,
-          protocol: port.protocol,
-          // Use the same naming convention as CLI new-app.
-          name: (port.containerPort + '-' + port.protocol).toLowerCase()
-        });
-      });
 
       return service;
     };

--- a/assets/app/views/directives/osc-routing.html
+++ b/assets/app/views/directives/osc-routing.html
@@ -102,13 +102,13 @@
           id="routeTargetPort"
           ng-if="route.portOptions.length"
           ng-model="route.targetPort"
-          ng-options="(portSpec.containerPort + '/' + portSpec.protocol) for portSpec in route.portOptions"
+          ng-options="portOption.label for portOption in route.portOptions"
           class="form-control"
           aria-describedby="target-port-help">
       </select>
       <div>
         <span id="target-port-help" class="help-block">
-          Container port that the service should direct traffic to.
+          Target port for traffic.
         </span>
       </div>
     </div>

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -128,10 +128,12 @@
                           Show only the first two ports if there are many since we don't have much space here.
                           The full list is visible elsewhere.
                           -->
-                          <span ng-repeat="portMapping in service.spec.ports | orderBy:'port' | limitTo:2" class="nowrap">
+                          <span ng-repeat="portMapping in service.spec.ports | orderBy:'port' | limitTo:2">
                             <!-- Group port mappings and allow multiple mappings to stack if needed -->
                             <span class="port-mappings">
-                              {{portMapping.port}}/{{portMapping.protocol}}&#8201;&#8594;&#8201;{{portMapping.targetPort}}<span ng-if="$index < (numPorts - 1)">, </span></span>
+                              <!-- TODO: Include the port name directly in the content.
+                                         There's just not enough room now, and we already have problems with wrapping. -->
+                              <span ng-attr-title="{{portMapping.name}}">{{portMapping.port}}/{{portMapping.protocol}}</span>&#8201;&#8594;&#8201;{{portMapping.targetPort}}<span ng-if="$index < (numPorts - 1)">, </span></span>
                           </span>
                           <span ng-if="numPorts > 2" ng-init="numRemaining = numPorts - 2">
                             and {{numRemaining}} {{numRemaining == 1 ? "other" : "others"}}


### PR DESCRIPTION
Use the service port name when creating a route rather than the container port number.

See also #6353 and #6265.
Fixes the nowrap issue #6189

@liggitt @jwforres 