### PR TITLE
Print more enlightening string if test fails

### DIFF
--- a/pkg/generate/git/git_test.go
+++ b/pkg/generate/git/git_test.go
@@ -112,7 +112,7 @@ func TestParseRepository(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(*got, want) {
-			t.Errorf("%s: got %v, want %v", scenario, got, want)
+			t.Errorf("%s: got %#v, want %#v", scenario, *got, want)
 		}
 	}
 }


### PR DESCRIPTION
This is to help understand and kill the flake reported in #6455.