### PR TITLE
Initial addition of BuildSecrets into all build strategies

### DIFF
--- a/api/definitions/v1.secretbuildsource/description.adoc
+++ b/api/definitions/v1.secretbuildsource/description.adoc
@@ -1,0 +1,1 @@
+SecretBuildSource describes a secret and its destination directory that will be used only at the build time. The content of the secret referenced here will be copied into the destination directory instead of mounting.

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -14684,7 +14684,8 @@
    "v1.BuildSource": {
     "id": "v1.BuildSource",
     "required": [
-     "type"
+     "type",
+     "secrets"
     ],
     "properties": {
      "type": {
@@ -14714,6 +14715,13 @@
      "sourceSecret": {
       "$ref": "v1.LocalObjectReference",
       "description": "supported auth methods are: ssh-privatekey"
+     },
+     "secrets": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.SecretBuildSource"
+      },
+      "description": "list of build secrets and destination directories"
      }
     }
    },
@@ -14798,6 +14806,22 @@
      "name": {
       "type": "string",
       "description": "Name of the referent. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
+     }
+    }
+   },
+   "v1.SecretBuildSource": {
+    "id": "v1.SecretBuildSource",
+    "required": [
+     "secret"
+    ],
+    "properties": {
+     "secret": {
+      "$ref": "v1.LocalObjectReference",
+      "description": "name of a secret to be used as a source"
+     },
+     "destinationDir": {
+      "type": "string",
+      "description": "destination directory for the secret files"
      }
     }
    },

--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -978,6 +978,7 @@ _oc_new-build()
 
     flags+=("--allow-missing-images")
     flags+=("--binary")
+    flags+=("--build-secret=")
     flags+=("--code=")
     flags+=("--context-dir=")
     flags+=("--docker-image=")

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -5973,6 +5973,7 @@ _openshift_cli_new-build()
 
     flags+=("--allow-missing-images")
     flags+=("--binary")
+    flags+=("--build-secret=")
     flags+=("--code=")
     flags+=("--context-dir=")
     flags+=("--docker-image=")

--- a/docs/generated/oc_by_example_content.adoc
+++ b/docs/generated/oc_by_example_content.adoc
@@ -587,6 +587,9 @@ Create a new build configuration
 
   # Create a build config from a remote repository and add custom environment variables
   $ oc new-build https://github.com/openshift/ruby-hello-world RACK_ENV=development
+
+  # Create a build config from a remote repository and inject the npmrc into a build
+  $ oc new-build https://github.com/openshift/ruby-hello-world --build-secret npmrc:.npmrc
 ----
 ====
 

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -984,6 +984,16 @@ func deepCopy_api_BuildSource(in buildapi.BuildSource, out *buildapi.BuildSource
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]buildapi.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := deepCopy_api_SecretBuildSource(in.Secrets[i], &out.Secrets[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -1257,6 +1267,16 @@ func deepCopy_api_ImageSource(in buildapi.ImageSource, out *buildapi.ImageSource
 
 func deepCopy_api_ImageSourcePath(in buildapi.ImageSourcePath, out *buildapi.ImageSourcePath, c *conversion.Cloner) error {
 	out.SourcePath = in.SourcePath
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func deepCopy_api_SecretBuildSource(in buildapi.SecretBuildSource, out *buildapi.SecretBuildSource, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Secret); err != nil {
+		return err
+	} else {
+		out.Secret = newVal.(pkgapi.LocalObjectReference)
+	}
 	out.DestinationDir = in.DestinationDir
 	return nil
 }
@@ -2961,6 +2981,7 @@ func init() {
 		deepCopy_api_ImageChangeTrigger,
 		deepCopy_api_ImageSource,
 		deepCopy_api_ImageSourcePath,
+		deepCopy_api_SecretBuildSource,
 		deepCopy_api_SecretSpec,
 		deepCopy_api_SourceBuildStrategy,
 		deepCopy_api_SourceControlUser,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1435,6 +1435,16 @@ func autoconvert_api_BuildSource_To_v1_BuildSource(in *buildapi.BuildSource, out
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]apiv1.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := convert_api_SecretBuildSource_To_v1_SecretBuildSource(&in.Secrets[i], &out.Secrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -1747,6 +1757,21 @@ func autoconvert_api_ImageSourcePath_To_v1_ImageSourcePath(in *buildapi.ImageSou
 
 func convert_api_ImageSourcePath_To_v1_ImageSourcePath(in *buildapi.ImageSourcePath, out *apiv1.ImageSourcePath, s conversion.Scope) error {
 	return autoconvert_api_ImageSourcePath_To_v1_ImageSourcePath(in, out, s)
+}
+
+func autoconvert_api_SecretBuildSource_To_v1_SecretBuildSource(in *buildapi.SecretBuildSource, out *apiv1.SecretBuildSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*buildapi.SecretBuildSource))(in)
+	}
+	if err := convert_api_LocalObjectReference_To_v1_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func convert_api_SecretBuildSource_To_v1_SecretBuildSource(in *buildapi.SecretBuildSource, out *apiv1.SecretBuildSource, s conversion.Scope) error {
+	return autoconvert_api_SecretBuildSource_To_v1_SecretBuildSource(in, out, s)
 }
 
 func autoconvert_api_SecretSpec_To_v1_SecretSpec(in *buildapi.SecretSpec, out *apiv1.SecretSpec, s conversion.Scope) error {
@@ -2202,6 +2227,16 @@ func autoconvert_v1_BuildSource_To_api_BuildSource(in *apiv1.BuildSource, out *b
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]buildapi.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := convert_v1_SecretBuildSource_To_api_SecretBuildSource(&in.Secrets[i], &out.Secrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -2515,6 +2550,21 @@ func autoconvert_v1_ImageSourcePath_To_api_ImageSourcePath(in *apiv1.ImageSource
 
 func convert_v1_ImageSourcePath_To_api_ImageSourcePath(in *apiv1.ImageSourcePath, out *buildapi.ImageSourcePath, s conversion.Scope) error {
 	return autoconvert_v1_ImageSourcePath_To_api_ImageSourcePath(in, out, s)
+}
+
+func autoconvert_v1_SecretBuildSource_To_api_SecretBuildSource(in *apiv1.SecretBuildSource, out *buildapi.SecretBuildSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1.SecretBuildSource))(in)
+	}
+	if err := convert_v1_LocalObjectReference_To_api_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func convert_v1_SecretBuildSource_To_api_SecretBuildSource(in *apiv1.SecretBuildSource, out *buildapi.SecretBuildSource, s conversion.Scope) error {
+	return autoconvert_v1_SecretBuildSource_To_api_SecretBuildSource(in, out, s)
 }
 
 func autoconvert_v1_SecretSpec_To_api_SecretSpec(in *apiv1.SecretSpec, out *buildapi.SecretSpec, s conversion.Scope) error {
@@ -7994,6 +8044,7 @@ func init() {
 		autoconvert_api_RouteStatus_To_v1_RouteStatus,
 		autoconvert_api_Route_To_v1_Route,
 		autoconvert_api_SELinuxOptions_To_v1_SELinuxOptions,
+		autoconvert_api_SecretBuildSource_To_v1_SecretBuildSource,
 		autoconvert_api_SecretSpec_To_v1_SecretSpec,
 		autoconvert_api_SecretVolumeSource_To_v1_SecretVolumeSource,
 		autoconvert_api_SecurityContext_To_v1_SecurityContext,
@@ -8151,6 +8202,7 @@ func init() {
 		autoconvert_v1_RouteStatus_To_api_RouteStatus,
 		autoconvert_v1_Route_To_api_Route,
 		autoconvert_v1_SELinuxOptions_To_api_SELinuxOptions,
+		autoconvert_v1_SecretBuildSource_To_api_SecretBuildSource,
 		autoconvert_v1_SecretSpec_To_api_SecretSpec,
 		autoconvert_v1_SecretVolumeSource_To_api_SecretVolumeSource,
 		autoconvert_v1_SecurityContext_To_api_SecurityContext,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1009,6 +1009,16 @@ func deepCopy_v1_BuildSource(in apiv1.BuildSource, out *apiv1.BuildSource, c *co
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]apiv1.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := deepCopy_v1_SecretBuildSource(in.Secrets[i], &out.Secrets[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -1283,6 +1293,16 @@ func deepCopy_v1_ImageSource(in apiv1.ImageSource, out *apiv1.ImageSource, c *co
 
 func deepCopy_v1_ImageSourcePath(in apiv1.ImageSourcePath, out *apiv1.ImageSourcePath, c *conversion.Cloner) error {
 	out.SourcePath = in.SourcePath
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func deepCopy_v1_SecretBuildSource(in apiv1.SecretBuildSource, out *apiv1.SecretBuildSource, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Secret); err != nil {
+		return err
+	} else {
+		out.Secret = newVal.(pkgapiv1.LocalObjectReference)
+	}
 	out.DestinationDir = in.DestinationDir
 	return nil
 }
@@ -2855,6 +2875,7 @@ func init() {
 		deepCopy_v1_ImageChangeTrigger,
 		deepCopy_v1_ImageSource,
 		deepCopy_v1_ImageSourcePath,
+		deepCopy_v1_SecretBuildSource,
 		deepCopy_v1_SecretSpec,
 		deepCopy_v1_SourceBuildStrategy,
 		deepCopy_v1_SourceControlUser,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1444,6 +1444,16 @@ func autoconvert_api_BuildSource_To_v1beta3_BuildSource(in *buildapi.BuildSource
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]apiv1beta3.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := convert_api_SecretBuildSource_To_v1beta3_SecretBuildSource(&in.Secrets[i], &out.Secrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -1756,6 +1766,21 @@ func autoconvert_api_ImageSourcePath_To_v1beta3_ImageSourcePath(in *buildapi.Ima
 
 func convert_api_ImageSourcePath_To_v1beta3_ImageSourcePath(in *buildapi.ImageSourcePath, out *apiv1beta3.ImageSourcePath, s conversion.Scope) error {
 	return autoconvert_api_ImageSourcePath_To_v1beta3_ImageSourcePath(in, out, s)
+}
+
+func autoconvert_api_SecretBuildSource_To_v1beta3_SecretBuildSource(in *buildapi.SecretBuildSource, out *apiv1beta3.SecretBuildSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*buildapi.SecretBuildSource))(in)
+	}
+	if err := convert_api_LocalObjectReference_To_v1beta3_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func convert_api_SecretBuildSource_To_v1beta3_SecretBuildSource(in *buildapi.SecretBuildSource, out *apiv1beta3.SecretBuildSource, s conversion.Scope) error {
+	return autoconvert_api_SecretBuildSource_To_v1beta3_SecretBuildSource(in, out, s)
 }
 
 func autoconvert_api_SecretSpec_To_v1beta3_SecretSpec(in *buildapi.SecretSpec, out *apiv1beta3.SecretSpec, s conversion.Scope) error {
@@ -2211,6 +2236,16 @@ func autoconvert_v1beta3_BuildSource_To_api_BuildSource(in *apiv1beta3.BuildSour
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]buildapi.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := convert_v1beta3_SecretBuildSource_To_api_SecretBuildSource(&in.Secrets[i], &out.Secrets[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -2524,6 +2559,21 @@ func autoconvert_v1beta3_ImageSourcePath_To_api_ImageSourcePath(in *apiv1beta3.I
 
 func convert_v1beta3_ImageSourcePath_To_api_ImageSourcePath(in *apiv1beta3.ImageSourcePath, out *buildapi.ImageSourcePath, s conversion.Scope) error {
 	return autoconvert_v1beta3_ImageSourcePath_To_api_ImageSourcePath(in, out, s)
+}
+
+func autoconvert_v1beta3_SecretBuildSource_To_api_SecretBuildSource(in *apiv1beta3.SecretBuildSource, out *buildapi.SecretBuildSource, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*apiv1beta3.SecretBuildSource))(in)
+	}
+	if err := convert_v1beta3_LocalObjectReference_To_api_LocalObjectReference(&in.Secret, &out.Secret, s); err != nil {
+		return err
+	}
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func convert_v1beta3_SecretBuildSource_To_api_SecretBuildSource(in *apiv1beta3.SecretBuildSource, out *buildapi.SecretBuildSource, s conversion.Scope) error {
+	return autoconvert_v1beta3_SecretBuildSource_To_api_SecretBuildSource(in, out, s)
 }
 
 func autoconvert_v1beta3_SecretSpec_To_api_SecretSpec(in *apiv1beta3.SecretSpec, out *buildapi.SecretSpec, s conversion.Scope) error {
@@ -7961,6 +8011,7 @@ func init() {
 		autoconvert_api_RouteStatus_To_v1beta3_RouteStatus,
 		autoconvert_api_Route_To_v1beta3_Route,
 		autoconvert_api_SELinuxOptions_To_v1beta3_SELinuxOptions,
+		autoconvert_api_SecretBuildSource_To_v1beta3_SecretBuildSource,
 		autoconvert_api_SecretSpec_To_v1beta3_SecretSpec,
 		autoconvert_api_SecretVolumeSource_To_v1beta3_SecretVolumeSource,
 		autoconvert_api_SecurityContext_To_v1beta3_SecurityContext,
@@ -8118,6 +8169,7 @@ func init() {
 		autoconvert_v1beta3_RouteStatus_To_api_RouteStatus,
 		autoconvert_v1beta3_Route_To_api_Route,
 		autoconvert_v1beta3_SELinuxOptions_To_api_SELinuxOptions,
+		autoconvert_v1beta3_SecretBuildSource_To_api_SecretBuildSource,
 		autoconvert_v1beta3_SecretSpec_To_api_SecretSpec,
 		autoconvert_v1beta3_SecretVolumeSource_To_api_SecretVolumeSource,
 		autoconvert_v1beta3_SecurityContext_To_api_SecurityContext,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -1017,6 +1017,16 @@ func deepCopy_v1beta3_BuildSource(in apiv1beta3.BuildSource, out *apiv1beta3.Bui
 	} else {
 		out.SourceSecret = nil
 	}
+	if in.Secrets != nil {
+		out.Secrets = make([]apiv1beta3.SecretBuildSource, len(in.Secrets))
+		for i := range in.Secrets {
+			if err := deepCopy_v1beta3_SecretBuildSource(in.Secrets[i], &out.Secrets[i], c); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Secrets = nil
+	}
 	return nil
 }
 
@@ -1291,6 +1301,16 @@ func deepCopy_v1beta3_ImageSource(in apiv1beta3.ImageSource, out *apiv1beta3.Ima
 
 func deepCopy_v1beta3_ImageSourcePath(in apiv1beta3.ImageSourcePath, out *apiv1beta3.ImageSourcePath, c *conversion.Cloner) error {
 	out.SourcePath = in.SourcePath
+	out.DestinationDir = in.DestinationDir
+	return nil
+}
+
+func deepCopy_v1beta3_SecretBuildSource(in apiv1beta3.SecretBuildSource, out *apiv1beta3.SecretBuildSource, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Secret); err != nil {
+		return err
+	} else {
+		out.Secret = newVal.(pkgapiv1beta3.LocalObjectReference)
+	}
 	out.DestinationDir = in.DestinationDir
 	return nil
 }
@@ -2845,6 +2865,7 @@ func init() {
 		deepCopy_v1beta3_ImageChangeTrigger,
 		deepCopy_v1beta3_ImageSource,
 		deepCopy_v1beta3_ImageSourcePath,
+		deepCopy_v1beta3_SecretBuildSource,
 		deepCopy_v1beta3_SecretSpec,
 		deepCopy_v1beta3_SourceBuildStrategy,
 		deepCopy_v1beta3_SourceControlUser,

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -206,6 +206,10 @@ type BuildSource struct {
 	// TODO: This needs to move under the GitBuildSource struct since it's only
 	// used for git authentication
 	SourceSecret *kapi.LocalObjectReference
+
+	// Secrets represents a list of secrets and their destinations that will
+	// be used only for the build.
+	Secrets []SecretBuildSource
 }
 
 // ImageSource describes an image that is used as source for the build
@@ -230,6 +234,25 @@ type ImageSourcePath struct {
 
 	// DestinationDir is the relative directory within the build directory
 	// where files copied from the image are placed.
+	DestinationDir string
+}
+
+// SecretBuildSource describes a secret and its destination directory that will be
+// used only at the build time. The content of the secret referenced here will
+// be copied into the destination directory instead of mounting.
+type SecretBuildSource struct {
+	// Secret is a reference to an existing secret that you want to use in your
+	// build.
+	Secret kapi.LocalObjectReference
+
+	// DestinationDir is the directory where the files from the secret should be
+	// available for the build time.
+	// For the Source build strategy, these will be injected into a container
+	// where the assemble script runs. Later, when the script finishes, all files
+	// injected will be truncated to zero length.
+	// For the Docker build strategy, these will be copied into the build
+	// directory, where the Dockerfile is located, so users can ADD or COPY them
+	// during docker build.
 	DestinationDir string
 }
 

--- a/pkg/build/api/v1/types.go
+++ b/pkg/build/api/v1/types.go
@@ -176,6 +176,10 @@ type BuildSource struct {
 	// data's key represent the authentication method to be used and value is
 	// the base64 encoded credentials. Supported auth methods are: ssh-privatekey.
 	SourceSecret *kapi.LocalObjectReference `json:"sourceSecret,omitempty" description:"supported auth methods are: ssh-privatekey"`
+
+	// Secrets represents a list of secrets and their destinations that will
+	// be used only for the build.
+	Secrets []SecretBuildSource `json:"secrets" description:"list of build secrets and destination directories"`
 }
 
 // ImageSource describes an image that is used as source for the build
@@ -201,6 +205,25 @@ type ImageSourcePath struct {
 	// DestinationDir is the relative directory within the build directory
 	// where files copied from the image are placed.
 	DestinationDir string `json:"destinationDir" description:"relative destination directory in build home"`
+}
+
+// SecretBuildSource describes a secret and its destination directory that will be
+// used only at the build time. The content of the secret referenced here will
+// be copied into the destination directory instead of mounting.
+type SecretBuildSource struct {
+	// Secret is a reference to an existing secret that you want to use in your
+	// build.
+	Secret kapi.LocalObjectReference `json:"secret" description:"name of a secret to be used as a source"`
+
+	// DestinationDir is the directory where the files from the secret should be
+	// available for the build time.
+	// For the Source build strategy, these will be injected into a container
+	// where the assemble script runs. Later, when the script finishes, all files
+	// injected will be truncated to zero length.
+	// For the Docker build strategy, these will be copied into the build
+	// directory, where the Dockerfile is located, so users can ADD or COPY them
+	// during docker build.
+	DestinationDir string `json:"destinationDir,omitempty" description:"destination directory for the secret files"`
 }
 
 type BinaryBuildSource struct {

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -172,6 +172,10 @@ type BuildSource struct {
 	// data's key represent the authentication method to be used and value is
 	// the base64 encoded credentials. Supported auth methods are: ssh-privatekey.
 	SourceSecret *kapi.LocalObjectReference `json:"sourceSecret,omitempty" description:"supported auth methods are: ssh-privatekey"`
+
+	// Secrets represents a list of secrets and their destinations that will
+	// be used only for the build.
+	Secrets []SecretBuildSource `json:"secrets" description:"list of build secrets and destination directories"`
 }
 
 // ImageSource describes an image that is used as source for the build
@@ -197,6 +201,25 @@ type ImageSourcePath struct {
 	// DestinationDir is the relative directory within the build directory
 	// where files copied from the image are placed.
 	DestinationDir string `json:"destinationDir" description:"relative destination directory in build home"`
+}
+
+// SecretBuildSource describes a secret and its destination directory that will be
+// used only at the build time. The content of the secret referenced here will
+// be copied into the destination directory instead of mounting.
+type SecretBuildSource struct {
+	// Secret is a reference to an existing secret that you want to use in your
+	// build.
+	Secret kapi.LocalObjectReference `json:"secret" description:"name of a secret to be used as a source"`
+
+	// DestinationDir is the directory where the files from the secret should be
+	// available for the build time.
+	// For the Source build strategy, these will be injected into a container
+	// where the assemble script runs. Later, when the script finishes, all files
+	// injected will be truncated to zero length.
+	// For the Docker build strategy, these will be copied into the build
+	// directory, where the Dockerfile is located, so users can ADD or COPY them
+	// during docker build.
+	DestinationDir string `json:"destinationDir,omitempty" description:"destination directory for the secret files"`
 }
 
 type BinaryBuildSource struct {

--- a/pkg/build/api/validation/validation_test.go
+++ b/pkg/build/api/validation/validation_test.go
@@ -855,7 +855,7 @@ func TestValidateSource(t *testing.T) {
 		},
 	}
 	for i, tc := range errorCases {
-		errors := validateSource(tc.source, false)
+		errors := validateSource(tc.source, false, false)
 		switch len(errors) {
 		case 0:
 			if !tc.ok {
@@ -883,7 +883,7 @@ func TestValidateSource(t *testing.T) {
 	}
 
 	errorCases[11].source.ContextDir = "."
-	validateSource(errorCases[11].source, false)
+	validateSource(errorCases[11].source, false, false)
 	if len(errorCases[11].source.ContextDir) != 0 {
 		t.Errorf("ContextDir was not cleaned: %s", errorCases[11].source.ContextDir)
 	}

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"
+	"github.com/openshift/origin/pkg/build/controller/strategy"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/generate/git"
 	imageapi "github.com/openshift/origin/pkg/image/api"
@@ -68,6 +70,7 @@ func (d *DockerBuilder) Build() error {
 	if err := d.addBuildParameters(buildDir); err != nil {
 		return err
 	}
+
 	glog.V(4).Infof("Starting Docker build from build config %s ...", d.build.Name)
 	// if there is no output target, set one up so the docker build logic
 	// (which requires a tag) will still work, but we won't push it at the end.
@@ -77,7 +80,7 @@ func (d *DockerBuilder) Build() error {
 		push = true
 	}
 
-	if err := d.dockerBuild(buildDir); err != nil {
+	if err := d.dockerBuild(buildDir, d.build.Spec.Source.Secrets); err != nil {
 		return err
 	}
 
@@ -97,6 +100,28 @@ func (d *DockerBuilder) Build() error {
 			return fmt.Errorf("Failed to push image: %v", err)
 		}
 		glog.Infof("Push successful")
+	}
+	return nil
+}
+
+// copySecrets copies all files from the directory where the secret is
+// mounted in the builder pod to a directory where the is the Dockerfile, so
+// users can ADD or COPY the files inside their Dockerfile.
+func (d *DockerBuilder) copySecrets(secrets []api.SecretBuildSource, buildDir string) error {
+	for _, s := range secrets {
+		dstDir := filepath.Join(buildDir, s.DestinationDir)
+		if err := os.MkdirAll(dstDir, 0777); err != nil {
+			return err
+		}
+		srcDir := filepath.Join(strategy.SecretBuildSourceBaseMountPath, s.Secret.Name)
+		glog.Infof("Copying files from the build secret %q to %q", s.Secret.Name, filepath.Clean(s.DestinationDir))
+		out, err := exec.Command("cp", "-vrf", srcDir+"/.", dstDir+"/").Output()
+		if err != nil {
+			glog.Infof("Secret %q failed to copy: %q", s.Secret.Name, string(out))
+			return err
+		}
+		// See what is copied where when debugging.
+		glog.V(5).Infof(string(out))
 	}
 	return nil
 }
@@ -222,7 +247,7 @@ func (d *DockerBuilder) setupPullSecret() (*docker.AuthConfigurations, error) {
 }
 
 // dockerBuild performs a docker build on the source that has been retrieved
-func (d *DockerBuilder) dockerBuild(dir string) error {
+func (d *DockerBuilder) dockerBuild(dir string, secrets []api.SecretBuildSource) error {
 	var noCache bool
 	var forcePull bool
 	dockerfilePath := defaultDockerfilePath
@@ -238,6 +263,9 @@ func (d *DockerBuilder) dockerBuild(dir string) error {
 	}
 	auth, err := d.setupPullSecret()
 	if err != nil {
+		return err
+	}
+	if err := d.copySecrets(secrets, dir); err != nil {
 		return err
 	}
 	return buildImage(d.dockerClient, dir, dockerfilePath, noCache, d.build.Status.OutputDockerImageReference, d.tar, auth, forcePull)

--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -246,7 +246,7 @@ func TestDockerfilePath(t *testing.T) {
 		}
 
 		// check that the docker client is called with the right Dockerfile parameter
-		if err = dockerBuilder.dockerBuild(buildDir); err != nil {
+		if err = dockerBuilder.dockerBuild(buildDir, []api.SecretBuildSource{}); err != nil {
 			t.Errorf("failed to build: %v", err)
 			continue
 		}

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -99,6 +99,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 		setupDockerSecrets(pod, build.Spec.Output.PushSecret, strategy.PullSecret, sourceImageSecret)
 	}
 	setupSourceSecrets(pod, build.Spec.Source.SourceSecret)
+	setupSecrets(pod, build.Spec.Source.Secrets)
 	setupAdditionalSecrets(pod, build.Spec.Strategy.CustomStrategy.Secrets)
 	return pod, nil
 }

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -83,5 +83,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 	setupDockerSecrets(pod, build.Spec.Output.PushSecret, strategy.PullSecret, sourceImageSecret)
 	setupSourceSecrets(pod, build.Spec.Source.SourceSecret)
+	setupSecrets(pod, build.Spec.Source.Secrets)
+
 	return pod, nil
 }

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -105,6 +105,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*kapi.Pod,
 	}
 	setupDockerSecrets(pod, build.Spec.Output.PushSecret, strategy.PullSecret, sourceImageSecret)
 	setupSourceSecrets(pod, build.Spec.Source.SourceSecret)
+	setupSecrets(pod, build.Spec.Source.Secrets)
 	return pod, nil
 }
 

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -48,7 +48,10 @@ You can use '%[1]s status' to check the progress.`
   $ %[1]s new-build -D $'FROM centos:7\nRUN yum install -y httpd'
 
   # Create a build config from a remote repository and add custom environment variables
-  $ %[1]s new-build https://github.com/openshift/ruby-hello-world RACK_ENV=development`
+  $ %[1]s new-build https://github.com/openshift/ruby-hello-world RACK_ENV=development
+
+  # Create a build config from a remote repository and inject the npmrc into a build
+  $ %[1]s new-build https://github.com/openshift/ruby-hello-world --build-secret npmrc:.npmrc`
 
 	newBuildNoInput = `You must specify one or more images, image streams, or source code locations to create a build.
 
@@ -97,6 +100,7 @@ func NewCmdNewBuild(fullName string, f *clientcmd.Factory, in io.Reader, out io.
 	cmd.Flags().StringSliceVar(&config.SourceRepositories, "code", config.SourceRepositories, "Source code in the build configuration.")
 	cmd.Flags().StringSliceVarP(&config.ImageStreams, "image", "i", config.ImageStreams, "Name of an image stream to to use as a builder.")
 	cmd.Flags().StringSliceVar(&config.DockerImages, "docker-image", config.DockerImages, "Name of a Docker image to use as a builder.")
+	cmd.Flags().StringSliceVar(&config.Secrets, "build-secret", config.Secrets, "Secret and destination to use as an input for the build.")
 	cmd.Flags().StringVar(&config.Name, "name", "", "Set name to use for generated build artifacts.")
 	cmd.Flags().StringVar(&config.To, "to", "", "Push built images to this image stream tag (or Docker image repository if --to-docker is set).")
 	cmd.Flags().BoolVar(&config.OutputDocker, "to-docker", false, "Have the build output push to a Docker repository.")

--- a/pkg/cmd/cli/describe/describer.go
+++ b/pkg/cmd/cli/describe/describer.go
@@ -3,6 +3,7 @@ package describe
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strconv"
@@ -213,6 +214,14 @@ func describeBuildSpec(p buildapi.BuildSpec, out *tabwriter.Writer) {
 		} else {
 			formatString(out, "Binary", "provided on build")
 		}
+	}
+
+	if len(p.Source.Secrets) > 0 {
+		result := []string{}
+		for _, s := range p.Source.Secrets {
+			result = append(result, fmt.Sprintf("%s->%s", s.Secret.Name, filepath.Clean(s.DestinationDir)))
+		}
+		formatString(out, "Build Secrets", strings.Join(result, ","))
 	}
 
 	switch {

--- a/pkg/generate/app/app.go
+++ b/pkg/generate/app/app.go
@@ -98,6 +98,7 @@ type SourceRef struct {
 	Dir        string
 	Name       string
 	ContextDir string
+	Secrets    []buildapi.SecretBuildSource
 
 	DockerfileContents string
 
@@ -137,6 +138,7 @@ func (r *SourceRef) BuildSource() (*buildapi.BuildSource, []buildapi.BuildTrigge
 		},
 	}
 	source := &buildapi.BuildSource{}
+	source.Secrets = r.Secrets
 
 	if len(r.DockerfileContents) != 0 {
 		source.Dockerfile = &r.DockerfileContents

--- a/pkg/generate/app/app_test.go
+++ b/pkg/generate/app/app_test.go
@@ -72,6 +72,26 @@ func TestBuildConfigNoOutput(t *testing.T) {
 	}
 }
 
+func TestBuildConfigWithSecrets(t *testing.T) {
+	url, err := url.Parse("https://github.com/openshift/origin.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	source := &SourceRef{URL: url, Secrets: []buildapi.SecretBuildSource{
+		{Secret: kapi.LocalObjectReference{Name: "foo"}, DestinationDir: "/var"},
+		{Secret: kapi.LocalObjectReference{Name: "bar"}},
+	}}
+	build := &BuildRef{Source: source}
+	config, err := build.BuildConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	secrets := config.Spec.Source.Secrets
+	if got := len(secrets); got != 2 {
+		t.Errorf("expected 2 source secrets in build config, got %d", got)
+	}
+}
+
 func TestSourceRefBuildSourceURI(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/generate/app/sourcelookup_test.go
+++ b/pkg/generate/app/sourcelookup_test.go
@@ -1,0 +1,58 @@
+package app
+
+import "testing"
+
+func TestAddBuildSecrets(t *testing.T) {
+	type result struct{ name, dest string }
+	type tc struct {
+		in     []string
+		expect []result
+	}
+	table := []tc{
+		{
+			in:     []string{"secret1"},
+			expect: []result{{name: "secret1", dest: "."}},
+		},
+		{
+			in: []string{"secret1", "secret1"},
+		},
+		{
+			in:     []string{"secret1:/var/lib/foo"},
+			expect: []result{{name: "secret1", dest: "/var/lib/foo"}},
+		},
+		{
+			in: []string{"secret1", "secret2:/foo"},
+			expect: []result{
+				{
+					name: "secret1",
+					dest: ".",
+				},
+				{
+					name: "secret2",
+					dest: "/foo",
+				},
+			},
+		},
+	}
+	for _, item := range table {
+		repo := &SourceRepository{}
+		err := repo.AddBuildSecrets(item.in)
+		if err != nil && len(item.expect) != 0 {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		for _, expect := range item.expect {
+			got := repo.Secrets()
+			found := false
+			for _, s := range got {
+				if s.Secret.Name == expect.name && s.DestinationDir == expect.dest {
+					found = true
+					continue
+				}
+			}
+			if !found {
+				t.Errorf("expected %+v secret in %#v not found", expect, got)
+			}
+		}
+	}
+}

--- a/test/extended/builds/build_secrets.go
+++ b/test/extended/builds/build_secrets.go
@@ -1,0 +1,95 @@
+package builds
+
+import (
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+var _ = g.Describe("builds: use build secrets", func() {
+	defer g.GinkgoRecover()
+	var (
+		buildSecretBaseDir   = filepath.Join("fixtures", "build-secrets")
+		secretsFixture       = filepath.Join(buildSecretBaseDir, "test-secret.json")
+		secondSecretsFixture = filepath.Join(buildSecretBaseDir, "test-secret-2.json")
+		isFixture            = filepath.Join(buildSecretBaseDir, "test-is.json")
+		dockerBuildFixture   = filepath.Join(buildSecretBaseDir, "test-docker-build.json")
+		sourceBuildFixture   = filepath.Join(buildSecretBaseDir, "test-sti-build.json")
+		oc                   = exutil.NewCLI("build-secrets", exutil.KubeConfigPath())
+	)
+
+	g.Describe("build with secrets", func() {
+		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
+		g.It("should print the secrets during the source strategy build", func() {
+			g.By("creating the sample secret files")
+			err := oc.Run("create").Args("-f", secretsFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = oc.Run("create").Args("-f", secondSecretsFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating the sample source build config and image stream")
+			err = oc.Run("create").Args("-f", isFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = oc.Run("create").Args("-f", sourceBuildFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting the sample source build")
+			out, err := oc.Run("start-build").Args("test", "--follow", "--wait").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("secret1=secret1"))
+			o.Expect(out).To(o.ContainSubstring("secret3=secret3"))
+			o.Expect(out).To(o.ContainSubstring("relative-secret1=secret1"))
+			o.Expect(out).To(o.ContainSubstring("relative-secret3=secret3"))
+
+			g.By("checking the status of the build")
+			build, err := oc.REST().Builds(oc.Namespace()).Get("test-1")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseComplete))
+
+			g.By("getting the image name")
+			image, err := exutil.GetDockerImageReference(oc.REST().ImageStreams(oc.Namespace()), "test", "latest")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying the build secrets are not present in the output image")
+			pod := exutil.GetPodForContainer(kapi.Container{Name: "test", Image: image})
+			oc.KubeFramework().TestContainerOutput("test-build-secret-source", pod, 0, []string{
+				"relative-secret1=empty",
+				"secret3=empty",
+			})
+		})
+
+		g.It("should print the secrets during the docker strategy build", func() {
+			g.By("creating the sample secret files")
+			err := oc.Run("create").Args("-f", secretsFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = oc.Run("create").Args("-f", secondSecretsFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating the sample source build config and image stream")
+			err = oc.Run("create").Args("-f", isFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = oc.Run("create").Args("-f", dockerBuildFixture).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("starting the sample source build")
+			out, err := oc.Run("start-build").Args("test", "--follow", "--wait").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(out).To(o.ContainSubstring("secret1=secret1"))
+			o.Expect(out).To(o.ContainSubstring("relative-secret2=secret2"))
+
+			g.By("checking the status of the build")
+			build, err := oc.REST().Builds(oc.Namespace()).Get("test-1")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(build.Status.Phase).Should(o.BeEquivalentTo(buildapi.BuildPhaseComplete))
+		})
+
+	})
+})

--- a/test/extended/fixtures/build-secrets/Dockerfile
+++ b/test/extended/fixtures/build-secrets/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos/ruby-22-centos7
+
+USER root
+ADD ./secret-dir /secrets
+COPY ./secret2 /
+
+RUN test -f /secrets/secret1 && echo -n "secret1=" && cat /secrets/secret1
+RUN test -f /secret2 && echo -n "relative-secret2=" && cat /secret2
+RUN rm -rf /secrets && rm -rf /secret2
+
+CMD ["true"]

--- a/test/extended/fixtures/build-secrets/s2i/assemble
+++ b/test/extended/fixtures/build-secrets/s2i/assemble
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+[[ -f secret1 ]] && echo "relative-secret1=$(cat secret1)"
+[[ -f secret2 ]] && echo "relative-secret2=$(cat secret2)"
+[[ -f secret3 ]] && echo "relative-secret3=$(cat secret3)"
+
+[[ -f /tmp/secret1 ]] && echo "secret1=$(cat /tmp/secret1)"
+[[ -f /tmp/secret2 ]] && echo "secret2=$(cat /tmp/secret2)"
+[[ -f /tmp/secret3 ]] && echo "secret3=$(cat /tmp/secret3)"

--- a/test/extended/fixtures/build-secrets/s2i/run
+++ b/test/extended/fixtures/build-secrets/s2i/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[[ ! -s secret1 ]] && echo "relative-secret1=empty"
+[[ ! -s /tmp/secret3 ]] && echo "secret3=empty"

--- a/test/extended/fixtures/build-secrets/test-docker-build.json
+++ b/test/extended/fixtures/build-secrets/test-docker-build.json
@@ -1,0 +1,51 @@
+{
+  "kind":"BuildConfig",
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"test",
+    "labels":{
+      "name":"test"
+    }
+  },
+  "spec":{
+    "triggers":[],
+    "source":{
+      "type":"Git",
+      "git":{
+        "uri":"https://github.com/mfojtik/origin",
+        "ref": "secrets"
+      },
+      "contextDir":"test/extended/fixtures/build-secrets",
+      "secrets": [
+        {
+          "secret": { "name": "testsecret" },
+          "destinationDir": "secret-dir"
+        },
+        {
+          "secret": { "name": "testsecret2" }
+        }
+      ]
+    },
+    "strategy":{
+      "type":"Docker",
+      "env": [
+        {
+          "name": "BUILD_LOGLEVEL",
+          "value": "5"
+        }
+      ],
+      "dockerStrategy":{
+        "from":{
+          "kind":"DockerImage",
+          "name":"centos/ruby-22-centos7"
+        }
+      }
+    },
+    "output":{
+      "to":{
+        "kind":"ImageStreamTag",
+        "name":"test:latest"
+      }
+    }
+  }
+}

--- a/test/extended/fixtures/build-secrets/test-is.json
+++ b/test/extended/fixtures/build-secrets/test-is.json
@@ -1,0 +1,7 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test"
+  }
+}

--- a/test/extended/fixtures/build-secrets/test-secret-2.json
+++ b/test/extended/fixtures/build-secrets/test-secret-2.json
@@ -1,0 +1,14 @@
+{
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "testsecret2",
+        "creationTimestamp": null
+    },
+    "data": {
+        "secret1": "c2VjcmV0MQo=",
+        "secret2": "c2VjcmV0Mgo=",
+        "secret3": "c2VjcmV0Mwo="
+    },
+    "type": "Opaque"
+}

--- a/test/extended/fixtures/build-secrets/test-secret.json
+++ b/test/extended/fixtures/build-secrets/test-secret.json
@@ -1,0 +1,14 @@
+{
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "testsecret",
+        "creationTimestamp": null
+    },
+    "data": {
+        "secret1": "c2VjcmV0MQo=",
+        "secret2": "c2VjcmV0Mgo=",
+        "secret3": "c2VjcmV0Mwo="
+    },
+    "type": "Opaque"
+}

--- a/test/extended/fixtures/build-secrets/test-sti-build.json
+++ b/test/extended/fixtures/build-secrets/test-sti-build.json
@@ -1,0 +1,52 @@
+{
+  "kind":"BuildConfig",
+  "apiVersion":"v1",
+  "metadata":{
+    "name":"test",
+    "labels":{
+      "name":"test"
+    }
+  },
+  "spec":{
+    "triggers":[],
+    "source":{
+      "type":"Git",
+      "git":{
+        "uri":"https://github.com/mfojtik/origin",
+        "ref": "secrets"
+      },
+      "contextDir":"test/extended/fixtures/test-build-app",
+      "secrets": [
+        {
+          "secret": { "name": "testsecret" },
+          "destinationDir": "/tmp"
+        },
+        {
+          "secret": { "name": "testsecret2" }
+        }
+      ]
+    },
+    "strategy":{
+      "type":"Source",
+      "env": [
+        {
+          "name": "BUILD_LOGLEVEL",
+          "value": "5"
+        }
+      ],
+      "sourceStrategy":{
+        "from":{
+          "kind":"DockerImage",
+          "name":"centos/ruby-22-centos7"
+        },
+        "scripts":"https://raw.githubusercontent.com/mfojtik/origin/secrets/test/extended/fixtures/build-secrets/s2i"
+      }
+    },
+    "output":{
+      "to":{
+        "kind":"ImageStreamTag",
+        "name":"test:latest"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/m5bPxwh4/643-8-allow-to-consume-secrets-in-builds
This PR will add new field into the `BuildSource` type:

```javascript
{
   "source":{
      "secrets":[
         {
            "destinationDir":"/tmp",
            "secret":{
               "name":"secret1"
            }
         },
         {
            "secret":{
               "name":"secret2"
            }
         }
      ],
      "git":{
         "uri":"https://github.com/openshift/ruby-hello-world.git"
      },
      "type":"Git"
   }
}
```

In the case of the `secret1`, all files that this secret contains will get injected into `/tmp` folder during the Source-To-Image build. That means, they will only be available for the `assemble` script and they will be truncated right after this script finish.
The `secret2` works the same way, but the `destinationDir` is not specified. In that case the files will be copied into the directory where the application source code resides (iow. WORKDIR).

For Docker strategy, this will work similar but the `destinationDir` has to be relative path. In that case the content of the secret will be copied relative to the directory where the Dockerfile is located (iow. into a build directory). In this case, it is up to user to cleanup the secrets in the Dockerfile. Also worth to mention that the secrets will be available in the layer where user do `ADD` or `COPY`. We can't do too much about that other than documenting this.

For the Custom strategy, the `buildSecret` is addition to existing `secrets` field. It is up to the custom builder image to use them and distinguish between them.
