### PR TITLE
diagnostics: logs and units for origin

### DIFF
--- a/pkg/diagnostics/systemd/analyze_logs.go
+++ b/pkg/diagnostics/systemd/analyze_logs.go
@@ -58,79 +58,81 @@ func (d AnalyzeLogs) Check() types.DiagnosticResult {
 	r := types.NewDiagnosticResult(AnalyzeLogsName)
 
 	for _, unit := range unitLogSpecs {
-		if svc := d.SystemdUnits[unit.Name]; svc.Enabled || svc.Active {
-			r.Info("DS0001", fmt.Sprintf("Checking journalctl logs for '%s' service", unit.Name))
+		for _, unitName := range unit.Names {
+			if svc := d.SystemdUnits[unitName]; svc.Enabled || svc.Active {
+				r.Info("DS0001", fmt.Sprintf("Checking journalctl logs for '%s' service", unitName))
 
-			cmd := exec.Command("journalctl", "-ru", unit.Name, "--output=json")
-			// JSON comes out of journalctl one line per record
-			lineReader, reader, err := func(cmd *exec.Cmd) (*bufio.Scanner, io.ReadCloser, error) {
-				stdout, err := cmd.StdoutPipe()
-				if err == nil {
-					lineReader := bufio.NewScanner(stdout)
-					if err = cmd.Start(); err == nil {
-						return lineReader, stdout, nil
+				cmd := exec.Command("journalctl", "-ru", unitName, "--output=json")
+				// JSON comes out of journalctl one line per record
+				lineReader, reader, err := func(cmd *exec.Cmd) (*bufio.Scanner, io.ReadCloser, error) {
+					stdout, err := cmd.StdoutPipe()
+					if err == nil {
+						lineReader := bufio.NewScanner(stdout)
+						if err = cmd.Start(); err == nil {
+							return lineReader, stdout, nil
+						}
 					}
-				}
-				return nil, nil, err
-			}(cmd)
+					return nil, nil, err
+				}(cmd)
 
-			if err != nil {
-				r.Error("DS0002", err, fmt.Sprintf(sdLogReadErr, unit.Name, errStr(err)))
-				return r
-			}
-			defer func() { // close out pipe once done reading
-				reader.Close()
-				cmd.Wait()
-			}()
-			timeLimit := time.Now().Add(-time.Hour)                     // if it didn't happen in the last hour, probably not too relevant
-			matchCopy := append([]logMatcher(nil), unit.LogMatchers...) // make a copy, will remove matchers after they match something
-			lineCount := 0                                              // each log entry is a line
-			for lineReader.Scan() {
-				lineCount += 1
-				if len(matchCopy) == 0 { // if no rules remain to match
-					break // don't waste time reading more log entries
+				if err != nil {
+					r.Error("DS0002", err, fmt.Sprintf(sdLogReadErr, unitName, errStr(err)))
+					return r
 				}
-				bytes, entry := lineReader.Bytes(), logEntry{}
-				if err := json.Unmarshal(bytes, &entry); err != nil {
-					r.Debug("DS0003", fmt.Sprintf("Couldn't read the JSON for this log message:\n%s\nGot error %s", string(bytes), errStr(err)))
-				} else {
-					if lineCount > 500 && stampTooOld(entry.TimeStamp, timeLimit) {
-						r.Debug("DS0004", fmt.Sprintf("Stopped reading %s log: timestamp %s too old", unit.Name, entry.TimeStamp))
-						break // if we've analyzed at least 500 entries, stop when age limit reached (don't scan days of logs)
+				defer func() { // close out pipe once done reading
+					reader.Close()
+					cmd.Wait()
+				}()
+				timeLimit := time.Now().Add(-time.Hour)                     // if it didn't happen in the last hour, probably not too relevant
+				matchCopy := append([]logMatcher(nil), unit.LogMatchers...) // make a copy, will remove matchers after they match something
+				lineCount := 0                                              // each log entry is a line
+				for lineReader.Scan() {
+					lineCount += 1
+					if len(matchCopy) == 0 { // if no rules remain to match
+						break // don't waste time reading more log entries
 					}
-					if unit.StartMatch.MatchString(entry.Message) {
-						break // saw log message for unit startup; don't analyze previous logs
-					}
-					for index, match := range matchCopy { // match log message against provided matchers
-						if strings := match.Regexp.FindStringSubmatch(entry.Message); strings != nil {
-							// if matches: print interpretation, remove from matchCopy, and go on to next log entry
-							keep := match.KeepAfterMatch // generic keep logic
-							if match.Interpret != nil {  // apply custom match logic
-								currKeep := match.Interpret(&entry, strings, r)
-								keep = currKeep
-							} else { // apply generic match processing
-								text := fmt.Sprintf("Found '%s' journald log message:\n  %s\n%s", unit.Name, entry.Message, match.Interpretation)
-								switch match.Level {
-								case log.DebugLevel:
-									r.Debug(match.Id, text)
-								case log.InfoLevel:
-									r.Info(match.Id, text)
-								case log.WarnLevel:
-									r.Warn(match.Id, nil, text)
-								case log.ErrorLevel:
-									r.Error(match.Id, nil, text)
+					bytes, entry := lineReader.Bytes(), logEntry{}
+					if err := json.Unmarshal(bytes, &entry); err != nil {
+						r.Debug("DS0003", fmt.Sprintf("Couldn't read the JSON for this log message:\n%s\nGot error %s", string(bytes), errStr(err)))
+					} else {
+						if lineCount > 500 && stampTooOld(entry.TimeStamp, timeLimit) {
+							r.Debug("DS0004", fmt.Sprintf("Stopped reading %s log: timestamp %s too old", unitName, entry.TimeStamp))
+							break // if we've analyzed at least 500 entries, stop when age limit reached (don't scan days of logs)
+						}
+						if unit.StartMatch.MatchString(entry.Message) {
+							break // saw log message for unit startup; don't analyze previous logs
+						}
+						for index, match := range matchCopy { // match log message against provided matchers
+							if strings := match.Regexp.FindStringSubmatch(entry.Message); strings != nil {
+								// if matches: print interpretation, remove from matchCopy, and go on to next log entry
+								keep := match.KeepAfterMatch // generic keep logic
+								if match.Interpret != nil {  // apply custom match logic
+									currKeep := match.Interpret(&entry, strings, r)
+									keep = currKeep
+								} else { // apply generic match processing
+									text := fmt.Sprintf("Found '%s' journald log message:\n  %s\n%s", unitName, entry.Message, match.Interpretation)
+									switch match.Level {
+									case log.DebugLevel:
+										r.Debug(match.Id, text)
+									case log.InfoLevel:
+										r.Info(match.Id, text)
+									case log.WarnLevel:
+										r.Warn(match.Id, nil, text)
+									case log.ErrorLevel:
+										r.Error(match.Id, nil, text)
+									}
 								}
-							}
 
-							if !keep { // remove matcher once seen
-								matchCopy = append(matchCopy[:index], matchCopy[index+1:]...)
+								if !keep { // remove matcher once seen
+									matchCopy = append(matchCopy[:index], matchCopy[index+1:]...)
+								}
+								break
 							}
-							break
 						}
 					}
 				}
-			}
 
+			}
 		}
 	}
 

--- a/pkg/diagnostics/systemd/locate_units.go
+++ b/pkg/diagnostics/systemd/locate_units.go
@@ -30,7 +30,7 @@ func GetSystemdUnits(logger *log.Logger) map[string]types.SystemdUnit {
 	}
 
 	logger.Notice("DS1001", "Performing systemd discovery")
-	for _, name := range []string{"openshift", "atomic-openshift-master", "atomic-openshift-node", "docker", "openvswitch", "iptables", "etcd", "kubernetes"} {
+	for _, name := range []string{"origin-master", "origin-node", "atomic-openshift-master", "atomic-openshift-node", "docker", "openvswitch", "iptables", "etcd", "kubernetes"} {
 		systemdUnits[name] = discoverSystemdUnit(logger, name)
 
 		if systemdUnits[name].Exists {


### PR DESCRIPTION
Origin systemd units are now origin-{master,node} parallel to
enterprise atomic-openshift-{master,node}. This change adjusts
log analysis and unit status diagnostics to recognize the Origin unit
names and treat them like the Enterprise names.