### PR TITLE
Send error output from verify-gofmt to stderr to allow piping to xargs to clean up

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -9,7 +9,7 @@ set -o pipefail
 GO_VERSION=($(go version))
 
 if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.4|go1.5') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping gofmt."
+  echo "Unknown go version '${GO_VERSION}', skipping gofmt." >&2
   exit 0
 fi
 
@@ -21,8 +21,9 @@ cd "${OS_ROOT}"
 
 bad_files=$(find_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then
-  echo "!!! gofmt needs to be run on the following files: "
+  echo "!!! gofmt needs to be run on the following files: " >&2
   echo "${bad_files}"
-  echo "Try running 'gofmt -s -d [path]'"
+  echo "Try running 'gofmt -s -d [path]'" >&2
+  echo "Or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'" >&2
   exit 1
 fi


### PR DESCRIPTION
Allows `hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w` for cleanup