### PR TITLE
Kibana archive link for build pod

### DIFF
--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -50,11 +50,14 @@ angular.module('openshiftConsole')
         // projectPromise rather than just a namespace, so we have to pass the
         // context into the log-viewer directive.
         $scope.logContext = context;
+        $scope.logOptions = {};
         DataService.get("builds", $routeParams.build, context).then(
           // success
           function(build) {
+
             $scope.loaded = true;
             $scope.build = build;
+            $scope.logOptions.container = $filter("annotation")(build, "buildPod");
             var buildNumber = $filter("annotation")(build, "buildNumber");
             if (buildNumber) {
               $scope.breadcrumbs[2].title = "#" + buildNumber;

--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -72,6 +72,7 @@ angular.module('openshiftConsole')
               }
             });
             activeDeployment = DeploymentsService.getActiveDeployment(deploymentsForConfig);
+            $scope.logContext.container = $filter("annotation")(activeDeployment, "pod");
             $scope.isActive = activeDeployment && activeDeployment.metadata.uid === $scope.deployment.metadata.uid;
           }));
         };

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -55,7 +55,7 @@ angular.module('openshiftConsole')
           function(pod) {
             $scope.loaded = true;
             $scope.pod = pod;
-            $scope.logOptions.container = $routeParams.container || pod.spec.containers[0].name;
+            $scope.logOptions.container = $routeParams.container || _.get(pod, 'spec.containers[0].name');
             var pods = {};
             pods[pod.metadata.name] = pod;
             ImageStreamResolver.fetchReferencedImageStreamImages(pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -233,16 +233,8 @@ angular.module('openshiftConsole')
             APIDiscovery
               .getLoggingURL()
               .then(function(url) {
-                // TODO: update lodash for _.get, would rather do this:
-                // var projectName = _.get($scope, 'context', 'project', 'metadata', 'name');
-                // var containerName = _.get($scope, 'options', 'container');
-                var projectName = $scope.context &&
-                                  $scope.context.project &&
-                                  $scope.context.project.metadata &&
-                                  $scope.context.project.metadata.name;
-
-                var containerName = $scope.options &&
-                                    $scope.options.container;
+                var projectName = _.get($scope.context, 'project.metadata.name');
+                var containerName = _.get($scope.options, 'container');
 
                 if(!(projectName && containerName && $scope.name && url)) {
                   return;

--- a/assets/app/scripts/filters/resources.js
+++ b/assets/app/scripts/filters/resources.js
@@ -30,7 +30,8 @@ angular.module('openshiftConsole')
         "deploymentVersion":        ["openshift.io/deployment-config.latest-version"],
         "displayName":              ["openshift.io/display-name"],
         "description":              ["openshift.io/description"],
-        "buildNumber":              ["openshift.io/build.number"]
+        "buildNumber":              ["openshift.io/build.number"],
+        "buildPod":                 ["openshift.io/build.pod-name"]
       };
       return annotationMap[annotationKey] || null;
     };

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -48,6 +48,7 @@
                   kind="builds/log"
                   name="build.metadata.name"
                   context="logContext"
+                  options="logOptions"
                   status="build.status.phase"
                   start="build.status.startTimestamp | date : 'short'"
                   end="build.status.completionTimestamp | date : 'short'">


### PR DESCRIPTION
Takes the `build.pod-name` annotation for the build and adds it to the `logOptions` object used to generate a link to kibana.

@jwforres @spadgett 