### PR TITLE
View etcd dump

### DIFF
--- a/hack/load-etcd-dump.sh
+++ b/hack/load-etcd-dump.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+
+# Go to the top of the tree.
+cd "${OS_ROOT}"
+
+os::build::setup_env
+
+export BASETMPDIR="/tmp/openshift/load-etcd-dump"
+rm -rf ${BASETMPDIR} || true
+
+go run tools/testdebug/load_etcd_dump.go $@

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -328,7 +328,7 @@ func (o MasterOptions) CreateCerts() error {
 	return nil
 }
 
-func buildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kubernetes.MasterConfig, error) {
+func BuildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kubernetes.MasterConfig, error) {
 	if openshiftConfig.Options.KubernetesMasterConfig == nil {
 		return nil, nil
 	}
@@ -371,7 +371,7 @@ func (m *Master) Start() error {
 		return err
 	}
 
-	kubeMasterConfig, err := buildKubernetesMasterConfig(openshiftConfig)
+	kubeMasterConfig, err := BuildKubernetesMasterConfig(openshiftConfig)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (m *Master) Start() error {
 		}
 		glog.Infof("Using images from %q", openshiftConfig.ImageFor("<component>"))
 
-		if err := startAPI(openshiftConfig, kubeMasterConfig); err != nil {
+		if err := StartAPI(openshiftConfig, kubeMasterConfig); err != nil {
 			return err
 		}
 
@@ -418,11 +418,11 @@ func startHealth(openshiftConfig *origin.MasterConfig) error {
 	return nil
 }
 
-// startAPI starts the components of the master that are considered part of the API - the Kubernetes
+// StartAPI starts the components of the master that are considered part of the API - the Kubernetes
 // API and core controllers, the Origin API, the group, policy, project, and authorization caches,
 // etcd, the asset server (for the UI), the OAuth server endpoints, and the DNS server.
 // TODO: allow to be more granularly targeted
-func startAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
+func StartAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
 	// start etcd
 	if oc.Options.EtcdConfig != nil {
 		etcdserver.RunEtcd(oc.Options.EtcdConfig)

--- a/tools/testdebug/cmd/load_etcd.go
+++ b/tools/testdebug/cmd/load_etcd.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	coreosetcdclient "github.com/coreos/etcd/client"
+	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/cmd/admin/policy"
+	"github.com/openshift/origin/pkg/cmd/flagtypes"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/server/etcd"
+	"github.com/openshift/origin/pkg/cmd/server/etcd/etcdserver"
+	"github.com/openshift/origin/pkg/cmd/server/origin"
+	"github.com/openshift/origin/pkg/cmd/server/start"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+const RecommendedLoadEtcdDumpName = "start-api"
+
+type DebugAPIServerOptions struct {
+	Out io.Writer
+
+	EtcdDumpFile string
+	AllowAll     bool
+}
+
+func NewDebugAPIServerCommand() *cobra.Command {
+	o := &DebugAPIServerOptions{Out: os.Stdout}
+
+	cmd := &cobra.Command{
+		Use:   RecommendedLoadEtcdDumpName + " etcd_dump.json",
+		Short: "Start API server using etcddump",
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(args))
+
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+
+	cmd.Flags().BoolVar(&o.AllowAll, "allow-all", true, "change policy to grant system:authenticated cluster-admin powers")
+
+	flagtypes.GLog(cmd.PersistentFlags())
+
+	return cmd
+}
+
+func (o *DebugAPIServerOptions) Complete(args []string) error {
+	if len(args) != 1 {
+		return errors.New("etcd_dump.json file is required")
+	}
+
+	o.EtcdDumpFile = args[0]
+
+	return nil
+}
+
+func (o *DebugAPIServerOptions) Run() error {
+	masterConfig, err := testserver.DefaultMasterOptionsWithTweaks(true /*start etcd server*/, true /*use default ports*/)
+	if err != nil {
+		return err
+	}
+
+	etcdConfig := masterConfig.EtcdConfig
+	masterConfig.EtcdConfig = nil
+	masterConfig.DNSConfig = nil
+
+	etcdserver.RunEtcd(etcdConfig)
+
+	if err := o.ImportEtcdDump(masterConfig.EtcdClientInfo); err != nil {
+		return err
+	}
+
+	if err := o.StartAPIServer(*masterConfig); err != nil {
+		return err
+	}
+
+	if o.AllowAll {
+		osClient, err := testutil.GetClusterAdminClient(testutil.GetBaseDir() + "/openshift.local.config/master/admin.kubeconfig")
+		if err != nil {
+			return err
+		}
+
+		addClusterAdmin := &policy.RoleModificationOptions{
+			RoleName:            bootstrappolicy.ClusterAdminRoleName,
+			RoleBindingAccessor: policy.ClusterRoleBindingAccessor{Client: osClient},
+			Groups:              []string{"system:authenticated"},
+		}
+		if err := addClusterAdmin.AddRole(); err != nil {
+			return err
+		}
+	}
+
+	select {}
+}
+
+func (o *DebugAPIServerOptions) StartAPIServer(masterConfig configapi.MasterConfig) error {
+	openshiftConfig, err := origin.BuildMasterConfig(masterConfig)
+	if err != nil {
+		return err
+	}
+
+	kubeMasterConfig, err := start.BuildKubernetesMasterConfig(openshiftConfig)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Starting master on %s\n", masterConfig.ServingInfo.BindAddress)
+	fmt.Printf("Public master address is %s\n", masterConfig.AssetConfig.MasterPublicURL)
+	return start.StartAPI(openshiftConfig, kubeMasterConfig)
+}
+
+func (o *DebugAPIServerOptions) ImportEtcdDump(etcdClientInfo configapi.EtcdConnectionInfo) error {
+	infile, err := os.Open(o.EtcdDumpFile)
+	if err != nil {
+		return err
+	}
+	etcdDump := &coreosetcdclient.Response{}
+	if err := json.NewDecoder(infile).Decode(etcdDump); err != nil {
+		return err
+	}
+
+	// Connect and setup etcd interfaces
+	etcdClient, err := etcd.GetAndTestEtcdClient(etcdClientInfo)
+	if err != nil {
+		return err
+	}
+
+	nodeList := []*coreosetcdclient.Node{}
+	nodeList = append(nodeList, etcdDump.Node)
+	for i := 0; i < len(nodeList); i++ {
+		node := nodeList[i]
+		for j := range node.Nodes {
+			nodeList = append(nodeList, node.Nodes[j])
+		}
+		if len(node.Key) == 0 {
+			continue
+		}
+
+		if node.Dir {
+			if _, err := etcdClient.CreateDir(node.Key, uint64(0)); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if _, err := etcdClient.Create(node.Key, node.Value, uint64(0)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tools/testdebug/load_etcd_dump.go
+++ b/tools/testdebug/load_etcd_dump.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/openshift/origin/tools/testdebug/cmd"
+)
+
+func main() {
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	command := cmd.NewDebugAPIServerCommand()
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This creates a helper command (in `tools`) to take one the etcd dumps from our test runs, load it into etcd, start an API server in front, and grant system:authenticated cluster-admin powers using `hack/load-etcd-dump.sh /home/deads/Downloads/etcd_dump.json`

This allows for navigation using all the client tooling we've build into kubectl and oc.  Things like get, describe, status, etc all work as expected.

@stevekuznetsov @liggitt ptal


