### PR TITLE
make os::cmd::try_until* output smarter

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -3,7 +3,8 @@
 # in a sub-shell and redirect all output. Tests in test-cmd *must* use these functions for testing.
 
 # We assume ${OS_ROOT} is set
-source "${OS_ROOT}/hack/text.sh" 
+source "${OS_ROOT}/hack/text.sh"
+source "${OS_ROOT}/hack/util.sh"
 
 # expect_success runs the cmd and expects an exit code of 0
 function os::cmd::expect_success() {
@@ -322,6 +323,38 @@ function os::cmd::internal::get_results() {
 	cat "${os_cmd_internal_tmpout}" "${os_cmd_internal_tmperr}"
 }
 
+# os::cmd::internal::get_try_until_results returns a concise view of the stdout and stderr output files
+# using a timeline format, where consecutive output lines that are the same are condensed into one line
+# with a counter
+function os::cmd::internal::print_try_until_results() {
+	if grep -vq $'\x1e' "${os_cmd_internal_tmpout}"; then 
+		echo "Standard output from the command:"
+		os::cmd::internal::compress_output "${os_cmd_internal_tmpout}"
+	else 
+		echo "There was no output from the command."                                      																																																																																																																
+	fi	
+
+	if grep -vq $'\x1e' "${os_cmd_internal_tmperr}"; then 
+		echo "Standard error from the command:"
+		os::cmd::internal::compress_output "${os_cmd_internal_tmperr}"
+	else 
+		echo "There was no error output from the command."                                      																																																																																																																
+	fi
+}
+
+# os::cmd::internal::mark_attempt marks the end of an attempt in the stdout and stderr log files
+# this is used to make the try_until_* output more concise
+function os::cmd::internal::mark_attempt() {
+	echo -e '\x1e' >> "${os_cmd_internal_tmpout}" | tee "${os_cmd_internal_tmperr}"
+}
+
+# os::cmd::internal::compress_output compresses an output file into timeline representation
+function os::cmd::internal::compress_output() {
+	local logfile=$1
+
+	awk -f ${OS_ROOT}/hack/compress.awk $logfile
+}
+
 # os::cmd::internal::print_results pretty-prints the stderr and stdout files
 function os::cmd::internal::print_results() {
 	if [[ -s "${os_cmd_internal_tmpout}" ]]; then 
@@ -386,6 +419,7 @@ function os::cmd::internal::run_until_exit_code() {
 			break
 		fi
 		sleep "${interval}"
+		os::cmd::internal::mark_attempt
 	done
 
 	local end_time=$(os::cmd::internal::seconds_since_epoch)
@@ -401,12 +435,12 @@ function os::cmd::internal::run_until_exit_code() {
 
 		os::text::print_green "SUCCESS after ${time_elapsed}s: ${description}"
 		if [[ -n ${VERBOSE-} ]]; then
-			os::cmd::internal::print_results
+			os::cmd::internal::print_try_until_results
 		fi
 		return 0
 	else
 		os::text::print_red_bold "FAILURE after ${time_elapsed}s: ${description}: the command timed out"
-		os::text::print_red "$(os::cmd::internal::print_results)"
+		os::text::print_red "$(os::cmd::internal::print_try_until_results)"
 		return 1
 	fi
 }
@@ -441,6 +475,7 @@ function os::cmd::internal::run_until_text() {
 			break
 		fi
 		sleep "${interval}"
+		os::cmd::internal::mark_attempt
 	done
 
 	local end_time=$(os::cmd::internal::seconds_since_epoch)
@@ -456,12 +491,12 @@ function os::cmd::internal::run_until_text() {
 
 		os::text::print_green "SUCCESS after ${time_elapsed}s: ${description}"
 		if [[ -n ${VERBOSE-} ]]; then
-			os::cmd::internal::print_results
+			os::cmd::internal::print_try_until_results
 		fi
 		return 0
 	else
 		os::text::print_red_bold "FAILURE after ${time_elapsed}s: ${description}: the command timed out"
-		os::text::print_red "$(os::cmd::internal::print_results)"
+		os::text::print_red "$(os::cmd::internal::print_try_until_results)"
 		return 1
 	fi
 }

--- a/hack/compress.awk
+++ b/hack/compress.awk
@@ -1,0 +1,41 @@
+# Helper functions
+function trim(s) {
+	gsub(/^[ \t\r\n]+|[ \t\r\n]+$/, "", s);
+	return s;
+}
+
+function printRecordAndCount(record, count) {
+	print record;
+	if (count > 1) {
+		printf("... repeated %d times\n", count)
+	}
+}
+
+BEGIN {
+	# Before processing, set the record separator to the ASCII record separator character \x1e
+	RS = "\x1e";
+}
+
+# This action is executed for each record
+{
+	# Build our current var from the trimmed record
+	current = trim($0);
+
+	# Bump the count of times we have seen it
+	seen[current]++;
+
+	# Print the previous record and its count (if it is not identical to the current record)
+	if (previous && previous != current) {
+		printRecordAndCount(previous, seen[previous]);
+	}
+
+	# Store the current record as the previous record
+	previous = current;
+}
+
+END {
+	# After processing, print the last record and count if it is non-empty
+	if (previous) {
+		printRecordAndCount(previous, seen[previous]);
+	}
+}

--- a/hack/test-cmd_util.sh
+++ b/hack/test-cmd_util.sh
@@ -379,3 +379,52 @@ if os::cmd::try_until_failure 'exit 0' $(( 1 * second )); then
 fi
 
 echo "try_until: ok"
+
+echo -e 'success
+line 2
+\x1e
+success
+line 2
+\x1e
+success
+line 2
+\x1e
+success NEW
+line 2
+\x1e
+success NEW
+line 2
+\x1e
+success NEW
+line 2
+\x1e
+success NEW
+line 2
+\x1e
+success OLD
+line 2
+\x1e
+success OLD
+line 2
+\x1e
+success OLD
+line 2
+\x1e
+\x1e
+\x1e
+\x1e
+\x1e' > /tmp/openshift/origin/test/cmd/compress_test.txt
+
+echo "success
+line 2
+... repeated 3 times
+success NEW
+line 2
+... repeated 4 times
+success OLD
+line 2
+... repeated 3 times" > /tmp/openshift/origin/test/cmd/compress_test.out
+
+os::cmd::internal::compress_output /tmp/openshift/origin/test/cmd/compress_test.txt > /tmp/openshift/origin/test/cmd/compressed.out
+diff /tmp/openshift/origin/test/cmd/compress_test.out /tmp/openshift/origin/test/cmd/compressed.out
+echo "compression: ok"


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/6405

@deads2k PTAL

Sample output:
```
Standard output from the command:
    1x 'some
multi line
output'
   25x 'other output'
```
