### PR TITLE
capability defaulting

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -2113,6 +2113,22 @@ func deepCopy_api_SecurityContextConstraints(in SecurityContextConstraints, out 
 	if err := deepCopy_api_SupplementalGroupsStrategyOptions(in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 		return err
 	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = in.DefaultAddCapabilities[i]
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = in.RequiredDropCapabilities[i]
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
+	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))
 		for i := range in.Users {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2143,7 +2143,16 @@ type SecurityContextConstraints struct {
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
 	AllowPrivilegedContainer bool
+	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
+	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
+	// DefaultAddCapabilities and RequiredDropCapabilities.
+	DefaultAddCapabilities []Capability
+	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
+	// are required to be dropped and cannot be added.
+	RequiredDropCapabilities []Capability
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
+	// Capabilities in this field maybe added at the pod author's discretion.
+	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	AllowedCapabilities []Capability
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	AllowHostDirVolumePlugin bool

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2760,6 +2760,22 @@ func convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in 
 	if err := convert_api_SupplementalGroupsStrategyOptions_To_v1_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
 	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = Capability(in.DefaultAddCapabilities[i])
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = Capability(in.RequiredDropCapabilities[i])
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
+	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))
 		for i := range in.Users {
@@ -5767,6 +5783,22 @@ func convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in 
 	}
 	if err := convert_v1_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
+	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]api.Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = api.Capability(in.DefaultAddCapabilities[i])
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]api.Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = api.Capability(in.RequiredDropCapabilities[i])
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
 	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -2162,6 +2162,22 @@ func deepCopy_v1_SecurityContextConstraints(in SecurityContextConstraints, out *
 	if err := deepCopy_v1_SupplementalGroupsStrategyOptions(in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 		return err
 	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = in.DefaultAddCapabilities[i]
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = in.RequiredDropCapabilities[i]
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
+	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))
 		for i := range in.Users {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -2597,7 +2597,16 @@ type SecurityContextConstraints struct {
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
 	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer" description:"allow containers to run as privileged"`
+	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
+	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
+	// DefaultAddCapabilities and RequiredDropCapabilities.
+	DefaultAddCapabilities []Capability `json:"defaultAddCapabilities" description:"capabilities that are added by default but may be dropped"`
+	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
+	// are required to be dropped and cannot be added.
+	RequiredDropCapabilities []Capability `json:"requiredDropCapabilities" description:"capabilities that will be dropped by default and may not be added"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
+	// Capabilities in this field maybe added at the pod author's discretion.
+	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	AllowedCapabilities []Capability `json:"allowedCapabilities" description:"capabilities that are allowed to be added"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" description:"allow the use of the host dir volume plugin"`

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -2144,6 +2144,22 @@ func convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraint
 	if err := convert_api_SupplementalGroupsStrategyOptions_To_v1beta3_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
 	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = Capability(in.DefaultAddCapabilities[i])
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = Capability(in.RequiredDropCapabilities[i])
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
+	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))
 		for i := range in.Users {
@@ -4477,6 +4493,22 @@ func convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraint
 	}
 	if err := convert_v1beta3_SupplementalGroupsStrategyOptions_To_api_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, s); err != nil {
 		return err
+	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]api.Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = api.Capability(in.DefaultAddCapabilities[i])
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]api.Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = api.Capability(in.RequiredDropCapabilities[i])
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
 	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
@@ -2143,6 +2143,22 @@ func deepCopy_v1beta3_SecurityContextConstraints(in SecurityContextConstraints, 
 	if err := deepCopy_v1beta3_SupplementalGroupsStrategyOptions(in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 		return err
 	}
+	if in.DefaultAddCapabilities != nil {
+		out.DefaultAddCapabilities = make([]Capability, len(in.DefaultAddCapabilities))
+		for i := range in.DefaultAddCapabilities {
+			out.DefaultAddCapabilities[i] = in.DefaultAddCapabilities[i]
+		}
+	} else {
+		out.DefaultAddCapabilities = nil
+	}
+	if in.RequiredDropCapabilities != nil {
+		out.RequiredDropCapabilities = make([]Capability, len(in.RequiredDropCapabilities))
+		for i := range in.RequiredDropCapabilities {
+			out.RequiredDropCapabilities[i] = in.RequiredDropCapabilities[i]
+		}
+	} else {
+		out.RequiredDropCapabilities = nil
+	}
 	if in.Users != nil {
 		out.Users = make([]string, len(in.Users))
 		for i := range in.Users {

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -2092,7 +2092,16 @@ type SecurityContextConstraints struct {
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
 	AllowPrivilegedContainer bool `json:"allowPrivilegedContainer" description:"allow containers to run as privileged"`
+	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
+	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
+	// DefaultAddCapabilities and RequiredDropCapabilities.
+	DefaultAddCapabilities []Capability `json:"defaultAddCapabilities" description:"capabilities that are added by default but may be dropped"`
+	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
+	// are required to be dropped and cannot be added.
+	RequiredDropCapabilities []Capability `json:"requiredDropCapabilities" description:"capabilities that will be dropped by default and may not be added"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
+	// Capabilities in this field maybe added at the pod author's discretion.
+	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	AllowedCapabilities []Capability `json:"allowedCapabilities" description:"capabilities that are allowed to be added"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin" description:"allow the use of the host dir volume plugin"`

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/validation/validation_test.go
@@ -4171,6 +4171,14 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 	negativePriority := validSCC()
 	negativePriority.Priority = &invalidPriority
 
+	requiredCapAddAndDrop := validSCC()
+	requiredCapAddAndDrop.DefaultAddCapabilities = []api.Capability{"foo"}
+	requiredCapAddAndDrop.RequiredDropCapabilities = []api.Capability{"foo"}
+
+	allowedCapListedInRequiredDrop := validSCC()
+	allowedCapListedInRequiredDrop.RequiredDropCapabilities = []api.Capability{"foo"}
+	allowedCapListedInRequiredDrop.AllowedCapabilities = []api.Capability{"foo"}
+
 	errorCases := map[string]struct {
 		scc         *api.SecurityContextConstraints
 		errorType   fielderrors.ValidationErrorType
@@ -4246,6 +4254,16 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 			errorType:   errors.ValidationErrorTypeInvalid,
 			errorDetail: "priority cannot be negative",
 		},
+		"invalid required caps": {
+			scc:         requiredCapAddAndDrop,
+			errorType:   errors.ValidationErrorTypeInvalid,
+			errorDetail: "capability is listed in defaultAddCapabilities and requiredDropCapabilities",
+		},
+		"allowed cap listed in required drops": {
+			scc:         allowedCapListedInRequiredDrop,
+			errorType:   errors.ValidationErrorTypeInvalid,
+			errorDetail: "capability is listed in allowedCapabilities and requiredDropCapabilities",
+		},
 	}
 
 	for k, v := range errorCases {
@@ -4266,6 +4284,14 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 	runAsNonRoot := validSCC()
 	runAsNonRoot.RunAsUser.Type = api.RunAsUserStrategyMustRunAsNonRoot
 
+	caseInsensitiveAddDrop := validSCC()
+	caseInsensitiveAddDrop.DefaultAddCapabilities = []api.Capability{"foo"}
+	caseInsensitiveAddDrop.RequiredDropCapabilities = []api.Capability{"FOO"}
+
+	caseInsensitiveAllowedDrop := validSCC()
+	caseInsensitiveAllowedDrop.RequiredDropCapabilities = []api.Capability{"FOO"}
+	caseInsensitiveAllowedDrop.AllowedCapabilities = []api.Capability{"foo"}
+
 	successCases := map[string]struct {
 		scc *api.SecurityContextConstraints
 	}{
@@ -4277,6 +4303,12 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 		},
 		"run as non-root (user only)": {
 			scc: runAsNonRoot,
+		},
+		"comparison for add -> drop is case sensitive": {
+			scc: caseInsensitiveAddDrop,
+		},
+		"comparison for allowed -> drop is case sensitive": {
+			scc: caseInsensitiveAllowedDrop,
 		},
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities/mustrunas.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities/mustrunas.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// defaultCapabilities implements the CapabilitiesSecurityContextConstraintsStrategy interface
+type defaultCapabilities struct {
+	defaultAddCapabilities   []api.Capability
+	requiredDropCapabilities []api.Capability
+	allowedCaps              []api.Capability
+}
+
+var _ CapabilitiesSecurityContextConstraintsStrategy = &defaultCapabilities{}
+
+// NewDefaultCapabilities creates a new defaultCapabilities strategy that will provide defaults and validation
+// based on the configured initial caps and allowed caps.
+func NewDefaultCapabilities(defaultAddCapabilities, requiredDropCapabilities, allowedCaps []api.Capability) (CapabilitiesSecurityContextConstraintsStrategy, error) {
+	return &defaultCapabilities{
+		defaultAddCapabilities:   defaultAddCapabilities,
+		requiredDropCapabilities: requiredDropCapabilities,
+		allowedCaps:              allowedCaps,
+	}, nil
+}
+
+// Generate creates the capabilities based on policy rules.  Generate will produce the following:
+// 1.  a capabilities.Add set containing all the required adds (unless the
+// 		container specifically is dropping the cap) and container requested adds
+// 2.  a capabilities.Drop set containing all the required drops and container requested drops
+func (s *defaultCapabilities) Generate(pod *api.Pod, container *api.Container) (*api.Capabilities, error) {
+	defaultAdd := makeCapSet(s.defaultAddCapabilities)
+	requiredDrop := makeCapSet(s.requiredDropCapabilities)
+	containerAdd := sets.NewString()
+	containerDrop := sets.NewString()
+
+	if container.SecurityContext != nil && container.SecurityContext.Capabilities != nil {
+		containerAdd = makeCapSet(container.SecurityContext.Capabilities.Add)
+		containerDrop = makeCapSet(container.SecurityContext.Capabilities.Drop)
+	}
+
+	// remove any default adds that the container is specifically dropping
+	defaultAdd = defaultAdd.Difference(containerDrop)
+
+	combinedAdd := defaultAdd.Union(containerAdd).List()
+	combinedDrop := requiredDrop.Union(containerDrop).List()
+
+	// nothing generated?  return nil
+	if len(combinedAdd) == 0 && len(combinedDrop) == 0 {
+		return nil, nil
+	}
+
+	return &api.Capabilities{
+		Add:  capabilityFromStringSlice(combinedAdd),
+		Drop: capabilityFromStringSlice(combinedDrop),
+	}, nil
+}
+
+// Validate ensures that the specified values fall within the range of the strategy.
+func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList {
+	allErrs := fielderrors.ValidationErrorList{}
+
+	// if the security context isn't set then we haven't generated correctly.  Shouldn't get here
+	// if using the provider correctly
+	if container.SecurityContext == nil {
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("securityContext", container.SecurityContext, "no security context is set"))
+		return allErrs
+	}
+
+	if container.SecurityContext.Capabilities == nil {
+		// if container.SC.Caps is nil then nothing was defaulted by the strat or requested by the pod author
+		// if there are no required caps on the strategy and nothing is requested on the pod
+		// then we can safely return here without further validation.
+		if len(s.defaultAddCapabilities) == 0 && len(s.requiredDropCapabilities) == 0 {
+			return allErrs
+		}
+
+		// container has no requested caps but we have required caps.  We should have something in
+		// at least the drops on the container.
+		allErrs = append(allErrs, fielderrors.NewFieldInvalid("capabilities", container.SecurityContext.Capabilities,
+			"required capabilities are not set on the securityContext"))
+		return allErrs
+	}
+
+	// validate that anything being added is in the default or allowed sets
+	defaultAdd := makeCapSet(s.defaultAddCapabilities)
+	allowedAdd := makeCapSet(s.allowedCaps)
+
+	for _, cap := range container.SecurityContext.Capabilities.Add {
+		sCap := string(cap)
+		if !defaultAdd.Has(sCap) && !allowedAdd.Has(sCap) {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("capabilities.add", sCap, "capability may not be added"))
+		}
+	}
+
+	// validate that anything that is required to be dropped is in the drop set
+	containerDrops := makeCapSet(container.SecurityContext.Capabilities.Drop)
+
+	for _, requiredDrop := range s.requiredDropCapabilities {
+		sDrop := string(requiredDrop)
+		if !containerDrops.Has(sDrop) {
+			allErrs = append(allErrs, fielderrors.NewFieldInvalid("capabilities.drop", container.SecurityContext.Capabilities.Drop,
+				fmt.Sprintf("%s is required to be dropped but was not found", sDrop)))
+		}
+	}
+
+	return allErrs
+}
+
+// capabilityFromStringSlice creates a capability slice from a string slice.
+func capabilityFromStringSlice(slice []string) []api.Capability {
+	if len(slice) == 0 {
+		return nil
+	}
+	caps := []api.Capability{}
+	for _, c := range slice {
+		caps = append(caps, api.Capability(c))
+	}
+	return caps
+}
+
+// makeCapSet makes a string set from capabilities and normalizes them to be all lower case to help
+// with comparisons.
+func makeCapSet(caps []api.Capability) sets.String {
+	s := sets.NewString()
+	for _, c := range caps {
+		s.Insert(string(c))
+	}
+	return s
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities/mustrunas_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities/mustrunas_test.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"reflect"
+	"testing"
+)
+
+func TestGenerateAdds(t *testing.T) {
+	tests := map[string]struct {
+		defaultAddCaps   []api.Capability
+		requiredDropCaps []api.Capability
+		containerCaps    *api.Capabilities
+		expectedCaps     *api.Capabilities
+	}{
+		"no required, no container requests": {
+			expectedCaps: nil,
+		},
+		"required, no container requests": {
+			defaultAddCaps: []api.Capability{"foo"},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+		},
+		"required, container requests add required": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+		},
+		"multiple required, container requests add required": {
+			defaultAddCaps: []api.Capability{"foo", "bar", "baz"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"bar", "baz", "foo"},
+			},
+		},
+		"required, container requests add non-required": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"bar"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"bar", "foo"},
+			},
+		},
+		"generation dedupes": {
+			defaultAddCaps: []api.Capability{"foo", "foo", "foo", "foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo", "foo", "foo"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+		},
+		"generation is case sensitive - will not dedupe": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"FOO"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"FOO", "foo"},
+			},
+		},
+	}
+
+	for k, v := range tests {
+		container := &api.Container{
+			SecurityContext: &api.SecurityContext{
+				Capabilities: v.containerCaps,
+			},
+		}
+
+		strategy, err := NewDefaultCapabilities(v.defaultAddCaps, v.requiredDropCaps, nil)
+		if err != nil {
+			t.Errorf("%s failed: %v", k, err)
+			continue
+		}
+		generatedCaps, err := strategy.Generate(nil, container)
+		if err != nil {
+			t.Errorf("%s failed generating: %v", k, err)
+			continue
+		}
+		if v.expectedCaps == nil && generatedCaps != nil {
+			t.Errorf("%s expected nil caps to be generated but got %v", k, generatedCaps)
+			continue
+		}
+		if !reflect.DeepEqual(v.expectedCaps, generatedCaps) {
+			t.Errorf("%s did not generate correctly.  Expected: %#v, Actual: %#v", k, v.expectedCaps, generatedCaps)
+		}
+	}
+}
+
+func TestGenerateDrops(t *testing.T) {
+	tests := map[string]struct {
+		defaultAddCaps   []api.Capability
+		requiredDropCaps []api.Capability
+		containerCaps    *api.Capabilities
+		expectedCaps     *api.Capabilities
+	}{
+		"no required, no container requests": {
+			expectedCaps: nil,
+		},
+		"required drops are defaulted": {
+			requiredDropCaps: []api.Capability{"foo"},
+			expectedCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo"},
+			},
+		},
+		"required drops are defaulted when making container requests": {
+			requiredDropCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo", "bar"},
+			},
+			expectedCaps: &api.Capabilities{
+				Drop: []api.Capability{"bar", "foo"},
+			},
+		},
+		"can drop a required add": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo"},
+			},
+			expectedCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo"},
+			},
+		},
+		"can drop non-required add": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"bar"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add:  []api.Capability{"foo"},
+				Drop: []api.Capability{"bar"},
+			},
+		},
+		"defaulting adds and drops, dropping a required add": {
+			defaultAddCaps:   []api.Capability{"foo", "bar", "baz"},
+			requiredDropCaps: []api.Capability{"abc"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add:  []api.Capability{"bar", "baz"},
+				Drop: []api.Capability{"abc", "foo"},
+			},
+		},
+		"generation dedupes": {
+			requiredDropCaps: []api.Capability{"bar", "bar", "bar", "bar"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"bar", "bar", "bar"},
+			},
+			expectedCaps: &api.Capabilities{
+				Drop: []api.Capability{"bar"},
+			},
+		},
+		"generation is case sensitive - will not dedupe": {
+			requiredDropCaps: []api.Capability{"bar"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"BAR"},
+			},
+			expectedCaps: &api.Capabilities{
+				Drop: []api.Capability{"BAR", "bar"},
+			},
+		},
+	}
+	for k, v := range tests {
+		container := &api.Container{
+			SecurityContext: &api.SecurityContext{
+				Capabilities: v.containerCaps,
+			},
+		}
+
+		strategy, err := NewDefaultCapabilities(v.defaultAddCaps, v.requiredDropCaps, nil)
+		if err != nil {
+			t.Errorf("%s failed: %v", k, err)
+			continue
+		}
+		generatedCaps, err := strategy.Generate(nil, container)
+		if err != nil {
+			t.Errorf("%s failed generating: %v", k, err)
+			continue
+		}
+		if v.expectedCaps == nil && generatedCaps != nil {
+			t.Errorf("%s expected nil caps to be generated but got %#v", k, generatedCaps)
+			continue
+		}
+		if !reflect.DeepEqual(v.expectedCaps, generatedCaps) {
+			t.Errorf("%s did not generate correctly.  Expected: %#v, Actual: %#v", k, v.expectedCaps, generatedCaps)
+		}
+	}
+}
+
+func TestValidateAdds(t *testing.T) {
+	tests := map[string]struct {
+		defaultAddCaps   []api.Capability
+		requiredDropCaps []api.Capability
+		allowedCaps      []api.Capability
+		containerCaps    *api.Capabilities
+		shouldPass       bool
+	}{
+		// no container requests
+		"no required, no allowed, no container requests": {
+			shouldPass: true,
+		},
+		"no required, allowed, no container requests": {
+			allowedCaps: []api.Capability{"foo"},
+			shouldPass:  true,
+		},
+		"required, no allowed, no container requests": {
+			defaultAddCaps: []api.Capability{"foo"},
+			shouldPass:     false,
+		},
+
+		// container requests match required
+		"required, no allowed, container requests valid": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+			shouldPass: true,
+		},
+		"required, no allowed, container requests invalid": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"bar"},
+			},
+			shouldPass: false,
+		},
+
+		// container requests match allowed
+		"no required, allowed, container requests valid": {
+			allowedCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+			shouldPass: true,
+		},
+		"no required, allowed, container requests invalid": {
+			allowedCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"bar"},
+			},
+			shouldPass: false,
+		},
+
+		// required and allowed
+		"required, allowed, container requests valid required": {
+			defaultAddCaps: []api.Capability{"foo"},
+			allowedCaps:    []api.Capability{"bar"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+			shouldPass: true,
+		},
+		"required, allowed, container requests valid allowed": {
+			defaultAddCaps: []api.Capability{"foo"},
+			allowedCaps:    []api.Capability{"bar"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"bar"},
+			},
+			shouldPass: true,
+		},
+		"required, allowed, container requests invalid": {
+			defaultAddCaps: []api.Capability{"foo"},
+			allowedCaps:    []api.Capability{"bar"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"baz"},
+			},
+			shouldPass: false,
+		},
+		"validation is case sensitive": {
+			defaultAddCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"FOO"},
+			},
+			shouldPass: false,
+		},
+	}
+
+	for k, v := range tests {
+		container := &api.Container{
+			SecurityContext: &api.SecurityContext{
+				Capabilities: v.containerCaps,
+			},
+		}
+
+		strategy, err := NewDefaultCapabilities(v.defaultAddCaps, v.requiredDropCaps, v.allowedCaps)
+		if err != nil {
+			t.Errorf("%s failed: %v", k, err)
+			continue
+		}
+		errs := strategy.Validate(nil, container)
+		if v.shouldPass && len(errs) > 0 {
+			t.Errorf("%s should have passed but had errors %v", k, errs)
+			continue
+		}
+		if !v.shouldPass && len(errs) == 0 {
+			t.Errorf("%s should have failed but recieved no errors", k)
+		}
+	}
+}
+
+func TestValidateDrops(t *testing.T) {
+	tests := map[string]struct {
+		defaultAddCaps   []api.Capability
+		requiredDropCaps []api.Capability
+		containerCaps    *api.Capabilities
+		shouldPass       bool
+	}{
+		// no container requests
+		"no required, no container requests": {
+			shouldPass: true,
+		},
+		"required, no container requests": {
+			requiredDropCaps: []api.Capability{"foo"},
+			shouldPass:       false,
+		},
+
+		// container requests match required
+		"required, container requests valid": {
+			requiredDropCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo"},
+			},
+			shouldPass: true,
+		},
+		"required, container requests invalid": {
+			requiredDropCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"bar"},
+			},
+			shouldPass: false,
+		},
+		"validation is case sensitive": {
+			requiredDropCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"FOO"},
+			},
+			shouldPass: false,
+		},
+	}
+
+	for k, v := range tests {
+		container := &api.Container{
+			SecurityContext: &api.SecurityContext{
+				Capabilities: v.containerCaps,
+			},
+		}
+
+		strategy, err := NewDefaultCapabilities(v.defaultAddCaps, v.requiredDropCaps, nil)
+		if err != nil {
+			t.Errorf("%s failed: %v", k, err)
+			continue
+		}
+		errs := strategy.Validate(nil, container)
+		if v.shouldPass && len(errs) > 0 {
+			t.Errorf("%s should have passed but had errors %v", k, errs)
+			continue
+		}
+		if !v.shouldPass && len(errs) == 0 {
+			t.Errorf("%s should have failed but recieved no errors", k)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/capabilities/types.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+)
+
+// CapabilitiesSecurityContextConstraintsStrategy defines the interface for all cap constraint strategies.
+type CapabilitiesSecurityContextConstraintsStrategy interface {
+	// Generate creates the capabilities based on policy rules.
+	Generate(pod *api.Pod, container *api.Container) (*api.Capabilities, error)
+	// Validate ensures that the specified values fall within the range of the strategy.
+	Validate(pod *api.Pod, container *api.Container) fielderrors.ValidationErrorList
+}

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -14743,6 +14743,8 @@
     "required": [
      "priority",
      "allowPrivilegedContainer",
+     "defaultAddCapabilities",
+     "requiredDropCapabilities",
      "allowedCapabilities",
      "allowHostDirVolumePlugin",
      "allowHostNetwork",
@@ -14770,6 +14772,20 @@
      "allowPrivilegedContainer": {
       "type": "boolean",
       "description": "allow containers to run as privileged"
+     },
+     "defaultAddCapabilities": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Capability"
+      },
+      "description": "capabilities that are added by default but may be dropped"
+     },
+     "requiredDropCapabilities": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Capability"
+      },
+      "description": "capabilities that will be dropped by default and may not be added"
      },
      "allowedCapabilities": {
       "type": "array",


### PR DESCRIPTION
@smarterclayton @eparis - here is the WIP for adding required add/drops into SCCs.  PTAL

The mechanics are:

1.  You may define `requiredCapabilities` in the SCC which can include adds and drops
1.  Defaulting will produce
     1.  Adds: all required caps + container requested adds - container requested drops (you can drop required adds if you want, just means your container can do less)
     1.  Drops: all required drops + container requested drops
1.  Validation will ensure
     1.  Adds: all adds must be in either the required or allowed add lists of the SCC
     1.  Drops:  all required drops are in the drop set