### PR TITLE
Webhooks: use constant-time string secret comparison

### DIFF
--- a/pkg/build/webhook/generic/generic.go
+++ b/pkg/build/webhook/generic/generic.go
@@ -1,6 +1,7 @@
 package generic
 
 import (
+	"crypto/hmac"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -28,7 +29,7 @@ func (p *WebHookPlugin) Extract(buildCfg *api.BuildConfig, secret, path string, 
 		return
 	}
 	glog.V(4).Infof("Checking if the provided secret for BuildConfig %s/%s matches", buildCfg.Namespace, buildCfg.Name)
-	if trigger.GenericWebHook.Secret != secret {
+	if !hmac.Equal([]byte(trigger.GenericWebHook.Secret), []byte(secret)) {
 		err = webhook.ErrSecretMismatch
 		return
 	}

--- a/pkg/build/webhook/github/github.go
+++ b/pkg/build/webhook/github/github.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"crypto/hmac"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,7 +42,7 @@ func (p *WebHook) Extract(buildCfg *api.BuildConfig, secret, path string, req *h
 		return
 	}
 	glog.V(4).Infof("Checking if the provided secret for BuildConfig %s/%s matches", buildCfg.Namespace, buildCfg.Name)
-	if trigger.GitHubWebHook.Secret != secret {
+	if !hmac.Equal([]byte(trigger.GitHubWebHook.Secret), []byte(secret)) {
 		err = webhook.ErrSecretMismatch
 		return
 	}


### PR DESCRIPTION
For performance reasons, string comparisons in most languages short-circuit at the first non-matching character. Unfortunately, when used for credential verification, this allows an attacker to figure out the actual credentials by trying values and seeing how long it takes for the authorization to fail. To avoid this, we use [the Go-provided `crypto/subtle.ConstantTimeCompare()` function][ConstantTimeCompare].

Fixes #6829.

[ConstantTimeCompare]: https://golang.org/pkg/crypto/subtle/#ConstantTimeCompare