### PR TITLE
addition of memory limits with online beta in mind

### DIFF
--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -48,8 +48,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -118,7 +117,11 @@
                     "value": "${MONGODB_ADMIN_PASSWORD}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -152,13 +155,21 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "384Mi"
+    },
+    {
       "name": "DATABASE_SERVICE_NAME",
-      "description": "Database service name",
+      "displayName": "Database service name",
+      "description": "The name of the OpenShift Service exposed for the database",
       "value": "mongodb",
       "required": true
     },
     {
       "name": "MONGODB_USER",
+      "displayName": "MongoDB user",
       "description": "Username for MongoDB user that will be used for accessing the database",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
@@ -166,6 +177,7 @@
     },
     {
       "name": "MONGODB_PASSWORD",
+      "displayName": "MongoDB password",
       "description": "Password for the MongoDB user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -173,12 +185,14 @@
     },
     {
       "name": "MONGODB_DATABASE",
-      "description": "Database name",
+      "displayName": "MongoDB database name",
+      "description": "Name of the MongoDB database accessed",
       "value": "sampledb",
       "required": true
     },
     {
       "name": "MONGODB_ADMIN_PASSWORD",
+      "displayName": "MongoDB admin password",
       "description": "Password for the database admin user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -65,8 +65,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -135,7 +134,11 @@
                     "value": "${MONGODB_ADMIN_PASSWORD}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -169,13 +172,21 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "128Mi"
+    },
+    {
       "name": "DATABASE_SERVICE_NAME",
-      "description": "Database service name",
+      "displayName": "Database service name",
+      "description": "The name of the OpenShift Service exposed for the database",
       "value": "mongodb",
       "required": true
     },
     {
       "name": "MONGODB_USER",
+      "displayName": "MongoDB user",
       "description": "Username for MongoDB user that will be used for accessing the database",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
@@ -183,6 +194,7 @@
     },
     {
       "name": "MONGODB_PASSWORD",
+      "displayName": "MongoDB password",
       "description": "Password for the MongoDB user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -190,12 +202,14 @@
     },
     {
       "name": "MONGODB_DATABASE",
-      "description": "Database name",
+      "displayName": "MongoDB database name",
+      "description": "Name of the MongoDB database accessed",
       "value": "sampledb",
       "required": true
     },
     {
       "name": "MONGODB_ADMIN_PASSWORD",
+      "displayName": "MongoDB admin password",
       "description": "Password for the database admin user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -203,6 +217,7 @@
     },
     {
       "name": "VOLUME_CAPACITY",
+      "displayName": "Volume capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi",
       "value": "512Mi",
       "required": true

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -48,8 +48,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -107,7 +106,11 @@
                     "value": "${MYSQL_DATABASE}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -141,13 +144,21 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "512Mi"
+    },
+    {
       "name": "DATABASE_SERVICE_NAME",
-      "description": "Database service name",
+      "displayName": "Database service name",
+      "description": "The name of the OpenShift Service exposed for the database",
       "value": "mysql",
       "required": true
     },
     {
       "name": "MYSQL_USER",
+      "displayName": "MySQL user",
       "description": "Username for MySQL user that will be used for accessing the database",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
@@ -155,6 +166,7 @@
     },
     {
       "name": "MYSQL_PASSWORD",
+      "displayName": "MySQL password",
       "description": "Password for the MySQL user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -162,7 +174,8 @@
     },
     {
       "name": "MYSQL_DATABASE",
-      "description": "Database name",
+      "displayName": "MySQL database name",
+      "description": "Name of the MySQL database accessed",
       "value": "sampledb",
       "required": true
     }

--- a/examples/db-templates/mysql-persistent-template.json
+++ b/examples/db-templates/mysql-persistent-template.json
@@ -65,8 +65,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -124,7 +123,11 @@
                     "value": "${MYSQL_DATABASE}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -158,13 +161,21 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "512Mi"
+    },
+    {
       "name": "DATABASE_SERVICE_NAME",
-      "description": "Database service name",
+      "displayName": "Database service name",
+      "description": "The name of the OpenShift Service exposed for the database",
       "value": "mysql",
       "required": true
     },
     {
       "name": "MYSQL_USER",
+      "displayName": "MySQL user",
       "description": "Username for MySQL user that will be used for accessing the database",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
@@ -172,6 +183,7 @@
     },
     {
       "name": "MYSQL_PASSWORD",
+      "displayName": "MySQL password",
       "description": "Password for the MySQL user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -179,12 +191,14 @@
     },
     {
       "name": "MYSQL_DATABASE",
-      "description": "Database name",
+      "displayName": "MySQL database name",
+      "description": "Name of the MySQL database accessed",
       "value": "sampledb",
       "required": true
     },
     {
       "name": "VOLUME_CAPACITY",
+      "displayName": "Volume capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi",
       "value": "512Mi",
       "required": true

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -48,8 +48,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -107,7 +106,11 @@
                     "value": "${POSTGRESQL_DATABASE}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -141,13 +144,21 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "128Mi"
+    },
+    {
       "name": "DATABASE_SERVICE_NAME",
-      "description": "Database service name",
+      "displayName": "Database service name",
+      "description": "The name of the OpenShift Service exposed for the database",
       "value": "postgresql",
       "required": true
     },
     {
       "name": "POSTGRESQL_USER",
+      "displayName": "PostgreSQL user",
       "description": "Username for PostgreSQL user that will be used for accessing the database",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
@@ -155,6 +166,7 @@
     },
     {
       "name": "POSTGRESQL_PASSWORD",
+      "displayName": "PostgreSQL password",
       "description": "Password for the PostgreSQL user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -162,7 +174,8 @@
     },
     {
       "name": "POSTGRESQL_DATABASE",
-      "description": "Database name",
+      "displayName": "PostgreSQL database name",
+      "description": "Name of the PostgreSQL database accessed",
       "value": "sampledb",
       "required": true
     }

--- a/examples/db-templates/postgresql-persistent-template.json
+++ b/examples/db-templates/postgresql-persistent-template.json
@@ -65,8 +65,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -124,7 +123,11 @@
                     "value": "${POSTGRESQL_DATABASE}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
@@ -158,13 +161,21 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "128Mi"
+    },
+    {
       "name": "DATABASE_SERVICE_NAME",
-      "description": "Database service name",
+      "displayName": "Database service name",
+      "description": "The name of the OpenShift Service exposed for the database",
       "value": "postgresql",
       "required": true
     },
     {
       "name": "POSTGRESQL_USER",
+      "displayName": "PostgreSQL user",
       "description": "Username for PostgreSQL user that will be used for accessing the database",
       "generate": "expression",
       "from": "user[A-Z0-9]{3}",
@@ -172,6 +183,7 @@
     },
     {
       "name": "POSTGRESQL_PASSWORD",
+      "displayName": "PostgreSQL password",
       "description": "Password for the PostgreSQL user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{16}",
@@ -179,12 +191,14 @@
     },
     {
       "name": "POSTGRESQL_DATABASE",
-      "description": "Database name",
+      "displayName": "PostgreSQL database name",
+      "description": "Name of the PostgreSQL database accessed",
       "value": "sampledb",
       "required": true
     },
     {
       "name": "VOLUME_CAPACITY",
+      "displayName": "Volume capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi",
       "value": "512Mi",
       "required": true

--- a/examples/jenkins/application-template.json
+++ b/examples/jenkins/application-template.json
@@ -73,8 +73,7 @@
             "updatePeriodSeconds": 1,
             "intervalSeconds": 1,
             "timeoutSeconds": 120
-          },
-          "resources": {}
+          }
         },
         "triggers": [
           {
@@ -116,7 +115,11 @@
                     "protocol": "TCP"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
                 "securityContext": {
@@ -253,8 +256,7 @@
             "updatePeriodSeconds": 1,
             "intervalSeconds": 1,
             "timeoutSeconds": 120
-          },
-          "resources": {}
+          }
         },
         "triggers": [
           {
@@ -296,7 +298,11 @@
                     "protocol": "TCP"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent",
                 "securityContext": {
@@ -315,14 +321,22 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "128Mi"
+    },
+   {
       "name": "ADMIN_USERNAME",
-      "description": "administrator username",
+      "displayName": "Administrator username",
+      "description": "Username for the administrator of this application",
       "generate": "expression",
       "from": "admin[A-Z0-9]{3}"
     },
     {
       "name": "ADMIN_PASSWORD",
-      "description": "administrator password",
+      "displayName": "Administrator password",
+      "description": "Password for the administrator of this application",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{8}"
     }

--- a/examples/jenkins/jenkins-ephemeral-template.json
+++ b/examples/jenkins/jenkins-ephemeral-template.json
@@ -65,8 +65,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -110,7 +109,11 @@
                     "value": "${JENKINS_PASSWORD}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${JENKINS_SERVICE_NAME}-data",
@@ -143,12 +146,20 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "512Mi"
+    },
+    {
       "name": "JENKINS_SERVICE_NAME",
-      "description": "Jenkins service name",
+      "displayName": "Jenkins service name",
+      "description": "The name of the OpenShift Service exposed for the Jenkins container",
       "value": "jenkins"
     },
     {
       "name": "JENKINS_PASSWORD",
+      "displayName": "Jenkins password",
       "description": "Password for the Jenkins user",
       "generate": "expression",
       "value": "password"

--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -82,8 +82,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+            "type": "Recreate"
         },
         "triggers": [
           {
@@ -127,7 +126,11 @@
                     "value": "${JENKINS_PASSWORD}"
                   }
                 ],
-                "resources": {},
+                "resources": {
+		    "limits": {
+			"memory": "${MEMORY_LIMIT}"
+		    }
+		},
                 "volumeMounts": [
                   {
                     "name": "${JENKINS_SERVICE_NAME}-data",
@@ -160,18 +163,27 @@
   ],
   "parameters": [
     {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory limit",
+      "description": "Maximum amount of memory the container can use",
+      "value": "512Mi"
+    },
+    {
       "name": "JENKINS_SERVICE_NAME",
-      "description": "Jenkins service name",
+      "displayName": "Jenkins service name",
+      "description": "The name of the OpenShift Service exposed for the Jenkins container",
       "value": "jenkins"
     },
     {
       "name": "JENKINS_PASSWORD",
+      "displayName": "Jenkins password",
       "description": "Password for the Jenkins user",
       "generate": "expression",
       "value": "password"
     },
     {
       "name": "VOLUME_CAPACITY",
+      "displayName": "Volume capacity",
       "description": "Volume space available for data, e.g. 512Mi, 2Gi",
       "value": "512Mi",
       "required": true


### PR DESCRIPTION
@bparees - hey, per our recent email exchange, I've got updates to some of the templates, introducing memory limit template parameters.

A couple of notes:
1) I only tackled the examples getting pulled in for the online beta
2) I went ahead and updated the ephemeral templates even though the initial beta currently is not supporting emptyDir / ephemeral storage; however, that appears to be a moment in time soft of statement, with a lot of activity and dialogue occurring around pulling that support into online at some point
3) for the mongodb templates, the fact that the limit for the persistent template is less than the ephemeral one is *not* an oversight; my analysis of the resource consumption repeated showed that peristent mongodb had smaller bring up costs.