### PR TITLE
Include update operation in build admission controller

### DIFF
--- a/pkg/build/admission/admission.go
+++ b/pkg/build/admission/admission.go
@@ -20,7 +20,7 @@ func init() {
 	admission.RegisterPlugin("BuildByStrategy", func(c kclient.Interface, config io.Reader) (admission.Interface, error) {
 		osClient, ok := c.(client.Interface)
 		if !ok {
-			return nil, errors.New("client is not an Origin client")
+			return nil, errors.New("client is not an Openshift client")
 		}
 		return NewBuildByStrategy(osClient), nil
 	})
@@ -35,7 +35,7 @@ type buildByStrategy struct {
 // on policy based on the build strategy type
 func NewBuildByStrategy(client client.Interface) admission.Interface {
 	return &buildByStrategy{
-		Handler: admission.NewHandler(admission.Create),
+		Handler: admission.NewHandler(admission.Create, admission.Update),
 		client:  client,
 	}
 }
@@ -57,7 +57,7 @@ func (a *buildByStrategy) Admit(attr admission.Attributes) error {
 	case *buildapi.BuildRequest:
 		return a.checkBuildRequestAuthorization(obj, attr)
 	default:
-		return admission.NewForbidden(attr, fmt.Errorf("Unrecognized request object %#v", obj))
+		return admission.NewForbidden(attr, fmt.Errorf("unrecognized request object %#v", obj))
 	}
 }
 

--- a/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/infra_sa_policy.go
@@ -98,6 +98,11 @@ func init() {
 					Verbs:     sets.NewString("update"),
 					Resources: sets.NewString("builds"),
 				},
+				// Create permission on virtual build type resources allows builds of those types to be updated
+				{
+					Verbs:     sets.NewString("create"),
+					Resources: sets.NewString("builds/docker", "builds/source", "builds/custom"),
+				},
 				// BuildController.ImageStreamClient (ControllerClient)
 				{
 					Verbs:     sets.NewString("get"),

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -971,6 +971,14 @@ items:
   - apiGroups: null
     attributeRestrictions: null
     resources:
+    - builds/custom
+    - builds/docker
+    - builds/source
+    verbs:
+    - create
+  - apiGroups: null
+    attributeRestrictions: null
+    resources:
     - imagestreams
     verbs:
     - get


### PR DESCRIPTION
It is possible to update a bc that was created with an allowed type to a type that is not allowed. This change closes that loophole.

Fixes #6556