### PR TITLE
add etcdserver launch mechanism

### DIFF
--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -291,6 +291,27 @@ _openshift_start_node()
     must_have_one_noun=()
 }
 
+_openshift_start_etcd()
+{
+    last_command="openshift_start_etcd"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("__handle_filename_extension_flag yaml|yml")
+    flags+=("--google-json-key=")
+    flags+=("--log-flush-frequency=")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--config=")
+    must_have_one_noun=()
+}
+
 _openshift_start_kubernetes_apiserver()
 {
     last_command="openshift_start_kubernetes_apiserver"
@@ -743,6 +764,7 @@ _openshift_start()
     commands=()
     commands+=("master")
     commands+=("node")
+    commands+=("etcd")
     commands+=("kubernetes")
 
     flags=()

--- a/pkg/cmd/server/etcd/etcd.go
+++ b/pkg/cmd/server/etcd/etcd.go
@@ -16,61 +16,6 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 )
 
-// RunEtcd starts an etcd server and runs it forever
-func RunEtcd(etcdServerConfig *configapi.EtcdConfig) {
-	cfg := &config{
-		name: defaultName,
-		dir:  etcdServerConfig.StorageDir,
-
-		TickMs:       100,
-		ElectionMs:   1000,
-		maxSnapFiles: 5,
-		maxWalFiles:  5,
-
-		initialClusterToken: "etcd-cluster",
-	}
-	var err error
-	if configapi.UseTLS(etcdServerConfig.ServingInfo) {
-		cfg.clientTLSInfo.CAFile = etcdServerConfig.ServingInfo.ClientCA
-		cfg.clientTLSInfo.CertFile = etcdServerConfig.ServingInfo.ServerCert.CertFile
-		cfg.clientTLSInfo.KeyFile = etcdServerConfig.ServingInfo.ServerCert.KeyFile
-	}
-	if cfg.lcurls, err = urlsFromStrings(etcdServerConfig.ServingInfo.BindAddress, cfg.clientTLSInfo); err != nil {
-		glog.Fatalf("Unable to build etcd client URLs: %v", err)
-	}
-
-	if configapi.UseTLS(etcdServerConfig.PeerServingInfo) {
-		cfg.peerTLSInfo.CAFile = etcdServerConfig.PeerServingInfo.ClientCA
-		cfg.peerTLSInfo.CertFile = etcdServerConfig.PeerServingInfo.ServerCert.CertFile
-		cfg.peerTLSInfo.KeyFile = etcdServerConfig.PeerServingInfo.ServerCert.KeyFile
-	}
-	if cfg.lpurls, err = urlsFromStrings(etcdServerConfig.PeerServingInfo.BindAddress, cfg.peerTLSInfo); err != nil {
-		glog.Fatalf("Unable to build etcd peer URLs: %v", err)
-	}
-
-	if cfg.acurls, err = urlsFromStrings(etcdServerConfig.Address, cfg.clientTLSInfo); err != nil {
-		glog.Fatalf("Unable to build etcd announce client URLs: %v", err)
-	}
-	if cfg.apurls, err = urlsFromStrings(etcdServerConfig.PeerAddress, cfg.peerTLSInfo); err != nil {
-		glog.Fatalf("Unable to build etcd announce peer URLs: %v", err)
-	}
-
-	if err := cfg.resolveUrls(); err != nil {
-		glog.Fatalf("Unable to resolve etcd URLs: %v", err)
-	}
-
-	cfg.initialCluster = fmt.Sprintf("%s=%s", cfg.name, cfg.apurls[0].String())
-
-	stopped, err := startEtcd(cfg)
-	if err != nil {
-		glog.Fatalf("Unable to start etcd: %v", err)
-	}
-	go func() {
-		glog.Infof("Started etcd at %s", etcdServerConfig.Address)
-		<-stopped
-	}()
-}
-
 // GetAndTestEtcdClient creates an etcd client based on the provided config. It will attempt to
 // connect to the etcd server and block until the server responds at least once, or return an
 // error if the server never responded.

--- a/pkg/cmd/server/etcd/etcdserver/run.go
+++ b/pkg/cmd/server/etcd/etcdserver/run.go
@@ -1,0 +1,64 @@
+package etcdserver
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+)
+
+// RunEtcd starts an etcd server and runs it forever
+func RunEtcd(etcdServerConfig *configapi.EtcdConfig) {
+	cfg := &config{
+		name: defaultName,
+		dir:  etcdServerConfig.StorageDir,
+
+		TickMs:       100,
+		ElectionMs:   1000,
+		maxSnapFiles: 5,
+		maxWalFiles:  5,
+
+		initialClusterToken: "etcd-cluster",
+	}
+	var err error
+	if configapi.UseTLS(etcdServerConfig.ServingInfo) {
+		cfg.clientTLSInfo.CAFile = etcdServerConfig.ServingInfo.ClientCA
+		cfg.clientTLSInfo.CertFile = etcdServerConfig.ServingInfo.ServerCert.CertFile
+		cfg.clientTLSInfo.KeyFile = etcdServerConfig.ServingInfo.ServerCert.KeyFile
+	}
+	if cfg.lcurls, err = urlsFromStrings(etcdServerConfig.ServingInfo.BindAddress, cfg.clientTLSInfo); err != nil {
+		glog.Fatalf("Unable to build etcd client URLs: %v", err)
+	}
+
+	if configapi.UseTLS(etcdServerConfig.PeerServingInfo) {
+		cfg.peerTLSInfo.CAFile = etcdServerConfig.PeerServingInfo.ClientCA
+		cfg.peerTLSInfo.CertFile = etcdServerConfig.PeerServingInfo.ServerCert.CertFile
+		cfg.peerTLSInfo.KeyFile = etcdServerConfig.PeerServingInfo.ServerCert.KeyFile
+	}
+	if cfg.lpurls, err = urlsFromStrings(etcdServerConfig.PeerServingInfo.BindAddress, cfg.peerTLSInfo); err != nil {
+		glog.Fatalf("Unable to build etcd peer URLs: %v", err)
+	}
+
+	if cfg.acurls, err = urlsFromStrings(etcdServerConfig.Address, cfg.clientTLSInfo); err != nil {
+		glog.Fatalf("Unable to build etcd announce client URLs: %v", err)
+	}
+	if cfg.apurls, err = urlsFromStrings(etcdServerConfig.PeerAddress, cfg.peerTLSInfo); err != nil {
+		glog.Fatalf("Unable to build etcd announce peer URLs: %v", err)
+	}
+
+	if err := cfg.resolveUrls(); err != nil {
+		glog.Fatalf("Unable to resolve etcd URLs: %v", err)
+	}
+
+	cfg.initialCluster = fmt.Sprintf("%s=%s", cfg.name, cfg.apurls[0].String())
+
+	stopped, err := startEtcd(cfg)
+	if err != nil {
+		glog.Fatalf("Unable to start etcd: %v", err)
+	}
+	go func() {
+		glog.Infof("Started etcd at %s", etcdServerConfig.Address)
+		<-stopped
+	}()
+}

--- a/pkg/cmd/server/etcd/etcdserver/server.go
+++ b/pkg/cmd/server/etcd/etcdserver/server.go
@@ -1,5 +1,5 @@
 // This is a somewhat faithful reproduction of etcdmain/etcd.go
-package etcd
+package etcdserver
 
 import (
 	"fmt"

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -114,8 +114,10 @@ func NewCommandStartAllInOne(basename string, out io.Writer) (*cobra.Command, *A
 
 	startMaster, _ := NewCommandStartMaster(basename, out)
 	startNode, _ := NewCommandStartNode(basename, out)
+	startEtcdServer, _ := NewCommandStartEtcdServer(RecommendedStartEtcdServerName, basename, out)
 	cmds.AddCommand(startMaster)
 	cmds.AddCommand(startNode)
+	cmds.AddCommand(startEtcdServer)
 
 	startKube := kubernetes.NewCommand("kubernetes", basename, out)
 	cmds.AddCommand(startKube)

--- a/pkg/cmd/server/start/start_etcd.go
+++ b/pkg/cmd/server/start/start_etcd.go
@@ -1,0 +1,117 @@
+package start
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/coreos/go-systemd/daemon"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/fielderrors"
+
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
+	"github.com/openshift/origin/pkg/cmd/server/api/validation"
+	"github.com/openshift/origin/pkg/cmd/server/etcd/etcdserver"
+)
+
+const RecommendedStartEtcdServerName = "etcd"
+
+type EtcdOptions struct {
+	ConfigFile string
+	Output     io.Writer
+}
+
+const etcdLong = `Start an etcd server for testing.
+
+This command starts an etcd server based on the config for testing.  It is not 
+Intended for production use.  Running
+
+  $ %[1]s start %[2]s
+
+will start the server listening for incoming requests. The server
+will run in the foreground until you terminate the process.`
+
+// NewCommandStartEtcdServer starts only the etcd server
+func NewCommandStartEtcdServer(name, basename string, out io.Writer) (*cobra.Command, *EtcdOptions) {
+	options := &EtcdOptions{Output: out}
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Launch etcd server",
+		Long:  fmt.Sprintf(etcdLong, basename, name),
+		Run: func(c *cobra.Command, args []string) {
+			kcmdutil.CheckErr(options.Validate())
+
+			startProfiler()
+
+			if err := options.StartEtcdServer(); err != nil {
+				if kerrors.IsInvalid(err) {
+					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
+						fmt.Fprintf(c.Out(), "Invalid %s %s\n", details.Kind, details.Name)
+						for _, cause := range details.Causes {
+							fmt.Fprintf(c.Out(), "  %s: %s\n", cause.Field, cause.Message)
+						}
+						os.Exit(255)
+					}
+				}
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	// This command only supports reading from config
+	flags.StringVar(&options.ConfigFile, "config", "", "Location of the master configuration file to run from.")
+	cmd.MarkFlagFilename("config", "yaml", "yml")
+	cmd.MarkFlagRequired("config")
+
+	return cmd, options
+}
+
+func (o *EtcdOptions) Validate() error {
+	if len(o.ConfigFile) == 0 {
+		return errors.New("--config is required for this command")
+	}
+
+	return nil
+}
+
+// StartEtcdServer calls RunEtcdServer and then waits forever
+func (o *EtcdOptions) StartEtcdServer() error {
+	if err := o.RunEtcdServer(); err != nil {
+		return err
+	}
+
+	go daemon.SdNotify("READY=1")
+	select {}
+}
+
+// RunEtcdServer takes the options and starts the etcd server
+func (o *EtcdOptions) RunEtcdServer() error {
+	masterConfig, err := configapilatest.ReadAndResolveMasterConfig(o.ConfigFile)
+	if err != nil {
+		return err
+	}
+
+	validationResults := validation.ValidateMasterConfig(masterConfig)
+	if len(validationResults.Warnings) != 0 {
+		for _, warning := range validationResults.Warnings {
+			glog.Warningf("%v", warning)
+		}
+	}
+	if len(validationResults.Errors) != 0 {
+		return kerrors.NewInvalid("MasterConfig", o.ConfigFile, validationResults.Errors)
+	}
+
+	if masterConfig.EtcdConfig == nil {
+		return kerrors.NewInvalid("MasterConfig.EtcConfig", o.ConfigFile, fielderrors.ValidationErrorList{fielderrors.NewFieldRequired("etcdConfig")})
+	}
+
+	etcdserver.RunEtcd(masterConfig.EtcdConfig)
+	return nil
+}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api/validation"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
+	"github.com/openshift/origin/pkg/cmd/server/etcd/etcdserver"
 	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -424,7 +425,7 @@ func startHealth(openshiftConfig *origin.MasterConfig) error {
 func startAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
 	// start etcd
 	if oc.Options.EtcdConfig != nil {
-		etcd.RunEtcd(oc.Options.EtcdConfig)
+		etcdserver.RunEtcd(oc.Options.EtcdConfig)
 	}
 
 	// verify we can connect to etcd with the provided config

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# This scripts starts the OpenShift server with a default configuration.
+# The OpenShift Docker registry and router are installed.
+# It will run all tests that are imported into test/extended.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${OS_ROOT}/hack/util.sh"
+source "${OS_ROOT}/hack/common.sh"
+os::log::install_errexit
+cd "${OS_ROOT}"
+
+os::build::setup_env
+
+export TMPDIR="${TMPDIR:-"/tmp"}"
+export BASETMPDIR="${TMPDIR}/openshift-extended-tests/alternate_launches"
+export EXTENDED_TEST_PATH="${OS_ROOT}/test/extended"
+
+function cleanup()
+{
+	out=$?
+	cleanup_openshift
+	echo "[INFO] Exiting"
+	exit $out
+}
+
+trap "exit" INT TERM
+trap "cleanup" EXIT
+
+
+echo "[INFO] Starting server as distinct processes"
+ensure_iptables_or_die
+setup_env_vars
+reset_tmp_dir
+configure_os_server
+
+echo "[INFO] `openshift version`"
+echo "[INFO] Server logs will be at:    ${LOG_DIR}/openshift.log"
+echo "[INFO] Test artifacts will be in: ${ARTIFACT_DIR}"
+echo "[INFO] Volumes dir is:            ${VOLUME_DIR}"
+echo "[INFO] Config dir is:             ${SERVER_CONFIG_DIR}"
+echo "[INFO] Using images:              ${USE_IMAGES}"
+echo "[INFO] MasterIP is:               ${MASTER_ADDR}"
+
+mkdir -p ${LOG_DIR}
+
+echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
+ps -ef | grep openshift
+echo "[INFO] Starting etcdserver"
+sudo env "PATH=${PATH}" OPENSHIFT_ON_PANIC=crash openshift start etcd \
+ --config=${MASTER_CONFIG_DIR}/master-config.yaml \
+ --loglevel=4 \
+&>"${LOG_DIR}/os-etcdserver.log" &
+
+echo "[INFO] Starting api server"
+sudo env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start master api \
+ --config=${MASTER_CONFIG_DIR}/master-config.yaml \
+ --loglevel=4 \
+&>"${LOG_DIR}/os-apiserver.log" &
+
+wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz" "apiserver: " 0.25 80
+wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/healthz/ready" "apiserver(ready): " 0.25 80
+echo "[INFO] OpenShift API server up at: "
+date
+
+echo "[INFO] Starting controllers"
+sudo env "PATH=${PATH}"  OPENSHIFT_ON_PANIC=crash openshift start master controllers \
+ --config=${MASTER_CONFIG_DIR}/master-config.yaml \
+ --loglevel=4 \
+&>"${LOG_DIR}/os-controllers.log" &
+
+echo "[INFO] Starting node"
+sudo env "PATH=${PATH}"  OPENSHIFT_ON_PANIC=crash openshift start node \
+ --config=${NODE_CONFIG_DIR}/node-config.yaml \
+ --loglevel=4 \
+&>"${LOG_DIR}/os-node.log" &
+export OS_PID=$!
+
+echo "[INFO] OpenShift server start at: "
+date
+
+wait_for_url "${KUBELET_SCHEME}://${KUBELET_HOST}:${KUBELET_PORT}/healthz" "[INFO] kubelet: " 0.5 60
+wait_for_url "${API_SCHEME}://${API_HOST}:${API_PORT}/api/v1/nodes/${KUBELET_HOST}" "apiserver(nodes): " 0.25 80
+echo "[INFO] OpenShift node health checks done at: "
+date
+
+# set our default KUBECONFIG location
+export KUBECONFIG="${ADMIN_KUBECONFIG}"
+
+${OS_ROOT}/test/end-to-end/core.sh


### PR DESCRIPTION
Adds the ability to launch an etcdserver using the exact same etcd level we'll use when launching an all-in-one or master by default.  It requires the config, same as `openshift start master api|controllers`.  Also adds a test that makes sure that e2e works when running as four separate processes.

This is something that @liggitt wanted (or something very similar) when debugging `hack/test-integration.sh`, I wanted it when debugging "failed to propose", @miminar wanted when dealing with separate api server and controllers, and would have made @csrwng's life easier when separating out the processes.

