### PR TITLE
[DO-NOT-MERGE] Add optional E2E test artifact to binary artifacts for openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ all build:
 	hack/build-go.sh $(WHAT)
 .PHONY: all build
 
+# Build Code with E2E tests artifact.
+# Example:
+# make e2e
+e2e:
+	hack/build-go.sh test/e2e/e2e.test
+.PHONY: e2e
+
 # Build and run unit tests
 #
 # Args:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,9 +1,10 @@
 package e2e
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	"k8s.io/kubernetes/test/e2e"
-	"testing"
 )
 
 var _ = Describe("Custom Extension", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,20 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	"k8s.io/kubernetes/test/e2e"
+	"testing"
+)
+
+var _ = Describe("Custom Extension", func() {
+	It("Should be extensible", func() {
+		By("Adding a new test on top of the other E2Es")
+		if 1 == 0 {
+			e2e.Failf("example test, will never fail.")
+		}
+	})
+})
+
+func TestE2EWrapper(t *testing.T) {
+	e2e.TestE2E(t)
+}


### PR DESCRIPTION
Im now testing this on real clusters, will update accordingly.  This Implementation takes into account all feedback from the previous implementation, and rolls it into a fresh PR.

This obsoletes #6395 