### PR TITLE
use direct mount for etcd data

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -77,11 +77,13 @@ out=$(
 echo "[INFO] `openshift version`"
 echo "[INFO] Using images:							${USE_IMAGES}"
 
+mkdir -p /tmp/openshift-e2e/etcd || true
+
 echo "[INFO] Starting OpenShift containerized server"
 sudo docker run -d --name="origin" \
 	--privileged --net=host --pid=host \
 	-v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
-	-v "${VOLUME_DIR}:${VOLUME_DIR}" \
+	-v "${VOLUME_DIR}:${VOLUME_DIR}" -v /tmp/openshift-e2e/etcd:/var/lib/origin/openshift.local.etcd:rw \
 	"openshift/origin:${TAG}" start --loglevel=4 --volume-dir=${VOLUME_DIR} --images="${USE_IMAGES}"
 
 


### PR DESCRIPTION
This makes the data for our all-in-one docker container write its etcd data outside the image.

@bparees if /tmp is a ramdisk, this should allow the e2e etcd to write directly to it.  All the other scripts already use /tmp

[test]