### PR TITLE
Reenabled original registry's /healthz route

### DIFF
--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -256,7 +256,8 @@ func RunCmdRegistry(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, cfg
 							TimeoutSeconds:      5,
 							Handler: kapi.Handler{
 								HTTPGet: &kapi.HTTPGetAction{
-									Path: "/",
+									// TODO: `/healthz` route is deprecated by `/`; remove it in future version
+									Path: "/healthz",
 									Port: kutil.NewIntOrStringFromInt(ports[0].ContainerPort),
 								},
 							},

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -73,6 +73,8 @@ func Execute(configFile io.Reader) {
 
 	app.RegisterHealthChecks()
 	handler := alive("/", app)
+	// TODO: temporarily keep for backwards compatibility; remove in the future
+	handler = alive("/healthz", handler)
 	handler = health.Handler(handler)
 	handler = panicHandler(handler)
 	handler = gorillahandlers.CombinedLoggingHandler(os.Stdout, handler)

--- a/pkg/image/prune/imagepruner.go
+++ b/pkg/image/prune/imagepruner.go
@@ -157,7 +157,8 @@ type defaultRegistryPinger struct {
 
 func (drp *defaultRegistryPinger) ping(registry string) error {
 	healthCheck := func(proto, registry string) error {
-		healthResponse, err := drp.client.Get(fmt.Sprintf("%s://%s/", proto, registry))
+		// TODO: `/healthz` route is deprecated by `/`; remove it in future versions
+		healthResponse, err := drp.client.Get(fmt.Sprintf("%s://%s/healthz", proto, registry))
 		if err != nil {
 			return err
 		}

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -89,6 +89,8 @@ registry="$(dig @${API_HOST} "docker-registry.default.svc.cluster.local." +short
 
 echo "[INFO] Verifying the docker-registry is up at ${DOCKER_REGISTRY}"
 wait_for_url_timed "http://${DOCKER_REGISTRY}/" "[INFO] Docker registry says: " $((2*TIME_MIN))
+# ensure original healthz route works as well
+curl -f "http://${DOCKER_REGISTRY}/healthz"
 
 [ "$(dig @${API_HOST} "docker-registry.default.local." A)" ]
 


### PR DESCRIPTION
`/` health route has been enabled recently as a replacement for `/healthz`. But
there are still old registry images being used. Let's support both of them for
a while and remove `/healthz` in the future.

Resolves: #6440