### PR TITLE
WIP: Support custom compiled auth UserIdentityMappers

### DIFF
--- a/pkg/auth/userregistry/identitymapper/mapper.go
+++ b/pkg/auth/userregistry/identitymapper/mapper.go
@@ -3,12 +3,34 @@ package identitymapper
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/util/sets"
+
 	authapi "github.com/openshift/origin/pkg/auth/api"
 	"github.com/openshift/origin/pkg/user"
 	identityregistry "github.com/openshift/origin/pkg/user/registry/identity"
 	userregistry "github.com/openshift/origin/pkg/user/registry/user"
 	mappingregistry "github.com/openshift/origin/pkg/user/registry/useridentitymapping"
 )
+
+// registeredMappers contains functions to build UserIdentityMappers by MappingMethodType.
+var registeredMappers = map[MappingMethodType]instantiateMapper{}
+
+// instantiateMapper knows how to make a UserIdentityMapper.
+type instantiateMapper func(identities identityregistry.Registry, users userregistry.Registry, initializer user.Initializer, mappingMethodConfig map[string]string) authapi.UserIdentityMapper
+
+// RegisterMapper registers a builder for a UserIdentityMapper for the given method.
+func RegisterMapper(method MappingMethodType, fn instantiateMapper) {
+	registeredMappers[method] = fn
+}
+
+// RegisteredMappingMethodTypes returns a set of all known MappingMethodTypes as strings.
+func RegisteredMappingMethodTypes() sets.String {
+	keys := make([]string, 0, len(registeredMappers))
+	for k := range registeredMappers {
+		keys = append(keys, string(k))
+	}
+	return sets.NewString(keys...)
+}
 
 type MappingMethodType string
 
@@ -29,31 +51,35 @@ const (
 	MappingMethodGenerate MappingMethodType = "generate"
 )
 
+func init() {
+	RegisterMapper(MappingMethodLookup, func(identities identityregistry.Registry, users userregistry.Registry, initializer user.Initializer, mappingMethodConfig map[string]string) authapi.UserIdentityMapper {
+		mappingStorage := mappingregistry.NewREST(users, identities)
+		mappingRegistry := mappingregistry.NewRegistry(mappingStorage)
+		return &lookupIdentityMapper{mappingRegistry, users}
+	})
+	RegisterMapper(MappingMethodAdd, func(identities identityregistry.Registry, users userregistry.Registry, initializer user.Initializer, mappingMethodConfig map[string]string) authapi.UserIdentityMapper {
+		return &provisioningIdentityMapper{identities, users, NewStrategyAdd(users, user.NewDefaultUserInitStrategy())}
+	})
+	RegisterMapper(MappingMethodClaim, func(identities identityregistry.Registry, users userregistry.Registry, initializer user.Initializer, mappingMethodConfig map[string]string) authapi.UserIdentityMapper {
+		return &provisioningIdentityMapper{identities, users, NewStrategyClaim(users, user.NewDefaultUserInitStrategy())}
+	})
+	RegisterMapper(MappingMethodGenerate, func(identities identityregistry.Registry, users userregistry.Registry, initializer user.Initializer, mappingMethodConfig map[string]string) authapi.UserIdentityMapper {
+		return &provisioningIdentityMapper{identities, users, NewStrategyGenerate(users, user.NewDefaultUserInitStrategy())}
+	})
+}
+
 // NewIdentityUserMapper returns a UserIdentityMapper that does the following:
 // 1. Returns an existing user if the identity exists and is associated with an existing user
 // 2. Returns an error if the identity exists and is not associated with a user (or is associated with a missing user)
 // 3. Handles new identities according to the requested method
-func NewIdentityUserMapper(identities identityregistry.Registry, users userregistry.Registry, method MappingMethodType) (authapi.UserIdentityMapper, error) {
+func NewIdentityUserMapper(identities identityregistry.Registry, users userregistry.Registry, method MappingMethodType, mappingMethodConfig map[string]string) (authapi.UserIdentityMapper, error) {
 	// initUser initializes fields in a User API object from its associated Identity
 	// called when adding the first Identity to a User (during create or update of a User)
 	initUser := user.NewDefaultUserInitStrategy()
 
-	switch method {
-	case MappingMethodLookup:
-		mappingStorage := mappingregistry.NewREST(users, identities)
-		mappingRegistry := mappingregistry.NewRegistry(mappingStorage)
-		return &lookupIdentityMapper{mappingRegistry, users}, nil
-
-	case MappingMethodClaim:
-		return &provisioningIdentityMapper{identities, users, NewStrategyClaim(users, initUser)}, nil
-
-	case MappingMethodAdd:
-		return &provisioningIdentityMapper{identities, users, NewStrategyAdd(users, initUser)}, nil
-
-	case MappingMethodGenerate:
-		return &provisioningIdentityMapper{identities, users, NewStrategyGenerate(users, initUser)}, nil
-
-	default:
+	instantiateMapper, ok := registeredMappers[method]
+	if !ok {
 		return nil, fmt.Errorf("unsupported mapping method %q", method)
 	}
+	return instantiateMapper(identities, users, initUser, mappingMethodConfig), nil
 }

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -545,6 +545,8 @@ type IdentityProvider struct {
 	UseAsLogin bool
 	// MappingMethod determines how identities from this provider are mapped to users
 	MappingMethod string
+	// MappingMethodConfig is used to configure custom MappingMethods.
+	MappingMethodConfig map[string]string
 	// Provider contains the information about how to set up a specific identity provider
 	Provider runtime.EmbeddedObject
 }

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -494,6 +494,8 @@ type IdentityProvider struct {
 	UseAsLogin bool `json:"login"`
 	// MappingMethod determines how identities from this provider are mapped to users
 	MappingMethod string `json:"mappingMethod"`
+	// MappingMethodConfig is used to configure custom MappingMethods.
+	MappingMethodConfig map[string]string `json:"mappingMethodConfig,omitempty"`
 	// Provider contains the information about how to set up a specific identity provider
 	Provider runtime.RawExtension `json:"provider"`
 }

--- a/pkg/cmd/server/api/validation/oauth.go
+++ b/pkg/cmd/server/api/validation/oauth.go
@@ -112,13 +112,6 @@ func ValidateOAuthConfig(config *api.OAuthConfig) ValidationResults {
 	return validationResults
 }
 
-var validMappingMethods = sets.NewString(
-	string(identitymapper.MappingMethodLookup),
-	string(identitymapper.MappingMethodClaim),
-	string(identitymapper.MappingMethodAdd),
-	string(identitymapper.MappingMethodGenerate),
-)
-
 func ValidateIdentityProvider(identityProvider api.IdentityProvider) ValidationResults {
 	validationResults := ValidationResults{}
 
@@ -131,8 +124,8 @@ func ValidateIdentityProvider(identityProvider api.IdentityProvider) ValidationR
 
 	if len(identityProvider.MappingMethod) == 0 {
 		validationResults.AddErrors(fielderrors.NewFieldRequired("mappingMethod"))
-	} else if !validMappingMethods.Has(identityProvider.MappingMethod) {
-		validationResults.AddErrors(fielderrors.NewFieldValueNotSupported("mappingMethod", identityProvider.MappingMethod, validMappingMethods.List()))
+	} else if !identitymapper.RegisteredMappingMethodTypes().Has(identityProvider.MappingMethod) {
+		validationResults.AddErrors(fielderrors.NewFieldValueNotSupported("mappingMethod", identityProvider.MappingMethod, identitymapper.RegisteredMappingMethodTypes().List()))
 	}
 
 	if !api.IsIdentityProviderType(identityProvider.Provider) {

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -328,7 +328,7 @@ func (c *AuthConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandler hand
 	redirectors := map[string]handlers.AuthenticationRedirector{}
 
 	for _, identityProvider := range c.Options.IdentityProviders {
-		identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod))
+		identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod), identityProvider.MappingMethodConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -471,7 +471,7 @@ func (c *AuthConfig) getOAuthProvider(identityProvider configapi.IdentityProvide
 }
 
 func (c *AuthConfig) getPasswordAuthenticator(identityProvider configapi.IdentityProvider) (authenticator.Password, error) {
-	identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod))
+	identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod), identityProvider.MappingMethodConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +553,7 @@ func (c *AuthConfig) getAuthenticationRequestHandler() (authenticator.Request, e
 	}
 
 	for _, identityProvider := range c.Options.IdentityProviders {
-		identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod))
+		identityMapper, err := identitymapper.NewIdentityUserMapper(c.IdentityRegistry, c.UserRegistry, identitymapper.MappingMethodType(identityProvider.MappingMethod), identityProvider.MappingMethodConfig)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### :construction:  WIP - DO NOT MERGE :construction: 

Refactor the identitymapper package to support custom compiled
UserIdentityMappers (including new mappingMethod values).

This allows forks of origin to implement new UserIdentityMappers
without modifying the origin core in any way.

Add a new MappingMethodConfig type to the auth config API to allow
opaque configuration of custom mapper implementations.

cc @liggitt @abhgupta 