### PR TITLE
homogenize tmpdirs

### DIFF
--- a/hack/cmd_util.sh
+++ b/hack/cmd_util.sh
@@ -136,8 +136,8 @@ function os::cmd::try_until_text() {
 
 # In order to harvest stderr and stdout at the same time into different buckets, we need to stick them into files 
 # in an intermediate step
-TMPDIR="${TMPDIR:-"/tmp"}"
-os_cmd_internal_tmpdir="${TMPDIR}/openshift/test/cmd"
+BASETMPDIR="${TMPDIR:-"/tmp"}/openshift"
+os_cmd_internal_tmpdir="${BASETMPDIR}/test-cmd"
 os_cmd_internal_tmpout="${os_cmd_internal_tmpdir}/tmp_stdout.log"
 os_cmd_internal_tmperr="${os_cmd_internal_tmpdir}/tmp_stderr.log"
 

--- a/hack/lib/log.sh
+++ b/hack/lib/log.sh
@@ -76,8 +76,6 @@ function os::log::clean_up_logger() {
         os::log::internal::plot "${log_subset_file}"
     done
 
-    set -o errexit
-
     return "${return_code}"
 }
 

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+# This script holds library functions for setting up the shell environment for OpenShift scripts
+#
+# This script assumes $OS_ROOT is set before being sourced
+source "${OS_ROOT}/hack/util.sh"
+
+# os::util::environment::use_sudo updates $USE_SUDO to be 'true', so that later scripts choosing between
+# execution using 'sudo' and execution without it chose to use 'sudo'
+#
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  - export USE_SUDO
+function os::util::environment::use_sudo() {
+    export USE_SUDO=true
+}
+
+# os::util::environment::setup_time_vars sets up environment variables that describe durations of time
+# These variables can be used to specify times for other utility functions
+#
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  - export TIME_MS
+#  - export TIME_SEC
+#  - export TIME_MIN
+function os::util::environment::setup_time_vars() {
+    export TIME_MS=1
+    export TIME_SEC="$(( 1000  * ${TIME_MS} ))"
+    export TIME_MIN="$(( 60 * ${TIME_SEC} ))"
+}
+
+# os::util::environment::setup_all_server_vars sets up all environment variables necessary to configure and start an OpenShift server
+#
+# Globals:
+#  - OS_ROOT
+#  - PATH
+#  - TMPDIR
+#  - LOG_DIR
+#  - ARTIFACT_DIR
+#  - KUBELET_SCHEME
+#  - KUBELET_BIND_HOST
+#  - KUBELET_HOST
+#  - KUBELET_PORT
+#  - BASETMPDIR
+#  - ETCD_PORT
+#  - ETCD_PEER_PORT
+#  - API_BIND_HOST
+#  - API_HOST
+#  - API_PORT
+#  - API_SCHEME
+#  - PUBLIC_MASTER_HOST
+#  - USE_IMAGES
+# Arguments:
+#  - 1: the path under the root temporary directory for OpenShift where these subdirectories should be made
+# Returns:
+#  - export PATH
+#  - export BASETMPDIR
+#  - export LOG_DIR
+#  - export VOLUME_DIR
+#  - export ARTIFACT_DIR
+#  - export FAKE_HOME_DIR
+#  - export HOME
+#  - export KUBELET_SCHEME
+#  - export KUBELET_BIND_HOST
+#  - export KUBELET_HOST
+#  - export KUBELET_PORT
+#  - export ETCD_PORT
+#  - export ETCD_PEER_PORT
+#  - export ETCD_DATA_DIR
+#  - export API_BIND_HOST
+#  - export API_HOST
+#  - export API_PORT
+#  - export API_SCHEME
+#  - export CURL_CA_BUNDLE
+#  - export CURL_CERT
+#  - export CURL_KEY
+#  - export SERVER_CONFIG_DIR
+#  - export MASTER_CONFIG_DIR
+#  - export NODE_CONFIG_DIR
+#  - export USE_IMAGES
+#  - export TAG
+function os::util::environment::setup_all_server_vars() {
+    local subtempdir=$1
+
+    os::util::environment::update_path_var
+    os::util::environment::setup_tmpdir_vars "${subtempdir}"
+    os::util::environment::setup_kubelet_vars
+    os::util::environment::setup_etcd_vars
+    os::util::environment::setup_server_vars
+    os::util::environment::setup_images_vars
+}
+
+# os::util::environment::update_path_var updates $PATH so that OpenShift binaries are available
+#
+# Globals:
+#  - OS_ROOT
+#  - PATH
+# Arguments:
+#  None
+# Returns:
+#  - export PATH
+function os::util::environment::update_path_var() {
+    export PATH="${OS_ROOT}/_output/local/bin/$(os::util::host_platform):${PATH}"
+}
+
+# os::util::environment::setup_misc_tmpdir_vars sets up temporary directory path variables
+#
+# Globals:
+#  - TMPDIR
+#  - LOG_DIR
+#  - ARTIFACT_DIR
+# Arguments:
+#  - 1: the path under the root temporary directory for OpenShift where these subdirectories should be made
+# Returns:
+#  - export BASETMPDIR
+#  - export LOG_DIR
+#  - export VOLUME_DIR
+#  - export ARTIFACT_DIR
+#  - export FAKE_HOME_DIR
+#  - export HOME
+function os::util::environment::setup_tmpdir_vars() {
+    local sub_dir=$1
+
+    export BASETMPDIR="${TPMDIR:-/tmp}/openshift/${sub_dir}"
+    export LOG_DIR="${LOG_DIR:-${BASETMPDIR}/logs}"
+    export VOLUME_DIR="${BASETMPDIR}/volumes"
+    export ARTIFACT_DIR="${ARTIFACT_DIR:-${BASETMPDIR}/artifacts}"
+
+    # change the location of $HOME so no one does anything naughty
+    export FAKE_HOME_DIR="${BASETMPDIR}/openshift.local.home"
+    export HOME="${FAKE_HOME_DIR}"
+
+    mkdir -p  "${BASETMPDIR}" "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${HOME}"
+}
+
+# os::util::environment::setup_kubelet_vars sets up environment variables necessary for interacting with the kubelet
+#
+# Globals:
+#  - KUBELET_SCHEME
+#  - KUBELET_BIND_HOST
+#  - KUBELET_HOST
+#  - KUBELET_PORT
+# Arguments:
+#  None
+# Returns:
+#  - export KUBELET_SCHEME
+#  - export KUBELET_BIND_HOST
+#  - export KUBELET_HOST
+#  - export KUBELET_PORT
+function os::util::environment::setup_kubelet_vars() {
+    export KUBELET_SCHEME="${KUBELET_SCHEME:-https}"
+    export KUBELET_BIND_HOST="${KUBELET_BIND_HOST:-$(openshift start --print-ip)}"
+    export KUBELET_HOST="${KUBELET_HOST:-${KUBELET_BIND_HOST}}"
+    export KUBELET_PORT="${KUBELET_PORT:-10250}"
+}
+
+# os::util::environment::setup_etcd_vars sets up environment variables necessary for interacting with etcd
+#
+# Globals:
+#  - BASETMPDIR
+#  - ETCD_HOST
+#  - ETCD_PORT
+#  - ETCD_PEER_PORT
+# Arguments:
+#  None
+# Returns:
+#  - export ETCD_HOST
+#  - export ETCD_PORT
+#  - export ETCD_PEER_PORT
+#  - export ETCD_DATA_DIR
+function os::util::environment::setup_etcd_vars() {
+    export ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
+    export ETCD_PORT="${ETCD_PORT:-4001}"
+    export ETCD_PEER_PORT="${ETCD_PEER_PORT:-7001}"
+
+    export ETCD_DATA_DIR="${BASETMPDIR}/etcd"
+
+    mkdir -p "${ETCD_DATA_DIR}"
+}
+
+# os::util::environment::setup_server_vars sets up environment variables necessary for interacting with the server
+# 
+# Globals:
+#  - BASETMPDIR
+#  - KUBELET_HOST
+#  - API_BIND_HOST
+#  - API_HOST
+#  - API_PORT
+#  - API_SCHEME
+#  - PUBLIC_MASTER_HOST
+# Arguments:
+#  None
+# Returns:
+#  - export API_BIND_HOST
+#  - export API_HOST
+#  - export API_PORT
+#  - export API_SCHEME
+#  - export CURL_CA_BUNDLE
+#  - export CURL_CERT
+#  - export CURL_KEY
+#  - export SERVER_CONFIG_DIR
+#  - export MASTER_CONFIG_DIR
+#  - export NODE_CONFIG_DIR
+function os::util::environment::setup_server_vars() {
+    export API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip)}"
+    export API_HOST="${API_HOST:-${API_BIND_HOST}}"
+    export API_PORT="${API_PORT:-8443}"
+    export API_SCHEME="${API_SCHEME:-https}"
+
+    export MASTER_ADDR="${API_SCHEME}://${API_HOST}:${API_PORT}"
+    export PUBLIC_MASTER_HOST="${PUBLIC_MASTER_HOST:-${API_HOST}}"
+
+    export SERVER_CONFIG_DIR="${BASETMPDIR}/openshift.local.config"
+    export MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
+    export NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-${KUBELET_HOST}"
+
+    mkdir -p "${SERVER_CONFIG_DIR}" "${MASTER_CONFIG_DIR}" "${NODE_CONFIG_DIR}"
+
+    if [[ "${API_SCHEME}" == "https" ]]; then
+        export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
+        export CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
+        export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
+    fi
+}
+
+# os::util::environment::setup_images_vars sets up environment variables necessary for interacting with release images
+#
+# Globals:
+#  - OS_ROOT
+#  - USE_IMAGES
+# Arguments:
+#  None
+# Returns:
+#  - export USE_IMAGES
+#  - export TAG
+function os::util::environment::setup_images_vars() {
+    # Use either the latest release built images, or latest.
+    if [[ -z "${USE_IMAGES-}" ]]; then
+        export TAG='latest'
+        export USE_IMAGES='openshift/origin-${component}:latest'
+
+        if [[ -e "${OS_ROOT}/_output/local/releases/.commit" ]]; then
+            export TAG="$(cat "${OS_ROOT}/_output/local/releases/.commit")"
+            export USE_IMAGES="openshift/origin-\${component}:${TAG}"
+        fi
+    fi
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -12,6 +12,7 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${OS_ROOT}"
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::log::install_errexit
 
 function cleanup()
@@ -57,18 +58,14 @@ tests=( $(find_tests ${1:-.*}) )
 # Setup environment
 
 # test-cmd specific defaults
-TMPDIR="${TMPDIR:-"/tmp"}"
-BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-cmd}"
-LOG_DIR=${BASETMPDIR}/logs
 API_HOST=${API_HOST:-127.0.0.1}
 export API_PORT=${API_PORT:-28443}
 
 export ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 export ETCD_PORT=${ETCD_PORT:-24001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
-setup_env_vars
-export SUDO=''
-mkdir -p "${ETCD_DATA_DIR}" "${VOLUME_DIR}" "${FAKE_HOME_DIR}" "${MASTER_CONFIG_DIR}" "${NODE_CONFIG_DIR}" "${LOG_DIR}"
+
+os::util::environment::setup_all_server_vars "test-cmd/"
 reset_tmp_dir
 
 echo "Logging to ${LOG_DIR}..."
@@ -79,7 +76,7 @@ os::log::start_system_logger
 unset KUBECONFIG
 
 # test wrapper functions
-${OS_ROOT}/hack/test-cmd_util.sh > ${BASETMPDIR}/wrappers.txt 2>&1
+${OS_ROOT}/hack/test-cmd_util.sh > ${LOG_DIR}/wrappers_test.log 2>&1
 
 
 # handle profiling defaults

--- a/hack/test-cmd_util.sh
+++ b/hack/test-cmd_util.sh
@@ -11,7 +11,8 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
-JUNIT_OUTPUT_FILE=/tmp/openshift-cmd/junit_output.txt
+BASETMPDIR="${TMPDIR:-/tmp}/openshift/test-tools"
+JUNIT_OUTPUT_FILE="${BASETMPDIR}/junit_output.txt"
 
 # set verbosity so we can see that command output renders correctly
 VERBOSE=1

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -11,14 +11,14 @@ STARTTIME=$(date +%s)
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
 
 echo "[INFO] Starting containerized end-to-end test"
 
 unset KUBECONFIG
 
-TMPDIR="${TMPDIR:-"/tmp"}"
-BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-e2e-containerized}"
-setup_env_vars
+os::util::environment::setup_all_server_vars "test-end-to-end-docker/"
+os::util::environment::use_sudo
 reset_tmp_dir
 
 function cleanup()
@@ -65,8 +65,7 @@ function cleanup()
 	exit $out
 }
 
-trap "exit" INT TERM
-trap "cleanup" EXIT
+trap "cleanup" EXIT INT TERM
 
 os::log::start_system_logger
 

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -11,6 +11,7 @@ STARTTIME=$(date +%s)
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::log::install_errexit
 
 ensure_iptables_or_die
@@ -39,9 +40,8 @@ trap "cleanup" EXIT
 
 
 # Start All-in-one server and wait for health
-TMPDIR="${TMPDIR:-"/tmp"}"
-BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-e2e}"
-setup_env_vars
+os::util::environment::setup_all_server_vars "test-end-to-end/"
+os::util::environment::use_sudo
 reset_tmp_dir
 
 os::log::start_system_logger

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -10,6 +10,7 @@ source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/text.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::log::install_errexit
 
 # Go to the top of the tree.
@@ -17,14 +18,11 @@ cd "${OS_ROOT}"
 
 os::build::setup_env
 
-TMPDIR="${TMPDIR:-"/tmp"}"
-export BASETMPDIR="${BASETMPDIR:-${TMPDIR}/openshift-integration}"
-export API_SCHEME=${API_SCHEME:-http}
+export API_SCHEME="http"
 export API_BIND_HOST="127.0.0.1"
 export ETCD_PORT=${ETCD_PORT:-44001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-47001}
-export SUDO=''
-setup_env_vars
+os::util::environment::setup_all_server_vars "test-integration/"
 reset_tmp_dir
 
 function cleanup() {

--- a/hack/test-tools.sh
+++ b/hack/test-tools.sh
@@ -13,13 +13,6 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/cmd_util.sh"
 os::log::install_errexit
 
-
-for tool in ${OS_ROOT}/tools/*; do
-	test_file=${tool}/test/integration.sh
-	if [ -e ${test_file} ]; then
-		# if the tool exposes an integration test, run it
-		os::cmd::expect_success "${test_file}"
-	fi
-done
+os::cmd::expect_success 'tools/junitreport/test/integration.sh'
 
 echo "test-tools: ok"

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -8,6 +8,7 @@ set -o pipefail
 
 OS_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::log::install_errexit
 
 function cleanup()
@@ -29,19 +30,13 @@ function cleanup()
 trap "exit" INT TERM
 trap "cleanup" EXIT
 
-set -e
-
-
-TMPDIR="${TMPDIR:-"/tmp"}"
-BASETMPDIR="${TMPDIR}/openshift-swagger"
 export ALL_IP_ADDRESSES=127.0.0.1
 export SERVER_HOSTNAME_LIST=127.0.0.1
 export API_BIND_HOST=127.0.0.1
 export API_PORT=38443
 export ETCD_PORT=34001
 export ETCD_PEER_PORT=37001
-export SUDO=''
-setup_env_vars
+os::util::environment::setup_all_server_vars "generate-swagger-spec/"
 reset_tmp_dir
 configure_os_server
 

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -2,65 +2,34 @@
 
 # Provides simple utility functions
 
-TIME_SEC=1000
-TIME_MIN=$((60 * $TIME_SEC))
-
-# setup_env_vars exports all the necessary environment variables for configuring and
-# starting OS server.
-function setup_env_vars {
-	# set path so OpenShift is available
-	GO_OUT="${OS_ROOT}/_output/local/bin/$(os::util::host_platform)"
-	export PATH="${GO_OUT}:${PATH}"
-
-	export ETCD_PORT="${ETCD_PORT:-4001}"
-	export ETCD_PEER_PORT="${ETCD_PEER_PORT:-7001}"
-	export API_BIND_HOST="${API_BIND_HOST:-$(openshift start --print-ip)}"
-	export API_HOST="${API_HOST:-${API_BIND_HOST}}"
-	export API_PORT="${API_PORT:-8443}"
-	export LOG_DIR="${LOG_DIR:-${BASETMPDIR}/logs}"
-	export ETCD_DATA_DIR="${BASETMPDIR}/etcd"
-	export VOLUME_DIR="${BASETMPDIR}/volumes"
-	export FAKE_HOME_DIR="${BASETMPDIR}/openshift.local.home"
-	export API_SCHEME="${API_SCHEME:-https}"
-	export MASTER_ADDR="${API_SCHEME}://${API_HOST}:${API_PORT}"
-	export PUBLIC_MASTER_HOST="${PUBLIC_MASTER_HOST:-${API_HOST}}"
-	export KUBELET_SCHEME="${KUBELET_SCHEME:-https}"
-	export KUBELET_BIND_HOST="${KUBELET_BIND_HOST:-$(openshift start --print-ip)}"
-	export KUBELET_HOST="${KUBELET_HOST:-${KUBELET_BIND_HOST}}"
-	export KUBELET_PORT="${KUBELET_PORT:-10250}"
-	export SERVER_CONFIG_DIR="${BASETMPDIR}/openshift.local.config"
-	export MASTER_CONFIG_DIR="${SERVER_CONFIG_DIR}/master"
-	export NODE_CONFIG_DIR="${SERVER_CONFIG_DIR}/node-${KUBELET_HOST}"
-	export ARTIFACT_DIR="${ARTIFACT_DIR:-${BASETMPDIR}/artifacts}"
-	if [ -z ${SUDO+x} ]; then
-		export SUDO="${SUDO:-1}"
-	fi
-
-	# Use either the latest release built images, or latest.
-	if [[ -z "${USE_IMAGES-}" ]]; then
-		IMAGES='openshift/origin-${component}:latest'
-		export TAG=latest
-		export USE_IMAGES=${IMAGES}
-		if [[ -e "${OS_ROOT}/_output/local/releases/.commit" ]]; then
-			COMMIT="$(cat "${OS_ROOT}/_output/local/releases/.commit")"
-			IMAGES="openshift/origin-\${component}:${COMMIT}"
-			export TAG=${COMMIT}
-			export USE_IMAGES=${IMAGES}
-		fi
-	fi
-
-	if [[ "${API_SCHEME}" == "https" ]]; then
-		export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"
-		export CURL_CERT="${MASTER_CONFIG_DIR}/admin.crt"
-		export CURL_KEY="${MASTER_CONFIG_DIR}/admin.key"
-	fi
-
-	# change the location of $HOME so no one does anything naughty
-	export HOME="${FAKE_HOME_DIR}"
-}
-
-# configure_and_start_os will create and write OS master certificates, node config,
-# OS config.
+# configure_os_server will create and write OS master certificates, node configurations, and OpenShift configurations.
+# It is recommended to run the following environment setup functions before configuring the OpenShift server:
+#  - os::util::environment::setup_all_server_vars
+#  - os::util::environment::use_sudo -- if your script should be using root privileges
+#
+# Globals:
+#  - ALL_IP_ADDRESSES
+#  - PUBLIC_MASTER_HOST
+#  - MASTER_CONFIG_DIR
+#  - MASTER_ADDR
+#  - API_SCHEME
+#  - PUBLIC_MASTER_HOST
+#  - API_PORT
+#  - KUBELET_SCHEME
+#  - KUBELET_BIND_HOST
+#  - KUBELET_PORT
+#  - NODE_CONFIG_DIR
+#  - KUBELET_HOST
+#  - API_BIND_HOST
+#  - VOLUME_DIR
+#  - ETCD_DATA_DIR
+#  - USE_IMAGES
+#  - USE_SUDO
+# Arguments:
+#  None
+# Returns:
+#  - export ADMIN_KUBECONFIG
+#  - export CLUSTER_ADMIN_CONTEXT
 function configure_os_server {
 	# find the same IP that openshift start will bind to.	This allows access from pods that have to talk back to master
 	if [[ -z "${ALL_IP_ADDRESSES-}" ]]; then
@@ -122,16 +91,37 @@ function configure_os_server {
 	# Make oc use ${MASTER_CONFIG_DIR}/admin.kubeconfig, and ignore anything in the running user's $HOME dir
 	export ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
 	export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template --template='{{index . "current-context"}}')
-	local sudo="${SUDO:+sudo}"
+	local sudo="${USE_SUDO:+sudo}"
 	${sudo} chmod -R a+rwX "${ADMIN_KUBECONFIG}"
 	echo "[INFO] To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
 }
 
 
-# start_os_server starts the OS server, exports the PID of the OS server
-# and waits until OS server endpoints are available
+# start_os_server starts the OpenShift server, exports the PID of the OpenShift server and waits until openshift server endpoints are available
+# It is advised to use this function after a successful run of 'configure_os_server'
+#
+# Globals:
+#  - USE_SUDO
+#  - LOG_DIR
+#  - ARTIFACT_DIR
+#  - VOLUME_DIR
+#  - SERVER_CONFIG_DIR
+#  - USE_IMAGES
+#  - MASTER_ADDR
+#  - MASTER_CONFIG_DIR
+#  - NODE_CONFIG_DIR
+#  - API_SCHEME
+#  - API_HOST
+#  - API_PORT
+#  - KUBELET_SCHEME
+#  - KUBELET_HOST
+#  - KUBELET_PORT
+# Arguments:
+#  None
+# Returns:
+#  - export OS_PID
 function start_os_server {
-	local sudo="${SUDO:+sudo}"
+	local sudo="${USE_SUDO:+sudo}"
 
 	echo "[INFO] `openshift version`"
 	echo "[INFO] Server logs will be at:    ${LOG_DIR}/openshift.log"
@@ -165,10 +155,26 @@ function start_os_server {
 	date
 }
 
-# start_os_master starts the OS server, exports the PID of the OS server
-# and waits until OS server endpoints are available
+# start_os_master starts the OpenShift master, exports the PID of the OpenShift master and waits until OpenShift master endpoints are available
+# It is advised to use this function after a successful run of 'configure_os_server'
+#
+# Globals:
+#  - USE_SUDO
+#  - LOG_DIR
+#  - ARTIFACT_DIR
+#  - SERVER_CONFIG_DIR
+#  - USE_IMAGES
+#  - MASTER_ADDR
+#  - MASTER_CONFIG_DIR
+#  - API_SCHEME
+#  - API_HOST
+#  - API_PORT
+# Arguments:
+#  None
+# Returns:
+#  - export OS_PID
 function start_os_master {
-	local sudo="${SUDO:+sudo}"
+	local sudo="${USE_SUDO:+sudo}"
 
 	echo "[INFO] `openshift version`"
 	echo "[INFO] Server logs will be at:    ${LOG_DIR}/openshift.log"
@@ -434,7 +440,7 @@ function validate_response {
 # 
 # $1 expression for which the mounts should be checked 
 reset_tmp_dir() {
-	local sudo="${SUDO:+sudo}"
+	local sudo="${USE_SUDO:+sudo}"
 
 	set +e
 	${sudo} rm -rf ${BASETMPDIR} &>/dev/null
@@ -452,7 +458,7 @@ reset_tmp_dir() {
 # all processes created by the test script.
 function kill_all_processes()
 {
-	local sudo="${SUDO:+sudo}"
+	local sudo="${USE_SUDO:+sudo}"
 
 	pids=($(jobs -pr))
 	for i in ${pids[@]-}; do
@@ -493,12 +499,12 @@ function delete_empty_logs() {
 
 # truncate_large_logs truncates large logs so we only download the last 20MB
 function truncate_large_logs() {
-	# Clean up large log files so they don't end up on jenkins
+	# Clean up large log files so they don't end up on jenkins		
 	local large_files=$(find "${ARTIFACT_DIR}" "${LOG_DIR}" -type f -name '*.log' \( -size +20M \))
-	for file in "${large_files}"; do
+	for file in ${large_files}; do
 		cp "${file}" "${file}.tmp"
 		echo "LOGFILE TOO LONG, PREVIOUS BYTES TRUNCATED. LAST 20M BYTES OF LOGFILE:" > "${file}"
-		tail -c 20M "${file}.tmp" > "${file}"
+		tail -c 20M "${file}.tmp" >> "${file}"
 		rm "${file}.tmp"
 	done
 }
@@ -555,8 +561,8 @@ function cleanup_openshift {
 function create_gitconfig {
 	USERNAME=sample-user
 	PASSWORD=password
-	TMPDIR="${TMPDIR:-"/tmp"}"
-	GITCONFIG_DIR=$(mktemp -d ${TMPDIR}/test-gitconfig.XXXX)
+	BASETMPDIR="${BASETMPDIR:-"/tmp"}"
+	GITCONFIG_DIR=$(mktemp -d ${BASETMPDIR}/test-gitconfig.XXXX)
 	touch ${GITCONFIG_DIR}/.gitconfig
 	git config --file ${GITCONFIG_DIR}/.gitconfig user.name ${USERNAME}
 	git config --file ${GITCONFIG_DIR}/.gitconfig user.token ${PASSWORD}
@@ -564,8 +570,8 @@ function create_gitconfig {
 }
 
 function create_valid_file {
-	TMPDIR="${TMPDIR:-"/tmp"}"
-	FILE_DIR=$(mktemp -d ${TMPDIR}/test-file.XXXX)
+	BASETMPDIR="${BASETMPDIR:-"/tmp"}"
+	FILE_DIR=$(mktemp -d ${BASETMPDIR}/test-file.XXXX)
 	touch ${FILE_DIR}/${1}
 	echo ${FILE_DIR}/${1}
 }

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -11,6 +11,9 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 os::log::install_errexit
 
+source "${OS_ROOT}/hack/lib/util/environment.sh"
+os::util::environment::setup_time_vars
+
 ROUTER_TESTS_ENABLED="${ROUTER_TESTS_ENABLED:-true}"
 TEST_ASSETS="${TEST_ASSETS:-false}"
 
@@ -333,7 +336,6 @@ oc exec -p ${registry_pod} du /registry > ${LOG_DIR}/prune-images.after.txt
 
 # make sure there were changes to the registry's storage
 [ -n "$(diff ${LOG_DIR}/prune-images.before.txt ${LOG_DIR}/prune-images.after.txt)" ]
-
 
 # UI e2e tests can be found in assets/test/e2e
 if [[ "$TEST_ASSETS" == "true" ]]; then

--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -90,12 +90,12 @@ package is not included by `test/extended`.
 Bash helpers for creating new test group runner
 -----------------------------------------------
 
-Common functions for extended tests are located in `./hack/util.sh`.
+Common functions for extended tests are located in `./hack/util.sh`. Environment setup scripts are located in `hack/lib/util/evironment.sh`.
 
 * `ginkgo_check_extended()` verify if the Ginkgo binary is installed.
 * `compile_extended()` perform the compilation of the Go tests into a test binary.
 * `test_privileges()` verify if you have permissions to start OpenShift server.
-* `setup_env_vars()` setup all required environment variables related to OpenShift server.
+* `os::util::environment::setup_all_server_vars()` setup all required environment variables related to OpenShift server.
 * `configure_os_server()` generates all configuration files for OpenShift server.
 * `start_os_server()` starts the OpenShift master and node.
 * `install_router_extended()` installs the OpenShift router service.

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+	#!/bin/bash
 #
 # This scripts starts the OpenShift server with a default configuration.
 # No registry or router is setup.
@@ -14,14 +14,13 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
 os::log::install_errexit
+
+source "${OS_ROOT}/hack/lib/util/environment.sh"
+os::util::environment::setup_time_vars
+
 cd "${OS_ROOT}"
 
 os::build::setup_env
-
-export TMPDIR="${TMPDIR:-"/tmp"}"
-export BASETMPDIR="${TMPDIR}/openshift-extended-tests/authentication"
-export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
-export KUBE_REPO_ROOT="${OS_ROOT}/../../../k8s.io/kubernetes"
 
 function cleanup()
 {
@@ -37,7 +36,8 @@ trap "cleanup" EXIT
 
 echo "[INFO] Starting server"
 
-setup_env_vars
+os::util::environment::setup_all_server_vars "test-extended/cmd/"
+os::util::environment::use_sudo
 reset_tmp_dir
 
 os::log::start_system_logger

--- a/test/extended/core.sh
+++ b/test/extended/core.sh
@@ -17,6 +17,10 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
 os::log::install_errexit
+
+source "${OS_ROOT}/hack/lib/util/environment.sh"
+os::util::environment::setup_time_vars
+
 cd "${OS_ROOT}"
 
 # ensure_ginkgo_or_die
@@ -26,8 +30,6 @@ os::build::setup_env
 #  go test -c ./test/extended -o ${OS_OUTPUT_BINPATH}/extended.test
 #fi
 
-export TMPDIR="${TMPDIR:-"/tmp"}"
-export BASETMPDIR="${TMPDIR}/openshift-extended-tests/core"
 export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
 
 # TODO: check out the version of Kube we need so that we have access to sample content - in the future,
@@ -105,7 +107,8 @@ if [[ -z ${TEST_ONLY+x} ]]; then
   trap "cleanup" EXIT
   echo "[INFO] Starting server"
 
-  setup_env_vars
+  os::util::environment::setup_all_server_vars "test-extended/core"
+  os::util::environment::use_sudo
   reset_tmp_dir
 
   os::log::start_system_logger

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -13,17 +13,13 @@ source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
 os::log::install_errexit
+
+source "${OS_ROOT}/hack/lib/util/environment.sh"
+os::util::environment::setup_time_vars
+
 cd "${OS_ROOT}"
 
 os::build::setup_env
-
-export TMPDIR="${TMPDIR:-"/tmp"}"
-export BASETMPDIR="${TMPDIR}/openshift-extended-tests/authentication"
-export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
-export KUBE_REPO_ROOT="${OS_ROOT}/../../../k8s.io/kubernetes"
-
-function join { local IFS="$1"; shift; echo "$*"; }
-
 
 function cleanup()
 {
@@ -39,7 +35,8 @@ trap "cleanup" EXIT
 echo "[INFO] Starting server"
 
 ensure_iptables_or_die
-setup_env_vars
+os::util::environment::setup_all_server_vars "test-extended/ldap_groups/"
+os::util::environment::use_sudo
 reset_tmp_dir
 
 os::log::start_system_logger

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -19,6 +19,7 @@ OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${OS_ROOT}/hack/util.sh"
 source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
+source "${OS_ROOT}/hack/lib/util/environment.sh"
 os::log::install_errexit
 
 # These strings filter the available tests.
@@ -222,9 +223,7 @@ else
     "${OPENSHIFT_INSTANCE_PREFIX}-node-2"
   )
 
-  export TMPDIR="${TMPDIR:-"/tmp"}"
-  export BASETMPDIR="${TMPDIR}/openshift-extended-tests/networking"
-  setup_env_vars
+  os::util::environment::setup_tmpdir_vars "test-extended/networking"
   reset_tmp_dir
 
   os::log::start_system_logger


### PR DESCRIPTION
Homogenizes our TMPDIR approach, making sure every script using scratch space has their own.

I changed `BASETMPDIR` to `TMPDIR` as the way we had it written before didn't really make sense.

This waits on https://github.com/openshift/vagrant-openshift/pull/378 to merge.

fixes https://github.com/openshift/origin/issues/5843

@deads2k @liggitt PTAL