### PR TITLE
suppress query scope issue on member extraction

### DIFF
--- a/pkg/cmd/admin/groups/sync/ad/augmented_ldapinterface.go
+++ b/pkg/cmd/admin/groups/sync/ad/augmented_ldapinterface.go
@@ -27,8 +27,8 @@ func NewAugmentedADLDAPInterface(clientConfig ldapclient.Config,
 	}
 }
 
-// LDAPInterface extracts the member list of an LDAP user entry from an LDAP server
-// with first-class LDAP entries for users and group.  Group membership is on the user. The LDAPInterface is *NOT* thread-safe.
+// AugmentedADLDAPInterface extracts the member list of an LDAP user entry from an LDAP server
+// with first-class LDAP entries for users and group.  Group membership is on the user. The AugmentedADLDAPInterface is *NOT* thread-safe.
 type AugmentedADLDAPInterface struct {
 	*ADLDAPInterface
 
@@ -47,8 +47,8 @@ var _ interfaces.LDAPMemberExtractor = &AugmentedADLDAPInterface{}
 var _ interfaces.LDAPGroupGetter = &AugmentedADLDAPInterface{}
 var _ interfaces.LDAPGroupLister = &AugmentedADLDAPInterface{}
 
-// GroupFor returns an LDAP group entry for the given group UID by searching the internal cache
-// of the LDAPInterface first, then sending an LDAP query if the cache did not contain the entry.
+// GroupEntryFor returns an LDAP group entry for the given group UID by searching the internal cache
+// of the AugmentedADLDAPInterface first, then sending an LDAP query if the cache did not contain the entry.
 // This also satisfies the LDAPGroupGetter interface
 func (e *AugmentedADLDAPInterface) GroupEntryFor(ldapGroupUID string) (*ldap.Entry, error) {
 	group, exists := e.cachedGroups[ldapGroupUID]

--- a/pkg/cmd/admin/groups/sync/cli/rfc2307.go
+++ b/pkg/cmd/admin/groups/sync/cli/rfc2307.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync"
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/interfaces"
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/rfc2307"
+	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/syncerror"
 	"github.com/openshift/origin/pkg/cmd/server/api"
 )
 
@@ -17,6 +18,8 @@ type RFC2307Builder struct {
 	Config       *api.RFC2307Config
 
 	rfc2307LDAPInterface *rfc2307.LDAPInterface
+
+	ErrorHandler syncerror.Handler
 }
 
 func (b *RFC2307Builder) GetGroupLister() (interfaces.LDAPGroupLister, error) {
@@ -58,7 +61,7 @@ func (b *RFC2307Builder) getRFC2307LDAPInterface() (*rfc2307.LDAPInterface, erro
 	}
 	b.rfc2307LDAPInterface = rfc2307.NewLDAPInterface(b.ClientConfig,
 		groupQuery, b.Config.GroupNameAttributes, b.Config.GroupMembershipAttributes,
-		userQuery, b.Config.UserNameAttributes)
+		userQuery, b.Config.UserNameAttributes, b.ErrorHandler)
 	return b.rfc2307LDAPInterface, nil
 }
 

--- a/pkg/cmd/admin/groups/sync/cli/sync.go
+++ b/pkg/cmd/admin/groups/sync/cli/sync.go
@@ -23,6 +23,7 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync"
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/interfaces"
+	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/syncerror"
 	"github.com/openshift/origin/pkg/cmd/server/api"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	"github.com/openshift/origin/pkg/cmd/server/api/validation"
@@ -74,8 +75,7 @@ const (
 var AllowedSourceTypes = []string{string(GroupSyncSourceLDAP), string(GroupSyncSourceOpenShift)}
 
 func ValidateSource(source GroupSyncSource) bool {
-	knownSources := sets.NewString(string(GroupSyncSourceLDAP), string(GroupSyncSourceOpenShift))
-	return knownSources.Has(string(source))
+	return sets.NewString(AllowedSourceTypes...).Has(string(source))
 }
 
 type SyncOptions struct {
@@ -102,6 +102,21 @@ type SyncOptions struct {
 
 	// Out is the writer to write output to
 	Out io.Writer
+}
+
+// CreateErrorHandler creates an error handler for the LDAP sync job
+func (o *SyncOptions) CreateErrorHandler() syncerror.Handler {
+	components := []syncerror.Handler{}
+	if o.Config.RFC2307Config != nil {
+		if o.Config.RFC2307Config.TolerateOutOfScopeMembers {
+			components = append(components, syncerror.NewMemberLookupOutOfBoundsSuppressor(o.Stderr))
+		}
+		if o.Config.RFC2307Config.TolerateMissingMembers {
+			components = append(components, syncerror.NewMemberLookupMemberNotFoundSuppressor(o.Stderr))
+		}
+	}
+
+	return syncerror.NewCompoundHandler(components...)
 }
 
 func NewSyncOptions() *SyncOptions {
@@ -327,7 +342,9 @@ func (o *SyncOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
 		return fmt.Errorf("could not determine LDAP client configuration: %v", err)
 	}
 
-	syncBuilder, err := buildSyncBuilder(clientConfig, o.Config)
+	errorHandler := o.CreateErrorHandler()
+
+	syncBuilder, err := buildSyncBuilder(clientConfig, o.Config, errorHandler)
 	if err != nil {
 		return err
 	}
@@ -399,10 +416,10 @@ func (o *SyncOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
 	return kerrs.NewAggregate(syncErrors)
 }
 
-func buildSyncBuilder(clientConfig ldapclient.Config, syncConfig *api.LDAPSyncConfig) (SyncBuilder, error) {
+func buildSyncBuilder(clientConfig ldapclient.Config, syncConfig *api.LDAPSyncConfig, errorHandler syncerror.Handler) (SyncBuilder, error) {
 	switch {
 	case syncConfig.RFC2307Config != nil:
-		return &RFC2307Builder{ClientConfig: clientConfig, Config: syncConfig.RFC2307Config}, nil
+		return &RFC2307Builder{ClientConfig: clientConfig, Config: syncConfig.RFC2307Config, ErrorHandler: errorHandler}, nil
 	case syncConfig.ActiveDirectoryConfig != nil:
 		return &ADBuilder{ClientConfig: clientConfig, Config: syncConfig.ActiveDirectoryConfig}, nil
 	case syncConfig.AugmentedActiveDirectoryConfig != nil:

--- a/pkg/cmd/admin/groups/sync/syncerror/errors.go
+++ b/pkg/cmd/admin/groups/sync/syncerror/errors.go
@@ -1,4 +1,4 @@
-package interfaces
+package syncerror
 
 import (
 	"fmt"
@@ -18,7 +18,7 @@ func (e *memberLookupError) Error() string {
 	return fmt.Sprintf("membership lookup for user %q in group %q failed because of %q", e.ldapUserUID, e.ldapGroupUID, e.causedBy.Error())
 }
 
-func IsmemberLookupError(e error) bool {
+func IsMemberLookupError(e error) bool {
 	if e == nil {
 		return false
 	}

--- a/pkg/cmd/admin/groups/sync/syncerror/handler.go
+++ b/pkg/cmd/admin/groups/sync/syncerror/handler.go
@@ -1,0 +1,90 @@
+package syncerror
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+)
+
+// Handler knows how to handle errors
+type Handler interface {
+	// HandleError processess an error without mutating it. If the error is determined to be fatal,
+	// a non-nil error should be returned.
+	HandleError(err error) (handled bool, fatalError error)
+}
+
+func NewCompoundHandler(handlers ...Handler) Handler {
+	return &compoundHandler{handlers: handlers}
+}
+
+// compoundHandler chains other error handlers
+type compoundHandler struct {
+	handlers []Handler
+}
+
+// HandleError asks each of the handlers to handle the error. If any handler decides the error is fatal or handles it,
+// the chain is broken.
+func (h *compoundHandler) HandleError(err error) (bool, error) {
+	for _, handler := range h.handlers {
+		handled, handleErr := handler.HandleError(err)
+		if handled || handleErr != nil {
+			return handled, handleErr
+		}
+	}
+
+	return false, nil
+}
+
+func NewMemberLookupOutOfBoundsSuppressor(err io.Writer) Handler {
+	return &memberLookupOutOfBoundsSuppressor{err: err}
+}
+
+// memberLookupOutOfBoundsSuppressor suppresses member lookup errors caused by a search trying to go out of the base DN bounds
+type memberLookupOutOfBoundsSuppressor struct {
+	// err determines where a log message will be printed
+	err io.Writer
+}
+
+// HandleError suppresses member lookup errors caused by out-of-bounds queries,
+func (h *memberLookupOutOfBoundsSuppressor) HandleError(err error) (bool, error) {
+	memberLookupError, isMemberLookupError := err.(*memberLookupError)
+	if !isMemberLookupError {
+		return false, nil
+	}
+
+	if ldaputil.IsQueryOutOfBoundsError(memberLookupError.causedBy) {
+		fmt.Fprintf(h.err, "For group %q, ignoring member %q: %v\n", memberLookupError.ldapGroupUID, memberLookupError.ldapUserUID, memberLookupError.causedBy)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func NewMemberLookupMemberNotFoundSuppressor(err io.Writer) Handler {
+	return &memberLookupMemberNotFoundSuppressor{err: err}
+}
+
+// memberLookupMemberNotFoundSuppressor supresses member lookup errors caused by a search returning no valid entries,
+// which can happen in two ways:
+//   - if the search is not by DN, an empty result list is returned
+//   - if the search is by DN, an error is returned from the LDAP server: no such object
+type memberLookupMemberNotFoundSuppressor struct {
+	// err determines where a log message will be printed
+	err io.Writer
+}
+
+// HandleError suppresses member lookup errors caused by no such object or entry not found errors,
+func (h *memberLookupMemberNotFoundSuppressor) HandleError(err error) (bool, error) {
+	memberLookupError, isMemberLookupError := err.(*memberLookupError)
+	if !isMemberLookupError {
+		return false, nil
+	}
+
+	if ldaputil.IsEntryNotFoundError(memberLookupError.causedBy) || ldaputil.IsNoSuchObjectError(memberLookupError.causedBy) {
+		fmt.Fprintf(h.err, "For group %q, ignoring member %q: %v\n", memberLookupError.ldapGroupUID, memberLookupError.ldapUserUID, memberLookupError.causedBy)
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/cmd/admin/groups/sync/syncerror/handler_test.go
+++ b/pkg/cmd/admin/groups/sync/syncerror/handler_test.go
@@ -1,0 +1,110 @@
+package syncerror
+
+import (
+	"errors"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/origin/pkg/auth/ldaputil"
+)
+
+func TestSuppressMemberLookupErrorOutOfBounds(t *testing.T) {
+	var testCases = []struct {
+		name               string
+		err                error
+		expectedHandled    bool
+		expectedFatalError error
+	}{
+		{
+			name:               "nil error",
+			err:                nil,
+			expectedHandled:    false,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "other error",
+			err:                errors.New("generic error"),
+			expectedHandled:    false,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "non-out-of-bounds member lookup error",
+			err:                NewMemberLookupError("", "", nil),
+			expectedHandled:    false,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "out-of-bounds member lookup error",
+			err:                NewMemberLookupError("", "", ldaputil.NewQueryOutOfBoundsError("", "")),
+			expectedHandled:    true,
+			expectedFatalError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		handler := NewMemberLookupOutOfBoundsSuppressor(ioutil.Discard)
+
+		actualHandled, actualFatalErr := handler.HandleError(testCase.err)
+		if actualHandled != testCase.expectedHandled {
+			t.Errorf("%s: handler did not handle as expected: wanted handled=%t, got handled=%t", testCase.name, testCase.expectedHandled, actualHandled)
+		}
+
+		if !reflect.DeepEqual(actualFatalErr, testCase.expectedFatalError) {
+			t.Errorf("%s: handler did not return correct error:\n\twanted\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedFatalError, actualFatalErr)
+		}
+	}
+}
+
+func TestSuppressMemberLookupErrorMemberNotFound(t *testing.T) {
+	var testCases = []struct {
+		name               string
+		err                error
+		expectedHandled    bool
+		expectedFatalError error
+	}{
+		{
+			name:               "nil error",
+			err:                nil,
+			expectedHandled:    false,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "other error",
+			err:                errors.New("generic error"),
+			expectedHandled:    false,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "non-member-not-found member lookup error",
+			err:                NewMemberLookupError("", "", nil),
+			expectedHandled:    false,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "no such object member lookup error",
+			err:                NewMemberLookupError("", "", ldaputil.NewNoSuchObjectError("")),
+			expectedHandled:    true,
+			expectedFatalError: nil,
+		},
+		{
+			name:               "member not found member lookup error",
+			err:                NewMemberLookupError("", "", ldaputil.NewEntryNotFoundError("", "")),
+			expectedHandled:    true,
+			expectedFatalError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		handler := NewMemberLookupMemberNotFoundSuppressor(ioutil.Discard)
+
+		actualHandled, actualFatalErr := handler.HandleError(testCase.err)
+		if actualHandled != testCase.expectedHandled {
+			t.Errorf("%s: handler did not handle as expected: wanted handled=%t, got handled=%t", testCase.name, testCase.expectedHandled, actualHandled)
+		}
+
+		if !reflect.DeepEqual(actualFatalErr, testCase.expectedFatalError) {
+			t.Errorf("%s: handler did not return correct error:\n\twanted\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedFatalError, actualFatalErr)
+		}
+	}
+}

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -927,6 +927,21 @@ type RFC2307Config struct {
 	// UserNameAttributes defines which attributes on an LDAP user entry will be interpreted as its OpenShift user name.
 	// This should match your PreferredUsername setting for your LDAPPasswordIdentityProvider
 	UserNameAttributes []string
+
+	// TolerateMissingMembers determines the behavior of the LDAP sync job when missing user entries are
+	// encountered. If 'true', an LDAP query for users that doesn't find any will be tolerated and an only
+	// and error will be logged. If 'false', the LDAP sync job will fail if a query for users doesn't find
+	// any. The default value is 'false'. Misconfigured LDAP sync jobs with this flag set to 'true' can cause
+	// group membership to be removed, so it is recommended to use this flag with caution.
+	TolerateMissingMembers bool
+
+	// TolerateOutOfScopeMembers determines the behavior of the LDAP sync job when out-of-scope user entries
+	// are encountered. If 'true', an LDAP query for a user that falls outside of the base DN given for the all
+	// user query will be tolerated and only an error will be logged. If 'false', the LDAP sync job will fail
+	// if a user query would search outside of the base DN specified by the all user query. Misconfigured LDAP
+	// sync jobs with this flag set to 'true' can result in groups missing users, so it is recommended to use
+	// this flag with caution.
+	TolerateOutOfScopeMembers bool
 }
 
 type ActiveDirectoryConfig struct {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -879,6 +879,21 @@ type RFC2307Config struct {
 	// UserNameAttributes defines which attributes on an LDAP user entry will be used, in order, as its OpenShift user name.
 	// The first attribute with a non-empty value is used. This should match your PreferredUsername setting for your LDAPPasswordIdentityProvider
 	UserNameAttributes []string `json:"userNameAttributes"`
+
+	// TolerateMissingMembers determines the behavior of the LDAP sync job when missing user entries are
+	// encountered. If 'true', an LDAP query for users that doesn't find any will be tolerated and an only
+	// and error will be logged. If 'false', the LDAP sync job will fail if a query for users doesn't find
+	// any. The default value is 'false'. Misconfigured LDAP sync jobs with this flag set to 'true' can cause
+	// group membership to be removed, so it is recommended to use this flag with caution.
+	TolerateMissingMembers bool `json:"tolerateMissingMembers"`
+
+	// TolerateOutOfScopeMembers determines the behavior of the LDAP sync job when out-of-scope user entries
+	// are encountered. If 'true', an LDAP query for a user that falls outside of the base DN given for the all
+	// user query will be tolerated and only an error will be logged. If 'false', the LDAP sync job will fail
+	// if a user query would search outside of the base DN specified by the all user query. Misconfigured LDAP
+	// sync jobs with this flag set to 'true' can result in groups missing users, so it is recommended to use
+	// this flag with caution.
+	TolerateOutOfScopeMembers bool `json:"tolerateOutOfScopeMembers"`
 }
 
 type ActiveDirectoryConfig struct {

--- a/test/extended/authentication/ldap/rfc2307/sync-config-tolerating.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-tolerating.yaml
@@ -1,0 +1,22 @@
+kind: LDAPSyncConfig
+apiVersion: v1
+url: ldap://LDAP_SERVICE_IP:389
+insecure: true
+rfc2307:
+    groupsQuery:
+        baseDN: "ou=groups,ou=incomplete-rfc2307,dc=example,dc=com"
+        scope: sub
+        derefAliases: never
+        filter: (objectclass=groupOfNames)
+    groupUIDAttribute: dn
+    groupNameAttributes: [ cn ]
+    groupMembershipAttributes: [ member ]
+    usersQuery:
+        baseDN: "ou=people,ou=rfc2307,dc=example,dc=com"
+        scope: sub
+        derefAliases: never
+        filter: (objectclass=inetOrgPerson)
+    userUIDAttribute: dn
+    userNameAttributes: [ mail ]
+    tolerateMissingMembers: true
+    tolerateOutOfScopeMembers: true

--- a/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_tolerating.yaml
+++ b/test/extended/authentication/ldap/rfc2307/valid_all_ldap_sync_tolerating.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group1,ou=groups,ou=incomplete-rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group1
+users:
+- person1smith@example.com
+- person2smith@example.com
+- person3smith@example.com
+- person4smith@example.com
+- person5smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group2,ou=groups,ou=incomplete-rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group2
+users:
+- person1smith@example.com
+- person2smith@example.com
+- person3smith@example.com
+apiVersion: v1
+kind: Group
+metadata:
+  annotations:
+    openshift.io/ldap.uid: cn=group3,ou=groups,ou=incomplete-rfc2307,dc=example,dc=com
+    openshift.io/ldap.url: LDAP_SERVICE_IP:389
+  creationTimestamp: null
+  labels:
+    openshift.io/ldap.host: LDAP_SERVICE_IP
+  name: group3
+users:
+- person1smith@example.com
+- person5smith@example.com

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -229,6 +229,17 @@ for (( i=0; i<${#schema[@]}; i++ )); do
     popd > /dev/null
 done
 
+# special test for RFC2307
+pushd ${BASETMPDIR}/rfc2307 > /dev/null
+echo -e "\tTEST: Sync groups from LDAP server, tolerating errors"
+oadm groups sync --sync-config=sync-config-tolerating.yaml --confirm 2>"${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group1,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=INVALID,ou=people,ou=rfc2307,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group2,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=OUTOFSCOPE,ou=people,ou=OUTOFSCOPE,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group3,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=INVALID,ou=people,ou=rfc2307,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group3,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=OUTOFSCOPE,ou=people,ou=OUTOFSCOPE,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+compare_and_cleanup valid_all_ldap_sync_tolerating.yaml		
+popd > /dev/null
+
 # special test for augmented-ad
 pushd ${BASETMPDIR}/augmented-ad > /dev/null
 echo -e "\tTEST: Sync all LDAP groups from LDAP server, remove LDAP group metadata entry, then prune OpenShift groups"


### PR DESCRIPTION
This PR changes behavior for LDAP sync to suppress out-of-scope query errors when extracting members using DN and RFC2307 schema. 

Do we need to explicitly mention this behavior in docs?
Do we want to add a spurious user to our `ldif` artifacts to test this? Do we have the gitserver to do that in a sane way?

@deads2k PTAL

/cc https://bugzilla.redhat.com/show_bug.cgi?id=1297798