### PR TITLE
sup group extended tests - don't fail for parsing error

### DIFF
--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -34,10 +34,12 @@ var _ = g.Describe("security: supplemental groups", func() {
 			o.Expect(err).NotTo(o.HaveOccurred(), "error getting docker environment")
 			version := env.Get("Version")
 			supports, err, requiredVersion := supportsSupplementalGroups(version)
-			o.Expect(err).NotTo(o.HaveOccurred())
 
-			if !supports {
+			if !supports || err != nil {
 				msg := fmt.Sprintf("skipping supplemental groups test, docker version %s does not meet required version %s", version, requiredVersion)
+				if err != nil {
+					msg = fmt.Sprintf("%s - encountered error: %v", msg, err)
+				}
 				g.Skip(msg)
 			}
 


### PR DESCRIPTION
Prompted by the failure in https://ci.openshift.redhat.com/jenkins/job/test_pull_requests_origin/9187/console

If the docker version contains a non-parseable segment we should not fail the test, we should skip it with a warning message.

@deads2k 