### PR TITLE
Bug 1273708 - mark --all in oc export deprecated in help

### DIFF
--- a/pkg/cmd/cli/cmd/export.go
+++ b/pkg/cmd/cli/cmd/export.go
@@ -72,7 +72,7 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 	cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().StringSliceVarP(&filenames, "filename", "f", filenames, "Filename, directory, or URL to file to use to edit the resource.")
 
-	cmd.Flags().Bool("all", true, "Select all resources in the namespace of the specified resource types")
+	cmd.Flags().Bool("all", true, "DEPRECATED: all is ignored, specifying a resource without a name selects all the instances of that resource")
 	cmd.Flags().MarkDeprecated("all", "all is ignored because specifying a resource without a name selects all the instances of that resource")
 	cmdutil.AddPrinterFlags(cmd)
 	return cmd


### PR DESCRIPTION
Properly mark `--all` as deprecated in the help of `oc export`.