### PR TITLE
Fix logic to add Dockerfile to BuildConfig

### DIFF
--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -90,6 +90,8 @@ type SourceRepository struct {
 	buildWithDocker  bool
 	ignoreRepository bool
 	binary           bool
+
+	forceAddDockerfile bool
 }
 
 // NewSourceRepository creates a reference to a local or remote source code repository from
@@ -259,6 +261,7 @@ func (r *SourceRepository) AddDockerfile(contents string) error {
 	}
 	r.info.Dockerfile = dockerfile
 	r.buildWithDocker = true
+	r.forceAddDockerfile = true
 	return nil
 }
 
@@ -378,7 +381,7 @@ func StrategyAndSourceForRepository(repo *SourceRepository, image *ImageRef) (*B
 		Binary: repo.binary,
 	}
 
-	if repo.Info() != nil && repo.Info().Dockerfile != nil {
+	if (repo.ignoreRepository || repo.forceAddDockerfile) && repo.Info() != nil && repo.Info().Dockerfile != nil {
 		source.DockerfileContents = repo.Info().Dockerfile.Contents()
 	}
 	if !repo.ignoreRepository {

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -167,4 +167,7 @@ os::cmd::expect_success 'oc new-app mongo -o json | python -m json.tool'
 # Ensure custom branch/ref works
 os::cmd::expect_success 'oc new-app https://github.com/openshift/ruby-hello-world#beta4'
 
+# Ensure the resulting BuildConfig doesn't have unexpected sources
+os::cmd::expect_success_and_not_text 'oc new-app https://github.com/openshift/ruby-hello-world --output-version=v1 -o=jsonpath="{.items[?(@.kind==\"BuildConfig\")].spec.source}"' 'dockerfile|binary'
+
 echo "new-app: ok"


### PR DESCRIPTION
Distinguish when AddDockerfile was called, and only then append the
Dockerfile contents.

This fixes a bug where 'oc new-app' would incorrectly add Dockerfile
contents if there is a Dockerfile in the source Git repository.

Fixes #6675.