### PR TITLE
Fix tito ldflag manipulation

### DIFF
--- a/.tito/lib/origin/builder/__init__.py
+++ b/.tito/lib/origin/builder/__init__.py
@@ -59,7 +59,7 @@ class OriginBuilder(Builder):
             ldflags = run_command("bash -c '{0}'".format(cmd))
             print("LDFLAGS::{0}".format(ldflags))
             update_ldflags = \
-                    "sed -i 's|^%%global ldflags .*$|%%global ldflags {0}|' {1}".format(
+                    "sed -i 's|^%global ldflags .*$|%global ldflags {0}|' {1}".format(
                         ' '.join([ldflag.strip() for ldflag in ldflags.split()]),
                         self.spec_file
                     )

--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -70,7 +70,7 @@ class OriginTagger(VersionTagger):
         new_version = re.sub(r"-.*", "", new_version)
         git_hash = get_latest_commit()
         update_commit = \
-            "sed -i 's/^%%global commit .*$/%%global commit {0}/' {1}".format(
+            "sed -i 's/^%global commit .*$/%global commit {0}/' {1}".format(
                 git_hash,
                 self.spec_file
             )
@@ -83,7 +83,7 @@ class OriginTagger(VersionTagger):
         # dirty
         ldflags = ldflags.replace('-dirty', '')
         update_ldflags = \
-            "sed -i 's|^%%global ldflags .*$|%%global ldflags {0}|' {1}".format(
+            "sed -i 's|^%global ldflags .*$|%global ldflags {0}|' {1}".format(
                 ldflags,
                 self.spec_file
             )


### PR DESCRIPTION
@maxamillion mind taking a look at this? I was seeing that `tito tag` and `tito release --test` (which uses the builder) weren't updating commit or ldflags properly.