### PR TITLE
Add the ability to disable SSL verification on git over HTTPS

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14743,6 +14743,10 @@
      "httpsProxy": {
       "type": "string",
       "description": "specifies a https proxy to be used during git clone operations"
+     },
+     "disableSSLCheck": {
+      "type": "boolean",
+      "description": "whether to verify the SSL certificate when fetching or pushing over HTTPS"
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1190,6 +1190,7 @@ func deepCopy_api_GitBuildSource(in buildapi.GitBuildSource, out *buildapi.GitBu
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1650,6 +1650,7 @@ func autoconvert_api_GitBuildSource_To_v1_GitBuildSource(in *buildapi.GitBuildSo
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 
@@ -2365,6 +2366,7 @@ func autoconvert_v1_GitBuildSource_To_api_GitBuildSource(in *apiv1.GitBuildSourc
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1216,6 +1216,7 @@ func deepCopy_v1_GitBuildSource(in apiv1.GitBuildSource, out *apiv1.GitBuildSour
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1659,6 +1659,7 @@ func autoconvert_api_GitBuildSource_To_v1beta3_GitBuildSource(in *buildapi.GitBu
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 
@@ -2374,6 +2375,7 @@ func autoconvert_v1beta3_GitBuildSource_To_api_GitBuildSource(in *apiv1beta3.Git
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1224,6 +1224,7 @@ func deepCopy_v1beta3_GitBuildSource(in apiv1beta3.GitBuildSource, out *apiv1bet
 	out.Ref = in.Ref
 	out.HTTPProxy = in.HTTPProxy
 	out.HTTPSProxy = in.HTTPSProxy
+	out.DisableSSLCheck = in.DisableSSLCheck
 	return nil
 }
 

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -246,6 +246,9 @@ type GitBuildSource struct {
 
 	// HTTPSProxy is a proxy used to reach the git repository over https
 	HTTPSProxy string
+
+	// DisableSSLCheck controls whether to verify the SSL certificate over HTTPS
+	DisableSSLCheck bool
 }
 
 // SourceControlUser defines the identity of a user of source control

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -219,6 +219,8 @@ type GitBuildSource struct {
 
 	// HTTPSProxy is a proxy used to reach the git repository over https
 	HTTPSProxy string `json:"httpsProxy,omitempty" description:"specifies a https proxy to be used during git clone operations"`
+
+	DisableSSLCheck bool `json:"disableSSLCheck,omitempty" description:"whether to verify the SSL certificate when fetching or pushing over HTTPS"`
 }
 
 // SourceControlUser defines the identity of a user of source control

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -212,6 +212,8 @@ type GitBuildSource struct {
 
 	// HTTPSProxy is a proxy used to reach the git repository over https
 	HTTPSProxy string `json:"httpsProxy,omitempty" description:"specifies a https proxy to be used during git clone operations"`
+
+	DisableSSLCheck bool `json:"disableSSLCheck,omitempty" description:"whether to verify the SSL certificate when fetching or pushing over HTTPS"`
 }
 
 // SourceControlUser defines the identity of a user of source control

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -79,6 +79,11 @@ func (c *builderConfig) setupGitEnvironment() ([]string, error) {
 
 	sourceSecret := c.build.Spec.Source.SourceSecret
 	gitEnv := []string{"GIT_ASKPASS=true"}
+
+	if gitSource.DisableSSLCheck {
+		gitEnv = append(gitEnv, "GIT_SSL_NO_VERIFY=true")
+	}
+
 	// If a source secret is present, set it up and add its environment variables
 	if sourceSecret != nil {
 		// TODO: this should be refactored to let each source type manage which secrets


### PR DESCRIPTION
Attempt to fix #6267.

This is done through the new boolean field "disableSSLCheck" inside GitBuildSource
object.

The use case is to allow the user to specify a git repository with a self-signed
SSL certificate. Currently sti build fails at git (ls-remote|clone) stage.

So, one can write a template like this
               ...
                "source": {
                    "contextDir": "${CONTEXT_DIR}",
                    "git": {
                        "disableSSLCheck": true,
                        "ref": "${SOURCE_REPOSITORY_REF}",
                        "uri": "${SOURCE_REPOSITORY_URL}"
                    },
                    "type": "Git"
                ...

In the future, with #3946 implemented, one might use a boolean parameter in the
template and have it rendered into a checkbox in the UI.