### PR TITLE
Add a crashlooping error to oc status and a suggestion

### DIFF
--- a/pkg/api/graph/interfaces.go
+++ b/pkg/api/graph/interfaces.go
@@ -1,8 +1,6 @@
 package graph
 
 import (
-	"fmt"
-
 	"github.com/gonum/graph"
 )
 
@@ -107,5 +105,5 @@ func (m ByKey) Less(i, j int) bool {
 type Suggestion string
 
 func (s Suggestion) String() string {
-	return fmt.Sprintf("try: %s", string(s))
+	return string(s)
 }

--- a/pkg/api/graph/test/restarting-pod.yaml
+++ b/pkg/api/graph/test/restarting-pod.yaml
@@ -86,5 +86,108 @@ items:
           reason: 'Image: openshift/ruby-hello-world is not ready on the node'
     phase: Pending
     startTime: 2015-07-13T19:36:05Z
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      kubernetes.io/created-by: |
+        {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"default","name":"gitlab-ce-1","uid":"f74e7dce-c6ad-11e5-9bbb-080027c5bfa9","apiVersion":"v1","resourceVersion":"120461"}}
+      openshift.io/deployment-config.latest-version: "1"
+      openshift.io/deployment-config.name: gitlab-ce
+      openshift.io/deployment.name: gitlab-ce-1
+      openshift.io/generated-by: OpenShiftNewApp
+      openshift.io/scc: restricted
+    creationTimestamp: 2016-01-29T17:30:21Z
+    generateName: gitlab-ce-1-
+    labels:
+      app: gitlab-ce
+      deployment: gitlab-ce-1
+      deploymentconfig: gitlab-ce
+    name: gitlab-ce-1-lc411
+    namespace: example
+    resourceVersion: "120976"
+    selfLink: /api/v1/namespaces/default/pods/gitlab-ce-1-lc411
+    uid: f9326429-c6ad-11e5-9bbb-080027c5bfa9
+  spec:
+    containers:
+    - image: gitlab/gitlab-ce@sha256:9ca5330d8081e27dfc6d6aca0fa0fcf3d02519f0c8ca1267e143b25326a63449
+      imagePullPolicy: IfNotPresent
+      name: gitlab-ce
+      ports:
+      - containerPort: 22
+        protocol: TCP
+      - containerPort: 80
+        protocol: TCP
+      - containerPort: 443
+        protocol: TCP
+      resources: {}
+      securityContext:
+        privileged: false
+        runAsUser: 1000000000
+        seLinuxOptions:
+          level: s0:c1,c0
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/opt/gitlab
+        name: gitlab-ce-volume-1
+      - mountPath: /etc/gitlab
+        name: gitlab-ce-volume-2
+      - mountPath: /var/log/gitlab
+        name: gitlab-ce-volume-3
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-esybu
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    host: openshiftdev.local
+    imagePullSecrets:
+    - name: default-dockercfg-x4mac
+    nodeName: openshiftdev.local
+    restartPolicy: Always
+    securityContext:
+      seLinuxOptions:
+        level: s0:c1,c0
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    volumes:
+    - emptyDir: {}
+      name: gitlab-ce-volume-1
+    - emptyDir: {}
+      name: gitlab-ce-volume-2
+    - emptyDir: {}
+      name: gitlab-ce-volume-3
+    - name: default-token-esybu
+      secret:
+        secretName: default-token-esybu
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: 2016-01-29T18:02:28Z
+      message: 'containers with unready status: [gitlab-ce]'
+      reason: ContainersNotReady
+      status: "False"
+      type: Ready
+    containerStatuses:
+    - containerID: docker://92984bd17a722893c9925d23eef5d3d0660b5016ac70a9d80990f233c8fd517f
+      image: gitlab/gitlab-ce@sha256:9ca5330d8081e27dfc6d6aca0fa0fcf3d02519f0c8ca1267e143b25326a63449
+      imageID: docker://cd86ee9d085d5892b3aefab7a16a38a33cd11f42dcddcf0275dbcfce4f220b81
+      lastState:
+        terminated:
+          containerID: docker://92984bd17a722893c9925d23eef5d3d0660b5016ac70a9d80990f233c8fd517f
+          exitCode: 1
+          finishedAt: 2016-01-29T18:02:21Z
+          reason: Error
+          startedAt: 2016-01-29T18:02:18Z
+      name: gitlab-ce
+      ready: false
+      restartCount: 12
+      state:
+        waiting:
+          message: Back-off 5m0s restarting failed container=gitlab-ce pod=gitlab-ce-1-lc411_default
+          reason: CrashLoopBackOff
+    hostIP: 10.0.2.15
+    phase: Running
+    podIP: 172.17.0.57
+    startTime: 2016-01-29T17:30:21Z
 kind: List
 metadata: {}

--- a/pkg/api/graph/test/restarting-pod.yaml
+++ b/pkg/api/graph/test/restarting-pod.yaml
@@ -19,6 +19,8 @@ items:
     uid: 669a3b5d-2996-11e5-b9e2-28d2447dc82b
   spec:
     containers:
+    - name: container2
+    - name: container3
     - env:
       - name: ADMIN_USERNAME
         value: admin6TM
@@ -63,6 +65,16 @@ items:
     - status: "False"
       type: Ready
     containerStatuses:
+    - name: container2
+      restartCount: 1
+      lastState:
+        terminated:
+          finishedAt: 2015-07-13T19:36:05Z
+    - name: container3
+      restartCount: 8
+      state:
+        waiting:
+          reason: CrashLoopBackOff
     - image: openshift/ruby-hello-world
       imageID: ""
       lastState: {}

--- a/pkg/api/kubegraph/analysis/pod.go
+++ b/pkg/api/kubegraph/analysis/pod.go
@@ -2,18 +2,27 @@ package analysis
 
 import (
 	"fmt"
+	"time"
+
+	. "github.com/MakeNowJust/heredoc/dot"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 )
 
 const (
+	CrashLoopingPodError = "CrashLoopingPod"
 	RestartingPodWarning = "RestartingPod"
 
-	RestartThreshold = 3
+	RestartThreshold      = 5
+	RestartRecentDuration = 10 * time.Minute
 )
+
+// exposed for testing
+var nowFn = unversioned.Now
 
 // FindRestartingPods inspects all Pods to see if they've restarted more than the threshold
 func FindRestartingPods(g osgraph.Graph, f osgraph.Namer) []osgraph.Marker {
@@ -27,7 +36,47 @@ func FindRestartingPods(g osgraph.Graph, f osgraph.Namer) []osgraph.Marker {
 		}
 
 		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.RestartCount >= RestartThreshold {
+			switch {
+			case containerCrashLoopBackOff(containerStatus):
+				var suggestion string
+				switch {
+				case containerIsNonRoot(pod, containerStatus.Name):
+					suggestion = D(`
+						The container is starting and exiting repeatedly, which usually means the container cannot
+						start, is misconfigured, or is unable to perform an action due to security restrictions on
+						the container. The container logs may contain messages indicating the reason the pod cannot
+						start.
+
+						This container is being run as as a non-root user due to administrative policy, and
+						some images may fail expecting to be able to change ownership or set permissions on
+						directories. Your administrator may need to grant permission for you to run root
+						containers.`)
+				default:
+					suggestion = D(`
+						The container is starting and exiting repeatedly, which usually means the container cannot
+						start, is misconfigured, or is unable to perform an action due to security restrictions on
+						the container. The container logs may contain messages indicating the reason the pod cannot
+						start.`)
+				}
+				markers = append(markers, osgraph.Marker{
+					Node: podNode,
+
+					Severity: osgraph.ErrorSeverity,
+					Key:      CrashLoopingPodError,
+					Message: fmt.Sprintf("container %q in %s is crash-looping", containerStatus.Name,
+						f.ResourceName(podNode)),
+					Suggestion: osgraph.Suggestion(suggestion),
+				})
+			case containerRestartedRecently(containerStatus, nowFn()):
+				markers = append(markers, osgraph.Marker{
+					Node: podNode,
+
+					Severity: osgraph.WarningSeverity,
+					Key:      RestartingPodWarning,
+					Message: fmt.Sprintf("container %q in %s has restarted within the last 10 minutes", containerStatus.Name,
+						f.ResourceName(podNode)),
+				})
+			case containerRestartedFrequently(containerStatus):
 				markers = append(markers, osgraph.Marker{
 					Node: podNode,
 
@@ -41,4 +90,36 @@ func FindRestartingPods(g osgraph.Graph, f osgraph.Namer) []osgraph.Marker {
 	}
 
 	return markers
+}
+
+func containerIsNonRoot(pod *kapi.Pod, container string) bool {
+	for _, c := range pod.Spec.Containers {
+		if c.Name != container || c.SecurityContext == nil {
+			continue
+		}
+		switch {
+		case c.SecurityContext.RunAsUser != nil && *c.SecurityContext.RunAsUser != 0:
+			//c.SecurityContext.RunAsNonRoot != nil && *c.SecurityContext.RunAsNonRoot,
+			return true
+		}
+	}
+	return false
+}
+
+func containerCrashLoopBackOff(status kapi.ContainerStatus) bool {
+	return status.State.Waiting != nil && status.State.Waiting.Reason == "CrashLoopBackOff"
+}
+
+func containerRestartedRecently(status kapi.ContainerStatus, now unversioned.Time) bool {
+	if status.RestartCount == 0 {
+		return false
+	}
+	if status.LastTerminationState.Terminated != nil && now.Sub(status.LastTerminationState.Terminated.FinishedAt.Time) < RestartRecentDuration {
+		return true
+	}
+	return false
+}
+
+func containerRestartedFrequently(status kapi.ContainerStatus) bool {
+	return status.RestartCount > RestartThreshold
 }

--- a/pkg/api/kubegraph/analysis/pod_test.go
+++ b/pkg/api/kubegraph/analysis/pod_test.go
@@ -2,6 +2,9 @@ package analysis
 
 import (
 	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api/unversioned"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	osgraphtest "github.com/openshift/origin/pkg/api/graph/test"
@@ -12,12 +15,34 @@ func TestRestartingPodWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer func() { nowFn = unversioned.Now }()
 
+	recent, _ := time.Parse(time.RFC3339, "2015-07-13T19:36:06Z")
+	nowFn = func() unversioned.Time { return unversioned.NewTime(recent.UTC()) }
 	markers := FindRestartingPods(g, osgraph.DefaultNamer)
-	if e, a := 1, len(markers); e != a {
+	if e, a := 3, len(markers); e != a {
 		t.Fatalf("expected %v, got %v", e, a)
 	}
 	if e, a := RestartingPodWarning, markers[0].Key; e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := CrashLoopingPodError, markers[1].Key; e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := RestartingPodWarning, markers[2].Key; e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	future, _ := time.Parse(time.RFC3339, "2015-07-13T19:46:06Z")
+	nowFn = func() unversioned.Time { return unversioned.NewTime(future.UTC()) }
+	markers = FindRestartingPods(g, osgraph.DefaultNamer)
+	if e, a := 2, len(markers); e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := CrashLoopingPodError, markers[0].Key; e != a {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := RestartingPodWarning, markers[1].Key; e != a {
 		t.Fatalf("expected %v, got %v", e, a)
 	}
 }

--- a/pkg/cmd/cli/cmd/logs.go
+++ b/pkg/cmd/cli/cmd/logs.go
@@ -30,7 +30,10 @@ Print the logs for a resource.
 Supported resources are builds, build configs (bc), deployment configs (dc), and pods.
 When a pod is specified and has more than one container, the container name should be
 specified via -c. When a build config or deployment config is specified, you can view
-the logs for a particular version of it via --version.`
+the logs for a particular version of it via --version.
+
+If your pod is failing to start, you may need to use the --previous option to see the
+logs of the last attempt.`
 
 	logsExample = `  # Start streaming the logs of the most recent build of the openldap build config.
   $ %[1]s -f bc/openldap

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -48,6 +48,9 @@ type StatusOptions struct {
 	describer     *describe.ProjectStatusDescriber
 	out           io.Writer
 	verbose       bool
+
+	logsCommandName             string
+	securityPolicyCommandFormat string
 }
 
 // NewCmdStatus implements the OpenShift cli status command.
@@ -85,6 +88,9 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args 
 		return cmdutil.UsageError(cmd, "no arguments should be provided")
 	}
 
+	o.logsCommandName = fmt.Sprintf("%s logs -p", cmd.Parent().CommandPath())
+	o.securityPolicyCommandFormat = "oadm policy add-scc-to-user anyuid -n %s -z %s"
+
 	client, kclient, err := f.Clients()
 	if err != nil {
 		return err
@@ -105,7 +111,15 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args 
 		o.namespace = namespace
 	}
 
-	o.describer = &describe.ProjectStatusDescriber{K: kclient, C: client, Server: config.Host, Suggest: o.verbose}
+	o.describer = &describe.ProjectStatusDescriber{
+		K:       kclient,
+		C:       client,
+		Server:  config.Host,
+		Suggest: o.verbose,
+
+		LogsCommandName:             o.logsCommandName,
+		SecurityPolicyCommandFormat: o.securityPolicyCommandFormat,
+	}
 
 	o.out = out
 

--- a/pkg/cmd/cli/describe/projectstatus_test.go
+++ b/pkg/cmd/cli/describe/projectstatus_test.go
@@ -268,6 +268,9 @@ func TestProjectStatus(t *testing.T) {
 			ErrFn: func(err error) bool { return err == nil },
 			Contains: []string{
 				`container "ruby-helloworld" in pod/frontend-app-1-bjwh8 has restarted 8 times`,
+				`container "gitlab-ce" in pod/gitlab-ce-1-lc411 is crash-looping`,
+				`oc logs -p gitlab-ce-1-lc411 -c gitlab-ce`, // verifies we print the log command
+				`policycommand example default`,             // verifies that we print the help command
 			},
 		},
 	}
@@ -290,7 +293,7 @@ func TestProjectStatus(t *testing.T) {
 			o.Add(obj)
 		}
 		oc, kc := testclient.NewFixtureClients(o)
-		d := ProjectStatusDescriber{C: oc, K: kc, Server: "https://example.com:8443", Suggest: true}
+		d := ProjectStatusDescriber{C: oc, K: kc, Server: "https://example.com:8443", Suggest: true, LogsCommandName: "oc logs -p", SecurityPolicyCommandFormat: "policycommand %s %s"}
 		out, err := d.Describe("example", "")
 		if !test.ErrFn(err) {
 			t.Errorf("%s: unexpected error: %v", k, err)


### PR DESCRIPTION
Make the suggestion vary based on whether the container is root or
non-root.

Fixes part of #6348

What I would still like to see (@deads2k) is to connect this marker to the pod description line
in the deployment status while still reusing code.  Opinions on best way to do that and reuse the marker logic?