### PR TITLE
Fix nw extended test support for skipping build

### DIFF
--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -193,14 +193,13 @@ esac
 
 TEST_EXTRA_ARGS="$@"
 
-os::build::setup_env
-
 os::log::info "Building networking test binary"
 TEST_BINARY="${OS_OUTPUT_BINPATH}/networking.test"
 if [ -f "${TEST_BINARY}" ] &&
    [ "${OPENSHIFT_SKIP_BUILD:-false}" = "true" ]; then
   os::log::warn "Skipping rebuild of test binary due to OPENSHIFT_SKIP_BUILD=true"
 else
+  os::build::setup_env
   go test -c ./test/extended/networking -o "${TEST_BINARY}"
 fi
 


### PR DESCRIPTION
Setting OPENSHIFT_SKIP_BUILD=true when running
test/extended/networking.sh allows running a pre-built test binary.
This change makes the build setup conditional as well to allow the test
runner to be invoked on a host without golang installed.