### PR TITLE
Improve namer.GetName

### DIFF
--- a/pkg/util/namer/namer.go
+++ b/pkg/util/namer/namer.go
@@ -13,28 +13,40 @@ import (
 // an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
 // it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
 func GetName(base, suffix string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
 	name := fmt.Sprintf("%s-%s", base, suffix)
-	if len(name) > maxLength {
-		baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
-
-		// if the suffix is too long, ignore it
-		if baseLength < 0 {
-			prefix := base[0:min(len(base), maxLength-9)]
-			// Calculate hash on initial base-suffix string
-			return fmt.Sprintf("%s-%s", prefix, hash(name))
-		}
-
-		prefix := base[0:baseLength]
-		// Calculate hash on initial base-suffix string
-		return fmt.Sprintf("%s-%s-%s", prefix, hash(base), suffix)
+	if len(name) <= maxLength {
+		return name
 	}
 
-	return name
+	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
+
+	// if the suffix is too long, ignore it
+	if baseLength < 0 {
+		prefix := base[0:min(len(base), max(0, maxLength-9))]
+		// Calculate hash on initial base-suffix string
+		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))
+		return shortName[:min(maxLength, len(shortName))]
+	}
+
+	prefix := base[0:baseLength]
+	// Calculate hash on initial base-suffix string
+	return fmt.Sprintf("%s-%s-%s", prefix, hash(base), suffix)
 }
 
 // GetPodName calls GetName with the length restriction for pods
 func GetPodName(base, suffix string) string {
 	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// max returns the greater of its 2 inputs
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
 }
 
 // min returns the lesser of its 2 inputs

--- a/pkg/util/namer/namer_test.go
+++ b/pkg/util/namer/namer_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestGetName(t *testing.T) {
-
 	for i := 0; i < 10; i++ {
 		shortName := randSeq(rand.Intn(kvalidation.DNS1123SubdomainMaxLength-1) + 1)
 		longName := randSeq(kvalidation.DNS1123SubdomainMaxLength + rand.Intn(100))
@@ -74,6 +73,19 @@ func TestGetNameIsDifferent(t *testing.T) {
 	builderName = GetName(longName, "build", kvalidation.DNS1123SubdomainMaxLength)
 	if deployerName == builderName {
 		t.Errorf("Expecting names to be different: %s\n", deployerName)
+	}
+}
+
+func TestGetNameReturnShortNames(t *testing.T) {
+	base := randSeq(32)
+	for maxLength := 0; maxLength < len(base)+2; maxLength++ {
+		for suffixLen := 0; suffixLen <= maxLength+1; suffixLen++ {
+			suffix := randSeq(suffixLen)
+			got := GetName(base, suffix, maxLength)
+			if len(got) > maxLength {
+				t.Fatalf("len(GetName(%[1]q, %[2]q, %[3]d)) = len(%[4]q) = %[5]d; want %[3]d", base, suffix, maxLength, got, len(got))
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
* Return early if `len(name) <= maxLength`
* Avoid "slice bounds out of range" panic if used with small `maxLength` values
* Guarantee that the length of the return value is always less than or equal `maxLength`