### PR TITLE
Fixed typo in junitreport properties

### DIFF
--- a/tools/junitreport/pkg/api/types.go
+++ b/tools/junitreport/pkg/api/types.go
@@ -46,7 +46,7 @@ type TestSuite struct {
 
 // TestSuiteProperty contains a mapping of a property name to a value
 type TestSuiteProperty struct {
-	XMLName xml.Name `xml:"propery"`
+	XMLName xml.Name `xml:"property"`
 
 	Name  string `xml:"name,attr"`
 	Value string `xml:"value,attr"`

--- a/tools/junitreport/test/gotest/reports/6_flat.xml
+++ b/tools/junitreport/test/gotest/reports/6_flat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
 	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
-		<propery name="coverage.statements.pct" value="13.37"></propery>
+		<property name="coverage.statements.pct" value="13.37"></property>
 		<testcase name="TestOne" time="0.06"></testcase>
 		<testcase name="TestTwo" time="0.1"></testcase>
 	</testsuite>

--- a/tools/junitreport/test/gotest/reports/6_nested.xml
+++ b/tools/junitreport/test/gotest/reports/6_nested.xml
@@ -2,7 +2,7 @@
 <testsuites>
 	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
 		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
-			<propery name="coverage.statements.pct" value="13.37"></propery>
+			<property name="coverage.statements.pct" value="13.37"></property>
 			<testcase name="TestOne" time="0.06"></testcase>
 			<testcase name="TestTwo" time="0.1"></testcase>
 		</testsuite>

--- a/tools/junitreport/test/gotest/reports/7_flat.xml
+++ b/tools/junitreport/test/gotest/reports/7_flat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
 	<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
-		<propery name="coverage.statements.pct" value="10.0"></propery>
+		<property name="coverage.statements.pct" value="10.0"></property>
 		<testcase name="TestOne" time="0.06"></testcase>
 		<testcase name="TestTwo" time="0.1"></testcase>
 	</testsuite>

--- a/tools/junitreport/test/gotest/reports/7_nested.xml
+++ b/tools/junitreport/test/gotest/reports/7_nested.xml
@@ -2,7 +2,7 @@
 <testsuites>
 	<testsuite name="package" tests="2" skipped="0" failures="0" time="0.16">
 		<testsuite name="package/name" tests="2" skipped="0" failures="0" time="0.16">
-			<propery name="coverage.statements.pct" value="10.0"></propery>
+			<property name="coverage.statements.pct" value="10.0"></property>
 			<testcase name="TestOne" time="0.06"></testcase>
 			<testcase name="TestTwo" time="0.1"></testcase>
 		</testsuite>


### PR DESCRIPTION
@stevekuznetsov while looking into your PR I found this typo. ptal