### PR TITLE
Fix typo in example `oc run` command.

### DIFF
--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -796,7 +796,7 @@ Run a particular image on the cluster.
   $ oc run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
 
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
-  $ oc run -i -tty nginx --image=nginx --restart=Never
+  $ oc run -i --tty nginx --image=nginx --restart=Never
 ----
 ====
 

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -310,7 +310,7 @@ foreground for an interactive container execution.  You may pass 'run-controller
   $ %[1]s run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
 
   # Start a single instance of nginx and keep it in the foreground, don't restart it if it exits.
-  $ %[1]s run -i -tty nginx --image=nginx --restart=Never`
+  $ %[1]s run -i --tty nginx --image=nginx --restart=Never`
 
 	// TODO: uncomment these when arguments are delivered upstream
 


### PR DESCRIPTION
Supercedes https://github.com/openshift/origin/pull/6271

No need for an UPSTREAM PR since all the relevant code is in Origin @dustymabe fyi

cc: @deads2k

[merge]