### PR TITLE
diagnostics: avoid some redundancy

### DIFF
--- a/pkg/cmd/experimental/diagnostics/client.go
+++ b/pkg/cmd/experimental/diagnostics/client.go
@@ -33,8 +33,16 @@ func (o DiagnosticsOptions) buildClientDiagnostics(rawConfig *clientcmdapi.Confi
 	for _, diagnosticName := range requestedDiagnostics {
 		switch diagnosticName {
 		case clientdiags.ConfigContextsName:
+			seen := map[string]bool{}
 			for contextName := range rawConfig.Contexts {
-				diagnostics = append(diagnostics, clientdiags.ConfigContext{RawConfig: rawConfig, ContextName: contextName})
+				diagnostic := clientdiags.ConfigContext{RawConfig: rawConfig, ContextName: contextName}
+				if clusterUser, defined := diagnostic.ContextClusterUser(); !defined {
+					// definitely want to diagnose the broken context
+					diagnostics = append(diagnostics, diagnostic)
+				} else if !seen[clusterUser] {
+					seen[clusterUser] = true // avoid validating same user for multiple projects
+					diagnostics = append(diagnostics, diagnostic)
+				}
 			}
 
 		default:

--- a/pkg/diagnostics/client/config_contexts.go
+++ b/pkg/diagnostics/client/config_contexts.go
@@ -175,6 +175,16 @@ func (d ConfigContext) CanRun() (bool, error) {
 	return true, nil
 }
 
+// ContextClusterUser returns user+cluster name, plus true if the context is defined
+func (d ConfigContext) ContextClusterUser() (string, bool) {
+	if context, exists := d.RawConfig.Contexts[d.ContextName]; exists {
+		return context.Cluster + " " + context.AuthInfo, true
+	} else {
+		return "", false
+	}
+}
+
+// Check is part of the Diagnostic interface; it runs the actual diagnostic logic
 func (d ConfigContext) Check() types.DiagnosticResult {
 	r := types.NewDiagnosticResult(ConfigContextsName)
 
@@ -188,7 +198,7 @@ func (d ConfigContext) Check() types.DiagnosticResult {
 		unusableLine = fmt.Sprintf("The current client config context '%s' is unusable", d.ContextName)
 	}
 
-	// check that the context and its constitutuents are defined in the kubeconfig
+	// check that the context and its constituents are defined in the kubeconfig
 	context, exists := d.RawConfig.Contexts[d.ContextName]
 	if !exists {
 		r.Error(errorKey, nil, fmt.Sprintf("%s:\n Client config context '%s' is not defined.", unusableLine, d.ContextName))


### PR DESCRIPTION
Avoid re-testing client config contexts that differ only by project.
It's especially annoying when your token expires and you get an
error for every single project you've ever used.