### PR TITLE
SCC caps defaults

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -191,6 +191,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			SupplementalGroups: kapi.SupplementalGroupsStrategyOptions{
 				Type: kapi.SupplementalGroupsStrategyRunAsAny,
 			},
+			// drops unsafe caps
+			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SYS_CHROOT", "SETUID", "SETGID"},
 		},
 		// SecurityContextConstraintsAnyUID allows no host access and allocates SELinux.
 		{
@@ -217,6 +219,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			},
 			// prefer the anyuid SCC over ones that force a uid
 			Priority: &securityContextConstraintsAnyUIDPriority,
+			// drops unsafe caps
+			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SYS_CHROOT", "SETUID", "SETGID"},
 		},
 	}
 


### PR DESCRIPTION
Part 2, dependent on https://github.com/openshift/origin/pull/6470 (second commit only)

Card: https://trello.com/c/7eesi2lw/586-add-defaulting-and-restrictions-in-scc-for-capabilities

@eparis @smarterclayton 

Based on the SCCs we currently have and the request in the card here is what I came up with:

References:

1.  default set of caps that are kept by Docker (corresponds with Eric's testing and comment in the card - I think this is correct but not 100%) https://github.com/docker/docker/blob/938d28e772ec32ed3b09bfb8907852e497990076/daemon/execdriver/native/template/default_template_linux.go
2.  confirmed we cannot drop `audit_write` https://github.com/docker/docker/pull/7179

SCCs

1.  restricted scc - drops unsafe caps, should have the default caps from docker but nothing is allowed or required to be explicitly added.
1.  anyuid scc - drops unsafe caps, should have the default caps from docker but nothing is allowed or required to be explicitly added.
1.  "safe" scc - I didn't implement anything for this - how is it different than the restricted SCC if the restricted SCC does not allow any additions?

I still need to test through the different scenarios to make sure things are working as expected.


cc @pmorie 