### PR TITLE
Include kube e2e service tests in networking suite

### DIFF
--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -21,7 +21,7 @@ source "${OS_ROOT}/hack/common.sh"
 os::log::install_errexit
 
 # These strings filter the available tests.
-NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking}"
+NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services}"
 NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
 
 DEFAULT_SKIP_LIST=(


### PR DESCRIPTION
This change depends on #6264 because the test of nodeport services requires the fix for replication controller security.