### PR TITLE
Strip library prefix just from docker registry

### DIFF
--- a/pkg/build/builder/cmd/dockercfg/cfg.go
+++ b/pkg/build/builder/cmd/dockercfg/cfg.go
@@ -17,12 +17,10 @@ import (
 
 //TODO: Remove this code once the methods in Kubernetes kubelet/dockertools/config.go are public
 
-// Default docker registry server
 const (
-	defaultRegistryServer = "https://index.docker.io/v1/"
-	PushAuthType          = "PUSH_DOCKERCFG_PATH"
-	PullAuthType          = "PULL_DOCKERCFG_PATH"
-	PullSourceAuthType    = "PULL_SOURCE_DOCKERCFG_PATH_"
+	PushAuthType       = "PUSH_DOCKERCFG_PATH"
+	PullAuthType       = "PULL_DOCKERCFG_PATH"
+	PullSourceAuthType = "PULL_SOURCE_DOCKERCFG_PATH_"
 )
 
 // Helper contains all the valid config options for reading the local dockercfg file

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -160,7 +160,7 @@ func (d *DockerBuilder) addBuildParameters(dir string) error {
 		// Reduce the name to a minimal canonical form for the daemon
 		name := d.build.Spec.Strategy.DockerStrategy.From.Name
 		if ref, err := imageapi.ParseDockerImageReference(name); err == nil {
-			name = ref.DaemonMinimal().String()
+			name = ref.DaemonMinimal().Exact()
 		}
 		err := replaceLastFrom(node, name)
 		if err != nil {
@@ -272,7 +272,7 @@ func (d *DockerBuilder) dockerBuild(dir string, secrets []api.SecretBuildSource)
 }
 
 // replaceLastFrom changes the last FROM instruction of node to point to the
-// base image image.
+// base image.
 func replaceLastFrom(node *parser.Node, image string) error {
 	if node == nil {
 		return nil

--- a/pkg/image/api/helper.go
+++ b/pkg/image/api/helper.go
@@ -182,20 +182,20 @@ func (r DockerImageReference) RegistryURL() *url.URL {
 
 // DaemonMinimal clears defaults that Docker assumes.
 func (r DockerImageReference) DaemonMinimal() DockerImageReference {
-	if r.Namespace == "library" {
-		r.Namespace = ""
-	}
 	switch r.Registry {
 	case DockerDefaultV1Registry, DockerDefaultV2Registry:
 		r.Registry = DockerDefaultRegistry
+	}
+	if IsRegistryDockerHub(r.Registry) && r.Namespace == DockerDefaultNamespace {
+		r.Namespace = ""
 	}
 	return r.Minimal()
 }
 
 func (r DockerImageReference) AsV2() DockerImageReference {
 	switch r.Registry {
-	case "index.docker.io", "docker.io":
-		r.Registry = "registry-1.docker.io"
+	case DockerDefaultV1Registry, DockerDefaultRegistry:
+		r.Registry = DockerDefaultV2Registry
 	}
 	return r
 }

--- a/pkg/image/api/helper_test.go
+++ b/pkg/image/api/helper_test.go
@@ -263,6 +263,79 @@ func TestDockerImageReferenceAsRepository(t *testing.T) {
 
 }
 
+func TestDockerImageReferenceDaemonMinimal(t *testing.T) {
+	testCases := []struct {
+		Registry, Namespace, Name, Tag, ID string
+		Expected                           string
+	}{
+		{
+			Namespace: "library",
+			Name:      "foo",
+			Tag:       "tag",
+			Expected:  "library/foo:tag",
+		},
+		{
+			Namespace: "bar",
+			Name:      "foo",
+			ID:        "sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+			Expected:  "bar/foo@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
+		},
+		{
+			Registry:  "bar",
+			Namespace: "foo",
+			Name:      "baz",
+			Expected:  "bar/foo/baz",
+		},
+		{
+			Registry:  "localhost:5000",
+			Namespace: "library",
+			Name:      "bar",
+			Tag:       "latest",
+			Expected:  "localhost:5000/library/bar",
+		},
+		{
+			Registry:  "index.docker.io",
+			Namespace: "foo",
+			Name:      "bar",
+			Tag:       "latest",
+			Expected:  "docker.io/foo/bar",
+		},
+		{
+			Registry:  "registry-1.docker.io",
+			Namespace: "library",
+			Name:      "foo",
+			Tag:       "bar",
+			Expected:  "docker.io/foo:bar",
+		},
+		{
+			Registry:  "docker.io",
+			Namespace: "foo",
+			Name:      "library",
+			Expected:  "docker.io/foo/library",
+		},
+		{
+			Registry: "registry-1.docker.io",
+			Name:     "library",
+			Tag:      "foo",
+			Expected: "docker.io/library:foo",
+		},
+	}
+
+	for i, testCase := range testCases {
+		ref := DockerImageReference{
+			Registry:  testCase.Registry,
+			Namespace: testCase.Namespace,
+			Name:      testCase.Name,
+			Tag:       testCase.Tag,
+			ID:        testCase.ID,
+		}
+		actual := ref.DaemonMinimal().Exact()
+		if e, a := testCase.Expected, actual; e != a {
+			t.Errorf("%d: expected %q, got %q", i, e, a)
+		}
+	}
+}
+
 func TestDockerImageReferenceString(t *testing.T) {
 	testCases := []struct {
 		Registry, Namespace, Name, Tag, ID string


### PR DESCRIPTION
Fixed DaemonMinimal() method of DockerImageReference, which used to
strip library prefix from all repositories.

Follow-up for #6777