### PR TITLE
hello-openshift example: make the ports configurable

### DIFF
--- a/examples/hello-openshift/hello_openshift.go
+++ b/examples/hello-openshift/hello_openshift.go
@@ -3,29 +3,35 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 )
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "Hello OpenShift!")
 }
 
+func listenAndServe(port string) {
+	fmt.Printf("serving on %s\n", port)
+	err := http.ListenAndServe(":"+port, nil)
+	if err != nil {
+		panic("ListenAndServe: " + err.Error())
+	}
+}
+
 func main() {
 	http.HandleFunc("/", helloHandler)
 
-	go func() {
-		fmt.Println("serving on 8080")
-		err := http.ListenAndServe(":8080", nil)
-		if err != nil {
-			panic("ListenAndServe: " + err.Error())
-		}
-	}()
+	port := os.Getenv("PORT")
+	if len(port) == 0 {
+		port = "8080"
+	}
+	go listenAndServe(port)
 
-	go func() {
-		fmt.Println("serving on 8888")
-		err := http.ListenAndServe(":8888", nil)
-		if err != nil {
-			panic("ListenAndServe: " + err.Error())
-		}
-	}()
+	port = os.Getenv("SECOND_PORT")
+	if len(port) == 0 {
+		port = "8888"
+	}
+	go listenAndServe(port)
+
 	select {}
 }


### PR DESCRIPTION
the hello-openshift example is great for starting to play with openshift, but it would be better if we could configure its ports with env vars (to play with the env vars)

I used the env vars PORT and PORT2 (default to 8080 and 8888).
I'm not a big fan of "PORT2", so if someone has a better idea...