### PR TITLE
Jenkins extended tests for ci.openshift testjob for pipeline plugin

### DIFF
--- a/test/extended/builds/forcepull.go
+++ b/test/extended/builds/forcepull.go
@@ -56,7 +56,8 @@ func doTest(bldPrefix, bldName, debugStr string, same bool, oc *exutil.CLI) {
 	// reset corrupted tagging for next test
 	exutil.ResetImage(resetData)
 	// dump tags/hexids for debug
-	exutil.DumpAndReturnTagging(tags)
+	_, err := exutil.DumpAndReturnTagging(tags)
+	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
 /*
@@ -118,7 +119,8 @@ var _ = g.Describe("[LocalNode][builds] forcePull should affect pulling builder 
 
 		// dump the image textual tags and hex ids out for debug
 		tags = []string{fullImageName + ":latest", corruptor + ":latest"}
-		hexIDs := exutil.DumpAndReturnTagging(tags)
+		hexIDs, err := exutil.DumpAndReturnTagging(tags)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		resetData = map[string]string{fullImageName: hexIDs[0], corruptor: hexIDs[1]}
 
 	})

--- a/test/extended/fixtures/jenkins-ephemeral-template-test-new-plugin.json
+++ b/test/extended/fixtures/jenkins-ephemeral-template-test-new-plugin.json
@@ -1,0 +1,145 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "jenkins-ephemeral",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "Jenkins service, without persistent storage. WARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+      "iconClass": "icon-jenkins",
+      "tags": "instant-app,jenkins"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${JENKINS_SERVICE_NAME}",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "web",
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "${JENKINS_SERVICE_NAME}"
+        },
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "jenkins",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "to": {
+          "kind": "Service",
+          "name": "${JENKINS_SERVICE_NAME}"
+        },
+        "tls": {
+          "termination": "edge",
+          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\n-----END CERTIFICATE-----",
+          "key": "-----BEGIN PRIVATE KEY-----\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\nTcFT4touIo7oriFJ\n-----END PRIVATE KEY-----",
+          "caCertificate": "-----BEGIN CERTIFICATE-----\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\n-----END CERTIFICATE-----"
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${JENKINS_SERVICE_NAME}",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "${JENKINS_SERVICE_NAME}"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "${JENKINS_SERVICE_NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "jenkins",
+                "image": "jenkins-plugin-snapshot-test:latest",
+                "env": [
+                  {
+                    "name": "JENKINS_PASSWORD",
+                    "value": "${JENKINS_PASSWORD}"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "${JENKINS_SERVICE_NAME}-data",
+                    "mountPath": "/var/lib/jenkins"
+                  }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "capabilities": {},
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+             "volumes": [
+              {
+                "name": "${JENKINS_SERVICE_NAME}-data",
+                "emptyDir": {
+                  "medium": ""
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "JENKINS_SERVICE_NAME",
+      "description": "Jenkins service name",
+      "value": "jenkins"
+    },
+    {
+      "name": "JENKINS_PASSWORD",
+      "description": "Password for the Jenkins user",
+      "generate": "expression",
+      "value": "password"
+    }
+  ],
+  "labels": {
+    "template": "jenkins-ephemeral-template"
+  }
+}

--- a/test/extended/jenkins/plugin.go
+++ b/test/extended/jenkins/plugin.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
+	"regexp"
 	"time"
 
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -62,7 +62,8 @@ func waitForJenkinsActivity(uri, verificationString string, status int) error {
 					return false, err
 				}
 				consoleLogs = string(contents)
-				if strings.Contains(consoleLogs, verificationString) {
+				re := regexp.MustCompile(verificationString)
+				if re.MatchString(consoleLogs) {
 					return true, nil
 				} else {
 					return false, nil
@@ -91,6 +92,15 @@ func jenkinsJobBytes(filename, namespace string) []byte {
 	return data
 }
 
+func readInCommitID(filename string) string {
+	data, err := ioutil.ReadFile(filename)
+	if err == nil {
+		commitID := string(data)
+		return commitID
+	}
+	return ""
+}
+
 var _ = g.Describe("[jenkins] openshift pipeline plugin", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("jenkins-plugin", exutil.KubeConfigPath())
@@ -103,7 +113,22 @@ var _ = g.Describe("[jenkins] openshift pipeline plugin", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("kick off the build for the jenkins ephermeral and application templates")
-		jenkinsEphemeralPath := exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json")
+		// the test_openshift_pipeline_plugin job on jenkins will store the commit ID for the given PR in this file
+		// where the jenkins-plugin repo is extracted off of the same parent directory as the origin repo
+		commitIDPath := exutil.FixturePath("..", "..", "..", "jenkins-plugin", "PR-Testing", "commitID")
+		commitID := readInCommitID(commitIDPath)
+		tag := []string{"jenkins-plugin-snapshot-test" + commitID + ":latest"}
+		hexIDs, err := exutil.DumpAndReturnTagging(tag)
+		var jenkinsEphemeralPath string
+		var testingSnapshot bool
+		if len(hexIDs) > 0 && err == nil {
+			// found an openshift pipeline plugin test image, must be testing a proposed change to the plugin
+			jenkinsEphemeralPath = exutil.FixturePath("fixtures", "jenkins-ephemeral-template-test-new-plugin.json")
+			testingSnapshot = true
+		} else {
+			// no test image, testing the base jenkins image with the current, supported version of the plugin
+			jenkinsEphemeralPath = exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json")
+		}
 		err = oc.Run("new-app").Args(jenkinsEphemeralPath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		jenkinsApplicationPath := exutil.FixturePath("..", "..", "examples", "jenkins", "application-template.json")
@@ -124,6 +149,12 @@ var _ = g.Describe("[jenkins] openshift pipeline plugin", func() {
 		g.By("wait for jenkins to come up")
 		err = waitForJenkinsActivity(fmt.Sprintf("http://%s", hostPort), "", 200)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if testingSnapshot {
+			g.By("verifying the test image is being used")
+			// for the test image, confirm that a snapshot version of the plugin is running in the jenkins image we'll test against
+			err = waitForJenkinsActivity(fmt.Sprintf("http://%s/pluginManager/plugin/openshift-pipeline/thirdPartyLicenses", hostPort), `About OpenShift Pipeline Jenkins Plugin ([0-9\.]+)-SNAPSHOT`, 200)
+		}
 
 	})
 
@@ -150,7 +181,7 @@ var _ = g.Describe("[jenkins] openshift pipeline plugin", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("get build console logs and see if succeeded")
-			err = waitForJenkinsActivity(fmt.Sprintf("http://%s/job/test-plugin-job/1/console", hostPort), "SUCCESS", 200)
+			err = waitForJenkinsActivity(fmt.Sprintf("http://%s/job/test-plugin-job/1/console", hostPort), "Finished: SUCCESS", 200)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 		})

--- a/test/extended/util/image_helpers.go
+++ b/test/extended/util/image_helpers.go
@@ -31,13 +31,15 @@ func ResetImage(tags map[string]string) {
 }
 
 //DumpAndReturnTagging takes and array of tags and obtains the hex image IDs, dumps them to ginkgo for printing, and then returns them
-func DumpAndReturnTagging(tags []string) []string {
+func DumpAndReturnTagging(tags []string) ([]string, error) {
 	hexIDs, err := GetImageIDForTags(tags)
-	o.Expect(err).NotTo(o.HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 	for i, hexID := range hexIDs {
 		g.By(fmt.Sprintf("tag %s hex id %s ", tags[i], hexID))
 	}
-	return hexIDs
+	return hexIDs, nil
 }
 
 //VerifyImagesSame will take the two supplied image tags and see if they reference the same hexadecimal image ID;  strategy is for debug


### PR DESCRIPTION
@bparees - I'm opening this PR to capture what I did wrt to vagrant experimentation and updates to the pending jenkins plugin extended test that would test and verify merge queue styled proposed changes to the openshift pipeline plugin for jenkins.

The first piece is a proposed change to the jenkins plugin/image extended test case that would allow it to dynamically test either a) the official plugin version in the jenkins image, or b) a snapshot / proposed version of the plugin that would be built from a git clone/pull (ultimately from the changes corresponding to the PR).

Here was the steps passed into a vagrant ssh -c call to facilitate this:

`vagrant ssh -c "cd /data/src/github.com/openshift; rm -rf jenkins-plugin ; git clone https://github.com/openshift/jenkins-plugin.git ; ls -la ; cd jenkins-plugin ; mvn clean package ; ls -la ; ls -la target/*.hpi ; cp target/openshift-pipeline.hpi /data/src/github.com/openshift/origin/test/extended/fixtures/jpi/openshift-pipeline.jpi ; ls -la /data/src/github.com/openshift/origin/test/extended/fixtures/jpi ; cd /data/src/github.com/openshift/origin/test/extended/fixtures ; docker build -f ./Dockerfile-jenkins-test-new-plugin -t jenkins-plugin-snapshot-test:latest . ; docker images | grep jenkins"`

Certainly the git extraction would be replaced with the existing vagrant-openshift extraction logic.  And this would be followed by the existing vagrant-openshift extraction logic to run the extended tests with the jenkins focus.

Aside from debating the pros/cons of the approach I took with updating the soon to be existing extended tests, based on the results of that discussion, we can than see which other pieces of the `vagrant ssh -c` invocation above get converted into vagrant-openshift changes (vs. just continuing to use `vagrant ssh -c`.

Thanks.