### PR TITLE
Fix route serialization flake

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -218,6 +218,12 @@ func fuzzInternalObject(t *testing.T, forVersion string, item runtime.Object, se
 				Name: j.To.Name,
 			}
 		},
+		func(j *route.TLSConfig, c fuzz.Continue) {
+			c.FuzzNoCustom(j)
+			if len(j.Termination) == 0 && len(j.DestinationCACertificate) == 0 {
+				j.Termination = route.TLSTerminationEdge
+			}
+		},
 		func(j *deploy.DeploymentConfig, c fuzz.Continue) {
 			c.FuzzNoCustom(j)
 			j.Spec.Triggers = []deploy.DeploymentTriggerPolicy{{Type: deploy.DeploymentTriggerOnConfigChange}}

--- a/pkg/route/api/v1beta3/conversion.go
+++ b/pkg/route/api/v1beta3/conversion.go
@@ -9,6 +9,19 @@ func init() {
 		func(obj *RouteSpec) {
 			obj.To.Kind = "Service"
 		},
+		func(obj *TLSConfig) {
+			if len(obj.Termination) == 0 && len(obj.DestinationCACertificate) == 0 {
+				obj.Termination = TLSTerminationEdge
+			}
+			switch obj.Termination {
+			case TLSTerminationType("Reencrypt"):
+				obj.Termination = TLSTerminationReencrypt
+			case TLSTerminationType("Edge"):
+				obj.Termination = TLSTerminationEdge
+			case TLSTerminationType("Passthrough"):
+				obj.Termination = TLSTerminationPassthrough
+			}
+		},
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/6656

@liggitt PTAL

Latest bash loop I am running against this fix was clean.
I think the problem is that there is no defaulting happening
when the internal object is fuzzed. 

Random fuzz test case:
1) TLS is specified
2) Termination field stays empty
3) After roundtripping, the defaults are set, resulting to the test flake

We do the same with the service that the route exposes (two lines above).