### PR TITLE
deployapi: remove obsolete templateRef reference

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -16128,7 +16128,7 @@
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "describes the pod that will be created if insufficient replicas are detected; takes precedence over a template reference"
+      "description": "describes the pod that will be created if insufficient replicas are detected"
      }
     }
    },

--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -270,8 +270,7 @@ type DeploymentConfigSpec struct {
 	Selector map[string]string
 
 	// Template is the object that describes the pod that will be created if
-	// insufficient replicas are detected. Internally, this takes precedence over a
-	// TemplateRef.
+	// insufficient replicas are detected.
 	Template *kapi.PodTemplateSpec
 }
 

--- a/pkg/deploy/api/v1/types.go
+++ b/pkg/deploy/api/v1/types.go
@@ -241,9 +241,8 @@ type DeploymentConfigSpec struct {
 	Selector map[string]string `json:"selector,omitempty" description:"a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"`
 
 	// Template is the object that describes the pod that will be created if
-	// insufficient replicas are detected. Internally, this takes precedence over a
-	// TemplateRef.
-	Template *kapi.PodTemplateSpec `json:"template,omitempty" description:"describes the pod that will be created if insufficient replicas are detected; takes precedence over a template reference"`
+	// insufficient replicas are detected.
+	Template *kapi.PodTemplateSpec `json:"template,omitempty" description:"describes the pod that will be created if insufficient replicas are detected"`
 }
 
 // DeploymentConfigStatus represents the current deployment state.

--- a/pkg/deploy/api/v1beta3/types.go
+++ b/pkg/deploy/api/v1beta3/types.go
@@ -258,9 +258,8 @@ type DeploymentConfigSpec struct {
 	Selector map[string]string `json:"selector,omitempty" description:"a label query over pods that should match the replicas count; if omitted, it will default to the podTemplate labels"`
 
 	// Template is the object that describes the pod that will be created if
-	// insufficient replicas are detected. Internally, this takes precedence over a
-	// TemplateRef.
-	Template *kapi.PodTemplateSpec `json:"template,omitempty" description:"describes the pod that will be created if insufficient replicas are detected; takes precedence over a template reference"`
+	// insufficient replicas are detected.
+	Template *kapi.PodTemplateSpec `json:"template,omitempty" description:"describes the pod that will be created if insufficient replicas are detected"`
 }
 
 type DeploymentConfigStatus struct {


### PR DESCRIPTION
TemplateRef is not a thing for DCs anymore

@ironcladlou @openshift/api-review 