### PR TITLE
POC of better quota admission (2000% improvement)

### DIFF
--- a/pkg/util/partitioningbucketer/partitioningbucketer.go
+++ b/pkg/util/partitioningbucketer/partitioningbucketer.go
@@ -1,0 +1,191 @@
+package partitioningbucketer
+
+import (
+	"fmt"
+	"hash/fnv"
+	"reflect"
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+type PartitioningBucketer struct {
+	partitions []Partition
+	keyFunc    KeyFunc
+
+	workAvailable chan int
+	stop          chan struct{}
+}
+
+type Partition struct {
+	partitionId int
+	lock        sync.Mutex
+	parent      *PartitioningBucketer
+
+	buckets   map[string]*Bucket
+	workQueue chan string
+
+	currentlyWorking sets.String
+}
+
+type Bucket struct {
+	partitionId int
+	key         string
+
+	IncomingWorkChannel chan WorkItem
+}
+
+type WorkItem struct {
+	Work interface{}
+
+	ResponseChannel chan interface{}
+}
+
+type KeyFunc func(interface{}) string
+type WorkFunc func(*Bucket)
+
+func NamespaceKeyFunc(obj interface{}) string {
+	fmt.Printf("#### looking for namespace in %v\n", reflect.TypeOf(obj))
+
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return ""
+	}
+	return meta.Namespace()
+}
+
+func NewPartitioningBucketer(numPartitions int, keyFunc KeyFunc, stop chan struct{}) *PartitioningBucketer {
+	partitioningBucketer := &PartitioningBucketer{}
+
+	partitions := []Partition{}
+	for i := 0; i < numPartitions; i++ {
+		partitions = append(partitions, *NewPartition(i, partitioningBucketer))
+	}
+
+	partitioningBucketer.partitions = partitions
+	partitioningBucketer.keyFunc = keyFunc
+	partitioningBucketer.stop = stop
+	partitioningBucketer.workAvailable = make(chan int, 1000)
+
+	return partitioningBucketer
+}
+
+func (p *PartitioningBucketer) AddWork(work interface{}, responseChannel chan interface{}) {
+	key := p.keyFunc(work)
+	partitionId := hash(key, uint32(len(p.partitions)))
+
+	p.partitions[partitionId].AddWork(key, work, responseChannel)
+}
+
+func (p *PartitioningBucketer) DoWork(worker WorkFunc) {
+	for {
+		partitionId := -1
+		select {
+		case partitionId = <-p.workAvailable:
+		case <-p.stop:
+			return
+		}
+
+		p.partitions[partitionId].WorkBucket(worker)
+	}
+}
+
+// hash calculates the hexadecimal representation (8-chars)
+// of the hash of the passed in string using the FNV-a algorithm
+func hash(s string, max uint32) int {
+	hash := fnv.New32a()
+	hash.Write([]byte(s))
+	return int(hash.Sum32() % max)
+}
+
+func NewPartition(partitionId int, parent *PartitioningBucketer) *Partition {
+	return &Partition{
+		partitionId:      partitionId,
+		parent:           parent,
+		buckets:          map[string]*Bucket{},
+		workQueue:        make(chan string, 100),
+		currentlyWorking: sets.String{},
+	}
+}
+
+func (p *Partition) AddWork(key string, work interface{}, responseChannel chan interface{}) {
+	fmt.Printf("#### Starting %v!\n", key)
+
+	workItem := WorkItem{
+		Work:            work,
+		ResponseChannel: responseChannel,
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	createdNew := false
+	bucket, exists := p.buckets[key]
+	if !exists {
+		bucket = &Bucket{
+			partitionId:         p.partitionId,
+			key:                 key,
+			IncomingWorkChannel: make(chan WorkItem, 100),
+		}
+		p.buckets[key] = bucket
+
+		createdNew = true
+	}
+
+	bucket.IncomingWorkChannel <- workItem
+
+	if createdNew {
+		fmt.Printf("#### made new for %v!\n", key)
+		p.workQueue <- key
+		p.parent.workAvailable <- p.partitionId
+	}
+}
+
+func (p *Partition) WorkBucket(worker WorkFunc) {
+	bucket := p.getBucket()
+	if bucket == nil {
+		return
+	}
+
+	worker(bucket)
+
+	// release the key
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.currentlyWorking.Delete(bucket.key)
+}
+
+func (p *Partition) getBucket() *Bucket {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	key := ""
+	select {
+	case key = <-p.workQueue:
+
+	case <-time.After(2 * time.Millisecond):
+		return nil
+	}
+
+	// don't work on the same key in parallel, make callers wait for a bit to calm down
+	// this effectively forces de-duping
+	if p.currentlyWorking.Has(key) {
+		time.Sleep(10 * time.Millisecond)
+		p.workQueue <- key
+		p.parent.workAvailable <- p.partitionId
+
+		return nil
+	}
+
+	bucket, exists := p.buckets[key]
+	if !exists {
+		return nil
+	}
+
+	delete(p.buckets, key)
+
+	p.currentlyWorking.Insert(key)
+	return bucket
+}

--- a/pkg/util/partitioningbucketer/partitioningbucketer_test.go
+++ b/pkg/util/partitioningbucketer/partitioningbucketer_test.go
@@ -1,0 +1,41 @@
+package partitioningbucketer
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSimpleCase(t *testing.T) {
+	stop := make(chan struct{})
+
+	pb := NewPartitioningBucketer(10, NamespaceKeyFunc, stop)
+
+	numIterations := 10
+
+	responseChannel := make(chan interface{}, 50)
+	go func() {
+		for i := 0; i < numIterations; i++ {
+			fmt.Printf("HERE!\n")
+			pb.AddWork(fmt.Sprintf("foo-%d", i), responseChannel)
+		}
+	}()
+
+	loggingWorker := func(b *Bucket) {
+		for {
+			if len(b.IncomingWorkChannel) == 0 {
+				break
+			}
+			workItem := <-b.IncomingWorkChannel
+			fmt.Printf("got %#v\n", workItem)
+			workItem.ResponseChannel <- fmt.Sprintf("done with %v!", workItem.Work)
+		}
+	}
+	go pb.DoWork(loggingWorker)
+
+	for i := 0; i < numIterations; i++ {
+		select {
+		case value := <-responseChannel:
+			fmt.Printf("received %v\n", value)
+		}
+	}
+}

--- a/pkg/util/partitioningbucketer/quota_worker.go
+++ b/pkg/util/partitioningbucketer/quota_worker.go
@@ -1,0 +1,123 @@
+package partitioningbucketer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kresource "k8s.io/kubernetes/pkg/api/resource"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+type QuotaHandler struct {
+	KubeClient *kclient.Client
+
+	PartitionBucketer *PartitioningBucketer
+}
+
+func (h *QuotaHandler) Start(numWorkers int) {
+	for i := 0; i < numWorkers; i++ {
+		go h.PartitionBucketer.DoWork(h.HandleQuotaBucket)
+	}
+}
+
+func (h *QuotaHandler) HandleQuotaBucket(bucket *Bucket) {
+	quotas, _ := h.KubeClient.ResourceQuotas(bucket.key).List(labels.Everything(), fields.Everything())
+	quota := kapi.ResourceQuota{}
+
+	projectedAccepts := []chan interface{}{}
+	acceptVal := []string{}
+	failureVal := []string{}
+
+	for {
+		if len(bucket.IncomingWorkChannel) == 0 {
+			break
+		}
+
+		workItem := <-bucket.IncomingWorkChannel
+
+		fmt.Printf("got %#v\n", workItem)
+		pod := workItem.Work.(*kapi.Pod)
+
+		if len(quotas.Items) < 1 {
+			fmt.Printf("#### MISSING!!!!")
+			acceptVal = append(acceptVal, fmt.Sprintf("accepted %v/%v ", pod.Namespace, pod.Name))
+			failureVal = append(failureVal, fmt.Sprintf("failure %v/%v", pod.Namespace, pod.Name))
+			projectedAccepts = append(projectedAccepts, workItem.ResponseChannel)
+			continue
+		}
+
+		// just an example, pull the first one
+		quota = quotas.Items[0]
+
+		podLimit := quota.Spec.Hard[kapi.ResourcePods]
+		maxPods := int((&podLimit).Value())
+
+		podUsed := quota.Status.Used[kapi.ResourcePods]
+		currPods := int((&podUsed).Value())
+		projectedPods := currPods + 1
+		if projectedPods > maxPods {
+			rejection := fmt.Sprintf("rejected %v/%v curr=%v max=%v!", pod.Namespace, pod.Name, currPods, maxPods)
+			workItem.ResponseChannel <- rejection
+			fmt.Printf("#### Planning to %s\n", rejection)
+			continue
+		}
+		quota.Status.Used[kapi.ResourcePods] = kresource.MustParse(fmt.Sprintf("%d", projectedPods))
+
+		acceptVal = append(acceptVal, fmt.Sprintf("accepted %v/%v curr=%v max=%v!", pod.Namespace, pod.Name, currPods, maxPods))
+		failureVal = append(failureVal, fmt.Sprintf("failure %v/%v curr=%v max=%v!", pod.Namespace, pod.Name, currPods, maxPods))
+		projectedAccepts = append(projectedAccepts, workItem.ResponseChannel)
+
+		fmt.Printf("#### Planning to %s\n", acceptVal)
+	}
+
+	fmt.Printf("#### About to update for %v with %#v\n", bucket.key, quota.Status.Used[kapi.ResourcePods])
+	if _, err := h.KubeClient.ResourceQuotas(bucket.key).UpdateStatus(&quota); err == nil {
+		for i, accept := range projectedAccepts {
+			accept <- acceptVal[i]
+		}
+
+	} else {
+		for i, accept := range projectedAccepts {
+			fmt.Printf("#### FAILURE %v for %v", err, failureVal[i])
+			accept <- failureVal[i]
+		}
+	}
+}
+
+func (h *QuotaHandler) Admit(a admission.Attributes) (err error) {
+
+	responseChannel := make(chan interface{})
+
+	if strings.Contains(strings.ToLower(a.GetResource()), "pod") {
+		fmt.Printf("#### IN HANDLER with %v\n", a.GetName())
+
+		h.PartitionBucketer.AddWork(a.GetObject(), responseChannel)
+
+		select {
+		case response := <-responseChannel:
+			answer := response.(string)
+			switch {
+			case strings.HasPrefix(answer, "accepted"):
+				fmt.Printf("#### ACCEPTED with %v\n", answer)
+				return nil
+			case strings.HasPrefix(answer, "rejected"):
+				fmt.Printf("#### REJECTED with %v\n", answer)
+				return admission.NewForbidden(a, errors.New(answer))
+			case strings.HasPrefix(answer, "failure"):
+				return errors.New(answer)
+
+			}
+		}
+	}
+
+	return errors.New("WTF!")
+}
+
+func (h *QuotaHandler) Handles(operation admission.Operation) bool {
+	return true
+}

--- a/pkg/util/partitioningbucketer/runner/runner.go
+++ b/pkg/util/partitioningbucketer/runner/runner.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/openshift/origin/pkg/util/partitioningbucketer"
+)
+
+func main() {
+	stop := make(chan struct{})
+
+	pb := partitioningbucketer.NewPartitioningBucketer(10, partitioningbucketer.NamespaceKeyFunc, stop)
+
+	numIterations := 10
+
+	responseChannel := make(chan interface{}, 50)
+	go func() {
+		for i := 0; i < numIterations; i++ {
+			fmt.Printf("HERE!\n")
+			pb.AddWork(fmt.Sprintf("foo-%d", i), responseChannel)
+		}
+	}()
+
+	loggingWorker := func(b *partitioningbucketer.Bucket) {
+		for {
+			if len(b.IncomingWorkChannel) == 0 {
+				break
+			}
+			workItem := <-b.IncomingWorkChannel
+			fmt.Printf("got %#v\n", workItem)
+			workItem.ResponseChannel <- fmt.Sprintf("done with %v!", workItem.Work)
+		}
+	}
+	go pb.DoWork(loggingWorker)
+
+	for i := 0; i < numIterations; i++ {
+		select {
+		case value := <-responseChannel:
+			fmt.Printf("received %v\n", value)
+		}
+	}
+}

--- a/test/integration/quota.go
+++ b/test/integration/quota.go
@@ -1,0 +1,93 @@
+// +build integration,etcd
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	kresource "k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util/wait"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+func TestSimpleQuota(t *testing.T) {
+	projectName := "quota"
+
+	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "david")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	quota := &kapi.ResourceQuota{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-quota"},
+		Spec: kapi.ResourceQuotaSpec{
+			Hard: kapi.ResourceList{
+				kapi.ResourcePods: kresource.MustParse("100"),
+			},
+		},
+	}
+	if _, err := clusterAdminKubeClient.ResourceQuotas(projectName).Create(quota); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rc := &kapi.ReplicationController{
+		ObjectMeta: kapi.ObjectMeta{Name: "my-rc"},
+		Spec: kapi.ReplicationControllerSpec{
+			Replicas: 100,
+			Selector: map[string]string{"whose": "mine"},
+			Template: &kapi.PodTemplateSpec{
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{Image: "scratch"},
+					},
+				},
+			},
+		},
+	}
+	if _, err := clusterAdminKubeClient.ReplicationControllers(projectName).Create(rc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	startTime := time.Now()
+	wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+		results, err := clusterAdminKubeClient.Pods(projectName).List(labels.Everything(), fields.Everything())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return false, nil
+		}
+
+		if len(results.Items) != 100 {
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	duration := time.Since(startTime)
+	t.Errorf("It too %v seconds", duration.Seconds())
+
+}


### PR DESCRIPTION
@derekwaynecarr This pull demonstrates a basic partitioning bucket based admission controller to eliminate ResourceQuota contention.  It gives about a 2000% (20x) improvement in quota calculation performance for non-competing RCs and moves the scaling from O(pod requests) to O(masters).   Based on the integration test, I saw

```
	// without quota: It took 3.261400093 seconds to scale up 100 pods
	// with quota: It took 10.015715218 seconds to scale up 13 pods
	// with fixed quota: It took 3.629586537 seconds to scale up 100 pods
```

@smarterclayton Do we want to pursue this upstream.  The implementation is more complicated, but its a huge gain, even per-master.  We could take this and front it with an http server.  That in combination with static pods, a leaser, and a controller balancing a service with a single endpoint would make this HA and O(cluster) instead of O(masters).  It would take a bit of work.

@danmcp It would take a little more work, but with consensus  and reconciliation this could be made to handle label selector based resource quota.  It is more work to do than the soft quota proposal.

@derekwaynecarr if you want to pursue this, in addition to obvious cleanup, you'll need to carefully apportion channel buffers to avoid a potential re-queue wedging problem.
