### PR TITLE
Avoid scrollbar flicker on build trends tooltip

### DIFF
--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -325,6 +325,13 @@ html, body {
   .build-trends-container {
     min-width: 600px;
     height: 235px;
+    // Set initial tooltip position to 0, 0 to avoid scrollbars flickering when
+    // c3 first shows the tooltip, but hasn't positioned it.
+    // (Doesn't change tooltip positioning.)
+    .c3-tooltip-container {
+      top: 0;
+      left: 0;
+    }
     // Disable the gray vertical line when hover over a bar.
     .c3-xgrid-focus {
       display: none;


### PR DESCRIPTION
Set an initial position of the c3 tooltip container to avoid momentary scrollbar flicker on Chrome before its true position is set.

@jwforres PTAL