### PR TITLE
Move limit range help text outside of header on settings page

### DIFF
--- a/assets/app/views/settings.html
+++ b/assets/app/views/settings.html
@@ -101,10 +101,8 @@
         </div>
       </div>
       <div ng-if="(limitRanges | hashSize) === 0">
-        <h2>
-          Limit Range
-          <div class="help-block">{{limitRangeHelp}}</div>
-        </h2>
+        <h2>Limit Range</h2>
+        <div class="help-block">{{limitRangeHelp}}</div>
         <p><em>{{emptyMessageLimitRanges}}</em></p>
       </div>
       <div ng-repeat="(limitRangeName, limitRange) in limitRanges">


### PR DESCRIPTION
Fixes a problem where the help text font for limit ranges is too big when no limit ranges are set. Introduced by #6723 :(

@jwforres PTAL