### PR TITLE
Block build cloning when BC is paused

### DIFF
--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -217,7 +217,7 @@ func (g *BuildGenerator) Instantiate(ctx kapi.Context, request *buildapi.BuildRe
 		return nil, err
 	}
 
-	if strings.ToLower(bc.Annotations[buildapi.BuildConfigPausedAnnotation]) == "true" {
+	if buildutil.IsPaused(bc) {
 		return nil, &GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", bc.Namespace, bc.Name)}
 	}
 
@@ -320,6 +320,10 @@ func (g *BuildGenerator) Clone(ctx kapi.Context, request *buildapi.BuildRequest)
 		buildConfig, err = g.Client.GetBuildConfig(ctx, build.Status.Config.Name)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, err
+		}
+
+		if buildutil.IsPaused(buildConfig) {
+			return nil, &GeneratorFatalError{fmt.Sprintf("can't instantiate from BuildConfig %s/%s: BuildConfig is paused", buildConfig.Namespace, buildConfig.Name)}
 		}
 	}
 

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -93,9 +93,22 @@ func TestInstantiateDeletingError(t *testing.T) {
 			}
 			return bc, nil
 		},
+		GetBuildFunc: func(ctx kapi.Context, name string) (*buildapi.Build, error) {
+			build := &buildapi.Build{
+				Status: buildapi.BuildStatus{
+					Config: &kapi.ObjectReference{
+						Name: "buildconfig",
+					},
+				},
+			}
+			return build, nil
+		},
 	}}
-
 	_, err := generator.Instantiate(kapi.NewDefaultContext(), &buildapi.BuildRequest{})
+	if err == nil || !strings.Contains(err.Error(), "BuildConfig is paused") {
+		t.Errorf("Expected error, got different %v", err)
+	}
+	_, err = generator.Clone(kapi.NewDefaultContext(), &buildapi.BuildRequest{})
 	if err == nil || !strings.Contains(err.Error(), "BuildConfig is paused") {
 		t.Errorf("Expected error, got different %v", err)
 	}

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -66,6 +66,11 @@ func IsBuildComplete(build *buildapi.Build) bool {
 	return build.Status.Phase != buildapi.BuildPhaseRunning && build.Status.Phase != buildapi.BuildPhasePending && build.Status.Phase != buildapi.BuildPhaseNew
 }
 
+// IsPaused returns true if the provided BuildConfig is paused and cannot be used to create a new Build
+func IsPaused(bc *buildapi.BuildConfig) bool {
+	return strings.ToLower(bc.Annotations[buildapi.BuildConfigPausedAnnotation]) == "true"
+}
+
 // BuildNameForConfigVersion returns the name of the version-th build
 // for the config that has the provided name
 func BuildNameForConfigVersion(name string, version int) string {


### PR DESCRIPTION
In #6185 we introduced a new annotation for pausing BCs as they are being deleted. We disable BC instantiation while this annotation is present. This PR disables it for build cloning as well.

@jhadvig found this one
@bparees might be interested in this one