### PR TITLE
deployapi: Make dc selector optional

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -15899,8 +15899,7 @@
     "required": [
      "strategy",
      "triggers",
-     "replicas",
-     "selector"
+     "replicas"
     ],
     "properties": {
      "strategy": {
@@ -15921,7 +15920,7 @@
      },
      "selector": {
       "type": "any",
-      "description": "a label query over pods that should match the replicas count"
+      "description": "a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",

--- a/pkg/deploy/api/v1/defaults.go
+++ b/pkg/deploy/api/v1/defaults.go
@@ -19,6 +19,9 @@ func init() {
 					{Type: DeploymentTriggerOnConfigChange},
 				}
 			}
+			if len(obj.Selector) == 0 && obj.Template != nil {
+				obj.Selector = obj.Template.Labels
+			}
 		},
 		func(obj *DeploymentStrategy) {
 			if len(obj.Type) == 0 {

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -238,18 +238,11 @@ type DeploymentConfigSpec struct {
 	Replicas int `json:"replicas" description:"the desired number of replicas"`
 
 	// Selector is a label query over pods that should match the Replicas count.
-	Selector map[string]string `json:"selector" description:"a label query over pods that should match the replicas count"`
-
-	// TODO removed from RCSpec, so this shouldn't exist
-	// TemplateRef is a reference to an object that describes the pod that will be created if
-	// insufficient replicas are detected. This reference is ignored if a Template is set.
-	// Must be set before converting to a v1 API object
-	// TemplateRef *kapi.ObjectReference `json:"templateRef,omitempty" description:"a reference to an object that describes the pod that will be created if insufficient replicas are detected; ignored if template is set"`
+	Selector map[string]string `json:"selector,omitempty" description:"a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"`
 
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. Internally, this takes precedence over a
 	// TemplateRef.
-	// Must be set before converting to a v1beta1 or v1beta2 API object.
 	Template *kapi.PodTemplateSpec `json:"template,omitempty" description:"describes the pod that will be created if insufficient replicas are detected; takes precedence over a template reference"`
 }
 

--- a/pkg/deploy/api/v1beta3/defaults.go
+++ b/pkg/deploy/api/v1beta3/defaults.go
@@ -13,6 +13,16 @@ func init() {
 	}
 
 	err := api.Scheme.AddDefaultingFuncs(
+		func(obj *DeploymentConfigSpec) {
+			if obj.Triggers == nil {
+				obj.Triggers = []DeploymentTriggerPolicy{
+					{Type: DeploymentTriggerOnConfigChange},
+				}
+			}
+			if len(obj.Selector) == 0 && obj.Template != nil {
+				obj.Selector = obj.Template.Labels
+			}
+		},
 		func(obj *DeploymentStrategy) {
 			if len(obj.Type) == 0 {
 				obj.Type = DeploymentStrategyTypeRolling

--- a/pkg/deploy/api/v1beta3/defaults_test.go
+++ b/pkg/deploy/api/v1beta3/defaults_test.go
@@ -16,11 +16,11 @@ import (
 func TestDefaults(t *testing.T) {
 	defaultIntOrString := util.NewIntOrStringFromString("25%")
 	differentIntOrString := util.NewIntOrStringFromInt(5)
-	tests := []struct {
+	tests := map[string]struct {
 		original *deployv1.DeploymentConfig
 		expected *deployv1.DeploymentConfig
 	}{
-		{
+		"empty dc": {
 			original: &deployv1.DeploymentConfig{},
 			expected: &deployv1.DeploymentConfig{
 				Spec: deployv1.DeploymentConfigSpec{
@@ -34,10 +34,15 @@ func TestDefaults(t *testing.T) {
 							MaxUnavailable:      &defaultIntOrString,
 						},
 					},
+					Triggers: []deployv1.DeploymentTriggerPolicy{
+						{
+							Type: deployv1.DeploymentTriggerOnConfigChange,
+						},
+					},
 				},
 			},
 		},
-		{
+		"recreate": {
 			original: &deployv1.DeploymentConfig{
 				Spec: deployv1.DeploymentConfigSpec{
 					Strategy: deployv1.DeploymentStrategy{
@@ -77,7 +82,7 @@ func TestDefaults(t *testing.T) {
 				},
 			},
 		},
-		{
+		"rolling": {
 			original: &deployv1.DeploymentConfig{
 				Spec: deployv1.DeploymentConfigSpec{
 					Strategy: deployv1.DeploymentStrategy{
@@ -117,7 +122,7 @@ func TestDefaults(t *testing.T) {
 				},
 			},
 		},
-		{
+		"rolling-2": {
 			original: &deployv1.DeploymentConfig{
 				Spec: deployv1.DeploymentConfigSpec{
 					Strategy: deployv1.DeploymentStrategy{
@@ -159,8 +164,8 @@ func TestDefaults(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Logf("test %d", i)
+	for name, test := range tests {
+		t.Logf("%s", name)
 		original := test.original
 		expected := test.expected
 		obj2 := roundTrip(t, runtime.Object(original))

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -255,18 +255,11 @@ type DeploymentConfigSpec struct {
 	Replicas int `json:"replicas" description:"the desired number of replicas"`
 
 	// Selector is a label query over pods that should match the Replicas count.
-	Selector map[string]string `json:"selector" description:"a label query over pods that should match the replicas count"`
-
-	// TODO removed from rc spec
-	// TemplateRef is a reference to an object that describes the pod that will be created if
-	// insufficient replicas are detected. This reference is ignored if a Template is set.
-	// Must be set before converting to a v1beta3 API object
-	// TemplateRef *kapi.ObjectReference `json:"templateRef,omitempty" description:"a reference to an object that describes the pod that will be created if insufficient replicas are detected; ignored if template is set"`
+	Selector map[string]string `json:"selector,omitempty" description:"a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"`
 
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. Internally, this takes precedence over a
 	// TemplateRef.
-	// Must be set before converting to a v1beta1 or v1beta2 API object.
 	Template *kapi.PodTemplateSpec `json:"template,omitempty" description:"describes the pod that will be created if insufficient replicas are detected; takes precedence over a template reference"`
 }
 

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -37,7 +37,7 @@ func ValidateDeploymentConfig(config *deployapi.DeploymentConfig) fielderrors.Va
 	if config.Spec.Replicas < 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("spec.replicas", config.Spec.Replicas, "replicas cannot be negative"))
 	}
-	if config.Spec.Selector == nil || len(config.Spec.Selector) == 0 {
+	if len(config.Spec.Selector) == 0 {
 		allErrs = append(allErrs, fielderrors.NewFieldInvalid("spec.selector", config.Spec.Selector, "selector cannot be empty"))
 	}
 	return allErrs


### PR DESCRIPTION
Default to podtemplate labels in case of an unspecified deployment
config selector.

Fixes https://github.com/openshift/origin/issues/6719

@ironcladlou @openshift/api-review 