### PR TITLE
kebab case all urls in web console

### DIFF
--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -93,7 +93,7 @@ angular
         templateUrl: 'views/projects.html',
         controller: 'ProjectsController'
       })
-      .when('/createProject', {
+      .when('/create-project', {
         templateUrl: 'views/createProject.html',
         controller: 'CreateProjectController'
       })
@@ -212,11 +212,11 @@ angular
         templateUrl: 'views/browse/route.html',
         controller: 'RouteController'
       })
-      .when('/project/:project/createRoute', {
+      .when('/project/:project/create-route', {
         templateUrl: 'views/createRoute.html',
         controller: 'CreateRouteController'
       })
-      .when('/project/:project/attachPVC', {
+      .when('/project/:project/attach-pvc', {
         templateUrl: 'views/attachPVC.html',
         controller: 'AttachPVCController'
       })
@@ -248,7 +248,16 @@ angular
         templateUrl: 'views/util/logout.html',
         controller: 'LogoutController'
       })
-
+      // legacy redirects
+      .when('/createProject', {
+        redirectTo: '/create-project'
+      })
+      .when('/project/:project/createRoute', {
+        redirectTo: '/project/:project/create-route'
+      })
+      .when('/project/:project/attachPVC', {
+        redirectTo: '/project/:project/attach-pvc'
+      })
       .otherwise({
         redirectTo: '/'
       });

--- a/assets/app/views/browse/_deployment-details.html
+++ b/assets/app/views/browse/_deployment-details.html
@@ -69,6 +69,6 @@
     builds="builds"
     detailed="true"></pod-template>
     <h4 style="margin-top: 20px;">Volumes</h4>
-    <a ng-href="project/{{project.metadata.name}}/attachPVC?deployment={{deployment.metadata.name}}">Attach storage</a>
+    <a ng-href="project/{{project.metadata.name}}/attach-pvc?deployment={{deployment.metadata.name}}">Attach storage</a>
     <volumes volumes="deployment.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
 </div>

--- a/assets/app/views/browse/_pod-details.html
+++ b/assets/app/views/browse/_pod-details.html
@@ -49,7 +49,7 @@
       </pod-template>
       <div ng-if="pod.spec.volumes.length">
         <h4 style="margin-top: 20px;">Volumes</h4>
-        <a ng-if="pod | annotation:'deploymentConfig'" ng-href="project/{{project.metadata.name}}/attachPVC?deploymentconfig={{pod | annotation:'deploymentConfig'}}">Attach storage and redeploy</a>
+        <a ng-if="pod | annotation:'deploymentConfig'" ng-href="project/{{project.metadata.name}}/attach-pvc?deploymentconfig={{pod | annotation:'deploymentConfig'}}">Attach storage and redeploy</a>
         <volumes volumes="pod.spec.volumes" namespace="project.metadata.name"></volumes>
       </div>
     </div>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -88,7 +88,7 @@
                     detailed="true"></pod-template>
             </dl>
             <h4 style="margin-top: 20px;">Volumes</h4>
-            <a ng-href="project/{{project.metadata.name}}/attachPVC?deploymentconfig={{deploymentConfig.metadata.name}}">Attach storage</a>
+            <a ng-href="project/{{project.metadata.name}}/attach-pvc?deploymentconfig={{deploymentConfig.metadata.name}}">Attach storage</a>
             <volumes volumes="deploymentConfig.spec.template.spec.volumes" namespace="project.metadata.name"></volumes>
           </div>
           <div class="col-lg-6">

--- a/assets/app/views/browse/routes.html
+++ b/assets/app/views/browse/routes.html
@@ -3,7 +3,7 @@
     <div>
       <div class="page-header page-header-bleed-right">
         <div class="actions pull-right">
-          <a ng-href="project/{{project.metadata.name}}/createRoute" class="btn btn-default">Create Route</a>
+          <a ng-href="project/{{project.metadata.name}}/create-route" class="btn btn-default">Create Route</a>
         </div>
         <h1>Routes</h1>
       </div>

--- a/assets/app/views/browse/service.html
+++ b/assets/app/views/browse/service.html
@@ -94,7 +94,7 @@
                 </dd>
               </dl>
               <div class="gutter-bottom">
-                <a ng-href="project/{{project.metadata.name}}/createRoute?service={{service.metadata.name}}">Create route</a>
+                <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}">Create route</a>
               </div>
               <annotations annotations="service.metadata.annotations"></annotations>
             </div>

--- a/assets/app/views/project.html
+++ b/assets/app/views/project.html
@@ -129,7 +129,7 @@
                   </span>
                 </span>
                 <div ng-if="!displayRouteByService[serviceId]" class="component-label add-route-link">
-                  <a ng-href="project/{{project.metadata.name}}/createRoute?service={{service.metadata.name}}">Create Route</a>
+                  <a ng-href="project/{{project.metadata.name}}/create-route?service={{service.metadata.name}}">Create Route</a>
                 </div>
               </div>
             </div>

--- a/assets/app/views/projects.html
+++ b/assets/app/views/projects.html
@@ -2,7 +2,7 @@
   <div ng-if="(projects | hashSize) === 0" class="text-muted">Loading...</div>
   <div ng-if="(projects | hashSize) !== 0">
     <h1 style="display: inline-block;">Projects</h1>
-    <a ng-if="canCreate" href="createProject" style="margin-top: 10px;" class="btn btn-lg btn-primary pull-right">New Project</a>
+    <a ng-if="canCreate" href="create-project" style="margin-top: 10px;" class="btn btn-lg btn-primary pull-right">New Project</a>
     <alerts alerts="alerts"></alerts>
     <div ng-repeat="project in projects | orderByDisplayName">
       <div row flex cross-axis="center" class="tile tile-project tile-click tile-flex">
@@ -48,7 +48,7 @@
     <span ng-if="canCreate">Create a project for your application.</span>
   </p>
 
-  <a ng-if="canCreate" href="createProject" class="btn btn-lg btn-primary">New Project</a>
+  <a ng-if="canCreate" href="create-project" class="btn btn-lg btn-primary">New Project</a>
 
   <p>To learn more, visit the OpenShift <a ng-href="{{'' | helpLink}}">documentation</a>.</p>
 


### PR DESCRIPTION
Minor change, kebab case (lower-with-hyphens) all our routes in the web console, while keeping existing camelCased routes as redirects at the end of the $routeProvider config.
    
- createProject is create-project, redirect at end of $routeProvider
- createRoute is create-route
- createPVS is create-pvc

@spadgett @jwforres 