### PR TITLE
removed global project cache

### DIFF
--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -29,7 +29,6 @@ import (
 	imagechangecontroller "github.com/openshift/origin/pkg/deploy/controller/imagechange"
 	"github.com/openshift/origin/pkg/dns"
 	imagecontroller "github.com/openshift/origin/pkg/image/controller"
-	projectcache "github.com/openshift/origin/pkg/project/cache"
 	projectcontroller "github.com/openshift/origin/pkg/project/controller"
 	securitycontroller "github.com/openshift/origin/pkg/security/controller"
 	"github.com/openshift/origin/pkg/security/mcs"
@@ -179,7 +178,7 @@ func (c *MasterConfig) RunDNSServer() {
 // RunProjectCache populates project cache, used by scheduler and project admission controller.
 func (c *MasterConfig) RunProjectCache() {
 	glog.Infof("Using default project node label selector: %s", c.Options.ProjectConfig.DefaultNodeSelector)
-	projectcache.RunProjectCache(c.PrivilegedLoopbackKubernetesClient, c.Options.ProjectConfig.DefaultNodeSelector)
+	c.ProjectCache.Run()
 }
 
 // RunBuildController starts the build sync loop for builds and buildConfig processing.

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -1,4 +1,4 @@
-package admission
+package lifecycle
 
 import (
 	"fmt"
@@ -41,7 +41,7 @@ func TestAdmissionExists(t *testing.T) {
 		return true, &kapi.Namespace{}, fmt.Errorf("DOES NOT EXIST")
 	})
 
-	projectcache.FakeProjectCache(mockClient, cache.NewStore(cache.MetaNamespaceKeyFunc), "")
+	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), cache.NewStore(cache.MetaNamespaceKeyFunc), ""))
 	handler := &lifecycle{client: mockClient}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
@@ -86,7 +86,7 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store := cache.NewStore(cache.IndexFuncToKeyFuncAdapter(cache.MetaNamespaceIndexFunc))
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
-	projectcache.FakeProjectCache(mockClient, store, "")
+	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), store, ""))
 	handler := &lifecycle{client: mockClient}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "other"},
@@ -166,7 +166,7 @@ func TestSAR(t *testing.T) {
 	mockClient.AddReactor("get", "namespaces", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, fmt.Errorf("shouldn't get here")
 	})
-	projectcache.FakeProjectCache(mockClient, store, "")
+	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), store, ""))
 	handler := &lifecycle{client: mockClient}
 
 	tests := map[string]struct {

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -1,4 +1,4 @@
-package admission
+package nodeenv
 
 import (
 	"testing"
@@ -104,7 +104,7 @@ func TestPodAdmission(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		projectcache.FakeProjectCache(mockClient, projectStore, test.defaultNodeSelector)
+		InitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), projectStore, test.defaultNodeSelector))
 		if !test.ignoreProjectNodeSelector {
 			project.ObjectMeta.Annotations = map[string]string{"openshift.io/node-selector": test.projectNodeSelector}
 		}
@@ -130,13 +130,15 @@ func TestHandles(t *testing.T) {
 		admission.Connect: false,
 		admission.Delete:  false,
 	} {
-		n, err := NewPodNodeEnvironment(nil)
+		InitializeCacheReference(&projectcache.ProjectCache{})
+
+		nodeEnvionment, err := NewPodNodeEnvironment(nil)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%v: error getting node environment: %v", op, err)
 			continue
 		}
 
-		if e, a := shouldHandle, n.Handles(op); e != a {
+		if e, a := shouldHandle, nodeEnvionment.Handles(op); e != a {
 			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/6375

This is not clean at all - the Kube interface for admission plugin constructors is strict and we can't get the cache reference in there, obviously, so we need to pass the reference somehow. I've created unexported references in the packages that need them and initialized them as necessary. This isn't ideal but since we want to cache namespaces, we need something of the sort.

I'm having issues with the test package - for `lifecycle`, the test package imports `"github.com/openshift/origin/pkg/cmd/server/origin"`, in which we initialize the references, causing a cycle. I do not know the best way to resolve this issue.  

@deads2k PTAL