### PR TITLE
stop etcd from retrying failures

### DIFF
--- a/pkg/cmd/server/etcd/etcd.go
+++ b/pkg/cmd/server/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"time"
 
 	etcdclient "github.com/coreos/go-etcd/etcd"
@@ -114,6 +115,7 @@ func EtcdClient(etcdClientInfo configapi.EtcdConnectionInfo) (*etcdclient.Client
 
 	etcdClient := etcdclient.NewClient(etcdClientInfo.URLs)
 	etcdClient.SetTransport(transport)
+	etcdClient.CheckRetry = NeverRetryOnFailure
 	return etcdClient, nil
 }
 
@@ -132,4 +134,20 @@ func TestEtcdClient(etcdClient *etcdclient.Client) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return nil
+}
+
+// NeverRetryOnFailure is a retry function for the etcdClient.  If there's only one machine, master election doesn't make much sense,
+// so we don't bother to retry, we simply dump the failure and return the error directly.
+func NeverRetryOnFailure(cluster *etcdclient.Cluster, numReqs int, lastResp http.Response, err error) error {
+	if len(cluster.Machines) > 1 {
+		return etcdclient.DefaultCheckRetry(cluster, numReqs, lastResp, err)
+	}
+
+	content, err := httputil.DumpResponse(&lastResp, true)
+	if err != nil {
+		glog.Errorf("failure dumping response: %v", err)
+	} else {
+		glog.Errorf("etcd failure response: %s", string(content))
+	}
+	return err
 }


### PR DESCRIPTION
Stop the etcdclient from retrying on our behalf and add logging to it.  We might actually want to do this, but for now its for gathering info about flakes.

@liggitt @smarterclayton opinions?  I guess I'll see how often this is actually happening for us, but I like the idea of trying once and failing instead of trying multiple times.

[test]