### PR TITLE
Web console: editing compute resource limits

### DIFF
--- a/assets/app/index.html
+++ b/assets/app/index.html
@@ -130,6 +130,7 @@
         <script src="scripts/services/metrics.js"></script>
         <script src="scripts/services/storage.js"></script>
         <script src="scripts/services/constants.js"></script>
+        <script src="scripts/services/limits.js"></script>
         <script src="scripts/controllers/projects.js"></script>
         <script src="scripts/controllers/pods.js"></script>
         <script src="scripts/controllers/pod.js"></script>
@@ -149,6 +150,7 @@
         <script src="scripts/controllers/route.js"></script>
         <script src="scripts/controllers/storage.js"></script>
         <script src="scripts/controllers/persistentVolumeClaim.js"></script>
+        <script src="scripts/controllers/setLimits.js"></script>
         <script src="scripts/controllers/edit/buildConfig.js"></script>
         <script src="scripts/controllers/create/createFromImage.js"></script>
         <script src="scripts/controllers/create/nextSteps.js"></script>
@@ -196,6 +198,7 @@
         <script src="scripts/directives/podStatusChart.js"></script>
         <script src="scripts/directives/quotaUsageChart.js"></script>
         <script src="scripts/directives/buildTrendsChart.js"></script>
+        <script src="scripts/directives/editRequestLimit.js"></script>
         <script src="scripts/filters/date.js"></script>
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/util.js"></script>

--- a/assets/app/scripts/app.js
+++ b/assets/app/scripts/app.js
@@ -240,6 +240,10 @@ angular
         templateUrl: 'views/create/nextSteps.html',
         controller: 'NextStepsController'
       })
+      .when('/project/:project/set-limits', {
+        templateUrl: 'views/set-limits.html',
+        controller: 'SetLimitsController'
+      })
       .when('/about', {
         templateUrl: 'views/about.html',
         controller: 'AboutController'
@@ -265,6 +269,7 @@ angular
   .constant("AUTH_CFG", angular.extend({}, (window.OPENSHIFT_CONFIG || {}).auth))
   .constant("LOGGING_URL", (window.OPENSHIFT_CONFIG || {}).loggingURL)
   .constant("METRICS_URL", (window.OPENSHIFT_CONFIG || {}).metricsURL)
+  .constant("LIMIT_REQUEST_OVERRIDES", _.get(window.OPENSHIFT_CONFIG, "limitRequestOverrides", {}))
   // Sometimes we need to know the css breakpoints, make sure to update this
   // if they ever change!
   .constant("BREAKPOINTS", {

--- a/assets/app/scripts/constants.js
+++ b/assets/app/scripts/constants.js
@@ -14,6 +14,7 @@ window.OPENSHIFT_CONSTANTS = {
     "deployment-operations":   "https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html#build-and-deployment-cli-operations",
     "route-types":             "https://docs.openshift.org/latest/architecture/core_concepts/routes.html#route-types",
     "persistent_volumes":      "https://docs.openshift.org/latest/dev_guide/persistent_volumes.html",
+    "compute_resources":       "https://docs.openshift.org/latest/dev_guide/compute_resources.html",
     "default":                 "https://docs.openshift.org/latest/welcome/index.html"
   },
   // Maps links names to URL's where the CLI tools can be downloaded, may point directly to files or to external pages in a CDN, for example.

--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('DeploymentController', function ($scope, $routeParams, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter) {
+  .controller('DeploymentController', function ($scope, $routeParams, AlertMessageService, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter) {
     $scope.projectName = $routeParams.project;
     $scope.deployment = null;
     $scope.deploymentConfig = null;
@@ -46,6 +46,12 @@ angular.module('openshiftConsole')
     }
 
     $scope.logOptions = {};
+
+    // get and clear any alerts
+    AlertMessageService.getAlerts().forEach(function(alert) {
+      $scope.alerts[alert.name] = alert.data;
+    });
+    AlertMessageService.clearAlerts();
 
     var watches = [];
 

--- a/assets/app/scripts/controllers/deploymentConfig.js
+++ b/assets/app/scripts/controllers/deploymentConfig.js
@@ -7,7 +7,7 @@
  * Controller of the openshiftConsole
  */
 angular.module('openshiftConsole')
-  .controller('DeploymentConfigController', function ($scope, $routeParams, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter, LabelFilter) {
+  .controller('DeploymentConfigController', function ($scope, $routeParams, AlertMessageService, DataService, ProjectsService, DeploymentsService, ImageStreamResolver, $filter, LabelFilter) {
     $scope.projectName = $routeParams.project;
     $scope.deploymentConfig = null;
     $scope.deployments = {};
@@ -40,6 +40,12 @@ angular.module('openshiftConsole')
       $scope.selectedTab = {};
       $scope.selectedTab[$routeParams.tab] = true;
     }
+
+    // get and clear any alerts
+    AlertMessageService.getAlerts().forEach(function(alert) {
+      $scope.alerts[alert.name] = alert.data;
+    });
+    AlertMessageService.clearAlerts();
 
     var watches = [];
 

--- a/assets/app/scripts/controllers/setLimits.js
+++ b/assets/app/scripts/controllers/setLimits.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreateRouteController
+ * @description
+ * # CreateRouteController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('SetLimitsController', function ($filter, $location, $parse, $routeParams, $scope, AlertMessageService, DataService, LimitRangesService, Navigate, ProjectsService) {
+    if ($routeParams.dcName && $routeParams.rcName) {
+      Navigate.toErrorPage("Replication controller and deployment config can't both be provided.");
+    }
+
+    $scope.hideCPU = LimitRangesService.hideCPUComputeResources();
+
+    var type, displayName;
+    if ($routeParams.dcName) {
+      type = "deploymentconfigs";
+      $scope.name = $routeParams.dcName;
+      displayName = 'Deployment Configuration "' + $scope.name + '"';
+      $scope.resourceURL = Navigate.resourceURL($scope.name, "DeploymentConfig", $routeParams.project);
+    } else if ($routeParams.rcName) {
+      type = "replicationcontrollers";
+      $scope.name = $routeParams.rcName;
+      displayName = 'Replication Controller "' + $scope.name + '"';
+      $scope.resourceURL = Navigate.resourceURL($scope.name, "ReplicationController", $routeParams.project);
+      $scope.showPodWarning = true;
+    } else {
+      Navigate.toErrorPage("A replication controller or deployment config must be provided.");
+    }
+
+    $scope.alerts = {};
+    $scope.renderOptions = {
+      hideFilterWidget: true
+    };
+
+    $scope.breadcrumbs = [{
+      title: $routeParams.project,
+      link: "project/" + $routeParams.project
+    }, {
+      title: "Deployments",
+      link: "project/" + $routeParams.project + "/browse/deployments"
+    }, {
+      title: $scope.name,
+      link: $scope.resourceURL
+    }, {
+      title: "Set Resource Limits"
+    }];
+
+    var getErrorDetails = $filter('getErrorDetails');
+
+    var displayError = function(errorMessage, errorDetails) {
+      $scope.alerts['set-compute-limits'] = {
+        type: "error",
+        message: errorMessage,
+        details: errorDetails
+      };
+    };
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        DataService.get(type, $scope.name, context).then(
+          function(result) {
+            var resource = angular.copy(result);
+            $scope.containers = _.get(resource, 'spec.template.spec.containers');
+            $scope.save = function() {
+              $scope.disableInputs = true;
+              DataService.update(type, $scope.name, resource, context).then(
+                function() {
+                  AlertMessageService.addAlert({
+                    name: $scope.name,
+                    data: {
+                      type: "success",
+                      message: displayName + " was updated."
+                    }
+                  });
+                  $location.url($scope.resourceURL);
+                },
+                function(result) {
+                  $scope.disableInputs = false;
+                  displayError(displayName + ' could not be updated.', getErrorDetails(result));
+                });
+            };
+          },
+          function(result) {
+            displayError(displayName + ' could not be loaded.', getErrorDetails(result));
+          }
+        );
+
+        var validatePodLimits = function() {
+          if (!$scope.hideCPU) {
+            $scope.cpuProblems = LimitRangesService.validatePodLimits($scope.limitRanges, 'cpu', $scope.containers);
+          }
+          $scope.memoryProblems = LimitRangesService.validatePodLimits($scope.limitRanges, 'memory', $scope.containers);
+        };
+
+        DataService.list("limitranges", context, function(limitRanges) {
+          $scope.limitRanges = limitRanges.by("metadata.name");
+          if ($filter('hashSize')(limitRanges) !== 0) {
+            $scope.$watch('containers', validatePodLimits, true);
+          }
+        });
+    }));
+  });

--- a/assets/app/scripts/directives/editRequestLimit.js
+++ b/assets/app/scripts/directives/editRequestLimit.js
@@ -1,0 +1,189 @@
+"use strict";
+
+angular.module('openshiftConsole')
+  .directive('computeResource', function($filter) {
+    return {
+      restrict: 'E',
+      require: 'ngModel',
+      scope: {
+        label: '@',
+        type: '@',
+        description: '@',
+        defaultValue: '=',
+        limitRangeMin: '=',
+        limitRangeMax: '=',
+        maxLimitRequestRatio: '=',
+        // If this is a limit, the value of the corresponding request to
+        // validate limit >= request.
+        request: '='
+      },
+      templateUrl: 'views/_compute-resource.html',
+      link: function(scope, elem, attrs, ngModel) {
+        var usageValue = $filter('usageValue');
+        var amountAndUnit = $filter('amountAndUnit');
+        var humanizeUnit = $filter('humanizeUnit');
+
+        // Create a unique ID for `label for` and `aria-describedby` attributes.
+        scope.id = _.uniqueId('compute-resource-');
+
+        // If unit is not already in options, add it.
+        var addUnitOption = function(unit) {
+          if (!_.some(scope.units, { value: unit })) {
+            scope.units.push({
+              value: unit,
+              label: humanizeUnit(unit, scope.type)
+            });
+          }
+        };
+
+        scope.$watch('defaultValue', function(defaultValue) {
+          // Set unit default based on default value or millicores/MiB if no default value.
+          // The amount input will have a placeholder using on limit range default.
+          var setDefault = _.spread(function(defaultAmount, defaultUnit) {
+            scope.placeholder = defaultAmount;
+            addUnitOption(defaultUnit);
+            // Only change selected unit if no value is set.
+            if (!scope.amount) {
+              scope.unit = defaultUnit;
+            }
+          });
+          if (defaultValue) {
+            setDefault(amountAndUnit(defaultValue, scope.type));
+          }
+        });
+
+        // Set unit options and based on type.
+        switch (scope.type) {
+        case 'cpu':
+          scope.unit = 'm';
+          scope.units = [{
+            value: "m",
+            label: "millicores"
+          }, {
+            value: "",
+            label: "cores"
+          }];
+          break;
+        case 'memory':
+          scope.unit = 'Mi';
+          scope.units = [{
+            value: "M",
+            label: "MB"
+          }, {
+            value: "G",
+            label: "GB"
+          }, {
+            value: "Mi",
+            label: "MiB"
+          }, {
+            value: "Gi",
+            label: "GiB"
+          }];
+          break;
+        }
+
+        var validateLimitRange = function() {
+          // Use usageValue filter to normalize units for comparison.
+          var value = scope.amount && usageValue(scope.amount + scope.unit),
+              min = scope.limitRangeMin && usageValue(scope.limitRangeMin),
+              max = scope.limitRangeMax && usageValue(scope.limitRangeMax),
+              minValid = true,
+              maxValid = true;
+
+          // Test against limit range min if defined.
+          if (value && min) {
+            minValid = value >= min;
+          }
+
+          // Test against limit range max if defined.
+          if (value && max) {
+            maxValid = value <= max;
+          }
+
+          scope.form.amount.$setValidity('limitRangeMin', minValid);
+          scope.form.amount.$setValidity('limitRangeMax', maxValid);
+        };
+
+        var validateLimitAgainstRequest = function() {
+          // Use usageValue filter to normalize units for comparison.
+          var limit,
+              request = scope.request && usageValue(scope.request),
+              limitLargerThanRequest = true,
+              limitWithinRatio = true;
+
+          // Limit is either the value set by the user or the default value if limit is unset.
+          if (scope.amount) {
+            limit = usageValue(scope.amount + scope.unit);
+          } else if (scope.defaultValue) {
+            limit = usageValue(scope.defaultValue);
+          }
+
+          if (request && limit) {
+            // Limit must be greater than or equal to request.
+            limitLargerThanRequest = limit >= request;
+
+            // Limit must be within the max limit/request ratio if defined.
+            if (scope.maxLimitRequestRatio) {
+              limitWithinRatio = (limit / request) <= scope.maxLimitRequestRatio;
+            }
+          }
+
+          if (request && !limit && scope.maxLimitRequestRatio) {
+            limitWithinRatio = false;
+          }
+
+          scope.form.amount.$setValidity('limitLargerThanRequest', limitLargerThanRequest);
+          scope.form.amount.$setValidity('limitWithinRatio', limitWithinRatio);
+        };
+
+        // Update view from model.
+        ngModel.$render = function() {
+          var update = _.spread(function(amount, unit) {
+            if (amount) {
+              scope.amount = Number(amount);
+              scope.unit = unit;
+              // If the unit already set in the resource isn't in the list, add it.
+              addUnitOption(unit);
+            } else {
+              scope.amount = null;
+            }
+          });
+          update(amountAndUnit(ngModel.$viewValue, scope.type));
+        };
+
+        // Update model from view.
+        scope.$watchGroup(['amount', 'unit'], function() {
+          validateLimitRange();
+          validateLimitAgainstRequest();
+          if (!scope.amount) {
+            ngModel.$setViewValue(undefined);
+          } else {
+            ngModel.$setViewValue(scope.amount + scope.unit);
+          }
+        });
+
+        scope.$watchGroup(['limitRangeMin', 'limitRangeMax'], validateLimitRange);
+        scope.$watch('request', validateLimitAgainstRequest);
+      }
+    };
+  })
+  .directive('editRequestLimit', function($filter, LimitRangesService) {
+    return {
+      restrict: 'E',
+      scope: {
+        resources: '=',
+        // 'cpu' or 'memory'
+        type: '@',
+        limitRanges: '='
+      },
+      templateUrl: 'views/_edit-request-limit.html',
+      link: function(scope) {
+        scope.requestCalculated = LimitRangesService.isRequestCalculated(scope.type);
+        scope.limitCalculated = LimitRangesService.isLimitCalculated(scope.type);
+
+        scope.$watch('limitRanges', function() {
+          scope.limits = LimitRangesService.getEffectiveLimitRange(scope.limitRanges, scope.type, 'Container');
+        }, true);
+      }
+    };
+  });

--- a/assets/app/scripts/directives/quotaUsageChart.js
+++ b/assets/app/scripts/directives/quotaUsageChart.js
@@ -43,7 +43,7 @@ angular.module('openshiftConsole')
               .attr('dy', 20)
               .attr('x', 0);
           });
-          replaceText(amountAndUnit($scope.total, $scope.type));
+          replaceText(amountAndUnit($scope.total, $scope.type, true));
         }
 
         // Adjust size based on legend position.

--- a/assets/app/scripts/filters/util.js
+++ b/assets/app/scripts/filters/util.js
@@ -94,9 +94,29 @@ angular.module('openshiftConsole')
       return number * multiplier;
     };
   })
+  .filter('humanizeUnit', function() {
+    return function(unit, type, singular) {
+      switch(type) {
+      case "memory":
+      case "storage":
+        if (!unit) {
+          return unit;
+        }
+        return unit + "B";
+      case "cpu":
+        if (unit === "m") {
+          unit = "milli";
+        }
+        var suffix = (singular) ? 'core' : 'cores';
+        return (unit || '') + suffix;
+      default:
+        return unit;
+      }
+    };
+  })
   // Returns the amount and unit for compute resources, normalizing the unit.
-  .filter('amountAndUnit', function() {
-    return function(value, type) {
+  .filter('amountAndUnit', function(humanizeUnitFilter) {
+    return function(value, type, humanizeUnits) {
       if (!value) {
         return [value, null];
       }
@@ -105,20 +125,13 @@ angular.module('openshiftConsole')
         // We didn't get an amount? shouldn't happen but just in case
         return [value, null];
       }
+
       var amount = split[1];
       var unit = split[2];
-      switch(type) {
-        case "memory":
-        case "storage":
-          unit += "B";
-          break;
-        case "cpu":
-          if (unit === "m") {
-            unit = "milli";
-          }
-          unit += (amount === "1" ? "core" : "cores");
-          break;
+      if (humanizeUnits) {
+        unit = humanizeUnitFilter(unit, type, amount === "1");
       }
+
       return [amount, unit];
     };
   })
@@ -133,7 +146,19 @@ angular.module('openshiftConsole')
         return amount + " " + unit;
       });
 
-      return toString(amountAndUnitFilter(value, type));
+      return toString(amountAndUnitFilter(value, type, true));
+    };
+  })
+  .filter('computeResourceLabel', function() {
+    return function(computeResourceType, capitalize) {
+      switch (computeResourceType) {
+      case 'cpu':
+        return 'CPU';
+      case 'memory':
+        return capitalize ? 'Memory' : 'memory';
+      default:
+        return computeResourceType;
+      }
     };
   })
   .filter('helpLink', function(Constants) {

--- a/assets/app/scripts/services/applicationGenerator.js
+++ b/assets/app/scripts/services/applicationGenerator.js
@@ -175,6 +175,14 @@ angular.module("openshiftConsole")
       var templateLabels = angular.copy(input.labels);
       templateLabels.deploymentconfig = input.name;
 
+      var container = {
+        image: imageSpec.toString(),
+        name: input.name,
+        ports: ports,
+        env: env,
+        resources: _.get(input, "container.resources")
+      };
+
       var deploymentConfig = {
         apiVersion: oApiVersion,
         kind: "DeploymentConfig",
@@ -194,14 +202,7 @@ angular.module("openshiftConsole")
               labels: templateLabels
             },
             spec: {
-              containers: [
-                {
-                  image: imageSpec.toString(),
-                  name: input.name,
-                  ports: ports,
-                  env: env
-                }
-              ]
+              containers: [ container ]
             }
           }
         }

--- a/assets/app/scripts/services/limits.js
+++ b/assets/app/scripts/services/limits.js
@@ -1,0 +1,187 @@
+'use strict';
+
+angular.module("openshiftConsole")
+  .factory("LimitRangesService", function($filter, LIMIT_REQUEST_OVERRIDES) {
+    var usageValue = $filter('usageValue');
+    var usageWithUnits = $filter('usageWithUnits');
+
+    var isSmaller = function(candidate, previous) {
+      if (!candidate) {
+        return false;
+      }
+
+      // No previous value, so use candidate.
+      if (!previous) {
+        return true;
+      }
+
+      // Normalize units to compare.
+      return usageValue(candidate) < usageValue(previous);
+    };
+
+    var isLarger = function(candidate, previous) {
+      if (!candidate) {
+        return false;
+      }
+
+      // No previous value, so use candidate.
+      if (!previous) {
+        return true;
+      }
+
+      // Normalize units to compare.
+      return usageValue(candidate) > usageValue(previous);
+    };
+
+    var hideCPUComputeResources = function() {
+      return LIMIT_REQUEST_OVERRIDES.enabled &&
+             LIMIT_REQUEST_OVERRIDES.limitCPUToMemoryRatio &&
+             LIMIT_REQUEST_OVERRIDES.cpuRequestToLimitRatio;
+    };
+
+    var isRequestCalculated = function(computeResource) {
+      if (!LIMIT_REQUEST_OVERRIDES.enabled) {
+        return false;
+      }
+
+      switch (computeResource) {
+      case "cpu":
+        return LIMIT_REQUEST_OVERRIDES.cpuRequestToLimitRatio;
+      case "memory":
+        return LIMIT_REQUEST_OVERRIDES.memoryRequestToLimitRatio;
+      default:
+        return false;
+      }
+    };
+
+    var isLimitCalculated = function(computeResource) {
+      return LIMIT_REQUEST_OVERRIDES.enabled &&
+             computeResource === 'cpu' &&
+             LIMIT_REQUEST_OVERRIDES.limitCPUToMemoryRatio;
+    };
+
+    // Reconciles multiple limit range resources for a compute resource ('cpu'
+    // or 'memory') and resource type ('Container' or 'Pod'). Returns an object
+    // with the following properties for if defined:
+    //
+    //   min, max, defaultLimit, defaultRequest, maxLimitRequestRatio
+    //
+    // For example,
+    //
+    // {
+    //   min: "100m",
+    //   max: "2",
+    //   defaultLimit: "300m",
+    //   defaultRequest: "200m",
+    //   maxLimitRequestRatio: "10"
+    //   min: "200m",
+    //   max: "2",
+    // }
+
+    var getEffectiveLimitRange = function(limitRanges, computeResource, resourceType) {
+      var effectiveRange = {};
+      angular.forEach(limitRanges, function(limitRange) {
+        angular.forEach(limitRange.spec.limits, function(limit) {
+          if (limit.type !== resourceType) {
+            return;
+          }
+
+          // Find the largest minimum.
+          if (limit.min && isLarger(limit.min[computeResource], effectiveRange.min)) {
+            effectiveRange.min = limit.min[computeResource];
+          }
+          // Find the smallest maximum.
+          if (limit.max && isSmaller(limit.max[computeResource], effectiveRange.max)) {
+            effectiveRange.max = limit.max[computeResource];
+          }
+          // Find default limit and request.
+          // TODO: Decide the correct behavior when there is more than one
+          //       limit range with different defaults set.
+          if (limit['default']) {
+            effectiveRange.defaultLimit = limit['default'][computeResource] || effectiveRange.defaultLimit;
+          }
+          if (limit.defaultRequest) {
+            effectiveRange.defaultRequest = limit.defaultRequest[computeResource] || effectiveRange.defaultRequest;
+          }
+          // Find the smallest max limit/request ratio.
+          var maxRatio;
+          if (limit.maxLimitRequestRatio) {
+            maxRatio = limit.maxLimitRequestRatio[computeResource];
+            if (maxRatio && (!effectiveRange.maxLimitRequestRatio ||
+                             maxRatio < effectiveRange.maxLimitRequestRatio)) {
+              effectiveRange.maxLimitRequestRatio = maxRatio;
+            }
+          }
+        });
+      });
+
+      return effectiveRange;
+    };
+
+    // Tests that the total request and total limit for all containers is
+    // within the limit range minimum and maximum, respectively, for the pod.
+    // Returns an array of error messages, or an empty array if no problems.
+    var validatePodLimits = function(limitRanges, computeResource, containers) {
+      if (!containers || !containers.length) {
+        return [];
+      }
+
+      var podLimits = getEffectiveLimitRange(limitRanges, computeResource, 'Pod');
+      var containerLimits = getEffectiveLimitRange(limitRanges, computeResource, 'Container');
+
+      // Use usageValue to normalize units.
+      var requestTotal = 0,
+          limitTotal = 0,
+          min = podLimits.min && usageValue(podLimits.min),
+          max = podLimits.max && usageValue(podLimits.max),
+          problems = [],
+          computeResourceLabel = $filter('computeResourceLabel')(computeResource, true);
+
+      // Total the usage for all containers.
+      angular.forEach(containers, function(container) {
+        // If no resources set, validate against defaults.
+        var resources = container.resources || {};
+
+        var request = (resources.requests && resources.requests[computeResource]) || containerLimits.defaultRequest;
+        if (request) {
+          requestTotal += usageValue(request);
+        }
+
+        var limit = (resources.limits && resources.limits[computeResource]) || containerLimits.defaultLimit;
+        if (limit) {
+          limitTotal += usageValue(limit);
+        }
+      });
+
+      // Only validate request if it's not calculated.
+      if (!isRequestCalculated(computeResource)) {
+        if (min && requestTotal < min) {
+          problems.push(computeResourceLabel + " request total for all containers is less than pod minimum (" + usageWithUnits(podLimits.min, computeResource) + ").");
+        }
+        if (max && requestTotal > max) {
+          problems.push(computeResourceLabel + " request total for all containers is greater than pod maximum (" + usageWithUnits(podLimits.max, computeResource) + ").");
+        }
+      }
+
+      // Only validate limit if it's not calculated.
+      if (!isLimitCalculated(computeResource)) {
+        if (min && limitTotal < min) {
+          problems.push(computeResourceLabel + " limit total for all containers is less than pod minimum (" + usageWithUnits(podLimits.min, computeResource) + ").");
+        }
+        if (max && limitTotal > max) {
+          problems.push(computeResourceLabel + " limit total for all containers is greater than pod maximum (" + usageWithUnits(podLimits.max, computeResource) + ").");
+        }
+      }
+
+      return problems;
+    };
+
+    return {
+      getEffectiveLimitRange: getEffectiveLimitRange,
+      hideCPUComputeResources: hideCPUComputeResources,
+      isRequestCalculated: isRequestCalculated,
+      isLimitCalculated: isLimitCalculated,
+      validatePodLimits: validatePodLimits
+    };
+  });
+

--- a/assets/app/styles/_core.less
+++ b/assets/app/styles/_core.less
@@ -408,6 +408,13 @@ label.checkbox {
   }
 }
 
+@media (max-width: @screen-xs-max) {
+  .compute-resource .inline-select {
+    // Spacing below input at mobile sizes.
+    margin-top: 5px;
+  }
+}
+
 .next-steps {
   .tile {
     margin-bottom: 0;

--- a/assets/app/views/_compute-resource.html
+++ b/assets/app/views/_compute-resource.html
@@ -1,0 +1,53 @@
+<ng-form name="form">
+  <fieldset class="form-inline compute-resource">
+    <label ng-if="label">{{label}}</label>
+    <div ng-class="{ 'has-error': form.$invalid }">
+      <label class="sr-only" ng-attr-for="{{id}}">Amount</label>
+      <input type="number"
+             name="amount"
+             ng-attr-id="{{id}}"
+             ng-model="amount"
+             min="0"
+             ng-attr-placeholder="{{placeholder}}"
+             class="form-control"
+             ng-attr-aria-describedby="{{description ? id + '-help' : undefined}}">
+      <label class="sr-only" ng-attr-for="{{id}}-unit">Unit</label>
+      <select ng-model="unit"
+              ng-options="option.value as option.label for option in units"
+              ng-attr-id="{{id}}-unit"
+              class="form-control inline-select">
+      </select>
+    </div>
+    <div ng-if="description" class="help-block" ng-attr-id="{{id}}-help">
+      {{description}}
+    </div>
+    <div ng-if="form.$invalid" class="has-error">
+      <div ng-if="form.amount.$error.number" class="help-block">
+        Must be a number.
+      </div>
+      <div ng-if="form.amount.$error.min" class="help-block">
+        Can't be negative.
+      </div>
+      <div ng-if="form.amount.$error.limitRangeMin" class="help-block">
+        Can't be less than {{limitRangeMin | usageWithUnits : type}}.
+      </div>
+      <div ng-if="form.amount.$error.limitRangeMax" class="help-block">
+        Can't be greater than {{limitRangeMax | usageWithUnits : type}}.
+      </div>
+      <div ng-if="form.amount.$error.limitLargerThanRequest" class="help-block">
+        Limit can't be less than request ({{request | usageWithUnits : type}}).
+      </div>
+      <div ng-if="form.amount.$error.limitWithinRatio" class="help-block">
+        <span ng-if="!amount && !defaultValue">
+          Limit is required if request is set. (Max Limit/Request Ratio: {{maxLimitRequestRatio}})
+        </span>
+        <span ng-if="amount || defaultValue">
+          Limit cannot be more than {{maxLimitRequestRatio}} times request value.
+          (Request: {{request | usageWithUnits : type}},
+          <!-- Show default if amount is unset. -->
+          Limit: {{(amount ? (amount + unit) : defaultValue) | usageWithUnits : type}})
+        </span>
+      </div>
+    </div>
+  </fieldset>
+</ng-form>

--- a/assets/app/views/_edit-request-limit.html
+++ b/assets/app/views/_edit-request-limit.html
@@ -1,0 +1,40 @@
+<ng-form name="form">
+  <h3>
+    {{type | computeResourceLabel : true}}
+    <small ng-if="limits.min && limits.max">
+      {{limits.min | usageWithUnits : type}} min to {{limits.max | usageWithUnits : type}} max
+    </small>
+    <small ng-if="limits.min && !limits.max">
+      Min: {{limits.min | usageWithUnits : type}}
+    </small>
+    <small ng-if="limits.max && !limits.min">
+      Max: {{limits.max | usageWithUnits : type}}
+    </small>
+  </h3>
+  <!-- Don't show the request fields if request is calculated from limit. -->
+  <compute-resource
+      ng-model="resources.requests[type]"
+      type="{{type}}"
+      label="Request"
+      description="The amount of {{type | computeResourceLabel}} the container requests."
+      default-value="limits.defaultRequest"
+      limit-range-min="limits.min"
+      limit-range-max="limits.max"
+      max-limit-request-ratio="limits.maxLimitRequestRatio"
+      ng-if="!requestCalculated">
+  </compute-resource>
+  <!-- Don't validate limit against request if request is calculated from the limit.
+       (Pass undefined to the compute-resource directive for request in that case.) -->
+  <compute-resource
+      ng-model="resources.limits[type]"
+      type="{{type}}"
+      label="{{requestCalculated ? undefined : 'Limit'}}"
+      description="The amount of {{type | computeResourceLabel : true}} the container is limited to use."
+      default-value="limits.defaultLimit"
+      limit-range-min="limits.min"
+      limit-range-max="limits.max"
+      request="requestCalculated ? undefined : resources.requests[type] || limits.defaultRequest"
+      max-limit-request-ratio="limits.maxLimitRequestRatio"
+      ng-if="!hideLimit">
+  </compute-resource>
+</ng-form>

--- a/assets/app/views/browse/deployment-config.html
+++ b/assets/app/views/browse/deployment-config.html
@@ -33,6 +33,11 @@
                       ><i class="fa fa-play fa-fw" aria-hidden="true"></i> Deploy</a>
                   </li>
                   <li>
+                    <a href="project/{{projectName}}/set-limits?dcName={{deploymentConfig.metadata.name}}"
+                      role="button"
+                      ><i class="fa fa-area-chart fa-fw" aria-hidden="true"></i> Set Resource Limits</a>
+                  </li>
+                  <li>
                     <edit-link
                       resource="deploymentConfig"
                       kind="deploymentconfigs"

--- a/assets/app/views/browse/replication-controller.html
+++ b/assets/app/views/browse/replication-controller.html
@@ -1,5 +1,5 @@
 <project-header class="top-header"></project-header>
-  <project-page>
+<project-page>
 
   <!-- Middle section -->
   <div class="middle-section">
@@ -22,6 +22,11 @@
                   <div class="pull-right dropdown">
                     <a href="" class="dropdown-toggle resource-actions-dropdown" data-toggle="dropdown"><i class="fa fa-ellipsis-v"></i><span class="sr-only">Actions</span></a>
                     <ul class="dropdown-menu actions action-button">
+                      <li>
+                        <a href="project/{{projectName}}/set-limits?rcName={{deployment.metadata.name}}"
+                          role="button"
+                          ><i class="fa fa-area-chart fa-fw" aria-hidden="true"></i> Set Resource Limits</a>
+                      </li>
                       <li>
                         <edit-link
                           resource="deployment"
@@ -53,4 +58,4 @@
       </div><!-- /middle-content -->
     </div><!-- /middle-container -->
   </div><!-- /middle-section -->
-  </project-page>
+</project-page>

--- a/assets/app/views/create/fromimage.html
+++ b/assets/app/views/create/fromimage.html
@@ -275,13 +275,41 @@
 
                             <!-- /scaling -->
 
+                            <osc-form-section
+                              header="Resource Limits"
+                              about-title="Resource Limits"
+                              about="Resource limits control compute resource usage by a container on a node."
+                              expand="true"
+                              can-toggle="false"
+                              >
+                              <edit-request-limit
+                                  resources="container.resources"
+                                  type="cpu"
+                                  limit-ranges="limitRanges"
+                                  ng-if="!hideCPU">
+                              </edit-request-limit>
+                              <edit-request-limit
+                                  resources="container.resources"
+                                  type="memory"
+                                  limit-ranges="limitRanges">
+                              </edit-request-limit>
+                              <div ng-repeat="problem in cpuProblems" class="has-error">
+                                <span class="help-block">{{problem}}</span>
+                              </div>
+                              <div ng-repeat="problem in memoryProblems" class="has-error">
+                                <span class="help-block">{{problem}}</span>
+                              </div>
+                            </osc-form-section>
+
+                            <!-- /limits -->
+
                             <label-editor labels="labels" expand="true" can-toggle="false"></label-editor>
                           </div>
                           <div class="buttons gutter-top-bottom gutter-top-bottom-2x">
                             <!-- unable to use form.valid.  need to fix validators in labels and key values directive -->
                             <button class="btn btn-primary btn-lg"
                                 ng-click="createApp()"
-                                ng-disabled="form.$invalid || nameTaken || disableInputs"
+                                ng-disabled="form.$invalid || nameTaken || cpuProblems.length || memoryProblems.length || disableInputs"
                                 >Create</button>
                             <a class="btn btn-default btn-lg" href="{{projectName | projectOverviewURL}}">Cancel</a>
                           </div>

--- a/assets/app/views/newfromtemplate.html
+++ b/assets/app/views/newfromtemplate.html
@@ -28,7 +28,7 @@
                           <h2>Images</h2>
                           <ul class="list-unstyled" ng-repeat="image in templateImages">
                             <li>
-                              <i class="pficon pficon-image"></i>
+                              <i class="pficon pficon-image" aria-hidden="true"></i>
                               <span class="name">{{ image.name }}</span>
                             </li>
                           </ul>

--- a/assets/app/views/set-limits.html
+++ b/assets/app/views/set-limits.html
@@ -1,0 +1,70 @@
+<default-header class="top-header"></default-header>
+<div class="wrap no-sidebar">
+  <div class="sidebar-left collapse navbar-collapse navbar-collapse-2">
+    <navbar-utility-mobile></navbar-utility-mobile>
+  </div>
+  <div class="middle">
+    <!-- Middle section -->
+    <div class="middle-section surface-shaded">
+      <div class="middle-container has-scroll">
+        <div class="middle-content">
+          <div class="container surface-shaded">
+            <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+            <div class="row">
+              <div class="col-md-12">
+                <alerts alerts="alerts"></alerts>
+                <div ng-show="!containers.length">Loading...</div>
+                <form ng-if="containers.length" name="form">
+                  <h1>Resource Limits: {{name}}</h1>
+                  <div class="help-block">
+                    Resource limits control how much <span ng-if="!hideCPU">CPU and</span> memory a container will consume on a node.
+                  </div>
+                  <div class="learn-more-block">
+                    <a href="{{'compute_resources' | helpLink}}" target="_blank">Learn more <i class="fa fa-external-link" aria-hidden> </i></a>
+                  </div>
+                  <div ng-if="showPodWarning" class="gutter-top">
+                    <span class="pficon pficon-warning-triangle-o" aria-hidden="true"></span>
+                    Changes will only apply to new pods.
+                  </div>
+                  <fieldset ng-disabled="disableInputs">
+                    <div ng-repeat="container in containers"
+                         ng-init="formName = container.name + '-form'">
+                      <h2 ng-if="containers.length > 1">Container {{container.name}}</h2>
+                      <edit-request-limit
+                          resources="container.resources"
+                          type="cpu"
+                          limit-ranges="limitRanges"
+                          ng-if="!hideCPU">
+                      </edit-request-limit>
+                      <edit-request-limit
+                          resources="container.resources"
+                          type="memory"
+                          limit-ranges="limitRanges">
+                      </edit-request-limit>
+                    </div>
+                    <div ng-repeat="problem in cpuProblems" class="has-error">
+                      <span class="help-block">{{problem}}</span>
+                    </div>
+                    <div ng-repeat="problem in memoryProblems" class="has-error">
+                      <span class="help-block">{{problem}}</span>
+                    </div>
+                    <div class="button-group gutter-top gutter-bottom">
+                      <button type="submit"
+                        class="btn btn-primary btn-lg"
+                        ng-click="save()"
+                        ng-disabled="form.$invalid || disableInputs || cpuProblems.length || memoryProblems.length"
+                        value="">Save</button>
+                      <a class="btn btn-default btn-lg" ng-href="{{resourceURL}}">Cancel</a>
+                    </div>
+                  </fieldset>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div><!-- /middle-content -->
+      </div><!-- /middle-container -->
+    </div><!-- /middle-section -->
+  </div><!-- /middle -->
+</div><!-- /wrap -->
+
+

--- a/assets/app/views/settings.html
+++ b/assets/app/views/settings.html
@@ -189,14 +189,7 @@
                       <tbody>
                         <tr ng-repeat-start="limit in limitRange.spec.limits"></tr>
                         <tr ng-repeat="(type, typeLimits) in limitsByType[limitRangeName][limit.type]">
-                          <td>
-                            {{limit.type}}
-                            <span ng-switch="type" class="hide-ng-leave">
-                              <span ng-switch-when="cpu">CPU</span>
-                              <span ng-switch-when="memory">Memory</span>
-                              <span ng-switch-default>{{type}}</span>
-                            </span>
-                          </td>
+                          <td>{{limit.type}} {{type | computeResourceLabel : true}}</td>
                           <td>{{(typeLimits.min | usageWithUnits : type) || "&mdash;"}}</td>
                           <td>{{(typeLimits.max | usageWithUnits : type) || "&mdash;"}}</td>
                           <td>{{(typeLimits.defaultRequest | usageWithUnits : type) || "&mdash;"}}</td>

--- a/assets/test/spec/services/applicationGeneratorSpec.js
+++ b/assets/test/spec/services/applicationGeneratorSpec.js
@@ -65,6 +65,9 @@ describe("ApplicationGenerator", function(){
       scaling: {
         replicas: 1
       },
+      container: {
+        resources: {}
+      },
       imageName: "origin-ruby-sample",
       imageTag: "latest",
       imageStream: {
@@ -422,7 +425,8 @@ describe("ApplicationGenerator", function(){
                         "name": "MYSQL_DATABASE",
                         "value": "root"
                       }
-                    ]
+                    ],
+                    "resources": {}
                   }
                 ]
               }
@@ -480,6 +484,27 @@ describe("ApplicationGenerator", function(){
             }
         }
       );
+    });
+  });
+
+  describe("generating pod template with requests and limits set", function(){
+    var resources, computeResources;
+    beforeEach(function(){
+      var testInput = _.clone(input);
+      testInput.container.resources = computeResources = {
+        limits: {
+          cpu: "1",
+          memory: "512M"
+        },
+        requests: {
+          memory: "128Mi"
+        }
+      };
+      resources = ApplicationGenerator.generate(testInput);
+    });
+
+    it("should create service ports for all exposed ports", function(){
+      expect(resources.deploymentConfig.spec.template.spec.containers[0].resources).toEqual(computeResources);
     });
   });
 


### PR DESCRIPTION
* Allow editing compute resource requests and limits for deployment configs and replication controllers that don't have a deployment config.
* Allow setting compute resource requests and limits during create.

https://trello.com/c/23NdtCwN

- [x] Add compute resources to create form
- [x] Disable form on submit
- [x] Update application generator unit tests
- [x] Update for #6901
- [x] Don't require limit if a default is set
- [x] https://bugzilla.redhat.com/show_bug.cgi?id=1303547

Browse deployment config:

<img width="757" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/12623359/c6770294-c4f7-11e5-833e-06802e651adf.png">

Set resource limits page:

<img width="844" alt="openshift_web_console" src="https://cloud.githubusercontent.com/assets/1167259/12623383/e8f4b85c-c4f7-11e5-84f6-19c7becd63a5.png">

/cc @jwforres @derekwaynecarr @sosiouxme 