### PR TITLE
disabling start build/rebuild button when bc is deleted

### DIFF
--- a/assets/app/scripts/controllers/buildConfig.js
+++ b/assets/app/scripts/controllers/buildConfig.js
@@ -47,6 +47,7 @@ angular.module('openshiftConsole')
           function(buildConfig) {
             $scope.loaded = true;
             $scope.buildConfig = buildConfig;
+            $scope.paused = BuildsService.isPaused($scope.buildConfig);
 
             if ($scope.buildConfig.spec.source.images) {
               $scope.imageSources = $scope.buildConfig.spec.source.images;
@@ -65,6 +66,7 @@ angular.module('openshiftConsole')
                 };
               }
               $scope.buildConfig = buildConfig;
+              $scope.paused = BuildsService.isPaused($scope.buildConfig);
             }));
           },
           // failure
@@ -118,6 +120,7 @@ angular.module('openshiftConsole')
             }
           }
 
+          $scope.canBuild = BuildsService.canBuild($scope.buildConfig, $scope.buildConfigBuildsInProgress);
           $scope.builds = LabelFilter.getLabelSelector().select($scope.unfilteredBuilds);
           updateFilterWarning();
           LabelFilter.addLabelSuggestionsFromResources($scope.unfilteredBuilds, $scope.labelSuggestions);
@@ -150,26 +153,8 @@ angular.module('openshiftConsole')
           });
         });
 
-        var hashSize = $filter('hashSize');
-        $scope.canBuild = function() {
-          if (!$scope.buildConfig) {
-            return false;
-          }
-
-          if ($scope.buildConfig.metadata.deletionTimestamp) {
-            return false;
-          }
-
-          if ($scope.buildConfigBuildsInProgress &&
-              hashSize($scope.buildConfigBuildsInProgress[$scope.buildConfig.metadata.name]) > 0) {
-            return false;
-          }
-
-          return true;
-        };
-
         $scope.startBuild = function() {
-          if ($scope.canBuild()) {
+          if ($scope.canBuild) {
             BuildsService.startBuild($scope.buildConfig.metadata.name, context, $scope);
           }
         };

--- a/assets/app/scripts/services/builds.js
+++ b/assets/app/scripts/services/builds.js
@@ -102,5 +102,30 @@ angular.module("openshiftConsole")
       return buildConfigBuildsInProgress;
     };
 
+    BuildsService.prototype.isPaused = function(buildConfig) {
+      return $filter('annotation')(buildConfig, "openshift.io/build-config.paused") === 'true';
+    };
+
+    BuildsService.prototype.canBuild = function(buildConfig, buildConfigBuildsInProgressMap) {
+      if (!buildConfig) {
+        return false;
+      }
+
+      if (buildConfig.metadata.deletionTimestamp) {
+        return false;
+      }
+
+      if (buildConfigBuildsInProgressMap &&
+          $filter('hashSize')(buildConfigBuildsInProgressMap[buildConfig.metadata.name]) > 0) {
+        return false;
+      }
+
+      if (this.isPaused(buildConfig)) {
+        return false;
+      }
+
+      return true;
+    };
+
     return new BuildsService();
   });

--- a/assets/app/views/browse/build-config.html
+++ b/assets/app/views/browse/build-config.html
@@ -10,12 +10,19 @@
             <div ng-if="!loaded">Loading...</div>
             <h1>
               {{buildConfigName}}
+              <span class="pficon pficon-warning-triangle-o"
+                    ng-if="paused"
+                    aria-hidden="true"
+                    data-toggle="tooltip"
+                    data-placement="bottom"
+                    data-original-title="Building from build configuration {{buildConfig.metadata.name}} has been paused.">
+              </span>
               <div class="pull-right dropdown" ng-if="buildConfig">
                 <!-- Primary Actions -->
                 <button
                     class="btn btn-default hidden-xs"
                     ng-click="startBuild()"
-                    ng-disabled="!canBuild()">
+                    ng-disabled="!canBuild">
                   Start Build
                 </button>
 
@@ -28,11 +35,11 @@
                    class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                    data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                 <ul class="dropdown-menu actions action-button">
-                  <li class="visible-xs-inline" ng-class="{ disabled: !canBuild() }">
+                  <li class="visible-xs-inline" ng-class="{ disabled: !canBuild }">
                     <a href=""
                       role="button"
-                      ng-attr-aria-disabled="{{canBuild() ? undefined : 'true'}}"
-                      ng-class="{ 'disabled-link': !canBuild() }"
+                      ng-attr-aria-disabled="{{canBuild ? undefined : 'true'}}"
+                      ng-class="{ 'disabled-link': !canBuild }"
                       ng-click="startBuild()">Start Build</a>
                   </li>
                   <li>

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -12,7 +12,14 @@
             <div ng-if="build">
               <h1>
                 {{build.metadata.name}}
-                <span ng-if="build.status.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-placement="right" data-trigger="hover" dynamic-content="{{build.status.message}}"></span>
+                <span ng-if="build.status.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-placement="bottom" data-trigger="hover" dynamic-content="{{build.status.message}}"></span>
+                <span class="pficon pficon-warning-triangle-o"
+                      ng-if="paused"
+                      aria-hidden="true"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      data-original-title="Building from build configuration {{buildConfig.metadata.name}} has been paused.">
+                </span>
                 <small class="meta">created <relative-timestamp timestamp="build.metadata.creationTimestamp"></relative-timestamp></small>
                 <div class="pull-right dropdown">
                   <!-- Primary Actions -->

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -63,7 +63,7 @@
                     </li>
                   </ul>
                 </div>
-                <span ng-if="deploymentConfig.status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-placement="right" data-trigger="hover" dynamic-content="{{deploymentConfig.status.details.message}}"></span>
+                <span ng-if="deploymentConfig.status.details.message" class="pficon pficon-warning-triangle-o" style="cursor: help;" data-toggle="popover" data-placement="bottom" data-trigger="hover" dynamic-content="{{deploymentConfig.status.details.message}}"></span>
                 <small class="meta" ng-if="deploymentConfig">created <relative-timestamp timestamp="deploymentConfig.metadata.creationTimestamp"></relative-timestamp></small>
               </h1>
               <labels labels="deploymentConfig.metadata.labels" clickable="true" kind="deployments" title-kind="deployment configs" project-name="{{deploymentConfig.metadata.namespace}}" limit="3"></labels>

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -17,7 +17,7 @@
                   class="pficon pficon-warning-triangle-o"
                   style="cursor: help; vertical-align: middle;"
                   data-toggle="tooltip"
-                  data-placement="right"
+                  data-placement="bottom"
                   data-trigger="hover"
                   title="The deployment's deployment config is missing."
                   aria-hidden="true">


### PR DESCRIPTION
Disable the `Start Build` and `Rebuild` buttons when deleting the buildConfig and the reaper is taking care of the instantiated/cloned builds.
Created a buildConfigs.js service and move the check there from the builds.js, since we are checking the buildConfig resource and not the build.
Fixing https://github.com/openshift/origin/issues/6703

@jwforres ptal