### PR TITLE
fixed shadowed variables in 'template' directory

### DIFF
--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -68,7 +68,7 @@ ALL_DIRS='./cmd
 ./test'
 
 # Whitelist some directories using a `grep`
-SHADOW_TEST_DIRS=$(echo "${ALL_DIRS}" | grep -E "\./stringmatchingnodirs")
+SHADOW_TEST_DIRS=$(echo "${ALL_DIRS}" | grep -E "\./plugins")
 for test_dir in $SHADOW_TEST_DIRS
 do
   go tool vet -shadow -shadowstrict $test_dir

--- a/plugins/router/f5/f5.go
+++ b/plugins/router/f5/f5.go
@@ -757,12 +757,12 @@ func (f5 *f5LTM) ensurePartitionPathExists(pathName string) error {
 	for _, v := range pathComponents {
 		p = path.Join(p, v)
 
-		exists, err := f5.checkPartitionPathExists(p)
+		exists, err = f5.checkPartitionPathExists(p)
 		if err != nil {
 			return err
 		}
 		if !exists {
-			if _, err := f5.addPartitionPath(p); err != nil {
+			if _, err = f5.addPartitionPath(p); err != nil {
 				return err
 			}
 		}
@@ -1519,11 +1519,11 @@ func (f5 *f5LTM) uploadCert(cert, certname string) error {
 		glog.V(4).Infof("Cleaning up tempfile for certificate %s on F5 BIG-IP...",
 			certname)
 		args := f5.buildSshArgs(sshUserHost, "rm", "-f", certfilePath)
-		out, err := execCommand("ssh", args...).CombinedOutput()
-		if err != nil {
+		out, execErr := execCommand("ssh", args...).CombinedOutput()
+		if execErr != nil {
 			glog.Errorf("Error deleting tempfile for certificate %s from F5 BIG-IP.\n"+
 				"\tOutput from ssh command: %s\n\tError: %v",
-				certname, out, err)
+				certname, out, execErr)
 		}
 	}()
 	out, err := execCommand("scp", args...).CombinedOutput()
@@ -1588,11 +1588,11 @@ func (f5 *f5LTM) uploadKey(privkey, keyname string) error {
 		glog.V(4).Infof("Cleaning up tempfile for key %s on F5 BIG-IP...",
 			keyname)
 		args := f5.buildSshArgs(sshUserHost, "rm", "-f", keyfilePath)
-		out, err := execCommand("ssh", args...).CombinedOutput()
-		if err != nil {
+		out, execErr := execCommand("ssh", args...).CombinedOutput()
+		if execErr != nil {
 			glog.Errorf("Error deleting tempfile for key %ss from F5 BIG-IP.\n"+
 				"\tOutput from ssh command: %s\n\tError: %v",
-				keyname, out, err)
+				keyname, out, execErr)
 		}
 	}()
 	out, err := execCommand("scp", args...).CombinedOutput()

--- a/plugins/router/f5/plugin.go
+++ b/plugins/router/f5/plugin.go
@@ -198,10 +198,10 @@ func (p *F5Plugin) deletePoolIfEmpty(poolname string) error {
 	}
 
 	if poolExists {
-		members, err := p.F5Client.GetPoolMembers(poolname)
-		if err != nil {
-			glog.V(4).Infof("F5Client.GetPoolMembers failed: %v", err)
-			return err
+		members, getErr := p.F5Client.GetPoolMembers(poolname)
+		if getErr != nil {
+			glog.V(4).Infof("F5Client.GetPoolMembers failed: %v", getErr)
+			return getErr
 		}
 
 		// We only delete the pool if the pool is empty, which it may not be

--- a/plugins/router/f5/plugin_test.go
+++ b/plugins/router/f5/plugin_test.go
@@ -1459,9 +1459,9 @@ func TestHandleEndpoints(t *testing.T) {
 			validate: func() error {
 				poolName := "openshift_foo_test"
 
-				poolExists, err := router.F5Client.PoolExists(poolName)
-				if err != nil {
-					return fmt.Errorf("PoolExists(%s) failed: %v", poolName, err)
+				poolExists, existsErr := router.F5Client.PoolExists(poolName)
+				if existsErr != nil {
+					return fmt.Errorf("PoolExists(%s) failed: %v", poolName, existsErr)
 				}
 
 				if poolExists != true {
@@ -1471,10 +1471,10 @@ func TestHandleEndpoints(t *testing.T) {
 
 				memberName := "1.1.1.1:345"
 
-				poolHasMember, err := router.F5Client.PoolHasMember(poolName, memberName)
-				if err != nil {
+				poolHasMember, hasErr := router.F5Client.PoolHasMember(poolName, memberName)
+				if hasErr != nil {
 					return fmt.Errorf("PoolHasMember(%s, %s) failed: %v",
-						poolName, memberName, err)
+						poolName, memberName, hasErr)
 				}
 
 				if poolHasMember != true {
@@ -1501,9 +1501,9 @@ func TestHandleEndpoints(t *testing.T) {
 			validate: func() error {
 				poolName := "openshift_foo_test"
 
-				poolExists, err := router.F5Client.PoolExists(poolName)
-				if err != nil {
-					return fmt.Errorf("PoolExists(%s) failed: %v", poolName, err)
+				poolExists, existsErr := router.F5Client.PoolExists(poolName)
+				if existsErr != nil {
+					return fmt.Errorf("PoolExists(%s) failed: %v", poolName, existsErr)
 				}
 
 				if poolExists != true {
@@ -1513,10 +1513,10 @@ func TestHandleEndpoints(t *testing.T) {
 
 				memberName := "2.2.2.2:8080"
 
-				poolHasMember, err := router.F5Client.PoolHasMember(poolName, memberName)
-				if err != nil {
+				poolHasMember, hasErr := router.F5Client.PoolHasMember(poolName, memberName)
+				if hasErr != nil {
 					return fmt.Errorf("PoolHasMember(%s, %s) failed: %v",
-						poolName, memberName, err)
+						poolName, memberName, hasErr)
 				}
 
 				if poolHasMember != true {
@@ -1540,9 +1540,9 @@ func TestHandleEndpoints(t *testing.T) {
 			validate: func() error {
 				poolName := "openshift_foo_test"
 
-				poolExists, err := router.F5Client.PoolExists(poolName)
-				if err != nil {
-					return fmt.Errorf("PoolExists(%s) failed: %v", poolName, err)
+				poolExists, existsErr := router.F5Client.PoolExists(poolName)
+				if existsErr != nil {
+					return fmt.Errorf("PoolExists(%s) failed: %v", poolName, existsErr)
 				}
 
 				if poolExists != false {

--- a/plugins/router/template/plugin_test.go
+++ b/plugins/router/template/plugin_test.go
@@ -380,9 +380,9 @@ func TestHandleRoute(t *testing.T) {
 	if !ok {
 		t.Errorf("TestHandleRoute was unable to find the service unit %s after HandleRoute was called", route.Spec.To.Name)
 	} else {
-		serviceAliasCfg, ok := actualSU.ServiceAliasConfigs[router.routeKey(route)]
+		serviceAliasCfg, routeKeyOK := actualSU.ServiceAliasConfigs[router.routeKey(route)]
 
-		if !ok {
+		if !routeKeyOK {
 			t.Errorf("TestHandleRoute expected route key %s", router.routeKey(route))
 		} else {
 			if serviceAliasCfg.Host != route.Spec.Host || serviceAliasCfg.Path != route.Spec.Path {
@@ -408,10 +408,10 @@ func TestHandleRoute(t *testing.T) {
 	if err := plugin.HandleRoute(watch.Added, duplicateRoute); err == nil {
 		t.Fatal("unexpected non-error")
 	}
-	if _, ok := router.FindServiceUnit("foo/TestService2"); ok {
+	if _, ok = router.FindServiceUnit("foo/TestService2"); ok {
 		t.Fatalf("unexpected second unit: %#v", router)
 	}
-	if r, ok := plugin.RoutesForHost("www.example.com"); !ok || r[0].Name != "test" {
+	if r, routeOK := plugin.RoutesForHost("www.example.com"); !routeOK || r[0].Name != "test" {
 		t.Fatalf("unexpected claimed routes: %#v", r)
 	}
 
@@ -419,13 +419,13 @@ func TestHandleRoute(t *testing.T) {
 	if err := plugin.HandleRoute(watch.Deleted, duplicateRoute); err == nil {
 		t.Fatal("unexpected non-error")
 	}
-	if _, ok := router.FindServiceUnit("foo/TestService2"); ok {
+	if _, ok = router.FindServiceUnit("foo/TestService2"); ok {
 		t.Fatalf("unexpected second unit: %#v", router)
 	}
-	if _, ok := router.FindServiceUnit("foo/TestService"); !ok {
+	if _, ok = router.FindServiceUnit("foo/TestService"); !ok {
 		t.Fatalf("unexpected first unit: %#v", router)
 	}
-	if r, ok := plugin.RoutesForHost("www.example.com"); !ok || r[0].Name != "test" {
+	if r, routeOK := plugin.RoutesForHost("www.example.com"); !routeOK || r[0].Name != "test" {
 		t.Fatalf("unexpected claimed routes: %#v", r)
 	}
 
@@ -441,7 +441,7 @@ func TestHandleRoute(t *testing.T) {
 	if len(actualSU.ServiceAliasConfigs) != 0 || len(otherSU.ServiceAliasConfigs) != 1 {
 		t.Errorf("incorrect router state: %#v", router)
 	}
-	if _, ok := actualSU.ServiceAliasConfigs[router.routeKey(route)]; ok {
+	if _, ok = actualSU.ServiceAliasConfigs[router.routeKey(route)]; ok {
 		t.Errorf("unexpected service alias config %s", router.routeKey(route))
 	}
 
@@ -457,9 +457,9 @@ func TestHandleRoute(t *testing.T) {
 	if !ok {
 		t.Errorf("TestHandleRoute was unable to find the service unit %s after HandleRoute was called", route.Spec.To.Name)
 	} else {
-		serviceAliasCfg, ok := actualSU.ServiceAliasConfigs[router.routeKey(route)]
+		serviceAliasCfg, serviceAliasOK := actualSU.ServiceAliasConfigs[router.routeKey(route)]
 
-		if !ok {
+		if !serviceAliasOK {
 			t.Errorf("TestHandleRoute expected route key %s", router.routeKey(route))
 		} else {
 			if serviceAliasCfg.Host != route.Spec.Host || serviceAliasCfg.Path != route.Spec.Path {
@@ -482,7 +482,7 @@ func TestHandleRoute(t *testing.T) {
 	if !ok {
 		t.Errorf("TestHandleRoute was unable to find the service unit %s after HandleRoute was called", route.Spec.To.Name)
 	} else {
-		_, ok := actualSU.ServiceAliasConfigs[router.routeKey(route)]
+		_, ok = actualSU.ServiceAliasConfigs[router.routeKey(route)]
 
 		if ok {
 			t.Errorf("TestHandleRoute did not expect route key %s", router.routeKey(route))

--- a/plugins/router/template/router_test.go
+++ b/plugins/router/template/router_test.go
@@ -168,7 +168,7 @@ func TestDeleteEndpoints(t *testing.T) {
 		} else {
 			router.DeleteEndpoints(suKey)
 
-			su, ok := router.FindServiceUnit(suKey)
+			su, ok = router.FindServiceUnit(suKey)
 
 			if !ok {
 				t.Errorf("Unable to find created service unit %s", suKey)
@@ -265,7 +265,7 @@ func TestRouteKey(t *testing.T) {
 		}
 
 		routeKey := router.routeKey(route)
-		_, ok := su.ServiceAliasConfigs[routeKey]
+		_, ok = su.ServiceAliasConfigs[routeKey]
 		if !ok {
 			t.Errorf("Unable to find created service alias config for route %s", routeKey)
 		}
@@ -314,9 +314,9 @@ func TestAddRoute(t *testing.T) {
 		t.Errorf("Unable to find created service unit %s", suKey)
 	} else {
 		routeKey := router.routeKey(route)
-		saCfg, ok := su.ServiceAliasConfigs[routeKey]
+		saCfg, saOK := su.ServiceAliasConfigs[routeKey]
 
-		if !ok {
+		if !saOK {
 			t.Errorf("Unable to find created serivce alias config for route %s", routeKey)
 		} else {
 			if saCfg.Host != route.Spec.Host || saCfg.Path != route.Spec.Path || !compareTLS(route, saCfg, t) {
@@ -402,10 +402,10 @@ func TestRemoveRoute(t *testing.T) {
 
 	router.RemoveRoute(suKey, route)
 	su, _ = router.FindServiceUnit(suKey)
-	if _, ok := su.ServiceAliasConfigs[routeKey]; ok {
+	if _, ok = su.ServiceAliasConfigs[routeKey]; ok {
 		t.Errorf("Route %v was expected to be deleted but was still found", route)
 	}
-	if _, ok := su.ServiceAliasConfigs[router.routeKey(route2)]; !ok {
+	if _, ok = su.ServiceAliasConfigs[router.routeKey(route2)]; !ok {
 		t.Errorf("Route %v was expected to exist but was not found", route2)
 	}
 }
@@ -695,9 +695,9 @@ func TestAddRouteEdgeTerminationInsecurePolicy(t *testing.T) {
 				tc.Name, suKey)
 		} else {
 			routeKey := router.routeKey(route)
-			saCfg, ok := su.ServiceAliasConfigs[routeKey]
+			saCfg, saOK := su.ServiceAliasConfigs[routeKey]
 
-			if !ok {
+			if !saOK {
 				t.Errorf("InsecureEdgeTerminationPolicy test %s: unable to find created service alias config for route %s",
 					tc.Name, routeKey)
 			} else {


### PR DESCRIPTION
This pull turns on `shadow` testing for `go tool vet` and fixes any shadowed variables detected by the tool in the `plugins` directory.


@liggitt @smarterclayton  FYI

@ramr @Miciah PTAL