### PR TITLE
Not every registry has library

### DIFF
--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -56,6 +56,12 @@ func TestParseDockerImageReference(t *testing.T) {
 			Name:      "baz",
 		},
 		{
+			From:      "bar/library/baz",
+			Registry:  "bar",
+			Namespace: "library",
+			Name:      "baz",
+		},
+		{
 			From:      "bar/foo/baz:tag",
 			Registry:  "bar",
 			Namespace: "foo",
@@ -76,10 +82,15 @@ func TestParseDockerImageReference(t *testing.T) {
 			Name:      "baz",
 		},
 		{
-			From:      "bar:5000/baz",
+			From:      "bar:5000/library/baz",
 			Registry:  "bar:5000",
-			Namespace: DockerDefaultNamespace,
+			Namespace: "library",
 			Name:      "baz",
+		},
+		{
+			From:     "bar:5000/baz",
+			Registry: "bar:5000",
+			Name:     "baz",
 		},
 		{
 			From:      "bar:5000/foo/baz:tag",
@@ -96,14 +107,36 @@ func TestParseDockerImageReference(t *testing.T) {
 			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
 		{
-			From:      "myregistry.io/foo",
-			Registry:  "myregistry.io",
-			Namespace: DockerDefaultNamespace,
-			Name:      "foo",
+			From:     "myregistry.io/foo",
+			Registry: "myregistry.io",
+			Name:     "foo",
 		},
 		{
-			From:      "localhost/bar",
-			Registry:  "localhost",
+			From:     "localhost/bar",
+			Registry: "localhost",
+			Name:     "bar",
+		},
+		{
+			From:      "docker.io/library/myapp",
+			Registry:  "docker.io",
+			Namespace: "library",
+			Name:      "myapp",
+		},
+		{
+			From:      "docker.io/myapp",
+			Registry:  "docker.io",
+			Namespace: DockerDefaultNamespace,
+			Name:      "myapp",
+		},
+		{
+			From:      "docker.io/user/myapp",
+			Registry:  "docker.io",
+			Namespace: "user",
+			Name:      "myapp",
+		},
+		{
+			From:      "index.docker.io/bar",
+			Registry:  "index.docker.io",
 			Namespace: DockerDefaultNamespace,
 			Name:      "bar",
 		},
@@ -238,22 +271,22 @@ func TestDockerImageReferenceString(t *testing.T) {
 	}{
 		{
 			Name:     "foo",
-			Expected: "library/foo",
+			Expected: "foo",
 		},
 		{
 			Name:     "foo",
 			Tag:      "tag",
-			Expected: "library/foo:tag",
+			Expected: "foo:tag",
 		},
 		{
 			Name:     "foo",
 			ID:       "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
-			Expected: "library/foo@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Expected: "foo@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
 		{
 			Name:     "foo",
 			ID:       "3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
-			Expected: "library/foo:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Expected: "foo:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
 		{
 			Namespace: "bar",
@@ -307,10 +340,35 @@ func TestDockerImageReferenceString(t *testing.T) {
 		},
 		{
 			Registry:  "bar:5000",
+			Namespace: "library",
+			Name:      "baz",
+			Tag:       "tag",
+			Expected:  "bar:5000/library/baz:tag",
+		},
+		{
+			Registry:  "bar:5000",
 			Namespace: "foo",
 			Name:      "baz",
 			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 			Expected:  "bar:5000/foo/baz@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+		},
+		{
+			Registry:  "docker.io",
+			Namespace: "user",
+			Name:      "app",
+			Expected:  "docker.io/user/app",
+		},
+		{
+			Registry: "index.docker.io",
+			Name:     "foo",
+			Expected: "index.docker.io/library/foo",
+		},
+		{
+			Registry:  "index.docker.io",
+			Namespace: "library",
+			Name:      "bar",
+			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Expected:  "index.docker.io/library/bar@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
 		},
 	}
 

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -36,7 +36,7 @@ os::cmd::expect_success 'oc delete is/binary-test bc/binary-test'
 
 # Build from Dockerfile with output to DockerImage
 os::cmd::expect_success "oc new-build -D \$'FROM openshift/origin:v1.1' --to-docker"
-os::cmd::expect_success_and_text "oc get bc/origin --template '${template}'" '^DockerImage library/origin:latest$'
+os::cmd::expect_success_and_text "oc get bc/origin --template '${template}'" '^DockerImage origin:latest$'
 
 os::cmd::expect_success 'oc delete is/origin'
 

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -15,13 +15,13 @@ os::cmd::expect_success_and_text 'oc new-app library/php mysql -o yaml' '3306'
 os::cmd::expect_success_and_text 'oc new-app library/php mysql --dry-run' "Image \"mysql\" runs as the 'root' user which may not be permitted by your cluster administrator"
 os::cmd::expect_failure 'oc new-app unknownhubimage -o yaml'
 # verify we can generate a Docker image based component "mongodb" directly
-os::cmd::expect_success_and_text 'oc new-app mongo -o yaml' 'library/mongo'
+os::cmd::expect_success_and_text 'oc new-app mongo -o yaml' 'image:\s*mongo'
 # the local image repository takes precedence over the Docker Hub "mysql" image
 os::cmd::expect_success 'oc create -f examples/image-streams/image-streams-centos7.json'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:latest'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:5.5'
 os::cmd::try_until_success 'oc get imagestreamtags mysql:5.6'
-os::cmd::expect_success_and_not_text 'oc new-app mysql -o yaml' 'library/mysql'
+os::cmd::expect_success_and_not_text 'oc new-app mysql -o yaml' 'image:\s*mysql'
 os::cmd::expect_success_and_not_text 'oc new-app mysql --dry-run' "runs as the 'root' user which may not be permitted by your cluster administrator"
 
 # docker strategy with repo that has no dockerfile


### PR DESCRIPTION
Add 'library/' prefix only for images belonging to Docker Hub.

Resolves #6570
Resolves #5327 