### PR TITLE
Make `oc cancel-build` to be suggested for `oc stop-build`

### DIFF
--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -39,7 +39,7 @@ func NewCmdCancelBuild(fullName string, f *clientcmd.Factory, out io.Writer) *co
 		Short:      "Cancel a pending or running build",
 		Long:       cancelBuildLong,
 		Example:    fmt.Sprintf(cancelBuildExample, fullName),
-		SuggestFor: []string{"builds"},
+		SuggestFor: []string{"builds", "stop-build"},
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunCancelBuild(f, out, cmd, args)
 			cmdutil.CheckErr(err)


### PR DESCRIPTION
PTAL @mfojtik 

Inspired by the IRC dialog:
```
<semushin> How I can stop the build in Pending state?
<cewong> semushin you should be able to cancel it
<jhadvig> semushin, cancel-build ?
<semushin> jhadvig, cewong, thanks... I was looking for stop-build (as opposite to start-build).
<jhadvig> semushin, yep, `oc cancel-build` should do the trick ;)
<cewong> semushin you should create a usability issue 
<semushin> cewong, yeah, I also think so, at least we could advice cancel-build for stop-build
<mfojtik> semushin: stop-build should be alias for cancel-build I guess
```