### PR TITLE
[wip] refactor test cmd startup to use our utility functions

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -60,10 +60,13 @@ tests=( $(find_tests ${1:-.*}) )
 # test-cmd specific defaults
 API_HOST=${API_HOST:-127.0.0.1}
 export API_PORT=${API_PORT:-28443}
+export API_BIND_HOST=${API_BIND_HOST:-${API_HOST}}
 
 export ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 export ETCD_PORT=${ETCD_PORT:-24001}
 export ETCD_PEER_PORT=${ETCD_PEER_PORT:-27001}
+
+export KUBELET_BIND_HOST=${KUBELET_BIND_HOST:-0.0.0.0}
 
 os::util::environment::setup_all_server_vars "test-cmd/"
 reset_tmp_dir
@@ -101,9 +104,23 @@ export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
 
 # Specify the scheme and port for the listen address, but let the IP auto-discover. Set --public-master to localhost, for a stable link to the console.
 echo "[INFO] Create certificates for the OpenShift server to ${MASTER_CONFIG_DIR}"
-# find the same IP that openshift start will bind to.  This allows access from pods that have to talk back to master
-SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},$(openshift start --print-ip),localhost"
+# find the same IP that openshift start will bind to. This allows access from pods that have to talk back to master
+if [[ -z "${ALL_IP_ADDRESSES-}" ]]; then
+  ALL_IP_ADDRESSES="$(openshift start --print-ip)"
+  SERVER_HOSTNAME_LIST="${PUBLIC_MASTER_HOST},localhost,172.30.0.1"
+              SERVER_HOSTNAME_LIST="${SERVER_HOSTNAME_LIST},kubernetes.default.svc.cluster.local,kubernetes.default.svc,kubernetes.default,kubernetes"
+              SERVER_HOSTNAME_LIST="${SERVER_HOSTNAME_LIST},openshift.default.svc.cluster.local,openshift.default.svc,openshift.default,openshift"
 
+  while read -r IP_ADDRESS
+  do
+    SERVER_HOSTNAME_LIST="${SERVER_HOSTNAME_LIST},${IP_ADDRESS}"
+  done <<< "${ALL_IP_ADDRESSES}"
+
+  export ALL_IP_ADDRESSES
+  export SERVER_HOSTNAME_LIST
+fi
+
+echo "[INFO] Creating certificates for the OpenShift server"
 openshift admin ca create-master-certs \
   --overwrite=false \
   --cert-dir="${MASTER_CONFIG_DIR}" \
@@ -111,8 +128,9 @@ openshift admin ca create-master-certs \
   --master="${MASTER_ADDR}" \
   --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}"
 
+echo "[INFO] Creating OpenShift node config"
 openshift admin create-node-config \
-  --listen="${KUBELET_SCHEME}://0.0.0.0:${KUBELET_PORT}" \
+  --listen="${KUBELET_SCHEME}://${KUBELET_BIND_HOST}:${KUBELET_PORT}" \
   --node-dir="${NODE_CONFIG_DIR}" \
   --node="${KUBELET_HOST}" \
   --hostnames="${KUBELET_HOST}" \
@@ -125,12 +143,13 @@ openshift admin create-node-config \
 
 oadm create-bootstrap-policy-file --filename="${MASTER_CONFIG_DIR}/policy.json"
 
-# create openshift config
+echo "[INFO] Creating OpenShift config"
 openshift start \
   --write-config=${SERVER_CONFIG_DIR} \
   --create-certs=false \
-  --master="${API_SCHEME}://${API_HOST}:${API_PORT}" \
-  --listen="${API_SCHEME}://${API_HOST}:${API_PORT}" \
+  --listen="${API_SCHEME}://${API_BIND_HOST}:${API_PORT}" \
+  --master="${MASTER_ADDR}" \
+  --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}" \
   --hostname="${KUBELET_HOST}" \
   --volume-dir="${VOLUME_DIR}" \
   --etcd-dir="${ETCD_DATA_DIR}" \
@@ -153,12 +172,18 @@ echo "validation: ok"
 os::util::sed "s/:4001$/:${ETCD_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
 os::util::sed "s/:7001$/:${ETCD_PEER_PORT}/g" ${SERVER_CONFIG_DIR}/master/master-config.yaml
 
-# Start openshift
-OPENSHIFT_ON_PANIC=crash openshift start master \
+# Make oc use ${MASTER_CONFIG_DIR}/admin.kubeconfig, and ignore anything in the running user's $HOME dir
+export ADMIN_KUBECONFIG="${MASTER_CONFIG_DIR}/admin.kubeconfig"
+export CLUSTER_ADMIN_CONTEXT=$(oc config view --config=${ADMIN_KUBECONFIG} --flatten -o template --template='{{index . "current-context"}}')
+local sudo="${USE_SUDO:+sudo}"
+${sudo} chmod -R a+rwX "${ADMIN_KUBECONFIG}"
+echo "[INFO] To debug: export KUBECONFIG=$ADMIN_KUBECONFIG"
+
+${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE="${OPENSHIFT_PROFILE:-web}" OPENSHIFT_ON_PANIC=crash openshift start master \
   --config=${MASTER_CONFIG_DIR}/master-config.yaml \
-  --loglevel=5 \
+  --loglevel=4 \
   &>"${LOG_DIR}/openshift.log" &
-OS_PID=$!
+export OS_PID=$!
 
 if [[ "${API_SCHEME}" == "https" ]]; then
     export CURL_CA_BUNDLE="${MASTER_CONFIG_DIR}/ca.crt"

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -136,7 +136,7 @@ function start_os_server {
 	echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
 	ps -ef | grep openshift
 	echo "[INFO] Starting OpenShift server"
-	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start \
+	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE="${OPENSHIFT_PROFILE:-web}" OPENSHIFT_ON_PANIC=crash openshift start \
 	 --master-config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --node-config=${NODE_CONFIG_DIR}/node-config.yaml \
 	 --loglevel=4 \
@@ -188,7 +188,7 @@ function start_os_master {
 	echo "[INFO] Scan of OpenShift related processes already up via ps -ef	| grep openshift : "
 	ps -ef | grep openshift
 	echo "[INFO] Starting OpenShift server"
-	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE=web OPENSHIFT_ON_PANIC=crash openshift start master \
+	${sudo} env "PATH=${PATH}" OPENSHIFT_PROFILE="${OPENSHIFT_PROFILE:-web}" OPENSHIFT_ON_PANIC=crash openshift start master \
 	 --config=${MASTER_CONFIG_DIR}/master-config.yaml \
 	 --loglevel=4 \
 	&>"${LOG_DIR}/openshift.log" &


### PR DESCRIPTION
The two methods seem mostly compatible. @deads2k I'm not familiar with the special cases of `test-cmd` so PTAL the first commit, are there any breaking changes?

@deads2k @bparees  PTAL

fixes https://github.com/openshift/origin/issues/6593

