### PR TITLE
Lock bootstrap-hover-dropdown version to 2.1.3

### DIFF
--- a/assets/bower.json
+++ b/assets/bower.json
@@ -31,7 +31,7 @@
     "kubernetes-container-terminal": "0.0.7",
     "openshift-object-describer": "1.1.1",
     "layout.attrs": "1.1.2",
-    "bootstrap-hover-dropdown": "~2.1.3",
+    "bootstrap-hover-dropdown": "2.1.3",
     "angular-ui-ace": "0.2.3",
     "ace-builds": "1.2.2",
     "yamljs": "0.1.5"


### PR DESCRIPTION
This is not currently causing a problem, but we should lock to a version for repeatable builds.

/cc @liggitt @jwforres 