### PR TITLE
added property deduping for junitreport

### DIFF
--- a/tools/junitreport/pkg/api/test_suite.go
+++ b/tools/junitreport/pkg/api/test_suite.go
@@ -2,8 +2,16 @@ package api
 
 import "time"
 
-// AddProperty adds a property to the test suite
+// AddProperty adds a property to the test suite, deduplicating multiple additions of the same property
+// by overwriting the previous record to reflect the new values
 func (t *TestSuite) AddProperty(name, value string) {
+	for _, property := range t.Properties {
+		if property.Name == name {
+			property.Value = value
+			return
+		}
+	}
+
 	t.Properties = append(t.Properties, &TestSuiteProperty{Name: name, Value: value})
 }
 

--- a/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
@@ -344,6 +344,35 @@ PASS`,
 				},
 			},
 		},
+		{
+			name:     "coverage statement in package result and inline",
+			testFile: "11.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package/name",
+						NumTests: 2,
+						Duration: 0.16,
+						Properties: []*api.TestSuiteProperty{
+							{
+								Name:  "coverage.statements.pct",
+								Value: "10.0",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
@@ -2,12 +2,9 @@ package gotest
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"reflect"
 	"testing"
-
-	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/openshift/origin/tools/junitreport/pkg/api"
 	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
@@ -460,6 +457,42 @@ PASS`, // we include this line greedily even though it does not belong to the te
 				},
 			},
 		},
+		{
+			name:     "coverage statement in package result and inline",
+			testFile: "11.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:     "package",
+						NumTests: 2,
+						Duration: 0.16,
+						Children: []*api.TestSuite{
+							{
+								Name:     "package/name",
+								NumTests: 2,
+								Duration: 0.16,
+								Properties: []*api.TestSuiteProperty{
+									{
+										Name:  "coverage.statements.pct",
+										Value: "10.0",
+									},
+								},
+								TestCases: []*api.TestCase{
+									{
+										Name:     "TestOne",
+										Duration: 0.06,
+									},
+									{
+										Name:     "TestTwo",
+										Duration: 0.1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -479,7 +512,6 @@ PASS`, // we include this line greedily even though it does not belong to the te
 		}
 
 		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
-			fmt.Println(util.ObjectGoPrintDiff(testSuites, testCase.expectedSuites))
 			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
 		}
 	}

--- a/tools/junitreport/test/gotest/reports/11_flat.xml
+++ b/tools/junitreport/test/gotest/reports/11_flat.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+		<property name="coverage.statements.pct" value="10.0"></property>
+		<testcase name="TestOne" time="0.06"></testcase>
+		<testcase name="TestTwo" time="0.1"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/11_nested.xml
+++ b/tools/junitreport/test/gotest/reports/11_nested.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
+		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
+			<property name="coverage.statements.pct" value="10.0"></property>
+			<testcase name="TestOne" time="0.06"></testcase>
+			<testcase name="TestTwo" time="0.1"></testcase>
+		</testsuite>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/summaries/11_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/11_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.160s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/testdata/11.txt
+++ b/tools/junitreport/test/gotest/testdata/11.txt
@@ -1,0 +1,7 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06 seconds)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10 seconds)
+PASS
+coverage: 10.0% of statements
+ok  	package/name 0.160s  coverage: 10.0% of statements


### PR DESCRIPTION
I noticed that we'd see duped coverage properties when coverage was reported both inline and after the package. I've deduped the property addition.

@deads2k @soltysh PTAL