### PR TITLE
Image pullthrough

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -16,3 +16,5 @@ auth:
 middleware:
   repository:
     - name: openshift
+      options:
+        pullthrough: true

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -337,7 +337,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				},
 				{
 					Verbs:     sets.NewString("get"),
-					Resources: sets.NewString("imagestreamimages", "imagestreamtags", "imagestreams"),
+					Resources: sets.NewString("imagestreamimages", "imagestreamtags", "imagestreams", "imagestreams/secrets"),
 				},
 				{
 					Verbs:     sets.NewString("update"),

--- a/pkg/dockerregistry/server/digestcache.go
+++ b/pkg/dockerregistry/server/digestcache.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru"
+
+	"github.com/docker/distribution/digest"
+)
+
+// digestToRepositoryCache maps image digests to recently seen remote repositories that
+// may contain that digest. Each digest is bucketed and remembering new repositories will
+// push old repositories out.
+type digestToRepositoryCache struct {
+	*lru.Cache
+}
+
+// newDigestToRepositoryCache creates a new LRU cache of image digests to possible remote
+// repository strings with the given size. It returns an error if the cache
+// cannot be created.
+func newDigestToRepositoryCache(size int) (digestToRepositoryCache, error) {
+	c, err := lru.New(size)
+	if err != nil {
+		return digestToRepositoryCache{}, err
+	}
+	return digestToRepositoryCache{Cache: c}, nil
+}
+
+const bucketSize = 10
+
+// RememberDigest associates a digest with a repository.
+func (c digestToRepositoryCache) RememberDigest(dgst digest.Digest, repo string) {
+	key := dgst.String()
+	value, ok := c.Get(key)
+	if !ok {
+		value = &repositoryBucket{}
+		if ok, _ := c.ContainsOrAdd(key, value); !ok {
+			return
+		}
+	}
+	repos := value.(*repositoryBucket)
+	repos.Add(repo)
+}
+
+// RepositoriesForDigest returns a list of repositories that may contain this digest.
+func (c digestToRepositoryCache) RepositoriesForDigest(dgst digest.Digest) []string {
+	value, ok := c.Get(dgst.String())
+	if !ok {
+		return nil
+	}
+	repos := value.(*repositoryBucket)
+	return repos.Copy()
+}
+
+type repositoryBucket struct {
+	mu   sync.Mutex
+	list []string
+}
+
+// Has returns true if the bucket contains this repository.
+func (i *repositoryBucket) Has(repo string) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for _, s := range i.list {
+		if s == repo {
+			return true
+		}
+	}
+	return false
+}
+
+// Add one or more repositories to this bucket.
+func (i *repositoryBucket) Add(repos ...string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	arr := i.list
+	for _, repo := range repos {
+		if len(arr) >= bucketSize {
+			arr = arr[1:]
+		}
+		arr = append(arr, repo)
+	}
+	i.list = arr
+}
+
+// Copy returns a copy of the contents of this bucket in a threadsafe fasion.
+func (i *repositoryBucket) Copy() []string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	out := make([]string, len(i.list))
+	copy(out, i.list)
+	return out
+}

--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+
+	"k8s.io/kubernetes/pkg/api/errors"
+
+	imageapi "github.com/openshift/origin/pkg/image/api"
+	"github.com/openshift/origin/pkg/image/importer"
+)
+
+// pullthroughBlobStore wraps a distribution.BlobStore and allows remote repositories to serve blobs from remote
+// repositories.
+type pullthroughBlobStore struct {
+	distribution.BlobStore
+
+	repo          *repository
+	digestToStore map[string]distribution.BlobStore
+}
+
+var _ distribution.BlobStore = &pullthroughBlobStore{}
+
+// Stat makes a local check for the blob, then falls through to the other servers referenced by
+// the image stream and looks for those that have the layer.
+func (r *pullthroughBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	// check the local store for the blob
+	desc, err := r.BlobStore.Stat(ctx, dgst)
+	switch {
+	case err == distribution.ErrBlobUnknown:
+		// continue on to the code below and look up the blob in a remote store since it is not in
+		// the local store
+	case err != nil:
+		context.GetLogger(r.repo.ctx).Errorf("Failed to find blob %q: %#v", dgst.String(), err)
+		fallthrough
+	default:
+		return desc, err
+	}
+
+	// look up the potential remote repositories that this blob could be part of (at this time,
+	// we don't know which image in the image stream surfaced the content).
+	is, err := r.repo.getImageStream()
+	if err != nil {
+		if errors.IsNotFound(err) || errors.IsForbidden(err) {
+			return distribution.Descriptor{}, distribution.ErrBlobUnknown
+		}
+		context.GetLogger(r.repo.ctx).Errorf("Error retrieving image stream for blob: %s", err)
+		return distribution.Descriptor{}, err
+	}
+
+	var localRegistry string
+	if local, err := imageapi.ParseDockerImageReference(is.Status.DockerImageRepository); err == nil {
+		// TODO: normalize further?
+		localRegistry = local.Registry
+	}
+
+	retriever := r.repo.importContext()
+	cached := r.repo.cachedLayers.RepositoriesForDigest(dgst)
+
+	// look at the first level of tagged repositories first
+	search := identifyCandidateRepositories(is, localRegistry, true)
+	if desc, err := r.findCandidateRepository(ctx, search, cached, dgst, retriever); err == nil {
+		return desc, nil
+	}
+
+	// look at all other repositories tagged by the server
+	secondary := identifyCandidateRepositories(is, localRegistry, false)
+	for k := range search {
+		delete(secondary, k)
+	}
+	if desc, err := r.findCandidateRepository(ctx, secondary, cached, dgst, retriever); err == nil {
+		return desc, nil
+	}
+
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}
+
+// proxyStat attempts to locate the digest in the provided remote repository or returns an error. If the digest is found,
+// r.digestToStore saves the store.
+func (r *pullthroughBlobStore) proxyStat(ctx context.Context, retriever importer.RepositoryRetriever, ref imageapi.DockerImageReference, dgst digest.Digest) (distribution.Descriptor, error) {
+	context.GetLogger(r.repo.ctx).Infof("Trying to stat %q from %q", dgst, ref.Exact())
+	repo, err := retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), false)
+	if err != nil {
+		context.GetLogger(r.repo.ctx).Errorf("Error getting remote repository for image %q: %v", ref.Exact(), err)
+		return distribution.Descriptor{}, err
+	}
+	pullthroughBlobStore := repo.Blobs(ctx)
+	desc, err := pullthroughBlobStore.Stat(r.repo.ctx, dgst)
+	if err != nil {
+		if err != distribution.ErrBlobUnknown {
+			context.GetLogger(r.repo.ctx).Errorf("Error getting pullthroughBlobStore for image %q: %v", ref.Exact(), err)
+		}
+		return distribution.Descriptor{}, err
+	}
+
+	r.digestToStore[dgst.String()] = pullthroughBlobStore
+	return desc, nil
+}
+
+// ServeBlob attempts to serve the requested digest onto w, using a remote proxy store if necessary.
+func (r *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	store, ok := r.digestToStore[dgst.String()]
+	if !ok {
+		return r.BlobStore.ServeBlob(ctx, w, req, dgst)
+	}
+
+	desc, err := store.Stat(ctx, dgst)
+	if err != nil {
+		context.GetLogger(r.repo.ctx).Errorf("Failed to stat digest %q: %v", dgst.String(), err)
+		return err
+	}
+
+	remoteReader, err := store.Open(ctx, dgst)
+	if err != nil {
+		context.GetLogger(r.repo.ctx).Errorf("Failure to open remote store %q: %v", dgst.String(), err)
+		return err
+	}
+
+	setResponseHeaders(w, desc.Size, desc.MediaType, dgst)
+
+	context.GetLogger(r.repo.ctx).Infof("Copying %d bytes of type %q for %q", desc.Size, desc.MediaType, dgst.String())
+	if _, err := io.CopyN(w, remoteReader, desc.Size); err != nil {
+		context.GetLogger(r.repo.ctx).Errorf("Failed copying content from remote store %q: %v", dgst.String(), err)
+		return err
+	}
+	return nil
+}
+
+// findCandidateRepository looks in search for a particular blob, referring to previously cached items
+func (r *pullthroughBlobStore) findCandidateRepository(ctx context.Context, search map[string]*imageapi.DockerImageReference, cachedLayers []string, dgst digest.Digest, retriever importer.RepositoryRetriever) (distribution.Descriptor, error) {
+	// no possible remote locations to search, exit early
+	if len(search) == 0 {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+
+	// see if any of the previously located repositories containing this digest are in this
+	// image stream
+	for _, repo := range cachedLayers {
+		ref, ok := search[repo]
+		if !ok {
+			continue
+		}
+		desc, err := r.proxyStat(ctx, retriever, *ref, dgst)
+		if err != nil {
+			delete(search, repo)
+			continue
+		}
+		context.GetLogger(r.repo.ctx).Infof("Found digest location from cache %q in %q: %v", dgst, repo, err)
+		return desc, nil
+	}
+
+	// search the remaining registries for this digest
+	for repo, ref := range search {
+		desc, err := r.proxyStat(ctx, retriever, *ref, dgst)
+		if err != nil {
+			continue
+		}
+		r.repo.cachedLayers.RememberDigest(dgst, repo)
+		context.GetLogger(r.repo.ctx).Infof("Found digest location by search %q in %q: %v", dgst, repo, err)
+		return desc, nil
+	}
+
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}
+
+// identifyCandidateRepositories returns a map of remote repositories referenced by this image stream.
+func identifyCandidateRepositories(is *imageapi.ImageStream, localRegistry string, primary bool) map[string]*imageapi.DockerImageReference {
+	// identify the canonical location of referenced registries to search
+	search := make(map[string]*imageapi.DockerImageReference)
+	for _, tagEvent := range is.Status.Tags {
+		var candidates []imageapi.TagEvent
+		if primary {
+			if len(tagEvent.Items) == 0 {
+				continue
+			}
+			candidates = tagEvent.Items[:1]
+		} else {
+			if len(tagEvent.Items) <= 1 {
+				continue
+			}
+			candidates = tagEvent.Items[1:]
+		}
+		for _, event := range candidates {
+			ref, err := imageapi.ParseDockerImageReference(event.DockerImageReference)
+			if err != nil {
+				continue
+			}
+			// skip anything that matches the innate registry
+			// TODO: there may be a better way to make this determination
+			if len(localRegistry) != 0 && localRegistry == ref.Registry {
+				continue
+			}
+			ref = ref.DockerClientDefaults()
+			search[ref.AsRepository().Exact()] = &ref
+		}
+	}
+	return search
+}
+
+// setResponseHeaders sets the appropriate content serving headers
+func setResponseHeaders(w http.ResponseWriter, length int64, mediaType string, digest digest.Digest) {
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("Docker-Content-Digest", digest.String())
+	w.Header().Set("Etag", digest.String())
+}

--- a/pkg/image/importer/importer.go
+++ b/pkg/image/importer/importer.go
@@ -66,7 +66,7 @@ type ImageStreamImporter struct {
 	retriever RepositoryRetriever
 	limiter   util.RateLimiter
 
-	imageCache map[gocontext.Context]map[manifestKey]*api.Image
+	digestToRepositoryCache map[gocontext.Context]map[manifestKey]*api.Image
 }
 
 // NewImageStreamImport creates an importer that will load images from a remote Docker registry into an
@@ -81,16 +81,16 @@ func NewImageStreamImporter(retriever RepositoryRetriever, maximumTagsPerRepo in
 		retriever: retriever,
 		limiter:   limiter,
 
-		imageCache: make(map[gocontext.Context]map[manifestKey]*api.Image),
+		digestToRepositoryCache: make(map[gocontext.Context]map[manifestKey]*api.Image),
 	}
 }
 
 // contextImageCache returns the image cache entry for a context.
 func (i *ImageStreamImporter) contextImageCache(ctx gocontext.Context) map[manifestKey]*api.Image {
-	cache := i.imageCache[ctx]
+	cache := i.digestToRepositoryCache[ctx]
 	if cache == nil {
 		cache = make(map[manifestKey]*api.Image)
-		i.imageCache[ctx] = cache
+		i.digestToRepositoryCache[ctx] = cache
 	}
 	return cache
 }

--- a/pkg/image/registry/image/etcd/etcd_test.go
+++ b/pkg/image/registry/image/etcd/etcd_test.go
@@ -154,6 +154,42 @@ const etcdManifest = `
    ]
 }`
 
+const etcdManifestNoSignature = `
+{
+   "schemaVersion": 1, 
+   "tag": "latest", 
+   "name": "coreos/etcd", 
+   "architecture": "amd64", 
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }, 
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }, 
+      {
+         "blobSum": "sha256:2560187847cadddef806eaf244b7755af247a9dbabb90ca953dd2703cf423766"
+      }, 
+      {
+         "blobSum": "sha256:744b46d0ac8636c45870a03830d8d82c20b75fbfb9bc937d5e61005d23ad4cfe"
+      }
+   ], 
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"fe50ac14986497fa6b5d2cc24feb4a561d01767bc64413752c0988cb70b0b8b9\",\"parent\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"created\":\"2015-12-30T22:29:13.967754365Z\",\"container\":\"c8d0f1a274b5f52fa5beb280775ef07cf18ec0f95e5ae42fbad01157e2614d42\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ENTRYPOINT \\u0026{[\\\"/etcd\\\"]}\"],\"Image\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":[\"/etcd\"],\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":[\"/etcd\"],\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      }, 
+      {
+         "v1Compatibility": "{\"id\":\"a5a18474fa96a3c6e240bc88e41de2afd236520caf904356ad9d5f8d875c3481\",\"parent\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"created\":\"2015-12-30T22:29:13.504159783Z\",\"container\":\"080708d544f85052a46fab72e701b4358c1b96cb4b805a5b2d66276fc2aaf85d\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) EXPOSE 2379/tcp 2380/tcp 4001/tcp 7001/tcp\"],\"Image\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":{\"2379/tcp\":{},\"2380/tcp\":{},\"4001/tcp\":{},\"7001/tcp\":{}},\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      }, 
+      {
+         "v1Compatibility": "{\"id\":\"796d581500e960cc02095dcdeccf55db215b8e54c57e3a0b11392145ffe60cf6\",\"parent\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"created\":\"2015-12-30T22:29:12.912813629Z\",\"container\":\"f28be899c9b8680d4cf8585e663ad20b35019db062526844e7cfef117ce9037f\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:e330b1da49d993059975e46560b3bd360691498b0f2f6e00f39fc160cf8d4ec3 in /\"],\"Image\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":13502144}"
+      }, 
+      {
+         "v1Compatibility": "{\"id\":\"309c960c7f875411ae2ee2bfb97b86eee5058f3dad77206dd0df4f97df8a77fa\",\"created\":\"2015-12-30T22:29:12.346834862Z\",\"container\":\"1b97abade59e4b5b935aede236980a54fb500cd9ee5bd4323c832c6d7b3ffc6e\",\"container_config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:74912593c6783292c4520514f5cc9313acbd1da0f46edee0fdbed2a24a264d6f in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.9.1\",\"config\":{\"Hostname\":\"1b97abade59e\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":15141568}"
+      }
+   ]
+}`
+
 func TestCreateSetsMetadata(t *testing.T) {
 	testCases := []struct {
 		image  *api.Image
@@ -293,7 +329,44 @@ func TestUpdateResetsMetadata(t *testing.T) {
 				DockerImageMetadata:  api.DockerImage{ID: "foo"},
 			},
 		},
-	}
+		// old manifest is replaced because the new manifest matches the digest
+		{
+			expect: func(image *api.Image) bool {
+				if image.DockerImageManifest != etcdManifest {
+					t.Errorf("unexpected manifest: %s", image.DockerImageManifest)
+					return false
+				}
+				if image.DockerImageMetadata.ID != "fe50ac14986497fa6b5d2cc24feb4a561d01767bc64413752c0988cb70b0b8b9" {
+					t.Errorf("unexpected docker image: %#v", image.DockerImageMetadata)
+					return false
+				}
+				if image.DockerImageReference != "openshift/ruby-19-centos-2" {
+					t.Errorf("image reference changed: %s", image.DockerImageReference)
+					return false
+				}
+				if image.DockerImageMetadata.Size != 28643712 {
+					t.Errorf("image had size %d", image.DockerImageMetadata.Size)
+					return false
+				}
+				if len(image.DockerImageLayers) != 4 || image.DockerImageLayers[0].Name != "sha256:744b46d0ac8636c45870a03830d8d82c20b75fbfb9bc937d5e61005d23ad4cfe" || image.DockerImageLayers[0].Size != 15141568 {
+					t.Errorf("unexpected layers: %#v", image.DockerImageLayers)
+					return false
+				}
+				return true
+			},
+			existing: &api.Image{
+				ObjectMeta:           kapi.ObjectMeta{Name: "sha256:54820434e2ccd1596892668504fef12ed980f0cc312f60eac93d6864445ba123", ResourceVersion: "1"},
+				DockerImageReference: "openshift/ruby-19-centos-2",
+				DockerImageLayers:    []api.ImageLayer{},
+				DockerImageManifest:  etcdManifestNoSignature,
+			},
+			image: &api.Image{
+				ObjectMeta:           kapi.ObjectMeta{Name: "sha256:54820434e2ccd1596892668504fef12ed980f0cc312f60eac93d6864445ba123", ResourceVersion: "1"},
+				DockerImageReference: "openshift/ruby-19-centos",
+				DockerImageMetadata:  api.DockerImage{ID: "foo"},
+				DockerImageManifest:  etcdManifest,
+			},
+		}}
 
 	for i, test := range testCases {
 		storage, server := newStorage(t)

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -106,7 +106,7 @@ oc login -u e2e-user -p pass
 # make sure viewers can see oc status
 oc status -n default
 
-# check to make sure a project admin can push an image
+# check to make sure a project admin can push an image to an image stream that doesn't exist
 oc project cache
 e2e_user_token=$(oc config view --flatten --minify -o template --template='{{with index .users 0}}{{.user.token}}{{end}}')
 [[ -n ${e2e_user_token} ]]
@@ -119,6 +119,10 @@ echo "[INFO] Tagging and pushing ruby-22-centos7 to ${DOCKER_REGISTRY}/cache/rub
 docker tag -f centos/ruby-22-centos7:latest ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
 docker push ${DOCKER_REGISTRY}/cache/ruby-22-centos7:latest
 echo "[INFO] Pushed ruby-22-centos7"
+
+# verify remote images can be pulled directly from the local registry
+oc import-image --confirm --from=mysql:latest mysql:pullthrough
+docker pull ${DOCKER_REGISTRY}/cache/mysql:pullthrough
 
 # check to make sure an image-pusher can push an image
 oc policy add-role-to-user system:image-pusher pusher

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -689,6 +689,7 @@ items:
     resources:
     - imagestreamimages
     - imagestreams
+    - imagestreams/secrets
     - imagestreamtags
     verbs:
     - get


### PR DESCRIPTION
An image tagged into an OpenShift image stream from a remote repository
(with the manifest implemented) can be pulled directly from the integrated
Docker registry by a user invoking "docker pull". The registry should look
up the credentials for those remote servers and attempt to fetch the
manifest and layers. Because layers are only addressed by repository, it's
possible to get a local request (to the image stream) and not know which
remote repository it matches. This PR will search the remote repositories
on the current tag branches, and if it finds a match, will download the
blob. If the blob is local no remote calls are made. A cache is added to
track the most recent repositories that have been identified as having a
blob, this provides a small optimization to avoid most searches.

This change also serializes the entire manifest to the OpenShift server,
instead of just the "payload". This allows all read requests to be served
directly from the server for manifests which ensures the data in the master
is complete (and could potentially be reestablished in the future if the
registry was impacted).

Builds on top of image import, still needs more test cases and integration tests.