### PR TITLE
Do not remove image after Docker build

### DIFF
--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -84,8 +84,6 @@ func (d *DockerBuilder) Build() error {
 		return err
 	}
 
-	defer removeImage(d.dockerClient, d.build.Status.OutputDockerImageReference)
-
 	if push {
 		// Get the Docker push authentication
 		pushAuthConfig, authPresent := dockercfg.NewHelper().GetDockerAuth(


### PR DESCRIPTION
This is to match the behavior with S2I builds.

Original discussion: https://github.com/openshift/origin/pull/6715/files#r50523339