### PR TITLE
Increase web console e2e login timeout

### DIFF
--- a/assets/test/integration/helpers.js
+++ b/assets/test/integration/helpers.js
@@ -30,7 +30,7 @@ exports.login = function(loginPageAlreadyLoaded) {
 
   driver.wait(function() {
     return driver.isElementPresent(by.css(".navbar-utility .username"));
-  }, 3000);
+  }, 5000);
 };
 
 exports.setInputValue = function(name, value) {


### PR DESCRIPTION
Increase the timeout for login from 3s to 5s to address this error:

https://github.com/openshift/origin/pull/6120#issuecomment-166998621

It looks like 3s is not always enough for the login redirects and loading the first web console page.

See also #5881

@jwforres 