### PR TITLE
Add support for crypt in HTPasswdPasswordIdentityProvider

### DIFF
--- a/pkg/auth/authenticator/password/htpasswd/htpasswd_test.go
+++ b/pkg/auth/authenticator/password/htpasswd/htpasswd_test.go
@@ -1,6 +1,9 @@
 package htpasswd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPasswordHashes(t *testing.T) {
 	testCases := []struct {
@@ -54,8 +57,8 @@ func TestPasswordHashes(t *testing.T) {
 			Name:     "crypt empty",
 			Password: "",
 			Hash:     "lNO4S8u4F4oNo",
-			Match:    false, // TODO: change to true if/when we add crypt support
-			Error:    true,  // TODO: change to false if/when we add crypt support
+			Match:    true,
+			Error:    false,
 		},
 		// htpasswd -d -n -b "username" "password"
 		// username:.zs/E.NK2vwFs
@@ -63,15 +66,15 @@ func TestPasswordHashes(t *testing.T) {
 			Name:     "crypt match",
 			Password: "password",
 			Hash:     ".zs/E.NK2vwFs",
-			Match:    false, // TODO: change to true if/when we add crypt support
-			Error:    true,  // TODO: change to false if/when we add crypt support
+			Match:    true,
+			Error:    false,
 		},
 		{
 			Name:     "crypt mismatch",
 			Password: "mypassword",
 			Hash:     ".zs/E.NK2vwFs",
-			Match:    false, // TODO: change to true if/when we add crypt support
-			Error:    true,  // TODO: change to false if/when we add crypt support
+			Match:    false,
+			Error:    false,
 		},
 		{
 			Name:     "crypt missing salt",
@@ -170,12 +173,23 @@ func TestPasswordHashes(t *testing.T) {
 			Match:    false,
 			Error:    true,
 		},
+
+		{
+			Name:     "crypt() with hash",
+			Password: "blah",
+			Hash:     "$1$HRN2HyTi$zuOdFM3DN1WiR0T/e.FS3.",
+			Match:    true,
+			Error:    false,
+		},
 	}
 
 	for _, testCase := range testCases {
 		match, err := testPassword(testCase.Password, testCase.Hash)
 		if testCase.Error != (err != nil) {
-			t.Errorf("%s: Expected error=%v, got %v", testCase.Name, testCase.Error, err)
+			// For crypt() on non-Linux platforms
+			if !strings.Contains(err.Error(), "not supported on this platform") {
+				t.Errorf("%s: Expected error=%v, got %v", testCase.Name, testCase.Error, err)
+			}
 		}
 		if match != testCase.Match {
 			t.Errorf("%s: Expected match=%v, got %v", testCase.Name, testCase.Match, match)

--- a/pkg/util/crypt.go
+++ b/pkg/util/crypt.go
@@ -1,0 +1,12 @@
+// +build !cgo !linux
+
+package util
+
+import (
+	"errors"
+)
+
+func Crypt(key string, salt string) (string, error) {
+	// We use the GNU reentrant form of crypt() ...
+	return "", errors.New("crypt() password hashes are not supported on this platform")
+}

--- a/pkg/util/crypt_linux.go
+++ b/pkg/util/crypt_linux.go
@@ -1,0 +1,47 @@
+// +build cgo,linux
+
+package util
+
+import (
+	"errors"
+	"unsafe"
+)
+
+/*
+#cgo LDFLAGS: -lcrypt
+#define _GNU_SOURCE
+#include <crypt.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *do_gnu_source_crypt_r(const char *key, const char *salt) {
+	struct crypt_data data = { 0, };
+	char *result = crypt_r(key, salt, &data);
+	if (!result)
+		return NULL;
+	result = strdup(result);
+	if (!result)
+		errno = ENOMEM;
+	return result;
+}
+*/
+import "C"
+
+func Crypt(key string, salt string) (string, error) {
+	ckey := C.CString(key)
+	csalt := C.CString(salt)
+	defer C.free(unsafe.Pointer(ckey))
+	defer C.free(unsafe.Pointer(csalt))
+
+	cres, err := C.do_gnu_source_crypt_r(ckey, csalt)
+	if cres == nil {
+		if err == nil {
+			err = errors.New("crypt() returned invalid result")
+		}
+		return "", err
+	}
+
+	defer C.free(unsafe.Pointer(cres))
+	return C.GoString(cres), nil
+}

--- a/pkg/util/crypt_test.go
+++ b/pkg/util/crypt_test.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCrypt(t *testing.T) {
+	cases := map[string]struct {
+		Key  string
+		Salt string
+		Out  string
+	}{
+		"crypt-simple": {
+			Key:  "blah",
+			Salt: "te",
+			Out:  "te56PdudR.x9M",
+		},
+		"crypt-extra": {
+			Key:  "blah",
+			Salt: "testanoeutu",
+			Out:  "te56PdudR.x9M",
+		},
+		"crypt-self": {
+			Key:  "blah",
+			Salt: "te56PdudR.x9M",
+			Out:  "te56PdudR.x9M",
+		},
+		"modern-sha512": {
+			Key:  "pass",
+			Salt: "$6$zLlJ8bbRxoBEsHmj$",
+			Out:  "$6$zLlJ8bbRxoBEsHmj$P2jDEu1tUP4aF2Nv5iRp1HUhNPsu/VKS6rDtC3k73G0Ijfx2m9qgZSMQI9aNDKDwqUuFSRhn5c0VLwyFRCxH7.",
+		},
+		"modern-self": {
+			Key:  "pass",
+			Salt: "$6$zLlJ8bbRxoBEsHmj$P2jDEu1tUP4aF2Nv5iRp1HUhNPsu/VKS6rDtC3k73G0Ijfx2m9qgZSMQI9aNDKDwqUuFSRhn5c0VLwyFRCxH7.",
+			Out:  "$6$zLlJ8bbRxoBEsHmj$P2jDEu1tUP4aF2Nv5iRp1HUhNPsu/VKS6rDtC3k73G0Ijfx2m9qgZSMQI9aNDKDwqUuFSRhn5c0VLwyFRCxH7.",
+		},
+		"modern-md5": {
+			Key:  "password",
+			Salt: "$1$6VmuPCYl$",
+			Out:  "$1$6VmuPCYl$tIEcT09v.tP3oo9YUAdUW/",
+		},
+		"modern-sha256": {
+			Key:  "password",
+			Salt: "$5$2034982094382039$",
+			Out:  "$5$2034982094382039$NUCJMGCYb/mOLNYa5xwbpl4BqWy0lFev3.Lrs5GynI9",
+		},
+	}
+
+	for k, testCase := range cases {
+		out, err := Crypt(testCase.Key, testCase.Salt)
+		if err != nil {
+			// For crypt() on non-Linux platforms
+			if !strings.Contains(err.Error(), "not supported on this platform") {
+				t.Errorf("%s: Failed: %q", k, err)
+			}
+		} else if out != testCase.Out {
+			t.Errorf("%s: Expected %s, got %s", k, testCase.Out, out)
+		}
+	}
+
+	_, err := Crypt("blah", "")
+	if err == nil {
+		t.Errorf("crypt-no-salt: Should have failed")
+	}
+}


### PR DESCRIPTION
- We can now support using in as /etc/shadow as a login file
- This means supporting more fields in the file and ignoring them
- Support the standard system crypt() using cgo
- [x] Basic implementation
- [x] Go tests
- [x] E2E test
