### PR TITLE
make project cache watchable

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -13365,7 +13365,7 @@
      {
       "type": "v1.ProjectList",
       "method": "GET",
-      "summary": "list objects of kind Project",
+      "summary": "list or watch objects of kind Project",
       "nickname": "listProject",
       "parameters": [
        {
@@ -13465,6 +13465,81 @@
       "produces": [
        "application/json",
        "application/yaml"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/watch/projects",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch individual changes to a list of Project",
+      "nickname": "watchProjectList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
       ],
       "consumes": [
        "*/*"
@@ -13641,6 +13716,89 @@
       "produces": [
        "application/json",
        "application/yaml"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/oapi/v1/watch/projects/{name}",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "json.WatchEvent",
+      "method": "GET",
+      "summary": "watch changes to an object of kind Project",
+      "nickname": "watchProject",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Project",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "json.WatchEvent"
+       }
+      ],
+      "produces": [
+       "application/json"
       ],
       "consumes": [
        "*/*"

--- a/pkg/client/projects.go
+++ b/pkg/client/projects.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/watch"
 
 	projectapi "github.com/openshift/origin/pkg/project/api"
 )
@@ -14,9 +15,11 @@ type ProjectsInterface interface {
 // ProjectInterface exposes methods on project resources.
 type ProjectInterface interface {
 	Create(p *projectapi.Project) (*projectapi.Project, error)
+	Update(p *projectapi.Project) (*projectapi.Project, error)
 	Delete(name string) error
 	Get(name string) (*projectapi.Project, error)
 	List(opts kapi.ListOptions) (*projectapi.ProjectList, error)
+	Watch(opts kapi.ListOptions) (watch.Interface, error)
 }
 
 type projects struct {
@@ -66,4 +69,13 @@ func (c *projects) Update(p *projectapi.Project) (result *projectapi.Project, er
 func (c *projects) Delete(name string) (err error) {
 	err = c.r.Delete().Resource("projects").Name(name).Do().Error()
 	return
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *projects) Watch(opts kapi.ListOptions) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Resource("projects").
+		VersionedParams(&opts, kapi.ParameterCodec).
+		Watch()
 }

--- a/pkg/client/testclient/fake_projects.go
+++ b/pkg/client/testclient/fake_projects.go
@@ -3,6 +3,7 @@ package testclient
 import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	ktestclient "k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/watch"
 
 	projectapi "github.com/openshift/origin/pkg/project/api"
 )
@@ -52,4 +53,8 @@ func (c *FakeProjects) Update(inObj *projectapi.Project) (*projectapi.Project, e
 func (c *FakeProjects) Delete(name string) error {
 	_, err := c.Fake.Invokes(ktestclient.NewRootDeleteAction("projects", name), &projectapi.Project{})
 	return err
+}
+
+func (c *FakeProjects) Watch(opts kapi.ListOptions) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(ktestclient.NewRootWatchAction("projects", opts))
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -299,7 +299,7 @@ func GetBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				{Verbs: sets.NewString("get"), Resources: sets.NewString("users"), ResourceNames: sets.NewString("~")},
 				{Verbs: sets.NewString("list"), Resources: sets.NewString("projectrequests")},
 				{Verbs: sets.NewString("list", "get"), Resources: sets.NewString("clusterroles")},
-				{Verbs: sets.NewString("list"), Resources: sets.NewString("projects")},
+				{Verbs: sets.NewString("list", "watch"), Resources: sets.NewString("projects")},
 				{Verbs: sets.NewString("create"), Resources: sets.NewString("subjectaccessreviews", "localsubjectaccessreviews"), AttributeRestrictions: &authorizationapi.IsPersonalSubjectAccessReview{}},
 			},
 		},

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -466,7 +466,7 @@ func (c *MasterConfig) GetRestStorage() map[string]rest.Storage {
 		GRFn: deployRollback.GenerateRollback,
 	}
 
-	projectStorage := projectproxy.NewREST(kclient.Namespaces(), c.ProjectAuthorizationCache)
+	projectStorage := projectproxy.NewREST(kclient.Namespaces(), c.ProjectAuthorizationCache, c.ProjectAuthorizationCache, c.ProjectCache)
 
 	namespace, templateName, err := configapi.ParseNamespaceAndName(c.Options.ProjectConfig.ProjectRequestTemplate)
 	if err != nil {

--- a/pkg/project/auth/watch.go
+++ b/pkg/project/auth/watch.go
@@ -1,0 +1,205 @@
+package auth
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/golang/glog"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/storage/etcd"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+	projectutil "github.com/openshift/origin/pkg/project/util"
+)
+
+type CacheWatcher interface {
+	// GroupMembershipChanged is called serially for all changes for all watchers.  This method MUST NOT BLOCK.
+	// The serial nature makes reasoning about the code easy, but if you block in this method you will doom all watchers.
+	GroupMembershipChanged(namespaceName string, latestUsers, latestGroups, removedUsers, removedGroups, addedUsers, addedGroups sets.String)
+}
+
+type WatchableCache interface {
+	// RemoveWatcher removes a watcher
+	RemoveWatcher(CacheWatcher)
+	// List returns the set of namespace names the user has access to view
+	List(userInfo user.Info) (*kapi.NamespaceList, error)
+}
+
+// userProjectWatcher converts a native etcd watch to a watch.Interface.
+type userProjectWatcher struct {
+	username string
+	groups   []string
+
+	// cacheIncoming is a buffered channel used for notification to watcher.  If the buffer fills up,
+	// then the watcher will be removed and the connection will be broken.
+	cacheIncoming chan watch.Event
+	// cacheError is a cached channel that is put to serially.  In theory, only one item will
+	// ever be placed on it.
+	cacheError chan error
+
+	// outgoing is the unbuffered `ResultChan` use for the watch.  Backups of this channel will block
+	// the default `emit` call.  That's why cacheError is a buffered channel.
+	outgoing chan watch.Event
+	// userStop lets a user stop his watch.
+	userStop chan struct{}
+
+	// stopLock keeps parallel stops from doing crazy things
+	stopLock sync.Mutex
+
+	// Injectable for testing. Send the event down the outgoing channel.
+	emit func(watch.Event)
+
+	projectCache *projectcache.ProjectCache
+	authCache    WatchableCache
+
+	knownProjects sets.String
+}
+
+var (
+	// watchChannelHWM tracks how backed up the most backed up channel got.  This mirrors etcd watch behavior and allows tuning
+	// of channel depth.
+	watchChannelHWM etcd.HighWaterMark
+)
+
+func NewUserProjectWatcher(username string, groups []string, projectCache *projectcache.ProjectCache, authCache WatchableCache) *userProjectWatcher {
+	userInfo := &user.DefaultInfo{Name: username, Groups: groups}
+	namespaces, _ := authCache.List(userInfo)
+	knownProjects := sets.String{}
+	for _, namespace := range namespaces.Items {
+		knownProjects.Insert(namespace.Name)
+	}
+
+	w := &userProjectWatcher{
+		username: username,
+		groups:   groups,
+
+		cacheIncoming: make(chan watch.Event, 1000),
+		cacheError:    make(chan error, 1),
+		outgoing:      make(chan watch.Event),
+		userStop:      make(chan struct{}),
+
+		projectCache:  projectCache,
+		authCache:     authCache,
+		knownProjects: knownProjects,
+	}
+	w.emit = func(e watch.Event) {
+		select {
+		case w.outgoing <- e:
+		case <-w.userStop:
+		}
+	}
+	return w
+}
+
+func (w *userProjectWatcher) GroupMembershipChanged(namespaceName string, latestUsers, lastestGroups, removedUsers, removedGroups, addedUsers, addedGroups sets.String) {
+	hasAccess := latestUsers.Has(w.username) || lastestGroups.HasAny(w.groups...)
+	removed := !hasAccess && (removedUsers.Has(w.username) || removedGroups.HasAny(w.groups...))
+
+	switch {
+	case removed:
+		if !w.knownProjects.Has(namespaceName) {
+			return
+		}
+		w.knownProjects.Delete(namespaceName)
+
+		select {
+		case w.cacheIncoming <- watch.Event{
+			Type:   watch.Deleted,
+			Object: projectutil.ConvertNamespace(&kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: namespaceName}}),
+		}:
+		default:
+			// remove the watcher so that we wont' be notified again and block
+			w.authCache.RemoveWatcher(w)
+			w.cacheError <- errors.New("delete notification timeout")
+		}
+
+	case hasAccess:
+		namespace, err := w.projectCache.GetNamespace(namespaceName)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		event := watch.Event{
+			Type:   watch.Added,
+			Object: projectutil.ConvertNamespace(namespace),
+		}
+
+		// if we already have this in our list, then we're getting notified because the object changed
+		if w.knownProjects.Has(namespaceName) {
+			event.Type = watch.Modified
+		}
+		w.knownProjects.Insert(namespace.Name)
+
+		select {
+		case w.cacheIncoming <- event:
+		default:
+			// remove the watcher so that we won't be notified again and block
+			w.authCache.RemoveWatcher(w)
+			w.cacheError <- errors.New("add notification timeout")
+		}
+
+	}
+
+}
+
+// Watch pulls stuff from etcd, converts, and pushes out the outgoing channel. Meant to be
+// called as a goroutine.
+func (w *userProjectWatcher) Watch() {
+	defer close(w.outgoing)
+	defer func() {
+		// when the watch ends, always remove the watcher from the cache to avoid leaking.
+		w.authCache.RemoveWatcher(w)
+	}()
+	defer utilruntime.HandleCrash()
+
+	for {
+		select {
+		case err := <-w.cacheError:
+			w.emit(watch.Event{
+				Type: watch.Error,
+				Object: &unversioned.Status{
+					Status:  unversioned.StatusFailure,
+					Message: err.Error(),
+				},
+			})
+			return
+
+		case <-w.userStop:
+			return
+
+		case event := <-w.cacheIncoming:
+			if curLen := int64(len(w.cacheIncoming)); watchChannelHWM.Update(curLen) {
+				// Monitor if this gets backed up, and how much.
+				glog.V(2).Infof("watch: %v objects queued in project cache watching channel.", curLen)
+			}
+
+			w.emit(event)
+		}
+	}
+}
+
+// ResultChan implements watch.Interface.
+func (w *userProjectWatcher) ResultChan() <-chan watch.Event {
+	return w.outgoing
+}
+
+// Stop implements watch.Interface.
+func (w *userProjectWatcher) Stop() {
+	// lock access so we don't race past the channel select
+	w.stopLock.Lock()
+	defer w.stopLock.Unlock()
+
+	// Prevent double channel closes.
+	select {
+	case <-w.userStop:
+		return
+	default:
+	}
+	close(w.userStop)
+}

--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/watch"
+
+	projectapi "github.com/openshift/origin/pkg/project/api"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
+)
+
+func newTestWatcher(user string, groups []string, namespaces ...*kapi.Namespace) (*userProjectWatcher, *fakeAuthCache) {
+	objects := []runtime.Object{}
+	for i := range namespaces {
+		objects = append(objects, namespaces[i])
+	}
+	mockClient := testclient.NewSimpleFake(objects...)
+
+	projectCache := projectcache.NewProjectCache(mockClient.Namespaces(), "")
+	projectCache.Run()
+	fakeAuthCache := &fakeAuthCache{}
+
+	return NewUserProjectWatcher(user, groups, projectCache, fakeAuthCache), fakeAuthCache
+}
+
+type fakeAuthCache struct {
+	namespaces []*kapi.Namespace
+
+	removed []CacheWatcher
+}
+
+func (w *fakeAuthCache) RemoveWatcher(watcher CacheWatcher) {
+	w.removed = append(w.removed, watcher)
+}
+
+func (w *fakeAuthCache) List(userInfo user.Info) (*kapi.NamespaceList, error) {
+	ret := &kapi.NamespaceList{}
+	if w.namespaces != nil {
+		for i := range w.namespaces {
+			ret.Items = append(ret.Items, *w.namespaces[i])
+		}
+	}
+
+	return ret, nil
+}
+
+func TestFullIncoming(t *testing.T) {
+	watcher, fakeAuthCache := newTestWatcher("bob", nil, newNamespaces("ns-01")...)
+	watcher.cacheIncoming = make(chan watch.Event)
+
+	go watcher.Watch()
+	watcher.cacheIncoming <- watch.Event{Type: watch.Added}
+
+	// this call should not block and we should see a failure
+	watcher.GroupMembershipChanged("ns-01", sets.NewString("bob"), sets.String{}, sets.String{}, sets.String{}, sets.NewString("bob"), sets.String{})
+	if len(fakeAuthCache.removed) != 1 {
+		t.Errorf("should have removed self")
+	}
+
+	err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (done bool, err error) {
+		if len(watcher.cacheError) > 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	for {
+		repeat := false
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				t.Fatalf("channel closed")
+			}
+			// this happens when the cacheIncoming block wins the select race
+			if event.Type == watch.Added {
+				repeat = true
+				break
+			}
+			// this should be an error
+			if event.Type != watch.Error {
+				t.Errorf("expected error, got %v", event)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timeout")
+		}
+		if !repeat {
+			break
+		}
+	}
+}
+
+func TestAddModifyDeleteEventsByUser(t *testing.T) {
+	watcher, _ := newTestWatcher("bob", nil, newNamespaces("ns-01")...)
+	go watcher.Watch()
+
+	watcher.GroupMembershipChanged("ns-01", sets.NewString("bob"), sets.String{}, sets.String{}, sets.String{}, sets.NewString("bob"), sets.String{})
+	select {
+	case event := <-watcher.ResultChan():
+		if event.Type != watch.Added {
+			t.Errorf("expected added, got %v", event)
+		}
+		if event.Object.(*projectapi.Project).Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	watcher.GroupMembershipChanged("ns-01", sets.NewString("bob"), sets.String{}, sets.String{}, sets.String{}, sets.String{}, sets.String{})
+	select {
+	case event := <-watcher.ResultChan():
+		if event.Type != watch.Modified {
+			t.Errorf("expected Modified, got %v", event)
+		}
+		if event.Object.(*projectapi.Project).Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	watcher.GroupMembershipChanged("ns-01", sets.NewString("alice"), sets.String{}, sets.NewString("bob"), sets.String{}, sets.String{}, sets.String{})
+	select {
+	case event := <-watcher.ResultChan():
+		if event.Type != watch.Deleted {
+			t.Errorf("expected Deleted, got %v", event)
+		}
+		if event.Object.(*projectapi.Project).Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+func TestAddModifyDeleteEventsByGroup(t *testing.T) {
+	watcher, _ := newTestWatcher("bob", []string{"group-one"}, newNamespaces("ns-01")...)
+	go watcher.Watch()
+
+	watcher.GroupMembershipChanged("ns-01", sets.String{}, sets.NewString("group-one"), sets.String{}, sets.String{}, sets.String{}, sets.NewString("group-one"))
+	select {
+	case event := <-watcher.ResultChan():
+		if event.Type != watch.Added {
+			t.Errorf("expected added, got %v", event)
+		}
+		if event.Object.(*projectapi.Project).Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	watcher.GroupMembershipChanged("ns-01", sets.String{}, sets.NewString("group-one"), sets.String{}, sets.String{}, sets.String{}, sets.String{})
+	select {
+	case event := <-watcher.ResultChan():
+		if event.Type != watch.Modified {
+			t.Errorf("expected Modified, got %v", event)
+		}
+		if event.Object.(*projectapi.Project).Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	watcher.GroupMembershipChanged("ns-01", sets.String{}, sets.NewString("group-two"), sets.String{}, sets.NewString("group-one"), sets.String{}, sets.String{})
+	select {
+	case event := <-watcher.ResultChan():
+		if event.Type != watch.Deleted {
+			t.Errorf("expected Deleted, got %v", event)
+		}
+		if event.Object.(*projectapi.Project).Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", event.Object)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+}
+
+func newNamespaces(names ...string) []*kapi.Namespace {
+	ret := []*kapi.Namespace{}
+	for _, name := range names {
+		ret = append(ret, &kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: name}})
+	}
+
+	return ret
+}

--- a/pkg/project/registry/project/proxy/proxy.go
+++ b/pkg/project/registry/project/proxy/proxy.go
@@ -12,12 +12,15 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	nsregistry "k8s.io/kubernetes/pkg/registry/namespace"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	"github.com/openshift/origin/pkg/project/api"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
+	projectcache "github.com/openshift/origin/pkg/project/cache"
 	projectregistry "github.com/openshift/origin/pkg/project/registry/project"
+	projectutil "github.com/openshift/origin/pkg/project/util"
 )
 
 type REST struct {
@@ -29,15 +32,21 @@ type REST struct {
 	createStrategy rest.RESTCreateStrategy
 	// Allows extended behavior during updates, required
 	updateStrategy rest.RESTUpdateStrategy
+
+	authCache    *projectauth.AuthorizationCache
+	projectCache *projectcache.ProjectCache
 }
 
 // NewREST returns a RESTStorage object that will work against Project resources
-func NewREST(client kclient.NamespaceInterface, lister projectauth.Lister) *REST {
+func NewREST(client kclient.NamespaceInterface, lister projectauth.Lister, authCache *projectauth.AuthorizationCache, projectCache *projectcache.ProjectCache) *REST {
 	return &REST{
 		client:         client,
 		lister:         lister,
 		createStrategy: projectregistry.Strategy,
 		updateStrategy: projectregistry.Strategy,
+
+		authCache:    authCache,
+		projectCache: projectCache,
 	}
 }
 
@@ -49,46 +58,6 @@ func (s *REST) New() runtime.Object {
 // NewList returns a new ProjectList
 func (*REST) NewList() runtime.Object {
 	return &api.ProjectList{}
-}
-
-// convertNamespace transforms a Namespace into a Project
-func convertNamespace(namespace *kapi.Namespace) *api.Project {
-	return &api.Project{
-		ObjectMeta: namespace.ObjectMeta,
-		Spec: api.ProjectSpec{
-			Finalizers: namespace.Spec.Finalizers,
-		},
-		Status: api.ProjectStatus{
-			Phase: namespace.Status.Phase,
-		},
-	}
-}
-
-// convertProject transforms a Project into a Namespace
-func convertProject(project *api.Project) *kapi.Namespace {
-	namespace := &kapi.Namespace{
-		ObjectMeta: project.ObjectMeta,
-		Spec: kapi.NamespaceSpec{
-			Finalizers: project.Spec.Finalizers,
-		},
-		Status: kapi.NamespaceStatus{
-			Phase: project.Status.Phase,
-		},
-	}
-	if namespace.Annotations == nil {
-		namespace.Annotations = map[string]string{}
-	}
-	namespace.Annotations[projectapi.ProjectDisplayName] = project.Annotations[projectapi.ProjectDisplayName]
-	return namespace
-}
-
-// convertNamespaceList transforms a NamespaceList into a ProjectList
-func convertNamespaceList(namespaceList *kapi.NamespaceList) *api.ProjectList {
-	projects := &api.ProjectList{}
-	for _, n := range namespaceList.Items {
-		projects.Items = append(projects.Items, *convertNamespace(&n))
-	}
-	return projects
 }
 
 var _ = rest.Lister(&REST{})
@@ -108,7 +77,22 @@ func (s *REST) List(ctx kapi.Context, options *kapi.ListOptions) (runtime.Object
 	if err != nil {
 		return nil, err
 	}
-	return convertNamespaceList(list.(*kapi.NamespaceList)), nil
+	return projectutil.ConvertNamespaceList(list.(*kapi.NamespaceList)), nil
+}
+
+func (s *REST) Watch(ctx kapi.Context, options *kapi.ListOptions) (watch.Interface, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("Context is nil")
+	}
+	userInfo, exists := kapi.UserFrom(ctx)
+	if !exists {
+		return nil, fmt.Errorf("no user")
+	}
+	watcher := projectauth.NewUserProjectWatcher(userInfo.GetName(), userInfo.GetGroups(), s.projectCache, s.authCache)
+	s.authCache.AddWatcher(watcher)
+
+	go watcher.Watch()
+	return watcher, nil
 }
 
 var _ = rest.Getter(&REST{})
@@ -119,7 +103,7 @@ func (s *REST) Get(ctx kapi.Context, name string) (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-	return convertNamespace(namespace), nil
+	return projectutil.ConvertNamespace(namespace), nil
 }
 
 var _ = rest.Creater(&REST{})
@@ -135,11 +119,11 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (runtime.Object, err
 	if errs := s.createStrategy.Validate(ctx, obj); len(errs) > 0 {
 		return nil, kerrors.NewInvalid(projectapi.Kind("Project"), project.Name, errs)
 	}
-	namespace, err := s.client.Create(convertProject(project))
+	namespace, err := s.client.Create(projectutil.ConvertProject(project))
 	if err != nil {
 		return nil, err
 	}
-	return convertNamespace(namespace), nil
+	return projectutil.ConvertNamespace(namespace), nil
 }
 
 var _ = rest.Updater(&REST{})
@@ -159,12 +143,12 @@ func (s *REST) Update(ctx kapi.Context, obj runtime.Object) (runtime.Object, boo
 		return nil, false, kerrors.NewInvalid(projectapi.Kind("Project"), project.Name, errs)
 	}
 
-	namespace, err := s.client.Update(convertProject(project))
+	namespace, err := s.client.Update(projectutil.ConvertProject(project))
 	if err != nil {
 		return nil, false, err
 	}
 
-	return convertNamespace(namespace), false, nil
+	return projectutil.ConvertNamespace(namespace), false, nil
 }
 
 var _ = rest.Deleter(&REST{})

--- a/pkg/project/registry/project/proxy/proxy_test.go
+++ b/pkg/project/registry/project/proxy/proxy_test.go
@@ -70,7 +70,7 @@ func TestCreateProjectBadObject(t *testing.T) {
 
 func TestCreateInvalidProject(t *testing.T) {
 	mockClient := &testclient.Fake{}
-	storage := NewREST(mockClient.Namespaces(), &mockLister{})
+	storage := NewREST(mockClient.Namespaces(), &mockLister{}, nil, nil)
 	_, err := storage.Create(nil, &api.Project{
 		ObjectMeta: kapi.ObjectMeta{
 			Annotations: map[string]string{"openshift.io/display-name": "h\t\ni"},
@@ -83,7 +83,7 @@ func TestCreateInvalidProject(t *testing.T) {
 
 func TestCreateProjectOK(t *testing.T) {
 	mockClient := &testclient.Fake{}
-	storage := NewREST(mockClient.Namespaces(), &mockLister{})
+	storage := NewREST(mockClient.Namespaces(), &mockLister{}, nil, nil)
 	_, err := storage.Create(kapi.NewContext(), &api.Project{
 		ObjectMeta: kapi.ObjectMeta{Name: "foo"},
 	})
@@ -100,7 +100,7 @@ func TestCreateProjectOK(t *testing.T) {
 
 func TestGetProjectOK(t *testing.T) {
 	mockClient := testclient.NewSimpleFake(&kapi.Namespace{ObjectMeta: kapi.ObjectMeta{Name: "foo"}})
-	storage := NewREST(mockClient.Namespaces(), &mockLister{})
+	storage := NewREST(mockClient.Namespaces(), &mockLister{}, nil, nil)
 	project, err := storage.Get(kapi.NewContext(), "foo")
 	if project == nil {
 		t.Error("Unexpected nil project")

--- a/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/fixtures/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -660,6 +660,7 @@ items:
     - projects
     verbs:
     - list
+    - watch
   - apiGroups: null
     attributeRestrictions:
       apiVersion: v1

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -4,10 +4,14 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/watch"
 
 	buildapi "github.com/openshift/origin/pkg/build/api"
+	policy "github.com/openshift/origin/pkg/cmd/admin/policy"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	projectapi "github.com/openshift/origin/pkg/project/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -53,8 +57,8 @@ func TestProjectIsNamespace(t *testing.T) {
 		ObjectMeta: kapi.ObjectMeta{
 			Name: "new-project",
 			Annotations: map[string]string{
-				"openshift.io/display-name":  "Hello World",
-				"openshift.io/node-selector": "env=test",
+				projectapi.ProjectDisplayName: "Hello World",
+				"openshift.io/node-selector":  "env=test",
 			},
 		},
 	}
@@ -71,8 +75,8 @@ func TestProjectIsNamespace(t *testing.T) {
 	if project.Name != namespace.Name {
 		t.Fatalf("Project name did not match namespace name, project %v, namespace %v", project.Name, namespace.Name)
 	}
-	if project.Annotations["openshift.io/display-name"] != namespace.Annotations["openshift.io/display-name"] {
-		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations["openshift.io/display-name"], namespace.Annotations["openshift.io/display-name"])
+	if project.Annotations[projectapi.ProjectDisplayName] != namespace.Annotations[projectapi.ProjectDisplayName] {
+		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations[projectapi.ProjectDisplayName], namespace.Annotations[projectapi.ProjectDisplayName])
 	}
 	if project.Annotations["openshift.io/node-selector"] != namespace.Annotations["openshift.io/node-selector"] {
 		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations["openshift.io/node-selector"], namespace.Annotations["openshift.io/node-selector"])
@@ -139,4 +143,131 @@ func TestProjectMustExist(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error on creation of a Origin resource because namespace does not exist")
 	}
+}
+
+func TestProjectWatch(t *testing.T) {
+	testutil.RequireEtcd(t)
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	bobClient, _, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "bob")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	w, err := bobClient.Projects().Watch(kapi.ListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-01", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case event := <-w.ResultChan():
+		if event.Type != watch.Added {
+			t.Errorf("expected added, got %v", event)
+		}
+		project := event.Object.(*projectapi.Project)
+		if project.Name != "ns-01" {
+			t.Fatalf("expected %v, got %#v", "ns-01", project)
+		}
+
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	select {
+	case event := <-w.ResultChan():
+		if event.Type != watch.Modified {
+			t.Errorf("expected Modified, got %v", event)
+		}
+		project := event.Object.(*projectapi.Project)
+		if project.Name != "ns-01" {
+			t.Fatalf("expected %v, got %#v", "ns-01", project)
+		}
+		project.Annotations[projectapi.ProjectDisplayName] = "whatever"
+		_, err := bobClient.Projects().Update(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	select {
+	case event := <-w.ResultChan():
+		if event.Type != watch.Modified {
+			t.Errorf("expected Modified, got %v", event)
+		}
+		project := event.Object.(*projectapi.Project)
+		if project.Name != "ns-01" {
+			t.Errorf("expected %v, got %#v", "ns-01", project)
+		}
+		if project.Annotations[projectapi.ProjectDisplayName] != "whatever" {
+			t.Errorf("expected %v, got %#v", "whatever", project)
+		}
+
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+
+	joeClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-02", "joe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	addBob := &policy.RoleModificationOptions{
+		RoleNamespace:       "",
+		RoleName:            bootstrappolicy.EditRoleName,
+		RoleBindingAccessor: policy.NewLocalRoleBindingAccessor("ns-02", joeClient),
+		Users:               []string{"bob"},
+	}
+	if err := addBob.AddRole(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// wait for the add
+	for {
+		select {
+		case event := <-w.ResultChan():
+			project := event.Object.(*projectapi.Project)
+			t.Logf("got %#v %#v", event, project)
+			if event.Type == watch.Added && project.Name == "ns-02" {
+				return
+			}
+
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timeout")
+		}
+	}
+
+	if err := addBob.RemoveRole(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// wait for the delete
+	for {
+		select {
+		case event := <-w.ResultChan():
+			project := event.Object.(*projectapi.Project)
+			t.Logf("got %#v %#v", event, project)
+			if event.Type == watch.Deleted && project.Name == "ns-02" {
+				return
+			}
+
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timeout")
+		}
+	}
+
 }


### PR DESCRIPTION
@jwforres @spadgett Let me know if this is useful to you before I make it fully operable.  This is **not** a normal watch, it is a watch of the project cache.  This means:

 1. You will be notified when a user gains access to a project
 1. You will be notified when a user loses access to a project
 1. You will be notified when a project you have access to changes
 3. You cannot start watching from a resource version.  You always start from "now".
