### PR TITLE
[WIP] SCC fields for AllowNodeName and AllowNodeSelector

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/deep_copy_generated.go
@@ -2113,6 +2113,8 @@ func deepCopy_api_SecurityContextConstraints(in SecurityContextConstraints, out 
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	out.AllowNodeName = in.AllowNodeName
+	out.AllowNodeSelector = in.AllowNodeSelector
 	if err := deepCopy_api_SELinuxContextStrategyOptions(in.SELinuxContext, &out.SELinuxContext, c); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/types.go
@@ -2194,6 +2194,10 @@ type SecurityContextConstraints struct {
 	AllowHostPID bool
 	// AllowHostIPC determines if the policy allows host ipc in the containers.
 	AllowHostIPC bool
+	// AllowNodeName determines if policy allows setting nodeName in the pod spec.
+	AllowNodeName bool
+	// AllowNodeSelector determines if policy allows setting nodeSelector in the pod spec.
+	AllowNodeSelector bool
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
 	SELinuxContext SELinuxContextStrategyOptions
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/conversion_generated.go
@@ -2760,6 +2760,8 @@ func convert_api_SecurityContextConstraints_To_v1_SecurityContextConstraints(in 
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	out.AllowNodeName = &in.AllowNodeName
+	out.AllowNodeSelector = &in.AllowNodeSelector
 	if err := convert_api_SELinuxContextStrategyOptions_To_v1_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}
@@ -5796,6 +5798,12 @@ func convert_v1_SecurityContextConstraints_To_api_SecurityContextConstraints(in 
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	if in.AllowNodeName != nil {
+		out.AllowNodeName = *in.AllowNodeName
+	}
+	if in.AllowNodeSelector != nil {
+		out.AllowNodeSelector = *in.AllowNodeSelector
+	}
 	if err := convert_v1_SELinuxContextStrategyOptions_To_api_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/deep_copy_generated.go
@@ -2160,6 +2160,18 @@ func deepCopy_v1_SecurityContextConstraints(in SecurityContextConstraints, out *
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	if in.AllowNodeName != nil {
+		out.AllowNodeName = new(bool)
+		*out.AllowNodeName = *in.AllowNodeName
+	} else {
+		out.AllowNodeName = nil
+	}
+	if in.AllowNodeSelector != nil {
+		out.AllowNodeSelector = new(bool)
+		*out.AllowNodeSelector = *in.AllowNodeSelector
+	} else {
+		out.AllowNodeSelector = nil
+	}
 	if err := deepCopy_v1_SELinuxContextStrategyOptions(in.SELinuxContext, &out.SELinuxContext, c); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults.go
@@ -303,4 +303,12 @@ func defaultSecurityContextConstraints(scc *SecurityContextConstraints) {
 	if len(scc.SupplementalGroups.Type) == 0 {
 		scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
 	}
+	if scc.AllowNodeName == nil {
+		scc.AllowNodeName = new(bool)
+		*scc.AllowNodeName = true
+	}
+	if scc.AllowNodeSelector == nil {
+		scc.AllowNodeSelector = new(bool)
+		*scc.AllowNodeSelector = true
+	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/defaults_test.go
@@ -569,11 +569,19 @@ func TestSetDefaultProbe(t *testing.T) {
 	}
 }
 
+func newBool(b bool) *bool {
+	ptr := new(bool)
+	ptr = &b
+	return ptr
+}
+
 func TestDefaultSecurityContextConstraints(t *testing.T) {
 	tests := map[string]struct {
-		scc              *versioned.SecurityContextConstraints
-		expectedFSGroup  versioned.FSGroupStrategyType
-		expectedSupGroup versioned.SupplementalGroupsStrategyType
+		scc                       *versioned.SecurityContextConstraints
+		expectedFSGroup           versioned.FSGroupStrategyType
+		expectedSupGroup          versioned.SupplementalGroupsStrategyType
+		expectedAllowNodeName     bool
+		expectedAllowNodeSelector bool
 	}{
 		"shouldn't default": {
 			scc: &versioned.SecurityContextConstraints{
@@ -583,9 +591,13 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 				SupplementalGroups: versioned.SupplementalGroupsStrategyOptions{
 					Type: versioned.SupplementalGroupsStrategyMustRunAs,
 				},
+				AllowNodeSelector: newBool(false),
+				AllowNodeName:     newBool(false),
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedFSGroup:           versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedAllowNodeSelector: false,
+			expectedAllowNodeName:     false,
 		},
 		"default fsgroup runAsAny": {
 			scc: &versioned.SecurityContextConstraints{
@@ -596,8 +608,10 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 					Type: versioned.SupplementalGroupsStrategyMustRunAs,
 				},
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyRunAsAny,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedFSGroup:           versioned.FSGroupStrategyRunAsAny,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedAllowNodeSelector: true,
+			expectedAllowNodeName:     true,
 		},
 		"default sup group runAsAny": {
 			scc: &versioned.SecurityContextConstraints{
@@ -608,8 +622,10 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 					Type: versioned.FSGroupStrategyMustRunAs,
 				},
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
+			expectedFSGroup:           versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyRunAsAny,
+			expectedAllowNodeSelector: true,
+			expectedAllowNodeName:     true,
 		},
 		"default fsgroup runAsAny with mustRunAs UID strat": {
 			scc: &versioned.SecurityContextConstraints{
@@ -620,8 +636,10 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 					Type: versioned.SupplementalGroupsStrategyMustRunAs,
 				},
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyRunAsAny,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedFSGroup:           versioned.FSGroupStrategyRunAsAny,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyMustRunAs,
+			expectedAllowNodeSelector: true,
+			expectedAllowNodeName:     true,
 		},
 		"default sup group runAsAny with mustRunAs UID strat": {
 			scc: &versioned.SecurityContextConstraints{
@@ -632,8 +650,28 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 					Type: versioned.FSGroupStrategyMustRunAs,
 				},
 			},
-			expectedFSGroup:  versioned.FSGroupStrategyMustRunAs,
-			expectedSupGroup: versioned.SupplementalGroupsStrategyRunAsAny,
+			expectedFSGroup:           versioned.FSGroupStrategyMustRunAs,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyRunAsAny,
+			expectedAllowNodeSelector: true,
+			expectedAllowNodeName:     true,
+		},
+		"default all except with AllowNodeSelector disabled": {
+			scc: &versioned.SecurityContextConstraints{
+				AllowNodeSelector: newBool(false),
+			},
+			expectedFSGroup:           versioned.FSGroupStrategyRunAsAny,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyRunAsAny,
+			expectedAllowNodeSelector: false,
+			expectedAllowNodeName:     true,
+		},
+		"default all except with AllowNodeName disabled": {
+			scc: &versioned.SecurityContextConstraints{
+				AllowNodeName: newBool(false),
+			},
+			expectedFSGroup:           versioned.FSGroupStrategyRunAsAny,
+			expectedSupGroup:          versioned.SupplementalGroupsStrategyRunAsAny,
+			expectedAllowNodeSelector: true,
+			expectedAllowNodeName:     false,
 		},
 	}
 	for k, v := range tests {
@@ -645,6 +683,12 @@ func TestDefaultSecurityContextConstraints(t *testing.T) {
 		}
 		if scc.SupplementalGroups.Type != v.expectedSupGroup {
 			t.Errorf("%s has invalid supplemental group.  Expected: %v got: %v", k, v.expectedSupGroup, scc.SupplementalGroups.Type)
+		}
+		if *scc.AllowNodeSelector != v.expectedAllowNodeSelector {
+			t.Errorf("%s has invalid AllowNodeSelector. Expected: %t got: %t", k, v.expectedAllowNodeSelector, *scc.AllowNodeSelector)
+		}
+		if *scc.AllowNodeName != v.expectedAllowNodeName {
+			t.Errorf("%s has invalid AllowNodeName. Expected: %t got: %t", k, v.expectedAllowNodeName, *scc.AllowNodeName)
 		}
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -2651,6 +2651,10 @@ type SecurityContextConstraints struct {
 	AllowHostPID bool `json:"allowHostPID" description:"allow the use of the host pid in the containers"`
 	// AllowHostIPC determines if the policy allows host ipc in the containers.
 	AllowHostIPC bool `json:"allowHostIPC" description:"allow the use of the host ipc in the containers"`
+	// AllowNodeName determines if policy allows setting nodeName in the pod spec.
+	AllowNodeName *bool `json:"allowNodeName" description:"allow the use of the nodeName specifier in the pod spec"`
+	// AllowNodeSelector determines if policy allows setting nodeSelector in the pod spec.
+	AllowNodeSelector *bool `json:"allowNodeSelector" description:"allow the use of the nodeSelector in the pod spec"`
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/conversion_generated.go
@@ -2132,6 +2132,8 @@ func convert_api_SecurityContextConstraints_To_v1beta3_SecurityContextConstraint
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	out.AllowNodeName = &in.AllowNodeName
+	out.AllowNodeSelector = &in.AllowNodeSelector
 	if err := convert_api_SELinuxContextStrategyOptions_To_v1beta3_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}
@@ -4482,6 +4484,12 @@ func convert_v1beta3_SecurityContextConstraints_To_api_SecurityContextConstraint
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	if in.AllowNodeName != nil {
+		out.AllowNodeName = *in.AllowNodeName
+	}
+	if in.AllowNodeSelector != nil {
+		out.AllowNodeSelector = *in.AllowNodeSelector
+	}
 	if err := convert_v1beta3_SELinuxContextStrategyOptions_To_api_SELinuxContextStrategyOptions(&in.SELinuxContext, &out.SELinuxContext, s); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/deep_copy_generated.go
@@ -2131,6 +2131,18 @@ func deepCopy_v1beta3_SecurityContextConstraints(in SecurityContextConstraints, 
 	out.AllowHostPorts = in.AllowHostPorts
 	out.AllowHostPID = in.AllowHostPID
 	out.AllowHostIPC = in.AllowHostIPC
+	if in.AllowNodeName != nil {
+		out.AllowNodeName = new(bool)
+		*out.AllowNodeName = *in.AllowNodeName
+	} else {
+		out.AllowNodeName = nil
+	}
+	if in.AllowNodeSelector != nil {
+		out.AllowNodeSelector = new(bool)
+		*out.AllowNodeSelector = *in.AllowNodeSelector
+	} else {
+		out.AllowNodeSelector = nil
+	}
 	if err := deepCopy_v1beta3_SELinuxContextStrategyOptions(in.SELinuxContext, &out.SELinuxContext, c); err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/defaults.go
@@ -231,4 +231,12 @@ func defaultSecurityContextConstraints(scc *SecurityContextConstraints) {
 	if len(scc.SupplementalGroups.Type) == 0 {
 		scc.SupplementalGroups.Type = SupplementalGroupsStrategyRunAsAny
 	}
+	if scc.AllowNodeName == nil {
+		scc.AllowNodeName = new(bool)
+		*scc.AllowNodeName = true
+	}
+	if scc.AllowNodeSelector == nil {
+		scc.AllowNodeSelector = new(bool)
+		*scc.AllowNodeSelector = true
+	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/v1beta3/types.go
@@ -2113,6 +2113,10 @@ type SecurityContextConstraints struct {
 	AllowHostPID bool `json:"allowHostPID" description:"allow the use of the host pid in the containers"`
 	// AllowHostIPC determines if the policy allows host ipc in the containers.
 	AllowHostIPC bool `json:"allowHostIPC" description:"allow the use of the host ipc in the containers"`
+	// AllowNodeName determines if policy allows setting nodeName in the pod spec.
+	AllowNodeName *bool `json:"allowNodeName" description:"allow the use of the nodeName specifier in the pod spec"`
+	// AllowNodeSelector determines if policy allows setting nodeSelector in the pod spec.
+	AllowNodeSelector *bool `json:"allowNodeSelector" description:"allow the use of the nodeSelector in the pod spec"`
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider.go
@@ -251,6 +251,18 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 		}
 	}
 
+	if !s.scc.AllowNodeName {
+		if pod.Spec.NodeName != "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeName"), pod.Spec.NodeName, "Node Names are not allowed to be used"))
+		}
+	}
+
+	if !s.scc.AllowNodeSelector {
+		if pod.Spec.NodeSelector != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeName"), pod.Spec.NodeSelector, "Node Selectors are not allowed to be used"))
+		}
+	}
+
 	if !s.scc.AllowHostNetwork && pod.Spec.SecurityContext.HostNetwork {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostNetwork"), pod.Spec.SecurityContext.HostNetwork, "Host network is not allowed to be used"))
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/securitycontextconstraints/provider_test.go
@@ -316,6 +316,16 @@ func TestValidateContainerSecurityContextFailures(t *testing.T) {
 	failHostPortPod := defaultPod()
 	failHostPortPod.Spec.Containers[0].Ports = []api.ContainerPort{{HostPort: 1}}
 
+	failAllowNodeNameSCC := defaultSCC()
+	failAllowNodeNameSCC.AllowNodeName = false
+	failAllowNodeNamePod := defaultPod()
+	failAllowNodeNamePod.Spec.NodeName = "bad node name"
+
+	failAllowNodeSelectorSCC := defaultSCC()
+	failAllowNodeSelectorSCC.AllowNodeSelector = false
+	failAllowNodeSelectorPod := defaultPod()
+	failAllowNodeSelectorPod.Spec.NodeSelector = map[string]string{"badlabel": "badvalue"}
+
 	errorCases := map[string]struct {
 		pod           *api.Pod
 		scc           *api.SecurityContextConstraints
@@ -350,6 +360,16 @@ func TestValidateContainerSecurityContextFailures(t *testing.T) {
 			pod:           failHostPortPod,
 			scc:           defaultSCC(),
 			expectedError: "Host ports are not allowed to be used",
+		},
+		"failAllowNodeNameSCC": {
+			pod:           failAllowNodeNamePod,
+			scc:           failAllowNodeNameSCC,
+			expectedError: "Node Names are not allowed to be used",
+		},
+		"failAllowNodeSelectorSCC": {
+			pod:           failAllowNodeSelectorPod,
+			scc:           failAllowNodeSelectorSCC,
+			expectedError: "Node Selectors are not allowed to be used",
 		},
 	}
 

--- a/api/swagger-spec/api-v1.json
+++ b/api/swagger-spec/api-v1.json
@@ -16283,7 +16283,9 @@
      "allowHostNetwork",
      "allowHostPorts",
      "allowHostPID",
-     "allowHostIPC"
+     "allowHostIPC",
+     "allowNodeName",
+     "allowNodeSelector"
     ],
     "properties": {
      "kind": {
@@ -16346,6 +16348,14 @@
      "allowHostIPC": {
       "type": "boolean",
       "description": "allow the use of the host ipc in the containers"
+     },
+     "allowNodeName": {
+      "type": "boolean",
+      "description": "allow the use of the nodeName specifier in the pod spec"
+     },
+     "allowNodeSelector": {
+      "type": "boolean",
+      "description": "allow the use of the nodeSelector in the pod spec"
      },
      "seLinuxContext": {
       "$ref": "v1.SELinuxContextStrategyOptions",

--- a/docs/proposals/security-context-constraints.md
+++ b/docs/proposals/security-context-constraints.md
@@ -90,6 +90,10 @@ type SecurityContextConstraints struct {
 	AllowedCapabilities []CapabilityType `json:"allowedCapabilities,omitempty" description:"capabilities that are allowed to be added"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	AllowHostDirVolumePlugin bool `json:"allowHostDirVolumePlugin,omitempty" description:"allow the use of the host dir volume plugin"`
+	// AllowNodeName determines if policy allows setting nodeName in the pod spec.
+	AllowNodeName bool `json:"allowNodeName" description:"allow the use of the nodeName specifier in the pod spec"`
+	// AllowNodeSelector determines if policy allows setting nodeSelector in the pod spec.
+	AllowNodeSelector bool `json:"allowNodeSelector" description:"allow the use of the nodeSelector in the pod spec"`
 	// SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
 	SELinuxContext SELinuxContextStrategyOptions `json:"seLinuxContext,omitempty" description:"strategy used to generate SELinuxOptions"`
 	// RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -63,6 +63,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			AllowHostPorts:           true,
 			AllowHostPID:             true,
 			AllowHostIPC:             true,
+			AllowNodeName:            true,
+			AllowNodeSelector:        true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				Type: kapi.SELinuxStrategyRunAsAny,
 			},
@@ -85,6 +87,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintNonRootDesc,
 				},
 			},
+			AllowNodeName:     true,
+			AllowNodeSelector: true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -113,6 +117,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				},
 			},
 			AllowHostDirVolumePlugin: true,
+			AllowNodeName:            true,
+			AllowNodeSelector:        true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -146,6 +152,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			AllowHostPorts:           true,
 			AllowHostPID:             true,
 			AllowHostIPC:             true,
+			AllowNodeName:            true,
+			AllowNodeSelector:        true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -173,6 +181,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintRestrictedDesc,
 				},
 			},
+			AllowNodeName:     true,
+			AllowNodeSelector: true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
@@ -200,6 +210,8 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintsAnyUIDDesc,
 				},
 			},
+			AllowNodeName:     true,
+			AllowNodeSelector: true,
 			SELinuxContext: kapi.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy


### PR DESCRIPTION
Implement https://trello.com/c/cGz8l1zD via SCCs

Adds two new fields to `SecurityContextConstraints` type: `AllowNodeName` and `AllowNodeSelector`
