### PR TITLE
bump(github.com/openshift/openshift-sdn): 04aafc3712ec4d612f668113285370f58075e1e2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -718,32 +718,32 @@
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/cmd/admin/network",
 			"Comment": "v0.1-404-gfccee21",
-			"Rev": "fccee2120e9e8662639df6b40f4e1adf07872105"
+			"Rev": "04aafc3712ec4d612f668113285370f58075e1e2"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/exec",
 			"Comment": "v0.1-404-gfccee21",
-			"Rev": "fccee2120e9e8662639df6b40f4e1adf07872105"
+			"Rev": "04aafc3712ec4d612f668113285370f58075e1e2"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/ipcmd",
 			"Comment": "v0.1-404-gfccee21",
-			"Rev": "fccee2120e9e8662639df6b40f4e1adf07872105"
+			"Rev": "04aafc3712ec4d612f668113285370f58075e1e2"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/netutils",
 			"Comment": "v0.1-404-gfccee21",
-			"Rev": "fccee2120e9e8662639df6b40f4e1adf07872105"
+			"Rev": "04aafc3712ec4d612f668113285370f58075e1e2"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/pkg/ovs",
 			"Comment": "v0.1-404-gfccee21",
-			"Rev": "fccee2120e9e8662639df6b40f4e1adf07872105"
+			"Rev": "04aafc3712ec4d612f668113285370f58075e1e2"
 		},
 		{
 			"ImportPath": "github.com/openshift/openshift-sdn/plugins/osdn",
 			"Comment": "v0.1-404-gfccee21",
-			"Rev": "fccee2120e9e8662639df6b40f4e1adf07872105"
+			"Rev": "04aafc3712ec4d612f668113285370f58075e1e2"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",


### PR DESCRIPTION
This is post-rebase bump, @deads2k you can safely drop https://github.com/openshift/origin/commit/ac6be3ef8113ea624c369982a1141195130929f9 upon next reabse.

@dcbw godep is a pain, unfortunately, you'd need to generally speaking go through the same process we do when rebasing k8s (see [this](https://github.com/openshift/origin/blob/master/HACKING.md#updating-kubernetes-from-upstream)). There's an easier alternative we're heavily using bumping s2i :wink: and since we now have the godeps cleared out, just copy the dirs and update Godeps.json manually, unless you're adding new subdirs then it would be good to go through that process, or just ping me :smile: 

Fixes #6428.