### PR TITLE
configure cmd for junit

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -180,6 +180,9 @@ For example, start the OpenShift server, create a "test" project, and then run
     $ oc new-project test
     $ test/cmd/newapp.sh
 
+In order to run the suite, generate a jUnit XML report, and see a summary of the test suite, use:
+
+    $ JUNIT_REPORT='true' hack/test-cmd.sh
 
 ### End-to-End (e2e) and Extended Tests
 

--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# This utility file contains functions that format test output to be parsed into jUnit XML
+
+# os::test::junit::declare_suite_start prints a message declaring the start of a test suite
+# Any number of suites can be in flight at any time, so there is no failure condition for this
+# script based on the number of suites in flight.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - NUM_OS_JUNIT_SUITES_IN_FLIGHT
+# Arguments:
+#  - 1: the suite name that is starting
+# Returns:
+#  - increment NUM_OS_JUNIT_SUITES_IN_FLIGHT
+function os::test::junit::declare_suite_start() {
+    local suite_name=$1
+    local num_suites=${NUM_OS_JUNIT_SUITES_IN_FLIGHT:-0}
+    
+    echo "=== BEGIN TEST SUITE github.com/openshift/origin/test/${suite_name} ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
+    NUM_OS_JUNIT_SUITES_IN_FLIGHT=$(( ${num_suites} + 1 ))
+    export NUM_OS_JUNIT_SUITES_IN_FLIGHT
+}
+
+# os::test::junit::declare_suite_end prints a message declaring the end of a test suite
+# If there aren't any suites in flight, this function will fail.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - NUM_OS_JUNIT_SUITES_IN_FLIGHT
+# Arguments:
+#  - 1: the suite name that is starting
+# Returns:
+#  - export/decrement NUM_OS_JUNIT_SUITES_IN_FLIGHT
+function os::test::junit::declare_suite_end() {
+    local num_suites=${NUM_OS_JUNIT_SUITES_IN_FLIGHT:-0}
+    if [[ "${num_suites}" -lt "1" ]]; then
+        # we can't end a suite if none have been started yet
+        echo "[ERROR] jUnit suite marker could not be placed, expected suites in flight, got ${num_suites}"
+        return 1
+    fi
+
+    echo "=== END TEST SUITE ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
+    NUM_OS_JUNIT_SUITES_IN_FLIGHT=$(( ${num_suites} - 1 ))
+    export NUM_OS_JUNIT_SUITES_IN_FLIGHT
+}
+
+# os::test::junit::declare_test_start prints a message declaring the start of a test case
+# If there is already a test marked as being in flight, this function will fail.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - NUM_OS_JUNIT_TESTS_IN_FLIGHT
+# Arguments:
+#  None
+# Returns:
+#  - increment NUM_OS_JUNIT_TESTS_IN_FLIGHT
+function os::test::junit::declare_test_start() {
+    local num_tests=${NUM_OS_JUNIT_TESTS_IN_FLIGHT:-0}
+    if [[ "${num_tests}" -ne "0" ]]; then
+        # someone's declaring the starting of a test when a test is already in flight
+        echo "[ERROR] jUnit test marker could not be placed, expected no tests in flight, got ${num_tests}"
+        return 1
+    fi
+
+    local num_suites=${NUM_OS_JUNIT_SUITES_IN_FLIGHT:-0}
+    if [[ "${num_suites}" -lt "1" ]]; then
+        # we can't end a test if no suites are in flight
+        echo "[ERROR] jUnit test marker could not be placed, expected suites in flight, got ${num_suites}"
+        return 1
+    fi
+
+    echo "=== BEGIN TEST CASE ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
+    NUM_OS_JUNIT_TESTS_IN_FLIGHT=$(( ${num_tests} + 1 ))
+    export NUM_OS_JUNIT_TESTS_IN_FLIGHT
+}
+
+# os::test::junit::declare_test_end prints a message declaring the end of a test case
+# If there is no test marked as being in flight, this function will fail.
+#
+# Globals:
+#  - JUNIT_REPORT_OUTPUT
+#  - NUM_OS_JUNIT_TESTS_IN_FLIGHT
+# Arguments:
+#  None
+# Returns:
+#  - decrement NUM_OS_JUNIT_TESTS_IN_FLIGHT
+function os::test::junit::declare_test_end() {
+    local num_tests=${NUM_OS_JUNIT_TESTS_IN_FLIGHT:-0}
+    if [[ "${num_tests}" -ne "1" ]]; then
+        # someone's declaring the end of a test when a test is not in flight
+        echo "[ERROR] jUnit test marker could not be placed, expected one test in flight, got ${num_tests}"
+        return 1
+    fi
+
+    echo "=== END TEST CASE ===" >> "${JUNIT_REPORT_OUTPUT:-/dev/null}"
+    NUM_OS_JUNIT_TESTS_IN_FLIGHT=$(( ${num_tests} - 1 ))
+    export NUM_OS_JUNIT_TESTS_IN_FLIGHT
+}
+
+# os::test::junit::check_test_counters checks that we do not have any test suites or test cases in flight
+# This function should be called at the very end of any test script using jUnit markers to make sure no error in 
+# marking has occured.
+#
+# Globals:
+#  - NUM_OS_JUNIT_SUITES_IN_FLIGHT
+#  - NUM_OS_JUNIT_TESTS_IN_FLIGHT
+# Arguments:
+#  None
+# Returns:
+#  None
+function os::test::junit::check_test_counters() {
+    if [[ "${NUM_OS_JUNIT_SUITES_IN_FLIGHT-}" -ne "0" ]]; then
+        echo "[ERROR] Expected no test suites to be marked as in-flight at the end of testing, got ${NUM_OS_JUNIT_SUITES_IN_FLIGHT-}"
+        return 1
+    elif [[ "${NUM_OS_JUNIT_TESTS_IN_FLIGHT-}" -ne "0" ]]; then
+        echo "[ERROR] Expected no test cases to be marked as in-flight at the end of testing, got ${NUM_OS_JUNIT_TESTS_IN_FLIGHT-}"
+        return 1
+    fi
+}
+
+# os::test::junit::reconcile_output appends the necessary suite and test end statements to the jUnit output file
+# in order to ensure that the file is in a consistent state to allow for parsing
+#
+# Globals:
+#  - NUM_OS_JUNIT_SUITES_IN_FLIGHT
+#  - NUM_OS_JUNIT_TESTS_IN_FLIGHT
+# Arguments:
+#  None
+# Returns:
+#  None
+function os::test::junit::reconcile_output() {
+    if [[ "${NUM_OS_JUNIT_TESTS_IN_FLIGHT:-0}" = "1" ]]; then
+        os::test::junit::declare_test_end
+    fi
+
+    for (( i = 0; i < ${NUM_OS_JUNIT_SUITES_IN_FLIGHT:-0}; i++ )); do
+        os::test::junit::declare_suite_end
+    done
+}

--- a/hack/test-lib.sh
+++ b/hack/test-lib.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script runs all of the test written for our Bash libraries.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function exit_trap() {
+    local return_code=$?
+
+    end_time=$(date +%s)
+    
+    if [[ "${return_code}" -eq "0" ]]; then
+        verb="succeeded"
+    else
+        verb="failed"
+    fi
+
+    echo "$0 ${verb} after $((${end_time} - ${start_time})) seconds"
+    exit "${return_code}"
+}
+
+trap exit_trap EXIT
+
+start_time=$(date +%s)
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
+os::log::install_errexit
+os::util::environment::setup_tmpdir_vars "test-lib"
+
+cd "${OS_ROOT}"
+
+library_tests="$( find 'hack/test-lib/' -type f -executable )"
+for test in ${library_tests}; do
+	# run each library test found in a subshell so that we can isolate them
+	( ${test} )
+	echo "$(basename "${test//.sh}"): ok"
+done

--- a/hack/test-lib/test/junit.sh
+++ b/hack/test-lib/test/junit.sh
@@ -26,6 +26,7 @@ trap exit_trap EXIT
 start_time=$(date +%s)
 OS_ROOT="$( dirname "${BASH_SOURCE}" )"/../../..
 source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 

--- a/hack/test-lib/test/junit.sh
+++ b/hack/test-lib/test/junit.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# This script tests os::test::junit functionality.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function exit_trap() {
+    local return_code=$?
+
+    end_time=$(date +%s)
+    
+    if [[ "${return_code}" -eq "0" ]]; then
+        verb="succeeded"
+    else
+        verb="failed"
+    fi
+
+    echo "$0 ${verb} after $((${end_time} - ${start_time})) seconds"
+    exit "${return_code}"
+}
+
+trap exit_trap EXIT
+
+start_time=$(date +%s)
+OS_ROOT="$( dirname "${BASH_SOURCE}" )"/../../..
+source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/cmd_util.sh"
+os::log::install_errexit
+
+# envars used to track these interactions are not propagated out of the subshells used to run these commands
+# therefore each os::cmd call is its own sandbox and complicated scenarios need to play out inside one call
+# however, envars from this scope *are* propagated into each subshell, so they need to be cleared in each call
+
+os::test::junit::declare_suite_start 'lib/test/junit'
+
+# shouldn't be able to end a suite straight away
+os::cmd::expect_failure_and_text 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_end' '\[ERROR\] jUnit suite marker could not be placed, expected suites in flight, got 0'
+# should be able to start one straight away
+os::cmd::expect_success 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever'
+# should be able to start and end a suite
+os::cmd::expect_success 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever
+os::test::junit::declare_suite_end'
+# should not be able to end more suites than are in flight
+os::cmd::expect_failure_and_text 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever
+os::test::junit::declare_suite_end
+os::test::junit::declare_suite_end' '\[ERROR\] jUnit suite marker could not be placed, expected suites in flight, got 0'
+# should not be able to end more suites than are in flight
+os::cmd::expect_failure_and_text 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever
+os::test::junit::declare_suite_start whateverelse
+os::test::junit::declare_suite_end
+os::test::junit::declare_suite_end
+os::test::junit::declare_suite_end' '\[ERROR\] jUnit suite marker could not be placed, expected suites in flight, got 0'
+# should be able to staart a test
+os::cmd::expect_success 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever
+os::test::junit::declare_test_start'
+# shouldn't be able to end a test that hasn't been started
+os::cmd::expect_failure_and_text 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_test_end' '\[ERROR\] jUnit test marker could not be placed, expected one test in flight, got 0'
+# should be able to start and end a test case
+os::cmd::expect_success 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever
+os::test::junit::declare_test_start
+os::test::junit::declare_test_end'
+# shouldn't be able to end too many test cases
+os::cmd::expect_failure_and_text 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_suite_start whatever
+os::test::junit::declare_test_start
+os::test::junit::declare_test_end
+os::test::junit::declare_test_end' '\[ERROR\] jUnit test marker could not be placed, expected one test in flight, got 0'
+# shouldn't be able to start a test without a suite
+os::cmd::expect_failure_and_text 'unset NUM_OS_JUNIT_SUITES_IN_FLIGHT NUM_OS_JUNIT_TESTS_IN_FLIGHT JUNIT_REPORT_OUTPUT
+os::test::junit::declare_test_start' '\[ERROR\] jUnit test marker could not be placed, expected suites in flight, got 0'
+
+os::test::junit::declare_suite_end

--- a/hack/test-tools.sh
+++ b/hack/test-tools.sh
@@ -11,8 +11,12 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${OS_ROOT}"
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+
+os::test::junit::declare_suite_start 'tools'
 
 os::cmd::expect_success 'tools/junitreport/test/integration.sh'
 
 echo "test-tools: ok"
+os::test::junit::declare_suite_end

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -9,14 +9,20 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
 
 BASETMPDIR="${TMPDIR:-/tmp}/openshift/test-tools"
-JUNIT_OUTPUT_FILE="${BASETMPDIR}/junit_output.txt"
+JUNIT_REPORT_OUTPUT="${BASETMPDIR}/junit_output.txt"
+mkdir -p "${BASETMPDIR}"
+touch "${JUNIT_REPORT_OUTPUT}"
 
 # set verbosity so we can see that command output renders correctly
 VERBOSE=1
 
+os::test::junit::declare_suite_start "cmd/util"
+
+os::test::junit::declare_suite_start "cmd/util/positive"
 # positive tests
 os::cmd::expect_success 'exit 0'
 
@@ -37,7 +43,9 @@ os::cmd::expect_code_and_text 'echo "hello" && exit 213' '213' 'hello'
 os::cmd::expect_code_and_not_text 'echo "goodbye" && exit 213' '213' 'hello'
 
 echo "positive tests: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/util/negative"
 # negative tests
 
 if os::cmd::expect_success 'exit 1'; then
@@ -125,7 +133,9 @@ if os::cmd::expect_code_and_not_text 'echo "hello" && exit 0' '1' 'hello'; then
 fi
 
 echo "negative tests: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/util/complex"
 # complex input tests
 
 # pipes
@@ -170,8 +180,9 @@ EOF
 os::cmd::expect_success 'grep hello <<< hello'
 
 echo "complex tests: ok"
+os::test::junit::declare_suite_end
 
-
+os::test::junit::declare_suite_start "cmd/util/output"
 # test for output correctness
 
 # expect_code
@@ -333,7 +344,9 @@ echo "${output}" | grep -q '; the output content test failed'
 echo "${output}" | grep -q 'hello' 
 
 echo "output tests: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/util/tryuntil"
 function current_time_millis_mod_1000() {
 	mod=$(expr $(date +%s000) % 1000)
 	if [ $mod -eq 0 ]; then
@@ -379,7 +392,9 @@ if os::cmd::try_until_failure 'exit 0' $(( 1 * second )); then
 fi
 
 echo "try_until: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/util/compression"
 TMPDIR="${TMPDIR:-"/tmp"}"
 TEST_DIR=${TMPDIR}/openshift/origin/test/cmd
 rm -rf ${TEST_DIR} || true
@@ -433,3 +448,8 @@ line 2
 os::cmd::internal::compress_output ${TEST_DIR}//compress_test.txt > ${TEST_DIR}/actual-compressed.out
 diff ${TEST_DIR}/expected-compressed.out ${TEST_DIR}/actual-compressed.out
 echo "compression: ok"
+os::test::junit::declare_suite_end
+
+os::test::junit::declare_suite_end
+
+os::test::junit::check_test_counters

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -11,6 +11,7 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 BASETMPDIR="${TMPDIR:-/tmp}/openshift/test-tools"
 JUNIT_REPORT_OUTPUT="${BASETMPDIR}/junit_output.txt"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -704,7 +704,7 @@ os::log::errexit() {
 }
 
 os::log::install_errexit() {
-	# trap ERR to provide an error handler whenever a command exits nonzero	this
+	# trap ERR to provide an error handler whenever a command exits nonzero this
 	# is a more verbose version of set -o errexit
 	trap 'os::log::errexit' ERR
 

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -20,6 +22,7 @@ os::log::install_errexit
 url=":${API_PORT:-8443}"
 project="$(oc project -q)"
 
+os::test::junit::declare_suite_start "cmd/builds"
 # This test validates builds and build related commands
 
 os::cmd::expect_success 'oc new-build centos/ruby-22-centos7 https://github.com/openshift/ruby-hello-world.git'
@@ -75,6 +78,7 @@ os::cmd::expect_success_and_text 'oc get bc/centos -o=jsonpath="{.spec.output.to
 # Ensure output is valid JSON
 os::cmd::expect_success 'oc new-build -D "FROM centos:7" -o json | python -m json.tool'
 
+os::test::junit::declare_suite_start "cmd/builds/postcommithook"
 # Ensure post commit hook is executed
 os::cmd::expect_success 'oc new-build -D "FROM busybox:1"'
 os::cmd::try_until_text 'oc get istag busybox:1' 'busybox@sha256:'
@@ -88,6 +92,7 @@ os::cmd::expect_success 'oc patch bc/busybox -p '\''{"spec":{"postCommit":{"args
 os::cmd::expect_success_and_text 'oc get bc/busybox -o=jsonpath="{.spec.postCommit['\''script'\'','\''args'\'','\''command'\'']}"' ' \[echo default entrypoint\] \[\]'
 # os::cmd::expect_success_and_text 'oc start-build --wait --follow busybox' 'default entrypoint'
 echo "postCommitHook: ok"
+os::test::junit::declare_suite_end
 
 os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -'
@@ -98,12 +103,15 @@ os::cmd::expect_success 'oc get builds'
 # make sure the imagestream has the latest tag before trying to test it or start a build with it
 os::cmd::try_until_text 'oc get is ruby-22-centos7' 'latest'
 
+os::test::junit::declare_suite_start "cmd/builds/patch-anon-fields"
 REAL_OUTPUT_TO=$(oc get bc/ruby-sample-build --template='{{ .spec.output.to.name }}')
 os::cmd::expect_success "oc patch bc/ruby-sample-build -p '{\"spec\":{\"output\":{\"to\":{\"name\":\"different:tag1\"}}}}'"
 os::cmd::expect_success_and_text "oc get bc/ruby-sample-build --template='{{ .spec.output.to.name }}'" 'different'
 os::cmd::expect_success "oc patch bc/ruby-sample-build -p '{\"spec\":{\"output\":{\"to\":{\"name\":\"${REAL_OUTPUT_TO}\"}}}}'"
 echo "patchAnonFields: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/builds/config"
 os::cmd::expect_success_and_text 'oc describe buildConfigs ruby-sample-build' "Webhook GitHub.+${url}/oapi/v1/namespaces/${project}/buildconfigs/ruby-sample-build/webhooks/secret101/github"
 os::cmd::expect_success_and_text 'oc describe buildConfigs ruby-sample-build' "Webhook Generic.+${url}/oapi/v1/namespaces/${project}/buildconfigs/ruby-sample-build/webhooks/secret101/generic"
 os::cmd::expect_success 'oc start-build --list-webhooks='all' ruby-sample-build'
@@ -116,7 +124,9 @@ os::cmd::expect_success "oc start-build --from-webhook=${webhook}"
 os::cmd::expect_success 'oc get builds'
 os::cmd::expect_success 'oc delete all -l build=docker'
 echo "buildConfig: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/builds/start-build"
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-buildcli.json'
 # a build for which there is not an upstream tag in the corresponding imagerepo, so
 # the build should use the image field as defined in the buildconfig
@@ -125,7 +135,9 @@ os::cmd::expect_success_and_text "oc describe build ${started}" 'centos/ruby-22-
 frombuild=$(oc start-build --from-build="${started}")
 os::cmd::expect_success_and_text "oc describe build ${frombuild}" 'centos/ruby-22-centos7$'
 echo "start-build: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/builds/cancel-build"
 os::cmd::expect_success_and_text "oc cancel-build ${started} --dump-logs --restart" "Restarted build ${started}."
 os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -'
@@ -136,3 +148,6 @@ os::cmd::expect_success_and_text 'oc cancel-build build/ruby-sample-build-1' 'Bu
 os::cmd::try_until_text 'oc cancel-build build/ruby-sample-build-1' 'A cancellation event was already triggered for the build ruby-sample-build-1.'
 os::cmd::expect_success 'oc delete all --all'
 echo "cancel-build: ok"
+os::test::junit::declare_suite_end
+
+os::test::junit::declare_suite_end

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -16,7 +18,7 @@ os::log::install_errexit
   exit 0
 ) &>/dev/null
 
-
+os::test::junit::declare_suite_start "cmd/debug"
 # This test validates the debug command
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-config.yaml'
 os::cmd::expect_success_and_text "oc debug dc/test-deployment-config -o yaml" '\- /bin/sh'
@@ -36,3 +38,4 @@ os::cmd::expect_success_and_not_text "oc debug -f examples/hello-openshift/hello
 os::cmd::expect_success_and_not_text "oc debug -f examples/hello-openshift/hello-pod.json -o yaml -- /bin/env" 'tty'
 # TODO: write a test that emulates a TTY to verify the correct defaulting of what the pod is created
 echo "debug: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -17,6 +19,7 @@ os::log::install_errexit
 ) &>/dev/null
 
 
+os::test::junit::declare_suite_start "cmd/deployments"
 # This test validates deployments and the env command
 
 os::cmd::expect_success 'oc get deploymentConfigs'
@@ -27,6 +30,7 @@ os::cmd::expect_success_and_text 'oc get dc -o name' 'deploymentconfig/test-depl
 os::cmd::try_until_success 'oc get rc/test-deployment-config-1'
 os::cmd::expect_success_and_text 'oc describe dc test-deployment-config' 'deploymentconfig=test-deployment-config'
 
+os::test::junit::declare_suite_start "cmd/deployments/env"
 # Patch a nil list
 os::cmd::expect_success 'oc env dc/test-deployment-config TEST=value'
 os::cmd::expect_success_and_text 'oc env dc/test-deployment-config --list' 'TEST=value'
@@ -66,10 +70,14 @@ os::cmd::expect_success_and_not_text 'oc env dc/test-deployment-config --list' '
 os::cmd::expect_success_and_not_text 'oc env dc/test-deployment-config --list' 'C=c'
 os::cmd::expect_success_and_not_text 'oc env dc/test-deployment-config --list' 'G=g'
 echo "env: ok"
+os::test::junit::declare_suite_end
+
+os::test::junit::declare_suite_start "cmd/deployments/config"
 os::cmd::expect_success 'oc deploy test-deployment-config'
 os::cmd::expect_success 'oc deploy dc/test-deployment-config'
 os::cmd::expect_success 'oc delete deploymentConfigs test-deployment-config'
 echo "deploymentConfigs: ok"
+os::test::junit::declare_suite_end
 
 os::cmd::expect_success 'oc delete all --all'
 # TODO: remove, flake caused by deployment controller updating the following dc
@@ -79,6 +87,7 @@ os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l app=dockerbuild | oc create -f -'
 os::cmd::try_until_success 'oc get rc/database-1'
 
+os::test::junit::declare_suite_start "cmd/deployments/rollback"
 os::cmd::expect_success 'oc rollback database --to-version=1 -o=yaml'
 os::cmd::expect_success 'oc rollback dc/database --to-version=1 -o=yaml'
 os::cmd::expect_success 'oc rollback dc/database --to-version=1 --dry-run'
@@ -87,7 +96,9 @@ os::cmd::expect_success 'oc rollback rc/database-1 -o=yaml'
 # should fail because there's no previous deployment
 os::cmd::expect_failure 'oc rollback database -o yaml'
 echo "rollback: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/deployments/stop"
 os::cmd::expect_success 'oc get dc/database'
 os::cmd::expect_success 'oc expose dc/database --name=fromdc'
 # should be a service
@@ -98,11 +109,15 @@ os::cmd::expect_success 'oc delete dc/database'
 os::cmd::expect_failure 'oc get dc/database'
 os::cmd::expect_failure 'oc get rc/database-1'
 echo "stop: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/deployments/autoscale"
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-config.yaml'
 os::cmd::expect_success 'oc autoscale dc/test-deployment-config --max 5'
 os::cmd::expect_success_and_text "oc get hpa/test-deployment-config --template='{{.spec.maxReplicas}}'" "5"
 os::cmd::expect_success 'oc delete dc/test-deployment-config'
 os::cmd::expect_success 'oc delete hpa/test-deployment-config'
 echo "autoscale: ok"
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_end

--- a/test/cmd/diagnostics.sh
+++ b/test/cmd/diagnostics.sh
@@ -8,6 +8,7 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # This test validates the diagnostics command
 
@@ -16,6 +17,7 @@ os::log::install_errexit
 # Without things feeding into systemd, AnalyzeLogs and UnitStatus are irrelevant.
 # The rest should be included in some fashion.
 
+os::test::junit::declare_suite_start "cmd/diagnostics"
 os::cmd::expect_success 'oadm diagnostics ClusterRoleBindings ClusterRoles ConfigContexts '
 # DiagnosticPod can't run without Docker, would just time out. Exercise flags instead.
 os::cmd::expect_success "oadm diagnostics DiagnosticPod --prevent-modification --images=foo"
@@ -33,3 +35,4 @@ os::cmd::expect_failure_and_text 'oadm diagnostics AnalyzeLogs AlsoMissing' 'Not
 # openshift ex diagnostics is deprecated but not removed. Make sure it works until we consciously remove it.
 os::cmd::expect_success 'openshift ex diagnostics ClusterRoleBindings ClusterRoles ConfigContexts '
 echo "diagnostics: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -17,6 +19,7 @@ os::log::install_errexit
 ) &>/dev/null
 
 
+os::test::junit::declare_suite_start "cmd/edit"
 # This test validates the edit command
 
 os::cmd::expect_success 'oc create -f examples/hello-openshift/hello-pod.json'
@@ -26,3 +29,4 @@ os::cmd::expect_success_and_text 'OC_EDITOR=cat oc edit pod/hello-openshift' 'na
 os::cmd::expect_success_and_text 'OC_EDITOR=cat oc edit --windows-line-endings pod/hello-openshift | file -' 'CRLF'
 os::cmd::expect_success_and_not_text 'OC_EDITOR=cat oc edit --windows-line-endings=false pod/hello-openshift | file -' 'CRFL'
 echo "edit: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -17,6 +19,7 @@ os::log::install_errexit
 ) &>/dev/null
 
 
+os::test::junit::declare_suite_start "cmd/export"
 # This test validates the export command
 
 os::cmd::expect_success 'oc new-app -f examples/sample-app/application-template-stibuild.json --name=sample'
@@ -41,3 +44,5 @@ os::cmd::expect_failure_and_text 'oc export svc -l a=b' 'no resources found'
 os::cmd::expect_success 'oc export svc -l app=sample'
 os::cmd::expect_success_and_text 'oc export -f examples/sample-app/application-template-stibuild.json --raw --output-version=v1' 'apiVersion: v1'
 echo "export: ok"
+os::test::junit::declare_suite_end
+

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -7,8 +7,11 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
+os::test::junit::declare_suite_start "cmd/help"
 # This test validates the help commands and output text
 
 # verify some default commands
@@ -128,3 +131,5 @@ os::cmd::expect_success_and_text 'openshift ex prune-groups --help' 'external pr
 os::cmd::expect_success_and_text 'openshift admin groups sync --help' 'external provider'
 os::cmd::expect_success_and_text 'openshift admin groups prune --help' 'external provider'
 os::cmd::expect_success_and_text 'openshift admin prune groups --help' 'external provider'
+
+os::test::junit::declare_suite_end

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -17,6 +19,7 @@ os::log::install_errexit
 ) &>/dev/null
 
 
+os::test::junit::declare_suite_start "cmd/newapp"
 # This test validates the new-app command
 
 os::cmd::expect_success_and_text 'oc new-app library/php mysql -o yaml' '3306'
@@ -241,3 +244,4 @@ os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-worl
 os::cmd::expect_success_and_not_text 'oc new-app https://github.com/openshift/ruby-hello-world --output-version=v1 -o=jsonpath="{.items[?(@.kind==\"BuildConfig\")].spec.source}"' 'dockerfile|binary'
 
 echo "new-app: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -7,8 +7,11 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
+os::test::junit::declare_suite_start "cmd/policy"
 # This test validates user level policy
 
 os::cmd::expect_failure_and_text 'oc policy add-role-to-user' 'you must specify a role'
@@ -70,3 +73,4 @@ os::util::sed "s/RESOURCE_VERSION/${resourceversion}/g" ${workingdir}/alternate_
 os::cmd::expect_failure_and_text "oc replace --config=${new_kubeconfig} clusterrole/alternate-cluster-admin -f ${workingdir}/alternate_cluster_admin.yaml" "attempt to grant extra privileges"
 
 echo "policy: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -20,6 +22,7 @@ os::log::install_errexit
 defaultimage="openshift/origin-\${component}:latest"
 USE_IMAGES=${USE_IMAGES:-$defaultimage}
 
+os::test::junit::declare_suite_start "cmd/router"
 # Test running a router
 os::cmd::expect_failure_and_text 'oadm router --dry-run' 'does not exist'
 os::cmd::expect_failure_and_text 'oadm router --dry-run -o yaml' 'service account "router" is not allowed to access the host network on nodes'
@@ -65,3 +68,4 @@ os::cmd::expect_success_and_text 'oc get dc/router -o yaml' 'readinessProbe'
 # only when using hostnetwork should we force the probes to use localhost
 os::cmd::expect_success_and_not_text "oadm router -o yaml --credentials=${KUBECONFIG} --host-network=false" 'host: localhost'
 echo "router: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -17,6 +19,7 @@ os::log::install_errexit
 ) &>/dev/null
 
 
+os::test::junit::declare_suite_start "cmd/secrets"
 # This test validates secret interaction
 os::cmd::expect_failure_and_text 'oc secrets new foo --type=blah makefile=Makefile' 'error: unknown secret type "blah"'
 os::cmd::expect_success 'oc secrets new foo --type=blah makefile=Makefile --confirm'
@@ -77,3 +80,4 @@ os::cmd::expect_success 'oc secret new-sshauth --help'
 os::cmd::expect_success 'oc secret add --help'
 
 echo "secrets: ok"
+os::test::junit::declare_suite_end

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -7,7 +7,9 @@ set -o pipefail
 OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
+source "${OS_ROOT}/hack/lib/test/junit.sh"
 os::log::install_errexit
+trap os::test::junit::reconcile_output EXIT
 
 # Cleanup cluster resources created by this test
 (
@@ -17,6 +19,7 @@ os::log::install_errexit
 ) &>/dev/null
 
 
+os::test::junit::declare_suite_start "cmd/volumes"
 # This test validates the 'volume' command
 
 os::cmd::expect_success 'oc create -f test/integration/fixtures/test-deployment-config.yaml'
@@ -50,3 +53,5 @@ os::cmd::expect_success 'oc set volumes dc/test-deployment-config --list'
 
 os::cmd::expect_success 'oc delete dc/test-deployment-config'
 echo "volumes: ok"
+os::test::junit::declare_suite_end
+

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -15,6 +15,9 @@ os::log::install_errexit
 source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::util::environment::setup_time_vars
 
+source "${OS_ROOT}/hack/lib/test/junit.sh"
+trap os::test::junit::reconcile_output EXIT
+
 TEST_ASSETS="${TEST_ASSETS:-false}"
 
 export VERBOSE=true
@@ -48,6 +51,7 @@ function wait_for_app() {
   wait_for_command '[[ "$(curl -s http://${FRONTEND_IP}:5432/keys/foo)" = "1337" ]]'
 }
 
+os::test::junit::declare_suite_start "end-to-end/core"
 # service dns entry is visible via master service
 # find the IP of the master service by asking the API_HOST to verify DNS is running there
 MASTER_SERVICE_IP="$(dig @${API_HOST} "kubernetes.default.svc.cluster.local." +short A | head -n 1)"
@@ -365,6 +369,7 @@ os::cmd::expect_success "oc exec -p ${registry_pod} du /registry > '${LOG_DIR}/p
 # make sure there were changes to the registry's storage
 os::cmd::expect_code "diff ${LOG_DIR}/prune-images.before.txt ${LOG_DIR}/prune-images.after.txt" 1
 
+os::test::junit::declare_suite_end
 unset VERBOSE
 
 # UI e2e tests can be found in assets/test/e2e

--- a/tools/junitreport/README.md
+++ b/tools/junitreport/README.md
@@ -8,7 +8,7 @@ In order to build and install `junitreport`, from the root of the OpenShift Orig
 
 ## Usage 
 
-`junitreport` can read the output of different types of tests. Specify which output is being read with `--type=<type>`. Supported test output types currently include `'gotest'`, for `go test` output. The default test type is `'gotest'`. 
+`junitreport` can read the output of different types of tests. Specify which output is being read with `--type=<type>`. Supported test output types currently include `'gotest'`, for `go test` output, and `'oscmd'`, for `os::cmd` output. The default test type is `'gotest'`. 
 
 `junitreport` can output flat or nested test suites. To choose which type of output to use, set `--suites=<type>` to either `'flat'` or `'nested'`. The default suite output structure is `'flat'`. When creating nested test suites, `junitreport` will use `/` as the delimeter between suite names: `github.com/maintainer/repository/suite` will be parsed as a hierarchy of `github.com`, `github.com/maintainer`, *etc.* If you are requesting nested test suite output but do not want the root suite(s) to be as general as `github.com`, for example, set `--roots=<root suite names>` to be a comma-delimited list of the names of the suites you wish to use as roots. If the parser encounters a package outside of those roots, it will ignore it. This allows a user to provide a root suite and only collect data for children of that root from a larger data set.
 

--- a/tools/junitreport/junitreport.go
+++ b/tools/junitreport/junitreport.go
@@ -51,9 +51,10 @@ const (
 	junitReportUsageLong = `Consume test output to create jUnit XML files and summarize jUnit XML files.
 
 %[1]s consumes test output through Stdin and creates jUnit XML files. Currently, only the output of 'go test'
-is supported. jUnit XML can be build with nested or flat test suites. Sub-trees of test suites can be selected
-when using the nested test-suites representation to only build XML for some subset of the test output. This
-parser is greedy, so all output not directly related to a test suite is considered test case output.
+and the output of 'oscmd' functions with $JUNIT_REPORT_OUTPUT set are supported. jUnit XML can be build with
+nested or flat test suites. Sub-trees of test suites can be selected when using the nested test-suites represen-
+tation to only build XML for some subset of the test output. This parser is greedy, so all output not directly 
+related to a test suite is considered test case output.
 `
 
 	junitReportUsage = `Usage:
@@ -82,6 +83,9 @@ parser is greedy, so all output not directly related to a test suite is consider
 
   # Describe failures and skipped tests in an existing jUnit XML file
   $ cat report.xml | %[1]s summarize
+
+  # Consume 'os::cmd' output from to create a jUnit XML file
+  $ JUNIT_REPORT='true' hack/test-cmd.sh | junitreport --type=os::cmd > report.xml
 `
 )
 

--- a/tools/junitreport/pkg/api/junit.xsd
+++ b/tools/junitreport/pkg/api/junit.xsd
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+   <xs:annotation>
+      <xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the GNU Lesser General Public License (LGPL) http://www.gnu.org/licenses/lgpl.html
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+   </xs:annotation>
+   <xs:element name="testsuite" type="testsuite" />
+   <xs:simpleType name="ISO8601_DATETIME_PATTERN">
+      <xs:restriction base="xs:dateTime">
+         <xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}" />
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:element name="testsuites">
+      <xs:annotation>
+         <xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:complexContent>
+                     <xs:extension base="testsuite">
+                        <xs:attribute name="package" type="xs:token" use="required">
+                           <xs:annotation>
+                              <xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+                           </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="id" type="xs:int" use="required">
+                           <xs:annotation>
+                              <xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+                           </xs:annotation>
+                        </xs:attribute>
+                     </xs:extension>
+                  </xs:complexContent>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:complexType name="testsuite">
+      <xs:annotation>
+         <xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="properties">
+            <xs:annotation>
+               <xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+            </xs:annotation>
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:attribute name="name" use="required">
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:minLength value="1" />
+                              </xs:restriction>
+                           </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="value" type="xs:string" use="required" />
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:choice minOccurs="0">
+                  <xs:element name="error">
+                     <xs:annotation>
+                        <xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+                     </xs:annotation>
+                     <xs:complexType>
+                        <xs:simpleContent>
+                           <xs:extension base="pre-string">
+                              <xs:attribute name="message" type="xs:string">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                              <xs:attribute name="type" type="xs:string" use="required">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                           </xs:extension>
+                        </xs:simpleContent>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="failure">
+                     <xs:annotation>
+                        <xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+                     </xs:annotation>
+                     <xs:complexType>
+                        <xs:simpleContent>
+                           <xs:extension base="pre-string">
+                              <xs:attribute name="message" type="xs:string">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                              <xs:attribute name="type" type="xs:string" use="required">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                           </xs:extension>
+                        </xs:simpleContent>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:choice>
+               <xs:attribute name="name" type="xs:token" use="required">
+                  <xs:annotation>
+                     <xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+               <xs:attribute name="classname" type="xs:token" use="required">
+                  <xs:annotation>
+                     <xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+               <xs:attribute name="time" type="xs:decimal" use="required">
+                  <xs:annotation>
+                     <xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="system-out">
+            <xs:annotation>
+               <xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="pre-string">
+                  <xs:whiteSpace value="preserve" />
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="system-err">
+            <xs:annotation>
+               <xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="pre-string">
+                  <xs:whiteSpace value="preserve" />
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="name" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:minLength value="1" />
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="hostname" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:minLength value="1" />
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tests" type="xs:int" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="failures" type="xs:int" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="errors" type="xs:int" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">The total number of tests in the suite that errorrd. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="time" type="xs:decimal" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:simpleType name="pre-string">
+      <xs:restriction base="xs:string">
+         <xs:whiteSpace value="preserve" />
+      </xs:restriction>
+   </xs:simpleType>
+</xs:schema>

--- a/tools/junitreport/pkg/api/test_suite.go
+++ b/tools/junitreport/pkg/api/test_suite.go
@@ -47,3 +47,18 @@ func (t *TestSuite) SetDuration(duration string) error {
 	t.Duration = float64(int(parsedDuration.Seconds()*1000)) / 1000
 	return nil
 }
+
+// ByName implements sort.Interface for []*TestSuite based on the Name field
+type ByName []*TestSuite
+
+func (n ByName) Len() int {
+	return len(n)
+}
+
+func (n ByName) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}
+
+func (n ByName) Less(i, j int) bool {
+	return n[i].Name < n[j].Name
+}

--- a/tools/junitreport/pkg/api/types.go
+++ b/tools/junitreport/pkg/api/types.go
@@ -6,6 +6,7 @@ import "encoding/xml"
 // XML schema, but do not contain all valid fields. For instance, the class name
 // field for test cases is omitted, as this concept does not directly apply to Go.
 // For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+// or view the XSD included in this package as 'junit.xsd'
 
 // TestSuites represents a flat collection of jUnit test suites.
 type TestSuites struct {

--- a/tools/junitreport/pkg/builder/flat/test_suites_builder.go
+++ b/tools/junitreport/pkg/builder/flat/test_suites_builder.go
@@ -19,9 +19,8 @@ type flatTestSuitesBuilder struct {
 }
 
 // AddSuite adds a test suite to the test suites collection being built
-func (b *flatTestSuitesBuilder) AddSuite(suite *api.TestSuite) error {
+func (b *flatTestSuitesBuilder) AddSuite(suite *api.TestSuite) {
 	b.testSuites.Suites = append(b.testSuites.Suites, suite)
-	return nil
 }
 
 // Build releases the test suites collection being built at whatever current state it is in

--- a/tools/junitreport/pkg/builder/flat/test_suites_builder_test.go
+++ b/tools/junitreport/pkg/builder/flat/test_suites_builder_test.go
@@ -63,9 +63,7 @@ func TestAddSuite(t *testing.T) {
 		}
 
 		for _, suite := range testCase.suitesToAdd {
-			if err := builder.AddSuite(suite); err != nil {
-				t.Errorf("%s: unexpected error adding test suite: %v", testCase.name, err)
-			}
+			builder.AddSuite(suite)
 		}
 
 		if expected, actual := testCase.expectedSuites, builder.Build(); !reflect.DeepEqual(expected, actual) {

--- a/tools/junitreport/pkg/builder/interfaces.go
+++ b/tools/junitreport/pkg/builder/interfaces.go
@@ -5,7 +5,7 @@ import "github.com/openshift/origin/tools/junitreport/pkg/api"
 // TestSuitesBuilder knows how to aggregate data to form a collection of test suites.
 type TestSuitesBuilder interface {
 	// AddSuite adds a test suite to the collection
-	AddSuite(suite *api.TestSuite) error
+	AddSuite(suite *api.TestSuite)
 
 	// Build retuns the built structure
 	Build() *api.TestSuites

--- a/tools/junitreport/pkg/builder/nested/test_suites_builder_test.go
+++ b/tools/junitreport/pkg/builder/nested/test_suites_builder_test.go
@@ -41,7 +41,7 @@ func TestAddSuite(t *testing.T) {
 	var testCases = []struct {
 		name           string
 		rootSuiteNames []string
-		seedSuites     *api.TestSuites
+		seedSuites     map[string]*treeNode
 		suiteToAdd     *api.TestSuite
 		expectedSuites *api.TestSuites
 	}{
@@ -92,9 +92,9 @@ func TestAddSuite(t *testing.T) {
 		},
 		{
 			name: "populated adding child",
-			seedSuites: &api.TestSuites{
-				Suites: []*api.TestSuite{
-					{
+			seedSuites: map[string]*treeNode{
+				"root": {
+					suite: &api.TestSuite{
 						Name: "root",
 					},
 				},
@@ -141,9 +141,9 @@ func TestAddSuite(t *testing.T) {
 		},
 		{
 			name: "populated overwriting record",
-			seedSuites: &api.TestSuites{
-				Suites: []*api.TestSuite{
-					{
+			seedSuites: map[string]*treeNode{
+				"root": {
+					suite: &api.TestSuite{
 						Name:     "root",
 						NumTests: 3,
 					},
@@ -168,12 +168,10 @@ func TestAddSuite(t *testing.T) {
 		builder := NewTestSuitesBuilder(testCase.rootSuiteNames)
 
 		if testCase.seedSuites != nil {
-			builder.(*nestedTestSuitesBuilder).testSuites = testCase.seedSuites
+			builder.(*nestedTestSuitesBuilder).nodes = testCase.seedSuites
 		}
 
-		if err := builder.AddSuite(testCase.suiteToAdd); err != nil {
-			t.Errorf("%s: unexpected error adding suite to suites: %v", testCase.name, err)
-		}
+		builder.AddSuite(testCase.suiteToAdd)
 
 		if actual, expected := builder.Build(), testCase.expectedSuites; !reflect.DeepEqual(actual, expected) {
 			t.Errorf("%s: did not get correct test suites after addition of test suite:\n\texpected:\n\t%s,\n\tgot\n\t%s", testCase.name, expected, actual)

--- a/tools/junitreport/pkg/cmd/junitreport.go
+++ b/tools/junitreport/pkg/cmd/junitreport.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
 	"github.com/openshift/origin/tools/junitreport/pkg/parser"
 	"github.com/openshift/origin/tools/junitreport/pkg/parser/gotest"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser/oscmd"
 )
 
 type testSuitesBuilderType string
@@ -26,9 +27,10 @@ type testParserType string
 
 const (
 	goTestParserType testParserType = "gotest"
+	osCmdParserType  testParserType = "oscmd"
 )
 
-var supportedTestParserTypes = []testParserType{goTestParserType}
+var supportedTestParserTypes = []testParserType{goTestParserType, osCmdParserType}
 
 type JUnitReportOptions struct {
 	// BuilderType is the type of test suites builder to use
@@ -65,6 +67,8 @@ func (o *JUnitReportOptions) Complete(builderType, parserType string, rootSuiteN
 	switch testParserType(parserType) {
 	case goTestParserType:
 		o.ParserType = goTestParserType
+	case osCmdParserType:
+		o.ParserType = osCmdParserType
 	default:
 		return fmt.Errorf("unrecognized test parser type: got %s, expected one of %v", parserType, supportedTestParserTypes)
 	}
@@ -87,6 +91,8 @@ func (o *JUnitReportOptions) Run() error {
 	switch o.ParserType {
 	case goTestParserType:
 		testParser = gotest.NewParser(builder, o.Stream)
+	case osCmdParserType:
+		testParser = oscmd.NewParser(builder, o.Stream)
 	}
 
 	testSuites, err := testParser.Parse(bufio.NewScanner(o.Input))

--- a/tools/junitreport/pkg/parser/gotest/data_parser.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser.go
@@ -32,11 +32,11 @@ func (p *testDataParser) MarksBeginning(line string) bool {
 
 // ExtractName extracts the name of the test case from test output line
 func (p *testDataParser) ExtractName(line string) (string, bool) {
-	if matches := p.testStartPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[1]) > 0 {
+	if matches := p.testStartPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[1]) > 0 {
 		return matches[1], true
 	}
 
-	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[2]) > 0 {
+	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 2 && len(matches[2]) > 0 {
 		return matches[2], true
 	}
 
@@ -45,7 +45,7 @@ func (p *testDataParser) ExtractName(line string) (string, bool) {
 
 // ExtractResult extracts the test result from a test output line
 func (p *testDataParser) ExtractResult(line string) (api.TestResult, bool) {
-	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[1]) > 0 {
+	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[1]) > 0 {
 		switch matches[1] {
 		case "PASS":
 			return api.TestResultPass, true
@@ -60,7 +60,7 @@ func (p *testDataParser) ExtractResult(line string) (api.TestResult, bool) {
 
 // ExtractDuration extracts the test duration from a test output line
 func (p *testDataParser) ExtractDuration(line string) (string, bool) {
-	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 2 && len(matches[3]) > 0 {
+	if matches := p.testResultPattern.FindStringSubmatch(line); len(matches) > 3 && len(matches[3]) > 0 {
 		return matches[3] + "s", true
 	}
 	return "", false
@@ -88,7 +88,7 @@ type testSuiteDataParser struct {
 
 // ExtractName extracts the name of the test suite from a test output line
 func (p *testSuiteDataParser) ExtractName(line string) (string, bool) {
-	if matches := p.packageResultPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[2]) > 0 {
+	if matches := p.packageResultPattern.FindStringSubmatch(line); len(matches) > 2 && len(matches[2]) > 0 {
 		return matches[2], true
 	}
 	return "", false
@@ -96,7 +96,7 @@ func (p *testSuiteDataParser) ExtractName(line string) (string, bool) {
 
 // ExtractDuration extracts the package duration from a test output line
 func (p *testSuiteDataParser) ExtractDuration(line string) (string, bool) {
-	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 2 && len(resultMatches[3]) > 0 {
+	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 3 && len(resultMatches[3]) > 0 {
 		return resultMatches[3], true
 	}
 	return "", false
@@ -110,13 +110,13 @@ const (
 func (p *testSuiteDataParser) ExtractProperties(line string) (map[string]string, bool) {
 	// the only test suite properties that Go testing can create are coverage values, which can either
 	// be present on their own line or in the package result line
-	if matches := p.coverageOutputPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[1]) > 0 {
+	if matches := p.coverageOutputPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[1]) > 0 {
 		return map[string]string{
 			coveragePropertyName: matches[1],
 		}, true
 	}
 
-	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 5 && len(resultMatches[6]) > 0 {
+	if resultMatches := p.packageResultPattern.FindStringSubmatch(line); len(resultMatches) > 6 && len(resultMatches[6]) > 0 {
 		return map[string]string{
 			coveragePropertyName: resultMatches[6],
 		}, true

--- a/tools/junitreport/pkg/parser/gotest/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/gotest/data_parser_test.go
@@ -30,9 +30,8 @@ func TestMarksTestBeginning(t *testing.T) {
 		},
 	}
 
+	parser := newTestDataParser()
 	for _, testCase := range testCases {
-		parser := newTestDataParser()
-
 		if !parser.MarksBeginning(testCase.testLine) {
 			t.Errorf("%s: did not correctly determine that line %q marked test beginning", testCase.name, testCase.testLine)
 		}
@@ -87,9 +86,8 @@ func TestExtractTestName(t *testing.T) {
 		},
 	}
 
+	parser := newTestDataParser()
 	for _, testCase := range testCases {
-		parser := newTestDataParser()
-
 		actual, contained := parser.ExtractName(testCase.testLine)
 		if !contained {
 			t.Errorf("%s: failed to extract name from line %q", testCase.name, testCase.testLine)
@@ -133,9 +131,8 @@ func TestExtractResult(t *testing.T) {
 		},
 	}
 
+	parser := newTestDataParser()
 	for _, testCase := range testCases {
-		parser := newTestDataParser()
-
 		actual, contained := parser.ExtractResult(testCase.testLine)
 		if !contained {
 			t.Errorf("%s: failed to extract result from line %q", testCase.name, testCase.testLine)
@@ -169,9 +166,8 @@ func TestExtractDuration(t *testing.T) {
 		},
 	}
 
+	parser := newTestDataParser()
 	for _, testCase := range testCases {
-		parser := newTestDataParser()
-
 		actual, contained := parser.ExtractDuration(testCase.testLine)
 		if !contained {
 			t.Errorf("%s: failed to extract duration from line %q", testCase.name, testCase.testLine)
@@ -220,9 +216,8 @@ func TestExtractSuiteName(t *testing.T) {
 		},
 	}
 
+	parser := newTestSuiteDataParser()
 	for _, testCase := range testCases {
-		parser := newTestSuiteDataParser()
-
 		actual, contained := parser.ExtractName(testCase.testLine)
 		if !contained {
 			t.Errorf("%s: failed to extract name from line %q", testCase.name, testCase.testLine)
@@ -256,9 +251,8 @@ func TestSuiteProperties(t *testing.T) {
 		},
 	}
 
+	parser := newTestSuiteDataParser()
 	for _, testCase := range testCases {
-		parser := newTestSuiteDataParser()
-
 		actual, contained := parser.ExtractProperties(testCase.testLine)
 		if !contained {
 			t.Errorf("%s: failed to extract properties from line %q", testCase.name, testCase.testLine)
@@ -296,9 +290,8 @@ func TestMarksCompletion(t *testing.T) {
 		},
 	}
 
+	parser := newTestSuiteDataParser()
 	for _, testCase := range testCases {
-		parser := newTestSuiteDataParser()
-
 		if !parser.MarksCompletion(testCase.testLine) {
 			t.Errorf("%s: did not correctly determine that line %q marked the end of a suite", testCase.name, testCase.testLine)
 		}

--- a/tools/junitreport/pkg/parser/oscmd/data_parser.go
+++ b/tools/junitreport/pkg/parser/oscmd/data_parser.go
@@ -1,0 +1,138 @@
+package oscmd
+
+import (
+	"regexp"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser/stack"
+)
+
+func newTestDataParser() stack.TestDataParser {
+	return &testDataParser{
+		// testStartPattern matches the test beginning bookend
+		testStartPattern: regexp.MustCompile(`=== BEGIN TEST CASE ===`),
+
+		// testDeclarationPattern matches the test declaration line, the full match is the name of the test being run
+		// as we're starting the test declaration line with a Unix path, misprinting a leading newline will cause this
+		// pattern to match the entire misprinted line
+		testDeclarationPattern: regexp.MustCompile(`.+:[0-9]+: executing '.+' expecting .+`),
+
+		// testConclusionPattern matches the test conclusion line, and contains the following submatches:
+		//  - 1: test result
+		//  - 2: test duration
+		//  - 3: test name
+		//  - 5: test result message
+		// In order to make this regex sane, we *require* a end-line anchor and therefore make us a little more fragile
+		// in the face of broken input
+		testConclusionPattern: regexp.MustCompile(`(SUCCESS|FAILURE) after ([0-9]+\.[0-9]+s): (.+:[0-9]+: executing '.*' expecting .*?)(: (.*))?$`),
+
+		// testEndPattern matches the test end bookend
+		testEndPattern: regexp.MustCompile(`=== END TEST CASE ===`),
+	}
+}
+
+type testDataParser struct {
+	testStartPattern       *regexp.Regexp
+	testDeclarationPattern *regexp.Regexp
+	testConclusionPattern  *regexp.Regexp
+	testEndPattern         *regexp.Regexp
+}
+
+// MarksBeginning determines if the line marks the begining of a test case
+func (p *testDataParser) MarksBeginning(line string) bool {
+	return p.testStartPattern.MatchString(line)
+}
+
+// ExtractName extracts the name of the test case from test output lines
+func (p *testDataParser) ExtractName(line string) (string, bool) {
+	// The test declaration pattern is technically a subset of the test conclusion pattern, and will therefore
+	// match anything the test declaration pattern matches. The match from the test conclusion pattern is more
+	// correct, if it exists, so we check the conclusion pattern first and return if we have a name candidate.
+	if matches := p.testConclusionPattern.FindStringSubmatch(line); len(matches) > 3 && len(matches[3]) > 0 {
+		return matches[3], true
+	}
+
+	if matches := p.testDeclarationPattern.FindStringSubmatch(line); len(matches) > 0 && len(matches[0]) > 0 {
+		return matches[0], true
+	}
+
+	return "", false
+}
+
+// ExtractResult extracts the test result from a test output line
+func (p *testDataParser) ExtractResult(line string) (api.TestResult, bool) {
+	if matches := p.testConclusionPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[1]) > 0 {
+		switch matches[1] {
+		case "SUCCESS":
+			return api.TestResultPass, true
+		case "FAILURE":
+			return api.TestResultFail, true
+		}
+	}
+
+	return "", false
+}
+
+// ExtractDuration extracts the test duration from a test output line
+func (p *testDataParser) ExtractDuration(line string) (string, bool) {
+	if matches := p.testConclusionPattern.FindStringSubmatch(line); len(matches) > 2 && len(matches[2]) > 0 {
+		return matches[2], true
+	}
+
+	return "", false
+}
+
+// ExtractMessage extracts a message (e.g. for signalling why a failure or skip occured) from a test output line
+func (p *testDataParser) ExtractMessage(line string) (string, bool) {
+	if matches := p.testConclusionPattern.FindStringSubmatch(line); len(matches) > 5 && len(matches[5]) > 0 {
+		return matches[5], true
+	}
+
+	return "", false
+}
+
+// MarksCompletion determines if the line marks the completion of a test case
+func (p *testDataParser) MarksCompletion(line string) bool {
+	return p.testEndPattern.MatchString(line)
+}
+
+func newTestSuiteDataParser() stack.TestSuiteDataParser {
+	return &testSuiteDataParser{
+		// suiteDeclarationPattern matches the suite declaration line and has the following submatches:
+		//  - 1: suite name
+		suiteDeclarationPattern: regexp.MustCompile(`=== BEGIN TEST SUITE (.*) ===`),
+
+		// suiteConclusionPattern matches the suite conclusion line
+		suiteConclusionPattern: regexp.MustCompile(`=== END TEST SUITE ===`),
+	}
+}
+
+type testSuiteDataParser struct {
+	suiteDeclarationPattern *regexp.Regexp
+	suiteConclusionPattern  *regexp.Regexp
+}
+
+// MarksBeginning determines if the line marks the begining of a test suite
+func (p *testSuiteDataParser) MarksBeginning(line string) bool {
+	return p.suiteDeclarationPattern.MatchString(line)
+}
+
+// ExtractName extracts the name of the test suite from a test output line
+func (p *testSuiteDataParser) ExtractName(line string) (string, bool) {
+	if matches := p.suiteDeclarationPattern.FindStringSubmatch(line); len(matches) > 1 && len(matches[1]) > 0 {
+		return matches[1], true
+	}
+
+	return "", false
+}
+
+// ExtractProperties extracts any metadata properties of the test suite from a test output line
+func (p *testSuiteDataParser) ExtractProperties(line string) (map[string]string, bool) {
+	// `os::cmd` suites cannot expose properties
+	return map[string]string{}, false
+}
+
+// MarksCompletion determines if the line marks the completion of a test suite
+func (p *testSuiteDataParser) MarksCompletion(line string) bool {
+	return p.suiteConclusionPattern.MatchString(line)
+}

--- a/tools/junitreport/pkg/parser/oscmd/data_parser_test.go
+++ b/tools/junitreport/pkg/parser/oscmd/data_parser_test.go
@@ -1,0 +1,300 @@
+package oscmd
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+)
+
+func TestMarksTestBeginning(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		testLine string
+	}{
+		{
+			name:     "default",
+			testLine: "=== BEGIN TEST CASE ===",
+		},
+		{
+			name:     "failed print before",
+			testLine: "some other text=== BEGIN TEST CASE ===",
+		},
+		{
+			name:     "failed print after",
+			testLine: "=== BEGIN TEST CASE ===some other text after",
+		},
+	}
+
+	parser := newTestDataParser()
+	for _, testCase := range testCases {
+		if !parser.MarksBeginning(testCase.testLine) {
+			t.Errorf("%s: did not correctly determine that line %q marked test beginning", testCase.name, testCase.testLine)
+		}
+	}
+}
+
+func TestExtractTestName(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		testLine     string
+		expectedName string
+	}{
+		{
+			name:         "test declaration",
+			testLine:     `hack/test-cmd.sh:152: executing 'openshift ex validate master-config /tmp/openshift/test-cmd//master-config-broken.yaml' expecting failure and text 'ERROR'`,
+			expectedName: `hack/test-cmd.sh:152: executing 'openshift ex validate master-config /tmp/openshift/test-cmd//master-config-broken.yaml' expecting failure and text 'ERROR'`,
+		},
+		{
+			name:         "test conclusion success",
+			testLine:     `SUCCESS after 0.041s: hack/../test/cmd/basicresources.sh:21: executing 'oc create -f test/fixtures/resource-builder/directory -f test/fixtures/resource-builder/json-no-extension -f test/fixtures/resource-builder/yml-no-extension' expecting success`,
+			expectedName: `hack/../test/cmd/basicresources.sh:21: executing 'oc create -f test/fixtures/resource-builder/directory -f test/fixtures/resource-builder/json-no-extension -f test/fixtures/resource-builder/yml-no-extension' expecting success`,
+		},
+		{
+			name:         "test conclusion failure",
+			testLine:     `FAILURE after 30.239s: hack/../test/cmd/builds.sh:68: executing 'oc new-build -D "FROM centos:7" -o json | python -m json.tool' expecting success: the command returned the wrong error code`,
+			expectedName: `hack/../test/cmd/builds.sh:68: executing 'oc new-build -D "FROM centos:7" -o json | python -m json.tool' expecting success`,
+		},
+		{
+			name:         "failed print: test conclusion success",
+			testLine:     `some other textSUCCESS after 0.041s: hack/../test/cmd/basicresources.sh:21: executing 'oc create -f test/fixtures/resource-builder/directory -f test/fixtures/resource-builder/json-no-extension -f test/fixtures/resource-builder/yml-no-extension' expecting success`,
+			expectedName: `hack/../test/cmd/basicresources.sh:21: executing 'oc create -f test/fixtures/resource-builder/directory -f test/fixtures/resource-builder/json-no-extension -f test/fixtures/resource-builder/yml-no-extension' expecting success`,
+		},
+	}
+
+	parser := newTestDataParser()
+	for _, testCase := range testCases {
+		actual, contained := parser.ExtractName(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract name from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedName != actual {
+			t.Errorf("%s: did not correctly extract name from line:\n%q:\n\texpected\n\t%q,\n\tgot\n\t%q", testCase.name, testCase.testLine, testCase.expectedName, actual)
+		}
+	}
+}
+
+func TestExtractResult(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		testLine       string
+		expectedResult api.TestResult
+	}{
+		{
+			name:           "success",
+			testLine:       `SUCCESS after 0.046s: hack/../test/cmd/basicresources.sh:35: executing 'oc delete pods hello-openshift' expecting success`,
+			expectedResult: api.TestResultPass,
+		},
+		{
+			name:           "failure",
+			testLine:       `FAILURE after 30.239s: hack/../test/cmd/builds.sh:68: executing 'oc new-build -D "FROM centos:7" -o json | python -m json.tool' expecting success: the command returned the wrong error code`,
+			expectedResult: api.TestResultFail,
+		},
+		{
+			name:           "try until failure",
+			testLine:       `SUCCESS after 0.044s: hack/../test/cmd/basicresources.sh:41: executing 'oc label pod/hello-openshift acustom=label' expecting success; re-trying every 0.2s until completion or 60.000s`,
+			expectedResult: api.TestResultPass,
+		},
+	}
+
+	parser := newTestDataParser()
+	for _, testCase := range testCases {
+		actual, contained := parser.ExtractResult(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract result from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedResult != actual {
+			t.Errorf("%s: did not correctly extract result from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedResult, actual)
+		}
+	}
+}
+
+func TestExtractDuration(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		testLine         string
+		expectedDuration string
+	}{
+		{
+			name:             "test conclusion success",
+			testLine:         `SUCCESS after 0.041s: hack/../test/cmd/basicresources.sh:21: executing 'oc create -f test/fixtures/resource-builder/directory -f test/fixtures/resource-builder/json-no-extension -f test/fixtures/resource-builder/yml-no-extension' expecting success`,
+			expectedDuration: "0.041s",
+		},
+		{
+			name:             "test conclusion failure",
+			testLine:         `FAILURE after 30.239s: hack/../test/cmd/builds.sh:68: executing 'oc new-build -D "FROM centos:7" -o json | python -m json.tool' expecting success: the command returned the wrong error code`,
+			expectedDuration: "30.239s",
+		},
+	}
+
+	parser := newTestDataParser()
+	for _, testCase := range testCases {
+		actual, contained := parser.ExtractDuration(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract duration from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedDuration != actual {
+			t.Errorf("%s: did not correctly extract duration from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedDuration, actual)
+		}
+	}
+}
+
+func TestExtractMessage(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		testLine        string
+		expectedMessage string
+	}{
+		{
+			name:            "fail on error code",
+			testLine:        `FAILURE after 0.041s: hack/../test/cmd/help.sh:32: executing 'oadm' expecting success: the command returned the wrong error code`,
+			expectedMessage: "the command returned the wrong error code",
+		},
+		{
+			name:            "fail on text",
+			testLine:        `FAILURE after 0.027s: hack/../test/cmd/help.sh:39: executing 'oc' expecting success and text 'Build and Deploy Commands:': the output content test failed`,
+			expectedMessage: "the output content test failed",
+		},
+		{
+			name:            "fail on both error code and text",
+			testLine:        `FAILURE after 0.024s: hack/../test/cmd/help.sh:40: executing 'oc' expecting success and text 'Other Commands:': the command returned the wrong error code; the output content test failed`,
+			expectedMessage: "the command returned the wrong error code; the output content test failed",
+		},
+		{
+			name:            "fail on timeout",
+			testLine:        `FAILURE after 13.514s: hack/../test/cmd/images.sh:54: executing 'oc get imagestreamtags wildfly:latest' expecting success; re-trying every 0.2s until completion or 60.000s: the command timed out`,
+			expectedMessage: "the command timed out",
+		},
+	}
+
+	parser := newTestDataParser()
+	for _, testCase := range testCases {
+		actual, contained := parser.ExtractMessage(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract duration from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedMessage != actual {
+			t.Errorf("%s: did not correctly extract message from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedMessage, actual)
+		}
+	}
+}
+
+func TestMarksTestCompletion(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		testLine string
+	}{
+		{
+			name:     "default",
+			testLine: "=== END TEST CASE ===",
+		},
+		{
+			name:     "failed print before",
+			testLine: "some other text=== END TEST CASE ===",
+		},
+		{
+			name:     "failed print after",
+			testLine: "=== END TEST CASE ===some other text after",
+		},
+	}
+
+	parser := newTestDataParser()
+	for _, testCase := range testCases {
+		if !parser.MarksCompletion(testCase.testLine) {
+			t.Errorf("%s: did not correctly determine that line %q marked test completion", testCase.name, testCase.testLine)
+		}
+	}
+}
+
+func TestMarksSuiteBeginning(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		testLine string
+	}{
+		{
+			name:     "basic",
+			testLine: "=== BEGIN TEST SUITE package/name ===",
+		},
+		{
+			name:     "numeric",
+			testLine: "=== BEGIN TEST SUITE 1234 ===",
+		},
+		{
+			name:     "url",
+			testLine: "=== BEGIN TEST SUITE github.com/maintainer/repository/package/file ===",
+		},
+		{
+			name:     "failed print",
+			testLine: `some other textok=== BEGIN TEST SUITE package/name ===`,
+		},
+	}
+
+	parser := newTestSuiteDataParser()
+	for _, testCase := range testCases {
+		if !parser.MarksBeginning(testCase.testLine) {
+			t.Errorf("%s: did not correctly determine that line %q marked the start of a suite", testCase.name, testCase.testLine)
+		}
+	}
+}
+
+func TestExtractSuiteName(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		testLine     string
+		expectedName string
+	}{
+		{
+			name:         "basic",
+			testLine:     "=== BEGIN TEST SUITE package/name ===",
+			expectedName: "package/name",
+		},
+		{
+			name:         "numeric",
+			testLine:     "=== BEGIN TEST SUITE 1234 ===",
+			expectedName: "1234",
+		},
+		{
+			name:         "url",
+			testLine:     "=== BEGIN TEST SUITE github.com/maintainer/repository/package/file ===",
+			expectedName: "github.com/maintainer/repository/package/file",
+		},
+		{
+			name:         "failed print",
+			testLine:     `some other text=== BEGIN TEST SUITE package/name ===`,
+			expectedName: "package/name",
+		},
+	}
+
+	parser := newTestSuiteDataParser()
+	for _, testCase := range testCases {
+		actual, contained := parser.ExtractName(testCase.testLine)
+		if !contained {
+			t.Errorf("%s: failed to extract name from line %q", testCase.name, testCase.testLine)
+		}
+		if testCase.expectedName != actual {
+			t.Errorf("%s: did not correctly extract suite name from line %q: expected %q, got %q", testCase.name, testCase.testLine, testCase.expectedName, actual)
+		}
+	}
+}
+
+func TestMarksSuiteCompletion(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		testLine string
+	}{
+		{
+			name:     "basic",
+			testLine: "=== END TEST SUITE ===",
+		},
+		{
+			name:     "failed print",
+			testLine: `some other text=== END TEST SUITE ===`,
+		},
+	}
+
+	parser := newTestSuiteDataParser()
+	for _, testCase := range testCases {
+		if !parser.MarksCompletion(testCase.testLine) {
+			t.Errorf("%s: did not correctly determine that line %q marked the end of a suite", testCase.name, testCase.testLine)
+		}
+	}
+}

--- a/tools/junitreport/pkg/parser/oscmd/parser.go
+++ b/tools/junitreport/pkg/parser/oscmd/parser.go
@@ -1,0 +1,12 @@
+package oscmd
+
+import (
+	"github.com/openshift/origin/tools/junitreport/pkg/builder"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser"
+	"github.com/openshift/origin/tools/junitreport/pkg/parser/stack"
+)
+
+// NewParser returns a new parser that's capable of parsing `os::cmd` test output
+func NewParser(builder builder.TestSuitesBuilder, stream bool) parser.TestOutputParser {
+	return stack.NewParser(builder, newTestDataParser(), newTestSuiteDataParser(), stream)
+}

--- a/tools/junitreport/pkg/parser/oscmd/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/oscmd/parser_flat_test.go
@@ -1,0 +1,209 @@
+package oscmd
+
+import (
+	"bufio"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder/flat"
+)
+
+// TestFlatParse tests that parsing the `os::cmd` output in the test directory with a flat builder works as expected
+func TestFlatParse(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		testFile       string
+		expectedSuites *api.TestSuites
+	}{
+		{
+			name:     "basic",
+			testFile: "1.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "failure",
+			testFile: "2.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package/name",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===`,
+									Message: "the command returned the wrong error code",
+								},
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "multiple suites",
+			testFile: "3.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+					{
+						Name:      "package/name2",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===`,
+									Message: "the command returned the wrong error code",
+								},
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nested",
+			testFile: "4.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+					{
+						Name:      "package/name/nested",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+								FailureOutput: &api.FailureOutput{
+									Output: `=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===`,
+									Message: "the command returned the wrong error code",
+								},
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+					{
+						Name:     "package/other/nested",
+						NumTests: 2,
+						Duration: 11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := NewParser(flat.NewTestSuitesBuilder(), false)
+
+		testFile := "./../../../test/oscmd/testdata/" + testCase.testFile
+
+		reader, err := os.Open(testFile)
+		if err != nil {
+			t.Errorf("%s: unexpected error opening file %q: %v", testCase.name, testFile, err)
+			continue
+		}
+		testSuites, err := parser.Parse(bufio.NewScanner(reader))
+		if err != nil {
+			t.Errorf("%s: unexpected error parsing file: %v", testCase.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
+			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
+		}
+	}
+}

--- a/tools/junitreport/pkg/parser/oscmd/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/oscmd/parser_nested_test.go
@@ -1,0 +1,275 @@
+package oscmd
+
+import (
+	"bufio"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/tools/junitreport/pkg/api"
+	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
+)
+
+// TestNestedParse tests that parsing the `go test` output in the test directory with a nested builder works as expected
+func TestNestedParse(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		testFile       string
+		rootSuiteNames []string
+		expectedSuites *api.TestSuites
+	}{
+		{
+			name:     "basic",
+			testFile: "1.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 11.245,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 11.245,
+								TestCases: []*api.TestCase{
+									{
+										Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+										Duration: 0.123,
+									},
+									{
+										Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+										Duration: 11.123,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "basic with restricted root",
+			testFile:       "1.txt",
+			rootSuiteNames: []string{"package/name"},
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 11.245,
+						TestCases: []*api.TestCase{
+							{
+								Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+								Duration: 0.123,
+							},
+							{
+								Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+								Duration: 11.123,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "failure",
+			testFile: "2.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package",
+						NumTests:  2,
+						NumFailed: 1,
+						Duration:  11.245,
+						Children: []*api.TestSuite{
+							{
+								Name:      "package/name",
+								NumTests:  2,
+								NumFailed: 1,
+								Duration:  11.245,
+								TestCases: []*api.TestCase{
+									{
+										Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+										Duration: 0.123,
+										FailureOutput: &api.FailureOutput{
+											Output: `=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===`,
+											Message: "the command returned the wrong error code",
+										},
+									},
+									{
+										Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+										Duration: 11.123,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "multiple suites",
+			testFile: "3.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package",
+						NumTests:  4,
+						Duration:  22.49,
+						NumFailed: 1,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 11.245,
+								TestCases: []*api.TestCase{
+									{
+										Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+										Duration: 0.123,
+									},
+									{
+										Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+										Duration: 11.123,
+									},
+								},
+							},
+							{
+								Name:      "package/name2",
+								NumTests:  2,
+								NumFailed: 1,
+								Duration:  11.245,
+								TestCases: []*api.TestCase{
+									{
+										Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+										Duration: 0.123,
+										FailureOutput: &api.FailureOutput{
+											Output: `=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===`,
+											Message: "the command returned the wrong error code",
+										},
+									},
+									{
+										Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+										Duration: 11.123,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nested",
+			testFile: "4.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "package",
+						NumTests:  6,
+						Duration:  33.735,
+						NumFailed: 1,
+						Children: []*api.TestSuite{
+							{
+								Name:      "package/name",
+								NumTests:  4,
+								Duration:  22.49,
+								NumFailed: 1,
+								TestCases: []*api.TestCase{
+									{
+										Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+										Duration: 0.123,
+									},
+									{
+										Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+										Duration: 11.123,
+									},
+								},
+								Children: []*api.TestSuite{
+									{
+										Name:      "package/name/nested",
+										NumTests:  2,
+										NumFailed: 1,
+										Duration:  11.245,
+										TestCases: []*api.TestCase{
+											{
+												Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+												Duration: 0.123,
+												FailureOutput: &api.FailureOutput{
+													Output: `=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===`,
+													Message: "the command returned the wrong error code",
+												},
+											},
+											{
+												Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+												Duration: 11.123,
+											},
+										},
+									},
+								},
+							},
+							{
+								Name:     "package/other",
+								NumTests: 2,
+								Duration: 11.245,
+								Children: []*api.TestSuite{
+									{
+										Name:     "package/other/nested",
+										NumTests: 2,
+										Duration: 11.245,
+										TestCases: []*api.TestCase{
+											{
+												Name:     `package/name/file.sh:23: executing 'some command' expecting success`,
+												Duration: 0.123,
+											},
+											{
+												Name:     `package/name/file.sh:24: executing 'some other command' expecting success`,
+												Duration: 11.123,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		parser := NewParser(nested.NewTestSuitesBuilder(testCase.rootSuiteNames), false)
+
+		testFile := "./../../../test/oscmd/testdata/" + testCase.testFile
+
+		reader, err := os.Open(testFile)
+		if err != nil {
+			t.Errorf("%s: unexpected error opening file %q: %v", testCase.name, testFile, err)
+			continue
+		}
+		testSuites, err := parser.Parse(bufio.NewScanner(reader))
+		if err != nil {
+			t.Errorf("%s: unexpected error parsing file: %v", testCase.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
+			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
+		}
+	}
+}

--- a/tools/junitreport/test/integration.sh
+++ b/tools/junitreport/test/integration.sh
@@ -9,6 +9,8 @@ set -o pipefail
 JUNITREPORT_ROOT=$(dirname "${BASH_SOURCE}")/..
 pushd "${JUNITREPORT_ROOT}" > /dev/null
 
+diff_args='-yd --tabsize=4 --suppress-common-lines'
+
 TMPDIR="/tmp/junitreport/test/integration"
 mkdir -p "${TMPDIR}"
 
@@ -27,24 +29,24 @@ for suite in test/*/; do
 		test_name=$( basename ${test} '.txt' )
 
 		cat "${test}" | ./junitreport -type "${suite_name}" -suites flat > "${WORKINGDIR}/${test_name}_flat.xml"
-		if ! diff "${suite}/reports/${test_name}_flat.xml" "${WORKINGDIR}/${test_name}_flat.xml"; then
+		if ! diff ${diff_args} "${suite}/reports/${test_name}_flat.xml" "${WORKINGDIR}/${test_name}_flat.xml"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for flat suite builder."
 			exit 1
 		fi
 
 		cat "${test}" | ./junitreport -type "${suite_name}" -suites nested > "${WORKINGDIR}/${test_name}_nested.xml"
-		if ! diff "${suite}/reports/${test_name}_nested.xml" "${WORKINGDIR}/${test_name}_nested.xml"; then
+		if ! diff ${diff_args} "${suite}/reports/${test_name}_nested.xml" "${WORKINGDIR}/${test_name}_nested.xml"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for nested suite builder."
 			exit 1
 		fi
 
 		cat "${WORKINGDIR}/${test_name}_flat.xml" | ./junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
-		if ! diff "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
+		if ! diff ${diff_args} "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize flat XML."
 		fi
 
 		cat "${WORKINGDIR}/${test_name}_nested.xml" | ./junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
-		if ! diff "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
+		if ! diff ${diff_args} "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize nested XML."
 		fi
 	done
@@ -55,14 +57,26 @@ done
 echo "[INFO] Testing restricted roots with nested suites..."
 # test some cases with nested suites and given roots
 cat "test/gotest/testdata/1.txt" | ./junitreport -type gotest -suites nested -roots package/name > "${TMPDIR}/gotest/1_nested_restricted.xml"
-if ! diff "test/gotest/reports/1_nested_restricted.xml" "${TMPDIR}/gotest/1_nested_restricted.xml"; then
+if ! diff ${diff_args} "test/gotest/reports/1_nested_restricted.xml" "${TMPDIR}/gotest/1_nested_restricted.xml"; then
 	echo "[FAIL] Test '1' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name'."
 	exit 1
 fi
 
+cat "test/oscmd/testdata/1.txt" | ./junitreport -type oscmd -suites nested -roots package/name > "${TMPDIR}/oscmd/1_nested_restricted.xml"
+if ! diff ${diff_args} "test/oscmd/reports/1_nested_restricted.xml" "${TMPDIR}/oscmd/1_nested_restricted.xml"; then
+	echo "[FAIL] Test '1' in suite 'oscmd' failed for nested suite builder with restricted roots: 'package/name'."
+	exit 1
+fi
+
 cat "test/gotest/testdata/9.txt" | ./junitreport -type gotest -suites nested -roots package/name,package/other > "${TMPDIR}/gotest/9_nested_restricted.xml"
-if ! diff "test/gotest/reports/9_nested_restricted.xml" "${TMPDIR}/gotest/9_nested_restricted.xml"; then
+if ! diff ${diff_args} "test/gotest/reports/9_nested_restricted.xml" "${TMPDIR}/gotest/9_nested_restricted.xml"; then
 	echo "[FAIL] Test '9' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name,package/other'."
+	exit 1
+fi
+
+cat "test/oscmd/testdata/4.txt" | ./junitreport -type oscmd -suites nested -roots package/name,package/other > "${TMPDIR}/oscmd/4_nested_restricted.xml"
+if ! diff ${diff_args} "test/oscmd/reports/4_nested_restricted.xml" "${TMPDIR}/oscmd/4_nested_restricted.xml"; then
+	echo "[FAIL] Test '4' in suite 'oscmd' failed for nested suite builder with restricted roots: 'package/name,package/other'."
 	exit 1
 fi
 echo "[PASS] Suite passed: restricted roots"

--- a/tools/junitreport/test/oscmd/reports/1_flat.xml
+++ b/tools/junitreport/test/oscmd/reports/1_flat.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/1_nested.xml
+++ b/tools/junitreport/test/oscmd/reports/1_nested.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="11.245">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="11.245">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/1_nested_restricted.xml
+++ b/tools/junitreport/test/oscmd/reports/1_nested_restricted.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/2_flat.xml
+++ b/tools/junitreport/test/oscmd/reports/2_flat.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="1" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+			<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+		</testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/2_nested.xml
+++ b/tools/junitreport/test/oscmd/reports/2_nested.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="1" time="11.245">
+		<testsuite name="package/name" tests="2" skipped="0" failures="1" time="11.245">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+				<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+			</testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/3_flat.xml
+++ b/tools/junitreport/test/oscmd/reports/3_flat.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+	<testsuite name="package/name2" tests="2" skipped="0" failures="1" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+			<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+		</testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/3_nested.xml
+++ b/tools/junitreport/test/oscmd/reports/3_nested.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="4" skipped="0" failures="1" time="22.49">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="11.245">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		</testsuite>
+		<testsuite name="package/name2" tests="2" skipped="0" failures="1" time="11.245">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+				<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+			</testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/4_flat.xml
+++ b/tools/junitreport/test/oscmd/reports/4_flat.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+	<testsuite name="package/name/nested" tests="2" skipped="0" failures="1" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+			<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+		</testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+	<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="11.245">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/4_nested.xml
+++ b/tools/junitreport/test/oscmd/reports/4_nested.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="6" skipped="0" failures="1" time="33.735">
+		<testsuite name="package/name" tests="4" skipped="0" failures="1" time="22.49">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+			<testsuite name="package/name/nested" tests="2" skipped="0" failures="1" time="11.245">
+				<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+					<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+				</testcase>
+				<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+			</testsuite>
+		</testsuite>
+		<testsuite name="package/other" tests="2" skipped="0" failures="0" time="11.245">
+			<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="11.245">
+				<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+				<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+			</testsuite>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/reports/4_nested_restricted.xml
+++ b/tools/junitreport/test/oscmd/reports/4_nested_restricted.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="4" skipped="0" failures="1" time="22.49">
+		<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+		<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		<testsuite name="package/name/nested" tests="2" skipped="0" failures="1" time="11.245">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123">
+				<failure message="the command returned the wrong error code">=== BEGIN TEST CASE ===&#xA;package/name/file.sh:23: executing &#39;some command&#39; expecting success&#xA;FAILURE after 0.1234s: package/name/file.sh:23: executing &#39;some command&#39; expecting success: the command returned the wrong error code&#xA;There was no output from the command.&#xA;There was no error output from the command.&#xA;=== END TEST CASE ===</failure>
+			</testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		</testsuite>
+	</testsuite>
+	<testsuite name="package/other" tests="2" skipped="0" failures="0" time="11.245">
+		<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="11.245">
+			<testcase name="package/name/file.sh:23: executing &#39;some command&#39; expecting success" time="0.123"></testcase>
+			<testcase name="package/name/file.sh:24: executing &#39;some other command&#39; expecting success" time="11.123"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/oscmd/summaries/1_summary.txt
+++ b/tools/junitreport/test/oscmd/summaries/1_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 11.245s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/oscmd/summaries/2_summary.txt
+++ b/tools/junitreport/test/oscmd/summaries/2_summary.txt
@@ -1,0 +1,10 @@
+Of 2 tests executed in 11.245s, 1 succeeded, 1 failed, and 0 were skipped.
+
+In suite "package/name", test case "package/name/file.sh:23: executing 'some command' expecting success" failed:
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+

--- a/tools/junitreport/test/oscmd/summaries/3_summary.txt
+++ b/tools/junitreport/test/oscmd/summaries/3_summary.txt
@@ -1,0 +1,10 @@
+Of 4 tests executed in 22.490s, 3 succeeded, 1 failed, and 0 were skipped.
+
+In suite "package/name2", test case "package/name/file.sh:23: executing 'some command' expecting success" failed:
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+

--- a/tools/junitreport/test/oscmd/summaries/4_summary.txt
+++ b/tools/junitreport/test/oscmd/summaries/4_summary.txt
@@ -1,0 +1,10 @@
+Of 6 tests executed in 33.735s, 5 succeeded, 1 failed, and 0 were skipped.
+
+In suite "package/name/nested", test case "package/name/file.sh:23: executing 'some command' expecting success" failed:
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+

--- a/tools/junitreport/test/oscmd/testdata/1.txt
+++ b/tools/junitreport/test/oscmd/testdata/1.txt
@@ -1,0 +1,14 @@
+=== BEGIN TEST SUITE package/name ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+SUCCESS after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===

--- a/tools/junitreport/test/oscmd/testdata/2.txt
+++ b/tools/junitreport/test/oscmd/testdata/2.txt
@@ -1,0 +1,14 @@
+=== BEGIN TEST SUITE package/name ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===

--- a/tools/junitreport/test/oscmd/testdata/3.txt
+++ b/tools/junitreport/test/oscmd/testdata/3.txt
@@ -1,0 +1,28 @@
+=== BEGIN TEST SUITE package/name ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+SUCCESS after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===
+=== BEGIN TEST SUITE package/name2 ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===

--- a/tools/junitreport/test/oscmd/testdata/4.txt
+++ b/tools/junitreport/test/oscmd/testdata/4.txt
@@ -1,0 +1,42 @@
+=== BEGIN TEST SUITE package/name ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+SUCCESS after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===
+=== BEGIN TEST SUITE package/name/nested ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+FAILURE after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success: the command returned the wrong error code
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===
+=== BEGIN TEST SUITE package/other/nested ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:23: executing 'some command' expecting success
+SUCCESS after 0.1234s: package/name/file.sh:23: executing 'some command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== BEGIN TEST CASE ===
+package/name/file.sh:24: executing 'some other command' expecting success
+SUCCESS after 11.123s: package/name/file.sh:24: executing 'some other command' expecting success
+There was no output from the command.
+There was no error output from the command.
+=== END TEST CASE ===
+=== END TEST SUITE ===


### PR DESCRIPTION
This pull does the following:
 * sets up a jUnit output text file artifact
 * gets tests using `os::cmd` to output to it
 * sets up test suite and test case bookends
 * inserts test suite markings into `test/cmd/*.sh`
 * formats tests to better break things up

@deads2k @liggitt @soltysh PTAL - I suggest to look at the first commit only to see changes, or look at the entire changes with whitespace disabled.  