### PR TITLE
Improve message for deprecated build-logs option

### DIFF
--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -37,7 +37,7 @@ func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobr
 		Short:      "Show logs from a build",
 		Long:       buildLogsLong,
 		Example:    fmt.Sprintf(buildLogsExample, fullName),
-		Deprecated: fmt.Sprintf("use %q instead.", LogsRecommendedName),
+		Deprecated: fmt.Sprintf("use \"oc %v build/<build-name>\" instead.", LogsRecommendedName),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunBuildLogs(fullName, f, out, cmd, opts, args)
 


### PR DESCRIPTION
Before: `Command "build-logs" is deprecated, use "logs" instead.`
After:`Command "build-logs" is deprecated, use "oc logs build/<build-name>" instead.`

Fix #6021