### PR TITLE
new-app: search local docker daemon if registry search fails

### DIFF
--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -566,8 +566,7 @@ The '%[2]s' command will match arguments to the following types:
   3. Templates in the current project or the 'openshift' project
   4. Git repository URLs or local paths that point to Git repositories
 
---allow-missing-images can be used to point to an image that does not exist yet
-or is only on the local system.
+--allow-missing-images can be used to point to an image that does not exist yet.
 
 See '%[2]s' for examples.
 `, t, c.Name())

--- a/pkg/generate/app/dockerimagelookup.go
+++ b/pkg/generate/app/dockerimagelookup.go
@@ -63,7 +63,7 @@ func (r DockerClientSearcher) Search(terms ...string) (ComponentMatches, error) 
 				termMatches = append(termMatches, matches...)
 			case ErrNoMatch:
 			default:
-				return nil, err
+				glog.V(5).Infof("An error occurred searching remote registry for %q: %v", ref.String(), err)
 			}
 		}
 


### PR DESCRIPTION
Prevent return with error when an error occurs searching a docker registry.

Fixes #6516