### PR TITLE
Install iptables-services for dev & dind clusters

### DIFF
--- a/contrib/vagrant/provision-master.sh
+++ b/contrib/vagrant/provision-master.sh
@@ -2,7 +2,7 @@
 
 source $(dirname $0)/provision-config.sh
 
-os::provision::base-provision
+os::provision::base-provision true
 
 os::provision::build-origin "${ORIGIN_ROOT}" "${SKIP_BUILD}"
 os::provision::build-etcd "${ORIGIN_ROOT}" "${SKIP_BUILD}"

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -23,7 +23,7 @@ VOLUME ["/run", "/tmp"]
 RUN yum -y update && yum -y install git golang hg tar make \
   hostname bind-utils iproute iputils which procps-ng openssh-server \
   # Node-specific packages
-  docker openvswitch bridge-utils ethtool \
+  docker openvswitch bridge-utils ethtool iptables-services \
   && yum clean all
 
 # sshd should be enabled as needed


### PR DESCRIPTION
iptables-services is installed by default on non-cloud/vm rhel/centos
and network plugins need to be compatible with it being installed.