### PR TITLE
update scripts to respect TMPDIR

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -136,7 +136,8 @@ function os::cmd::try_until_text() {
 
 # In order to harvest stderr and stdout at the same time into different buckets, we need to stick them into files 
 # in an intermediate step
-os_cmd_internal_tmpdir="/tmp/openshift/test/cmd"
+TMPDIR="${TMPDIR:-"/tmp"}"
+os_cmd_internal_tmpdir="${TMPDIR}/openshift/test/cmd"
 os_cmd_internal_tmpout="${os_cmd_internal_tmpdir}/tmp_stdout.log"
 os_cmd_internal_tmperr="${os_cmd_internal_tmpdir}/tmp_stderr.log"
 

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -86,7 +86,8 @@ DOCKER_CMD=${DOCKER_CMD:-"sudo docker"}
 
 # Override the default CONFIG_ROOT path with one that is
 # cluster-specific.
-CONFIG_ROOT=${OPENSHIFT_CONFIG_ROOT:-/tmp/openshift-dind-cluster/${INSTANCE_PREFIX}}
+TMPDIR="${TMPDIR:-"/tmp"}"
+CONFIG_ROOT=${OPENSHIFT_CONFIG_ROOT:-${TMPDIR}/openshift-dind-cluster/${INSTANCE_PREFIX}}
 
 DEPLOY_SSH=${OPENSHIFT_DEPLOY_SSH:-true}
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -56,7 +56,8 @@ tests=( $(find_tests ${1:-.*}) )
 # Setup environment
 
 # test-cmd specific defaults
-BASETMPDIR=${USE_TEMP:-$(mkdir -p /tmp/openshift-cmd && mktemp -d /tmp/openshift-cmd/XXXX)}
+TMPDIR="${TMPDIR:-"/tmp"}"
+BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-cmd}"
 LOG_DIR=${BASETMPDIR}/logs
 API_HOST=${API_HOST:-127.0.0.1}
 export API_PORT=${API_PORT:-28443}
@@ -67,6 +68,7 @@ export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
 setup_env_vars
 export SUDO=''
 mkdir -p "${ETCD_DATA_DIR}" "${VOLUME_DIR}" "${FAKE_HOME_DIR}" "${MASTER_CONFIG_DIR}" "${NODE_CONFIG_DIR}" "${LOG_DIR}"
+reset_tmp_dir
 
 echo "Logging to ${LOG_DIR}..."
 

--- a/hack/test-cmd_util.sh
+++ b/hack/test-cmd_util.sh
@@ -11,7 +11,6 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
-mkdir -p /tmp/openshift/origin/test/cmd/
 JUNIT_OUTPUT_FILE=/tmp/openshift-cmd/junit_output.txt
 
 # set verbosity so we can see that command output renders correctly
@@ -380,6 +379,11 @@ fi
 
 echo "try_until: ok"
 
+TMPDIR="${TMPDIR:-"/tmp"}"
+TEST_DIR=${TMPDIR}/openshift/origin/test/cmd
+rm -rf ${TEST_DIR} || true
+mkdir -p ${TEST_DIR}
+
 echo -e 'success
 line 2
 \x1e
@@ -413,7 +417,7 @@ line 2
 \x1e
 \x1e
 \x1e
-\x1e' > /tmp/openshift/origin/test/cmd/compress_test.txt
+\x1e' > ${TEST_DIR}/compress_test.txt
 
 echo "success
 line 2
@@ -423,8 +427,8 @@ line 2
 ... repeated 4 times
 success OLD
 line 2
-... repeated 3 times" > /tmp/openshift/origin/test/cmd/compress_test.out
+... repeated 3 times" > ${TEST_DIR}/expected-compressed.out
 
-os::cmd::internal::compress_output /tmp/openshift/origin/test/cmd/compress_test.txt > /tmp/openshift/origin/test/cmd/compressed.out
-diff /tmp/openshift/origin/test/cmd/compress_test.out /tmp/openshift/origin/test/cmd/compressed.out
+os::cmd::internal::compress_output ${TEST_DIR}//compress_test.txt > ${TEST_DIR}/actual-compressed.out
+diff ${TEST_DIR}/expected-compressed.out ${TEST_DIR}/actual-compressed.out
 echo "compression: ok"

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -39,7 +39,7 @@ trap "cleanup" EXIT
 
 # Start All-in-one server and wait for health
 TMPDIR="${TMPDIR:-"/tmp"}"
-BASETMPDIR="${TMPDIR}/openshift-e2e"
+BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-e2e}"
 setup_env_vars
 reset_tmp_dir
 configure_os_server

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -54,8 +54,8 @@ package="${OS_TEST_PACKAGE:-test/integration}"
 tags="${OS_TEST_TAGS:-integration !docker etcd}"
 
 export GOMAXPROCS="$(grep "processor" -c /proc/cpuinfo 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || 1)"
-TMPDIR=${TMPDIR:-/tmp}
-export BASETMPDIR=${BASETMPDIR:-${TMPDIR}/openshift-integration}
+TMPDIR="${TMPDIR:-"/tmp"}"
+export BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-integration}"
 rm -rf ${BASETMPDIR} | true
 mkdir -p ${BASETMPDIR}
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -544,7 +544,8 @@ function cleanup_openshift {
 function create_gitconfig {
 	USERNAME=sample-user
 	PASSWORD=password
-	GITCONFIG_DIR=$(mktemp -d /tmp/test-gitconfig.XXXX)
+	TMPDIR="${TMPDIR:-"/tmp"}"
+	GITCONFIG_DIR=$(mktemp -d ${TMPDIR}/test-gitconfig.XXXX)
 	touch ${GITCONFIG_DIR}/.gitconfig
 	git config --file ${GITCONFIG_DIR}/.gitconfig user.name ${USERNAME}
 	git config --file ${GITCONFIG_DIR}/.gitconfig user.token ${PASSWORD}
@@ -552,7 +553,8 @@ function create_gitconfig {
 }
 
 function create_valid_file {
-	FILE_DIR=$(mktemp -d /tmp/test-file.XXXX)
+	TMPDIR="${TMPDIR:-"/tmp"}"
+	FILE_DIR=$(mktemp -d ${TMPDIR}/test-file.XXXX)
 	touch ${FILE_DIR}/${1}
 	echo ${FILE_DIR}/${1}
 }


### PR DESCRIPTION
To reduce memory stress on our test and merge queue, we can move some of our work out `/tmp` by setting `TMPDIR`.  Not all scripts respected `TMPDIR`.  This updates them to respect that env var and then we can set it to somewhere else in our jenkins jobs.

@stevekuznetsov ptal