### PR TITLE
Support a config file per admission control plugin on openshift master

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -196,6 +196,9 @@ type MasterConfig struct {
 	ControllerLeaseTTL int
 	// TODO: the next field added to controllers must be added to a new controllers struct
 
+	// AdmissionPluginConfig allows specifying a configuration file per admission control plugin
+	AdmissionPluginConfig map[string]string
+
 	// Allow to disable OpenShift components
 	DisabledFeatures FeatureList
 

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -143,6 +143,9 @@ type MasterConfig struct {
 	// omitted) and controller election can be disabled with -1.
 	ControllerLeaseTTL int `json:"controllerLeaseTTL"`
 
+	// AdmissionPluginConfig allows specifying a configuration file per admission control plugin
+	AdmissionPluginConfig map[string]string `json:"admissionPluginConfig,omitempty"`
+
 	// DisabledFeatures is a list of features that should not be started.  We
 	// omitempty here because its very unlikely that anyone will want to
 	// manually disable features and we don't want to encourage it.

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -55,7 +55,9 @@ volumeDirectory: ""
 	// Before modifying this constant, ensure any changes have corresponding issues filed for:
 	// - documentation: https://github.com/openshift/openshift-docs/
 	// - install: https://github.com/openshift/openshift-ansible/
-	expectedSerializedMasterConfig = `apiLevels: null
+	expectedSerializedMasterConfig = `admissionPluginConfig:
+  pluginName: configFilePath
+apiLevels: null
 apiVersion: v1
 assetConfig:
   extensionDevelopment: false
@@ -351,7 +353,8 @@ func TestMasterConfig(t *testing.T) {
 		AssetConfig: &internal.AssetConfig{
 			Extensions: []internal.AssetExtensionsConfig{{}},
 		},
-		DNSConfig: &internal.DNSConfig{},
+		DNSConfig:             &internal.DNSConfig{},
+		AdmissionPluginConfig: map[string]string{"pluginName": "configFilePath"}, // Must be specified explicitly becase it's omitempty
 	}
 	serializedConfig, err := writeYAML(config)
 	if err != nil {

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -124,7 +124,11 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 			plugins = append(plugins, saAdmitter)
 
 		default:
-			plugin := admission.InitPlugin(pluginName, kubeClient, server.AdmissionControlConfigFile)
+			configFile := server.AdmissionControlConfigFile
+			if _, hasConfig := options.AdmissionPluginConfig[pluginName]; hasConfig {
+				configFile = options.AdmissionPluginConfig[pluginName]
+			}
+			plugin := admission.InitPlugin(pluginName, kubeClient, configFile)
 			if plugin != nil {
 				plugins = append(plugins, plugin)
 			}


### PR DESCRIPTION
Allows specifying a separate config file per admission control plugin
Related to #6571