### PR TITLE
Fix help message of openshift start node

### DIFF
--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -35,10 +35,10 @@ Start a node
 
 This command helps you launch a node.  Running
 
-  $ %[1]s start node --master=<masterIP>
+  $ %[1]s start node --config=<node-config>
 
-will start a node that attempts to connect to the master on the provided IP. The
-node will run in the foreground until you terminate the process.`
+will start a node with given configuration file. The node will run in the
+foreground until you terminate the process.`
 
 // NewCommandStartNode provides a CLI handler for 'start node' command
 func NewCommandStartNode(basename string, out io.Writer) (*cobra.Command, *NodeOptions) {


### PR DESCRIPTION
`--master` options is no longer supported by `start node` command.

Signed-off-by: Michal Minar <miminar@redhat.com>