### PR TITLE
Remove global project cache and use interfaces for admission plugin config

### DIFF
--- a/pkg/build/admission/admission_test.go
+++ b/pkg/build/admission/admission_test.go
@@ -15,6 +15,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/api"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/client/testclient"
+	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 )
 
 func TestBuildAdmission(t *testing.T) {
@@ -142,7 +143,9 @@ func TestBuildAdmission(t *testing.T) {
 	ops := []admission.Operation{admission.Create, admission.Update}
 	for _, test := range tests {
 		for _, op := range ops {
-			c := NewBuildByStrategy(fakeClient(test.expectedResource, test.reviewResponse, test.responseObject))
+			client := fakeClient(test.expectedResource, test.reviewResponse, test.responseObject)
+			c := NewBuildByStrategy()
+			c.(oadmission.WantsOpenshiftClient).SetOpenshiftClient(client)
 			attrs := admission.NewAttributesRecord(test.object, test.kind, "default", "name", test.resource, test.subResource, op, fakeUser())
 			err := c.Admit(attrs)
 			if err != nil && test.expectAccept {

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -1,0 +1,40 @@
+package admission
+
+import (
+	"k8s.io/kubernetes/pkg/admission"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/project/cache"
+)
+
+type PluginInitializer struct {
+	OpenshiftClient client.Interface
+	ProjectCache    *cache.ProjectCache
+}
+
+// Initialize will check the initialization interfaces implemented by each plugin
+// and provide the appropriate initialization data
+func (i *PluginInitializer) Initialize(plugins []admission.Interface) {
+	for _, plugin := range plugins {
+		if wantsOpenshiftClient, ok := plugin.(WantsOpenshiftClient); ok {
+			wantsOpenshiftClient.SetOpenshiftClient(i.OpenshiftClient)
+		}
+		if wantsProjectCache, ok := plugin.(WantsProjectCache); ok {
+			wantsProjectCache.SetProjectCache(i.ProjectCache)
+		}
+	}
+}
+
+// Validate will call the Validate function in each plugin if they implement
+// the Validator interface.
+func Validate(plugins []admission.Interface) error {
+	for _, plugin := range plugins {
+		if validater, ok := plugin.(Validator); ok {
+			err := validater.Validate()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -1,0 +1,24 @@
+package admission
+
+import (
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/project/cache"
+)
+
+// WantsOpenshiftClient should be implemented by admission plugins that need
+// an Openshift client
+type WantsOpenshiftClient interface {
+	SetOpenshiftClient(client.Interface)
+}
+
+// WantsProjectCache should be implemented by admission plugins that need a
+// project cache
+type WantsProjectCache interface {
+	SetProjectCache(*cache.ProjectCache)
+}
+
+// Validator should be implemented by admission plugins that can validate themselves
+// after initialization has happened.
+type Validator interface {
+	Validate() error
+}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -53,7 +53,10 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	accesstokenregistry "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
+	"github.com/openshift/origin/pkg/project/admission/lifecycle"
+	"github.com/openshift/origin/pkg/project/admission/nodeenv"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/serviceaccounts"
 	usercache "github.com/openshift/origin/pkg/user/cache"
 	groupregistry "github.com/openshift/origin/pkg/user/registry/group"
@@ -78,6 +81,7 @@ type MasterConfig struct {
 	PolicyCache               policycache.ReadOnlyCache
 	GroupCache                *usercache.GroupCache
 	ProjectAuthorizationCache *projectauth.AuthorizationCache
+	ProjectCache              *projectcache.ProjectCache
 
 	// RequestContextMapper maps requests to contexts
 	RequestContextMapper kapi.RequestContextMapper
@@ -192,6 +196,11 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 	authorizer := newAuthorizer(policyClient, options.ProjectConfig.ProjectRequestMessage)
 
+	projectCache := projectcache.NewProjectCache(privilegedLoopbackKubeClient.Namespaces(), options.ProjectConfig.DefaultNodeSelector)
+	// pass reference to the cache to the necessary admission packages so it can be injected into the admission plugin constructors
+	lifecycle.InitializeCacheReference(projectCache)
+	nodeenv.InitializeCacheReference(projectCache)
+
 	config := &MasterConfig{
 		Options: options,
 
@@ -202,6 +211,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 		PolicyCache:               policyCache,
 		GroupCache:                groupCache,
 		ProjectAuthorizationCache: newProjectAuthorizationCache(authorizer, privilegedLoopbackKubeClient, policyClient),
+		ProjectCache:              projectCache,
 
 		RequestContextMapper: requestContextMapper,
 

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -29,7 +29,6 @@ import (
 	imagechangecontroller "github.com/openshift/origin/pkg/deploy/controller/imagechange"
 	"github.com/openshift/origin/pkg/dns"
 	imagecontroller "github.com/openshift/origin/pkg/image/controller"
-	projectcache "github.com/openshift/origin/pkg/project/cache"
 	projectcontroller "github.com/openshift/origin/pkg/project/controller"
 	securitycontroller "github.com/openshift/origin/pkg/security/controller"
 	"github.com/openshift/origin/pkg/security/mcs"
@@ -179,7 +178,7 @@ func (c *MasterConfig) RunDNSServer() {
 // RunProjectCache populates project cache, used by scheduler and project admission controller.
 func (c *MasterConfig) RunProjectCache() {
 	glog.Infof("Using default project node label selector: %s", c.Options.ProjectConfig.DefaultNodeSelector)
-	projectcache.RunProjectCache(c.PrivilegedLoopbackKubernetesClient, c.Options.ProjectConfig.DefaultNodeSelector)
+	c.ProjectCache.Run()
 }
 
 // RunBuildController starts the build sync loop for builds and buildConfig processing.

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -332,7 +332,7 @@ func buildKubernetesMasterConfig(openshiftConfig *origin.MasterConfig) (*kuberne
 	if openshiftConfig.Options.KubernetesMasterConfig == nil {
 		return nil, nil
 	}
-	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient())
+	kubeConfig, err := kubernetes.BuildKubernetesMasterConfig(openshiftConfig.Options, openshiftConfig.RequestContextMapper, openshiftConfig.KubeClient(), openshiftConfig.ProjectCache)
 	return kubeConfig, err
 }
 

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -1,4 +1,4 @@
-package admission
+package lifecycle
 
 import (
 	"fmt"
@@ -41,7 +41,7 @@ func TestAdmissionExists(t *testing.T) {
 		return true, &kapi.Namespace{}, fmt.Errorf("DOES NOT EXIST")
 	})
 
-	projectcache.FakeProjectCache(mockClient, cache.NewStore(cache.MetaNamespaceKeyFunc), "")
+	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), cache.NewStore(cache.MetaNamespaceKeyFunc), ""))
 	handler := &lifecycle{client: mockClient}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
@@ -86,7 +86,7 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store := cache.NewStore(cache.IndexFuncToKeyFuncAdapter(cache.MetaNamespaceIndexFunc))
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
-	projectcache.FakeProjectCache(mockClient, store, "")
+	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), store, ""))
 	handler := &lifecycle{client: mockClient}
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "other"},
@@ -166,7 +166,7 @@ func TestSAR(t *testing.T) {
 	mockClient.AddReactor("get", "namespaces", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, fmt.Errorf("shouldn't get here")
 	})
-	projectcache.FakeProjectCache(mockClient, store, "")
+	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), store, ""))
 	handler := &lifecycle{client: mockClient}
 
 	tests := map[string]struct {

--- a/pkg/project/admission/lifecycle/admission_test.go
+++ b/pkg/project/admission/lifecycle/admission_test.go
@@ -41,8 +41,9 @@ func TestAdmissionExists(t *testing.T) {
 		return true, &kapi.Namespace{}, fmt.Errorf("DOES NOT EXIST")
 	})
 
-	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), cache.NewStore(cache.MetaNamespaceKeyFunc), ""))
+	cache := projectcache.NewFake(mockClient.Namespaces(), cache.NewStore(cache.MetaNamespaceKeyFunc), "")
 	handler := &lifecycle{client: mockClient}
+	handler.SetProjectCache(cache)
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid"},
 		Spec: buildapi.BuildSpec{
@@ -86,8 +87,9 @@ func TestAdmissionLifecycle(t *testing.T) {
 	store := cache.NewStore(cache.IndexFuncToKeyFuncAdapter(cache.MetaNamespaceIndexFunc))
 	store.Add(namespaceObj)
 	mockClient := &testclient.Fake{}
-	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), store, ""))
+	cache := projectcache.NewFake(mockClient.Namespaces(), store, "")
 	handler := &lifecycle{client: mockClient}
+	handler.SetProjectCache(cache)
 	build := &buildapi.Build{
 		ObjectMeta: kapi.ObjectMeta{Name: "buildid", Namespace: "other"},
 		Spec: buildapi.BuildSpec{
@@ -166,8 +168,9 @@ func TestSAR(t *testing.T) {
 	mockClient.AddReactor("get", "namespaces", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, fmt.Errorf("shouldn't get here")
 	})
-	IntitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), store, ""))
+	cache := projectcache.NewFake(mockClient.Namespaces(), store, "")
 	handler := &lifecycle{client: mockClient}
+	handler.SetProjectCache(cache)
 
 	tests := map[string]struct {
 		kind     string

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -1,4 +1,4 @@
-package admission
+package nodeenv
 
 import (
 	"testing"
@@ -104,7 +104,7 @@ func TestPodAdmission(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		projectcache.FakeProjectCache(mockClient, projectStore, test.defaultNodeSelector)
+		InitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), projectStore, test.defaultNodeSelector))
 		if !test.ignoreProjectNodeSelector {
 			project.ObjectMeta.Annotations = map[string]string{"openshift.io/node-selector": test.projectNodeSelector}
 		}
@@ -130,13 +130,15 @@ func TestHandles(t *testing.T) {
 		admission.Connect: false,
 		admission.Delete:  false,
 	} {
-		n, err := NewPodNodeEnvironment(nil)
+		InitializeCacheReference(&projectcache.ProjectCache{})
+
+		nodeEnvionment, err := NewPodNodeEnvironment(nil)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%v: error getting node environment: %v", op, err)
 			continue
 		}
 
-		if e, a := shouldHandle, n.Handles(op); e != a {
+		if e, a := shouldHandle, nodeEnvionment.Handles(op); e != a {
 			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
 		}
 	}

--- a/pkg/project/admission/nodeenv/admission_test.go
+++ b/pkg/project/admission/nodeenv/admission_test.go
@@ -104,7 +104,8 @@ func TestPodAdmission(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		InitializeCacheReference(projectcache.NewFake(mockClient.Namespaces(), projectStore, test.defaultNodeSelector))
+		cache := projectcache.NewFake(mockClient.Namespaces(), projectStore, test.defaultNodeSelector)
+		handler.SetProjectCache(cache)
 		if !test.ignoreProjectNodeSelector {
 			project.ObjectMeta.Annotations = map[string]string{"openshift.io/node-selector": test.projectNodeSelector}
 		}
@@ -130,8 +131,6 @@ func TestHandles(t *testing.T) {
 		admission.Connect: false,
 		admission.Delete:  false,
 	} {
-		InitializeCacheReference(&projectcache.ProjectCache{})
-
 		nodeEnvionment, err := NewPodNodeEnvironment(nil)
 		if err != nil {
 			t.Errorf("%v: error getting node environment: %v", op, err)


### PR DESCRIPTION
Follow-up to #6572 
Adds interfaces that plugins implement to request objects on initialization