### PR TITLE
Run user-provided command as part of build flow

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -17373,6 +17373,10 @@
       "$ref": "v1.ResourceRequirements",
       "description": "the desired compute resources the build should have"
      },
+     "postCommit": {
+      "$ref": "v1.BuildPostCommitSpec",
+      "description": "an action executed after the build output image is committed"
+     },
      "completionDeadlineSeconds": {
       "type": "integer",
       "format": "int64",
@@ -17924,6 +17928,29 @@
      }
     }
    },
+   "v1.BuildPostCommitSpec": {
+    "id": "v1.BuildPostCommitSpec",
+    "properties": {
+     "command": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "command to be executed in a container running the build output image replacing the image's entrypoint"
+     },
+     "args": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "arguments to command, script or the default image entrypoint"
+     },
+     "script": {
+      "type": "string",
+      "description": "shell script to be executed in a container running the build output image"
+     }
+    }
+   },
    "v1.BuildConfigStatus": {
     "id": "v1.BuildConfigStatus",
     "required": [
@@ -18187,6 +18214,10 @@
      "resources": {
       "$ref": "v1.ResourceRequirements",
       "description": "the desired compute resources the build should have"
+     },
+     "postCommit": {
+      "$ref": "v1.BuildPostCommitSpec",
+      "description": "an action executed after the build output image is committed"
      },
      "completionDeadlineSeconds": {
       "type": "integer",

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -881,6 +881,27 @@ func deepCopy_api_BuildOutput(in buildapi.BuildOutput, out *buildapi.BuildOutput
 	return nil
 }
 
+func deepCopy_api_BuildPostCommitSpec(in buildapi.BuildPostCommitSpec, out *buildapi.BuildPostCommitSpec, c *conversion.Cloner) error {
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
 func deepCopy_api_BuildRequest(in buildapi.BuildRequest, out *buildapi.BuildRequest, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -1026,6 +1047,9 @@ func deepCopy_api_BuildSpec(in buildapi.BuildSpec, out *buildapi.BuildSpec, c *c
 		return err
 	} else {
 		out.Resources = newVal.(pkgapi.ResourceRequirements)
+	}
+	if err := deepCopy_api_BuildPostCommitSpec(in.PostCommit, &out.PostCommit, c); err != nil {
+		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
 		out.CompletionDeadlineSeconds = new(int64)
@@ -3292,6 +3316,7 @@ func init() {
 		deepCopy_api_BuildLog,
 		deepCopy_api_BuildLogOptions,
 		deepCopy_api_BuildOutput,
+		deepCopy_api_BuildPostCommitSpec,
 		deepCopy_api_BuildRequest,
 		deepCopy_api_BuildSource,
 		deepCopy_api_BuildSpec,

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1172,6 +1172,34 @@ func autoConvert_api_BuildOutput_To_v1_BuildOutput(in *buildapi.BuildOutput, out
 	return nil
 }
 
+func autoConvert_api_BuildPostCommitSpec_To_v1_BuildPostCommitSpec(in *buildapi.BuildPostCommitSpec, out *v1.BuildPostCommitSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*buildapi.BuildPostCommitSpec))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
+func Convert_api_BuildPostCommitSpec_To_v1_BuildPostCommitSpec(in *buildapi.BuildPostCommitSpec, out *v1.BuildPostCommitSpec, s conversion.Scope) error {
+	return autoConvert_api_BuildPostCommitSpec_To_v1_BuildPostCommitSpec(in, out, s)
+}
+
 func autoConvert_api_BuildRequest_To_v1_BuildRequest(in *buildapi.BuildRequest, out *v1.BuildRequest, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildRequest))(in)
@@ -1321,6 +1349,9 @@ func autoConvert_api_BuildSpec_To_v1_BuildSpec(in *buildapi.BuildSpec, out *v1.B
 		return err
 	}
 	if err := Convert_api_ResourceRequirements_To_v1_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if err := Convert_api_BuildPostCommitSpec_To_v1_BuildPostCommitSpec(&in.PostCommit, &out.PostCommit, s); err != nil {
 		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
@@ -1978,6 +2009,34 @@ func autoConvert_v1_BuildOutput_To_api_BuildOutput(in *v1.BuildOutput, out *buil
 	return nil
 }
 
+func autoConvert_v1_BuildPostCommitSpec_To_api_BuildPostCommitSpec(in *v1.BuildPostCommitSpec, out *buildapi.BuildPostCommitSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1.BuildPostCommitSpec))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
+func Convert_v1_BuildPostCommitSpec_To_api_BuildPostCommitSpec(in *v1.BuildPostCommitSpec, out *buildapi.BuildPostCommitSpec, s conversion.Scope) error {
+	return autoConvert_v1_BuildPostCommitSpec_To_api_BuildPostCommitSpec(in, out, s)
+}
+
 func autoConvert_v1_BuildRequest_To_api_BuildRequest(in *v1.BuildRequest, out *buildapi.BuildRequest, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1.BuildRequest))(in)
@@ -2128,6 +2187,9 @@ func autoConvert_v1_BuildSpec_To_api_BuildSpec(in *v1.BuildSpec, out *buildapi.B
 		return err
 	}
 	if err := Convert_v1_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if err := Convert_v1_BuildPostCommitSpec_To_api_BuildPostCommitSpec(&in.PostCommit, &out.PostCommit, s); err != nil {
 		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
@@ -8626,6 +8688,7 @@ func init() {
 		autoConvert_api_BuildLogOptions_To_v1_BuildLogOptions,
 		autoConvert_api_BuildLog_To_v1_BuildLog,
 		autoConvert_api_BuildOutput_To_v1_BuildOutput,
+		autoConvert_api_BuildPostCommitSpec_To_v1_BuildPostCommitSpec,
 		autoConvert_api_BuildRequest_To_v1_BuildRequest,
 		autoConvert_api_BuildSource_To_v1_BuildSource,
 		autoConvert_api_BuildSpec_To_v1_BuildSpec,
@@ -8800,6 +8863,7 @@ func init() {
 		autoConvert_v1_BuildLogOptions_To_api_BuildLogOptions,
 		autoConvert_v1_BuildLog_To_api_BuildLog,
 		autoConvert_v1_BuildOutput_To_api_BuildOutput,
+		autoConvert_v1_BuildPostCommitSpec_To_api_BuildPostCommitSpec,
 		autoConvert_v1_BuildRequest_To_api_BuildRequest,
 		autoConvert_v1_BuildSource_To_api_BuildSource,
 		autoConvert_v1_BuildSpec_To_api_BuildSpec,

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -901,6 +901,27 @@ func deepCopy_v1_BuildOutput(in apiv1.BuildOutput, out *apiv1.BuildOutput, c *co
 	return nil
 }
 
+func deepCopy_v1_BuildPostCommitSpec(in apiv1.BuildPostCommitSpec, out *apiv1.BuildPostCommitSpec, c *conversion.Cloner) error {
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
 func deepCopy_v1_BuildRequest(in apiv1.BuildRequest, out *apiv1.BuildRequest, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -1047,6 +1068,9 @@ func deepCopy_v1_BuildSpec(in apiv1.BuildSpec, out *apiv1.BuildSpec, c *conversi
 		return err
 	} else {
 		out.Resources = newVal.(pkgapiv1.ResourceRequirements)
+	}
+	if err := deepCopy_v1_BuildPostCommitSpec(in.PostCommit, &out.PostCommit, c); err != nil {
+		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
 		out.CompletionDeadlineSeconds = new(int64)
@@ -3181,6 +3205,7 @@ func init() {
 		deepCopy_v1_BuildLog,
 		deepCopy_v1_BuildLogOptions,
 		deepCopy_v1_BuildOutput,
+		deepCopy_v1_BuildPostCommitSpec,
 		deepCopy_v1_BuildRequest,
 		deepCopy_v1_BuildSource,
 		deepCopy_v1_BuildSpec,

--- a/pkg/api/v1beta3/conversion_generated.go
+++ b/pkg/api/v1beta3/conversion_generated.go
@@ -1180,6 +1180,34 @@ func autoConvert_api_BuildOutput_To_v1beta3_BuildOutput(in *buildapi.BuildOutput
 	return nil
 }
 
+func autoConvert_api_BuildPostCommitSpec_To_v1beta3_BuildPostCommitSpec(in *buildapi.BuildPostCommitSpec, out *v1beta3.BuildPostCommitSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*buildapi.BuildPostCommitSpec))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
+func Convert_api_BuildPostCommitSpec_To_v1beta3_BuildPostCommitSpec(in *buildapi.BuildPostCommitSpec, out *v1beta3.BuildPostCommitSpec, s conversion.Scope) error {
+	return autoConvert_api_BuildPostCommitSpec_To_v1beta3_BuildPostCommitSpec(in, out, s)
+}
+
 func autoConvert_api_BuildSource_To_v1beta3_BuildSource(in *buildapi.BuildSource, out *v1beta3.BuildSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*buildapi.BuildSource))(in)
@@ -1264,6 +1292,9 @@ func autoConvert_api_BuildSpec_To_v1beta3_BuildSpec(in *buildapi.BuildSpec, out 
 		return err
 	}
 	if err := Convert_api_ResourceRequirements_To_v1beta3_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if err := Convert_api_BuildPostCommitSpec_To_v1beta3_BuildPostCommitSpec(&in.PostCommit, &out.PostCommit, s); err != nil {
 		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
@@ -1921,6 +1952,34 @@ func autoConvert_v1beta3_BuildOutput_To_api_BuildOutput(in *v1beta3.BuildOutput,
 	return nil
 }
 
+func autoConvert_v1beta3_BuildPostCommitSpec_To_api_BuildPostCommitSpec(in *v1beta3.BuildPostCommitSpec, out *buildapi.BuildPostCommitSpec, s conversion.Scope) error {
+	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
+		defaulting.(func(*v1beta3.BuildPostCommitSpec))(in)
+	}
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
+func Convert_v1beta3_BuildPostCommitSpec_To_api_BuildPostCommitSpec(in *v1beta3.BuildPostCommitSpec, out *buildapi.BuildPostCommitSpec, s conversion.Scope) error {
+	return autoConvert_v1beta3_BuildPostCommitSpec_To_api_BuildPostCommitSpec(in, out, s)
+}
+
 func autoConvert_v1beta3_BuildSource_To_api_BuildSource(in *v1beta3.BuildSource, out *buildapi.BuildSource, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*v1beta3.BuildSource))(in)
@@ -2006,6 +2065,9 @@ func autoConvert_v1beta3_BuildSpec_To_api_BuildSpec(in *v1beta3.BuildSpec, out *
 		return err
 	}
 	if err := Convert_v1beta3_ResourceRequirements_To_api_ResourceRequirements(&in.Resources, &out.Resources, s); err != nil {
+		return err
+	}
+	if err := Convert_v1beta3_BuildPostCommitSpec_To_api_BuildPostCommitSpec(&in.PostCommit, &out.PostCommit, s); err != nil {
 		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
@@ -6781,6 +6843,7 @@ func init() {
 		autoConvert_api_BuildLogOptions_To_v1beta3_BuildLogOptions,
 		autoConvert_api_BuildLog_To_v1beta3_BuildLog,
 		autoConvert_api_BuildOutput_To_v1beta3_BuildOutput,
+		autoConvert_api_BuildPostCommitSpec_To_v1beta3_BuildPostCommitSpec,
 		autoConvert_api_BuildSource_To_v1beta3_BuildSource,
 		autoConvert_api_BuildSpec_To_v1beta3_BuildSpec,
 		autoConvert_api_BuildStatus_To_v1beta3_BuildStatus,
@@ -6924,6 +6987,7 @@ func init() {
 		autoConvert_v1beta3_BuildLogOptions_To_api_BuildLogOptions,
 		autoConvert_v1beta3_BuildLog_To_api_BuildLog,
 		autoConvert_v1beta3_BuildOutput_To_api_BuildOutput,
+		autoConvert_v1beta3_BuildPostCommitSpec_To_api_BuildPostCommitSpec,
 		autoConvert_v1beta3_BuildSource_To_api_BuildSource,
 		autoConvert_v1beta3_BuildSpec_To_api_BuildSpec,
 		autoConvert_v1beta3_BuildStatus_To_api_BuildStatus,

--- a/pkg/api/v1beta3/deep_copy_generated.go
+++ b/pkg/api/v1beta3/deep_copy_generated.go
@@ -909,6 +909,27 @@ func deepCopy_v1beta3_BuildOutput(in apiv1beta3.BuildOutput, out *apiv1beta3.Bui
 	return nil
 }
 
+func deepCopy_v1beta3_BuildPostCommitSpec(in apiv1beta3.BuildPostCommitSpec, out *apiv1beta3.BuildPostCommitSpec, c *conversion.Cloner) error {
+	if in.Command != nil {
+		out.Command = make([]string, len(in.Command))
+		for i := range in.Command {
+			out.Command[i] = in.Command[i]
+		}
+	} else {
+		out.Command = nil
+	}
+	if in.Args != nil {
+		out.Args = make([]string, len(in.Args))
+		for i := range in.Args {
+			out.Args[i] = in.Args[i]
+		}
+	} else {
+		out.Args = nil
+	}
+	out.Script = in.Script
+	return nil
+}
+
 func deepCopy_v1beta3_BuildRequest(in apiv1beta3.BuildRequest, out *apiv1beta3.BuildRequest, c *conversion.Cloner) error {
 	if newVal, err := c.DeepCopy(in.TypeMeta); err != nil {
 		return err
@@ -1055,6 +1076,9 @@ func deepCopy_v1beta3_BuildSpec(in apiv1beta3.BuildSpec, out *apiv1beta3.BuildSp
 		return err
 	} else {
 		out.Resources = newVal.(pkgapiv1beta3.ResourceRequirements)
+	}
+	if err := deepCopy_v1beta3_BuildPostCommitSpec(in.PostCommit, &out.PostCommit, c); err != nil {
+		return err
 	}
 	if in.CompletionDeadlineSeconds != nil {
 		out.CompletionDeadlineSeconds = new(int64)
@@ -2999,6 +3023,7 @@ func init() {
 		deepCopy_v1beta3_BuildLog,
 		deepCopy_v1beta3_BuildLogOptions,
 		deepCopy_v1beta3_BuildOutput,
+		deepCopy_v1beta3_BuildPostCommitSpec,
 		deepCopy_v1beta3_BuildRequest,
 		deepCopy_v1beta3_BuildSource,
 		deepCopy_v1beta3_BuildSpec,

--- a/pkg/build/api/types.go
+++ b/pkg/build/api/types.go
@@ -62,6 +62,10 @@ type BuildSpec struct {
 	// Compute resource requirements to execute the build
 	Resources kapi.ResourceRequirements
 
+	// PostCommit is a build hook executed after the build output image is
+	// committed, before it is pushed to a registry.
+	PostCommit BuildPostCommitSpec
+
 	// Optional duration in seconds, counted from the time when a build pod gets
 	// scheduled in the system, that the build may be active on a node before the
 	// system actively tries to terminate the build; value must be positive integer
@@ -413,6 +417,89 @@ type SourceBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool
+}
+
+// A BuildPostCommitSpec holds a build post commit hook specification. The hook
+// executes a command in a temporary container running the build output image,
+// immediately after the last layer of the image is committed and before the
+// image is pushed to a registry. The command is executed with the current
+// working directory ($PWD) set to the image's WORKDIR.
+//
+// The build will be marked as failed if the hook execution fails. It will fail
+// if the script or command return a non-zero exit code, or if there is any
+// other error related to starting the temporary container.
+//
+// There are five different ways to configure the hook. As an example, all forms
+// below are equivalent and will execute `rake test --verbose`.
+//
+// 1. Shell script:
+//
+// 	BuildPostCommitSpec{
+// 		Script: "rake test --verbose",
+// 	}
+//
+// The above is a convenient form which is equivalent to:
+//
+// 	BuildPostCommitSpec{
+// 		Command: []string{"/bin/sh", "-c"},
+// 		Args: []string{"rake test --verbose"},
+// 	}
+//
+// 2. Command as the image entrypoint:
+//
+// 	BuildPostCommitSpec{
+// 		Command: []string{"rake", "test", "--verbose"},
+// 	}
+//
+// Command overrides the image entrypoint in the exec form, as documented in
+// Docker: https://docs.docker.com/engine/reference/builder/#entrypoint.
+//
+// 3. Pass arguments to the default entrypoint:
+//
+// 	BuildPostCommitSpec{
+// 		Args: []string{"rake", "test", "--verbose"},
+// 	}
+//
+// This form is only useful if the image entrypoint can handle arguments.
+//
+// 4. Shell script with arguments:
+//
+// 	BuildPostCommitSpec{
+// 		Script: "rake test $1",
+// 		Args: []string{"--verbose"},
+// 	}
+//
+// This form is useful if you need to pass arguments that would otherwise be
+// hard to quote properly in the shell script. In the script, $0 will be
+// "/bin/sh" and $1, $2, etc, are the positional arguments from Args.
+//
+// 5. Command with arguments:
+//
+// 	BuildPostCommitSpec{
+// 		Command: []string{"rake", "test"},
+// 		Args: []string{"--verbose"},
+// 	}
+//
+// This form is equivalent to appending the arguments to the Command slice.
+//
+// It is invalid to provide both Script and Command simultaneously. If none of
+// the fields are specified, the hook is not executed.
+type BuildPostCommitSpec struct {
+	// Command is the command to run. It may not be specified with Script.
+	// This might be needed if the image doesn't have "/bin/sh", or if you
+	// do not want to use a shell. In all other cases, using Script might be
+	// more convenient.
+	Command []string
+	// Args is a list of arguments that are provided to either Command,
+	// Script or the Docker image's default entrypoint. The arguments are
+	// placed immediately after the command to be run.
+	Args []string
+	// Script is a shell script to be run with `/bin/sh -c`. It may not be
+	// specified with Command. Use Script when a shell script is appropriate
+	// to execute the post build hook, for example for running unit tests
+	// with "rake test". If you need control over the image entrypoint, or
+	// if the image does not have "/bin/sh", use Command and/or Args.
+	Script string
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/api/v1beta3/types.go
+++ b/pkg/build/api/v1beta3/types.go
@@ -43,6 +43,10 @@ type BuildSpec struct {
 	// Compute resource requirements to execute the build
 	Resources kapi.ResourceRequirements `json:"resources,omitempty" description:"the desired compute resources the build should have"`
 
+	// PostCommit is a build hook executed after the build output image is
+	// committed, before it is pushed to a registry.
+	PostCommit BuildPostCommitSpec `json:"postCommit,omitempty" description:"an action executed after the build output image is committed"`
+
 	// Optional duration in seconds, counted from the time when a build pod gets
 	// scheduled in the system, that the build may be active on a node before the
 	// system actively tries to terminate the build; value must be positive integer
@@ -383,6 +387,89 @@ type SourceBuildStrategy struct {
 
 	// ForcePull describes if the builder should pull the images from registry prior to building.
 	ForcePull bool `json:"forcePull,omitempty" description:"forces the source build to pull the image if true"`
+}
+
+// A BuildPostCommitSpec holds a build post commit hook specification. The hook
+// executes a command in a temporary container running the build output image,
+// immediately after the last layer of the image is committed and before the
+// image is pushed to a registry. The command is executed with the current
+// working directory ($PWD) set to the image's WORKDIR.
+//
+// The build will be marked as failed if the hook execution fails. It will fail
+// if the script or command return a non-zero exit code, or if there is any
+// other error related to starting the temporary container.
+//
+// There are five different ways to configure the hook. As an example, all forms
+// below are equivalent and will execute `rake test --verbose`.
+//
+// 1. Shell script:
+//
+// 	BuildPostCommitSpec{
+// 		Script: "rake test --verbose",
+// 	}
+//
+// The above is a convenient form which is equivalent to:
+//
+// 	BuildPostCommitSpec{
+// 		Command: []string{"/bin/sh", "-c"},
+// 		Args: []string{"rake test --verbose"},
+// 	}
+//
+// 2. Command as the image entrypoint:
+//
+// 	BuildPostCommitSpec{
+// 		Command: []string{"rake", "test", "--verbose"},
+// 	}
+//
+// Command overrides the image entrypoint in the exec form, as documented in
+// Docker: https://docs.docker.com/engine/reference/builder/#entrypoint.
+//
+// 3. Pass arguments to the default entrypoint:
+//
+// 	BuildPostCommitSpec{
+// 		Args: []string{"rake", "test", "--verbose"},
+// 	}
+//
+// This form is only useful if the image entrypoint can handle arguments.
+//
+// 4. Shell script with arguments:
+//
+// 	BuildPostCommitSpec{
+// 		Script: "rake test $1",
+// 		Args: []string{"--verbose"},
+// 	}
+//
+// This form is useful if you need to pass arguments that would otherwise be
+// hard to quote properly in the shell script. In the script, $0 will be
+// "/bin/sh" and $1, $2, etc, are the positional arguments from Args.
+//
+// 5. Command with arguments:
+//
+// 	BuildPostCommitSpec{
+// 		Command: []string{"rake", "test"},
+// 		Args: []string{"--verbose"},
+// 	}
+//
+// This form is equivalent to appending the arguments to the Command slice.
+//
+// It is invalid to provide both Script and Command simultaneously. If none of
+// the fields are specified, the hook is not executed.
+type BuildPostCommitSpec struct {
+	// Command is the command to run. It may not be specified with Script.
+	// This might be needed if the image doesn't have "/bin/sh", or if you
+	// do not want to use a shell. In all other cases, using Script might be
+	// more convenient.
+	Command []string `json:"command,omitempty" description:"command to be executed in a container running the build output image replacing the image's entrypoint"`
+	// Args is a list of arguments that are provided to either Command,
+	// Script or the Docker image's default entrypoint. The arguments are
+	// placed immediately after the command to be run.
+	Args []string `json:"args,omitempty" description:"arguments to command, script or the default image entrypoint"`
+	// Script is a shell script to be run with `/bin/sh -c`. It may not be
+	// specified with Command. Use Script when a shell script is appropriate
+	// to execute the post build hook, for example for running unit tests
+	// with "rake test". If you need control over the image entrypoint, or
+	// if the image does not have "/bin/sh", use Command and/or Args.
+	Script string `json:"script,omitempty" description:"shell script to be executed in a container running the build output image"`
 }
 
 // BuildOutput is input to a build strategy and describes the Docker image that the strategy

--- a/pkg/build/api/validation/validation.go
+++ b/pkg/build/api/validation/validation.go
@@ -117,6 +117,7 @@ func validateBuildSpec(spec *buildapi.BuildSpec, fldPath *field.Path) field.Erro
 
 	allErrs = append(allErrs, validateOutput(&spec.Output, fldPath.Child("output"))...)
 	allErrs = append(allErrs, validateStrategy(&spec.Strategy, fldPath.Child("strategy"))...)
+	allErrs = append(allErrs, validatePostCommit(spec.PostCommit, fldPath.Child("postCommit"))...)
 
 	// TODO: validate resource requirements (prereq: https://github.com/kubernetes/kubernetes/pull/7059)
 	return allErrs
@@ -545,6 +546,14 @@ func ValidateStrategyEnv(vars []kapi.EnvVar, fldPath *field.Path) field.ErrorLis
 		if ev.ValueFrom != nil {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("valueFrom"), ev.ValueFrom, "valueFrom is not supported in build strategy environment variables"))
 		}
+	}
+	return allErrs
+}
+
+func validatePostCommit(spec buildapi.BuildPostCommitSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if spec.Script != "" && len(spec.Command) > 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath, spec, "cannot use command and script together"))
 	}
 	return allErrs
 }

--- a/pkg/build/builder/common_test.go
+++ b/pkg/build/builder/common_test.go
@@ -1,7 +1,9 @@
 package builder
 
 import (
+	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 
 	kapi "k8s.io/kubernetes/pkg/api"
@@ -47,5 +49,54 @@ func TestBuildInfo(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("buildInfo(%+v) = %+v; want %+v", b, got, want)
+	}
+}
+
+func TestRandomBuildTag(t *testing.T) {
+	tests := []struct {
+		namespace, name string
+		want            string
+	}{
+		{"test", "build-1", "test/build-1:f1f85ff5"},
+		// For long build namespace + build name, the returned random build tag
+		// would be longer than the limit of reference.NameTotalLengthMax (255
+		// chars). We do not truncate the repository name because it could create an
+		// invalid repository name (e.g., namespace=abc, name=d, repo=abc/d,
+		// trucated=abc/ -> invalid), so we simply take a SHA1 hash of the
+		// repository name (which is guaranteed to be a valid repository name) and
+		// preserve the random tag.
+		{
+			"namespace" + strings.Repeat(".namespace", 20),
+			"name" + strings.Repeat(".name", 20),
+			"47c1d5c686ce4563521c625457e79ca23c07bc27:f1f85ff5",
+		},
+	}
+	for _, tt := range tests {
+		rand.Seed(0)
+		got := randomBuildTag(tt.namespace, tt.name)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("randomBuildTag(%q, %q) = %q, want %q", tt.namespace, tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestRandomBuildTagNoDupes(t *testing.T) {
+	rand.Seed(0)
+	previous := make(map[string]struct{})
+	for i := 0; i < 100; i++ {
+		tag := randomBuildTag("test", "build-1")
+		_, exists := previous[tag]
+		if exists {
+			t.Errorf("randomBuildTag returned a recently seen tag: %q", tag)
+		}
+		previous[tag] = struct{}{}
+	}
+}
+
+func TestContainerName(t *testing.T) {
+	got := containerName("test-strategy", "my-build", "ns", "hook")
+	want := "openshift_test-strategy-build_my-build_ns_hook"
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -58,6 +58,7 @@ func NewDockerBuilder(dockerClient DockerClient, buildsClient client.BuildInterf
 // Build executes a Docker build
 func (d *DockerBuilder) Build() error {
 	var push bool
+	pushTag := d.build.Status.OutputDockerImageReference
 
 	buildDir, err := ioutil.TempDir("", "docker-build")
 	if err != nil {
@@ -83,21 +84,35 @@ func (d *DockerBuilder) Build() error {
 		push = true
 	}
 
-	if err := d.dockerBuild(buildDir, d.build.Spec.Source.Secrets); err != nil {
+	buildTag := randomBuildTag(d.build.Namespace, d.build.Name)
+
+	if err := d.dockerBuild(buildDir, buildTag, d.build.Spec.Source.Secrets); err != nil {
 		return err
+	}
+
+	cname := containerName("docker", d.build.Name, d.build.Namespace, "post-commit")
+	if err := execPostCommitHook(d.dockerClient, d.build.Spec.PostCommit, buildTag, cname); err != nil {
+		return err
+	}
+
+	if err := tagImage(d.dockerClient, buildTag, pushTag); err != nil {
+		return err
+	}
+	if err := removeImage(d.dockerClient, buildTag); err != nil {
+		glog.Warningf("Failed to remove temporary build tag %v: %v", buildTag, err)
 	}
 
 	if push {
 		// Get the Docker push authentication
 		pushAuthConfig, authPresent := dockercfg.NewHelper().GetDockerAuth(
-			d.build.Status.OutputDockerImageReference,
+			pushTag,
 			dockercfg.PushAuthType,
 		)
 		if authPresent {
 			glog.V(4).Infof("Authenticating Docker push with user %q", pushAuthConfig.Username)
 		}
-		glog.Infof("Pushing image %s ...", d.build.Status.OutputDockerImageReference)
-		if err := pushImage(d.dockerClient, d.build.Status.OutputDockerImageReference, pushAuthConfig); err != nil {
+		glog.Infof("Pushing image %s ...", pushTag)
+		if err := pushImage(d.dockerClient, pushTag, pushAuthConfig); err != nil {
 			return fmt.Errorf("Failed to push image: %v", err)
 		}
 		glog.Infof("Push successful")
@@ -255,7 +270,7 @@ func (d *DockerBuilder) setupPullSecret() (*docker.AuthConfigurations, error) {
 }
 
 // dockerBuild performs a docker build on the source that has been retrieved
-func (d *DockerBuilder) dockerBuild(dir string, secrets []api.SecretBuildSource) error {
+func (d *DockerBuilder) dockerBuild(dir string, tag string, secrets []api.SecretBuildSource) error {
 	var noCache bool
 	var forcePull bool
 	dockerfilePath := defaultDockerfilePath
@@ -276,7 +291,7 @@ func (d *DockerBuilder) dockerBuild(dir string, secrets []api.SecretBuildSource)
 	if err := d.copySecrets(secrets, dir); err != nil {
 		return err
 	}
-	return buildImage(d.dockerClient, dir, dockerfilePath, noCache, d.build.Status.OutputDockerImageReference, d.tar, auth, forcePull, d.cgLimits)
+	return buildImage(d.dockerClient, dir, dockerfilePath, noCache, tag, d.tar, auth, forcePull, d.cgLimits)
 }
 
 // replaceLastFrom changes the last FROM instruction of node to point to the

--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -246,7 +246,7 @@ func TestDockerfilePath(t *testing.T) {
 		}
 
 		// check that the docker client is called with the right Dockerfile parameter
-		if err = dockerBuilder.dockerBuild(buildDir, []api.SecretBuildSource{}); err != nil {
+		if err = dockerBuilder.dockerBuild(buildDir, "", []api.SecretBuildSource{}); err != nil {
 			t.Errorf("failed to build: %v", err)
 			continue
 		}

--- a/pkg/build/builder/dockerutil_test.go
+++ b/pkg/build/builder/dockerutil_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/fsouza/go-dockerclient"
@@ -15,6 +16,13 @@ type FakeDocker struct {
 	pushImageCalled   bool
 	removeImageCalled bool
 	errPushImage      error
+
+	callLog []methodCall
+}
+
+type methodCall struct {
+	methodName string
+	args       []interface{}
 }
 
 func (d *FakeDocker) BuildImage(opts docker.BuildImageOptions) error {
@@ -51,6 +59,20 @@ func (d *FakeDocker) RemoveContainer(opts docker.RemoveContainerOptions) error {
 func (d *FakeDocker) InspectImage(name string) (*docker.Image, error) {
 	return &docker.Image{}, nil
 }
+func (d *FakeDocker) StartContainer(id string, hostConfig *docker.HostConfig) error {
+	return nil
+}
+func (d *FakeDocker) WaitContainer(id string) (int, error) {
+	return 0, nil
+}
+func (d *FakeDocker) Logs(opts docker.LogsOptions) error {
+	return nil
+}
+func (d *FakeDocker) TagImage(name string, opts docker.TagImageOptions) error {
+	d.callLog = append(d.callLog, methodCall{"TagImage", []interface{}{name, opts}})
+	return nil
+}
+
 func TestDockerPush(t *testing.T) {
 	verifyFunc := func(opts docker.PushImageOptions, auth docker.AuthConfiguration) error {
 		if opts.Name != "test/image" {
@@ -60,4 +82,29 @@ func TestDockerPush(t *testing.T) {
 	}
 	fd := &FakeDocker{pushImageFunc: verifyFunc}
 	pushImage(fd, "test/image", docker.AuthConfiguration{})
+}
+
+func TestTagImage(t *testing.T) {
+	tests := []struct {
+		old, new, newRepo, newTag string
+	}{
+		{"test/image", "new/image:tag", "new/image", "tag"},
+		{"test/image:1.0", "new-name", "new-name", ""},
+	}
+	for _, tt := range tests {
+		dockerClient := &FakeDocker{}
+		tagImage(dockerClient, tt.old, tt.new)
+		got := dockerClient.callLog
+		tagOpts := docker.TagImageOptions{
+			Repo:  tt.newRepo,
+			Tag:   tt.newTag,
+			Force: true,
+		}
+		want := []methodCall{
+			{"TagImage", []interface{}{tt.old, tagOpts}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("dockerClient called with %#v, want %#v", got, want)
+		}
+	}
 }

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -380,6 +380,7 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx kapi.Context, bc *buildapi.
 			Output:                    bcCopy.Spec.Output,
 			Revision:                  revision,
 			Resources:                 bcCopy.Spec.Resources,
+			PostCommit:                bcCopy.Spec.PostCommit,
 			CompletionDeadlineSeconds: bcCopy.Spec.CompletionDeadlineSeconds,
 		},
 		ObjectMeta: kapi.ObjectMeta{

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -75,6 +75,20 @@ os::cmd::expect_success_and_text 'oc get bc/centos -o=jsonpath="{.spec.output.to
 # Ensure output is valid JSON
 os::cmd::expect_success 'oc new-build -D "FROM centos:7" -o json | python -m json.tool'
 
+# Ensure post commit hook is executed
+os::cmd::expect_success 'oc new-build -D "FROM busybox:1"'
+os::cmd::try_until_text 'oc get istag busybox:1' 'busybox@sha256:'
+os::cmd::expect_success 'oc patch bc/busybox -p '\''{"spec":{"postCommit":{"script":"echo hello $1","args":["world"],"command":null}}}'\'
+os::cmd::expect_success_and_text 'oc get bc/busybox -o=jsonpath="{.spec.postCommit['\''script'\'','\''args'\'','\''command'\'']}"' '^echo hello \$1 \[world\] \[\]$'
+# os::cmd::expect_success_and_text 'oc start-build --wait --follow busybox' 'hello world'
+os::cmd::expect_success 'oc patch bc/busybox -p '\''{"spec":{"postCommit":{"command":["sh","-c"],"args":["echo explicit command"],"script":""}}}'\'
+os::cmd::expect_success_and_text 'oc get bc/busybox -o=jsonpath="{.spec.postCommit['\''script'\'','\''args'\'','\''command'\'']}"' ' \[echo explicit command\] \[sh -c\]'
+# os::cmd::expect_success_and_text 'oc start-build --wait --follow busybox' 'explicit command'
+os::cmd::expect_success 'oc patch bc/busybox -p '\''{"spec":{"postCommit":{"args":["echo","default entrypoint"],"command":null,"script":""}}}'\'
+os::cmd::expect_success_and_text 'oc get bc/busybox -o=jsonpath="{.spec.postCommit['\''script'\'','\''args'\'','\''command'\'']}"' ' \[echo default entrypoint\] \[\]'
+# os::cmd::expect_success_and_text 'oc start-build --wait --follow busybox' 'default entrypoint'
+echo "postCommitHook: ok"
+
 os::cmd::expect_success 'oc delete all --all'
 os::cmd::expect_success 'oc process -f examples/sample-app/application-template-dockerbuild.json -l build=docker | oc create -f -'
 os::cmd::expect_success 'oc get buildConfigs'


### PR DESCRIPTION
This is meant to be used for running project unit tests as part of a build.

Trello card: https://trello.com/c/I1v1YeOf
Closes #6758

This PR/card won't introduce changes to `oc new-build` nor `oc new-app` nor the Web Console.
For now, the feature can be used via `oc edit bc`.

-----------------------
Pending work:
- [x] agreement on API changes
- [x] tests
- [x] clean up
- [x] maybe move some code to source-to-image
- [ ] ~~if build fails because of failure in the post commit hook, there should be a clear error message to reflect that (see [pkg/build/builder/common.go#L56](https://github.com/openshift/origin/blob/1f99c77a509d2bf179e948c17c68332462811e35/pkg/build/builder/common.go#L56) and [pkg/build/registry/build/strategy.go#L103](https://github.com/openshift/origin/blob/1f99c77a509d2bf179e948c17c68332462811e35/pkg/build/registry/build/strategy.go#L103))~~ trello: https://trello.com/c/nAPDRELK/852-update-build-status-when-post-commit-hook-fails