### PR TITLE
made system logger get real error code

### DIFF
--- a/hack/lib/log.sh
+++ b/hack/lib/log.sh
@@ -28,8 +28,7 @@ function os::log::install_system_logger_cleanup() {
 # Returns:  
 #  None
 function os::log::clean_up_logger() {
-    local return_code
-    return_code=$?
+    local return_code=$?
 
     # we don't want failures in this logger to 
     set +o errexit


### PR DESCRIPTION
Previously the system logger was erroneously getting the exit code of `local` - which was always 0. This leads to masking of test failures like in [this](https://ci.openshift.redhat.com/jenkins/job/test_pull_requests_origin/8976/consoleFull) log.

@deads2k 