### PR TITLE
diagnostics: improve master/node config warnings

### DIFF
--- a/pkg/cmd/admin/validate/master.go
+++ b/pkg/cmd/admin/validate/master.go
@@ -60,7 +60,7 @@ func NewCommandValidateMasterConfig(name, fullName string, out io.Writer) *cobra
 				os.Exit(1)
 			}
 
-			fmt.Fprintf(options.Out, "SUCCESS: Validation succeded for file: %s\n", options.MasterConfigFile)
+			fmt.Fprintf(options.Out, "SUCCESS: Validation succeeded for file: %s\n", options.MasterConfigFile)
 		},
 	}
 

--- a/pkg/diagnostics/host/check_master_config.go
+++ b/pkg/diagnostics/host/check_master_config.go
@@ -42,8 +42,20 @@ func (d MasterConfigCheck) Check() types.DiagnosticResult {
 
 	r.Info("DH0003", fmt.Sprintf("Found a master config file: %[1]s", d.MasterConfigFile))
 
-	for _, err := range configvalidation.ValidateMasterConfig(masterConfig).Errors {
-		r.Error("DH0004", err, fmt.Sprintf("Validation of master config file '%s' failed:\n(%T) %[2]v", d.MasterConfigFile, err))
+	results := configvalidation.ValidateMasterConfig(masterConfig)
+	if len(results.Errors) > 0 {
+		errText := fmt.Sprintf("Validation of master config file '%s' failed:\n", d.MasterConfigFile)
+		for _, err := range results.Errors {
+			errText += fmt.Sprintf("%v\n", err)
+		}
+		r.Error("DH0004", nil, errText)
+	}
+	if len(results.Warnings) > 0 {
+		warnText := fmt.Sprintf("Validation of master config file '%s' warned:\n", d.MasterConfigFile)
+		for _, warn := range results.Warnings {
+			warnText += fmt.Sprintf("%v\n", warn)
+		}
+		r.Warn("DH0005", nil, warnText)
 	}
 	return r
 }

--- a/pkg/diagnostics/host/check_node_config.go
+++ b/pkg/diagnostics/host/check_node_config.go
@@ -42,11 +42,19 @@ func (d NodeConfigCheck) Check() types.DiagnosticResult {
 	r.Info("DH1003", fmt.Sprintf("Found a node config file: %[1]s", d.NodeConfigFile))
 
 	results := configvalidation.ValidateNodeConfig(nodeConfig)
-	for _, err := range results.Errors {
-		r.Error("DH1004", err, fmt.Sprintf("Validation of node config file '%s' failed:\n(%T) %[2]v", d.NodeConfigFile, err))
+	if len(results.Errors) > 0 {
+		errText := fmt.Sprintf("Validation of node config file '%s' failed:\n", d.NodeConfigFile)
+		for _, err := range results.Errors {
+			errText += fmt.Sprintf("%v\n", err)
+		}
+		r.Error("DH1004", nil, errText)
 	}
-	for _, err := range results.Warnings {
-		r.Warn("DH1005", err, fmt.Sprintf("Validation of node config file '%s' warning:\n(%T) %[2]v", d.NodeConfigFile, err))
+	if len(results.Warnings) > 0 {
+		warnText := fmt.Sprintf("Validation of node config file '%s' warned:\n", d.NodeConfigFile)
+		for _, warn := range results.Warnings {
+			warnText += fmt.Sprintf("%v\n", warn)
+		}
+		r.Warn("DH1005", nil, warnText)
 	}
 	return r
 }


### PR DESCRIPTION
For diagnostics, the master config validations now report warnings in addition to errors.
Errors/warnings consolidated to one per config, same done for node (which however already reported warnings).