### PR TITLE
stop status from checking SA mountable secrets

### DIFF
--- a/pkg/cmd/cli/describe/projectstatus.go
+++ b/pkg/cmd/cli/describe/projectstatus.go
@@ -297,7 +297,6 @@ func getMarkerScanners() []osgraph.MarkerScanner {
 	return []osgraph.MarkerScanner{
 		kubeanalysis.FindRestartingPods,
 		kubeanalysis.FindDuelingReplicationControllers,
-		kubeanalysis.FindUnmountableSecrets,
 		kubeanalysis.FindMissingSecrets,
 		buildanalysis.FindUnpushableBuildConfigs,
 		buildanalysis.FindCircularBuilds,
@@ -305,6 +304,9 @@ func getMarkerScanners() []osgraph.MarkerScanner {
 		deployanalysis.FindDeploymentConfigTriggerErrors,
 		routeanalysis.FindMissingPortMapping,
 		routeanalysis.FindMissingTLSTerminationType,
+
+		// We disable this feature by default and we don't have a capability detection for this sort of thing.  Disable this check for now.
+		// kubeanalysis.FindUnmountableSecrets,
 	}
 }
 

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -94,8 +94,6 @@ func TestProjectStatus(t *testing.T) {
 				"In project example on server https://example.com:8443\n",
 				"rc/my-rc runs centos/mysql-56-centos7",
 				"0/1 pods growing to 1",
-				"rc/my-rc is attempting to mount a secret secret/existing-secret disallowed by sa/default",
-				"rc/my-rc is attempting to mount a secret secret/dne disallowed by sa/default",
 				"rc/my-rc is attempting to mount a missing secret secret/dne",
 			},
 		},


### PR DESCRIPTION
This feature is disabled by default and without server capability checking, we can't determine if we should use it or not.  Disable the check for now since that's usually the correct answer.

@kargakis @stevekuznetsov ptal

