### PR TITLE
Delay fetching of logs on pod, build & deployment until logs are ready to run

### DIFF
--- a/assets/app/scripts/controllers/build.js
+++ b/assets/app/scripts/controllers/build.js
@@ -72,6 +72,9 @@ angular.module('openshiftConsole')
                 };
               }
               $scope.build = build;
+              // TODO: if build.status.phase === 'Error' then we should not
+              // fetch the log, BUT ALSO indicate this somehow in UI
+              $scope.logCanRun = !(_.includes(['New', 'Pending', 'Error'], build.status.phase));
             }));
           },
           // failure

--- a/assets/app/scripts/controllers/deployment.js
+++ b/assets/app/scripts/controllers/deployment.js
@@ -74,6 +74,7 @@ angular.module('openshiftConsole')
             activeDeployment = DeploymentsService.getActiveDeployment(deploymentsForConfig);
             $scope.logContext.container = $filter("annotation")(activeDeployment, "pod");
             $scope.isActive = activeDeployment && activeDeployment.metadata.uid === $scope.deployment.metadata.uid;
+            $scope.logCanRun = !(_.includes(['New', 'Pending'], $filter('deploymentStatus')(activeDeployment)));
           }));
         };
 

--- a/assets/app/scripts/controllers/pod.js
+++ b/assets/app/scripts/controllers/pod.js
@@ -55,7 +55,8 @@ angular.module('openshiftConsole')
           function(pod) {
             $scope.loaded = true;
             $scope.pod = pod;
-            $scope.logOptions.container = $routeParams.container || _.get(pod, 'spec.containers[0].name');
+            $scope.logOptions.container = $routeParams.container || pod.spec.containers[0].name;
+            $scope.logCanRun = !(_.includes(['New', 'Pending', 'Unknown'], pod.status.phase));
             var pods = {};
             pods[pod.metadata.name] = pod;
             ImageStreamResolver.fetchReferencedImageStreamImages(pods, $scope.imagesByDockerReference, $scope.imageStreamImageRefByDockerReference, context);

--- a/assets/app/scripts/directives/logViewer.js
+++ b/assets/app/scripts/directives/logViewer.js
@@ -37,11 +37,13 @@ angular.module('openshiftConsole')
           status: '=?',
           start: '=?',
           end: '=?',
-          chromeless: '=?'
+          chromeless: '=?',
+          run: '=?'  // will wait for run to be truthy before requesting logs
         },
         controller: [
           '$scope',
           function($scope) {
+
             $scope.loading = true;
 
             // Default to false. Let the user click the follow link to start auto-scrolling.
@@ -138,6 +140,10 @@ angular.module('openshiftConsole')
               stopStreaming();
 
               if (!$scope.name) {
+                return;
+              }
+
+              if(!$scope.run) {
                 return;
               }
 

--- a/assets/app/views/browse/build.html
+++ b/assets/app/views/browse/build.html
@@ -57,7 +57,8 @@
                   options="logOptions"
                   status="build.status.phase"
                   start="build.status.startTimestamp | date : 'short'"
-                  end="build.status.completionTimestamp | date : 'short'">
+                  end="build.status.completionTimestamp | date : 'short'"
+                  run="logCanRun">
                 </log-viewer>
               </uib-tab>
             </uib-tabset>

--- a/assets/app/views/browse/deployment.html
+++ b/assets/app/views/browse/deployment.html
@@ -70,7 +70,8 @@
                   context="logContext"
                   options="logOptions"
                   status="deployment | deploymentStatus"
-                  start="deployment.metadata.creationTimestamp | date : 'short'">
+                  start="deployment.metadata.creationTimestamp | date : 'short'"
+                  run="logCanRun">
                 </log-viewer>
               </uib-tab>
             </uib-tabset>

--- a/assets/app/views/browse/pod.html
+++ b/assets/app/views/browse/pod.html
@@ -84,7 +84,8 @@
                     context="logContext"
                     options="logOptions"
                     status="pod.status.phase"
-                    start="pod.status.startTime | date : 'short'">
+                    start="pod.status.startTime | date : 'short'"
+                    run="logCanRun">
                 </log-viewer>
               </uib-tab>
 


### PR DESCRIPTION
Adds `run` attribute to the directive, allowing a simple boolean to indicate when the logViewer should begin fetching logs.

@jwforres  @spadgett 
(yay, a small PR!)