### PR TITLE
Enable openshift-sdn sdn node by default

### DIFF
--- a/contrib/vagrant/provision-config.sh
+++ b/contrib/vagrant/provision-config.sh
@@ -27,7 +27,6 @@ NETWORK_PLUGIN=${OPENSHIFT_NETWORK_PLUGIN:-""}
 NODE_INDEX=0
 CONFIG_ROOT=${ORIGIN_ROOT}
 SKIP_BUILD=${OPENSHIFT_SKIP_BUILD:-false}
-SDN_NODE=${OPENSHIFT_SDN_NODE_ON_MASTER:-false}
 
 # Parse optional arguments
 # Skip the positional arguments
@@ -49,9 +48,6 @@ while getopts ":i:n:c:fs" opt; do
     s)
       SKIP_BUILD=true
       ;;
-    o)
-      SDN_NODE=true
-      ;;
     \?)
       echo "Invalid option: -${OPTARG}" >&2
       exit 1
@@ -69,8 +65,15 @@ NODE_IPS=(${NODE_IPS//,/ })
 if [ "${CONFIG_ROOT}" = "/" ]; then
   CONFIG_ROOT=""
 fi
+
 NETWORK_PLUGIN=$(os::provision::get-network-plugin "${NETWORK_PLUGIN}" \
   "${DIND_MANAGEMENT_SCRIPT:-false}")
+if [[ "${NETWORK_PLUGIN}" =~ redhat/ ]]; then
+  SDN_NODE="true"
+else
+  SDN_NODE="false"
+fi
+
 MASTER_NAME="${INSTANCE_PREFIX}-master"
 NODE_PREFIX="${INSTANCE_PREFIX}-node-"
 NODE_NAMES=( $(eval echo ${NODE_PREFIX}{1..${NODE_COUNT}}) )

--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -12,13 +12,12 @@ os::provision::install-cmds "${ORIGIN_ROOT}"
 os::provision::install-sdn "${ORIGIN_ROOT}"
 
 if [ "${SDN_NODE}" = "true" ]; then
-  # Running an openshift node on the master ensures connectivity between
-  # the openshift service and pods.  This supports kube API calls that
-  # query a service and require that the endpoints of the service be
-  # reachable from the master.
-  #
-  # TODO(marun) This is required for connectivity with openshift-sdn,
-  # but may not make sense for other plugins.
+  # Running an sdn node on the master when using an openshift sdn
+  # plugin ensures connectivity between the openshift service and
+  # pods.  This enables kube API calls that query a service and
+  # require that the endpoints of the service be reachable from the
+  # master.  This capability is used extensively in the kube e2e
+  # tests.
   NODE_NAMES+=(${SDN_NODE_NAME})
   NODE_IPS+=(127.0.0.1)
   # Force the addition of a hosts entry for the sdn node.

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -192,9 +192,6 @@ function start() {
   if [ "${SKIP_BUILD}" = "true" ]; then
       args="${args} -s"
   fi
-  if [ "${SDN_NODE}" = "true" ]; then
-      args="${args} -o"
-  fi
 
   echo "Provisioning ${MASTER_NAME}"
   local cmd="${SCRIPT_ROOT}/provision-master.sh ${args} -c \


### PR DESCRIPTION
The kubernetes api supports making get requests against the cluster, and
this capability is used extensively by the kube e2e tests.  To enable
this, the master needs connectivity to pods and this is achieved by
running a node on the master that has scheduling disabled (sdn node).