### PR TITLE
Add admission plugin to force builds to pull

### DIFF
--- a/pkg/build/admission/alwayspull.go
+++ b/pkg/build/admission/alwayspull.go
@@ -1,0 +1,58 @@
+package admission
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/kubernetes/pkg/admission"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+func init() {
+	admission.RegisterPlugin("AlwaysPullBuildImages", func(c kclient.Interface, config io.Reader) (admission.Interface, error) {
+		return NewAlwaysPullBuildImages(), nil
+	})
+}
+
+type alwaysPull struct {
+	*admission.Handler
+}
+
+// NewAlwaysPullBuildImages returns an admission controller for builds that sets ForcePull to true
+// regardless of the user's desired value. This is to ensure that a user has access to use the
+// image, since once an image has been pulled to a given node, access to that image is not
+// restricted or verified in any way (yet).
+func NewAlwaysPullBuildImages() admission.Interface {
+	return &alwaysPull{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+
+func (a *alwaysPull) Admit(attr admission.Attributes) error {
+	if resource := attr.GetResource(); resource != buildsResource && resource != buildConfigsResource {
+		return nil
+	}
+	switch obj := attr.GetObject().(type) {
+	case *buildapi.Build:
+		setForcePull(obj.Spec.Strategy)
+		return nil
+	case *buildapi.BuildConfig:
+		setForcePull(obj.Spec.Strategy)
+		return nil
+	default:
+		return admission.NewForbidden(attr, fmt.Errorf("unrecognized request object %#v", obj))
+	}
+}
+
+func setForcePull(strategy buildapi.BuildStrategy) {
+	switch {
+	case strategy.DockerStrategy != nil:
+		strategy.DockerStrategy.ForcePull = true
+	case strategy.CustomStrategy != nil:
+		strategy.CustomStrategy.ForcePull = true
+	case strategy.SourceStrategy != nil:
+		strategy.SourceStrategy.ForcePull = true
+	}
+}

--- a/pkg/build/admission/alwayspull_test.go
+++ b/pkg/build/admission/alwayspull_test.go
@@ -1,0 +1,163 @@
+package admission
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/runtime"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
+)
+
+func TestAlwaysPullBuildImagesAdmission(t *testing.T) {
+	tests := []struct {
+		name           string
+		kind           string
+		resource       string
+		object         runtime.Object
+		responseObject runtime.Object
+		expectAccept   bool
+		expectedError  string
+	}{
+		{
+			name: "build - custom",
+			object: &buildapi.Build{
+				Spec: buildapi.BuildSpec{
+					Strategy: buildapi.BuildStrategy{
+						CustomStrategy: &buildapi.CustomBuildStrategy{
+							ForcePull: false,
+						},
+					},
+				},
+			},
+			kind:         "Build",
+			resource:     buildsResource,
+			expectAccept: true,
+		},
+		{
+			name: "build - docker",
+			object: &buildapi.Build{
+				Spec: buildapi.BuildSpec{
+					Strategy: buildapi.BuildStrategy{
+						DockerStrategy: &buildapi.DockerBuildStrategy{
+							ForcePull: false,
+						},
+					},
+				},
+			},
+			kind:         "Build",
+			resource:     buildsResource,
+			expectAccept: true,
+		},
+		{
+			name: "build - source",
+			object: &buildapi.Build{
+				Spec: buildapi.BuildSpec{
+					Strategy: buildapi.BuildStrategy{
+						SourceStrategy: &buildapi.SourceBuildStrategy{
+							ForcePull: false,
+						},
+					},
+				},
+			},
+			kind:         "Build",
+			resource:     buildsResource,
+			expectAccept: true,
+		},
+		{
+			name: "build config - custom",
+			object: &buildapi.BuildConfig{
+				Spec: buildapi.BuildConfigSpec{
+					BuildSpec: buildapi.BuildSpec{
+						Strategy: buildapi.BuildStrategy{
+							CustomStrategy: &buildapi.CustomBuildStrategy{
+								ForcePull: false,
+							},
+						},
+					},
+				},
+			},
+			kind:         "BuildConfig",
+			resource:     buildConfigsResource,
+			expectAccept: true,
+		},
+		{
+			name: "build config - docker",
+			object: &buildapi.BuildConfig{
+				Spec: buildapi.BuildConfigSpec{
+					BuildSpec: buildapi.BuildSpec{
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								ForcePull: false,
+							},
+						},
+					},
+				},
+			},
+			kind:         "BuildConfig",
+			resource:     buildConfigsResource,
+			expectAccept: true,
+		},
+		{
+			name: "build config - source",
+			object: &buildapi.BuildConfig{
+				Spec: buildapi.BuildConfigSpec{
+					BuildSpec: buildapi.BuildSpec{
+						Strategy: buildapi.BuildStrategy{
+							SourceStrategy: &buildapi.SourceBuildStrategy{
+								ForcePull: false,
+							},
+						},
+					},
+				},
+			},
+			kind:         "BuildConfig",
+			resource:     buildConfigsResource,
+			expectAccept: true,
+		},
+	}
+
+	ops := []admission.Operation{admission.Create, admission.Update}
+	for _, test := range tests {
+		for _, op := range ops {
+			c := NewAlwaysPullBuildImages()
+			attrs := admission.NewAttributesRecord(test.object, test.kind, "default", "name", test.resource, "", op, nil)
+			err := c.Admit(attrs)
+			if err != nil && test.expectAccept {
+				t.Errorf("%s: unexpected error: %v", test.name, err)
+			}
+
+			if !apierrors.IsForbidden(err) && !test.expectAccept {
+				if (len(test.expectedError) != 0) || (test.expectedError == err.Error()) {
+					continue
+				}
+				t.Errorf("%s: expecting reject error, got %v", test.name, err)
+			}
+
+			var strategy *buildapi.BuildStrategy
+			switch obj := test.object.(type) {
+			case *buildapi.Build:
+				strategy = &obj.Spec.Strategy
+			case *buildapi.BuildConfig:
+				strategy = &obj.Spec.Strategy
+			}
+
+			switch {
+			case strategy.CustomStrategy != nil:
+				if strategy.CustomStrategy.ForcePull == false {
+					t.Errorf("%s: force pull was false")
+				}
+			case strategy.DockerStrategy != nil:
+				if strategy.DockerStrategy.ForcePull == false {
+					t.Errorf("%s: force pull was false")
+				}
+			case strategy.SourceStrategy != nil:
+				if strategy.SourceStrategy.ForcePull == false {
+					t.Errorf("%s: force pull was false")
+				}
+			}
+
+		}
+	}
+}

--- a/pkg/build/api/helpers.go
+++ b/pkg/build/api/helpers.go
@@ -50,3 +50,15 @@ func hasBuildConfigLabel(build Build, labelName, labelValue string) bool {
 	value, ok := build.Labels[labelName]
 	return ok && value == labelValue
 }
+
+// SetBuildForcePull sets the appropriate strategy's ForcePull value to true.
+func SetBuildForcePull(strategy BuildStrategy) {
+	switch {
+	case strategy.DockerStrategy != nil:
+		strategy.DockerStrategy.ForcePull = true
+	case strategy.CustomStrategy != nil:
+		strategy.CustomStrategy.ForcePull = true
+	case strategy.SourceStrategy != nil:
+		strategy.SourceStrategy.ForcePull = true
+	}
+}

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -17,6 +17,9 @@ const (
 	BuildCloneAnnotation = "openshift.io/build.clone-of"
 	// BuildPodNameAnnotation is an annotation whose value is the name of the pod running this build
 	BuildPodNameAnnotation = "openshift.io/build.pod-name"
+	// BuildAlwaysPullImagesAnnotation is an annotation that indicates that builds generated from
+	// BuildRequests should always pull images.
+	BuildAlwaysPullImagesAnnotation = "openshift.io/build.always-pull-images"
 	// BuildLabel is the key of a Pod label whose value is the Name of a Build which is run.
 	BuildLabel = "openshift.io/build.name"
 	// DefaultDockerLabelNamespace is the key of a Build label, whose values are build metadata.

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -223,6 +223,10 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 		return nil, err
 	}
 
+	if request.Annotations != nil && request.Annotations[buildapi.BuildAlwaysPullImagesAnnotation] == "true" {
+		buildapi.SetBuildForcePull(newBuild.Spec.Strategy)
+	}
+
 	// Ideally we would create the build *before* updating the BC to ensure that we don't set the LastTriggeredImageID
 	// on the BC and then fail to create the corresponding build, however doing things in that order allows for a race
 	// condition in which two builds get kicked off.  Doing it in this order ensures that we catch the race while
@@ -310,6 +314,10 @@ func (g *BuildGenerator) Clone(ctx kapi.Context, request *buildapi.BuildRequest)
 			glog.V(4).Infof("Failed to update BuildConfig %s/%s so no Build will be created", buildConfig.Namespace, buildConfig.Name)
 			return nil, err
 		}
+	}
+
+	if request.Annotations != nil && request.Annotations[buildapi.BuildAlwaysPullImagesAnnotation] == "true" {
+		buildapi.SetBuildForcePull(newBuild.Spec.Strategy)
 	}
 
 	return g.createBuild(ctx, newBuild)


### PR DESCRIPTION
Add a new admission controller plugin that sets forcePull to true on every build and build config,
regardless of user intent. This is not meant to be enabled by default. It's useful to ensure that a
user is not allowed to run an image that's already been pulled down to a node if they don't have the
authorization to use it.

For https://trello.com/c/OJ7uk5Rh/293-2-containers-should-not-be-able-to-use-pre-pulled-copies-of-images-without-authorization