### PR TITLE
add probe for mongodb template

### DIFF
--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -87,6 +87,13 @@
               {
                 "name": "mongodb",
                 "image": "mongodb",
+                "readinessProbe": {
+                    "tcpSocket":{
+                        "port": 27017
+                    },
+                    "initialDelaySeconds": 15,
+                    "timeoutSeconds": 1
+                },
                 "ports": [
                   {
                     "containerPort": 27017,

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -104,6 +104,13 @@
               {
                 "name": "mongodb",
                 "image": "mongodb",
+                "readinessProbe": {
+                    "tcpSocket":{
+                        "port": 27017
+                    },
+                    "initialDelaySeconds": 15,
+                    "timeoutSeconds": 1
+                },
                 "ports": [
                   {
                     "containerPort": 27017,


### PR DESCRIPTION
I add a probe for the mongodb template , without this, once the pod is running and mongodb service not started, the pod status is still ready . 