### PR TITLE
Wait for access tokens to be available in clustered etcd

### DIFF
--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -100,9 +100,9 @@ func (c *AuthConfig) InstallAPI(container *restful.Container) []string {
 	// TODO: register into container
 	mux := container.ServeMux
 
-	accessTokenStorage := accesstokenetcd.NewREST(c.EtcdHelper)
+	accessTokenStorage := accesstokenetcd.NewREST(c.EtcdHelper, c.EtcdBackends...)
 	accessTokenRegistry := accesstokenregistry.NewRegistry(accessTokenStorage)
-	authorizeTokenStorage := authorizetokenetcd.NewREST(c.EtcdHelper)
+	authorizeTokenStorage := authorizetokenetcd.NewREST(c.EtcdHelper, c.EtcdBackends...)
 	authorizeTokenRegistry := authorizetokenregistry.NewRegistry(authorizeTokenStorage)
 	clientStorage := clientetcd.NewREST(c.EtcdHelper)
 	clientRegistry := clientregistry.NewRegistry(clientStorage)

--- a/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
@@ -1,7 +1,10 @@
 package etcd
 
 import (
+	"time"
+
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
@@ -12,6 +15,7 @@ import (
 	"github.com/openshift/origin/pkg/oauth/api"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	"github.com/openshift/origin/pkg/util"
+	"github.com/openshift/origin/pkg/util/observe"
 )
 
 // rest implements a RESTStorage for access tokens against etcd
@@ -23,7 +27,7 @@ type REST struct {
 const EtcdPrefix = "/oauth/accesstokens"
 
 // NewREST returns a RESTStorage object that will work against access tokens
-func NewREST(s storage.Interface) *REST {
+func NewREST(s storage.Interface, backends ...storage.Interface) *REST {
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.OAuthAccessToken{} },
 		NewListFunc: func() runtime.Object { return &api.OAuthAccessTokenList{} },
@@ -51,6 +55,22 @@ func NewREST(s storage.Interface) *REST {
 	}
 
 	store.CreateStrategy = oauthaccesstoken.Strategy
+
+	if len(backends) > 0 {
+		// Build identical stores that talk to a single etcd, so we can verify the token is distributed after creation
+		watchers := []rest.Watcher{}
+		for i := range backends {
+			watcher := *store
+			watcher.Storage = backends[i]
+			watchers = append(watchers, &watcher)
+		}
+		// Observe the cluster for the particular resource version, requiring at least one backend to succeed
+		observer := observe.NewClusterObserver(s.Versioner(), watchers, 1)
+		// After creation, wait for the new token to propagate
+		store.AfterCreate = func(obj runtime.Object) error {
+			return observer.ObserveResourceVersion(obj.(*api.OAuthAccessToken).ResourceVersion, 5*time.Second)
+		}
+	}
 
 	return &REST{store}
 }

--- a/pkg/util/observe/cluster.go
+++ b/pkg/util/observe/cluster.go
@@ -1,0 +1,125 @@
+package observe
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/storage"
+	kutil "k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/watch"
+
+	"github.com/golang/glog"
+)
+
+type clusterResourceVersionObserver struct {
+	versioner        storage.Versioner
+	watchers         []rest.Watcher
+	successThreshold int
+}
+
+// NewClusterObserver returns a ResourceVersionObserver that watches for the specified resourceVersion on all of the provided watchers.
+// If at least successThreshold watchers observe the resourceVersion within the timeout, no error is returned.
+func NewClusterObserver(versioner storage.Versioner, watchers []rest.Watcher, successThreshold int) ResourceVersionObserver {
+	return &clusterResourceVersionObserver{
+		versioner:        versioner,
+		watchers:         watchers,
+		successThreshold: successThreshold,
+	}
+}
+
+func (c *clusterResourceVersionObserver) ObserveResourceVersion(resourceVersion string, timeout time.Duration) error {
+	if len(c.watchers) == 0 {
+		return nil
+	}
+
+	wg := &sync.WaitGroup{}
+	backendErrors := make([]error, len(c.watchers), len(c.watchers))
+	for i, watcher := range c.watchers {
+		wg.Add(1)
+		go func(i int, watcher rest.Watcher) {
+			defer kutil.HandleCrash()
+			defer wg.Done()
+			backendErrors[i] = watchForResourceVersion(c.versioner, watcher, resourceVersion, timeout)
+		}(i, watcher)
+	}
+
+	glog.V(5).Infof("waiting for resourceVersion %s to be distributed", resourceVersion)
+	wg.Wait()
+
+	successes := 0
+	for _, err := range backendErrors {
+		if err == nil {
+			successes++
+		} else {
+			glog.V(4).Infof("error verifying resourceVersion %s: %v", resourceVersion, err)
+		}
+	}
+	glog.V(5).Infof("resourceVersion %s was distributed to %d etcd cluster members (out of %d)", resourceVersion, successes, len(c.watchers))
+
+	if successes >= c.successThreshold {
+		return nil
+	}
+
+	return fmt.Errorf("resourceVersion %s was observed on %d cluster members (threshold %d): %v", resourceVersion, successes, c.successThreshold, backendErrors)
+}
+
+// watchForResourceVersion watches for an Add/Modify event matching the given resourceVersion.
+// If an error, timeout, or unexpected event is received, an error is returned.
+// If an add/modify event is observed with the correct resource version, nil is returned.
+func watchForResourceVersion(versioner storage.Versioner, watcher rest.Watcher, resourceVersion string, timeout time.Duration) error {
+	// Watch from the previous resource version, so the first watch event is the desired version
+	previousVersion, err := previousResourceVersion(versioner, resourceVersion)
+	if err != nil {
+		return err
+	}
+
+	w, err := watcher.Watch(context.TODO(), labels.Everything(), fields.Everything(), previousVersion)
+	if err != nil {
+		return fmt.Errorf("error verifying resourceVersion %s: %v", resourceVersion, err)
+	}
+	defer w.Stop()
+
+	select {
+	case event := <-w.ResultChan():
+		if event.Type != watch.Added && event.Type != watch.Modified {
+			return fmt.Errorf("unexpected watch event verifying resourceVersion %s: %q", resourceVersion, event.Type)
+		}
+		if event.Object == nil {
+			return fmt.Errorf("unexpected watch event verifying resourceVersion %s: object was nil", resourceVersion)
+		}
+		accessor, err := meta.Accessor(event.Object)
+		if err != nil {
+			return err
+		}
+		actualResourceVersion := accessor.ResourceVersion()
+		if actualResourceVersion != resourceVersion {
+			return fmt.Errorf("unexpected watch event verifying resourceVersion %s: resource version was %s)", resourceVersion, actualResourceVersion)
+		}
+		return nil
+
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout verifying resourceVersion %s", resourceVersion)
+	}
+}
+
+// previousResourceVersion returns the resource version one prior to the given resourceVersion.
+// The first event seen by a watch started at the returned version should be the create/update of the object.
+func previousResourceVersion(v storage.Versioner, resourceVersion string) (string, error) {
+	// Any API object will do. We'll just use an Event
+	e := &kapi.Event{}
+	e.ResourceVersion = resourceVersion
+	version, err := v.ObjectResourceVersion(e)
+	if err != nil {
+		return "", err
+	}
+	v.UpdateObject(e, nil, version-1)
+	return e.ResourceVersion, nil
+}

--- a/pkg/util/observe/interfaces.go
+++ b/pkg/util/observe/interfaces.go
@@ -1,0 +1,8 @@
+package observe
+
+import "time"
+
+type ResourceVersionObserver interface {
+	// ObserveResourceVersion waits until the given resourceVersion is observed, up to the specified timeout.
+	ObserveResourceVersion(resourceVersion string, timeout time.Duration) error
+}


### PR DESCRIPTION
Adds the ability to wait until etcd cluster members have observed a specific resourceVersion before returning newly minted OAuth authorization and access tokens, since those are expected to be able to be used immediately, even in an HA cluster