### PR TITLE
Change default ClusterNetworkCIDR and HostSubnetLength

### DIFF
--- a/pkg/cmd/server/start/network_args.go
+++ b/pkg/cmd/server/start/network_args.go
@@ -30,8 +30,8 @@ func BindNetworkArgs(args *NetworkArgs, flags *pflag.FlagSet, prefix string) {
 func NewDefaultNetworkArgs() *NetworkArgs {
 	config := &NetworkArgs{
 		NetworkPluginName:  "",
-		ClusterNetworkCIDR: "10.1.0.0/16",
-		HostSubnetLength:   8,
+		ClusterNetworkCIDR: "10.128.0.0/14",
+		HostSubnetLength:   9,
 		ServiceNetworkCIDR: "172.30.0.0/16",
 	}
 


### PR DESCRIPTION
From https://trello.com/c/bCmIOTeJ/ ("SDN out of box configuration and scale"). This patch changes the SDN defaults in two ways:

1. Change the default cluster network range from `10.1.0.0/16` to `10.128.0.0/16`. With #6349 it is now possible to expand a deployed cluster to a larger CIDR range, as long as the new network overlaps the old one. But with the default value of `10.1.0.0/16`, any expansion would have to also cover `10.0.0.0/16`, which is the section of `10.0.0.0/8` most likely to already be used by some other network (which is presumably why we currently default to `10.1.0.0/16` not `10.0.0.0/16`). So change the default to `10.128.0.0/16`, so that expanding it would use other high-numbered subnets.
2. Change HostSubnetLength to 7. The old default of 8, with a /16 network, allows for 256 nodes with 254 pods each. But we don't expect nodes to work well with [more than 100 containers](http://lists.openshift.redhat.com/openshift-archives/dev/2016-January/msg00001.html), so it makes
sense to default to fewer pods and more nodes (512 nodes / 126 pods). (We could drop it further, but we don't currently support changing HostSubnetLength in a deployed cluster, so expanding ClusterNetworkCIDR can only increase the number of nodes, not the number of pods per node, so I figured it was better to err on the side of too high a default value.)

This is just a proposal; we might want to change only one of those two things, or neither, for backward-compatibility/documentation reasons... Thoughts?

@openshift/networking 