### PR TITLE
Revert "warn on missing log and metric URLs for console"

### DIFF
--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -317,16 +317,12 @@ func ValidateAssetConfig(config *api.AssetConfig) ValidationResults {
 		if _, loggingURLErrs := ValidateSecureURL(config.LoggingPublicURL, "loggingPublicURL"); len(loggingURLErrs) > 0 {
 			validationResults.AddErrors(loggingURLErrs...)
 		}
-	} else {
-		validationResults.AddWarnings(fielderrors.NewFieldInvalid("loggingPublicURL", "", "required to view aggregated container logs in the console"))
 	}
 
 	if len(config.MetricsPublicURL) > 0 {
 		if _, metricsURLErrs := ValidateSecureURL(config.MetricsPublicURL, "metricsPublicURL"); len(metricsURLErrs) > 0 {
 			validationResults.AddErrors(metricsURLErrs...)
 		}
-	} else {
-		validationResults.AddWarnings(fielderrors.NewFieldInvalid("metricsPublicURL", "", "required to view cluster metrics in the console"))
 	}
 
 	for i, scriptFile := range config.ExtensionScripts {


### PR DESCRIPTION
This reverts commit 363e9a33daa9d9fd737932aec5aeb9ccb0bb7973.

I contend that a warning for this validation is counterproductive. It is not invalid to run without aggregated logging/metrics, and since the config object doesn't represent a difference between missing and "deliberately left empty" the only way to shut up the warning is to put something in the config. This implies either going through the substantial exercise of deploying the subsystem... or misconfiguring the system as if you had. Not a good choice to force on users.

Meanwhile, if users actually deploy the relevant subsystem(s) at some point, they are bound to come across the instructions for configuring the referring URLs. They don't particularly need a warning to alert them to a new optional feature.