### PR TITLE
Show empty RCs in some cases on overview when no service

### DIFF
--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -204,13 +204,8 @@
         <!-- Show deploymentsConfigs not in a service -->
         <section ng-repeat="(deploymentConfigId, deployments) in deploymentsByServiceByDeploymentConfig['']" class="components">
 
-          <!--
-          TODO: right now we ONLY show deployments / RCs if they have pods
-          We may also want to show them if they are idled down to zero (but only if we can filter old deployments)
-          -->
           <div ng-repeat="(deploymentId, deployment) in deploymentsByServiceByDeploymentConfig[''][deploymentConfigId] track by (deployment | uid)"
-               ng-if="(podsByDeployment[deployment.metadata.name] | hashSize) > 0">
-
+               ng-if="isVisibleDeployment(deployment)">
             <div class="builds-no-service" ng-if="deploymentConfigs[deploymentConfigId] && deploymentConfigsByService[''][deploymentConfigId]">
               <!--
               Pods in deployments created from this deployment config will not be routed to by any service.


### PR DESCRIPTION
Apply the same rules for showing and hiding RCs regardless of whether it has a service.

Fixes #6201
https://bugzilla.redhat.com/show_bug.cgi?id=1292361